### PR TITLE
Use <Link /> in tables

### DIFF
--- a/lib/experimental/Collections/Table/index.tsx
+++ b/lib/experimental/Collections/Table/index.tsx
@@ -156,10 +156,7 @@ export const TableCollection = <
         </TableHeader>
         <TableBody>
           {data.map((item, index) => {
-            const itemHref =
-              "href" in item && typeof item.href === "string"
-                ? item.href
-                : undefined
+            const itemHref = source.itemUrl ? source.itemUrl(item) : undefined
 
             return (
               <TableRow key={`row-${index}`}>

--- a/lib/experimental/Collections/index.stories.tsx
+++ b/lib/experimental/Collections/index.stories.tsx
@@ -71,7 +71,6 @@ const mockUsers = [
     department: DEPARTMENTS[0],
     status: "active",
     isStarred: true,
-    href: "/users/john-doe",
   },
   {
     id: "user-2",
@@ -81,7 +80,6 @@ const mockUsers = [
     department: DEPARTMENTS[1],
     status: "active",
     isStarred: false,
-    href: "/users/jane-smith",
   },
   {
     id: "user-3",
@@ -91,7 +89,6 @@ const mockUsers = [
     department: DEPARTMENTS[2],
     status: "inactive",
     isStarred: false,
-    href: "/users/bob-johnson",
   },
   {
     id: "user-4",
@@ -101,7 +98,6 @@ const mockUsers = [
     department: DEPARTMENTS[3],
     status: "active",
     isStarred: true,
-    href: "/users/alice-williams",
   },
 ]
 
@@ -428,6 +424,122 @@ export const BasicTableView: Story = {
                     label: "Department",
                     render: (item) => item.department,
                     sorting: "department",
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      </div>
+    )
+  },
+}
+
+// Basic examples with single visualization
+export const WithLinkedItems: Story = {
+  render: () => {
+    const dataSource = useDataSource({
+      filters,
+      presets: filterPresets,
+      itemUrl: (item) => `/users/${item.id}`,
+      sortings: {
+        name: {
+          label: "Name",
+        },
+        email: {
+          label: "Email",
+        },
+        role: {
+          label: "Role",
+        },
+        department: {
+          label: "Department",
+        },
+      },
+      dataAdapter: {
+        fetchData: createPromiseDataFetch(),
+      },
+      actions: (item) => [
+        {
+          label: "Edit",
+          icon: Pencil,
+          onClick: () => console.log(`Editing ${item.name}`),
+          description: "Modify user information",
+        },
+        {
+          label: "View Profile",
+          icon: Ai,
+          onClick: () => console.log(`Viewing ${item.name}'s profile`),
+        },
+        "separator",
+        {
+          label: item.isStarred ? "Remove Star" : "Star User",
+          icon: Star,
+          onClick: () => console.log(`Toggling star for ${item.name}`),
+          description: item.isStarred
+            ? "Remove from favorites"
+            : "Add to favorites",
+        },
+        {
+          label: "Delete",
+          icon: Delete,
+          onClick: () => console.log(`Deleting ${item.name}`),
+          critical: true,
+          description: "Permanently remove user",
+          enabled:
+            item.department === "Engineering" && item.status === "active",
+        },
+      ],
+    })
+
+    return (
+      <div className="space-y-4">
+        <DataCollection
+          source={dataSource}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                columns: [
+                  {
+                    label: "Name",
+                    render: (item) => item.name,
+                    sorting: "name",
+                  },
+                  {
+                    label: "Email",
+                    render: (item) => item.email,
+                    sorting: "email",
+                  },
+                  {
+                    label: "Role",
+                    render: (item) => item.role,
+                    sorting: "role",
+                  },
+                  {
+                    label: "Department",
+                    render: (item) => item.department,
+                    sorting: "department",
+                  },
+                ],
+              },
+            },
+            {
+              type: "card",
+              options: {
+                title: (item) => item.name,
+                cardProperties: [
+                  {
+                    label: "Email",
+                    render: (item) => item.email,
+                  },
+                  {
+                    label: "Role",
+                    render: (item) => item.role,
+                  },
+                  {
+                    label: "Department",
+                    render: (item) => item.department,
                   },
                 ],
               },

--- a/lib/experimental/Collections/index.tsx
+++ b/lib/experimental/Collections/index.tsx
@@ -45,12 +45,9 @@ export const useDataSource = <
   Actions extends ActionsDefinition<Record>,
 >(
   {
-    filters,
     currentFilters: initialCurrentFilters = {},
-    dataAdapter,
-    actions,
-    presets,
-    sortings,
+    filters,
+    ...rest
   }: DataSourceDefinition<Record, Filters, Sortings, Actions>,
   deps: ReadonlyArray<unknown> = []
 ): DataSource<Record, Filters, Sortings, Actions> => {
@@ -68,12 +65,9 @@ export const useDataSource = <
     filters: memoizedFilters,
     currentFilters,
     setCurrentFilters,
-    dataAdapter,
-    actions,
-    presets,
-    sortings,
     currentSortings,
     setCurrentSortings,
+    ...rest,
   }
 }
 

--- a/lib/experimental/Collections/types.ts
+++ b/lib/experimental/Collections/types.ts
@@ -20,6 +20,8 @@ export type DataSourceDefinition<
   filters?: Filters
   /** Predefined filter configurations that can be applied */
   presets?: Presets<Filters>
+  /** URL for a single item in the collection */
+  itemUrl?: (item: Record) => string
   /** Available actions that can be performed on records */
   actions?: Actions
   /** Current state of applied filters */

--- a/lib/experimental/OneTable/TableCell/index.tsx
+++ b/lib/experimental/OneTable/TableCell/index.tsx
@@ -1,4 +1,5 @@
 import { useI18n } from "@/lib/i18n-provider"
+import { Link } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
 import { TableCell as TableCellRoot } from "@/ui/table"
 import { AnimatePresence, motion } from "framer-motion"
@@ -63,13 +64,13 @@ export function TableCell({
         {children}
       </div>
       {href && (
-        <a
+        <Link
           href={href}
           className="absolute inset-0 block"
           tabIndex={firstCell ? undefined : -1}
         >
           <span className="sr-only">{actions.view}</span>
-        </a>
+        </Link>
       )}
     </TableCellRoot>
   )


### PR DESCRIPTION
## Description

Tables were using a straight `a` element, and also trusting an `href` property in items. This adds an `itemUrl` function to figure that out, and uses the `<Link />` to render it, which will delegate to react routes on production.

## Screenshots (if applicable)

*None*

### Figma Link

*None*

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other
