### PR TITLE
Multiline events support for `EventsList`

### DIFF
--- a/lib/experimental/Widgets/Content/EventsList/event.tsx
+++ b/lib/experimental/Widgets/Content/EventsList/event.tsx
@@ -22,7 +22,7 @@ export const Event = forwardRef<HTMLDivElement, EventProps>(
           }}
         />
         <div
-          className="rounded-2xs min-h-10 min-w-1"
+          className="min-h-10 min-w-1 rounded-2xs"
           style={
             isPending
               ? {
@@ -40,7 +40,7 @@ export const Event = forwardRef<HTMLDivElement, EventProps>(
           }
         />
         <div className="flex flex-col gap-0.5">
-          <p className="font-medium line-clamp-3">
+          <p className="line-clamp-3 font-medium">
             {title}
             <span className="pl-1">{subtitle}</span>
           </p>

--- a/lib/experimental/Widgets/Content/EventsList/event.tsx
+++ b/lib/experimental/Widgets/Content/EventsList/event.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
 
 export interface EventProps {
@@ -14,7 +13,7 @@ export const Event = forwardRef<HTMLDivElement, EventProps>(
     return (
       <div
         ref={ref}
-        className="relative flex flex-row items-center gap-3 overflow-hidden rounded-sm px-2 py-1.5"
+        className="relative flex flex-row items-stretch gap-3 overflow-hidden rounded-sm px-2 py-1.5"
       >
         <div
           className="absolute bottom-0 left-0 right-0 top-0 opacity-10"
@@ -23,7 +22,7 @@ export const Event = forwardRef<HTMLDivElement, EventProps>(
           }}
         />
         <div
-          className={cn("h-10 w-1 rounded-2xs")}
+          className="rounded-2xs min-h-10 min-w-1"
           style={
             isPending
               ? {
@@ -41,10 +40,10 @@ export const Event = forwardRef<HTMLDivElement, EventProps>(
           }
         />
         <div className="flex flex-col gap-0.5">
-          <div className="flex flex-row gap-1 font-medium">
-            <p>{title}</p>
-            <p>{subtitle}</p>
-          </div>
+          <p className="font-medium line-clamp-3">
+            {title}
+            <span className="pl-1">{subtitle}</span>
+          </p>
           <p className="text-f1-foreground-secondary">{description}</p>
         </div>
       </div>

--- a/lib/experimental/Widgets/Content/EventsList/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/EventsList/index.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta = {
     title: "Events",
     events: [
       {
-        title: "Product Review",
+        title: "Birthday of Kyriakos Papadopoulos",
         subtitle: "(2 days)",
         description: "02/07 - 04/07",
         color: "orange",

--- a/lib/experimental/Widgets/Content/EventsList/index.tsx
+++ b/lib/experimental/Widgets/Content/EventsList/index.tsx
@@ -14,9 +14,9 @@ export const EventsList = forwardRef<HTMLDivElement, EventsListProps>(
     }
 
     return (
-      <div ref={ref}>
+      <div className="flex flex-col gap-3" ref={ref}>
         {title && (
-          <p className="mb-3 text-sm font-semibold uppercase text-f1-foreground-secondary">
+          <p className="text-sm font-semibold uppercase text-f1-foreground-secondary">
             {title}
           </p>
         )}


### PR DESCRIPTION
## 🔑 What?

- allow up to 3 lines of event title (before it was breaking the layout)
- added an example to the storybook

![CleanShot 2024-09-26 at 18 30 39@2x](https://github.com/user-attachments/assets/62763df4-a726-42d2-ab08-00d7636955d7)
