### PR TITLE
Fix Menu items focus ring being cut

### DIFF
--- a/lib/experimental/Navigation/Sidebar/Menu/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Menu/index.tsx
@@ -66,7 +66,7 @@ const MenuItem = ({ item }: { item: MenuItem }) => {
       {...props}
       className={cn(
         "flex cursor-pointer items-center rounded py-1.5 pl-1.5 pr-2 no-underline transition-colors",
-        focusRing(),
+        focusRing("focus-visible:ring-inset"),
         active
           ? "bg-f1-background-secondary text-f1-foreground"
           : "hover:bg-f1-background-secondary"

--- a/lib/experimental/Navigation/Sidebar/User/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/User/index.tsx
@@ -23,7 +23,7 @@ export function User({ firstName, lastName, avatarUrl, options }: UserProps) {
         <button
           className={cn(
             "flex w-full items-center gap-1.5 rounded p-1.5 font-medium transition-colors hover:bg-f1-background-secondary data-[state=open]:bg-f1-background-secondary",
-            focusRing()
+            focusRing("focus-visible:ring-inset")
           )}
         >
           <PersonAvatar


### PR DESCRIPTION
## Description

The menu items focus ring is getting cut as their container has a needed `overflow:hidden` class for the show/hide animation. This PR changes the focus ring to be inset on the element so it does not look cut.

## Screenshots

![image](https://github.com/user-attachments/assets/96b68bb2-b00c-406d-b433-5a5c826e4660)

_Before_


![image](https://github.com/user-attachments/assets/957fd594-036e-4ea2-8a70-21916f17f874)

_After_

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other