### PR TITLE
Add inset border to Avatars

### DIFF
--- a/lib/ui/avatar.tsx
+++ b/lib/ui/avatar.tsx
@@ -25,7 +25,7 @@ export const color = [
 ] as const
 
 const avatarVariants = cva(
-  "relative flex shrink-0 items-center justify-center overflow-hidden text-center font-semibold",
+  "relative flex shrink-0 items-center justify-center overflow-hidden text-center font-semibold ring-1 ring-inset ring-f1-border-secondary",
   {
     variants: {
       size: {


### PR DESCRIPTION
## Description

Add a subtle inset border to Avatars, as we have in Figma. It was missing, and it's important so no matter the background, the avatar can be easily differentiated from it.

## Screenshots

<img width="286" alt="image" src="https://github.com/user-attachments/assets/a41dca8a-1dc4-48f9-a402-201ebf151084">


### Figma Link

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=1-3)
