### PR TITLE
Add experimental warning

### DIFF
--- a/.storybook/DocsContainer.tsx
+++ b/.storybook/DocsContainer.tsx
@@ -8,14 +8,27 @@ import { addons } from "@storybook/preview-api"
 import { FC, PropsWithChildren, useEffect, useState } from "react"
 import { DARK_MODE_EVENT_NAME } from "storybook-dark-mode"
 import lightTheme, { darkTheme } from "./FactorialOne"
+import { DOCS_RENDERED } from "@storybook/core-events"
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "../lib/components/Information/Alert"
 
 const channel = addons.getChannel()
 
-export const DocsContainer: FC<PropsWithChildren<DocsContainerProps>> = ({
-  children,
-  context,
-}) => {
+export const DocsContainer: FC<PropsWithChildren<DocsContainerProps>> = (
+  props
+) => {
   const [isDark, setDark] = useState(false)
+  let { context, children } = props
+  const [storyId, setStoryId] = useState<string | null>(null)
+
+  context.channel.on(DOCS_RENDERED, (id) => {
+    setStoryId(id)
+  })
+
+  let experimental = storyId && storyId.startsWith("experimental-")
 
   useEffect(() => {
     channel.on(DARK_MODE_EVENT_NAME, setDark)
@@ -23,7 +36,22 @@ export const DocsContainer: FC<PropsWithChildren<DocsContainerProps>> = ({
   }, [channel])
 
   return (
-    <BaseContainer theme={isDark ? darkTheme : lightTheme} context={context}>
+    <BaseContainer theme={isDark ? darkTheme : lightTheme} {...props}>
+      {experimental && (
+        <div className="sb-unstyled">
+          <Alert variant="destructive" className="mb-8">
+            <AlertTitle>Experimental component</AlertTitle>
+            <AlertDescription>
+              Please don't use experimental components in production unless
+              you're part of a testing group. To know more about our testing
+              process please check out our{" "}
+              <a href="/?path=/docs/components-maturity--documentation">
+                Component Maturity Model
+              </a>
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
       {children}
     </BaseContainer>
   )

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -36,7 +36,9 @@ const config: StorybookConfig = {
     name: "@storybook/react-vite",
     options: {},
   },
-  docs: {},
+  docs: {
+    defaultName: "Documentation",
+  },
   typescript: {
     reactDocgen: "react-docgen-typescript",
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,6 +15,7 @@ export default {
     "./src/**/*.{ts,tsx}",
     "./lib/**/*.{ts,tsx}",
     "./docs/**/*.{mdx,ts,tsx}",
+    "./storybook/**/*.{mdx,ts,tsx}",
   ],
   prefix: "",
   theme: {


### PR DESCRIPTION
## 🚪 Why?

People have started using experimental components and we'd like to prevent that until they become stable.

## 🔑 What?

Adds a banner on top of experimental components.
