### PR TITLE
feat: add numeric summaries widget

### DIFF
--- a/lib/components/Widgets/Charts/ChartContainer.tsx
+++ b/lib/components/Widgets/Charts/ChartContainer.tsx
@@ -2,14 +2,14 @@ import { forwardRef, ReactNode } from "react"
 import { WidgetContainer, WidgetContainerProps } from "../WidgetContainer"
 import ChartCounter from "./chart-counter"
 
-type ChartContainerPropsBase = WidgetContainerProps & {
+export type ChartContainerPropsBase = WidgetContainerProps & {
   summaries?: Array<{ label: string; value: number; unit?: string }>
 }
 
 const Container = forwardRef<
   HTMLDivElement,
   ChartContainerPropsBase & {
-    chart: ReactNode
+    chart?: ReactNode
   }
 >(({ chart, summaries, ...props }, ref) => (
   <WidgetContainer ref={ref} {...props}>
@@ -30,7 +30,9 @@ const Container = forwardRef<
         ))}
       </div>
     )}
-    <div className="relative flex min-h-40 grow items-stretch">{chart}</div>
+    {chart && (
+      <div className="relative flex min-h-40 grow items-stretch">{chart}</div>
+    )}
   </WidgetContainer>
 ))
 

--- a/lib/components/Widgets/Charts/SummariesWidget/index.stories.tsx
+++ b/lib/components/Widgets/Charts/SummariesWidget/index.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { SummariesWidget } from "."
+
+const meta = {
+  component: SummariesWidget,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    summaries: [
+      {
+        value: 12,
+        label: "Total",
+      },
+      {
+        value: 20,
+        label: "Count",
+      },
+    ],
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full min-w-80">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SummariesWidget>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/lib/components/Widgets/Charts/SummariesWidget/index.tsx
+++ b/lib/components/Widgets/Charts/SummariesWidget/index.tsx
@@ -1,0 +1,10 @@
+import { withSkeleton } from "@/lib/skeleton"
+import { forwardRef } from "react"
+import { ChartContainer, ChartContainerPropsBase } from "../ChartContainer"
+
+export const SummariesWidget = withSkeleton(
+  forwardRef<HTMLDivElement, ChartContainerPropsBase>((props, ref) => (
+    <ChartContainer ref={ref} {...props} chart={null} />
+  )),
+  ChartContainer.Skeleton
+)

--- a/lib/components/Widgets/Charts/exports.tsx
+++ b/lib/components/Widgets/Charts/exports.tsx
@@ -3,6 +3,7 @@ import { AreaChartWidget as AreaChartWidgetComponent } from "./AreaChartWidget"
 import { BarChartWidget as BarChartWidgetComponent } from "./BarChartWidget"
 import { LineChartWidget as LineChartWidgetComponent } from "./LineChartWidget"
 import { PieChartWidget as PieChartWidgetComponent } from "./PieChartWidget"
+import { SummariesWidget as SummariesWidgetComponent } from "./SummariesWidget"
 import { VerticalBarChartWidget as VerticalBarChartWidgetComponent } from "./VerticalBarChartWidget"
 
 export const AreaChartWidget = Component(
@@ -43,4 +44,12 @@ export const VerticalBarChartWidget = Component(
     type: "info",
   },
   VerticalBarChartWidgetComponent
+)
+
+export const SummariesWidget = Component(
+  {
+    name: "SummariesWidget",
+    type: "info",
+  },
+  SummariesWidgetComponent
 )

--- a/lib/components/Widgets/WidgetContainer/index.tsx
+++ b/lib/components/Widgets/WidgetContainer/index.tsx
@@ -34,17 +34,17 @@ const Container = forwardRef<
         <div className="flex flex-1 flex-col truncate">
           <div className="flex flex-row justify-between">
             <div className="flex min-h-6 grow flex-row items-center gap-1.5 truncate">
-              {header?.title && <CardTitle>{header?.title}</CardTitle>}
-              {header?.subtitle && (
-                <CardSubtitle>{header?.subtitle}</CardSubtitle>
+              {header.title && <CardTitle>{header.title}</CardTitle>}
+              {header.subtitle && (
+                <CardSubtitle>{header.subtitle}</CardSubtitle>
               )}
-              {header?.info && <CardInfo content={header?.info} />}
+              {header.info && <CardInfo content={header.info} />}
             </div>
-            {header?.link && (
+            {header.link && (
               <CardLink href={header.link.url} title={header.link.title} />
             )}
           </div>
-          {header?.comment && <CardComment>{header.comment}</CardComment>}
+          {header.comment && <CardComment>{header.comment}</CardComment>}
         </div>
       </CardHeader>
     )}

--- a/lib/components/Widgets/WidgetContainer/index.tsx
+++ b/lib/components/Widgets/WidgetContainer/index.tsx
@@ -15,8 +15,8 @@ import { cva, VariantProps } from "class-variance-authority"
 import { forwardRef, ReactNode } from "react"
 
 export interface WidgetContainerProps {
-  header: {
-    title: string
+  header?: {
+    title?: string
     subtitle?: string
     comment?: string
     info?: string
@@ -29,21 +29,25 @@ const Container = forwardRef<
   WidgetContainerProps & { children: ReactNode }
 >(({ header, children }, ref) => (
   <Card ref={ref}>
-    <CardHeader>
-      <div className="flex flex-1 flex-col truncate">
-        <div className="flex flex-row justify-between">
-          <div className="flex min-h-6 grow flex-row items-center gap-1.5 truncate">
-            <CardTitle>{header.title}</CardTitle>
-            {header.subtitle && <CardSubtitle>{header.subtitle}</CardSubtitle>}
-            {header.info && <CardInfo content={header.info} />}
+    {header && (
+      <CardHeader>
+        <div className="flex flex-1 flex-col truncate">
+          <div className="flex flex-row justify-between">
+            <div className="flex min-h-6 grow flex-row items-center gap-1.5 truncate">
+              {header?.title && <CardTitle>{header?.title}</CardTitle>}
+              {header?.subtitle && (
+                <CardSubtitle>{header?.subtitle}</CardSubtitle>
+              )}
+              {header?.info && <CardInfo content={header?.info} />}
+            </div>
+            {header?.link && (
+              <CardLink href={header.link.url} title={header.link.title} />
+            )}
           </div>
-          {header.link && (
-            <CardLink href={header.link.url} title={header.link.title} />
-          )}
+          {header?.comment && <CardComment>{header.comment}</CardComment>}
         </div>
-        {header.comment && <CardComment>{header.comment}</CardComment>}
-      </div>
-    </CardHeader>
+      </CardHeader>
+    )}
     <CardContent>{children}</CardContent>
   </Card>
 ))

--- a/lib/components/Widgets/WidgetStrip/index.tsx
+++ b/lib/components/Widgets/WidgetStrip/index.tsx
@@ -11,7 +11,7 @@ type DashboardProps = {
 const Container: React.FC<{ children: ReactNode }> = ({ children }) => (
   <div
     className={cn(
-      "flex min-h-72 flex-row items-stretch gap-4 [&>*]:min-w-96 [&>*]:max-w-lg [&>*]:flex-grow [&>*]:basis-0"
+      "flex min-h-48 flex-row items-stretch gap-4 [&>*]:min-w-96 [&>*]:max-w-lg [&>*]:flex-grow [&>*]:basis-0"
     )}
   >
     {children}


### PR DESCRIPTION
## 🚪 Why?
We have some usecase where we need to display numeric values without charts.
## 🔑 What?
This PR adds a `SummariesWidget` widget that can take `summaries` prop and displays  numeric values same as the `summaries` we are displaying for the other widgets with charts

## 📸 Visual proof

<img width="353" alt="image" src="https://github.com/user-attachments/assets/25379688-5bcd-47ae-8222-366facc1fd2c">

