### PR TITLE
Fix some display stuff in clock-in graph and controls

### DIFF
--- a/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
@@ -119,3 +119,21 @@ export const WithLongProjectName: Story = {
     projectName: "Bolt’s project with a very long name",
   },
 }
+
+export const ClockedOutWithSomeTime: Story = {
+  args: {
+    remainingMinutes: 320,
+    data: [
+      {
+        from: new Date("2024-03-20T09:02:00"),
+        to: new Date("2024-03-20T12:00:00"),
+        variant: "clocked-in",
+      },
+      {
+        from: new Date("2024-03-20T12:00:00"),
+        to: new Date("2024-03-20T12:00:00"),
+        variant: "clocked-out",
+      },
+    ],
+  },
+}

--- a/lib/experimental/Widgets/Content/ClockIn/ClockInGraph/helpers.ts
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInGraph/helpers.ts
@@ -52,34 +52,23 @@ export const getLabels = ({
   remainingMinutes,
 }: ClockInGraphProps) => {
   const clockedInAt = data.find((entry) => entry.variant === "clocked-in")?.from
-  const clockedOutAt = data.find(
-    (entry) => entry.variant === "clocked-out"
-  )?.from
 
-  const lastEntry = data[data.length - 1]
-
-  const lastClockedInEntry = data
-    .slice()
-    .reverse()
-    .find((entry) => entry.variant === "clocked-in")
+  const lastEntry = data.at(-1)
 
   const primaryLabel = clockedInAt
     ? formatTime24Hours(clockedInAt)
     : EMPTY_LABEL
 
   const secondaryLabel = (() => {
-    if (remainingMinutes && remainingMinutes < 0) {
-      return lastClockedInEntry
-        ? formatTime24Hours(lastClockedInEntry.to)
-        : EMPTY_LABEL
-    }
+    if (remainingMinutes === undefined || remainingMinutes > 0)
+      return EMPTY_LABEL
 
-    return clockedOutAt ? formatTime24Hours(clockedOutAt) : EMPTY_LABEL
+    return lastEntry ? formatTime24Hours(lastEntry.to) : EMPTY_LABEL
   })()
 
-  const isLastEntryClockedIn = lastEntry?.variant === "clocked-in"
+  const isLastEntryBreak = lastEntry?.variant === "break"
 
-  const totalTime = isLastEntryClockedIn
+  const totalTime = !isLastEntryBreak
     ? data.reduce((acc, entry) => {
         if (entry.variant === "clocked-in") {
           return acc + (entry.to.getTime() - entry.from.getTime())


### PR DESCRIPTION
## Description

There are a couple of things that I needed to fix regarding the clock-in graph and controls:
- When it's clocked-out, we still need to show the amount of time that the user has clocked-in previously.
- We shouldn't show any "ending time" unless the user has no remaining time left.

What we're seeing while using this component that needs to be fixed:
<img width="477" alt="Screenshot 2025-01-28 at 15 29 45" src="https://github.com/user-attachments/assets/7c207333-1805-4ebc-9966-27f7b3ba7d80" />
