### PR TITLE
feat: bar chart

### DIFF
--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -1,0 +1,50 @@
+import { Meta, StoryObj } from "@storybook/react"
+import { BarChart } from "."
+
+const dataConfig = {
+  desktop: {
+    label: "Desktop",
+  },
+  mobile: {
+    label: "Mobile",
+  },
+}
+
+const Component = BarChart<typeof dataConfig>
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+  title: "Charts/BarChart",
+  args: {},
+} satisfies Meta<typeof Component>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    dataConfig: {
+      desktop: {
+        label: "Desktop",
+        color: "hsl(var(--chart-1))",
+      },
+      mobile: {
+        label: "Mobile",
+        color: "hsl(var(--chart-2))",
+      },
+    },
+    xAxis: {
+      hide: false,
+    },
+    lines: true,
+    data: [
+      { label: "January", values: { desktop: 186, mobile: 80 } },
+      { label: "February", values: { desktop: 305, mobile: 200 } },
+      { label: "March", values: { desktop: 237, mobile: 120 } },
+      { label: "April", values: { desktop: 73, mobile: 190 } },
+      { label: "May", values: { desktop: 209, mobile: 130 } },
+      { label: "June", values: { desktop: 214, mobile: 140 } },
+    ],
+  },
+}

--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -34,6 +34,10 @@ export const Default: Story = {
         color: "hsl(var(--chart-2))",
       },
     },
+    label: true,
+    yAxis: {
+      hide: false,
+    },
     xAxis: {
       hide: false,
     },

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -74,12 +74,11 @@ export const _Bar = <
           )
         })}
 
-        {lines ? (
+        {lines &&
           bars.map((l, lt) => {
             return (
               <>
                 <Line
-                  layout="vertical"
                   key={lt}
                   type="monotone"
                   dataKey={l}
@@ -88,10 +87,7 @@ export const _Bar = <
                 />
               </>
             )
-          })
-        ) : (
-          <></>
-        )}
+          })}
       </ComposedChart>
     </ChartContainer>
   )

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -1,0 +1,70 @@
+import { ChartContainer } from "@/ui/chart"
+import { ForwardedRef } from "react"
+import { fixedForwardRef } from "../utils/forwardRef"
+import { ChartConfig, ChartPropsBase, InferChartKeys } from "../utils/types"
+
+import { Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts"
+import { prepareData } from "../utils/bar"
+import { xAxisProps, yAxisProps } from "../utils/elements"
+
+export type BarChartProps<
+  DataConfig extends ChartConfig = ChartConfig,
+  Keys extends string = InferChartKeys<DataConfig>,
+> = ChartPropsBase<DataConfig, Keys> & { lines?: boolean }
+
+export const _Bar = <
+  DataConfig extends ChartConfig,
+  Keys extends string = string,
+>(
+  { dataConfig, xAxis, yAxis, data, lines }: BarChartProps<DataConfig, Keys>,
+  ref: ForwardedRef<HTMLDivElement>
+) => {
+  const bars = Object.keys(dataConfig) as Array<keyof typeof dataConfig>
+
+  return (
+    <ChartContainer config={dataConfig} ref={ref}>
+      <ComposedChart
+        accessibilityLayer
+        data={prepareData(data)}
+        margin={{ left: 12, right: 12 }}
+      >
+        <CartesianGrid vertical={false} />
+        {!xAxis?.hide && <XAxis {...xAxisProps(xAxis)} />}
+        {!yAxis?.hide && <YAxis {...yAxisProps(xAxis)} />}
+
+        {bars.map((l, lt) => {
+          return (
+            <>
+              <Bar
+                key={`line-${lt}`}
+                dataKey={l}
+                fill={dataConfig[l].color}
+                radius={4}
+              />
+            </>
+          )
+        })}
+
+        {lines ? (
+          bars.map((l, lt) => {
+            return (
+              <>
+                <Line
+                  key={lt}
+                  type="monotone"
+                  dataKey={l}
+                  fill={dataConfig[l].color}
+                  stroke={dataConfig[l].color}
+                />
+              </>
+            )
+          })
+        ) : (
+          <></>
+        )}
+      </ComposedChart>
+    </ChartContainer>
+  )
+}
+
+export const BarChart = fixedForwardRef(_Bar)

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -3,20 +3,40 @@ import { ForwardedRef } from "react"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { ChartConfig, ChartPropsBase, InferChartKeys } from "../utils/types"
 
-import { Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts"
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  LabelList,
+  Line,
+  XAxis,
+  YAxis,
+} from "recharts"
 import { prepareData } from "../utils/bar"
 import { xAxisProps, yAxisProps } from "../utils/elements"
+
+type BarChartConfigProps = {
+  label: boolean
+  lines?: boolean
+}
 
 export type BarChartProps<
   DataConfig extends ChartConfig = ChartConfig,
   Keys extends string = InferChartKeys<DataConfig>,
-> = ChartPropsBase<DataConfig, Keys> & { lines?: boolean }
+> = ChartPropsBase<DataConfig, Keys> & BarChartConfigProps
 
 export const _Bar = <
   DataConfig extends ChartConfig,
   Keys extends string = string,
 >(
-  { dataConfig, xAxis, yAxis, data, lines }: BarChartProps<DataConfig, Keys>,
+  {
+    dataConfig,
+    xAxis,
+    yAxis,
+    data,
+    lines,
+    label,
+  }: BarChartProps<DataConfig, Keys>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const bars = Object.keys(dataConfig) as Array<keyof typeof dataConfig>
@@ -40,7 +60,16 @@ export const _Bar = <
                 dataKey={l}
                 fill={dataConfig[l].color}
                 radius={4}
-              />
+              >
+                {label && (
+                  <LabelList
+                    position="top"
+                    offset={10}
+                    className="fill-foreground"
+                    fontSize={12}
+                  />
+                )}
+              </Bar>
             </>
           )
         })}
@@ -50,6 +79,7 @@ export const _Bar = <
             return (
               <>
                 <Line
+                  layout="vertical"
                   key={lt}
                   type="monotone"
                   dataKey={l}

--- a/lib/components/Charts/utils/bar.ts
+++ b/lib/components/Charts/utils/bar.ts
@@ -1,0 +1,5 @@
+import { ChartItem } from "./types"
+
+export function prepareData<Keys extends string>(data: ChartItem<Keys>[]) {
+  return data.map((item) => ({ x: item.label, ...item.values }))
+}


### PR DESCRIPTION
## 🚪 Why?

Factorial one doesn't have a Bar component in order to use it with other charts components

## 🔑 What?

This PR adds a Bar chart to draw Bar components and Lines in the insights components and data graph component; this Bar chart has the following interface:

- **dataConfig** Configures each data point with a label and colour
- **xAxis** 
  - **hide** Hides the X-axis
  - **formatter** Arguments that receive a function to customize the X-axis labels
- **lines** Draw a line over the Bar components
- **data** required data by the Bar component to draw the Bars and Lines
- **yAxis** 
  - **hide** Hides the X-axis
  - **formatter** Arguments that receive a function to customize the X-axis labels

## 🏡 Context

https://www.figma.com/design/9pLsRzdinid0ha0qRWta2D/Employee-Profile?node-id=378-19759&t=cFvdNpMxrdkyqDqn-0

## 📸 Visual proof

![Screenshot 2024-07-24 at 11 38 39](https://github.com/user-attachments/assets/1c71c25b-ddcf-4598-b7ce-4a38db30dfc4)

