### PR TITLE
Move HomeLayout component to PageLayouts

### DIFF
--- a/lib/experimental/PageLayouts/HomeLayout/index.stories.tsx
+++ b/lib/experimental/PageLayouts/HomeLayout/index.stories.tsx
@@ -1,21 +1,21 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
+import { AreaChartWidget } from "@/experimental/Widgets/Charts/AreaChartWidget"
 import { Placeholder } from "@/lib/storybook-utils/placeholder"
 import { HomeLayout } from "."
-import { AreaChartWidget } from "../../Charts/AreaChartWidget"
 
 import { AreaChartProps } from "@/components/Charts/AreaChart"
-import AreaChartWidgetStoriesMeta from "../../Charts/AreaChartWidget/index.stories"
-import { BarChartWidget } from "../../Charts/BarChartWidget"
-import BarChartWidgetStoriesMeta from "../../Charts/BarChartWidget/index.stories"
-import { ComposeChartContainerProps } from "../../Charts/ChartContainer"
-import { LineChartWidget } from "../../Charts/LineChartWidget"
-import LineChartWidgetStoriesMeta from "../../Charts/LineChartWidget/index.stories"
-import { RadialProgressWidget } from "../../Charts/RadialProgressWidget"
-import RadialProgressWidgetStoriesMeta from "../../Charts/RadialProgressWidget/index.stories"
-import { VerticalBarChartWidget } from "../../Charts/VerticalBarChartWidget"
-import VerticalBarChartWidgetStoriesMeta from "../../Charts/VerticalBarChartWidget/index.stories"
-import { Widget } from "../../Widget"
+import AreaChartWidgetStoriesMeta from "@/experimental/Widgets/Charts/AreaChartWidget/index.stories"
+import { BarChartWidget } from "@/experimental/Widgets/Charts/BarChartWidget"
+import BarChartWidgetStoriesMeta from "@/experimental/Widgets/Charts/BarChartWidget/index.stories"
+import { ComposeChartContainerProps } from "@/experimental/Widgets/Charts/ChartContainer"
+import { LineChartWidget } from "@/experimental/Widgets/Charts/LineChartWidget"
+import LineChartWidgetStoriesMeta from "@/experimental/Widgets/Charts/LineChartWidget/index.stories"
+import { RadialProgressWidget } from "@/experimental/Widgets/Charts/RadialProgressWidget"
+import RadialProgressWidgetStoriesMeta from "@/experimental/Widgets/Charts/RadialProgressWidget/index.stories"
+import { VerticalBarChartWidget } from "@/experimental/Widgets/Charts/VerticalBarChartWidget"
+import VerticalBarChartWidgetStoriesMeta from "@/experimental/Widgets/Charts/VerticalBarChartWidget/index.stories"
+import { Widget } from "@/experimental/Widgets/Widget"
 
 const widgets = [
   <AreaChartWidget

--- a/lib/experimental/PageLayouts/HomeLayout/index.tsx
+++ b/lib/experimental/PageLayouts/HomeLayout/index.tsx
@@ -1,3 +1,4 @@
+import { WidgetStrip } from "@/experimental/Widgets/Layout/WidgetStrip"
 import {
   Children,
   forwardRef,
@@ -6,7 +7,6 @@ import {
   useRef,
 } from "react"
 import { useResizeObserver } from "usehooks-ts"
-import { WidgetStrip } from "../WidgetStrip"
 
 type Props = {
   widgets?: ReactNode[]

--- a/lib/experimental/PageLayouts/exports.tsx
+++ b/lib/experimental/PageLayouts/exports.tsx
@@ -1,5 +1,6 @@
 import { Component } from "@/lib/component"
 import { FullscreenLayout as FullscreenLayoutComponent } from "./FullscreenLayout"
+import { HomeLayout as HomeLayoutComponent } from "./HomeLayout"
 import { OverviewLayout as OverviewLayoutComponent } from "./OverviewLayout"
 import {
   InfoPaneLayout as InfoPaneLayoutComponent,
@@ -33,4 +34,12 @@ export const OverviewLayout = Component(
     type: "layout",
   },
   OverviewLayoutComponent
+)
+
+export const HomeLayout = Component(
+  {
+    name: "HomeLayout",
+    type: "layout",
+  },
+  HomeLayoutComponent
 )

--- a/lib/experimental/Widgets/Layout/exports.tsx
+++ b/lib/experimental/Widgets/Layout/exports.tsx
@@ -1,3 +1,2 @@
 export * from "./Dashboard"
-export * from "./HomeLayout"
 export * from "./WidgetStrip"


### PR DESCRIPTION
## Description

Move HomeLayout component to PageLayouts. The `Layouts` inside `Widgets` was for those components that only accept widgets, but it's not the case of this `HomeLayout` as we also have that main area where we have the community feed.
