### PR TITLE
Revert "Chromatic takes care of deployment now"

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,29 @@
+name: Build and Publish Storybook to GitHub Pages
+
+on:
+  push:
+    branches:
+      - "main"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+env:
+  PUBLIC_BUILD: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "21.x"
+          cache: npm
+      - uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
+        with:
+          install_command: npm install
+          build_command: npm run build-storybook
+          path: storybook-static


### PR DESCRIPTION
Reverts factorialco/factorial-one#604

Reason: we cannot point custom domain to our chromatic builds on the Standard plan:
![CleanShot 2024-09-30 at 18 08 28@2x](https://github.com/user-attachments/assets/5a470817-078b-469f-865e-a682d71d4f42)
