### PR TITLE
Add `Banner` slot to `ApplicationFrame`

### DIFF
--- a/lib/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/lib/experimental/Navigation/ApplicationFrame/index.tsx
@@ -5,14 +5,19 @@ import { FrameProvider, useSidebar } from "./FrameProvider"
 import { useReducedMotion } from "@/lib/a11y"
 import { AnimatePresence } from "framer-motion"
 interface ApplicationFrameProps {
+  banner?: React.ReactNode
   sidebar: React.ReactNode
   children: React.ReactNode
 }
 
-export function ApplicationFrame({ children, sidebar }: ApplicationFrameProps) {
+export function ApplicationFrame({
+  children,
+  sidebar,
+  banner,
+}: ApplicationFrameProps) {
   return (
     <FrameProvider>
-      <ApplicationFrameContent sidebar={sidebar}>
+      <ApplicationFrameContent sidebar={sidebar} banner={banner}>
         {children}
       </ApplicationFrameContent>
     </FrameProvider>
@@ -32,7 +37,11 @@ const SkipToContentButton = ({ contentId }: { contentId?: string }) => {
   )
 }
 
-function ApplicationFrameContent({ children, sidebar }: ApplicationFrameProps) {
+function ApplicationFrameContent({
+  children,
+  sidebar,
+  banner,
+}: ApplicationFrameProps) {
   const { sidebarState, toggleSidebar, isSmallScreen } = useSidebar()
   const shouldReduceMotion = useReducedMotion()
 
@@ -46,45 +55,48 @@ function ApplicationFrameContent({ children, sidebar }: ApplicationFrameProps) {
           duration: shouldReduceMotion ? 0 : 0.2,
         }}
       >
-        <div className="relative isolate flex h-full flex-row">
-          <AnimatePresence>
-            {sidebarState === "unlocked" && (
-              <motion.div
-                className={cn("fixed inset-0 z-[5] bg-f1-background-bold", {
-                  hidden: !isSmallScreen,
-                })}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 0.1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
-                onClick={toggleSidebar}
-              />
-            )}
-          </AnimatePresence>
-          <div
-            className={cn(
-              { "transition-all": !shouldReduceMotion },
-              sidebarState === "locked" ? "w-[240px] shrink-0 pl-3" : "w-0"
-            )}
-          >
-            {sidebar}
+        <div className="grid h-screen grid-cols-1 grid-rows-[auto_minmax(0,1fr)] items-stretch">
+          <div className="col-[1/-1]">{banner}</div>
+          <div className="relative isolate flex h-full">
+            <AnimatePresence>
+              {sidebarState === "unlocked" && (
+                <motion.div
+                  className={cn("fixed inset-0 z-[5] bg-f1-background-bold", {
+                    hidden: !isSmallScreen,
+                  })}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 0.1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
+                  onClick={toggleSidebar}
+                />
+              )}
+            </AnimatePresence>
+            <div
+              className={cn(
+                { "transition-all": !shouldReduceMotion },
+                sidebarState === "locked" ? "w-[240px] shrink-0 pl-3" : "w-0"
+              )}
+            >
+              {sidebar}
+            </div>
+            <motion.main
+              id="content"
+              className={cn(
+                "flex max-w-full flex-1 overflow-auto xs:py-1 xs:pr-1",
+                sidebarState === "locked" ? "pl-0" : "xs:pl-1"
+              )}
+              layout
+              transition={{
+                duration: shouldReduceMotion ? 0 : 0.3,
+                type: "spring",
+                stiffness: 300,
+                damping: 30,
+              }}
+            >
+              {children}
+            </motion.main>
           </div>
-          <motion.main
-            id="content"
-            className={cn(
-              "flex max-w-full flex-1 overflow-auto xs:py-1 xs:pr-1",
-              sidebarState === "locked" ? "pl-0" : "xs:pl-1"
-            )}
-            layout
-            transition={{
-              duration: shouldReduceMotion ? 0 : 0.3,
-              type: "spring",
-              stiffness: 300,
-              damping: 30,
-            }}
-          >
-            {children}
-          </motion.main>
         </div>
       </MotionConfig>
     </>

--- a/lib/experimental/Navigation/Sidebar/Sidebar.tsx
+++ b/lib/experimental/Navigation/Sidebar/Sidebar.tsx
@@ -42,7 +42,7 @@ export function Sidebar({ header, body, footer }: SidebarProps) {
     <motion.div
       initial={false}
       className={cn(
-        "absolute left-0 top-0 z-10 flex w-[240px] flex-col transition-[background-color]",
+        "absolute bottom-0 left-0 top-0 z-10 flex w-[240px] flex-col transition-[background-color]",
         sidebarState === "locked"
           ? "h-full"
           : cn(

--- a/lib/experimental/Navigation/Sidebar/Sidebar.tsx
+++ b/lib/experimental/Navigation/Sidebar/Sidebar.tsx
@@ -42,14 +42,14 @@ export function Sidebar({ header, body, footer }: SidebarProps) {
     <motion.div
       initial={false}
       className={cn(
-        "absolute bottom-0 left-0 top-0 z-10 flex w-[240px] flex-col transition-[background-color]",
+        "absolute left-0 top-0 z-10 flex w-[240px] flex-col transition-[background-color]",
         sidebarState === "locked"
-          ? "h-screen"
+          ? "h-full"
           : cn(
               "border-solid border-f1-border-secondary shadow-lg backdrop-blur-2xl",
               isSmallScreen
-                ? "h-screen border-y-transparent border-l-transparent bg-f1-background/90"
-                : "h-[calc(100vh-16px)] bg-f1-background/60"
+                ? "h-full border-y-transparent border-l-transparent bg-f1-background/90"
+                : "h-[calc(100%-16px)] bg-f1-background/60"
             )
       )}
       animate={{


### PR DESCRIPTION
## Description

Adds a new slot to the `ApplicationFrame` component, `Banner`, that lets you add anything on top of the layout. In our case, we want to display a few banners for upgrading, trials, etc.

## Screenshots

![image](https://github.com/user-attachments/assets/3e5473ca-1efa-484a-b9a0-ce39a2e6fe3e)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other