### PR TITLE
Make WidgetEmptyState component more flexible

### DIFF
--- a/lib/experimental/Widgets/WidgetEmptyState/index.stories.tsx
+++ b/lib/experimental/Widgets/WidgetEmptyState/index.stories.tsx
@@ -12,18 +12,19 @@ const meta: Meta<typeof WidgetEmptyState> = {
     title: "Title",
     description: "Description",
     emoji: "🍆",
-    actions: {
-      primary: {
+    actions: [
+      {
         icon: PlaceholderIcon,
         onClick: () => {},
         label: "Label",
       },
-      outline: {
+      {
         icon: PlaceholderIcon,
         onClick: () => {},
         label: "Label",
+        variant: "outline",
       },
-    },
+    ],
   },
   decorators: [
     (Story) => (
@@ -52,6 +53,20 @@ export const WidgetEmptyStateWithLongTexts: Story = {
       "Really really long title that we want to show that we want to show to our users for them to read",
     description:
       "Really really long description that we want to show to our users for them to read and express their thoughts",
+  },
+}
+
+export const WidgetEmptyStateWithOnlyOutlineAction: Story = {
+  args: {
+    emoji: undefined,
+    actions: [
+      {
+        icon: PlaceholderIcon,
+        onClick: () => {},
+        label: "Label",
+        variant: "outline",
+      },
+    ],
   },
 }
 

--- a/lib/experimental/Widgets/WidgetEmptyState/index.tsx
+++ b/lib/experimental/Widgets/WidgetEmptyState/index.tsx
@@ -1,24 +1,20 @@
-import { Button } from "@/components/Actions/Button"
+import { Button, ButtonProps } from "@/components/Actions/Button"
 import { IconType } from "@/components/Utilities/Icon"
 import { AlertAvatar } from "@/experimental/Information/Avatars/AlertAvatar"
 import { EmojiAvatar } from "@/experimental/Information/Avatars/EmojiAvatar"
+
+type Action = {
+  label: string
+  onClick: () => void
+  icon?: IconType
+  variant?: ButtonProps["variant"]
+}
 
 export type WidgetEmptyStateProps = {
   title: string
   description: string
   emoji?: string
-  actions?: {
-    primary: {
-      label: string
-      onClick: () => void
-      icon?: IconType
-    }
-    outline: {
-      label: string
-      onClick: () => void
-      icon?: IconType
-    }
-  }
+  actions?: Action[]
 }
 
 export function WidgetEmptyState({
@@ -42,17 +38,15 @@ export function WidgetEmptyState({
       </div>
       {!!actions && (
         <div className="mt-5 flex flex-row gap-3">
-          <Button
-            label={actions.primary.label}
-            icon={actions.primary.icon}
-            onClick={actions.primary.onClick}
-          />
-          <Button
-            label={actions.outline.label}
-            icon={actions.outline.icon}
-            onClick={actions.outline.onClick}
-            variant="outline"
-          />
+          {actions.map((action) => (
+            <Button
+              key={action.label}
+              label={action.label}
+              icon={action.icon}
+              onClick={action.onClick}
+              variant={action.variant}
+            />
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Description

Make WidgetEmptyState component more flexible.

Added support to show buttons with different variants. Before we only were allowed to include both a primary and outline action, now we can include only an outline action or a promote action for example, which are both use cases reflected in figma.