### PR TITLE
chore: indicator accepts a string

### DIFF
--- a/lib/components/Widgets/IndicatorsList/index.stories.tsx
+++ b/lib/components/Widgets/IndicatorsList/index.stories.tsx
@@ -7,13 +7,13 @@ import { IndicatorsList } from "."
 const taskCategories = [
   {
     label: "Overdue",
-    count: 1,
+    content: "1",
     icon: AlertCircle,
     color: "text-f1-icon-critical",
   },
   {
     label: "Due",
-    count: 3,
+    content: "3",
     icon: Circle,
     color: "text-f1-icon",
   },
@@ -46,7 +46,7 @@ export const ThreeElements: Story = {
   args: {
     items: taskCategories.concat({
       label: "No due",
-      count: 5,
+      content: "5",
       icon: Circle,
       color: "text-f1-icon-secondary",
     }),

--- a/lib/components/Widgets/IndicatorsList/index.tsx
+++ b/lib/components/Widgets/IndicatorsList/index.tsx
@@ -9,9 +9,14 @@ export const IndicatorsList = forwardRef<HTMLDivElement, IndicatorsListProps>(
   ({ items }, ref) => {
     return (
       <div ref={ref} className="flex flex-grow flex-row justify-between">
-        {items.map(({ label, count, icon, color }) => (
+        {items.map(({ label, content, icon, color }) => (
           <div key={label} className="flex-1">
-            <Indicator label={label} count={count} icon={icon} color={color} />
+            <Indicator
+              label={label}
+              content={content}
+              icon={icon}
+              color={color}
+            />
           </div>
         ))}
       </div>

--- a/lib/ui/indicator.tsx
+++ b/lib/ui/indicator.tsx
@@ -3,19 +3,19 @@ import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
 
 interface IndicatorProps {
-  count: number
+  content: string
   label: string
-  color: string
+  color?: string
   icon?: IconType
 }
 
 export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
-  ({ count, label, icon, color }, ref) => {
+  ({ content, label, icon, color }, ref) => {
     return (
       <div key={label} className="grid-row-2 col-span-1 grid" ref={ref}>
         <p className="font-medium text-f1-foreground-secondary">{label}</p>
         <div className="flex items-center gap-1">
-          <p className="text-xl font-semibold">{count}</p>
+          <p className="text-xl font-semibold">{content}</p>
           {icon && (
             <span className={cn("flex", color)}>
               <Icon icon={icon} size="md" />

--- a/src/playground/Widgets/Tasks/index.tsx
+++ b/src/playground/Widgets/Tasks/index.tsx
@@ -12,11 +12,11 @@ export interface TasksInsightData {
   dueTasks: string[]
   noDueTasks: string[]
   overdueLabel: string
-  overdueTasksCount: number
+  overdueTasksCount: string
   dueLabel: string
-  dueTasksCount: number
+  dueTasksCount: string
   noDueLabel: string
-  noDueTasksCount: number
+  noDueTasksCount: string
   linkUrl: string
   linkTitle: string
   handleNavigate: () => void
@@ -49,19 +49,19 @@ export const TasksInsight = forwardRef<HTMLDivElement, TasksInsightProps>(
     const taskCategories = [
       {
         label: overdueLabel,
-        count: overdueTasksCount,
+        content: overdueTasksCount,
         icon: AlertCircle,
         color: "text-critical-50",
       },
       {
         label: dueLabel,
-        count: dueTasksCount,
+        content: dueTasksCount,
         icon: Circle,
         color: "text-f1-foreground-secondary",
       },
       {
         label: noDueLabel,
-        count: noDueTasksCount,
+        content: noDueTasksCount,
         icon: Circle,
         color: "text-f1-foreground-secondary",
       },
@@ -76,11 +76,11 @@ export const TasksInsight = forwardRef<HTMLDivElement, TasksInsightProps>(
         }}
       >
         <div className="grid grid-cols-3">
-          {taskCategories.map(({ label, count, icon, color }) => (
+          {taskCategories.map(({ label, content, icon, color }) => (
             <Indicator
               key={label}
               label={label}
-              count={count}
+              content={content}
               icon={icon}
               color={color}
             />


### PR DESCRIPTION
## 🚪 Why?

Sometimes we need to show text in this component

## 🔑 What?

It will accept a string instead of a number

## 🏡 Context

https://www.figma.com/design/9pLsRzdinid0ha0qRWta2D/Employee-Profile?node-id=604-7408&node-type=frame&t=QeWzqpPSgYqms5yY-0

<img width="462" alt="image" src="https://github.com/user-attachments/assets/3e0aa97b-7d0b-4c97-a49e-c5a89d5cdc4e">

