### PR TITLE
Ensure that texts in CommunityPost have right color

### DIFF
--- a/lib/experimental/Information/Communities/Post/CommunityPost/index.tsx
+++ b/lib/experimental/Information/Communities/Post/CommunityPost/index.tsx
@@ -164,7 +164,7 @@ export const BaseCommunityPost = ({
               </div>
             </div>
           </div>
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-1 text-f1-foreground">
             <p className="text-xl font-semibold">{title}</p>
             {description && <PostDescription content={description} collapsed />}
           </div>


### PR DESCRIPTION
## Description

Just realized that on production the texts in title and description don't have the right color. This PR fixes that.

<img width="664" alt="Screenshot 2025-01-17 at 17 07 13" src="https://github.com/user-attachments/assets/b2d3dfdb-0dc0-4241-8cc7-da5844be7ea0" />
