### PR TITLE
Enhancements to area insights

### DIFF
--- a/lib/components/Insights/Container/index.tsx
+++ b/lib/components/Insights/Container/index.tsx
@@ -6,7 +6,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/ui/card"
-import { TrendingUp } from "lucide-react"
 import { forwardRef, ReactNode } from "react"
 
 export interface InsightsContainerProps {
@@ -14,7 +13,7 @@ export interface InsightsContainerProps {
     title: string
     description: string
   }
-  footer: {
+  footer?: {
     trend: string
     time: string
   }
@@ -26,21 +25,23 @@ export const InsightsContainer = forwardRef<
 >(({ header, footer, children }, ref) => (
   <Card ref={ref}>
     <CardHeader>
-      <CardTitle>{header.title}</CardTitle>
       <CardDescription>{header.description}</CardDescription>
+      <CardTitle className="font-light">{header.title}</CardTitle>
     </CardHeader>
     <CardContent>{children}</CardContent>
-    <CardFooter>
-      <div className="flex w-full items-start gap-2 text-sm">
-        <div className="grid gap-2">
-          <div className="flex items-center gap-2 font-medium leading-none">
-            {footer.trend} <TrendingUp className="h-4 w-4" />
-          </div>
-          <div className="flex items-center gap-2 leading-none text-muted-foreground">
-            {footer.time}
+    {footer && (
+      <CardFooter>
+        <div className="flex w-full items-start gap-2 text-sm">
+          <div className="grid gap-2">
+            <div className="flex items-center gap-2 font-medium leading-none">
+              {footer.trend}
+            </div>
+            <div className="flex items-center gap-2 leading-none text-muted-foreground">
+              {footer.time}
+            </div>
           </div>
         </div>
-      </div>
-    </CardFooter>
+      </CardFooter>
+    )}
   </Card>
 ))

--- a/lib/components/Insights/Types/AreaInsight/index.stories.tsx
+++ b/lib/components/Insights/Types/AreaInsight/index.stories.tsx
@@ -5,11 +5,8 @@ import { AreaInsight, AreaProps } from "."
 const Component = AreaInsight
 
 const dataConfig = {
-  desktop: {
-    label: "Desktop",
-  },
-  mobile: {
-    label: "Mobile",
+  score: {
+    label: "Score",
   },
 }
 
@@ -22,34 +19,26 @@ const meta = {
   args: {
     xAxis: {
       hide: false,
-      tickFormatter: (value: string) => value.slice(0, 3),
     },
     yAxis: {
-      hide: true,
+      hide: false,
+      tickCount: 3,
     },
     data: [
-      { label: "January", values: { mobile: 4000, desktop: 2400 } },
-      { label: "February", values: { mobile: 3000, desktop: 1398 } },
-      { label: "March", values: { mobile: 2000, desktop: 4000 } },
-      { label: "April", values: { mobile: 1500, desktop: 8000 } },
-      { label: "May", values: { mobile: 2000, desktop: 6000 } },
-      { label: "June", values: { mobile: 3500, desktop: 4000 } },
-      { label: "July", values: { mobile: 4500, desktop: 2000 } },
-      { label: "August", values: { mobile: 5500, desktop: 1000 } },
-      { label: "September", values: { mobile: 6500, desktop: 500 } },
-      { label: "October", values: { mobile: 7500, desktop: 300 } },
-      { label: "November", values: { mobile: 8500, desktop: 200 } },
-      { label: "December", values: { mobile: 9500, desktop: 500 } },
+      { label: "Q1 24", values: { score: 1.2 } },
+      { label: "Q2 24", values: { score: 1.7 } },
+      { label: "Q3 24", values: { score: 2.1 } },
+      { label: "Q4 24", values: { score: 3 } },
+      { label: "Q1 25", values: { score: 3.4 } },
+      { label: "Q2 25", values: { score: 4.2 } },
+      { label: "Q3 25", values: { score: 4.9 } },
     ],
     dataConfig,
     header: {
-      title: "Area Insight",
-      description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+      title: "3,5 - Meets expectations",
+      description: "Performance evolution",
     },
-    footer: {
-      trend: "Increased by 12%",
-      time: "Since last month",
-    },
+    showLegend: true,
   } satisfies AreaProps<typeof dataConfig>,
 } satisfies Meta<typeof Component>
 

--- a/lib/components/Insights/Types/AreaInsight/index.tsx
+++ b/lib/components/Insights/Types/AreaInsight/index.tsx
@@ -1,9 +1,12 @@
 import {
   ChartConfig,
   ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from "@/ui/chart"
+
 import { ForwardedRef, forwardRef } from "react"
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
 import { InsightsContainer, InsightsContainerProps } from "../../Container"
@@ -19,6 +22,7 @@ type ChartItem<AreaKeys extends Key> = {
 type AxisConfig = {
   hide?: boolean
   tickFormatter?: (value: string) => string
+  tickCount?: number
 }
 
 type AreaConfig<Keys extends Key = string> = Record<Keys, ChartConfig[string]>
@@ -33,6 +37,7 @@ export type AreaProps<
   data: ChartItem<AreaKeys>[]
   xAxis?: AxisConfig
   yAxis?: AxisConfig
+  showLegend?: boolean
 }
 
 function fixedForwardRef<T, P>(
@@ -52,6 +57,7 @@ export const _AreaInsight = <
     dataConfig,
     xAxis,
     yAxis,
+    showLegend,
     ...containerProps
   }: AreaProps<DataConfig, Keys>,
   ref: ForwardedRef<HTMLDivElement>
@@ -81,23 +87,48 @@ export const _AreaInsight = <
               tickLine={false}
               axisLine={false}
               tickMargin={8}
+              tickCount={yAxis?.tickCount}
               tickFormatter={yAxis?.tickFormatter}
             />
           )}
           <ChartTooltip
             cursor
-            content={<ChartTooltipContent indicator="dot" />}
+            content={<ChartTooltipContent indicator="line" />}
           />
+          <defs>
+            {areas.map((area, index) => (
+              <linearGradient id={`fill${area}`} x1="0" y1="0" x2="0" y2="1">
+                <stop
+                  offset="5%"
+                  stopColor={dataConfig[area].color || autoColor(index)}
+                  stopOpacity={0.8}
+                />
+                <stop
+                  offset="95%"
+                  stopColor={dataConfig[area].color || autoColor(index)}
+                  stopOpacity={0.1}
+                />
+              </linearGradient>
+            ))}
+          </defs>
           {areas.map((area, index) => (
             <Area
               key={area}
               dataKey={area}
               type="natural"
-              fill={dataConfig[area].color || autoColor(index)}
+              fill={`url(#fill${area})`}
               fillOpacity={0.4}
+              dot={true}
               stroke={dataConfig[area].color || autoColor(index)}
             />
           ))}
+          {showLegend && (
+            <ChartLegend
+              className="flex justify-start"
+              iconType="star"
+              content={<ChartLegendContent />}
+            />
+          )}
         </AreaChart>
       </ChartContainer>
     </InsightsContainer>


### PR DESCRIPTION
## 🚪 Why?
As part of adding Insights components to factorial-one, we needed to do some modifications to the `AreaInsight` to be similar to the figma [design](https://www.figma.com/design/9pLsRzdinid0ha0qRWta2D/Employee-Profile?node-id=378-17717&t=FAizWfjAkwVfRWSg-0)

## 🔑 What?
- Make the footer optional
- Add Legend, color gradient, and axis tick count to `AreaInsight`
- Update the `AreaInsight` storybook example

## 📸 Visual proof
<img width="436" alt="image" src="https://github.com/user-attachments/assets/af5adae0-61cf-42cc-b4ce-3ab2122acfeb">

