### PR TITLE
Fix focus order & ring in `ResourceHeader`

### DIFF
--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -117,53 +117,30 @@ export function BaseHeader({
             )}
           </div>
         </div>
+
         {allMetadata.length > 0 && (
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
             <Metadata items={allMetadata} />
           </div>
         )}
-        <div className="flex w-full shrink-0 flex-wrap items-center gap-x-2 gap-y-3 md:w-fit md:flex-row-reverse md:gap-y-2 md:overflow-x-auto">
+
+        <div className="flex w-full shrink-0 flex-col gap-x-2 gap-y-3 md:hidden">
           {isPrimaryActionVisible && (
-            <>
-              <div className="hidden md:block">
-                <ButtonWithTooltip
-                  label={primaryAction.label}
-                  onClick={primaryAction.onClick}
-                  variant="default"
-                  icon={primaryAction.icon}
-                  disabled={primaryAction.disabled}
-                  tooltip={primaryAction.tooltip}
-                />
-              </div>
-              <div className="w-full md:hidden [&>*]:w-full">
-                <ButtonWithTooltip
-                  label={primaryAction.label}
-                  onClick={primaryAction.onClick}
-                  variant="default"
-                  icon={primaryAction.icon}
-                  size="lg"
-                  disabled={primaryAction.disabled}
-                  tooltip={primaryAction.tooltip}
-                />
-              </div>
-            </>
+            <div className="w-full md:hidden [&>*]:w-full">
+              <ButtonWithTooltip
+                label={primaryAction.label}
+                onClick={primaryAction.onClick}
+                variant="default"
+                icon={primaryAction.icon}
+                size="lg"
+                disabled={primaryAction.disabled}
+                tooltip={primaryAction.tooltip}
+              />
+            </div>
           )}
-          {isPrimaryActionVisible &&
-            (hasSecondaryActions || hasOtherActions) && (
-              <div className="mx-1 hidden h-4 w-px bg-f1-background-secondary md:block" />
-            )}
+
           {visibleSecondaryActions.map((action) => (
             <Fragment key={action.label}>
-              <div className="hidden md:block">
-                <ButtonWithTooltip
-                  label={action.label}
-                  onClick={action.onClick}
-                  variant={action.variant ?? "outline"}
-                  icon={action.icon}
-                  disabled={action.disabled}
-                  tooltip={action.tooltip}
-                />
-              </div>
               <div className="w-full md:hidden [&>*]:w-full">
                 <ButtonWithTooltip
                   label={action.label}
@@ -177,15 +154,49 @@ export function BaseHeader({
               </div>
             </Fragment>
           ))}
+
           {visibleOtherActions.length > 0 && (
-            <>
+            <div className="w-full">
+              <MobileDropdown items={visibleOtherActions} />
+            </div>
+          )}
+        </div>
+
+        <div className="-m-1 hidden w-fit shrink-0 flex-wrap items-center gap-x-2 gap-y-2 p-1 md:flex md:overflow-x-auto">
+          {visibleOtherActions.length > 0 && (
+            <div>
+              <Dropdown items={visibleOtherActions} />
+            </div>
+          )}
+          {visibleSecondaryActions.map((action) => (
+            <Fragment key={action.label}>
               <div className="hidden md:block">
-                <Dropdown items={visibleOtherActions} />
+                <ButtonWithTooltip
+                  label={action.label}
+                  onClick={action.onClick}
+                  variant={action.variant ?? "outline"}
+                  icon={action.icon}
+                  disabled={action.disabled}
+                  tooltip={action.tooltip}
+                />
               </div>
-              <div className="w-full md:hidden">
-                <MobileDropdown items={visibleOtherActions} />
-              </div>
-            </>
+            </Fragment>
+          ))}
+          {isPrimaryActionVisible &&
+            (hasSecondaryActions || hasOtherActions) && (
+              <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
+            )}
+          {isPrimaryActionVisible && (
+            <div className="hidden md:block">
+              <ButtonWithTooltip
+                label={primaryAction.label}
+                onClick={primaryAction.onClick}
+                variant="default"
+                icon={primaryAction.icon}
+                disabled={primaryAction.disabled}
+                tooltip={primaryAction.tooltip}
+              />
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Description

Fix the focus order of the actions in the ResourceHeader. It was reversed due to CSS. Also fixed the focus being cut because of an overflow.

## Screenshots

https://github.com/user-attachments/assets/a04d4f79-04a7-474a-abbd-65dcc2c006ea


---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other