### PR TITLE
Add support to add multiline text to details item

### DIFF
--- a/lib/experimental/Lists/DataList/ItemContainer.tsx
+++ b/lib/experimental/Lists/DataList/ItemContainer.tsx
@@ -55,7 +55,9 @@ export const ItemContainer = forwardRef<HTMLLIElement, ItemContainerProps>(
             ) : (
               <Icon icon={LeftIcon} size="md" aria-hidden="true" />
             ))}
-          <div className="line-clamp-2 flex-1 text-left">{text}</div>
+          <div className="line-clamp-5 flex-1 whitespace-pre-line text-left">
+            {text}
+          </div>
         </Action>
       </li>
     )

--- a/lib/experimental/PageLayouts/Utils/DetailsItem/index.stories.tsx
+++ b/lib/experimental/PageLayouts/Utils/DetailsItem/index.stories.tsx
@@ -22,4 +22,30 @@ const meta: Meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Primary: Story = {}
+export const Default: Story = {}
+
+export const WithLongText: Story = {
+  args: {
+    title: "Address",
+    content: {
+      type: "item",
+      text: "Paseo Mara, 62, Bajos\nPáez del Vallès\nCeuta",
+      action: {
+        type: "copy",
+      },
+    },
+  },
+}
+
+export const WithMoreLinesThanAllowed: Story = {
+  args: {
+    title: "Address",
+    content: {
+      type: "item",
+      text: "Paseo Mara, 62, Bajos\nPáez del Vallès\nCeuta\nPaseo Mara, 62, Bajos\nPáez del Vallès\nCeuta",
+      action: {
+        type: "copy",
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Description

In Finance they have a valid use case of this component for showing an address that has more that one line.

## Screenshots

<img width="326" alt="Screenshot 2024-11-14 at 13 23 11" src="https://github.com/user-attachments/assets/2ce5143c-429b-489e-9ea2-5fe735f71288">
