### PR TITLE
Prevent resize loops on masonry layout

### DIFF
--- a/lib/experimental/Widgets/Layout/Dashboard/index.tsx
+++ b/lib/experimental/Widgets/Layout/Dashboard/index.tsx
@@ -40,27 +40,29 @@ const DashboardComponent = forwardRef<HTMLDivElement, DashboardProps>(
 
     return (
       <div ref={ref} className="overflow-hidden">
-        {columns === 1 ? (
-          <div className="flex flex-col gap-4">{arrayChildren}</div>
-        ) : (
-          columns &&
-          columns > 1 && (
-            <div className="relative -mr-4" ref={containerRef}>
-              <Masonry key={columns}>
-                {arrayChildren.map((child) => (
-                  <div
-                    style={{
-                      width: `${Math.floor((1 / columns) * 10000) / 100}%`,
-                    }}
-                    className="pb-4 pr-4"
-                  >
-                    {child}
-                  </div>
-                ))}
-              </Masonry>
-            </div>
-          )
-        )}
+        <div ref={containerRef}>
+          {columns === 1 ? (
+            <div className="flex flex-col gap-4">{arrayChildren}</div>
+          ) : (
+            columns &&
+            columns > 1 && (
+              <div className="relative -mr-4">
+                <Masonry key={columns}>
+                  {arrayChildren.map((child) => (
+                    <div
+                      style={{
+                        width: `${Math.floor((1 / columns) * 10000) / 100}%`,
+                      }}
+                      className="pb-4 pr-4"
+                    >
+                      {child}
+                    </div>
+                  ))}
+                </Masonry>
+              </div>
+            )
+          )}
+        </div>
       </div>
     )
   }

--- a/lib/experimental/Widgets/Layout/Dashboard/index.tsx
+++ b/lib/experimental/Widgets/Layout/Dashboard/index.tsx
@@ -4,21 +4,15 @@ import {
   ComponentProps,
   forwardRef,
   ReactNode,
-  useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react"
 import { Masonry } from "react-masonry"
-import { useResizeObserver } from "usehooks-ts"
 import { Widget } from "../../Widget"
 
 type DashboardProps = {
   children?: ReactNode[]
-}
-
-type Size = {
-  width?: number
-  height?: number
 }
 
 const DashboardComponent = forwardRef<HTMLDivElement, DashboardProps>(
@@ -27,41 +21,46 @@ const DashboardComponent = forwardRef<HTMLDivElement, DashboardProps>(
 
     const arrayChildren = Children.toArray(children)
 
-    const onResize = useCallback(
-      ({ width }: Size) => {
-        if (width) {
-          setColumns(Math.floor(width / 340) || 1)
-        }
-      },
-      [setColumns]
-    )
-
     const containerRef = useRef<HTMLDivElement>(null)
-    useResizeObserver({ ref: containerRef, onResize })
+
+    useEffect(() => {
+      const handleResize = () => {
+        const width = containerRef.current?.offsetWidth
+        if (width) setColumns(Math.floor(width / 340) || 1)
+      }
+
+      handleResize()
+
+      window.addEventListener("resize", handleResize)
+
+      return () => {
+        window.removeEventListener("resize", handleResize)
+      }
+    }, [setColumns])
 
     return (
-      <div ref={ref}>
-        <div ref={containerRef} className="overflow-hidden">
-          {columns === 1 ? (
-            <div className="flex flex-col gap-4">{arrayChildren}</div>
-          ) : (
-            columns &&
-            columns > 1 && (
-              <div className="-mr-4">
-                <Masonry key={columns}>
-                  {arrayChildren.map((child) => (
-                    <div
-                      style={{ width: `${(1 / columns) * 100}%` }}
-                      className="pb-4 pr-4"
-                    >
-                      {child}
-                    </div>
-                  ))}
-                </Masonry>
-              </div>
-            )
-          )}
-        </div>
+      <div ref={ref} className="overflow-hidden">
+        {columns === 1 ? (
+          <div className="flex flex-col gap-4">{arrayChildren}</div>
+        ) : (
+          columns &&
+          columns > 1 && (
+            <div className="relative -mr-4" ref={containerRef}>
+              <Masonry key={columns}>
+                {arrayChildren.map((child) => (
+                  <div
+                    style={{
+                      width: `${Math.floor((1 / columns) * 10000) / 100}%`,
+                    }}
+                    className="pb-4 pr-4"
+                  >
+                    {child}
+                  </div>
+                ))}
+              </Masonry>
+            </div>
+          )
+        )}
       </div>
     )
   }

--- a/lib/experimental/Widgets/Layout/Dashboard/index.tsx
+++ b/lib/experimental/Widgets/Layout/Dashboard/index.tsx
@@ -48,8 +48,9 @@ const DashboardComponent = forwardRef<HTMLDivElement, DashboardProps>(
             columns > 1 && (
               <div className="relative -mr-4">
                 <Masonry key={columns}>
-                  {arrayChildren.map((child) => (
+                  {arrayChildren.map((child, index) => (
                     <div
+                      key={index}
                       style={{
                         width: `${Math.floor((1 / columns) * 10000) / 100}%`,
                       }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,6 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "18.3.1",
         "react-hook-form": "^7.52.1",
-        "react-layout-masonry": "^1.1.0",
         "react-masonry": "^1.0.7",
         "recharts": "^2.12.7",
         "ress": "^5.0.2",
@@ -16243,16 +16242,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-layout-masonry": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-layout-masonry/-/react-layout-masonry-1.1.0.tgz",
-      "integrity": "sha512-EVDj8ICCKiZIYAfdZZyuIHzYTTXcwWdLr9B6IB+vKBa39tpIjoTIhpgcLsxurrYy3+le6JXTsQIduS2/8MpmFQ==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
     },
     "node_modules/react-masonry": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "18.3.1",
     "react-hook-form": "^7.52.1",
-    "react-layout-masonry": "^1.1.0",
     "react-masonry": "^1.0.7",
     "recharts": "^2.12.7",
     "ress": "^5.0.2",


### PR DESCRIPTION
This observes the window resize event instead of using a `resizeObserver` to prevent infinite loops when the sidebar appears/disappears and distorts the content width.