### PR TITLE
Align carousel items to start when no show peek is set

### DIFF
--- a/lib/experimental/Navigation/Carousel/index.stories.tsx
+++ b/lib/experimental/Navigation/Carousel/index.stories.tsx
@@ -192,3 +192,10 @@ export const MultipleWidths: Story = {
     showDots: false,
   },
 }
+
+export const FewItemsWithColumns: Story = {
+  args: {
+    ...CustomColumns.args,
+    children: SLIDES.slice(0, 2),
+  },
+}

--- a/lib/experimental/Navigation/Carousel/index.tsx
+++ b/lib/experimental/Navigation/Carousel/index.tsx
@@ -69,7 +69,7 @@ export const Carousel = ({
     <ShadCarousel
       className="flex w-full flex-col gap-3"
       opts={{
-        align: "center",
+        align: !showPeek ? "start" : "center",
         slidesToScroll: "auto",
         duration: 20,
         containScroll: false,


### PR DESCRIPTION
## Description

When using this component we were observing that items were always centered and that is not necessarily how we want them to look in most cases.

<img width="1503" alt="Screenshot 2025-01-31 at 13 18 06" src="https://github.com/user-attachments/assets/3046d8ba-49db-4df2-b929-2def9b3ecf08" />
