### PR TITLE
Skip framer motion animations on chromatic

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,12 +3,16 @@ import React, { useState } from "react"
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport"
 import type { Preview } from "@storybook/react"
 import { action } from "@storybook/addon-actions"
+import { MotionGlobalConfig } from "framer-motion"
+import isChromatic from "chromatic/isChromatic"
 
 import "../styles.css"
 
 import { ThemeProvider } from "../lib/lib/theme-provider"
 import { FactorialOneProvider } from "../lib/lib/one-provider"
 import { DocsContainer } from "./DocsContainer"
+
+MotionGlobalConfig.skipAnimations = isChromatic()
 
 export const withTheme = () => {
   // eslint-disable-next-line react/display-name

--- a/lib/experimental/Information/Spinner/index.tsx
+++ b/lib/experimental/Information/Spinner/index.tsx
@@ -24,7 +24,11 @@ interface SpinnerProps extends VariantProps<typeof spinnerVariants> {
 
 function Spinner({ size, className }: SpinnerProps) {
   return (
-    <div className={cn(spinnerVariants({ size, className }))}>
+    <div
+      className={cn(spinnerVariants({ size, className }))}
+      aria-live="polite"
+      aria-busy={true}
+    >
       <svg
         viewBox="0 0 32 32"
         fill="none"


### PR DESCRIPTION
## Description

Animations on Chromatic are flaky, as chromatic sometimes captures them at different frames. This makes sure they are disabled in framer motion when in chromatic.

## Screenshots (if applicable)

Nothing, just a saner CI!

### Figma Link

No Figma link

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other
