### PR TITLE
Refactor skeleton structure

### DIFF
--- a/lib/components/Widgets/WidgetContainer/index.stories.tsx
+++ b/lib/components/Widgets/WidgetContainer/index.stories.tsx
@@ -2,10 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react"
 
 import { Placeholder } from "@/lib/storybook-utils"
 import { ComponentProps } from "react"
-import { Widget } from "."
+import { WidgetContainer } from "."
 
 const meta = {
-  component: Widget.Container,
+  component: WidgetContainer,
   parameters: {
     layout: "centered",
   },
@@ -24,8 +24,8 @@ const meta = {
       info: "Lorem ipsum dolor",
     },
     children: <Placeholder>Put your content in there</Placeholder>,
-  } satisfies ComponentProps<typeof Widget.Container>,
-} satisfies Meta<typeof Widget.Container>
+  } satisfies ComponentProps<typeof WidgetContainer>,
+} satisfies Meta<typeof WidgetContainer>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/lib/components/Widgets/WidgetContainer/index.tsx
+++ b/lib/components/Widgets/WidgetContainer/index.tsx
@@ -7,7 +7,7 @@ import {
   CardSubtitle,
   CardTitle,
 } from "@/ui/card"
-import { Skeleton } from "@/ui/skeleton"
+import { Skeleton as SkeletonPrimitive } from "@/ui/skeleton"
 import { forwardRef, ReactNode } from "react"
 
 export interface WidgetContainerProps {
@@ -26,7 +26,7 @@ export interface WidgetSkeletonProps {
   }
 }
 
-export const WidgetContainer = forwardRef<
+const Container = forwardRef<
   HTMLDivElement,
   WidgetContainerProps & { children: ReactNode }
 >(({ header, children }, ref) => (
@@ -45,7 +45,7 @@ export const WidgetContainer = forwardRef<
   </Card>
 ))
 
-export const WidgetSkeleton = forwardRef<HTMLDivElement, WidgetSkeletonProps>(
+const Skeleton = forwardRef<HTMLDivElement, WidgetSkeletonProps>(
   ({ header }, ref) => (
     <Card ref={ref} aria-live="polite" aria-busy={true}>
       <CardHeader>
@@ -56,14 +56,14 @@ export const WidgetSkeleton = forwardRef<HTMLDivElement, WidgetSkeletonProps>(
           {header?.title ? (
             <CardTitle>{header.title}</CardTitle>
           ) : (
-            <Skeleton className="h-4 w-full max-w-16" />
+            <SkeletonPrimitive className="h-4 w-full max-w-16" />
           )}
           {header?.subtitle && <CardSubtitle>{header.subtitle}</CardSubtitle>}
         </div>
       </CardHeader>
       <CardContent aria-hidden={true}>
         {[...Array(4)].map((_, i) => (
-          <Skeleton
+          <SkeletonPrimitive
             key={i}
             className={`mb-1 h-6 ${["w-full", "w-1/2", "w-3/4", "w-1/4"][i]}`}
           />
@@ -73,7 +73,6 @@ export const WidgetSkeleton = forwardRef<HTMLDivElement, WidgetSkeletonProps>(
   )
 )
 
-export const Widget = {
-  Container: WidgetContainer,
-  Skeleton: WidgetSkeleton,
-}
+export const WidgetContainer = Object.assign(Container, {
+  Skeleton: Skeleton,
+})

--- a/lib/components/Widgets/WidgetContainer/skeleton.stories.tsx
+++ b/lib/components/Widgets/WidgetContainer/skeleton.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { ComponentProps } from "react"
-import { Widget } from "."
+import { WidgetContainer } from "."
 
-const meta: Meta<ComponentProps<typeof Widget.Skeleton>> = {
+const meta: Meta<ComponentProps<typeof WidgetContainer.Skeleton>> = {
   title: "Widgets/WidgetContainer/Skeleton",
-  component: Widget.Skeleton,
+  component: WidgetContainer.Skeleton,
   parameters: {
     layout: "centered",
   },
@@ -18,7 +18,7 @@ const meta: Meta<ComponentProps<typeof Widget.Skeleton>> = {
 }
 
 export default meta
-export type Story = StoryObj<typeof Widget.Skeleton>
+export type Story = StoryObj<typeof WidgetContainer.Skeleton>
 
 export const Default: Story = {}
 


### PR DESCRIPTION
Refactors the way we export components to make the API friendlier. Now we can have `WidgetContainer` and `WidgetContainer.Skeleton`.

We can repeat the same pattern in every other component thanks to TypeScript's support of `Object.assign`!