### PR TITLE
Create dumb WidgetSection component

### DIFF
--- a/lib/experimental/Widgets/WidgetSection/index.stories.tsx
+++ b/lib/experimental/Widgets/WidgetSection/index.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { Placeholder } from "@/lib/storybook-utils"
+import { WidgetSection } from "."
+
+const meta: Meta = {
+  component: WidgetSection,
+  parameters: {
+    layout: "centered",
+    tags: ["autodocs"],
+  },
+  args: {
+    title: "Worked / Planned hours",
+    children: <Placeholder>Put your content in there</Placeholder>,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithoutTitle: Story = {
+  args: {
+    title: undefined,
+  },
+}

--- a/lib/experimental/Widgets/WidgetSection/index.tsx
+++ b/lib/experimental/Widgets/WidgetSection/index.tsx
@@ -11,9 +11,9 @@ export const WidgetSection = forwardRef<HTMLDivElement, Props>(
 
     return (
       <div ref={ref} className="flex flex-col gap-2">
-        <h4 className="text-base font-medium text-f1-foreground-secondary">
+        <p className="text-base font-medium text-f1-foreground-secondary">
           {title}
-        </h4>
+        </p>
         {children}
       </div>
     )

--- a/lib/experimental/Widgets/WidgetSection/index.tsx
+++ b/lib/experimental/Widgets/WidgetSection/index.tsx
@@ -11,9 +11,9 @@ export const WidgetSection = forwardRef<HTMLDivElement, Props>(
 
     return (
       <div ref={ref} className="flex flex-col gap-2">
-        <p className="text-base font-medium text-f1-foreground-secondary">
+        <h4 className="text-base font-medium text-f1-foreground-secondary">
           {title}
-        </p>
+        </h4>
         {children}
       </div>
     )

--- a/lib/experimental/Widgets/WidgetSection/index.tsx
+++ b/lib/experimental/Widgets/WidgetSection/index.tsx
@@ -1,0 +1,23 @@
+import { useTextFormatEnforcer } from "@/lib/text"
+import { forwardRef, PropsWithChildren } from "react"
+
+type Props = PropsWithChildren & {
+  title?: string
+}
+
+export const WidgetSection = forwardRef<HTMLDivElement, Props>(
+  ({ title, children }, ref) => {
+    useTextFormatEnforcer(title, { disallowEmpty: true })
+
+    return (
+      <div ref={ref} className="flex flex-col gap-2">
+        <p className="text-base font-medium text-f1-foreground-secondary">
+          {title}
+        </p>
+        {children}
+      </div>
+    )
+  }
+)
+
+WidgetSection.displayName = "WidgetSection"

--- a/lib/lib/text.ts
+++ b/lib/lib/text.ts
@@ -22,8 +22,10 @@ const textFormatEnforcer = (text: string, rules: Rules) => {
   }
 }
 
-export const useTextFormatEnforcer = (text: string, rules: Rules) => {
+export const useTextFormatEnforcer = (text?: string, rules?: Rules) => {
   useEffect(() => {
-    textFormatEnforcer(text, rules)
+    if (text !== undefined && rules) {
+      textFormatEnforcer(text, rules)
+    }
   }, [text, rules])
 }


### PR DESCRIPTION
## 🔑 What?

Create dumb WidgetSection component.

## 🚪 Why?

I just noticed a pattern of every content separated in our widgets, some of them have some title, but they shouldn't actually be tied to the component itself that is there but it should be more related to the widget itself. We have this title accompanying various components that we have here, and we didn't have a common component to spread this change of removing the uppercase in all of them.

<img width="494" alt="Screenshot 2024-10-28 at 12 35 34" src="https://github.com/user-attachments/assets/e18471f1-e80f-42c5-8948-da5a5a054cc0">

## 👁️ Visual proof

<img width="286" alt="Screenshot 2024-10-28 at 12 38 07" src="https://github.com/user-attachments/assets/be005d6c-a77f-4b38-b11c-fec7de9265bb">
