### PR TITLE
Add `Preset` component

### DIFF
--- a/lib/experimental/Information/Counter/index.tsx
+++ b/lib/experimental/Information/Counter/index.tsx
@@ -2,15 +2,14 @@ import { cn } from "@/lib/utils"
 import { cva, type VariantProps } from "cva"
 
 const counterVariants = cva({
-  base: "inline-flex items-center justify-center whitespace-nowrap rounded-xs text-sm font-medium tabular-nums",
+  base: "inline-flex items-center justify-center whitespace-nowrap rounded-xs text-sm font-medium tabular-nums transition-all",
   variants: {
     size: {
       md: "min-w-5 p-0.5",
       sm: "min-w-4 px-0.5",
     },
     type: {
-      default:
-        "border border-solid border-f1-border bg-f1-background-secondary",
+      default: "bg-f1-background-secondary outline outline-1 outline-f1-border",
       selected: "bg-f1-background-selected-bold text-f1-foreground-inverse",
       bold: "bg-f1-background-accent-bold text-f1-foreground-inverse",
     },

--- a/lib/experimental/OnePreset/index.mdx
+++ b/lib/experimental/OnePreset/index.mdx
@@ -1,0 +1,32 @@
+import { Canvas, Meta, Unstyled, Controls } from "@storybook/blocks"
+import * as PresetStories from "./index.stories"
+
+<Meta of={PresetStories} />
+
+# Preset
+
+Selectable button that represents predefined options or filters.
+
+```tsx
+import { OnePreset } from "@factorialco/factorial-one/dist/experimental"
+```
+
+## Anatomy
+
+<Canvas of={PresetStories.Default} />
+<Controls of={PresetStories.Default} />
+
+## Examples
+
+### No counter
+
+If no `number` prop is provided, the preset will not display a counter.
+
+<Canvas of={PresetStories.NoNumber} />
+
+### Non-interactive
+
+If the `onClick` prop is not provided, the preset will not be interactive, but
+will still display the label and counter if provided.
+
+<Canvas of={PresetStories.NotInteractive} />

--- a/lib/experimental/OnePreset/index.stories.tsx
+++ b/lib/experimental/OnePreset/index.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { fn } from "@storybook/test"
+import { useState } from "react"
+import { Preset } from "."
+
+const meta = {
+  component: Preset,
+  title: "Preset",
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs", "experimental"],
+  argTypes: {
+    label: {
+      description: "The label of the preset",
+    },
+    number: {
+      description: "The number of the preset",
+    },
+  },
+} satisfies Meta<typeof Preset>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    label: "Label",
+    number: 2,
+    onClick: fn(),
+    selected: false,
+  },
+  render: (args) => {
+    const [isSelected, setIsSelected] = useState(false)
+
+    return (
+      <Preset
+        {...args}
+        selected={isSelected}
+        onClick={() => setIsSelected(!isSelected)}
+      />
+    )
+  },
+}
+
+export const NoNumber: Story = {
+  args: {
+    label: "Label",
+    number: undefined,
+    onClick: fn(),
+    selected: false,
+  },
+  render: (args) => {
+    const [isSelected, setIsSelected] = useState(false)
+
+    return (
+      <Preset
+        {...args}
+        selected={isSelected}
+        onClick={() => setIsSelected(!isSelected)}
+      />
+    )
+  },
+}
+
+export const NotInteractive: Story = {
+  args: {
+    label: "Label",
+    number: 2,
+  },
+}

--- a/lib/experimental/OnePreset/index.tsx
+++ b/lib/experimental/OnePreset/index.tsx
@@ -1,5 +1,6 @@
 import { Counter } from "@/experimental/Information/Counter"
-import { cn, focusRing } from "@/lib/utils"
+import { cn } from "@/lib/utils"
+
 interface PresetProps {
   label: string
   number?: number
@@ -9,21 +10,27 @@ interface PresetProps {
 
 export const Preset = ({ label, number, onClick, selected }: PresetProps) => {
   return (
-    <button
+    <label
       className={cn(
         "flex cursor-default appearance-none items-center gap-2 rounded px-2.5 py-1.5 font-medium text-f1-foreground outline outline-1 outline-f1-border transition-all",
-        "focus:outline focus:outline-1",
+        onClick &&
+          "focus-within:ring-2 focus-within:ring-f1-border-selected focus-within:ring-offset-2",
         number && "pr-1.5",
         onClick && "cursor-pointer hover:outline-f1-border-hover",
-        selected && "bg-f1-background-selected text-f1-foreground-selected",
-        onClick && focusRing()
+        selected &&
+          "bg-f1-background-selected-secondary text-f1-foreground-selected"
       )}
-      onClick={onClick}
     >
+      <input
+        type="checkbox"
+        className="sr-only"
+        checked={selected}
+        onChange={() => onClick?.()}
+      />
       <span>{label}</span>
       {number && (
         <Counter value={number} type={selected ? "selected" : "default"} />
       )}
-    </button>
+    </label>
   )
 }

--- a/lib/experimental/OnePreset/index.tsx
+++ b/lib/experimental/OnePreset/index.tsx
@@ -1,0 +1,29 @@
+import { Counter } from "@/experimental/Information/Counter"
+import { cn, focusRing } from "@/lib/utils"
+interface PresetProps {
+  label: string
+  number?: number
+  onClick?: () => void
+  selected?: boolean
+}
+
+export const Preset = ({ label, number, onClick, selected }: PresetProps) => {
+  return (
+    <button
+      className={cn(
+        "flex cursor-default appearance-none items-center gap-2 rounded px-2.5 py-1.5 font-medium outline outline-1 outline-f1-border transition-all",
+        "focus:outline focus:outline-1",
+        number && "pr-1.5",
+        onClick && "cursor-pointer hover:outline-f1-border-hover",
+        selected && "bg-f1-background-selected text-f1-foreground-selected",
+        onClick && focusRing()
+      )}
+      onClick={onClick}
+    >
+      <span>{label}</span>
+      {number && (
+        <Counter value={number} type={selected ? "selected" : "default"} />
+      )}
+    </button>
+  )
+}

--- a/lib/experimental/OnePreset/index.tsx
+++ b/lib/experimental/OnePreset/index.tsx
@@ -11,7 +11,7 @@ export const Preset = ({ label, number, onClick, selected }: PresetProps) => {
   return (
     <button
       className={cn(
-        "flex cursor-default appearance-none items-center gap-2 rounded px-2.5 py-1.5 font-medium outline outline-1 outline-f1-border transition-all",
+        "flex cursor-default appearance-none items-center gap-2 rounded px-2.5 py-1.5 font-medium text-f1-foreground outline outline-1 outline-f1-border transition-all",
         "focus:outline focus:outline-1",
         number && "pr-1.5",
         onClick && "cursor-pointer hover:outline-f1-border-hover",


### PR DESCRIPTION
## Description

`Preset` is another component that we need for Data Collections. It's a selectable button that represents predefined options or filters.

## Screenshots

<img width="789" alt="image" src="https://github.com/user-attachments/assets/2ab46364-c9c2-40e2-b4cc-280f5eae9e5c" />

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=4230-61640&t=8wvvVtYa5FvU4Pyj-4)

---

## Type of Change

- [x] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other
