### PR TITLE
Overview in PieChart

### DIFF
--- a/lib/components/Charts/PieChart/index.stories.tsx
+++ b/lib/components/Charts/PieChart/index.stories.tsx
@@ -23,6 +23,13 @@ const meta: Meta<typeof Component> = {
       },
     },
   },
+  decorators: [
+    (Story) => (
+      <div className="max-w-80">
+        <Story />
+      </div>
+    ),
+  ],
 } satisfies Meta<typeof Component>
 
 export default meta
@@ -66,4 +73,14 @@ export const Default: Story = {
       { label: "june", value: 214 },
     ],
   } as PieChartProps<typeof dataConfig>,
+}
+
+export const WithOverview: Story = {
+  args: {
+    ...Default.args,
+    overview: {
+      label: "Total",
+      number: 224,
+    },
+  },
 }

--- a/lib/components/Charts/PieChart/index.tsx
+++ b/lib/components/Charts/PieChart/index.tsx
@@ -1,6 +1,12 @@
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/ui/chart"
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/ui/chart"
 import { ComponentProps, ForwardedRef } from "react"
-import { LabelList, Pie, PieChart as PieChartPrimitive } from "recharts"
+import { Label, Pie, PieChart as PieChartPrimitive } from "recharts"
 import { autoColor } from "../utils/colors"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { ChartConfig, InferChartKeys } from "../utils/types"
@@ -17,12 +23,12 @@ export type PieChartProps<
 > = {
   dataConfig: ChartConfig<Keys>
   data: PieChartItem[]
-  donutPieChart?: boolean
+  overview?: { number: number; label: string }
   aspect?: ComponentProps<typeof ChartContainer>["aspect"]
 }
 
 export const _PieChart = <DataConfig extends ChartConfig>(
-  { data, dataConfig, donutPieChart, aspect }: PieChartProps<DataConfig>,
+  { data, dataConfig, overview, aspect }: PieChartProps<DataConfig>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const preparedData = data.map((item, index) => ({
@@ -34,7 +40,7 @@ export const _PieChart = <DataConfig extends ChartConfig>(
 
   return (
     <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
-      <PieChartPrimitive accessibilityLayer margin={{ left: 12, right: 12 }}>
+      <PieChartPrimitive accessibilityLayer margin={{ left: 0, right: 0 }}>
         <ChartTooltip cursor content={<ChartTooltipContent hideLabel />} />
         <Pie
           isAnimationActive={false}
@@ -42,15 +48,46 @@ export const _PieChart = <DataConfig extends ChartConfig>(
           legendType="circle"
           dataKey={"value"}
           data={preparedData}
-          innerRadius={donutPieChart ? 60 : 0}
+          innerRadius={overview ? 50 : 40}
+          paddingAngle={2.5}
         >
-          <LabelList
-            dataKey="browser"
-            className="fill-background"
-            stroke="none"
-            fontSize={12}
+          <Label
+            content={({ viewBox }) => {
+              if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                return (
+                  <text
+                    x={viewBox.cx}
+                    y={viewBox.cy}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                  >
+                    <tspan
+                      x={viewBox.cx}
+                      y={(viewBox.cy || 0) + 8}
+                      className="fill-foreground text-3xl font-semibold"
+                    >
+                      {overview?.number}
+                    </tspan>
+                    <tspan
+                      x={viewBox.cx}
+                      y={(viewBox.cy || 0) - 16}
+                      className="fill-muted-foreground"
+                    >
+                      {overview?.label}
+                    </tspan>
+                  </text>
+                )
+              }
+            }}
           />
         </Pie>
+        <ChartLegend
+          content={<ChartLegendContent />}
+          align="right"
+          verticalAlign="middle"
+          layout="vertical"
+          className="flex-col items-start gap-1 pr-3 pt-0"
+        />
       </PieChartPrimitive>
     </ChartContainer>
   )


### PR DESCRIPTION
Gives a "donut" style to our PieChart component, also adding an `Overview` prop, displaying a label and number inside the donut.

This PR also shows and positions the legend to the right of the pie chart.

![image](https://github.com/user-attachments/assets/6b411e1b-0e68-4145-85d4-b11ffd3e08f3)

