### PR TITLE
Use the `Link` component for tabs

### DIFF
--- a/lib/components/Actions/Link/index.tsx
+++ b/lib/components/Actions/Link/index.tsx
@@ -3,7 +3,7 @@ import ExternalLink from "@/icons/ExternalLink"
 import {
   Link as BaseLink,
   LinkProps as BaseLinkProps,
-  useLink,
+  useNavigation,
 } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
 import { cva, VariantProps } from "class-variance-authority"
@@ -35,7 +35,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 ) {
   const { target } = props
   const external = target === "_blank"
-  const { isActive } = useLink()
+  const { isActive } = useNavigation()
 
   return (
     <BaseLink

--- a/lib/experimental/Navigation/Tabs/index.stories.tsx
+++ b/lib/experimental/Navigation/Tabs/index.stories.tsx
@@ -1,18 +1,6 @@
+import { useNavigation } from "@/lib/linkHandler"
 import type { Meta, StoryObj } from "@storybook/react"
 import { Tabs } from "."
-
-const meta: Meta<typeof Tabs> = {
-  component: Tabs,
-  tags: ["autodocs"],
-  argTypes: {
-    secondary: {
-      control: "boolean",
-    },
-  },
-}
-
-export default meta
-type Story = StoryObj<typeof Tabs>
 
 const tabItems = [
   { label: "Overview", link: "/" },
@@ -22,24 +10,42 @@ const tabItems = [
   { label: "Requests", link: "/requests" },
 ]
 
-const TabsExample = ({ secondary = false }: { secondary?: boolean }) => {
-  return (
-    <div onClick={(e) => e.preventDefault()}>
-      <Tabs tabs={tabItems} secondary={secondary} />
-    </div>
-  )
+const meta: Meta<typeof Tabs> = {
+  component: Tabs,
+  tags: ["autodocs"],
+  argTypes: {
+    secondary: {
+      control: "boolean",
+    },
+  },
+  render: ({ secondary = false }: { secondary?: boolean }) => {
+    const { isActive } = useNavigation()
+    const activeTab = tabItems.find((tab) =>
+      isActive(tab.link, { exact: true })
+    )
+
+    return (
+      <div onClick={(e) => e.preventDefault()}>
+        <Tabs tabs={tabItems} secondary={secondary} />
+        <p className="mt-4 flex h-full min-h-60 items-center justify-center rounded-lg bg-f1-background-secondary/50 p-4 text-f1-foreground-secondary">
+          {activeTab?.label}
+        </p>
+      </div>
+    )
+  },
 }
+
+export default meta
+type Story = StoryObj<typeof Tabs>
 
 export const Primary: Story = {
   args: {
     secondary: false,
   },
-  render: (args) => <TabsExample {...args} />,
 }
 
 export const Secondary: Story = {
   args: {
     secondary: true,
   },
-  render: (args) => <TabsExample {...args} />,
 }

--- a/lib/experimental/Navigation/Tabs/index.stories.tsx
+++ b/lib/experimental/Navigation/Tabs/index.stories.tsx
@@ -1,6 +1,4 @@
-import { action } from "@storybook/addon-actions"
 import type { Meta, StoryObj } from "@storybook/react"
-import { useState } from "react"
 import { Tabs } from "."
 
 const meta: Meta<typeof Tabs> = {
@@ -17,7 +15,7 @@ export default meta
 type Story = StoryObj<typeof Tabs>
 
 const tabItems = [
-  { label: "Overview", link: "/overview" },
+  { label: "Overview", link: "/" },
   { label: "Courses", link: "/courses" },
   { label: "Categories", link: "/categories" },
   { label: "Catalog", link: "/catalog" },
@@ -25,22 +23,9 @@ const tabItems = [
 ]
 
 const TabsExample = ({ secondary = false }: { secondary?: boolean }) => {
-  const [activeTab, setActiveTab] = useState("Overview")
-
   return (
     <div onClick={(e) => e.preventDefault()}>
-      <Tabs
-        tabs={tabItems}
-        activeTab={activeTab}
-        onTabChange={(tab) => {
-          setActiveTab(tab.label)
-          action("Tab changed")(tab)
-        }}
-        secondary={secondary}
-      />
-      <p className="mt-4 flex h-full min-h-60 items-center justify-center rounded-lg bg-f1-background-secondary/50 p-4 text-f1-foreground-secondary">
-        {activeTab}
-      </p>
+      <Tabs tabs={tabItems} secondary={secondary} />
     </div>
   )
 }

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -1,4 +1,4 @@
-import { Link, useLink } from "@/lib/linkHandler"
+import { Link, useNavigation } from "@/lib/linkHandler"
 import { TabNavigation, TabNavigationLink } from "@/ui/tab-navigation"
 
 interface TabItem {
@@ -12,7 +12,7 @@ interface TabsProps {
 }
 
 export function Tabs({ tabs, secondary = false }: TabsProps) {
-  const { isActive } = useLink()
+  const { isActive } = useNavigation()
 
   return (
     <TabNavigation secondary={secondary}>

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -1,3 +1,4 @@
+import { Link, useLink } from "@/lib/linkHandler"
 import { TabNavigation, TabNavigationLink } from "@/ui/tab-navigation"
 
 interface TabItem {
@@ -7,28 +8,23 @@ interface TabItem {
 
 interface TabsProps {
   tabs: TabItem[]
-  activeTab: string
-  onTabChange: (tab: TabItem) => void
   secondary?: boolean
 }
 
-export function Tabs({
-  tabs,
-  activeTab,
-  onTabChange,
-  secondary = false,
-}: TabsProps) {
+export function Tabs({ tabs, secondary = false }: TabsProps) {
+  const { isActive } = useLink()
+
   return (
     <TabNavigation secondary={secondary}>
       {tabs.map((tab) => (
         <TabNavigationLink
           key={tab.label}
-          active={activeTab === tab.label}
-          onClick={() => onTabChange(tab)}
+          active={isActive(tab.link, { exact: true })}
           href={tab.link}
           secondary={secondary}
+          asChild
         >
-          {tab.label}
+          <Link href={tab.link}>{tab.label}</Link>
         </TabNavigationLink>
       ))}
     </TabNavigation>

--- a/lib/lib/linkHandler.spec.tsx
+++ b/lib/lib/linkHandler.spec.tsx
@@ -1,4 +1,4 @@
-import { Link, LinkProvider, useLink } from "@/lib/linkHandler"
+import { Link, LinkProvider, useNavigation } from "@/lib/linkHandler"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, test } from "vitest"
 
@@ -17,7 +17,7 @@ describe("LinkProvider", () => {
 
 describe("useLink", () => {
   const Component: React.FC<{ href: string }> = ({ href }) => {
-    const { isActive } = useLink()
+    const { isActive } = useNavigation()
     return <a href={href} data-is-active={isActive(href)} />
   }
 

--- a/lib/lib/linkHandler.tsx
+++ b/lib/lib/linkHandler.tsx
@@ -41,7 +41,7 @@ export const useLinkContext = () => {
 
 export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
-export const useLink = () => {
+export const useNavigation = () => {
   const { currentPath } = useLinkContext()
 
   const isActive = (
@@ -54,6 +54,7 @@ export const useLink = () => {
   }
 
   return {
+    currentPath,
     isActive,
   }
 }
@@ -61,7 +62,7 @@ export const useLink = () => {
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
   function Link(props, ref) {
     const { component } = useLinkContext()
-    const { isActive } = useLink()
+    const { isActive } = useNavigation()
 
     const overridenProps = {
       "data-is-active": isActive(props.href) || undefined,

--- a/lib/lib/linkHandler.tsx
+++ b/lib/lib/linkHandler.tsx
@@ -44,8 +44,12 @@ export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 export const useLink = () => {
   const { currentPath } = useLinkContext()
 
-  const isActive = (path: string | undefined) => {
+  const isActive = (
+    path: string | undefined,
+    { exact }: { exact: boolean } = { exact: false }
+  ) => {
     if (currentPath === undefined || path === undefined) return false
+    if (exact) return currentPath === path
     return currentPath.startsWith(path)
   }
 


### PR DESCRIPTION
## 🚪 Why?

Tabs need to be route aware in order to be properly highlighted. The previous approach relied on `onClick` and local state.

## 🔑 What?

This uses our `Link` component instead, plus our `useLink` hook to highlight the right element.
