### PR TITLE
Add support to hide CategoryBar tooltip and adjust its colors

### DIFF
--- a/lib/components/Charts/CategoryBarChart/index.tsx
+++ b/lib/components/Charts/CategoryBarChart/index.tsx
@@ -16,10 +16,11 @@ export interface CategoryBarProps {
     color?: string
   }[]
   legend: boolean
+  hideTooltip?: boolean
 }
 
 const _CategoryBarChart = (
-  { data, legend = true }: CategoryBarProps,
+  { data, legend = true, hideTooltip = false }: CategoryBarProps,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const total = data.reduce((sum, category) => sum + category.value, 0)
@@ -55,18 +56,20 @@ const _CategoryBarChart = (
                     tabIndex={0}
                   />
                 </TooltipTrigger>
-                <TooltipContent className="flex items-center gap-1 text-sm">
-                  <div
-                    className="h-2.5 w-2.5 shrink-0 translate-y-px rounded-full"
-                    style={{ backgroundColor: color }}
-                  />
-                  <span className="pl-0.5 pr-2 text-f1-foreground-secondary">
-                    {category.name}
-                  </span>
-                  <span className="font-mono font-medium tabular-nums text-f1-foreground">
-                    {category.value} ({formatPercentage(category.value)}%)
-                  </span>
-                </TooltipContent>
+                {!hideTooltip && (
+                  <TooltipContent className="flex items-center gap-1 text-sm">
+                    <div
+                      className="h-2.5 w-2.5 shrink-0 translate-y-px rounded-full"
+                      style={{ backgroundColor: color }}
+                    />
+                    <span className="pl-0.5 pr-2 text-f1-foreground-inverse-secondary dark:text-f1-foreground-secondary">
+                      {category.name}
+                    </span>
+                    <span className="font-mono font-medium tabular-nums text-f1-foreground-inverse dark:text-f1-foreground">
+                      {category.value} ({formatPercentage(category.value)}%)
+                    </span>
+                  </TooltipContent>
+                )}
               </Tooltip>
             )
           })}

--- a/lib/experimental/Widgets/Content/CategoryBarSection/index.tsx
+++ b/lib/experimental/Widgets/Content/CategoryBarSection/index.tsx
@@ -9,6 +9,7 @@ interface CategoryBarSectionProps {
   data: CategoryBarProps["data"]
   helpText?: string
   legend?: boolean
+  hideTooltip?: boolean
 }
 
 export function CategoryBarSection({
@@ -17,6 +18,7 @@ export function CategoryBarSection({
   data,
   helpText,
   legend = false,
+  hideTooltip = false,
 }: CategoryBarSectionProps) {
   return (
     <div>
@@ -25,7 +27,11 @@ export function CategoryBarSection({
         <span className="text-xl text-f1-foreground-secondary">{subtitle}</span>
       </div>
       <div className="mt-2">
-        <CategoryBarChart data={data} legend={legend} />
+        <CategoryBarChart
+          data={data}
+          legend={legend}
+          hideTooltip={hideTooltip}
+        />
       </div>
       {!!helpText && (
         <div className="mt-1">


### PR DESCRIPTION
## Description

There are some cases when we need to hide the CategoryBar tooltip. Besides that, the text colors in these tooltips weren't visible at all.