### PR TITLE
Align reaction button properly when theres no image

### DIFF
--- a/lib/experimental/Information/Communities/Celebration/components/avatar.tsx
+++ b/lib/experimental/Information/Communities/Celebration/components/avatar.tsx
@@ -63,7 +63,13 @@ export function CelebrationAvatar({
             />
           </div>
           {canReact && (
-            <div ref={pickerRef} className="absolute -right-0.5 bottom-0.5">
+            <div
+              ref={pickerRef}
+              className={cn(
+                "absolute -right-0.5",
+                src ? "bottom-0.5" : "-bottom-[3px]"
+              )}
+            >
               <Picker
                 lastEmojiReaction={lastEmojiReaction}
                 onSelect={onReactionSelect}


### PR DESCRIPTION
## Before

<img width="1228" alt="Screenshot 2025-02-27 at 16 25 33" src="https://github.com/user-attachments/assets/846b0a3e-4679-4a35-8a95-b60389de4a27" />

## After

<img width="1228" alt="Screenshot 2025-02-27 at 16 24 43" src="https://github.com/user-attachments/assets/d3102bc0-9d2b-4e48-a8fd-bbd539b6ba4d" />
