### PR TITLE
Add NumberInput

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,5 +10,16 @@ module.exports = {
   ignorePatterns: ["dist", ".eslintrc.cjs"],
   parser: "@typescript-eslint/parser",
   plugins: ["react-refresh"],
-  rules: {},
-};
+  rules: {
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        vars: "all",
+        varsIgnorePattern: "^_",
+        args: "after-used",
+        argsIgnorePattern: "^_",
+      },
+    ],
+  },
+}

--- a/lib/components/Forms/Fields/Input/index.tsx
+++ b/lib/components/Forms/Fields/Input/index.tsx
@@ -1,11 +1,13 @@
 export * from "@/ui/input"
 import { Input as ShadcnInput } from "@/ui/input"
-import { ComponentProps } from "react"
+import { ComponentProps, HTMLInputTypeAttribute } from "react"
 
-type InputProps = Pick<
+export type InputProps = Pick<
   ComponentProps<typeof ShadcnInput>,
-  "ref" | "type" | "disabled" | "size" | "onChange" | "value" | "placeholder"
->
+  "ref" | "disabled" | "size" | "onChange" | "value" | "placeholder"
+> & {
+  type?: Exclude<HTMLInputTypeAttribute, "number">
+}
 
 const Input: React.FC<InputProps> = ShadcnInput
 

--- a/lib/components/Forms/Fields/NumberInput/extractNumber.test.ts
+++ b/lib/components/Forms/Fields/NumberInput/extractNumber.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "vitest"
+import { Options, extractNumber } from "./extractNumber"
+
+describe("extractNumber", () => {
+  const integerOptions: Options = { maxDecimals: 0 }
+  const decimalOptions: Options = { maxDecimals: 2 }
+
+  describe("integer options", () => {
+    test("empty string", () => {
+      const input = ""
+      expect(extractNumber(input, integerOptions)).toEqual({
+        formattedValue: input,
+        value: null,
+      })
+    })
+
+    test("minus sign", () => {
+      const input = "-"
+      expect(extractNumber(input, integerOptions)).toEqual({
+        formattedValue: input,
+        value: null,
+      })
+    })
+
+    test("zero", () => {
+      const input = "0"
+      expect(extractNumber(input, integerOptions)).toEqual({
+        formattedValue: input,
+        value: 0,
+      })
+    })
+
+    test("integer", () => {
+      const input = "123"
+      expect(extractNumber(input, integerOptions)).toEqual({
+        formattedValue: input,
+        value: 123,
+      })
+    })
+
+    test("leading 0", () => {
+      expect(extractNumber("0123", integerOptions)).toEqual({
+        formattedValue: "123",
+        value: 123,
+      })
+    })
+
+    test("leading negative 0", () => {
+      expect(extractNumber("-0123", integerOptions)).toEqual({
+        formattedValue: "-123",
+        value: -123,
+      })
+    })
+
+    test("negative integer", () => {
+      const input = "-123"
+      expect(extractNumber(input, integerOptions)).toEqual({
+        formattedValue: input,
+        value: -123,
+      })
+    })
+
+    test("appended dot", () => {
+      const input = "123."
+
+      expect(extractNumber(input, integerOptions)).toEqual({
+        formattedValue: "123",
+        value: 123,
+      })
+    })
+
+    test("negative appended dot", () => {
+      const input = "-123."
+      expect(extractNumber(input, integerOptions)).toEqual({
+        formattedValue: "-123",
+        value: -123,
+      })
+    })
+
+    test("decimal number", () => {
+      const input = "123.45"
+
+      expect(extractNumber(input, integerOptions)).toEqual({
+        formattedValue: "123",
+        value: 123,
+      })
+    })
+
+    test("negative decimal number", () => {
+      const input = "-123.456"
+
+      expect(extractNumber(input, integerOptions)).toEqual({
+        formattedValue: "-123",
+        value: -123,
+      })
+    })
+
+    test("appended letter", () => {
+      expect(extractNumber("123a", integerOptions)).toBeNull()
+    })
+
+    test("prepended letter", () => {
+      expect(extractNumber("a123", integerOptions)).toBeNull()
+    })
+
+    test("letter in the middle", () => {
+      expect(extractNumber("1a23", integerOptions)).toBeNull()
+    })
+  })
+
+  describe("decimal options", () => {
+    test("empty string", () => {
+      const input = ""
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: input,
+        value: null,
+      })
+    })
+
+    test("lone decimal", () => {
+      const input = "."
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: input,
+        value: null,
+      })
+    })
+
+    test("minus sign", () => {
+      const input = "-"
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: input,
+        value: null,
+      })
+    })
+
+    test("zero", () => {
+      const input = "0"
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: input,
+        value: 0,
+      })
+    })
+
+    test("integer", () => {
+      const input = "123"
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: input,
+        value: 123,
+      })
+    })
+
+    test("negative integer", () => {
+      const input = "-123"
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: input,
+        value: -123,
+      })
+    })
+
+    test("appended dot", () => {
+      const input = "123."
+
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: input,
+        value: 123,
+      })
+    })
+
+    test("negative appended dot", () => {
+      const input = "-123."
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: input,
+        value: -123,
+      })
+    })
+
+    test("decimal number", () => {
+      const input = "123.45"
+
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: input,
+        value: 123.45,
+      })
+    })
+
+    test("Comma decimal number", () => {
+      const input = "123,45"
+
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: "123,45",
+        value: 123.45,
+      })
+    })
+
+    test("truncates decimal number", () => {
+      expect(extractNumber("123.456", decimalOptions)).toEqual({
+        formattedValue: "123.45",
+        value: 123.45,
+      })
+    })
+
+    test("doesn't truncate when no max decimals specified", () => {
+      expect(extractNumber("123.456", {})).toEqual({
+        formattedValue: "123.456",
+        value: 123.456,
+      })
+    })
+
+    test("negative decimal number", () => {
+      const input = "-123.456"
+
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: "-123.45",
+        value: -123.45,
+      })
+    })
+
+    test("no leading integer decimal number", () => {
+      const input = "-.456"
+
+      expect(extractNumber(input, decimalOptions)).toEqual({
+        formattedValue: "-.45",
+        value: -0.45,
+      })
+    })
+
+    test("appended letter", () => {
+      expect(extractNumber("123a", decimalOptions)).toBeNull()
+    })
+
+    test("prepended letter", () => {
+      expect(extractNumber("a123", decimalOptions)).toBeNull()
+    })
+
+    test("letter in the middle", () => {
+      expect(extractNumber("1a23", decimalOptions)).toBeNull()
+    })
+  })
+})

--- a/lib/components/Forms/Fields/NumberInput/extractNumber.ts
+++ b/lib/components/Forms/Fields/NumberInput/extractNumber.ts
@@ -1,0 +1,57 @@
+// eslint-disable-next-line no-useless-escape
+const COMPLETE_NUMBER_FORMAT = /^(-?)([0-9]+)?(?:([\.,])([0-9]+)?)?$/
+
+interface ExtractedNumber {
+  formattedValue: string
+  value: number | null
+}
+
+export interface Options {
+  /**
+   * The maximum number of decimals to allow. Set to 0 to only allow integers.
+   */
+  maxDecimals?: number
+}
+
+/**
+ *
+ * @param input The text from which to extract a number
+ * @returns an object with the formatted number and the value as a number
+ *
+ * TODO: Make internationalization-friendly to support grouping character
+ */
+export function extractNumber(
+  input: string,
+  { maxDecimals }: Options
+): ExtractedNumber | null {
+  if (!input || input === "-") {
+    return {
+      formattedValue: input ?? "",
+      value: null,
+    }
+  }
+
+  const match = input.match(COMPLETE_NUMBER_FORMAT)
+  if (!match) return null
+
+  // eslint-disable-next-line prefer-const
+  let [_, sign, integers, separator, decimals] = match
+  if (maxDecimals && (decimals?.length ?? 0) > maxDecimals) {
+    decimals = decimals?.slice(0, maxDecimals)
+  } else if (maxDecimals === 0) {
+    decimals = ""
+  }
+
+  integers =
+    integers?.replace(/^0+(\d)/, (_substring, firstDigit) => firstDigit) ?? ""
+
+  const formattedValue = `${sign}${integers}${
+    maxDecimals !== 0 ? `${separator ?? ""}${decimals ?? ""}` : ""
+  }`
+  const valueAsNumber = parseFloat(formattedValue.replace(",", "."))
+
+  return {
+    formattedValue: formattedValue,
+    value: !Number.isNaN(valueAsNumber) ? valueAsNumber : null,
+  }
+}

--- a/lib/components/Forms/Fields/NumberInput/index.stories.tsx
+++ b/lib/components/Forms/Fields/NumberInput/index.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
+import { useState } from "react"
 import { NumberInput } from "."
 
 const meta = {
@@ -34,6 +35,18 @@ type Story = StoryObj<typeof meta>
 
 export const Primary: Story = {
   args: {},
+}
+
+export const WithStep: Story = {
+  args: {
+    min: 1,
+    max: 5,
+    step: 1,
+  },
+  render: (props) => {
+    const [value, setValue] = useState<number | null>(1)
+    return <NumberInput {...props} value={value} onChange={setValue} />
+  },
 }
 
 export const Disabled: Story = {

--- a/lib/components/Forms/Fields/NumberInput/index.stories.tsx
+++ b/lib/components/Forms/Fields/NumberInput/index.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { NumberInput } from "."
+
+const meta = {
+  render: (props) => <NumberInput key={JSON.stringify(props)} {...props} />,
+  tags: ["autodocs"],
+  args: {
+    disabled: false,
+    placeholder: "Placeholder text here",
+    locale: "en-US",
+  },
+  argTypes: {
+    value: {
+      control: { type: "number" },
+    },
+    locale: {
+      options: ["en-US", "es-ES", "pt-BR"],
+      control: { type: "select" },
+    },
+    maxDecimals: {
+      control: { type: "number" },
+    },
+  },
+  parameters: {
+    jsx: {
+      filterProps: (_: unknown, propName: string) => propName !== "key",
+    },
+  },
+} satisfies Meta<typeof NumberInput>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {},
+}
+
+export const Disabled: Story = {
+  args: {
+    value: 32.5,
+    disabled: true,
+    locale: "es-ES",
+  },
+}

--- a/lib/components/Forms/Fields/NumberInput/index.stories.tsx
+++ b/lib/components/Forms/Fields/NumberInput/index.stories.tsx
@@ -44,7 +44,7 @@ export const WithStep: Story = {
     step: 1,
   },
   render: (props) => {
-    const [value, setValue] = useState<number | null>(1)
+    const [value, setValue] = useState<number | null>(props.value ?? 1)
     return <NumberInput {...props} value={value} onChange={setValue} />
   },
 }

--- a/lib/components/Forms/Fields/NumberInput/index.test.tsx
+++ b/lib/components/Forms/Fields/NumberInput/index.test.tsx
@@ -1,0 +1,73 @@
+import { composeStory } from "@storybook/react"
+import { userEvent } from "@storybook/test"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, test, vi } from "vitest"
+import { NumberInput } from "."
+import Meta, { WithStep } from "./index.stories"
+
+const WithStepStory = composeStory(WithStep, Meta)
+
+describe("NumberInput", () => {
+  test("renders the input", () => {
+    render(<NumberInput locale="es-ES" value={123.456} maxDecimals={2} />)
+    const input = screen.getByRole("textbox")
+    expect(input).toHaveValue("123,46")
+  })
+
+  describe("when the value is null", () => {
+    test("renders an empty input", () => {
+      render(<NumberInput locale="en-US" value={null} />)
+      const input = screen.getByRole("textbox")
+      expect(input).toHaveValue("")
+    })
+  })
+
+  describe("when typing a number", () => {
+    test("trigger the onChange callback with the number", async () => {
+      const onChange = vi.fn()
+      render(<NumberInput locale="en-US" maxDecimals={0} onChange={onChange} />)
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "-12.")
+
+      expect(input).toHaveValue("-12")
+      expect(onChange).toHaveBeenLastCalledWith(-12)
+    })
+  })
+
+  describe("with step", () => {
+    test("increases and decreases the value", async () => {
+      render(<WithStepStory />)
+
+      const input = screen.getByRole("textbox")
+
+      const incrementButton = await screen.getAllByRole("button")[0]
+      await userEvent.click(incrementButton)
+      expect(input).toHaveValue("2")
+
+      const decrementButton = await screen.getAllByRole("button")[1]
+      await userEvent.click(decrementButton)
+      expect(input).toHaveValue("1")
+    })
+
+    test("does not increase the value above the max", async () => {
+      render(<WithStepStory value={5} />)
+
+      const input = screen.getByRole("textbox")
+      const incrementButton = screen.getAllByRole("button")[0]
+      await userEvent.click(incrementButton)
+
+      expect(input).toHaveValue("5")
+    })
+
+    test("does not decrease the value below the min", async () => {
+      render(<WithStepStory value={1} />)
+
+      const input = screen.getByRole("textbox")
+      const decrementButton = screen.getAllByRole("button")[1]
+      await userEvent.click(decrementButton)
+
+      expect(input).toHaveValue("1")
+    })
+  })
+})

--- a/lib/components/Forms/Fields/NumberInput/index.tsx
+++ b/lib/components/Forms/Fields/NumberInput/index.tsx
@@ -1,0 +1,77 @@
+import { forwardRef, useEffect, useState } from "react"
+import { Input, InputProps } from "../Input"
+
+const FORMAT = /^([0-9]+)$/
+// eslint-disable-next-line no-useless-escape
+const FORMAT_WITH_DECIMALS = /^([0-9]+)(?:[\.,]([0-9]+)?)?$/
+
+const parseValue = (value: string) => parseFloat(value.replace(",", "."))
+
+type NumberInputProps = Omit<InputProps, "value" | "type" | "onChange"> & {
+  locale: string
+  value?: number
+  maxDecimals?: number
+  onChange?: (value: number | null) => void
+}
+
+export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
+  ({ locale, value, maxDecimals, onChange, ...props }, ref) => {
+    const formatValue = (value: number, maxDecimals?: number) =>
+      new Intl.NumberFormat(locale, {
+        maximumFractionDigits: maxDecimals,
+        useGrouping: false,
+      }).format(value)
+
+    const [fieldValue, setFieldValue] = useState<string>(() =>
+      value != null ? formatValue(value, maxDecimals) : ""
+    )
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value
+
+      if (!value) {
+        setFieldValue("")
+        return onChange?.(null)
+      }
+
+      const match = value.match(
+        maxDecimals !== 0 ? FORMAT_WITH_DECIMALS : FORMAT
+      )
+      if (!match) return
+
+      const [_, integers, decimals] = match
+      if (maxDecimals && decimals && decimals.length > maxDecimals) return
+
+      const valueWithNoLeadingZero = value.match(/^0\d$/)
+        ? value.slice(1)
+        : value
+
+      const valueAsNumber = parseFloat(`${integers}.${decimals ?? 0}`)
+
+      setFieldValue(valueWithNoLeadingZero)
+      onChange?.(valueAsNumber)
+    }
+
+    // We need the logic "parseValue(fieldValue) !== value" below to ensure we don't remove the decimal separator while the user is modifying the decimals.
+    // For example, if the input value is 18,3 and I want to change it to 18,5. I'll delete the last digit and the input will become "18,"
+    // At this point, we have fired the "onChange" callback with the value 18 because it's the most precise valid value ("18," isn't a valid one),
+    // then the useEffect below will be triggered, since the "value" changed from "18,3" to "18", and it'll not modify the "fieldValue" to keep the decimal separator
+    // unless if the value really changed.
+    useEffect(() => {
+      if (value === null) return setFieldValue("")
+      if (value != null && parseValue(fieldValue) !== value)
+        setFieldValue(formatValue(value, maxDecimals))
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [fieldValue, value])
+
+    return (
+      <Input
+        type="text"
+        ref={ref}
+        value={fieldValue}
+        onChange={handleChange}
+        {...props}
+      />
+    )
+  }
+)

--- a/lib/components/Forms/Fields/NumberInput/index.tsx
+++ b/lib/components/Forms/Fields/NumberInput/index.tsx
@@ -10,6 +10,12 @@ const FORMAT_WITH_DECIMALS = /^([0-9]+)(?:[\.,]([0-9]+)?)?$/
 
 const parseValue = (value: string) => parseFloat(value.replace(",", "."))
 
+const formatValue = (value: number, locale: string, maxDecimals?: number) =>
+  new Intl.NumberFormat(locale, {
+    maximumFractionDigits: maxDecimals,
+    useGrouping: false,
+  }).format(value)
+
 type NumberInputProps = Omit<InputProps, "value" | "type" | "onChange"> & {
   locale: string
   value?: number | null
@@ -22,14 +28,8 @@ type NumberInputProps = Omit<InputProps, "value" | "type" | "onChange"> & {
 
 export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
   ({ locale, value, maxDecimals, step, min, max, onChange, ...props }, ref) => {
-    const formatValue = (value: number, maxDecimals?: number) =>
-      new Intl.NumberFormat(locale, {
-        maximumFractionDigits: maxDecimals,
-        useGrouping: false,
-      }).format(value)
-
     const [fieldValue, setFieldValue] = useState<string>(() =>
-      value != null ? formatValue(value, maxDecimals) : ""
+      value != null ? formatValue(value, locale, maxDecimals) : ""
     )
 
     const handleChange = (value: string) => {
@@ -60,7 +60,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       if (!step) return
       if (value == null) {
         const initialValue = step ?? min ?? 0
-        return handleChange(formatValue(initialValue, maxDecimals))
+        return handleChange(formatValue(initialValue, locale, maxDecimals))
       }
 
       const newValue = type === "increase" ? value + step : value - step
@@ -68,7 +68,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
         return
       }
 
-      handleChange(formatValue(newValue, maxDecimals))
+      handleChange(formatValue(newValue, locale, maxDecimals))
     }
 
     const Arrows = () => {
@@ -76,7 +76,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
 
       return (
         <div
-          className="absolute right-2 top-0.5 flex h-full flex-col group-focus-within:flex group-hover:flex"
+          className="absolute right-2 top-0.5 hidden h-full flex-col group-focus-within:flex group-hover:flex"
           onClick={(e) => e.preventDefault()}
         >
           <div onClick={handleStep("increase")} className="h-4 cursor-pointer">
@@ -97,7 +97,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     useEffect(() => {
       if (value === null) return setFieldValue("")
       if (value != null && parseValue(fieldValue) !== value)
-        setFieldValue(formatValue(value, maxDecimals))
+        setFieldValue(formatValue(value, locale, maxDecimals))
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fieldValue, value])
 

--- a/lib/components/Forms/Fields/NumberInput/index.tsx
+++ b/lib/components/Forms/Fields/NumberInput/index.tsx
@@ -1,5 +1,8 @@
+import { Icon } from "@/components/Utilities/Icon"
+import { ChevronDown, ChevronUp } from "@/icons"
+import { Input } from "@/ui/input"
 import { forwardRef, useEffect, useState } from "react"
-import { Input, InputProps } from "../Input"
+import { InputProps } from "../Input"
 
 const FORMAT = /^([0-9]+)$/
 // eslint-disable-next-line no-useless-escape
@@ -9,13 +12,16 @@ const parseValue = (value: string) => parseFloat(value.replace(",", "."))
 
 type NumberInputProps = Omit<InputProps, "value" | "type" | "onChange"> & {
   locale: string
-  value?: number
+  value?: number | null
+  step?: number
+  min?: number
+  max?: number
   maxDecimals?: number
   onChange?: (value: number | null) => void
 }
 
 export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
-  ({ locale, value, maxDecimals, onChange, ...props }, ref) => {
+  ({ locale, value, maxDecimals, step, min, max, onChange, ...props }, ref) => {
     const formatValue = (value: number, maxDecimals?: number) =>
       new Intl.NumberFormat(locale, {
         maximumFractionDigits: maxDecimals,
@@ -26,9 +32,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       value != null ? formatValue(value, maxDecimals) : ""
     )
 
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value
-
+    const handleChange = (value: string) => {
       if (!value) {
         setFieldValue("")
         return onChange?.(null)
@@ -52,6 +56,39 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       onChange?.(valueAsNumber)
     }
 
+    const handleStep = (type: "increase" | "decrease") => () => {
+      if (!step) return
+      if (value == null) {
+        const initialValue = step ?? min ?? 0
+        return handleChange(formatValue(initialValue, maxDecimals))
+      }
+
+      const newValue = type === "increase" ? value + step : value - step
+      if ((min != null && newValue < min) || (max != null && newValue > max)) {
+        return
+      }
+
+      handleChange(formatValue(newValue, maxDecimals))
+    }
+
+    const Arrows = () => {
+      if (!step) return null
+
+      return (
+        <div
+          className="absolute right-2 top-0.5 flex h-full flex-col group-focus-within:flex group-hover:flex"
+          onClick={(e) => e.preventDefault()}
+        >
+          <div onClick={handleStep("increase")} className="h-4 cursor-pointer">
+            <Icon size="sm" icon={ChevronUp} />
+          </div>
+          <div onClick={handleStep("decrease")} className="h-4 cursor-pointer">
+            <Icon size="sm" icon={ChevronDown} />
+          </div>
+        </div>
+      )
+    }
+
     // We need the logic "parseValue(fieldValue) !== value" below to ensure we don't remove the decimal separator while the user is modifying the decimals.
     // For example, if the input value is 18,3 and I want to change it to 18,5. I'll delete the last digit and the input will become "18,"
     // At this point, we have fired the "onChange" callback with the value 18 because it's the most precise valid value ("18," isn't a valid one),
@@ -65,13 +102,17 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     }, [fieldValue, value])
 
     return (
-      <Input
-        type="text"
-        ref={ref}
-        value={fieldValue}
-        onChange={handleChange}
-        {...props}
-      />
+      <div className="group relative">
+        <Input
+          type="text"
+          ref={ref}
+          value={fieldValue}
+          className="group-focus-within:pr-5 group-hover:pr-5"
+          onChange={(e) => handleChange(e.target.value)}
+          {...props}
+        />
+        <Arrows />
+      </div>
     )
   }
 )

--- a/lib/components/Forms/Fields/exports.ts
+++ b/lib/components/Forms/Fields/exports.ts
@@ -1,5 +1,6 @@
 import { Component } from "@/lib/component"
 import { Input as RawInput } from "./Input"
+import { NumberInput as RawNumberInput } from "./NumberInput"
 export * from "./Calendar"
 export * from "./Select"
 
@@ -11,4 +12,12 @@ export const Input = Component(
     type: "form",
   },
   RawInput
+)
+
+export const NumberInput = Component(
+  {
+    name: "NumberInput",
+    type: "form",
+  },
+  RawNumberInput
 )

--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -108,10 +108,7 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries<
     | { color?: string; theme?: never }
     | { color?: never; theme: Record<keyof typeof THEMES, string> }
-  >(config).filter(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    ([_, config]) => config.theme || config.color
-  )
+  >(config).filter(([_, config]) => config.theme || config.color)
 
   if (!colorConfig.length) {
     return null

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
     /* Shadcn */
     "baseUrl": ".",
     "types": [
-      "vite/client"
+      "vite/client",
+      "@testing-library/jest-dom"
     ],
     "paths": {
       "@/*": [


### PR DESCRIPTION
## 🚪 Why?

We recently introduced a `NumberField` component to Gamma to solve many problems we had with the numeric input components. Since we still don't have a numeric input in Factorial One and using an input with `type="number"` will not offer the best UX for our users, we need to port that component to Factorial One.

## 🔑 What?

Add the `NumberInput` component.

## 🏡 Context

- [Gamma NumberField](https://github.com/factorialco/factorial/pull/47179)

## 📸 Visual proof

https://github.com/user-attachments/assets/4d4bb57c-dae0-49d6-996a-1b7c57c5ccfe

