### PR TITLE
Export `CategoryBarChart`

### DIFF
--- a/lib/components/Charts/CategoryBarChart/index.stories.tsx
+++ b/lib/components/Charts/CategoryBarChart/index.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta } from "@storybook/react"
-import { CategoryBar } from "."
+import { CategoryBarChart } from "."
 
 const meta = {
-  component: CategoryBar,
+  component: CategoryBarChart,
   tags: ["autodocs"],
   args: {
     data: [
@@ -18,13 +18,13 @@ const meta = {
       </div>
     ),
   ],
-} satisfies Meta<typeof CategoryBar>
+} satisfies Meta<typeof CategoryBarChart>
 
 export default meta
 
 export const Default = {}
 
-export const MultipleValues: Meta<typeof CategoryBar> = {
+export const MultipleValues: Meta<typeof CategoryBarChart> = {
   args: {
     data: [
       { name: "Employee Eng.", value: 42 },

--- a/lib/components/Charts/CategoryBarChart/index.tsx
+++ b/lib/components/Charts/CategoryBarChart/index.tsx
@@ -4,7 +4,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/ui/tooltip"
+import { ForwardedRef } from "react"
+
 import { autoColor } from "../utils/colors"
+import { fixedForwardRef } from "../utils/forwardRef"
 
 export interface CategoryBarProps {
   data: {
@@ -15,12 +18,15 @@ export interface CategoryBarProps {
   legend: boolean
 }
 
-export function CategoryBar({ data, legend = true }: CategoryBarProps) {
+const _CategoryBarChart = (
+  { data, legend = true }: CategoryBarProps,
+  ref: ForwardedRef<HTMLDivElement>
+) => {
   const total = data.reduce((sum, category) => sum + category.value, 0)
 
   return (
     <TooltipProvider>
-      <div className="w-full">
+      <div className="w-full" ref={ref}>
         <div className="flex h-2 gap-1 overflow-hidden">
           {data.map((category, index) => {
             const percentage = (category.value / total) * 100
@@ -95,3 +101,5 @@ export function CategoryBar({ data, legend = true }: CategoryBarProps) {
     </TooltipProvider>
   )
 }
+
+export const CategoryBarChart = fixedForwardRef(_CategoryBarChart)

--- a/lib/components/Charts/exports.ts
+++ b/lib/components/Charts/exports.ts
@@ -31,7 +31,6 @@ export const CategoryBarChart = Component(
   CategoryBarChartComponent
 )
 
-
 export const LineChart = Component(
   {
     name: "LineChart",

--- a/lib/components/Charts/exports.ts
+++ b/lib/components/Charts/exports.ts
@@ -2,6 +2,7 @@ import { Component } from "@/lib/component"
 
 import { AreaChart as AreaChartComponent } from "./AreaChart"
 import { BarChart as BarChartComponent } from "./BarChart"
+import { CategoryBarChart as CategoryBarChartComponent } from "./CategoryBarChart"
 import { LineChart as LineChartComponent } from "./LineChart"
 import { PieChart as PieChartComponent } from "./PieChart"
 import { VerticalBarChart as VerticalBarChartComponent } from "./VerticalBarChart"
@@ -21,6 +22,15 @@ export const BarChart = Component(
   },
   BarChartComponent
 )
+
+export const CategoryBarChart = Component(
+  {
+    name: "CategoryBarChart",
+    type: "info",
+  },
+  CategoryBarChartComponent
+)
+
 
 export const LineChart = Component(
   {

--- a/lib/components/Widgets/CategoryBarSection/index.tsx
+++ b/lib/components/Widgets/CategoryBarSection/index.tsx
@@ -1,5 +1,5 @@
 import {
-  CategoryBar,
+  CategoryBarChart,
   CategoryBarProps,
 } from "@/components/Charts/CategoryBarChart"
 
@@ -29,7 +29,7 @@ export function CategoryBarSection({
         </div>
       </div>
       <div className="mt-2">
-        <CategoryBar data={data} legend={legend} />
+        <CategoryBarChart data={data} legend={legend} />
       </div>
       {!!helpText && (
         <div className="mt-1">


### PR DESCRIPTION
## 🚪 Why?

Users cannot use `CategoryBarChart` because it is not exported (see [slack message](https://factorialteam.slack.com/archives/C06QT46115K/p1726583043746279))

## 🔑 What?

- renames `CategoryBar` to `CategoryBarChart` to match the code with the documentation
- exports `CategoryBarChart`
