### PR TITLE
Allow custom status tag

### DIFF
--- a/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -84,6 +84,21 @@ export const FirstLevelWithTagAndActions: Story = {
   },
 }
 
+const StatusTag = () => {
+  return <span>This is custom tag</span>
+}
+
+export const FirstLevelWithCustomTag: Story = {
+  args: {
+    module: {
+      name: "Documents",
+      href: "/documents",
+      icon: Recruitment,
+    },
+    statusTagComponent: <StatusTag />,
+  },
+}
+
 export const LongBreadcrumbs: Story = {
   args: {
     module: {

--- a/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -88,14 +88,14 @@ const StatusTag = () => {
   return <span>This is custom tag</span>
 }
 
-export const FirstLevelWithCustomTag: Story = {
+export const FirstLevelWithCustomStatus: Story = {
   args: {
     module: {
       name: "Documents",
       href: "/documents",
       icon: Recruitment,
     },
-    statusTagComponent: <StatusTag />,
+    statusComponent: <StatusTag />,
   },
 }
 

--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -24,7 +24,7 @@ type HeaderProps = {
     href: string
     icon: IconType
   }
-  statusTagComponent?: ReactElement
+  statusComponent?: ReactElement
   statusTag?: {
     text: string
     variant: StatusVariant
@@ -35,7 +35,7 @@ type HeaderProps = {
 
 export function PageHeader({
   module,
-  statusTagComponent,
+  statusComponent,
   statusTag = undefined,
   breadcrumbs = [],
   actions = [],
@@ -46,8 +46,8 @@ export function PageHeader({
     { label: module.name, href: module.href, icon: module.icon },
     ...breadcrumbs,
   ]
-  const [hasStatus, StatusTagComponent] = getStatusTagComponent({
-    statusTagComponent,
+  const [hasStatus, StatusComponent] = getStatusComponent({
+    statusComponent,
     statusTag,
   })
   const hasNavigation = breadcrumbs.length > 0
@@ -95,7 +95,7 @@ export function PageHeader({
       </div>
       <div className="flex items-center">
         {!hasNavigation && hasStatus && (
-          <div className="pe-3">{StatusTagComponent}</div>
+          <div className="pe-3">{StatusComponent}</div>
         )}
         {hasStatus && hasActions && (
           <div className="right-0 h-4 w-px bg-f1-border-secondary"></div>
@@ -124,15 +124,15 @@ function PageAction({ action }: { action: PageAction }) {
   )
 }
 
-const getStatusTagComponent = ({
-  statusTagComponent,
+const getStatusComponent = ({
+  statusComponent,
   statusTag,
-}: Pick<HeaderProps, "statusTagComponent" | "statusTag">):
+}: Pick<HeaderProps, "statusComponent" | "statusTag">):
   | [true, ReactElement]
   | [false, null] => {
   switch (true) {
-    case isValidElement(statusTagComponent):
-      return [true, statusTagComponent]
+    case isValidElement(statusComponent):
+      return [true, statusComponent]
     case statusTag !== undefined:
       return [
         true,

--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -136,7 +136,11 @@ const getStatusTagComponent = ({
     case statusTag !== undefined:
       return [
         true,
-        <StatusTag text={statusTag.text} variant={statusTag.variant} />,
+        <StatusTag
+          key={statusTag.text}
+          text={statusTag.text}
+          variant={statusTag.variant}
+        />,
       ]
     default:
       return [false, null]

--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -10,6 +10,7 @@ import Breadcrumbs, { type BreadcrumbItemType } from "../Breadcrumbs"
 
 import { ModuleAvatar } from "@/experimental/Information/ModuleAvatar"
 import { Link } from "@/lib/linkHandler"
+import { ReactElement, isValidElement } from "react"
 
 export type PageAction = {
   label: string
@@ -23,6 +24,7 @@ type HeaderProps = {
     href: string
     icon: IconType
   }
+  statusTagComponent?: ReactElement
   statusTag?: {
     text: string
     variant: StatusVariant
@@ -33,6 +35,7 @@ type HeaderProps = {
 
 export function PageHeader({
   module,
+  statusTagComponent,
   statusTag = undefined,
   breadcrumbs = [],
   actions = [],
@@ -43,8 +46,10 @@ export function PageHeader({
     { label: module.name, href: module.href, icon: module.icon },
     ...breadcrumbs,
   ]
-
-  const hasStatus = statusTag && Object.keys(statusTag).length !== 0
+  const [hasStatus, StatusTagComponent] = getStatusTagComponent({
+    statusTagComponent,
+    statusTag,
+  })
   const hasNavigation = breadcrumbs.length > 0
   const hasActions = actions.length > 0
 
@@ -90,9 +95,7 @@ export function PageHeader({
       </div>
       <div className="flex items-center">
         {!hasNavigation && hasStatus && (
-          <div className="pe-3">
-            <StatusTag text={statusTag.text} variant={statusTag.variant} />
-          </div>
+          <div className="pe-3">{StatusTagComponent}</div>
         )}
         {hasStatus && hasActions && (
           <div className="right-0 h-4 w-px bg-f1-border-secondary"></div>
@@ -119,4 +122,23 @@ function PageAction({ action }: { action: PageAction }) {
       <Icon icon={action.icon} size="md" />
     </Link>
   )
+}
+
+const getStatusTagComponent = ({
+  statusTagComponent,
+  statusTag,
+}: Pick<HeaderProps, "statusTagComponent" | "statusTag">):
+  | [true, ReactElement]
+  | [false, null] => {
+  switch (true) {
+    case isValidElement(statusTagComponent):
+      return [true, statusTagComponent]
+    case statusTag !== undefined:
+      return [
+        true,
+        <StatusTag text={statusTag.text} variant={statusTag.variant} />,
+      ]
+    default:
+      return [false, null]
+  }
 }


### PR DESCRIPTION
## Description

Allows users to provide custom component to render in the status. 

This is needed because the status is a value that can come not only from the graphQL, or be static, but rather after some calculation in React. In this approach users can reach hooks and provide us the status component based on it.

## API

```tsx
<PageHeader module={{
      name: "Documents",
      href: "/documents",
      icon: Recruitment,
    }} 
    statusTagComponent={<StatusTag />}
/>
```

## Screenshots (if applicable)

![CleanShot 2024-12-02 at 17 32 52@2x](https://github.com/user-attachments/assets/658176d6-7da9-4d1b-8422-16a810b10924)
