### PR TITLE
Add missing w-full to Carousel

### DIFF
--- a/lib/experimental/Navigation/Carousel/index.tsx
+++ b/lib/experimental/Navigation/Carousel/index.tsx
@@ -67,7 +67,7 @@ export const Carousel = ({
 
   return (
     <ShadCarousel
-      className="flex flex-col gap-3"
+      className="flex w-full flex-col gap-3"
       opts={{
         align: "center",
         slidesToScroll: "auto",


### PR DESCRIPTION
## Description

When using the `Carousel` component I realized we were missing this `w-full` to always adapt to the full width of its parent.