### PR TITLE
F1SearchBox component

### DIFF
--- a/lib/experimental/Forms/Fields/F1SearchBox/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/F1SearchBox/index.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { F1SearchBox } from "."
+
+const meta = {
+  component: F1SearchBox,
+  title: "Forms/Fields/F1SearchBox",
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "This components provides the input search themed. Input can debouced to avoid several requests",
+      },
+    },
+  },
+  tags: ["autodocs", "experimental"],
+  args: {
+    placeholder: "",
+  },
+
+  argTypes: {
+    disabled: {
+      control: "boolean",
+    },
+    threshold: {
+      description: "Min number of characteres before call `onChange`",
+      defaultValue: 0,
+    },
+    debounceTime: {
+      description:
+        "Debouce time in ms. It avoids to make repeated calls when the value changes",
+      defaultValue: 0,
+    },
+  },
+} satisfies Meta<typeof F1SearchBox>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Basic Variants
+export const Default: Story = {
+  args: {
+    placeholder: "Search...",
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    placeholder: "Search...",
+    disabled: true,
+  },
+}
+
+export const Clearable: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Display a clear button to reset the input value. It will only be displayed if the input is not disabled and has content",
+      },
+    },
+  },
+  args: {
+    placeholder: "Search...",
+    clearable: true,
+  },
+}
+
+export const WithThreshold: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Check console to see onChange updates",
+      },
+    },
+  },
+  args: {
+    placeholder: "Search...",
+    threshold: 3,
+    onChange: (value) => console.log("Change:", value),
+  },
+}
+
+export const WithDebounce: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Check console to see onChange updates. It will only happens every 3s",
+      },
+    },
+  },
+  args: {
+    placeholder: "Search...",
+    debounceTime: 3000,
+    onChange: (value) => console.log("Debounced change:", value),
+  },
+}

--- a/lib/experimental/Forms/Fields/F1SearchBox/index.test.tsx
+++ b/lib/experimental/Forms/Fields/F1SearchBox/index.test.tsx
@@ -1,0 +1,143 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { F1SearchBox } from "./index"
+
+describe("F1SearchBox", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  describe("threshold behavior", () => {
+    it("does not trigger onChange when input length is below threshold", () => {
+      const onChange = vi.fn()
+      render(<F1SearchBox threshold={3} onChange={onChange} />)
+
+      const input = screen.getByRole("searchbox")
+      fireEvent.change(input, { target: { value: "ab" } })
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it("triggers onChange when input length reaches threshold", () => {
+      const onChange = vi.fn()
+      render(<F1SearchBox threshold={3} onChange={onChange} />)
+
+      const input = screen.getByRole("searchbox")
+      fireEvent.change(input, { target: { value: "abc" } })
+
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(onChange).toHaveBeenCalledWith("abc")
+    })
+
+    it("always triggers onChange when clearing the input", () => {
+      const onChange = vi.fn()
+      render(<F1SearchBox threshold={3} onChange={onChange} value="initial" />)
+
+      const input = screen.getByRole("searchbox")
+      fireEvent.change(input, { target: { value: "" } })
+
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(onChange).toHaveBeenCalledWith("")
+    })
+  })
+
+  describe("debounce behavior", () => {
+    it("debounces the onChange callback", () => {
+      const onChange = vi.fn()
+      render(<F1SearchBox debounceTime={500} onChange={onChange} />)
+
+      const input = screen.getByRole("searchbox")
+
+      // Type 'test' quickly
+      fireEvent.change(input, { target: { value: "t" } })
+      fireEvent.change(input, { target: { value: "te" } })
+      fireEvent.change(input, { target: { value: "tes" } })
+      fireEvent.change(input, { target: { value: "test" } })
+
+      expect(onChange).not.toHaveBeenCalled()
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith("test")
+    })
+
+    it("updates the value with the most recent input after debounce", () => {
+      const onChange = vi.fn()
+      render(<F1SearchBox debounceTime={500} onChange={onChange} />)
+
+      const input = screen.getByRole("searchbox")
+
+      fireEvent.change(input, { target: { value: "first" } })
+
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      fireEvent.change(input, { target: { value: "second" } })
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith("second")
+    })
+  })
+
+  describe("combined threshold and debounce behavior", () => {
+    it("respects both threshold and debounce", () => {
+      const onChange = vi.fn()
+      render(
+        <F1SearchBox threshold={3} debounceTime={500} onChange={onChange} />
+      )
+
+      const input = screen.getByRole("searchbox")
+
+      // Type below threshold
+      fireEvent.change(input, { target: { value: "ab" } })
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+
+      expect(onChange).not.toHaveBeenCalled()
+
+      // Type above threshold
+      fireEvent.change(input, { target: { value: "abc" } })
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith("abc")
+    })
+  })
+
+  describe("clearable behavior", () => {
+    it("hides clear button when clearable is false", () => {
+      render(<F1SearchBox clearable={false} />)
+      const input = screen.getByRole("searchbox")
+      expect(input.className).toContain(
+        "[&::-webkit-search-cancel-button]:hidden"
+      )
+    })
+
+    it("shows clear button when clearable is true", () => {
+      render(<F1SearchBox clearable={true} />)
+      const input = screen.getByRole("searchbox")
+      expect(input.className).not.toContain(
+        "[&::-webkit-search-cancel-button]:hidden"
+      )
+    })
+  })
+})

--- a/lib/experimental/Forms/Fields/F1SearchBox/index.tsx
+++ b/lib/experimental/Forms/Fields/F1SearchBox/index.tsx
@@ -1,0 +1,58 @@
+import { Search } from "@/icons/app"
+import { Input } from "@/ui/input"
+import { ChangeEventHandler, useRef } from "react"
+
+type F1SearchBoxProps = {
+  placeholder?: string
+  value?: string
+  disabled?: boolean
+  threshold?: number
+  debounceTime?: number
+  clearable?: boolean
+  onChange?: (value: string) => void
+}
+
+const F1SearchBox = ({
+  value,
+  threshold = 0,
+  onChange,
+  debounceTime = 0,
+  clearable = false,
+  ...props
+}: F1SearchBoxProps) => {
+  const valueToEmitRef = useRef<string | undefined>(undefined)
+
+  const onChangeLocal: ChangeEventHandler<HTMLInputElement> = (e) => {
+    if (
+      onChange &&
+      // It should emit the change when the user clears the field
+      (e.target.value.length >= threshold || e.target.value.length === 0)
+    ) {
+      // Debounces the onChange callback
+      if (valueToEmitRef.current === undefined) {
+        setTimeout(() => {
+          if (valueToEmitRef.current !== undefined) {
+            onChange(valueToEmitRef.current)
+          }
+          valueToEmitRef.current = undefined
+        }, debounceTime)
+      }
+      valueToEmitRef.current = e.target.value
+    }
+  }
+
+  return (
+    <Input
+      type="search"
+      icon={Search}
+      value={value}
+      placeholder={props.placeholder}
+      disabled={props.disabled}
+      onChange={onChangeLocal}
+      role="searchbox"
+      clearable={clearable}
+    />
+  )
+}
+
+export { F1SearchBox }

--- a/lib/experimental/Forms/Fields/exports.ts
+++ b/lib/experimental/Forms/Fields/exports.ts
@@ -1,4 +1,5 @@
 export * from "./Calendar"
+export * from "./F1SearchBox"
 export * from "./Input"
 export * from "./NumberInput"
 export * from "./Select"

--- a/lib/ui/input.tsx
+++ b/lib/ui/input.tsx
@@ -12,9 +12,11 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <div
         className={cn(
-          "flex h-10 w-full rounded-sm border-2 border-solid border-f1-border bg-f1-background px-3 py-2 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-f1-foreground-secondary/60 hover:border-f1-border-hover disabled:cursor-not-allowed disabled:bg-f1-background-secondary disabled:opacity-50",
+          "flex h-10 w-full rounded-sm border-2 border-solid border-f1-border bg-f1-background px-3 py-2 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-f1-foreground-secondary/60 hover:border-f1-border-hover",
           focusRing("focus-visible:border-f1-border-hover"),
           icon ? "flex gap-1.5 ps-2" : "ps-3",
+          props.disabled &&
+            "cursor-not-allowed bg-f1-background-secondary opacity-50",
           className
         )}
       >
@@ -25,7 +27,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           {...props}
           className={cn(
             !clearable ? "[&::-webkit-search-cancel-button]:hidden" : "",
-            "growth w-full shrink"
+            "growth w-full shrink disabled:cursor-not-allowed"
           )}
         />
       </div>

--- a/lib/ui/input.tsx
+++ b/lib/ui/input.tsx
@@ -1,21 +1,34 @@
+import { Icon, IconType } from "@/components/Utilities/Icon"
 import { cn, focusRing } from "@/lib/utils"
 import * as React from "react"
 
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  icon?: IconType
+  clearable?: boolean
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, icon, clearable, ...props }, ref) => {
     return (
-      <input
-        type={type}
+      <div
         className={cn(
           "flex h-10 w-full rounded-sm border-2 border-solid border-f1-border bg-f1-background px-3 py-2 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-f1-foreground-secondary/60 hover:border-f1-border-hover disabled:cursor-not-allowed disabled:bg-f1-background-secondary disabled:opacity-50",
           focusRing("focus-visible:border-f1-border-hover"),
+          icon ? "flex gap-1.5 ps-2" : "ps-3",
           className
         )}
-        ref={ref}
-        {...props}
-      />
+      >
+        {icon && <Icon icon={icon} />}
+        <input
+          type={type}
+          ref={ref}
+          {...props}
+          className={cn(
+            !clearable ? "[&::-webkit-search-cancel-button]:hidden" : "",
+            "growth w-full shrink"
+          )}
+        />
+      </div>
     )
   }
 )


### PR DESCRIPTION
- **feat: F1SearchBox component**


## Description

Adds the F1SearchBox component to provide a searchbox functionality including, debounce, clearable, threshold, icon etc
Modifies internal `Input` component to allow to prepend an icon


## Screenshots 

![image](https://github.com/user-attachments/assets/8cf3069b-e29d-4e51-978a-bed44e1d7ae4)


### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [x] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist

- [x] Component added to `experimental` folder
- [x] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

