### PR TITLE
Update icon sizes

### DIFF
--- a/lib/components/Utilities/Icon/index.stories.tsx
+++ b/lib/components/Utilities/Icon/index.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
     layout: "centered",
   },
   args: {
-    size: "xl",
+    size: "md",
     icon: AddAvatar,
   },
   tags: ["autodocs"],

--- a/lib/components/Utilities/Icon/index.tsx
+++ b/lib/components/Utilities/Icon/index.tsx
@@ -10,16 +10,13 @@ import {
 const iconVariants = cva("inline-block shrink-0", {
   variants: {
     size: {
-      xl: "h-12 w-12",
-      lg: "h-8 w-8",
-      md: "h-5 w-5",
-      sm: "h-4 w-4",
-      xs: "h-3 w-3",
+      lg: "w-[24px]",
+      md: "w-[20px]",
+      sm: "w-[16px]",
     },
   },
-
   defaultVariants: {
-    size: "xl",
+    size: "md",
   },
 })
 
@@ -43,7 +40,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
     <Component
       ref={ref}
       {...props}
-      className={cn(iconVariants({ size }), className)}
+      className={cn("aspect-square", iconVariants({ size }), className)}
     />
   )
 })

--- a/lib/components/Utilities/Icon/index.tsx
+++ b/lib/components/Utilities/Icon/index.tsx
@@ -10,9 +10,9 @@ import {
 const iconVariants = cva("inline-block shrink-0", {
   variants: {
     size: {
-      lg: "w-[24px]",
-      md: "w-[20px]",
-      sm: "w-[16px]",
+      lg: "w-6",
+      md: "w-5",
+      sm: "w-4",
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## 🔑 What?

Update icon sizes.

## 🚪 Why?

The sizes that we have for our icons now are not the ones declared in F1 in Figma.

## 🏡 Context

- [🧵 Slack](https://factorialteam.slack.com/archives/C07LQSJ5UQY/p1730205706523929)
