### PR TITLE
Prevent legend from overflowing the chart

### DIFF
--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -209,7 +209,11 @@ export const _AreaChart = <K extends LineChartConfig>(
           <ChartLegend
             className="flex justify-start"
             iconType="star"
-            content={<ChartLegendContent />}
+            content={
+              <ChartLegendContent
+                leftShift={isYAxisVisible ? Math.round(yAxisWidth) : 0}
+              />
+            }
           />
         )}
       </AreaChartPrimitive>

--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -209,11 +209,7 @@ export const _AreaChart = <K extends LineChartConfig>(
           <ChartLegend
             className="flex justify-start"
             iconType="star"
-            content={
-              <ChartLegendContent
-                leftShift={isYAxisVisible ? Math.round(yAxisWidth) : 0}
-              />
-            }
+            content={<ChartLegendContent />}
           />
         )}
       </AreaChartPrimitive>

--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -329,18 +329,10 @@ const ChartLegendContent = React.forwardRef<
     Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
       hideIcon?: boolean
       nameKey?: string
-      leftShift?: number
     }
 >(
   (
-    {
-      className,
-      hideIcon = false,
-      payload,
-      verticalAlign = "bottom",
-      nameKey,
-      leftShift = 0,
-    },
+    { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
     ref
   ) => {
     const { config } = useChart()
@@ -353,11 +345,10 @@ const ChartLegendContent = React.forwardRef<
       <div
         ref={ref}
         className={cn(
-          "relative flex items-center justify-center gap-4 text-f1-foreground-secondary",
+          "relative flex flex-wrap items-center justify-center gap-4 text-f1-foreground-secondary",
           verticalAlign === "top" ? "pb-2" : "pt-2",
           className
         )}
-        style={{ left: leftShift }}
       >
         {payload.map((item) => {
           const key = `${nameKey || item.dataKey || "value"}`

--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -329,10 +329,18 @@ const ChartLegendContent = React.forwardRef<
     Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
       hideIcon?: boolean
       nameKey?: string
+      leftShift?: number
     }
 >(
   (
-    { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
+    {
+      className,
+      hideIcon = false,
+      payload,
+      verticalAlign = "bottom",
+      nameKey,
+      leftShift = 0,
+    },
     ref
   ) => {
     const { config } = useChart()
@@ -349,6 +357,7 @@ const ChartLegendContent = React.forwardRef<
           verticalAlign === "top" ? "pb-2" : "pt-2",
           className
         )}
+        style={{ marginLeft: leftShift }}
       >
         {payload.map((item) => {
           const key = `${nameKey || item.dataKey || "value"}`


### PR DESCRIPTION
## 🔑 What?

Prevent legend from overflowing the chart.

## 🚪 Why?

Moving the legend like that was causing it to overflow the widget container.
