### PR TITLE
Fix content margins in Storybook docs

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -80,6 +80,7 @@
 
   .sb-bar {
     border-bottom: 1px dashed #dce0e5;
+    box-shadow: none !important;
   }
 
   nav.sidebar-container

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -99,7 +99,9 @@
   }
 
   .sbdocs-wrapper {
-    padding-top: 32px !important;
+    padding-top: 64px !important;
+    padding-left: 72px !important;
+    padding-right: 72px !important;
   }
 
   .sbdocs-preview:not(.docs-story *) {
@@ -153,6 +155,10 @@
 
   .toc-list li {
     font-size: 12px !important;
+  }
+
+  .toc-list .toc-list-item > a.is-active-link {
+    color: #e51943 !important;
   }
 
   input[type="radio"] {


### PR DESCRIPTION
## Description

Margins are too tight on Storybook docs' content, making it tough to read and analyze. This PR adds more spacing and fixes a few small visual quirks.

Related: [Slack](https://factorialteam.slack.com/archives/C07LQSJ5UQY/p1739187068097509?thread_ts=1738943398.115069&cid=C07LQSJ5UQY)

## Screenshots

![image](https://github.com/user-attachments/assets/edd6e47f-bf69-413b-aca2-4bc2f5d0fdbe)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
