### PR TITLE
Rename `AlertAvatar` props

### DIFF
--- a/lib/experimental/Information/Avatars/AlertAvatar/index.tsx
+++ b/lib/experimental/Information/Avatars/AlertAvatar/index.tsx
@@ -24,12 +24,12 @@ const alertAvatarVariants = cva({
   },
 })
 
-export type Props = VariantProps<typeof alertAvatarVariants> & {
+export type AlertAvatarProps = VariantProps<typeof alertAvatarVariants> & {
   type: "critical" | "warning" | "info"
   size?: "sm" | "md" | "lg"
 }
 
-export const AlertAvatar = ({ type, size }: Props) => {
+export const AlertAvatar = ({ type, size }: AlertAvatarProps) => {
   const iconMap = {
     critical: AlertCircle,
     warning: Warning,

--- a/lib/experimental/Overlays/Dialog/index.tsx
+++ b/lib/experimental/Overlays/Dialog/index.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps } from "@/components/Actions/Button"
 import {
   AlertAvatar,
-  type Props as AlertAvatarProps,
+  type AlertAvatarProps,
 } from "@/experimental/Information/Avatars/AlertAvatar"
 import {
   Dialog,


### PR DESCRIPTION
## Description

The `AlertAvatar` component has their props named in a generic way, which forces the user to rename it when importing the props:

```jsx
import {
  AlertAvatar,
  type Props as AlertAvatarProps,
} from "@/experimental/Information/Avatars/AlertAvatar"
```

By just renaming these props, this is not needed and the user can just import them with their name.

```diff
- export type Props
+ export type AlertAvatarProps
```
