### PR TITLE
Fix ResourceHeader alignment and jump animation in metadata

### DIFF
--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -118,8 +118,18 @@ export function BaseHeader({
 
   return (
     <div className="flex flex-col gap-3 px-6 pb-5 pt-3">
-      <div className="flex flex-col items-start justify-start gap-4 md:flex-row">
-        <div className="flex grow flex-col items-start justify-start gap-3 md:flex-row md:items-start">
+      <div
+        className={cn(
+          "flex flex-col items-start justify-start gap-4 md:flex-row",
+          !description && "md:items-center"
+        )}
+      >
+        <div
+          className={cn(
+            "flex grow flex-col items-start justify-start gap-3 md:flex-row md:items-start",
+            !description && "md:items-center"
+          )}
+        >
           {avatar && (
             <div className="flex items-start">
               <Avatar
@@ -146,7 +156,7 @@ export function BaseHeader({
                       : (descriptionSize.height ?? "3rem"),
                   }}
                   transition={{
-                    duration: 0.15,
+                    duration: needsTruncation ? 0.15 : 0,
                     ease: [0.165, 0.84, 0.44, 1],
                   }}
                   className="overflow-hidden"

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -410,3 +410,56 @@ export const WithLongDescription: Story = {
       "This is a long description that will be truncated. This is a long description that will be truncated. This is a long description that will be truncated. This is a long description that will be truncated. This is a long description that will be truncated. This is a long description that will be truncated. This is a long description that will be truncated. This is a long description that will be truncated.",
   },
 }
+
+export const NoDescription: Story = {
+  args: {
+    title: "Product designers",
+    avatar: {
+      type: "team",
+      name: "Product designers",
+    },
+    primaryAction: {
+      label: "Add members",
+      icon: Icon.Add,
+      onClick: fn(),
+    },
+    secondaryActions: [
+      {
+        label: "Edit",
+        icon: Icon.Pencil,
+        onClick: fn(),
+      },
+    ],
+    metadata: [
+      {
+        label: "Team leader",
+        value: {
+          type: "avatar",
+          variant: {
+            type: "person",
+            firstName: "Josep Jaume",
+            lastName: "Rey",
+            src: "https://github.com/josepjaume.png",
+          },
+          text: "Josep Jaume Rey",
+        },
+        actions: [
+          {
+            label: "Edit",
+            icon: Icon.Pencil,
+            onClick: fn(),
+          },
+          {
+            label: "Comment",
+            icon: Icon.Comment,
+            onClick: fn(),
+          },
+        ],
+      },
+      {
+        label: "Members",
+        value: { type: "text", content: "22" },
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Description

When there's no description in a ResourceHeader, the title and buttons aren't vertically aligned with the avatar. This PR fixes that, and also removes an unintended 'jump' animation the metadata bar had because of the description.

Related: [Slack](https://factorialteam.slack.com/archives/C082ZNKS403/p1740485711369759)

## Screenshots

<img width="793" alt="image" src="https://github.com/user-attachments/assets/e8783924-f785-4e51-affb-652d8088bc41" />

_This is how the ResourceHeader looks without description with the changes_

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
