### PR TITLE
Define button icon colors

### DIFF
--- a/lib/components/Actions/Button/index.tsx
+++ b/lib/components/Actions/Button/index.tsx
@@ -1,5 +1,9 @@
 import { Icon, IconType } from "@/components/Utilities/Icon"
-import { Button as ShadcnButton } from "@/ui/button"
+import {
+  Button as ShadcnButton,
+  iconOnlyVariants,
+  iconVariants,
+} from "@/ui/button"
 import { ComponentProps, forwardRef, useState } from "react"
 
 export type ButtonProps = Pick<
@@ -27,6 +31,7 @@ const Button: React.FC<ButtonProps> = forwardRef<
       disabled,
       loading: forceLoading,
       icon,
+      variant = "default",
       ...props
     },
     ref
@@ -54,11 +59,22 @@ const Button: React.FC<ButtonProps> = forwardRef<
         title={hideLabel ? label : undefined}
         onClick={handleClick}
         disabled={disabled || loading || forceLoading}
-        round={hideLabel}
         ref={ref}
+        variant={variant}
+        round={hideLabel}
         {...props}
       >
-        {icon && <Icon size="md" icon={icon} />}
+        {icon && (
+          <Icon
+            size="md"
+            icon={icon}
+            className={
+              hideLabel
+                ? iconOnlyVariants({ variant })
+                : iconVariants({ variant })
+            }
+          />
+        )}
         {!hideLabel && label}
       </ShadcnButton>
     )

--- a/lib/ui/button.tsx
+++ b/lib/ui/button.tsx
@@ -13,7 +13,7 @@ export const variants = [
 ] as const
 
 const buttonVariants = cva(
-  "focus-visible:ring-offset focus-visible:ring-ring inline-flex h-10 items-center justify-center gap-1 whitespace-nowrap rounded-xl border-none text-base font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50",
+  "focus-visible:ring-offset focus-visible:ring-ring group inline-flex h-10 items-center justify-center gap-1 whitespace-nowrap rounded-xl border-none text-base font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -42,6 +42,39 @@ const buttonVariants = cva(
   }
 )
 
+const iconVariants = cva("transition-colors", {
+  variants: {
+    variant: {
+      default: "text-f1-icon-inverse-secondary",
+      outline: "text-f1-icon",
+      neutral: "text-f1-icon",
+      critical:
+        "text-f1-icon-critical-bold group-hover:text-f1-icon-inverse-secondary",
+      ghost: "text-f1-icon",
+      promote: "text-f1-icon",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+})
+
+const iconOnlyVariants = cva("transition-colors", {
+  variants: {
+    variant: {
+      default: "text-f1-icon-inverse",
+      outline: "text-f1-icon-bold",
+      neutral: "text-f1-icon-bold",
+      critical: "text-f1-icon-critical-bold group-hover:text-f1-icon-inverse",
+      ghost: "text-f1-icon-bold",
+      promote: "text-f1-icon-bold",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+})
+
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
@@ -62,4 +95,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 Button.displayName = "Button"
 
-export { Button, buttonVariants }
+export { Button, buttonVariants, iconOnlyVariants, iconVariants }

--- a/lib/ui/button.tsx
+++ b/lib/ui/button.tsx
@@ -45,11 +45,11 @@ const buttonVariants = cva(
 const iconVariants = cva("transition-colors", {
   variants: {
     variant: {
-      default: "text-f1-icon-inverse-secondary",
+      default: "text-f1-icon-inverse/80",
       outline: "text-f1-icon",
       neutral: "text-f1-icon",
       critical:
-        "text-f1-icon-critical-bold group-hover:text-f1-icon-inverse-secondary",
+        "text-f1-icon-critical-bold group-hover:text-f1-icon-inverse/80",
       ghost: "text-f1-icon",
       promote: "text-f1-icon",
     },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -139,7 +139,10 @@ export default {
           foreground: {
             DEFAULT: "hsl(var(--neutral-100))",
             secondary: "hsl(var(--neutral-50))",
-            inverse: "hsl(var(--neutral-0))",
+            inverse: {
+              DEFAULT: "hsl(var(--neutral-0))",
+              secondary: "hsl(var(--neutral-0) / 0.8)",
+            },
             disabled: "hsl(var(--neutral-30))",
             accent: {
               DEFAULT: "hsl(var(--accent-70))",
@@ -203,10 +206,14 @@ export default {
           icon: {
             DEFAULT: "hsl(var(--neutral-50))",
             secondary: "hsl(var(--neutral-40))",
-            inverse: "hsl(var(--neutral-0))",
+            inverse: {
+              DEFAULT: "hsl(var(--neutral-0))",
+              secondary: "hsl(var(--neutral-0) / 0.8)",
+            },
             bold: "hsl(var(--neutral-100))",
             critical: {
               DEFAULT: "hsl(var(--critical-50))",
+              bold: "hsl(var(--critical-70))",
             },
             info: {
               DEFAULT: "hsl(var(--info-50))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -203,10 +203,7 @@ export default {
           icon: {
             DEFAULT: "hsl(var(--neutral-50))",
             secondary: "hsl(var(--neutral-40))",
-            inverse: {
-              DEFAULT: "hsl(var(--neutral-0))",
-              secondary: "hsl(var(--neutral-0) / 0.8)",
-            },
+            inverse: "hsl(var(--neutral-0))",
             bold: "hsl(var(--neutral-100))",
             critical: {
               DEFAULT: "hsl(var(--critical-50))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -139,10 +139,7 @@ export default {
           foreground: {
             DEFAULT: "hsl(var(--neutral-100))",
             secondary: "hsl(var(--neutral-50))",
-            inverse: {
-              DEFAULT: "hsl(var(--neutral-0))",
-              secondary: "hsl(var(--neutral-0) / 0.8)",
-            },
+            inverse: "hsl(var(--neutral-0))",
             disabled: "hsl(var(--neutral-30))",
             accent: {
               DEFAULT: "hsl(var(--accent-70))",


### PR DESCRIPTION
## 🚪 Why?

Button icons have their own color system. When a label is displayed, the icon should have a lighter color to give prominence to the label. When there's no label, the icon takes center stage, displaying a stronger color.

<img width="165" alt="image" src="https://github.com/user-attachments/assets/9dc39d52-fe98-4861-ad6f-ec5ffd8a29b4">

_Notice how the icon has a lighter color than the label_

## 🔑 What?

- Add icon color variants, with and without a label.
- Add needed tokens.

## 🏡 Context

- [🎨 Figma](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=14-976)
