### PR TITLE
Use tabular numbers in Clock-in

### DIFF
--- a/lib/experimental/Widgets/Content/ClockIn/ClockInGraph/index.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInGraph/index.tsx
@@ -62,7 +62,7 @@ export function ClockInGraph({
 
       {/* Time display */}
       <div className="absolute inset-0 flex items-center justify-center">
-        <span className="text-2xl font-semibold text-f1-foreground">
+        <span className="text-2xl font-semibold text-f1-foreground tabular-nums">
           {time}
         </span>
       </div>


### PR DESCRIPTION
Tabular numbers have constant width. Using them for timers helps to avoid unpleasant horizontal shifts when time changes