### PR TITLE
Fix buggy `Menu` animation

### DIFF
--- a/lib/experimental/Navigation/Sidebar/Menu/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Menu/index.tsx
@@ -114,15 +114,16 @@ const CategoryItem = ({ category }: { category: MenuCategory }) => {
         <AnimatePresence initial={false}>
           {isOpen && (
             <motion.div
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.15, ease: "easeInOut" }}
-              className="flex flex-col gap-1 pb-3"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.15, ease: [0.165, 0.84, 0.44, 1] }}
             >
-              {category.items.map((item, index) => (
-                <MenuItem key={index} item={item} />
-              ))}
+              <div className="flex flex-col gap-1 pb-3">
+                {category.items.map((item, index) => (
+                  <MenuItem key={index} item={item} />
+                ))}
+              </div>
             </motion.div>
           )}
         </AnimatePresence>


### PR DESCRIPTION
The open/close animation of a category in the `Menu` component is a bit bugged. This PR solves the issue, separating the style of the list, from the div that has the motion applied. Somehow mixing them in the same div does weird things if you're animating the height.

### Before

_Look at the small "jump" the close animation does near the end._

https://github.com/user-attachments/assets/9205ad65-a94c-421f-a734-796e4fe2ff74

---

### After

https://github.com/user-attachments/assets/c75ebdfe-98b7-4170-b710-042029df245a

