### PR TITLE
Add first class vscode support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,11 @@
   "editor.formatOnSave": true,
   "[mdx]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "tailwindCSS.experimental.classRegex": [
+    [
+      "cva\\(([^)]*)\\)",
+      "[\"'`]([^\"'`]*).*?[\"'`]"
+    ],
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-plugin-storybook": "^0.8.0",
         "postcss": "^8.4.38",
         "prettier": "^3.2.5",
+        "prettier-plugin-tailwindcss": "^0.5.13",
         "storybook": "^8.0.5",
         "storybook-addon-themes": "^6.1.0",
         "tailwindcss": "^3.4.3",
@@ -16725,6 +16726,80 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.13.tgz",
+      "integrity": "sha512-2tPWHCFNC+WRjAC4SIWQNSOdcL1NNkydXim8w7TDqlZi+/ulZYz2OouAI6qMtkggnPt7lGamboj6LcTMwcCvoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig-melody": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig-melody": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-storybook": "^0.8.0",
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",
+    "prettier-plugin-tailwindcss": "^0.5.13",
     "storybook": "^8.0.5",
     "storybook-addon-themes": "^6.1.0",
     "tailwindcss": "^3.4.3",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -20,7 +20,11 @@ let config = {
     "",
     "^[./]",
   ],
-  plugins: ["@ianvs/prettier-plugin-sort-imports"],
+  plugins: [
+    "@ianvs/prettier-plugin-sort-imports",
+    "prettier-plugin-tailwindcss",
+  ],
+  tailwindFunctions: ["cva"],
 }
 
 export default config

--- a/src/experiments/application/index.tsx
+++ b/src/experiments/application/index.tsx
@@ -24,7 +24,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/foundations/popover"
 import { ScrollArea } from "@/foundations/scrollarea"
 
 const Title: React.FC<{ title: string }> = ({ title }) => (
-  <div className="flex h-14 items-center gap-2 text-secondary-foreground font-medium px-3">
+  <div className="flex h-14 items-center gap-2 px-3 font-medium text-secondary-foreground">
     <Target size="20" />
     {title}
   </div>
@@ -34,8 +34,8 @@ const Layout: React.FC = () => {
   const [activeSection, setActiveSection] = React.useState("dashboard")
 
   return (
-    <div className="-m-4 bg-secondary/60 min-h-screen h-screen p-3 grid grid-cols-1 md:grid-cols-[264px_1fr]">
-      <div className="block md:hidden pb-2">
+    <div className="-m-4 grid h-screen min-h-screen grid-cols-1 bg-secondary/60 p-3 md:grid-cols-[264px_1fr]">
+      <div className="block pb-2 md:hidden">
         <Button size="icon-sm" variant="ghost">
           <Menu size="16" />
         </Button>
@@ -43,26 +43,26 @@ const Layout: React.FC = () => {
       <ScrollArea className="hidden flex-col pr-3 md:flex">
         <Title title="A Cool Company 2" />
         <nav className="flex flex-col pt-3">
-          <div className="h-9 flex gap-2 items-center rounded-lg text-sm text-secondary-foreground font-medium p-1.5 transition-colors hover:bg-secondary hover:cursor-pointer">
+          <div className="flex h-9 items-center gap-2 rounded-lg p-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:cursor-pointer hover:bg-secondary">
             <Home size="16" /> Dashboard
           </div>
 
-          <div className="h-9 flex gap-2 items-center rounded-lg text-sm text-secondary-foreground font-medium p-1.5 transition-colors hover:bg-secondary hover:cursor-pointer">
+          <div className="flex h-9 items-center gap-2 rounded-lg p-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:cursor-pointer hover:bg-secondary">
             <Inbox size="16" /> Inbox
           </div>
 
-          <div className="h-9 flex gap-2 items-center rounded-lg text-sm text-secondary-foreground font-medium p-1.5 transition-colors hover:bg-secondary hover:cursor-pointer">
+          <div className="flex h-9 items-center gap-2 rounded-lg p-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:cursor-pointer hover:bg-secondary">
             <Store size="16" /> Marketplace
           </div>
 
-          <div className="pt-4 px-1.5 pb-1 my-2 uppercase text-xs text-secondary-foreground/70 font-medium">
+          <div className="my-2 px-1.5 pb-1 pt-4 text-xs font-medium uppercase text-secondary-foreground/70">
             You
           </div>
 
           <Accordion.Root type="single" collapsible>
             <Accordion.Item value="item-1">
-              <Accordion.Trigger className="group w-full h-9 flex items-center rounded-lg text-sm text-secondary-foreground font-medium p-1.5 transition-colors hover:bg-secondary hover:cursor-pointer">
-                <div className="flex flex-1 gap-2 items-center">
+              <Accordion.Trigger className="group flex h-9 w-full items-center rounded-lg p-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:cursor-pointer hover:bg-secondary">
+                <div className="flex flex-1 items-center gap-2">
                   <UserRound size="16" />
                   Me
                 </div>
@@ -70,12 +70,12 @@ const Layout: React.FC = () => {
                   <ChevronDown size="12" />
                 </div>
               </Accordion.Trigger>
-              <Accordion.Content className="overflow-hidden mb-2 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-                <div className="flex flex-col border-l-2 ml-3">
-                  <div className="flex text-sm text-secondary-foreground font-normal h-8 items-center pl-5 hover:text-foreground hover:cursor-pointer">
+              <Accordion.Content className="mb-2 overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+                <div className="ml-3 flex flex-col border-l-2">
+                  <div className="flex h-8 items-center pl-5 text-sm font-normal text-secondary-foreground hover:cursor-pointer hover:text-foreground">
                     Profile
                   </div>
-                  <div className="flex text-sm text-secondary-foreground font-normal h-8 items-center pl-5 hover:text-foreground hover:cursor-pointer">
+                  <div className="flex h-8 items-center pl-5 text-sm font-normal text-secondary-foreground hover:cursor-pointer hover:text-foreground">
                     Personal
                   </div>
                 </div>
@@ -85,39 +85,39 @@ const Layout: React.FC = () => {
 
           {activeSection == "dashboard" && (
             <>
-              <div className="h-9 flex gap-2 items-center rounded-lg text-sm text-secondary-foreground font-medium p-1.5 transition-colors hover:bg-secondary hover:cursor-pointer">
+              <div className="flex h-9 items-center gap-2 rounded-lg p-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:cursor-pointer hover:bg-secondary">
                 <Clock size="16" /> Clock in
               </div>
 
-              <div className="h-9 flex gap-2 items-center rounded-lg text-sm text-secondary-foreground font-medium p-1.5 transition-colors hover:bg-secondary hover:cursor-pointer">
+              <div className="flex h-9 items-center gap-2 rounded-lg p-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:cursor-pointer hover:bg-secondary">
                 <TreePalm size="16" /> Time off
               </div>
 
-              <div className="bg-secondary h-9 flex gap-2 items-center rounded-lg text-sm text-foreground font-medium p-1.5 transition-colors hover:bg-secondary-intermediate/50 hover:cursor-pointer">
+              <div className="flex h-9 items-center gap-2 rounded-lg bg-secondary p-1.5 text-sm font-medium text-foreground transition-colors hover:cursor-pointer hover:bg-secondary-intermediate/50">
                 <Folders size="16" /> My documents
               </div>
 
-              <div className="h-9 flex gap-2 items-center rounded-lg text-sm text-secondary-foreground font-medium p-1.5 transition-colors hover:bg-secondary hover:cursor-pointer">
+              <div className="flex h-9 items-center gap-2 rounded-lg p-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:cursor-pointer hover:bg-secondary">
                 <BookCheck size="16" /> Tasks
               </div>
 
-              <div className="pt-4 px-1.5 pb-1 my-2 uppercase text-xs text-secondary-foreground/70 font-medium">
+              <div className="my-2 px-1.5 pb-1 pt-4 text-xs font-medium uppercase text-secondary-foreground/70">
                 Your company
               </div>
 
-              <div className="h-9 flex gap-2 items-center rounded-lg text-sm text-secondary-foreground font-medium p-1.5 transition-colors hover:bg-secondary hover:cursor-pointer">
+              <div className="flex h-9 items-center gap-2 rounded-lg p-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:cursor-pointer hover:bg-secondary">
                 <UsersRound size="16" /> Employees
               </div>
 
-              <div className="h-9 flex gap-2 items-center rounded-lg text-sm text-secondary-foreground font-medium p-1.5 transition-colors hover:bg-secondary hover:cursor-pointer">
+              <div className="flex h-9 items-center gap-2 rounded-lg p-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:cursor-pointer hover:bg-secondary">
                 <Calendar size="16" /> Calendar
               </div>
             </>
           )}
         </nav>
       </ScrollArea>
-      <ScrollArea className="bg-background rounded-lg shadow">
-        <div className="flex h-14 border-b items-center p-4 text-sm text-secondary-foreground font-medium">
+      <ScrollArea className="rounded-lg bg-background shadow">
+        <div className="flex h-14 items-center border-b p-4 text-sm font-medium text-secondary-foreground">
           <div className="flex-1">My documents</div>
           <div className="flex flex-none gap-1.5">
             <Button
@@ -140,7 +140,7 @@ const Layout: React.FC = () => {
           </div>
         </div>
         <div className="p-6 md:p-12">
-          <div className="flex flex-col gap-2 mb-6">
+          <div className="mb-6 flex flex-col gap-2">
             <Folders size="28" className="text-primary-foreground" />
             <div className="flex flex-col">
               <h1 className="text-2xl font-semibold">Personal folders</h1>
@@ -149,10 +149,10 @@ const Layout: React.FC = () => {
               </span>
             </div>
           </div>
-          <div className="grid gap-4 md:gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6 lg:grid-cols-3">
             {[...Array(6)].map((_, i) => (
-              <div className="flex flex-col rounded-lg border p-4 hover:bg-muted/50 hover:cursor-pointer font-medium transition-colors">
-                <Folder size="16" className="text-secondary-foreground mb-1" />
+              <div className="flex flex-col rounded-lg border p-4 font-medium transition-colors hover:cursor-pointer hover:bg-muted/50">
+                <Folder size="16" className="mb-1 text-secondary-foreground" />
                 Folder {++i}
               </div>
             ))}

--- a/src/experiments/themes/theme-switcher.stories.tsx
+++ b/src/experiments/themes/theme-switcher.stories.tsx
@@ -15,9 +15,9 @@ type Story = StoryObj<typeof meta>
 export const Basic: Story = {
   render: () => {
     return (
-      <div className="bg-background max-w-96 p-10">
-        <div className="flex flex-col gap-3 rounded-lg bg-card p-6 border">
-          <div className="flex gap-3 items-center">
+      <div className="max-w-96 bg-background p-10">
+        <div className="flex flex-col gap-3 rounded-lg border bg-card p-6">
+          <div className="flex items-center gap-3">
             <h1 className="text-xl font-medium">Theme Switcher example</h1>
             <div className="flex-shrink-0">
               <ThemeSwitcher />

--- a/src/foundations/avatar.tsx
+++ b/src/foundations/avatar.tsx
@@ -18,12 +18,12 @@ export const sizes = [
 const avatarVariants = cva("relative flex shrink-0 overflow-hidden", {
   variants: {
     size: {
-      xsmall: "w-8 h-8 rounded-xl text-xs",
-      small: "w-10 h-10 rounded-xl text-sm",
-      medium: "w-12 h-12 rounded-xl",
-      large: "w-16 h-16 rounded-2xl text-xl",
-      xlarge: "w-20 h-20 rounded-2xl text-2xl",
-      xxlarge: "w-32 h-32 rounded-3xl text-3xl",
+      xsmall: "h-8 w-8 rounded-xl text-xs",
+      small: "h-10 w-10 rounded-xl text-sm",
+      medium: "h-12 w-12 rounded-xl",
+      large: "h-16 w-16 rounded-2xl text-xl",
+      xlarge: "h-20 w-20 rounded-2xl text-2xl",
+      xxlarge: "h-32 w-32 rounded-3xl text-3xl",
     } satisfies Record<(typeof sizes)[number], string>,
   },
   defaultVariants: {

--- a/src/foundations/button.tsx
+++ b/src/foundations/button.tsx
@@ -21,15 +21,15 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-background text-primary-foreground hover:bg-primary border-2 border-primary-intermediate",
+          "border-2 border-primary-intermediate bg-background text-primary-foreground hover:bg-primary",
         secondary:
-          "bg-background text-secondary-foreground hover:bg-secondary border-2 border-secondary-intermediate",
+          "border-2 border-secondary-intermediate bg-background text-secondary-foreground hover:bg-secondary",
         outline:
-          "bg-background text-secondary-foreground hover:bg-secondary border-2 border-secondary-intermediate",
+          "border-2 border-secondary-intermediate bg-background text-secondary-foreground hover:bg-secondary",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/70 border-2 border-destructive-intermediate",
+          "border-2 border-destructive-intermediate bg-destructive text-destructive-foreground hover:bg-destructive/70",
         positive:
-          "bg-positive text-positive-foreground hover:bg-positive/70 border-2 border-positive-intermediate",
+          "border-2 border-positive-intermediate bg-positive text-positive-foreground hover:bg-positive/70",
         ghost: "text-intermediate hover:bg-accent hover:text-accent-foreground",
       } satisfies Record<(typeof variants)[number], string>,
       size: {

--- a/src/foundations/calendar.stories.tsx
+++ b/src/foundations/calendar.stories.tsx
@@ -41,11 +41,11 @@ export const Multiple: Story = {
 
     const footer =
       days && days.length > 0 ? (
-        <p className="w-[252px] text-sm mt-3 text-secondary-foreground text-wrap">
+        <p className="mt-3 w-[252px] text-wrap text-sm text-secondary-foreground">
           You selected {days.length} day(s).
         </p>
       ) : (
-        <p className="w-[252px] text-sm mt-3 text-secondary-foreground text-wrap">
+        <p className="mt-3 w-[252px] text-wrap text-sm text-secondary-foreground">
           Please pick one or more days.
         </p>
       )
@@ -72,20 +72,20 @@ export const Range: Story = {
     const [range, setRange] = useState<DateRange | undefined>(defaultSelected)
 
     let footer = (
-      <p className="w-[252px] text-sm mt-3 text-secondary-foreground text-wrap">
+      <p className="mt-3 w-[252px] text-wrap text-sm text-secondary-foreground">
         Please pick the first day.
       </p>
     )
     if (range?.from) {
       if (!range.to) {
         footer = (
-          <p className="w-[252px] text-sm mt-3 text-secondary-foreground text-wrap">
+          <p className="mt-3 w-[252px] text-wrap text-sm text-secondary-foreground">
             {format(range.from, "PPP")}
           </p>
         )
       } else if (range.to) {
         footer = (
-          <p className="w-[252px] text-sm mt-3 text-secondary-foreground text-wrap">
+          <p className="mt-3 w-[252px] text-wrap text-sm text-secondary-foreground">
             {format(range.from, "PPP")} - {format(range.to, "PPP")}
           </p>
         )

--- a/src/foundations/dialog.tsx
+++ b/src/foundations/dialog.tsx
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-3 top-3 p-2 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-3 top-3 rounded-sm p-2 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -59,7 +59,7 @@ const DialogIcon = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "absolute left-8 top-0 translate-y-[-50%] bg-background shadow-md p-4 rounded-2xl text-primary-foreground",
+      "absolute left-8 top-0 translate-y-[-50%] rounded-2xl bg-background p-4 text-primary-foreground shadow-md",
       className
     )}
     {...props}
@@ -72,7 +72,7 @@ const DialogHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("flex flex-col space-y-1.5 mt-6 text-left", className)}
+    className={cn("mt-6 flex flex-col space-y-1.5 text-left", className)}
     {...props}
   />
 )
@@ -84,7 +84,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse gap-1 bg-secondary/50 border-t px-8 py-4 -mx-8 -mb-8 mt-4 rounded-bl-2xl rounded-br-2xl sm:flex-row sm:justify-end sm:space-x-2",
+      "-mx-8 -mb-8 mt-4 flex flex-col-reverse gap-1 rounded-bl-2xl rounded-br-2xl border-t bg-secondary/50 px-8 py-4 sm:flex-row sm:justify-end sm:space-x-2",
       className
     )}
     {...props}

--- a/src/foundations/input.stories.tsx
+++ b/src/foundations/input.stories.tsx
@@ -34,7 +34,7 @@ export const Primary: Story = {
   },
   render: (props) => {
     return (
-      <div className="w-full flex flex-col gap-1.5">
+      <div className="flex w-full flex-col gap-1.5">
         <Label htmlFor="input">Label</Label>
         <Input id="input" {...props} />
       </div>

--- a/src/foundations/input.tsx
+++ b/src/foundations/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-lg border-2 border-input bg-background px-3 py-2 text-sm transition-colors ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 hover:border-input-hover focus-visible:border-input-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted",
+          "flex h-10 w-full rounded-lg border-2 border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 hover:border-input-hover focus-visible:border-input-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/foundations/select.tsx
+++ b/src/foundations/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-lg border-2 border-input bg-background px-3 py-2 text-sm transition-colors hover:border-input-hover focus-visible:border-input-hover ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 disabled:bg-muted",
+      "flex h-10 w-full items-center justify-between rounded-lg border-2 border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors placeholder:text-muted-foreground hover:border-input-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus-visible:border-input-hover disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}


### PR DESCRIPTION
This improves vscode support with two changes:

* Correctly reads the class names with a regexp when using the `cva` modifier, so you get autocomplete, hover, etc
* I adds autosorting with prettier, which should keep class names under control