### PR TITLE
Add Sidebar User Menu

### DIFF
--- a/lib/experimental/Navigation/Sidebar/User/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/User/index.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { User } from "."
+
+const meta = {
+  component: User,
+  tags: ["autodocs"],
+} satisfies Meta<typeof User>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    name: "Dani Moreno",
+    avatarUrl: "https://github.com/dani-moreno.png",
+    avatarAlt: "DM",
+    options: [
+      { label: "Preferences", href: "/preferences" },
+      { label: "Notifications", href: "/notifications" },
+      { label: "Logout", href: "/logout" },
+    ],
+  },
+}

--- a/lib/experimental/Navigation/Sidebar/User/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/User/index.tsx
@@ -1,0 +1,24 @@
+import { Avatar } from "@/experimental/Information/Avatar"
+import { Dropdown } from "@/experimental/Navigation/Dropdown"
+
+interface UserProps {
+  name: string
+  avatarUrl?: string
+  avatarAlt: string
+  options: {
+    label: string
+    href?: string
+    onClick?: () => void
+  }[]
+}
+
+export function User({ name, avatarUrl, avatarAlt, options }: UserProps) {
+  return (
+    <Dropdown items={options}>
+      <div className="flex items-center gap-1.5 rounded p-1.5 font-medium transition-colors hover:bg-f1-background-secondary-hover data-[state=open]:bg-f1-background-secondary-hover">
+        <Avatar src={avatarUrl} alt={avatarAlt} size="xxsmall" />
+        {name}
+      </div>
+    </Dropdown>
+  )
+}

--- a/lib/experimental/Navigation/Sidebar/User/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/User/index.tsx
@@ -1,5 +1,6 @@
 import { Avatar } from "@/experimental/Information/Avatar"
 import { Dropdown } from "@/experimental/Navigation/Dropdown"
+import { cn, focusRing } from "@/lib/utils"
 
 interface UserProps {
   name: string
@@ -15,10 +16,15 @@ interface UserProps {
 export function User({ name, avatarUrl, avatarAlt, options }: UserProps) {
   return (
     <Dropdown items={options}>
-      <div className="flex items-center gap-1.5 rounded p-1.5 font-medium transition-colors hover:bg-f1-background-secondary-hover data-[state=open]:bg-f1-background-secondary-hover">
+      <button
+        className={cn(
+          "flex w-full items-center gap-1.5 rounded p-1.5 font-medium transition-colors hover:bg-f1-background-secondary-hover data-[state=open]:bg-f1-background-secondary-hover",
+          focusRing()
+        )}
+      >
         <Avatar src={avatarUrl} alt={avatarAlt} size="xxsmall" />
         {name}
-      </div>
+      </button>
     </Dropdown>
   )
 }

--- a/lib/experimental/Navigation/Sidebar/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/index.stories.tsx
@@ -5,6 +5,8 @@ import * as SidebarMenuStories from "./Menu/index.stories"
 import { SearchBar } from "./Searchbar"
 import * as SearchBarStories from "./Searchbar/index.stories"
 import { Sidebar } from "./Sidebar"
+import { User } from "./User"
+import * as UserStories from "./User/index.stories"
 
 const meta: Meta<typeof Sidebar> = {
   component: Sidebar,
@@ -24,6 +26,7 @@ const meta: Meta<typeof Sidebar> = {
       <>
         <SearchBar {...SearchBarStories.Default.args} />
         <Menu {...SidebarMenuStories.Default.args} />
+        <User {...UserStories.Default.args} />
       </>
     ),
   } satisfies ComponentProps<typeof Sidebar>,

--- a/lib/experimental/Navigation/Sidebar/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/index.tsx
@@ -1,3 +1,4 @@
 export * from "./Menu"
 export * from "./Searchbar"
 export * from "./Sidebar"
+export * from "./User"

--- a/lib/ui/avatar.tsx
+++ b/lib/ui/avatar.tsx
@@ -7,6 +7,7 @@ import { cva } from "class-variance-authority"
 import * as React from "react"
 
 export const sizes = [
+  "xxsmall",
   "xsmall",
   "small",
   "medium",
@@ -18,6 +19,7 @@ export const sizes = [
 const avatarVariants = cva("relative flex shrink-0 overflow-hidden", {
   variants: {
     size: {
+      xxsmall: "h-5 w-5 rounded-md text-sm",
       xsmall: "h-6 w-6 rounded-md text-sm",
       small: "h-10 w-10 rounded-md text-sm",
       medium: "h-12 w-12 rounded-md",


### PR DESCRIPTION
## 🔑 What?

Add the component for the user menu, that will stay at the bottom of the sidebar.

<img width="277" alt="image" src="https://github.com/user-attachments/assets/e3373b16-ef83-44ca-b4a5-e52db2cbbb47">


## 🏡 Context

- [🎨 Figma](https://www.figma.com/design/uImdC0GKxH59DkjzBqRJEF/Layouts-%26-Blocks?node-id=572-138330&t=6a75e6tnBiCCYazo-4)
