### PR TITLE
Fix truncate company name and skip to content button position

### DIFF
--- a/lib/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/lib/experimental/Navigation/ApplicationFrame/index.tsx
@@ -29,7 +29,7 @@ const SkipToContentButton = ({ contentId }: { contentId?: string }) => {
     <a
       href={`#${contentId}`}
       className={focusRing(
-        "absolute z-50 -translate-y-full translate-x-4 rounded-md bg-f1-background px-4 py-2.5 text-base font-medium text-f1-foreground no-underline transition-transform duration-200 focus-visible:translate-y-4"
+        "absolute z-50 -translate-y-[250%] translate-x-4 rounded-md bg-f1-background px-4 py-2.5 text-base font-medium text-f1-foreground no-underline transition-transform duration-200 focus-visible:translate-y-4"
       )}
     >
       Skip to content

--- a/lib/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/lib/experimental/Navigation/ApplicationFrame/index.tsx
@@ -29,7 +29,7 @@ const SkipToContentButton = ({ contentId }: { contentId?: string }) => {
     <a
       href={`#${contentId}`}
       className={focusRing(
-        "absolute z-50 -translate-y-[250%] translate-x-4 rounded-md bg-f1-background px-4 py-2.5 text-base font-medium text-f1-foreground no-underline transition-transform duration-200 focus-visible:translate-y-4"
+        "absolute z-50 -translate-y-[1000px] translate-x-4 rounded-md bg-f1-background px-4 py-2.5 text-base font-medium text-f1-foreground no-underline transition-transform duration-200 focus-visible:translate-y-4"
       )}
     >
       Skip to content

--- a/lib/experimental/Navigation/Sidebar/CompanySelector/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/CompanySelector/index.tsx
@@ -53,7 +53,7 @@ export function CompanySelector({
 
   if (companies.length + (additionalOptions?.length || 0) === 1) {
     return (
-      <div className="p-1.5">
+      <div className="max-w-[calc(240px - 72px)] p-1.5">
         <SelectedCompanyLabel
           company={selectedCompany}
           withNotification={withNotification}


### PR DESCRIPTION
## Description

Fixes a couple of reported visual bugs in the layout:

- Company name not getting truncated [[#1](https://factorialteam.slack.com/archives/C082ZNKS403/p1737025100422449), [#2](https://factorialteam.slack.com/archives/C082ZNKS403/p1737107896894529)]
- Skip to content button visible when a banner is visible [[#1](https://factorialteam.slack.com/archives/C082ZNKS403/p1736954615364759)]