### PR TITLE
Primary button in SectionHeader

### DIFF
--- a/lib/experimental/Information/Headers/SectionHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/SectionHeader/index.stories.tsx
@@ -51,3 +51,14 @@ export const NoAction: Story = {
     },
   },
 }
+
+export const PrimaryAction: Story = {
+  args: {
+    ...Default.args,
+    action: {
+      label: "Add template",
+      icon: Icon.Add,
+      variant: "default",
+    },
+  },
+}

--- a/lib/experimental/Information/Headers/SectionHeader/index.tsx
+++ b/lib/experimental/Information/Headers/SectionHeader/index.tsx
@@ -13,6 +13,7 @@ type Props = {
   /**  Complementary action specific to the section */
   action?: Pick<ButtonProps, "label" | "onClick"> & {
     icon?: IconType
+    variant?: "default" | "outline"
   }
 
   /** Optional Link to related documentation (Help center or other link))*/
@@ -67,7 +68,7 @@ export const SectionHeader = ({
           <div className="hidden md:block">
             <Button
               label={action.label}
-              variant="outline"
+              variant={action.variant ?? "outline"}
               icon={action.icon}
               size="md"
               onClick={action.onClick}
@@ -76,7 +77,7 @@ export const SectionHeader = ({
           <div className="w-full md:hidden [&>button]:w-full">
             <Button
               label={action.label}
-              variant="outline"
+              variant={action.variant ?? "outline"}
               icon={action.icon}
               size="lg"
               onClick={action.onClick}


### PR DESCRIPTION
## Description

Related to [this](https://factorialteam.slack.com/archives/C06QT46115K/p1739805171617479?thread_ts=1738255159.685149&cid=C06QT46115K), we decided to let the button in the SectionHeader be the primary button, not just the outline one.

## Screenshots

<img width="787" alt="image" src="https://github.com/user-attachments/assets/e3ecd2f1-d867-4702-95b7-7ec701a852ca" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other

