### PR TITLE
fix: resolve the conflict of color gradients when multiple charts are rendering

### DIFF
--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -17,6 +17,7 @@ import { autoColor } from "../utils/colors"
 import { cartesianGridProps } from "../utils/elements"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { prepareData } from "../utils/muncher"
+import { nanoid } from "nanoid"
 import { ChartConfig, ChartPropsBase, InferChartKeys } from "../utils/types"
 
 export type AreaChartProps<
@@ -41,6 +42,7 @@ export const _AreaChart = <
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const areas = Object.keys(dataConfig) as Array<keyof typeof dataConfig>
+  const chartId = nanoid(12)
 
   return (
     <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
@@ -76,7 +78,7 @@ export const _AreaChart = <
           {areas.map((area, index) => (
             <linearGradient
               key={index}
-              id={`fill${area}`}
+              id={`fill${area}-${chartId}`}
               x1="0"
               y1="0"
               x2="0"
@@ -101,7 +103,7 @@ export const _AreaChart = <
             key={area}
             dataKey={area}
             type={lineType}
-            fill={`url(#fill${area})`}
+            fill={`url(#fill${area}-${chartId})`}
             fillOpacity={0.4}
             stroke={dataConfig[area].color || autoColor(index)}
             strokeWidth={1.5}

--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -5,6 +5,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/ui/chart"
+import { nanoid } from "nanoid"
 import { ForwardedRef } from "react"
 import {
   Area,
@@ -17,7 +18,6 @@ import { autoColor } from "../utils/colors"
 import { cartesianGridProps } from "../utils/elements"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { prepareData } from "../utils/muncher"
-import { nanoid } from "nanoid"
 import { ChartConfig, ChartPropsBase, InferChartKeys } from "../utils/types"
 
 export type AreaChartProps<

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "date-fns": "^3.6.0",
         "framer-motion": "^11.3.17",
         "lucide-react": "^0.383.0",
+        "nanoid": "^5.0.7",
         "react": "18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "18.3.1",
@@ -16377,20 +16378,21 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
+      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -17830,6 +17832,23 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.5.3",
     "usehooks-ts": "^3.1.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "nanoid": "^5.0.7"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.6.1",


### PR DESCRIPTION
## 🚪 Problem
When we have multiple charts using the color gradients, it conflicts in a way such that the `linearGradient` id is the same, so when we use the same id at other charts in the same page, the `fill` will be using the first chart with this id.
A fix to this is to append a chart id to the `linearGradient` id to avoid this conflict

## 📸 Visual proof
**Before**
<img width="1048" alt="SCR-20240822-kktm" src="https://github.com/user-attachments/assets/31b4c30f-2f3a-43a5-8185-d9da3443d412">
**After**
<img width="1050" alt="SCR-20240822-klwc" src="https://github.com/user-attachments/assets/5706e05c-9b03-4729-a339-c9b50b5f4378">

