### PR TITLE
Truncate user name

### DIFF
--- a/lib/experimental/Navigation/Sidebar/User/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/User/index.tsx
@@ -32,7 +32,7 @@ export function User({ firstName, lastName, avatarUrl, options }: UserProps) {
             lastName={lastName}
             size="xsmall"
           />
-          <span className="text-f1-foreground">
+          <span className="min-w-0 truncate text-f1-foreground">
             {firstName} {lastName}
           </span>
         </button>


### PR DESCRIPTION
## Description

Truncate the user name in the sidebar, so if it is large enough, it will show an ellipsis.

## Screenshots

<img width="531" alt="image" src="https://github.com/user-attachments/assets/b6e92abe-d49d-4cea-8c45-39035b638601">

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
