### PR TITLE
Add StatusTag in the PageHeader for the first level

### DIFF
--- a/lib/experimental/Information/Tags/StatusTag/index.tsx
+++ b/lib/experimental/Information/Tags/StatusTag/index.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
 import { BaseTag } from "../BaseTag"
 
-export type Variant = "neutral" | "info" | "positive" | "warning" | "critical"
+type Variant = "neutral" | "info" | "positive" | "warning" | "critical"
 
 export type StatusVariant = Variant
 

--- a/lib/experimental/Information/Tags/StatusTag/index.tsx
+++ b/lib/experimental/Information/Tags/StatusTag/index.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
 import { BaseTag } from "../BaseTag"
 
-type Variant = "neutral" | "info" | "positive" | "warning" | "critical"
+export type Variant = "neutral" | "info" | "positive" | "warning" | "critical"
 
 export type StatusVariant = Variant
 

--- a/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -49,6 +49,20 @@ export const FirstLevel: Story = {
   },
 }
 
+export const FirstLevelWithTag: Story = {
+  args: {
+    module: {
+      name: "Recruitment",
+      href: "/recruitment",
+      icon: "Recruitment",
+    },
+    statusTag: {
+      text: "Published",
+      variant: "positive",
+    },
+  },
+}
+
 export const LongBreadcrumbs: Story = {
   args: {
     module: {

--- a/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -54,12 +54,38 @@ export const FirstLevelWithTag: Story = {
     module: {
       name: "Recruitment",
       href: "/recruitment",
-      icon: "Recruitment",
+      icon: Recruitment,
     },
     statusTag: {
       text: "Published",
       variant: "positive",
     },
+  },
+}
+
+export const FirstLevelWithTagAndActions: Story = {
+  args: {
+    module: {
+      name: "Documents",
+      href: "/documents",
+      icon: Recruitment,
+    },
+    statusTag: {
+      text: "Published",
+      variant: "positive",
+    },
+    actions: [
+      {
+        label: "Settings",
+        icon: Settings,
+        onClick: () => console.log("Settings clicked"),
+      },
+      {
+        label: "More options",
+        icon: EllipsisHorizontal,
+        onClick: () => console.log("More clicked"),
+      },
+    ],
   },
 }
 

--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -1,5 +1,7 @@
 import { Button } from "@/components/Actions/Button"
 import { IconType } from "@/components/Utilities/Icon"
+import type { Variant } from "@/experimental/Information/Tags/StatusTag"
+import { StatusTag } from "@/experimental/Information/Tags/StatusTag"
 import { useSidebar } from "@/experimental/Navigation/ApplicationFrame/FrameProvider"
 import AlignTextJustify from "@/icons/app/AlignTextJustify"
 import { cn } from "@/lib/utils"
@@ -14,6 +16,10 @@ type HeaderProps = {
     href: string
     icon: IconType
   }
+  statusTag?: {
+    text: string
+    variant: Variant
+  }
   breadcrumbs?: BreadcrumbItemType[]
   actions?: {
     label: string
@@ -24,6 +30,7 @@ type HeaderProps = {
 
 export function PageHeader({
   module,
+  statusTag = undefined,
   breadcrumbs = [],
   actions = [],
 }: HeaderProps) {
@@ -34,6 +41,7 @@ export function PageHeader({
     ...breadcrumbs,
   ]
 
+  const hasStatus = statusTag && Object.keys(statusTag).length !== 0
   const hasNavigation = breadcrumbs.length > 0
 
   return (
@@ -71,6 +79,9 @@ export function PageHeader({
             <Breadcrumbs breadcrumbs={breadcrumbsTree} />
           ) : (
             <div className="text-xl font-semibold">{module.name}</div>
+          )}
+          {!hasNavigation && hasStatus && (
+            <StatusTag text={statusTag.text} variant={statusTag.variant} />
           )}
         </div>
       </div>

--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/Actions/Button"
 import { IconType } from "@/components/Utilities/Icon"
-import type { Variant } from "@/experimental/Information/Tags/StatusTag"
+import type { StatusVariant } from "@/experimental/Information/Tags/StatusTag"
 import { StatusTag } from "@/experimental/Information/Tags/StatusTag"
 import { useSidebar } from "@/experimental/Navigation/ApplicationFrame/FrameProvider"
 import AlignTextJustify from "@/icons/app/AlignTextJustify"
@@ -18,7 +18,7 @@ type HeaderProps = {
   }
   statusTag?: {
     text: string
-    variant: Variant
+    variant: StatusVariant
   }
   breadcrumbs?: BreadcrumbItemType[]
   actions?: {

--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -43,6 +43,7 @@ export function PageHeader({
 
   const hasStatus = statusTag && Object.keys(statusTag).length !== 0
   const hasNavigation = breadcrumbs.length > 0
+  const hasActions = actions.length > 0
 
   return (
     <div
@@ -80,26 +81,33 @@ export function PageHeader({
           ) : (
             <div className="text-xl font-semibold">{module.name}</div>
           )}
-          {!hasNavigation && hasStatus && (
-            <StatusTag text={statusTag.text} variant={statusTag.variant} />
-          )}
         </div>
       </div>
-      {actions && (
-        <div className="flex items-center gap-2">
-          {actions.map((action, index) => (
-            <Button
-              hideLabel
-              round
-              key={index}
-              variant="outline"
-              onClick={action.onClick}
-              label={action.label}
-              icon={action.icon}
-            />
-          ))}
-        </div>
-      )}
+      <div className="flex items-center">
+        {!hasNavigation && hasStatus && (
+          <div className="pe-3">
+            <StatusTag text={statusTag.text} variant={statusTag.variant} />
+          </div>
+        )}
+        {hasStatus && hasActions && (
+          <div className="right-0 h-4 w-px bg-f1-border-secondary"></div>
+        )}
+        {hasActions && (
+          <div className="items-right flex gap-2 ps-3">
+            {actions.map((action, index) => (
+              <Button
+                hideLabel
+                round
+                key={index}
+                variant="outline"
+                onClick={action.onClick}
+                label={action.label}
+                icon={action.icon}
+              />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 🔑 What?
Add the `StatusTag` component for the first level `PageHeader`

## 🚪 Why?
In ShiftManagement we have a status related to the shifts in the view. In the approved designs from some weeks ago, we included it in the top bar when we saw the first level view
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/5547c8a8-46a3-40cb-bb4e-b8891dfe4b1b">
<img width="826" alt="image" src="https://github.com/user-attachments/assets/f51d40bd-8b06-4274-8799-38871d53c155">

## 🏡 Context
- [🎨 Figma](https://www.figma.com/design/MbxR3tIzVFCwvXZ9gmpU0w/%F0%9F%9F%A3-Factorial-One-%C2%B7-Nav?node-id=120-18140&t=v805BtucFRgGnUrq-0)
