### PR TITLE
Pass icons as components

### DIFF
--- a/lib/experimental/Navigation/Sidebar/Menu/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Menu/index.stories.tsx
@@ -1,3 +1,4 @@
+import * as Icons from "@/icons"
 import type { Meta, StoryObj } from "@storybook/react"
 import { Menu } from "."
 
@@ -25,16 +26,16 @@ export const Default: Story = {
       {
         title: "Root",
         items: [
-          { label: "Home", icon: "Home", href: "/", exactMatch: true },
+          { label: "Home", icon: Icons.Home, href: "/", exactMatch: true },
           {
             label: "Inbox",
-            icon: "Envelope",
+            icon: Icons.Envelope,
             href: "/inbox",
             badge: 6,
           },
           {
             label: "Discover Factorial",
-            icon: "UpgradePlan",
+            icon: Icons.UpgradePlan,
             href: "/discover",
           },
         ],
@@ -43,17 +44,17 @@ export const Default: Story = {
       {
         title: "You",
         items: [
-          { label: "Me", icon: "Person", href: "/me" },
-          { label: "Clock in", icon: "Clock", href: "/clock-in" },
-          { label: "Time off", icon: "TimeOff", href: "/time-off" },
+          { label: "Me", icon: Icons.Person, href: "/me" },
+          { label: "Clock in", icon: Icons.Clock, href: "/clock-in" },
+          { label: "Time off", icon: Icons.TimeOff, href: "/time-off" },
         ],
         isOpen: true,
       },
       {
         title: "Your company",
         items: [
-          { label: "Organization", icon: "Manager", href: "/organization" },
-          { label: "Calendar", icon: "Calendar", href: "/calendar" },
+          { label: "Organization", icon: Icons.Manager, href: "/organization" },
+          { label: "Calendar", icon: Icons.Calendar, href: "/calendar" },
         ],
         isOpen: true,
       },

--- a/lib/experimental/Navigation/Sidebar/Menu/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Menu/index.tsx
@@ -13,12 +13,12 @@ import { AnimatePresence, motion } from "framer-motion"
 import React from "react"
 import { NavigationItem } from "../../utils"
 
-interface MenuItem extends NavigationItem {
+export interface MenuItem extends NavigationItem {
   icon: IconType
   badge?: number
 }
 
-interface MenuCategory {
+export interface MenuCategory {
   title: string
   items: MenuItem[]
   isRoot?: boolean

--- a/lib/experimental/Navigation/Sidebar/Menu/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Menu/index.tsx
@@ -1,3 +1,4 @@
+import { IconType } from "@/components/Utilities/Icon"
 import { Counter } from "@/experimental/Information/Counter"
 import * as Icons from "@/icons"
 import { useReducedMotion } from "@/lib/a11y"
@@ -12,10 +13,8 @@ import { AnimatePresence, motion } from "framer-motion"
 import React from "react"
 import { NavigationItem } from "../../utils"
 
-type IconName = keyof typeof Icons
-
 interface MenuItem extends NavigationItem {
-  icon: IconName
+  icon: IconType
   badge?: number
 }
 
@@ -37,7 +36,7 @@ const MenuItemContent = ({
   item: MenuItem
   active: boolean
 }) => {
-  const IconComponent = Icons[item.icon]
+  const IconComponent = item.icon
 
   return (
     <div className="flex w-full items-center justify-between">


### PR DESCRIPTION
This uses the same approach as `Button` where icons are passed as components and not as strings. This has the advantage of being able to prevent the whole icon library to be compiled with the app, and allows external icons.

If we reconsider the approach, we should reconsider it in all places -- this at least makes it consistent.