### PR TITLE
Set correct icon size for RawTag component

### DIFF
--- a/lib/experimental/Information/Tags/RawTag/index.tsx
+++ b/lib/experimental/Information/Tags/RawTag/index.tsx
@@ -23,7 +23,7 @@ export const RawTag = forwardRef<HTMLDivElement, Props>(
         )}
         left={
           icon ? (
-            <Icon icon={icon} size="md" aria-hidden className="text-f1-icon" />
+            <Icon icon={icon} size="sm" className="text-f1-icon" aria-hidden />
           ) : null
         }
         text={text}


### PR DESCRIPTION
## 🔑 What?

Set correct icon size for RawTag component.
