### PR TITLE
Fixes masonry calculation

### DIFF
--- a/lib/experimental/Widgets/Layout/Dashboard/index.tsx
+++ b/lib/experimental/Widgets/Layout/Dashboard/index.tsx
@@ -52,7 +52,7 @@ const DashboardComponent = forwardRef<HTMLDivElement, DashboardProps>(
                     <div
                       key={index}
                       style={{
-                        width: `${Math.floor((1 / columns) * 10000) / 100}%`,
+                        width: `${Math.floor((1 / columns) * 10000) / 100 - 0.05}%`,
                       }}
                       className="pb-4 pr-4"
                     >


### PR DESCRIPTION
Unfortunately, the library we use for masonry seems to have issues with certain column sizes due to floating point errors. This works around it by subtracting a small, unnoticeable amount from the column width.