### PR TITLE
Force color on header text

### DIFF
--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -79,7 +79,9 @@ export function PageHeader({
           {breadcrumbsTree.length > 1 ? (
             <Breadcrumbs breadcrumbs={breadcrumbsTree} />
           ) : (
-            <div className="text-xl font-semibold">{module.name}</div>
+            <div className="text-xl font-semibold text-f1-foreground">
+              {module.name}
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Description

Force the token `foreground` to the text on the page header, so it takes that color instead of the default Gamma one.

## Screenshots

<img width="239" alt="image" src="https://github.com/user-attachments/assets/4a52e711-a8cf-4a22-ac1f-58fa49f68ebf">

_This is how it is looking now, with a grey Gamma color._

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other