### PR TITLE
Update UserMenu to use `Dropdown` item

### DIFF
--- a/lib/experimental/Navigation/Sidebar/User/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/User/index.stories.tsx
@@ -18,6 +18,7 @@ export const Default: Story = {
     options: [
       { label: "Preferences", href: "/preferences", icon: Icons.Sliders },
       { label: "Notifications", href: "/notifications", icon: Icons.Bell },
+      "separator",
       { label: "Logout", href: "/logout", icon: Icons.Exit, critical: true },
     ],
   },

--- a/lib/experimental/Navigation/Sidebar/User/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/User/index.tsx
@@ -1,19 +1,12 @@
-import { IconType } from "@/components/Utilities/Icon"
 import { PersonAvatar } from "@/experimental/Information/Avatars/PersonAvatar"
-import { Dropdown } from "@/experimental/Navigation/Dropdown"
+import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { cn, focusRing } from "@/lib/utils"
 
 interface UserProps {
   firstName: string
   lastName: string
   avatarUrl?: string
-  options: {
-    label: string
-    href?: string
-    icon?: IconType
-    onClick?: () => void
-    critical?: boolean
-  }[]
+  options: DropdownItem[]
 }
 
 export function User({ firstName, lastName, avatarUrl, options }: UserProps) {

--- a/lib/ui/dropdown-menu.tsx
+++ b/lib/ui/dropdown-menu.tsx
@@ -46,7 +46,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -64,7 +64,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-solid border-f1-border-secondary bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border border-solid border-f1-border-secondary bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Description

The User menu in the sidebar is using a `Dropdown` to show options, so it makes sense to leverage its defined props. This approach helps us dodge prop repetition.

Also, made two simple style changes to the Dropdown:
- The minimum width of the dropdown is the size of the trigger.
- Removed the zooming in and out of the open/close animation, as it looks weird if the popover is large enough.

## Screenshots

<img width="588" alt="image" src="https://github.com/user-attachments/assets/0ebca9cd-c799-4a19-a0bc-468463ddc721" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other