### PR TITLE
Make blur from private box more restrictive

### DIFF
--- a/lib/experimental/Utilities/PrivateBox/index.tsx
+++ b/lib/experimental/Utilities/PrivateBox/index.tsx
@@ -5,5 +5,12 @@ import { FC, PropsWithChildren } from "react"
 export const PrivateBox: FC<PropsWithChildren> = ({ children }) => {
   const { enabled } = usePrivacyMode()
 
-  return <div className={cn(enabled && "blur-md", "inline")}>{children}</div>
+  return (
+    <div
+      className={cn(enabled && "select-none blur-sm", "inline")}
+      aria-hidden={enabled}
+    >
+      {children}
+    </div>
+  )
 }


### PR DESCRIPTION
## Description

Make blur from private box more restrictive.

- Ensure that we do not "expose" information to screen readers.
- Do not allow text selection when that's enabled.
- Make blur a little less aggressive.