### PR TITLE
Use `IconType` in Select

### DIFF
--- a/lib/experimental/Forms/Fields/Select/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/Select/index.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { fn } from "@storybook/test"
 import { Select } from "."
 
+import { Appearance, Circle, Desktop } from "@/icons/app"
+
 const meta: Meta = {
   component: Select,
   parameters: {
@@ -17,20 +19,20 @@ const meta: Meta = {
       {
         value: "light",
         label: "Light",
-        icon: "Circle",
+        icon: Circle,
         description:
           "A bright and airy theme for a visually appealing interface",
       },
       {
         value: "dark",
         label: "Dark",
-        icon: "Appearance",
+        icon: Appearance,
         description: "A sleek and modern theme for a sophisticated look",
       },
       {
         value: "system",
         label: "System",
-        icon: "Desktop",
+        icon: Desktop,
         description: "A theme that adapts to the system's default appearance",
       },
     ],

--- a/lib/experimental/Forms/Fields/Select/index.tsx
+++ b/lib/experimental/Forms/Fields/Select/index.tsx
@@ -1,8 +1,9 @@
+import { Icon, IconType } from "@/components/Utilities/Icon"
 import {
   AvatarVariant,
   renderAvatar,
 } from "@/experimental/Information/Avatars/utils"
-import * as Icons from "@/icons/app"
+import { ChevronDown } from "@/icons/app"
 import { cn, focusRing } from "@/lib/utils"
 import {
   SelectContent,
@@ -13,12 +14,10 @@ import {
 } from "@/ui/select"
 import { forwardRef } from "react"
 
-type IconName = keyof typeof Icons
-
 type SelectItemProps<T> = {
   value: T
   label: string
-  icon?: IconName
+  icon?: IconType
   description?: string
   avatar?: AvatarVariant
 }
@@ -35,12 +34,15 @@ type SelectProps<T> = {
 }
 
 const SelectItem = ({ item }: { item: SelectItemProps<string> }) => {
-  const Icon = item.icon && Icons[item.icon]
   return (
     <SelectItemPrimitive value={item.value}>
       <div className="flex items-start gap-1.5">
         {item.avatar && renderAvatar(item.avatar, "xsmall")}
-        {Icon && <Icon className="h-5 w-5 shrink-0 text-f1-icon" />}
+        {item.icon && (
+          <div className="text-f1-icon">
+            <Icon icon={item.icon} />
+          </div>
+        )}
         <div className="flex flex-col">
           <span className="font-medium">{item.label}</span>
           {item.description && (
@@ -55,10 +57,13 @@ const SelectItem = ({ item }: { item: SelectItemProps<string> }) => {
 }
 
 const SelectValue = ({ item }: { item: SelectItemProps<string> }) => {
-  const Icon = item.icon && Icons[item.icon]
   return (
     <div className="flex items-center gap-1.5">
-      {Icon && <Icon className="h-5 w-5 shrink-0 text-f1-icon" />}
+      {item.icon && (
+        <div className="h-5 shrink-0 text-f1-icon">
+          <Icon icon={item.icon} />
+        </div>
+      )}
       {item.label}
     </div>
   )
@@ -106,7 +111,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps<string>>(
               </SelectValuePrimitive>
               <div className="flex h-6 w-6 items-center justify-center">
                 <div className="h-4 w-4 rounded-2xs bg-f1-background-secondary">
-                  <Icons.ChevronDown className="h-3 w-3" />
+                  <Icon icon={ChevronDown} size="xs" />
                 </div>
               </div>
             </button>

--- a/lib/ui/select.tsx
+++ b/lib/ui/select.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import CheckCircle from "@/icons/app/CheckCircle"
+import { Icon } from "@/components/Utilities/Icon"
+import { CheckCircle, ChevronDown, ChevronUp } from "@/icons/app"
 import { cn } from "@/lib/utils"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import { ChevronDown, ChevronUp } from "lucide-react"
 import * as React from "react"
 
 const Select = SelectPrimitive.Root
@@ -29,12 +29,12 @@ const SelectScrollUpButton = React.forwardRef<
   <SelectPrimitive.ScrollUpButton
     ref={ref}
     className={cn(
-      "flex cursor-default items-center justify-center py-1",
+      "flex cursor-default items-center justify-center py-1 text-f1-icon",
       className
     )}
     {...props}
   >
-    <ChevronUp className="h-4 w-4 text-f1-foreground" />
+    <Icon icon={ChevronUp} size="sm" />
   </SelectPrimitive.ScrollUpButton>
 ))
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
@@ -46,12 +46,12 @@ const SelectScrollDownButton = React.forwardRef<
   <SelectPrimitive.ScrollDownButton
     ref={ref}
     className={cn(
-      "flex cursor-default items-center justify-center py-1",
+      "flex cursor-default items-center justify-center py-1 text-f1-icon",
       className
     )}
     {...props}
   >
-    <ChevronDown className="h-4 w-4 text-f1-foreground" />
+    <Icon icon={ChevronDown} size="sm" />
   </SelectPrimitive.ScrollDownButton>
 ))
 SelectScrollDownButton.displayName =
@@ -115,8 +115,8 @@ const SelectItem = React.forwardRef<
     {...props}
   >
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-    <SelectPrimitive.ItemIndicator className="flex">
-      <CheckCircle className="size-5 text-f1-icon-selected" />
+    <SelectPrimitive.ItemIndicator className="flex text-f1-icon-selected">
+      <Icon icon={CheckCircle} size="md" />
     </SelectPrimitive.ItemIndicator>
   </SelectPrimitive.Item>
 ))


### PR DESCRIPTION
## Description

`Select` is still using an outdated method for implementing and displaying icons. This PR updates the component to use the `Icon` wrapper component and the `IconType`.

Now, every icon in this component is displayed through the `Icon` component, which handles stroke widths, sizes, etc.

## Screenshots

<img width="791" alt="image" src="https://github.com/user-attachments/assets/4fed0e05-b61a-42ad-85e3-11e3bf3a1cd4" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other