### PR TITLE
Define supported font weights

### DIFF
--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -8,7 +8,7 @@ The typography comprises five predefined font sizes. The base font size of the
 app is 14px when used with the default browser settings.
 
 <Unstyled>
-  <div className="grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-4">
+  <div className="mb-8 grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-4">
     <p className="text-right text-sm text-gray-600">
       <pre className="inline">text-2xl</pre>, 26px
     </p>
@@ -29,5 +29,28 @@ app is 14px when used with the default browser settings.
       <pre className="inline">text-sm</pre>, 12px
     </p>
     <p className="text-sm">The quick brown fox jumped over the lazy dog.</p>
+  </div>
+</Unstyled>
+
+## Weight
+
+We support three font weights in our UI:
+
+<Unstyled>
+  <div className="mb-8 grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-4">
+    <p className="text-right text-sm text-gray-600">
+      <pre className="inline">font-normal</pre>, 400
+    </p>
+    <p>The quick brown fox jumped over the lazy dog.</p>
+    <p className="text-right text-sm text-gray-600">
+      <pre className="inline">font-medium</pre>, 500
+    </p>
+    <p className="font-medium">The quick brown fox jumped over the lazy dog.</p>
+    <p className="text-right text-sm text-gray-600">
+      <pre className="inline">font-semibold</pre>, 600
+    </p>
+    <p className="font-semibold">
+      The quick brown fox jumped over the lazy dog.
+    </p>
   </div>
 </Unstyled>

--- a/lib/lib/xray.tsx
+++ b/lib/lib/xray.tsx
@@ -69,7 +69,7 @@ export const XRayProvider: React.FC<{ children: ReactNode }> = ({
             gap="2"
             className="fixed right-2 top-2 z-50 rounded-sm border-solid border-f1-border bg-white p-4 opacity-80 shadow-md"
           >
-            <div className="text-md z-50 font-bold">XRay</div>
+            <div className="text-md font-bold z-50">XRay</div>
             <Stack gap="2">
               {componentTypes.map((type) => (
                 <label className="block">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,9 +25,6 @@ export default {
         "2xl": "1400px",
       },
     },
-    fontFamily: {
-      sans: ["Inter", "sans-serif"],
-    },
     colors: {
       white: "0 0% 100%",
       current: "currentColor",
@@ -81,6 +78,14 @@ export default {
         60: "38 79% 45%",
         70: "38 80% 36%",
       },
+    },
+    fontFamily: {
+      sans: ["Inter", "sans-serif"],
+    },
+    fontWeight: {
+      normal: "400",
+      medium: "500",
+      semibold: "600",
     },
     fontSize: {
       sm: [


### PR DESCRIPTION
## 🚪 Why?

We define foundations

## 🔑 What?

![CleanShot 2024-09-13 at 17 24 23@2x](https://github.com/user-attachments/assets/f175291a-50b8-4136-864a-688d82a8b756)

Sets three supported font weights, overwriting the full list provided by the Tailwind

## 🏡 Context

- [🎨 Figma](https://www.figma.com/design/b0A4ttd9C576bp2roJh0hX/Foundations?node-id=307-4037&node-type=frame&m=dev)
