### PR TITLE
Add metadata `List` to the headers

### DIFF
--- a/lib/experimental/Information/Headers/Metadata/index.stories.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.stories.tsx
@@ -40,6 +40,25 @@ export const Default: Story = {
           variant: "warning",
         },
       },
+      {
+        label: "Type",
+        value: {
+          type: "List",
+          variant: "person",
+          avatars: [
+            {
+              type: "person",
+              firstName: "Josep Jaume",
+              lastName: "Rey",
+            },
+            {
+              type: "person",
+              firstName: "Nik",
+              lastName: "Lopin",
+            },
+          ],
+        },
+      },
     ],
   },
 }

--- a/lib/experimental/Information/Headers/Metadata/index.stories.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.stories.tsx
@@ -43,7 +43,7 @@ export const Default: Story = {
       {
         label: "Type",
         value: {
-          type: "List",
+          type: "list",
           variant: "person",
           avatars: [
             {

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -4,6 +4,7 @@ import {
   Avatar,
   AvatarVariant,
 } from "@/experimental/Information/Avatars/Avatar"
+import { AvatarList } from "@/experimental/Information/Avatars/AvatarList"
 import {
   StatusTag,
   StatusVariant,
@@ -18,6 +19,7 @@ type MetadataItemValue =
   | { type: "text"; content: string }
   | { type: "avatar"; variant: AvatarVariant; text: string }
   | { type: "status"; label: string; variant: StatusVariant }
+  | { type: "List"; variant: AvatarVariant["type"]; avatars: AvatarVariant[] }
 
 type MetadataAction = {
   icon: IconType
@@ -53,6 +55,14 @@ function MetadataValue({ item }: { item: MetadataItem }) {
       )
     case "status":
       return <StatusTag text={item.value.label} variant={item.value.variant} />
+    case "List":
+      return (
+        <AvatarList
+          avatars={item.value.avatars}
+          size="xsmall"
+          type={item.value.variant}
+        />
+      )
   }
 }
 

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -19,7 +19,7 @@ type MetadataItemValue =
   | { type: "text"; content: string }
   | { type: "avatar"; variant: AvatarVariant; text: string }
   | { type: "status"; label: string; variant: StatusVariant }
-  | { type: "List"; variant: AvatarVariant["type"]; avatars: AvatarVariant[] }
+  | { type: "list"; variant: AvatarVariant["type"]; avatars: AvatarVariant[] }
 
 type MetadataAction = {
   icon: IconType
@@ -55,7 +55,7 @@ function MetadataValue({ item }: { item: MetadataItem }) {
       )
     case "status":
       return <StatusTag text={item.value.label} variant={item.value.variant} />
-    case "List":
+    case "list":
       return (
         <AvatarList
           avatars={item.value.avatars}

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -88,6 +88,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
         onFocus={() => isAction && setIsActive(true)}
         onBlur={() => isAction && setIsActive(false)}
         className="relative flex h-5 w-fit items-center hover:cursor-default"
+        aria-label={`${item.label} actions`}
       >
         <div
           className={cn(

--- a/lib/experimental/Information/Headers/index.mdx
+++ b/lib/experimental/Information/Headers/index.mdx
@@ -146,6 +146,8 @@ characteristics:
    (User, company and team)
 3. **Status**: Represent a state or situation associated with the resource, such
    as "Active," "Inactive," "Pending.”, etc.
+4. **List**: Display team members, task owners, or people associated with a
+   specific resource.
 
 ### Guidelines
 


### PR DESCRIPTION
## Description

Add a new metadata type, `List`, that shows a list of avatars.

## Screenshots

<img width="121" alt="image" src="https://github.com/user-attachments/assets/511d97ca-cbf0-4699-bdb7-104f87078ccf" />

### Figma Link

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=3145-1703&t=pNB2owM7kG0Va8ZO-4)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other