### PR TITLE
Support separators in `Select` and `Dropdown`

### DIFF
--- a/lib/experimental/Forms/Fields/Select/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/Select/index.stories.tsx
@@ -54,6 +54,7 @@ export const WithCustomTrigger: Story = {
     options: [
       { value: "red", label: "Red" },
       { value: "green", label: "Green" },
+      "separator",
       { value: "blue", label: "Blue" },
     ],
   },

--- a/lib/experimental/Forms/Fields/Select/index.tsx
+++ b/lib/experimental/Forms/Fields/Select/index.tsx
@@ -9,18 +9,21 @@ import {
   SelectContent,
   SelectItem as SelectItemPrimitive,
   Select as SelectPrimitive,
+  SelectSeparator,
   SelectTrigger,
   SelectValue as SelectValuePrimitive,
 } from "@/ui/select"
 import { forwardRef } from "react"
 
-type SelectItemProps<T> = {
+type SelectItemObject<T> = {
   value: T
   label: string
   icon?: IconType
   description?: string
   avatar?: AvatarVariant
 }
+
+type SelectItemProps<T> = SelectItemObject<T> | "separator"
 
 type SelectProps<T> = {
   placeholder: string
@@ -33,7 +36,7 @@ type SelectProps<T> = {
   onOpenChange?: (open: boolean) => void
 }
 
-const SelectItem = ({ item }: { item: SelectItemProps<string> }) => {
+const SelectItem = ({ item }: { item: SelectItemObject<string> }) => {
   return (
     <SelectItemPrimitive value={item.value}>
       <div className="flex items-start gap-1.5">
@@ -56,7 +59,7 @@ const SelectItem = ({ item }: { item: SelectItemProps<string> }) => {
   )
 }
 
-const SelectValue = ({ item }: { item: SelectItemProps<string> }) => {
+const SelectValue = ({ item }: { item: SelectItemObject<string> }) => {
   return (
     <div className="flex items-center gap-1.5">
       {item.icon && (
@@ -87,7 +90,10 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps<string>>(
     },
     ref
   ) {
-    const selectedOption = options.find((option) => option.value === value)
+    const selectedOption = options.find(
+      (option): option is Exclude<typeof option, "separator"> =>
+        option !== "separator" && option.value === value
+    )
 
     return (
       <SelectPrimitive
@@ -118,9 +124,13 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps<string>>(
           )}
         </SelectTrigger>
         <SelectContent>
-          {options.map((option) => (
-            <SelectItem key={option.value} item={option} />
-          ))}
+          {options.map((option, index) =>
+            option === "separator" ? (
+              <SelectSeparator key={`separator-${index}`} />
+            ) : (
+              <SelectItem key={option.value} item={option} />
+            )
+          )}
         </SelectContent>
       </SelectPrimitive>
     )

--- a/lib/experimental/Navigation/Dropdown/index.stories.tsx
+++ b/lib/experimental/Navigation/Dropdown/index.stories.tsx
@@ -33,6 +33,7 @@ export const Default: Story = {
         icon: Icons.Save,
         description: "Preserve changes",
       },
+      "separator",
       {
         label: "Delete",
         onClick: () => console.log("Delete clicked"),

--- a/lib/experimental/Navigation/Dropdown/index.tsx
+++ b/lib/experimental/Navigation/Dropdown/index.tsx
@@ -11,11 +11,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu"
 import { NavigationItem } from "../utils"
 
-export type DropdownItem = NavigationItem & {
+export type DropdownItemObject = NavigationItem & {
   onClick?: () => void
   icon?: IconType
   description?: string
@@ -23,12 +24,14 @@ export type DropdownItem = NavigationItem & {
   avatar?: AvatarVariant
 }
 
+export type DropdownItem = DropdownItemObject | "separator"
+
 type DropdownProps = {
   items: DropdownItem[]
   children?: React.ReactNode
 }
 
-const DropdownItem = ({ item }: { item: DropdownItem }) => {
+const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
   const { label, ...props } = item
 
   const content = (
@@ -101,15 +104,19 @@ export function Dropdown({ items, children }: DropdownProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent className="min-w-[var(--radix-dropdown-menu-trigger-width)]">
         <div className="flex flex-col">
-          {items.map((item, index) => (
-            <DropdownItem
-              key={index}
-              item={{
-                ...item,
-                onClick: item.onClick,
-              }}
-            />
-          ))}
+          {items.map((item, index) =>
+            item === "separator" ? (
+              <DropdownMenuSeparator key={`separator-${index}`} />
+            ) : (
+              <DropdownItem
+                key={index}
+                item={{
+                  ...item,
+                  onClick: item.onClick,
+                }}
+              />
+            )
+          )}
         </div>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Description

Add support to show separators between options in `Select` and `Dropdown`. Writing "separator" between two options will show a separator in that place.

```
options: [
   { value: "green", label: "Green" },
   "separator",
   { value: "blue", label: "Blue" },
],
```

## Screenshots

<img width="223" alt="image" src="https://github.com/user-attachments/assets/8742fa13-677b-4f62-80d3-d100ebd61115" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other