### PR TITLE
Loading state for tabs

### DIFF
--- a/lib/experimental/Navigation/Tabs/index.stories.tsx
+++ b/lib/experimental/Navigation/Tabs/index.stories.tsx
@@ -16,9 +16,6 @@ const meta = {
     secondary: {
       control: "boolean",
     },
-    loading: {
-      control: "boolean",
-    },
   },
 } satisfies Meta<typeof Tabs>
 
@@ -32,14 +29,6 @@ export const Primary: Story = {
   },
 }
 
-export const PrimaryLoading: Story = {
-  args: {
-    tabs: tabItems,
-    secondary: false,
-    loading: true,
-  },
-}
-
 export const Secondary: Story = {
   args: {
     tabs: tabItems,
@@ -47,10 +36,9 @@ export const Secondary: Story = {
   },
 }
 
-export const SecondaryLoading: Story = {
+export const Skeleton: Story = {
   args: {
-    tabs: tabItems,
-    secondary: true,
-    loading: true,
+    tabs: [],
   },
+  render: ({ secondary }) => <Tabs.Skeleton secondary={secondary} />,
 }

--- a/lib/experimental/Navigation/Tabs/index.stories.tsx
+++ b/lib/experimental/Navigation/Tabs/index.stories.tsx
@@ -16,6 +16,9 @@ const meta = {
     secondary: {
       control: "boolean",
     },
+    loading: {
+      control: "boolean",
+    },
   },
 } satisfies Meta<typeof Tabs>
 
@@ -29,9 +32,25 @@ export const Primary: Story = {
   },
 }
 
+export const PrimaryLoading: Story = {
+  args: {
+    tabs: tabItems,
+    secondary: false,
+    loading: true,
+  },
+}
+
 export const Secondary: Story = {
   args: {
     tabs: tabItems,
     secondary: true,
+  },
+}
+
+export const SecondaryLoading: Story = {
+  args: {
+    tabs: tabItems,
+    secondary: true,
+    loading: true,
   },
 }

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigation } from "@/lib/linkHandler"
+import { withSkeleton } from "@/lib/skeleton"
 import { TabNavigation, TabNavigationLink } from "@/ui/tab-navigation"
 
 export type TabItem = {
@@ -10,38 +11,43 @@ export type TabItem = {
 interface TabsProps {
   tabs: TabItem[]
   secondary?: boolean
-  loading?: boolean
 }
 
-export function Tabs({ tabs, secondary = false, loading = false }: TabsProps) {
+export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
   const { isActive } = useNavigation()
   const activeTabIndex = findActiveTabIndex(tabs, isActive)
 
   return (
     <TabNavigation secondary={secondary}>
-      {!loading ? (
-        tabs.map(({ label, ...props }, index) => (
-          <TabNavigationLink
-            key={index}
-            active={activeTabIndex === index}
-            href={props.href}
-            secondary={secondary}
-            asChild
-          >
-            <Link {...props}>{label}</Link>
-          </TabNavigationLink>
-        ))
-      ) : (
-        <>
-          <TabNavigationLink.Skeleton className="w-24" />
-          <TabNavigationLink.Skeleton className="w-20" />
-          <TabNavigationLink.Skeleton className="w-28" />
-          <TabNavigationLink.Skeleton className="w-20" />
-        </>
-      )}
+      {tabs.map(({ label, ...props }, index) => (
+        <TabNavigationLink
+          key={index}
+          active={activeTabIndex === index}
+          href={props.href}
+          secondary={secondary}
+          asChild
+        >
+          <Link {...props}>{label}</Link>
+        </TabNavigationLink>
+      ))}
     </TabNavigation>
   )
 }
+
+export const TabsSkeleton: React.FC<Pick<TabsProps, "secondary">> = ({
+  secondary,
+}) => {
+  return (
+    <TabNavigation secondary={secondary}>
+      <TabNavigationLink.Skeleton className="w-24" />
+      <TabNavigationLink.Skeleton className="w-20" />
+      <TabNavigationLink.Skeleton className="w-28" />
+      <TabNavigationLink.Skeleton className="w-20" />
+    </TabNavigation>
+  )
+}
+
+export const Tabs = withSkeleton(BaseTabs, TabsSkeleton)
 
 // The following piece of code is used to find the right active tab when
 // one of the tabs is an index one. Since index tabs are usually `/` while

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -10,25 +10,35 @@ export type TabItem = {
 interface TabsProps {
   tabs: TabItem[]
   secondary?: boolean
+  loading?: boolean
 }
 
-export function Tabs({ tabs, secondary = false }: TabsProps) {
+export function Tabs({ tabs, secondary = false, loading = false }: TabsProps) {
   const { isActive } = useNavigation()
   const activeTabIndex = findActiveTabIndex(tabs, isActive)
 
   return (
     <TabNavigation secondary={secondary}>
-      {tabs.map(({ label, ...props }, index) => (
-        <TabNavigationLink
-          key={index}
-          active={activeTabIndex === index}
-          href={props.href}
-          secondary={secondary}
-          asChild
-        >
-          <Link {...props}>{label}</Link>
-        </TabNavigationLink>
-      ))}
+      {!loading ? (
+        tabs.map(({ label, ...props }, index) => (
+          <TabNavigationLink
+            key={index}
+            active={activeTabIndex === index}
+            href={props.href}
+            secondary={secondary}
+            asChild
+          >
+            <Link {...props}>{label}</Link>
+          </TabNavigationLink>
+        ))
+      ) : (
+        <>
+          <TabNavigationLink.Skeleton className="w-24" />
+          <TabNavigationLink.Skeleton className="w-20" />
+          <TabNavigationLink.Skeleton className="w-28" />
+          <TabNavigationLink.Skeleton className="w-20" />
+        </>
+      )}
     </TabNavigation>
   )
 }

--- a/lib/ui/tab-navigation.tsx
+++ b/lib/ui/tab-navigation.tsx
@@ -1,9 +1,11 @@
+import { withSkeleton } from "@/lib/skeleton"
 import { cn } from "@/lib/utils"
 import * as NavigationMenuPrimitives from "@radix-ui/react-navigation-menu"
 import { cva, type VariantProps } from "class-variance-authority"
 import { LayoutGroup, motion } from "framer-motion"
 import * as React from "react"
 import { useId } from "react"
+import { Skeleton } from "./skeleton"
 
 function getSubtree(
   options: { asChild: boolean | undefined; children: React.ReactNode },
@@ -95,14 +97,14 @@ interface TabNavigationLinkProps
   active?: boolean
 }
 
-const TabNavigationLink = React.forwardRef<
+const _TabNavigationLink = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitives.Link>,
   TabNavigationLinkProps
->(
-  (
-    { asChild, disabled, active, className, children, secondary, ...props },
-    forwardedRef
-  ) => (
+>(function TabNavigationLink(
+  { asChild, disabled, active, className, children, secondary, ...props },
+  forwardedRef
+) {
+  return (
     <NavigationMenuPrimitives.Item className="flex">
       <NavigationMenuPrimitives.Link
         data-active={active ? "true" : undefined}
@@ -141,8 +143,26 @@ const TabNavigationLink = React.forwardRef<
       </NavigationMenuPrimitives.Link>
     </NavigationMenuPrimitives.Item>
   )
-)
+})
 
-TabNavigationLink.displayName = "TabNavigationLink"
+const TabNavigationLinkSkeleton: React.FC<{ className?: string }> = ({
+  className,
+}) => {
+  return (
+    <Skeleton
+      className={cn(
+        "mr-4 w-20 rounded-md border border-solid border-transparent py-1.5",
+        className
+      )}
+    >
+      &nbsp;
+    </Skeleton>
+  )
+}
+
+const TabNavigationLink = withSkeleton(
+  _TabNavigationLink,
+  TabNavigationLinkSkeleton
+)
 
 export { TabNavigation, TabNavigationLink }


### PR DESCRIPTION
## Description

We try to add skeletons to elements that can have loading states. Unfortunately, our tabs do fetch data and thus potentially have a loading state. This adds a skeleton we can use while we wait for the data.

## Screenshots (if applicable)

<img width="486" alt="image" src="https://github.com/user-attachments/assets/89fa4923-b600-48c1-85c7-875e471d58c8">

### Figma Link

There's no figma design.

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other

---

## Experimental Component Checklist (if applicable)

- [X] Component added to `experimental` folder
- [X] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)