### PR TITLE
Fix `CompanyAvatar` size in `CompanySelector`

### DIFF
--- a/lib/experimental/Navigation/Sidebar/CompanySelector/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/CompanySelector/index.tsx
@@ -135,7 +135,7 @@ const SelectedCompanyLabel = ({
       <CompanyAvatar
         name={company?.name?.[0]}
         src={company?.logo}
-        size="xsmall"
+        size="small"
       />
       <div className="min-w-0 flex-1">
         <span className="block truncate">{company?.name}</span>


### PR DESCRIPTION
## Description

The `CompanyAvatar` in the `CompanySelector` component has a `xsmall` size (20px) when it should have `small` size (24px), like in Figma.

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
