### PR TITLE
Add cursor pointer to link items in `Dropdown`

### DIFF
--- a/lib/experimental/Navigation/Dropdown/index.tsx
+++ b/lib/experimental/Navigation/Dropdown/index.tsx
@@ -66,15 +66,14 @@ const DropdownItem = ({ item }: { item: DropdownItem }) => {
   )
 
   return (
-    <DropdownMenuItem
-      asChild
-      onClick={item.onClick}
-      className={cn(itemClass, item.href && "hover:cursor-pointer")}
-    >
+    <DropdownMenuItem asChild onClick={item.onClick} className={itemClass}>
       {item.href ? (
         <Link
           href={item.href}
-          className={cn(itemClass, "text-f1-foreground no-underline")}
+          className={cn(
+            itemClass,
+            "text-f1-foreground no-underline hover:cursor-pointer"
+          )}
           {...props}
         >
           {content}

--- a/lib/experimental/Navigation/Dropdown/index.tsx
+++ b/lib/experimental/Navigation/Dropdown/index.tsx
@@ -66,7 +66,11 @@ const DropdownItem = ({ item }: { item: DropdownItem }) => {
   )
 
   return (
-    <DropdownMenuItem asChild onClick={item.onClick} className={itemClass}>
+    <DropdownMenuItem
+      asChild
+      onClick={item.onClick}
+      className={cn(itemClass, item.href && "hover:cursor-pointer")}
+    >
       {item.href ? (
         <Link
           href={item.href}


### PR DESCRIPTION
## Description

Shows a pointer cursor when hovering an item that is a link in `Dropdown`.

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
