### PR TITLE
Add DateAvatar

### DIFF
--- a/lib/experimental/Information/Avatars/DateAvatar/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/DateAvatar/index.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { DateAvatar } from "."
+
+const meta: Meta<typeof DateAvatar> = {
+  component: DateAvatar,
+  tags: ["autodocs"],
+}
+
+export default meta
+
+type Story = StoryObj<typeof DateAvatar>
+
+export const Default: Story = {
+  args: {
+    month: "January",
+    day: 15,
+  },
+}

--- a/lib/experimental/Information/Avatars/DateAvatar/index.tsx
+++ b/lib/experimental/Information/Avatars/DateAvatar/index.tsx
@@ -1,0 +1,19 @@
+type Props = {
+  month: string
+  day: number
+}
+
+export const DateAvatar = ({ month, day }: Props) => {
+  const monthName = month.slice(0, 3)
+
+  return (
+    <div className="flex h-10 w-10 flex-col items-center justify-center rounded border border-solid border-f1-border-secondary">
+      <div className="text-xs pt-0.5 font-semibold uppercase leading-3 text-f1-foreground-critical">
+        {monthName}
+      </div>
+      <div className="flex items-center justify-center text-lg font-medium leading-tight">
+        {day}
+      </div>
+    </div>
+  )
+}

--- a/lib/experimental/Information/Avatars/DateAvatar/index.tsx
+++ b/lib/experimental/Information/Avatars/DateAvatar/index.tsx
@@ -7,8 +7,8 @@ export const DateAvatar = ({ month, day }: Props) => {
   const monthName = month.slice(0, 3)
 
   return (
-    <div className="flex h-10 w-10 flex-col items-center justify-center rounded border border-solid border-f1-border-secondary">
-      <div className="text-xs pt-0.5 font-semibold uppercase leading-3 text-f1-foreground-critical">
+    <div className="bg-f1-background-inverse-secondary flex h-10 w-10 flex-col items-center justify-center rounded border border-solid border-f1-border-secondary">
+      <div className="text-xs pt-0.5 font-semibold uppercase leading-3 text-f1-foreground-critical dark:text-f1-foreground-inverse-secondary">
         {monthName}
       </div>
       <div className="flex items-center justify-center text-lg font-medium leading-tight">

--- a/lib/experimental/Information/Avatars/DateAvatar/index.tsx
+++ b/lib/experimental/Information/Avatars/DateAvatar/index.tsx
@@ -7,8 +7,8 @@ export const DateAvatar = ({ month, day }: Props) => {
   const monthName = month.slice(0, 3)
 
   return (
-    <div className="bg-f1-background-inverse-secondary flex h-10 w-10 flex-col items-center justify-center rounded border border-solid border-f1-border-secondary">
-      <div className="text-xs pt-0.5 font-semibold uppercase leading-3 text-f1-foreground-critical dark:text-f1-foreground-inverse-secondary">
+    <div className="flex h-10 w-10 flex-col items-center justify-center rounded border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary">
+      <div className="pt-0.5 text-xs font-semibold uppercase leading-3 text-f1-foreground-critical dark:text-f1-foreground-inverse-secondary">
         {monthName}
       </div>
       <div className="flex items-center justify-center text-lg font-medium leading-tight">

--- a/lib/experimental/Information/Avatars/exports.ts
+++ b/lib/experimental/Information/Avatars/exports.ts
@@ -1,4 +1,5 @@
 export * from "./CompanyAvatar"
+export * from "./DateAvatar"
 export * from "./PersonAvatar"
 export * from "./TeamAvatar"
 export * from "./utils"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,6 +37,12 @@ export default {
       semibold: "600",
     },
     fontSize: {
+      xs: [
+        ".625rem",
+        {
+          lineHeight: "0.5rem",
+        },
+      ],
       sm: [
         ".75rem",
         {


### PR DESCRIPTION
## Description

Add [DateAvatar](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=2043-24804&t=Ju4W7T0TfT6gs8mm-4), one of the avatars in our web components. We use this one in the events list, and the event post in communities.

## Screenshots

https://github.com/user-attachments/assets/56803c6a-172c-4773-a70c-78faf1453c63

### Figma Link

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=2043-24804&t=Ju4W7T0TfT6gs8mm-4)