### PR TITLE
Prevent add emoji button to look odd

### DIFF
--- a/lib/experimental/Information/Reactions/index.stories.tsx
+++ b/lib/experimental/Information/Reactions/index.stories.tsx
@@ -78,3 +78,9 @@ export const Default: Story = {
     ],
   },
 }
+
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+}

--- a/lib/experimental/Information/Reactions/picker.tsx
+++ b/lib/experimental/Information/Reactions/picker.tsx
@@ -1,9 +1,8 @@
-import { Icon } from "@/components/Utilities/Icon"
+import { Button } from "@/components/Actions/Button"
 import { Reaction } from "@/icons/app"
 import { useReducedMotion } from "@/lib/a11y"
 import { EmojiImage, getEmojiLabel } from "@/lib/emojis"
 import { cn, focusRing } from "@/lib/utils"
-import { Button } from "@/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 import { AnimatePresence, motion } from "framer-motion"
 import { useState } from "react"
@@ -23,11 +22,13 @@ export function Picker({ onSelect }: PickerProps) {
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          className={cn("h-auto px-1.5", isOpen && "border-f1-border-hover")}
-          aria-label="Add reaction"
-        >
-          <Icon icon={Reaction} aria-hidden="true" />
-        </Button>
+          label="Add reaction"
+          icon={Reaction}
+          onClick={(event) => {
+            event.stopPropagation()
+          }}
+          hideLabel
+        />
       </PopoverTrigger>
       <PopoverContent
         side="top"


### PR DESCRIPTION
## Description

When found without emojis, the `Reactions` component looked like this:

<img width="254" alt="Screenshot 2025-01-10 at 17 50 45" src="https://github.com/user-attachments/assets/20a183d1-0e4a-4a66-9bf1-3653605aab90" />

Now it should look like this instead:

<img width="254" alt="Screenshot 2025-01-10 at 17 51 10" src="https://github.com/user-attachments/assets/75955277-fa76-4e80-a20d-41625d8a21ff" />
