### PR TITLE
neutral-balance-tag-plus-improve-tags-x-spacings-and-unify

### DIFF
--- a/lib/experimental/Information/Tags/BalanceTag/index.stories.tsx
+++ b/lib/experimental/Information/Tags/BalanceTag/index.stories.tsx
@@ -19,6 +19,12 @@ type Story = StoryObj<typeof meta>
 
 export const PositiveBalanceTag: Story = {}
 
+export const NeutralBalanceTag: Story = {
+  args: {
+    status: "neutral",
+  },
+}
+
 export const NegativeBalanceTag: Story = {
   args: {
     status: "negative",

--- a/lib/experimental/Information/Tags/BalanceTag/index.tsx
+++ b/lib/experimental/Information/Tags/BalanceTag/index.tsx
@@ -6,14 +6,14 @@ import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
 import { BaseTag } from "../BaseTag"
 
-type Status = "positive" | "negative"
+type Status = "positive" | "neutral" | "negative"
 
 interface Props {
   text: string
   status: Status
 }
 
-const iconMap: Record<Status, IconType> = {
+const iconMap: Record<Exclude<Status, "neutral">, IconType> = {
   positive: ArrowUp,
   negative: ArrowDown,
 }
@@ -26,23 +26,26 @@ export const BalanceTag = forwardRef<HTMLDivElement, Props>(
       <BaseTag
         ref={ref}
         className={cn(
-          "pl-1",
           {
             positive: "bg-f1-background-positive text-f1-foreground-positive",
+            neutral: "bg-f1-background-secondary text-f1-foreground-secondary",
             negative: "bg-f1-background-critical text-f1-foreground-critical",
           }[status]
         )}
         left={
-          <Icon
-            icon={iconMap[status]}
-            size="sm"
-            className={cn(
-              {
-                positive: "text-f1-icon-positive",
-                negative: "text-f1-icon-critical",
-              }[status]
-            )}
-          />
+          status === "neutral" ? null : (
+            <Icon
+              icon={iconMap[status]}
+              size="sm"
+              className={cn(
+                {
+                  positive: "text-f1-icon-positive",
+                  neutral: "text-f1-icon-secondary",
+                  negative: "text-f1-icon-critical",
+                }[status]
+              )}
+            />
+          )
         }
         additionalAccesibleText={`${status} balance`}
         text={text}

--- a/lib/experimental/Information/Tags/BaseTag/index.tsx
+++ b/lib/experimental/Information/Tags/BaseTag/index.tsx
@@ -14,8 +14,9 @@ export const BaseTag = forwardRef<HTMLDivElement, Props>(
     <div
       ref={ref}
       className={cn(
-        "line-clamp-1 flex flex-row items-center justify-start gap-0.5 rounded-full py-0.5 pl-0.5 pr-2 text-base font-medium",
+        "line-clamp-1 flex flex-row items-center justify-start gap-0.5 rounded-full py-0.5 pr-[10px] text-base font-medium",
         onClick && "cursor-pointer hover:bg-f1-background-hover",
+        !left ? "pl-[10px]" : "pl-1",
         className
       )}
       onClick={onClick}

--- a/lib/experimental/Information/Tags/DotTag/index.tsx
+++ b/lib/experimental/Information/Tags/DotTag/index.tsx
@@ -32,7 +32,7 @@ export const DotTag = forwardRef<HTMLDivElement, Props>(
     return (
       <BaseTag
         ref={ref}
-        className="border-[1px] border-solid border-f1-border-secondary pl-1"
+        className="border-[1px] border-solid border-f1-border-secondary"
         left={
           <div
             className="m-1 aspect-square w-2 rounded-full"

--- a/lib/experimental/Information/Tags/RawTag/index.tsx
+++ b/lib/experimental/Information/Tags/RawTag/index.tsx
@@ -17,10 +17,7 @@ export const RawTag = forwardRef<HTMLDivElement, Props>(
     return (
       <BaseTag
         ref={ref}
-        className={cn(
-          "border-[1px] border-solid border-f1-border-secondary pl-1",
-          icon ? "pl-1" : "pl-2"
-        )}
+        className={cn("border-[1px] border-solid border-f1-border-secondary")}
         left={
           icon ? (
             <Icon icon={icon} size="sm" className="text-f1-icon" aria-hidden />

--- a/lib/experimental/Information/Tags/StatusTag/index.tsx
+++ b/lib/experimental/Information/Tags/StatusTag/index.tsx
@@ -20,7 +20,6 @@ export const StatusTag = forwardRef<HTMLDivElement, Props>(
       <BaseTag
         ref={ref}
         className={cn(
-          "pl-1",
           {
             neutral: "bg-f1-background-secondary text-f1-foreground-secondary",
             info: "bg-f1-background-info text-f1-foreground-info",


### PR DESCRIPTION
## Description

Add neutral balance tag + improve spacing in all tags, to unify all in BaseTag

## Screenshots (if applicable)

![Screenshot 2024-12-11 at 10 53 04](https://github.com/user-attachments/assets/ec190960-f064-4525-9558-e9216af8d70e)

### Figma Link

[Figma](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=1687-17377&node-type=frame&t=1dqKos6gW8yne5Pn-0)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---
