### PR TITLE
Add support to show counter on widget header

### DIFF
--- a/lib/experimental/Widgets/Widget/index.stories.tsx
+++ b/lib/experimental/Widgets/Widget/index.stories.tsx
@@ -22,6 +22,7 @@ const meta: Meta = {
     header: {
       title: "A widget",
       subtitle: "2024",
+      count: 2,
     },
     children: <Placeholder>Put your content in there</Placeholder>,
   } satisfies ComponentProps<typeof Widget>,

--- a/lib/experimental/Widgets/Widget/index.tsx
+++ b/lib/experimental/Widgets/Widget/index.tsx
@@ -1,4 +1,5 @@
 import { Button, ButtonProps } from "@/components/Actions/Button"
+import { Counter } from "@/experimental/Information/Counter"
 import { AlertTag } from "@/experimental/Information/Tags/AlertTag"
 import {
   StatusTag,
@@ -31,6 +32,7 @@ export interface WidgetProps {
     comment?: string
     canBeBlurred?: boolean
     link?: { title: string; url: string }
+    count?: number
   }
   action?: ButtonProps
   summaries?: Array<{
@@ -95,6 +97,11 @@ const Container = forwardRef<
                     <CardSubtitle className="truncate">
                       {header.subtitle}
                     </CardSubtitle>
+                  </div>
+                )}
+                {header.count && (
+                  <div className="ml-0.5">
+                    <Counter value={header.count} />
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Screenshots

<img width="349" alt="Screenshot 2024-11-13 at 10 00 56" src="https://github.com/user-attachments/assets/670b6419-5953-487e-b87f-0d461a286dd6">
