### PR TITLE
Enable columns width in DataCollection table

### DIFF
--- a/lib/experimental/Collections/Table/index.tsx
+++ b/lib/experimental/Collections/Table/index.tsx
@@ -53,7 +53,11 @@ export const TableCollection = <
         <TableHeader>
           <TableRow>
             {columns.map((column) => (
-              <TableHead key={String(column.label)} info={column.info}>
+              <TableHead
+                key={String(column.label)}
+                info={column.info}
+                width={column.width}
+              >
                 {column.label}
               </TableHead>
             ))}

--- a/lib/experimental/Collections/index.stories.tsx
+++ b/lib/experimental/Collections/index.stories.tsx
@@ -1038,3 +1038,39 @@ export const WithPresetsAndObservable: Story = {
     usePresets: true,
   },
 }
+
+export const WithCustomColumnWidths: Story = {
+  render: () => {
+    const dataSource = useDataSource({
+      filters,
+      dataAdapter: {
+        fetchData: createPromiseDataFetch(),
+      },
+    })
+
+    return (
+      <div className="space-y-4">
+        <DataCollection
+          source={dataSource}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                columns: [
+                  { label: "Name", width: "40", render: (item) => item.name },
+                  { label: "Email", width: "20", render: (item) => item.email },
+                  { label: "Role", width: "20", render: (item) => item.role },
+                  {
+                    label: "Department",
+                    width: "20",
+                    render: (item) => item.department,
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      </div>
+    )
+  },
+}

--- a/lib/experimental/Collections/utils.ts
+++ b/lib/experimental/Collections/utils.ts
@@ -1,8 +1,20 @@
+import { ColumnWidth } from "@/experimental/OneTable/utils/sizes"
 import { ReactNode } from "react"
 
 export type PropertyDefinition<T> = {
   label: string
+
+  /**
+   * Optional tooltip text. When provided, displays an info icon next to the header content
+   * that shows this text in a tooltip when hovered.
+   */
   info?: string
+
+  /**
+   * The width of the column. If not provided, the width will be "auto"
+   */
+  width?: ColumnWidth
+
   render: (item: T) => ReactNode
 }
 


### PR DESCRIPTION
## Description

Columns in the `OneTable` component has a default auto width, but we also let the user choose a percentage width for each one. This PR adds this feature also to the `DataCollection` table.

## Screenshots

<img width="797" alt="image" src="https://github.com/user-attachments/assets/8dbc47e5-b36a-4214-858f-b8a3bf83eb1d" />

_In this screenshot, the first column has a 40% width, while the others have 20%_

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
