### PR TITLE
Hide project selector in ClockInControls for now

### DIFF
--- a/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
@@ -44,7 +44,6 @@ const meta: Meta<typeof ClockInControls> = {
       },
     ],
     locationId: "1",
-    projectName: "Bolt’s project",
   },
   render: (args) => (
     <div className="max-w-[350px]">
@@ -128,13 +127,6 @@ export const Collapsed: Story = {
 export const WithNoLocationOrProject: Story = {
   args: {
     locationId: undefined,
-    projectName: undefined,
-  },
-}
-
-export const WithLongProjectName: Story = {
-  args: {
-    projectName: "Bolt’s project with a very long name",
   },
 }
 
@@ -160,7 +152,6 @@ export const WithDisabledSelectors: Story = {
   args: {
     ...ClockedOut.args,
     locationSelectorDisabled: true,
-    projectSelectorDisabled: true,
   },
 }
 
@@ -168,6 +159,5 @@ export const WithHiddenLocationAndProject: Story = {
   args: {
     ...ClockedOut.args,
     canShowLocation: false,
-    canShowProject: false,
   },
 }

--- a/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
@@ -35,12 +35,12 @@ export interface ClockInControlsProps {
     name: string
     icon: IconType
   }[]
-  // canShowProject?: boolean
+  canShowProject?: boolean
   canShowLocation?: boolean
   locationSelectorDisabled?: boolean
-  // projectSelectorDisabled?: boolean
+  projectSelectorDisabled?: boolean
   canShowBreakButton?: boolean
-  // projectName?: string
+  projectName?: string
   /** Callback when Clock In button is clicked */
   onClockIn?: () => void
   /** Callback when Clock Out button is clicked */
@@ -57,11 +57,8 @@ export function ClockInControls({
   labels,
   locationId,
   locations,
-  // canShowProject = true,
   canShowLocation = true,
   locationSelectorDisabled = false,
-  // projectSelectorDisabled = false,
-  // projectName,
   onClockIn,
   onClockOut,
   onBreak,

--- a/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
@@ -2,12 +2,7 @@ import { Button } from "@/components/Actions/Button"
 import { IconType } from "@/components/Utilities/Icon"
 import { Select } from "@/experimental/exports"
 import { RawTag } from "@/experimental/Information/Tags/RawTag"
-import {
-  SolidPause,
-  SolidPlay,
-  SolidStop,
-  Suitcase as SuitcaseIcon,
-} from "@/icons/app"
+import { SolidPause, SolidPlay, SolidStop } from "@/icons/app"
 import { motion } from "framer-motion"
 import { Dispatch, useState } from "react"
 import { ClockInGraph, ClockInGraphProps } from "../ClockInGraph"
@@ -40,12 +35,12 @@ export interface ClockInControlsProps {
     name: string
     icon: IconType
   }[]
-  canShowProject?: boolean
+  // canShowProject?: boolean
   canShowLocation?: boolean
   locationSelectorDisabled?: boolean
-  projectSelectorDisabled?: boolean
+  // projectSelectorDisabled?: boolean
   canShowBreakButton?: boolean
-  projectName?: string
+  // projectName?: string
   /** Callback when Clock In button is clicked */
   onClockIn?: () => void
   /** Callback when Clock Out button is clicked */
@@ -53,7 +48,7 @@ export interface ClockInControlsProps {
   /** Callback when Break button is clicked */
   onBreak?: () => void
   /** Callback when Project Selector is clicked */
-  onClickProjectSelector?: () => void
+  // onClickProjectSelector?: () => void
 }
 
 export function ClockInControls({
@@ -62,16 +57,16 @@ export function ClockInControls({
   labels,
   locationId,
   locations,
-  canShowProject = true,
+  // canShowProject = true,
   canShowLocation = true,
   locationSelectorDisabled = false,
-  projectSelectorDisabled = false,
-  projectName,
+  // projectSelectorDisabled = false,
+  // projectName,
   onClockIn,
   onClockOut,
   onBreak,
   canShowBreakButton = true,
-  onClickProjectSelector,
+  // onClickProjectSelector,
   onChangeLocationId,
 }: ClockInControlsProps) {
   const { status, statusText, subtitle, statusColor } = getInfo({
@@ -87,10 +82,10 @@ export function ClockInControls({
     locations.length &&
     !locationSelectorDisabled &&
     canShowLocation
-  const canSelectProject =
-    showLocationAndProjectSelectors &&
-    !projectSelectorDisabled &&
-    canShowProject
+  // const canSelectProject =
+  //   showLocationAndProjectSelectors &&
+  //   !projectSelectorDisabled &&
+  //   canShowProject
 
   const location = locations.find((location) => location.id === locationId)
 
@@ -216,7 +211,7 @@ export function ClockInControls({
               </>
             )
           )}
-          {canSelectProject ? (
+          {/* {canSelectProject ? (
             <Selector
               text={projectName}
               placeholder={labels.selectProject}
@@ -229,7 +224,7 @@ export function ClockInControls({
                 <RawTag text={projectName} icon={SuitcaseIcon} />
               </>
             )
-          )}
+          )} */}
         </div>
       </div>
     </div>

--- a/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
@@ -35,20 +35,15 @@ export interface ClockInControlsProps {
     name: string
     icon: IconType
   }[]
-  canShowProject?: boolean
   canShowLocation?: boolean
   locationSelectorDisabled?: boolean
-  projectSelectorDisabled?: boolean
   canShowBreakButton?: boolean
-  projectName?: string
   /** Callback when Clock In button is clicked */
   onClockIn?: () => void
   /** Callback when Clock Out button is clicked */
   onClockOut?: () => void
   /** Callback when Break button is clicked */
   onBreak?: () => void
-  /** Callback when Project Selector is clicked */
-  // onClickProjectSelector?: () => void
 }
 
 export function ClockInControls({
@@ -208,20 +203,6 @@ export function ClockInControls({
               </>
             )
           )}
-          {/* {canSelectProject ? (
-            <Selector
-              text={projectName}
-              placeholder={labels.selectProject}
-              icon={SuitcaseIcon}
-              onClick={onClickProjectSelector}
-            />
-          ) : (
-            canShowProject && (
-              <>
-                <RawTag text={projectName} icon={SuitcaseIcon} />
-              </>
-            )
-          )} */}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

As we won't be using our new project selector yet for the ClockInControls, we should hide it for now, because we will provide a custom implementation in the frontend for it. I just leave it commented because it's something we should recover later on.