### PR TITLE
Fix Storybook dark theme

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,57 +1,58 @@
 <link rel="icon" href="/logo.svg" type="image/svg+xml" />
 <style>
-  #storybook-explorer-tree .sidebar-item {
+  .sidebar-container .sidebar-item {
     border-radius: 8px;
     margin-bottom: 1px;
   }
 
-  #storybook-explorer-tree .sidebar-subheading-action {
+  .sidebar-container .sidebar-subheading-action {
     display: none;
   }
 
-  #storybook-explorer-tree .sidebar-item > a,
-  #storybook-explorer-tree .sidebar-item button {
+  .sidebar-container .sidebar-item > a,
+  .sidebar-container .sidebar-item button {
     padding-top: 4px;
     padding-bottom: 4px;
     line-height: 1.5;
     font-weight: 500;
   }
 
-  #storybook-explorer-tree .sidebar-item button > div {
+  .sidebar-container .sidebar-item button > div {
     margin-right: 0px;
   }
 
-  #storybook-explorer-tree .sidebar-item a > div {
+  .sidebar-container .sidebar-item a > div {
     margin-right: 6px;
   }
 
-  #storybook-explorer-tree .sidebar-item:hover,
-  #storybook-explorer-tree .sidebar-item[aria-expanded="true"] {
+  .sidebar-container .sidebar-item:hover,
+  .sidebar-container .sidebar-item[aria-expanded="true"] {
     background-color: #f0f2f5;
     color: #0d1625;
   }
 
-  #storybook-explorer-tree .sidebar-item[data-selected="true"],
-  #storybook-explorer-tree .sidebar-item[data-selected="true"]:hover {
-    background-color: #f0f2f5;
+  .sidebar-container .sidebar-item[data-selected="true"],
+  .sidebar-container .sidebar-item[data-selected="true"]:hover,
+  .sidebar-container .sidebar-item[data-selected="true"]:focus {
+    background-color: #f0f2f5 !important;
     color: #0d1625;
     font-weight: 500;
   }
 
-  #storybook-explorer-tree svg {
+  .sidebar-container svg {
     color: #a1abbd;
   }
 
-  #storybook-explorer-tree .sidebar-item[data-selected="true"] svg {
+  .sidebar-container .sidebar-item[data-selected="true"] svg {
     color: #303d55;
   }
 
-  #storybook-explorer-tree .sidebar-subheading {
+  .sidebar-container .sidebar-subheading {
     margin-top: 32px;
     position: relative;
   }
 
-  #storybook-explorer-tree .sidebar-subheading:after {
+  .sidebar-container .sidebar-subheading:after {
     content: "";
     display: block;
     height: 1px;
@@ -89,33 +90,49 @@
     padding: 24px;
   }
 
+  #storybook-testing-module {
+    transition: none;
+    box-shadow: none;
+  }
+
   /* -- DARK -- */
 
-  body.dark #storybook-explorer-tree .sidebar-item:hover,
-  body.dark #storybook-explorer-tree .sidebar-item[aria-expanded="true"] {
+  body.dark,
+  body.dark .sidebar-container {
+    background-color: #161f30;
+  }
+
+  body.dark .sidebar-container .sidebar-item:hover,
+  body.dark .sidebar-container .sidebar-item[aria-expanded="true"] {
     background-color: #1a2437;
     color: #a1abbd;
   }
 
-  body.dark #storybook-explorer-tree .sidebar-item[data-selected="true"],
-  body.dark #storybook-explorer-tree .sidebar-item[data-selected="true"]:hover {
-    background-color: #1a2437;
+  body.dark .sidebar-container .sidebar-item[data-selected="true"],
+  body.dark .sidebar-container .sidebar-item[data-selected="true"]:hover,
+  body.dark .sidebar-container .sidebar-item[data-selected="true"]:focus {
+    background-color: #1a2437 !important;
     color: #a1abbd;
   }
 
-  body.dark #storybook-explorer-tree svg {
+  body.dark .sidebar-container svg {
     color: #647084;
   }
 
-  body.dark #storybook-explorer-tree .sidebar-item[data-selected="true"] svg {
+  body.dark .sidebar-container .sidebar-item[data-selected="true"] svg {
     color: #a1abbd;
   }
 
   body.dark .sb-bar {
     border-bottom: 1px dashed #202c42;
+    background: #0d1625;
   }
 
-  body.dark #storybook-explorer-tree .sidebar-subheading:after {
+  body.dark .sbdocs-preview .sb-bar {
+    background: #161f30;
+  }
+
+  body.dark .sidebar-container .sidebar-subheading:after {
     border-bottom: 1px dashed #202c42;
   }
 

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -71,7 +71,7 @@
     margin-top: 32px !important;
   }
 
-  #storybook-docs li:not(.docs-story *) {
+  #storybook-docs li:not(.docs-story *, .docblock-argstable-body *) {
     font-size: 16px;
     line-height: 1.5;
     color: #65636d !important;
@@ -191,13 +191,19 @@
   /* -- DARK -- */
   body.dark #storybook-docs h1,
   body.dark #storybook-docs h2,
-  body.dark #storybook-docs h3 {
+  body.dark #storybook-docs h3,
+  body.dark #storybook-docs h4,
+  body.dark #storybook-docs h5,
+  body.dark #storybook-docs h6 {
     color: #fff !important;
   }
 
   body.dark #storybook-docs h1 > a,
   body.dark #storybook-docs h2 > a,
-  body.dark #storybook-docs h3 > a {
+  body.dark #storybook-docs h3 > a,
+  body.dark #storybook-docs h4 > a,
+  body.dark #storybook-docs h5 > a,
+  body.dark #storybook-docs h6 > a {
     float: left;
     line-height: inherit;
     padding-right: 10px;
@@ -213,7 +219,13 @@
     border-left-color: #202c42 !important;
   }
 
-  body.dark .docblock-source {
+  body.dark #storybook-docs p:not(.docs-story *, .docblock-argstable-body *),
+  body.dark #storybook-docs li:not(.docs-story *) {
+    color: #a1abbd !important;
+  }
+
+  body.dark .docblock-source,
+  body.dark code:not(.docs-story *) {
     background: #161f30 !important;
     border: rgba(255, 255, 255, 0.1) 1px solid !important;
     box-shadow: 0px 2px 20px #0d1625 !important;
@@ -223,6 +235,10 @@
     border-left-color: #647084 !important;
   }
 
+  body.dark .toc-list .toc-list-item > a {
+    color: #647084 !important;
+  }
+
   body.dark .toc-list .toc-list-item > a.is-active-link {
     color: #fff !important;
   }
@@ -230,6 +246,11 @@
   body.dark .sbdocs-preview {
     border: rgba(255, 255, 255, 0.1) 1px solid !important;
     box-shadow: 0px 2px 20px #0d1625 !important;
+    background: transparent !important;
+  }
+
+  body.dark .sbdocs-preview .sb-bar {
+    background: #161f30 !important;
   }
 
   body.dark .sb-unstyled table,
@@ -249,8 +270,37 @@
     background: #0d1625;
   }
 
+  body.dark .sb-unstyled tbody > tr > td,
+  body.dark .docblock-argstable-body > tr > td > span {
+    color: #a1abbd !important;
+  }
+
+  body.dark .docblock-argstable-body > tr > td > span,
+  body.dark .docblock-argstable-body > tr > td > div > span,
+  body.dark .docblock-argstable-body > tr > td > div > div > span {
+    color: #a1abbd !important;
+    background: #161f30 !important;
+    border-color: #2d3545 !important;
+  }
+
+  body.dark .docblock-argstable-body textarea,
+  body.dark .docblock-argstable-body input[type="number"],
+  body.dark .docblock-argstable-body input[type="text"],
+  body.dark .docblock-argstable-body select,
+  body.dark .docblock-argstable-body button {
+    color: #a1abbd !important;
+    background: #161f30 !important;
+    border-color: #2d3545 !important;
+    box-shadow: none !important;
+  }
+
   body.dark .sb-unstyled tbody > tr:nth-child(even) > td,
   body.dark .docblock-argstable-body > tr:nth-child(even) > td {
+    background: #0d1625 !important;
+  }
+
+  body.dark .sb-unstyled tbody > tr:nth-child(odd) > td,
+  body.dark .docblock-argstable-body > tr:nth-child(odd) > td {
     background: #111a2a !important;
   }
 
@@ -262,6 +312,43 @@
   body.dark input[type="radio"] {
     border: 1px solid #202c42;
     background-color: #161f30;
+  }
+
+  body.dark code:not(.docs-story *) {
+    background: #202c42 !important;
+    color: #a1abbd !important;
+  }
+
+  body.dark .language-bash {
+    color: #fff !important;
+  }
+
+  body.dark .language-bash .token.function,
+  body.dark .language-jsx .token.function,
+  body.dark .language-bash .token.maybe-class-name,
+  body.dark .language-jsx .token.maybe-class-name,
+  body.dark .language-bash .token.punctuation,
+  body.dark .language-jsx .token.punctuation {
+    color: #bcbac7 !important;
+  }
+
+  body.dark .language-bash .token.comment,
+  body.dark .language-jsx .token.comment {
+    color: #12a594 !important;
+  }
+
+  body.dark .language-bash .token.keyword,
+  body.dark .language-jsx .token.keyword {
+    color: #5753c6 !important;
+  }
+
+  body.dark .language-jsx .token.string,
+  body.dark .language-bash .token.string {
+    color: #ce2c31 !important;
+  }
+
+  body.dark #panel-tab-content {
+    background: #0d1625 !important;
   }
 </style>
 <script src="https://cdn.jsdelivr.net/npm/react-render-tracker"></script>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -90,7 +90,7 @@ const preview: Preview = {
     backgrounds: {
       default: "content",
       values: [
-        { name: "content", value: "hsl(var(--background))" },
+        { name: "content", value: "hsl(var(--neutral-0))" },
         { name: "page", value: "hsl(var(--page-background))" },
       ],
     },
@@ -161,8 +161,6 @@ const preview: Preview = {
     },
     darkMode: {
       stylePreview: true,
-      current: "light",
-      disable: true,
     },
   },
   tags: ["autodocs"],

--- a/docs/components/BareColor.tsx
+++ b/docs/components/BareColor.tsx
@@ -19,13 +19,13 @@ export function BareColor({ name }: Props) {
   }
 
   return (
-    <div className="flex max-w-[600px] flex-row items-center space-x-3 rounded-sm border border-solid border-f1-border bg-f1-background-secondary px-2 py-1.5 dark:border-f1-border/10 dark:bg-f1-background-secondary/5">
+    <div className="flex max-w-[600px] flex-row items-center space-x-3 rounded-sm border border-solid border-f1-border bg-f1-background-secondary px-2 py-1.5 dark:border-f1-border-secondary dark:bg-f1-background">
       <div
         className="h-8 w-12 rounded-sm"
         style={{ background: `hsl(var(--${name}))` }}
       />
       <div className="flex flex-1 flex-col space-y-0">
-        <span className="font-mono flex-grow font-semibold text-f1-foreground dark:text-f1-foreground-inverse/80">
+        <span className="font-mono flex-grow font-semibold text-f1-foreground dark:text-f1-foreground-inverse">
           {name}
         </span>
       </div>

--- a/docs/components/ColorToken.tsx
+++ b/docs/components/ColorToken.tsx
@@ -20,10 +20,10 @@ export function ColorToken({ name, description }: Props) {
   }
 
   return (
-    <div className="flex max-w-[600px] flex-row items-center space-x-3 rounded-sm border border-solid border-f1-border bg-f1-background-secondary px-2 py-1.5 dark:border-f1-border/10 dark:bg-f1-background-secondary/5">
+    <div className="flex max-w-[600px] flex-row items-center space-x-3 rounded-sm border border-solid border-f1-border bg-f1-background-secondary px-2 py-1.5 dark:border-f1-border-secondary dark:bg-f1-background">
       <div className={cn("h-8 w-12 rounded-sm", `bg-${name}`)} />
       <div className="flex flex-1 flex-col space-y-0">
-        <span className="font-mono flex-grow font-semibold text-f1-foreground dark:text-f1-foreground-inverse/80">
+        <span className="font-mono flex-grow font-semibold text-f1-foreground dark:text-f1-foreground-inverse">
           {name}
         </span>
         <p className="text-sm text-f1-foreground-secondary">{description}</p>

--- a/docs/components/FeatureCard.tsx
+++ b/docs/components/FeatureCard.tsx
@@ -14,11 +14,11 @@ export function FeatureCard({
   href,
 }: FeatureCardProps) {
   return (
-    <div className="rounded-lg border border-solid border-f1-border bg-f1-background shadow transition-all hover:border-f1-border-hover hover:shadow-md dark:border-f1-border/10 dark:hover:border-f1-border/20">
+    <div className="rounded-lg border border-solid border-f1-border bg-f1-background shadow transition-all hover:border-f1-border-hover hover:shadow-md dark:border-f1-border-secondary dark:hover:border-f1-border">
       <a href={href} className="block h-full p-6 no-underline">
         <div className="mb-4">
-          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-f1-background-secondary dark:bg-f1-background-secondary/10">
-            <Icon className="h-6 w-6 text-f1-icon dark:text-f1-foreground-inverse/80" />
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-f1-background-secondary dark:bg-f1-background-secondary">
+            <Icon className="h-6 w-6 text-f1-icon dark:text-f1-foreground-inverse" />
           </div>
         </div>
         <h4 className="mb-2 text-xl font-semibold text-f1-foreground dark:text-f1-foreground-inverse">

--- a/styles.css
+++ b/styles.css
@@ -158,5 +158,5 @@
 }
 
 body {
-  @apply bg-f1-background font-sans text-base text-f1-foreground antialiased;
+  @apply font-sans text-base text-f1-foreground antialiased;
 }

--- a/styles.css
+++ b/styles.css
@@ -158,5 +158,5 @@
 }
 
 body {
-  @apply font-sans text-base text-f1-foreground antialiased;
+  @apply bg-f1-background font-sans text-base text-f1-foreground antialiased;
 }


### PR DESCRIPTION
## Description

Dark theme in Storybook has been broken for a while, due to upgrading to newer versions that changed a few things. I've fixed the most notorious style issues to make the dark theme readable again, even though it's far from perfect.

In my opinion, it's not worth to make it perfect if we're going to use another tool for docs, but it's important to make it usable at least, so we can check if components are working correctly in both themes, light and dark.

## Screenshots

![image](https://github.com/user-attachments/assets/2a1f1fd8-e5c1-42b6-8ec4-44810a3bd0d6)

_Main page_

---

![image](https://github.com/user-attachments/assets/f388118f-7ba8-4627-9e1e-78bbce4f228c)

_Component documentation_

---

![image](https://github.com/user-attachments/assets/2c0d6621-4403-4f84-9e11-3c1244348ccc)

_MDX file_

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other