### PR TITLE
Remove `PageHeader` separator

### DIFF
--- a/lib/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.tsx
@@ -112,10 +112,7 @@ export function PageHeader({
     <div
       className={cn(
         "flex items-center justify-between px-5 py-4 xs:px-6",
-        embedded ? "h-12" : "h-16",
-        hasNavigation &&
-          !embedded &&
-          "border-b border-dashed border-transparent border-b-f1-border"
+        embedded ? "h-12" : "h-16"
       )}
     >
       <div className="flex flex-grow items-center">


### PR DESCRIPTION
## Description

We are removing the border on the `PageHeader` component, just a stylistic choice :D

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](https://www.figma.com/design/uImdC0GKxH59DkjzBqRJEF/Design-Patterns?node-id=3883-58664&t=82ExqQte3BHa84pW-4)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
