### PR TITLE
chore: add tasks empty state; make tasks types optional; refactor

### DIFF
--- a/lib/experimental/Widgets/Content/TasksList/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/TasksList/index.stories.tsx
@@ -21,26 +21,41 @@ type Story = StoryObj<typeof TasksList>
 
 export const Default: Story = {
   args: {
-    inProgressTasks: ["Migrate to new CRM"],
-    dueTasks: [],
-    noDueTasks: [
-      "Connect to Slack",
-      "Write changelog",
-      "Product review",
-      "Final conclusions",
-    ],
+    tasks: {
+      inProgress: ["Migrate to new CRM"],
+      due: [],
+      noDue: [
+        "Connect to Slack",
+        "Write changelog",
+        "Product review",
+        "Final conclusions",
+      ],
+    },
   },
 }
 
 export const WithLongTaskTitles: Story = {
   args: {
-    inProgressTasks: [
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin ut sem accumsan ipsum malesuada maximus id vitae libero. Maecenas iaculis felis id massa elementum tristique.",
-    ],
-    dueTasks: [],
-    noDueTasks: [
-      "Nam et dapibus lorem. Sed tristique, metus iaculis viverra accumsan, urna purus auctor purus, quis tempor risus augue nec dui.",
-      "Quisque tellus orci, tincidunt auctor imperdiet ac, molestie non nisl. Aliquam scelerisque lacus turpis, et tempor erat volutpat et.",
-    ],
+    tasks: {
+      inProgress: [
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin ut sem accumsan ipsum malesuada maximus id vitae libero. Maecenas iaculis felis id massa elementum tristique.",
+      ],
+      due: [],
+      noDue: [
+        "Nam et dapibus lorem. Sed tristique, metus iaculis viverra accumsan, urna purus auctor purus, quis tempor risus augue nec dui.",
+        "Quisque tellus orci, tincidunt auctor imperdiet ac, molestie non nisl. Aliquam scelerisque lacus turpis, et tempor erat volutpat et.",
+      ],
+    },
+  },
+}
+
+export const EmptyState: Story = {
+  args: {
+    emptyMessage: "No tasks assigned",
+    tasks: {
+      inProgress: [],
+      due: [],
+      noDue: [],
+    },
   },
 }

--- a/lib/experimental/Widgets/Content/TasksList/index.tsx
+++ b/lib/experimental/Widgets/Content/TasksList/index.tsx
@@ -32,50 +32,56 @@ function TaskItem({ title, status, onClick }: TaskItemProps) {
   )
 }
 
+interface Tasks {
+  inProgress?: string[]
+  noDue?: string[]
+  due?: string[]
+}
+
 interface Props {
-  inProgressTasks: string[]
-  noDueTasks: string[]
-  dueTasks: string[]
+  tasks: Pick<Tasks, "inProgress" | "noDue" | "due">
   maxTasksToShow?: number
   onClickTask?: (status: TaskStatus) => void
+  emptyMessage?: string
 }
 
 export function TasksList({
-  inProgressTasks,
-  dueTasks,
-  noDueTasks,
+  tasks,
   onClickTask,
   maxTasksToShow = 5,
+  emptyMessage = "No tasks assigned",
 }: Props) {
-  const tasksToRender = [
-    ...inProgressTasks.map((t) => ({
-      title: t,
-      status: "in-progress" as TaskStatus,
-    })),
-    ...dueTasks.map((t) => ({
-      title: t,
-      status: "due" as TaskStatus,
-    })),
-    ...noDueTasks.map((t) => ({
-      title: t,
-      status: "no-due" as TaskStatus,
-    })),
-  ]
+  const taskTypes = [
+    { key: "inProgress", status: "in-progress" },
+    { key: "due", status: "due" },
+    { key: "noDue", status: "no-due" },
+  ] as const
 
-  if (!tasksToRender.length) {
-    return null
-  }
+  const tasksToRender = taskTypes.flatMap(({ key, status }) =>
+    (tasks?.[key] || []).map((title) => ({
+      title,
+      status: status as TaskStatus,
+    }))
+  )
+
+  const isEmpty = !tasksToRender.length
 
   return (
     <div className="flex flex-col gap-3">
-      {tasksToRender.slice(0, maxTasksToShow).map((task, i) => (
-        <TaskItem
-          key={`${task} ${i}`}
-          title={task.title}
-          status={task.status}
-          onClick={onClickTask}
-        />
-      ))}
+      {isEmpty ? (
+        <p className="font-medium">{emptyMessage}</p>
+      ) : (
+        tasksToRender
+          .slice(0, maxTasksToShow)
+          .map((task, i) => (
+            <TaskItem
+              key={`${task} ${i}`}
+              title={task.title}
+              status={task.status}
+              onClick={onClickTask}
+            />
+          ))
+      )}
     </div>
   )
 }

--- a/src/playground/Widgets/Tasks/index.tsx
+++ b/src/playground/Widgets/Tasks/index.tsx
@@ -88,9 +88,11 @@ export const TasksInsight = forwardRef<HTMLDivElement, TasksInsightProps>(
         </div>
         {(inProgressTasks.length || dueTasks.length || noDueTasks.length) && (
           <TasksList
-            inProgressTasks={inProgressTasks}
-            noDueTasks={noDueTasks}
-            dueTasks={dueTasks}
+            tasks={{
+              inProgress: inProgressTasks,
+              noDue: noDueTasks,
+              due: dueTasks,
+            }}
           />
         )}
         {buttonLabel && (


### PR DESCRIPTION
## 🚪 Why?

Our current empty state for tasks doesn't match exactly with wire frames. After discussing with designer, we should show a text with no icon. 

## 🔑 What?

Instead of returning null we show a message when tasks are empty. All tasks are now inside an object for a cleaner look and if there are no tasks of a type you can omit the those tasks instead of passing an empty array.

I will update Factorial as soon as this is merged.

## 🏡 Context

https://www.figma.com/design/9pLsRzdinid0ha0qRWta2D/Employee-Profile?node-id=1037-18867&node-type=frame&t=SF1vqrEv2ud97pwf-0

<img width="264" alt="image" src="https://github.com/user-attachments/assets/42cdc8ec-c161-4cdd-b3b1-335f22ac0778">
