### PR TITLE
Add maturity table to documentation

### DIFF
--- a/docs/components/OneMeta.tsx
+++ b/docs/components/OneMeta.tsx
@@ -1,7 +1,7 @@
 import { Meta, Title, Unstyled } from "@storybook/blocks"
 
 import { ComponentProps } from "react"
-import { Check, Cross, ExternalLink } from "../../icons/app"
+import { Check, Cross, ExternalLink } from "../../lib/icons/app"
 import { Icon } from "../../lib/components/Utilities/Icon"
 
 type OneMetaProps = {
@@ -42,7 +42,7 @@ const Status = ({ value }: { value: boolean }) => (
   <div>
     <Icon
       icon={value ? Check : Cross}
-      className={value ? "" : "translate-y-0.5"}
+      className={value ? "translate-y-[1px]" : "translate-y-0.5"}
     />
   </div>
 )

--- a/docs/components/OneMeta.tsx
+++ b/docs/components/OneMeta.tsx
@@ -7,6 +7,9 @@ import { Icon } from "../../lib/components/Utilities/Icon"
 type OneMetaProps = {
   title: string
   maturity: {
+    /**
+     * Direct link to Figma Component or null if it doesn't exist
+     */
     figmaComponent: string | null
     /**
      * Whether the component has unit and screenshot tests

--- a/docs/components/OneMeta.tsx
+++ b/docs/components/OneMeta.tsx
@@ -1,0 +1,89 @@
+import { Meta, Title, Unstyled } from "@storybook/blocks"
+
+import { ComponentProps } from "react"
+import { Check, Cross, ExternalLink } from "../../icons/app"
+import { Icon } from "../../lib/components/Utilities/Icon"
+
+type OneMetaProps = {
+  title: string
+  maturity: {
+    figmaComponent: string | null
+    /**
+     * Whether the component has unit and screenshot tests
+     */
+    tested: boolean
+    /**
+     * Whether the component adjusts layout or behavior
+     * based on the size or orientation of the display or viewport
+     */
+    responsive: boolean
+    /**
+     * Whether the component meets the  AA accessibility level
+     */
+    accessibility: boolean
+    /**
+     * Whether the component contains full documentation
+     * (false if it has the basic one)
+     */
+    documentation: boolean
+    /**
+     * Whether the component exposes the composable API.
+     * It is a low-level API allowing the users to reconstruct the component using
+     * exposed blocks
+     */
+    composableApi: boolean
+  }
+} & Omit<ComponentProps<typeof Meta>, "title">
+
+const Status = ({ value }: { value: boolean }) => (
+  <div>
+    <Icon
+      icon={value ? Check : Cross}
+      className={value ? "" : "translate-y-0.5"}
+    />
+  </div>
+)
+
+export const OneMeta = ({ title, maturity, ...rest }: OneMetaProps) => {
+  return (
+    <>
+      <Meta {...rest} />
+      <Title>{title}</Title>
+      <Unstyled>
+        <div className="mb-6 flex flex-wrap items-center gap-2 *:flex *:items-center *:text-sm">
+          {maturity.figmaComponent && (
+            <a
+              href={maturity.figmaComponent}
+              target="_blank"
+              rel="noreferrer"
+              className="no-underline"
+            >
+              Figma <Icon icon={ExternalLink} />
+            </a>
+          )}
+          {maturity.figmaComponent === null && (
+            <div>
+              Figma <Status value={false} />
+            </div>
+          )}
+          <div>
+            Documentation <Status value={maturity.documentation} />
+          </div>
+
+          <div>
+            Tested <Status value={maturity.tested} />
+          </div>
+          <div>
+            Responsive <Status value={maturity.responsive} />
+          </div>
+          <div>
+            Accessibility <Status value={maturity.accessibility} />
+          </div>
+          <div>
+            Composable API <Status value={maturity.composableApi} />
+          </div>
+        </div>
+      </Unstyled>
+    </>
+  )
+}

--- a/docs/components/OneMeta.tsx
+++ b/docs/components/OneMeta.tsx
@@ -50,7 +50,7 @@ export const OneMeta = ({ title, maturity, ...rest }: OneMetaProps) => {
       <Meta {...rest} />
       <Title>{title}</Title>
       <Unstyled>
-        <div className="mb-6 flex flex-wrap items-center gap-2 *:flex *:items-center *:text-sm">
+        <div className="mb-6 flex flex-wrap items-center gap-2.5 *:flex *:items-center *:text-sm">
           {maturity.figmaComponent && (
             <a
               href={maturity.figmaComponent}

--- a/lib/experimental/Information/Badge/index.mdx
+++ b/lib/experimental/Information/Badge/index.mdx
@@ -1,9 +1,20 @@
 import { Canvas, Meta, Unstyled } from "@storybook/blocks"
 import * as BadgeStories from "./index.stories"
+import { OneMeta } from "~/docs/components/OneMeta"
 
-<Meta of={BadgeStories} />
-
-# Badge
+<OneMeta
+  of={BadgeStories}
+  maturity={{
+    figmaComponent:
+      "https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=2378-105583&t=1Q0nr9ZJG6p9bJyy-0",
+    documentation: false,
+    composableApi: false,
+    responsive: true,
+    tested: false,
+    accessibility: false,
+  }}
+  title="Badge"
+/>
 
 Badges are compact visual indicators. They provide quick visual cues to users
 about the state or nature of an item.

--- a/lib/experimental/Information/Badge/index.mdx
+++ b/lib/experimental/Information/Badge/index.mdx
@@ -1,9 +1,10 @@
-import { Canvas, Meta, Unstyled } from "@storybook/blocks"
+import { Canvas, Unstyled } from "@storybook/blocks"
 import * as BadgeStories from "./index.stories"
 import { OneMeta } from "~/docs/components/OneMeta"
 
 <OneMeta
   of={BadgeStories}
+  title="Badge"
   maturity={{
     figmaComponent:
       "https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=2378-105583&t=1Q0nr9ZJG6p9bJyy-0",
@@ -13,7 +14,6 @@ import { OneMeta } from "~/docs/components/OneMeta"
     tested: false,
     accessibility: false,
   }}
-  title="Badge"
 />
 
 Badges are compact visual indicators. They provide quick visual cues to users


### PR DESCRIPTION
## Description

Instead of having 99% of the library marked experimental, let's provide granular information about the state of components.

## How

Use `OneMeta` component instead of built-in `Meta`. It requires you to pass a maturity object and renders the table based on it.


https://github.com/user-attachments/assets/733eae6a-3414-4550-a687-5b00e3fcc407

![CleanShot 2025-03-04 at 18 09 22@2x](https://github.com/user-attachments/assets/ed84c726-413b-440d-b994-d9c453903c71)

