### PR TITLE
Better state for not clickable Widget HighlightButton

### DIFF
--- a/lib/experimental/Widgets/Content/Highlights/WidgetHighlightButton/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/Highlights/WidgetHighlightButton/index.stories.tsx
@@ -37,3 +37,10 @@ export const WithLongTitle: Story = {
     label: "This item will show a really really long title",
   },
 }
+
+export const WithoutOnClick: Story = {
+  args: {
+    ...Default.args,
+    onClick: undefined,
+  },
+}

--- a/lib/experimental/Widgets/Content/Highlights/WidgetHighlightButton/index.tsx
+++ b/lib/experimental/Widgets/Content/Highlights/WidgetHighlightButton/index.tsx
@@ -20,11 +20,13 @@ const Wrapper: React.FC<WrapperProps> = ({ onClick, children }) => {
   const className =
     "block rounded-lg border border-solid border-transparent p-[1px] -m-1"
 
+  console.log({ onClick })
+
   return onClick ? (
     <a
       className={cn(
         className,
-        "focus:border-f1-background-selected-bold focus:outline-none"
+        "cursor-pointer focus:border-f1-background-selected-bold focus:outline-none"
       )}
       onClick={onClick}
       tabIndex={0}
@@ -47,7 +49,12 @@ export function WidgetHighlightButton({
 }: Props) {
   return (
     <Wrapper onClick={onClick}>
-      <div className="flex cursor-pointer flex-col gap-0.5 rounded-md border border-solid border-f1-border-secondary px-3 py-2.5 hover:border-f1-border-hover">
+      <div
+        className={cn(
+          "flex flex-col gap-0.5 rounded-md border border-solid border-f1-border-secondary px-3 py-2.5",
+          onClick && "hover:border-f1-border-hover"
+        )}
+      >
         <div className="flex flex-row items-center">
           <p className="line-clamp-1 flex-1 text-f1-foreground-secondary">
             {label}


### PR DESCRIPTION
## Description

When a widget HighlightButton is not clickable we need to make it more obvious.

## Screenshots

Before:

(With cursor pointer)
<img width="342" alt="Screenshot 2025-02-10 at 10 41 24" src="https://github.com/user-attachments/assets/83972de2-b059-4b60-bf1e-e27797679770" />

After:

(Without cursor pointer)
<img width="342" alt="Screenshot 2025-02-10 at 10 41 39" src="https://github.com/user-attachments/assets/04bd429f-f722-4cf8-b61a-2519996e3594" />
