### PR TITLE
Fix Button radius & docs

### DIFF
--- a/docs/borders.mdx
+++ b/docs/borders.mdx
@@ -23,9 +23,9 @@ below:
     </p>
     <div className="size-10 bg-f1-foreground-accent rounded-xs"></div>
     <p className="text-right text-sm">
-      <pre className="inline">rounded-md</pre>, 8px
+      <pre className="inline">rounded-sm</pre>, 8px
     </p>
-    <div className="size-10 bg-f1-foreground-accent rounded-md"></div>
+    <div className="size-10 bg-f1-foreground-accent rounded-sm"></div>
 
     <p className="text-right text-sm">
       <pre className="inline">rounded</pre>, 10px

--- a/lib/ui/button.tsx
+++ b/lib/ui/button.tsx
@@ -37,8 +37,8 @@ const buttonVariants = cva(
       } satisfies Record<(typeof variants)[number], string>,
       size: {
         sm: "h-6 rounded-sm px-2",
-        md: "h-8 rounded-md px-3",
-        lg: "h-10 rounded-md px-4",
+        md: "h-8 rounded px-3",
+        lg: "h-10 rounded px-4",
       } satisfies Record<(typeof sizes)[number], string>,
       round: {
         true: "aspect-square px-0",


### PR DESCRIPTION
Fixes a couple of things:

- Border radius of Button `md` and `lg` sizes were wrongly set to `rounded-md` (12px) instead of `rounded` (10px).
- There was a mistake in our Borders docs, showing `rounded-md` when it should have been `rounded-sm`.