### PR TITLE
Compile in docs mode in production

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -38,7 +38,7 @@ const config: StorybookConfig = {
   },
   docs: {
     defaultName: "Documentation",
-    docsMode: process.env.PUBLIC_BUILD ? true : false,
+    docsMode: process.env.PUBLIC_BUILD || process.env.DOCS_MODE ? true : false,
   },
   typescript: {
     reactDocgen: "react-docgen-typescript",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -36,7 +36,10 @@ const config: StorybookConfig = {
     name: "@storybook/react-vite",
     options: {},
   },
-  docs: {},
+  docs: {
+    defaultName: "Documentation",
+    docsMode: process.env.PUBLIC_BUILD ? true : false,
+  },
   typescript: {
     reactDocgen: "react-docgen-typescript",
   },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -78,6 +78,9 @@ const preview: Preview = {
     },
     docs: {
       container: DocsContainer,
+      canvas: {
+        sourceState: "shown",
+      },
       toc: {
         headingSelector: "h2, h3",
       },

--- a/docs/Introduction.mdx
+++ b/docs/Introduction.mdx
@@ -15,19 +15,19 @@ Factorial One.
       icon={Rocket}
       title="Getting Started"
       description="Explore how to start with tutorials and getting started guides."
-      href="/?path=/docs/components-maturity--docs"
+      href="/?path=/docs/components-maturity--documentation"
     />
     <FeatureCard
       icon={Dashboard}
       title="Foundations"
       description="Explore the foundations like colors, typography, or spacing."
-      href="/?path=/docs/foundations-colors--docs"
+      href="/?path=/docs/foundations-colors--documentation"
     />
     <FeatureCard
       icon={Folder}
       title="Components"
       description="Discover our comprehensive collection of UI components."
-      href="/?path=/docs/components-actions-button--docs"
+      href="/?path=/docs/components-actions-button--documentation"
     />
   </div>
 </Unstyled>

--- a/lib/experimental/Widgets/index.mdx
+++ b/lib/experimental/Widgets/index.mdx
@@ -58,4 +58,4 @@ format. It's a bit more complex than the other widgets, but it's still a widget.
 <Canvas of={BarChartWidgetStories.Default} />
 
 You can find more examples of charts in the
-[charts section](/docs/experimental-widgets-charts-areachartwidget--docs).
+[charts section](/docs/experimental-widgets-charts-areachartwidget--documentation).

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "dev": "storybook dev -p 6006",
-    "dev:docs": "storybook dev --docs",
+    "dev:docs": "DOCS_MODE=true npm run dev",
     "start": "npm run dev",
     "build": "tsc --p ./tsconfig-build.json && BUILD_TYPES=true vite build && npm run build:tailwind && run-p build-icons",
     "build-icons": "tsc --p ./tsconfig-build-icons.json",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "dev": "storybook dev -p 6006",
+    "dev:docs": "storybook dev --docs",
     "start": "npm run dev",
     "build": "tsc --p ./tsconfig-build.json && BUILD_TYPES=true vite build && npm run build:tailwind && run-p build-icons",
     "build-icons": "tsc --p ./tsconfig-build-icons.json",
@@ -29,7 +30,6 @@
     "test-storybook": "test-storybook",
     "prettier:format": "prettier --write \"lib/**/*.{ts,tsx,js,md,mdx,css,yaml}\"",
     "prettier:check:ci": "prettier --check \"lib/**/*.{ts,tsx,js,md,mdx,css,yaml}\"",
-    "storybook-docs": "storybook dev --docs",
     "tsc": "tsc --noEmit",
     "vitest": "vitest dev",
     "vitest:ci": "vitest run"


### PR DESCRIPTION
## 🚪 Why?

The amount of information in Storybook can be overwhelming.

## 🔑 What?

Storybook has something called the "docs" mode, in which the resulting storybook project only includes the documentation (either manual or autogenerated) and not every story as a separate page.

I believe this will help us keep the project decluttered, clearer and what's important - more useful.