### PR TITLE
Add additional info to headers in Data Collections

### DIFF
--- a/lib/experimental/Collections/Table/index.tsx
+++ b/lib/experimental/Collections/Table/index.tsx
@@ -55,7 +55,9 @@ export const TableCollection = <
         <TableHeader>
           <TableRow>
             {columns.map((column) => (
-              <TableHead key={String(column.label)}>{column.label}</TableHead>
+              <TableHead key={String(column.label)} info={column.info}>
+                {column.label}
+              </TableHead>
             ))}
             {link && <TableHead key="actions">Actions</TableHead>}
           </TableRow>

--- a/lib/experimental/Collections/index.stories.tsx
+++ b/lib/experimental/Collections/index.stories.tsx
@@ -193,7 +193,11 @@ export const BasicTableView: Story = {
             options: {
               columns: [
                 { label: "Name", render: (item) => item.name },
-                { label: "Email", render: (item) => item.email },
+                {
+                  label: "Email",
+                  info: "Work email",
+                  render: (item) => item.email,
+                },
                 { label: "Role", render: (item) => item.role },
                 { label: "Department", render: (item) => item.department },
               ],

--- a/lib/experimental/Collections/utils.ts
+++ b/lib/experimental/Collections/utils.ts
@@ -2,6 +2,7 @@ import { ReactNode } from "react"
 
 export type PropertyDefinition<T> = {
   label: string
+  info?: string
   render: (item: T) => ReactNode
 }
 


### PR DESCRIPTION
## Description

Let the user define an optional info string for headers, as we already have that option in the Table component.

## Screenshots

<img width="346" alt="image" src="https://github.com/user-attachments/assets/4684a793-93f7-485f-b07f-f552a9a3ed4d" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other