### PR TITLE
Enable `DotTag` as metadata type

### DIFF
--- a/lib/experimental/Information/Headers/Metadata/index.stories.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.stories.tsx
@@ -97,6 +97,14 @@ export const Default: Story = {
           tags: ["Projects", "Recruitment", "Tasks"],
         },
       },
+      {
+        label: "Type",
+        value: {
+          type: "dot-tag",
+          label: "Dot tag",
+          color: "malibu",
+        },
+      },
     ],
   },
 }

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -5,6 +5,7 @@ import {
   AvatarVariant,
 } from "@/experimental/Information/Avatars/Avatar"
 import { AvatarList } from "@/experimental/Information/Avatars/AvatarList"
+import { DotTag, NewColor } from "@/experimental/Information/Tags/DotTag"
 import { RawTag } from "@/experimental/Information/Tags/exports"
 import {
   StatusTag,
@@ -23,6 +24,7 @@ type MetadataItemValue =
   | { type: "list"; variant: AvatarVariant["type"]; avatars: AvatarVariant[] }
   | { type: "data-list"; data: string[] }
   | { type: "tag-list"; tags: string[] }
+  | { type: "dot-tag"; label: string; color: NewColor }
 
 type MetadataAction = {
   icon: IconType
@@ -121,6 +123,9 @@ function MetadataValue({
           ))}
         </div>
       )
+
+    case "dot-tag":
+      return <DotTag text={item.value.label} color={item.value.color} />
   }
 }
 

--- a/lib/experimental/Information/Tags/DotTag/index.tsx
+++ b/lib/experimental/Information/Tags/DotTag/index.tsx
@@ -3,7 +3,7 @@ import { baseColors } from "@/tokens/colors"
 import { forwardRef } from "react"
 import { BaseTag } from "../BaseTag"
 
-type NewColor = Extract<
+export type NewColor = Extract<
   keyof typeof baseColors,
   | "viridian"
   | "malibu"


### PR DESCRIPTION
## Description

After reviewing [this case](https://factorialteam.slack.com/archives/C06QT46115K/p1740060973037939), we decided to add `DotTag` as another metadata type. Especially useful in their case where the status one falls short.

## Screenshots

<img width="185" alt="image" src="https://github.com/user-attachments/assets/7893f823-0ac7-41f5-ada7-116fa8d1b36e" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other