### PR TITLE
Responsive breadcrumbs

### DIFF
--- a/lib/experimental/Navigation/Dropdown/index.tsx
+++ b/lib/experimental/Navigation/Dropdown/index.tsx
@@ -13,7 +13,7 @@ import { NavigationItem } from "../utils"
 
 type IconName = keyof typeof Icons
 
-type DropdownItem = NavigationItem & {
+export type DropdownItem = NavigationItem & {
   onClick?: () => void
   icon?: IconName
   description?: string

--- a/lib/experimental/Navigation/Header/Breadcrumbs/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/Breadcrumbs/index.stories.tsx
@@ -20,15 +20,6 @@ export const Default: Story = {
   },
 }
 
-export const Short: Story = {
-  args: {
-    breadcrumbs: [
-      { label: "Recruitment", href: "/recruitment", icon: "Recruitment" },
-      { label: "Candidates" },
-    ],
-  },
-}
-
 export const LongBreadcrumbs: Story = {
   args: {
     breadcrumbs: [

--- a/lib/experimental/Navigation/Header/Breadcrumbs/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/Breadcrumbs/index.stories.tsx
@@ -19,3 +19,36 @@ export const Default: Story = {
     ],
   },
 }
+
+export const Short: Story = {
+  args: {
+    breadcrumbs: [
+      { label: "Recruitment", href: "/recruitment", icon: "Recruitment" },
+      { label: "Candidates" },
+    ],
+  },
+}
+
+export const LongBreadcrumbs: Story = {
+  args: {
+    breadcrumbs: [
+      { label: "Documents", href: "/", icon: "Documents" },
+      { label: "Employee Documents", href: "/documents" },
+      { label: "Human Resources", href: "/documents/hr" },
+      { label: "Recruitment", href: "/documents/hr/recruitment" },
+      { label: "Candidates", href: "/documents/hr/recruitment/candidates" },
+      {
+        label: "Dani Moreno",
+        href: "/dani-moreno",
+      },
+      {
+        label: "Applications",
+        href: "/dani-moreno/applications",
+      },
+      {
+        label: "Interviews",
+        href: "/dani-moreno/applications/interviews",
+      },
+    ],
+  },
+}

--- a/lib/experimental/Navigation/Header/Breadcrumbs/index.tsx
+++ b/lib/experimental/Navigation/Header/Breadcrumbs/index.tsx
@@ -130,9 +130,9 @@ export default function Breadcrumbs({ breadcrumbs }: BreadcrumbsProps) {
         {collapsedItems.length > 0 && (
           <>
             <Dropdown items={collapsedItems as DropdownItemWithoutIcon[]}>
-              <div className="rounded-sm px-1.5 py-0.5 font-medium text-f1-foreground no-underline transition-colors hover:bg-f1-background-secondary">
+              <li className="rounded-sm px-1.5 py-0.5 font-medium text-f1-foreground no-underline transition-colors hover:bg-f1-background-secondary">
                 ...
-              </div>
+              </li>
             </Dropdown>
             <BreadcrumbSeparator>
               <ChevronRight className="h-4 w-4 text-f1-icon-secondary" />

--- a/lib/experimental/Navigation/Header/Breadcrumbs/index.tsx
+++ b/lib/experimental/Navigation/Header/Breadcrumbs/index.tsx
@@ -12,7 +12,7 @@ import {
   type IconType,
 } from "@/experimental/Information/ModuleAvatar"
 
-import { Dropdown } from "@/experimental/Navigation/Dropdown"
+import { Dropdown, type DropdownItem } from "@/experimental/Navigation/Dropdown"
 
 import { ChevronRight } from "@/icons"
 import { Link } from "@/lib/linkHandler"
@@ -29,6 +29,8 @@ interface BreadcrumbItemProps {
   item: BreadcrumbItemType
   isLast: boolean
 }
+
+type DropdownItemWithoutIcon = Omit<DropdownItem, "icon">
 
 function BreadcrumbItem({ item, isLast }: BreadcrumbItemProps) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -118,7 +120,7 @@ export default function Breadcrumbs({ breadcrumbs }: BreadcrumbsProps) {
         <BreadcrumbItem item={firstItem} isLast={false} />
         {collapsedItems.length > 0 && (
           <>
-            <Dropdown items={collapsedItems}>
+            <Dropdown items={collapsedItems as DropdownItemWithoutIcon[]}>
               <div className="rounded-sm px-1.5 py-0.5 font-medium text-f1-foreground no-underline transition-colors hover:bg-f1-background-secondary">
                 ...
               </div>

--- a/lib/experimental/Navigation/Header/Breadcrumbs/index.tsx
+++ b/lib/experimental/Navigation/Header/Breadcrumbs/index.tsx
@@ -12,10 +12,14 @@ import {
   type IconType,
 } from "@/experimental/Information/ModuleAvatar"
 
+import { Dropdown } from "@/experimental/Navigation/Dropdown"
+
 import { ChevronRight } from "@/icons"
 import { Link } from "@/lib/linkHandler"
 import { cn, focusRing } from "@/lib/utils"
 import { NavigationItem } from "../../utils"
+
+import { useEffect, useRef, useState } from "react"
 
 export type BreadcrumbItemType = NavigationItem & {
   icon?: IconType
@@ -34,13 +38,16 @@ function BreadcrumbItem({ item, isLast }: BreadcrumbItemProps) {
     <ShadBreadcrumbItem>
       {!isLast ? (
         <>
-          <BreadcrumbLink className={item.icon && "pl-0.5"} asChild>
+          <BreadcrumbLink
+            className={cn("max-w-40", item.icon && "pl-0.5")}
+            asChild
+          >
             <Link
               {...props}
               className={cn("flex items-center gap-1.5", focusRing())}
             >
               {item.icon && <ModuleAvatar icon={item.icon} size="sm" />}
-              {item.label}
+              <span className="truncate">{item.label}</span>
             </Link>
           </BreadcrumbLink>
           <BreadcrumbSeparator>
@@ -59,14 +66,73 @@ interface BreadcrumbsProps {
 }
 
 export default function Breadcrumbs({ breadcrumbs }: BreadcrumbsProps) {
+  const [visibleCount, setVisibleCount] = useState(2)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const updateVisibleBreadcrumb = () => {
+      if (!containerRef.current || breadcrumbs.length <= 2) {
+        setVisibleCount(breadcrumbs.length)
+        return
+      }
+
+      const containerWidth = containerRef.current.offsetWidth
+      const itemWidth = 150
+      const dropdownWidth = 50
+
+      let availableWidth = containerWidth - itemWidth
+      let count = 1
+
+      for (let i = breadcrumbs.length - 1; i > 0; i--) {
+        if (availableWidth < itemWidth) {
+          break
+        }
+        availableWidth -= itemWidth
+        count++
+      }
+
+      if (count < breadcrumbs.length - 1) {
+        availableWidth -= dropdownWidth
+        while (availableWidth < 0 && count > 1) {
+          availableWidth += itemWidth
+          count--
+        }
+      }
+
+      setVisibleCount(count)
+    }
+
+    updateVisibleBreadcrumb()
+    window.addEventListener("resize", updateVisibleBreadcrumb)
+
+    return () => window.removeEventListener("resize", updateVisibleBreadcrumb)
+  }, [breadcrumbs])
+
+  const firstItem = breadcrumbs[0]
+  const lastItems = breadcrumbs.slice(-visibleCount + 1)
+  const collapsedItems = breadcrumbs.slice(1, -visibleCount + 1)
+
   return (
-    <Breadcrumb>
+    <Breadcrumb ref={containerRef} className="w-full">
       <BreadcrumbList>
-        {breadcrumbs.map((item, index) => (
+        <BreadcrumbItem item={firstItem} isLast={false} />
+        {collapsedItems.length > 0 && (
+          <>
+            <Dropdown items={collapsedItems}>
+              <div className="rounded-sm px-1.5 py-0.5 font-medium text-f1-foreground no-underline transition-colors hover:bg-f1-background-secondary">
+                ...
+              </div>
+            </Dropdown>
+            <BreadcrumbSeparator>
+              <ChevronRight className="h-4 w-4 text-f1-icon-secondary" />
+            </BreadcrumbSeparator>
+          </>
+        )}
+        {lastItems.map((item, index) => (
           <BreadcrumbItem
             key={index}
             item={item}
-            isLast={index === breadcrumbs.length - 1}
+            isLast={index === lastItems.length - 1}
           />
         ))}
       </BreadcrumbList>

--- a/lib/experimental/Navigation/Header/Breadcrumbs/index.tsx
+++ b/lib/experimental/Navigation/Header/Breadcrumbs/index.tsx
@@ -72,6 +72,9 @@ export default function Breadcrumbs({ breadcrumbs }: BreadcrumbsProps) {
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
     const updateVisibleBreadcrumb = () => {
       if (!containerRef.current || breadcrumbs.length <= 2) {
         setVisibleCount(breadcrumbs.length)
@@ -104,10 +107,16 @@ export default function Breadcrumbs({ breadcrumbs }: BreadcrumbsProps) {
       setVisibleCount(count)
     }
 
-    updateVisibleBreadcrumb()
-    window.addEventListener("resize", updateVisibleBreadcrumb)
+    const resizeObserver = new ResizeObserver(() => {
+      updateVisibleBreadcrumb()
+    })
 
-    return () => window.removeEventListener("resize", updateVisibleBreadcrumb)
+    resizeObserver.observe(container)
+    updateVisibleBreadcrumb()
+
+    return () => {
+      resizeObserver.disconnect()
+    }
   }, [breadcrumbs])
 
   const firstItem = breadcrumbs[0]

--- a/lib/experimental/Navigation/Header/Header/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/Header/index.stories.tsx
@@ -55,3 +55,47 @@ export const FirstLevel: Story = {
     },
   },
 }
+
+export const LongBreadcrumbs: Story = {
+  args: {
+    module: {
+      name: "Documents",
+      href: "/documents",
+      icon: "Documents",
+    },
+    breadcrumbs: [
+      { label: "Employee Documents", href: "/documents" },
+      { label: "Human Resources", href: "/documents/hr" },
+      { label: "Recruitment", href: "/documents/hr/recruitment" },
+      { label: "Candidates", href: "/documents/hr/recruitment/candidates" },
+      {
+        label: "Dani Moreno",
+        href: "/dani-moreno",
+      },
+      {
+        label: "Applications",
+        href: "/dani-moreno/applications",
+      },
+      {
+        label: "Interviews",
+        href: "/dani-moreno/applications/interviews",
+      },
+    ],
+    actions: [
+      {
+        label: "Settings",
+        icon: Settings,
+        onClick: () => console.log("Settings clicked"),
+      },
+      {
+        label: "More options",
+        icon: EllipsisHorizontal,
+        onClick: () => console.log("More clicked"),
+      },
+    ],
+    menu: {
+      show: true,
+      onClick: () => console.log("Menu clicked"),
+    },
+  },
+}

--- a/lib/experimental/Navigation/Header/Header/index.tsx
+++ b/lib/experimental/Navigation/Header/Header/index.tsx
@@ -48,7 +48,7 @@ export default function Header({
           "border-b border-dashed border-transparent border-b-f1-border/80"
       )}
     >
-      <div className="flex items-center gap-3">
+      <div className="flex flex-grow items-center gap-3">
         {menu.show && (
           <Button
             variant="ghost"

--- a/lib/experimental/Navigation/Header/Header/index.tsx
+++ b/lib/experimental/Navigation/Header/Header/index.tsx
@@ -44,7 +44,7 @@ export default function Header({
     <div
       className={cn(
         "flex h-16 items-center justify-between rounded-t-lg bg-f1-background/80 p-4 backdrop-blur-xl",
-        !hasNavigation &&
+        hasNavigation &&
           "border-b border-dashed border-transparent border-b-f1-border/80"
       )}
     >

--- a/lib/ui/breadcrumb.tsx
+++ b/lib/ui/breadcrumb.tsx
@@ -19,7 +19,7 @@ const BreadcrumbList = React.forwardRef<
   <ol
     ref={ref}
     className={cn(
-      "flex list-none flex-wrap items-center gap-1 break-words text-f1-foreground-secondary",
+      "flex list-none flex-nowrap items-center gap-1 text-f1-foreground-secondary",
       className
     )}
     {...props}
@@ -69,7 +69,7 @@ const BreadcrumbPage = React.forwardRef<
     role="link"
     aria-disabled="true"
     aria-current="page"
-    className={cn("px-1.5 py-0.5 text-f1-foreground", className)}
+    className={cn("truncate px-1.5 py-0.5 text-f1-foreground", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## 🚪 Why?

In some cases, the header breadcrumbs will have a long list of items (e.g., Documents, where you can go as deep as you want in folders). That's why we need a way to truncate them.

We're going the "Notion" route, so when there are too many items to display:
- The first item is always shown, so it's easy for the user to know which section they're in.
- The last items are displayed until there's no more space.
- The remaining items are collapsed into a dropdown.

https://github.com/user-attachments/assets/367f30b0-d0bf-4cc4-b658-f68cb7ddb0d0


## 🔑 What?

Items that has to be collapsed are calculated at load and when the screen resizes. This is briefly what's happening:

- Get the breadcrumb container width.
- Define a fixed width for each breadcrumb item.
- From right to left, subtract an item width until there's not enough space.
- The final count represents how many breadcrumbs can be shown.
- items beyond this count will be collapsed into the dropdown.

The function prioritizes showing the last (rightmost) breadcrumbs, while ensuring there's space for the dropdown if needed.

----

_Note: This is the 'safest' approach and a good starting point, but calculating the actual width of each item instead of using a fixed width will lead to a more accurate calculation. The current method leaves a lot of blank space on the right, as it assumes every item has the maximum possible width._

## 🏡 Context

- [🎨 Figma](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=14-564)