### PR TITLE
Set new typography size

### DIFF
--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -21,7 +21,7 @@ app is 14px when used with the default browser settings.
     <tbody>
       <tr>
         <td>
-          <pre className="inline">text-3xl</pre>
+          <pre className="inline">text-4xl</pre>
         </td>
         <td>36px</td>
         <td className="text-3xl">
@@ -30,9 +30,18 @@ app is 14px when used with the default browser settings.
       </tr>
       <tr>
         <td>
-          <pre className="inline">text-2xl</pre>
+          <pre className="inline">text-3xl</pre>
         </td>
         <td>26px</td>
+        <td className="text-3xl">
+          The quick brown fox jumped over the lazy dog.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <pre className="inline">text-2xl</pre>
+        </td>
+        <td>22px</td>
         <td className="text-2xl">
           The quick brown fox jumped over the lazy dog.
         </td>

--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -50,7 +50,7 @@ app is 14px when used with the default browser settings.
         <td>
           <pre className="inline">text-xl</pre>
         </td>
-        <td>22px</td>
+        <td>20px</td>
         <td className="text-xl">
           The quick brown fox jumped over the lazy dog.
         </td>

--- a/lib/components/Charts/PieChart/index.tsx
+++ b/lib/components/Charts/PieChart/index.tsx
@@ -98,7 +98,7 @@ export const _PieChart = (
                     <tspan
                       x={viewBox.cx}
                       y={(viewBox.cy || 0) + 8}
-                      className="text-4xl fill-f1-foreground font-semibold"
+                      className="fill-f1-foreground text-4xl font-semibold"
                     >
                       {overview?.number
                         ? tickFormatter

--- a/lib/components/Charts/PieChart/index.tsx
+++ b/lib/components/Charts/PieChart/index.tsx
@@ -98,7 +98,7 @@ export const _PieChart = (
                     <tspan
                       x={viewBox.cx}
                       y={(viewBox.cy || 0) + 8}
-                      className="fill-f1-foreground text-2xl font-semibold"
+                      className="text-4xl fill-f1-foreground font-semibold"
                     >
                       {overview?.number
                         ? tickFormatter

--- a/lib/components/Charts/RadialProgressChart/index.tsx
+++ b/lib/components/Charts/RadialProgressChart/index.tsx
@@ -51,7 +51,7 @@ export function RadialProgressChart({
           <span className="text-sm text-f1-foreground-secondary">
             {overview.label}
           </span>
-          <span className="text-2xl font-semibold leading-none text-f1-foreground">
+          <span className="text-4xl font-semibold leading-none text-f1-foreground">
             {overview.number}
           </span>
         </div>

--- a/lib/experimental/Information/Avatars/AvatarList/MaxCounter.tsx
+++ b/lib/experimental/Information/Avatars/AvatarList/MaxCounter.tsx
@@ -14,8 +14,8 @@ const sizeVariants = cva({
       xsmall: "h-5 w-5 rounded-xs text-sm",
       small: "h-6 min-w-6 rounded-sm px-1 text-sm",
       medium: "h-8 min-w-8 rounded px-1.5",
-      large: "h-14 min-w-14 rounded-xl px-3 text-xl",
-      xlarge: "h-18 min-w-18 rounded-[20px] px-4 text-2xl",
+      large: "h-14 min-w-14 rounded-xl px-3 text-2xl",
+      xlarge: "h-18 min-w-18 rounded-[20px] px-4 text-3xl",
     },
     type: {
       base: "",

--- a/lib/experimental/Information/Communities/Post/PostDescription/TextEditorTheme.css
+++ b/lib/experimental/Information/Communities/Post/PostDescription/TextEditorTheme.css
@@ -25,15 +25,15 @@
 }
 
 .FactorialOneTextEditor .TextEditorTheme__h1 {
-  @apply m-0 mb-3 p-0 text-xl font-semibold;
+  @apply m-0 mb-3 p-0 text-lg font-semibold;
 }
 
 .FactorialOneTextEditor .TextEditorTheme__h2 {
-  @apply m-0 mt-2.5 p-0 text-lg;
+  @apply m-0 mt-2.5 p-0 text-lg font-medium;
 }
 
 .FactorialOneTextEditor .TextEditorTheme__h3 {
-  @apply m-0 mt-2.5 p-0 text-base;
+  @apply m-0 mt-2.5 p-0 text-base font-semibold;
 }
 
 .FactorialOneTextEditor .TextEditorTheme__textBold {

--- a/lib/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/lib/experimental/Information/Headers/BaseHeader/index.tsx
@@ -143,7 +143,7 @@ export function BaseHeader({
             </div>
           )}
           <div className="flex flex-col gap-1">
-            <span className="text-xl font-semibold text-f1-foreground">
+            <span className="text-2xl font-semibold text-f1-foreground">
               {title}
             </span>
             {description && (

--- a/lib/experimental/Navigation/Header/Breadcrumbs/index.tsx
+++ b/lib/experimental/Navigation/Header/Breadcrumbs/index.tsx
@@ -186,7 +186,7 @@ const BreadcrumbContent = React.forwardRef<
       className={cn(
         "flex items-center gap-2 px-1.5",
         isFirst && "pl-0",
-        isOnly && "text-xl font-semibold"
+        isOnly && "text-2xl font-semibold"
       )}
       transition={{ duration: 0.15 }}
     >

--- a/lib/experimental/Widgets/Content/CategoryBarSection/index.tsx
+++ b/lib/experimental/Widgets/Content/CategoryBarSection/index.tsx
@@ -24,7 +24,7 @@ export function CategoryBarSection({
   return (
     <div>
       <div className="flex items-baseline justify-between">
-        <span className="text-2xl font-semibold">{title}</span>
+        <span className="text-3xl font-semibold">{title}</span>
         <span className="text-xl text-f1-foreground-secondary">{subtitle}</span>
       </div>
       <div className="mt-2">

--- a/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
@@ -100,7 +100,7 @@ export function ClockInControls({
           <div className="flex-1 space-y-4">
             <div className="flex flex-col items-center space-y-0.5 @xs:items-start">
               <div className="flex items-center gap-2">
-                <span className="line-clamp-1 text-xl font-semibold text-f1-foreground">
+                <span className="line-clamp-1 text-2xl font-semibold text-f1-foreground">
                   {statusText}
                 </span>
                 <div className="relative aspect-square h-4">

--- a/lib/experimental/Widgets/Content/ClockIn/ClockInGraph/index.tsx
+++ b/lib/experimental/Widgets/Content/ClockIn/ClockInGraph/index.tsx
@@ -62,7 +62,7 @@ export function ClockInGraph({
 
       {/* Time display */}
       <div className="absolute inset-0 flex items-center justify-center">
-        <span className="text-2xl font-semibold tabular-nums text-f1-foreground">
+        <span className="text-3xl font-semibold tabular-nums text-f1-foreground">
           {time}
         </span>
       </div>

--- a/lib/experimental/Widgets/Content/Highlights/WidgetHighlightButton/index.tsx
+++ b/lib/experimental/Widgets/Content/Highlights/WidgetHighlightButton/index.tsx
@@ -59,7 +59,7 @@ export function WidgetHighlightButton({
           </p>
           <Icon icon={icon} size="md" className={iconClassName} />
         </div>
-        <p className="line-clamp-1 flex-1 text-2xl font-semibold text-f1-foreground">
+        <p className="line-clamp-1 flex-1 text-3xl font-semibold text-f1-foreground">
           {count}
         </p>
       </div>

--- a/lib/experimental/Widgets/Widget/index.tsx
+++ b/lib/experimental/Widgets/Widget/index.tsx
@@ -161,7 +161,7 @@ const Container = forwardRef<
                 <div className="mb-0.5 text-sm text-f1-foreground-secondary">
                   {summary.label}
                 </div>
-                <div className="flex flex-row items-end gap-0.5 text-xl font-semibold">
+                <div className="flex flex-row items-end gap-0.5 text-2xl font-semibold">
                   {!!summary.prefixUnit && (
                     <div className="text-lg font-medium">
                       {summary.prefixUnit}

--- a/lib/ui/avatar.tsx
+++ b/lib/ui/avatar.tsx
@@ -31,8 +31,8 @@ export const avatarVariants = cva({
       xsmall: "size-5 rounded-xs text-sm",
       small: "size-6 rounded-sm text-sm",
       medium: "size-8 rounded",
-      large: "size-14 rounded-xl text-xl",
-      xlarge: "size-18 rounded-[20px] text-2xl",
+      large: "size-14 rounded-xl text-2xl",
+      xlarge: "size-18 rounded-[20px] text-3xl",
     } satisfies Record<(typeof sizes)[number], string>,
     type: {
       base: "",

--- a/lib/ui/card.tsx
+++ b/lib/ui/card.tsx
@@ -136,7 +136,7 @@ const CardComment = React.forwardRef<
   return (
     <div
       ref={ref}
-      className={cn("flex text-2xl font-semibold", className)}
+      className={cn("flex text-3xl font-semibold", className)}
       {...props}
     />
   )

--- a/lib/ui/indicator.tsx
+++ b/lib/ui/indicator.tsx
@@ -13,7 +13,7 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
   function Indicator({ content, label, icon, color }, ref) {
     return (
       <div key={label} className="grid-row-2 col-span-1 grid" ref={ref}>
-        <p className="text-2xl font-semibold">{content}</p>
+        <p className="text-3xl font-semibold">{content}</p>
         <div className="flex items-center gap-1">
           <p
             className="line-clamp-1 text-f1-foreground-secondary"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -64,20 +64,27 @@ export default {
         },
       ],
       xl: [
-        "1.375rem",
+        "1.125rem",
         {
           lineHeight: "1.75rem",
           letterSpacing: "-0.01em",
         },
       ],
       "2xl": [
+        "1.375rem",
+        {
+          lineHeight: "1.75rem",
+          letterSpacing: "-0.01em",
+        },
+      ],
+      "3xl": [
         "1.625rem",
         {
           lineHeight: "2rem",
           letterSpacing: "-0.01em",
         },
       ],
-      "3xl": [
+      "4xl": [
         "2.25rem",
         {
           lineHeight: "2.5rem",


### PR DESCRIPTION
## Description

Add a missing text size (20px), which becomes the xl size, and bumps up the rest of the higher text sizes we had. We have this size in figma but it was missing in code.

i've changed the size where we were using one of the affected sizes.

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other