### PR TITLE
CartesianGrid on charts

### DIFF
--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "recharts"
 
 import { autoColor } from "../utils/colors"
-import { xAxisProps, yAxisProps } from "../utils/elements"
+import { cartesianGridProps, xAxisProps, yAxisProps } from "../utils/elements"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { prepareData } from "../utils/muncher"
 import { ChartConfig, ChartPropsBase, InferChartKeys } from "../utils/types"
@@ -44,7 +44,7 @@ const _BarChart = <
         margin={{ left: 12, right: 12, top: label ? 24 : 0 }}
       >
         <ChartTooltip cursor content={<ChartTooltipContent />} />
-        <CartesianGrid vertical={false} />
+        <CartesianGrid {...cartesianGridProps()} />
         <YAxis {...yAxisProps(yAxis)} hide={yAxis?.hide} />
         <XAxis {...xAxisProps(xAxis)} hide={xAxis?.hide} />
 

--- a/lib/components/Charts/VerticalBarChart/index.tsx
+++ b/lib/components/Charts/VerticalBarChart/index.tsx
@@ -14,6 +14,7 @@ import {
 import { prepareData } from "../utils/bar"
 import { autoColor } from "../utils/colors"
 import {
+  cartesianGridProps,
   xAxisProps as xAxisConfigureProps,
   yAxisProps as yAxisConfigureProps,
 } from "../utils/elements"
@@ -87,7 +88,11 @@ const _VBarChart = <
         margin={{ left: 24, right: label ? 32 : 0 }}
       >
         <ChartTooltip cursor content={<ChartTooltipContent />} />
-        <CartesianGrid vertical={true} horizontal={false} />
+        <CartesianGrid
+          {...cartesianGridProps()}
+          vertical={true}
+          horizontal={false}
+        />
         <XAxis {...xAxisProps} hide={xAxis?.hide} />
         <YAxis {...yAxisProps} hide={yAxis?.hide} />
 

--- a/lib/components/Charts/utils/elements.tsx
+++ b/lib/components/Charts/utils/elements.tsx
@@ -25,4 +25,5 @@ export const yAxisProps = (
 
 export const cartesianGridProps = () => ({
   vertical: false,
+  strokeDasharray: "4",
 })


### PR DESCRIPTION
Adds the `CartesianGrid` to those charts that were missing it, and uses the props defined on `elements.tsx`.
Also, adds a dashed stroke to this `CartesianGrid`, as we have in Figma.
