### PR TITLE
Display custom scrollbar in `Sidebar`

### DIFF
--- a/lib/experimental/Navigation/Sidebar/Sidebar.tsx
+++ b/lib/experimental/Navigation/Sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useReducedMotion } from "@/lib/a11y"
 import { cn } from "@/lib/utils"
+import { ScrollArea } from "@/ui/scrollarea"
 import { AnimatePresence, motion } from "framer-motion"
 import { ReactNode } from "react"
 import { useIntersectionObserver } from "usehooks-ts"
@@ -88,11 +89,11 @@ export function Sidebar({ header, body, footer }: SidebarProps) {
       <div className="flex-shrink-0">{header}</div>
       {body && (
         <div className="relative flex-grow overflow-y-hidden">
-          <div className="h-full overflow-y-auto">
+          <ScrollArea className="h-full">
             <div ref={topRef} className="h-px" aria-hidden="true" />
             {body}
             <div ref={bottomRef} className="h-px" aria-hidden="true" />
-          </div>
+          </ScrollArea>
 
           <AnimatePresence>
             {!isAtTop && <ScrollShadow position="top" />}

--- a/lib/ui/scrollarea.tsx
+++ b/lib/ui/scrollarea.tsx
@@ -40,16 +40,16 @@ const ScrollBar = React.forwardRef<
     orientation={orientation}
     forceMount
     className={cn(
-      "z-50 flex touch-none select-none p-[1px]",
+      "group/scrollbar z-50 flex touch-none select-none p-[1px]",
       "transition-opacity data-[state=hidden]:pointer-events-none data-[state=visible]:pointer-events-auto data-[state=hidden]:opacity-0 data-[state=visible]:opacity-100",
-      orientation === "vertical" && "mr-[2px] h-full w-2.5",
-      orientation === "horizontal" && "mt-[2px] h-2.5 flex-col",
+      orientation === "vertical" && "mr-[2px] h-full w-2",
+      orientation === "horizontal" && "mt-[2px] h-2 flex-col",
       className
     )}
     {...props}
   >
     {showBar && (
-      <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-f1-background-secondary opacity-50" />
+      <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-f1-background-bold opacity-30 transition-opacity group-hover/scrollbar:opacity-50" />
     )}
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ))


### PR DESCRIPTION
## Description

We want to control how the scrollbar looks in the sidebar, as there is not much space and the default scrollbar can appear too bulky and take up valuable real estate. A thinner, more minimal scrollbar helps maintain the clean aesthetic while still providing necessary functionality.

This uses [Radix ScrollArea](https://www.radix-ui.com/primitives/docs/components/scroll-area), which uses the native scroll under the hood, and is extensively tested.

Related: [JIRA](https://factorialmakers.atlassian.net/browse/FCT-21512)

## Screenshots

https://github.com/user-attachments/assets/86be7159-753f-48e3-bf2f-b2fb715f8800

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other