### PR TITLE
Dropdown and Select items hover zone

### DIFF
--- a/lib/experimental/Navigation/Dropdown/index.tsx
+++ b/lib/experimental/Navigation/Dropdown/index.tsx
@@ -97,7 +97,7 @@ export function Dropdown({ items, children }: DropdownProps) {
         )}
       </DropdownMenuTrigger>
       <DropdownMenuContent className="min-w-[var(--radix-dropdown-menu-trigger-width)]">
-        <div className="flex flex-col p-1">
+        <div className="flex flex-col py-1">
           {items.map((item, index) => (
             <DropdownItem
               key={index}

--- a/lib/experimental/Navigation/Dropdown/index.tsx
+++ b/lib/experimental/Navigation/Dropdown/index.tsx
@@ -97,7 +97,7 @@ export function Dropdown({ items, children }: DropdownProps) {
         )}
       </DropdownMenuTrigger>
       <DropdownMenuContent className="min-w-[var(--radix-dropdown-menu-trigger-width)]">
-        <div className="flex flex-col py-1">
+        <div className="flex flex-col">
           {items.map((item, index) => (
             <DropdownItem
               key={index}

--- a/lib/ui/dropdown-menu.tsx
+++ b/lib/ui/dropdown-menu.tsx
@@ -82,7 +82,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded px-3 py-2 text-base font-medium outline-none transition-colors after:absolute after:inset-x-1 after:inset-y-0 after:h-full after:rounded after:bg-f1-background-secondary after:opacity-0 after:transition-opacity after:duration-75 after:content-[''] hover:after:opacity-100 focus:after:opacity-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded px-3 py-2 text-base font-medium outline-none transition-colors after:absolute after:inset-x-1 after:inset-y-0 after:h-full after:rounded after:bg-f1-background-secondary after:opacity-0 after:transition-opacity after:duration-75 after:content-[''] first:pt-3 first:after:top-1 first:after:h-[calc(100%-0.25rem)] last:pb-3 last:after:bottom-1 last:after:h-[calc(100%-0.25rem)] hover:after:opacity-100 focus:after:opacity-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}

--- a/lib/ui/dropdown-menu.tsx
+++ b/lib/ui/dropdown-menu.tsx
@@ -82,7 +82,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded p-2 text-base font-medium outline-none transition-colors hover:bg-f1-background-secondary focus:bg-f1-background-secondary data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded px-3 py-2 text-base font-medium outline-none transition-colors after:absolute after:inset-x-1 after:inset-y-0 after:h-full after:rounded after:bg-f1-background-secondary after:opacity-0 after:transition-opacity after:duration-75 after:content-[''] hover:after:opacity-100 focus:after:opacity-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}

--- a/lib/ui/select.tsx
+++ b/lib/ui/select.tsx
@@ -76,7 +76,6 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          "py-1",
           position === "popper" &&
             "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
         )}
@@ -108,7 +107,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative grid w-full cursor-default select-none grid-cols-[1fr_20px] gap-x-1.5 rounded px-3 py-2 outline-none transition-colors after:absolute after:inset-x-1 after:inset-y-0 after:h-full after:rounded after:bg-f1-background-secondary after:opacity-0 after:transition-opacity after:duration-75 after:content-[''] hover:after:opacity-100 focus:after:bg-f1-background-hover focus:after:text-f1-foreground focus:after:opacity-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative grid w-full cursor-default select-none grid-cols-[1fr_20px] gap-x-1.5 rounded px-3 py-2 outline-none transition-colors after:absolute after:inset-x-1 after:inset-y-0 after:h-full after:rounded after:bg-f1-background-secondary after:opacity-0 after:transition-opacity after:duration-75 after:content-[''] first:pt-3 first:after:top-1 first:after:h-[calc(100%-0.25rem)] last:pb-3 last:after:bottom-1 last:after:h-[calc(100%-0.25rem)] hover:after:opacity-100 focus:after:bg-f1-background-hover focus:after:text-f1-foreground focus:after:opacity-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       "data-[state=checked]:after:bg-f1-background-selected-bold/10 data-[state=checked]:after:opacity-100 hover:data-[state=checked]:after:bg-f1-background-selected-bold/10 dark:data-[state=checked]:after:bg-f1-background-selected-bold/20 dark:hover:data-[state=checked]:after:bg-f1-background-selected-bold/20",
       className
     )}

--- a/lib/ui/select.tsx
+++ b/lib/ui/select.tsx
@@ -76,7 +76,7 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          "p-1",
+          "py-1",
           position === "popper" &&
             "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
         )}
@@ -108,8 +108,8 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative grid w-full cursor-default select-none grid-cols-[1fr_20px] gap-x-1.5 rounded p-2 outline-none transition-colors focus:bg-f1-background-hover focus:text-f1-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      "data-[state=checked]:bg-f1-background-selected-bold/10 hover:data-[state=checked]:bg-f1-background-selected-bold/10 dark:data-[state=checked]:bg-f1-background-selected-bold/20 dark:hover:data-[state=checked]:bg-f1-background-selected-bold/20",
+      "relative grid w-full cursor-default select-none grid-cols-[1fr_20px] gap-x-1.5 rounded px-3 py-2 outline-none transition-colors after:absolute after:inset-x-1 after:inset-y-0 after:h-full after:rounded after:bg-f1-background-secondary after:opacity-0 after:transition-opacity after:duration-75 after:content-[''] hover:after:opacity-100 focus:after:bg-f1-background-hover focus:after:text-f1-foreground focus:after:opacity-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "data-[state=checked]:after:bg-f1-background-selected-bold/10 data-[state=checked]:after:opacity-100 hover:data-[state=checked]:after:bg-f1-background-selected-bold/10 dark:data-[state=checked]:after:bg-f1-background-selected-bold/20 dark:hover:data-[state=checked]:after:bg-f1-background-selected-bold/20",
       className
     )}
     {...props}


### PR DESCRIPTION
## Description

_Here's a change that no one asked for and does not drive revenue, yay! But hey we are committed to quality._

This change extends the _hoverable_ zone of each item in a Select and Dropdown to cover the entire row, not just the visible hover background. This makes it easier to click on an item that you, as a user, are visually hovering over, even if you're not exactly on top of it.

_PS: Linear or MacOS use this trick, so if your cursor is on the dropdown, an item is focused, no matter if you're not exactly on top of it._

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/849138c3-47d0-41dd-9e41-1d5416260e8e)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other