### PR TITLE
Fix avatar background with image

### DIFF
--- a/lib/experimental/Information/Avatars/BaseAvatar/index.tsx
+++ b/lib/experimental/Information/Avatars/BaseAvatar/index.tsx
@@ -47,6 +47,9 @@ export const BaseAvatar = forwardRef<HTMLDivElement, Props>(
         aria-hidden={!hasAria}
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledby}
+        className={
+          src ? "dark:bg-f1-background-inverse-secondary bg-f1-background" : ""
+        }
       >
         <AvatarImage src={src} alt={initials} />
         <AvatarFallback>{initials}</AvatarFallback>

--- a/lib/experimental/Information/Avatars/BaseAvatar/index.tsx
+++ b/lib/experimental/Information/Avatars/BaseAvatar/index.tsx
@@ -48,7 +48,7 @@ export const BaseAvatar = forwardRef<HTMLDivElement, Props>(
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledby}
         className={
-          src ? "dark:bg-f1-background-inverse-secondary bg-f1-background" : ""
+          src ? "bg-f1-background dark:bg-f1-background-inverse-secondary" : ""
         }
       >
         <AvatarImage src={src} alt={initials} />


### PR DESCRIPTION
## Description

In avatars, when using an image with a transparent background, you can see the randomly picked color background behind, [which blends in weird and unintended ways](https://factorialteam.slack.com/archives/C071PC4TL1L/p1731945764284419). This PR changes that, forcing a white background when there's an image specified, so we make it look good.

(Also supporting dark mode)

## Screenshots

https://github.com/user-attachments/assets/a78f1ab7-e50d-43dc-a9fa-76d1e6f77cc7

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other