### PR TITLE
Fix Select check icon

### DIFF
--- a/lib/ui/select.tsx
+++ b/lib/ui/select.tsx
@@ -108,14 +108,14 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative grid w-full cursor-default select-none grid-cols-[1fr_20px] items-center gap-x-1.5 rounded p-2 outline-none transition-colors focus:bg-f1-background-secondary focus:text-f1-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative grid w-full cursor-default select-none grid-cols-[1fr_20px] gap-x-1.5 rounded p-2 outline-none transition-colors focus:bg-f1-background-secondary focus:text-f1-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       "data-[state=checked]:bg-f1-background-selected-bold/5 hover:data-[state=checked]:bg-f1-background-selected-bold/10",
       className
     )}
     {...props}
   >
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-    <SelectPrimitive.ItemIndicator className="flex items-center justify-center">
+    <SelectPrimitive.ItemIndicator className="flex">
       <CheckCircle className="text-f1-icon-selected size-5" />
     </SelectPrimitive.ItemIndicator>
   </SelectPrimitive.Item>

--- a/lib/ui/select.tsx
+++ b/lib/ui/select.tsx
@@ -116,7 +116,7 @@ const SelectItem = React.forwardRef<
   >
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     <SelectPrimitive.ItemIndicator className="flex">
-      <CheckCircle className="text-f1-icon-selected size-5" />
+      <CheckCircle className="size-5 text-f1-icon-selected" />
     </SelectPrimitive.ItemIndicator>
   </SelectPrimitive.Item>
 ))

--- a/lib/ui/select.tsx
+++ b/lib/ui/select.tsx
@@ -108,19 +108,16 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded p-2 outline-none transition-colors focus:bg-f1-background-secondary focus:text-f1-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative grid w-full cursor-default select-none grid-cols-[1fr_20px] items-center gap-x-1.5 rounded p-2 outline-none transition-colors focus:bg-f1-background-secondary focus:text-f1-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       "data-[state=checked]:bg-f1-background-selected-bold/5 hover:data-[state=checked]:bg-f1-background-selected-bold/10",
       className
     )}
     {...props}
   >
-    <div className="absolute right-2 top-2 flex items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <CheckCircle className="h-5 w-5 text-f1-icon-selected" />
-      </SelectPrimitive.ItemIndicator>
-    </div>
-
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <SelectPrimitive.ItemIndicator className="flex items-center justify-center">
+      <CheckCircle className="text-f1-icon-selected size-5" />
+    </SelectPrimitive.ItemIndicator>
   </SelectPrimitive.Item>
 ))
 SelectItem.displayName = SelectPrimitive.Item.displayName


### PR DESCRIPTION
The check icon for the selected option could overlap the label if the label is the longer one.

<img width="394" alt="Screenshot 2024-10-10 at 18 57 23" src="https://github.com/user-attachments/assets/da87a3b9-49fb-4a77-9fd6-1b5c1805a1e4">

---

This PR fixes that by using a grid to hold the icon instead of an absolute position:

<img width="418" alt="Screenshot 2024-10-10 at 19 05 08" src="https://github.com/user-attachments/assets/a73b119f-0609-42e5-bab4-e1c8feaa5221">
