### PR TITLE
fix: remove empty nodes separator

### DIFF
--- a/lib/components/Widgets/WidgetContainer/index.spec.tsx
+++ b/lib/components/Widgets/WidgetContainer/index.spec.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react"
+import { Fragment } from "react"
+import { expect, test } from "vitest"
+import { WidgetContainer } from "."
+
+const renderWidgetContainer = () => {
+  return render(
+    <WidgetContainer>
+      <></>
+      <Fragment></Fragment>
+      {false && <p>asd</p>}
+      {null}
+      {undefined}
+      <p>1</p>
+      <p>2</p>
+      <p>3</p>
+      <></>
+      <Fragment></Fragment>
+      {false && <p>asd</p>}
+      {null}
+      {undefined}
+    </WidgetContainer>
+  )
+}
+
+test("only valid elements are rendered", async () => {
+  renderWidgetContainer()
+
+  const paragraphs = screen.getAllByText(/.+/)
+  expect(paragraphs).toHaveLength(3)
+})
+
+test("there is one separator between each valid element", async () => {
+  renderWidgetContainer()
+
+  const separators = screen.queryAllByRole("separator")
+  expect(separators).toHaveLength(2)
+})

--- a/lib/components/Widgets/WidgetContainer/index.stories.tsx
+++ b/lib/components/Widgets/WidgetContainer/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 
 import { Placeholder } from "@/lib/storybook-utils"
 import { fn } from "@storybook/test"
-import { ComponentProps, Fragment } from "react"
+import { ComponentProps } from "react"
 import { WidgetContainer } from "."
 
 const meta = {
@@ -74,32 +74,6 @@ export const MultipleContent: Story = {
           Content {index + 1}
         </div>
       )),
-    ],
-  },
-}
-
-export const MultipleContentWihNulls: Story = {
-  args: {
-    ...meta.args,
-    children: [
-      undefined,
-      null,
-      false,
-      <Fragment></Fragment>,
-      <></>,
-      Array.from({ length: 3 }).map((_, index) => (
-        <div
-          key={index}
-          className="rounded-lg bg-muted p-3 text-center text-foreground"
-        >
-          Content {index + 1}
-        </div>
-      )),
-      undefined,
-      null,
-      false,
-      <Fragment></Fragment>,
-      <></>,
     ],
   },
 }

--- a/lib/components/Widgets/WidgetContainer/index.stories.tsx
+++ b/lib/components/Widgets/WidgetContainer/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 
 import { Placeholder } from "@/lib/storybook-utils"
 import { fn } from "@storybook/test"
-import { ComponentProps } from "react"
+import { ComponentProps, Fragment } from "react"
 import { WidgetContainer } from "."
 
 const meta = {
@@ -74,6 +74,32 @@ export const MultipleContent: Story = {
           Content {index + 1}
         </div>
       )),
+    ],
+  },
+}
+
+export const MultipleContentWihNulls: Story = {
+  args: {
+    ...meta.args,
+    children: [
+      undefined,
+      null,
+      false,
+      <Fragment></Fragment>,
+      <></>,
+      Array.from({ length: 3 }).map((_, index) => (
+        <div
+          key={index}
+          className="rounded-lg bg-muted p-3 text-center text-foreground"
+        >
+          Content {index + 1}
+        </div>
+      )),
+      undefined,
+      null,
+      false,
+      <Fragment></Fragment>,
+      <></>,
     ],
   },
 }

--- a/lib/components/Widgets/WidgetContainer/index.tsx
+++ b/lib/components/Widgets/WidgetContainer/index.tsx
@@ -44,6 +44,17 @@ const Container = forwardRef<
   HTMLDivElement,
   WidgetContainerProps & { children: ReactNode }
 >(({ header, alert, children, action, summaries }, ref) => {
+  const isRealNode = (node: React.ReactNode): boolean => {
+    return (
+      !!node &&
+      !(
+        React.isValidElement(node) &&
+        node.type === React.Fragment &&
+        React.Children.count(node.props.children) === 0
+      )
+    )
+  }
+
   return (
     <Card ref={ref}>
       {header && (
@@ -108,12 +119,16 @@ const Container = forwardRef<
             ))}
           </div>
         )}
-        {React.Children.toArray(children).map((child, index, array) => (
-          <>
-            {child}
-            {index < array.length - 1 && <Separator />}
-          </>
-        ))}
+        {React.Children.toArray(children)
+          .filter(isRealNode)
+          .map((child, index) => {
+            return (
+              <>
+                {index > 0 && <Separator />}
+                {child}
+              </>
+            )
+          })}
       </CardContent>
       {(action || alert) && (
         <CardFooter>

--- a/lib/ui/separator.tsx
+++ b/lib/ui/separator.tsx
@@ -7,6 +7,7 @@ export const Separator = forwardRef<
   return (
     <div
       ref={ref}
+      role="separator"
       className="my-4 h-[1px] w-full"
       style={{
         backgroundImage:


### PR DESCRIPTION
## 🚪 Why?

In some cases we have conditional parts of a widget that should not show a separator

## 🔑 What?

We check that the node actually has any content

## 🏡 Context

https://www.figma.com/design/9pLsRzdinid0ha0qRWta2D/Employee-Profile?node-id=604-7408&node-type=frame&t=vOiPf49zpJBIE1r9-0

<img width="476" alt="image" src="https://github.com/user-attachments/assets/36dd4a00-7deb-4697-8135-32e3dcf01671">
