### PR TITLE
Make avatar images cover instead of stretching

### DIFF
--- a/lib/ui/avatar.tsx
+++ b/lib/ui/avatar.tsx
@@ -57,7 +57,7 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
+    className={cn("aspect-square h-full w-full object-cover", className)}
     {...props}
     asChild
   >


### PR DESCRIPTION
Avatars should always look nice, and this means using `object-fit: cover` instead of stretching them :)