### PR TITLE
Show label on chart tooltips

### DIFF
--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -42,7 +42,7 @@ const _BarChart = <
         data={prepareData(data)}
         margin={{ left: 12, right: 12, top: label ? 24 : 0 }}
       >
-        <ChartTooltip cursor content={<ChartTooltipContent hideLabel />} />
+        <ChartTooltip cursor content={<ChartTooltipContent />} />
         <CartesianGrid vertical={false} />
         <YAxis {...yAxisProps(yAxis)} hide={yAxis?.hide} />
         <XAxis {...xAxisProps(xAxis)} hide={xAxis?.hide} />

--- a/lib/components/Charts/LineChart/index.tsx
+++ b/lib/components/Charts/LineChart/index.tsx
@@ -46,7 +46,7 @@ export const _LineChart = <
         <CartesianGrid {...cartesianGridProps()} />
         {!xAxis?.hide && <XAxis {...xAxisProps(xAxis)} />}
         {!yAxis?.hide && <YAxis {...yAxisProps(yAxis)} />}
-        <ChartTooltip cursor content={<ChartTooltipContent hideLabel />} />
+        <ChartTooltip cursor content={<ChartTooltipContent />} />
         {lines.map((line, index) => (
           <Line
             key={line}

--- a/lib/components/Charts/PieChart/index.tsx
+++ b/lib/components/Charts/PieChart/index.tsx
@@ -41,7 +41,7 @@ export const _PieChart = <DataConfig extends ChartConfig>(
   return (
     <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
       <PieChartPrimitive accessibilityLayer margin={{ left: 0, right: 0 }}>
-        <ChartTooltip cursor content={<ChartTooltipContent hideLabel />} />
+        <ChartTooltip cursor content={<ChartTooltipContent />} />
         <Pie
           isAnimationActive={false}
           nameKey={"label"}


### PR DESCRIPTION
This PR removes the `hidelabel` on some ChartTooltip. It is a lot easier to read the info if the label is displayed.

![image](https://github.com/user-attachments/assets/d33c400f-7ec1-4b81-9fef-6af83c71ba62)
_Here, "March" is the label_