### PR TITLE
Make widget separator go full width

### DIFF
--- a/lib/ui/separator.tsx
+++ b/lib/ui/separator.tsx
@@ -11,7 +11,7 @@ export const Separator = forwardRef<HTMLDivElement, SeparatorProps>(
       <div
         ref={ref}
         role="separator"
-        className={cn("h-[1px] w-full", !bare ? "my-4" : undefined)}
+        className={cn("-mx-4 h-[1px]", !bare ? "my-4" : undefined)}
         style={{
           backgroundImage:
             "repeating-linear-gradient(to right, hsl(var(--neutral-30)) 0, hsl(var(--neutral-30)) 3px, transparent 3px, transparent 7px)",


### PR DESCRIPTION
## 🔑 What?

Make widget separator go full width.

<img width="323" alt="Screenshot 2024-10-24 at 16 26 21" src="https://github.com/user-attachments/assets/a5f0b987-dfda-4565-b3d5-4d48b1a01767">
