### PR TITLE
Expose CompanySelector

### DIFF
--- a/lib/experimental/Navigation/Sidebar/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/index.tsx
@@ -1,3 +1,4 @@
+export * from "./CompanySelector"
 export * from "./Header"
 export * from "./Menu"
 export * from "./Searchbar"


### PR DESCRIPTION
We show company selector in sidebar and its the main use case.

At the same time, we want to show the company selector preview in the customization page. There is no need to create another one in the main repo since we want to show the exact same look there as a preview
