### PR TITLE
Storybook styles leftovers

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -53,7 +53,7 @@
     margin-top: 8px !important;
   }
 
-  #storybook-docs p:not(.docs-story *, .docblock-argstable-body *) {
+  #storybook-docs p:not(.docs-story *, .docblock-argstable-body *, table *) {
     font-size: 16px;
     line-height: 1.5;
     color: #65636d !important;
@@ -192,6 +192,11 @@
 
   input[type="radio"]:checked::before {
     transform: scale(1);
+  }
+
+  .rejt-tree {
+    max-width: 240px;
+    overflow-x: scroll;
   }
 
   /* -- DARK -- */


### PR DESCRIPTION
## Description

Some Storybook styles leftovers/bugs.

1. A font-size is being applied to all paragraphs, affecting also those inside tables, breaking the preview of the typographies for example.

<img width="937" alt="image" src="https://github.com/user-attachments/assets/7c2f6a81-e3d6-46f9-b442-4dfe3f921c21" />

_Before_

---

<img width="956" alt="image" src="https://github.com/user-attachments/assets/9fb832f7-c491-4f05-bd91-ee5e590d8347" />

_After_

---

2. Some argument table controls get large, making the important part (name, description and so on) difficult to read. Most of our users won't look at it anyways. I've added a max-width with a scroll to keep it small even in these cases.

<img width="934" alt="image" src="https://github.com/user-attachments/assets/4775daed-2039-4200-973f-de854c49d9e5" />

_Before_

---

<img width="941" alt="image" src="https://github.com/user-attachments/assets/fd47f6fc-4703-4bf8-8774-8092e31c71c9" />

_After_
