### PR TITLE
Add link controller

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,7 +13,6 @@ import { FactorialOneProvider } from "../lib/lib/one-provider"
 import lightTheme, { darkTheme } from "./FactorialOne"
 import { DocsContainer } from "./DocsContainer"
 import { useDarkMode } from "storybook-dark-mode"
-import { fn } from "@storybook/test"
 import { action } from "@storybook/addon-actions"
 
 export const withTheme = () => {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -32,17 +32,17 @@ export const FactorialOne = (Story, { parameters }) => {
         fullScreen: parameters.layout === "fullscreen",
       }}
       link={{
-        controller: (props) => ({
-          onClick: (...args) => {
-            const e = args[0]
-            action("Link clicked")({
-              href: props.href,
-              e,
-              props,
-            })
-            e.preventDefault()
-          },
-        }),
+        component: (props, ref) => (
+          <a
+            ref={ref}
+            {...props}
+            onClick={(event, ...args) => {
+              action("Link clicked")(event, ...args)
+              props?.onClick?.(event, ...args)
+              event.preventDefault()
+            }}
+          />
+        ),
       }}
     >
       <Story />

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,6 +13,8 @@ import { FactorialOneProvider } from "../lib/lib/one-provider"
 import lightTheme, { darkTheme } from "./FactorialOne"
 import { DocsContainer } from "./DocsContainer"
 import { useDarkMode } from "storybook-dark-mode"
+import { fn } from "@storybook/test"
+import { action } from "@storybook/addon-actions"
 
 export const withTheme = () => {
   return (Story) => {
@@ -29,6 +31,19 @@ export const FactorialOne = (Story, { parameters }) => {
     <FactorialOneProvider
       layout={{
         fullScreen: parameters.layout === "fullscreen",
+      }}
+      link={{
+        controller: (props) => ({
+          onClick: (...args) => {
+            const e = args[0]
+            action("Link clicked")({
+              href: props.href,
+              e,
+              props,
+            })
+            e.preventDefault()
+          },
+        }),
       }}
     >
       <Story />

--- a/lib/components/Actions/Link/index.stories.tsx
+++ b/lib/components/Actions/Link/index.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
-import { LinkProvider } from "@/lib/linkHandler"
 import { Link } from "."
 
 const meta = {
@@ -20,19 +19,3 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Basic: Story = {}
-export const WithProvider: Story = {
-  decorators: [
-    (Story) => (
-      <LinkProvider
-        controller={({ href }) => ({
-          onClick: (event) => {
-            alert(`Cicked: ${href}`)
-            event.preventDefault()
-          },
-        })}
-      >
-        <Story />
-      </LinkProvider>
-    ),
-  ],
-}

--- a/lib/components/Actions/Link/index.stories.tsx
+++ b/lib/components/Actions/Link/index.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { LinkProvider } from "@/lib/linkHandler"
+import { Link } from "."
+
+const meta = {
+  component: Link,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    children: "This is a link",
+    href: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    target: "_blank",
+  },
+} satisfies Meta<typeof Link>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Basic: Story = {}
+export const WithProvider: Story = {
+  decorators: [
+    (Story) => (
+      <LinkProvider
+        controller={({ href }) => ({
+          onClick: (event) => {
+            alert(`Cicked: ${href}`)
+            event.preventDefault()
+          },
+        })}
+      >
+        <Story />
+      </LinkProvider>
+    ),
+  ],
+}

--- a/lib/components/Actions/Link/index.tsx
+++ b/lib/components/Actions/Link/index.tsx
@@ -1,7 +1,7 @@
 import { useLinkContext } from "@/lib/linkHandler"
 import { AnchorHTMLAttributes, forwardRef } from "react"
 
-export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
+export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {}
 
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
   const { controller } = useLinkContext()

--- a/lib/components/Actions/Link/index.tsx
+++ b/lib/components/Actions/Link/index.tsx
@@ -1,0 +1,10 @@
+import { useLinkContext } from "@/lib/linkHandler"
+import { AnchorHTMLAttributes, forwardRef } from "react"
+
+export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
+  const { controller } = useLinkContext()
+
+  return <a ref={ref} {...props} {...(controller?.(props) || {})} />
+})

--- a/lib/components/Actions/Link/index.tsx
+++ b/lib/components/Actions/Link/index.tsx
@@ -4,7 +4,10 @@ import { AnchorHTMLAttributes, forwardRef } from "react"
 export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {}
 
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
-  const { controller } = useLinkContext()
+  const { component } = useLinkContext()
 
-  return <a ref={ref} {...props} {...(controller?.(props) || {})} />
+  if (!component) return <a ref={ref} {...props} />
+  const Component = forwardRef(component)
+
+  return <Component ref={ref} {...props} />
 })

--- a/lib/lib/linkHandler.tsx
+++ b/lib/lib/linkHandler.tsx
@@ -1,8 +1,14 @@
-import type { LinkProps } from "@/components/Actions/Link"
-import { createContext, HTMLAttributes, ReactNode, useContext } from "react"
+import {
+  AnchorHTMLAttributes,
+  createContext,
+  ReactNode,
+  useContext,
+} from "react"
 
-type LinkContextValue = {
-  controller?: (props: LinkProps) => HTMLAttributes<HTMLAnchorElement>
+export type LinkContextValue = {
+  controller?: (
+    props: AnchorHTMLAttributes<HTMLAnchorElement>
+  ) => AnchorHTMLAttributes<HTMLAnchorElement>
 }
 
 const LinkContext = createContext<LinkContextValue | undefined>(undefined)

--- a/lib/lib/linkHandler.tsx
+++ b/lib/lib/linkHandler.tsx
@@ -1,14 +1,16 @@
 import {
   AnchorHTMLAttributes,
   createContext,
+  ForwardedRef,
   ReactNode,
   useContext,
 } from "react"
 
 export type LinkContextValue = {
-  controller?: (
-    props: AnchorHTMLAttributes<HTMLAnchorElement>
-  ) => AnchorHTMLAttributes<HTMLAnchorElement>
+  component?: (
+    props: AnchorHTMLAttributes<HTMLAnchorElement>,
+    ref: ForwardedRef<HTMLAnchorElement>
+  ) => JSX.Element
 }
 
 const LinkContext = createContext<LinkContextValue | undefined>(undefined)
@@ -17,9 +19,9 @@ export const LinkProvider: React.FC<
   {
     children: ReactNode
   } & LinkContextValue
-> = ({ children, controller }) => {
+> = ({ children, component }) => {
   return (
-    <LinkContext.Provider value={{ controller }}>
+    <LinkContext.Provider value={{ component }}>
       {children}
     </LinkContext.Provider>
   )

--- a/lib/lib/linkHandler.tsx
+++ b/lib/lib/linkHandler.tsx
@@ -1,0 +1,29 @@
+import type { LinkProps } from "@/components/Actions/Link"
+import { createContext, HTMLAttributes, ReactNode, useContext } from "react"
+
+type LinkContextValue = {
+  controller?: (props: LinkProps) => HTMLAttributes<HTMLAnchorElement>
+}
+
+const LinkContext = createContext<LinkContextValue | undefined>(undefined)
+
+export const LinkProvider: React.FC<
+  {
+    children: ReactNode
+  } & LinkContextValue
+> = ({ children, controller }) => {
+  return (
+    <LinkContext.Provider value={{ controller }}>
+      {children}
+    </LinkContext.Provider>
+  )
+}
+
+export const useLinkContext = () => {
+  const context = useContext(LinkContext)
+
+  return {
+    controller: () => ({}),
+    ...context,
+  }
+}

--- a/lib/lib/one-provider.tsx
+++ b/lib/lib/one-provider.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react"
 import { useIsomorphicLayoutEffect } from "usehooks-ts"
+import { LinkProvider } from "./linkHandler"
 import { cn } from "./utils"
 import { XRayProvider } from "./xray"
 
@@ -66,11 +67,14 @@ export const LayoutProvider: React.FC<
 
 export const FactorialOneProvider: React.FC<{
   children: React.ReactNode
+  link?: ComponentProps<typeof LinkProvider>
   layout?: Omit<ComponentProps<typeof LayoutProvider>, "children">
-}> = ({ children, layout }) => {
+}> = ({ children, layout, link }) => {
   return (
     <LayoutProvider {...layout}>
-      <XRayProvider>{children}</XRayProvider>
+      <XRayProvider>
+        <LinkProvider {...link}>{children}</LinkProvider>
+      </XRayProvider>
     </LayoutProvider>
   )
 }

--- a/lib/lib/one-provider.tsx
+++ b/lib/lib/one-provider.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from "react"
 import { useIsomorphicLayoutEffect } from "usehooks-ts"
-import { LinkProvider } from "./linkHandler"
+import { LinkContextValue, LinkProvider } from "./linkHandler"
 import { cn } from "./utils"
 import { XRayProvider } from "./xray"
 
@@ -67,7 +67,7 @@ export const LayoutProvider: React.FC<
 
 export const FactorialOneProvider: React.FC<{
   children: React.ReactNode
-  link?: ComponentProps<typeof LinkProvider>
+  link?: LinkContextValue
   layout?: Omit<ComponentProps<typeof LayoutProvider>, "children">
 }> = ({ children, layout, link }) => {
   return (


### PR DESCRIPTION
I've been wondering how can we support client-side links without getting coupled to any of the routing libraries. They usually rely on you explicitly using a `<Link>` component, but I didn't want us to have to do that, with the potential resulting inconsistencies.

This adds a `<LinkProvider>` component that is merged into the `<FactorialOne />` provider. This link provider allows us to define a `Component` for any link.

You can define a component like this:

```tsx
<LinkProvider
  component: (props, ref) => (
    <a
      ref={ref}
      {...props}
      onClick={(event, ...args) => {
        console.log(props.href)
        props?.onClick?.(event, ...args)
        event.preventDefault()
      }}
    />
  ),
>
  <App />
</LinkProvider>
```

As you can see, `component` receives the props from the link, and it allows you to define a new component. This means that we can easily use our `<Link />` component of choice coming from our routing library!