### PR TITLE
Do not make toDate prop required in CalendarEvent component

### DIFF
--- a/lib/experimental/Widgets/Content/CalendarEvent/index.tsx
+++ b/lib/experimental/Widgets/Content/CalendarEvent/index.tsx
@@ -56,7 +56,7 @@ export interface CalendarEventProps {
   leftTags?: Tag[]
   rightTags?: Tag[]
   fromDate?: Date
-  toDate: Date
+  toDate?: Date
   noBackground?: boolean
 }
 


### PR DESCRIPTION
## Description

Not every item that we list as an event will have a date on the right.