### PR TITLE
Enable links in tables row

### DIFF
--- a/lib/experimental/Collections/Table/index.tsx
+++ b/lib/experimental/Collections/Table/index.tsx
@@ -81,7 +81,14 @@ export const TableCollection = <
                 </TableCell>
               ))}
               {source.actions && (
-                <TableCell key="actions">
+                <TableCell
+                  key="actions"
+                  href={
+                    "href" in item && typeof item.href === "string"
+                      ? item.href
+                      : undefined
+                  }
+                >
                   <ActionsDropdown item={item} actions={source.actions} />
                 </TableCell>
               )}

--- a/lib/experimental/Collections/Table/index.tsx
+++ b/lib/experimental/Collections/Table/index.tsx
@@ -67,8 +67,11 @@ export const TableCollection = <
         <TableBody>
           {data.map((item, index) => (
             <TableRow key={`row-${index}`}>
-              {columns.map((column) => (
-                <TableCell key={String(column.label)}>
+              {columns.map((column, cellIndex) => (
+                <TableCell
+                  key={String(column.label)}
+                  firstCell={cellIndex === 0}
+                >
                   {renderValue(item, column)}
                 </TableCell>
               ))}

--- a/lib/experimental/Collections/Table/index.tsx
+++ b/lib/experimental/Collections/Table/index.tsx
@@ -71,6 +71,11 @@ export const TableCollection = <
                 <TableCell
                   key={String(column.label)}
                   firstCell={cellIndex === 0}
+                  href={
+                    "href" in item && typeof item.href === "string"
+                      ? item.href
+                      : undefined
+                  }
                 >
                   {renderValue(item, column)}
                 </TableCell>

--- a/lib/experimental/Collections/index.stories.tsx
+++ b/lib/experimental/Collections/index.stories.tsx
@@ -70,6 +70,7 @@ const mockUsers = [
     department: DEPARTMENTS[0],
     status: "active",
     isStarred: true,
+    href: "/users/john-doe",
   },
   {
     id: "user-2",
@@ -79,6 +80,7 @@ const mockUsers = [
     department: DEPARTMENTS[1],
     status: "active",
     isStarred: false,
+    href: "/users/jane-smith",
   },
   {
     id: "user-3",
@@ -88,6 +90,7 @@ const mockUsers = [
     department: DEPARTMENTS[2],
     status: "inactive",
     isStarred: false,
+    href: "/users/bob-johnson",
   },
   {
     id: "user-4",
@@ -97,6 +100,7 @@ const mockUsers = [
     department: DEPARTMENTS[3],
     status: "active",
     isStarred: true,
+    href: "/users/alice-williams",
   },
 ]
 
@@ -831,6 +835,7 @@ const generateMockUsers = (count: number) => {
     department: DEPARTMENTS[index % DEPARTMENTS.length],
     status: index % 5 === 0 ? "inactive" : "active",
     isStarred: index % 3 === 0,
+    href: `/users/user-${index + 1}`,
   }))
 }
 

--- a/lib/experimental/OneTable/TableCell/index.tsx
+++ b/lib/experimental/OneTable/TableCell/index.tsx
@@ -7,21 +7,39 @@ interface TableCellProps {
   children: React.ReactNode
 
   /**
+   * The URL to navigate to when the cell is clicked
+   */
+  href?: string
+
+  /**
+   * Defines if the cell is the first cell in the row
+   * @default false
+   */
+  firstCell?: boolean
+
+  /**
    * When true, the cell will stick to the left side of the table when scrolling horizontally
    * @default false
    */
   sticky?: boolean
 }
 
-export function TableCell({ children, sticky = false }: TableCellProps) {
+export function TableCell({
+  children,
+  href,
+  firstCell = false,
+  sticky = false,
+}: TableCellProps) {
   const { isScrolled } = useTable()
 
   return (
     <TableCellRoot
-      className={cn({
-        "sticky left-0 z-10 bg-f1-background before:absolute before:inset-0 before:z-[-1] before:h-[calc(100%-1px)] before:w-full before:bg-f1-background before:transition-all before:content-[''] group-hover:before:bg-f1-background-hover":
-          sticky && isScrolled,
-      })}
+      className={cn(
+        firstCell && "peer",
+        sticky &&
+          isScrolled &&
+          "sticky left-0 z-10 bg-f1-background before:absolute before:inset-0 before:z-[-1] before:h-[calc(100%-1px)] before:w-full before:bg-f1-background before:transition-all before:content-[''] group-hover:before:bg-f1-background-hover"
+      )}
     >
       <AnimatePresence>
         {isScrolled && sticky && (
@@ -33,7 +51,23 @@ export function TableCell({ children, sticky = false }: TableCellProps) {
           />
         )}
       </AnimatePresence>
-      {children}
+      <div
+        className={cn(
+          "[&:has([role=checkbox])]:relative [&:has([role=checkbox])]:z-[1]",
+          "[&:has([type=button])]:relative [&:has([type=button])]:z-[1]"
+        )}
+      >
+        {children}
+      </div>
+      {href && (
+        <a
+          href={href}
+          className="absolute inset-0 block"
+          tabIndex={firstCell ? undefined : -1}
+        >
+          <span className="sr-only">View</span>
+        </a>
+      )}
     </TableCellRoot>
   )
 }

--- a/lib/experimental/OneTable/TableCell/index.tsx
+++ b/lib/experimental/OneTable/TableCell/index.tsx
@@ -54,7 +54,8 @@ export function TableCell({
       <div
         className={cn(
           "[&:has([role=checkbox])]:relative [&:has([role=checkbox])]:z-[1]",
-          "[&:has([type=button])]:relative [&:has([type=button])]:z-[1]"
+          "[&:has([type=button])]:relative [&:has([type=button])]:z-[1]",
+          "[&:has(a)]:relative [&:has(a)]:z-[1]"
         )}
       >
         {children}

--- a/lib/experimental/OneTable/TableRow/index.tsx
+++ b/lib/experimental/OneTable/TableRow/index.tsx
@@ -17,7 +17,7 @@ export function TableRow({ children, selected, className }: TableRowProps) {
       )}
     >
       {children}
-      <div className="absolute inset-0 [.group:has(a:focus)_&]:bg-f1-background-hover" />
+      <div className="pointer-events-none absolute inset-0 [.group:has(a:focus)_&]:rounded-sm [.group:has(a:focus)_&]:ring-1 [.group:has(a:focus)_&]:ring-inset [.group:has(a:focus)_&]:ring-f1-ring" />
     </TableRowRoot>
   )
 }

--- a/lib/experimental/OneTable/TableRow/index.tsx
+++ b/lib/experimental/OneTable/TableRow/index.tsx
@@ -17,6 +17,7 @@ export function TableRow({ children, selected, className }: TableRowProps) {
       )}
     >
       {children}
+      <div className="absolute inset-0 [.group:has(a:focus)_&]:bg-f1-background-hover" />
     </TableRowRoot>
   )
 }

--- a/lib/experimental/OneTable/index.stories.tsx
+++ b/lib/experimental/OneTable/index.stories.tsx
@@ -590,3 +590,83 @@ export const Actions: Story = {
     </OneTable>
   ),
 }
+
+export const WithLinks: Story = {
+  render: () => (
+    <OneTable>
+      <TableHeader>
+        <TableRow>
+          <TableHead width="fit">
+            <Checkbox checked={false} title="Select all" hideLabel />
+          </TableHead>
+          <TableHead>Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Role</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead width="fit" hidden>
+            Actions
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {sampleData.map((row) => (
+          <TableRow key={row.id}>
+            <TableCell firstCell href="/">
+              <Checkbox checked={false} title="Select" hideLabel />
+            </TableCell>
+            <TableCell href="/">
+              <div className="flex items-center gap-2">
+                <PersonAvatar
+                  firstName={row.name.split(" ")[0]}
+                  lastName={row.name.split(" ")[1]}
+                  size="small"
+                />
+                <span className="font-medium">{row.name}</span>
+              </div>
+            </TableCell>
+            <TableCell href="/">{row.email}</TableCell>
+            <TableCell href="/">
+              <div className="w-fit">
+                <RawTag text={row.role} />
+              </div>
+            </TableCell>
+            <TableCell href="/">
+              <div className="w-fit">
+                <StatusTag
+                  text={row.status.label}
+                  variant={row.status.variant}
+                />
+              </div>
+            </TableCell>
+            <TableCell href="/">
+              <Dropdown
+                items={[
+                  {
+                    label: "Edit",
+                    icon: Pencil,
+                    onClick: () => {},
+                  },
+                  {
+                    label: "Delete",
+                    icon: Delete,
+                    onClick: () => {},
+                    critical: true,
+                  },
+                ]}
+              >
+                <Button
+                  hideLabel
+                  variant="ghost"
+                  icon={Ellipsis}
+                  onClick={() => {}}
+                  round
+                  label="Actions"
+                />
+              </Dropdown>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </OneTable>
+  ),
+}


### PR DESCRIPTION
## Description

Adds the option to define a link for each row in the Data Collection (also adding it to the `OneTable` component).

Followed [this article](https://robertcooper.me/post/table-row-links#solution-3-use-css-grid-to-create-a-table) to make accessible links:

- Each row is focusable, also interactive elements inside.
- Interactive elements has a higher z-index, making it not fire the link that is behind.
- Works well with tab navigation.

There are a few cons with this approach, though.

- For every interactive element that we want to be focusable, we need to select it through css and add a `relative` and a `z-index ` class.

## Screenshots

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/84f34ae7-f321-4022-ba6e-438556c1c319" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other