### PR TITLE
Add SidebarHeader

### DIFF
--- a/lib/experimental/Navigation/Sidebar/CompanySelector/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/CompanySelector/index.stories.tsx
@@ -18,8 +18,8 @@ export default meta
 type Story = StoryObj<typeof CompanySelector>
 
 const exampleCompanies = [
-  { id: "1", name: "Factorial" },
-  { id: "2", name: "Dazlog" },
+  { id: "1", name: "Factorial", logo: "https://github.com/factorial.png" },
+  { id: "2", name: "Dazlog", logo: "https://github.com/dazlog.png" },
   { id: "3", name: "Acme Corp" },
 ]
 

--- a/lib/experimental/Navigation/Sidebar/CompanySelector/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/CompanySelector/index.tsx
@@ -10,7 +10,7 @@ interface Company {
   name: string
 }
 
-interface CompanySelectorProps {
+export type CompanySelectorProps = {
   companies: Company[]
   selected: string
   onChange: (value: string) => void
@@ -42,15 +42,15 @@ export function CompanySelector({
     >
       <div
         className={cn(
-          "group flex w-fit items-center gap-2 rounded p-1.5 text-lg font-semibold text-f1-foreground transition-colors hover:bg-f1-background-secondary-hover data-[state=open]:bg-f1-background-secondary-hover",
+          "group flex w-fit flex-nowrap items-center gap-2 truncate rounded p-1.5 text-lg font-semibold text-f1-foreground transition-colors hover:bg-f1-background-secondary-hover data-[state=open]:bg-f1-background-secondary-hover",
           focusRing()
         )}
         tabIndex={0}
         title={selectedCompany?.name}
       >
         <Avatar alt={selectedCompany?.name?.[0]} size="xsmall" />
-        {selectedCompany?.name}
-        <div className="h-6 w-6 p-1">
+        <span className="truncate">{selectedCompany?.name}</span>
+        <div className="h-6 w-6 shrink-0 p-1">
           <div className="flex h-4 w-4 items-center justify-center rounded-xs bg-f1-background-secondary-hover transition-all group-hover:brightness-90 group-data-[state=open]:brightness-90">
             <motion.div
               animate={{ rotate: open ? 180 : 0 }}

--- a/lib/experimental/Navigation/Sidebar/CompanySelector/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/CompanySelector/index.tsx
@@ -8,6 +8,7 @@ import { useState } from "react"
 interface Company {
   id: string
   name: string
+  logo?: string
 }
 
 export type CompanySelectorProps = {
@@ -48,7 +49,11 @@ export function CompanySelector({
         tabIndex={0}
         title={selectedCompany?.name}
       >
-        <Avatar alt={selectedCompany?.name?.[0]} size="xsmall" />
+        <Avatar
+          alt={selectedCompany?.name?.[0]}
+          src={selectedCompany?.logo}
+          size="xsmall"
+        />
         <span className="truncate">{selectedCompany?.name}</span>
         <div className="h-6 w-6 shrink-0 p-1">
           <div className="flex h-4 w-4 items-center justify-center rounded-xs bg-f1-background-secondary-hover transition-all group-hover:brightness-90 group-data-[state=open]:brightness-90">

--- a/lib/experimental/Navigation/Sidebar/Header/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Header/index.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { SidebarHeader } from "./index"
+
+const meta: Meta<typeof SidebarHeader> = {
+  component: SidebarHeader,
+  tags: ["autodocs"],
+} satisfies Meta<typeof SidebarHeader>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    companies: [
+      { id: "1", name: "Factorial" },
+      { id: "2", name: "Dazlog" },
+      { id: "3", name: "Acme Corp" },
+    ],
+    selected: "1",
+    onChange: (company) => console.log("Selected company:", company),
+    isExpanded: true,
+  },
+}

--- a/lib/experimental/Navigation/Sidebar/Header/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Header/index.stories.tsx
@@ -12,8 +12,8 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     companies: [
-      { id: "1", name: "Factorial" },
-      { id: "2", name: "Dazlog" },
+      { id: "1", name: "Factorial", logo: "https://github.com/factorial.png" },
+      { id: "2", name: "Dazlog", logo: "https://github.com/dazlog.png" },
       { id: "3", name: "Acme Corp" },
     ],
     selected: "1",

--- a/lib/experimental/Navigation/Sidebar/Header/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Header/index.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { SidebarHeader } from "./index"
 
-const meta: Meta<typeof SidebarHeader> = {
+const meta = {
   component: SidebarHeader,
   tags: ["autodocs"],
 } satisfies Meta<typeof SidebarHeader>

--- a/lib/experimental/Navigation/Sidebar/Header/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Header/index.tsx
@@ -1,0 +1,22 @@
+import { CompanySelector, type CompanySelectorProps } from "../CompanySelector"
+import { SidebarIcon, type SidebarIconProps } from "../Icon"
+
+export type SidebarHeaderProps = CompanySelectorProps & SidebarIconProps
+
+export function SidebarHeader({
+  companies,
+  selected,
+  onChange,
+  isExpanded,
+}: SidebarHeaderProps) {
+  return (
+    <div className="flex h-[72px] items-center justify-between gap-3">
+      <CompanySelector
+        companies={companies}
+        selected={selected}
+        onChange={onChange}
+      />
+      <SidebarIcon isExpanded={isExpanded} />
+    </div>
+  )
+}

--- a/lib/experimental/Navigation/Sidebar/Icon/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Icon/index.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils"
 import { Button } from "@/ui/button"
 
-type SidebarIconProps = {
+export type SidebarIconProps = {
   isExpanded: boolean
   onClick?: () => void
 }
@@ -62,7 +62,7 @@ function SidebarIconSvg({ isExpanded }: { isExpanded: boolean }) {
 export function SidebarIcon({ isExpanded, onClick }: SidebarIconProps) {
   return (
     <Button
-      variant="outline"
+      variant="ghost"
       size="md"
       round
       onClick={onClick}

--- a/lib/experimental/Navigation/Sidebar/Sidebar.tsx
+++ b/lib/experimental/Navigation/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 export const Sidebar: React.FC<{ children?: React.ReactNode }> = ({
   children,
 }) => {
-  return <div className="flex flex-col gap-2">{children}</div>
+  return <div className="flex flex-col gap-2 px-3">{children}</div>
 }

--- a/lib/experimental/Navigation/Sidebar/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { ComponentProps } from "react"
-import { SidebarHeader, type SidebarHeaderProps } from "./Header"
+import { SidebarHeader } from "./Header"
 import * as SidebarHeaderStories from "./Header/index.stories"
 import { Menu } from "./Menu"
 import * as SidebarMenuStories from "./Menu/index.stories"
@@ -23,9 +23,7 @@ const meta: Meta<typeof Sidebar> = {
   args: {
     children: (
       <>
-        <SidebarHeader
-          {...(SidebarHeaderStories.Default.args as SidebarHeaderProps)}
-        />
+        <SidebarHeader {...SidebarHeaderStories.Default.args} />
         <SearchBar {...SearchBarStories.Default.args} />
         <Menu {...SidebarMenuStories.Default.args} />
       </>

--- a/lib/experimental/Navigation/Sidebar/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/index.stories.tsx
@@ -1,11 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { ComponentProps } from "react"
+import { SidebarHeader, type SidebarHeaderProps } from "./Header"
+import * as SidebarHeaderStories from "./Header/index.stories"
 import { Menu } from "./Menu"
 import * as SidebarMenuStories from "./Menu/index.stories"
 import { SearchBar } from "./Searchbar"
 import * as SearchBarStories from "./Searchbar/index.stories"
 import { Sidebar } from "./Sidebar"
-
 const meta: Meta<typeof Sidebar> = {
   component: Sidebar,
   tags: ["autodocs"],
@@ -14,7 +15,7 @@ const meta: Meta<typeof Sidebar> = {
   },
   decorators: [
     (Story) => (
-      <div className="w-[240px] bg-f1-background-tertiary p-3">
+      <div className="w-[240px] bg-f1-background-tertiary">
         <Story />
       </div>
     ),
@@ -22,6 +23,9 @@ const meta: Meta<typeof Sidebar> = {
   args: {
     children: (
       <>
+        <SidebarHeader
+          {...(SidebarHeaderStories.Default.args as SidebarHeaderProps)}
+        />
         <SearchBar {...SearchBarStories.Default.args} />
         <Menu {...SidebarMenuStories.Default.args} />
       </>

--- a/lib/experimental/Navigation/Sidebar/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/index.tsx
@@ -1,3 +1,4 @@
+export * from "./Header"
 export * from "./Menu"
 export * from "./Searchbar"
 export * from "./Sidebar"


### PR DESCRIPTION
## 🔑 What?

- Add `SidebarHeader,` which contains the company selector and the hide/show sidebar icon. This is the component we'll use in the sidebar.

<img width="238" alt="image" src="https://github.com/user-attachments/assets/2f3121e5-de83-4e56-a299-e69982369552">

Also:
- Adapted the `CompanySelector` title to truncate if there's not enough space.
- Changed the sidebar icon from `outline` to `ghost` following a conversation with Mario.

## 🏡 Context

- [🎨 Figma](https://www.figma.com/design/uImdC0GKxH59DkjzBqRJEF/Layouts-%26-Blocks?node-id=572-138322&t=6a75e6tnBiCCYazo-4)
