### PR TITLE
chore: adding bar chart insight example

### DIFF
--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -1,54 +1,42 @@
 import { Meta, StoryObj } from "@storybook/react"
-import { BarChart } from "."
+import { BarChart, BarChartProps } from "."
 
 const dataConfig = {
   desktop: {
     label: "Desktop",
+    color: "hsl(var(--chart-1))",
   },
   mobile: {
     label: "Mobile",
+    color: "hsl(var(--chart-2))",
   },
 }
 
 const Component = BarChart<typeof dataConfig>
 
-const meta: Meta<typeof Component> = {
+const meta = {
   component: Component,
-  title: "Charts/BarChart",
-  args: {},
+  tags: ["autodocs"],
+  args: {
+    dataConfig,
+    xAxis: {
+      tickFormatter: (value: string) => value.slice(0, 3),
+    },
+    yAxis: {
+      hide: true,
+    },
+    label: false,
+    data: [
+      { label: "January", values: { mobile: 4000, desktop: 2400 } },
+      { label: "February", values: { mobile: 3000, desktop: 1398 } },
+      { label: "March", values: { mobile: 2000, desktop: 4000 } },
+      { label: "April", values: { mobile: 1500, desktop: 8000 } },
+      { label: "May", values: { mobile: 2000, desktop: 6000 } },
+    ],
+  } satisfies BarChartProps<typeof dataConfig>,
 } satisfies Meta<typeof Component>
 
 export default meta
-
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
-  args: {
-    dataConfig: {
-      desktop: {
-        label: "Desktop",
-        color: "hsl(var(--chart-1))",
-      },
-      mobile: {
-        label: "Mobile",
-        color: "hsl(var(--chart-2))",
-      },
-    },
-    label: true,
-    yAxis: {
-      hide: false,
-    },
-    xAxis: {
-      hide: false,
-    },
-    lines: true,
-    data: [
-      { label: "January", values: { desktop: 186, mobile: 80 } },
-      { label: "February", values: { desktop: 305, mobile: 200 } },
-      { label: "March", values: { desktop: 237, mobile: 120 } },
-      { label: "April", values: { desktop: 73, mobile: 190 } },
-      { label: "May", values: { desktop: 209, mobile: 130 } },
-      { label: "June", values: { desktop: 214, mobile: 140 } },
-    ],
-  },
-}
+export const Default: Story = {}

--- a/lib/components/Insights/Charts/BarChartInsight/index.stories.tsx
+++ b/lib/components/Insights/Charts/BarChartInsight/index.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import BarChartStory from "@/components/Charts/BarChart/index.stories"
+import { BarChartInsight } from "."
+import { containerStoryArgs } from "../storybook-utils"
+
+const meta = {
+  component: BarChartInsight,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    ...containerStoryArgs,
+    header: {
+      ...containerStoryArgs.header,
+      title: "A line chart",
+    },
+    chart: BarChartStory.args,
+  },
+} satisfies Meta<typeof BarChartInsight>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/lib/components/Insights/Charts/BarChartInsight/index.stories.tsx
+++ b/lib/components/Insights/Charts/BarChartInsight/index.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
     ...containerStoryArgs,
     header: {
       ...containerStoryArgs.header,
-      title: "A line chart",
+      title: "A bar chart",
     },
     chart: BarChartStory.args,
   },

--- a/lib/components/Insights/Charts/BarChartInsight/index.tsx
+++ b/lib/components/Insights/Charts/BarChartInsight/index.tsx
@@ -1,0 +1,4 @@
+import { BarChart } from "@/components/Charts/BarChart"
+import { wrap } from "../../InsightsContainer"
+
+export const BarChartInsight = wrap(BarChart, "chart")


### PR DESCRIPTION
## 🚪 Why?

Bar chart didn't have bar chart insights examples

## 🔑 What?

This PR adds a Bar chart insights example

## 🏡 Context

https://github.com/factorialco/factorial-one/pull/335#issuecomment-2248551038

## 📸 Visual proof

<img width="495" alt="Screenshot 2024-07-26 at 11 30 40" src="https://github.com/user-attachments/assets/29b8230d-ac7a-40db-bc17-d3a00e3d1575">

