### PR TITLE
Beautify docs tables 💅

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -45,6 +45,77 @@
     border-radius: 12px !important;
   }
 
+  .sb-unstyled table,
+  .docblock-argstable {
+    background: #f5f6f8;
+    border-radius: 12px;
+    border: #f5f6f8 4px solid;
+    border-spacing: 0 !important;
+    width: 100%;
+  }
+
+  .sb-unstyled tbody,
+  .docblock-argstable-body {
+    filter: none !important;
+    outline: rgba(0, 0, 0, 0.1) 1px solid !important;
+    border-radius: 10px;
+    overflow: hidden;
+    background: #fff;
+  }
+
+  .sb-unstyled tbody > tr:nth-child(even) > td,
+  .docblock-argstable-body > tr:nth-child(even) > td {
+    background: #fafbfc !important;
+  }
+
+  .sb-unstyled tbody > tr:not(:last-child) > td,
+  .docblock-argstable-body > tr:not(:last-child) > td {
+    border-bottom: #dce0e5 1px solid !important;
+  }
+
+  .sb-unstyled thead > tr > th {
+    padding: 10px 20px;
+    color: #647084;
+    text-align: left;
+  }
+
+  .sb-unstyled tbody > tr > td {
+    padding: 16px 20px;
+  }
+
+  input[type="radio"] {
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 1px solid #dce0e5;
+    background-color: #fff;
+    position: relative;
+    transition: border 0.2s ease-in-out;
+  }
+
+  input[type="radio"]:hover,
+  input[type="radio"]:checked {
+    border: 1px solid #a1abbd;
+  }
+
+  input[type="radio"]::before {
+    content: "";
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    transform: scale(0);
+    transition: 120ms transform ease-in-out;
+    box-shadow: inset 1em 1em #ff355e;
+    position: absolute;
+    left: 3px;
+    top: 3px;
+  }
+
+  input[type="radio"]:checked::before {
+    transform: scale(1);
+  }
+
   /* -- DARK -- */
   body.dark #storybook-docs h1,
   body.dark #storybook-docs h2,
@@ -85,31 +156,36 @@
     box-shadow: 0px 2px 20px #0d1625 !important;
   }
 
+  body.dark .sb-unstyled table,
+  body.dark .docblock-argstable {
+    background: #161f30;
+    border: #161f30 4px solid;
+  }
+
+  body.dark .sb-unstyled thead > tr > th,
+  body.dark .docblock-argstable-head > tr > th > span {
+    color: #a1abbd !important;
+  }
+
+  body.dark .sb-unstyled tbody,
+  body.dark .docblock-argstable-body {
+    outline: none !important;
+    background: #0d1625;
+  }
+
+  body.dark .sb-unstyled tbody > tr:nth-child(even) > td,
+  body.dark .docblock-argstable-body > tr:nth-child(even) > td {
+    background: #111a2a !important;
+  }
+
+  body.dark .sb-unstyled tbody > tr:not(:last-child) > td,
+  body.dark .docblock-argstable-body > tr:not(:last-child) > td {
+    border-bottom: #172031 1px solid !important;
+  }
+
   body.dark input[type="radio"] {
-    appearance: none;
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
     border: 1px solid #202c42;
     background-color: #161f30;
-    position: relative;
-  }
-
-  body.dark input[type="radio"]::before {
-    content: "";
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    transform: scale(0);
-    transition: 120ms transform ease-in-out;
-    box-shadow: inset 1em 1em #fff;
-    position: absolute;
-    left: 3px;
-    top: 3px;
-  }
-
-  body.dark input[type="radio"]:checked::before {
-    transform: scale(1);
   }
 </style>
 <script src="https://cdn.jsdelivr.net/npm/react-render-tracker"></script>

--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -7,54 +7,111 @@ import { Meta, Unstyled } from "@storybook/blocks"
 The typography comprises five predefined font sizes. The base font size of the
 app is 14px when used with the default browser settings.
 
+## Font sizes
+
 <Unstyled>
-  <div className="mb-8 grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-4 dark:text-f1-foreground-inverse/80">
-    <p className="text-right text-sm">
-      <pre className="inline">text-3xl</pre>, 36px
-    </p>
-    <p className="text-3xl">The quick brown fox jumped over the lazy dog.</p>
-    <p className="text-right text-sm">
-      <pre className="inline">text-2xl</pre>, 26px
-    </p>
-    <p className="text-2xl">The quick brown fox jumped over the lazy dog.</p>
-    <p className="text-right text-sm">
-      <pre className="inline">text-xl</pre>, 22px
-    </p>
-    <p className="text-xl">The quick brown fox jumped over the lazy dog.</p>
-    <p className="text-right text-sm">
-      <pre className="inline">text-lg</pre>, 16px
-    </p>
-    <p className="text-lg">The quick brown fox jumped over the lazy dog.</p>
-    <p className="text-right text-sm">
-      <pre className="inline">text-base</pre>, 14px
-    </p>
-    <p>The quick brown fox jumped over the lazy dog.</p>
-    <p className="text-right text-sm">
-      <pre className="inline">text-sm</pre>, 12px
-    </p>
-    <p className="text-sm">The quick brown fox jumped over the lazy dog.</p>
-  </div>
+  <table className="mb-8 dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Class</th>
+        <th className="text-left">Size</th>
+        <th className="text-left">Preview</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <pre className="inline">text-3xl</pre>
+        </td>
+        <td>36px</td>
+        <td className="text-3xl">
+          The quick brown fox jumped over the lazy dog.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <pre className="inline">text-2xl</pre>
+        </td>
+        <td>26px</td>
+        <td className="text-2xl">
+          The quick brown fox jumped over the lazy dog.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <pre className="inline">text-xl</pre>
+        </td>
+        <td>22px</td>
+        <td className="text-xl">
+          The quick brown fox jumped over the lazy dog.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <pre className="inline">text-lg</pre>
+        </td>
+        <td>16px</td>
+        <td className="text-lg">
+          The quick brown fox jumped over the lazy dog.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <pre className="inline">text-base</pre>
+        </td>
+        <td>14px</td>
+        <td>The quick brown fox jumped over the lazy dog.</td>
+      </tr>
+      <tr>
+        <td>
+          <pre className="inline">text-sm</pre>
+        </td>
+        <td>12px</td>
+        <td className="text-sm">
+          The quick brown fox jumped over the lazy dog.
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </Unstyled>
 
 ## Weight
 
-We support three font weights in our UI:
-
 <Unstyled>
-  <div className="mb-8 grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-4 dark:text-f1-foreground-inverse/80">
-    <p className="text-right text-sm">
-      <pre className="inline">font-normal</pre>, 400
-    </p>
-    <p>The quick brown fox jumped over the lazy dog.</p>
-    <p className="text-right text-sm">
-      <pre className="inline">font-medium</pre>, 500
-    </p>
-    <p className="font-medium">The quick brown fox jumped over the lazy dog.</p>
-    <p className="text-right text-sm">
-      <pre className="inline">font-semibold</pre>, 600
-    </p>
-    <p className="font-semibold">
-      The quick brown fox jumped over the lazy dog.
-    </p>
-  </div>
+  <table className="mb-8 dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th>Font Style</th>
+        <th>Weight</th>
+        <th>Preview</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <pre>font-normal</pre>
+        </td>
+        <td>400</td>
+        <td>The quick brown fox jumped over the lazy dog.</td>
+      </tr>
+      <tr>
+        <td>
+          <pre>font-medium</pre>
+        </td>
+        <td>500</td>
+        <td className="font-medium">
+          The quick brown fox jumped over the lazy dog.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <pre>font-semibold</pre>
+        </td>
+        <td>600</td>
+        <td className="font-semibold">
+          The quick brown fox jumped over the lazy dog.
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </Unstyled>


### PR DESCRIPTION
Another bunch of classes to make tables look better and make them easier to scan and read.

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/89719ca1-dc98-4221-9ef6-34bf2b6745f1)  | ![image](https://github.com/user-attachments/assets/f3a74400-50fd-438e-b832-0f64302b18de) |

I also took the opportunity to turn the Typography page into a table, making it more readable:

![image](https://github.com/user-attachments/assets/e8903033-ceac-4819-bc70-51a509bbc167)
