### PR TITLE
Fix layout bg color and sidebar width

### DIFF
--- a/lib/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/lib/experimental/Navigation/ApplicationFrame/index.tsx
@@ -64,7 +64,7 @@ function ApplicationFrameContent({ children, sidebar }: ApplicationFrameProps) {
           <div
             className={cn(
               { "transition-all": !shouldReduceMotion },
-              sidebarState === "locked" ? "w-64 pl-3" : "w-0"
+              sidebarState === "locked" ? "w-[240px] shrink-0 pl-3" : "w-0"
             )}
           >
             {sidebar}

--- a/lib/experimental/Navigation/Sidebar/Sidebar.tsx
+++ b/lib/experimental/Navigation/Sidebar/Sidebar.tsx
@@ -42,7 +42,7 @@ export function Sidebar({ header, body, footer }: SidebarProps) {
     <motion.div
       initial={false}
       className={cn(
-        "absolute bottom-0 left-0 top-0 z-10 flex w-64 flex-col transition-[background-color]",
+        "absolute bottom-0 left-0 top-0 z-10 flex w-[240px] flex-col transition-[background-color]",
         sidebarState === "locked"
           ? "h-screen"
           : cn(

--- a/lib/lib/one-provider.tsx
+++ b/lib/lib/one-provider.tsx
@@ -47,7 +47,7 @@ export const LayoutProvider: React.FC<
         ref={ref}
         id="factorial-one-layout"
         className={cn({
-          "flex h-screen w-screen flex-col bg-f1-background-tertiary dark:bg-f1-background":
+          "flex h-screen w-screen flex-col bg-[#F5F6F8] dark:bg-[#0D1625]":
             fullScreen,
         })}
       >


### PR DESCRIPTION
## Description

Small fix for two things:

#### Background color
In Factorial, we use a Gamma color as the background, and when F1 is active, the provider also applies a background color. Since F1 grey colors have opacity, this background color blends with the Gamma color, making the background color darker than it should be.

I've set a solid color to our provider as a temporary solution. It doesn't have transparency, so the Gamma color won't be visible. Once Gamma is phased out, we can switch back to using a token.


#### Sidebar with
The sidebar width is 240px in Figma, but it was a bit larger in the code. I got fooled by Tailwind Intellisense (_dammit_), and the width I was applying was not 240px, but 256px. It's now set to 240px.

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
