### PR TITLE
Add HighlightBanner

### DIFF
--- a/lib/experimental/Information/Communities/HighlightBanner/index.stories.tsx
+++ b/lib/experimental/Information/Communities/HighlightBanner/index.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { fn } from "@storybook/test"
+import { HighlightBanner } from "./index"
+
+const meta: Meta<typeof HighlightBanner> = {
+  component: HighlightBanner,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-2">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+
+type Story = StoryObj<typeof HighlightBanner>
+
+export const Default: Story = {
+  args: {
+    title: "Thank you for their amazing work!",
+    subtitle: "Show appreciation and spread positivity",
+    buttonLabel: "Send claps",
+    onClick: fn(),
+  },
+}

--- a/lib/experimental/Information/Communities/HighlightBanner/index.tsx
+++ b/lib/experimental/Information/Communities/HighlightBanner/index.tsx
@@ -1,0 +1,38 @@
+import { ModuleAvatar } from "@/experimental/Information/ModuleAvatar/"
+import { Kudos } from "@/icons/modules/"
+import { Button } from "@/ui/button"
+
+type HighlightBannerProps = {
+  title: string
+  subtitle: string
+  buttonLabel: string
+  onClick?: () => void
+}
+
+export const HighlightBanner = ({
+  title,
+  subtitle,
+  buttonLabel,
+  onClick,
+}: HighlightBannerProps) => {
+  return (
+    <div className="flex w-full flex-col items-start justify-between gap-4 rounded-md bg-gradient-to-r from-[#F5A51C]/30 via-[#E51943]/30 to-[#5596F6]/30 px-3 py-3 ring-1 ring-inset ring-f1-border-secondary sm:flex-row sm:items-center sm:px-4">
+      <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+        <ModuleAvatar icon={Kudos} size="lg" />
+        <div className="flex flex-col gap-0">
+          <span className="font-medium text-f1-foreground">{title}</span>
+          <span className="text-f1-foreground-secondary">{subtitle}</span>
+        </div>
+      </div>
+      <div className="w-full sm:w-fit">
+        <Button
+          variant="outline"
+          onClick={onClick}
+          className="w-full sm:w-auto"
+        >
+          {buttonLabel}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/lib/ui/button.tsx
+++ b/lib/ui/button.tsx
@@ -25,7 +25,7 @@ const buttonVariants = cva(
         default:
           "bg-f1-background-accent-bold text-f1-foreground-inverse hover:bg-f1-background-accent-bold-hover",
         outline:
-          "border border-solid border-f1-border bg-f1-background text-f1-foreground hover:border-f1-border-hover",
+          "border border-solid border-f1-border bg-f1-background-inverse-secondary text-f1-foreground hover:border-f1-border-hover",
         neutral:
           "bg-f1-background-secondary text-f1-foreground hover:bg-f1-background-secondary-hover",
         critical:


### PR DESCRIPTION
## Description

`HighlightBanner` is a small piece in Communities inside the new Home. It's designed to draw attention to Claps and guide the user to create a post.

## Screenshots

<img width="521" alt="image" src="https://github.com/user-attachments/assets/17cb1617-5ec7-4157-8284-fa4d56fff51b">

_Regular look_


<img width="334" alt="image" src="https://github.com/user-attachments/assets/bded06c4-98c6-4f64-85e9-48c8f3032e5c">

_Responsive behaviour_

<img width="341" alt="image" src="https://github.com/user-attachments/assets/63bc5bb6-4d34-427c-9b22-6e21fdbb4535">

_It also looks pretty cool in dark mode, yay!_

### Figma Link

[Link to Figma Design](https://www.figma.com/design/060q78tnGIGaRc1sxecTvV/Home-Web?node-id=1152-34472&t=m8wZWvtK19VUUyv8-4)

---

## Type of Change

- [x] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other
