### PR TITLE
Adds explicit exports from the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,18 @@
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/factorial-one.js",
+      "types": "./dist/factorial-one.d.ts"
+    },
+    "./experimental": {
+      "import": "./dist/experimental.js",
+      "types": "./dist/experimental.d.ts"
+    },
+    "./dist/styles.css": "./dist/styles.css",
+    "./assets/fonts/*": "./assets/fonts/*"
+  },
   "packageManager": "npm@10.8.2",
   "files": [
     "assets",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
       "import": "./dist/experimental.js",
       "types": "./dist/experimental.d.ts"
     },
+    "./icons": {
+      "import": "./icons/index.js",
+      "types": "./icons/index.d.ts"
+    },
     "./dist/styles.css": "./dist/styles.css",
-    "./assets/fonts/*": "./assets/fonts/*",
-    "./icons/*": "./icons/*"
+    "./assets/fonts/*": "./assets/fonts/*"
   },
   "packageManager": "npm@10.8.2",
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
       "types": "./dist/experimental.d.ts"
     },
     "./dist/styles.css": "./dist/styles.css",
-    "./assets/fonts/*": "./assets/fonts/*"
+    "./assets/fonts/*": "./assets/fonts/*",
+    "./icons/*": "./icons/*"
   },
   "packageManager": "npm@10.8.2",
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,6 @@ export default defineConfig({
     lib: {
       entry: {
         ["factorial-one"]: resolve(__dirname, "lib/factorial-one.ts"),
-        ["playground"]: resolve(__dirname, "src/playground/exports.ts"),
         ["experimental"]: resolve(__dirname, "lib/experimental/exports.ts"),
       },
       fileName: (_, entryName) => {


### PR DESCRIPTION
Describe what is possible to import from the package:
- all stable components from `@factorialco/factorial-one`
- experimental components from `@factorialco/factorial-one/experimental`
- styles 
- fonts

Everything else will throw an error on import