### PR TITLE
new Carousel for widget strip

### DIFF
--- a/lib/experimental/Navigation/Carousel/index.stories.tsx
+++ b/lib/experimental/Navigation/Carousel/index.stories.tsx
@@ -1,3 +1,6 @@
+import { BarChartProps } from "@/components/Charts/BarChart"
+import BarChartStory from "@/components/Charts/BarChart/index.stories"
+import { BarChartWidget } from "@/experimental/Widgets/Charts/BarChartWidget"
 import { Placeholder } from "@/lib/storybook-utils/placeholder"
 import { Meta, StoryObj } from "@storybook/react"
 import { Carousel } from "."
@@ -22,6 +25,21 @@ const SLIDES = Array.from({ length: 6 }, (_, i) => (
     Slide {i + 1}
   </Placeholder>
 ))
+
+const randomClasses = ["h-64", "h-full", "h-32", "w-32", "w-full", "w-64"]
+
+const SLIDES_RANDOM = [
+  <BarChartWidget key="widget" chart={BarChartStory.args as BarChartProps} />,
+  ...Array.from({ length: 6 }, (_, i) => {
+    const randomHeight = randomClasses[Math.floor(i / 2)]
+    const randomWidth = randomClasses[Math.floor(i / 2) + 3]
+    return (
+      <Placeholder key={i + 1} className={`${randomHeight} ${randomWidth}`}>
+        Slide {i + 1} ({randomHeight} {randomWidth})
+      </Placeholder>
+    )
+  }),
+]
 
 export const Default: Story = {
   decorators: [
@@ -162,5 +180,32 @@ export const FadeEdges: Story = {
       md: 3,
       lg: 3,
     },
+  },
+}
+
+/**
+ * auto columns
+ */
+export const AutoColumns: Story = {
+  decorators: [
+    (Story) => (
+      <div className="h-full w-full p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+    showFade: { control: "boolean" },
+  },
+  args: {
+    showArrows: true,
+    children: SLIDES_RANDOM,
+    showFade: true,
+    showPeek: true,
+    showDots: false,
   },
 }

--- a/lib/experimental/Navigation/Carousel/index.stories.tsx
+++ b/lib/experimental/Navigation/Carousel/index.stories.tsx
@@ -4,11 +4,12 @@ import { Carousel } from "."
 
 const meta: Meta<typeof Carousel> = {
   component: Carousel,
-  parameters: {
-    layout: "fullscreen",
-  },
   argTypes: {
     autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+    showFade: { control: "boolean" },
   },
 }
 
@@ -24,31 +25,52 @@ const SLIDES = Array.from({ length: 6 }, (_, i) => (
 
 export const Default: Story = {
   decorators: [
-    (Story) => (
+    (Story, args) => (
       <div className="w-full p-6">
-        <Story />
+        <Story {...args} />
       </div>
     ),
   ],
   argTypes: {
-    autoplay: { table: { disable: true } },
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+    showFade: { control: "boolean" },
   },
   args: {
     autoplay: false,
+    showArrows: true,
+    showDots: true,
+    showPeek: false,
+    showFade: false,
     children: SLIDES,
   },
 }
 
+/**
+ * `columns`: An object specifying the number of columns to display at different breakpoints:
+ *   - `xs`: Number of columns for extra small screens. Default is `2`.
+ *   - `sm`: Number of columns for small screens. Default is `3`.
+ *   - `md`: Number of columns for medium screens. Default is `4`.
+ *   - `lg`: Number of columns for large screens. Default is `6`.
+ *
+ * Try to **resize the window** to see the number of columns change.
+ */
 export const CustomColumns: Story = {
   decorators: [
-    (Story) => (
+    (Story, args) => (
       <div className="w-full p-6">
-        <Story />
+        <Story {...args} />
       </div>
     ),
   ],
   argTypes: {
-    autoplay: { table: { disable: true } },
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+    showFade: { control: "boolean" },
   },
   args: {
     autoplay: false,
@@ -62,6 +84,9 @@ export const CustomColumns: Story = {
   },
 }
 
+/**
+ * `autoplay`: Whether to automatically scroll through the slides. Default is `false`.
+ */
 export const AutoScroll: Story = {
   decorators: [
     (Story) => (
@@ -70,6 +95,13 @@ export const AutoScroll: Story = {
       </div>
     ),
   ],
+  argTypes: {
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+    showFade: { control: "boolean" },
+  },
   args: {
     autoplay: true,
     delay: 3000,
@@ -77,6 +109,9 @@ export const AutoScroll: Story = {
   },
 }
 
+/**
+ * `sneakPeek`: Whether to show a peek of the next slide. Default is `false`.
+ */
 export const SneakPeek: Story = {
   decorators: [
     (Story) => (
@@ -85,9 +120,47 @@ export const SneakPeek: Story = {
       </div>
     ),
   ],
+  argTypes: {
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+    showFade: { control: "boolean" },
+  },
   args: {
     showArrows: false,
     children: SLIDES,
     showPeek: true,
+  },
+}
+
+/**
+ * `showFade`: Whether to fade the edges of the carousel. Default is `false`.
+ */
+export const FadeEdges: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-full p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+    showFade: { control: "boolean" },
+  },
+  args: {
+    showArrows: true,
+    children: SLIDES,
+    showFade: true,
+    columns: {
+      xs: 2,
+      sm: 2,
+      md: 3,
+      lg: 3,
+    },
   },
 }

--- a/lib/experimental/Navigation/Carousel/index.stories.tsx
+++ b/lib/experimental/Navigation/Carousel/index.stories.tsx
@@ -26,7 +26,7 @@ const SLIDES = Array.from({ length: 6 }, (_, i) => (
   </Placeholder>
 ))
 
-const randomClasses = ["h-64", "h-full", "h-32", "w-32", "w-full", "w-64"]
+const randomClasses = ["h-full", "h-64", "h-32", "w-32", "w-full", "w-64"]
 
 const SLIDES_RANDOM = [
   <BarChartWidget key="widget" chart={BarChartStory.args as BarChartProps} />,

--- a/lib/experimental/Navigation/Carousel/index.tsx
+++ b/lib/experimental/Navigation/Carousel/index.tsx
@@ -73,7 +73,7 @@ export const Carousel = ({
       onMouseEnter={autoplay ? handleMouseEnter : undefined}
       onMouseLeave={autoplay ? handleMouseLeave : undefined}
     >
-      <div className="flex flex-col gap-3">
+      <div className="flex h-full flex-col gap-3">
         <div className="relative">
           <CarouselContent showFade={showFade}>
             {React.Children.map(childrenArray, (child, index) => (

--- a/lib/experimental/Navigation/Carousel/index.tsx
+++ b/lib/experimental/Navigation/Carousel/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/ui/carousel"
 import Autoplay from "embla-carousel-autoplay"
 import { WheelGesturesPlugin } from "embla-carousel-wheel-gestures"
-import React from "react"
+import React, { useMemo } from "react"
 import {
   type CarouselBreakpoints,
   carouselItemVariants,
@@ -24,6 +24,7 @@ interface CarouselProps {
   delay?: number
   columns?: CarouselBreakpoints
   showPeek?: boolean
+  showFade?: boolean
 }
 
 export const Carousel = ({
@@ -34,22 +35,23 @@ export const Carousel = ({
   delay = 3000,
   columns = { default: 1 },
   showPeek = false,
+  showFade = false,
 }: CarouselProps) => {
   const childrenArray = React.Children.toArray(children)
 
-  const plugin = React.useRef(
-    autoplay ? Autoplay({ delay: delay, stopOnInteraction: true }) : undefined
-  )
+  const plugin = useMemo(() => {
+    return autoplay ? Autoplay({ delay, stopOnInteraction: true }) : undefined
+  }, [autoplay, delay])
 
   const handleMouseEnter = () => {
-    if (plugin.current) {
-      plugin.current.stop()
+    if (plugin) {
+      plugin.stop()
     }
   }
 
   const handleMouseLeave = () => {
-    if (plugin.current) {
-      plugin.current.play()
+    if (plugin) {
+      plugin.play()
     }
   }
 
@@ -64,18 +66,16 @@ export const Carousel = ({
     <ShadCarousel
       className="flex flex-col gap-3"
       opts={{
-        align: "center",
-        slidesToScroll: "auto",
-        duration: 20,
-        containScroll: false,
+        align: "start",
+        slidesToScroll: 1,
       }}
-      plugins={[plugin.current, WheelGesturesPlugin()].filter(Boolean)}
+      plugins={[plugin, WheelGesturesPlugin()].filter(Boolean)}
       onMouseEnter={autoplay ? handleMouseEnter : undefined}
       onMouseLeave={autoplay ? handleMouseLeave : undefined}
     >
       <div className="flex flex-col gap-3">
         <div className="relative">
-          <CarouselContent>
+          <CarouselContent showFade={showFade}>
             {React.Children.map(childrenArray, (child, index) => (
               <CarouselItem
                 key={index}

--- a/lib/experimental/Navigation/DynamicCarousel/index.stories.tsx
+++ b/lib/experimental/Navigation/DynamicCarousel/index.stories.tsx
@@ -1,0 +1,43 @@
+import { BarChartProps } from "@/components/Charts/BarChart"
+import BarChartStory from "@/components/Charts/BarChart/index.stories"
+import { BarChartWidget } from "@/experimental/Widgets/Charts/BarChartWidget"
+import { Placeholder } from "@/lib/storybook-utils/placeholder"
+import { Meta, StoryObj } from "@storybook/react"
+import { DynamicCarousel } from "."
+
+const meta: Meta<typeof DynamicCarousel> = {
+  component: DynamicCarousel,
+}
+
+export default meta
+
+type Story = StoryObj<typeof DynamicCarousel>
+
+const randomClasses = ["h-full", "h-64", "h-32", "w-32", "w-full", "w-64"]
+
+const SLIDES_RANDOM = [
+  <BarChartWidget key="widget" chart={BarChartStory.args as BarChartProps} />,
+  <BarChartWidget key="widget" chart={BarChartStory.args as BarChartProps} />,
+  ...Array.from({ length: 6 }, (_, i) => {
+    const randomHeight = randomClasses[Math.floor(i / 2)]
+    const randomWidth = randomClasses[Math.floor(i / 2) + 3]
+    return (
+      <Placeholder key={i + 1} className={`${randomHeight} ${randomWidth}`}>
+        Slide {i + 1} ({randomHeight} {randomWidth})
+      </Placeholder>
+    )
+  }),
+]
+
+export const Default: Story = {
+  decorators: [
+    (Story, args) => (
+      <div className="w-full p-6">
+        <Story {...args} />
+      </div>
+    ),
+  ],
+  args: {
+    children: SLIDES_RANDOM,
+  },
+}

--- a/lib/experimental/Navigation/DynamicCarousel/index.tsx
+++ b/lib/experimental/Navigation/DynamicCarousel/index.tsx
@@ -1,0 +1,172 @@
+import { Icon } from "@/factorial-one"
+import { ArrowLeft, ArrowRight } from "@/icons/app"
+import { cn } from "@/lib/utils"
+import { Button } from "@/ui/button"
+import { PropsWithChildren, useEffect, useRef, useState } from "react"
+
+export const DynamicCarousel = ({ children }: PropsWithChildren) => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const [canScrollNext, setCanScrollNext] = useState(true)
+  const [canScrollPrev, setCanScrollPrev] = useState(false)
+
+  const scrollToNextItem = (direction: "left" | "right") => {
+    if (scrollContainerRef.current) {
+      const container = scrollContainerRef.current
+      const { scrollLeft } = container
+
+      if (direction === "right") {
+        const nextItem = Array.from(container.children).find((child) => {
+          const childLeft = (child as HTMLElement).offsetLeft
+          return childLeft - 28 > scrollLeft
+        })
+        if (nextItem) {
+          container.scrollTo({
+            left: (nextItem as HTMLElement).offsetLeft - 28,
+            behavior: "smooth",
+          })
+        }
+      } else {
+        const previousItem = Array.from(container.children)
+          .reverse()
+          .find((child) => {
+            const childRight =
+              (child as HTMLElement).offsetLeft +
+              (child as HTMLElement).offsetWidth
+            return childRight < scrollLeft
+          })
+        if (previousItem) {
+          container.scrollTo({
+            left: (previousItem as HTMLElement).offsetLeft - 28,
+            behavior: "smooth",
+          })
+        }
+      }
+    }
+  }
+
+  const updateScrollState = () => {
+    if (scrollContainerRef.current) {
+      const { scrollLeft, scrollWidth, clientWidth } =
+        scrollContainerRef.current
+      setCanScrollPrev(scrollLeft > 0)
+      setCanScrollNext(scrollLeft + clientWidth < scrollWidth)
+    }
+  }
+
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (container) {
+      container.addEventListener("scroll", updateScrollState)
+      updateScrollState()
+    }
+    return () => {
+      if (container) {
+        container.removeEventListener("scroll", updateScrollState)
+      }
+    }
+  }, [])
+
+  return (
+    <div className="relative">
+      <div
+        ref={scrollContainerRef}
+        className="relative flex gap-4 overflow-x-auto overflow-y-visible scroll-smooth"
+        style={{
+          scrollbarWidth: "none", // Para Firefox
+          msOverflowStyle: "none", // Para IE y Edge
+          margin: "-28px",
+          padding: "28px",
+          height: "calc(100% + 56px)",
+          width: "calc(100% + 56px)",
+        }}
+      >
+        <style>
+          {`
+              /* Para ocultar scrollbar en Chrome, Safari y Edge */
+              .no-scrollbar::-webkit-scrollbar {
+                display: none;
+              }
+            `}
+        </style>
+        {Array.isArray(children)
+          ? children.map((child, index) => (
+              <div
+                key={index}
+                className="flex-shrink-0"
+                style={{ scrollSnapAlign: "start" }}
+              >
+                {child}
+              </div>
+            ))
+          : children && (
+              <div
+                className="flex-shrink-0"
+                style={{ scrollSnapAlign: "start" }}
+              >
+                {children}
+              </div>
+            )}
+      </div>
+
+      {/* Gradientes dinámicos para los bordes */}
+      {canScrollPrev && (
+        <div
+          className={cn(
+            "w-[60px]",
+            "absolute",
+            "h-full",
+            "top-0",
+            "left-[-28px]",
+            "bg-gradient-to-l from-transparent from-0% to-f1-background to-100%"
+          )}
+        ></div>
+      )}
+      {canScrollNext && (
+        <div
+          className={cn(
+            "w-[60px]",
+            "absolute",
+            "h-full",
+            "top-0",
+            "right-[-28px]",
+            "bg-gradient-to-r from-transparent from-0% to-f1-background to-100%"
+          )}
+        ></div>
+      )}
+
+      {/* Botón Izquierdo dinámico */}
+      {canScrollPrev && (
+        <Button
+          size="sm"
+          variant={"outline"}
+          round
+          className={cn(
+            "absolute opacity-100 transition-all",
+            "-left-3 top-1/2 -translate-y-1/2"
+          )}
+          onClick={() => scrollToNextItem("left")}
+        >
+          <Icon size="sm" icon={ArrowLeft} />
+          <span className="sr-only">Previous</span>
+        </Button>
+      )}
+
+      {/* Botón Derecho dinámico */}
+      {canScrollNext && (
+        <Button
+          size="sm"
+          variant={"outline"}
+          round
+          className={cn(
+            "absolute opacity-100 transition-all",
+            "-right-3 top-1/2 -translate-y-1/2"
+          )}
+          onClick={() => scrollToNextItem("right")}
+        >
+          <Icon size="sm" icon={ArrowRight} />
+          <span className="sr-only">Next</span>
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/lib/experimental/Navigation/DynamicCarousel/types.ts
+++ b/lib/experimental/Navigation/DynamicCarousel/types.ts
@@ -1,0 +1,84 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+export type ColumnNumber = 1 | 2 | 3 | 4 | 6
+export type PeekVariant = `peek${ColumnNumber}`
+
+export interface CarouselBreakpoints {
+  default?: ColumnNumber
+  xs?: ColumnNumber
+  sm?: ColumnNumber
+  md?: ColumnNumber
+  lg?: ColumnNumber
+}
+
+export const carouselItemVariants = cva("", {
+  variants: {
+    peek: { true: "", false: "" },
+    default: {
+      1: "basis-full",
+      2: "basis-1/2",
+      3: "basis-1/3",
+      4: "basis-1/4",
+      6: "basis-1/6",
+      peek1: "basis-[85%]",
+      peek2: "basis-[48%]",
+      peek3: "basis-[32%]",
+      peek4: "basis-[24%]",
+      peek6: "basis-[16%]",
+    },
+    xs: {
+      1: "xs:basis-full",
+      2: "xs:basis-1/2",
+      3: "xs:basis-1/3",
+      4: "xs:basis-1/4",
+      6: "xs:basis-1/6",
+      peek1: "xs:basis-[85%]",
+      peek2: "xs:basis-[48%]",
+      peek3: "xs:basis-[32%]",
+      peek4: "xs:basis-[24%]",
+      peek6: "xs:basis-[16%]",
+    },
+    sm: {
+      1: "sm:basis-full",
+      2: "sm:basis-1/2",
+      3: "sm:basis-1/3",
+      4: "sm:basis-1/4",
+      6: "sm:basis-1/6",
+      peek1: "sm:basis-[85%]",
+      peek2: "sm:basis-[48%]",
+      peek3: "sm:basis-[32%]",
+      peek4: "sm:basis-[24%]",
+      peek6: "sm:basis-[16%]",
+    },
+    md: {
+      1: "md:basis-full",
+      2: "md:basis-1/2",
+      3: "md:basis-1/3",
+      4: "md:basis-1/4",
+      6: "md:basis-1/6",
+      peek1: "md:basis-[85%]",
+      peek2: "md:basis-[48%]",
+      peek3: "md:basis-[32%]",
+      peek4: "md:basis-[24%]",
+      peek6: "md:basis-[16%]",
+    },
+    lg: {
+      1: "lg:basis-full",
+      2: "lg:basis-1/2",
+      3: "lg:basis-1/3",
+      4: "lg:basis-1/4",
+      6: "lg:basis-1/6",
+      peek1: "lg:basis-[85%]",
+      peek2: "lg:basis-[48%]",
+      peek3: "lg:basis-[32%]",
+      peek4: "lg:basis-[24%]",
+      peek6: "lg:basis-[16%]",
+    },
+  },
+  defaultVariants: {
+    peek: false,
+    default: 1,
+  },
+})
+
+export type CarouselItemVariants = VariantProps<typeof carouselItemVariants>

--- a/lib/experimental/Widgets/Charts/ChartContainer.tsx
+++ b/lib/experimental/Widgets/Charts/ChartContainer.tsx
@@ -17,7 +17,7 @@ export const ChartContainer = Object.assign(
   >(function ChartContainer({ chart, summaries, ...props }, ref) {
     return (
       <Widget ref={ref} {...props} summaries={summaries}>
-        {chart && <div className="min-h-52 grow pt-2">{chart}</div>}
+        {chart && <div className="min-h-52 min-w-52 grow pt-2">{chart}</div>}
       </Widget>
     )
   }),

--- a/lib/experimental/Widgets/Widget/index.tsx
+++ b/lib/experimental/Widgets/Widget/index.tsx
@@ -82,7 +82,10 @@ const Container = forwardRef<
   }
 
   return (
-    <Card className="relative flex gap-4 border-f1-border-secondary" ref={ref}>
+    <Card
+      className="relative flex h-full gap-4 border-f1-border-secondary"
+      ref={ref}
+    >
       {header && (
         <CardHeader className="-mr-1 -mt-1">
           <div className="flex w-full flex-1 flex-col gap-4">
@@ -138,7 +141,7 @@ const Container = forwardRef<
           </div>
         </CardHeader>
       )}
-      <CardContent className="flex flex-col gap-4">
+      <CardContent className="flex h-full flex-col gap-4">
         {summaries && (
           <div className="flex flex-row">
             {summaries.map((summary, index) => (

--- a/lib/ui/carousel.tsx
+++ b/lib/ui/carousel.tsx
@@ -282,7 +282,7 @@ const CarouselNext = React.forwardRef<
       {...props}
     >
       <Icon size="sm" icon={ArrowRight} />
-      <span className="sr-only">Mext</span>
+      <span className="sr-only">Next</span>
     </Button>
   )
 })

--- a/lib/ui/carousel.tsx
+++ b/lib/ui/carousel.tsx
@@ -153,22 +153,53 @@ Carousel.displayName = "Carousel"
 
 const CarouselContent = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => {
-  const { carouselRef, orientation } = useCarousel()
+  React.HTMLAttributes<HTMLDivElement> & { showFade: boolean }
+>(({ className, showFade, ...props }, ref) => {
+  const { carouselRef, orientation, canScrollNext, canScrollPrev } =
+    useCarousel()
 
   return (
-    <div ref={carouselRef} className="overflow-hidden">
-      <div
-        ref={ref}
-        className={cn(
-          "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
-          className
-        )}
-        {...props}
-      />
-    </div>
+    <>
+      <div ref={carouselRef} className="overflow-hidden">
+        <div
+          ref={ref}
+          className={cn(
+            "flex",
+            orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+            className
+          )}
+          {...props}
+        />
+      </div>
+      {showFade && canScrollPrev && (
+        <div
+          className={cn(
+            "w-[60px]",
+            "absolute",
+            "h-full",
+            "top-0",
+            "left-0",
+            orientation === "horizontal"
+              ? "bg-gradient-to-l from-transparent from-0% to-f1-background to-100%"
+              : "bg-gradient-to-t from-transparent from-0% to-f1-background to-100%"
+          )}
+        ></div>
+      )}
+      {showFade && canScrollNext && (
+        <div
+          className={cn(
+            "w-[60px]",
+            "absolute",
+            "h-full",
+            "top-0",
+            "right-0",
+            orientation === "horizontal"
+              ? "bg-gradient-to-r from-transparent from-0% to-f1-background to-100%"
+              : "bg-gradient-to-b from-transparent from-0% to-f1-background to-100%"
+          )}
+        ></div>
+      )}
+    </>
   )
 })
 CarouselContent.displayName = "CarouselContent"


### PR DESCRIPTION
## Description
Improve Carousel component.
This component is need it for new Finance Overview. We can't use Dashboard, as we want to classify widgets per sections, So we want to use N widgetStrips. The problem is widgetStrip expands Widgets too fit all space. We don't want this behaviour. We need to have widgets responsive and let know the user that there are more widgets to see (with Arrow buttons)

## Screenshots

Simplified PR, just improving current Carousel

https://github.com/user-attachments/assets/8f2f606b-9c95-45b8-8218-2e7a11b73284


## Type of Change

- [] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other

**Responsiveness**

  - [x] Verified the component works across various screen sizes

**Testing**

  - [x] Component includes unit tests with sufficient coverage

**Accessibility**

  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
