### PR TITLE
Ignore charts in chromatic

### DIFF
--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -103,6 +103,7 @@ const ChartContainerComponent = (
   return (
     <ChartContext.Provider value={{ config }}>
       <div
+        data-chromatic="ignore"
         data-chart={chartId}
         ref={ref || anotherRef}
         className={cn(


### PR DESCRIPTION
We get a lot of flakiness coming from charts. Until we figure out what's happening, let's disable snapshot testing.