### PR TITLE
Fix secondary tabs bg color

### DIFF
--- a/lib/ui/tab-navigation.tsx
+++ b/lib/ui/tab-navigation.tsx
@@ -29,7 +29,7 @@ const tabNavigationVariants = cva(
   {
     variants: {
       secondary: {
-        true: "bg-f1-background-secondary/25 dark:bg-f1-foreground/[.02]",
+        true: "bg-f1-foreground/[.02] dark:bg-f1-foreground/[.02]",
         false: "bg-f1-background-transparent pt-1",
       },
     },


### PR DESCRIPTION
## Description

Quick fix of the background color of secondary tabs. This is a temporal fix until we decide the token for it.

## Screenshots

![image](https://github.com/user-attachments/assets/433c70ff-5c3e-44fe-872b-b2ac15bebee0)

_Before_

<img width="345" alt="image" src="https://github.com/user-attachments/assets/231bb8ac-8ad8-4419-8cb0-45443978cac5">

_After_

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other