### PR TITLE
Add date type to Metadata used in resource header

### DIFF
--- a/lib/experimental/Information/Headers/Metadata/MetadataValue.tsx
+++ b/lib/experimental/Information/Headers/Metadata/MetadataValue.tsx
@@ -1,0 +1,115 @@
+import { Icon, IconType } from "@/components/Utilities/Icon"
+import { Avatar } from "@/experimental/Information/Avatars/Avatar"
+import { AvatarList } from "@/experimental/Information/Avatars/AvatarList"
+import { DotTag } from "@/experimental/Information/Tags/DotTag"
+import { RawTag } from "@/experimental/Information/Tags/RawTag"
+import { StatusTag } from "@/experimental/Information/Tags/StatusTag"
+import { AlertCircle, Warning } from "@/icons/app"
+import { cn } from "@/lib/utils"
+import { MetadataItem, MetadataItemValue } from "./index"
+
+const DATE_ICON_STYLES: Record<
+  NonNullable<Extract<MetadataItemValue, { type: "date" }>["icon"]>,
+  { icon: IconType; iconColor: string; textColor: string }
+> = {
+  warning: {
+    icon: Warning,
+    iconColor: "text-f1-icon-warning",
+    textColor: "text-f1-foreground-warning",
+  },
+  critical: {
+    icon: AlertCircle,
+    iconColor: "text-f1-icon-critical",
+    textColor: "text-f1-foreground-critical",
+  },
+}
+
+export function MetadataValue({
+  item,
+  collapse = false,
+}: {
+  item: MetadataItem
+  collapse?: boolean
+}) {
+  switch (item.value.type) {
+    case "text":
+      return <span>{item.value.content}</span>
+
+    case "avatar":
+      return (
+        <div className="flex items-center gap-1">
+          <Avatar avatar={item.value.variant} size="xsmall" />
+          {item.value.text && <span>{item.value.text}</span>}
+        </div>
+      )
+
+    case "status":
+      return <StatusTag text={item.value.label} variant={item.value.variant} />
+    case "list":
+      return (
+        <AvatarList
+          avatars={item.value.avatars}
+          size="xsmall"
+          type={item.value.variant}
+          max={3}
+        />
+      )
+
+    case "data-list":
+      return collapse ? (
+        <div className="flex items-center justify-center gap-1 font-medium">
+          {item.value.data[0]}
+          {item.value.data.length > 1 && (
+            <span className="tabular-nums text-f1-foreground-secondary">
+              +{item.value.data.length - 1}
+            </span>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {item.value.data.map((data) => (
+            <span key={data}>{data}</span>
+          ))}
+        </div>
+      )
+
+    case "tag-list":
+      return collapse ? (
+        <div className="flex flex-wrap items-center justify-center gap-1 font-medium">
+          <RawTag text={item.value.tags[0]} />
+          {item.value.tags.length > 1 && (
+            <span className="tabular-nums text-f1-foreground-secondary">
+              +{item.value.tags.length - 1}
+            </span>
+          )}
+        </div>
+      ) : (
+        <div
+          className={cn(
+            "flex flex-col gap-1 [&>div]:w-fit",
+            item.value.tags.length > 1 && "-mt-[3px]"
+          )}
+        >
+          {item.value.tags.map((tag) => (
+            <RawTag key={tag} text={tag} />
+          ))}
+        </div>
+      )
+
+    case "dot-tag":
+      return <DotTag text={item.value.label} color={item.value.color} />
+    case "date": {
+      if (item.value.icon === undefined) {
+        return <span>{item.value.formattedDate}</span>
+      }
+
+      const { icon, iconColor, textColor } = DATE_ICON_STYLES[item.value.icon]
+      return (
+        <div className="flex items-center justify-center gap-0.5 font-medium">
+          <Icon icon={icon} className={iconColor} />
+          <span className={textColor}>{item.value.formattedDate}</span>
+        </div>
+      )
+    }
+  }
+}

--- a/lib/experimental/Information/Headers/Metadata/MetadataValue.tsx
+++ b/lib/experimental/Information/Headers/Metadata/MetadataValue.tsx
@@ -31,26 +31,27 @@ export function MetadataValue({
   item: MetadataItem
   collapse?: boolean
 }) {
-  switch (item.value.type) {
+  const { value } = item
+  switch (value.type) {
     case "text":
-      return <span>{item.value.content}</span>
+      return <span>{value.content}</span>
 
     case "avatar":
       return (
         <div className="flex items-center gap-1">
-          <Avatar avatar={item.value.variant} size="xsmall" />
-          {item.value.text && <span>{item.value.text}</span>}
+          <Avatar avatar={value.variant} size="xsmall" />
+          {value.text && <span>{value.text}</span>}
         </div>
       )
 
     case "status":
-      return <StatusTag text={item.value.label} variant={item.value.variant} />
+      return <StatusTag text={value.label} variant={value.variant} />
     case "list":
       return (
         <AvatarList
-          avatars={item.value.avatars}
+          avatars={value.avatars}
           size="xsmall"
-          type={item.value.variant}
+          type={value.variant}
           max={3}
         />
       )
@@ -58,16 +59,16 @@ export function MetadataValue({
     case "data-list":
       return collapse ? (
         <div className="flex items-center justify-center gap-1 font-medium">
-          {item.value.data[0]}
-          {item.value.data.length > 1 && (
+          {value.data[0]}
+          {value.data.length > 1 && (
             <span className="tabular-nums text-f1-foreground-secondary">
-              +{item.value.data.length - 1}
+              +{value.data.length - 1}
             </span>
           )}
         </div>
       ) : (
         <div className="flex flex-col gap-1.5">
-          {item.value.data.map((data) => (
+          {value.data.map((data) => (
             <span key={data}>{data}</span>
           ))}
         </div>
@@ -76,10 +77,10 @@ export function MetadataValue({
     case "tag-list":
       return collapse ? (
         <div className="flex flex-wrap items-center justify-center gap-1 font-medium">
-          <RawTag text={item.value.tags[0]} />
-          {item.value.tags.length > 1 && (
+          <RawTag text={value.tags[0]} />
+          {value.tags.length > 1 && (
             <span className="tabular-nums text-f1-foreground-secondary">
-              +{item.value.tags.length - 1}
+              +{value.tags.length - 1}
             </span>
           )}
         </div>
@@ -87,27 +88,27 @@ export function MetadataValue({
         <div
           className={cn(
             "flex flex-col gap-1 [&>div]:w-fit",
-            item.value.tags.length > 1 && "-mt-[3px]"
+            value.tags.length > 1 && "-mt-[3px]"
           )}
         >
-          {item.value.tags.map((tag) => (
+          {value.tags.map((tag) => (
             <RawTag key={tag} text={tag} />
           ))}
         </div>
       )
 
     case "dot-tag":
-      return <DotTag text={item.value.label} color={item.value.color} />
+      return <DotTag text={value.label} color={value.color} />
     case "date": {
-      if (item.value.icon === undefined) {
-        return <span>{item.value.formattedDate}</span>
+      if (value.icon === undefined) {
+        return <span>{value.formattedDate}</span>
       }
 
-      const { icon, iconColor, textColor } = DATE_ICON_STYLES[item.value.icon]
+      const { icon, iconColor, textColor } = DATE_ICON_STYLES[value.icon]
       return (
         <div className="flex items-center justify-center gap-0.5 font-medium">
           <Icon icon={icon} className={iconColor} />
-          <span className={textColor}>{item.value.formattedDate}</span>
+          <span className={textColor}>{value.formattedDate}</span>
         </div>
       )
     }

--- a/lib/experimental/Information/Headers/Metadata/index.stories.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.stories.tsx
@@ -110,9 +110,9 @@ export const Default: Story = {
         value: {
           type: "date",
           formattedDate: new Date().toLocaleDateString(),
-          icon: "warning"
-        }
-      }
+          icon: "warning",
+        },
+      },
     ],
   },
 }
@@ -141,16 +141,16 @@ export const WithActions: Story = {
         value: {
           type: "date",
           formattedDate: new Date().toLocaleDateString(),
-          icon: "critical"
+          icon: "critical",
         },
         actions: [
           {
             label: "Copy",
             icon: Icon.LayersFront,
             onClick: fn(),
-          }
-        ]
-      }
+          },
+        ],
+      },
     ],
   },
 }

--- a/lib/experimental/Information/Headers/Metadata/index.stories.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Metadata> = {
   parameters: {
     layout: "padded",
   },
-  tags: ["no-sidebar"],
+  tags: ["no-sidebar", "internal"],
 }
 
 export default meta
@@ -105,6 +105,14 @@ export const Default: Story = {
           color: "malibu",
         },
       },
+      {
+        label: "Created",
+        value: {
+          type: "date",
+          formattedDate: new Date().toLocaleDateString(),
+          icon: "warning"
+        }
+      }
     ],
   },
 }
@@ -128,6 +136,21 @@ export const WithActions: Story = {
           },
         ],
       },
+      {
+        label: "Created",
+        value: {
+          type: "date",
+          formattedDate: new Date().toLocaleDateString(),
+          icon: "critical"
+        },
+        actions: [
+          {
+            label: "Copy",
+            icon: Icon.LayersFront,
+            onClick: fn(),
+          }
+        ]
+      }
     ],
   },
 }

--- a/lib/experimental/Information/Headers/Metadata/index.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.tsx
@@ -1,21 +1,15 @@
 import { Button } from "@/components/Actions/Button"
 import { IconType } from "@/components/Utilities/Icon"
-import {
-  Avatar,
-  AvatarVariant,
-} from "@/experimental/Information/Avatars/Avatar"
-import { AvatarList } from "@/experimental/Information/Avatars/AvatarList"
-import { DotTag, NewColor } from "@/experimental/Information/Tags/DotTag"
-import { RawTag } from "@/experimental/Information/Tags/exports"
-import {
-  StatusTag,
-  StatusVariant,
-} from "@/experimental/Information/Tags/StatusTag"
+
+import { AvatarVariant } from "@/experimental/Information/Avatars/Avatar"
+import { NewColor } from "@/experimental/Information/Tags/DotTag"
+import { StatusVariant } from "@/experimental/Information/Tags/StatusTag"
 import { MobileDropdown } from "@/experimental/Navigation/Dropdown"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { cn } from "@/lib/utils"
 import { AnimatePresence, motion } from "framer-motion"
 import { memo, useState } from "react"
+import { MetadataValue } from "./MetadataValue"
 
 type MetadataItemValue =
   | { type: "text"; content: string }
@@ -25,6 +19,7 @@ type MetadataItemValue =
   | { type: "data-list"; data: string[] }
   | { type: "tag-list"; tags: string[] }
   | { type: "dot-tag"; label: string; color: NewColor }
+  | { type: "date"; formattedDate: string; icon?: "warning" | "critical" }
 
 type MetadataAction = {
   icon: IconType
@@ -50,83 +45,6 @@ export interface MetadataProps {
    * If true and the metadata type is a list, it will be collapsed to the first item
    */
   collapse?: boolean
-}
-
-function MetadataValue({
-  item,
-  collapse = false,
-}: {
-  item: MetadataItem
-  collapse?: boolean
-}) {
-  switch (item.value.type) {
-    case "text":
-      return <span>{item.value.content}</span>
-
-    case "avatar":
-      return (
-        <div className="flex items-center gap-1">
-          <Avatar avatar={item.value.variant} size="xsmall" />
-          {item.value.text && <span>{item.value.text}</span>}
-        </div>
-      )
-
-    case "status":
-      return <StatusTag text={item.value.label} variant={item.value.variant} />
-    case "list":
-      return (
-        <AvatarList
-          avatars={item.value.avatars}
-          size="xsmall"
-          type={item.value.variant}
-          max={3}
-        />
-      )
-
-    case "data-list":
-      return collapse ? (
-        <div className="flex items-center justify-center gap-1 font-medium">
-          {item.value.data[0]}
-          {item.value.data.length > 1 && (
-            <span className="tabular-nums text-f1-foreground-secondary">
-              +{item.value.data.length - 1}
-            </span>
-          )}
-        </div>
-      ) : (
-        <div className="flex flex-col gap-1.5">
-          {item.value.data.map((data) => (
-            <span key={data}>{data}</span>
-          ))}
-        </div>
-      )
-
-    case "tag-list":
-      return collapse ? (
-        <div className="flex flex-wrap items-center justify-center gap-1 font-medium">
-          <RawTag text={item.value.tags[0]} />
-          {item.value.tags.length > 1 && (
-            <span className="tabular-nums text-f1-foreground-secondary">
-              +{item.value.tags.length - 1}
-            </span>
-          )}
-        </div>
-      ) : (
-        <div
-          className={cn(
-            "flex flex-col gap-1 [&>div]:w-fit",
-            item.value.tags.length > 1 && "-mt-[3px]"
-          )}
-        >
-          {item.value.tags.map((tag) => (
-            <RawTag key={tag} text={tag} />
-          ))}
-        </div>
-      )
-
-    case "dot-tag":
-      return <DotTag text={item.value.label} color={item.value.color} />
-  }
 }
 
 function MetadataItem({ item }: { item: MetadataItem }) {

--- a/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/lib/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -148,7 +148,7 @@ export const Metadata: Story = {
     metadata: [
       {
         label: "Created",
-        value: { type: "text", content: "2024-01-01" },
+        value: { type: "date", formattedDate: "2024-01-01", icon: "critical" },
         actions: [
           {
             label: "Copy",

--- a/lib/experimental/Information/Headers/index.mdx
+++ b/lib/experimental/Information/Headers/index.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Unstyled } from "@storybook/blocks"
-import LinkTo from "@storybook/addon-links/react"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as ResourceHeaderStories from "./ResourceHeader/index.stories"
@@ -158,9 +157,17 @@ characteristics:
 2. **Avatar**: Represents entities that can be visualized with an avatar icon.
    (User, company and team)
 3. **Status**: Represent a state or situation associated with the resource, such
-   as "Active," "Inactive," "Pending.”, etc.
+   as "Active," "Inactive," "Pending.", etc.
 4. **List**: Display team members, task owners, or people associated with a
    specific resource.
+5. **Data List**: Display a list of text items that can be collapsed to show
+   only the first item with a count indicator.
+6. **Tag List**: Display a collection of tags that can be collapsed to show only
+   the first tag with a count indicator.
+7. **Dot Tag**: Display a colored dot with a label, useful for categorization or
+   status indication.
+8. **Date**: Display formatted dates with optional warning or critical icons for
+   time-sensitive information.
 
 ### Guidelines
 

--- a/lib/experimental/Information/Headers/index.mdx
+++ b/lib/experimental/Information/Headers/index.mdx
@@ -160,14 +160,12 @@ characteristics:
    as "Active," "Inactive," "Pending.", etc.
 4. **List**: Display team members, task owners, or people associated with a
    specific resource.
-5. **Data List**: Display a list of text items that can be collapsed to show
-   only the first item with a count indicator.
-6. **Tag List**: Display a collection of tags that can be collapsed to show only
-   the first tag with a count indicator.
-7. **Dot Tag**: Display a colored dot with a label, useful for categorization or
-   status indication.
-8. **Date**: Display formatted dates with optional warning or critical icons for
-   time-sensitive information.
+5. **Data List**: Display a vertical list of related data elements or values associated with the resource.
+Useful for showing multiple pieces of information in a stacked format.
+6. **Tag List**: Identify or classify a resource with a generic labels.
+7. **Dot Tag**: Same as TagList, allows to set the color of the tag.
+8. **Date**: Display temporal information in a standardized format.
+Can show dates like creation dates, due dates, or any other relevant timestamps for the resource.
 
 ### Guidelines
 

--- a/lib/experimental/Information/Headers/index.mdx
+++ b/lib/experimental/Information/Headers/index.mdx
@@ -160,12 +160,14 @@ characteristics:
    as "Active," "Inactive," "Pending.", etc.
 4. **List**: Display team members, task owners, or people associated with a
    specific resource.
-5. **Data List**: Display a vertical list of related data elements or values associated with the resource.
-Useful for showing multiple pieces of information in a stacked format.
+5. **Data List**: Display a vertical list of related data elements or values
+   associated with the resource. Useful for showing multiple pieces of
+   information in a stacked format.
 6. **Tag List**: Identify or classify a resource with a generic labels.
 7. **Dot Tag**: Same as TagList, allows to set the color of the tag.
-8. **Date**: Display temporal information in a standardized format.
-Can show dates like creation dates, due dates, or any other relevant timestamps for the resource.
+8. **Date**: Display temporal information in a standardized format. Can show
+   dates like creation dates, due dates, or any other relevant timestamps for
+   the resource.
 
 ### Guidelines
 


### PR DESCRIPTION
## Description

We were missing the date metadata, [defined in Figma](https://www.figma.com/design/0zY3l4YFvzAHIUBqSZzCjo/Components?node-id=14-11717&t=z6qVfWMCuThYur48-0)

I decided not to go into the date formatting topic and request already formatted date from the user. The requested format is an extension of the _text_ metadata type with an optional `icon` property which sets one of two available icons together with related styles

## Screenshots

![CleanShot 2025-03-11 at 16 51 37@2x](https://github.com/user-attachments/assets/5dae6fb3-6e5a-44b7-b01f-b330980e69ba)

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
