### PR TITLE
Hide internal tags in Storybook filter menu

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -96,6 +96,12 @@
     box-shadow: none;
   }
 
+  #list-item-tag-no-sidebar,
+  #list-item-tag-play-fn,
+  #list-item-tag-internal {
+    display: none;
+  }
+
   /* -- DARK -- */
 
   body.dark,

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -149,8 +149,8 @@
 
 <script>
   ;(function () {
-    // Hide internal tags in production builds menu
-    if (window["CONFIG_TYPE"] === "PRODUCTION") {
+    // Function to apply the styles when in production mode
+    function applyProductionStyles() {
       const style = document.createElement("style")
       style.textContent = `
         #list-item-tag-no-sidebar,
@@ -161,5 +161,26 @@
       `
       document.head.appendChild(style)
     }
+
+    // Check if CONFIG_TYPE is already set
+    if (window["CONFIG_TYPE"] === "PRODUCTION") {
+      applyProductionStyles()
+      return
+    }
+
+    // If not set yet, wait for DOMContentLoaded which happens after most scripts run
+    window.addEventListener("DOMContentLoaded", function () {
+      if (window["CONFIG_TYPE"] === "PRODUCTION") {
+        applyProductionStyles()
+        return
+      }
+
+      // If still not set, use a short delay to check again after everything is loaded
+      setTimeout(function () {
+        if (window["CONFIG_TYPE"] === "PRODUCTION") {
+          applyProductionStyles()
+        }
+      }, 1000)
+    })
   })()
 </script>

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -149,38 +149,19 @@
 
 <script>
   ;(function () {
-    // Function to apply the styles when in production mode
-    function applyProductionStyles() {
-      const style = document.createElement("style")
-      style.textContent = `
-        #list-item-tag-no-sidebar,
-        #list-item-tag-play-fn,
-        #list-item-tag-internal {
-          display: none;
-        }
-      `
-      document.head.appendChild(style)
-    }
-
-    // Check if CONFIG_TYPE is already set
-    if (window["CONFIG_TYPE"] === "PRODUCTION") {
-      applyProductionStyles()
-      return
-    }
-
-    // If not set yet, wait for DOMContentLoaded which happens after most scripts run
-    window.addEventListener("DOMContentLoaded", function () {
+    // hide internal tags in production builds menu
+    setTimeout(function () {
       if (window["CONFIG_TYPE"] === "PRODUCTION") {
-        applyProductionStyles()
-        return
+        const style = document.createElement("style")
+        style.textContent = `
+          #list-item-tag-no-sidebar,
+          #list-item-tag-play-fn,
+          #list-item-tag-internal {
+            display: none;
+          }
+        `
+        document.head.appendChild(style)
       }
-
-      // If still not set, use a short delay to check again after everything is loaded
-      setTimeout(function () {
-        if (window["CONFIG_TYPE"] === "PRODUCTION") {
-          applyProductionStyles()
-        }
-      }, 1000)
-    })
+    }, 100)
   })()
 </script>

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -96,12 +96,6 @@
     box-shadow: none;
   }
 
-  #list-item-tag-no-sidebar,
-  #list-item-tag-play-fn,
-  #list-item-tag-internal {
-    display: none;
-  }
-
   /* -- DARK -- */
 
   body.dark,
@@ -152,3 +146,20 @@
     color: #647084;
   }
 </style>
+
+<script>
+  ;(function () {
+    // Hide internal tags in production builds menu
+    if (window["CONFIG_TYPE"] === "PRODUCTION") {
+      const style = document.createElement("style")
+      style.textContent = `
+        #list-item-tag-no-sidebar,
+        #list-item-tag-play-fn,
+        #list-item-tag-internal {
+          display: none;
+        }
+      `
+      document.head.appendChild(style)
+    }
+  })()
+</script>


### PR DESCRIPTION
## Description

Hide the internal tags that are not used to depict a component status in the Storybook filter menu. Only applies in production builds.

## Screenshots

<img width="371" alt="image" src="https://github.com/user-attachments/assets/20e01fae-ab45-4325-adf1-39f50b33ae83" />

_Before_

---

<img width="336" alt="image" src="https://github.com/user-attachments/assets/a31548f7-4204-4e68-89ec-32dd0da4e51b" />

_After_