### PR TITLE
fix: Use `primary-navigation` as `aria-label` when it is primary navigation

### DIFF
--- a/lib/experimental/Navigation/Tabs/index.spec.tsx
+++ b/lib/experimental/Navigation/Tabs/index.spec.tsx
@@ -54,7 +54,7 @@ describe("Tabs", () => {
     render(<BaseTabs tabs={defaultTabs} secondary />)
 
     const nav = screen.getByRole("navigation")
-    expect(nav).toHaveAttribute("aria-label", "primary-navigation")
+    expect(nav).toHaveAttribute("aria-label", "secondary-navigation")
   })
 
   describe("TabsSkeleton", () => {

--- a/lib/experimental/Navigation/Tabs/index.tsx
+++ b/lib/experimental/Navigation/Tabs/index.tsx
@@ -33,7 +33,7 @@ export const BaseTabs: React.FC<TabsProps> = ({
     <TabNavigation
       secondary={secondary}
       asChild
-      aria-label={secondary ? "primary-navigation" : "secondary-navigation"}
+      aria-label={secondary ? "secondary-navigation" : "primary-navigation"}
     >
       {visibleTabs.length === 1 ? (
         <li className="flex h-8 items-center justify-center whitespace-nowrap text-lg font-medium text-f1-foreground">


### PR DESCRIPTION
## Description

I have asked Claude for a Haiku to celebrate my first PR in Factorial one

> Cursor guides with care
> Sometimes perfect, sometimes not
> Perhaps not its fault

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other