### PR TITLE
Add Home icon to Info component

### DIFF
--- a/lib/experimental/Widgets/Info/index.tsx
+++ b/lib/experimental/Widgets/Info/index.tsx
@@ -1,11 +1,13 @@
 import { Icon } from "@/components/Utilities/Icon"
 import BriefcaseIcon from "@/icons/Briefcase"
+import HomeIcon from "@/icons/Home"
 import OfficeIcon from "@/icons/Office"
 import { forwardRef } from "react"
 
 const iconsMap = {
   office: OfficeIcon,
   briefcase: BriefcaseIcon,
+  home: HomeIcon,
 }
 
 interface InfoProps {
@@ -22,7 +24,7 @@ export const Info = forwardRef<HTMLDivElement, InfoProps>(
         className="flex flex-row items-center gap-1 text-f1-foreground-secondary"
       >
         <Icon icon={iconSvg} size={"md"} />
-        <p className="font-medium">{text}</p>
+        <p className="font-medium text-f1-foreground">{text}</p>
       </div>
     )
   }


### PR DESCRIPTION
## 🔑 What?

Add Home icon to Info component.

## 🚪 Why?

We need to show in the clock-in status widget the "Home" label along with the "home" icon when the user is working from home.

<img width="1033" alt="Screenshot 2024-09-20 at 16 15 29" src="https://github.com/user-attachments/assets/eedfc82d-29e6-4f84-a238-d9398bfd9b95">
