### PR TITLE
`StandardLayout`: sets min-height to 100%

### DIFF
--- a/lib/experimental/PageLayouts/StandardLayout/index.tsx
+++ b/lib/experimental/PageLayouts/StandardLayout/index.tsx
@@ -8,7 +8,7 @@ export interface StandardLayoutProps
 }
 
 const layoutVariants = cva(
-  "relative flex w-full flex-1 flex-col gap-4 place-self-center overflow-y-auto px-6 py-5",
+  "relative flex min-h-full w-full flex-col gap-4 place-self-center overflow-y-auto px-6 py-5",
   {
     variants: {
       variant: {


### PR DESCRIPTION
We have many pages that relies on "fill the rest of vertical space" behavior. One example is the employee activity page. 

However since StandardLayout is not a flex container (@sauldom102 do you recall why?) there is no way to fill all empty space, content only takes the the vertical space defined by its' intrinsic height. This produces a bug:

![CleanShot 2024-12-03 at 18 43 23@2x](https://github.com/user-attachments/assets/8c87e70d-55a6-4311-b6d6-c5338ec59fd4)


The fix is to allow the the StandartLayout to take all available space all the time.:
![CleanShot 2024-12-03 at 18 47 13@2x](https://github.com/user-attachments/assets/3ada8210-4e6c-4c99-a67f-b4089d792dce)

