### PR TITLE
Does not expose all input properties and add form as xray type

### DIFF
--- a/lib/components/Forms/Input/index.tsx
+++ b/lib/components/Forms/Input/index.tsx
@@ -1,1 +1,19 @@
 export * from "@/ui/input"
+import { Component } from "@/lib/component"
+import { Input as ShadcnInput } from "@/ui/input"
+import { ComponentProps } from "react"
+
+const Input: React.FC<
+  Pick<
+    ComponentProps<typeof ShadcnInput>,
+    "type" | "disabled" | "size" | "onChange" | "value" | "placeholder"
+  >
+> = Component(
+  {
+    name: "Input",
+    type: "form",
+  },
+  ShadcnInput
+)
+
+export { Input }

--- a/lib/lib/component.tsx
+++ b/lib/lib/component.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
 import { useComponentXRay } from "./xray"
 
-export const componentTypes = ["layout", "info", "action"] as const
+export const componentTypes = ["layout", "info", "action", "form"] as const
 export type ComponentTypes = (typeof componentTypes)[number]
 
 export interface ComponentMetadata {

--- a/lib/lib/xray.tsx
+++ b/lib/lib/xray.tsx
@@ -49,6 +49,7 @@ const variants = cva("outline-dashed outline-1 outline-red-500", {
       layout: "outline-red-500",
       info: "outline-blue-500",
       action: "outline-green-600",
+      form: "outline-purple-500",
     } satisfies TypeVariant,
   },
 })
@@ -59,6 +60,7 @@ const tagVariants = cva("px-2 py-1 text-xs uppercase", {
       layout: "bg-red-500  text-white",
       info: "bg-blue-500  text-white",
       action: "bg-green-600  text-white",
+      form: "bg-purple-600 text-white",
     } satisfies TypeVariant,
   },
 })

--- a/lib/ui/input.tsx
+++ b/lib/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-lg border-2 border-solid border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 hover:border-input-hover",
+          "flex h-10 w-full rounded-lg border-2 border-solid border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 hover:border-input-hover focus-visible:border-input-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/lib/ui/input.tsx
+++ b/lib/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-lg border-2 border-solid border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 hover:border-input-hover focus-visible:border-input-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-50",
+          "flex h-10 w-full rounded-lg border-2 border-solid border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 hover:border-input-hover",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## 🚪 Why?

Right now the input component is just forwarded from shadcn

## 🔑 What?
In this first PR I'm changing it to just expose the Input with some props. Apart from that I removed the ring styles for the component and I also added `form` as a new component type in order to xray have an specific color for forms components.

https://github.com/factorialco/factorial-one/assets/52708/9e521a27-dea7-4c64-9ef1-a9c746058b53



