### PR TITLE
`Weekdays`: update colors and typography

### DIFF
--- a/lib/experimental/Widgets/Content/Weekdays/index.tsx
+++ b/lib/experimental/Widgets/Content/Weekdays/index.tsx
@@ -28,11 +28,12 @@ export const Weekdays = forwardRef<HTMLDivElement, WeekdaysProps>(
       >
         {daysOfTheWeek.map((day) => (
           <ToggleGroupItem
+            aria-label={day}
             key={day}
             value={day}
-            className="h-6 w-6 disabled:bg-f1-background-secondary disabled:text-f1-foreground disabled:opacity-100 disabled:data-[state=on]:bg-f1-background-bold disabled:data-[state=on]:text-f1-foreground-inverse"
+            className="h-6 w-6 shrink-0 grow-0 basis-6 p-0 text-sm font-medium disabled:select-none disabled:bg-f1-background-tertiary disabled:text-f1-foreground-secondary disabled:opacity-100 disabled:data-[state=on]:border disabled:data-[state=on]:border-solid disabled:data-[state=on]:border-f1-border-selected disabled:data-[state=on]:bg-f1-background-selected disabled:data-[state=on]:text-f1-foreground-selected"
           >
-            <p className="h-auto text-sm">{day[0]}</p>
+            {day[0]}
           </ToggleGroupItem>
         ))}
       </ToggleGroup>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -182,6 +182,9 @@ export default {
             positive: {
               DEFAULT: "hsl(var(--positive-70))",
             },
+            selected: {
+              DEFAULT: "hsl(var(--selected-70))",
+            },
           },
           background: {
             DEFAULT: "hsl(var(--neutral-0))",
@@ -216,7 +219,7 @@ export default {
               DEFAULT: "hsl(var(--positive-50) / 0.1)",
             },
             selected: {
-              DEFAULT: "hsl(var(--selected-50) / 0.1)",
+              DEFAULT: "hsl(var(--selected-50) / 0.2)",
               bold: "hsl(var(--selected-50))",
             },
           },
@@ -226,6 +229,9 @@ export default {
             secondary: "hsl(var(--neutral-10))",
             promote: {
               DEFAULT: "hsl(var(--promote-50) / 0.4)",
+            },
+            selected: {
+              DEFAULT: "hsl(var(--selected-50) / 0.2)",
             },
           },
           icon: {


### PR DESCRIPTION
## 🔑 What?

- sets new colors 
- uses full day names for ARIA. Screen readers will read the full day name instead of one letter abbreviation

| Before | After |
|--------|--------|
| ![CleanShot 2024-09-30 at 12 54 25@2x](https://github.com/user-attachments/assets/80dcad8c-e353-4eac-b7f2-74a9b6cf1532) | ![CleanShot 2024-09-30 at 12 48 15@2x](https://github.com/user-attachments/assets/538bcdd4-4099-45c6-ac3b-3f2f988aac78) |