### PR TITLE
Fix `main` content width

### DIFF
--- a/lib/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/lib/experimental/Navigation/ApplicationFrame/index.tsx
@@ -72,7 +72,7 @@ function ApplicationFrameContent({ children, sidebar }: ApplicationFrameProps) {
           <motion.main
             id="content"
             className={cn(
-              "flex max-w-full flex-1 xs:py-1 xs:pr-1",
+              "flex max-w-full flex-1 overflow-auto xs:py-1 xs:pr-1",
               sidebarState === "locked" ? "pl-0" : "xs:pl-1"
             )}
             layout


### PR DESCRIPTION
## Description

The width of the page container needs to be constrained somehow, or otherwise it overlaps the sidebar. This fixes it.

## Screenshots (if applicable)

*None*

### Figma Link

*None*

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other
