### PR TITLE
Add single tab support in `Tabs` component

### DIFF
--- a/lib/experimental/Navigation/Tabs/index.stories.tsx
+++ b/lib/experimental/Navigation/Tabs/index.stories.tsx
@@ -63,3 +63,15 @@ export const Skeleton: Story = {
   },
   render: ({ secondary }) => <Tabs.Skeleton secondary={secondary} />,
 }
+
+export const SingleTab: Story = {
+  args: {
+    tabs: [],
+  },
+  render: () => (
+    <div>
+      <Tabs tabs={[{ label: "Overview", href: "/" }]} secondary={false} />
+      <Tabs tabs={[{ label: "Overview", href: "/" }]} secondary={true} />
+    </div>
+  ),
+}

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -28,7 +28,7 @@ export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
   return (
     <TabNavigation
       secondary={secondary}
-      asChild={!isSingleTab}
+      asChild
       aria-label={secondary ? "primary-navigation" : "secondary-navigation"}
     >
       {isSingleTab ? (

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -31,11 +31,9 @@ export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
       aria-label={secondary ? "primary-navigation" : "secondary-navigation"}
     >
       {tabs.length === 1 ? (
-        <TabNavigationLink disabled secondary={secondary} className="p-0">
-          <span className="flex h-8 items-center justify-center whitespace-nowrap text-lg font-medium text-f1-foreground">
-            {tabs[0].label}
-          </span>
-        </TabNavigationLink>
+        <li className="flex h-8 items-center justify-center whitespace-nowrap text-lg font-medium text-f1-foreground">
+          {tabs[0].label}
+        </li>
       ) : (
         tabs.map(({ label, ...props }, index) => (
           <TabNavigationLink

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -32,9 +32,11 @@ export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
       aria-label={secondary ? "primary-navigation" : "secondary-navigation"}
     >
       {isSingleTab ? (
-        <div className="flex h-8 items-center justify-center whitespace-nowrap text-lg font-medium text-f1-foreground">
-          {tabs[0].label}
-        </div>
+        <TabNavigationLink disabled secondary={secondary} className="p-0">
+          <span className="flex h-8 items-center justify-center whitespace-nowrap text-lg font-medium text-f1-foreground">
+            {tabs[0].label}
+          </span>
+        </TabNavigationLink>
       ) : (
         tabs.map(({ label, ...props }, index) => (
           <TabNavigationLink

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -15,6 +15,7 @@ interface TabsProps {
 
 export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
   const { isActive } = useNavigation()
+  const isSingleTab = tabs.length === 1
 
   // Index tabs are usually `/` while other tabs are `/some-other-path`.
   // We need to find the right active tab by checking if the current path
@@ -27,22 +28,28 @@ export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
   return (
     <TabNavigation
       secondary={secondary}
-      asChild
+      asChild={!isSingleTab}
       aria-label={secondary ? "primary-navigation" : "secondary-navigation"}
     >
-      {tabs.map(({ label, ...props }, index) => (
-        <TabNavigationLink
-          key={index}
-          active={activeTab?.href === props.href}
-          href={props.href}
-          secondary={secondary}
-          asChild
-        >
-          <Link role="link" {...props}>
-            {label}
-          </Link>
-        </TabNavigationLink>
-      ))}
+      {isSingleTab ? (
+        <div className="flex h-8 items-center justify-center whitespace-nowrap text-lg font-medium text-f1-foreground">
+          {tabs[0].label}
+        </div>
+      ) : (
+        tabs.map(({ label, ...props }, index) => (
+          <TabNavigationLink
+            key={index}
+            active={activeTab?.href === props.href}
+            href={props.href}
+            secondary={secondary}
+            asChild
+          >
+            <Link role="link" {...props}>
+              {label}
+            </Link>
+          </TabNavigationLink>
+        ))
+      )}
     </TabNavigation>
   )
 }

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -15,7 +15,6 @@ interface TabsProps {
 
 export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
   const { isActive } = useNavigation()
-  const isSingleTab = tabs.length === 1
 
   // Index tabs are usually `/` while other tabs are `/some-other-path`.
   // We need to find the right active tab by checking if the current path
@@ -31,7 +30,7 @@ export const BaseTabs: React.FC<TabsProps> = ({ tabs, secondary = false }) => {
       asChild
       aria-label={secondary ? "primary-navigation" : "secondary-navigation"}
     >
-      {isSingleTab ? (
+      {tabs.length === 1 ? (
         <TabNavigationLink disabled secondary={secondary} className="p-0">
           <span className="flex h-8 items-center justify-center whitespace-nowrap text-lg font-medium text-f1-foreground">
             {tabs[0].label}


### PR DESCRIPTION
## Description

We have cases (usually due of permissions) were we only display a single tab. In these cases, we want to still display them, but make them look more like a title, rather than a tab.

This PR adds that option. When there is only a single tab in the `tabs` prop, it will be displayed with a different style, and with no link.

## Screenshots

<img width="190" alt="image" src="https://github.com/user-attachments/assets/4a0c6f4e-e6ab-4b70-ad07-fae13ae4c484" />

### Links

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=323-16471&t=xvQ6ftl11zlH8Kuv-4)
[JIRA ticket](https://factorialmakers.atlassian.net/browse/FCT-22056)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other