### PR TITLE
Add Progress Bar component

### DIFF
--- a/lib/components/Charts/ProgressChart/index.stories.tsx
+++ b/lib/components/Charts/ProgressChart/index.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { ProgressBar } from "."
+
+const meta = {
+  component: ProgressBar,
+  tags: ["autodocs"],
+  args: {
+    value: 60,
+    label: "Label",
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-80">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ProgressBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/lib/components/Charts/ProgressChart/index.tsx
+++ b/lib/components/Charts/ProgressChart/index.tsx
@@ -25,8 +25,8 @@ export function ProgressBar({
           value={percentage}
           className="w-full"
           aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={percentage}
+          aria-valuemax={max}
+          aria-valuenow={value}
           aria-label={`${percentage.toFixed(1)}%`}
         />
       </div>

--- a/lib/components/Charts/ProgressChart/index.tsx
+++ b/lib/components/Charts/ProgressChart/index.tsx
@@ -3,26 +3,35 @@ import { autoColor } from "../utils/colors"
 
 export interface ProgressBarProps {
   value: number
+  max?: number
   label?: string
   color?: string
 }
 
-export function ProgressBar({ value, label, color }: ProgressBarProps) {
+export function ProgressBar({
+  value,
+  max = 100,
+  label,
+  color,
+}: ProgressBarProps) {
   const barColor = color || autoColor(0)
+  const percentage = (value / max) * 100
+
   return (
-    <div className={`flex items-center space-x-2`}>
+    <div className="flex items-center space-x-2" aria-live="polite">
       <div className="flex-grow">
         <Progress
           color={barColor}
-          value={value}
+          value={percentage}
           className="w-full"
-          aria-label={`${value}%`}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={percentage}
+          aria-label={`${percentage.toFixed(1)}%`}
         />
       </div>
       {label && (
-        <div className="flex-shrink-0 text-sm font-medium" aria-live="polite">
-          {label}
-        </div>
+        <div className="flex-shrink-0 text-sm font-medium">{label}</div>
       )}
     </div>
   )

--- a/lib/components/Charts/ProgressChart/index.tsx
+++ b/lib/components/Charts/ProgressChart/index.tsx
@@ -1,0 +1,29 @@
+import { Progress } from "@/ui/progress"
+import { autoColor } from "../utils/colors"
+
+export interface ProgressBarProps {
+  value: number
+  label?: string
+  color?: string
+}
+
+export function ProgressBar({ value, label, color }: ProgressBarProps) {
+  const barColor = color || autoColor(0)
+  return (
+    <div className={`flex items-center space-x-2`}>
+      <div className="flex-grow">
+        <Progress
+          color={barColor}
+          value={value}
+          className="w-full"
+          aria-label={`${value}%`}
+        />
+      </div>
+      {label && (
+        <div className="flex-shrink-0 text-sm font-medium" aria-live="polite">
+          {label}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/ui/progress.tsx
+++ b/lib/ui/progress.tsx
@@ -18,7 +18,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className={`h-full w-full flex-1 transition-all`}
+      className="h-full w-full flex-1 transition-all"
       style={{
         backgroundColor: props.color,
         transform: `translateX(-${100 - (value || 0)}%)`,

--- a/lib/ui/progress.tsx
+++ b/lib/ui/progress.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className={`h-full w-full flex-1 transition-all`}
+      style={{
+        backgroundColor: props.color,
+        transform: `translateX(-${100 - (value || 0)}%)`,
+      }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@factorialco/factorial-one",
       "version": "0.0.1",
       "dependencies": {
+        "@radix-ui/react-progress": "^1.1.0",
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0"
       },
@@ -4665,6 +4666,30 @@
       "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
       "dependencies": {
         "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.0.tgz",
+      "integrity": "sha512-aSzvnYpP725CROcxAOEBVZZSIQVQdHgBr2QQFKySsaD14u8dNT0batuXI+AAGDdAHfXH8rbnHmjYFqVJ21KkRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "date-fns": "^3.6.0",
     "framer-motion": "^11.3.17",
     "lucide-react": "^0.383.0",
+    "nanoid": "^5.0.7",
     "react": "18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "18.3.1",
@@ -67,8 +68,7 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.5.3",
     "usehooks-ts": "^3.1.0",
-    "zod": "^3.23.8",
-    "nanoid": "^5.0.7"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.6.1",
@@ -120,6 +120,7 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
+    "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0"
   }


### PR DESCRIPTION
Adds a `Progress Bar` component, which is essential for the Employee Profile and Insights.

![image](https://github.com/user-attachments/assets/8d48cc3a-df88-46d9-8c72-ed43c467b007)

This `Progress Bar` serves as a wrapper for the `Progress` shadcn component, adding a bit more functionality, similar to what we do with our Button component, for example.

The component allows the user to define a label displayed to its right, and the color is customizable (or it defaults to one of our chart colors if not specified), exactly as we have in [Figma](https://www.figma.com/design/O8578qyVUfgzm6ZkVkBJwW/%E2%8C%9B%EF%B8%8F-Charts-UI-Kit-2.0?node-id=604-42741&t=c8rb5Q5q1GFByc3a-4).