### PR TITLE
Add missing export for CalendarEvent component

### DIFF
--- a/lib/experimental/Widgets/Content/exports.tsx
+++ b/lib/experimental/Widgets/Content/exports.tsx
@@ -1,3 +1,4 @@
+export * from "./CalendarEvent"
 export * from "./CalendarEventList"
 export * from "./CategoryBarSection"
 export * from "./ClockIn/exports"


### PR DESCRIPTION
## Description

I didn't exported it previously because the idea was to use `CalendarEventList` component instead, but we have already encountered with an use case where this component needs to be used in isolation.