### PR TITLE
Fix tab matching logic

### DIFF
--- a/lib/experimental/Navigation/Tabs/index.stories.tsx
+++ b/lib/experimental/Navigation/Tabs/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { Tabs } from "."
 
 const tabItems = [
-  { label: "Overview", href: "/", exactMatch: true },
+  { label: "Overview", href: "/", index: true },
   { label: "Courses", href: "/courses" },
   { label: "Categories", href: "/categories" },
   { label: "Catalog", href: "/catalog" },

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -15,7 +15,9 @@ interface TabsProps {
 
 export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
   const { isActive } = useNavigation()
-  const activeTabIndex = findActiveTabIndex(tabs, isActive)
+
+  const sortedTabs = tabs.sort((a, b) => (a.index ? 1 : b.index ? -1 : 0))
+  const activeTabIndex = sortedTabs.findIndex((tab) => isActive(tab.href))
 
   return (
     <TabNavigation secondary={secondary}>
@@ -48,31 +50,3 @@ export const TabsSkeleton: React.FC<Pick<TabsProps, "secondary">> = ({
 }
 
 export const Tabs = withSkeleton(BaseTabs, TabsSkeleton)
-
-// The following piece of code is used to find the right active tab when
-// one of the tabs is an index one. Since index tabs are usually `/` while
-// other tabs are `/some-other-path`, we need to find the right tab by
-// checking if the current path is active without the index first, and then
-// checking if it's active with the index.
-//
-// Otherwise, we would incorrectly match the index tab as active, resulting
-// in two tabs being active at the same time.
-const findActiveTabIndex = (
-  tabs: TabItem[],
-  isActive: (href: string) => boolean
-) => {
-  const tabsWithIndex = tabs.map((tab, index) => ({
-    index,
-    tab,
-  }))
-
-  const nonIndexActiveTab = tabsWithIndex
-    .filter((indexedTab) => !indexedTab.tab.index)
-    .find((indexedTab) => isActive(indexedTab.tab.href))
-
-  const activeTab = nonIndexActiveTab
-    ? nonIndexActiveTab
-    : tabsWithIndex.find((indexedTab) => isActive(indexedTab.tab.href))
-
-  return activeTab?.index
-}

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -21,15 +21,15 @@ export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
   // is active without the index first, and then with the index. Otherwise,
   // we would incorrectly match the index tab as active, resulting in two tabs
   // being active at the same time.
-  const sortedTabs = tabs.sort((a, b) => (a.index ? 1 : b.index ? -1 : 0))
-  const activeTabIndex = sortedTabs.findIndex((tab) => isActive(tab.href))
+  const sortedTabs = [...tabs].sort((a, b) => (a.index ? 1 : b.index ? -1 : 0))
+  const activeTab = sortedTabs.find((tab) => isActive(tab.href))
 
   return (
     <TabNavigation secondary={secondary}>
       {tabs.map(({ label, ...props }, index) => (
         <TabNavigationLink
           key={index}
-          active={activeTabIndex === index}
+          active={activeTab?.href === props.href}
           href={props.href}
           secondary={secondary}
           asChild

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -16,6 +16,11 @@ interface TabsProps {
 export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
   const { isActive } = useNavigation()
 
+  // Index tabs are usually `/` while other tabs are `/some-other-path`.
+  // We need to find the right active tab by checking if the current path
+  // is active without the index first, and then with the index. Otherwise,
+  // we would incorrectly match the index tab as active, resulting in two tabs
+  // being active at the same time.
   const sortedTabs = tabs.sort((a, b) => (a.index ? 1 : b.index ? -1 : 0))
   const activeTabIndex = sortedTabs.findIndex((tab) => isActive(tab.href))
 


### PR DESCRIPTION
## Description

The logic to find the active tag when using `index` was overly complicated. This simplifies things by quite a lot and makes the more understandable.

## Screenshots (if applicable)

None

### Figma Link

None

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other
