### PR TITLE
`ResourceHeader` new props: disabled, tooltip and isVisible

### DIFF
--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/Actions/Button"
+import { Button, ButtonProps } from "@/components/Actions/Button"
 import {
   Avatar,
   AvatarVariant,
@@ -13,6 +13,8 @@ import {
   DropdownItem,
   MobileDropdown,
 } from "@/experimental/Navigation/Dropdown"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { Fragment, memo } from "react"
 import { Metadata, MetadataAction, MetadataItem } from "../Metadata"
 
 interface BaseHeaderProps {
@@ -31,6 +33,23 @@ interface BaseHeaderProps {
   }
   metadata?: MetadataItem[]
 }
+
+const ButtonWithTooltip = memo(function ButtonWithTooltip({
+  tooltip,
+  ...buttonProps
+}: ButtonProps & { tooltip?: string }) {
+  if (tooltip) {
+    const Wrapper = buttonProps.disabled ? "span" : Fragment
+    return (
+      <Tooltip description={tooltip}>
+        <Wrapper>
+          <Button {...buttonProps} />
+        </Wrapper>
+      </Tooltip>
+    )
+  }
+  return <Button {...buttonProps} />
+})
 
 export function BaseHeader({
   title,
@@ -91,22 +110,24 @@ export function BaseHeader({
           {primaryAction && (
             <>
               <div className="hidden md:block">
-                <Button
+                <ButtonWithTooltip
                   label={primaryAction.label}
                   onClick={primaryAction.onClick}
                   variant="default"
                   icon={primaryAction.icon}
                   disabled={primaryAction.disabled}
+                  tooltip={primaryAction.tooltip}
                 />
               </div>
               <div className="w-full md:hidden [&>*]:w-full">
-                <Button
+                <ButtonWithTooltip
                   label={primaryAction.label}
                   onClick={primaryAction.onClick}
                   variant="default"
                   icon={primaryAction.icon}
                   size="lg"
                   disabled={primaryAction.disabled}
+                  tooltip={primaryAction.tooltip}
                 />
               </div>
             </>
@@ -118,17 +139,18 @@ export function BaseHeader({
             secondaryActions.map((action) => (
               <>
                 <div className="hidden md:block">
-                  <Button
+                  <ButtonWithTooltip
                     key={action.label}
                     label={action.label}
                     onClick={action.onClick}
                     variant={action.variant ?? "outline"}
                     icon={action.icon}
                     disabled={action.disabled}
+                    tooltip={action.tooltip}
                   />
                 </div>
                 <div className="w-full md:hidden [&>*]:w-full">
-                  <Button
+                  <ButtonWithTooltip
                     key={action.label}
                     label={action.label}
                     onClick={action.onClick}
@@ -136,6 +158,7 @@ export function BaseHeader({
                     icon={action.icon}
                     size="lg"
                     disabled={action.disabled}
+                    tooltip={action.tooltip}
                   />
                 </div>
               </>

--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -96,6 +96,7 @@ export function BaseHeader({
                   onClick={primaryAction.onClick}
                   variant="default"
                   icon={primaryAction.icon}
+                  disabled={primaryAction.disabled}
                 />
               </div>
               <div className="w-full md:hidden [&>*]:w-full">
@@ -105,6 +106,7 @@ export function BaseHeader({
                   variant="default"
                   icon={primaryAction.icon}
                   size="lg"
+                  disabled={primaryAction.disabled}
                 />
               </div>
             </>
@@ -122,6 +124,7 @@ export function BaseHeader({
                     onClick={action.onClick}
                     variant={action.variant ?? "outline"}
                     icon={action.icon}
+                    disabled={action.disabled}
                   />
                 </div>
                 <div className="w-full md:hidden [&>*]:w-full">
@@ -132,6 +135,7 @@ export function BaseHeader({
                     variant={action.variant ?? "outline"}
                     icon={action.icon}
                     size="lg"
+                    disabled={action.disabled}
                   />
                 </div>
               </>

--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -24,7 +24,7 @@ interface BaseHeaderProps {
   eyebrow?: React.ReactNode
   primaryAction?: PrimaryAction
   secondaryActions?: SecondaryAction[]
-  otherActions?: DropdownItem[]
+  otherActions?: (DropdownItem & { isVisible?: boolean })[]
   status?: {
     label: string
     text: string
@@ -33,6 +33,9 @@ interface BaseHeaderProps {
   }
   metadata?: MetadataItem[]
 }
+
+const isVisible = (action: { isVisible?: boolean }) =>
+  action.isVisible !== false
 
 const ButtonWithTooltip = memo(function ButtonWithTooltip({
   tooltip,
@@ -57,10 +60,10 @@ export function BaseHeader({
   description,
   eyebrow,
   primaryAction,
-  secondaryActions,
-  otherActions,
+  secondaryActions = [],
+  otherActions = [],
   status,
-  metadata,
+  metadata = [],
 }: BaseHeaderProps) {
   const allMetadata = status
     ? [
@@ -74,9 +77,15 @@ export function BaseHeader({
           actions: status.actions,
           hideLabel: true,
         },
-        ...(metadata ?? []),
+        ...metadata,
       ]
     : metadata
+
+  const visibleSecondaryActions = secondaryActions.filter(isVisible)
+  const visibleOtherActions = otherActions.filter(isVisible)
+  const isPrimaryActionVisible = primaryAction && isVisible(primaryAction)
+  const hasSecondaryActions = visibleSecondaryActions.length > 0
+  const hasOtherActions = visibleOtherActions.length > 0
 
   return (
     <div className="flex flex-col gap-3 px-6 pb-5 pt-3">
@@ -103,11 +112,13 @@ export function BaseHeader({
             )}
           </div>
         </div>
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
-          {allMetadata && <Metadata items={allMetadata} />}
-        </div>
+        {allMetadata.length > 0 && (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
+            <Metadata items={allMetadata} />
+          </div>
+        )}
         <div className="flex w-full shrink-0 flex-wrap items-center gap-x-2 gap-y-3 md:w-fit md:flex-row-reverse md:gap-y-2 md:overflow-x-auto">
-          {primaryAction && (
+          {isPrimaryActionVisible && (
             <>
               <div className="hidden md:block">
                 <ButtonWithTooltip
@@ -132,52 +143,52 @@ export function BaseHeader({
               </div>
             </>
           )}
-          {primaryAction && (secondaryActions || otherActions) && (
-            <div className="mx-1 hidden h-4 w-px bg-f1-background-secondary md:block" />
-          )}
-          {secondaryActions &&
-            secondaryActions.map((action) => (
-              <>
-                <div className="hidden md:block">
-                  <ButtonWithTooltip
-                    key={action.label}
-                    label={action.label}
-                    onClick={action.onClick}
-                    variant={action.variant ?? "outline"}
-                    icon={action.icon}
-                    disabled={action.disabled}
-                    tooltip={action.tooltip}
-                  />
-                </div>
-                <div className="w-full md:hidden [&>*]:w-full">
-                  <ButtonWithTooltip
-                    key={action.label}
-                    label={action.label}
-                    onClick={action.onClick}
-                    variant={action.variant ?? "outline"}
-                    icon={action.icon}
-                    size="lg"
-                    disabled={action.disabled}
-                    tooltip={action.tooltip}
-                  />
-                </div>
-              </>
-            ))}
-          {otherActions && otherActions.length > 0 && (
+          {isPrimaryActionVisible &&
+            (hasSecondaryActions || hasOtherActions) && (
+              <div className="mx-1 hidden h-4 w-px bg-f1-background-secondary md:block" />
+            )}
+          {visibleSecondaryActions.map((action) => (
+            <Fragment key={action.label}>
+              <div className="hidden md:block">
+                <ButtonWithTooltip
+                  label={action.label}
+                  onClick={action.onClick}
+                  variant={action.variant ?? "outline"}
+                  icon={action.icon}
+                  disabled={action.disabled}
+                  tooltip={action.tooltip}
+                />
+              </div>
+              <div className="w-full md:hidden [&>*]:w-full">
+                <ButtonWithTooltip
+                  label={action.label}
+                  onClick={action.onClick}
+                  variant={action.variant ?? "outline"}
+                  icon={action.icon}
+                  size="lg"
+                  disabled={action.disabled}
+                  tooltip={action.tooltip}
+                />
+              </div>
+            </Fragment>
+          ))}
+          {visibleOtherActions.length > 0 && (
             <>
               <div className="hidden md:block">
-                <Dropdown items={otherActions} />
+                <Dropdown items={visibleOtherActions} />
               </div>
               <div className="w-full md:hidden">
-                <MobileDropdown items={otherActions} />
+                <MobileDropdown items={visibleOtherActions} />
               </div>
             </>
           )}
         </div>
       </div>
-      <div className="hidden flex-wrap items-center gap-x-3 gap-y-1 md:block">
-        {allMetadata && <Metadata items={allMetadata} />}
-      </div>
+      {allMetadata.length > 0 && (
+        <div className="hidden flex-wrap items-center gap-x-3 gap-y-1 md:block">
+          <Metadata items={allMetadata} />
+        </div>
+      )}
     </div>
   )
 }

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -145,7 +145,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
   )
 }
 
-export const Metadata = memo( function Metadata({ items }: MetadataProps) {
+export const Metadata = memo(function Metadata({ items }: MetadataProps) {
   return (
     <div className="flex flex-col items-start gap-x-3 gap-y-0 md:flex-row md:flex-wrap md:items-center">
       {items.map((item, index) => (

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -12,7 +12,7 @@ import { MobileDropdown } from "@/experimental/Navigation/Dropdown"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { cn } from "@/lib/utils"
 import { AnimatePresence, motion } from "framer-motion"
-import { useState } from "react"
+import { memo, useState } from "react"
 
 type MetadataItemValue =
   | { type: "text"; content: string }
@@ -33,7 +33,7 @@ interface MetadataItem {
 }
 
 interface MetadataProps {
-  items?: MetadataItem[]
+  items: MetadataItem[]
 }
 
 function MetadataValue({ item }: { item: MetadataItem }) {
@@ -145,9 +145,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
   )
 }
 
-export function Metadata({ items }: MetadataProps) {
-  if (!items?.length) return null
-
+export const Metadata = memo( function Metadata({ items }: MetadataProps) {
   return (
     <div className="flex flex-col items-start gap-x-3 gap-y-0 md:flex-row md:flex-wrap md:items-center">
       {items.map((item, index) => (
@@ -163,6 +161,6 @@ export function Metadata({ items }: MetadataProps) {
       ))}
     </div>
   )
-}
+})
 
 export type { MetadataAction, MetadataItem, MetadataItemValue }

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -62,10 +62,9 @@ export const Default: Story = {
 export const Simple: Story = {
   args: {
     ...Default.args,
-    status: undefined
+    status: undefined,
   },
 }
-
 
 export const Metadata: Story = {
   args: {

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -131,6 +131,7 @@ export const WithOtherActions: Story = {
       {
         label: "Promote",
         onClick: fn(),
+        disabled: true,
       },
     ],
     otherActions: [

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -59,6 +59,14 @@ export const Default: Story = {
   },
 }
 
+export const Simple: Story = {
+  args: {
+    ...Default.args,
+    status: undefined
+  },
+}
+
+
 export const Metadata: Story = {
   args: {
     ...Default.args,

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -132,6 +132,7 @@ export const WithOtherActions: Story = {
         label: "Promote",
         onClick: fn(),
         disabled: true,
+        tooltip: "Recharge your account",
       },
     ],
     otherActions: [

--- a/lib/experimental/Information/utils.tsx
+++ b/lib/experimental/Information/utils.tsx
@@ -4,6 +4,7 @@ export interface PrimaryAction {
   label: string
   icon?: IconType
   onClick: () => void
+  disabled?: boolean
 }
 
 export interface SecondaryAction extends PrimaryAction {

--- a/lib/experimental/Information/utils.tsx
+++ b/lib/experimental/Information/utils.tsx
@@ -5,6 +5,7 @@ export interface PrimaryAction {
   icon?: IconType
   onClick: () => void
   disabled?: boolean
+  tooltip?: string
 }
 
 export interface SecondaryAction extends PrimaryAction {

--- a/lib/experimental/Information/utils.tsx
+++ b/lib/experimental/Information/utils.tsx
@@ -6,6 +6,7 @@ export interface PrimaryAction {
   onClick: () => void
   disabled?: boolean
   tooltip?: string
+  isVisible?: boolean
 }
 
 export interface SecondaryAction extends PrimaryAction {


### PR DESCRIPTION
## Description

Adds several features to cover use cases:
- `disabled` prop for primary and secondary action. It will render the button in a disabled state
- `tooltip` for primary and secondary actions
- `isVisible` prop to make the use of the component simpler. Right now if I have to check for permissions before rendering an action I have to manually build the array I pass to one of the action props. It is cumbersome, the declarative approach works better and give less friction