### PR TITLE
Introduce typography scale

### DIFF
--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -1,0 +1,33 @@
+import { Meta, Unstyled } from "@storybook/blocks"
+
+<Meta title="essentials/Typography" />
+
+# Typography
+
+The typography comprises five predefined font sizes. The base font size of the
+app is 14px when used with the default browser settings.
+
+<Unstyled>
+  <div className="grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-4">
+    <p className="text-right text-sm text-gray-600">
+      <pre className="inline">text-2xl</pre>, 26px
+    </p>
+    <p className="text-2xl">The quick brown fox jumped over the lazy dog.</p>
+    <p className="text-right text-sm text-gray-600">
+      <pre className="inline">text-xl</pre>, 22px
+    </p>
+    <p className="text-xl">The quick brown fox jumped over the lazy dog.</p>
+    <p className="text-right text-sm text-gray-600">
+      <pre className="inline">text-lg</pre>, 16px
+    </p>
+    <p className="text-lg">The quick brown fox jumped over the lazy dog.</p>
+    <p className="text-right text-sm text-gray-600">
+      <pre className="inline">text-base</pre>, 14px
+    </p>
+    <p>The quick brown fox jumped over the lazy dog.</p>
+    <p className="text-right text-sm text-gray-600">
+      <pre className="inline">text-sm</pre>, 12px
+    </p>
+    <p className="text-sm">The quick brown fox jumped over the lazy dog.</p>
+  </div>
+</Unstyled>

--- a/lib/components/Charts/PieChart/index.tsx
+++ b/lib/components/Charts/PieChart/index.tsx
@@ -61,7 +61,7 @@ export const _PieChart = (
                     <tspan
                       x={viewBox.cx}
                       y={(viewBox.cy || 0) + 8}
-                      className="fill-foreground text-3xl font-semibold"
+                      className="fill-foreground text-2xl font-semibold"
                     >
                       {overview?.number}
                     </tspan>

--- a/lib/components/Charts/RadialProgressChart/index.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.tsx
@@ -48,10 +48,10 @@ export function RadialProgressChart({
       </svg>
       {overview && (
         <div className="absolute inset-0 flex translate-y-0.5 flex-col items-center justify-center">
-          <span className="text-xs text-muted-foreground">
+          <span className="text-sm text-muted-foreground">
             {overview.label}
           </span>
-          <span className="text-3xl font-semibold leading-none text-foreground">
+          <span className="text-2xl font-semibold leading-none text-foreground">
             {overview.number}
           </span>
         </div>

--- a/lib/components/Widgets/WidgetContainer/index.tsx
+++ b/lib/components/Widgets/WidgetContainer/index.tsx
@@ -68,7 +68,7 @@ const Container = forwardRef<
               <div className="mb-0.5 text-sm text-muted-foreground">
                 {summary.label}
               </div>
-              <div className="flex flex-row items-end gap-0.5 text-2xl font-semibold">
+              <div className="flex flex-row items-end gap-0.5 text-xl font-semibold">
                 {!!summary.prefixUnit && (
                   <div className="text-lg font-medium">
                     {summary.prefixUnit}

--- a/lib/lib/xray.tsx
+++ b/lib/lib/xray.tsx
@@ -111,7 +111,7 @@ const wrapperVariants = cva(
 )
 
 const tagVariants = cva(
-  "absolute z-40 bg-opacity-50 px-2 py-1 text-xs uppercase",
+  "absolute z-40 bg-opacity-50 px-2 py-1 text-sm uppercase",
   {
     variants: {
       type: {

--- a/lib/ui/avatar.tsx
+++ b/lib/ui/avatar.tsx
@@ -22,8 +22,8 @@ const avatarVariants = cva("relative flex shrink-0 overflow-hidden", {
       small: "h-10 w-10 rounded-xl text-sm",
       medium: "h-12 w-12 rounded-xl",
       large: "h-16 w-16 rounded-2xl text-xl",
-      xlarge: "h-20 w-20 rounded-2xl text-2xl",
-      xxlarge: "h-32 w-32 rounded-3xl text-3xl",
+      xlarge: "h-20 w-20 rounded-2xl text-xl",
+      xxlarge: "h-32 w-32 rounded-3xl text-2xl",
     } satisfies Record<(typeof sizes)[number], string>,
   },
   defaultVariants: {

--- a/lib/ui/badge.tsx
+++ b/lib/ui/badge.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border border-solid px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-full border border-solid px-2.5 py-0.5 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {

--- a/lib/ui/card.tsx
+++ b/lib/ui/card.tsx
@@ -137,7 +137,7 @@ const CardComment = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("mt-2 flex text-2xl", className)} {...props} />
+  <div ref={ref} className={cn("mt-2 flex text-xl", className)} {...props} />
 ))
 CardFooter.displayName = "CardComment"
 

--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -85,7 +85,7 @@ const ChartContainerComponent = (
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex w-full justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line-line]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex w-full justify-center text-sm [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line-line]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           variants({ aspect }),
           className
         )}

--- a/lib/ui/dropdown-menu.tsx
+++ b/lib/ui/dropdown-menu.tsx
@@ -173,7 +173,7 @@ const DropdownMenuShortcut = ({
 }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      className={cn("ml-auto text-sm tracking-widest opacity-60", className)}
       {...props}
     />
   )

--- a/lib/ui/tooltip.tsx
+++ b/lib/ui/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-lg bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 overflow-hidden rounded-lg bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}

--- a/src/app-layout.tsx
+++ b/src/app-layout.tsx
@@ -66,7 +66,7 @@ export const AppLayout: React.FC<{ children: React.ReactNode }> = ({
               </Stack>
 
               <Stack>
-                <div className="my-2 px-1.5 pb-1 text-xs font-medium uppercase text-secondary-foreground/70">
+                <div className="my-2 px-1.5 pb-1 text-sm font-medium uppercase text-secondary-foreground/70">
                   You
                 </div>
 
@@ -111,7 +111,7 @@ export const AppLayout: React.FC<{ children: React.ReactNode }> = ({
                 </div>
               </Stack>
               <Stack>
-                <div className="my-2 px-1.5 pb-1 text-xs font-medium uppercase text-secondary-foreground/70">
+                <div className="my-2 px-1.5 pb-1 text-sm font-medium uppercase text-secondary-foreground/70">
                   Your company
                 </div>
 

--- a/src/playground/Pages/Header/index.tsx
+++ b/src/playground/Pages/Header/index.tsx
@@ -14,7 +14,7 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(
       <div className="flex px-10 py-6" ref={ref}>
         <Avatar size="xlarge" src={src} alt={alt} />
         <div className="flex flex-col gap-2 pl-5">
-          <h1 className="pt-2 text-2xl font-medium text-foreground">{title}</h1>
+          <h1 className="pt-2 text-xl font-medium text-foreground">{title}</h1>
           <h2 className="text-lg font-normal text-intermediate">{subtitle}</h2>
         </div>
       </div>

--- a/src/playground/Weekdays/index.tsx
+++ b/src/playground/Weekdays/index.tsx
@@ -32,7 +32,7 @@ export const Weekdays = forwardRef<HTMLDivElement, WeekdaysProps>(
             value={day}
             className="h-6 w-6 disabled:bg-muted disabled:text-card-foreground disabled:opacity-100 disabled:data-[state=on]:bg-secondary-foreground disabled:data-[state=on]:text-card"
           >
-            <p className="h-auto text-xs">{day[0]}</p>
+            <p className="h-auto text-sm">{day[0]}</p>
           </ToggleGroupItem>
         ))}
       </ToggleGroup>

--- a/src/playground/Widgets/ProgressSection/index.tsx
+++ b/src/playground/Widgets/ProgressSection/index.tsx
@@ -41,7 +41,7 @@ export function ProgressSection({
           {label}
         </span>
         <div className="flex items-baseline gap-2">
-          <span className="text-2xl font-bold text-foreground">
+          <span className="text-xl font-bold text-foreground">
             {value}
             {unit}
             {showMax && ` / ${max}${unit}`}

--- a/src/playground/Widgets/ui/indicator.tsx
+++ b/src/playground/Widgets/ui/indicator.tsx
@@ -15,7 +15,7 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
       <div key={label} className="grid-row-2 col-span-1 grid" ref={ref}>
         <p className="font-medium text-intermediate">{label}</p>
         <div className="flex items-center gap-1">
-          <p className="text-2xl font-semibold">{count}</p>
+          <p className="text-xl font-semibold">{count}</p>
           {icon && (
             <span className={cn("flex", color)}>
               <Icon icon={icon} size="md" />

--- a/styles.css
+++ b/styles.css
@@ -133,10 +133,6 @@
   }
 }
 
-html {
-  font-size: 15px;
-}
-
 body {
   @apply font-sans text-base text-foreground;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,7 @@ export default {
     "./app/**/*.{ts,tsx}",
     "./src/**/*.{ts,tsx}",
     "./lib/**/*.{ts,tsx}",
+    "./docs/**/*.mdx",
   ],
   prefix: "",
   theme: {
@@ -23,6 +24,42 @@ export default {
     },
     fontFamily: {
       sans: ["Inter", "sans-serif"],
+    },
+    fontSize: {
+      sm: [
+        ".75rem",
+        {
+          lineHeight: "1rem",
+        },
+      ],
+      base: [
+        ".875rem",
+        {
+          lineHeight: "1.25rem",
+          letterSpacing: "-0.005em",
+        },
+      ],
+      lg: [
+        "1rem",
+        {
+          lineHeight: "1.5rem",
+          letterSpacing: "-0.01em",
+        },
+      ],
+      xl: [
+        "1.375rem",
+        {
+          lineHeight: "1.75rem",
+          letterSpacing: "-0.01em",
+        },
+      ],
+      "2xl": [
+        "1.625rem",
+        {
+          lineHeight: "2rem",
+          letterSpacing: "-0.01em",
+        },
+      ],
     },
     spacing: {
       px: "1px",


### PR DESCRIPTION

![CleanShot 2024-09-06 at 16 14 06@2x](https://github.com/user-attachments/assets/af871ddd-2a0c-4467-aa9e-ca2342c3a4cf)

## 🚪 Why?

We are setting up foundations of the design system: colors, spaces, typography, etc.

## 🔑 What?

- sets a font scale in the Tailwind theme; We now have only 5 allowed font sizes for external users
- adds a basic documentation page
- removes the 15px font-size set to the root of the page
- adjusts font-sizes of existing components

Factorial app uses fixed font size scale set in pixels. The new scale, in contrary, uses relative units to provide better accessibility. This approach will not create any style mismatches when used together with the old design system.

## 🏡 Context

- [🎨 Typography in Figma](https://www.figma.com/design/b0A4ttd9C576bp2roJh0hX/Foundations?node-id=1-2&t=RaffcNrezm0ObtqA-1)
