### PR TITLE
Add Navigation in Header

### DIFF
--- a/lib/experimental/Navigation/Header/Header/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/Header/index.stories.tsx
@@ -1,5 +1,6 @@
 import EllipsisHorizontal from "@/icons/EllipsisHorizontal"
 import Settings from "@/icons/Settings"
+import { action } from "@storybook/addon-actions"
 
 import type { Meta, StoryObj } from "@storybook/react"
 import Header from "."
@@ -96,6 +97,37 @@ export const LongBreadcrumbs: Story = {
     menu: {
       show: true,
       onClick: () => console.log("Menu clicked"),
+    },
+  },
+}
+
+export const WithNavigation: Story = {
+  args: {
+    module: {
+      name: "Recruitment",
+      href: "/recruitment",
+      icon: "Recruitment",
+    },
+    breadcrumbs: [
+      { label: "Candidates", href: "/recruitment/candidates" },
+      { label: "Dani Moreno" },
+    ],
+    actions: [
+      {
+        label: "More options",
+        icon: EllipsisHorizontal,
+        onClick: action("More clicked"),
+      },
+    ],
+    menu: {
+      show: false,
+      onClick: action("Menu clicked"),
+    },
+    navigation: {
+      current: 3,
+      total: 10,
+      onPrevious: action("Previous clicked"),
+      onNext: action("Next clicked"),
     },
   },
 }

--- a/lib/experimental/Navigation/Header/Header/index.tsx
+++ b/lib/experimental/Navigation/Header/Header/index.tsx
@@ -3,6 +3,7 @@ import { IconType } from "@/components/Utilities/Icon"
 import AlignTextJustify from "@/icons/AlignTextJustify"
 import { cn } from "@/lib/utils"
 import Breadcrumbs, { type BreadcrumbItemType } from "../Breadcrumbs"
+import { Navigation, NavigationProps } from "../Navigation"
 
 import {
   ModuleAvatar,
@@ -25,6 +26,7 @@ type HeaderProps = {
     show: boolean
     onClick: () => void
   }
+  navigation?: NavigationProps
 }
 
 export default function Header({
@@ -32,6 +34,7 @@ export default function Header({
   breadcrumbs = [],
   actions = [],
   menu,
+  navigation,
 }: HeaderProps) {
   const breadcrumbsTree: BreadcrumbItemType[] = [
     { label: module.name, href: module.href, icon: module.icon },
@@ -66,21 +69,34 @@ export default function Header({
           <div className="text-xl font-semibold">{module.name}</div>
         )}
       </div>
-      {actions && (
-        <div className="flex items-center gap-2">
-          {actions.map((action, index) => (
-            <Button
-              hideLabel
-              round
-              key={index}
-              variant="outline"
-              onClick={action.onClick}
-              label={action.label}
-              icon={action.icon}
-            />
-          ))}
-        </div>
-      )}
+      <div className="flex items-center gap-3">
+        {navigation && (
+          <Navigation
+            current={navigation.current}
+            total={navigation.total}
+            onPrevious={navigation.onPrevious}
+            onNext={navigation.onNext}
+          />
+        )}
+        {navigation && actions && actions.length > 0 && (
+          <div className="h-4 w-px bg-f1-border-secondary" />
+        )}
+        {actions && actions.length > 0 && (
+          <div className="flex items-center gap-2">
+            {actions.map((action, index) => (
+              <Button
+                hideLabel
+                round
+                key={index}
+                variant="outline"
+                onClick={action.onClick}
+                label={action.label}
+                icon={action.icon}
+              />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/lib/experimental/Navigation/Header/Navigation/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/Navigation/index.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { Navigation } from "./index"
+
+const meta: Meta<typeof Navigation> = {
+  component: Navigation,
+  tags: ["autodocs"],
+}
+
+export default meta
+
+type Story = StoryObj<typeof Navigation>
+
+export const Default: Story = {
+  args: {
+    current: 1,
+    total: 5,
+    onPrevious: () => console.log("Previous clicked"),
+    onNext: () => console.log("Next clicked"),
+  },
+}

--- a/lib/experimental/Navigation/Header/Navigation/index.tsx
+++ b/lib/experimental/Navigation/Header/Navigation/index.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@/components/Actions/Button"
+import { ChevronDown, ChevronUp } from "@/icons"
+
+export interface NavigationProps {
+  current: number
+  total: number
+  onPrevious: () => void
+  onNext: () => void
+}
+
+export function Navigation({
+  current,
+  total,
+  onPrevious,
+  onNext,
+}: NavigationProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="text-sm tabular-nums text-f1-foreground-secondary">
+        {current}/{total}
+      </div>
+      <Button
+        round
+        size="sm"
+        variant="outline"
+        onClick={onPrevious}
+        label="Previous"
+        icon={ChevronUp}
+        hideLabel
+        disabled={current === 1}
+      />
+      <Button
+        round
+        size="sm"
+        variant="outline"
+        onClick={onNext}
+        label="Next"
+        icon={ChevronDown}
+        hideLabel
+        disabled={current === total}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## 🚪 Why?

The `Header` component can contain navigation between items. For example, when navigating employees, tasks, and so on.

## 🔑 What?

- Add `Navigation` component inside Header.
- Uses `Navigation` inside the `Header` component.


<img width="228" alt="image" src="https://github.com/user-attachments/assets/3993edc4-29a9-4464-a4f5-b181ce78ad0e">


## 🏡 Context

- [🎨 Figma](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=38-709&t=4HWatFmVqrVyRgCP-4)
