### PR TITLE
Change Page style to display a border

### DIFF
--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -59,7 +59,7 @@ export function PageHeader({
   return (
     <div
       className={cn(
-        "flex h-16 items-center justify-between px-5 py-4 backdrop-blur-xl xs:px-6",
+        "flex h-16 items-center justify-between px-5 py-4 xs:px-6",
         hasNavigation &&
           "border-b border-dashed border-transparent border-b-f1-border"
       )}

--- a/lib/experimental/Navigation/Page/index.tsx
+++ b/lib/experimental/Navigation/Page/index.tsx
@@ -7,7 +7,7 @@ interface PageProps {
 
 export function Page({ children, header }: PageProps) {
   return (
-    <div className="flex w-full flex-col overflow-hidden rounded-xl bg-f1-page shadow">
+    <div className="flex w-full flex-col overflow-hidden rounded-xl bg-f1-page ring-1 ring-inset ring-f1-border-secondary">
       {header && <div className="flex flex-col">{header}</div>}
       <div className="isolate flex w-full flex-1 flex-col overflow-auto [&>*]:flex-1">
         {children}


### PR DESCRIPTION
## Description

The `Page` component has a `shadow` that gets cut as it needs an `overflow` class [to control the content inside it](https://github.com/factorialco/factorial-one/pull/909).

We changed the design to avoid this shadow by adding a subtle border that still helps distinguish this element from the background, but is `inset` so it doesn't get cut.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/64f2ed73-54fe-4bef-9d12-246683b97c36)

### Figma Link

[Link to Figma Design](https://www.figma.com/design/uImdC0GKxH59DkjzBqRJEF/Layouts-%26-Patterns?node-id=4213-292545&t=kSH0hFrwtvFACWJw-4)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
