### PR TITLE
Add implicit loading state to buttons

### DIFF
--- a/lib/components/Actions/Button/index.stories.tsx
+++ b/lib/components/Actions/Button/index.stories.tsx
@@ -61,7 +61,16 @@ export const WithIcon: Story = {
   },
 }
 
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}
+
 export const LoadingState: Story = {
+  args: {
+    label: "Async button with a promise",
+  },
   render: (args) => {
     const onClick = async (
       event: React.MouseEvent<HTMLButtonElement, MouseEvent>

--- a/lib/components/Actions/Button/index.stories.tsx
+++ b/lib/components/Actions/Button/index.stories.tsx
@@ -60,3 +60,17 @@ export const WithIcon: Story = {
     icon: BellRing,
   },
 }
+
+export const LoadingState: Story = {
+  render: (args) => {
+    const onClick = async (
+      event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    ) => {
+      args.onClick?.(event)
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      alert("Done!")
+    }
+
+    return <Button {...args} onClick={onClick} />
+  },
+}

--- a/lib/components/Actions/Button/index.tsx
+++ b/lib/components/Actions/Button/index.tsx
@@ -1,23 +1,45 @@
 import { Button as ShadcnButton } from "@/ui/button"
 import { LucideIcon } from "lucide-react"
-import { ComponentProps, forwardRef } from "react"
+import { ComponentProps, forwardRef, useState } from "react"
 
 type Props = Pick<
   ComponentProps<typeof ShadcnButton>,
-  "variant" | "size" | "onClick"
+  "variant" | "size" | "disabled"
 > & {
+  onClick?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void | Promise<unknown>
   label: string
   icon?: LucideIcon
   hideLabel?: boolean
 }
 
 const Button: React.FC<Props> = forwardRef<HTMLButtonElement, Props>(
-  ({ label, hideLabel, icon, ...props }, ref) => {
+  ({ label, hideLabel, onClick, disabled, icon, ...props }, ref) => {
     const Icon = icon
+    const [loading, setLoading] = useState(false)
+
+    const handleClick = async (
+      event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    ) => {
+      const result = onClick?.(event)
+
+      if (result instanceof Promise) {
+        setLoading(true)
+
+        try {
+          await result
+        } finally {
+          setLoading(false)
+        }
+      }
+    }
 
     return (
       <ShadcnButton
         title={hideLabel ? label : undefined}
+        onClick={handleClick}
+        disabled={disabled || loading}
         rounded={hideLabel}
         ref={ref}
         {...props}


### PR DESCRIPTION
We often want a button to get disabled while we wait for an action to complete. Often times, we implement this by using a hook's "loading" state and passing it to the "disabled" property of the button.

This is error prone (we can forget about it) and inconsistent (people can implement this many different ways).

This introduces an extra behavior to buttons where they will handle this internally. If you pass a promise to their `onClick` handler, they will get disabled in the meanwhile. Extra useful and one less piece of UI state we need to care about!