### PR TITLE
Polish DetailsItemList component according to figma

### DIFF
--- a/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.stories.tsx
+++ b/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.stories.tsx
@@ -21,6 +21,19 @@ const meta: Meta = {
         },
       },
       {
+        title: "Manager",
+        content: {
+          type: "person",
+          firstName: "Saul",
+          lastName: "Dominguez",
+          avatarUrl: "https://github.com/sauldom102.png",
+          action: {
+            type: "navigate",
+            href: "",
+          },
+        },
+      },
+      {
         title: "Workable days",
         content: {
           type: "weekdays",

--- a/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.tsx
+++ b/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.tsx
@@ -13,11 +13,11 @@ export const DetailsItemsList = forwardRef<
   return (
     <div ref={ref} className="flex flex-col gap-4">
       {!!title && (
-        <p className="mb-1 pl-3 text-sm font-semibold text-f1-foreground-secondary">
+        <p className="mb-1 pl-1.5 text-sm font-semibold text-f1-foreground-secondary">
           {title.toLocaleUpperCase()}
         </p>
       )}
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col gap-3">
         {details?.map((item) => (
           <DetailsItem
             title={item.title}

--- a/lib/tokens/colors.ts
+++ b/lib/tokens/colors.ts
@@ -140,7 +140,7 @@ export const f1Colors = {
     warning: "hsl(var(--warning-50) / 0.1)",
     positive: "hsl(var(--positive-50) / 0.1)",
     selected: {
-      DEFAULT: "hsl(var(--selected-50) / 0.2)",
+      DEFAULT: "hsl(var(--selected-50) / 0.1)",
       bold: "hsl(var(--selected-50))",
     },
   },

--- a/lib/ui/toggle.tsx
+++ b/lib/ui/toggle.tsx
@@ -6,7 +6,7 @@ import { cn, focusRing } from "@/lib/utils"
 
 const toggleVariants = cva(
   cn(
-    "inline-flex items-center justify-center rounded-xs text-sm font-medium transition-colors hover:bg-f1-background-secondary hover:text-f1-foreground-secondary disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-f1-background-secondary data-[state=on]:text-f1-foreground",
+    "inline-flex items-center justify-center rounded-sm text-sm font-medium transition-colors hover:bg-f1-background-secondary hover:text-f1-foreground-secondary disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-f1-background-secondary data-[state=on]:text-f1-foreground",
     focusRing()
   ),
   {

--- a/lib/ui/toggleGroup.tsx
+++ b/lib/ui/toggleGroup.tsx
@@ -19,7 +19,7 @@ const ToggleGroup = React.forwardRef<
 >(({ className, variant, size, children, ...props }, ref) => (
   <ToggleGroupPrimitive.Root
     ref={ref}
-    className={cn("flex items-center justify-center gap-1", className)}
+    className={cn("flex items-center justify-center gap-1.5", className)}
     {...props}
   >
     <ToggleGroupContext.Provider value={{ variant, size }}>


### PR DESCRIPTION
## Description

Polish DetailsItemList component according to Figma.

## Screenshots

Before:

<img width="508" alt="Screenshot 2024-11-14 at 16 16 49" src="https://github.com/user-attachments/assets/86a6bbe5-3f23-4628-963c-fdff5a242995">

After:

<img width="508" alt="Screenshot 2024-11-14 at 16 16 04" src="https://github.com/user-attachments/assets/e916f730-8286-4206-bbca-f1ca1c4a57fb">

### Figma Link

https://www.figma.com/design/uImdC0GKxH59DkjzBqRJEF/Layouts-%26-Blocks?node-id=2660-420692&t=Exx9aFvQOPvP3M5f-4