### PR TITLE
Only partially match when there's subroutes involved

### DIFF
--- a/lib/lib/linkHandler.spec.tsx
+++ b/lib/lib/linkHandler.spec.tsx
@@ -33,7 +33,7 @@ describe("useLink", () => {
     )
   })
 
-  test("isActive returns true if the current path starts with href", async () => {
+  test("isActive returns true if the current path starts with href including trailing slash", async () => {
     render(
       <LinkProvider currentPath="/foo/bar">
         <Component href="/foo" />
@@ -42,6 +42,18 @@ describe("useLink", () => {
 
     expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
       "true"
+    )
+  })
+
+  test("isActive returns true if the current path starts with href with no trailing slash", async () => {
+    render(
+      <LinkProvider currentPath="/foo_bar">
+        <Component href="/foo" />
+      </LinkProvider>
+    )
+
+    expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
+      "false"
     )
   })
 

--- a/lib/lib/linkHandler.tsx
+++ b/lib/lib/linkHandler.tsx
@@ -61,7 +61,7 @@ export const useNavigation = () => {
       if (exact)
         return stripTrailingSlash(currentPath) === stripTrailingSlash(path)
 
-      return stripTrailingSlash(currentPath).startsWith(
+      return `${stripTrailingSlash(currentPath)}/`.startsWith(
         `${stripTrailingSlash(path)}/`
       )
     },

--- a/lib/lib/linkHandler.tsx
+++ b/lib/lib/linkHandler.tsx
@@ -4,6 +4,7 @@ import {
   ForwardedRef,
   forwardRef,
   ReactNode,
+  useCallback,
   useContext,
   useMemo,
 } from "react"
@@ -43,17 +44,29 @@ export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   exactMatch?: boolean
 }
 
+function stripTrailingSlash(path: string) {
+  return path.endsWith("/") ? path.slice(0, -1) : path
+}
+
 export const useNavigation = () => {
   const { currentPath } = useLinkContext()
 
-  const isActive = (
-    path: string | undefined,
-    { exact = false }: { exact?: boolean } = { exact: false }
-  ) => {
-    if (currentPath === undefined || path === undefined) return false
-    if (exact) return currentPath === path
-    return currentPath.startsWith(path)
-  }
+  const isActive = useCallback(
+    (
+      path: string | undefined,
+      { exact = false }: { exact?: boolean } = { exact: false }
+    ) => {
+      if (currentPath === undefined || path === undefined) return false
+
+      if (exact)
+        return stripTrailingSlash(currentPath) === stripTrailingSlash(path)
+
+      return stripTrailingSlash(currentPath).startsWith(
+        `${stripTrailingSlash(path)}/`
+      )
+    },
+    [currentPath]
+  )
 
   return {
     currentPath,


### PR DESCRIPTION
## Description

This fixes our default link matching logic to prevent URLs like `/performance_reviews` to match `/performance`.

## Screenshots (if applicable)

*None*

### Figma Link

*None*

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other