### PR TITLE
Bundle all libraries

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,6 @@ import path, { resolve } from "path"
 import { defineConfig } from "vite"
 import dts from "vite-plugin-dts"
 import { libInjectCss } from "vite-plugin-lib-inject-css"
-import { peerDependencies } from "./package.json"
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -41,7 +40,7 @@ export default defineConfig({
     },
     copyPublicDir: false,
     rollupOptions: {
-      external: [...Object.keys(peerDependencies), "react/jsx-runtime"],
+      external: ["react/jsx-runtime"],
       output: {
         globals: {
           react: "React",


### PR DESCRIPTION
This will bundle all libraries with `factorial-one`. It's an attempt to debug a weird behavior on production that I believe it's due to a version clash.

If this works, I will try to dig into the issue more carefully, but right now I need to validate that's the case.