### PR TITLE
Allow subitems on page header actions

### DIFF
--- a/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -33,7 +33,16 @@ export const Default: Story = {
       {
         label: "More options",
         icon: EllipsisHorizontal,
-        href: "/recruitment/settings",
+        actions: [
+          {
+            label: "Profile",
+            href: "/recruitment/profile",
+          },
+          {
+            label: "Whatever",
+            href: "/whatever",
+          },
+        ],
       },
     ],
   },

--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -10,13 +10,21 @@ import Breadcrumbs, { type BreadcrumbItemType } from "../Breadcrumbs"
 
 import { ModuleAvatar } from "@/experimental/Information/ModuleAvatar"
 import { Link } from "@/lib/linkHandler"
+import { cva } from "class-variance-authority"
 import { ReactElement, isValidElement } from "react"
+import { Dropdown } from "../../Dropdown"
 
 export type PageAction = {
   label: string
   icon: IconType
-  href: string
-}
+} & (
+  | {
+      href: string
+    }
+  | {
+      actions: Array<{ label: string; href: string }>
+    }
+)
 
 type HeaderProps = {
   module: {
@@ -112,12 +120,26 @@ export function PageHeader({
   )
 }
 
-function PageAction({ action }: { action: PageAction }) {
+const pageActionButtonVariants = cva(
+  "inline-flex aspect-square h-8 items-center justify-center rounded border border-solid border-f1-border bg-f1-background-inverse-secondary px-0 text-f1-foreground hover:border-f1-border-hover"
+)
+
+function PageAction({ action }: { action: PageAction }): ReactElement {
+  if ("actions" in action) {
+    return (
+      <Dropdown items={action.actions}>
+        <button title={action.label} className={pageActionButtonVariants()}>
+          <Icon icon={action.icon} size="md" />
+        </button>
+      </Dropdown>
+    )
+  }
+
   return (
     <Link
       href={action.href}
       title={action.label}
-      className="inline-flex aspect-square h-8 items-center justify-center rounded border border-solid border-f1-border bg-f1-background-inverse-secondary px-0 text-f1-foreground hover:border-f1-border-hover"
+      className={pageActionButtonVariants()}
     >
       <Icon icon={action.icon} size="md" />
     </Link>


### PR DESCRIPTION
## Description

Allows for items in the page's subnavigation.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/06cc2dc5-6d0e-4b25-abc7-f073b3fb1768)

### Figma Link

*None*

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other