### PR TITLE
Fix space between ModuleAvatar and title

### DIFF
--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -87,7 +87,7 @@ export function PageHeader({
             </motion.div>
           )}
         </AnimatePresence>
-        <div className="flex flex-grow items-center gap-3">
+        <div className="flex flex-grow items-center gap-2">
           {!hasNavigation && <ModuleAvatar icon={module.icon} size="lg" />}
           {breadcrumbsTree.length > 1 ? (
             <Breadcrumbs breadcrumbs={breadcrumbsTree} />


### PR DESCRIPTION
## Description

The space between the `ModuleAvatar` and the title in the `Header` component was wrongly set to 12px, when it's 8px in Figma.

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other