### PR TITLE
Add Counter component

### DIFF
--- a/lib/experimental/Information/Counter/index.stories.tsx
+++ b/lib/experimental/Information/Counter/index.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
   tags: ["autodocs"],
   args: {
     value: 42,
-    size: "base",
+    size: "md",
     type: "default",
     maxValue: undefined,
   } satisfies ComponentProps<typeof Counter>,

--- a/lib/experimental/Information/Counter/index.stories.tsx
+++ b/lib/experimental/Information/Counter/index.stories.tsx
@@ -6,12 +6,17 @@ const meta = {
   component: Counter,
   parameters: {
     layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=252-8537&t=SrGKlGDdzYxFSTb8-4",
+    },
   },
   tags: ["autodocs"],
   args: {
     value: 42,
     size: "base",
     type: "default",
+    maxValue: undefined,
   } satisfies ComponentProps<typeof Counter>,
 } satisfies Meta<typeof Counter>
 
@@ -19,3 +24,11 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const MaxValue: Story = {
+  args: {
+    value: 123,
+    maxValue: 99,
+    type: "bold",
+  },
+}

--- a/lib/experimental/Information/Counter/index.stories.tsx
+++ b/lib/experimental/Information/Counter/index.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { ComponentProps } from "react"
+import { Counter } from "."
+
+const meta = {
+  component: Counter,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    value: 42,
+    size: "base",
+    type: "default",
+  } satisfies ComponentProps<typeof Counter>,
+} satisfies Meta<typeof Counter>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/lib/experimental/Information/Counter/index.tsx
+++ b/lib/experimental/Information/Counter/index.tsx
@@ -9,7 +9,7 @@ interface CounterProps {
 }
 
 const counterVariants = cva(
-  "rounded-xs inline-flex items-center justify-center whitespace-nowrap text-sm font-medium tabular-nums",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-xs text-sm font-medium tabular-nums",
   {
     variants: {
       size: {

--- a/lib/experimental/Information/Counter/index.tsx
+++ b/lib/experimental/Information/Counter/index.tsx
@@ -2,10 +2,10 @@ import { cva } from "class-variance-authority"
 import React from "react"
 
 interface CounterProps {
+  size?: "md" | "sm"
+  type?: "default" | "selected" | "bold"
   value: number
   maxValue?: number
-  size?: "base" | "sm"
-  type?: "default" | "selected" | "bold"
 }
 
 const counterVariants = cva(
@@ -13,7 +13,7 @@ const counterVariants = cva(
   {
     variants: {
       size: {
-        base: "min-w-5 p-0.5",
+        md: "min-w-5 p-0.5",
         sm: "min-w-4 px-0.5",
       },
       type: {
@@ -24,14 +24,14 @@ const counterVariants = cva(
       },
     },
     defaultVariants: {
-      size: "base",
+      size: "md",
       type: "default",
     },
   }
 )
 
 const Counter: React.FC<CounterProps> = ({
-  size = "base",
+  size = "md",
   type = "default",
   value,
   maxValue,

--- a/lib/experimental/Information/Counter/index.tsx
+++ b/lib/experimental/Information/Counter/index.tsx
@@ -3,6 +3,7 @@ import React from "react"
 
 interface CounterProps {
   value: number
+  maxValue?: number
   size?: "base" | "sm"
   type?: "default" | "selected" | "bold"
 }
@@ -33,8 +34,12 @@ const Counter: React.FC<CounterProps> = ({
   size = "base",
   type = "default",
   value,
+  maxValue,
 }) => {
-  return <div className={counterVariants({ size, type })}>{value}</div>
+  const displayValue =
+    maxValue !== undefined && value > maxValue ? `+${maxValue}` : value
+
+  return <div className={counterVariants({ size, type })}>{displayValue}</div>
 }
 
 export { Counter }

--- a/lib/experimental/Information/Counter/index.tsx
+++ b/lib/experimental/Information/Counter/index.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority"
 
 const counterVariants = cva(
-  "rounded-xs inline-flex items-center justify-center whitespace-nowrap text-sm font-medium tabular-nums",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-xs text-sm font-medium tabular-nums",
   {
     variants: {
       size: {

--- a/lib/experimental/Information/Counter/index.tsx
+++ b/lib/experimental/Information/Counter/index.tsx
@@ -1,15 +1,7 @@
-import { cva } from "class-variance-authority"
-import React from "react"
-
-interface CounterProps {
-  size?: "md" | "sm"
-  type?: "default" | "selected" | "bold"
-  value: number
-  maxValue?: number
-}
+import { cva, type VariantProps } from "class-variance-authority"
 
 const counterVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-xs text-sm font-medium tabular-nums",
+  "rounded-xs inline-flex items-center justify-center whitespace-nowrap text-sm font-medium tabular-nums",
   {
     variants: {
       size: {
@@ -30,16 +22,13 @@ const counterVariants = cva(
   }
 )
 
-const Counter: React.FC<CounterProps> = ({
-  size = "md",
-  type = "default",
-  value,
-  maxValue,
-}) => {
-  const displayValue =
-    maxValue !== undefined && value > maxValue ? `+${maxValue}` : value
+type CounterProps = {
+  value: number
+  maxValue?: number
+} & VariantProps<typeof counterVariants>
+
+export function Counter({ size, type, value, maxValue }: CounterProps) {
+  const displayValue = maxValue && value > maxValue ? `+${maxValue}` : value
 
   return <div className={counterVariants({ size, type })}>{displayValue}</div>
 }
-
-export { Counter }

--- a/lib/experimental/Information/Counter/index.tsx
+++ b/lib/experimental/Information/Counter/index.tsx
@@ -1,0 +1,40 @@
+import { cva } from "class-variance-authority"
+import React from "react"
+
+interface CounterProps {
+  value: number
+  size?: "base" | "sm"
+  type?: "default" | "selected" | "bold"
+}
+
+const counterVariants = cva(
+  "rounded-xs inline-flex items-center justify-center whitespace-nowrap text-sm font-medium tabular-nums",
+  {
+    variants: {
+      size: {
+        base: "min-w-5 p-0.5",
+        sm: "min-w-4 px-0.5",
+      },
+      type: {
+        default:
+          "border border-solid border-f1-border bg-f1-background-secondary",
+        selected: "bg-f1-background-selected-bold text-f1-foreground-inverse",
+        bold: "bg-f1-background-accent-bold text-f1-foreground-inverse",
+      },
+    },
+    defaultVariants: {
+      size: "base",
+      type: "default",
+    },
+  }
+)
+
+const Counter: React.FC<CounterProps> = ({
+  size = "base",
+  type = "default",
+  value,
+}) => {
+  return <div className={counterVariants({ size, type })}>{value}</div>
+}
+
+export { Counter }


### PR DESCRIPTION
## 🚪 Why?

Counter is one of our basic Web Components. Needed this component for the sidebar, so went ahead and built it.

## 🔑 What?

Add the [Counter](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=252-8537&t=SrGKlGDdzYxFSTb8-4) component, which displays a number in a label.

It features:
- A couple of sizes (`md` and `sm`).
- Three types (`default`, `selected` and `bold`).
- Max value as optional prop, to display a maximum number like `+99`.


https://github.com/user-attachments/assets/87ddce20-10c2-4159-8082-3b104afadeb9


## 🏡 Context

- [📖 Notion](https://www.notion.so/factorialco/Counter-1035e6e051ee804eaf3cec96bd2fdc42)
- [🎨 Figma](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=252-8537&t=SrGKlGDdzYxFSTb8-4)
