### PR TITLE
Fix ModuleAvatar icon sizes

### DIFF
--- a/lib/experimental/Information/ModuleAvatar/index.tsx
+++ b/lib/experimental/Information/ModuleAvatar/index.tsx
@@ -22,8 +22,8 @@ const iconSizeVariants = cva(
   {
     variants: {
       size: {
-        sm: "h-3 w-3",
-        md: "h-4 w-4",
+        sm: "h-[14px] w-[14px]",
+        md: "h-[18px] w-[18px]",
         lg: "h-6 w-6",
       },
     },


### PR DESCRIPTION
## Description

Icons in the `ModuleAvatar` component look a bit small. This PR changes the size of the `sm` and `md` size icons to look a bit larger.

_PS: The values in Figma are also arbitrary. It's a pretty special case, so let's just use them here._

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
