### PR TITLE
Reorder the sidebar 2

### DIFF
--- a/lib/components/Utilities/Image/index.stories.tsx
+++ b/lib/components/Utilities/Image/index.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "stable"],
+  tags: ["autodocs", "stable", "no-sidebar"],
   args: {
     src: heart,
     width: 100,

--- a/lib/experimental/Collections/Filters/index.stories.tsx
+++ b/lib/experimental/Collections/Filters/index.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from "./utils"
 
 const meta = {
-  title: "Experimental/Collections/Filters",
+  title: "Data Collection/Filters",
   component: Filters,
 } satisfies Meta<typeof Filters>
 

--- a/lib/experimental/Collections/index.stories.tsx
+++ b/lib/experimental/Collections/index.stories.tsx
@@ -151,7 +151,7 @@ const ExampleComponent = ({
 }
 
 const meta = {
-  title: "Experimental/Collections/DataSource",
+  title: "Data Collection/DataSource",
   component: ExampleComponent,
   parameters: {
     layout: "padded",

--- a/lib/experimental/Forms/Fields/F1SearchBox/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/F1SearchBox/index.stories.tsx
@@ -4,7 +4,7 @@ import { F1SearchBox } from "."
 
 const meta = {
   component: F1SearchBox,
-  title: "Forms/Fields/F1SearchBox",
+  title: "Input/Search",
   parameters: {
     layout: "centered",
     docs: {

--- a/lib/experimental/Forms/Fields/Input/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/Input/index.stories.tsx
@@ -4,7 +4,7 @@ import { Input } from "."
 
 const meta = {
   component: Input,
-  title: "Input",
+  title: "Input/Text",
   tags: ["autodocs", "experimental"],
   args: {
     type: "text",

--- a/lib/experimental/Forms/Fields/NumberInput/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/NumberInput/index.stories.tsx
@@ -5,7 +5,7 @@ import { NumberInput } from "."
 
 const meta = {
   render: (props) => <NumberInput key={JSON.stringify(props)} {...props} />,
-  title: "NumberInput",
+  title: "Input/Number",
   component: NumberInput,
   tags: ["autodocs", "experimental"],
   args: {

--- a/lib/experimental/Forms/Fields/Select/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/Select/index.stories.tsx
@@ -31,7 +31,7 @@ const SelectWithHooks = (props: SelectProps<string>) => {
 }
 
 const meta: Meta = {
-  title: "Select",
+  title: "Input/Select",
   component: SelectWithHooks,
   parameters: {
     a11y: {

--- a/lib/experimental/Forms/Fields/TextArea/index.stories.tsx
+++ b/lib/experimental/Forms/Fields/TextArea/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { Textarea } from "."
 
 const meta = {
-  title: "TextArea",
+  title: "Input/TextArea",
   component: Textarea,
   tags: ["autodocs", "experimental"],
   args: {

--- a/lib/experimental/Information/Communities/Celebration/index.stories.tsx
+++ b/lib/experimental/Information/Communities/Celebration/index.stories.tsx
@@ -3,7 +3,7 @@ import { Celebration } from "."
 
 const meta: Meta<typeof Celebration> = {
   component: Celebration,
-  title: "Communities/Celebration",
+  title: "Home/Communities/Celebration",
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Information/Communities/HighlightBanner/index.stories.tsx
+++ b/lib/experimental/Information/Communities/HighlightBanner/index.stories.tsx
@@ -4,7 +4,7 @@ import { HighlightBanner } from "./index"
 
 const meta: Meta<typeof HighlightBanner> = {
   component: HighlightBanner,
-  title: "Communities/HighlightBanner",
+  title: "Home/Communities/HighlightBanner",
   tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",

--- a/lib/experimental/Information/Communities/Post/CommunityPost/index.stories.tsx
+++ b/lib/experimental/Information/Communities/Post/CommunityPost/index.stories.tsx
@@ -4,7 +4,7 @@ import { CommunityPost } from "."
 
 const meta: Meta<typeof CommunityPost> = {
   component: CommunityPost,
-  title: "Communities/Post/CommunityPost",
+  title: "Home/Communities/Post/CommunityPost",
   tags: ["autodocs", "experimental"],
 }
 

--- a/lib/experimental/Information/Communities/Post/PostDescription/index.stories.tsx
+++ b/lib/experimental/Information/Communities/Post/PostDescription/index.stories.tsx
@@ -3,7 +3,7 @@ import { PostDescription } from "."
 
 const meta: Meta<typeof PostDescription> = {
   component: PostDescription,
-  title: "Communities/Post/PostDescription",
+  title: "Home/Communities/Post/PostDescription",
   tags: ["autodocs", "experimental"],
 }
 

--- a/lib/experimental/Information/Communities/Post/PostEvent/index.stories.tsx
+++ b/lib/experimental/Information/Communities/Post/PostEvent/index.stories.tsx
@@ -4,7 +4,7 @@ import cat from "../../../../../../storybook-assets/cat.jpeg"
 
 const meta: Meta<typeof PostEvent> = {
   component: PostEvent,
-  title: "Communities/Post/PostEvent",
+  title: "Home/Communities/Post/PostEvent",
   tags: ["autodocs", "experimental"],
 }
 

--- a/lib/experimental/Lists/DataList/index.stories.tsx
+++ b/lib/experimental/Lists/DataList/index.stories.tsx
@@ -4,7 +4,7 @@ import { Check } from "@/icons/app"
 import { DataList } from "."
 
 const meta: Meta<typeof DataList> = {
-  title: "DataList",
+  title: "List/DataList",
   component: DataList,
   tags: ["autodocs", "experimental"],
   args: {

--- a/lib/experimental/Lists/PersonListItem/index.stories.tsx
+++ b/lib/experimental/Lists/PersonListItem/index.stories.tsx
@@ -5,7 +5,7 @@ import avatar from "../../../../storybook-assets/avatar.jpeg"
 import { PersonListItem } from "./index"
 
 const meta = {
-  title: "PersonListItem",
+  title: "List/PersonListItem",
   component: PersonListItem,
   tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof PersonListItem>

--- a/lib/experimental/Navigation/ApplicationFrame/index.stories.tsx
+++ b/lib/experimental/Navigation/ApplicationFrame/index.stories.tsx
@@ -9,7 +9,7 @@ import { Sidebar } from "../Sidebar/Sidebar"
 const meta: Meta<typeof ApplicationFrame> = {
   title: "ApplicationFrame",
   component: ApplicationFrame,
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "experimental", "no-sidebar"],
   parameters: {
     layout: "fullscreen",
   },

--- a/lib/experimental/Navigation/Header/Breadcrumbs/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/Breadcrumbs/index.stories.tsx
@@ -6,7 +6,7 @@ import { useState } from "react"
 import Breadcrumbs, { BreadcrumbItemType } from "./index"
 
 const meta: Meta<typeof Breadcrumbs> = {
-  title: "Header/Breadcrumbs",
+  title: "Navigation/Breadcrumbs",
   component: Breadcrumbs,
   tags: ["autodocs", "experimental"],
 }

--- a/lib/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbSelect/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbSelect/index.stories.tsx
@@ -2,7 +2,7 @@ import { Search } from "@/icons/app"
 import type { Meta, StoryObj } from "@storybook/react"
 import { BreadcrumbSelect } from "."
 const meta: Meta<typeof BreadcrumbSelect> = {
-  title: "Header/Breadcrumbs/BreadcrumbSelect",
+  title: "Navigation/BreadcrumbSelect",
   component: BreadcrumbSelect,
   tags: ["autodocs", "internal"],
 }

--- a/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/lib/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { PageHeader } from "."
 
 const meta = {
-  title: "Header/PageHeader",
+  title: "Navigation/PageHeader",
   component: PageHeader,
   tags: ["autodocs", "experimental"],
   parameters: {

--- a/lib/experimental/Navigation/Page/index.stories.tsx
+++ b/lib/experimental/Navigation/Page/index.stories.tsx
@@ -16,7 +16,7 @@ import { ComponentProps } from "react"
 type TabsProps = ComponentProps<typeof Tabs>
 
 const meta: Meta<typeof Page> = {
-  title: "Page",
+  title: "Navigation/Page",
   component: Page,
   tags: ["autodocs", "experimental"],
   parameters: {

--- a/lib/experimental/Navigation/Sidebar/CompanySelector/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/CompanySelector/index.stories.tsx
@@ -4,7 +4,7 @@ import { CompanySelector } from "./index"
 const meta: Meta<typeof CompanySelector> = {
   title: "Sidebar/CompanySelector",
   component: CompanySelector,
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "experimental", "no-sidebar"],
   decorators: [
     (Story) => (
       <div className="max-w-[300px] bg-f1-background-tertiary p-3">

--- a/lib/experimental/Navigation/Sidebar/Header/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Header/index.stories.tsx
@@ -5,7 +5,7 @@ import { SidebarHeader } from "./index"
 const meta = {
   title: "Sidebar/Header",
   component: SidebarHeader,
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "experimental", "no-sidebar"],
 } satisfies Meta<typeof SidebarHeader>
 
 export default meta

--- a/lib/experimental/Navigation/Sidebar/Icon/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Icon/index.stories.tsx
@@ -4,7 +4,7 @@ import { SidebarIcon } from "."
 const meta: Meta<typeof SidebarIcon> = {
   title: "Sidebar/Icon",
   component: SidebarIcon,
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "experimental", "no-sidebar"],
 }
 
 export default meta

--- a/lib/experimental/Navigation/Sidebar/Menu/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Menu/index.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
       </div>
     ),
   ],
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "experimental", "no-sidebar"],
 } satisfies Meta<typeof Menu>
 
 export default meta

--- a/lib/experimental/Navigation/Sidebar/Searchbar/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/Searchbar/index.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
       </div>
     ),
   ],
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "experimental", "no-sidebar"],
 } satisfies Meta<typeof SearchBar>
 
 export default meta

--- a/lib/experimental/Navigation/Sidebar/User/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/User/index.stories.tsx
@@ -5,7 +5,7 @@ import { User } from "."
 const meta = {
   title: "Sidebar/User",
   component: User,
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "experimental", "no-sidebar"],
 } satisfies Meta<typeof User>
 
 export default meta

--- a/lib/experimental/Navigation/Sidebar/index.stories.tsx
+++ b/lib/experimental/Navigation/Sidebar/index.stories.tsx
@@ -13,7 +13,7 @@ import * as UserStories from "./User/index.stories"
 const meta: Meta<typeof Sidebar> = {
   title: "Sidebar",
   component: Sidebar,
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "experimental", "no-sidebar"],
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Navigation/Tabs/index.stories.tsx
+++ b/lib/experimental/Navigation/Tabs/index.stories.tsx
@@ -16,7 +16,7 @@ const secondaryTabItems = [
 ]
 
 const meta: Meta<typeof Tabs> = {
-  title: "Tabs",
+  title: "Navigation/Tabs",
   component: Tabs,
   tags: ["autodocs", "experimental"],
   argTypes: {

--- a/lib/experimental/OnePagination/index.stories.tsx
+++ b/lib/experimental/OnePagination/index.stories.tsx
@@ -4,7 +4,7 @@ import { OnePagination } from "."
 
 const meta: Meta<typeof OnePagination> = {
   component: OnePagination,
-  title: "Pagination",
+  title: "Data Collection/Pagination",
   parameters: {
     layout: "centered",
   },

--- a/lib/experimental/Overlays/Dialog/index.stories.tsx
+++ b/lib/experimental/Overlays/Dialog/index.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
     children: <span>Dialog Content</span>,
     open: true,
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "experimental", "no-sidebar"],
 } satisfies Meta<typeof Dialog>
 
 export default meta

--- a/lib/experimental/PageLayouts/Utils/DetailsItem/index.stories.tsx
+++ b/lib/experimental/PageLayouts/Utils/DetailsItem/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { DetailsItem } from "."
 
 const meta: Meta = {
-  title: "DetailsItem",
+  title: "List/DetailsItem",
   component: DetailsItem,
   tags: ["autodocs", "experimental"],
   args: {

--- a/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.stories.tsx
+++ b/lib/experimental/PageLayouts/Utils/DetailsItemsList/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { DetailsItemsList } from "."
 
 const meta: Meta = {
-  title: "DetailsItemsList",
+  title: "List/DetailsItemsList",
   component: DetailsItemsList,
   tags: ["autodocs", "experimental"],
   args: {

--- a/lib/experimental/PageLayouts/Utils/InfoPaneLayout/index.stories.tsx
+++ b/lib/experimental/PageLayouts/Utils/InfoPaneLayout/index.stories.tsx
@@ -9,7 +9,7 @@ import { ComponentProps } from "react"
 import { InfoPaneLayout } from "."
 
 const meta = {
-  title: "InfoPaneLayout",
+  title: "Layout/InfoPaneLayout",
   component: InfoPaneLayout,
   tags: ["autodocs", "experimental"],
   decorators: [PageDecorator],

--- a/lib/experimental/Utilities/Layout/AutoGrid/index.stories.tsx
+++ b/lib/experimental/Utilities/Layout/AutoGrid/index.stories.tsx
@@ -4,7 +4,7 @@ import { Placeholder } from "@/lib/storybook-utils/placeholder"
 import { AutoGrid } from "."
 
 const meta = {
-  title: "AutoGrid",
+  title: "Layout/Blocks/AutoGrid",
   component: AutoGrid,
   tags: ["autodocs", "experimental"],
   args: {

--- a/lib/experimental/Utilities/Layout/Split/index.stories.tsx
+++ b/lib/experimental/Utilities/Layout/Split/index.stories.tsx
@@ -4,7 +4,7 @@ import { Placeholder } from "@/lib/storybook-utils/placeholder"
 import { Split } from "."
 
 const meta = {
-  title: "Split",
+  title: "Layout/Blocks/Split",
   component: Split,
   tags: ["autodocs", "experimental"],
   args: {

--- a/lib/experimental/Utilities/Layout/Stack/index.stories.tsx
+++ b/lib/experimental/Utilities/Layout/Stack/index.stories.tsx
@@ -4,7 +4,7 @@ import { Placeholder } from "@/lib/storybook-utils/placeholder"
 import { Stack } from "."
 
 const meta = {
-  title: "Stack",
+  title: "Layout/Blocks/Stack",
   component: Stack,
   tags: ["autodocs", "experimental"],
   render: (args) => (

--- a/lib/experimental/Utilities/PrivateBox/index.stories.tsx
+++ b/lib/experimental/Utilities/PrivateBox/index.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { PrivateBox } from "."
 
 const meta: Meta = {
-  title: "PrivateBox",
+  title: "Profile/PrivateBox",
   tags: ["autodocs", "experimental"],
 }
 

--- a/lib/experimental/Utilities/ScrollArea/index.stories.tsx
+++ b/lib/experimental/Utilities/ScrollArea/index.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "experimental", "no-sidebar"],
   args: {},
 } satisfies Meta<typeof ScrollArea>
 

--- a/lib/experimental/Widgets/Content/CategoryBarSection/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/CategoryBarSection/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { CategoryBarSection } from "./index"
 
 const meta: Meta<typeof CategoryBarSection> = {
-  title: "CategoryBarSection",
+  title: "Profile/CategoryBarSection",
   component: CategoryBarSection,
   tags: ["autodocs", "experimental"],
   parameters: {

--- a/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
@@ -21,7 +21,7 @@ const defaultLabels = {
 }
 
 const meta: Meta<typeof ClockInControls> = {
-  title: "ClockInControls",
+  title: "Home/ClockInControls",
   component: ClockInControls,
   tags: ["autodocs", "experimental"],
   args: {

--- a/lib/experimental/Widgets/Content/ClockIn/ClockInGraph/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInGraph/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { ClockInGraph } from "."
 
 const meta: Meta<typeof ClockInGraph> = {
-  title: "ClockInGraph",
+  title: "Home/ClockInGraph",
   component: ClockInGraph,
   tags: ["autodocs", "experimental"],
   args: {

--- a/lib/experimental/Widgets/Content/ProgressBarDuo/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/ProgressBarDuo/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { ProgressBarDuo } from "./index"
 
 const meta: Meta<typeof ProgressBarDuo> = {
-  title: "ProgressBarDuo",
+  title: "Charts/ProgressBarDuo",
   component: ProgressBarDuo,
   tags: ["autodocs", "experimental"],
   args: {

--- a/lib/experimental/Widgets/Content/TasksList/TaskItem/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/TasksList/TaskItem/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { TaskItem, TaskItemProps } from "./index"
 
 const meta: Meta<TaskItemProps> = {
-  title: "TaskItem",
+  title: "Profile/TaskItem",
   component: TaskItem,
   tags: ["autodocs", "experimental"],
   parameters: {

--- a/lib/experimental/Widgets/Content/TasksList/index.stories.tsx
+++ b/lib/experimental/Widgets/Content/TasksList/index.stories.tsx
@@ -3,7 +3,7 @@ import { fn } from "@storybook/test"
 import { TasksList, TasksListProps } from "./index"
 
 const meta: Meta<TasksListProps> = {
-  title: "TasksList",
+  title: "Profile/TasksList",
   component: TasksList,
   tags: ["autodocs", "experimental"],
   parameters: {


### PR DESCRIPTION
## Description

Unifying the storybook content index with the goal of making it more accessible and easier to consume for everyone. I’ve streamlined the content by hiding unnecessary sections with the `no-sidebar` tag and prioritizing what’s most useful to have on the radar.

What was done:

- Add the `no-sidebar` tag to the sections that have been considered more confusing than useful for the end users of storybook
- Renamed and reorganized some elements for better clarity.
- Improved the overall structure for easier navigation.

## Screenshots
<img width="175" alt="Screenshot 2025-02-26 at 15 21 40" src="https://github.com/user-attachments/assets/fecec05a-39b2-4129-a866-0280ab571a63" />


