### PR TITLE
Force light theme

### DIFF
--- a/.storybook/DocsContainer.tsx
+++ b/.storybook/DocsContainer.tsx
@@ -7,7 +7,7 @@ import {
 import { addons } from "@storybook/preview-api"
 import { FC, PropsWithChildren, useEffect, useState } from "react"
 import { DARK_MODE_EVENT_NAME } from "storybook-dark-mode"
-import lightTheme, { darkTheme } from "./FactorialOne"
+import lightTheme from "./FactorialOne"
 import { DOCS_RENDERED } from "@storybook/core-events"
 import {
   Alert,
@@ -36,7 +36,7 @@ export const DocsContainer: FC<PropsWithChildren<DocsContainerProps>> = (
   }, [channel])
 
   return (
-    <BaseContainer theme={isDark ? darkTheme : lightTheme} {...props}>
+    <BaseContainer theme={lightTheme} {...props}>
       {experimental && (
         <div className="sb-unstyled">
           <Alert variant="destructive" className="mb-8">

--- a/.storybook/DocsContainer.tsx
+++ b/.storybook/DocsContainer.tsx
@@ -7,7 +7,7 @@ import {
 import { addons } from "@storybook/preview-api"
 import { FC, PropsWithChildren, useEffect, useState } from "react"
 import { DARK_MODE_EVENT_NAME } from "storybook-dark-mode"
-import lightTheme from "./FactorialOne"
+import lightTheme, { darkTheme } from "./FactorialOne"
 import { DOCS_RENDERED } from "@storybook/core-events"
 import {
   Alert,
@@ -36,7 +36,7 @@ export const DocsContainer: FC<PropsWithChildren<DocsContainerProps>> = (
   }, [channel])
 
   return (
-    <BaseContainer theme={lightTheme} {...props}>
+    <BaseContainer theme={isDark ? darkTheme : lightTheme} {...props}>
       {experimental && (
         <div className="sb-unstyled">
           <Alert variant="destructive" className="mb-8">

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,19 +3,17 @@ import React, { useState } from "react"
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport"
 import type { Preview } from "@storybook/react"
 import { action } from "@storybook/addon-actions"
-import { useDarkMode } from "storybook-dark-mode"
 
 import "../styles.css"
 
 import { ThemeProvider } from "../lib/lib/theme-provider"
 import { FactorialOneProvider } from "../lib/lib/one-provider"
-import lightTheme, { darkTheme } from "./FactorialOne"
 import { DocsContainer } from "./DocsContainer"
 
 export const withTheme = () => {
   return (Story) => {
     return (
-      <ThemeProvider theme={useDarkMode() ? "dark" : "light"}>
+      <ThemeProvider theme="light">
         <Story />
       </ThemeProvider>
     )
@@ -106,9 +104,9 @@ const preview: Preview = {
       },
     },
     darkMode: {
-      dark: darkTheme,
-      light: lightTheme,
       stylePreview: true,
+      current: "light",
+      disable: true,
     },
   },
   tags: ["autodocs"],


### PR DESCRIPTION
Forces the light theme in the docs since we don’t have a dark mode in our components, so we prefer to display the light mode as default.

P.S. This doesn’t disable the theme toggle. I’ll try to fix the dark theme.