### PR TITLE
Add Headers (Person, Company and Resource)

### DIFF
--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -1,0 +1,92 @@
+import { Button } from "@/components/Actions/Button"
+import { IconType } from "@/components/Utilities/Icon"
+import {
+  AvatarVariant,
+  renderAvatar,
+} from "@/experimental/Information/Avatars/utils"
+import { cn } from "@/lib/utils"
+
+interface BaseHeaderProps {
+  title: string
+  avatar?: AvatarVariant
+  description?: string
+  eyebrow?: React.ReactNode
+  footer?: React.ReactNode
+  primaryAction?: {
+    label: string
+    icon?: IconType
+    onClick: () => void
+  }
+  secondaryActions?: Array<{
+    label: string
+    icon?: IconType
+    onClick: () => void
+    variant?: "outline" | "critical"
+  }>
+}
+
+export function BaseHeader({
+  title,
+  avatar,
+  description,
+  eyebrow,
+  footer,
+  primaryAction,
+  secondaryActions,
+}: BaseHeaderProps) {
+  return (
+    <div className="flex flex-col items-start justify-start gap-4 p-8 md:flex-row">
+      <div className="flex grow flex-col items-start justify-start gap-4 md:flex-row md:items-center">
+        {avatar && (
+          <div className="flex items-start">
+            {renderAvatar(avatar, "large")}
+          </div>
+        )}
+        <div className="flex flex-col gap-1">
+          {eyebrow && (
+            <div className="w-fit text-f1-foreground-secondary">{eyebrow}</div>
+          )}
+          <span className="text-xl font-semibold text-f1-foreground">
+            {title}
+          </span>
+          {description && (
+            <div className="text-lg text-f1-foreground-secondary">
+              {description}
+            </div>
+          )}
+          {footer && (
+            <div className="w-fit text-f1-foreground-secondary">{footer}</div>
+          )}
+        </div>
+      </div>
+      <div
+        className={cn(
+          "flex shrink-0 flex-wrap items-center gap-x-3 gap-y-2 overflow-x-auto md:flex-row-reverse",
+          avatar && "md:pt-1.5"
+        )}
+      >
+        {primaryAction && (
+          <Button
+            label={primaryAction.label}
+            onClick={primaryAction.onClick}
+            variant="default"
+            icon={primaryAction.icon}
+          />
+        )}
+        {primaryAction && secondaryActions && (
+          <div className="hidden h-4 w-px bg-f1-background-secondary md:block" />
+        )}
+        {secondaryActions &&
+          secondaryActions.map((action) => (
+            <Button
+              key={action.label}
+              label={action.label}
+              onClick={action.onClick}
+              variant={action.variant ?? "outline"}
+              icon={action.icon}
+            />
+          ))}
+      </div>
+    </div>
+  )
+}

--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -1,9 +1,12 @@
 import { Button } from "@/components/Actions/Button"
-import { IconType } from "@/components/Utilities/Icon"
 import {
   AvatarVariant,
   renderAvatar,
 } from "@/experimental/Information/Avatars/utils"
+import {
+  PrimaryAction,
+  SecondaryAction,
+} from "@/experimental/Information/utils"
 import { cn } from "@/lib/utils"
 
 interface BaseHeaderProps {
@@ -12,17 +15,8 @@ interface BaseHeaderProps {
   description?: string
   eyebrow?: React.ReactNode
   footer?: React.ReactNode
-  primaryAction?: {
-    label: string
-    icon?: IconType
-    onClick: () => void
-  }
-  secondaryActions?: Array<{
-    label: string
-    icon?: IconType
-    onClick: () => void
-    variant?: "outline" | "critical"
-  }>
+  primaryAction?: PrimaryAction
+  secondaryActions?: SecondaryAction[]
 }
 
 export function BaseHeader({

--- a/lib/experimental/Information/Headers/CompanyHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/CompanyHeader/index.stories.tsx
@@ -1,0 +1,42 @@
+import * as Icon from "@/icons/app/"
+import type { Meta, StoryObj } from "@storybook/react"
+import { CompanyHeader } from "./index"
+
+const meta: Meta<typeof CompanyHeader> = {
+  component: CompanyHeader,
+  parameters: {
+    layout: "centered",
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof CompanyHeader>
+
+export const Default: Story = {
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    name: "Factorial",
+    description: "HR Software to Empower Your Team",
+    src: "https://github.com/factorialco.png",
+    primaryAction: {
+      label: "Edit",
+      icon: Icon.Pencil,
+      onClick: () => console.log("Edit clicked"),
+    },
+    secondaryActions: [
+      {
+        label: "Promote",
+        onClick: () => console.log("Promote clicked"),
+      },
+      {
+        label: "Remove",
+        icon: Icon.Delete,
+        variant: "critical",
+        onClick: () => console.log("Remove clicked"),
+      },
+    ],
+  },
+}

--- a/lib/experimental/Information/Headers/CompanyHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/CompanyHeader/index.stories.tsx
@@ -14,9 +14,6 @@ export default meta
 type Story = StoryObj<typeof CompanyHeader>
 
 export const Default: Story = {
-  parameters: {
-    layout: "fullscreen",
-  },
   args: {
     name: "Factorial",
     description: "HR Software to Empower Your Team",
@@ -38,5 +35,17 @@ export const Default: Story = {
         onClick: () => console.log("Remove clicked"),
       },
     ],
+  },
+  parameters: {
+    a11y: {
+      config: {
+        rules: [
+          {
+            id: "color-contrast",
+            enabled: false,
+          },
+        ],
+      },
+    },
   },
 }

--- a/lib/experimental/Information/Headers/CompanyHeader/index.tsx
+++ b/lib/experimental/Information/Headers/CompanyHeader/index.tsx
@@ -1,0 +1,32 @@
+import { ComponentProps } from "react"
+import { BaseHeader } from "../BaseHeader"
+
+type BaseHeaderProps = ComponentProps<typeof BaseHeader>
+
+type Props = {
+  name: string
+  description: string
+  src?: string
+} & Pick<BaseHeaderProps, "primaryAction" | "secondaryActions">
+
+export const CompanyHeader = ({
+  name,
+  description,
+  src,
+  primaryAction,
+  secondaryActions,
+}: Props) => {
+  return (
+    <BaseHeader
+      title={name}
+      description={description}
+      avatar={{
+        type: "company",
+        name,
+        src,
+      }}
+      primaryAction={primaryAction}
+      secondaryActions={secondaryActions}
+    />
+  )
+}

--- a/lib/experimental/Information/Headers/PersonHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/PersonHeader/index.stories.tsx
@@ -1,0 +1,43 @@
+import * as Icon from "@/icons/app/"
+import type { Meta, StoryObj } from "@storybook/react"
+import { PersonHeader } from "./index"
+
+const meta: Meta<typeof PersonHeader> = {
+  component: PersonHeader,
+  parameters: {
+    layout: "centered",
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof PersonHeader>
+
+export const Default: Story = {
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    firstName: "Josep Jaume",
+    lastName: "Rey",
+    description: "Chief Confetti Officer",
+    src: "https://github.com/josepjaume.png",
+    primaryAction: {
+      label: "Edit",
+      icon: Icon.Pencil,
+      onClick: () => console.log("Edit clicked"),
+    },
+    secondaryActions: [
+      {
+        label: "Promote",
+        onClick: () => console.log("Promote clicked"),
+      },
+      {
+        label: "Remove",
+        icon: Icon.Delete,
+        variant: "critical",
+        onClick: () => console.log("Remove clicked"),
+      },
+    ],
+  },
+}

--- a/lib/experimental/Information/Headers/PersonHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/PersonHeader/index.stories.tsx
@@ -14,9 +14,6 @@ export default meta
 type Story = StoryObj<typeof PersonHeader>
 
 export const Default: Story = {
-  parameters: {
-    layout: "fullscreen",
-  },
   args: {
     firstName: "Josep Jaume",
     lastName: "Rey",

--- a/lib/experimental/Information/Headers/PersonHeader/index.tsx
+++ b/lib/experimental/Information/Headers/PersonHeader/index.tsx
@@ -1,0 +1,35 @@
+import { ComponentProps } from "react"
+import { BaseHeader } from "../BaseHeader"
+
+type BaseHeaderProps = ComponentProps<typeof BaseHeader>
+
+type Props = {
+  firstName: string
+  lastName: string
+  description: string
+  src?: string
+} & Pick<BaseHeaderProps, "primaryAction" | "secondaryActions">
+
+export const PersonHeader = ({
+  firstName,
+  lastName,
+  description,
+  src,
+  primaryAction,
+  secondaryActions,
+}: Props) => {
+  return (
+    <BaseHeader
+      title={`${firstName} ${lastName}`}
+      description={description}
+      avatar={{
+        type: "person",
+        firstName,
+        lastName,
+        src,
+      }}
+      primaryAction={primaryAction}
+      secondaryActions={secondaryActions}
+    />
+  )
+}

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -1,0 +1,46 @@
+import * as Icon from "@/icons/app/"
+import type { Meta, StoryObj } from "@storybook/react"
+import { ResourceHeader } from "./index"
+
+const meta: Meta<typeof ResourceHeader> = {
+  component: ResourceHeader,
+  parameters: {
+    layout: "centered",
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof ResourceHeader>
+
+export const Default: Story = {
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    title: "Senior Product Designer",
+    description:
+      "Open position on our team, seeking an experienced product designer to lead design initiatives",
+    status: {
+      label: "Published",
+      variant: "positive",
+    },
+    primaryAction: {
+      label: "Edit",
+      icon: Icon.Pencil,
+      onClick: () => console.log("Edit clicked"),
+    },
+    secondaryActions: [
+      {
+        label: "Promote",
+        onClick: () => console.log("Promote clicked"),
+      },
+      {
+        label: "Remove",
+        icon: Icon.Delete,
+        variant: "critical",
+        onClick: () => console.log("Remove clicked"),
+      },
+    ],
+  },
+}

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -14,9 +14,6 @@ export default meta
 type Story = StoryObj<typeof ResourceHeader>
 
 export const Default: Story = {
-  parameters: {
-    layout: "fullscreen",
-  },
   args: {
     title: "Senior Product Designer",
     description:

--- a/lib/experimental/Information/Headers/ResourceHeader/index.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.tsx
@@ -1,0 +1,38 @@
+import {
+  StatusTag,
+  StatusVariant,
+} from "@/experimental/Information/Tags/StatusTag"
+import { ComponentProps } from "react"
+import { BaseHeader } from "../BaseHeader"
+
+type BaseHeaderProps = ComponentProps<typeof BaseHeader>
+
+type Props = {
+  status?: {
+    label: string
+    variant: StatusVariant
+  }
+} & Pick<
+  BaseHeaderProps,
+  "title" | "description" | "primaryAction" | "secondaryActions"
+>
+
+export const ResourceHeader = ({
+  title,
+  description,
+  primaryAction,
+  secondaryActions,
+  status,
+}: Props) => {
+  return (
+    <BaseHeader
+      title={title}
+      description={description}
+      primaryAction={primaryAction}
+      secondaryActions={secondaryActions}
+      eyebrow={
+        status && <StatusTag text={status.label} variant={status.variant} />
+      }
+    />
+  )
+}

--- a/lib/experimental/Information/Headers/exports.ts
+++ b/lib/experimental/Information/Headers/exports.ts
@@ -1,0 +1,3 @@
+export * from "./CompanyHeader"
+export * from "./PersonHeader"
+export * from "./ResourceHeader"

--- a/lib/experimental/Information/exports.tsx
+++ b/lib/experimental/Information/exports.tsx
@@ -1,6 +1,7 @@
 export * from "./Alert"
 export * from "./Avatars/exports"
 export * from "./Counter"
+export * from "./Headers/exports"
 export * from "./ModuleAvatar"
 export * from "./Shortcut"
 export * from "./Tags/exports"

--- a/lib/experimental/Information/utils.tsx
+++ b/lib/experimental/Information/utils.tsx
@@ -1,0 +1,11 @@
+import { IconType } from "@/components/Utilities/Icon"
+
+export interface PrimaryAction {
+  label: string
+  icon?: IconType
+  onClick: () => void
+}
+
+export interface SecondaryAction extends PrimaryAction {
+  variant?: "outline" | "critical"
+}

--- a/lib/ui/button.tsx
+++ b/lib/ui/button.tsx
@@ -29,7 +29,7 @@ const buttonVariants = cva(
         neutral:
           "bg-f1-background-secondary text-f1-foreground hover:bg-f1-background-secondary-hover",
         critical:
-          "border border-solid border-f1-border bg-f1-background-secondary text-f1-foreground-critical hover:border-none hover:bg-f1-background-critical-bold hover:text-f1-foreground-inverse",
+          "border border-solid border-f1-border bg-f1-background-secondary text-f1-foreground-critical hover:border-transparent hover:bg-f1-background-critical-bold hover:text-f1-foreground-inverse",
         ghost:
           "bg-transparent text-f1-foreground hover:bg-f1-background-secondary-hover",
         promote:


### PR DESCRIPTION
## Description

Add the Headers of the content as F1 components. We have (for now), three types of headers. They all use a `BaseHeader` as base component, as well as we do with Avatars or Tags, for example.

**PersonHeader**
<img width="379" alt="image" src="https://github.com/user-attachments/assets/a9a44132-d2dd-4928-9db4-e8500aceaf27">

**CompanyHeader**
<img width="360" alt="image" src="https://github.com/user-attachments/assets/7d3a41b8-84d9-4f3d-8d5f-99733a1827dc">

**ResourceHeader**
<img width="597" alt="image" src="https://github.com/user-attachments/assets/3051ab9a-1fd9-4ecb-b448-80e5ae6ba65b">

### Figma Link

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=2006-14256&t=Gk81wzJb1RvvETTW-4)

---

## Type of Change

- [x] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [x] Component added to `experimental` folder
- [x] Component is documented with basic stories
- [x] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [x] **Responsiveness**

  - [x] Verified the component works across various screen sizes

- [x] **Accessibility**
  - [x] Accessibility standards meet at least AA level requirements
  - [x] All interactive elements are keyboard-navigable and have focus states
  - [x] Proper ARIA attributes are used where needed
