### PR TITLE
Use index for days of the week for the `activatedDays` prop

### DIFF
--- a/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.stories.tsx
+++ b/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta = {
         title: "Workable days",
         content: {
           type: "weekdays",
-          activatedDays: ["Monday", "Tuesday", "Wednesday"],
+          activatedDays: [0, 1, 2],
         },
         spacingAtTheBottom: true,
       },

--- a/lib/experimental/Widgets/Content/Weekdays/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/Weekdays/index.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta = {
     layout: "centered",
   },
   args: {
-    activatedDays: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+    activatedDays: [0, 3, 1, 4],
   },
 }
 
@@ -18,3 +18,10 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Primary: Story = {}
+
+export const CustomDays: Story = {
+  args: {
+    daysOfTheWeek: ["M", "T", "W", "T", "F", "S", "S"],
+    activatedDays: [1, 5],
+  },
+}

--- a/lib/experimental/Widgets/Content/Weekdays/index.tsx
+++ b/lib/experimental/Widgets/Content/Weekdays/index.tsx
@@ -2,7 +2,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/ui/toggleGroup"
 import { forwardRef } from "react"
 
 interface WeekdaysProps {
-  activatedDays?: string[]
+  activatedDays?: number[]
   daysOfTheWeek?: string[]
 }
 
@@ -21,19 +21,23 @@ export const Weekdays = forwardRef<HTMLDivElement, WeekdaysProps>(
     { daysOfTheWeek = DAYS_OF_THE_WEEK, activatedDays = [] },
     ref
   ) {
+    const activatedDayValues = activatedDays.map(
+      (index) => `${index}-${daysOfTheWeek[index]}`
+    )
+
     return (
       <ToggleGroup
         type="multiple"
-        value={activatedDays}
+        value={activatedDayValues}
         disabled
         className="flex justify-start"
         ref={ref}
       >
-        {daysOfTheWeek.map((day) => (
+        {daysOfTheWeek.map((day, index) => (
           <ToggleGroupItem
             aria-label={day}
             key={day}
-            value={day}
+            value={`${index}-${day}`}
             className="h-6 w-6 shrink-0 grow-0 basis-6 p-0 text-sm font-medium disabled:select-none disabled:bg-f1-background-tertiary disabled:text-f1-foreground-secondary disabled:opacity-100 disabled:data-[state=on]:border disabled:data-[state=on]:border-solid disabled:data-[state=on]:border-f1-border-selected disabled:data-[state=on]:bg-f1-background-selected disabled:data-[state=on]:text-f1-foreground-selected"
           >
             {day[0]}


### PR DESCRIPTION
## The issue

When passing the string values in activated days and weekdays, we can face the collision because we compare them by value. For example, if `daysOfTheWeek` is ["M", "T", "W", "T", "F", "S", "S"] and `activatedDays` are ["T", "S"] will lead to four values being selected because there is no difference between them.

We have this bug in production. An employee has working days set to Tuesday and Friday, but we select both Ts in the component because we cannot distinguish them:
![CleanShot 2025-02-17 at 18 54 36@2x](https://github.com/user-attachments/assets/6c62437f-efa6-4a91-8cd4-ab6adf6f2ee5)

## The fix

In the fix `activedDays` now expects indices which will then generate a unique value index+day to avoid collisions

