### PR TITLE
Only show Data Collection filters container when there are active ones

### DIFF
--- a/lib/experimental/Collections/Filters/index.tsx
+++ b/lib/experimental/Collections/Filters/index.tsx
@@ -149,27 +149,29 @@ export function Filters<Definition extends FiltersDefinition>({
           Here should be the presets
         </div> */}
       </div>
-      <div className="flex flex-wrap items-center gap-2">
-        <AnimatePresence presenceAffectsLayout initial={false}>
-          {(Object.keys(value) as Array<keyof Definition>).map((key) => {
-            const filter = schema[key]
-            if (!value[key]) return null
+      {Object.keys(value).length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <AnimatePresence presenceAffectsLayout initial={false}>
+            {(Object.keys(value) as Array<keyof Definition>).map((key) => {
+              const filter = schema[key]
+              if (!value[key]) return null
 
-            return (
-              <FilterButton
-                key={String(key)}
-                filter={filter}
-                value={value[key]}
-                onSelect={() => {
-                  setSelectedFilterKey(key)
-                  setIsOpen(true)
-                }}
-                onRemove={() => handleRemoveFilter(key)}
-              />
-            )
-          })}
-        </AnimatePresence>
-      </div>
+              return (
+                <FilterButton
+                  key={String(key)}
+                  filter={filter}
+                  value={value[key]}
+                  onSelect={() => {
+                    setSelectedFilterKey(key)
+                    setIsOpen(true)
+                  }}
+                  onRemove={() => handleRemoveFilter(key)}
+                />
+              )
+            })}
+          </AnimatePresence>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Description

There is a huge gap between the filters button and the table because the filters container is still present even when there are no filters active. This fixes it.

### Before

<img width="680" alt="image" src="https://github.com/user-attachments/assets/a8722da8-a10b-4f65-9056-7bbb63bf9402" />

### After

<img width="674" alt="image" src="https://github.com/user-attachments/assets/d575d7a5-6e08-44c5-ac5d-96f241d3c0b1" />
