### PR TITLE
Fix line in Tabs component

### DIFF
--- a/lib/ui/tab-navigation.tsx
+++ b/lib/ui/tab-navigation.tsx
@@ -23,7 +23,7 @@ function getSubtree(
 }
 
 const tabNavigationVariants = cva(
-  "flex items-center justify-start gap-1 overflow-x-auto whitespace-nowrap border-x-0 border-b border-t-0 border-solid border-f1-border-secondary px-6 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+  "relative flex items-center justify-start gap-1 overflow-x-auto overflow-y-visible whitespace-nowrap px-6 py-3 [scrollbar-width:none] before:absolute before:inset-x-0 before:bottom-0 before:-z-10 before:h-px before:bg-f1-border-secondary before:content-[''] [&::-webkit-scrollbar]:hidden",
   {
     variants: {
       secondary: {

--- a/lib/ui/tab-navigation.tsx
+++ b/lib/ui/tab-navigation.tsx
@@ -23,7 +23,7 @@ function getSubtree(
 }
 
 const tabNavigationVariants = cva(
-  "relative flex items-center justify-start gap-1 overflow-x-auto whitespace-nowrap px-6 py-3 [scrollbar-width:none] before:absolute before:inset-x-0 before:bottom-0 before:-z-10 before:h-px before:bg-f1-border-secondary before:content-[''] [&::-webkit-scrollbar]:hidden",
+  "relative flex items-center justify-start gap-1 overflow-x-auto whitespace-nowrap px-6 py-3 [scrollbar-width:none] before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-f1-border-secondary before:content-[''] [&::-webkit-scrollbar]:hidden",
   {
     variants: {
       secondary: {

--- a/lib/ui/tab-navigation.tsx
+++ b/lib/ui/tab-navigation.tsx
@@ -23,7 +23,7 @@ function getSubtree(
 }
 
 const tabNavigationVariants = cva(
-  "relative flex items-center justify-start gap-1 overflow-x-auto overflow-y-visible whitespace-nowrap px-6 py-3 [scrollbar-width:none] before:absolute before:inset-x-0 before:bottom-0 before:-z-10 before:h-px before:bg-f1-border-secondary before:content-[''] [&::-webkit-scrollbar]:hidden",
+  "relative flex items-center justify-start gap-1 overflow-x-auto whitespace-nowrap px-6 py-3 [scrollbar-width:none] before:absolute before:inset-x-0 before:bottom-0 before:-z-10 before:h-px before:bg-f1-border-secondary before:content-[''] [&::-webkit-scrollbar]:hidden",
   {
     variants: {
       secondary: {


### PR DESCRIPTION
| Before | After |
|--------|-------|
| <img width="379" alt="image" src="https://github.com/user-attachments/assets/4f9befdc-681a-4fca-9c20-54bf805a7d1e"> | <img width="397" alt="image" src="https://github.com/user-attachments/assets/5640be8b-aafb-4d0b-9c6e-c3bf7da800db"> |

The line of the selected element was misaligned with the border by 1px, and it kept me up at night.

I had to mimic the bottom border with an absolute element since the line of the selected element couldn't be drawn on top of the container's border.