### PR TITLE
Do not allow more than one line in indicator item

### DIFF
--- a/lib/ui/indicator.tsx
+++ b/lib/ui/indicator.tsx
@@ -15,7 +15,12 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
       <div key={label} className="grid-row-2 col-span-1 grid" ref={ref}>
         <p className="text-2xl font-semibold">{content}</p>
         <div className="flex items-center gap-1">
-          <p className="text-f1-foreground-secondary">{label}</p>
+          <p
+            className="line-clamp-1 text-f1-foreground-secondary"
+            title={label}
+          >
+            {label}
+          </p>
           {icon && (
             <span className={cn("flex", color)}>
               <Icon icon={icon} />


### PR DESCRIPTION
## Description

Do not allow more than one line in indicator item.

## Screenshots

Before:

<img width="463" alt="Screenshot 2024-11-20 at 14 25 13" src="https://github.com/user-attachments/assets/365ebc2b-89a5-4544-9fa3-e6fd0acd0c3d">

After:

<img width="464" alt="Screenshot 2024-11-20 at 14 24 30" src="https://github.com/user-attachments/assets/1ae93df8-db3d-4539-9efb-d8626ac469ed">
