### PR TITLE
Widget Gallery

### DIFF
--- a/lib/components/Widgets/WidgetGallery/index.stories.tsx
+++ b/lib/components/Widgets/WidgetGallery/index.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { Gallery } from "."
+import { AreaChartWidget } from "../Charts/AreaChartWidget"
+import { LineChartWidget } from "../Charts/LineChartWidget"
+import { PieChartWidget } from "../Charts/PieChartWidget"
+import { VerticalBarChartWidget } from "../Charts/VerticalBarChartWidget"
+
+import AreaChartWidgetStoriesMeta from "../Charts/AreaChartWidget/index.stories"
+import LineChartWidgetStoriesMeta from "../Charts/LineChartWidget/index.stories"
+import PieChartWidgetStoriesMeta from "../Charts/PieChartWidget/index.stories"
+import VerticalBarChartWidgetStoriesMeta from "../Charts/VerticalBarChartWidget/index.stories"
+
+const meta = {
+  component: Gallery,
+  tags: ["autodocs"],
+  args: {
+    items: [
+      { component: <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} /> },
+      { component: <LineChartWidget {...LineChartWidgetStoriesMeta.args} /> },
+      { component: <PieChartWidget {...PieChartWidgetStoriesMeta.args} /> },
+      {
+        component: (
+          <VerticalBarChartWidget {...VerticalBarChartWidgetStoriesMeta.args} />
+        ),
+      },
+    ],
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-[960px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Gallery>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const FullWidth: Story = {
+  args: {
+    items: [
+      {
+        component: <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} />,
+        fullWidth: true,
+      },
+      { component: <LineChartWidget {...LineChartWidgetStoriesMeta.args} /> },
+      { component: <PieChartWidget {...PieChartWidgetStoriesMeta.args} /> },
+      {
+        component: (
+          <VerticalBarChartWidget {...VerticalBarChartWidgetStoriesMeta.args} />
+        ),
+      },
+      { component: <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} /> },
+    ],
+  },
+}
+
+export const Skeleton: Story = {
+  render() {
+    return <Gallery.Skeleton />
+  },
+}

--- a/lib/components/Widgets/WidgetGallery/index.stories.tsx
+++ b/lib/components/Widgets/WidgetGallery/index.stories.tsx
@@ -2,19 +2,19 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { Gallery } from "."
 import { AreaChartWidget } from "../Charts/AreaChartWidget"
 import { LineChartWidget } from "../Charts/LineChartWidget"
-import { PieChartWidget } from "../Charts/PieChartWidget"
+import { RadialProgressWidget } from "../Charts/RadialProgressWidget"
 import { VerticalBarChartWidget } from "../Charts/VerticalBarChartWidget"
 
 import AreaChartWidgetStoriesMeta from "../Charts/AreaChartWidget/index.stories"
 import LineChartWidgetStoriesMeta from "../Charts/LineChartWidget/index.stories"
-import PieChartWidgetStoriesMeta from "../Charts/PieChartWidget/index.stories"
+import RadialProgressWidgetStoriesMeta from "../Charts/RadialProgressWidget/index.stories"
 import VerticalBarChartWidgetStoriesMeta from "../Charts/VerticalBarChartWidget/index.stories"
 
 const renderWidget = (index: number) => {
   const Widgets = [
     () => <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} />,
     () => <LineChartWidget {...LineChartWidgetStoriesMeta.args} />,
-    () => <PieChartWidget {...PieChartWidgetStoriesMeta.args} />,
+    () => <RadialProgressWidget {...RadialProgressWidgetStoriesMeta.args} />,
     () => (
       <VerticalBarChartWidget {...VerticalBarChartWidgetStoriesMeta.args} />
     ),
@@ -49,7 +49,7 @@ export const FullWidth: Story = {
     children: [
       <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} data-full-width />,
       <LineChartWidget {...LineChartWidgetStoriesMeta.args} />,
-      <PieChartWidget {...PieChartWidgetStoriesMeta.args} />,
+      <RadialProgressWidget {...RadialProgressWidgetStoriesMeta.args} />,
       <VerticalBarChartWidget {...VerticalBarChartWidgetStoriesMeta.args} />,
       <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} />,
     ],

--- a/lib/components/Widgets/WidgetGallery/index.stories.tsx
+++ b/lib/components/Widgets/WidgetGallery/index.stories.tsx
@@ -10,20 +10,25 @@ import LineChartWidgetStoriesMeta from "../Charts/LineChartWidget/index.stories"
 import PieChartWidgetStoriesMeta from "../Charts/PieChartWidget/index.stories"
 import VerticalBarChartWidgetStoriesMeta from "../Charts/VerticalBarChartWidget/index.stories"
 
+const renderWidget = (index: number) => {
+  const Widgets = [
+    () => <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} />,
+    () => <LineChartWidget {...LineChartWidgetStoriesMeta.args} />,
+    () => <PieChartWidget {...PieChartWidgetStoriesMeta.args} />,
+    () => (
+      <VerticalBarChartWidget {...VerticalBarChartWidgetStoriesMeta.args} />
+    ),
+  ]
+
+  const Component = Widgets[index % Widgets.length]
+  return <Component />
+}
+
 const meta = {
   component: Gallery,
   tags: ["autodocs"],
   args: {
-    items: [
-      { component: <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} /> },
-      { component: <LineChartWidget {...LineChartWidgetStoriesMeta.args} /> },
-      { component: <PieChartWidget {...PieChartWidgetStoriesMeta.args} /> },
-      {
-        component: (
-          <VerticalBarChartWidget {...VerticalBarChartWidgetStoriesMeta.args} />
-        ),
-      },
-    ],
+    children: Array.from({ length: 6 }).map((_, i) => renderWidget(i)),
   },
   decorators: [
     (Story) => (
@@ -41,19 +46,12 @@ export const Default: Story = {}
 
 export const FullWidth: Story = {
   args: {
-    items: [
-      {
-        component: <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} />,
-        fullWidth: true,
-      },
-      { component: <LineChartWidget {...LineChartWidgetStoriesMeta.args} /> },
-      { component: <PieChartWidget {...PieChartWidgetStoriesMeta.args} /> },
-      {
-        component: (
-          <VerticalBarChartWidget {...VerticalBarChartWidgetStoriesMeta.args} />
-        ),
-      },
-      { component: <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} /> },
+    children: [
+      <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} data-full-width />,
+      <LineChartWidget {...LineChartWidgetStoriesMeta.args} />,
+      <PieChartWidget {...PieChartWidgetStoriesMeta.args} />,
+      <VerticalBarChartWidget {...VerticalBarChartWidgetStoriesMeta.args} />,
+      <AreaChartWidget {...AreaChartWidgetStoriesMeta.args} />,
     ],
   },
 }

--- a/lib/components/Widgets/WidgetGallery/index.tsx
+++ b/lib/components/Widgets/WidgetGallery/index.tsx
@@ -1,0 +1,45 @@
+import { Blend, withSkeleton } from "@/lib/skeleton"
+import { WidgetContainer } from "../WidgetContainer"
+
+type GalleryProps = {
+  items?: GalleryItemProps[]
+}
+
+type GalleryItemProps = {
+  component: React.ReactNode
+  fullWidth?: boolean
+}
+
+const GalleryItem: React.FC<GalleryItemProps> = ({ component, fullWidth }) => (
+  <div
+    className={`${fullWidth ? "col-span-full" : "col-span-full sm:col-span-1"}`}
+  >
+    {component}
+  </div>
+)
+
+function GalleryComponent({ items = [] }: GalleryProps) {
+  return (
+    <div className="mx-auto w-full p-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {items.map((item: GalleryItemProps, index) => (
+          <GalleryItem key={index} {...item} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export const Gallery = withSkeleton(GalleryComponent, () => (
+  <Blend>
+    <GalleryComponent
+      items={[
+        ...Array(6)
+          .fill(null)
+          .map(() => ({
+            component: <WidgetContainer.Skeleton />,
+          })),
+      ]}
+    />
+  </Blend>
+))

--- a/lib/components/Widgets/WidgetGallery/index.tsx
+++ b/lib/components/Widgets/WidgetGallery/index.tsx
@@ -1,8 +1,10 @@
 import { Blend, withSkeleton } from "@/lib/skeleton"
+import React from "react"
 import { WidgetContainer } from "../WidgetContainer"
 
 type GalleryProps = {
   items?: GalleryItemProps[]
+  children?: React.ReactNode
 }
 
 type GalleryItemProps = {
@@ -18,11 +20,18 @@ const GalleryItem: React.FC<GalleryItemProps> = ({ component, fullWidth }) => (
   </div>
 )
 
-function GalleryComponent({ items = [] }: GalleryProps) {
+const GalleryComponent: React.FC<GalleryProps> = ({ children }) => {
+  const items = React.Children.map(children, (child) => {
+    const isFullWidth =
+      React.isValidElement(child) &&
+      child.props["data-full-width"] !== undefined
+    return { component: child, fullWidth: isFullWidth }
+  })
+
   return (
     <div className="mx-auto w-full p-4">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {items.map((item: GalleryItemProps, index) => (
+        {items?.map((item: GalleryItemProps, index: number) => (
           <GalleryItem key={index} {...item} />
         ))}
       </div>
@@ -32,14 +41,10 @@ function GalleryComponent({ items = [] }: GalleryProps) {
 
 export const Gallery = withSkeleton(GalleryComponent, () => (
   <Blend>
-    <GalleryComponent
-      items={[
-        ...Array(6)
-          .fill(null)
-          .map(() => ({
-            component: <WidgetContainer.Skeleton />,
-          })),
-      ]}
-    />
+    <GalleryComponent>
+      {Array.from({ length: 6 }, (_, index) => (
+        <WidgetContainer.Skeleton key={index} />
+      ))}
+    </GalleryComponent>
   </Blend>
 ))


### PR DESCRIPTION
Adds `Widget Gallery`, a layout component designed to display multiple widgets together in a grid, with the option to showcase a widget at full width.

This is a pretty simple implementation that can be expanded as needed. Some teams are already designing widgets using a grid layout, so this is just the first step toward implementing those designs.

<img width="876" alt="image" src="https://github.com/user-attachments/assets/7980a23d-2d72-4e69-811a-b2d6cf239844">