### PR TITLE
Add missing overflow-y in DaytimePage component

### DIFF
--- a/lib/experimental/Navigation/Page/index.tsx
+++ b/lib/experimental/Navigation/Page/index.tsx
@@ -61,7 +61,7 @@ export function DaytimePage({
     >
       <div className={daytimePageVariants({ period })} />
       {header && <div className="flex flex-col">{header}</div>}
-      <div className="isolate flex w-full flex-1 flex-col [&>*]:flex-1">
+      <div className="isolate flex w-full flex-1 flex-col overflow-y-auto [&>*]:flex-1">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Description

After previously removing `overflow-auto` I noticed we cannot scroll anymore on the new Home in the frontend, we need this overflow auto in the Y axis at least.