### PR TITLE
Fix spacing between category item and menu in Sidebar

### DIFF
--- a/lib/experimental/Navigation/Sidebar/Menu/index.tsx
+++ b/lib/experimental/Navigation/Sidebar/Menu/index.tsx
@@ -92,7 +92,11 @@ const CategoryItem = ({ category }: { category: MenuCategory }) => {
   }
 
   return (
-    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="flex w-full flex-col gap-0.5"
+    >
       <CollapsibleTrigger
         className={cn(
           "flex w-full cursor-pointer items-center gap-1 rounded px-1.5 py-2 text-sm font-medium text-f1-foreground-secondary hover:bg-f1-background-secondary",


### PR DESCRIPTION
## Description

Adding a bit of spacing between the category title and the menu.

Related: [Slack](https://factorialteam.slack.com/archives/C07LQSJ5UQY/p1737440561539109)

## Screenshots 

<img width="232" alt="image" src="https://github.com/user-attachments/assets/a4362a37-7f0f-4cdf-9d4d-03a3fb5505d1" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other