### PR TITLE
TabBar: allow onClick handler

### DIFF
--- a/lib/experimental/Navigation/utils.tsx
+++ b/lib/experimental/Navigation/utils.tsx
@@ -1,5 +1,8 @@
 import { LinkProps } from "@/lib/linkHandler"
 
-export type NavigationItem = Pick<LinkProps, "href" | "exactMatch"> & {
+export type NavigationItem = Pick<
+  LinkProps,
+  "href" | "exactMatch" | "onClick"
+> & {
   label: string
 }


### PR DESCRIPTION
## 🚪 Why?

We want to track tab clicks. For example, we have tracking when user goes to the notification tab on the Inbox screen

