### PR TITLE
Add `Badge` components

### DIFF
--- a/lib/components/Utilities/Icon/index.tsx
+++ b/lib/components/Utilities/Icon/index.tsx
@@ -13,7 +13,7 @@ const iconVariants = cva("inline-block shrink-0", {
       lg: "w-6 [&_circle]:stroke-lg [&_path]:stroke-lg [&_rect]:stroke-lg",
       md: "w-5 [&_circle]:stroke-md [&_path]:stroke-md [&_rect]:stroke-md",
       sm: "w-4 [&_circle]:stroke-sm [&_path]:stroke-sm [&_rect]:stroke-sm",
-      xs: "[&_circle]:stroke-xs [&_path]:stroke-xs [&_rect]:stroke-xs w-3",
+      xs: "w-3 [&_circle]:stroke-xs [&_path]:stroke-xs [&_rect]:stroke-xs",
     },
   },
   defaultVariants: {

--- a/lib/components/Utilities/Icon/index.tsx
+++ b/lib/components/Utilities/Icon/index.tsx
@@ -13,6 +13,7 @@ const iconVariants = cva("inline-block shrink-0", {
       lg: "w-6 [&_circle]:stroke-lg [&_path]:stroke-lg [&_rect]:stroke-lg",
       md: "w-5 [&_circle]:stroke-md [&_path]:stroke-md [&_rect]:stroke-md",
       sm: "w-4 [&_circle]:stroke-sm [&_path]:stroke-sm [&_rect]:stroke-sm",
+      xs: "[&_circle]:stroke-xs [&_path]:stroke-xs [&_rect]:stroke-xs w-3",
     },
   },
   defaultVariants: {

--- a/lib/experimental/Information/Badges/EmojiBadge/index.stories.tsx
+++ b/lib/experimental/Information/Badges/EmojiBadge/index.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { EmojiBadge } from "."
+
+const meta: Meta<typeof EmojiBadge> = {
+  component: EmojiBadge,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+}
+
+export default meta
+type Story = StoryObj<typeof EmojiBadge>
+
+export const Default: Story = {
+  args: {
+    emoji: "🍆",
+  },
+}

--- a/lib/experimental/Information/Badges/EmojiBadge/index.tsx
+++ b/lib/experimental/Information/Badges/EmojiBadge/index.tsx
@@ -1,0 +1,13 @@
+import { EmojiImage } from "@/lib/emojis"
+
+interface EmojiBadgeProps {
+  emoji: string
+}
+
+export const EmojiBadge = ({ emoji }: EmojiBadgeProps) => {
+  return (
+    <div className="flex h-5 w-5 items-center justify-center rounded-full bg-f1-background-secondary">
+      <EmojiImage emoji={emoji} size="xs" />
+    </div>
+  )
+}

--- a/lib/experimental/Information/Badges/StatusBadge/index.stories.tsx
+++ b/lib/experimental/Information/Badges/StatusBadge/index.stories.tsx
@@ -21,3 +21,14 @@ export const Default: Story = {
     size: "md",
   },
 }
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-row gap-2">
+      <StatusBadge icon={Icons.Placeholder} size="md" />
+      <StatusBadge icon={Icons.Check} status="positive" size="md" />
+      <StatusBadge icon={Icons.Cross} status="critical" size="md" />
+      <StatusBadge icon={Icons.Alert} status="warning" size="md" />
+    </div>
+  ),
+}

--- a/lib/experimental/Information/Badges/StatusBadge/index.stories.tsx
+++ b/lib/experimental/Information/Badges/StatusBadge/index.stories.tsx
@@ -1,0 +1,23 @@
+import * as Icons from "@/icons/app"
+import type { Meta, StoryObj } from "@storybook/react"
+import { StatusBadge } from "."
+
+const meta: Meta<typeof StatusBadge> = {
+  component: StatusBadge,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+}
+
+export default meta
+
+type Story = StoryObj<typeof StatusBadge>
+
+export const Default: Story = {
+  args: {
+    status: "neutral",
+    icon: Icons.Placeholder,
+    size: "md",
+  },
+}

--- a/lib/experimental/Information/Badges/StatusBadge/index.tsx
+++ b/lib/experimental/Information/Badges/StatusBadge/index.tsx
@@ -1,0 +1,46 @@
+import { Icon, IconType } from "@/components/Utilities/Icon"
+import { cva, VariantProps } from "class-variance-authority"
+
+const statusBadgeVariants = cva(
+  "flex shrink-0 items-center justify-center rounded-full",
+  {
+    variants: {
+      status: {
+        neutral: "bg-transparent text-f1-icon",
+        positive: "bg-f1-background-positive-bold text-f1-foreground-inverse",
+        critical: "bg-f1-background-critical-bold text-f1-foreground-inverse",
+        warning: "bg-f1-background-warning-bold text-f1-foreground-inverse",
+      },
+      size: {
+        sm: "h-3 w-3",
+        md: "h-5 w-5",
+      },
+    },
+    defaultVariants: {
+      status: "neutral",
+      size: "md",
+    },
+  }
+)
+
+const iconSizes = {
+  sm: "xs",
+  md: "sm",
+} as const
+
+interface StatusBadgeProps extends VariantProps<typeof statusBadgeVariants> {
+  icon: IconType
+  size: keyof typeof iconSizes
+}
+
+export const StatusBadge = ({
+  status,
+  size = "md",
+  icon,
+}: StatusBadgeProps) => {
+  return (
+    <div className={statusBadgeVariants({ status, size })}>
+      <Icon icon={icon} size={iconSizes[size]} />
+    </div>
+  )
+}

--- a/lib/experimental/Information/Badges/exports.ts
+++ b/lib/experimental/Information/Badges/exports.ts
@@ -1,0 +1,2 @@
+export * from "./EmojiBadge"
+export * from "./StatusBadge"

--- a/lib/experimental/Information/Badges/index.mdx
+++ b/lib/experimental/Information/Badges/index.mdx
@@ -1,0 +1,52 @@
+import { Canvas, Meta, Unstyled } from "@storybook/blocks"
+import * as StatusBadgeStories from "./StatusBadge/index.stories"
+import * as EmojiBadgeStories from "./EmojiBadge/index.stories"
+
+# Badges
+
+Badges are compact visual indicators. They provide quick visual cues to users
+about the state or nature of an item.
+
+## StatusBadge
+
+A badge that displays status through icons. Useful for showing status or alert
+levels.
+
+<Canvas of={StatusBadgeStories.Variants} />
+
+### Variants
+
+<Unstyled>
+  <table>
+    <thead>
+      <tr>
+        <th>Variant</th>
+        <th>Usage</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Neutral</td>
+        <td>Default state, used for general information</td>
+      </tr>
+      <tr>
+        <td>Positive</td>
+        <td>Indicates success or completion</td>
+      </tr>
+      <tr>
+        <td>Critical</td>
+        <td>Shows errors or critical states</td>
+      </tr>
+      <tr>
+        <td>Warning</td>
+        <td>Highlights potential issues or important notices</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## EmojiBadge
+
+A badge that displays an emoji. Useful for showing a reaction.
+
+<Canvas of={EmojiBadgeStories.Default} />

--- a/lib/experimental/Information/exports.tsx
+++ b/lib/experimental/Information/exports.tsx
@@ -1,5 +1,6 @@
 export * from "./Alert"
 export * from "./Avatars/exports"
+export * from "./Badges/exports"
 export * from "./Communities/exports"
 export * from "./Counter"
 export * from "./Headers/exports"

--- a/lib/tokens/colors.ts
+++ b/lib/tokens/colors.ts
@@ -155,11 +155,20 @@ export const f1Colors = {
     },
     critical: {
       DEFAULT: "hsl(var(--critical-50) / 0.1)",
-      bold: "hsl(var(--critical-70))",
+      bold: "hsl(var(--critical-50))",
     },
-    info: "hsl(var(--info-50) / 0.1)",
-    warning: "hsl(var(--warning-50) / 0.1)",
-    positive: "hsl(var(--positive-50) / 0.1)",
+    info: {
+      DEFAULT: "hsl(var(--info-50) / 0.1)",
+      bold: "hsl(var(--info-50))",
+    },
+    warning: {
+      DEFAULT: "hsl(var(--warning-50) / 0.1)",
+      bold: "hsl(var(--warning-50))",
+    },
+    positive: {
+      DEFAULT: "hsl(var(--positive-50) / 0.1)",
+      bold: "hsl(var(--positive-50))",
+    },
     selected: {
       DEFAULT: "hsl(var(--selected-50) / 0.1)",
       bold: "hsl(var(--selected-50))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -145,6 +145,7 @@ export default {
         lg: "1.4px",
         md: "1.3px",
         sm: "1.2px",
+        xs: "1px",
       },
     },
   },


### PR DESCRIPTION
## Description

Add the `StatusBadge` and `EmojiBadge` components to experimental. Both will be used alongside other components, like avatars, to depict statuses or display more information.

## Screenshots

### StatusBadge

Useful for showing status or alert levels.

<img width="841" alt="image" src="https://github.com/user-attachments/assets/4f70fd1e-0afc-4e40-86bc-2c4d6289a10a" />

### EmojiBadge

Useful for showing a reaction.

<img width="846" alt="image" src="https://github.com/user-attachments/assets/238fae10-3f3b-4cb1-affe-9cc33fd2a979" />

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=2359-37082)

---

## Type of Change

- [x] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other
