### PR TITLE
chore: adapt widget container to new design

### DIFF
--- a/lib/experimental/Widgets/WidgetContainer/index.tsx
+++ b/lib/experimental/Widgets/WidgetContainer/index.tsx
@@ -40,6 +40,10 @@ export interface WidgetContainerProps {
   }>
 }
 
+const InlineDot = () => (
+  <div className="h-[0.15rem] w-[0.15rem] rounded-full bg-f1-foreground-secondary" />
+)
+
 const Container = forwardRef<
   HTMLDivElement,
   WidgetContainerProps & { children: ReactNode }
@@ -64,10 +68,14 @@ const Container = forwardRef<
               <div className="flex min-h-6 grow flex-row items-center gap-1.5 truncate">
                 {header.title && <CardTitle>{header.title}</CardTitle>}
                 {header.subtitle && (
-                  <CardSubtitle>{header.subtitle}</CardSubtitle>
+                  <>
+                    <InlineDot />
+                    <CardSubtitle>{header.subtitle}</CardSubtitle>
+                  </>
                 )}
                 {header.info && <CardInfo content={header.info} />}
               </div>
+              {alert && <Badge text={alert} variant="critical" hasDot />}
               {header.link && (
                 <CardLink href={header.link.url} title={header.link.title} />
               )}
@@ -130,10 +138,9 @@ const Container = forwardRef<
             )
           })}
       </CardContent>
-      {(action || alert) && (
+      {action && (
         <CardFooter>
-          {alert && <Badge text={alert} variant="critical" hasDot />}
-          {action && <Button variant="outline" {...action} />}
+          <Button variant="outline" size="md" {...action} />
         </CardFooter>
       )}
     </Card>

--- a/lib/ui/card.tsx
+++ b/lib/ui/card.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-import ArrowRight from "@/icons/ArrowRight"
+import ChevronRight from "@/icons/ChevronRight"
 import InfoCircleLine from "@/icons/InfoCircleLine"
 
 import { Icon } from "@/components/Utilities/Icon"
@@ -97,13 +97,13 @@ const CardLink = React.forwardRef<
   return (
     <Link
       className={cn(
-        "flex h-6 w-6 items-center justify-center text-f1-foreground-secondary transition-colors hover:text-f1-foreground",
+        "flex h-6 w-6 items-center justify-center rounded-sm border border-solid border-f1-border text-f1-foreground-secondary transition-colors hover:text-f1-foreground",
         className
       )}
       aria-label={title}
       {...props}
     >
-      <Icon icon={ArrowRight} size="md" />
+      <Icon icon={ChevronRight} size="sm" />
     </Link>
   )
 })


### PR DESCRIPTION
## 🚪 Why?

We are making the widgets match  the designs as much as possible

## 🔑 What?

Alert changes position, the link now has a different icon, title and subtitle are separated by a dot

## 🏡 Context

https://www.figma.com/design/9pLsRzdinid0ha0qRWta2D/Employee-Profile?node-id=378-17717&node-type=canvas&t=Du1ir1wtJRXblJI7-0
