### PR TITLE
Get rid of empty spaces in dashboard

### DIFF
--- a/lib/experimental/Widgets/Layout/Dashboard/index.tsx
+++ b/lib/experimental/Widgets/Layout/Dashboard/index.tsx
@@ -54,7 +54,7 @@ const _Dashboard = forwardRef<HTMLDivElement, DashboardProps>(
                       style={{
                         width: `${Math.floor((1 / columns) * 10000) / 100 - 0.05}%`,
                       }}
-                      className="pb-4 pr-4 *:shadow"
+                      className="pb-[0.01px] pr-4 *:mb-4 *:shadow"
                     >
                       {child}
                     </div>


### PR DESCRIPTION
## 🔑 What?

Get rid of empty spaces in dashboard.

## 🚪 Why?

When having some widgets that are empty we can see some weird spaces being rendered on the dashboard between them and it worsens how it looks for the user.

## 👁️ Visual proof

Before the change:

<img width="875" alt="Screenshot 2024-10-07 at 14 25 05" src="https://github.com/user-attachments/assets/52150599-9939-4c4c-8933-481e23208a85">

After the change:

<img width="875" alt="Screenshot 2024-10-07 at 14 24 30" src="https://github.com/user-attachments/assets/03d64b30-b435-454f-b57e-b22a8ca832db">

## 🏡 Context

- [💼 Jira](https://factorialmakers.atlassian.net/browse/FCT-19398)
