### PR TITLE
Update InfoPaneLayout component spacings

### DIFF
--- a/lib/experimental/PageLayouts/InfoPaneLayout/index.stories.tsx
+++ b/lib/experimental/PageLayouts/InfoPaneLayout/index.stories.tsx
@@ -1,8 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
+import { DetailsItemsList } from "@/experimental/PageLayouts/Utils/DetailsItemsList"
+import * as DetailsItemsListStories from "@/experimental/PageLayouts/Utils/DetailsItemsList/index.stories"
 import { Dashboard } from "@/experimental/Widgets/Layout/Dashboard"
 import * as DashboardStories from "@/experimental/Widgets/Layout/Dashboard/index.stories"
 import { PageDecorator } from "@/lib/storybook-utils/pageDecorator"
+import { ComponentProps } from "react"
 import { InfoPaneLayout } from "."
 
 const meta = {
@@ -34,8 +37,16 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
 export const Profile: Story = {
   args: {
     children: <Dashboard {...DashboardStories.default.args} />,
+    sideContent: (
+      <DetailsItemsList
+        {...(DetailsItemsListStories.default.args as ComponentProps<
+          typeof DetailsItemsList
+        >)}
+      />
+    ),
   },
 }

--- a/lib/experimental/PageLayouts/InfoPaneLayout/index.tsx
+++ b/lib/experimental/PageLayouts/InfoPaneLayout/index.tsx
@@ -10,8 +10,8 @@ export const InfoPaneLayout = forwardRef<HTMLDivElement, InfoPaneLayoutProps>(
     return (
       <div ref={ref} className="overflow-auto sm:min-h-full">
         <div className="flex flex-col-reverse overflow-auto text-f1-foreground sm:min-h-full sm:flex-row">
-          <div className="p-6 sm:basis-3/4">{mainContent}</div>
-          <div className="border-0 p-6 pb-0 sm:basis-1/4 sm:border-l sm:border-solid sm:border-l-f1-border-secondary sm:pb-6">
+          <div className="px-6 py-5 sm:basis-3/4">{mainContent}</div>
+          <div className="border-0 py-5 pl-2 pr-4 sm:basis-1/4 sm:border-l sm:border-solid sm:border-l-f1-border-secondary sm:pb-6">
             {sideContent}
           </div>
         </div>

--- a/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.stories.tsx
+++ b/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.stories.tsx
@@ -51,7 +51,7 @@ const meta: Meta = {
       },
     ],
   },
-}
+} satisfies Meta<typeof DetailsItemsList>
 
 export default meta
 type Story = StoryObj<typeof meta>


### PR DESCRIPTION
## 🔑 What?

Update InfoPaneLayout component spacings.

## 🚪 Why?

The spacing that we had in this layout was bigger than the one shown in Figma.

## 👁️ Visual proof

<img width="1005" alt="Screenshot 2024-11-06 at 12 07 10" src="https://github.com/user-attachments/assets/1add3a35-232f-41ec-b91d-26fb93c9a2aa">
