### PR TITLE
Button size variants

### DIFF
--- a/lib/components/Actions/Button/index.tsx
+++ b/lib/components/Actions/Button/index.tsx
@@ -8,7 +8,7 @@ import { ComponentProps, forwardRef, useState } from "react"
 
 export type ButtonProps = Pick<
   ComponentProps<typeof ShadcnButton>,
-  "variant" | "disabled" | "type" | "round"
+  "variant" | "size" | "disabled" | "type" | "round"
 > & {
   onClick?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -32,6 +32,7 @@ const Button: React.FC<ButtonProps> = forwardRef<
       loading: forceLoading,
       icon,
       variant = "default",
+      size = "medium",
       ...props
     },
     ref
@@ -61,12 +62,13 @@ const Button: React.FC<ButtonProps> = forwardRef<
         disabled={disabled || loading || forceLoading}
         ref={ref}
         variant={variant}
+        size={size}
         round={hideLabel}
         {...props}
       >
         {icon && (
           <Icon
-            size="md"
+            size={size === "small" ? "sm" : "md"}
             icon={icon}
             className={
               hideLabel

--- a/lib/components/Actions/Button/index.tsx
+++ b/lib/components/Actions/Button/index.tsx
@@ -32,7 +32,7 @@ const Button: React.FC<ButtonProps> = forwardRef<
       loading: forceLoading,
       icon,
       variant = "default",
-      size = "medium",
+      size = "md",
       ...props
     },
     ref
@@ -68,7 +68,7 @@ const Button: React.FC<ButtonProps> = forwardRef<
       >
         {icon && (
           <Icon
-            size={size === "small" ? "sm" : "md"}
+            size={size === "sm" ? "sm" : "md"}
             icon={icon}
             className={
               hideLabel

--- a/lib/components/Utilities/Icon/index.tsx
+++ b/lib/components/Utilities/Icon/index.tsx
@@ -13,7 +13,8 @@ const iconVariants = cva("inline-block", {
       xl: "h-12 w-12",
       lg: "h-8 w-8",
       md: "h-5 w-5",
-      sm: "h-3 w-3",
+      sm: "h-4 w-4",
+      xs: "h-3 w-3",
     },
   },
 

--- a/lib/ui/button.tsx
+++ b/lib/ui/button.tsx
@@ -12,7 +12,7 @@ export const variants = [
   "promote",
 ] as const
 
-export const sizes = ["small", "medium", "large"] as const
+export const sizes = ["sm", "md", "lg"] as const
 
 const buttonVariants = cva(
   "group inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md border-none text-base font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50",
@@ -33,9 +33,9 @@ const buttonVariants = cva(
           "border border-solid border-f1-border-promote bg-f1-background-promote text-f1-foreground hover:bg-f1-background-promote-hover",
       } satisfies Record<(typeof variants)[number], string>,
       size: {
-        small: "h-6 rounded-sm px-2",
-        medium: "h-8 rounded-md px-3",
-        large: "h-10 rounded-md px-4",
+        sm: "h-6 rounded-sm px-2",
+        md: "h-8 rounded-md px-3",
+        lg: "h-10 rounded-md px-4",
       } satisfies Record<(typeof sizes)[number], string>,
       round: {
         true: "aspect-square px-0",
@@ -43,7 +43,7 @@ const buttonVariants = cva(
     },
     defaultVariants: {
       variant: "default",
-      size: "medium",
+      size: "md",
       round: false,
     },
   }

--- a/lib/ui/button.tsx
+++ b/lib/ui/button.tsx
@@ -12,8 +12,10 @@ export const variants = [
   "promote",
 ] as const
 
+export const sizes = ["small", "medium", "large"] as const
+
 const buttonVariants = cva(
-  "focus-visible:ring-offset focus-visible:ring-ring group inline-flex h-10 items-center justify-center gap-1 whitespace-nowrap rounded-md border-none text-base font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50",
+  "group inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md border-none text-base font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -30,19 +32,24 @@ const buttonVariants = cva(
         promote:
           "border border-solid border-f1-border-promote bg-f1-background-promote text-f1-foreground hover:bg-f1-background-promote-hover",
       } satisfies Record<(typeof variants)[number], string>,
+      size: {
+        small: "h-6 rounded-sm px-2",
+        medium: "h-8 rounded-md px-3",
+        large: "h-10 rounded-md px-4",
+      } satisfies Record<(typeof sizes)[number], string>,
       round: {
         true: "aspect-square px-0",
-        false: "px-4",
       },
     },
     defaultVariants: {
       variant: "default",
+      size: "medium",
       round: false,
     },
   }
 )
 
-const iconVariants = cva("transition-colors", {
+const iconVariants = cva("-ml-0.5 transition-colors", {
   variants: {
     variant: {
       default: "text-f1-icon-inverse/80",
@@ -82,11 +89,11 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, round, variant, asChild = false, ...props }, ref) => {
+  ({ className, round, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
-        className={cn(buttonVariants({ variant, round }), className)}
+        className={cn(buttonVariants({ variant, size, round }), className)}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
## 🚪 Why?

There are several [size variants](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=41-1256&t=DAwXjJrhRku80x3Z-4) for the Button in Figma that we were missing in code. This PR adds them.

## 🔑 What?

- `size` prop in Button.
- Add a new icon size, `sm`, that is 16px (pretty common in our designs and we were missing it).
