### PR TITLE
Update Dialog component

### DIFF
--- a/lib/experimental/Information/Avatars/AlertAvatar/index.tsx
+++ b/lib/experimental/Information/Avatars/AlertAvatar/index.tsx
@@ -24,7 +24,7 @@ const alertAvatarVariants = cva({
   },
 })
 
-type Props = VariantProps<typeof alertAvatarVariants> & {
+export type Props = VariantProps<typeof alertAvatarVariants> & {
   type: "critical" | "warning" | "info"
   size?: "sm" | "md" | "lg"
 }

--- a/lib/experimental/Overlays/Dialog/index.stories.tsx
+++ b/lib/experimental/Overlays/Dialog/index.stories.tsx
@@ -1,6 +1,7 @@
+import { Button } from "@/components/Actions/Button"
+import { Delete } from "@/icons/app"
 import type { Meta, StoryObj } from "@storybook/react"
-
-import { LogoAvatar } from "@/icons/app"
+import { useState } from "react"
 import { Dialog } from "."
 
 const meta = {
@@ -8,66 +9,119 @@ const meta = {
   component: Dialog,
   parameters: {
     layout: "fullscreen",
-    a11y: {
-      skipCi: true,
-    },
     docs: {
-      story: { inline: false, height: "800px" },
+      story: { inline: false, height: "400px" },
     },
   },
   args: {
-    children: <span>Dialog Content</span>,
+    header: {
+      title: "Remove job opening",
+      description:
+        "If you cancel the job opening, you won’t see it on your company’s career page or receive new candidates.",
+      type: "critical",
+    },
+    actions: {
+      primary: {
+        label: "Remove",
+        icon: Delete,
+        onClick: () => alert("Remove"),
+        variant: "critical",
+      },
+      secondary: {
+        label: "Cancel",
+        onClick: () => alert("Cancel"),
+      },
+    },
     open: true,
   },
-  tags: ["autodocs", "experimental", "no-sidebar"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof Dialog>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Basic: Story = {}
+export const Critical: Story = {}
 
-export const Header: Story = {
+export const Warning: Story = {
   args: {
     header: {
-      title: "Dialog title",
-      description: "Dialog description",
-      icon: LogoAvatar,
+      title: "Top up account",
+      description:
+        "Your account balance is under 1.000,00 €. Top up to avoid failed payments.",
+      type: "warning",
     },
-  },
-}
-
-export const WithActions: Story = {
-  args: {
-    ...Header.args,
     actions: {
       primary: {
-        label: "Primary",
-        onClick: () => alert("Primary"),
+        label: "Add money",
+        onClick: () => alert("Add money"),
       },
       secondary: {
-        label: "Secondary",
-        onClick: () => alert("Secondary"),
+        label: "Cancel",
+        onClick: () => alert("Cancel"),
       },
     },
   },
 }
 
-export const Overflow: Story = {
+export const Info: Story = {
   args: {
-    children: (
-      <>
-        {Array.from({ length: 100 }).map((_, i) => (
-          <p key={i}>Content</p>
-        ))}
-      </>
-    ),
+    header: {
+      title: "Account number is missing",
+      description:
+        "Hellen the HR’s account number is missing. Review now to avoid failed payroll.",
+      type: "info",
+    },
+    actions: {
+      primary: {
+        label: "Review",
+        onClick: () => alert("Review"),
+        variant: "neutral",
+      },
+      secondary: {
+        label: "Cancel",
+        onClick: () => alert("Cancel"),
+      },
+    },
   },
 }
 
-export const Loading: Story = {
-  args: {
-    ...WithActions.args,
-    loading: true,
+export const WithTrigger = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false)
+
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <Button
+          variant="critical"
+          icon={Delete}
+          label="Delete file"
+          onClick={() => setIsOpen(true)}
+        />
+        <Dialog
+          open={isOpen}
+          onClose={() => setIsOpen(false)}
+          header={{
+            title: "Delete file",
+            description: "Are you sure you want to delete this file?",
+            type: "critical",
+          }}
+          actions={{
+            primary: {
+              label: "Delete",
+              icon: Delete,
+              variant: "critical",
+              onClick: () => {
+                alert("Confirmed")
+                setIsOpen(false)
+              },
+            },
+            secondary: {
+              label: "Cancel",
+              onClick: () => setIsOpen(false),
+            },
+          }}
+        />
+      </div>
+    )
   },
 }

--- a/lib/experimental/Overlays/Dialog/index.tsx
+++ b/lib/experimental/Overlays/Dialog/index.tsx
@@ -1,37 +1,42 @@
 import { Button, ButtonProps } from "@/components/Actions/Button"
-import { Icon, IconType } from "@/components/Utilities/Icon"
+import {
+  AlertAvatar,
+  type Props as AlertAvatarProps,
+} from "@/experimental/Information/Avatars/AlertAvatar"
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogIcon,
   DialogTitle,
 } from "@/ui/dialog"
-import { Skeleton } from "@/ui/skeleton"
-import { forwardRef, ReactNode, useCallback, useState } from "react"
+import { forwardRef, useCallback, useState } from "react"
 
-type Action = Pick<ButtonProps, "label" | "onClick" | "disabled">
+type BaseAction = Pick<ButtonProps, "label" | "onClick" | "icon" | "disabled">
+
+type PrimaryActionVariant = "default" | "critical" | "neutral"
+type PrimaryAction = BaseAction & {
+  variant?: PrimaryActionVariant
+}
+type SecondaryAction = BaseAction
 
 type DialogProps = {
-  header?: {
-    icon?: IconType
+  header: {
+    type: AlertAvatarProps["type"]
     title: string
     description: string
   }
-  actions?: {
-    primary: Action
-    secondary?: Action
+  actions: {
+    primary: PrimaryAction
+    secondary: SecondaryAction
   }
-  loading?: boolean
-  children: ReactNode
   open?: boolean
   onClose?: () => void
 }
 
 const OneDialog = forwardRef<HTMLDivElement, DialogProps>(
-  ({ header, children, loading, actions, open, onClose }, ref) => {
+  ({ header, actions, open, onClose }, ref) => {
     // We do this in order to give the illusion of a controlled state via `open`, but in reality
     // we're taking control and closing the dialog after a few milliseconds to give the closing
     // animation time to play out.
@@ -53,34 +58,38 @@ const OneDialog = forwardRef<HTMLDivElement, DialogProps>(
         open={open && !closing}
         onOpenChange={(open) => !open && handleClose?.()}
       >
-        <DialogContent ref={ref}>
-          {header && (
-            <DialogHeader>
-              {header.icon && (
-                <DialogIcon>
-                  <Icon size="lg" icon={header.icon} />
-                </DialogIcon>
-              )}
-              <DialogTitle>{header.title}</DialogTitle>
-              <DialogDescription>{header.description}</DialogDescription>
-            </DialogHeader>
-          )}
-          <div className="flex-grow flex-col">
-            {loading ? (
-              <div className="flex flex-col gap-4">
-                <Skeleton className="h-6 w-full rounded-full" />
-                <Skeleton className="h-6 w-full rounded-full" />
-              </div>
-            ) : (
-              children
-            )}
-          </div>
+        <DialogContent
+          ref={ref}
+          className="bottom-3 top-auto max-w-[400px] translate-y-0 data-[state=closed]:slide-out-to-top-[2%] data-[state=open]:slide-in-from-top-[2%] sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%] sm:data-[state=closed]:slide-out-to-top-[48%] sm:data-[state=open]:slide-in-from-top-[48%]"
+        >
+          <DialogHeader className="flex flex-col gap-4 px-4 py-5">
+            <AlertAvatar type={header.type} size="lg" />
+            <div className="flex flex-col gap-0.5">
+              <DialogTitle className="text-xl sm:text-lg">
+                {header.title}
+              </DialogTitle>
+              <DialogDescription className="text-lg sm:text-base">
+                {header.description}
+              </DialogDescription>
+            </div>
+          </DialogHeader>
           {actions && (
-            <DialogFooter>
-              {actions.secondary && (
+            <DialogFooter className="px-4 pb-4 pt-2 [&_button]:w-full">
+              <div className="hidden sm:flex sm:flex-row sm:justify-between sm:gap-3">
                 <Button variant="outline" {...actions.secondary} />
-              )}
-              <Button variant="default" {...actions.primary} />
+                <Button
+                  {...actions.primary}
+                  variant={actions.primary.variant || "default"}
+                />
+              </div>
+              <div className="flex flex-col-reverse gap-2 sm:hidden">
+                <Button variant="outline" {...actions.secondary} size="lg" />
+                <Button
+                  {...actions.primary}
+                  variant={actions.primary.variant || "default"}
+                  size="lg"
+                />
+              </div>
             </DialogFooter>
           )}
         </DialogContent>

--- a/lib/ui/dialog.tsx
+++ b/lib/ui/dialog.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { cn } from "@/lib/utils"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
 import * as React from "react"
+
+import { cn } from "@/lib/utils"
 
 const Dialog = DialogPrimitive.Root
 
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-f1-background-bold/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-f1-background-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -31,50 +31,28 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => {
-  return (
-    <DialogPortal>
-      <DialogOverlay className="grid place-items-center overflow-y-auto sm:p-8">
-        <DialogPrimitive.Content
-          ref={ref}
-          onInteractOutside={(event) => event.preventDefault()}
-          className={cn(
-            "relative z-50 grid w-full origin-center gap-4 border bg-f1-background p-8 shadow-xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:w-fit sm:min-w-[400px] sm:rounded-xl md:min-w-[456px]",
-            className
-          )}
-          {...props}
-        >
-          {children}
-          <DialogPrimitive.Close className="ring-offset-background focus:ring-ring absolute right-2 top-2 rounded-2xs p-2 text-f1-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-f1-background-secondary data-[state=open]:text-f1-foreground-secondary">
-            <X className="h-5 w-5" />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        </DialogPrimitive.Content>
-      </DialogOverlay>
-    </DialogPortal>
-  )
-})
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-[90%] translate-x-[-50%] translate-y-[-50%] rounded-xl border bg-f1-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
 DialogContent.displayName = DialogPrimitive.Content.displayName
-
-const DialogIcon = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "text-icon-neutral-bold absolute left-8 top-0 h-16 w-16 translate-y-[-50%] rounded-xl bg-f1-background p-4 shadow-md",
-      className
-    )}
-    {...props}
-  />
-)
-DialogIcon.displayName = "DialogIcon"
 
 const DialogHeader = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("mt-5 flex flex-col text-left", className)} {...props} />
+  <div className={className} {...props} />
 )
 DialogHeader.displayName = "DialogHeader"
 
@@ -82,13 +60,7 @@ const DialogFooter = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "-mx-8 -mb-8 mt-4 flex flex-col-reverse gap-0 rounded-bl-xl rounded-br-xl border-0 border-t border-solid border-f1-border bg-f1-background-secondary/50 px-8 py-4 sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
+  <div className={className} {...props} />
 )
 DialogFooter.displayName = "DialogFooter"
 
@@ -98,7 +70,7 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("mt-1 text-xl font-medium leading-none", className)}
+    className={cn("text-lg font-medium text-f1-foreground", className)}
     {...props}
   />
 ))
@@ -110,7 +82,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("mt-2 text-base text-f1-foreground-secondary", className)}
+    className={cn("text-f1-foreground-secondary", className)}
     {...props}
   />
 ))
@@ -123,7 +95,6 @@ export {
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogIcon,
   DialogOverlay,
   DialogPortal,
   DialogTitle,


### PR DESCRIPTION
## Description

Updates the [Dialog](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Internal-Components?node-id=1382-14258) component according to what we have in Figma.

The current Dialog is a generic modal that's become obsolete (still using Gamma styles) and was pretty open-ended. Although we'll have a generic modal (still not design-ready), the Dialog modal in Figma has a much more specific purpose.

- The `OneDialog` component is transformed to a specific use case (confirmation dialogs) instead of a generic modal.
- The `Dialog` inside the ui folder now acts as a generic modal-like component, serving as a base for other components (like this one, or any other modals we create).

## Screenshots

<img width="528" alt="image" src="https://github.com/user-attachments/assets/7dc1ec1b-22e2-495a-a46a-4655d910b768" />

_Critical type dialog_

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Internal-Components?node-id=1382-14258)