### PR TITLE
Do not show tooltip when we are blurring the chart

### DIFF
--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -182,15 +182,17 @@ export const _AreaChart = <K extends LineChartConfig>(
             className={cn(yAxis?.isBlur && "blur-sm")}
           />
         )}
-        <ChartTooltip
-          cursor
-          content={
-            <ChartTooltipContent
-              indicator="dot"
-              yAxisFormatter={yAxis?.tickFormatter}
-            />
-          }
-        />
+        {!yAxis?.isBlur && (
+          <ChartTooltip
+            cursor
+            content={
+              <ChartTooltipContent
+                indicator="dot"
+                yAxisFormatter={yAxis?.tickFormatter}
+              />
+            }
+          />
+        )}
         {areas.map((area, index) => (
           <Area
             isAnimationActive={false}


### PR DESCRIPTION
## 🔑 What?

Do not show tooltip when we are blurring the chart.

## 🚪 Why?

We shouldn't show any tooltip when hovering the chart in case it's blurred.

## 👁️ Visual proof

https://github.com/user-attachments/assets/4a5e00b8-f7d0-445b-9308-fc3de43a8a2d
