### PR TITLE
Add text area

### DIFF
--- a/lib/components/Forms/TextArea/index.stories.tsx
+++ b/lib/components/Forms/TextArea/index.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { Textarea } from "."
+
+const meta = {
+  component: Textarea,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    disabled: false,
+    placeholder: "Placeholder text here",
+    rows: 10,
+    cols: 50,
+  },
+  argTypes: {
+    value: {
+      control: { rows: 20, cols: 50 },
+    },
+  },
+} satisfies Meta<typeof Textarea>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    placeholder: "Placeholder text here",
+  },
+}

--- a/lib/components/Forms/TextArea/index.tsx
+++ b/lib/components/Forms/TextArea/index.tsx
@@ -1,0 +1,19 @@
+export * from "@/ui/input"
+import { Component } from "@/lib/component"
+import { Textarea as ShadcnTextarea } from "@/ui/textarea"
+import { ComponentProps } from "react"
+
+const Textarea: React.FC<
+  Pick<
+    ComponentProps<typeof ShadcnTextarea>,
+    "disabled" | "onChange" | "value" | "placeholder" | "rows" | "cols"
+  >
+> = Component(
+  {
+    name: "Textarea",
+    type: "form",
+  },
+  ShadcnTextarea
+)
+
+export { Textarea }

--- a/lib/ui/textarea.tsx
+++ b/lib/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-lg border-2 border-solid border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 hover:border-input-hover focus-visible:border-input-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }


### PR DESCRIPTION
## 🚪 Why?

In order to use all components from factorial-one in the changelogger we are missing the text area.

## 🔑 What?

Add Textarea field.

## 📸 Screenshots

![image](https://github.com/factorialco/factorial-one/assets/52708/48ad9ac2-ee51-4b43-93e9-ca1acca39c95)
