### PR TITLE
add legend to bar chart

### DIFF
--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -1,6 +1,8 @@
 import {
   ChartConfig,
   ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from "@/ui/chart"
@@ -29,6 +31,7 @@ export type BarChartProps<K extends ChartConfig = ChartConfig> =
   ChartPropsBase<K> & {
     type?: "simple" | "stacked" | "stacked-by-sign"
     label?: boolean
+    legend?: boolean
   }
 
 const _BarChart = <K extends ChartConfig>(
@@ -40,6 +43,7 @@ const _BarChart = <K extends ChartConfig>(
     label = false,
     type = "simple",
     aspect,
+    legend,
   }: BarChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
@@ -107,6 +111,15 @@ const _BarChart = <K extends ChartConfig>(
             )}
           </Bar>
         ))}
+        {legend && (
+          <ChartLegend
+            content={<ChartLegendContent nameKey="label" />}
+            align={"center"}
+            verticalAlign={"bottom"}
+            layout="vertical"
+            className={"flex-row items-start gap-4 pr-3 pt-2"}
+          />
+        )}
       </BarChartPrimitive>
     </ChartContainer>
   )

--- a/lib/ui/chart.tsx
+++ b/lib/ui/chart.tsx
@@ -433,6 +433,8 @@ function getPayloadConfigFromPayload(
     typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
   ) {
     configLabelKey = payloadPayload[key as keyof typeof payloadPayload]
+  } else if ("dataKey" in payload && typeof payload["dataKey"] === "string") {
+    configLabelKey = payload["dataKey"]
   }
 
   if (hiddenKey && hiddenKey === configLabelKey) {


### PR DESCRIPTION
## Description

We noticed that bar chart does not include the option to show a legend like the other charts.

This PR adds a prop to Bar Chart to give the option to show the legend. By default it won't show the legend as its actual behavior

It also adapts the getPayloadConfigFromPayload function to support the config of this type of chart on the legend, example:
{
  "desktop": {
    "label": "Desktop"
  },
  "mobile": {
    "label": "Mobile"
  },
  "tablet": {
    "label": "Tablet"
  }
}

## Screenshots (if applicable)

![bar chart legend](https://github.com/user-attachments/assets/234b319c-3370-42f9-9407-abd84759a96d)

## Type of Change

- [X] Maintenance / Bug Fix / Other

