### PR TITLE
Correct WidgetHighlightButton placement

### DIFF
--- a/lib/experimental/Widgets/Content/Highlights/WidgetHighlightButton/index.tsx
+++ b/lib/experimental/Widgets/Content/Highlights/WidgetHighlightButton/index.tsx
@@ -18,7 +18,7 @@ type WrapperProps = {
 
 const Wrapper: React.FC<WrapperProps> = ({ onClick, children }) => {
   const className =
-    "block rounded-lg border border-solid border-transparent p-[1px]"
+    "block rounded-lg border border-solid border-transparent p-[1px] -m-1"
 
   return onClick ? (
     <a


### PR DESCRIPTION
## Description

Due to a couple of borders that we have for this component we need to apply a small negative margin to it in order to correct its placement visually.
