### PR TITLE
Let widgets grow if container lets them

### DIFF
--- a/lib/experimental/Navigation/Carousel/index.stories.tsx
+++ b/lib/experimental/Navigation/Carousel/index.stories.tsx
@@ -1,14 +1,17 @@
+import { BarChartProps } from "@/components/Charts/BarChart"
+import BarChartStory from "@/components/Charts/BarChart/index.stories"
+import { BarChartWidget } from "@/experimental/Widgets/Charts/BarChartWidget"
 import { Placeholder } from "@/lib/storybook-utils/placeholder"
 import { Meta, StoryObj } from "@storybook/react"
 import { Carousel } from "."
 
 const meta: Meta<typeof Carousel> = {
   component: Carousel,
-  parameters: {
-    layout: "fullscreen",
-  },
   argTypes: {
     autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
   },
 }
 
@@ -24,31 +27,49 @@ const SLIDES = Array.from({ length: 6 }, (_, i) => (
 
 export const Default: Story = {
   decorators: [
-    (Story) => (
+    (Story, args) => (
       <div className="w-full p-6">
-        <Story />
+        <Story {...args} />
       </div>
     ),
   ],
   argTypes: {
-    autoplay: { table: { disable: true } },
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
   },
   args: {
     autoplay: false,
+    showArrows: true,
+    showDots: true,
+    showPeek: false,
     children: SLIDES,
   },
 }
 
+/**
+ * `columns`: An object specifying the number of columns to display at different breakpoints:
+ *   - `xs`: Number of columns for extra small screens. Default is `2`.
+ *   - `sm`: Number of columns for small screens. Default is `3`.
+ *   - `md`: Number of columns for medium screens. Default is `4`.
+ *   - `lg`: Number of columns for large screens. Default is `6`.
+ *
+ * Try to **resize the window** to see the number of columns change.
+ */
 export const CustomColumns: Story = {
   decorators: [
-    (Story) => (
+    (Story, args) => (
       <div className="w-full p-6">
-        <Story />
+        <Story {...args} />
       </div>
     ),
   ],
   argTypes: {
-    autoplay: { table: { disable: true } },
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
   },
   args: {
     autoplay: false,
@@ -62,6 +83,9 @@ export const CustomColumns: Story = {
   },
 }
 
+/**
+ * `autoplay`: Whether to automatically scroll through the slides. Default is `false`.
+ */
 export const AutoScroll: Story = {
   decorators: [
     (Story) => (
@@ -70,6 +94,12 @@ export const AutoScroll: Story = {
       </div>
     ),
   ],
+  argTypes: {
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+  },
   args: {
     autoplay: true,
     delay: 3000,
@@ -77,6 +107,9 @@ export const AutoScroll: Story = {
   },
 }
 
+/**
+ * `sneakPeek`: Whether to show a peek of the next slide. Default is `false`.
+ */
 export const SneakPeek: Story = {
   decorators: [
     (Story) => (
@@ -85,9 +118,59 @@ export const SneakPeek: Story = {
       </div>
     ),
   ],
+  argTypes: {
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+  },
   args: {
     showArrows: false,
     children: SLIDES,
     showPeek: true,
+  },
+}
+
+const randomClasses = ["h-64", "h-full", "h-32", "w-32", "w-full", "w-64"]
+
+const SLIDES_RANDOM = [
+  <BarChartWidget
+    key="widget"
+    chart={BarChartStory.args as BarChartProps}
+    fullHeight
+  />,
+  ...Array.from({ length: 6 }, (_, i) => {
+    const randomHeight = randomClasses[Math.floor(i / 2)]
+    const randomWidth = randomClasses[Math.floor(i / 2) + 3]
+    return (
+      <Placeholder key={i + 1} className={`${randomHeight} ${randomWidth}`}>
+        Slide {i + 1} ({randomHeight} {randomWidth})
+      </Placeholder>
+    )
+  }),
+]
+
+/**
+ * Care using this component for distinct size widgets.
+ */
+export const MultipleWidths: Story = {
+  decorators: [
+    (Story) => (
+      <div className="h-full w-full p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+  },
+  args: {
+    showArrows: true,
+    children: SLIDES_RANDOM,
+    showPeek: true,
+    showDots: false,
   },
 }

--- a/lib/experimental/Widgets/Widget/index.tsx
+++ b/lib/experimental/Widgets/Widget/index.tsx
@@ -46,6 +46,7 @@ export interface WidgetProps {
     text: string
     variant: StatusVariant
   }
+  fullHeight?: boolean
 }
 
 const InlineDot = () => (
@@ -56,7 +57,7 @@ const Container = forwardRef<
   HTMLDivElement,
   WidgetProps & { children: ReactNode }
 >(function Container(
-  { header, children, action, summaries, alert, status },
+  { header, children, action, summaries, alert, status, fullHeight = false },
   ref
 ) {
   const { enabled: privacyModeEnabled, toggle: togglePrivacyMode } =
@@ -82,7 +83,13 @@ const Container = forwardRef<
   }
 
   return (
-    <Card className="relative flex gap-4 border-f1-border-secondary" ref={ref}>
+    <Card
+      className={cn(
+        fullHeight ? "h-full" : "",
+        "relative flex gap-4 border-f1-border-secondary"
+      )}
+      ref={ref}
+    >
       {header && (
         <CardHeader className="-mr-1 -mt-1">
           <div className="flex w-full flex-1 flex-col gap-4">
@@ -138,7 +145,7 @@ const Container = forwardRef<
           </div>
         </CardHeader>
       )}
-      <CardContent className="flex flex-col gap-4">
+      <CardContent className="flex h-full flex-col gap-4">
         {summaries && (
           <div className="flex flex-row">
             {summaries.map((summary, index) => (


### PR DESCRIPTION
## Description

For that PR: https://github.com/factorialco/factorial-one/pull/961 we need the widget to expand to all available height, now this is not posible as there are som flex flex-col without a h-full that prevents that.

## Screenshots (if applicable)

Problem:
![Screenshot 2024-12-11 at 15 01 46](https://github.com/user-attachments/assets/19cb3991-4955-47ca-ae06-9eeea010c057)

With this PR the chart fills the space:
![Screenshot 2024-12-11 at 15 02 45](https://github.com/user-attachments/assets/c4638e69-87d7-40c3-a25e-bc40ff53a216)

## Type of Change

- [x] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
