### PR TITLE
Ignore pie chart on Chromatic

### DIFF
--- a/lib/components/Charts/PieChart/index.tsx
+++ b/lib/components/Charts/PieChart/index.tsx
@@ -36,7 +36,12 @@ export const _PieChart = (
   }))
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
+    <ChartContainer
+      config={dataConfig}
+      ref={ref}
+      aspect={aspect}
+      data-chromatic="ignore"
+    >
       <PieChartPrimitive accessibilityLayer margin={{ left: 0, right: 0 }}>
         <ChartTooltip cursor content={<ChartTooltipContent />} />
         <Pie


### PR DESCRIPTION
The Pie Chart, being an SVG, seems to render slightly differently in each run. This is creating noise and false positives, so let's ignore it for the moment.