### PR TITLE
Adds Radial Progress component

### DIFF
--- a/lib/components/Charts/PieChart/index.stories.tsx
+++ b/lib/components/Charts/PieChart/index.stories.tsx
@@ -9,6 +9,18 @@ const dataConfig = {
   february: {
     label: "February",
   },
+  march: {
+    label: "March",
+  },
+  april: {
+    label: "April",
+  },
+  may: {
+    label: "May",
+  },
+  june: {
+    label: "June",
+  },
 }
 
 const Component = PieChart<typeof dataConfig>
@@ -38,26 +50,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    dataConfig: {
-      january: {
-        label: "January",
-      },
-      february: {
-        label: "February",
-      },
-      march: {
-        label: "March",
-      },
-      april: {
-        label: "April",
-      },
-      may: {
-        label: "May",
-      },
-      june: {
-        label: "June",
-      },
-    },
+    dataConfig,
     data: [
       { label: "january", value: 186 },
       { label: "february", value: 305 },

--- a/lib/components/Charts/RadialProgressChart/index.stories.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.stories.tsx
@@ -6,6 +6,7 @@ const meta = {
   tags: ["autodocs"],
   args: {
     value: 75,
+    max: 100,
   },
   decorators: [
     (Story) => (

--- a/lib/components/Charts/RadialProgressChart/index.stories.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { RadialProgressChart } from "."
+
+const meta = {
+  component: RadialProgressChart,
+  tags: ["autodocs"],
+  args: {
+    value: 75,
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-80">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RadialProgressChart>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithOverview: Story = {
+  args: {
+    value: 75,
+    overview: { number: 75, label: "Completed" },
+  },
+}

--- a/lib/components/Charts/RadialProgressChart/index.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.tsx
@@ -1,0 +1,60 @@
+import { autoColor } from "../utils/colors"
+
+interface RadialProgressProps {
+  value: number
+  color?: string
+  overview?: { number: number; label: string }
+}
+
+export function RadialProgressChart({
+  value,
+  color = autoColor(0),
+  overview,
+}: RadialProgressProps) {
+  const size = 100
+  const center = size / 2
+  const radius = center - 10 / 2
+  const circumference = 2 * Math.PI * radius
+  const progressOffset = ((100 - value) / 100) * circumference
+
+  return (
+    <div className="relative inline-flex aspect-video items-center justify-center">
+      <svg
+        width="100%"
+        height="100%"
+        viewBox={`0 0 ${size} ${size}`}
+        className="-rotate-90 transform"
+      >
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="hsl(var(--muted))"
+          strokeWidth={10}
+        />
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={10}
+          strokeDasharray={circumference}
+          strokeDashoffset={progressOffset}
+          strokeLinecap="round"
+        />
+      </svg>
+      {overview && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-xs text-muted-foreground">
+            {overview.label}
+          </span>
+          <span className="text-3xl font-semibold text-foreground">
+            {overview.number}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/components/Charts/RadialProgressChart/index.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.tsx
@@ -13,19 +13,18 @@ export function RadialProgressChart({
   color = autoColor(0),
   overview,
 }: RadialProgressProps) {
+  const strokeWidth = 20
   const size = 100
   const center = size / 2
-  const radius = center - 10 / 2
+  const radius = center - strokeWidth / 2
   const circumference = 2 * Math.PI * radius
   const progressOffset = ((max - Math.min(value, max)) / max) * circumference
 
   return (
     <div className="relative inline-flex aspect-video items-center justify-center">
       <svg
-        width="100%"
-        height="100%"
         viewBox={`0 0 ${size} ${size}`}
-        className="-rotate-90 transform"
+        className="h-full w-full -rotate-90 transform"
       >
         <circle
           cx={center}
@@ -33,7 +32,7 @@ export function RadialProgressChart({
           r={radius}
           fill="none"
           stroke="hsl(var(--muted))"
-          strokeWidth={10}
+          strokeWidth={strokeWidth}
         />
         <circle
           cx={center}
@@ -41,18 +40,17 @@ export function RadialProgressChart({
           r={radius}
           fill="none"
           stroke={color}
-          strokeWidth={10}
+          strokeWidth={strokeWidth}
           strokeDasharray={circumference}
           strokeDashoffset={progressOffset}
-          strokeLinecap="round"
         />
       </svg>
       {overview && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <div className="absolute inset-0 flex translate-y-0.5 flex-col items-center justify-center">
           <span className="text-xs text-muted-foreground">
             {overview.label}
           </span>
-          <span className="text-3xl font-semibold text-foreground">
+          <span className="text-3xl font-semibold leading-none text-foreground">
             {overview.number}
           </span>
         </div>

--- a/lib/components/Charts/RadialProgressChart/index.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.tsx
@@ -13,7 +13,7 @@ export function RadialProgressChart({
   color = autoColor(0),
   overview,
 }: RadialProgressProps) {
-  const strokeWidth = 16
+  const strokeWidth = 12
   const size = 100
   const center = size / 2
   const radius = center - strokeWidth / 2
@@ -43,6 +43,7 @@ export function RadialProgressChart({
           strokeWidth={strokeWidth}
           strokeDasharray={circumference}
           strokeDashoffset={progressOffset}
+          strokeLinecap="round"
         />
       </svg>
       {overview && (

--- a/lib/components/Charts/RadialProgressChart/index.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.tsx
@@ -2,12 +2,14 @@ import { autoColor } from "../utils/colors"
 
 interface RadialProgressProps {
   value: number
+  max?: number
   color?: string
   overview?: { number: number; label: string }
 }
 
 export function RadialProgressChart({
   value,
+  max = 100,
   color = autoColor(0),
   overview,
 }: RadialProgressProps) {
@@ -15,7 +17,7 @@ export function RadialProgressChart({
   const center = size / 2
   const radius = center - 10 / 2
   const circumference = 2 * Math.PI * radius
-  const progressOffset = ((100 - value) / 100) * circumference
+  const progressOffset = ((max - Math.min(value, max)) / max) * circumference
 
   return (
     <div className="relative inline-flex aspect-video items-center justify-center">

--- a/lib/components/Charts/RadialProgressChart/index.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.tsx
@@ -1,6 +1,6 @@
 import { autoColor } from "../utils/colors"
 
-interface RadialProgressProps {
+export interface RadialProgressProps {
   value: number
   max?: number
   color?: string
@@ -13,7 +13,7 @@ export function RadialProgressChart({
   color = autoColor(0),
   overview,
 }: RadialProgressProps) {
-  const strokeWidth = 20
+  const strokeWidth = 16
   const size = 100
   const center = size / 2
   const radius = center - strokeWidth / 2
@@ -21,7 +21,7 @@ export function RadialProgressChart({
   const progressOffset = ((max - Math.min(value, max)) / max) * circumference
 
   return (
-    <div className="relative inline-flex aspect-video items-center justify-center">
+    <div className="relative inline-flex aspect-video items-center justify-center overflow-hidden">
       <svg
         viewBox={`0 0 ${size} ${size}`}
         className="h-full w-full -rotate-90 transform"

--- a/lib/components/Widgets/Charts/RadialProgressWidget/index.stories.tsx
+++ b/lib/components/Widgets/Charts/RadialProgressWidget/index.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { RadialProgressWidget } from "."
+
+const meta = {
+  component: RadialProgressWidget,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    header: {
+      title: "A Radial Progress Chart",
+      subtitle: "2024",
+      info: "This is a radial progress chart",
+    },
+    chart: {
+      value: 75,
+      max: 100,
+      color: "hsl(var(--chart-1))",
+      overview: { number: 75, label: "Completed" },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full min-w-80">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RadialProgressWidget>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const CustomColor: Story = {
+  args: {
+    chart: {
+      value: 60,
+      max: 100,
+      color: "hsl(var(--chart-3))",
+      overview: { number: 60, label: "Progress" },
+    },
+  },
+}

--- a/lib/components/Widgets/Charts/RadialProgressWidget/index.tsx
+++ b/lib/components/Widgets/Charts/RadialProgressWidget/index.tsx
@@ -1,0 +1,30 @@
+import {
+  RadialProgressChart,
+  RadialProgressProps,
+} from "@/components/Charts/RadialProgressChart"
+import { withSkeleton } from "@/lib/skeleton"
+import { forwardRef } from "react"
+import { WidgetContainer } from "../../WidgetContainer"
+
+export type RadialProgressWidgetProps = {
+  header: {
+    title: string
+    subtitle?: string
+    info?: string
+    link?: { title: string; url: string }
+  }
+  chart: RadialProgressProps
+}
+
+export const RadialProgressWidget = withSkeleton(
+  forwardRef<HTMLDivElement, RadialProgressWidgetProps>(
+    ({ header, chart }, ref) => (
+      <WidgetContainer ref={ref} header={header}>
+        <div className="flex h-full items-center justify-center">
+          <RadialProgressChart {...chart} />
+        </div>
+      </WidgetContainer>
+    )
+  ),
+  WidgetContainer.Skeleton
+)

--- a/lib/components/Widgets/Dashboard/index.stories.tsx
+++ b/lib/components/Widgets/Dashboard/index.stories.tsx
@@ -9,6 +9,8 @@ import { LineChartWidget } from "../Charts/LineChartWidget"
 import LineChartWidgetStoriesMeta from "../Charts/LineChartWidget/index.stories"
 import { PieChartWidget } from "../Charts/PieChartWidget"
 import PieChartWidgetStoriesMeta from "../Charts/PieChartWidget/index.stories"
+import { RadialProgressWidget } from "../Charts/RadialProgressWidget"
+import RadialProgressWidgetStoriesMeta from "../Charts/RadialProgressWidget/index.stories"
 import { VerticalBarChartWidget } from "../Charts/VerticalBarChartWidget"
 import VerticalBarChartWidgetStoriesMeta from "../Charts/VerticalBarChartWidget/index.stories"
 import { WidgetContainer } from "../WidgetContainer"
@@ -40,6 +42,7 @@ const renderWidget = (index: number) => {
     () => (
       <VerticalBarChartWidget {...VerticalBarChartWidgetStoriesMeta.args} />
     ),
+    () => <RadialProgressWidget {...RadialProgressWidgetStoriesMeta.args} />,
   ]
 
   const Component = Widgets[index % Widgets.length]


### PR DESCRIPTION
Adds a Radial progress component, as a chart and also as a complete widget, as we have in [Figma](https://www.figma.com/design/O8578qyVUfgzm6ZkVkBJwW/%E2%8C%9B%EF%B8%8F-Insight-UI-Kit-2.0?node-id=495-46406&t=p9U94211dxh0uTWf-4).

![image](https://github.com/user-attachments/assets/a31afad7-7c65-45b6-a65d-d2dbfad27649)

_Example of a RadialProgressWidget_

---

Note: This chart is a custom one, as the [RadialChart](https://recharts.org/en-US/api/RadialBarChart) from recharts is not built to show progress, but to compare different values.
