### PR TITLE
Increase snapshot threshold

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -62,6 +62,7 @@ const preview: Preview = {
         showLineNumbers: true, // default: false
         wrapLines: true, // default: true
       },
+      chromatic: { diffThreshold: 0.2 },
     },
     backgrounds: {
       default: "content",


### PR DESCRIPTION
We've been seeing lots of false positives in Chromatic lately. This adjusts the threshold [as per the documentation](https://www.chromatic.com/docs/threshold/) to hopefully prevent them.