### PR TITLE
Adds "other actions" dropdown to `ResourceHeader`

### DIFF
--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -40,11 +40,11 @@ export function BaseHeader({
         {
           label: status.label,
           value: {
-            type: "status",
+            type: "status" as const,
             label: status.text,
             variant: status.variant,
           },
-        } satisfies MetadataItem,
+        },
         ...(metadata ?? []),
       ]
     : metadata
@@ -77,54 +77,27 @@ export function BaseHeader({
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
           {metadata && <Metadata items={allMetadata} />}
         </div>
-        <div className="flex w-full shrink-0 flex-wrap items-center gap-x-3 gap-y-4 md:w-fit md:flex-row-reverse md:gap-y-2 md:overflow-x-auto">
+        <div className="flex w-full shrink-0 flex-wrap items-center gap-x-3 gap-y-4 md:w-fit md:flex-row-reverse md:gap-y-2 md:overflow-x-auto [&>*]:w-full [&>*]:md:w-auto">
           {primaryAction && (
-            <>
-              <div className="hidden md:block">
-                <Button
-                  label={primaryAction.label}
-                  onClick={primaryAction.onClick}
-                  variant="default"
-                  icon={primaryAction.icon}
-                />
-              </div>
-              <div className="w-full md:hidden [&>*]:w-full">
-                <Button
-                  label={primaryAction.label}
-                  onClick={primaryAction.onClick}
-                  variant="default"
-                  icon={primaryAction.icon}
-                  size="lg"
-                />
-              </div>
-            </>
+            <Button
+              label={primaryAction.label}
+              onClick={primaryAction.onClick}
+              variant="default"
+              icon={primaryAction.icon}
+            />
           )}
           {primaryAction && secondaryActions && (
             <div className="hidden h-4 w-px bg-f1-background-secondary md:block" />
           )}
           {secondaryActions &&
             secondaryActions.map((action) => (
-              <>
-                <div className="hidden md:block">
-                  <Button
-                    key={action.label}
-                    label={action.label}
-                    onClick={action.onClick}
-                    variant={action.variant ?? "outline"}
-                    icon={action.icon}
-                  />
-                </div>
-                <div className="w-full md:hidden [&>*]:w-full">
-                  <Button
-                    key={action.label}
-                    label={action.label}
-                    onClick={action.onClick}
-                    variant={action.variant ?? "outline"}
-                    icon={action.icon}
-                    size="lg"
-                  />
-                </div>
-              </>
+              <Button
+                key={action.label}
+                label={action.label}
+                onClick={action.onClick}
+                variant={action.variant ?? "outline"}
+                icon={action.icon}
+              />
             ))}
         </div>
       </div>

--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -8,6 +8,7 @@ import {
   PrimaryAction,
   SecondaryAction,
 } from "@/experimental/Information/utils"
+import { Dropdown, MobileDropdown } from "@/experimental/Navigation/Dropdown"
 import { Metadata, MetadataItem } from "../Metadata"
 
 interface BaseHeaderProps {
@@ -17,6 +18,7 @@ interface BaseHeaderProps {
   eyebrow?: React.ReactNode
   primaryAction?: PrimaryAction
   secondaryActions?: SecondaryAction[]
+  otherActions?: SecondaryAction[]
   status?: {
     label: string
     text: string
@@ -32,6 +34,7 @@ export function BaseHeader({
   eyebrow,
   primaryAction,
   secondaryActions,
+  otherActions,
   status,
   metadata,
 }: BaseHeaderProps) {
@@ -99,7 +102,7 @@ export function BaseHeader({
               </div>
             </>
           )}
-          {primaryAction && secondaryActions && (
+          {primaryAction && (secondaryActions || otherActions) && (
             <div className="hidden h-4 w-px bg-f1-background-secondary md:block" />
           )}
           {secondaryActions &&
@@ -126,6 +129,30 @@ export function BaseHeader({
                 </div>
               </>
             ))}
+          {otherActions && otherActions.length > 0 && (
+            <>
+              <div className="hidden md:block">
+                <Dropdown
+                  items={otherActions.map((action) => ({
+                    label: action.label,
+                    icon: action.icon,
+                    onClick: action.onClick,
+                    critical: action.variant === "critical",
+                  }))}
+                />
+              </div>
+              <div className="w-full md:hidden">
+                <MobileDropdown
+                  items={otherActions.map((action) => ({
+                    label: action.label,
+                    icon: action.icon,
+                    onClick: action.onClick,
+                    critical: action.variant === "critical",
+                  }))}
+                />
+              </div>
+            </>
+          )}
         </div>
       </div>
       <div className="flex hidden flex-wrap items-center gap-x-3 gap-y-1 md:block">

--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -77,27 +77,54 @@ export function BaseHeader({
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
           {metadata && <Metadata items={allMetadata} />}
         </div>
-        <div className="flex w-full shrink-0 flex-wrap items-center gap-x-3 gap-y-4 md:w-fit md:flex-row-reverse md:gap-y-2 md:overflow-x-auto [&>*]:w-full [&>*]:md:w-auto">
+        <div className="flex w-full shrink-0 flex-wrap items-center gap-x-3 gap-y-4 md:w-fit md:flex-row-reverse md:gap-y-2 md:overflow-x-auto">
           {primaryAction && (
-            <Button
-              label={primaryAction.label}
-              onClick={primaryAction.onClick}
-              variant="default"
-              icon={primaryAction.icon}
-            />
+            <>
+              <div className="hidden md:block">
+                <Button
+                  label={primaryAction.label}
+                  onClick={primaryAction.onClick}
+                  variant="default"
+                  icon={primaryAction.icon}
+                />
+              </div>
+              <div className="w-full md:hidden [&>*]:w-full">
+                <Button
+                  label={primaryAction.label}
+                  onClick={primaryAction.onClick}
+                  variant="default"
+                  icon={primaryAction.icon}
+                  size="lg"
+                />
+              </div>
+            </>
           )}
           {primaryAction && secondaryActions && (
             <div className="hidden h-4 w-px bg-f1-background-secondary md:block" />
           )}
           {secondaryActions &&
             secondaryActions.map((action) => (
-              <Button
-                key={action.label}
-                label={action.label}
-                onClick={action.onClick}
-                variant={action.variant ?? "outline"}
-                icon={action.icon}
-              />
+              <>
+                <div className="hidden md:block">
+                  <Button
+                    key={action.label}
+                    label={action.label}
+                    onClick={action.onClick}
+                    variant={action.variant ?? "outline"}
+                    icon={action.icon}
+                  />
+                </div>
+                <div className="w-full md:hidden [&>*]:w-full">
+                  <Button
+                    key={action.label}
+                    label={action.label}
+                    onClick={action.onClick}
+                    variant={action.variant ?? "outline"}
+                    icon={action.icon}
+                    size="lg"
+                  />
+                </div>
+              </>
             ))}
         </div>
       </div>

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -55,8 +55,8 @@ function MetadataItem({ item }: { item: MetadataItem }) {
   const isAction = item.actions?.length
 
   return (
-    <div className="flex h-8 items-center gap-2 text-sm">
-      <div className="w-28 truncate text-sm text-f1-foreground-secondary md:w-fit">
+    <div className="flex h-8 items-center gap-2">
+      <div className="w-28 truncate text-f1-foreground-secondary md:w-fit">
         {item.label}
       </div>
       <div
@@ -83,7 +83,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
               exit={{ opacity: 0 }}
               transition={{ duration: 0.1 }}
             >
-              <div className="flex h-5 items-center text-sm font-medium text-f1-foreground">
+              <div className="flex h-5 items-center font-medium text-f1-foreground">
                 {renderMetadataValue(item)}
               </div>
               {isAction && (

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -95,7 +95,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
                   transition={{ duration: 0.1 }}
                 >
                   {item.actions?.map((action, index) => (
-                    <Tooltip label={action.label}>
+                    <Tooltip label={action.label} key={`tooltip-${index}`}>
                       <Button
                         key={`action-${index}`}
                         size="sm"

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -8,6 +8,7 @@ import {
   StatusTag,
   StatusVariant,
 } from "@/experimental/Information/Tags/StatusTag"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { cn } from "@/lib/utils"
 import { AnimatePresence, motion } from "framer-motion"
 import { useState } from "react"
@@ -50,7 +51,7 @@ function renderMetadataValue(item: MetadataItem) {
 }
 
 function MetadataItem({ item }: { item: MetadataItem }) {
-  const [isHovered, setIsHovered] = useState(false)
+  const [isActive, setIsActive] = useState(false)
   const isAction = item.actions?.length
 
   return (
@@ -59,15 +60,19 @@ function MetadataItem({ item }: { item: MetadataItem }) {
         {item.label}
       </div>
       <div
-        onMouseEnter={() => isAction && setIsHovered(true)}
-        onMouseLeave={() => isAction && setIsHovered(false)}
-        className="relative flex h-5 w-fit items-center"
+        role="button"
+        tabIndex={isAction ? 0 : -1}
+        onMouseEnter={() => isAction && setIsActive(true)}
+        onMouseLeave={() => isAction && setIsActive(false)}
+        onFocus={() => isAction && setIsActive(true)}
+        onBlur={() => isAction && setIsActive(false)}
+        className="relative flex h-5 w-fit items-center hover:cursor-default"
       >
         <div className="font-medium text-f1-foreground">
           {renderMetadataValue(item)}
         </div>
         <AnimatePresence>
-          {isHovered && isAction && (
+          {isActive && isAction && (
             <motion.div
               className={cn(
                 "absolute -left-1.5 -top-1.5 z-50 flex hidden h-8 items-center justify-center gap-1.5 whitespace-nowrap rounded-sm bg-f1-background py-1 pl-1.5 shadow-md ring-1 ring-inset ring-f1-border-secondary md:flex",
@@ -90,16 +95,18 @@ function MetadataItem({ item }: { item: MetadataItem }) {
                   transition={{ duration: 0.1 }}
                 >
                   {item.actions?.map((action, index) => (
-                    <Button
-                      key={`action-${index}`}
-                      size="sm"
-                      variant="neutral"
-                      round
-                      label={action.label}
-                      hideLabel
-                      icon={action.icon}
-                      onClick={action.onClick}
-                    />
+                    <Tooltip label={action.label}>
+                      <Button
+                        key={`action-${index}`}
+                        size="sm"
+                        variant="neutral"
+                        round
+                        label={action.label}
+                        hideLabel
+                        icon={action.icon}
+                        onClick={action.onClick}
+                      />
+                    </Tooltip>
                   ))}
                 </motion.div>
               )}

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -8,7 +8,6 @@ import {
   StatusTag,
   StatusVariant,
 } from "@/experimental/Information/Tags/StatusTag"
-import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { cn } from "@/lib/utils"
 import { AnimatePresence, motion } from "framer-motion"
 import { useState } from "react"
@@ -51,28 +50,24 @@ function renderMetadataValue(item: MetadataItem) {
 }
 
 function MetadataItem({ item }: { item: MetadataItem }) {
-  const [isActive, setIsActive] = useState(false)
+  const [isHovered, setIsHovered] = useState(false)
   const isAction = item.actions?.length
 
   return (
-    <div className="flex h-8 items-center gap-2">
-      <div className="w-28 truncate text-f1-foreground-secondary md:w-fit">
+    <div className="flex h-8 items-center gap-2 text-sm">
+      <div className="w-28 truncate text-sm text-f1-foreground-secondary md:w-fit">
         {item.label}
       </div>
       <div
-        role="button"
-        tabIndex={isAction ? 0 : -1}
-        onMouseEnter={() => isAction && setIsActive(true)}
-        onMouseLeave={() => isAction && setIsActive(false)}
-        onFocus={() => isAction && setIsActive(true)}
-        onBlur={() => isAction && setIsActive(false)}
-        className="relative flex h-5 w-fit items-center hover:cursor-default"
+        onMouseEnter={() => isAction && setIsHovered(true)}
+        onMouseLeave={() => isAction && setIsHovered(false)}
+        className="relative flex h-5 w-fit items-center"
       >
         <div className="font-medium text-f1-foreground">
           {renderMetadataValue(item)}
         </div>
         <AnimatePresence>
-          {isActive && isAction && (
+          {isHovered && isAction && (
             <motion.div
               className={cn(
                 "absolute -left-1.5 -top-1.5 z-50 flex hidden h-8 items-center justify-center gap-1.5 whitespace-nowrap rounded-sm bg-f1-background py-1 pl-1.5 shadow-md ring-1 ring-inset ring-f1-border-secondary md:flex",
@@ -83,32 +78,24 @@ function MetadataItem({ item }: { item: MetadataItem }) {
               exit={{ opacity: 0 }}
               transition={{ duration: 0.1 }}
             >
-              <div className="flex h-5 items-center font-medium text-f1-foreground">
+              <div className="flex h-5 items-center text-sm font-medium text-f1-foreground">
                 {renderMetadataValue(item)}
               </div>
               {isAction && (
-                <motion.div
-                  className="flex gap-1"
-                  initial={{ x: -16 }}
-                  animate={{ x: 0 }}
-                  exit={{ x: -16 }}
-                  transition={{ duration: 0.1 }}
-                >
+                <div className="flex gap-1">
                   {item.actions?.map((action, index) => (
-                    <Tooltip label={action.label} key={`tooltip-${index}`}>
-                      <Button
-                        key={`action-${index}`}
-                        size="sm"
-                        variant="neutral"
-                        round
-                        label={action.label}
-                        hideLabel
-                        icon={action.icon}
-                        onClick={action.onClick}
-                      />
-                    </Tooltip>
+                    <Button
+                      key={`action-${index}`}
+                      size="sm"
+                      variant="neutral"
+                      round
+                      label={action.label}
+                      hideLabel
+                      icon={action.icon}
+                      onClick={action.onClick}
+                    />
                   ))}
-                </motion.div>
+                </div>
               )}
             </motion.div>
           )}
@@ -122,7 +109,7 @@ export function Metadata({ items }: MetadataProps) {
   if (!items?.length) return null
 
   return (
-    <div className="flex flex-col items-start gap-x-3 gap-y-0 md:flex-row md:flex-wrap md:items-center">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-0">
       {items.map((item, index) => (
         <>
           <MetadataItem key={`item-${index}`} item={item} />

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -109,7 +109,7 @@ export function Metadata({ items }: MetadataProps) {
   if (!items?.length) return null
 
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-0">
+    <div className="flex flex-col items-start gap-x-3 gap-y-0 md:flex-row md:flex-wrap md:items-center">
       {items.map((item, index) => (
         <>
           <MetadataItem key={`item-${index}`} item={item} />

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -82,7 +82,13 @@ function MetadataItem({ item }: { item: MetadataItem }) {
                 {renderMetadataValue(item)}
               </div>
               {isAction && (
-                <div className="flex gap-1">
+                <motion.div
+                  className="flex gap-1"
+                  initial={{ x: -16 }}
+                  animate={{ x: 0 }}
+                  exit={{ x: -16 }}
+                  transition={{ duration: 0.1 }}
+                >
                   {item.actions?.map((action, index) => (
                     <Button
                       key={`action-${index}`}
@@ -95,7 +101,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
                       onClick={action.onClick}
                     />
                   ))}
-                </div>
+                </motion.div>
               )}
             </motion.div>
           )}

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -59,6 +59,7 @@ export const Default: Story = {
 export const Metadata: Story = {
   args: {
     ...defaultArgs,
+    primaryAction: undefined,
     secondaryActions: [
       {
         label: "Edit",

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -69,14 +69,9 @@ export const Metadata: Story = {
     ],
     metadata: [
       {
-        label: "Created at a large label indeed",
+        label: "Created",
         value: { type: "text", content: "2024-01-01" },
         actions: [
-          {
-            label: "Edit",
-            icon: Pencil,
-            onClick: fn(),
-          },
           {
             label: "Copy",
             icon: LayersFront,

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -1,4 +1,11 @@
-import { Comment, LayersFront, Pencil } from "@/icons/app"
+import {
+  Archive,
+  Comment,
+  Download,
+  ExternalLink,
+  LayersFront,
+  Pencil,
+} from "@/icons/app"
 import * as Icon from "@/icons/app/"
 import type { Meta, StoryObj } from "@storybook/react"
 import { fn } from "@storybook/test"
@@ -15,31 +22,35 @@ export default meta
 
 type Story = StoryObj<typeof ResourceHeader>
 
+const defaultArgs = {
+  title: "Senior Product Designer",
+  description:
+    "Open position on our team, seeking an experienced product designer to lead design initiatives",
+  status: {
+    label: "Status",
+    text: "Published",
+    variant: "positive",
+  },
+  primaryAction: {
+    label: "Edit",
+    icon: Icon.Pencil,
+    onClick: fn(),
+  },
+} as const
+
 export const Default: Story = {
   args: {
-    title: "Senior Product Designer",
-    description:
-      "Open position on our team, seeking an experienced product designer to lead design initiatives",
-    status: {
-      label: "Status",
-      text: "Published",
-      variant: "positive",
-    },
-    primaryAction: {
-      label: "Edit",
-      icon: Icon.Pencil,
-      onClick: () => console.log("Edit clicked"),
-    },
+    ...defaultArgs,
     secondaryActions: [
       {
         label: "Promote",
-        onClick: () => console.log("Promote clicked"),
+        onClick: fn(),
       },
       {
         label: "Remove",
         icon: Icon.Delete,
         variant: "critical",
-        onClick: () => console.log("Remove clicked"),
+        onClick: fn(),
       },
     ],
   },
@@ -47,14 +58,7 @@ export const Default: Story = {
 
 export const Metadata: Story = {
   args: {
-    title: "Senior Product Designer",
-    description:
-      "Open position on our team, seeking an experienced product designer to lead design initiatives",
-    status: {
-      label: "Status",
-      text: "Published",
-      variant: "positive",
-    },
+    ...defaultArgs,
     secondaryActions: [
       {
         label: "Edit",
@@ -111,6 +115,36 @@ export const Metadata: Story = {
           label: "Pending",
           variant: "warning",
         },
+      },
+    ],
+  },
+}
+
+export const WithOtherActions: Story = {
+  args: {
+    ...defaultArgs,
+    secondaryActions: [
+      {
+        label: "Promote",
+        onClick: fn(),
+      },
+    ],
+    otherActions: [
+      {
+        label: "Share",
+        icon: ExternalLink,
+        onClick: fn(),
+      },
+      {
+        label: "Download",
+        icon: Download,
+        onClick: fn(),
+      },
+      {
+        label: "Archive",
+        icon: Archive,
+        variant: "critical",
+        onClick: fn(),
       },
     ],
   },

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -69,9 +69,14 @@ export const Metadata: Story = {
     ],
     metadata: [
       {
-        label: "Created",
+        label: "Created at a large label indeed",
         value: { type: "text", content: "2024-01-01" },
         actions: [
+          {
+            label: "Edit",
+            icon: Pencil,
+            onClick: fn(),
+          },
           {
             label: "Copy",
             icon: LayersFront,

--- a/lib/experimental/Information/Headers/ResourceHeader/index.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.tsx
@@ -9,6 +9,7 @@ type Props = {} & Pick<
   | "description"
   | "primaryAction"
   | "secondaryActions"
+  | "otherActions"
   | "metadata"
   | "status"
 >
@@ -18,6 +19,7 @@ export const ResourceHeader = ({
   description,
   primaryAction,
   secondaryActions,
+  otherActions,
   status,
   metadata,
 }: Props) => {
@@ -27,6 +29,7 @@ export const ResourceHeader = ({
       description={description}
       primaryAction={primaryAction}
       secondaryActions={secondaryActions}
+      otherActions={otherActions}
       status={status}
       metadata={metadata}
     />

--- a/lib/experimental/Navigation/Dropdown/DropdownItem.tsx
+++ b/lib/experimental/Navigation/Dropdown/DropdownItem.tsx
@@ -1,0 +1,72 @@
+import { Icon, IconType } from "@/components/Utilities/Icon"
+import { AvatarVariant, renderAvatar } from "@/experimental/exports"
+import { Link } from "@/lib/linkHandler"
+import { cn } from "@/lib/utils"
+import { DropdownMenuItem } from "@radix-ui/react-dropdown-menu"
+import { NavigationItem } from "../utils"
+
+export type DropdownItemObject = NavigationItem & {
+  onClick?: () => void
+  icon?: IconType
+  description?: string
+  critical?: boolean
+  avatar?: AvatarVariant
+}
+
+const Content = ({ item }: { item: DropdownItemObject }) => (
+  <>
+    {item.avatar && renderAvatar(item.avatar, "xsmall")}
+    {item.icon && (
+      <Icon
+        icon={item.icon}
+        size="md"
+        className={cn("text-f1-icon", item.critical && "text-f1-icon-critical")}
+      />
+    )}
+    <div className="flex flex-col items-start">
+      {item.label}
+      {item.description && (
+        <div
+          className={cn(
+            "font-normal text-f1-foreground-secondary",
+            item.critical && "text-f1-foreground-critical"
+          )}
+        >
+          {item.description}
+        </div>
+      )}
+    </div>
+  </>
+)
+
+const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
+  const { label, ...props } = item
+
+  const itemClass = cn(
+    "flex items-start gap-1.5 w-full",
+    item.critical && "text-f1-foreground-critical"
+  )
+
+  return (
+    <DropdownMenuItem asChild onClick={item.onClick} className={itemClass}>
+      {item.href ? (
+        <Link
+          href={item.href}
+          className={cn(
+            itemClass,
+            "text-f1-foreground no-underline hover:cursor-pointer"
+          )}
+          {...props}
+        >
+          <Content item={item} />
+        </Link>
+      ) : (
+        <div className={itemClass}>
+          <Content item={item} />
+        </div>
+      )}
+    </DropdownMenuItem>
+  )
+}
+
+export { DropdownItem, Content as DropdownItemContent }

--- a/lib/experimental/Navigation/Dropdown/DropdownItem.tsx
+++ b/lib/experimental/Navigation/Dropdown/DropdownItem.tsx
@@ -40,8 +40,6 @@ const Content = ({ item }: { item: DropdownItemObject }) => (
 )
 
 const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
-  const { label, ...props } = item
-
   const itemClass = cn(
     "flex items-start gap-1.5 w-full",
     item.critical && "text-f1-foreground-critical"
@@ -56,7 +54,7 @@ const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
             itemClass,
             "text-f1-foreground no-underline hover:cursor-pointer"
           )}
-          {...props}
+          {...item}
         >
           <Content item={item} />
         </Link>

--- a/lib/experimental/Navigation/Dropdown/index.tsx
+++ b/lib/experimental/Navigation/Dropdown/index.tsx
@@ -1,91 +1,32 @@
 import { Button } from "@/components/Actions/Button"
-import { Icon, IconType } from "@/components/Utilities/Icon"
-import {
-  AvatarVariant,
-  renderAvatar,
-} from "@/experimental/Information/Avatars/utils"
-import { Ellipsis } from "@/icons/app"
+import { Ellipsis, EllipsisHorizontal } from "@/icons/app"
 import { Link } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
 import {
+  Drawer,
+  DrawerContent,
+  DrawerOverlay,
+  DrawerTrigger,
+} from "@/ui/drawer"
+import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu"
-import { NavigationItem } from "../utils"
-
-export type DropdownItemObject = NavigationItem & {
-  onClick?: () => void
-  icon?: IconType
-  description?: string
-  critical?: boolean
-  avatar?: AvatarVariant
-}
+import { Separator } from "@/ui/separator"
+import { useState } from "react"
+import {
+  DropdownItem,
+  DropdownItemContent,
+  DropdownItemObject,
+} from "./DropdownItem"
 
 export type DropdownItem = DropdownItemObject | "separator"
 
 type DropdownProps = {
   items: DropdownItem[]
   children?: React.ReactNode
-}
-
-const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
-  const { label, ...props } = item
-
-  const content = (
-    <>
-      {item.avatar && renderAvatar(item.avatar, "xsmall")}
-      {item.icon && (
-        <Icon
-          icon={item.icon}
-          size="md"
-          className={cn(
-            "text-f1-icon",
-            item.critical && "text-f1-icon-critical"
-          )}
-        />
-      )}
-      <div className="flex flex-col items-start">
-        {label}
-        {item.description && (
-          <div
-            className={cn(
-              "font-normal text-f1-foreground-secondary",
-              item.critical && "text-f1-foreground-critical"
-            )}
-          >
-            {item.description}
-          </div>
-        )}
-      </div>
-    </>
-  )
-
-  const itemClass = cn(
-    "flex items-start gap-1.5 w-full",
-    item.critical && "text-f1-foreground-critical"
-  )
-
-  return (
-    <DropdownMenuItem asChild onClick={item.onClick} className={itemClass}>
-      {item.href ? (
-        <Link
-          href={item.href}
-          className={cn(
-            itemClass,
-            "text-f1-foreground no-underline hover:cursor-pointer"
-          )}
-          {...props}
-        >
-          {content}
-        </Link>
-      ) : (
-        <div className={itemClass}>{content}</div>
-      )}
-    </DropdownMenuItem>
-  )
 }
 
 export function Dropdown({ items, children }: DropdownProps) {
@@ -112,5 +53,60 @@ export function Dropdown({ items, children }: DropdownProps) {
         )}
       </DropdownMenuContent>
     </DropdownMenu>
+  )
+}
+
+export const MobileDropdown = ({ items, children }: DropdownProps) => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>
+        <div className="w-full [&>*]:w-full">
+          {children || (
+            <Button
+              label="Other actions"
+              icon={EllipsisHorizontal}
+              variant="outline"
+              size="lg"
+            />
+          )}
+        </div>
+      </DrawerTrigger>
+      <DrawerOverlay className="bg-f1-background-overlay" />
+      <DrawerContent className="bg-f1-background">
+        <div className="flex flex-col gap-2 p-4">
+          {items.map((item, index) =>
+            item === "separator" ? (
+              <Separator key={`separator-${index}`} />
+            ) : item.href ? (
+              <Link
+                {...item}
+                href={item.href}
+                className={cn(
+                  "flex w-full items-start gap-1.5",
+                  item.critical && "text-f1-foreground-critical",
+                  "text-f1-foreground no-underline hover:cursor-pointer"
+                )}
+              >
+                <DropdownItemContent item={item} />
+              </Link>
+            ) : (
+              <Button
+                key={item.label}
+                label={item.label}
+                onClick={() => {
+                  item.onClick?.()
+                  setOpen(false)
+                }}
+                variant={item.critical ? "critical" : "outline"}
+                icon={item.icon}
+                size="lg"
+              />
+            )
+          )}
+        </div>
+      </DrawerContent>
+    </Drawer>
   )
 }

--- a/lib/experimental/Navigation/Dropdown/index.tsx
+++ b/lib/experimental/Navigation/Dropdown/index.tsx
@@ -22,6 +22,7 @@ import {
   DropdownItemObject,
 } from "./DropdownItem"
 
+export type { DropdownItemObject } from "./DropdownItem"
 export type DropdownItem = DropdownItemObject | "separator"
 
 type DropdownProps = {

--- a/lib/tokens/colors.ts
+++ b/lib/tokens/colors.ts
@@ -176,6 +176,9 @@ export const f1Colors = {
       DEFAULT: "hsl(var(--selected-50) / 0.1)",
       bold: "hsl(var(--selected-50))",
     },
+    overlay: {
+      DEFAULT: "hsl(var(--neutral-40))",
+    },
   },
   border: {
     DEFAULT: "hsl(var(--neutral-30))",

--- a/lib/ui/drawer.tsx
+++ b/lib/ui/drawer.tsx
@@ -1,0 +1,116 @@
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+)
+Drawer.displayName = "Drawer"
+
+const DrawerTrigger = DrawerPrimitive.Trigger
+
+const DrawerPortal = DrawerPrimitive.Portal
+
+const DrawerClose = DrawerPrimitive.Close
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+))
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        className
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+))
+DrawerContent.displayName = "DrawerContent"
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    {...props}
+  />
+)
+DrawerHeader.displayName = "DrawerHeader"
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+)
+DrawerFooter.displayName = "DrawerFooter"
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/lib/ui/drawer.tsx
+++ b/lib/ui/drawer.tsx
@@ -26,7 +26,7 @@ const DrawerOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
     ref={ref}
-    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    className={cn("bg-black/80 fixed inset-0 z-50", className)}
     {...props}
   />
 ))
@@ -41,12 +41,12 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        "bg-background fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border",
         className
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      <div className="bg-muted mx-auto mt-4 h-2 w-[100px] rounded-full" />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>
@@ -96,7 +96,7 @@ const DrawerDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-muted-foreground text-sm", className)}
     {...props}
   />
 ))
@@ -104,13 +104,13 @@ DrawerDescription.displayName = DrawerPrimitive.Description.displayName
 
 export {
   Drawer,
-  DrawerPortal,
-  DrawerOverlay,
-  DrawerTrigger,
   DrawerClose,
   DrawerContent,
-  DrawerHeader,
-  DrawerFooter,
-  DrawerTitle,
   DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "embla-carousel-autoplay": "^8.5.1",
         "embla-carousel-react": "^8.5.1",
-        "embla-carousel-wheel-gestures": "^8.0.1"
+        "embla-carousel-wheel-gestures": "^8.0.1",
+        "vaul": "^1.1.2"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.3",
@@ -79,8 +80,8 @@
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-checkbox": "^1.0.4",
-        "@radix-ui/react-collapsible": "^1.1.1",
-        "@radix-ui/react-dialog": "^1.0.5",
+        "@radix-ui/react-collapsible": "^1.1.2",
+        "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-navigation-menu": "^1.2.0",
@@ -2860,18 +2861,18 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.1.tgz",
-      "integrity": "sha512-1///SnrfQHJEofLokyczERxQbWfCGQlQ2XsCZMucVs6it+lq9iw4vXy+uDn1edlb58cOZOWSldnfPAYcT4O/Yg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.2.tgz",
+      "integrity": "sha512-PliMB63vxz7vggcyq0IxNYk8vGDrLXVWw4+W4B8YnwI1s18x7YZYqlG9PLX7XxAJUi0g2DxP4XKJMFHh/iVh9A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@radix-ui/primitive": "1.1.0",
-        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-presence": "1.1.1",
-        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.0"
       },
@@ -2886,6 +2887,29 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2907,13 +2931,13 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-presence": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.1.tgz",
-      "integrity": "sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
@@ -2927,6 +2951,49 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2991,26 +3058,25 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
-      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.4.tgz",
+      "integrity": "sha512-Ur7EV1IwQGCyaAuyDRiOLA5JIUZxELJljF+MbM/2NC0BYwfuRrbpS30BiQBJrVruscgUkieKkqXYDOoByaxIoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@radix-ui/primitive": "1.1.0",
-        "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.0",
-        "@radix-ui/react-focus-guards": "1.1.0",
-        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-portal": "1.1.1",
-        "@radix-ui/react-presence": "1.1.0",
-        "@radix-ui/react-primitive": "2.0.0",
-        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.5.7"
+        "react-remove-scroll": "^2.6.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3023,6 +3089,223 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.3.tgz",
+      "integrity": "sha512-onrWn/72lQoEucDmJnr8uczSNTujT0vJnA/X5+3AkChVPowr8n1yvIKIabhWyMQeMvvmdpsvcyDqx3X1LEXCPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.1.tgz",
+      "integrity": "sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.3.tgz",
+      "integrity": "sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/react-remove-scroll": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz",
+      "integrity": "sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3148,7 +3431,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
       "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.0"
       },
@@ -3688,7 +3970,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
       "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -3704,7 +3985,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
       "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.0"
       },
@@ -3723,7 +4003,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
       "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.0"
       },
@@ -3742,7 +4021,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
       "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -6855,7 +7133,6 @@
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
       "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -8717,8 +8994,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -10320,7 +10596,6 @@
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11057,16 +11332,6 @@
       "peer": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -16178,21 +16443,20 @@
       }
     },
     "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
-      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "react-style-singleton": "^2.2.1",
+        "react-style-singleton": "^2.2.2",
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -16217,22 +16481,20 @@
       }
     },
     "node_modules/react-style-singleton": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -18407,11 +18669,10 @@
       "license": "MIT"
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
-      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -18419,8 +18680,8 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -18433,7 +18694,6 @@
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
       "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
@@ -18525,6 +18785,19 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/victory-vendor": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-checkbox": "^1.0.4",
-    "@radix-ui/react-collapsible": "^1.1.1",
-    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-collapsible": "^1.1.2",
+    "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-navigation-menu": "^1.2.0",
@@ -146,6 +146,7 @@
   "dependencies": {
     "embla-carousel-autoplay": "^8.5.1",
     "embla-carousel-react": "^8.5.1",
-    "embla-carousel-wheel-gestures": "^8.0.1"
+    "embla-carousel-wheel-gestures": "^8.0.1",
+    "vaul": "^1.1.2"
   }
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,7 +1,9 @@
 import "@testing-library/jest-dom/vitest"
 import { cleanup } from "@testing-library/react"
-import { afterEach } from "vitest"
+import { afterEach, vi } from "vitest"
 
 afterEach(() => {
   cleanup()
 })
+
+vi.stubGlobal("CSS", { supports: () => true })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,3 +7,14 @@ afterEach(() => {
 })
 
 vi.stubGlobal("CSS", { supports: () => true })
+
+vi.stubGlobal("matchMedia", (query) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}))


### PR DESCRIPTION
## Description

Introduces new `otherActions` prop to `ResourceHeader` and `BaseHeader`. It accepts the list of actions and shows a dropdown with them

I also created a new dropdown component for mobile, which shows a bottom sheet as per [Figma design](https://www.figma.com/design/uImdC0GKxH59DkjzBqRJEF/Layouts-%26-Patterns?node-id=2763-45951&p=f&t=dhxmvvUfRFnLBsVI-0), but I'm a bit hesitant to have two components under the same roof of Dropdown. What do you think about the approach?


## Screenshots

https://github.com/user-attachments/assets/9050a475-7288-40f2-ad2f-f69520285e7a


