### PR TITLE
Remove empty pattern from the tailwind safelist

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -268,9 +268,5 @@ export default {
       pattern: /^border-f1-/,
       variants: ["hover", "focus", "active"],
     },
-    {
-      pattern: /^icon-f1-/,
-      variants: ["hover", "focus", "active"],
-    },
   ],
 } satisfies Config


### PR DESCRIPTION
## 🚪 Why?

The pattern matches nothing which raises warnings in the console. The icons already fall into the `text-f1-` regexp, so there is no need to keep this.

The next will be to reconsider the `safelist` entirely