### PR TITLE
feature: add quick introduction to form libraries in forms documentation

### DIFF
--- a/lib/experimental/Forms/Form/index.mdx
+++ b/lib/experimental/Forms/Form/index.mdx
@@ -1,0 +1,129 @@
+{/* FormStories.mdx */}
+
+import { Meta, Primary, Controls, Story, Canvas } from "@storybook/blocks"
+import * as FormStories from "./index.stories.tsx"
+
+<Meta of={FormStories} />
+
+## Introduction
+
+This is a quick Introduction of [React hook form](https://react-hook-form.com/)
+and [Zod](https://zod.dev/).
+
+### General definition of form
+
+We use the hook `useForm` which allow us (passing a Zod squema) to interact with
+a form. We did a simplication of this process with the hook `useFormSchema`. But
+a more complete example can be:
+
+```javascript
+const form = useForm<SchemaType>({
+    defaultValues: {
+      companyId: getCurrentCompanyId(),
+      reporterId: useCurrentEmployeeId()
+    },
+    context: formContext,
+    resolver: async (values, context, options) => {
+      const createResolver = zodResolver(
+       mySchema
+      )
+
+      return createResolver(values, context, options)
+    }
+```
+
+As you can see you can specify different schemas if you define a function so you
+can use for example different schemas to validate.
+
+### React hook form API frequent commands
+
+- How do I access values? → React hook form got you covered. You can use
+  `form.getValues()` to access all the values and you can access to the specific
+  you want to.
+- I do not see my values update. → you can use `form.watch` to subscribe to
+  field changes. You can pass to that method an array of methods you want to
+  listen to. This is specially useful if you don’t use controlled inputs.
+- I want to set an specific field to a value → you can do this `form.setValue`
+- I want to reset a field → you can reset the state of an specific value with
+  `form.resetField`
+- I change a value but I cannot see the validations → you can trigger
+  validations over specific fields or the general form with `form.trigger`
+
+### Zod usage
+
+`Zod` is the library we use to define the schema against it will validate our
+forms. A general example of this:
+
+```javascript
+const schema = z
+  .object({
+    username: z
+      .string()
+      .min(2)
+      .max(10)
+      .refine((username) => username !== "admin", {
+        message: "Username cannot be admin",
+      }),
+    fullName: z.string().min(6).max(50),
+    email: z.string().email(),
+    password: z.string().min(8).max(50),
+    passwordConfirmation: z.string(),
+    bio: z.string().max(500),
+    tag: z.string(),
+    acceptedTerms: z.boolean(),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: "Passwords do not match",
+    path: ["passwordConfirmation"],
+  })
+```
+
+As you saw, we have different primitives to define values, (more info in
+[primitives](https://zod.dev/?id=primitives)) such as strings, booleans,
+numbers, etc. You can improve validations setting this primitives as optional, a
+max value, min value, parsing values, etc. But if you want to perform more
+complex validations over an specific field you can use the refine function where
+you can specify a path and an error message for it:
+
+```javascript
+const mySupercoolField = z.string()
+mySupercoolField.refine((data) => condition, {
+  message: "This is invalid",
+  path: ["mySupercoolFieldPath"],
+})
+```
+
+Or if you want to validate the whole form, you can use superRefine:
+
+```javascript
+mySchema.superRefine(({ field1, field2 }, context) => {
+  validationFucntion1()
+
+  validationFucntion2()
+})
+```
+
+If you want a more complete example you can check this
+[notion](https://www.notion.so/factorialco/How-to-use-react-hook-form-zod-in-forms-14d5e6e051ee8009a266ed7ed517c944)
+where we describe how we use this libraries in order to build the forms in the
+mobile app for Expenses.
+
+### Default
+
+<Canvas of={FormStories.Default} />
+
+### AsyncFieldValidation
+
+<Canvas of={FormStories.AsyncFieldValidation} />
+
+### AsyncSubmit
+
+<Canvas of={FormStories.AsyncSubmit} />
+
+### MultipleTypeSchema
+
+<Canvas of={FormStories.MultipleTypeSchema} />
+
+### NestedSchemas
+
+<Canvas of={FormStories.NestedSchemas} />


### PR DESCRIPTION
I wanted to have a more complete example of usage of React Hook Form + Zod so I created an index.mdx in order to define the doc for the Form and appended a section explaining the tools.

## 📸 Screenshots / Video

https://github.com/user-attachments/assets/3dde0b01-858e-4a1f-ac68-02bf8303436f
