### PR TITLE
Fix blur on area chart widget

### DIFF
--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -63,7 +63,7 @@ const ChartAreaBoundedTick = ({
   )
 }
 
-export const _AreaChart = <K extends LineChartConfig>(
+export const BaseAreaChart = <K extends LineChartConfig>(
   {
     data,
     dataConfig,
@@ -231,4 +231,4 @@ export const _AreaChart = <K extends LineChartConfig>(
   )
 }
 
-export const AreaChart = fixedForwardRef(_AreaChart)
+export const AreaChart = fixedForwardRef(BaseAreaChart)

--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -1,3 +1,4 @@
+import { usePrivacyMode } from "@/lib/privacyMode"
 import { cn } from "@/lib/utils"
 import {
   ChartContainer,
@@ -31,6 +32,7 @@ export type AreaChartProps<K extends LineChartConfig = LineChartConfig> =
   LineChartPropsBase<K> & {
     lineType?: allowedLineTypes
     marginTop?: number
+    canBeBlurred?: boolean
   }
 
 // Rechart props give any
@@ -67,12 +69,15 @@ export const _AreaChart = <K extends LineChartConfig>(
     dataConfig,
     xAxis,
     yAxis,
+    canBeBlurred,
     lineType = "monotoneX",
     aspect,
     marginTop = 0,
   }: AreaChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
+  const { enabled: privacyModeEnabled } = usePrivacyMode()
+
   const areas = Object.keys(dataConfig) as (keyof LineChartConfig)[]
   const chartId = nanoid(12)
 
@@ -91,6 +96,9 @@ export const _AreaChart = <K extends LineChartConfig>(
   const yAxisWidth = yAxis?.width ?? maxLabelWidth + 20
   const isYAxisVisible = !yAxis?.hide
   const isXAxisVisible = !xAxis?.hide
+
+  const showTooltip = !canBeBlurred || !privacyModeEnabled
+
   return (
     <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
       <AreaChartPrimitive
@@ -179,18 +187,20 @@ export const _AreaChart = <K extends LineChartConfig>(
             ticks={yAxis?.ticks}
             domain={yAxis?.domain}
             width={yAxisWidth}
-            className={cn(yAxis?.isBlur && "blur-sm")}
+            className={cn(canBeBlurred && privacyModeEnabled && "blur-md")}
           />
         )}
-        <ChartTooltip
-          cursor
-          content={
-            <ChartTooltipContent
-              indicator="dot"
-              yAxisFormatter={yAxis?.tickFormatter}
-            />
-          }
-        />
+        {showTooltip && (
+          <ChartTooltip
+            cursor
+            content={
+              <ChartTooltipContent
+                indicator="dot"
+                yAxisFormatter={yAxis?.tickFormatter}
+              />
+            }
+          />
+        )}
         {areas.map((area, index) => (
           <Area
             isAnimationActive={false}

--- a/lib/components/Charts/utils/types.ts
+++ b/lib/components/Charts/utils/types.ts
@@ -18,7 +18,6 @@ export type AxisConfig = {
   tickCount?: number
   ticks?: number[]
   domain?: number[]
-  isBlur?: boolean
   width?: number
 }
 

--- a/lib/experimental/Utilities/PrivateBox/index.tsx
+++ b/lib/experimental/Utilities/PrivateBox/index.tsx
@@ -5,5 +5,5 @@ import { FC, PropsWithChildren } from "react"
 export const PrivateBox: FC<PropsWithChildren> = ({ children }) => {
   const { enabled } = usePrivacyMode()
 
-  return <div className={cn(enabled && "blur-sm", "inline")}>{children}</div>
+  return <div className={cn(enabled && "blur-md", "inline")}>{children}</div>
 }

--- a/lib/experimental/Widgets/Charts/AreaChartWidget/index.stories.tsx
+++ b/lib/experimental/Widgets/Charts/AreaChartWidget/index.stories.tsx
@@ -60,7 +60,7 @@ export const WithComment = {
 
 export const WithBlur = {
   args: {
-    hasBlur: true,
+    canBeBlurred: true,
     header: {
       ...containerStoryArgs.header,
       title: "An area chart",

--- a/lib/experimental/Widgets/Charts/AreaChartWidget/index.tsx
+++ b/lib/experimental/Widgets/Charts/AreaChartWidget/index.tsx
@@ -1,44 +1,36 @@
 import { AreaChart, AreaChartProps } from "@/components/Charts/AreaChart"
 import { withSkeleton } from "@/lib/skeleton"
-import { forwardRef, useState } from "react"
+import { forwardRef } from "react"
 import { ChartContainer, ComposeChartContainerProps } from "../ChartContainer"
 
 export interface AreaChartWidgetProps
   extends ComposeChartContainerProps<AreaChartProps> {
-  hasBlur?: boolean
+  canBeBlurred?: boolean
 }
 
 export const AreaChartWidget = withSkeleton(
   forwardRef<HTMLDivElement, AreaChartWidgetProps>(function AreaChartWidget(
-    { hasBlur, ...props },
+    { canBeBlurred, ...props },
     ref
   ) {
-    const [isBlur, setIsBlur] = useState<boolean>(!!hasBlur)
-
-    const toggleBlur = () => setIsBlur((prev) => !prev)
-
     const newContainerProps = {
       ...props,
       header: {
         ...props.header,
-        hasBlur,
-        isBlur,
-        toggleBlur,
+        canBeBlurred,
       },
     }
 
     const newPropsChart = {
       ...props.chart,
-      yAxis: props.chart.yAxis
-        ? { ...props.chart.yAxis, isBlur }
-        : { hide: true },
+      yAxis: props.chart.yAxis ? { ...props.chart.yAxis } : { hide: true },
     }
 
     return (
       <ChartContainer
         ref={ref}
         {...newContainerProps}
-        chart={<AreaChart {...newPropsChart} />}
+        chart={<AreaChart {...newPropsChart} canBeBlurred={canBeBlurred} />}
       />
     )
   }),

--- a/lib/experimental/Widgets/Widget/index.tsx
+++ b/lib/experimental/Widgets/Widget/index.tsx
@@ -1,6 +1,8 @@
 import { Button, ButtonProps } from "@/components/Actions/Button"
 import { Badge } from "@/components/Information/Badge"
+import { PrivateBox } from "@/experimental/Utilities/PrivateBox"
 import { EyeInvisible, EyeVisible } from "@/icons"
+import { usePrivacyMode } from "@/lib/privacyMode"
 import { withSkeleton } from "@/lib/skeleton"
 import { cn } from "@/lib/utils"
 import {
@@ -24,9 +26,7 @@ export interface WidgetProps {
     title?: string
     subtitle?: string
     comment?: string
-    hasBlur?: boolean
-    isBlur?: boolean
-    toggleBlur?: () => void
+    canBeBlurred?: boolean
     info?: string
     link?: { title: string; url: string }
   }
@@ -48,6 +48,9 @@ const Container = forwardRef<
   HTMLDivElement,
   WidgetProps & { children: ReactNode }
 >(function Container({ header, alert, children, action, summaries }, ref) {
+  const { enabled: privacyModeEnabled, toggle: togglePrivacyMode } =
+    usePrivacyMode()
+
   const isRealNode = (node: React.ReactNode): boolean => {
     return (
       !!node &&
@@ -63,14 +66,18 @@ const Container = forwardRef<
     <Card className="flex gap-4 border-f1-border-secondary" ref={ref}>
       {header && (
         <CardHeader>
-          <div className="flex flex-1 flex-col gap-4 truncate">
+          <div className="flex flex-1 flex-col gap-4">
             <div className="flex flex-row items-center justify-between gap-2">
               <div className="flex min-h-6 grow flex-row items-center gap-1.5 truncate">
-                {header.title && <CardTitle>{header.title}</CardTitle>}
+                {header.title && (
+                  <CardTitle className="truncate">{header.title}</CardTitle>
+                )}
                 {header.subtitle && (
                   <>
                     <InlineDot />
-                    <CardSubtitle>{header.subtitle}</CardSubtitle>
+                    <CardSubtitle className="truncate">
+                      {header.subtitle}
+                    </CardSubtitle>
                   </>
                 )}
                 {header.info && <CardInfo content={header.info} />}
@@ -81,19 +88,19 @@ const Container = forwardRef<
               )}
             </div>
             {header.comment && (
-              <div className="flex flex-row items-center gap-3">
-                <CardComment className={cn(!!header.isBlur && "blur-md")}>
-                  {header.comment}
-                </CardComment>
-                {!!header.hasBlur && (
+              <div className="flex flex-row items-center gap-3 overflow-visible">
+                <PrivateBox>
+                  <CardComment>{header.comment}</CardComment>
+                </PrivateBox>
+                {!!header.canBeBlurred && (
                   <span>
                     <Button
-                      icon={header.isBlur ? EyeInvisible : EyeVisible}
+                      icon={privacyModeEnabled ? EyeInvisible : EyeVisible}
                       hideLabel
                       label="hide/show"
                       variant="outline"
                       round
-                      onClick={header.toggleBlur}
+                      onClick={togglePrivacyMode}
                       size="sm"
                     />
                   </span>


### PR DESCRIPTION
## 🔑 What?

Fix blur on area chart widget.
Three key changes here:
- Fixed cut-off blur box.
- Tooltip no longer showing up when it's supposed to be hidden.
- We now use the privacy mode provider values instead of heavily relying on props.

## 👁️ Visual proof

Before:

https://github.com/user-attachments/assets/f6187179-fd91-45f9-b771-0eacaba99e09

After:

https://github.com/user-attachments/assets/9f42127d-0033-4791-8ae3-cb35d82db25a
