### PR TITLE
Add Table grouping

### DIFF
--- a/lib/experimental/OneTable/TableGroup/index.tsx
+++ b/lib/experimental/OneTable/TableGroup/index.tsx
@@ -1,0 +1,9 @@
+import { TableCell as TableCellRoot } from "@/ui/table"
+
+interface TableCellProps {
+  children: React.ReactNode
+}
+
+export function TableGroup({ children }: TableCellProps) {
+  return <TableCellRoot>{children}</TableCellRoot>
+}

--- a/lib/experimental/OneTable/TableGroup/index.tsx
+++ b/lib/experimental/OneTable/TableGroup/index.tsx
@@ -1,9 +1,43 @@
+import { Icon } from "@/components/Utilities/Icon"
+import { Counter } from "@/experimental/Information/Counter"
+import { ChevronDown } from "@/icons/app"
+import { cn } from "@/lib/utils"
 import { TableCell as TableCellRoot } from "@/ui/table"
+import { motion } from "framer-motion"
 
 interface TableCellProps {
-  children: React.ReactNode
+  label: string
+  number?: number
+  open?: boolean
+  onClick?: () => void
 }
 
-export function TableGroup({ children }: TableCellProps) {
-  return <TableCellRoot>{children}</TableCellRoot>
+export function TableGroup({
+  label,
+  number,
+  open = false,
+  onClick,
+}: TableCellProps) {
+  return (
+    <TableCellRoot
+      colSpan={100}
+      className={cn(
+        "bg-f1-background-tertiary py-2.5 font-semibold",
+        onClick && "hover:cursor-pointer"
+      )}
+      onClick={onClick}
+    >
+      <div className="flex items-center gap-1.5">
+        <motion.div
+          className="h-4 w-4"
+          animate={{ rotate: open ? 0 : -90 }}
+          transition={{ duration: 0.2 }}
+        >
+          <Icon icon={ChevronDown} className="h-4 w-4 text-f1-icon-secondary" />
+        </motion.div>
+        <span>{label}</span>
+        {number && <Counter value={number} />}
+      </div>
+    </TableCellRoot>
+  )
 }

--- a/lib/experimental/OneTable/index.stories.tsx
+++ b/lib/experimental/OneTable/index.stories.tsx
@@ -602,10 +602,10 @@ export const Grouping: Story = {
       <OneTable>
         <TableHeader>
           <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Email</TableHead>
-            <TableHead>Role</TableHead>
-            <TableHead>Status</TableHead>
+            <TableHead width="30">Name</TableHead>
+            <TableHead width="30">Email</TableHead>
+            <TableHead width="20">Role</TableHead>
+            <TableHead width="20">Status</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/lib/experimental/OneTable/index.stories.tsx
+++ b/lib/experimental/OneTable/index.stories.tsx
@@ -15,6 +15,7 @@ import {
   OneTable,
   TableBody,
   TableCell,
+  TableGroup,
   TableHead,
   TableHeader,
   TableRow,
@@ -583,6 +584,56 @@ export const Actions: Story = {
                   label="Actions"
                 />
               </Dropdown>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </OneTable>
+  ),
+}
+
+export const Grouping: Story = {
+  render: () => (
+    <OneTable>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Role</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableGroup>
+            <span className="font-medium">Group</span>
+          </TableGroup>
+        </TableRow>
+        {sampleData.map((row) => (
+          <TableRow key={row.id}>
+            <TableCell>
+              <div className="flex items-center gap-2">
+                <PersonAvatar
+                  firstName={row.name.split(" ")[0]}
+                  lastName={row.name.split(" ")[1]}
+                  size="small"
+                />
+                <span className="font-medium">{row.name}</span>
+              </div>
+            </TableCell>
+            <TableCell>{row.email}</TableCell>
+            <TableCell>
+              <div className="w-fit">
+                <RawTag text={row.role} />
+              </div>
+            </TableCell>
+            <TableCell>
+              <div className="w-fit">
+                <StatusTag
+                  text={row.status.label}
+                  variant={row.status.variant}
+                />
+              </div>
             </TableCell>
           </TableRow>
         ))}

--- a/lib/experimental/OneTable/index.stories.tsx
+++ b/lib/experimental/OneTable/index.stories.tsx
@@ -10,6 +10,7 @@ import { Dropdown } from "@/experimental/Navigation/Dropdown"
 import { OnePagination } from "@/experimental/OnePagination"
 import { Delete, Ellipsis, Pencil } from "@/icons/app"
 import type { Meta, StoryObj } from "@storybook/react"
+import { AnimatePresence } from "framer-motion"
 import React, { useState } from "react"
 import {
   OneTable,
@@ -593,51 +594,108 @@ export const Actions: Story = {
 }
 
 export const Grouping: Story = {
-  render: () => (
-    <OneTable>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Name</TableHead>
-          <TableHead>Email</TableHead>
-          <TableHead>Role</TableHead>
-          <TableHead>Status</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        <TableRow>
-          <TableGroup>
-            <span className="font-medium">Group</span>
-          </TableGroup>
-        </TableRow>
-        {sampleData.map((row) => (
-          <TableRow key={row.id}>
-            <TableCell>
-              <div className="flex items-center gap-2">
-                <PersonAvatar
-                  firstName={row.name.split(" ")[0]}
-                  lastName={row.name.split(" ")[1]}
-                  size="small"
-                />
-                <span className="font-medium">{row.name}</span>
-              </div>
-            </TableCell>
-            <TableCell>{row.email}</TableCell>
-            <TableCell>
-              <div className="w-fit">
-                <RawTag text={row.role} />
-              </div>
-            </TableCell>
-            <TableCell>
-              <div className="w-fit">
-                <StatusTag
-                  text={row.status.label}
-                  variant={row.status.variant}
-                />
-              </div>
-            </TableCell>
+  render: () => {
+    const [engineeringOpen, setEngineeringOpen] = useState(true)
+    const [designOpen, setDesignOpen] = useState(false)
+
+    return (
+      <OneTable>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Role</TableHead>
+            <TableHead>Status</TableHead>
           </TableRow>
-        ))}
-      </TableBody>
-    </OneTable>
-  ),
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableGroup
+              label="Engineering"
+              number={2}
+              open={engineeringOpen}
+              onClick={() => setEngineeringOpen(!engineeringOpen)}
+            />
+          </TableRow>
+          <AnimatePresence>
+            {engineeringOpen && (
+              <>
+                {sampleData.slice(0, 2).map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <PersonAvatar
+                          firstName={row.name.split(" ")[0]}
+                          lastName={row.name.split(" ")[1]}
+                          size="small"
+                        />
+                        <span className="font-medium">{row.name}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>{row.email}</TableCell>
+                    <TableCell>
+                      <div className="w-fit">
+                        <RawTag text={row.role} />
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="w-fit">
+                        <StatusTag
+                          text={row.status.label}
+                          variant={row.status.variant}
+                        />
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </>
+            )}
+          </AnimatePresence>
+
+          <TableRow>
+            <TableGroup
+              label="Design"
+              number={2}
+              open={designOpen}
+              onClick={() => setDesignOpen(!designOpen)}
+            />
+          </TableRow>
+          <AnimatePresence>
+            {designOpen && (
+              <>
+                {sampleData.slice(2, 4).map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <PersonAvatar
+                          firstName={row.name.split(" ")[0]}
+                          lastName={row.name.split(" ")[1]}
+                          size="small"
+                        />
+                        <span className="font-medium">{row.name}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>{row.email}</TableCell>
+                    <TableCell>
+                      <div className="w-fit">
+                        <RawTag text={row.role} />
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="w-fit">
+                        <StatusTag
+                          text={row.status.label}
+                          variant={row.status.variant}
+                        />
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </>
+            )}
+          </AnimatePresence>
+        </TableBody>
+      </OneTable>
+    )
+  },
 }

--- a/lib/experimental/OneTable/index.tsx
+++ b/lib/experimental/OneTable/index.tsx
@@ -1,6 +1,7 @@
 export * from "./Table"
 export * from "./TableBody"
 export * from "./TableCell"
+export * from "./TableGroup"
 export * from "./TableHead"
 export * from "./TableHeader"
 export * from "./TableRow"


### PR DESCRIPTION
## Description

Add basic component for grouping in tables. (Only in the `OneTable` for now)

## Screenshots 

https://github.com/user-attachments/assets/caf04915-0297-4c5d-b494-cb5ded23f446

**Next steps:**

- Animation (Motion does not get along really well with tables)
- Avoid content jumps when there's no column width specified.

### Figma Link

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=4209-53388&t=O2gFsRTICUj11exo-4)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other