### PR TITLE
Dynamic dots in Carousel + small fixes

### DIFF
--- a/lib/ui/carousel.tsx
+++ b/lib/ui/carousel.tsx
@@ -221,7 +221,7 @@ const CarouselPrevious = React.forwardRef<
     <div
       className={cn(
         "absolute flex h-6 w-6 items-center justify-center rounded-sm bg-f1-background opacity-0 backdrop-blur-sm transition-opacity group-hover/carousel:opacity-100",
-        !canScrollPrev && "disabled:opacity-0",
+        !canScrollPrev && "opacity-0 group-hover/carousel:opacity-0",
         orientation === "horizontal"
           ? "-left-3 top-1/2 -translate-y-1/2"
           : "-top-3 left-1/2 -translate-x-1/2 rotate-90"
@@ -259,7 +259,7 @@ const CarouselNext = React.forwardRef<
     <div
       className={cn(
         "absolute flex h-6 w-6 items-center justify-center rounded-sm bg-f1-background opacity-0 backdrop-blur-sm transition-opacity group-hover/carousel:opacity-100",
-        !canScrollNext && "disabled:opacity-0",
+        !canScrollNext && "opacity-0 group-hover/carousel:opacity-0",
         orientation === "horizontal"
           ? "-right-3 top-1/2 -translate-y-1/2"
           : "-bottom-3 left-1/2 -translate-x-1/2 rotate-90"
@@ -325,6 +325,25 @@ const CarouselDots = React.forwardRef<
     })
   }, [currentSlide])
 
+  // Prevent user scrolling
+  React.useEffect(() => {
+    const container = dotsContainerRef.current
+    if (!container) return
+
+    const preventScroll = (e: Event) => {
+      e.preventDefault()
+      e.stopPropagation()
+    }
+
+    container.addEventListener("wheel", preventScroll, { passive: false })
+    container.addEventListener("touchmove", preventScroll, { passive: false })
+
+    return () => {
+      container.removeEventListener("wheel", preventScroll)
+      container.removeEventListener("touchmove", preventScroll)
+    }
+  }, [])
+
   if (numberOfSlides <= 1) {
     return null
   }
@@ -359,7 +378,7 @@ const CarouselDots = React.forwardRef<
       >
         <div
           ref={dotsContainerRef}
-          className="pointer-events-none flex w-full touch-none select-none gap-0 overflow-x-scroll"
+          className="flex w-full gap-0 overflow-x-scroll"
           style={{
             scrollbarWidth: "none",
             overscrollBehavior: "none",
@@ -371,6 +390,7 @@ const CarouselDots = React.forwardRef<
               className="group/dot flex h-4 w-4 flex-shrink-0 items-center justify-center p-0"
               aria-label={`Go to slide ${i + 1}`}
               onClick={() => api?.scrollTo(i)}
+              tabIndex={-1}
             >
               <div
                 className={cn(

--- a/lib/ui/carousel.tsx
+++ b/lib/ui/carousel.tsx
@@ -383,12 +383,24 @@ const CarouselDots = React.forwardRef<
             scrollbarWidth: "none",
             overscrollBehavior: "none",
           }}
+          tabIndex={0}
+          aria-label="Carousel pagination"
+          onKeyDown={(e) => {
+            if (e.key === "ArrowLeft") {
+              e.preventDefault()
+              api?.scrollPrev()
+            } else if (e.key === "ArrowRight") {
+              e.preventDefault()
+              api?.scrollNext()
+            }
+          }}
         >
           {allDots.map((i) => (
             <button
               key={i}
               className="group/dot flex h-4 w-4 flex-shrink-0 items-center justify-center p-0"
               aria-label={`Go to slide ${i + 1}`}
+              aria-current={i === currentSlide ? "true" : undefined}
               onClick={() => api?.scrollTo(i)}
               tabIndex={-1}
             >


### PR DESCRIPTION
## Description

Make the dots in the Carousel a bit more dynamic:

- If there are more than 5 pages in the carousel, [the dots display a different design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-Components?node-id=7369-4197&t=ixCg1og6rh4vJJHr-4), to avoid displaying a huge list of dots.
- Dots can be clicked to go to a specific page.
- Left/Right arrows are only shown when the user has the cursor over the carousel.
- Left/Right arrows have a container with a background to avoid merging the buttons colors with the background.

## Screenshots

https://github.com/user-attachments/assets/6718dd55-cabd-4de8-af5a-5b6c5b51cf43

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other