### PR TITLE
Swap `alpha` status to `experimental`

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -12,7 +12,7 @@ addons.setConfig({
   },
   tagBadges: [
     {
-      tags: "alpha",
+      tags: "experimental",
       badge: {
         text: "🚧",
         bgColor: "transparent",

--- a/lib/experimental/Charts/RadarChart/index.stories.tsx
+++ b/lib/experimental/Charts/RadarChart/index.stories.tsx
@@ -14,7 +14,7 @@ const dataConfig = {
 const meta: Meta<typeof RadarChart<typeof dataConfig>> = {
   title: "Charts/RadarChart",
   component: RadarChart,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     dataConfig,
     data: [

--- a/lib/experimental/Forms/AvatarNameSelector/AvatarNameListItem/index.stories.tsx
+++ b/lib/experimental/Forms/AvatarNameSelector/AvatarNameListItem/index.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [
     (Story) => (
       <div className="w-full min-w-72 max-w-96">

--- a/lib/experimental/Forms/AvatarNameSelector/AvatarNameListTag/index.stories.tsx
+++ b/lib/experimental/Forms/AvatarNameSelector/AvatarNameListTag/index.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [
     (Story) => (
       <div className="w-full min-w-72 max-w-96">

--- a/lib/experimental/Forms/AvatarNameSelector/AvatarNameSelectorTrigger/index.stories.tsx
+++ b/lib/experimental/Forms/AvatarNameSelector/AvatarNameSelectorTrigger/index.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [
     (Story) => (
       <div className="w-full min-w-72 max-w-96">

--- a/lib/experimental/Forms/AvatarNameSelector/index.stories.tsx
+++ b/lib/experimental/Forms/AvatarNameSelector/index.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta<typeof AvatarNameSelector> = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [
     (Story) => (
       <div className="w-full min-w-72 max-w-96">

--- a/lib/experimental/Forms/Fields/Calendar/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/Calendar/index.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
       },
     },
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     defaultMonth: new Date(2024, 10, 15),
   },

--- a/lib/experimental/Forms/Fields/Checkbox/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/Checkbox/index.stories.tsx
@@ -3,7 +3,7 @@ import Checkbox from "."
 
 const meta = {
   component: Checkbox,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   title: "Checkbox",
 } satisfies Meta<typeof Checkbox>
 

--- a/lib/experimental/Forms/Fields/Input/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/Input/index.stories.tsx
@@ -5,7 +5,7 @@ import { Input } from "."
 const meta = {
   component: Input,
   title: "Input",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     type: "text",
     disabled: false,

--- a/lib/experimental/Forms/Fields/NumberInput/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/NumberInput/index.stories.tsx
@@ -6,7 +6,8 @@ import { NumberInput } from "."
 const meta = {
   render: (props) => <NumberInput key={JSON.stringify(props)} {...props} />,
   title: "NumberInput",
-  tags: ["autodocs", "alpha"],
+  component: NumberInput,
+  tags: ["autodocs", "experimental"],
   args: {
     disabled: false,
     placeholder: "Placeholder text here",

--- a/lib/experimental/Forms/Fields/Select/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/Select/index.stories.tsx
@@ -39,7 +39,7 @@ const meta: Meta = {
     ],
     disabled: false,
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof Select>
 
 export default meta

--- a/lib/experimental/Forms/Fields/TextArea/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/TextArea/index.stories.tsx
@@ -4,7 +4,7 @@ import { Textarea } from "."
 const meta = {
   title: "TextArea",
   component: Textarea,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     disabled: false,
     placeholder: "Placeholder text here",

--- a/lib/experimental/Forms/Fields/ToggleGroup/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/ToggleGroup/index.stories.tsx
@@ -12,7 +12,7 @@ const children: React.ReactNode = (
 const meta = {
   title: "ToggleGroup",
   component: ToggleGroup,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     type: "multiple",
     children,

--- a/lib/experimental/Forms/Form/index.stories.tsx
+++ b/lib/experimental/Forms/Form/index.stories.tsx
@@ -17,7 +17,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const meta = {
   title: "Form",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     a11y: {
       skipCi: true,

--- a/lib/experimental/Information/Alert/index.stories.tsx
+++ b/lib/experimental/Information/Alert/index.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   parameters: {
     layout: "padded",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof Alert>
 
 export default meta
@@ -36,7 +36,7 @@ export const Positive: Story = {
     <Alert {...props}>
       <AlertTitle>Training completed!</AlertTitle>
       <AlertDescription>
-        You successfully completed the training ‘Eat. Sleep. Command Z. Repeat’.
+        You successfully completed the training 'Eat. Sleep. Command Z. Repeat'.
       </AlertDescription>
     </Alert>
   ),

--- a/lib/experimental/Information/Avatars/AlertAvatar/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/AlertAvatar/index.stories.tsx
@@ -4,7 +4,7 @@ import { AlertAvatar } from "./index"
 const meta: Meta<typeof AlertAvatar> = {
   component: AlertAvatar,
   title: "Avatars/AlertAvatar",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Information/Avatars/AvatarList/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/AvatarList/index.stories.tsx
@@ -4,7 +4,7 @@ import { AvatarList } from "./index"
 const meta: Meta<typeof AvatarList> = {
   component: AvatarList,
   title: "Avatars/AvatarList",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     size: "medium",
     type: "person",

--- a/lib/experimental/Information/Avatars/CompanyAvatar/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/CompanyAvatar/index.stories.tsx
@@ -6,7 +6,7 @@ import { CompanyAvatar } from "."
 const meta: Meta<typeof CompanyAvatar> = {
   component: CompanyAvatar,
   title: "Avatars/CompanyAvatar",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   argTypes: {
     size: {
       control: "select",

--- a/lib/experimental/Information/Avatars/DateAvatar/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/DateAvatar/index.stories.tsx
@@ -4,7 +4,7 @@ import { DateAvatar } from "."
 const meta: Meta<typeof DateAvatar> = {
   component: DateAvatar,
   title: "Avatars/DateAvatar",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Information/Avatars/EmojiAvatar/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/EmojiAvatar/index.stories.tsx
@@ -4,7 +4,7 @@ import { EmojiAvatar } from "."
 const meta: Meta<typeof EmojiAvatar> = {
   component: EmojiAvatar,
   title: "Avatars/EmojiAvatar",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   argTypes: {
     size: {
       control: "select",

--- a/lib/experimental/Information/Avatars/PersonAvatar/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/PersonAvatar/index.stories.tsx
@@ -6,7 +6,7 @@ import { PersonAvatar } from "."
 const meta: Meta<typeof PersonAvatar> = {
   component: PersonAvatar,
   title: "Avatars/PersonAvatar",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   argTypes: {
     size: {
       control: "select",

--- a/lib/experimental/Information/Avatars/TeamAvatar/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/TeamAvatar/index.stories.tsx
@@ -6,7 +6,7 @@ import { TeamAvatar } from "."
 const meta: Meta<typeof TeamAvatar> = {
   component: TeamAvatar,
   title: "Avatars/TeamAvatar",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   argTypes: {
     size: {
       control: "select",

--- a/lib/experimental/Information/Badge/index.stories.tsx
+++ b/lib/experimental/Information/Badge/index.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof Badge> = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Information/Communities/Celebration/index.stories.tsx
+++ b/lib/experimental/Information/Communities/Celebration/index.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof Celebration> = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Information/Communities/HighlightBanner/index.stories.tsx
+++ b/lib/experimental/Information/Communities/HighlightBanner/index.stories.tsx
@@ -5,7 +5,7 @@ import { HighlightBanner } from "./index"
 const meta: Meta<typeof HighlightBanner> = {
   component: HighlightBanner,
   title: "Communities/HighlightBanner",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Information/Communities/Post/CommunityPost/index.stories.tsx
+++ b/lib/experimental/Information/Communities/Post/CommunityPost/index.stories.tsx
@@ -5,7 +5,7 @@ import { CommunityPost } from "."
 const meta: Meta<typeof CommunityPost> = {
   component: CommunityPost,
   title: "Communities/Post/CommunityPost",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Information/Communities/Post/PostDescription/index.stories.tsx
+++ b/lib/experimental/Information/Communities/Post/PostDescription/index.stories.tsx
@@ -4,7 +4,7 @@ import { PostDescription } from "."
 const meta: Meta<typeof PostDescription> = {
   component: PostDescription,
   title: "Communities/Post/PostDescription",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Information/Communities/Post/PostEvent/index.stories.tsx
+++ b/lib/experimental/Information/Communities/Post/PostEvent/index.stories.tsx
@@ -5,7 +5,7 @@ import cat from "../../../../../../storybook-assets/cat.jpeg"
 const meta: Meta<typeof PostEvent> = {
   component: PostEvent,
   title: "Communities/Post/PostEvent",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Information/Counter/index.stories.tsx
+++ b/lib/experimental/Information/Counter/index.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
       url: "https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=252-8537&t=SrGKlGDdzYxFSTb8-4",
     },
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     value: 42,
     size: "md",

--- a/lib/experimental/Information/ModuleAvatar/index.stories.tsx
+++ b/lib/experimental/Information/ModuleAvatar/index.stories.tsx
@@ -5,7 +5,7 @@ import { ModuleAvatar } from "."
 const meta: Meta<typeof ModuleAvatar> = {
   component: ModuleAvatar,
   title: "Avatars/ModuleAvatar",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   argTypes: {
     size: {
       control: "radio",

--- a/lib/experimental/Information/Reactions/index.stories.tsx
+++ b/lib/experimental/Information/Reactions/index.stories.tsx
@@ -4,7 +4,7 @@ import { Reactions } from "."
 const meta: Meta<typeof Reactions> = {
   component: Reactions,
   title: "Reactions",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Information/Shortcut/index.stories.tsx
+++ b/lib/experimental/Information/Shortcut/index.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
       url: "https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=172-2793",
     },
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     keys: ["cmd", "k"],
   } satisfies ComponentProps<typeof Shortcut>,

--- a/lib/experimental/Information/Spinner/index.stories.tsx
+++ b/lib/experimental/Information/Spinner/index.stories.tsx
@@ -7,7 +7,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof Spinner>
 
 export default meta

--- a/lib/experimental/Information/Tags/AlertTag/index.stories.tsx
+++ b/lib/experimental/Information/Tags/AlertTag/index.stories.tsx
@@ -5,7 +5,7 @@ import { AlertTag } from "."
 const meta: Meta = {
   component: AlertTag,
   title: "Tag/AlertTag",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Information/Tags/BalanceTag/index.stories.tsx
+++ b/lib/experimental/Information/Tags/BalanceTag/index.stories.tsx
@@ -5,7 +5,7 @@ import { BalanceTag } from "."
 const meta: Meta = {
   component: BalanceTag,
   title: "Tag/BalanceTag",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Information/Tags/CompanyTag/index.stories.tsx
+++ b/lib/experimental/Information/Tags/CompanyTag/index.stories.tsx
@@ -5,7 +5,7 @@ import { CompanyTag } from "."
 const meta: Meta = {
   component: CompanyTag,
   title: "Tag/CompanyTag",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Information/Tags/DotTag/index.stories.tsx
+++ b/lib/experimental/Information/Tags/DotTag/index.stories.tsx
@@ -5,7 +5,7 @@ import { DotTag } from "."
 const meta: Meta = {
   component: DotTag,
   title: "Tag/DotTag",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Information/Tags/PersonTag/index.stories.tsx
+++ b/lib/experimental/Information/Tags/PersonTag/index.stories.tsx
@@ -5,7 +5,7 @@ import { PersonTag } from "."
 const meta: Meta = {
   component: PersonTag,
   title: "Tag/PersonTag",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Information/Tags/RawTag/index.stories.tsx
+++ b/lib/experimental/Information/Tags/RawTag/index.stories.tsx
@@ -6,7 +6,7 @@ import { RawTag } from "."
 const meta: Meta = {
   component: RawTag,
   title: "Tag/RawTag",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Information/Tags/StatusTag/index.stories.tsx
+++ b/lib/experimental/Information/Tags/StatusTag/index.stories.tsx
@@ -5,7 +5,7 @@ import { StatusTag } from "."
 const meta: Meta = {
   component: StatusTag,
   title: "Tag/StatusTag",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Information/Tags/TeamTag/index.stories.tsx
+++ b/lib/experimental/Information/Tags/TeamTag/index.stories.tsx
@@ -5,7 +5,7 @@ import { TeamTag } from "."
 const meta: Meta = {
   component: TeamTag,
   title: "Tag/TeamTag",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Lists/DataList/index.stories.tsx
+++ b/lib/experimental/Lists/DataList/index.stories.tsx
@@ -6,7 +6,7 @@ import { DataList } from "."
 const meta: Meta<typeof DataList> = {
   title: "DataList",
   component: DataList,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     children: (
       <>

--- a/lib/experimental/Lists/PersonListItem/index.stories.tsx
+++ b/lib/experimental/Lists/PersonListItem/index.stories.tsx
@@ -7,7 +7,7 @@ import { PersonListItem } from "./index"
 const meta = {
   title: "PersonListItem",
   component: PersonListItem,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof PersonListItem>
 
 export default meta

--- a/lib/experimental/Navigation/ApplicationFrame/index.stories.tsx
+++ b/lib/experimental/Navigation/ApplicationFrame/index.stories.tsx
@@ -9,7 +9,7 @@ import { Sidebar } from "../Sidebar/Sidebar"
 const meta: Meta<typeof ApplicationFrame> = {
   title: "ApplicationFrame",
   component: ApplicationFrame,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "fullscreen",
   },

--- a/lib/experimental/Navigation/Carousel/DynamicCarousel/index.stories.tsx
+++ b/lib/experimental/Navigation/Carousel/DynamicCarousel/index.stories.tsx
@@ -8,7 +8,7 @@ import { DynamicCarousel } from "."
 const meta: Meta<typeof DynamicCarousel> = {
   title: "Carousel/DynamicCarousel",
   component: DynamicCarousel,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Navigation/Carousel/index.stories.tsx
+++ b/lib/experimental/Navigation/Carousel/index.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Carousel> = {
     showArrows: { control: "boolean" },
     showPeek: { control: "boolean" },
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Navigation/Dropdown/index.stories.tsx
+++ b/lib/experimental/Navigation/Dropdown/index.stories.tsx
@@ -6,7 +6,7 @@ import { Dropdown } from "."
 const meta: Meta<typeof Dropdown> = {
   title: "Dropdown",
   component: Dropdown,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Navigation/Header/Breadcrumbs/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/Breadcrumbs/index.stories.tsx
@@ -8,7 +8,7 @@ import Breadcrumbs, { BreadcrumbItemType } from "./index"
 const meta: Meta<typeof Breadcrumbs> = {
   title: "Header/Breadcrumbs",
   component: Breadcrumbs,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -5,7 +5,7 @@ import { PageHeader } from "."
 const meta = {
   title: "Header/PageHeader",
   component: PageHeader,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "fullscreen",
     a11y: {

--- a/lib/experimental/Navigation/Page/index.stories.tsx
+++ b/lib/experimental/Navigation/Page/index.stories.tsx
@@ -18,7 +18,7 @@ type TabsProps = ComponentProps<typeof Tabs>
 const meta: Meta<typeof Page> = {
   title: "Page",
   component: Page,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "fullscreen",
   },

--- a/lib/experimental/Navigation/Sidebar/CompanySelector/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/CompanySelector/index.stories.tsx
@@ -4,7 +4,7 @@ import { CompanySelector } from "./index"
 const meta: Meta<typeof CompanySelector> = {
   title: "Sidebar/CompanySelector",
   component: CompanySelector,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [
     (Story) => (
       <div className="max-w-[300px] bg-f1-background-tertiary p-3">

--- a/lib/experimental/Navigation/Sidebar/Header/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Header/index.stories.tsx
@@ -5,7 +5,7 @@ import { SidebarHeader } from "./index"
 const meta = {
   title: "Sidebar/Header",
   component: SidebarHeader,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof SidebarHeader>
 
 export default meta

--- a/lib/experimental/Navigation/Sidebar/Icon/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Icon/index.stories.tsx
@@ -4,7 +4,7 @@ import { SidebarIcon } from "."
 const meta: Meta<typeof SidebarIcon> = {
   title: "Sidebar/Icon",
   component: SidebarIcon,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 export default meta

--- a/lib/experimental/Navigation/Sidebar/Menu/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Menu/index.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
       </div>
     ),
   ],
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof Menu>
 
 export default meta

--- a/lib/experimental/Navigation/Sidebar/Searchbar/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Searchbar/index.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
       </div>
     ),
   ],
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof SearchBar>
 
 export default meta

--- a/lib/experimental/Navigation/Sidebar/User/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/User/index.stories.tsx
@@ -5,7 +5,7 @@ import { User } from "."
 const meta = {
   title: "Sidebar/User",
   component: User,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof User>
 
 export default meta

--- a/lib/experimental/Navigation/Sidebar/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/index.stories.tsx
@@ -13,7 +13,7 @@ import * as UserStories from "./User/index.stories"
 const meta: Meta<typeof Sidebar> = {
   title: "Sidebar",
   component: Sidebar,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Navigation/Tabs/index.stories.tsx
+++ b/lib/experimental/Navigation/Tabs/index.stories.tsx
@@ -18,7 +18,7 @@ const secondaryTabItems = [
 const meta: Meta<typeof Tabs> = {
   title: "Tabs",
   component: Tabs,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   argTypes: {
     secondary: {
       control: "boolean",

--- a/lib/experimental/Overlays/Dialog/index.stories.tsx
+++ b/lib/experimental/Overlays/Dialog/index.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
     children: <span>Dialog Content</span>,
     open: true,
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof Dialog>
 
 export default meta

--- a/lib/experimental/Overlays/Tooltip/index.stories.tsx
+++ b/lib/experimental/Overlays/Tooltip/index.stories.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from "."
 const meta: Meta<typeof Tooltip> = {
   title: "Tooltip",
   component: Tooltip,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [
     (Story) => (
       <div className="flex h-32 items-center justify-center p-6">{Story()}</div>

--- a/lib/experimental/PageLayouts/FullscreenLayout/index.stories.tsx
+++ b/lib/experimental/PageLayouts/FullscreenLayout/index.stories.tsx
@@ -7,7 +7,7 @@ import { FullscreenLayout } from "."
 const meta = {
   title: "Layout/FullscreenLayout",
   component: FullscreenLayout,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [PageDecorator],
   args: {
     children: <Placeholder>Content</Placeholder>,

--- a/lib/experimental/PageLayouts/HomeLayout/index.stories.tsx
+++ b/lib/experimental/PageLayouts/HomeLayout/index.stories.tsx
@@ -43,7 +43,7 @@ const widgets = [
 const meta = {
   title: "Layout/HomeLayout",
   component: HomeLayout,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     children: (
       <div>

--- a/lib/experimental/PageLayouts/OverviewLayout/index.stories.tsx
+++ b/lib/experimental/PageLayouts/OverviewLayout/index.stories.tsx
@@ -15,7 +15,7 @@ const DETAILS_ITEMS_ARGS = DetailsItemsListStories.default
 const meta = {
   title: "Layout/OverviewLayout",
   component: OverviewLayout,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [PageDecorator],
   args: {
     children: <Placeholder className="h-[450px]">Main</Placeholder>,

--- a/lib/experimental/PageLayouts/StandardLayout/index.stories.tsx
+++ b/lib/experimental/PageLayouts/StandardLayout/index.stories.tsx
@@ -7,7 +7,7 @@ import { StandardLayout } from "."
 const meta = {
   title: "Layout/StandardLayout",
   component: StandardLayout,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [PageDecorator],
   args: {
     children: (

--- a/lib/experimental/PageLayouts/Utils/DetailsItem/index.stories.tsx
+++ b/lib/experimental/PageLayouts/Utils/DetailsItem/index.stories.tsx
@@ -5,7 +5,7 @@ import { DetailsItem } from "."
 const meta: Meta = {
   title: "DetailsItem",
   component: DetailsItem,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     title: "Email",
     content: {

--- a/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.stories.tsx
+++ b/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.stories.tsx
@@ -5,7 +5,7 @@ import { DetailsItemsList } from "."
 const meta: Meta = {
   title: "DetailsItemsList",
   component: DetailsItemsList,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     title: "Details",
     details: [

--- a/lib/experimental/PageLayouts/Utils/InfoPaneLayout/index.stories.tsx
+++ b/lib/experimental/PageLayouts/Utils/InfoPaneLayout/index.stories.tsx
@@ -11,7 +11,7 @@ import { InfoPaneLayout } from "."
 const meta = {
   title: "InfoPaneLayout",
   component: InfoPaneLayout,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [PageDecorator],
   args: {
     children: (

--- a/lib/experimental/Utilities/Layout/AutoGrid/index.stories.tsx
+++ b/lib/experimental/Utilities/Layout/AutoGrid/index.stories.tsx
@@ -6,7 +6,7 @@ import { AutoGrid } from "."
 const meta = {
   title: "AutoGrid",
   component: AutoGrid,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     tileSize: "md",
     gap: "4",

--- a/lib/experimental/Utilities/Layout/Split/index.stories.tsx
+++ b/lib/experimental/Utilities/Layout/Split/index.stories.tsx
@@ -6,7 +6,7 @@ import { Split } from "."
 const meta = {
   title: "Split",
   component: Split,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     gap: "4",
   },

--- a/lib/experimental/Utilities/Layout/Stack/index.stories.tsx
+++ b/lib/experimental/Utilities/Layout/Stack/index.stories.tsx
@@ -6,7 +6,7 @@ import { Stack } from "."
 const meta = {
   title: "Stack",
   component: Stack,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   render: (args) => (
     <Stack {...args}>
       {Array.from({ length: 10 }).map((_, i) => (

--- a/lib/experimental/Utilities/PrivateBox/index.stories.tsx
+++ b/lib/experimental/Utilities/PrivateBox/index.stories.tsx
@@ -6,7 +6,7 @@ import { PrivateBox } from "."
 
 const meta: Meta = {
   title: "PrivateBox",
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
 }
 
 type Story = StoryObj

--- a/lib/experimental/Utilities/ScrollArea/index.stories.tsx
+++ b/lib/experimental/Utilities/ScrollArea/index.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {},
 } satisfies Meta<typeof ScrollArea>
 

--- a/lib/experimental/Widgets/ChartWidgetEmptyState/index.stories.tsx
+++ b/lib/experimental/Widgets/ChartWidgetEmptyState/index.stories.tsx
@@ -6,7 +6,7 @@ import { ChartWidgetEmptyState } from "."
 const meta: Meta<typeof ChartWidgetEmptyState> = {
   title: "Widgets/EmptyState",
   component: ChartWidgetEmptyState,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     title: "Performance",
     content: "See how Hugo's performance evolved over time",

--- a/lib/experimental/Widgets/Charts/AreaChartWidget/index.stories.tsx
+++ b/lib/experimental/Widgets/Charts/AreaChartWidget/index.stories.tsx
@@ -8,7 +8,7 @@ import { containerStoryArgs, WidgetDecorator } from "../storybook-utils"
 const meta: Meta<typeof AreaChartWidget> = {
   title: "Widgets/Charts/AreaChartWidget",
   component: AreaChartWidget,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
     chromatic: { diffThreshold: 0.5 },

--- a/lib/experimental/Widgets/Charts/BarChartWidget/index.stories.tsx
+++ b/lib/experimental/Widgets/Charts/BarChartWidget/index.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     ...containerStoryArgs,
     header: {

--- a/lib/experimental/Widgets/Charts/LineChartWidget/index.stories.tsx
+++ b/lib/experimental/Widgets/Charts/LineChartWidget/index.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     ...containerStoryArgs,
     header: {

--- a/lib/experimental/Widgets/Charts/PieChartWidget/index.stories.tsx
+++ b/lib/experimental/Widgets/Charts/PieChartWidget/index.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
       },
     },
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     ...containerStoryArgs,
     header: {

--- a/lib/experimental/Widgets/Charts/RadialProgressWidget/index.stories.tsx
+++ b/lib/experimental/Widgets/Charts/RadialProgressWidget/index.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     header: {
       title: "A Radial Progress Chart",

--- a/lib/experimental/Widgets/Charts/SummariesWidget/index.stories.tsx
+++ b/lib/experimental/Widgets/Charts/SummariesWidget/index.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     summaries: [
       {

--- a/lib/experimental/Widgets/Charts/VerticalBarChartWidget/index.stories.tsx
+++ b/lib/experimental/Widgets/Charts/VerticalBarChartWidget/index.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     ...containerStoryArgs,
     header: {

--- a/lib/experimental/Widgets/Content/CalendarEvent/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/CalendarEvent/index.stories.tsx
@@ -6,7 +6,7 @@ import { CalendarEvent } from "."
 const meta: Meta = {
   title: "Widgets/Content/CalendarEvent",
   component: CalendarEvent,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/CalendarEventList/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/CalendarEventList/index.stories.tsx
@@ -5,7 +5,7 @@ import { CalendarEventList } from "."
 const meta: Meta = {
   title: "Widgets/Content/CalendarEventList",
   component: CalendarEventList,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/CategoryBarSection/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/CategoryBarSection/index.stories.tsx
@@ -4,7 +4,7 @@ import { CategoryBarSection } from "./index"
 const meta: Meta<typeof CategoryBarSection> = {
   title: "CategoryBarSection",
   component: CategoryBarSection,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
@@ -19,7 +19,7 @@ const defaultLabels = {
 const meta: Meta<typeof ClockInControls> = {
   title: "ClockInControls",
   component: ClockInControls,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     labels: defaultLabels,
     location: {

--- a/lib/experimental/Widgets/Content/ClockIn/ClockInGraph/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInGraph/index.stories.tsx
@@ -4,7 +4,7 @@ import { ClockInGraph } from "."
 const meta: Meta<typeof ClockInGraph> = {
   title: "ClockInGraph",
   component: ClockInGraph,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     remainingMinutes: 60 * 4 + 39,
     data: [],

--- a/lib/experimental/Widgets/Content/Highlights/WidgetHighlightButton/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/Highlights/WidgetHighlightButton/index.stories.tsx
@@ -5,7 +5,7 @@ import { WidgetHighlightButton, WidgetHighlightButtonProps } from "./index"
 const meta: Meta<WidgetHighlightButtonProps> = {
   title: "Widgets/WidgetHighlightButton",
   component: WidgetHighlightButton,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/IndicatorsList/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/IndicatorsList/index.stories.tsx
@@ -25,7 +25,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     items: taskCategories,
   },

--- a/lib/experimental/Widgets/Content/ListItems/WidgetInboxListItem/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ListItems/WidgetInboxListItem/index.stories.tsx
@@ -5,7 +5,7 @@ import { WidgetInboxListItem, WidgetInboxListItemProps } from "./index"
 const meta: Meta<WidgetInboxListItemProps> = {
   title: "Widgets/WidgetInboxListItem",
   component: WidgetInboxListItem,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/ListItems/WidgetSimpleListItem/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ListItems/WidgetSimpleListItem/index.stories.tsx
@@ -5,7 +5,7 @@ import { Props, WidgetSimpleListItem } from "./index"
 const meta: Meta<Props> = {
   title: "Widgets/WidgetSimpleListItem",
   component: WidgetSimpleListItem,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/Lists/WidgetInboxList/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/Lists/WidgetInboxList/index.stories.tsx
@@ -9,7 +9,7 @@ import { WidgetInboxList, WidgetInboxListProps } from "./index"
 const meta: Meta<WidgetInboxListProps> = {
   title: "Widgets/WidgetInboxList",
   component: WidgetInboxList,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/Lists/WidgetSimpleList/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/Lists/WidgetSimpleList/index.stories.tsx
@@ -8,7 +8,7 @@ import { WidgetSimpleList, WidgetSimpleListProps } from "./index"
 const meta: Meta<WidgetSimpleListProps> = {
   title: "Widgets/WidgetSimpleList",
   component: WidgetSimpleList,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/ProgressBarDuo/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ProgressBarDuo/index.stories.tsx
@@ -4,7 +4,7 @@ import { ProgressBarDuo } from "./index"
 const meta: Meta<typeof ProgressBarDuo> = {
   title: "ProgressBarDuo",
   component: ProgressBarDuo,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     value: 50,
     max: 100,

--- a/lib/experimental/Widgets/Content/TasksList/TaskItem/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/TasksList/TaskItem/index.stories.tsx
@@ -4,7 +4,7 @@ import { TaskItem, TaskItemProps } from "./index"
 const meta: Meta<TaskItemProps> = {
   title: "TaskItem",
   component: TaskItem,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/TasksList/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/TasksList/index.stories.tsx
@@ -5,7 +5,7 @@ import { TasksList, TasksListProps } from "./index"
 const meta: Meta<TasksListProps> = {
   title: "TasksList",
   component: TasksList,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/TwoColumnsList/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/TwoColumnsList/index.stories.tsx
@@ -6,7 +6,7 @@ import { ProgressBarDuo } from "../ProgressBarDuo"
 const meta: Meta = {
   title: "Widgets/Content/TwoColumnsList",
   component: TwoColumnsList,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Content/Weekdays/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/Weekdays/index.stories.tsx
@@ -5,7 +5,7 @@ import { Weekdays } from "."
 const meta: Meta = {
   title: "Widgets/Content/Weekdays",
   component: Weekdays,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Layout/Dashboard/index.stories.tsx
+++ b/lib/experimental/Widgets/Layout/Dashboard/index.stories.tsx
@@ -40,7 +40,7 @@ const widgets = [
 const meta = {
   title: "Widgets/Layout/Dashboard",
   component: Dashboard,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   argTypes: {
     widgetWidth: {
       control: "select",

--- a/lib/experimental/Widgets/Layout/WidgetStrip/index.stories.tsx
+++ b/lib/experimental/Widgets/Layout/WidgetStrip/index.stories.tsx
@@ -34,7 +34,7 @@ const widgets = [
 const meta = {
   title: "Widgets/Layout/WidgetStrip",
   component: WidgetStrip,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     children: Array.from({ length: 4 }, (_, i) => widgets[i % widgets.length]),
   },

--- a/lib/experimental/Widgets/Widget/Skeleton.stories.tsx
+++ b/lib/experimental/Widgets/Widget/Skeleton.stories.tsx
@@ -5,7 +5,7 @@ import { Widget } from "."
 const meta: Meta<ComponentProps<typeof Widget.Skeleton>> = {
   title: "Widgets/Widget/Skeleton",
   component: Widget.Skeleton,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Widgets/Widget/index.stories.tsx
+++ b/lib/experimental/Widgets/Widget/index.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   decorators: [
     (Story) => (
       <div className="w-full min-w-72 max-w-96">

--- a/lib/experimental/Widgets/WidgetEmptyState/index.stories.tsx
+++ b/lib/experimental/Widgets/WidgetEmptyState/index.stories.tsx
@@ -6,7 +6,7 @@ import { WidgetEmptyState } from "."
 const meta: Meta<typeof WidgetEmptyState> = {
   title: "Widgets/WidgetEmptyState",
   component: WidgetEmptyState,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   args: {
     title: "Title",
     description: "Description",

--- a/lib/experimental/Widgets/WidgetSection/index.stories.tsx
+++ b/lib/experimental/Widgets/WidgetSection/index.stories.tsx
@@ -6,7 +6,7 @@ import { WidgetSection } from "."
 const meta: Meta = {
   title: "Widgets/WidgetSection",
   component: WidgetSection,
-  tags: ["autodocs", "alpha"],
+  tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },


### PR DESCRIPTION
## Description

We named the status `alpha` initially as we wanted a shorter name than `experimental` to show a badge in the sidebar, but as we're using just an emoji now, there's no need to change the naming, so I'm swapping here every "alpha" tag to "experimental".
