### PR TITLE
Order documents sections

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,6 +2,8 @@
 import React from "react"
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport"
 import type { Preview } from "@storybook/react"
+import { action } from "@storybook/addon-actions"
+import { useDarkMode } from "storybook-dark-mode"
 
 import "../styles.css"
 
@@ -9,8 +11,6 @@ import { ThemeProvider } from "../lib/lib/theme-provider"
 import { FactorialOneProvider } from "../lib/lib/one-provider"
 import lightTheme, { darkTheme } from "./FactorialOne"
 import { DocsContainer } from "./DocsContainer"
-import { useDarkMode } from "storybook-dark-mode"
-import { action } from "@storybook/addon-actions"
 
 export const withTheme = () => {
   return (Story) => {
@@ -86,14 +86,23 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
-
+    options: {
+      storySort: {
+        order: [
+          "Foundations",
+          ["Typography", "Spacing"],
+          "Components",
+          "Playground",
+          "Experiments",
+        ],
+      },
+    },
     darkMode: {
       dark: darkTheme,
       light: lightTheme,
       stylePreview: true,
     },
   },
-
   tags: ["autodocs"],
 }
 

--- a/docs/spacing.mdx
+++ b/docs/spacing.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/blocks"
 
-<Meta title="essentials/Spacing" />
+<Meta title="Foundations/Spacing" />
 
 # Spacing
 

--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -1,6 +1,6 @@
 import { Meta, Unstyled } from "@storybook/blocks"
 
-<Meta title="essentials/Typography" />
+<Meta title="Foundations/Typography" />
 
 # Typography
 


### PR DESCRIPTION
## 🚪 Why?

It is easy to remember things that doesn't change

## 🔑 What?

- renames "essentials" to "foundations" to match the naming with the design team
- sets hierarchy: Foundations → Components → Playground → Experiments. Before that, an alphabetical order was used


| **Before** | **After** |
|--------|--------|
| ![CleanShot 2024-09-16 at 13 10 42](https://github.com/user-attachments/assets/d1422385-7c62-42cc-baa4-e2c8dbbd8103) | ![CleanShot 2024-09-16 at 13 11 33](https://github.com/user-attachments/assets/7bbee8f6-d7c5-459c-b058-52917ae1661e) | 
