### PR TITLE
fixing avif url

### DIFF
--- a/docs/colors.mdx
+++ b/docs/colors.mdx
@@ -189,10 +189,7 @@ Use these tokens for icons.
 
 Token names are generated using the naming convention:
 
-<img
-  src="/semantic-tokens-naming.avif"
-  alt="semantic token naming convention"
-/>
+<img src="semantic-tokens-naming.avif" alt="semantic token naming convention" />
 
 ## Bare colors
 


### PR DESCRIPTION
## 🚪 Why?

Right now, token naming convention image is broken
<img width="533" alt="image" src="https://github.com/user-attachments/assets/f2157b79-a83e-486a-9616-6678d306673a">


## 🔑 What?

This removes the initial "/" to fix the image. Pretty wild huh?