### PR TITLE
Rename page header

### DIFF
--- a/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -2,12 +2,12 @@ import EllipsisHorizontal from "@/icons/EllipsisHorizontal"
 import Settings from "@/icons/Settings"
 
 import type { Meta, StoryObj } from "@storybook/react"
-import Header from "."
+import { PageHeader } from "."
 
 const meta = {
-  component: Header,
+  component: PageHeader,
   tags: ["autodocs"],
-} satisfies Meta<typeof Header>
+} satisfies Meta<typeof PageHeader>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -25,7 +25,7 @@ type HeaderProps = {
   }[]
 }
 
-export default function Header({
+export function PageHeader({
   module,
   breadcrumbs = [],
   actions = [],

--- a/lib/experimental/Navigation/Header/index.tsx
+++ b/lib/experimental/Navigation/Header/index.tsx
@@ -1,2 +1,2 @@
 export * from "./Breadcrumbs"
-export * from "./Header"
+export * from "./PageHeader"

--- a/lib/experimental/Navigation/Page/index.stories.tsx
+++ b/lib/experimental/Navigation/Page/index.stories.tsx
@@ -2,8 +2,8 @@ import { Placeholder } from "@/lib/storybook-utils"
 import type { Meta, StoryObj } from "@storybook/react"
 import { Page } from "."
 
-import Header from "../Header/Header"
-import * as HeaderStories from "../Header/Header/index.stories"
+import { PageHeader } from "../Header/PageHeader"
+import * as HeaderStories from "../Header/PageHeader/index.stories"
 import { Tabs } from "../Tabs"
 import * as TabsStories from "../Tabs/index.stories"
 
@@ -31,7 +31,7 @@ export const Default: Story = {
   args: {
     header: (
       <>
-        <Header {...HeaderStories.FirstLevel.args} />
+        <PageHeader {...HeaderStories.FirstLevel.args} />
         <Tabs {...TabsStories.Primary.args} />
       </>
     ),


### PR DESCRIPTION
Renames page header from a very generic `Header` component to `PageHeader`.