### PR TITLE
add type prop to stacked bars

### DIFF
--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -71,3 +71,47 @@ export const MultipleValues: Meta<typeof BarChart<typeof dataMultiConfig>> = {
     },
   },
 }
+
+const financialDataConfig = {
+  profit: {
+    label: "Profit",
+  },
+  losses: {
+    label: "Losses",
+  },
+}
+
+export const FinancialValues: Meta<
+  typeof BarChart<typeof financialDataConfig>
+> = {
+  args: {
+    type: "stacked-by-sign",
+    dataConfig: financialDataConfig,
+    data: [
+      {
+        label: "January",
+        values: { profit: 4000, losses: -1200 },
+      },
+      {
+        label: "February",
+        values: { profit: 3200, losses: -800 },
+      },
+      {
+        label: "March",
+        values: { profit: 5000, losses: -3000 },
+      },
+      {
+        label: "April",
+        values: { profit: 7000, losses: -1000 },
+      },
+      {
+        label: "May",
+        values: { profit: 4500, losses: -1500 },
+      },
+    ],
+    xAxis: {
+      hide: false,
+      tickFormatter: (value: string) => value.slice(0, 3),
+    },
+  },
+}

--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -113,5 +113,9 @@ export const FinancialValues: Meta<
       hide: false,
       tickFormatter: (value: string) => value.slice(0, 3),
     },
+    yAxis: {
+      hide: false,
+      tickFormatter: (value: string) => value + " €",
+    },
   },
 }

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -48,7 +48,10 @@ const _BarChart = <K extends ChartConfig>(
         margin={{ left: 12, right: 12, top: label ? 24 : 0 }}
         stackOffset={type === "stacked-by-sign" ? "sign" : undefined}
       >
-        <ChartTooltip cursor content={<ChartTooltipContent />} />
+        <ChartTooltip
+          cursor
+          content={<ChartTooltipContent yAxisFormatter={yAxis.tickFormatter} />}
+        />
         <CartesianGrid {...cartesianGridProps()} />
         <YAxis {...yAxisProps(yAxis)} hide={yAxis?.hide} />
         <XAxis {...xAxisProps(xAxis)} hide={xAxis?.hide} />

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -67,7 +67,7 @@ const _BarChart = <K extends ChartConfig>(
                 : undefined
             }
             fill={dataConfig[key].color || autoColor(index)}
-            radius={4}
+            radius={[4, 4, 0, 0]}
             maxBarSize={32}
           >
             {label && (

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -67,7 +67,7 @@ const _BarChart = <K extends ChartConfig>(
                 : undefined
             }
             fill={dataConfig[key].color || autoColor(index)}
-            radius={[4, 4, 0, 0]}
+            radius={type === "stacked-by-sign" ? [4, 4, 0, 0] : 4}
             maxBarSize={32}
           >
             {label && (

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -22,6 +22,7 @@ import { ChartPropsBase } from "../utils/types"
 
 export type BarChartProps<K extends ChartConfig = ChartConfig> =
   ChartPropsBase<K> & {
+    type?: "simple" | "stacked" | "stacked-by-sign"
     label?: boolean
   }
 
@@ -32,6 +33,7 @@ const _BarChart = <K extends ChartConfig>(
     xAxis,
     yAxis = { hide: true },
     label = false,
+    type = "simple",
     aspect,
   }: BarChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
@@ -44,6 +46,7 @@ const _BarChart = <K extends ChartConfig>(
         accessibilityLayer
         data={prepareData(data)}
         margin={{ left: 12, right: 12, top: label ? 24 : 0 }}
+        stackOffset={type === "stacked-by-sign" ? "sign" : undefined}
       >
         <ChartTooltip cursor content={<ChartTooltipContent />} />
         <CartesianGrid {...cartesianGridProps()} />
@@ -55,6 +58,11 @@ const _BarChart = <K extends ChartConfig>(
             key={`bar-${key}`}
             isAnimationActive={false}
             dataKey={key}
+            stackId={
+              type === "stacked" || type === "stacked-by-sign"
+                ? "stack"
+                : undefined
+            }
             fill={dataConfig[key].color || autoColor(index)}
             radius={4}
             maxBarSize={32}

--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -174,11 +174,6 @@ const ChartTooltipContent = React.forwardRef<
   ) => {
     const { config } = useChart()
 
-    console.log("config", config)
-    console.log("nameKey", nameKey)
-    console.log("payload", payload)
-    console.log("labelKey", labelKey)
-
     const tooltipLabel = React.useMemo(() => {
       if (hideLabel || !payload?.length) {
         return null

--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -150,6 +150,7 @@ const ChartTooltipContent = React.forwardRef<
       indicator?: "line" | "dot" | "dashed"
       nameKey?: string
       labelKey?: string
+      yAxisFormatter?: (value: string) => string
     }
 >(
   (
@@ -164,6 +165,7 @@ const ChartTooltipContent = React.forwardRef<
       labelFormatter,
       labelClassName,
       formatter,
+      yAxisFormatter,
       color,
       nameKey,
       labelKey,
@@ -171,6 +173,11 @@ const ChartTooltipContent = React.forwardRef<
     ref
   ) => {
     const { config } = useChart()
+
+    console.log("config", config)
+    console.log("nameKey", nameKey)
+    console.log("payload", payload)
+    console.log("labelKey", labelKey)
 
     const tooltipLabel = React.useMemo(() => {
       if (hideLabel || !payload?.length) {
@@ -279,7 +286,9 @@ const ChartTooltipContent = React.forwardRef<
                       </div>
                       {item.value && (
                         <span className="font-mono font-medium tabular-nums text-f1-foreground">
-                          {item.value.toLocaleString()}
+                          {yAxisFormatter
+                            ? yAxisFormatter(String(item.value))
+                            : item.value.toLocaleString()}
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
## 🚪 Why?

In finance we need to stack by sign (and add a line xD)
[Figma](https://www.figma.com/design/sjXPhNmfJI3OnVpWmfn6Lc/Accounts-Payable?node-id=2069-104049&node-type=FRAME&t=lZTzqOFb7KJNsu2r-0)


## 🔑 What?

Add a prop "type" (by default "simple") in bar charts, to can choose between (normal, stacked, stacked by sign)


https://github.com/user-attachments/assets/ad9433fb-8a50-4b55-ad80-e9a438e05ee6

Also add a feature to use same yAxis.tickFormatter, to format values in tooltip

![Screenshot 2024-09-04 at 09 34 50](https://github.com/user-attachments/assets/9a353e60-2274-4c7c-90cc-5e4c631526cc)

Fix radius (only in extremes)
![Screenshot 2024-09-16 at 10 40 10](https://github.com/user-attachments/assets/6013e0b8-5ab1-4b33-908b-9c33eb788e47)



