### PR TITLE
Fix to allow charts be responsive

### DIFF
--- a/lib/components/Charts/AreaChart/index.stories.tsx
+++ b/lib/components/Charts/AreaChart/index.stories.tsx
@@ -33,7 +33,7 @@ const meta: Meta<typeof AreaChart<typeof dataConfig>> = {
   },
   decorators: [
     (Story) => (
-      <div className="max-w-80">
+      <div className="h-52 w-full">
         <Story />
       </div>
     ),

--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof BarChart<typeof dataConfig>> = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <div className="max-w-96">
+      <div className="w-100 h-52">
         <Story />
       </div>
     ),

--- a/lib/components/Charts/CategoryBarChart/index.stories.tsx
+++ b/lib/components/Charts/CategoryBarChart/index.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <div className="max-w-80">
+      <div className="w-100 h-12">
         <Story />
       </div>
     ),

--- a/lib/components/Charts/LineChart/index.stories.tsx
+++ b/lib/components/Charts/LineChart/index.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof LineChart<typeof singleDataConfig>> = {
   },
   decorators: [
     (Story) => (
-      <div className="max-w-80">
+      <div className="h-52 w-full">
         <Story />
       </div>
     ),

--- a/lib/components/Charts/PieChart/index.stories.tsx
+++ b/lib/components/Charts/PieChart/index.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof PieChart> = {
   },
   decorators: [
     (Story) => (
-      <div className="max-w-80">
+      <div className="h-52 w-full">
         <Story />
       </div>
     ),

--- a/lib/components/Charts/RadialProgressChart/index.stories.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof RadialProgressChart> = {
   },
   decorators: [
     (Story) => (
-      <div className="max-w-80">
+      <div className="h-52 w-full">
         <Story />
       </div>
     ),

--- a/lib/components/Charts/RadialProgressChart/index.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.tsx
@@ -21,7 +21,7 @@ export function RadialProgressChart({
   const progressOffset = ((max - Math.min(value, max)) / max) * circumference
 
   return (
-    <div className="relative inline-flex aspect-video items-center justify-center overflow-hidden">
+    <div className="relative inline-flex aspect-auto h-full w-full items-center justify-center overflow-hidden">
       <svg
         viewBox={`0 0 ${size} ${size}`}
         className="h-full w-full -rotate-90 transform"

--- a/lib/components/Charts/VerticalBarChart/index.stories.tsx
+++ b/lib/components/Charts/VerticalBarChart/index.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof VerticalBarChart<typeof dataConfig>> = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <div className="max-w-96">
+      <div className="h-52 w-full">
         <Story />
       </div>
     ),

--- a/lib/components/Widgets/Charts/ChartContainer.tsx
+++ b/lib/components/Widgets/Charts/ChartContainer.tsx
@@ -11,9 +11,7 @@ const Container = forwardRef<
 >(({ chart, summaries, ...props }, ref) => (
   <WidgetContainer ref={ref} {...props} summaries={summaries}>
     {chart && (
-      <div className="relative flex min-h-40 grow items-stretch pt-6">
-        {chart}
-      </div>
+      <div className="relative flex h-52 grow items-stretch pt-6">{chart}</div>
     )}
   </WidgetContainer>
 ))

--- a/lib/components/Widgets/Charts/RadialProgressWidget/index.tsx
+++ b/lib/components/Widgets/Charts/RadialProgressWidget/index.tsx
@@ -20,7 +20,7 @@ export const RadialProgressWidget = withSkeleton(
   forwardRef<HTMLDivElement, RadialProgressWidgetProps>(
     ({ header, chart }, ref) => (
       <WidgetContainer ref={ref} header={header}>
-        <div className="flex h-full items-center justify-center">
+        <div className="flex h-40 items-center justify-center">
           <RadialProgressChart {...chart} />
         </div>
       </WidgetContainer>

--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -70,7 +70,7 @@ const ChartContainerComponent = (
     id,
     className,
     children,
-    aspect = "wide",
+    aspect,
     config,
     ...props
   }: ChartContainerComponentProps,
@@ -85,8 +85,8 @@ const ChartContainerComponent = (
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex w-full justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line-line]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
-          variants({ aspect }),
+          "flex w-full justify-center align-middle text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line-line]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          aspect ? variants({ aspect }) : "aspect-auto h-full",
           className
         )}
         {...props}


### PR DESCRIPTION
## 🚪 Why?

To have responsive charts. Now we have by default "aspect: wide" (aspect-ratio: 16/9) this makes imposible that a line chart expand only in one direction. So for example a line chart that I want to be just 200px height and allow to expand full width is not posible, but the library recharts allow it: https://recharts.org/en-US/examples/ComposedResponsiveContainer
But we are wrapping the "ResponsiveContainer" with an aspect ratio loosing this responsive feature.

## 🔑 What?

* Remove the default aspect: wide
* If aspect is not given, then add css aspect-auto and h-full to let "Responsive" component to act correctly
* Modify stories to fix a nice height
* modify widgets to fix a height


https://github.com/user-attachments/assets/4d54a42e-8b2f-4a1a-bc5a-c2b3d9e67669


