### PR TITLE
Fix some sidebar details

### DIFF
--- a/lib/experimental/Navigation/Sidebar/Header/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Header/index.tsx
@@ -9,7 +9,7 @@ export function SidebarHeader({
   onChange,
 }: SidebarHeaderProps) {
   return (
-    <div className="flex h-[72px] items-center justify-between gap-3">
+    <div className="flex h-[72px] items-center justify-between gap-3 px-3">
       <CompanySelector
         companies={companies}
         selected={selected}

--- a/lib/experimental/Navigation/Sidebar/Menu/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Menu/index.tsx
@@ -142,7 +142,7 @@ const CategoryItem = ({ category }: { category: MenuCategory }) => {
 
 export function Menu({ tree }: MenuProps) {
   return (
-    <div className="w-full bg-transparent">
+    <div className="w-full bg-transparent px-3">
       {tree.map((category, index) => (
         <CategoryItem key={index} category={category} />
       ))}

--- a/lib/experimental/Navigation/Sidebar/Searchbar/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Searchbar/index.tsx
@@ -20,7 +20,7 @@ export function SearchBar({
       <button
         onClick={onClick}
         className={cn(
-          "mb-4 mt-2 flex w-full cursor-pointer items-center justify-between rounded border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary p-1.5 text-f1-foreground-secondary transition-colors hover:border-f1-border-hover",
+          "mb-[calc(0.75rem-1px)] flex w-full cursor-pointer items-center justify-between rounded bg-f1-background-inverse-secondary p-1.5 text-f1-foreground-secondary ring-1 ring-inset ring-f1-border-secondary transition-all hover:ring-f1-border-hover",
           focusRing()
         )}
         type="button"

--- a/lib/experimental/Navigation/Sidebar/Searchbar/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Searchbar/index.tsx
@@ -16,22 +16,24 @@ export function SearchBar({
   ...props
 }: SearchBarProps) {
   return (
-    <button
-      onClick={onClick}
-      className={cn(
-        "mb-4 mt-2 flex w-full cursor-pointer items-center justify-between rounded border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary p-1.5 text-f1-foreground-secondary transition-colors hover:border-f1-border-hover",
-        focusRing()
-      )}
-      type="button"
-      {...props}
-    >
-      <div className="flex items-center gap-1">
-        <Icon icon={Search} size="md" />
-        <span>{placeholder}</span>
-      </div>
-      <div className="hidden xs:block">
-        <Shortcut keys={shortcut} />
-      </div>
-    </button>
+    <div className="px-3">
+      <button
+        onClick={onClick}
+        className={cn(
+          "mb-4 mt-2 flex w-full cursor-pointer items-center justify-between rounded border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary p-1.5 text-f1-foreground-secondary transition-colors hover:border-f1-border-hover",
+          focusRing()
+        )}
+        type="button"
+        {...props}
+      >
+        <div className="flex items-center gap-1">
+          <Icon icon={Search} size="md" />
+          <span>{placeholder}</span>
+        </div>
+        <div className="hidden xs:block">
+          <Shortcut keys={shortcut} />
+        </div>
+      </button>
+    </div>
   )
 }

--- a/lib/experimental/Navigation/Sidebar/Sidebar.tsx
+++ b/lib/experimental/Navigation/Sidebar/Sidebar.tsx
@@ -42,11 +42,11 @@ export function Sidebar({ header, body, footer }: SidebarProps) {
     <motion.div
       initial={false}
       className={cn(
-        "absolute bottom-0 left-0 top-0 z-10 flex w-64 flex-col px-3 transition-[background-color]",
+        "absolute bottom-0 left-0 top-0 z-10 flex w-64 flex-col transition-[background-color]",
         sidebarState === "locked"
           ? "h-screen"
           : cn(
-              "border-solid border-f1-border-secondary pb-3 shadow-lg backdrop-blur-2xl",
+              "border-solid border-f1-border-secondary shadow-lg backdrop-blur-2xl",
               isSmallScreen
                 ? "h-screen border-y-transparent border-l-transparent bg-f1-background/90"
                 : "h-[calc(100vh-16px)] bg-f1-background/60"
@@ -70,10 +70,10 @@ export function Sidebar({ header, body, footer }: SidebarProps) {
             {isScrolled && (
               <motion.div
                 initial={{ opacity: 0 }}
-                animate={{ opacity: 0.2 }}
+                animate={{ opacity: 0.5 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.2, ease: "easeOut" }}
-                className="pointer-events-none absolute inset-x-0 top-0 z-10 h-5 bg-gradient-to-b from-f1-background-bold to-transparent [mask-image:linear-gradient(to_right,transparent,black_30%,black_60%,transparent)]"
+                className="pointer-events-none absolute inset-x-0 top-0 z-10 h-3 bg-gradient-to-b from-f1-background-secondary to-transparent after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-f1-background-bold after:opacity-[0.04] after:content-['']"
               />
             )}
           </AnimatePresence>

--- a/lib/experimental/Navigation/Sidebar/User/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/User/index.tsx
@@ -18,7 +18,7 @@ interface UserProps {
 
 export function User({ firstName, lastName, avatarUrl, options }: UserProps) {
   return (
-    <div className="border-t border-dashed border-transparent border-t-f1-border pt-4">
+    <div className="mx-3 border-t border-dashed border-transparent border-t-f1-border pb-3 pt-4">
       <Dropdown items={options}>
         <button
           className={cn(

--- a/lib/ui/tab-navigation.tsx
+++ b/lib/ui/tab-navigation.tsx
@@ -25,7 +25,7 @@ function getSubtree(
 }
 
 const tabNavigationVariants = cva(
-  "relative flex items-center justify-start gap-1 overflow-x-auto whitespace-nowrap px-6 py-3 [scrollbar-width:none] before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-f1-border-secondary before:content-[''] [&::-webkit-scrollbar]:hidden",
+  "relative flex items-center justify-start gap-1 overflow-x-auto whitespace-nowrap px-6 pb-3 pt-1 [scrollbar-width:none] before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-f1-border-secondary before:content-[''] [&::-webkit-scrollbar]:hidden",
   {
     variants: {
       secondary: {
@@ -73,7 +73,7 @@ const tabNavigationLinkVariants = cva(
   {
     variants: {
       secondary: {
-        true: "group-hover:border-f1-border group-data-[active=true]:border-f1-border group-data-[active=true]:bg-f1-background-inverse-secondary group-data-[active=true]:text-f1-foreground",
+        true: "group-hover:ring-f1-border group-data-[active=true]:bg-f1-background-inverse-secondary group-data-[active=true]:text-f1-foreground group-data-[active=true]:ring-f1-border",
         false:
           "bg-f1-background-transparent group-hover:bg-f1-background-tertiary group-hover:text-f1-foreground group-data-[active=true]:bg-f1-background-tertiary group-data-[active=true]:text-f1-foreground",
       },
@@ -121,7 +121,7 @@ const _TabNavigationLink = React.forwardRef<
         {getSubtree({ asChild, children }, (children) => (
           <span
             className={cn(
-              "border border-solid border-transparent text-f1-foreground-secondary",
+              "text-f1-foreground-secondary ring-1 ring-inset ring-transparent",
               tabNavigationLinkVariants({ secondary, disabled }),
               className
             )}
@@ -152,7 +152,7 @@ const TabNavigationLinkSkeleton: React.FC<{ className?: string }> = ({
     <li className="list-none">
       <Skeleton
         className={cn(
-          "mr-4 w-20 rounded-md border border-solid border-transparent py-1.5",
+          "mr-4 w-20 rounded-md py-1.5 ring-1 ring-inset ring-transparent",
           className
         )}
       >


### PR DESCRIPTION
## Description

This PR updates a few styling details in the sidebar, noted [here](https://factorialmakers.atlassian.net/browse/FCT-21381) and also some others.

- Update the shadow between the header and content of the sidebar, to be more subtle as we have in Figma.
- Add some spacing at the end of the sidebar, so the user menu is not touching the edge of the screen.
- Change the padding left and right to be inside of the elements of the sidebar, so the scroll of the menu is at the right edge, and not on top of the content.
- Some spacing fixes to a few elements: tabs and searchbar. Mario and I have been tweaking them to look more compact _(I've done a few tricks here, couldn't find a better solution)._

## Screenshots

https://github.com/user-attachments/assets/d660fcff-a466-4bdc-bcfd-7aa1495cd4df

### Figma Link

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=1998-70571&t=xYqw3DBrxRORrf0A-4)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
