### PR TITLE
Add max counter on `AvatarList`

### DIFF
--- a/lib/experimental/Information/Avatars/AvatarList/MaxCounter.tsx
+++ b/lib/experimental/Information/Avatars/AvatarList/MaxCounter.tsx
@@ -1,14 +1,11 @@
 import { Icon } from "@/components/Utilities/Icon"
 import { EllipsisHorizontal } from "@/icons/app"
+import { cn } from "@/lib/utils"
 import { sizes, type } from "@/ui/avatar"
-import {
-  TooltipContent,
-  Tooltip as TooltipPrimitive,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/ui/tooltip"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/ui/hover-card"
+import { ScrollArea, ScrollBar } from "@/ui/scrollarea"
 import { cva } from "cva"
-import { type AvatarVariant } from "../Avatar"
+import { Avatar, AvatarVariant } from "../Avatar"
 
 const sizeVariants = cva({
   base: "flex shrink-0 items-center justify-center bg-f1-background-secondary font-medium text-f1-foreground-secondary",
@@ -25,6 +22,28 @@ const sizeVariants = cva({
       rounded: "!rounded-full",
     },
   },
+  compoundVariants: [
+    {
+      size: "small",
+      type: "rounded",
+      className: "px-1.5",
+    },
+    {
+      size: "medium",
+      type: "rounded",
+      className: "px-2",
+    },
+    {
+      size: "large",
+      type: "rounded",
+      className: "px-4",
+    },
+    {
+      size: "xlarge",
+      type: "rounded",
+      className: "px-5",
+    },
+  ],
   defaultVariants: {
     size: "medium",
     type: "base",
@@ -45,7 +64,7 @@ export const MaxCounter = ({
   list,
 }: Props) => {
   const counter = (
-    <div className={sizeVariants({ size, type })}>
+    <div className={cn("font-medium", sizeVariants({ size, type }))}>
       {size === "xsmall" ? (
         <Icon icon={EllipsisHorizontal} size="xs" />
       ) : (
@@ -57,21 +76,31 @@ export const MaxCounter = ({
   if (!list?.length) return counter
 
   return (
-    <TooltipProvider>
-      <TooltipPrimitive>
-        <TooltipTrigger asChild>{counter}</TooltipTrigger>
-        <TooltipContent>
-          <div className="flex flex-col gap-1">
-            {list.map((avatar, index) => (
-              <div key={index}>
+    <HoverCard>
+      <HoverCardTrigger asChild>{counter}</HoverCardTrigger>
+      <HoverCardContent side="top">
+        <ScrollArea className="[*[data-state=visible]_div]:bg-f1-background flex max-h-[172px] flex-col">
+          {list.map((avatar, index) => (
+            <div
+              key={index}
+              className="flex w-[180px] min-w-0 items-center gap-1.5 px-2 py-1 [&:first-child]:pt-2 [&:last-child]:pb-2"
+            >
+              <div className="h-6 w-6 shrink-0">
+                <Avatar avatar={avatar} size="small" />
+              </div>
+              <div className="min-w-0 flex-1 truncate font-semibold">
                 {avatar.type === "person"
                   ? `${avatar.firstName} ${avatar.lastName}`
                   : avatar.name}
               </div>
-            ))}
-          </div>
-        </TooltipContent>
-      </TooltipPrimitive>
-    </TooltipProvider>
+            </div>
+          ))}
+          <ScrollBar
+            orientation="vertical"
+            className="[&_div]:bg-f1-background"
+          />
+        </ScrollArea>
+      </HoverCardContent>
+    </HoverCard>
   )
 }

--- a/lib/experimental/Information/Avatars/AvatarList/MaxCounter.tsx
+++ b/lib/experimental/Information/Avatars/AvatarList/MaxCounter.tsx
@@ -1,0 +1,77 @@
+import { Icon } from "@/components/Utilities/Icon"
+import { EllipsisHorizontal } from "@/icons/app"
+import { sizes, type } from "@/ui/avatar"
+import {
+  TooltipContent,
+  Tooltip as TooltipPrimitive,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/ui/tooltip"
+import { cva } from "cva"
+import { type AvatarVariant } from "../Avatar"
+
+const sizeVariants = cva({
+  base: "flex shrink-0 items-center justify-center bg-f1-background-secondary font-medium text-f1-foreground-secondary",
+  variants: {
+    size: {
+      xsmall: "h-5 w-5 rounded-xs text-sm",
+      small: "h-6 min-w-6 rounded-sm px-1 text-sm",
+      medium: "h-8 min-w-8 rounded px-1.5",
+      large: "h-14 min-w-14 rounded-xl px-3 text-xl",
+      xlarge: "h-18 min-w-18 rounded-[20px] px-4 text-2xl",
+    },
+    type: {
+      base: "",
+      rounded: "!rounded-full",
+    },
+  },
+  defaultVariants: {
+    size: "medium",
+    type: "base",
+  },
+})
+
+type Props = {
+  count: number
+  size?: (typeof sizes)[number]
+  type?: (typeof type)[number]
+  list?: AvatarVariant[]
+}
+
+export const MaxCounter = ({
+  count,
+  size = "medium",
+  type = "base",
+  list,
+}: Props) => {
+  const counter = (
+    <div className={sizeVariants({ size, type })}>
+      {size === "xsmall" ? (
+        <Icon icon={EllipsisHorizontal} size="xs" />
+      ) : (
+        `+${count}`
+      )}
+    </div>
+  )
+
+  if (!list?.length) return counter
+
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive>
+        <TooltipTrigger asChild>{counter}</TooltipTrigger>
+        <TooltipContent>
+          <div className="flex flex-col gap-1">
+            {list.map((avatar, index) => (
+              <div key={index}>
+                {avatar.type === "person"
+                  ? `${avatar.firstName} ${avatar.lastName}`
+                  : avatar.name}
+              </div>
+            ))}
+          </div>
+        </TooltipContent>
+      </TooltipPrimitive>
+    </TooltipProvider>
+  )
+}

--- a/lib/experimental/Information/Avatars/AvatarList/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/AvatarList/index.stories.tsx
@@ -65,21 +65,7 @@ const meta: Meta<typeof AvatarList> = {
   args: {
     size: "medium",
     type: "person",
-    avatars: [
-      {
-        type: "person",
-        firstName: "Nik",
-        lastName: "Lopin",
-        src: "https://github.com/nlopin.png",
-      },
-      {
-        type: "person",
-        firstName: "Josep Jaume",
-        lastName: "Rey",
-        src: "https://github.com/josepjaume.png",
-      },
-      { type: "person", firstName: "Saúl", lastName: "Domínguez" },
-    ],
+    avatars: getDummyAvatars(3, "person"),
   },
   parameters: {
     layout: "centered",
@@ -96,15 +82,7 @@ export const Companies: Story = {
   args: {
     size: "medium",
     type: "company",
-    avatars: [
-      {
-        type: "company",
-        name: "Factorial",
-        src: "https://github.com/factorialco.png",
-      },
-      { type: "company", name: "Itnig" },
-      { type: "company", name: "Another cool company" },
-    ],
+    avatars: getDummyAvatars(3, "company"),
   },
 }
 
@@ -112,11 +90,7 @@ export const Teams: Story = {
   args: {
     size: "medium",
     type: "team",
-    avatars: [
-      { type: "team", name: "Designers" },
-      { type: "team", name: "Engineering" },
-      { type: "team", name: "Product Management" },
-    ],
+    avatars: getDummyAvatars(3, "team"),
   },
 }
 

--- a/lib/experimental/Information/Avatars/AvatarList/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/AvatarList/index.stories.tsx
@@ -72,3 +72,37 @@ export const CompaniesWithTooltip: Story = {
     showTooltip: true,
   },
 }
+
+export const WithMaxAvatars: Story = {
+  args: {
+    ...Default.args,
+    avatars: Array(50)
+      .fill(0)
+      .map((_, index: number) => ({
+        type: "person" as const,
+        firstName: `Employee ${index + 1}`,
+        lastName: "Surname",
+      })),
+    max: 3,
+  },
+}
+
+export const CompaniesWithMaxAvatars: Story = {
+  args: {
+    ...Companies.args,
+    avatars: Array(50)
+      .fill(0)
+      .map((_, index: number) => ({
+        type: "company" as const,
+        name: `Company ${index + 1}`,
+      })),
+    max: 3,
+  },
+}
+
+export const WithMaxAvatarsAndTooltip: Story = {
+  args: {
+    ...WithMaxAvatars.args,
+    showTooltip: true,
+  },
+}

--- a/lib/experimental/Information/Avatars/AvatarList/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/AvatarList/index.stories.tsx
@@ -1,6 +1,63 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { AvatarList } from "./index"
 
+const dummyPeople = [
+  {
+    type: "person" as const,
+    firstName: "Nik",
+    lastName: "Lopin",
+    src: "https://github.com/nlopin.png",
+  },
+  {
+    type: "person" as const,
+    firstName: "Josep Jaume",
+    lastName: "Rey",
+    src: "https://github.com/josepjaume.png",
+  },
+  {
+    type: "person" as const,
+    firstName: "Saúl",
+    lastName: "Domínguez",
+  },
+]
+
+const dummyCompanies = [
+  {
+    type: "company" as const,
+    name: "Factorial",
+    src: "https://github.com/factorialco.png",
+  },
+  {
+    type: "company" as const,
+    name: "Itnig",
+  },
+  {
+    type: "company" as const,
+    name: "Another cool company",
+  },
+]
+
+const dummyTeams = [
+  { type: "team" as const, name: "Designers" },
+  { type: "team" as const, name: "Engineering" },
+  { type: "team" as const, name: "Product Management" },
+]
+
+function getDummyAvatars(
+  count: number,
+  type: "person" | "company" | "team" = "person"
+) {
+  const sourceData = {
+    person: dummyPeople,
+    company: dummyCompanies,
+    team: dummyTeams,
+  }[type]
+
+  return Array.from({ length: count }, (_, index) => ({
+    ...sourceData[index % sourceData.length],
+  }))
+}
+
 const meta: Meta<typeof AvatarList> = {
   component: AvatarList,
   title: "Avatars/AvatarList",
@@ -23,6 +80,9 @@ const meta: Meta<typeof AvatarList> = {
       },
       { type: "person", firstName: "Saúl", lastName: "Domínguez" },
     ],
+  },
+  parameters: {
+    layout: "centered",
   },
 } satisfies Meta<typeof AvatarList>
 
@@ -76,13 +136,7 @@ export const CompaniesWithTooltip: Story = {
 export const WithMaxAvatars: Story = {
   args: {
     ...Default.args,
-    avatars: Array(50)
-      .fill(0)
-      .map((_, index: number) => ({
-        type: "person" as const,
-        firstName: `Employee ${index + 1}`,
-        lastName: "Surname",
-      })),
+    avatars: getDummyAvatars(50, "person"),
     max: 3,
   },
 }
@@ -90,12 +144,7 @@ export const WithMaxAvatars: Story = {
 export const CompaniesWithMaxAvatars: Story = {
   args: {
     ...Companies.args,
-    avatars: Array(50)
-      .fill(0)
-      .map((_, index: number) => ({
-        type: "company" as const,
-        name: `Company ${index + 1}`,
-      })),
+    avatars: getDummyAvatars(50, "company"),
     max: 3,
   },
 }

--- a/lib/experimental/Information/Avatars/AvatarList/index.tsx
+++ b/lib/experimental/Information/Avatars/AvatarList/index.tsx
@@ -2,6 +2,7 @@ import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { sizes } from "@/ui/avatar"
 import { cva } from "cva"
 import { Avatar, AvatarVariant } from "../Avatar"
+import { MaxCounter } from "./MaxCounter"
 
 type AvatarType = AvatarVariant["type"]
 
@@ -61,6 +62,12 @@ type Props = {
    * @default false
    */
   showTooltip?: boolean
+
+  /**
+   * The maximum number of avatars to display.
+   * @default 3
+   */
+  max?: number
 }
 
 export const AvatarList = ({
@@ -68,10 +75,16 @@ export const AvatarList = ({
   size = "medium",
   type,
   showTooltip = false,
+  max = 3,
 }: Props) => {
+  const visibleAvatars = avatars.slice(0, max)
+  const remainingAvatars = avatars.slice(max)
+  const remainingCount = avatars.length - max
+  const showCounter = remainingCount > 0
+
   return (
     <div className={avatarListVariants({ size })}>
-      {avatars.map((avatar, index) => {
+      {visibleAvatars.map((avatar, index) => {
         const displayName =
           avatar.type === "person"
             ? `${avatar.firstName} ${avatar.lastName}`
@@ -103,6 +116,14 @@ export const AvatarList = ({
           </div>
         )
       })}
+      {showCounter && (
+        <MaxCounter
+          count={remainingCount}
+          size={size}
+          type={type === "person" ? "rounded" : "base"}
+          list={showTooltip ? remainingAvatars : undefined}
+        />
+      )}
     </div>
   )
 }

--- a/lib/experimental/Information/Headers/Metadata/index.stories.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.stories.tsx
@@ -57,6 +57,26 @@ export const Default: Story = {
               firstName: "Nik",
               lastName: "Lopin",
             },
+            {
+              type: "person",
+              firstName: "Josep Jaume",
+              lastName: "Rey",
+            },
+            {
+              type: "person",
+              firstName: "Nik",
+              lastName: "Lopin",
+            },
+            {
+              type: "person",
+              firstName: "Josep Jaume",
+              lastName: "Rey",
+            },
+            {
+              type: "person",
+              firstName: "Nik",
+              lastName: "Lopin",
+            },
           ],
         },
       },

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -61,6 +61,8 @@ function MetadataValue({ item }: { item: MetadataItem }) {
           avatars={item.value.avatars}
           size="xsmall"
           type={item.value.variant}
+          max={3}
+          showTooltip
         />
       )
   }

--- a/lib/ui/avatar.tsx
+++ b/lib/ui/avatar.tsx
@@ -24,7 +24,7 @@ export const color = [
   "camel",
 ] as const
 
-const avatarVariants = cva({
+export const avatarVariants = cva({
   base: "relative flex shrink-0 items-center justify-center overflow-hidden text-center font-semibold ring-1 ring-inset ring-f1-border-secondary",
   variants: {
     size: {

--- a/lib/ui/hover-card.tsx
+++ b/lib/ui/hover-card.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const HoverCard = HoverCardPrimitive.Root
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 w-[200px] rounded bg-f1-background-bold font-medium text-f1-foreground-inverse outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardContent, HoverCardTrigger }

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "@rollup/rollup-linux-x64-gnu": "^4.34"
   },
   "dependencies": {
+    "@radix-ui/react-hover-card": "^1.1.6",
     "cva": "1.0.0-beta.3",
     "embla-carousel-autoplay": "^8.5.2",
     "embla-carousel-react": "^8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.0.6
         version: 2.1.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-hover-card':
+        specifier: ^1.1.6
+        version: 1.1.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-label':
         specifier: ^2.1.0
         version: 2.1.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1072,6 +1075,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-arrow@1.1.2':
+    resolution: {integrity: sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-avatar@1.1.2':
     resolution: {integrity: sha512-GaC7bXQZ5VgZvVvsJ5mu/AEbjYLnhhkoidOboC50Z6FFlLA03wG2ianUoH+zgDQ31/9gCF59bE4+2bBgTyMiig==}
     peerDependencies:
@@ -1177,6 +1193,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.5':
+    resolution: {integrity: sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-dropdown-menu@2.1.5':
     resolution: {integrity: sha512-50ZmEFL1kOuLalPKHrLWvPFMons2fGx9TqQCWlPwDVpbAnaUJ1g4XNcKqFNMQymYU0kKWR4MDDi+9vUQBGFgcQ==}
     peerDependencies:
@@ -1201,6 +1230,19 @@ packages:
 
   '@radix-ui/react-focus-scope@1.1.1':
     resolution: {integrity: sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.6':
+    resolution: {integrity: sha512-E4ozl35jq0VRlrdc4dhHrNSV0JqBb4Jy73WAhBEK7JoYnQ83ED5r0Rb/XdVKw89ReAJN38N492BAPBZQ57VmqQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1286,8 +1328,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.2.2':
+    resolution: {integrity: sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.3':
     resolution: {integrity: sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.4':
+    resolution: {integrity: sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1314,6 +1382,19 @@ packages:
 
   '@radix-ui/react-primitive@2.0.1':
     resolution: {integrity: sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1379,6 +1460,15 @@ packages:
 
   '@radix-ui/react-slot@1.1.1':
     resolution: {integrity: sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -6673,6 +6763,15 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
+  '@radix-ui/react-arrow@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
   '@radix-ui/react-avatar@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
@@ -6782,6 +6881,19 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
+  '@radix-ui/react-dismissable-layer@1.1.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
   '@radix-ui/react-dropdown-menu@2.1.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -6808,6 +6920,23 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
+  '@radix-ui/react-hover-card@1.1.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.4(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -6919,9 +7048,37 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
+  '@radix-ui/react-popper@1.2.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/rect': 1.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
   '@radix-ui/react-portal@1.1.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
+  '@radix-ui/react-portal@1.1.4(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -6942,6 +7099,15 @@ snapshots:
   '@radix-ui/react-primitive@2.0.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@18.3.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -7022,6 +7188,13 @@ snapshots:
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
   '@radix-ui/react-slot@1.1.1(@types/react@18.3.18)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.18
+
+  '@radix-ui/react-slot@1.1.2(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
       react: 18.3.1


### PR DESCRIPTION
## Description

Add a new prop to the `AvatarList` component, `max`, that sets a limited number of avatars to display. The remaining ones are moved to a counter at the end of the list. If `showTooltip` is set to true, it shows a popover with the list of the rest of avatars.

https://github.com/user-attachments/assets/5e228e15-c7e3-451c-ab5e-313ed3332991

Also modifies the metadata component to show tooltips on each avatar and this max counter.

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other