### PR TITLE
Fix CompanySelector not truncating

### DIFF
--- a/lib/experimental/Navigation/Sidebar/CompanySelector/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/CompanySelector/index.tsx
@@ -42,7 +42,7 @@ export function CompanySelector({
 
   if (companies.length === 1) {
     return (
-      <div className="w-fit p-1.5">
+      <div className="p-1.5">
         <SelectedCompanyLabel company={selectedCompany} />
       </div>
     )


### PR DESCRIPTION
## Description

When a company only has a single workplace, we just display the name in the`CompanySelector` component. In this case, the text of the company was not truncating if it was long enough to do so.

![image](https://github.com/user-attachments/assets/cd99fb3d-fa75-41d8-a763-5b564d8dea7c)

_Related: [Slack](https://factorialteam.slack.com/archives/C06QT46115K/p1733921231811509)_

This PR fixes that bug.

## Screenshots

<img width="299" alt="image" src="https://github.com/user-attachments/assets/147c5189-9956-4758-8195-9fd505cf93e7" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other