### PR TITLE
Animated icons for introduction blocks

### DIFF
--- a/docs/Introduction.mdx
+++ b/docs/Introduction.mdx
@@ -1,8 +1,6 @@
 import { Meta, Unstyled } from "@storybook/blocks"
 import { FeatureCard } from "./components/FeatureCard"
-import Rocket from "@/icons/app/Rocket"
-import Masonry from "@/icons/app/Masonry"
-import Folder from "@/icons/app/Folder"
+import * as AnimatedIcon from "@/icons/animated"
 
 # Welcome to Factorial One
 
@@ -12,19 +10,19 @@ Factorial One.
 <Unstyled>
   <div className="mt-6 grid grid-cols-1 gap-6 pb-8 md:grid-cols-3">
     <FeatureCard
-      icon={Rocket}
+      icon={AnimatedIcon.RocketAnimated}
       title="Getting Started"
       description="Explore how to start with tutorials and getting started guides."
       href="/?path=/docs/components-maturity--documentation"
     />
     <FeatureCard
-      icon={Masonry}
+      icon={AnimatedIcon.BookAnimated}
       title="Foundations"
       description="Explore the foundations like colors, typography, or spacing."
       href="/?path=/docs/foundations-colors--documentation"
     />
     <FeatureCard
-      icon={Folder}
+      icon={AnimatedIcon.FoldersAnimated}
       title="Components"
       description="Discover our comprehensive collection of UI components."
       href="/?path=/docs/components-actions-button--documentation"

--- a/docs/components/FeatureCard.tsx
+++ b/docs/components/FeatureCard.tsx
@@ -1,24 +1,35 @@
-import React from "react"
+import { Icon, IconType } from "@/components/Utilities/Icon"
+import { useState } from "react"
 
 interface FeatureCardProps {
-  icon: React.ElementType
+  icon: IconType
   title: string
   description: string
   href: string
 }
 
 export function FeatureCard({
-  icon: Icon,
+  icon,
   title,
   description,
   href,
 }: FeatureCardProps) {
+  const [isHovered, setIsHovered] = useState(false)
+
   return (
-    <div className="rounded-lg border border-solid border-f1-border bg-f1-background shadow transition-all hover:border-f1-border-hover hover:shadow-md dark:border-f1-border-secondary dark:hover:border-f1-border">
+    <div
+      className="rounded-lg border border-solid border-f1-border bg-f1-background transition-all hover:shadow dark:border-f1-border-secondary dark:hover:border-f1-border"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       <a href={href} className="block h-full p-6 no-underline">
         <div className="mb-4">
           <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-f1-background-secondary dark:bg-f1-background-secondary">
-            <Icon className="h-6 w-6 text-f1-icon dark:text-f1-foreground-inverse" />
+            <Icon
+              icon={icon}
+              state={isHovered ? "animate" : "normal"}
+              className="h-6 w-6 text-f1-icon dark:text-f1-foreground-inverse"
+            />
           </div>
         </div>
         <h4 className="mb-2 text-xl font-semibold text-f1-foreground dark:text-f1-foreground-inverse">


### PR DESCRIPTION
## Description

Probably the most unneeded change. Using the Icon component for the cards in the intro page of Storybook, and using the animated icons there.

## Screenshots 

https://github.com/user-attachments/assets/fdeb7154-24f8-4638-9e0b-fc25765e938f

