### PR TITLE
Ignore video element

### DIFF
--- a/lib/experimental/Information/Communities/Post/CommunityPost/index.tsx
+++ b/lib/experimental/Information/Communities/Post/CommunityPost/index.tsx
@@ -173,7 +173,11 @@ export const BaseCommunityPost = ({
         {mediaUrl && !event && (
           <div className="relative aspect-video overflow-hidden rounded-xl md:w-2/3">
             {isVideo(mediaUrl) ? (
-              <video controls className="h-full w-full object-cover">
+              <video
+                controls
+                className="h-full w-full object-cover"
+                data-chromatic="ignore"
+              >
                 <source src={mediaUrl} />
               </video>
             ) : (


### PR DESCRIPTION
## Description

Ignores video elements on chromatic snapshots, as the loading bar is flaky and gets different snapshots.

## Screenshots (if applicable)

*None*

### Figma Link

*None*

[Link to Figma Design](Figma URL here)