### PR TITLE
Update Header layout and status behavior

### DIFF
--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -13,7 +13,7 @@ import {
   DropdownItem,
   MobileDropdown,
 } from "@/experimental/Navigation/Dropdown"
-import { Metadata, MetadataItem } from "../Metadata"
+import { Metadata, MetadataAction, MetadataItem } from "../Metadata"
 
 interface BaseHeaderProps {
   title: string
@@ -27,6 +27,7 @@ interface BaseHeaderProps {
     label: string
     text: string
     variant: StatusVariant
+    actions?: MetadataAction[]
   }
   metadata?: MetadataItem[]
 }
@@ -51,13 +52,15 @@ export function BaseHeader({
             label: status.text,
             variant: status.variant,
           },
+          actions: status.actions ? [...status.actions] : undefined,
+          hideLabel: true,
         },
         ...(metadata ?? []),
       ]
     : metadata
 
   return (
-    <div className="flex flex-col gap-3 p-8">
+    <div className="flex flex-col gap-3 px-6 pb-5 pt-3">
       <div className="flex flex-col items-start justify-start gap-4 md:flex-row">
         <div className="flex grow flex-col items-start justify-start gap-3 md:flex-row md:items-center">
           {avatar && (
@@ -82,7 +85,9 @@ export function BaseHeader({
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
-          {metadata && <Metadata items={allMetadata} />}
+          {allMetadata && allMetadata.length > 0 && (
+            <Metadata items={allMetadata} />
+          )}
         </div>
         <div className="flex w-full shrink-0 flex-wrap items-center gap-x-3 gap-y-4 md:w-fit md:flex-row-reverse md:gap-y-2 md:overflow-x-auto">
           {primaryAction && (
@@ -145,8 +150,10 @@ export function BaseHeader({
           )}
         </div>
       </div>
-      <div className="flex hidden flex-wrap items-center gap-x-3 gap-y-1 md:block">
-        {metadata && <Metadata items={allMetadata} />}
+      <div className="hidden flex-wrap items-center gap-x-3 gap-y-1 md:block">
+        {allMetadata && allMetadata.length > 0 && (
+          <Metadata items={allMetadata} />
+        )}
       </div>
     </div>
   )

--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -52,7 +52,7 @@ export function BaseHeader({
             label: status.text,
             variant: status.variant,
           },
-          actions: status.actions ? [...status.actions] : undefined,
+          actions: status.actions,
           hideLabel: true,
         },
         ...(metadata ?? []),
@@ -85,9 +85,7 @@ export function BaseHeader({
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
-          {allMetadata && allMetadata.length > 0 && (
-            <Metadata items={allMetadata} />
-          )}
+          {allMetadata && <Metadata items={allMetadata} />}
         </div>
         <div className="flex w-full shrink-0 flex-wrap items-center gap-x-3 gap-y-4 md:w-fit md:flex-row-reverse md:gap-y-2 md:overflow-x-auto">
           {primaryAction && (
@@ -151,9 +149,7 @@ export function BaseHeader({
         </div>
       </div>
       <div className="hidden flex-wrap items-center gap-x-3 gap-y-1 md:block">
-        {allMetadata && allMetadata.length > 0 && (
-          <Metadata items={allMetadata} />
-        )}
+        {allMetadata && <Metadata items={allMetadata} />}
       </div>
     </div>
   )

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -28,6 +28,7 @@ interface MetadataItem {
   label: string
   value: MetadataItemValue
   actions?: MetadataAction[]
+  hideLabel?: boolean
 }
 
 interface MetadataProps {
@@ -56,7 +57,12 @@ function MetadataItem({ item }: { item: MetadataItem }) {
 
   return (
     <div className="flex h-8 items-center gap-2">
-      <div className="w-28 truncate text-f1-foreground-secondary md:w-fit">
+      <div
+        className={cn(
+          "w-28 truncate text-f1-foreground-secondary md:w-fit",
+          item.hideLabel && "md:hidden"
+        )}
+      >
         {item.label}
       </div>
       <div
@@ -75,7 +81,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
           {isActive && isAction && (
             <motion.div
               className={cn(
-                "absolute -left-1.5 -top-1.5 z-50 flex hidden h-8 items-center justify-center gap-1.5 whitespace-nowrap rounded-sm bg-f1-background py-1 pl-1.5 shadow-md ring-1 ring-inset ring-f1-border-secondary md:flex",
+                "absolute -left-1.5 -top-1.5 z-50 hidden h-8 items-center justify-center gap-1.5 whitespace-nowrap rounded-sm bg-f1-background py-1 pl-1.5 shadow-md ring-1 ring-inset ring-f1-border-secondary md:flex",
                 isAction ? "pr-1" : "pr-1.5"
               )}
               initial={{ opacity: 0 }}
@@ -138,4 +144,4 @@ export function Metadata({ items }: MetadataProps) {
   )
 }
 
-export type { MetadataItem, MetadataItemValue }
+export type { MetadataAction, MetadataItem, MetadataItemValue }

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -22,25 +22,28 @@ export default meta
 
 type Story = StoryObj<typeof ResourceHeader>
 
-const defaultArgs = {
-  title: "Senior Product Designer",
-  description:
-    "Open position on our team, seeking an experienced product designer to lead design initiatives",
-  status: {
-    label: "Status",
-    text: "Published",
-    variant: "positive",
-  },
-  primaryAction: {
-    label: "Edit",
-    icon: Icon.Pencil,
-    onClick: fn(),
-  },
-} as const
-
 export const Default: Story = {
   args: {
-    ...defaultArgs,
+    title: "Senior Product Designer",
+    description:
+      "Open position on our team, seeking an experienced product designer to lead design initiatives",
+    status: {
+      label: "Status",
+      text: "Published",
+      variant: "positive",
+      actions: [
+        {
+          label: "Edit",
+          icon: Icon.Pencil,
+          onClick: fn(),
+        },
+      ],
+    },
+    primaryAction: {
+      label: "Edit",
+      icon: Icon.Pencil,
+      onClick: fn(),
+    },
     secondaryActions: [
       {
         label: "Promote",
@@ -58,7 +61,7 @@ export const Default: Story = {
 
 export const Metadata: Story = {
   args: {
-    ...defaultArgs,
+    ...Default.args,
     primaryAction: undefined,
     secondaryActions: [
       {
@@ -123,7 +126,7 @@ export const Metadata: Story = {
 
 export const WithOtherActions: Story = {
   args: {
-    ...defaultArgs,
+    ...Default.args,
     secondaryActions: [
       {
         label: "Promote",


### PR DESCRIPTION
## Description

A few tweaks needed for the Header component:

- Match Header padding [with the Figma design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=3066-2491&t=HEAyzwP4y3vnHIUM-4)
- Hide the status label in desktop ([as we do in Figma](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=3397-8626&t=HEAyzwP4y3vnHIUM-4))
- Fix that the status tag was not displayed if there were no metadata defined
- Add option for actions in the status tag

## Screenshots

<img width="299" alt="image" src="https://github.com/user-attachments/assets/618fd6dd-27ee-4abc-980f-daa0ee9b64ea" />

### Figma Link

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=501-54520)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other