### PR TITLE
Use a standardized antialiasing strategy

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -120,5 +120,5 @@
 }
 
 body {
-  @apply text-f1-foreground font-sans text-base;
+  @apply font-sans text-base text-f1-foreground antialiased;
 }


### PR DESCRIPTION
Different operating systems use different font aliasing methods. Mac OS usually defaults to `subpixel` while the rest use a more standard approach (called just `antialiasing`).

This is annoying as it makes things slightly inconsistent. Most notably, it makes fonts *bolder* in Mac.

**Antialiased**:
![image](https://github.com/user-attachments/assets/ac289862-e610-42a0-8bee-4c22d5c4172b)

**Subpixel-antialiased**:
![image](https://github.com/user-attachments/assets/07447c58-b99c-4e80-a89b-fa0546138f24)


This PR defaults to using plain `antialiased` for two reasons:

* Consistency, as mentioned above
* Most notably, the current Factorial app is already defaulting to `antialiased` on the `body` CSS, so regardless of what we do, they will still use that antialiasing.

We might revisit this in the future, but I think this is the most reasonable option at the moment.