### PR TITLE
Add optional onClick inside header.link prop

### DIFF
--- a/lib/experimental/Widgets/Widget/index.stories.tsx
+++ b/lib/experimental/Widgets/Widget/index.stories.tsx
@@ -39,7 +39,7 @@ export const WithLink: Story = {
     header: {
       title: "Wellness programs",
       subtitle: "Boosting workplace health",
-      link: { url: "/", title: "Go to link" },
+      link: { url: "/", title: "Go to link", onClick: fn() },
     },
   },
 }

--- a/lib/experimental/Widgets/Widget/index.tsx
+++ b/lib/experimental/Widgets/Widget/index.tsx
@@ -31,7 +31,7 @@ export interface WidgetProps {
     subtitle?: string
     comment?: string
     canBeBlurred?: boolean
-    link?: { title: string; url: string }
+    link?: { title: string; url: string; onClick?: () => void }
     count?: number
   }
   action?: ButtonProps
@@ -81,6 +81,10 @@ const Container = forwardRef<
     )
   }
 
+  const handleLinkClick = () => {
+    header?.link?.onClick?.()
+  }
+
   return (
     <Card className="relative flex gap-4 border-f1-border-secondary" ref={ref}>
       {header && (
@@ -111,7 +115,11 @@ const Container = forwardRef<
                   <StatusTag text={status.text} variant={status.variant} />
                 )}
                 {header.link && (
-                  <CardLink href={header.link.url} title={header.link.title} />
+                  <CardLink
+                    onClick={handleLinkClick}
+                    href={header.link.url}
+                    title={header.link.title}
+                  />
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Description

We want to track clicks on widget links navigations, but as this component doesn't propagate this event we can't. So in this PR we are adding this optional prop.

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
