### PR TITLE
feat: bar chart horizontal layout

### DIFF
--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -1,0 +1,50 @@
+import { Meta, StoryObj } from "@storybook/react"
+import { BarChart } from "."
+
+const dataConfig = {
+  desktop: {
+    label: "Desktop",
+  },
+  mobile: {
+    label: "Mobile",
+  },
+}
+
+const Component = BarChart<typeof dataConfig>
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+  title: "Charts/BarChart",
+  args: {},
+} satisfies Meta<typeof Component>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    dataConfig: {
+      desktop: {
+        label: "Desktop",
+        color: "hsl(var(--chart-1))",
+      },
+      mobile: {
+        label: "Mobile",
+        color: "hsl(var(--chart-2))",
+      },
+    },
+    xAxis: {
+      hide: false,
+    },
+    lines: true,
+    data: [
+      { label: "January", values: { desktop: 186, mobile: 80 } },
+      { label: "February", values: { desktop: 305, mobile: 200 } },
+      { label: "March", values: { desktop: 237, mobile: 120 } },
+      { label: "April", values: { desktop: 73, mobile: 190 } },
+      { label: "May", values: { desktop: 209, mobile: 130 } },
+      { label: "June", values: { desktop: 214, mobile: 140 } },
+    ],
+  },
+}

--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -34,6 +34,10 @@ export const Default: Story = {
         color: "hsl(var(--chart-2))",
       },
     },
+    label: true,
+    yAxis: {
+      hide: false,
+    },
     xAxis: {
       hide: false,
     },

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -84,8 +84,8 @@ export const _Bar = <
     ? { type: "number", dataKey: getMaxValueByKey(munchedData) }
     : undefined
 
-  // NOTE: When the chart is vertical, the Y axis uses the label rather than the
-  // numeric values.
+  // NOTE: When the chart is vertical, the Y axis uses the label rather
+  // than the numeric values.
   const internalYAxis: axisLayout = isVertical
     ? { type: "category", dataKey: "x" }
     : undefined

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -74,12 +74,11 @@ export const _Bar = <
           )
         })}
 
-        {lines ? (
+        {lines &&
           bars.map((l, lt) => {
             return (
               <>
                 <Line
-                  layout="vertical"
                   key={lt}
                   type="monotone"
                   dataKey={l}
@@ -88,10 +87,7 @@ export const _Bar = <
                 />
               </>
             )
-          })
-        ) : (
-          <></>
-        )}
+          })}
       </ComposedChart>
     </ChartContainer>
   )

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -1,8 +1,6 @@
 import { ChartContainer } from "@/ui/chart"
+import { cloneDeep } from "lodash"
 import { ForwardedRef } from "react"
-import { fixedForwardRef } from "../utils/forwardRef"
-import { ChartConfig, ChartPropsBase, InferChartKeys } from "../utils/types"
-
 import {
   Bar,
   CartesianGrid,
@@ -14,16 +12,52 @@ import {
 } from "recharts"
 import { prepareData } from "../utils/bar"
 import { xAxisProps, yAxisProps } from "../utils/elements"
+import { fixedForwardRef } from "../utils/forwardRef"
+import {
+  ChartConfig,
+  ChartPropsBase,
+  InferChartKeys,
+  typeAxisType,
+} from "../utils/types"
+
+type Layout = "vertical" | "horizontal"
 
 type BarChartConfigProps = {
   label: boolean
   lines?: boolean
+  layout: Layout
 }
+
+type axisLayout = { type: typeAxisType; dataKey: string } | undefined
 
 export type BarChartProps<
   DataConfig extends ChartConfig = ChartConfig,
   Keys extends string = InferChartKeys<DataConfig>,
 > = ChartPropsBase<DataConfig, Keys> & BarChartConfigProps
+
+const getMaxValueByKey = (
+  data: ({ x: unknown } & Record<string, number>)[]
+): string => {
+  const clonedData = cloneDeep(data)
+
+  let label: string = ""
+  let max: number = 0
+
+  clonedData.forEach((datapoint) => {
+    delete datapoint.x
+
+    Object.entries(datapoint as Record<string, number>).forEach(
+      ([newLabel, value]) => {
+        if (max < value) {
+          max = value
+          label = newLabel
+        }
+      }
+    )
+  })
+
+  return label
+}
 
 export const _Bar = <
   DataConfig extends ChartConfig,
@@ -33,29 +67,60 @@ export const _Bar = <
     dataConfig,
     xAxis,
     yAxis,
-    data,
-    lines,
     label,
+    data,
+    layout,
+    lines,
   }: BarChartProps<DataConfig, Keys>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const bars = Object.keys(dataConfig) as Array<keyof typeof dataConfig>
+  const munchedData = prepareData(data)
+  const isVertical = layout == "vertical"
+
+  // NOTE: When the chart is vertical, we need to set the data key
+  // with the maximum value in order not to cut the bars.
+  const internalXAxis: axisLayout = isVertical
+    ? { type: "number", dataKey: getMaxValueByKey(munchedData) }
+    : undefined
+
+  // NOTE: When the chart is vertical, the Y axis uses the label rather than the
+  // numeric values.
+  const internalYAxis: axisLayout = isVertical
+    ? { type: "category", dataKey: "x" }
+    : undefined
 
   return (
     <ChartContainer config={dataConfig} ref={ref}>
       <ComposedChart
+        layout={layout}
         accessibilityLayer
-        data={prepareData(data)}
+        data={munchedData}
         margin={{ left: 12, right: 12 }}
       >
-        <CartesianGrid vertical={false} />
-        {!xAxis?.hide && <XAxis {...xAxisProps(xAxis)} />}
-        {!yAxis?.hide && <YAxis {...yAxisProps(xAxis)} />}
+        {!isVertical && <CartesianGrid vertical={false} />}
+
+        <XAxis
+          {...xAxisProps({
+            ...xAxis,
+            ...internalXAxis,
+          })}
+          hide={xAxis?.hide}
+        />
+
+        <YAxis
+          {...yAxisProps({
+            ...yAxis,
+            ...internalYAxis,
+          })}
+          hide={yAxis?.hide}
+        />
 
         {bars.map((l, lt) => {
           return (
             <>
               <Bar
+                layout={layout}
                 key={`line-${lt}`}
                 dataKey={l}
                 fill={dataConfig[l].color}
@@ -63,7 +128,7 @@ export const _Bar = <
               >
                 {label && (
                   <LabelList
-                    position="top"
+                    position={isVertical ? "right" : "top"}
                     offset={10}
                     className="fill-foreground"
                     fontSize={12}

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -1,0 +1,70 @@
+import { ChartContainer } from "@/ui/chart"
+import { ForwardedRef } from "react"
+import { fixedForwardRef } from "../utils/forwardRef"
+import { ChartConfig, ChartPropsBase, InferChartKeys } from "../utils/types"
+
+import { Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts"
+import { prepareData } from "../utils/bar"
+import { xAxisProps, yAxisProps } from "../utils/elements"
+
+export type BarChartProps<
+  DataConfig extends ChartConfig = ChartConfig,
+  Keys extends string = InferChartKeys<DataConfig>,
+> = ChartPropsBase<DataConfig, Keys> & { lines?: boolean }
+
+export const _Bar = <
+  DataConfig extends ChartConfig,
+  Keys extends string = string,
+>(
+  { dataConfig, xAxis, yAxis, data, lines }: BarChartProps<DataConfig, Keys>,
+  ref: ForwardedRef<HTMLDivElement>
+) => {
+  const bars = Object.keys(dataConfig) as Array<keyof typeof dataConfig>
+
+  return (
+    <ChartContainer config={dataConfig} ref={ref}>
+      <ComposedChart
+        accessibilityLayer
+        data={prepareData(data)}
+        margin={{ left: 12, right: 12 }}
+      >
+        <CartesianGrid vertical={false} />
+        {!xAxis?.hide && <XAxis {...xAxisProps(xAxis)} />}
+        {!yAxis?.hide && <YAxis {...yAxisProps(xAxis)} />}
+
+        {bars.map((l, lt) => {
+          return (
+            <>
+              <Bar
+                key={`line-${lt}`}
+                dataKey={l}
+                fill={dataConfig[l].color}
+                radius={4}
+              />
+            </>
+          )
+        })}
+
+        {lines ? (
+          bars.map((l, lt) => {
+            return (
+              <>
+                <Line
+                  key={lt}
+                  type="monotone"
+                  dataKey={l}
+                  fill={dataConfig[l].color}
+                  stroke={dataConfig[l].color}
+                />
+              </>
+            )
+          })
+        ) : (
+          <></>
+        )}
+      </ComposedChart>
+    </ChartContainer>
+  )
+}
+
+export const BarChart = fixedForwardRef(_Bar)

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -3,20 +3,40 @@ import { ForwardedRef } from "react"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { ChartConfig, ChartPropsBase, InferChartKeys } from "../utils/types"
 
-import { Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts"
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  LabelList,
+  Line,
+  XAxis,
+  YAxis,
+} from "recharts"
 import { prepareData } from "../utils/bar"
 import { xAxisProps, yAxisProps } from "../utils/elements"
+
+type BarChartConfigProps = {
+  label: boolean
+  lines?: boolean
+}
 
 export type BarChartProps<
   DataConfig extends ChartConfig = ChartConfig,
   Keys extends string = InferChartKeys<DataConfig>,
-> = ChartPropsBase<DataConfig, Keys> & { lines?: boolean }
+> = ChartPropsBase<DataConfig, Keys> & BarChartConfigProps
 
 export const _Bar = <
   DataConfig extends ChartConfig,
   Keys extends string = string,
 >(
-  { dataConfig, xAxis, yAxis, data, lines }: BarChartProps<DataConfig, Keys>,
+  {
+    dataConfig,
+    xAxis,
+    yAxis,
+    data,
+    lines,
+    label,
+  }: BarChartProps<DataConfig, Keys>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const bars = Object.keys(dataConfig) as Array<keyof typeof dataConfig>
@@ -40,7 +60,16 @@ export const _Bar = <
                 dataKey={l}
                 fill={dataConfig[l].color}
                 radius={4}
-              />
+              >
+                {label && (
+                  <LabelList
+                    position="top"
+                    offset={10}
+                    className="fill-foreground"
+                    fontSize={12}
+                  />
+                )}
+              </Bar>
             </>
           )
         })}
@@ -50,6 +79,7 @@ export const _Bar = <
             return (
               <>
                 <Line
+                  layout="vertical"
                   key={lt}
                   type="monotone"
                   dataKey={l}

--- a/lib/components/Charts/utils/bar.ts
+++ b/lib/components/Charts/utils/bar.ts
@@ -1,0 +1,5 @@
+import { ChartItem } from "./types"
+
+export function prepareData<Keys extends string>(data: ChartItem<Keys>[]) {
+  return data.map((item) => ({ x: item.label, ...item.values }))
+}

--- a/lib/components/Charts/utils/elements.tsx
+++ b/lib/components/Charts/utils/elements.tsx
@@ -5,7 +5,8 @@ import { AxisConfig } from "./types"
 export const xAxisProps = (
   config?: AxisConfig
 ): Partial<ComponentProps<typeof XAxis>> => ({
-  dataKey: "x",
+  dataKey: config?.dataKey || "x",
+  type: config?.type,
   tickLine: false,
   axisLine: false,
   tickMargin: 8,
@@ -15,6 +16,8 @@ export const xAxisProps = (
 export const yAxisProps = (
   config?: AxisConfig
 ): Partial<ComponentProps<typeof YAxis>> => ({
+  dataKey: config?.dataKey,
+  type: config?.type,
   tickLine: false,
   axisLine: false,
   tickMargin: 8,

--- a/lib/components/Charts/utils/types.ts
+++ b/lib/components/Charts/utils/types.ts
@@ -5,8 +5,12 @@ export type ChartItem<LineKeys extends string> = {
   values: Record<LineKeys, number>
 }
 
+export type typeAxisType = "category" | "number"
+
 export type AxisConfig = {
+  dataKey?: string
   hide?: boolean
+  type?: typeAxisType
   tickFormatter?: (value: string) => string
 }
 


### PR DESCRIPTION
## 🚪 Why?

The first version of Bar chat didn't have a setting to configure the bar layout

## 🔑 What?

This PR adds the `layout` property with two available options:

**vertical**: This property draws the Bar chart component in vertical direction  

**horizontal**: This property draws the Bar chart component in horizontal direction  

## 📸 Visual proof

<img width="716" alt="Screenshot 2024-07-25 at 15 50 49" src="https://github.com/user-attachments/assets/43317d9d-01f4-4351-aa99-a6c7c7f5f69a">

