### PR TITLE
Fix card pagination

### DIFF
--- a/lib/experimental/Collections/Card/index.tsx
+++ b/lib/experimental/Collections/Card/index.tsx
@@ -49,12 +49,11 @@ export const CardCollection = <
   // screen size (2 columns on sm, 3 on lg, 4 on xl)
   const overridenSource = useMemo(() => {
     if (source.dataAdapter.paginationType === "pages") {
-      const currentPerPage = source.dataAdapter.perPage ?? 24
       return {
         ...source,
         dataAdapter: {
           ...source.dataAdapter,
-          perPage: findNextMultiple(currentPerPage),
+          perPage: findNextMultiple(source.dataAdapter.perPage ?? 24),
         },
       }
     }

--- a/lib/experimental/Collections/Card/index.tsx
+++ b/lib/experimental/Collections/Card/index.tsx
@@ -21,6 +21,13 @@ export type CardVisualizationOptions<
   title: (record: T) => string
 }
 
+// Find the next number that is divisible by 2, 3, and 4
+const findNextMultiple = (n: number): number => {
+  // LCM of 2, 3, and 4 is 12
+  const lcm = 12
+  return Math.ceil(n / lcm) * lcm
+}
+
 export const CardCollection = <
   Record extends RecordType,
   Filters extends FiltersDefinition,
@@ -37,16 +44,17 @@ export const CardCollection = <
   Actions,
   CardVisualizationOptions<Record, Filters, Sortings>
 >) => {
-  // We override this to force a perPage of 24 (unless set at the dataAdapter
-  // level), which is a multiple of 2, 3 and 4 This is to ensure that the cards
-  // are always aligned in a grid
+  // We override the perPage to ensure it's always a multiple of 2, 3, and 4
+  // This ensures the cards are always aligned in a grid regardless of the
+  // screen size (2 columns on sm, 3 on lg, 4 on xl)
   const overridenSource = useMemo(() => {
     if (source.dataAdapter.paginationType === "pages") {
+      const currentPerPage = source.dataAdapter.perPage ?? 24
       return {
         ...source,
         dataAdapter: {
           ...source.dataAdapter,
-          perPage: source.dataAdapter.perPage ?? 24,
+          perPage: findNextMultiple(currentPerPage),
         },
       }
     }

--- a/lib/ui/card.tsx
+++ b/lib/ui/card.tsx
@@ -21,6 +21,7 @@ const Card = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
+    role="article"
     className={cn(
       "flex flex-col items-stretch rounded-xl border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary p-4 shadow",
       className


### PR DESCRIPTION
## Description

Fixes card pagination by finding the next multiple of 12, so it shows well in 2, 3 and 4 columns.


### Figma Link

*None*

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other
