### PR TITLE
Add Focus Ring class

### DIFF
--- a/lib/experimental/Navigation/Sidebar/Menu/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Menu/index.tsx
@@ -1,6 +1,6 @@
 import { Counter } from "@/experimental/Information/Counter"
 import * as Icons from "@/icons"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import {
   Collapsible,
   CollapsibleContent,
@@ -53,7 +53,8 @@ const MenuItem = ({ item }: { item: MenuItem }) => (
   <a
     href={item.href}
     className={cn(
-      "flex cursor-pointer items-center rounded py-1.5 pl-1.5 pr-2 no-underline transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-ring focus-visible:ring-offset-1",
+      "flex cursor-pointer items-center rounded py-1.5 pl-1.5 pr-2 no-underline transition-colors",
+      focusRing(),
       item.isActive
         ? "bg-f1-background-secondary-hover text-f1-foreground"
         : "hover:bg-f1-background-secondary-hover"
@@ -78,7 +79,12 @@ const CategoryItem = ({ category }: { category: MenuCategory }) => {
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger className="flex w-full cursor-pointer items-center justify-between border-t border-dashed border-transparent border-t-f1-border px-1.5 pb-2 pt-4 text-sm font-semibold uppercase tracking-wide text-f1-foreground-secondary focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-ring focus-visible:ring-offset-1">
+      <CollapsibleTrigger
+        className={cn(
+          "flex w-full cursor-pointer items-center justify-between border-t border-dashed border-transparent border-t-f1-border px-1.5 pb-2 pt-4 text-sm font-semibold uppercase tracking-wide text-f1-foreground-secondary",
+          focusRing("focus-visible:rounded-md")
+        )}
+      >
         {category.title}
         <motion.div
           initial={false}

--- a/lib/lib/utils.ts
+++ b/lib/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function focusRing(extraClasses?: string) {
+  return cn(
+    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-ring focus-visible:ring-offset-1",
+    extraClasses
+  )
+}

--- a/lib/ui/badge.tsx
+++ b/lib/ui/badge.tsx
@@ -1,10 +1,13 @@
 import { cva, type VariantProps } from "class-variance-authority"
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "focus:ring-ring text inline-flex items-center rounded-full border border-solid px-2.5 py-0.5 font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2",
+  cn(
+    "focus:ring-ring text inline-flex items-center rounded-full border border-solid px-2.5 py-0.5 font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2",
+    focusRing()
+  ),
   {
     variants: {
       variant: {

--- a/lib/ui/button.tsx
+++ b/lib/ui/button.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 import * as React from "react"
@@ -15,7 +15,10 @@ export const variants = [
 export const sizes = ["sm", "md", "lg"] as const
 
 const buttonVariants = cva(
-  "group inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md border-none text-base font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50",
+  cn(
+    "group inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md border-none text-base font-medium transition-colors disabled:pointer-events-none disabled:opacity-50",
+    focusRing()
+  ),
   {
     variants: {
       variant: {

--- a/lib/ui/checkbox.tsx
+++ b/lib/ui/checkbox.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { Check } from "lucide-react"
 import * as React from "react"
@@ -10,7 +10,8 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "border-primary ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary peer h-4 w-4 shrink-0 rounded-2xs border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:text-f1-foreground",
+      "border-primary ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary peer h-4 w-4 shrink-0 rounded-2xs border disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:text-f1-foreground",
+      focusRing(),
       className
     )}
     {...props}

--- a/lib/ui/input.tsx
+++ b/lib/ui/input.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import * as React from "react"
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
@@ -9,7 +9,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-sm border-2 border-solid border-f1-border bg-f1-background px-3 py-2 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-f1-foreground-secondary/60 hover:border-f1-border-hover focus-visible:border-f1-border-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-f1-background-secondary disabled:opacity-50",
+          "flex h-10 w-full rounded-sm border-2 border-solid border-f1-border bg-f1-background px-3 py-2 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-f1-foreground-secondary/60 hover:border-f1-border-hover disabled:cursor-not-allowed disabled:bg-f1-background-secondary disabled:opacity-50",
+          focusRing("focus-visible:border-f1-border-hover"),
           className
         )}
         ref={ref}

--- a/lib/ui/select.tsx
+++ b/lib/ui/select.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 import * as React from "react"
@@ -18,7 +18,8 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "ring-offset-background focus:ring-ring flex h-10 w-full items-center justify-between rounded-sm border-2 border-solid border-f1-border bg-f1-background px-3 py-2 text-sm transition-colors placeholder:text-f1-foreground-secondary hover:border-f1-border-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus-visible:border-f1-border-hover disabled:cursor-not-allowed disabled:bg-f1-background-secondary disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-sm border-2 border-solid border-f1-border bg-f1-background px-3 py-2 text-sm transition-colors placeholder:text-f1-foreground-secondary hover:border-f1-border-hover disabled:cursor-not-allowed disabled:bg-f1-background-secondary disabled:opacity-50 [&>span]:line-clamp-1",
+      focusRing("focus-visible:border-f1-border-hover"),
       className
     )}
     {...props}

--- a/lib/ui/toggle.tsx
+++ b/lib/ui/toggle.tsx
@@ -2,10 +2,13 @@ import * as TogglePrimitive from "@radix-ui/react-toggle"
 import { cva, type VariantProps } from "class-variance-authority"
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "ring-offset-background focus-visible:ring-ring inline-flex items-center justify-center rounded-xs text-sm font-medium transition-colors hover:bg-f1-background-secondary hover:text-f1-foreground-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-f1-background-secondary data-[state=on]:text-f1-foreground",
+  cn(
+    "inline-flex items-center justify-center rounded-xs text-sm font-medium transition-colors hover:bg-f1-background-secondary hover:text-f1-foreground-secondary disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-f1-background-secondary data-[state=on]:text-f1-foreground",
+    focusRing()
+  ),
   {
     variants: {
       variant: {


### PR DESCRIPTION
## 🚪 Why?

We use a [focus ring/indicator](https://web.dev/articles/style-focus) in a few components, adding several Tailwind classes to create it.

If we want to change it, we'd have to go through each component one by one to update those classes. It’s also easy to misalign and establish a different focus ring, leading to inconsistency. That’s why I built this utility class to apply the styles consistently.

## 🔑 What?

- Add a `focusRing` utility class. This class accepts extra classes, in case it is needed.
- Apply it to several components already using a focus ring.
