### PR TITLE
Add AlertAvatar

### DIFF
--- a/lib/experimental/Information/Avatars/AlertAvatar/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/AlertAvatar/index.stories.tsx
@@ -9,17 +9,15 @@ const meta: Meta<typeof AlertAvatar> = {
 export default meta
 type Story = StoryObj<typeof AlertAvatar>
 
+const SIZES = ["sm", "md", "lg"] as const
+const TYPES = ["info", "warning", "critical"] as const
 export const Default: Story = {
   render: () => (
     <div className="flex w-fit flex-col gap-2">
-      {["sm", "md", "lg"].map((size) => (
+      {SIZES.map((size) => (
         <div key={size} className="flex flex-row gap-2">
-          {["info", "warning", "critical"].map((type) => (
-            <AlertAvatar
-              key={`${size}-${type}`}
-              size={size as "sm" | "md" | "lg"}
-              type={type as "info" | "warning" | "critical"}
-            />
+          {TYPES.map((type) => (
+            <AlertAvatar key={`${size}-${type}`} size={size} type={type} />
           ))}
         </div>
       ))}

--- a/lib/experimental/Information/Avatars/AlertAvatar/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/AlertAvatar/index.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { AlertAvatar } from "./index"
+
+const meta: Meta<typeof AlertAvatar> = {
+  component: AlertAvatar,
+  tags: ["autodocs"],
+}
+
+export default meta
+type Story = StoryObj<typeof AlertAvatar>
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex w-fit flex-col gap-2">
+      {["sm", "md", "lg"].map((size) => (
+        <div key={size} className="flex flex-row gap-2">
+          {["info", "warning", "critical"].map((type) => (
+            <AlertAvatar
+              key={`${size}-${type}`}
+              size={size as "sm" | "md" | "lg"}
+              type={type as "info" | "warning" | "critical"}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}

--- a/lib/experimental/Information/Avatars/AlertAvatar/index.tsx
+++ b/lib/experimental/Information/Avatars/AlertAvatar/index.tsx
@@ -1,0 +1,46 @@
+import { Icon } from "@/components/Utilities/Icon"
+import { AlertCircle, InfoCircle, Warning } from "@/icons/app"
+import { cva, type VariantProps } from "class-variance-authority"
+
+const alertAvatarVariants = cva(
+  "flex items-center justify-center border border-solid",
+  {
+    variants: {
+      type: {
+        critical:
+          "border-f1-border-critical bg-f1-background-critical text-f1-icon-critical",
+        warning:
+          "border-f1-border-warning bg-f1-background-warning text-f1-icon-warning",
+        info: "border-f1-border-info bg-f1-background-info text-f1-icon-info",
+      },
+      size: {
+        sm: "h-6 w-6 rounded-sm",
+        md: "h-8 w-8 rounded",
+        lg: "h-10 w-10 rounded-md",
+      },
+    },
+    defaultVariants: {
+      type: "info",
+      size: "md",
+    },
+  }
+)
+
+type Props = VariantProps<typeof alertAvatarVariants> & {
+  type: "critical" | "warning" | "info"
+  size?: "sm" | "md" | "lg"
+}
+
+export const AlertAvatar = ({ type, size }: Props) => {
+  const iconMap = {
+    critical: AlertCircle,
+    warning: Warning,
+    info: InfoCircle,
+  }
+
+  return (
+    <div className={alertAvatarVariants({ type, size })}>
+      <Icon icon={iconMap[type]} size={size} />
+    </div>
+  )
+}

--- a/lib/experimental/Information/Avatars/exports.ts
+++ b/lib/experimental/Information/Avatars/exports.ts
@@ -1,3 +1,4 @@
+export * from "./AlertAvatar"
 export * from "./CompanyAvatar"
 export * from "./PersonAvatar"
 export * from "./TeamAvatar"

--- a/lib/tokens/colors.ts
+++ b/lib/tokens/colors.ts
@@ -160,6 +160,12 @@ export const f1Colors = {
     accent: {
       alpha20: "hsl(var(--accent-50) / 0.2)",
     },
+    critical: {
+      DEFAULT: "hsl(var(--critical-50) / 0.1)",
+      bold: "hsl(var(--critical-50))",
+    },
+    warning: "hsl(var(--warning-50) / 0.1)",
+    info: "hsl(var(--info-50) / 0.1)",
   },
   icon: {
     DEFAULT: "hsl(var(--neutral-50))",


### PR DESCRIPTION
## Description

Add [AlertAvatar](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=1687-17374&t=Ju4W7T0TfT6gs8mm-4) as one of the avatars in F1. It's primarily used in the Alert component, but we also use it as a standalone icon in other places, like Home.

## Screenshots

<img width="183" alt="image" src="https://github.com/user-attachments/assets/27913a0d-c851-48f1-b324-5984be65aab2">

### Figma Link

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=1687-17374&t=Ju4W7T0TfT6gs8mm-4)

---

## Type of Change

- [x] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other
