### PR TITLE
fix-carousel-clip-shadows

### DIFF
--- a/lib/experimental/Navigation/Carousel/DynamicCarousel/index.tsx
+++ b/lib/experimental/Navigation/Carousel/DynamicCarousel/index.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/ui/button"
 import { PropsWithChildren, useEffect, useRef, useState } from "react"
 
-const SPACE_FOR_WIDGET_SHADOW = 28
+export const SPACE_FOR_WIDGET_SHADOW = 28
 
 export const DynamicCarousel = ({ children }: PropsWithChildren) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -71,28 +71,34 @@ export const DynamicCarousel = ({ children }: PropsWithChildren) => {
     }
   }, [])
 
+  let maskImageStyle = ""
+  if (canScrollPrev && canScrollNext) {
+    maskImageStyle = `linear-gradient(to right, transparent 0px, transparent ${SPACE_FOR_WIDGET_SHADOW}px, black ${2 * SPACE_FOR_WIDGET_SHADOW}px, black calc(100% - ${2 * SPACE_FOR_WIDGET_SHADOW}px), transparent calc(100% - ${SPACE_FOR_WIDGET_SHADOW}px), transparent 100%)`
+  } else if (canScrollPrev && !canScrollNext) {
+    maskImageStyle = `linear-gradient(to right, transparent 0px, transparent ${SPACE_FOR_WIDGET_SHADOW}px, black ${2 * SPACE_FOR_WIDGET_SHADOW}px, black 100%)`
+  } else if (!canScrollPrev && canScrollNext) {
+    maskImageStyle = `linear-gradient(to right, black 0px, black calc(100% - ${2 * SPACE_FOR_WIDGET_SHADOW}px), transparent calc(100% - ${SPACE_FOR_WIDGET_SHADOW}px), transparent 100%)`
+  } else {
+    maskImageStyle = "none"
+  }
+
   return (
     <div className="relative">
       <div
         ref={scrollContainerRef}
         className="relative flex gap-4 overflow-x-auto overflow-y-visible scroll-smooth"
         style={{
-          scrollbarWidth: "none", // Para Firefox
-          msOverflowStyle: "none", // Para IE y Edge
+          scrollbarWidth: "none", // Firefox
+          msOverflowStyle: "none", // IE & Edge
           margin: `-${SPACE_FOR_WIDGET_SHADOW}px`,
           padding: `${SPACE_FOR_WIDGET_SHADOW}px`,
           height: `calc(100% + ${SPACE_FOR_WIDGET_SHADOW * 2}px)`,
           width: `calc(100% + ${SPACE_FOR_WIDGET_SHADOW * 2}px)`,
+          maskImage: maskImageStyle,
+          WebkitMaskImage: maskImageStyle,
         }}
       >
-        <style>
-          {`
-              /* Para ocultar scrollbar en Chrome, Safari y Edge */
-              .no-scrollbar::-webkit-scrollbar {
-                display: none;
-              }
-            `}
-        </style>
+        <style></style>
         {Array.isArray(children)
           ? children.map((child, index) => (
               <div
@@ -113,33 +119,6 @@ export const DynamicCarousel = ({ children }: PropsWithChildren) => {
             )}
       </div>
 
-      {/* Gradientes dinámicos para los bordes */}
-      {canScrollPrev && (
-        <div
-          className={cn(
-            "w-[60px]",
-            "absolute",
-            "h-full",
-            "top-0",
-            "bg-gradient-to-l from-transparent from-0% to-f1-background to-100%"
-          )}
-          style={{ left: `-${SPACE_FOR_WIDGET_SHADOW}px` }}
-        ></div>
-      )}
-      {canScrollNext && (
-        <div
-          className={cn(
-            "w-[60px]",
-            "absolute",
-            "h-full",
-            "top-0",
-            "bg-gradient-to-r from-transparent from-0% to-f1-background to-100%"
-          )}
-          style={{ right: `-${SPACE_FOR_WIDGET_SHADOW}px` }}
-        ></div>
-      )}
-
-      {/* Botón Izquierdo dinámico */}
       {canScrollPrev && (
         <Button
           size="sm"
@@ -156,7 +135,6 @@ export const DynamicCarousel = ({ children }: PropsWithChildren) => {
         </Button>
       )}
 
-      {/* Botón Derecho dinámico */}
       {canScrollNext && (
         <Button
           size="sm"

--- a/lib/experimental/Navigation/Carousel/index.stories.tsx
+++ b/lib/experimental/Navigation/Carousel/index.stories.tsx
@@ -193,6 +193,35 @@ export const MultipleWidths: Story = {
   },
 }
 
+export const RandomWithColumns: Story = {
+  decorators: [
+    (Story) => (
+      <div className="h-full w-full p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    autoplay: { control: "boolean" },
+    showDots: { control: "boolean" },
+    showArrows: { control: "boolean" },
+    showPeek: { control: "boolean" },
+    columns: { default: 1 },
+  },
+  args: {
+    showArrows: true,
+    children: SLIDES_RANDOM,
+    showPeek: true,
+    showDots: false,
+    columns: {
+      xs: 2,
+      sm: 3,
+      md: 3,
+      lg: 3,
+    },
+  },
+}
+
 export const FewItemsWithColumns: Story = {
   args: {
     ...CustomColumns.args,

--- a/lib/ui/carousel.tsx
+++ b/lib/ui/carousel.tsx
@@ -156,6 +156,8 @@ const CarouselContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
+  const maskImageStyle = `linear-gradient(to right, transparent 0px, transparent ${SPACE_FOR_WIDGET_SHADOW / 2}px, black ${SPACE_FOR_WIDGET_SHADOW}px, black calc(100% - ${SPACE_FOR_WIDGET_SHADOW}px), transparent calc(100% - ${SPACE_FOR_WIDGET_SHADOW / 2}px), transparent 100%)`
+
   const { carouselRef, orientation } = useCarousel()
 
   return (
@@ -169,6 +171,8 @@ const CarouselContent = React.forwardRef<
         padding: `${SPACE_FOR_WIDGET_SHADOW}px`,
         height: `calc(100% + ${SPACE_FOR_WIDGET_SHADOW * 2}px)`,
         width: `calc(100% + ${SPACE_FOR_WIDGET_SHADOW * 2}px)`,
+        maskImage: maskImageStyle,
+        WebkitMaskImage: maskImageStyle,
       }}
     >
       <div

--- a/lib/ui/carousel.tsx
+++ b/lib/ui/carousel.tsx
@@ -7,6 +7,7 @@ import useEmblaCarousel, {
 } from "embla-carousel-react"
 import * as React from "react"
 
+import { SPACE_FOR_WIDGET_SHADOW } from "@/experimental/Navigation/Carousel/DynamicCarousel"
 import { cn } from "@/lib/utils"
 import { Button } from "@/ui/button"
 
@@ -158,7 +159,18 @@ const CarouselContent = React.forwardRef<
   const { carouselRef, orientation } = useCarousel()
 
   return (
-    <div ref={carouselRef} className="overflow-hidden">
+    <div
+      ref={carouselRef}
+      className="overflow-hidden"
+      style={{
+        scrollbarWidth: "none", // For Firefox
+        msOverflowStyle: "none", // For IE and Edge
+        margin: `-${SPACE_FOR_WIDGET_SHADOW}px`,
+        padding: `${SPACE_FOR_WIDGET_SHADOW}px`,
+        height: `calc(100% + ${SPACE_FOR_WIDGET_SHADOW * 2}px)`,
+        width: `calc(100% + ${SPACE_FOR_WIDGET_SHADOW * 2}px)`,
+      }}
+    >
       <div
         ref={ref}
         className={cn(


### PR DESCRIPTION
## Description

Current carousels clip shadows because of its overflow-hidden. To fix that I've applied the same strategy done in DynamicCarousel add negative margin and postive padding to not affect the final layout but give space for shadows.

Also I'd improved the way we make the fade-off in Dynamic Carousel to make it work in both light/dark mode (using a mask instead of a overlaped div)

## Screenshots

![Screenshot 2025-02-05 at 22 11 17](https://github.com/user-attachments/assets/c97023bb-50f6-4491-8ed5-c151fb149e2c)

![Screenshot 2025-02-05 at 22 13 27](https://github.com/user-attachments/assets/00c0254f-823a-4d38-a83e-ae782069f1d4)

## Before:


![Screenshot 2025-02-05 at 23 18 11](https://github.com/user-attachments/assets/546dacdf-fe2c-4648-88fc-24dc4ef41cd2)

https://github.com/user-attachments/assets/bd0fdd3e-24e2-416b-955d-91084a0eae25


## After (The color RED is only to make it easy to see):


https://github.com/user-attachments/assets/ff9ff603-051a-46c7-9aff-d670e5e76edf

## Type of Change

- [x] Maintenance / Bug Fix / Other
