### PR TITLE
Change showTooltip to noTooltip in `AvatarList`

### DIFF
--- a/lib/experimental/Information/Avatars/AvatarList/index.stories.tsx
+++ b/lib/experimental/Information/Avatars/AvatarList/index.stories.tsx
@@ -66,6 +66,7 @@ const meta: Meta<typeof AvatarList> = {
     size: "medium",
     type: "person",
     avatars: getDummyAvatars(3, "person"),
+    noTooltip: false,
   },
   parameters: {
     layout: "centered",
@@ -94,19 +95,6 @@ export const Teams: Story = {
   },
 }
 
-export const WithTooltip: Story = {
-  args: {
-    showTooltip: true,
-  },
-}
-
-export const CompaniesWithTooltip: Story = {
-  args: {
-    ...Companies.args,
-    showTooltip: true,
-  },
-}
-
 export const WithMaxAvatars: Story = {
   args: {
     ...Default.args,
@@ -120,12 +108,5 @@ export const CompaniesWithMaxAvatars: Story = {
     ...Companies.args,
     avatars: getDummyAvatars(50, "company"),
     max: 3,
-  },
-}
-
-export const WithMaxAvatarsAndTooltip: Story = {
-  args: {
-    ...WithMaxAvatars.args,
-    showTooltip: true,
   },
 }

--- a/lib/experimental/Information/Avatars/AvatarList/index.tsx
+++ b/lib/experimental/Information/Avatars/AvatarList/index.tsx
@@ -58,10 +58,10 @@ type Props = {
   type?: AvatarType
 
   /**
-   * Whether to show a tooltip in each avatar.
+   * Whether to hide tooltips in each avatar.
    * @default false
    */
-  showTooltip?: boolean
+  noTooltip?: boolean
 
   /**
    * The maximum number of avatars to display.
@@ -74,7 +74,7 @@ export const AvatarList = ({
   avatars,
   size = "medium",
   type,
-  showTooltip = false,
+  noTooltip = false,
   max = 3,
 }: Props) => {
   const visibleAvatars = avatars.slice(0, max)
@@ -108,10 +108,10 @@ export const AvatarList = ({
 
         return (
           <div key={index}>
-            {showTooltip ? (
-              <Tooltip label={displayName}>{clippedAvatar}</Tooltip>
-            ) : (
+            {noTooltip ? (
               clippedAvatar
+            ) : (
+              <Tooltip label={displayName}>{clippedAvatar}</Tooltip>
             )}
           </div>
         )
@@ -121,7 +121,7 @@ export const AvatarList = ({
           count={remainingCount}
           size={size}
           type={type === "person" ? "rounded" : "base"}
-          list={showTooltip ? remainingAvatars : undefined}
+          list={noTooltip ? undefined : remainingAvatars}
         />
       )}
     </div>

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -62,7 +62,6 @@ function MetadataValue({ item }: { item: MetadataItem }) {
           size="xsmall"
           type={item.value.variant}
           max={3}
-          showTooltip
         />
       )
   }


### PR DESCRIPTION
## Description

Changes the `showTooltip` to `noTooltip` prop in the AvatarList, which simplifies the code and makes for a better DX.  We're now showing the tooltip by default, so I removed some stories that no longer made sense.

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other