### PR TITLE
chore: Hide specific stories in the sidebar

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,10 @@
 import type { StorybookConfig } from "@storybook/react-vite"
+import * as process from "node:process"
+
+// We should add the STORYBOOK_ prefix to make sure that the environment variables are in browser mode (for example manager.ts file)
+if (process.env.PUBLIC_BUILD) {
+  process.env.STORYBOOK_PUBLIC_BUILD = process.env.PUBLIC_BUILD
+}
 
 const config: StorybookConfig = {
   stories: [
@@ -12,7 +18,7 @@ const config: StorybookConfig = {
       directory: "../lib/experimental",
       titlePrefix: "Components",
     },
-    ...(process.env.PUBLIC_BUILD
+    ...(process.env.STORYBOOK_PUBLIC_BUILD
       ? []
       : [
           {
@@ -42,7 +48,10 @@ const config: StorybookConfig = {
   },
   docs: {
     defaultName: "Documentation",
-    docsMode: process.env.PUBLIC_BUILD || process.env.DOCS_MODE ? true : false,
+    docsMode:
+      process.env.STORYBOOK_PUBLIC_BUILD || process.env.DOCS_MODE
+        ? true
+        : false,
   },
   typescript: {
     reactDocgen: "react-docgen-typescript",

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -9,6 +9,15 @@ addons.setConfig({
     showRoots: true,
     collapsedRoots: ["playground"],
     renderLabel,
+    filters: {
+      internal: (item) => {
+        return (
+          !process.env.STORYBOOK_PUBLIC_BUILD ||
+          !item.tags?.includes("internal")
+        )
+      },
+      noSidebar: (item) => !item.tags?.includes("no-sidebar"),
+    },
   },
   tagBadges: [
     {

--- a/docs/storybook/index.md
+++ b/docs/storybook/index.md
@@ -1,0 +1,33 @@
+# Storybook
+
+The Storybook is a tool that allows us to visualize and interact with the components in our design system. It is a great
+way to test and develop components in isolation, and to document them.
+
+## Who will use storybook
+
+We can group the users of Storybook into two categories:
+
+- factorial's developers and designers
+- factorial-one developers and designers
+
+Most of the content is shared content for both groups, but for the factorial-one developers and designers needs to know
+more about the components internal.
+
+Check the next sections for futher information
+
+## Internal stories
+
+The objective is to write documentation as much as possible, and as many component have subcomponents is a good practice
+to document the subcomponents as well, but as we want to provide concise information, avoiding anything unnecessary for
+the ones are not developing `factorial-one` we will use the `internal` tag to hide the content from the public.
+
+The stories with this tags will not shown in the sidebar in the public build, but they will be available running
+storybook in local.
+
+## No-sidebar stories
+
+Some stories are used to provide context or sections to other stories and we don't want to show then in the sidebar in
+any case.
+
+The stories with the tag `no-sidedar` will not shown in the sidebar nor the public build, nor the local build.
+

--- a/lib/experimental/Information/Headers/Metadata/index.stories.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.stories.tsx
@@ -9,6 +9,7 @@ const meta: Meta<typeof Metadata> = {
   parameters: {
     layout: "padded",
   },
+  tags: ["no-sidebar"],
 }
 
 export default meta


### PR DESCRIPTION
## Description

Allow to hide some some stories in the sidebar
- the stories tagged as `internal` only will be shown in dev mode
- the stories tagged as `no-sidebar`  will be never shown in in the sidebar

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other
