### PR TITLE
adjust area chart styling and aspect

### DIFF
--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -21,22 +21,7 @@ import { fixedForwardRef } from "../utils/forwardRef"
 import { prepareData } from "../utils/muncher"
 import { ChartConfig, ChartPropsBase, InferChartKeys } from "../utils/types"
 
-type allowedLineTypes =
-  | "basis"
-  | "basisClosed"
-  | "basisOpen"
-  | "bumpX"
-  | "bumpY"
-  | "bump"
-  | "linear"
-  | "linearClosed"
-  | "natural"
-  | "monotoneX"
-  | "monotoneY"
-  | "monotone"
-  | "step"
-  | "stepBefore"
-  | "stepAfter"
+type allowedLineTypes = "natural" | "linear" | "step" | "monotoneX"
 
 export type AreaChartProps<
   DataConfig extends ChartConfig = ChartConfig,

--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -1,4 +1,11 @@
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/ui/chart"
+import { cn } from "@/lib/utils"
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/ui/chart"
 import { nanoid } from "nanoid"
 import { ForwardedRef } from "react"
 import {
@@ -14,26 +21,28 @@ import { fixedForwardRef } from "../utils/forwardRef"
 import { prepareData } from "../utils/muncher"
 import { ChartConfig, ChartPropsBase, InferChartKeys } from "../utils/types"
 
+type allowedLineTypes =
+  | "basis"
+  | "basisClosed"
+  | "basisOpen"
+  | "bumpX"
+  | "bumpY"
+  | "bump"
+  | "linear"
+  | "linearClosed"
+  | "natural"
+  | "monotoneX"
+  | "monotoneY"
+  | "monotone"
+  | "step"
+  | "stepBefore"
+  | "stepAfter"
+
 export type AreaChartProps<
   DataConfig extends ChartConfig = ChartConfig,
   Keys extends string = InferChartKeys<DataConfig>,
 > = ChartPropsBase<DataConfig, Keys> & {
-  lineType?:
-    | "basis"
-    | "basisClosed"
-    | "basisOpen"
-    | "bumpX"
-    | "bumpY"
-    | "bump"
-    | "linear"
-    | "linearClosed"
-    | "natural"
-    | "monotoneX"
-    | "monotoneY"
-    | "monotone"
-    | "step"
-    | "stepBefore"
-    | "stepAfter"
+  lineType?: allowedLineTypes
   fullWidth?: boolean
   marginTop?: number
 }
@@ -127,6 +136,13 @@ export const _AreaChart = <
             strokeWidth={1.5}
           />
         ))}
+        {Object.keys(dataConfig).length > 1 && (
+          <ChartLegend
+            className={cn("flex justify-start", fullWidth && "ml-10")}
+            iconType="star"
+            content={<ChartLegendContent />}
+          />
+        )}
       </AreaChartPrimitive>
     </ChartContainer>
   )

--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -1,11 +1,4 @@
-import { cn } from "@/lib/utils"
-import {
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/ui/chart"
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/ui/chart"
 import { nanoid } from "nanoid"
 import { ForwardedRef } from "react"
 import {
@@ -25,7 +18,22 @@ export type AreaChartProps<
   DataConfig extends ChartConfig = ChartConfig,
   Keys extends string = InferChartKeys<DataConfig>,
 > = ChartPropsBase<DataConfig, Keys> & {
-  lineType?: "natural" | "linear" | "step"
+  lineType?:
+    | "basis"
+    | "basisClosed"
+    | "basisOpen"
+    | "bumpX"
+    | "bumpY"
+    | "bump"
+    | "linear"
+    | "linearClosed"
+    | "natural"
+    | "monotoneX"
+    | "monotoneY"
+    | "monotone"
+    | "step"
+    | "stepBefore"
+    | "stepAfter"
   fullWidth?: boolean
   marginTop?: number
 }
@@ -39,7 +47,7 @@ export const _AreaChart = <
     dataConfig,
     xAxis,
     yAxis,
-    lineType = "natural",
+    lineType = "monotoneX",
     aspect,
     fullWidth = false,
     marginTop = 0,
@@ -66,6 +74,7 @@ export const _AreaChart = <
             tickFormatter={xAxis?.tickFormatter}
             ticks={xAxis?.ticks}
             domain={xAxis?.domain}
+            interval={0}
           />
         )}
         {!yAxis?.hide && (
@@ -118,11 +127,6 @@ export const _AreaChart = <
             strokeWidth={1.5}
           />
         ))}
-        <ChartLegend
-          className={cn("flex justify-start", fullWidth && "ml-10")}
-          iconType="star"
-          content={<ChartLegendContent />}
-        />
       </AreaChartPrimitive>
     </ChartContainer>
   )

--- a/lib/components/Widgets/Charts/AreaChartWidget/index.tsx
+++ b/lib/components/Widgets/Charts/AreaChartWidget/index.tsx
@@ -10,7 +10,7 @@ export const AreaChartWidget = withSkeleton(
         ref={ref}
         {...props}
         chart={
-          <AreaChart aspect={null} yAxis={{ hide: true }} {...props.chart} />
+          <AreaChart aspect={"small"} yAxis={{ hide: true }} {...props.chart} />
         }
       />
     )

--- a/lib/components/Widgets/Charts/ChartContainer.tsx
+++ b/lib/components/Widgets/Charts/ChartContainer.tsx
@@ -1,8 +1,14 @@
 import { forwardRef, ReactNode } from "react"
 import { WidgetContainer, WidgetContainerProps } from "../WidgetContainer"
+import ChartCounter from "./chart-counter"
 
 export type ChartContainerPropsBase = WidgetContainerProps & {
-  summaries?: Array<{ label: string; value: number; unit?: string }>
+  summaries?: Array<{
+    label: string
+    value: number
+    prefixUnit?: string
+    postfixUnit?: string
+  }>
 }
 
 const Container = forwardRef<
@@ -20,8 +26,9 @@ const Container = forwardRef<
               {summary.label}
             </div>
             <div className="flex flex-row items-end gap-0.5 text-2xl font-semibold">
-              {summary.unit}
-              {summary.value}
+              {summary.prefixUnit && summary.prefixUnit}
+              <ChartCounter value={summary.value} />
+              {summary.postfixUnit && summary.postfixUnit}
             </div>
           </div>
         ))}

--- a/lib/components/Widgets/Charts/ChartContainer.tsx
+++ b/lib/components/Widgets/Charts/ChartContainer.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, ReactNode } from "react"
 import { WidgetContainer, WidgetContainerProps } from "../WidgetContainer"
-import ChartCounter from "./chart-counter"
 
 export type ChartContainerPropsBase = WidgetContainerProps & {
   summaries?: Array<{ label: string; value: number; unit?: string }>
@@ -20,18 +19,16 @@ const Container = forwardRef<
             <div className="mb-0.5 text-sm text-muted-foreground">
               {summary.label}
             </div>
-            <div className="flex flex-row items-end gap-0.5">
-              <ChartCounter value={summary.value} />
-              {summary.unit && (
-                <div className="text-sm leading-tight">{summary.unit}</div>
-              )}
+            <div className="flex flex-row items-end gap-0.5 text-2xl font-semibold">
+              {summary.unit}
+              {summary.value}
             </div>
           </div>
         ))}
       </div>
     )}
     {chart && (
-      <div className="relative flex min-h-40 grow items-stretch">{chart}</div>
+      <div className="relative flex grow items-stretch pt-6">{chart}</div>
     )}
   </WidgetContainer>
 ))

--- a/lib/components/Widgets/Charts/ChartContainer.tsx
+++ b/lib/components/Widgets/Charts/ChartContainer.tsx
@@ -28,7 +28,9 @@ const Container = forwardRef<
       </div>
     )}
     {chart && (
-      <div className="relative flex grow items-stretch pt-6">{chart}</div>
+      <div className="relative flex min-h-40 grow items-stretch pt-6">
+        {chart}
+      </div>
     )}
   </WidgetContainer>
 ))

--- a/lib/components/Widgets/Charts/chart-counter.tsx
+++ b/lib/components/Widgets/Charts/chart-counter.tsx
@@ -25,14 +25,14 @@ export default function ChartCounter({ value }: { value: number }) {
       springValue.on("change", (latest) => {
         if (ref.current) {
           ref.current.textContent = Intl.NumberFormat("en-US").format(
-            Math.round(latest)
+            parseFloat(latest.toFixed(2))
           )
         }
       }),
     [springValue]
   )
   return (
-    <div className="relative text-2xl font-medium tabular-nums leading-none">
+    <div className="relative pl-2">
       <div className="invisible" aria-hidden="true">
         {value}
       </div>

--- a/lib/components/Widgets/WidgetStrip/index.stories.tsx
+++ b/lib/components/Widgets/WidgetStrip/index.stories.tsx
@@ -151,7 +151,7 @@ export const EmployeesList: Story = {
           {
             label: "Rate",
             value: 20,
-            unit: "%",
+            postfixUnit: "%",
           },
         ]}
         chart={{

--- a/lib/components/Widgets/WidgetStrip/index.tsx
+++ b/lib/components/Widgets/WidgetStrip/index.tsx
@@ -11,7 +11,7 @@ type DashboardProps = {
 const Container: React.FC<{ children: ReactNode }> = ({ children }) => (
   <div
     className={cn(
-      "flex min-h-48 flex-row items-stretch gap-4 [&>*]:min-w-96 [&>*]:max-w-lg [&>*]:flex-grow [&>*]:basis-0"
+      "flex min-h-40 flex-row items-stretch gap-4 [&>*]:min-w-96 [&>*]:max-w-lg [&>*]:flex-grow [&>*]:basis-0"
     )}
   >
     {children}

--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -9,7 +9,7 @@ const variants = cva("", {
     aspect: {
       square: "aspect-square",
       wide: "aspect-video",
-      small: "h-20",
+      small: "h-40",
     },
   },
 })

--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -9,6 +9,7 @@ const variants = cva("", {
     aspect: {
       square: "aspect-square",
       wide: "aspect-video",
+      small: "h-20",
     },
   },
 })


### PR DESCRIPTION
## 🚪 Why?
- I needed to add a new aspect to the area chart.
- The current line type caused the area chart lines to goes above the max value or below the min value if the values between the ticks fluctuates between the min and max. 

## 🔑 What?
- Add a new aspect `small` and use by default for the area chart widget
- Add `recharts` line types and use `monotoneX` as a default line type
- Fix the summary value when the value is decimal
- Always show the x axis ticks by setting `interval` to 0. This is required as using the default value `preserveEnd ` could potential drop some ticks from the x axis.
- Show the area chart legend only if we have more than 1 area, and hide it otherwise
## 📸 Visual proof
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/61b6d3dc-0940-4e7f-94d9-c96c80c7db2e">
