### PR TITLE
add tickFormatter to ChartTooltip and width to yAxis

### DIFF
--- a/lib/components/Charts/AreaChart/index.stories.tsx
+++ b/lib/components/Charts/AreaChart/index.stories.tsx
@@ -21,6 +21,8 @@ const meta: Meta<typeof AreaChart<typeof dataConfig>> = {
     },
     yAxis: {
       hide: true,
+      tickFormatter: (value: string) =>
+        `${Number.isNaN(parseFloat(value)) ? value : (parseFloat(value) / 100).toFixed(2) + "€"}`,
     },
     data: [
       { label: "January", values: { mobile: 1200, desktop: 500 } },

--- a/lib/components/Charts/AreaChart/index.stories.tsx
+++ b/lib/components/Charts/AreaChart/index.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<typeof AreaChart<typeof dataConfig>> = {
     yAxis: {
       hide: true,
       tickFormatter: (value: string) =>
-        `${Number.isNaN(parseFloat(value)) ? value : (parseFloat(value) / 100).toFixed(2) + "€"}`,
+        `${Number.isNaN(parseFloat(value)) ? value : (parseFloat(value) / 100).toFixed(2) + ",00 Euros"}`,
     },
     data: [
       { label: "January", values: { mobile: 1200, desktop: 500 } },

--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -63,7 +63,11 @@ export const _AreaChart = <K extends LineChartConfig>(
       <AreaChartPrimitive
         accessibilityLayer
         data={preparedData}
-        margin={{ left: 12, right: 12, top: marginTop }}
+        margin={{
+          left: yAxis && !yAxis.hide ? 0 : 12,
+          right: 12,
+          top: marginTop,
+        }}
       >
         <CartesianGrid {...cartesianGridProps()} />
         {!xAxis?.hide && (
@@ -87,7 +91,7 @@ export const _AreaChart = <K extends LineChartConfig>(
             tickFormatter={yAxis?.tickFormatter}
             ticks={yAxis?.ticks}
             domain={yAxis?.domain}
-            width={yAxis?.width ?? maxLabelWidth + 10}
+            width={yAxis?.width ?? maxLabelWidth + 20}
             className={cn(yAxis?.isBlur && "blur-sm")}
           />
         )}

--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -67,7 +67,6 @@ export const _AreaChart = <K extends LineChartConfig>(
         )}
         {!yAxis?.hide && (
           <YAxis
-            width={32} // TODO fix width so its dynamic based on the max width of the yAxis labels
             tickLine={false}
             axisLine={false}
             tickMargin={8}
@@ -80,7 +79,12 @@ export const _AreaChart = <K extends LineChartConfig>(
         )}
         <ChartTooltip
           cursor
-          content={<ChartTooltipContent indicator="dot" />}
+          content={
+            <ChartTooltipContent
+              indicator="dot"
+              yAxisFormatter={yAxis?.tickFormatter}
+            />
+          }
         />
         <defs>
           {areas.map((area, index) => (

--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -17,7 +17,7 @@ import {
   YAxis,
 } from "recharts"
 import { autoColor } from "../utils/colors"
-import { cartesianGridProps } from "../utils/elements"
+import { cartesianGridProps, measureTextWidth } from "../utils/elements"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { prepareData } from "../utils/muncher"
 import { LineChartPropsBase } from "../utils/types"
@@ -45,11 +45,24 @@ export const _AreaChart = <K extends LineChartConfig>(
   const areas = Object.keys(dataConfig) as (keyof LineChartConfig)[]
   const chartId = nanoid(12)
 
+  const preparedData = prepareData(data)
+  const maxLabelWidth = Math.max(
+    ...preparedData.flatMap((el) =>
+      areas.map((key) =>
+        measureTextWidth(
+          yAxis?.tickFormatter
+            ? yAxis.tickFormatter(`${el[key]}`)
+            : `${el[key]}`
+        )
+      )
+    )
+  )
+
   return (
     <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
       <AreaChartPrimitive
         accessibilityLayer
-        data={prepareData(data)}
+        data={preparedData}
         margin={{ left: 12, right: 12, top: marginTop }}
       >
         <CartesianGrid {...cartesianGridProps()} />
@@ -74,6 +87,7 @@ export const _AreaChart = <K extends LineChartConfig>(
             tickFormatter={yAxis?.tickFormatter}
             ticks={yAxis?.ticks}
             domain={yAxis?.domain}
+            width={yAxis?.width ?? maxLabelWidth + 10}
             className={cn(yAxis?.isBlur && "blur-sm")}
           />
         )}

--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -115,7 +115,7 @@ export const FinancialValues: Meta<
     },
     yAxis: {
       hide: false,
-      tickFormatter: (value: string) => value + " €fkdlkasldfjklasdfjaklfj",
+      tickFormatter: (value: string) => value + " €",
     },
   },
 }

--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -115,7 +115,7 @@ export const FinancialValues: Meta<
     },
     yAxis: {
       hide: false,
-      tickFormatter: (value: string) => value + " €",
+      tickFormatter: (value: string) => value + " €fkdlkasldfjklasdfjaklfj",
     },
   },
 }

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -15,7 +15,12 @@ import {
 } from "recharts"
 
 import { autoColor } from "../utils/colors"
-import { cartesianGridProps, xAxisProps, yAxisProps } from "../utils/elements"
+import {
+  cartesianGridProps,
+  measureTextWidth,
+  xAxisProps,
+  yAxisProps,
+} from "../utils/elements"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { prepareData } from "../utils/muncher"
 import { ChartPropsBase } from "../utils/types"
@@ -39,12 +44,24 @@ const _BarChart = <K extends ChartConfig>(
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const bars = Object.keys(dataConfig) as (keyof ChartConfig)[]
+  const preparedData = prepareData(data)
+  const maxLabelWidth = Math.max(
+    ...preparedData.flatMap((el) =>
+      bars.map((key) =>
+        measureTextWidth(
+          yAxis?.tickFormatter
+            ? yAxis.tickFormatter(`${el[key]}`)
+            : `${el[key]}`
+        )
+      )
+    )
+  )
 
   return (
     <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
       <BarChartPrimitive
         accessibilityLayer
-        data={prepareData(data)}
+        data={preparedData}
         margin={{ left: 12, right: 12, top: label ? 24 : 0 }}
         stackOffset={type === "stacked-by-sign" ? "sign" : undefined}
       >
@@ -53,7 +70,11 @@ const _BarChart = <K extends ChartConfig>(
           content={<ChartTooltipContent yAxisFormatter={yAxis.tickFormatter} />}
         />
         <CartesianGrid {...cartesianGridProps()} />
-        <YAxis {...yAxisProps(yAxis)} hide={yAxis?.hide} />
+        <YAxis
+          width={maxLabelWidth + 10}
+          {...yAxisProps(yAxis)}
+          hide={yAxis?.hide}
+        />
         <XAxis {...xAxisProps(xAxis)} hide={xAxis?.hide} />
 
         {bars.map((key, index) => (

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -62,7 +62,11 @@ const _BarChart = <K extends ChartConfig>(
       <BarChartPrimitive
         accessibilityLayer
         data={preparedData}
-        margin={{ left: 12, right: 12, top: label ? 24 : 0 }}
+        margin={{
+          left: yAxis && !yAxis.hide ? 0 : 12,
+          right: 12,
+          top: label ? 24 : 0,
+        }}
         stackOffset={type === "stacked-by-sign" ? "sign" : undefined}
       >
         <ChartTooltip
@@ -71,9 +75,10 @@ const _BarChart = <K extends ChartConfig>(
         />
         <CartesianGrid {...cartesianGridProps()} />
         <YAxis
-          width={maxLabelWidth + 10}
           {...yAxisProps(yAxis)}
-          hide={yAxis?.hide}
+          tick
+          width={yAxis.width ?? maxLabelWidth + 20}
+          hide={yAxis.hide}
         />
         <XAxis {...xAxisProps(xAxis)} hide={xAxis?.hide} />
 

--- a/lib/components/Charts/LineChart/index.stories.tsx
+++ b/lib/components/Charts/LineChart/index.stories.tsx
@@ -38,6 +38,8 @@ export const Default: Meta<typeof LineChart<typeof singleDataConfig>> = {
     },
     yAxis: {
       hide: true,
+      tickFormatter: (value: string) =>
+        `${Number.isNaN(parseFloat(value)) ? value : (parseFloat(value) / 100).toFixed(2) + "€"}`,
     },
     data: [
       { label: "January", values: { desktop: 186 } },

--- a/lib/components/Charts/LineChart/index.stories.tsx
+++ b/lib/components/Charts/LineChart/index.stories.tsx
@@ -39,7 +39,7 @@ export const Default: Meta<typeof LineChart<typeof singleDataConfig>> = {
     yAxis: {
       hide: true,
       tickFormatter: (value: string) =>
-        `${Number.isNaN(parseFloat(value)) ? value : (parseFloat(value) / 100).toFixed(2) + "€"}`,
+        `${Number.isNaN(parseFloat(value)) ? value : (parseFloat(value) / 100).toFixed(2) + " €"}`,
     },
     data: [
       { label: "January", values: { desktop: 186 } },

--- a/lib/components/Charts/LineChart/index.tsx
+++ b/lib/components/Charts/LineChart/index.tsx
@@ -13,7 +13,12 @@ import {
   YAxis,
 } from "recharts"
 import { autoColor } from "../utils/colors"
-import { cartesianGridProps, xAxisProps, yAxisProps } from "../utils/elements"
+import {
+  cartesianGridProps,
+  measureTextWidth,
+  xAxisProps,
+  yAxisProps,
+} from "../utils/elements"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { prepareData } from "../utils/muncher"
 import { LineChartPropsBase } from "../utils/types"
@@ -35,17 +40,34 @@ export const _LineChart = <K extends LineChartConfig>(
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const lines = Object.keys(dataConfig) as (keyof LineChartConfig)[]
+  const preparedData = prepareData(data)
+  const maxLabelWidth = Math.max(
+    ...preparedData.flatMap((el) =>
+      lines.map((key) =>
+        measureTextWidth(
+          yAxis?.tickFormatter
+            ? yAxis.tickFormatter(`${el[key]}`)
+            : `${el[key]}`
+        )
+      )
+    )
+  )
 
   return (
     <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
       <LineChartPrimitive
         accessibilityLayer
-        data={prepareData(data)}
-        margin={{ left: 12, right: 12 }}
+        data={preparedData}
+        margin={{ left: yAxis && !yAxis.hide ? 0 : 12, right: 12 }}
       >
         <CartesianGrid {...cartesianGridProps()} />
         {!xAxis?.hide && <XAxis {...xAxisProps(xAxis)} />}
-        {!yAxis?.hide && <YAxis {...yAxisProps(yAxis)} />}
+        {!yAxis?.hide && (
+          <YAxis
+            {...yAxisProps(yAxis)}
+            width={yAxis.width ?? maxLabelWidth + 20}
+          />
+        )}
         <ChartTooltip
           cursor
           content={

--- a/lib/components/Charts/LineChart/index.tsx
+++ b/lib/components/Charts/LineChart/index.tsx
@@ -46,7 +46,12 @@ export const _LineChart = <K extends LineChartConfig>(
         <CartesianGrid {...cartesianGridProps()} />
         {!xAxis?.hide && <XAxis {...xAxisProps(xAxis)} />}
         {!yAxis?.hide && <YAxis {...yAxisProps(yAxis)} />}
-        <ChartTooltip cursor content={<ChartTooltipContent />} />
+        <ChartTooltip
+          cursor
+          content={
+            <ChartTooltipContent yAxisFormatter={yAxis?.tickFormatter} />
+          }
+        />
         {lines.map((line, index) => (
           <Line
             key={line}

--- a/lib/components/Charts/PieChart/index.stories.tsx
+++ b/lib/components/Charts/PieChart/index.stories.tsx
@@ -55,6 +55,8 @@ export const Default: Meta<typeof PieChart> = {
       { label: "may", value: 209 },
       { label: "june", value: 214 },
     ],
+    tickFormatter: (value: string) =>
+      `${Number.isNaN(parseFloat(value)) ? value : (parseFloat(value) / 100).toFixed(2) + "€"}`,
   },
 }
 

--- a/lib/components/Charts/PieChart/index.tsx
+++ b/lib/components/Charts/PieChart/index.tsx
@@ -20,12 +20,13 @@ export type PieChartItem = {
 export type PieChartProps = {
   dataConfig: ChartConfig
   data: PieChartItem[]
+  tickFormatter?: (value: string) => string
   overview?: { number: number; label: string }
   aspect?: ComponentProps<typeof ChartContainer>["aspect"]
 }
 
 export const _PieChart = (
-  { data, dataConfig, overview, aspect }: PieChartProps,
+  { data, dataConfig, overview, aspect, tickFormatter }: PieChartProps,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const preparedData = data.map((item, index) => ({
@@ -38,7 +39,10 @@ export const _PieChart = (
   return (
     <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
       <PieChartPrimitive accessibilityLayer margin={{ left: 0, right: 0 }}>
-        <ChartTooltip cursor content={<ChartTooltipContent />} />
+        <ChartTooltip
+          cursor
+          content={<ChartTooltipContent yAxisFormatter={tickFormatter} />}
+        />
         <Pie
           isAnimationActive={false}
           nameKey={"label"}

--- a/lib/components/Charts/VerticalBarChart/index.stories.tsx
+++ b/lib/components/Charts/VerticalBarChart/index.stories.tsx
@@ -26,6 +26,11 @@ const meta: Meta<typeof VerticalBarChart<typeof dataConfig>> = {
       { label: "Performance Score", values: { value: 88 } },
       { label: "Recruitment Efficiency", values: { value: 100 } },
     ],
+    yAxis: {
+      width: 80,
+      tickFormatter: (value: string) =>
+        `${Number.isNaN(parseFloat(value)) ? value : (parseFloat(value) / 100).toFixed(2) + "€"}`,
+    },
   },
 }
 

--- a/lib/components/Charts/VerticalBarChart/index.tsx
+++ b/lib/components/Charts/VerticalBarChart/index.tsx
@@ -84,7 +84,12 @@ const _VBarChart = <K extends ChartConfig>(
         data={prepareData(data)}
         margin={{ left: 24, right: label ? 32 : 0 }}
       >
-        <ChartTooltip cursor content={<ChartTooltipContent />} />
+        <ChartTooltip
+          cursor
+          content={
+            <ChartTooltipContent yAxisFormatter={yAxis?.tickFormatter} />
+          }
+        />
         <CartesianGrid
           {...cartesianGridProps()}
           vertical={true}

--- a/lib/components/Charts/VerticalBarChart/index.tsx
+++ b/lib/components/Charts/VerticalBarChart/index.tsx
@@ -15,6 +15,7 @@ import { prepareData } from "../utils/bar"
 import { autoColor } from "../utils/colors"
 import {
   cartesianGridProps,
+  measureTextWidth,
   xAxisProps as xAxisConfigureProps,
   yAxisProps as yAxisConfigureProps,
 } from "../utils/elements"
@@ -62,12 +63,15 @@ const _VBarChart = <K extends ChartConfig>(
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const bars = Object.keys(dataConfig) as (keyof ChartConfig)[]
-  const munchedData = prepareData<K>(data)
+  const preparedData = prepareData<K>(data)
+  const maxLabelWidth = Math.max(
+    ...preparedData.map((el) => measureTextWidth(`${el.x}`))
+  )
 
   const xAxisProps: XAxisProps = {
     ...xAxisConfigureProps(xAxis),
     type: "number",
-    dataKey: getMaxValueByKey(munchedData),
+    dataKey: getMaxValueByKey(preparedData),
   }
 
   const yAxisProps: YAxisProps = {
@@ -81,8 +85,8 @@ const _VBarChart = <K extends ChartConfig>(
       <BarChartPrimitive
         layout="vertical"
         accessibilityLayer
-        data={prepareData(data)}
-        margin={{ left: 24, right: label ? 32 : 0 }}
+        data={preparedData}
+        margin={{ left: yAxis && !yAxis.hide ? 0 : 12, right: label ? 32 : 0 }}
       >
         <ChartTooltip
           cursor
@@ -96,7 +100,11 @@ const _VBarChart = <K extends ChartConfig>(
           horizontal={false}
         />
         <XAxis {...xAxisProps} hide={xAxis?.hide} />
-        <YAxis {...yAxisProps} hide={yAxis?.hide} />
+        <YAxis
+          {...yAxisProps}
+          hide={yAxis?.hide}
+          width={yAxis?.width ?? maxLabelWidth + 20}
+        />
 
         {bars.map((key, index) => {
           return (

--- a/lib/components/Charts/utils/elements.tsx
+++ b/lib/components/Charts/utils/elements.tsx
@@ -11,6 +11,7 @@ export const xAxisProps = (
   tickMargin: 8,
   tickCount: config?.tickCount,
   tickFormatter: config?.tickFormatter,
+  width: config?.width,
 })
 
 export const yAxisProps = (
@@ -21,6 +22,7 @@ export const yAxisProps = (
   tickMargin: 8,
   tickCount: config?.tickCount,
   tickFormatter: config?.tickFormatter,
+  width: config?.width,
 })
 
 export const cartesianGridProps = () => ({

--- a/lib/components/Charts/utils/elements.tsx
+++ b/lib/components/Charts/utils/elements.tsx
@@ -4,13 +4,12 @@ import { AxisConfig } from "./types"
 
 export function measureTextWidth(
   text: string,
-  font = "Inter, sans-serif"
+  font = "12px Inter, sans-serif"
 ): number {
   const canvas = document.createElement("canvas")
   const context = canvas.getContext("2d")
   if (context) {
     context.font = font
-    console.log(`mesurement of ${text}: `, context.measureText(text).width)
     return context.measureText(text).width
   }
   return 0
@@ -25,7 +24,6 @@ export const xAxisProps = (
   tickMargin: 8,
   tickCount: config?.tickCount,
   tickFormatter: config?.tickFormatter,
-  width: config?.width,
 })
 
 export const yAxisProps = (
@@ -36,7 +34,6 @@ export const yAxisProps = (
   tickMargin: 8,
   tickCount: config?.tickCount,
   tickFormatter: config?.tickFormatter,
-  width: config?.width,
 })
 
 export const cartesianGridProps = () => ({

--- a/lib/components/Charts/utils/elements.tsx
+++ b/lib/components/Charts/utils/elements.tsx
@@ -2,6 +2,20 @@ import { ComponentProps } from "react"
 import { XAxis, YAxis } from "recharts"
 import { AxisConfig } from "./types"
 
+export function measureTextWidth(
+  text: string,
+  font = "Inter, sans-serif"
+): number {
+  const canvas = document.createElement("canvas")
+  const context = canvas.getContext("2d")
+  if (context) {
+    context.font = font
+    console.log(`mesurement of ${text}: `, context.measureText(text).width)
+    return context.measureText(text).width
+  }
+  return 0
+}
+
 export const xAxisProps = (
   config?: AxisConfig
 ): Partial<ComponentProps<typeof XAxis>> => ({

--- a/lib/components/Charts/utils/types.ts
+++ b/lib/components/Charts/utils/types.ts
@@ -19,6 +19,7 @@ export type AxisConfig = {
   ticks?: number[]
   domain?: number[]
   isBlur?: boolean
+  width?: number
 }
 
 export type ChartConfig = Record<


### PR DESCRIPTION
## 🚪 Why?

To improve chart customization 

## 🔑 What?

* Add tickTransformation to tooltip match values (normally from yAxis)
* Remove fixed 32 wifth on yAxis and let user config by prop or by default is auto calculated from labels

https://github.com/user-attachments/assets/6de690a5-a4e5-4204-9904-ba9c8697c89a


https://github.com/user-attachments/assets/ec7b938c-c4bb-4785-8f6b-b62a395bb54a

