### PR TITLE
chore: tweak to wireframe

### DIFF
--- a/lib/experimental/Widgets/Content/CategoryBarSection/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/CategoryBarSection/index.stories.tsx
@@ -21,8 +21,9 @@ type Story = StoryObj<typeof CategoryBarSection>
 
 export const Default: Story = {
   args: {
-    label: "Status",
-    title: "90% / 10%",
+    label: "Worked / Planned hours",
+    title: "121h 04m",
+    subtitle: "+3h 05m",
     data: [
       {
         name: "Achieved",

--- a/lib/experimental/Widgets/Content/CategoryBarSection/index.tsx
+++ b/lib/experimental/Widgets/Content/CategoryBarSection/index.tsx
@@ -6,6 +6,7 @@ import {
 interface CategoryBarSectionProps {
   label: string
   title: string
+  subtitle: string
   data: CategoryBarProps["data"]
   helpText?: string
   legend?: boolean
@@ -14,18 +15,22 @@ interface CategoryBarSectionProps {
 export function CategoryBarSection({
   label,
   title,
+  subtitle,
   data,
   helpText,
   legend = false,
 }: CategoryBarSectionProps) {
   return (
     <div>
-      <div className="space-y-0.5">
-        <span className="text-base leading-none text-f1-foreground-secondary">
+      <div className="space-y-2">
+        <span className="text-sm font-semibold uppercase leading-none text-f1-foreground-secondary">
           {label}
         </span>
-        <div className="flex items-baseline gap-2">
+        <div className="flex items-baseline justify-between">
           <span className="text-2xl font-semibold">{title}</span>
+          <span className="text-2xl font-semibold text-f1-foreground-secondary">
+            {subtitle}
+          </span>
         </div>
       </div>
       <div className="mt-2">

--- a/src/playground/Widgets/Examples/timesheet.stories.tsx
+++ b/src/playground/Widgets/Examples/timesheet.stories.tsx
@@ -36,7 +36,8 @@ export const Timesheet: Story = {
       >
         <CategoryBarSection
           label="Worked / Planned hours"
-          title="75h / 100h"
+          title="75h"
+          subtitle="100h"
           data={[
             {
               name: "Worked",
@@ -52,7 +53,8 @@ export const Timesheet: Story = {
         />
         <CategoryBarSection
           label="Balance"
-          title="9h / 50h"
+          title="9h"
+          subtitle="50h"
           data={[
             {
               name: "Worked",
@@ -87,7 +89,8 @@ export const TimesheetOvertime: Story = {
       >
         <CategoryBarSection
           label="Worked / Planned hours"
-          title="121h / 100h"
+          title="121h"
+          subtitle="100h"
           data={[
             {
               name: "Regular",
@@ -104,7 +107,7 @@ export const TimesheetOvertime: Story = {
         <CategoryBarSection
           label="Balance"
           title="+9h"
-          helpText="of 50h max"
+          subtitle="50h"
           data={[
             {
               name: "Regular",


### PR DESCRIPTION
## 🚪 Why?

We have some design changes in the Timesheet widget

## 🔑 What?

We adapt the CategoryBarSection to match spacing and positioning

## 🏡 Context

https://www.figma.com/design/9pLsRzdinid0ha0qRWta2D/Employee-Profile?node-id=946-24240&node-type=frame&t=yyyyi1rRyI2asVNY-0

<img width="575" alt="image" src="https://github.com/user-attachments/assets/923745dc-3beb-4724-a333-d39694c7df12">
