### PR TITLE
Refactor link and image handlers

### DIFF
--- a/lib/components/Actions/Link/index.tsx
+++ b/lib/components/Actions/Link/index.tsx
@@ -1,13 +1,1 @@
-import { useLinkContext } from "@/lib/linkHandler"
-import { AnchorHTMLAttributes, forwardRef } from "react"
-
-export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {}
-
-export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
-  const { component } = useLinkContext()
-
-  if (!component) return <a ref={ref} {...props} />
-  const Component = forwardRef(component)
-
-  return <Component ref={ref} {...props} />
-})
+export { Link } from "@/lib/linkHandler"

--- a/lib/components/Utilities/Image/index.tsx
+++ b/lib/components/Utilities/Image/index.tsx
@@ -1,18 +1,1 @@
-import { useImageContext } from "@/lib/imageHandler"
-import { forwardRef, ImgHTMLAttributes } from "react"
-
-export type ImageProps = ImgHTMLAttributes<HTMLImageElement>
-
-export type SrcProps = Pick<
-  ImgHTMLAttributes<HTMLImageElement>,
-  "src" | "srcSet" | "sizes"
->
-
-export const Image = forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
-  const { src } = useImageContext()
-
-  if (!src) return <img ref={ref} {...props} />
-  const extraProps = src(props)
-
-  return <img ref={ref} {...props} {...extraProps} />
-})
+export { Image } from "@/lib/imageHandler"

--- a/lib/lib/imageHandler.tsx
+++ b/lib/lib/imageHandler.tsx
@@ -1,5 +1,10 @@
-import type { ImageProps, SrcProps } from "@/components/Utilities/Image"
-import { createContext, ReactNode, useContext } from "react"
+import {
+  createContext,
+  forwardRef,
+  ImgHTMLAttributes,
+  ReactNode,
+  useContext,
+} from "react"
 
 export type ImageContextValue = {
   src?: (props: ImageProps) => SrcProps
@@ -22,3 +27,19 @@ export const useImageContext = () => {
     ...context,
   }
 }
+
+export type ImageProps = ImgHTMLAttributes<HTMLImageElement>
+
+export type SrcProps = Pick<
+  ImgHTMLAttributes<HTMLImageElement>,
+  "src" | "srcSet" | "sizes"
+>
+
+export const Image = forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
+  const { src } = useImageContext()
+
+  if (!src) return <img ref={ref} {...props} />
+  const extraProps = src(props)
+
+  return <img ref={ref} {...props} {...extraProps} />
+})

--- a/lib/lib/linkHandler.tsx
+++ b/lib/lib/linkHandler.tsx
@@ -1,5 +1,11 @@
-import { LinkProps } from "@/components/Actions/Link"
-import { createContext, ForwardedRef, ReactNode, useContext } from "react"
+import {
+  AnchorHTMLAttributes,
+  createContext,
+  ForwardedRef,
+  forwardRef,
+  ReactNode,
+  useContext,
+} from "react"
 
 export type LinkContextValue = {
   component?: (
@@ -30,3 +36,14 @@ export const useLinkContext = () => {
     ...context,
   }
 }
+
+export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {}
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
+  const { component } = useLinkContext()
+
+  if (!component) return <a ref={ref} {...props} />
+  const Component = forwardRef(component)
+
+  return <Component ref={ref} {...props} />
+})

--- a/lib/ui/avatar.tsx
+++ b/lib/ui/avatar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Image } from "@/components/Utilities/Image"
+import { Image } from "@/lib/imageHandler"
 import { cn } from "@/lib/utils"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
 import { cva } from "class-variance-authority"

--- a/lib/ui/card.tsx
+++ b/lib/ui/card.tsx
@@ -6,6 +6,7 @@ import ArrowRight from "@/icons/ArrowRight"
 import InfoCircleLine from "@/icons/InfoCircleLine"
 
 import { Icon } from "@/components/Utilities/Icon"
+import { Link } from "@/lib/linkHandler"
 import {
   Tooltip,
   TooltipContent,
@@ -94,7 +95,7 @@ const CardLink = React.forwardRef<
   React.ComponentPropsWithoutRef<"a">
 >(({ className, title, ...props }) => {
   return (
-    <a
+    <Link
       className={cn(
         "flex h-6 w-6 items-center justify-center text-muted-foreground transition-colors hover:text-foreground",
         className
@@ -103,7 +104,7 @@ const CardLink = React.forwardRef<
       {...props}
     >
       <Icon icon={ArrowRight} size="md" />
-    </a>
+    </Link>
   )
 })
 CardLink.displayName = "CardLink"


### PR DESCRIPTION
Refactors image and link handlers files to prevent weird circular dependencies between `ui` (ShadCN) and our own `components`.