### PR TITLE
Update privacy area styling

### DIFF
--- a/lib/components/Charts/AreaChart/index.tsx
+++ b/lib/components/Charts/AreaChart/index.tsx
@@ -1,5 +1,4 @@
 import { usePrivacyMode } from "@/lib/privacyMode"
-import { cn } from "@/lib/utils"
 import {
   ChartContainer,
   ChartLegend,
@@ -183,11 +182,14 @@ export const BaseAreaChart = <K extends LineChartConfig>(
             axisLine={false}
             tickMargin={8}
             tickCount={yAxis?.tickCount}
-            tickFormatter={yAxis?.tickFormatter}
+            tickFormatter={
+              canBeBlurred && privacyModeEnabled
+                ? () => "**"
+                : yAxis?.tickFormatter
+            }
             ticks={yAxis?.ticks}
             domain={yAxis?.domain}
             width={yAxisWidth}
-            className={cn(canBeBlurred && privacyModeEnabled && "blur-md")}
           />
         )}
         {showTooltip && (

--- a/lib/experimental/Utilities/PrivateBox/index.tsx
+++ b/lib/experimental/Utilities/PrivateBox/index.tsx
@@ -5,5 +5,15 @@ import { FC, PropsWithChildren } from "react"
 export const PrivateBox: FC<PropsWithChildren> = ({ children }) => {
   const { enabled } = usePrivacyMode()
 
-  return <div className={cn(enabled && "blur-md", "inline")}>{children}</div>
+  return (
+    <div
+      className={cn(
+        "inline-flex",
+        enabled &&
+          "overflow-hidden rounded-sm ring-1 ring-inset ring-f1-border-secondary"
+      )}
+    >
+      <div className={cn(enabled && "opacity-30 blur")}>{children}</div>
+    </div>
+  )
 }

--- a/lib/experimental/Utilities/PrivateBox/index.tsx
+++ b/lib/experimental/Utilities/PrivateBox/index.tsx
@@ -1,5 +1,6 @@
 import { usePrivacyMode } from "@/lib/privacyMode"
 import { cn } from "@/lib/utils"
+import { motion } from "framer-motion"
 import { FC, PropsWithChildren } from "react"
 
 export const PrivateBox: FC<PropsWithChildren> = ({ children }) => {
@@ -8,13 +9,22 @@ export const PrivateBox: FC<PropsWithChildren> = ({ children }) => {
   return (
     <div
       className={cn(
-        "inline-flex",
+        "inline-flex ring-1 ring-inset ring-transparent transition-all duration-150",
         enabled &&
-          "select-none overflow-hidden rounded-sm ring-1 ring-inset ring-f1-border-secondary"
+          "select-none overflow-hidden rounded-sm ring-f1-border-secondary"
       )}
       aria-hidden={enabled}
     >
-      <div className={cn(enabled && "opacity-30 blur")}>{children}</div>
+      <motion.div
+        className="h-full w-full"
+        animate={{
+          opacity: enabled ? 0.3 : 1,
+          filter: enabled ? "blur(5px)" : "blur(0px)",
+        }}
+        transition={{ duration: 0.15 }}
+      >
+        {children}
+      </motion.div>
     </div>
   )
 }

--- a/lib/experimental/Utilities/PrivateBox/index.tsx
+++ b/lib/experimental/Utilities/PrivateBox/index.tsx
@@ -11,15 +11,15 @@ export const PrivateBox: FC<PropsWithChildren> = ({ children }) => {
       className={cn(
         "inline-flex ring-1 ring-inset ring-transparent transition-all duration-150",
         enabled &&
-          "select-none overflow-hidden rounded-sm ring-f1-border-secondary"
+          "select-none overflow-hidden rounded-sm bg-f1-background-tertiary ring-f1-border-secondary"
       )}
       aria-hidden={enabled}
     >
       <motion.div
         className="h-full w-full"
         animate={{
-          opacity: enabled ? 0.3 : 1,
-          filter: enabled ? "blur(5px)" : "blur(0px)",
+          opacity: enabled ? 0 : 1,
+          scale: enabled ? 0.95 : 1,
         }}
         transition={{ duration: 0.15 }}
       >


### PR DESCRIPTION
## Description

Makes the blur of a privacy area [a bit more contained](https://factorialteam.slack.com/archives/C07LQSJ5UQY/p1732876277064169?thread_ts=1732870097.350609&cid=C07LQSJ5UQY) in its area itself.

## Screenshots

https://github.com/user-attachments/assets/08c97230-a7fb-4022-a05d-85ae3ce9b3ee


---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
