### PR TITLE
Better type discrimination

### DIFF
--- a/lib/experimental/Collections/useData.ts
+++ b/lib/experimental/Collections/useData.ts
@@ -194,7 +194,7 @@ export function useData<
         }
 
         const observable: Observable<DataType<ResultType>> =
-          result instanceof Observable ? result : promiseToObservable(result)
+          "subscribe" in result ? result : promiseToObservable(result)
 
         const subscription = observable.subscribe({
           next: (state) => {


### PR DESCRIPTION
## Description

`Observable` doesn't mean the same in `Factorial` than in `Factorial One`, as the bundled libraries are different. This was making observables fail. Checking for "subscribe" serves as a discrimination and it's more reliable!

## Screenshots (if applicable)

*None*

### Figma Link

*None*

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other
