### PR TITLE
Add DaytimePage

### DIFF
--- a/lib/experimental/Navigation/Page/index.stories.tsx
+++ b/lib/experimental/Navigation/Page/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Placeholder } from "@/lib/storybook-utils/placeholder"
 import type { Meta, StoryObj } from "@storybook/react"
-import { Page } from "."
+import { DaytimePage, DaytimePageProps, Page } from "."
 
 import { PageHeader } from "../Header/PageHeader"
 import * as HeaderStories from "../Header/PageHeader/index.stories"
@@ -25,7 +25,7 @@ const meta: Meta<typeof Page> = {
 }
 
 export default meta
-type Story = StoryObj
+type Story = StoryObj<DaytimePageProps>
 
 export const Default: Story = {
   args: {
@@ -45,4 +45,36 @@ export const Default: Story = {
       </StandardLayout>
     ),
   },
+}
+
+export const Daytime: Story = {
+  args: {
+    period: "morning",
+  },
+  argTypes: {
+    period: {
+      control: "select",
+      options: ["morning", "afternoon", "evening"],
+    },
+  },
+  render: ({ period }) => (
+    <DaytimePage
+      period={period}
+      header={
+        <>
+          <PageHeader {...HeaderStories.FirstLevel.args} />
+          <Tabs {...TabsStories.Primary.args} />
+        </>
+      }
+      children={
+        <StandardLayout>
+          {Array(25)
+            .fill(0)
+            .map((_, index) => (
+              <Placeholder key={index} className="min-h-24" />
+            ))}
+        </StandardLayout>
+      }
+    />
+  ),
 }

--- a/lib/experimental/Navigation/Page/index.stories.tsx
+++ b/lib/experimental/Navigation/Page/index.stories.tsx
@@ -63,18 +63,16 @@ export const Daytime: Story = {
       header={
         <>
           <PageHeader {...HeaderStories.FirstLevel.args} />
-          <Tabs {...TabsStories.Primary.args} />
         </>
       }
-      children={
-        <StandardLayout>
-          {Array(25)
-            .fill(0)
-            .map((_, index) => (
-              <Placeholder key={index} className="min-h-24" />
-            ))}
-        </StandardLayout>
-      }
-    />
+    >
+      <StandardLayout>
+        {Array(25)
+          .fill(0)
+          .map((_, index) => (
+            <Placeholder key={index} className="min-h-24" />
+          ))}
+      </StandardLayout>
+    </DaytimePage>
   ),
 }

--- a/lib/experimental/Navigation/Page/index.tsx
+++ b/lib/experimental/Navigation/Page/index.tsx
@@ -24,11 +24,11 @@ const daytimePageVariants = cva(
     variants: {
       period: {
         morning:
-          "bg-gradient-to-bl from-[#E51943] from-20% via-[#F97316] to-transparent to-80%",
+          "bg-gradient-to-bl from-[#E51943] from-20% via-[#F97316] via-35% to-transparent to-50%",
         afternoon:
-          "bg-gradient-to-bl from-[#5596F6] from-20% via-[#10B881] to-transparent to-80%",
+          "bg-gradient-to-bl from-[#5596F6] from-20% via-[#10B881] via-35% to-transparent to-50%",
         evening:
-          "bg-gradient-to-bl from-[#3739A8] from-20% via-[#CB6687] to-transparent to-80%",
+          "bg-gradient-to-bl from-[#3739A8] from-20% via-[#CB6687] via-35% to-transparent to-50%",
       },
     },
     defaultVariants: {

--- a/lib/experimental/Navigation/Page/index.tsx
+++ b/lib/experimental/Navigation/Page/index.tsx
@@ -1,3 +1,5 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
 interface PageProps {
   children?: React.ReactNode
   header?: React.ReactNode
@@ -5,7 +7,7 @@ interface PageProps {
 
 export function Page({ children, header }: PageProps) {
   return (
-    <div className="flex w-full flex-col overflow-hidden rounded-xl bg-f1-page shadow">
+    <div className="bg-f1-page flex w-full flex-col overflow-hidden rounded-xl shadow">
       {header && <div className="flex flex-col">{header}</div>}
       <div className="isolate flex w-full flex-1 flex-col overflow-auto [&>*]:flex-1">
         {children}
@@ -13,3 +15,44 @@ export function Page({ children, header }: PageProps) {
     </div>
   )
 }
+
+Page.displayName = "Page"
+
+const daytimePageVariants = cva(
+  "pointer-events-none absolute inset-0 h-screen max-h-[1000px] opacity-[0.08]",
+  {
+    variants: {
+      period: {
+        morning:
+          "bg-gradient-to-bl from-[#E51943] from-20% via-[#F97316] to-transparent to-80%",
+        afternoon:
+          "bg-gradient-to-bl from-[#5596F6] from-20% via-[#10B881] to-transparent to-80%",
+        evening:
+          "bg-gradient-to-bl from-[#3739A8] from-20% via-[#CB6687] to-transparent to-80%",
+      },
+    },
+    defaultVariants: {
+      period: "morning",
+    },
+  }
+)
+
+export interface DaytimePageProps
+  extends VariantProps<typeof daytimePageVariants> {
+  children?: React.ReactNode
+  header?: React.ReactNode
+}
+
+export function DaytimePage({ children, header, period }: DaytimePageProps) {
+  return (
+    <div className="bg-f1-page relative flex w-full flex-col overflow-hidden rounded-xl shadow">
+      <div className={daytimePageVariants({ period })} />
+      {header && <div className="flex flex-col">{header}</div>}
+      <div className="isolate flex w-full flex-1 flex-col overflow-auto [&>*]:flex-1">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+DaytimePage.displayName = "DaytimePage"

--- a/lib/experimental/Navigation/Page/index.tsx
+++ b/lib/experimental/Navigation/Page/index.tsx
@@ -7,7 +7,7 @@ interface PageProps {
 
 export function Page({ children, header }: PageProps) {
   return (
-    <div className="bg-f1-page flex w-full flex-col overflow-hidden rounded-xl shadow">
+    <div className="flex w-full flex-col overflow-hidden rounded-xl bg-f1-page shadow">
       {header && <div className="flex flex-col">{header}</div>}
       <div className="isolate flex w-full flex-1 flex-col overflow-auto [&>*]:flex-1">
         {children}
@@ -45,7 +45,7 @@ export interface DaytimePageProps
 
 export function DaytimePage({ children, header, period }: DaytimePageProps) {
   return (
-    <div className="bg-f1-page relative flex w-full flex-col overflow-hidden rounded-xl shadow">
+    <div className="relative flex w-full flex-col overflow-hidden rounded-xl bg-f1-page shadow">
       <div className={daytimePageVariants({ period })} />
       {header && <div className="flex flex-col">{header}</div>}
       <div className="isolate flex w-full flex-1 flex-col overflow-auto [&>*]:flex-1">

--- a/lib/ui/card.tsx
+++ b/lib/ui/card.tsx
@@ -21,7 +21,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "flex flex-col items-stretch rounded-xl border border-solid border-f1-border bg-f1-background p-4",
+      "bg-f1-background-inverse-secondary flex flex-col items-stretch rounded-xl border border-solid border-f1-border-secondary p-4 shadow",
       className
     )}
     {...props}

--- a/lib/ui/card.tsx
+++ b/lib/ui/card.tsx
@@ -21,7 +21,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "bg-f1-background-inverse-secondary flex flex-col items-stretch rounded-xl border border-solid border-f1-border-secondary p-4 shadow",
+      "flex flex-col items-stretch rounded-xl border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary p-4 shadow",
       className
     )}
     {...props}


### PR DESCRIPTION
## Description

`DaytimePage` is a variant of the `Page` component that will be used on the Home. It's pretty similar but features a gradient background that changes depending on the time of day: morning, afternoon, or evening.

## Screenshots (if applicable)

<img width="764" alt="image" src="https://github.com/user-attachments/assets/95d5c722-46e5-466e-89b7-54dcb1a19d29">

_Morning_

<img width="761" alt="image" src="https://github.com/user-attachments/assets/cb6f5562-4be1-4352-be51-f899a32ee8f2">

_Afternoon_

<img width="761" alt="image" src="https://github.com/user-attachments/assets/eb1cb454-de71-45e7-bd48-7354b2907d9c">

_Evening_

### Figma Link

[Link to Figma Design](https://www.figma.com/design/060q78tnGIGaRc1sxecTvV/Home-Web?node-id=1234-75084&t=anWU04NUVRrWfwop-4)