### PR TITLE
feat: add onClick to BarChart

### DIFF
--- a/lib/components/Charts/BarChart/index.stories.tsx
+++ b/lib/components/Charts/BarChart/index.stories.tsx
@@ -30,6 +30,9 @@ const meta: Meta<typeof BarChart<typeof dataConfig>> = {
       { label: "April", values: { desktop: 1500 } },
       { label: "May", values: { desktop: 2000 } },
     ],
+    onClick: (data) => {
+      console.log("Bar clicked", data)
+    },
   },
 }
 

--- a/lib/components/Charts/BarChart/index.tsx
+++ b/lib/components/Charts/BarChart/index.tsx
@@ -27,11 +27,24 @@ import { fixedForwardRef } from "../utils/forwardRef"
 import { prepareData } from "../utils/muncher"
 import { ChartPropsBase } from "../utils/types"
 
+type ChartDataPoint<K extends ChartConfig> = {
+  label: string
+  values: {
+    [key in keyof K]: number
+  }
+}
+
+type ActivePayload<K> = Array<{
+  name: keyof K
+  value: number
+}>
+
 export type BarChartProps<K extends ChartConfig = ChartConfig> =
   ChartPropsBase<K> & {
     type?: "simple" | "stacked" | "stacked-by-sign"
     label?: boolean
     legend?: boolean
+    onClick?: (data: ChartDataPoint<K>) => void
   }
 
 const _BarChart = <K extends ChartConfig>(
@@ -44,6 +57,7 @@ const _BarChart = <K extends ChartConfig>(
     type = "simple",
     aspect,
     legend,
+    onClick,
   }: BarChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
@@ -72,6 +86,22 @@ const _BarChart = <K extends ChartConfig>(
           top: label ? 24 : 0,
         }}
         stackOffset={type === "stacked-by-sign" ? "sign" : undefined}
+        onClick={(data) => {
+          if (!onClick || !data.activeLabel || !data.activePayload) {
+            return
+          }
+
+          const chartData = {
+            label: data.activeLabel,
+            values: {},
+          } as ChartDataPoint<K>
+
+          for (const payload of data.activePayload as ActivePayload<K>) {
+            chartData.values[payload.name] = payload.value
+          }
+
+          onClick(chartData)
+        }}
       >
         <ChartTooltip
           cursor


### PR DESCRIPTION
## Description

In the Talent Analytics page we want to allow filtering the table by clicking the chart bars:

![image](https://github.com/user-attachments/assets/23b283f7-ec66-4c40-9db9-80ddfee92e2f)

To do so we need to have an `onClick` handler in the `BarChart` that allows us to know what have been clicked.

The typing is awful, but `activePayload` is `any[]` in `recharts`, any feedback and improvements are welcomed!

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/8e0637fb-2d4f-4681-8a8e-677ded6823b2)
