### PR TITLE
IconList and Icons adjustments

### DIFF
--- a/lib/components/Utilities/Icon/index.tsx
+++ b/lib/components/Utilities/Icon/index.tsx
@@ -10,11 +10,11 @@ import {
 const iconVariants = cva("inline-block", {
   variants: {
     size: {
-      xl: "h-12 w-12",
-      lg: "h-8 w-8",
-      md: "h-5 w-5",
-      sm: "h-4 w-4",
-      xs: "h-3 w-3",
+      xl: "h-12 w-12 min-w-12",
+      lg: "h-8 w-8 min-w-8",
+      md: "h-5 w-5 min-w-5",
+      sm: "h-4 w-4 min-w-4",
+      xs: "h-3 w-3 min-w-3",
     },
   },
 

--- a/lib/experimental/Widgets/Content/IconText/index.tsx
+++ b/lib/experimental/Widgets/Content/IconText/index.tsx
@@ -21,21 +21,24 @@ export const IconText = forwardRef<HTMLDivElement, IconTextProps>(
     return (
       <div
         ref={ref}
-        className="flex flex-row items-center gap-1 text-f1-foreground-secondary"
+        className="flex flex-row items-start gap-1 text-f1-foreground-secondary"
       >
-        <Icon icon={iconSvg} size={"sm"} />
-        {texts.map((text, index) => {
-          return (
-            <div className="flex flex-row items-center justify-center gap-1">
+        <div className="pt-0.5">
+          <Icon icon={iconSvg} size="sm" />
+        </div>
+        <p className="font-medium text-f1-foreground">
+          {texts.map((text, index) => (
+            <>
               {index > 0 && (
-                <div className="h-[0.15rem] w-[0.15rem] rounded-full bg-f1-foreground" />
+                <span
+                  key={`dot-${index}`}
+                  className="mx-1 inline-block h-[0.15rem] w-[0.15rem] min-w-[0.15rem] rounded-full bg-f1-foreground align-middle"
+                />
               )}
-              <p key={index} className="font-medium text-f1-foreground">
-                {text}
-              </p>
-            </div>
-          )
-        })}
+              {text}
+            </>
+          ))}
+        </p>
       </div>
     )
   }

--- a/lib/experimental/Widgets/Content/IconTextsList/index.tsx
+++ b/lib/experimental/Widgets/Content/IconTextsList/index.tsx
@@ -8,7 +8,7 @@ interface IconTextsListProps {
 export const IconTextsList = forwardRef<HTMLDivElement, IconTextsListProps>(
   ({ list }, ref) => {
     return (
-      <div ref={ref} className="mt-2 flex flex-col gap-2">
+      <div ref={ref} className="flex flex-col gap-2">
         {list.map((item) => (
           <IconText key={item.texts[0]} icon={item.icon} texts={item.texts} />
         ))}


### PR DESCRIPTION
- sets min-width for icon sizes because flex containers squash them when they need to grow other columns
- removes outer margins for the icon list component and simplifies the rendering
