### PR TITLE
Add a working example of the layout

### DIFF
--- a/lib/experimental/Navigation/ApplicationFrame/FrameProvider.tsx
+++ b/lib/experimental/Navigation/ApplicationFrame/FrameProvider.tsx
@@ -1,0 +1,87 @@
+import React, {
+  createContext,
+  PointerEvent,
+  useCallback,
+  useContext,
+  useState,
+} from "react"
+import { useMediaQuery } from "usehooks-ts"
+
+type SidebarState = "locked" | "unlocked" | "hidden"
+
+interface FrameContextType {
+  isSmallScreen: boolean
+  sidebarState: SidebarState
+  toggleSidebar: () => void
+}
+
+const FrameContext = createContext<FrameContextType | undefined>(undefined)
+
+export function useSidebar(): FrameContextType {
+  const context = useContext(FrameContext)
+  if (context === undefined) {
+    return {
+      isSmallScreen: false,
+      sidebarState: "locked",
+      toggleSidebar: () => {},
+    }
+  }
+  return context
+}
+
+interface FrameProviderProps {
+  children: React.ReactNode
+}
+
+export function FrameProvider({ children }: FrameProviderProps) {
+  const isSmallScreen = useMediaQuery("(max-width: 900px)", {
+    initializeWithValue: true,
+  })
+
+  const [locked, setLocked] = useState(true)
+  const [visible, setVisible] = useState(false)
+
+  const toggleSidebar = useCallback(() => {
+    if (isSmallScreen) setVisible(!visible)
+    setLocked(!locked)
+  }, [isSmallScreen, visible, locked, setLocked, setVisible])
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (isSmallScreen) return
+
+      if (e.clientX < 32) {
+        setVisible(true)
+      }
+
+      if (e.clientX > 280) {
+        setVisible(false)
+      }
+    },
+    [isSmallScreen, setVisible]
+  )
+
+  const sidebarState: SidebarState = (() => {
+    if (isSmallScreen) {
+      if (visible) return "unlocked"
+      return "hidden"
+    }
+    if (!locked && !visible) return "hidden"
+    if (!locked && visible) return "unlocked"
+    return "locked"
+  })()
+
+  return (
+    <FrameContext.Provider
+      value={{
+        isSmallScreen,
+        sidebarState,
+        toggleSidebar,
+      }}
+    >
+      <div onPointerMove={handlePointerMove} className="h-screen w-screen">
+        {children}
+      </div>
+    </FrameContext.Provider>
+  )
+}

--- a/lib/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/lib/experimental/Navigation/ApplicationFrame/index.tsx
@@ -1,16 +1,67 @@
+import { cn } from "@/lib/utils"
+import { motion, MotionConfig } from "framer-motion"
+import { FrameProvider, useSidebar } from "./FrameProvider"
+
+import { AnimatePresence } from "framer-motion"
 interface ApplicationFrameProps {
   sidebar: React.ReactNode
   children: React.ReactNode
 }
 
-export const ApplicationFrame: React.FC<ApplicationFrameProps> = ({
-  children,
-  sidebar,
-}) => {
+export function ApplicationFrame({ children, sidebar }: ApplicationFrameProps) {
   return (
-    <div className="flex h-full flex-row gap-3">
-      <div className="w-64 pl-3">{sidebar}</div>
-      <div className="flex flex-1 py-1 pr-1">{children}</div>
-    </div>
+    <FrameProvider>
+      <ApplicationFrameContent sidebar={sidebar}>
+        {children}
+      </ApplicationFrameContent>
+    </FrameProvider>
+  )
+}
+
+function ApplicationFrameContent({ children, sidebar }: ApplicationFrameProps) {
+  const { sidebarState, toggleSidebar, isSmallScreen } = useSidebar()
+
+  return (
+    <MotionConfig transition={{ ease: [0.25, 0.1, 0.25, 1], duration: 0.2 }}>
+      <div className="relative flex h-full flex-row">
+        <AnimatePresence>
+          {sidebarState === "unlocked" && (
+            <motion.div
+              className={cn("fixed inset-0 z-[5] bg-f1-background-bold/60", {
+                hidden: !isSmallScreen,
+              })}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              onClick={toggleSidebar}
+            />
+          )}
+        </AnimatePresence>
+        <div
+          className={cn(
+            "transition-all",
+            sidebarState === "locked" ? "w-64 pl-3" : "w-0"
+          )}
+        >
+          {sidebar}
+        </div>
+        <motion.div
+          className={cn(
+            "xs:py-1 xs:pr-1 flex max-w-full flex-1 overflow-x-hidden",
+            sidebarState === "locked" ? "pl-0" : "xs:pl-1"
+          )}
+          layout
+          transition={{
+            duration: 0.3,
+            type: "spring",
+            stiffness: 300,
+            damping: 30,
+          }}
+        >
+          {children}
+        </motion.div>
+      </div>
+    </MotionConfig>
   )
 }

--- a/lib/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/lib/experimental/Navigation/ApplicationFrame/index.tsx
@@ -48,7 +48,7 @@ function ApplicationFrameContent({ children, sidebar }: ApplicationFrameProps) {
         </div>
         <motion.div
           className={cn(
-            "xs:py-1 xs:pr-1 flex max-w-full flex-1 overflow-x-hidden",
+            "flex max-w-full flex-1 overflow-x-hidden xs:py-1 xs:pr-1",
             sidebarState === "locked" ? "pl-0" : "xs:pl-1"
           )}
           layout

--- a/lib/experimental/Navigation/Header/Header/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/Header/index.stories.tsx
@@ -35,10 +35,6 @@ export const Default: Story = {
         onClick: () => console.log("More clicked"),
       },
     ],
-    menu: {
-      show: true,
-      onClick: () => console.log("Menu clicked"),
-    },
   },
 }
 
@@ -48,10 +44,6 @@ export const FirstLevel: Story = {
       name: "Recruitment",
       href: "/recruitment",
       icon: "Recruitment",
-    },
-    menu: {
-      show: true,
-      onClick: () => console.log("Menu clicked"),
     },
   },
 }
@@ -93,9 +85,5 @@ export const LongBreadcrumbs: Story = {
         onClick: () => console.log("More clicked"),
       },
     ],
-    menu: {
-      show: true,
-      onClick: () => console.log("Menu clicked"),
-    },
   },
 }

--- a/lib/experimental/Navigation/Header/Header/index.tsx
+++ b/lib/experimental/Navigation/Header/Header/index.tsx
@@ -1,7 +1,9 @@
 import { Button } from "@/components/Actions/Button"
 import { IconType } from "@/components/Utilities/Icon"
+import { useSidebar } from "@/experimental/Navigation/ApplicationFrame/FrameProvider"
 import AlignTextJustify from "@/icons/AlignTextJustify"
 import { cn } from "@/lib/utils"
+import { AnimatePresence, motion } from "framer-motion"
 import Breadcrumbs, { type BreadcrumbItemType } from "../Breadcrumbs"
 
 import {
@@ -21,18 +23,15 @@ type HeaderProps = {
     icon: IconType
     onClick: () => void
   }[]
-  menu: {
-    show: boolean
-    onClick: () => void
-  }
 }
 
 export default function Header({
   module,
   breadcrumbs = [],
   actions = [],
-  menu,
 }: HeaderProps) {
+  const { sidebarState, toggleSidebar } = useSidebar()
+
   const breadcrumbsTree: BreadcrumbItemType[] = [
     { label: module.name, href: module.href, icon: module.icon },
     ...breadcrumbs,
@@ -43,28 +42,40 @@ export default function Header({
   return (
     <div
       className={cn(
-        "flex h-16 items-center justify-between bg-f1-background/80 px-6 py-4 backdrop-blur-xl",
+        "flex h-16 items-center justify-between bg-f1-background/80 px-5 py-4 backdrop-blur-xl xs:px-6",
         hasNavigation &&
           "border-b border-dashed border-transparent border-b-f1-border/80"
       )}
     >
-      <div className="flex flex-grow items-center gap-3">
-        {menu.show && (
-          <Button
-            variant="ghost"
-            hideLabel
-            round
-            onClick={menu.onClick}
-            label="Menu"
-            icon={AlignTextJustify}
-          />
-        )}
-        {!hasNavigation && <ModuleAvatar icon={module.icon} size="lg" />}
-        {breadcrumbsTree.length > 1 ? (
-          <Breadcrumbs breadcrumbs={breadcrumbsTree} />
-        ) : (
-          <div className="text-xl font-semibold">{module.name}</div>
-        )}
+      <div className="flex flex-grow items-center">
+        <AnimatePresence>
+          {sidebarState !== "locked" && (
+            <motion.div
+              initial={{ opacity: 0, width: 0 }}
+              animate={{ opacity: 1, width: "auto" }}
+              exit={{ opacity: 0, width: 0 }}
+            >
+              <div className="mr-3">
+                <Button
+                  variant="ghost"
+                  hideLabel
+                  round
+                  onClick={toggleSidebar}
+                  label="Menu"
+                  icon={AlignTextJustify}
+                />
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+        <div className="flex flex-grow items-center gap-3">
+          {!hasNavigation && <ModuleAvatar icon={module.icon} size="lg" />}
+          {breadcrumbsTree.length > 1 ? (
+            <Breadcrumbs breadcrumbs={breadcrumbsTree} />
+          ) : (
+            <div className="text-xl font-semibold">{module.name}</div>
+          )}
+        </div>
       </div>
       {actions && (
         <div className="flex items-center gap-2">

--- a/lib/experimental/Navigation/Page/index.stories.tsx
+++ b/lib/experimental/Navigation/Page/index.stories.tsx
@@ -31,10 +31,7 @@ export const Default: Story = {
   args: {
     header: (
       <>
-        <Header
-          {...HeaderStories.FirstLevel.args}
-          menu={{ show: false, onClick: () => {} }}
-        />
+        <Header {...HeaderStories.FirstLevel.args} />
         <Tabs {...TabsStories.Primary.args} />
       </>
     ),

--- a/lib/experimental/Navigation/Sidebar/Header/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Header/index.tsx
@@ -7,7 +7,6 @@ export function SidebarHeader({
   companies,
   selected,
   onChange,
-  isExpanded,
 }: SidebarHeaderProps) {
   return (
     <div className="flex h-[72px] items-center justify-between gap-3">
@@ -16,7 +15,7 @@ export function SidebarHeader({
         selected={selected}
         onChange={onChange}
       />
-      <SidebarIcon isExpanded={isExpanded} />
+      <SidebarIcon />
     </div>
   )
 }

--- a/lib/experimental/Navigation/Sidebar/Icon/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Icon/index.tsx
@@ -1,3 +1,6 @@
+import { Icon } from "@/components/Utilities/Icon"
+import { useSidebar } from "@/experimental/Navigation/ApplicationFrame/FrameProvider"
+import { Cross } from "@/icons"
 import { cn } from "@/lib/utils"
 import { Button } from "@/ui/button"
 
@@ -6,7 +9,7 @@ export type SidebarIconProps = {
   onClick?: () => void
 }
 
-function SidebarIconSvg({ isExpanded }: { isExpanded: boolean }) {
+function SidebarIconSvg({ isExpanded }: SidebarIconProps) {
   return (
     <svg
       width="20"
@@ -59,17 +62,24 @@ function SidebarIconSvg({ isExpanded }: { isExpanded: boolean }) {
   )
 }
 
-export function SidebarIcon({ isExpanded, onClick }: SidebarIconProps) {
+export function SidebarIcon() {
+  const { sidebarState, toggleSidebar, isSmallScreen } = useSidebar()
+
   return (
     <Button
       variant="ghost"
       size="md"
       round
-      onClick={onClick}
+      onClick={toggleSidebar}
       className="group"
       title="Toggle Sidebar"
     >
-      <SidebarIconSvg isExpanded={isExpanded} />
+      <div className={cn("hidden", { flex: !isSmallScreen })}>
+        <SidebarIconSvg isExpanded={sidebarState === "locked"} />
+      </div>
+      <div className={cn("hidden", { flex: isSmallScreen })}>
+        <Icon icon={Cross} size="md" />
+      </div>
     </Button>
   )
 }

--- a/lib/experimental/Navigation/Sidebar/Searchbar/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Searchbar/index.tsx
@@ -29,7 +29,9 @@ export function SearchBar({
         <Icon icon={Search} size="md" />
         <span>{placeholder}</span>
       </div>
-      <Shortcut keys={shortcut} />
+      <div className="hidden xs:block">
+        <Shortcut keys={shortcut} />
+      </div>
     </button>
   )
 }

--- a/lib/experimental/Navigation/Sidebar/Sidebar.tsx
+++ b/lib/experimental/Navigation/Sidebar/Sidebar.tsx
@@ -1,4 +1,7 @@
+import { cn } from "@/lib/utils"
+import { motion } from "framer-motion"
 import { ReactNode } from "react"
+import { useSidebar } from "../ApplicationFrame/FrameProvider"
 
 interface SidebarProps {
   header?: ReactNode
@@ -7,11 +10,51 @@ interface SidebarProps {
 }
 
 export function Sidebar({ header, body, footer }: SidebarProps) {
+  const { sidebarState, isSmallScreen } = useSidebar()
+
+  const transition = {
+    x: {
+      ease:
+        sidebarState !== "locked"
+          ? isSmallScreen
+            ? [0.25, 0.46, 0.45, 0.94]
+            : [0.175, 0.885, 0.32, 1.1]
+          : [0, 0, 0.58, 1],
+      duration: sidebarState !== "locked" && !isSmallScreen ? 0.3 : 0.2,
+    },
+    top: { duration: 0.1 },
+    left: { duration: 0.1 },
+    default: { duration: 0.2 },
+  }
+
   return (
-    <div className="flex h-full flex-col gap-2">
-      {header && <div className="flex-shrink-0">{header}</div>}
+    <motion.div
+      initial={false}
+      className={cn(
+        "absolute bottom-0 left-0 top-0 z-10 flex w-64 flex-col px-3 transition-[background-color]",
+        sidebarState === "locked"
+          ? "h-screen"
+          : cn(
+              "pb-3",
+              isSmallScreen
+                ? "h-screen bg-f1-background-secondary"
+                : "h-[calc(100vh-16px)] border-solid border-f1-border/40 bg-f1-background/60 shadow-lg backdrop-blur-2xl"
+            )
+      )}
+      animate={{
+        top: sidebarState === "locked" ? 0 : isSmallScreen ? 0 : "8px",
+        borderRadius:
+          sidebarState === "locked" ? "0" : isSmallScreen ? "0" : "12px",
+        left: sidebarState === "locked" ? "0" : isSmallScreen ? 0 : "8px",
+        x: sidebarState === "hidden" ? -260 : 0,
+        opacity: sidebarState === "hidden" ? (isSmallScreen ? 0.7 : 0) : 1,
+        pointerEvents: sidebarState === "hidden" ? "none" : "auto",
+      }}
+      transition={transition}
+    >
+      <div className="flex-shrink-0">{header}</div>
       {body && <div className="flex-grow overflow-y-auto">{body}</div>}
-      {footer && <div className="flex-shrink-0">{footer}</div>}
-    </div>
+      <div className="flex-shrink-0">{footer}</div>
+    </motion.div>
   )
 }

--- a/lib/lib/one-provider.tsx
+++ b/lib/lib/one-provider.tsx
@@ -1,3 +1,4 @@
+import { MotionConfig } from "framer-motion"
 import {
   ComponentProps,
   createContext,
@@ -56,6 +57,12 @@ export const LayoutProvider: React.FC<
   )
 }
 
+const MotionProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>
+}
+
 export const FactorialOneProvider: React.FC<{
   children: React.ReactNode
   link?: LinkContextValue
@@ -64,14 +71,16 @@ export const FactorialOneProvider: React.FC<{
   layout?: Omit<ComponentProps<typeof LayoutProvider>, "children">
 }> = ({ children, layout, link, privacyModeInitiallyEnabled, image }) => {
   return (
-    <LayoutProvider {...layout}>
-      <XRayProvider>
-        <PrivacyModeProvider initiallyEnabled={privacyModeInitiallyEnabled}>
-          <LinkProvider {...link}>
-            <ImageProvider {...image}>{children}</ImageProvider>
-          </LinkProvider>
-        </PrivacyModeProvider>
-      </XRayProvider>
-    </LayoutProvider>
+    <MotionProvider>
+      <LayoutProvider {...layout}>
+        <XRayProvider>
+          <PrivacyModeProvider initiallyEnabled={privacyModeInitiallyEnabled}>
+            <LinkProvider {...link}>
+              <ImageProvider {...image}>{children}</ImageProvider>
+            </LinkProvider>
+          </PrivacyModeProvider>
+        </XRayProvider>
+      </LayoutProvider>
+    </MotionProvider>
   )
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build-icons": "tsc --p ./tsconfig-build-icons.json",
     "build:tailwind": "NODE_ENV=production tailwindcss -i ./styles.css -o ./dist/styles.css --postcss --minify",
     "lint": "eslint -c eslint.config.mjs . --report-unused-disable-directives --max-warnings 0",
+    "lint-fix": "npm run lint -- --fix",
     "preview": "vite preview",
     "generate-icons": "npx @svgr/cli --out-dir lib/icons assets/icons",
     "build-storybook": "storybook build",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -279,6 +279,9 @@ export default {
         "11xl": "192rem",
         "12xl": "240rem",
       },
+      screens: {
+        xs: "480px",
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
This PR adds a working example of the layout, with the show/hide sidebar functionality and the rest of the layout adapting to it.


https://github.com/user-attachments/assets/67d12af1-6c46-4c59-ba5e-1145bbd0e3e5



---

**Note:** The layout isn't entirely finished as it lacks a few things and has a few bugs, but it's enough to try out. I'll keep working on it when I'm back! 👀🪛

**Things to be improved:**
- I'm using the `useMediaQuery` hook in some places, but I'd like to investigate if I can avoid it in some places (probably yes!).
- A few details yet to be done.