### PR TITLE
chore: create progess bar duo; adapt two columns list

### DIFF
--- a/lib/experimental/Widgets/Content/ProgressBarDuo/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ProgressBarDuo/index.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { ProgressBarDuo } from "./index"
+
+const meta: Meta<typeof ProgressBarDuo> = {
+  component: ProgressBarDuo,
+  tags: ["autodocs"],
+  args: {
+    value: 50,
+    max: 100,
+  },
+  argTypes: {
+    value: {
+      control: {
+        type: "range",
+        min: 0,
+        max: 100,
+        step: 1,
+      },
+    },
+  },
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[150px]">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof ProgressBarDuo>
+
+export const Default: Story = {}
+
+export const Empty: Story = {
+  args: {
+    value: 0,
+  },
+}
+
+export const Full: Story = {
+  args: {
+    value: 100,
+  },
+}
+
+export const TwentyFive: Story = {
+  args: {
+    value: 25,
+  },
+}
+
+export const SeventyFive: Story = {
+  args: {
+    value: 75,
+  },
+}
+
+export const CustomMax: Story = {
+  args: {
+    value: 75,
+    max: 200,
+  },
+  argTypes: {
+    value: {
+      control: {
+        type: "range",
+        min: 0,
+        max: 200,
+        step: 1,
+      },
+    },
+  },
+}

--- a/lib/experimental/Widgets/Content/ProgressBarDuo/index.tsx
+++ b/lib/experimental/Widgets/Content/ProgressBarDuo/index.tsx
@@ -1,0 +1,32 @@
+import { autoColor } from "@/components/Charts/utils/colors"
+import { cn } from "@/lib/utils"
+import { forwardRef } from "react"
+
+interface DualProgressBarProps {
+  value: number
+  max?: number
+}
+
+export const ProgressBarDuo = forwardRef<HTMLDivElement, DualProgressBarProps>(
+  function ProgressBarDuo({ value, max = 100 }: DualProgressBarProps, ref) {
+    const percentage = Math.min(100, Math.max(0, (value / max) * 100))
+
+    return (
+      <div ref={ref} className="flex h-2 w-full gap-0.5 overflow-hidden">
+        <div
+          className={cn(
+            "rounded transition-all duration-300 ease-in-out",
+            `bg-[${autoColor(0)}]`
+          )}
+          style={{ width: `${percentage}%` }}
+        />
+        <div
+          className="rounded bg-f1-foreground-disabled transition-all duration-300 ease-in-out"
+          style={{ width: `${100 - percentage}%` }}
+        />
+      </div>
+    )
+  }
+)
+
+ProgressBarDuo.displayName = "ProgressBarDuo"

--- a/lib/experimental/Widgets/Content/TwoColumnsList/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/TwoColumnsList/index.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
 import { TwoColumnsList } from "."
+import { ProgressBarDuo } from "../ProgressBarDuo"
 
 const meta: Meta = {
   component: TwoColumnsList,
@@ -26,7 +27,7 @@ const meta: Meta = {
   },
   decorators: [
     (Story) => (
-      <div className="w-[300px]">
+      <div className="w-[386px]">
         <Story />
       </div>
     ),
@@ -37,3 +38,25 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Primary: Story = {}
+
+export const Title: Story = {
+  args: {
+    title: "Soft skills",
+  },
+}
+
+export const Progress: Story = {
+  args: {
+    title: "Soft skills",
+    list: [
+      {
+        title: "Research & Analysis",
+        info: <ProgressBarDuo value={65} />,
+      },
+      {
+        title: "Ideation & Planning",
+        info: <ProgressBarDuo value={75} />,
+      },
+    ],
+  },
+}

--- a/lib/experimental/Widgets/Content/TwoColumnsList/index.tsx
+++ b/lib/experimental/Widgets/Content/TwoColumnsList/index.tsx
@@ -12,7 +12,7 @@ interface TwoColumnsListType {
 
 const Item = ({ title, info }: TwoColumnsItemType) => (
   <div className="flex items-center justify-between">
-    <div className="flex text-f1-foreground-secondary">{title}</div>
+    <p className="flex text-f1-foreground-secondary">{title}</p>
     <div className="basis-16 justify-self-end text-right font-medium">
       {info}
     </div>
@@ -24,11 +24,9 @@ export const TwoColumnsList = forwardRef<HTMLDivElement, TwoColumnsListType>(
     return (
       <div ref={ref} className="flex flex-col gap-2">
         {title && <div className="font-medium">{title}</div>}
-        <div className="flex flex-col gap-2">
-          {list.map((item) => (
-            <Item key={item.title} title={item.title} info={item.info} />
-          ))}
-        </div>
+        {list.map((item) => (
+          <Item key={item.title} title={item.title} info={item.info} />
+        ))}
       </div>
     )
   }

--- a/lib/experimental/Widgets/Content/TwoColumnsList/index.tsx
+++ b/lib/experimental/Widgets/Content/TwoColumnsList/index.tsx
@@ -1,28 +1,34 @@
-import { forwardRef } from "react"
+import { forwardRef, ReactNode } from "react"
 
 interface TwoColumnsItemType {
   title: string
-  info: string
+  info: string | ReactNode
 }
 
 interface TwoColumnsListType {
+  title?: string
   list: TwoColumnsItemType[]
 }
 
 const Item = ({ title, info }: TwoColumnsItemType) => (
-  <>
-    <div className="line-clamp-2 text-f1-foreground-secondary">{title}</div>
-    <div className="font-medium">{info}</div>
-  </>
+  <div className="flex items-center justify-between">
+    <div className="flex text-f1-foreground-secondary">{title}</div>
+    <div className="basis-16 justify-self-end text-right font-medium">
+      {info}
+    </div>
+  </div>
 )
 
 export const TwoColumnsList = forwardRef<HTMLDivElement, TwoColumnsListType>(
-  function TwoColumnsList({ list }, ref) {
+  function TwoColumnsList({ title, list }, ref) {
     return (
-      <div ref={ref} className="grid grid-cols-[1fr_auto] gap-2">
-        {list.map((item) => (
-          <Item key={item.title} title={item.title} info={item.info} />
-        ))}
+      <div ref={ref} className="flex flex-col gap-2">
+        {title && <div className="font-medium">{title}</div>}
+        <div className="flex flex-col gap-2">
+          {list.map((item) => (
+            <Item key={item.title} title={item.title} info={item.info} />
+          ))}
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## 🚪 Why?

We need to display a two column list with a progress bar for the competencies widget

## 🔑 What?

We create the progress bar duo component and adapt the two colum list together with a story.

## 🏡 Context

https://www.figma.com/design/9pLsRzdinid0ha0qRWta2D/Employee-Profile?node-id=604-7408&node-type=frame&t=9ILoPFa3hL2KCP3V-0

<img width="633" alt="image" src="https://github.com/user-attachments/assets/ca564137-73c9-4563-9ff8-324e8b9e2d31">