### PR TITLE
Changes order for direction for consistency with the backend

### DIFF
--- a/lib/experimental/Collections/Table/index.spec.tsx
+++ b/lib/experimental/Collections/Table/index.spec.tsx
@@ -537,7 +537,7 @@ describe("TableCollection", () => {
       // Check the result of the function
       expect(result).toEqual({
         field: "name",
-        direction: "asc",
+        direction: "asc" as const,
       })
     })
 
@@ -611,7 +611,7 @@ describe("TableCollection", () => {
       // Check the result of the function
       expect(result).toEqual({
         field: "name",
-        direction: "desc",
+        direction: "desc" as const,
       })
     })
 

--- a/lib/experimental/Collections/Table/index.spec.tsx
+++ b/lib/experimental/Collections/Table/index.spec.tsx
@@ -537,11 +537,11 @@ describe("TableCollection", () => {
       // Check the result of the function
       expect(result).toEqual({
         field: "name",
-        direction: "asc" as const,
+        order: "asc" as const,
       })
     })
 
-    it("toggles sort direction when clicking the same column twice", async () => {
+    it("toggles sort order when clicking the same column twice", async () => {
       // Given a table with sortings already applied
       const setCurrentSortingsMock = vi.fn()
 
@@ -549,7 +549,7 @@ describe("TableCollection", () => {
         ...createTestSource(),
         currentSortings: {
           field: "name",
-          direction: "asc" as const,
+          order: "asc" as const,
         },
         setCurrentSortings: setCurrentSortingsMock,
         sortings: {
@@ -611,7 +611,7 @@ describe("TableCollection", () => {
       // Check the result of the function
       expect(result).toEqual({
         field: "name",
-        direction: "desc" as const,
+        order: "desc" as const,
       })
     })
 
@@ -623,7 +623,7 @@ describe("TableCollection", () => {
         ...createTestSource(),
         currentSortings: {
           field: "name",
-          direction: "desc" as const,
+          order: "desc" as const,
         },
         setCurrentSortings: setCurrentSortingsMock,
         sortings: {

--- a/lib/experimental/Collections/Table/index.tsx
+++ b/lib/experimental/Collections/Table/index.tsx
@@ -78,7 +78,7 @@ export const TableCollection = <
     }
 
     return currentSortings.field === columnSorting
-      ? currentSortings.direction
+      ? currentSortings.order
       : "none"
   }
 
@@ -90,12 +90,12 @@ export const TableCollection = <
       if (!currentSortings || currentSortings.field !== columnSorting) {
         return {
           field: columnSorting,
-          direction: "asc",
+          order: "asc",
         }
-      } else if (currentSortings.direction === "asc") {
+      } else if (currentSortings.order === "asc") {
         return {
           field: columnSorting,
-          direction: "desc",
+          order: "desc",
         }
       } else {
         return null

--- a/lib/experimental/Collections/index.spec.tsx
+++ b/lib/experimental/Collections/index.spec.tsx
@@ -417,7 +417,7 @@ describe("Collections", () => {
 
               if (sortings && sortings.field === "name") {
                 sorted.sort((a, b) => {
-                  const direction = sortings.direction === "asc" ? 1 : -1
+                  const direction = sortings.order === "asc" ? 1 : -1
                   return a.name.localeCompare(b.name) * direction
                 })
               }

--- a/lib/experimental/Collections/index.stories.tsx
+++ b/lib/experimental/Collections/index.stories.tsx
@@ -129,22 +129,20 @@ const filterUsers = <
 
       // Handle string comparisons
       if (typeof aValue === "string" && typeof bValue === "string") {
-        return sortingState.direction === "asc"
+        return sortingState.order === "asc"
           ? aValue.localeCompare(bValue)
           : bValue.localeCompare(aValue)
       }
 
       // Handle number comparisons
       if (typeof aValue === "number" && typeof bValue === "number") {
-        return sortingState.direction === "asc"
-          ? aValue - bValue
-          : bValue - aValue
+        return sortingState.order === "asc" ? aValue - bValue : bValue - aValue
       }
 
       // Handle boolean comparisons
       if (typeof aValue === "boolean" && typeof bValue === "boolean") {
         // false comes before true when ascending
-        return sortingState.direction === "asc"
+        return sortingState.order === "asc"
           ? aValue === bValue
             ? 0
             : aValue
@@ -158,7 +156,7 @@ const filterUsers = <
       }
 
       // Default case: use string representation
-      return sortingState.direction === "asc"
+      return sortingState.order === "asc"
         ? String(aValue).localeCompare(String(bValue))
         : String(bValue).localeCompare(String(aValue))
     })
@@ -944,7 +942,7 @@ function createDataAdapter<
     // Apply sorting if available
     if (sortingsState) {
       const sortField = sortingsState.field as keyof TRecord
-      const sortDirection = sortingsState.direction
+      const sortDirection = sortingsState.order
 
       filteredRecords.sort((a, b) => {
         const aValue = a[sortField]
@@ -1568,7 +1566,7 @@ export const WithSyncSearch: Story = {
           // Apply sorting if provided
           if (sortings) {
             const field = sortings.field as keyof (typeof mockUserData)[0]
-            const direction = sortings.direction
+            const direction = sortings.order
 
             filteredUsers.sort((a, b) => {
               const aValue = a[field]
@@ -1715,7 +1713,7 @@ export const WithAsyncSearch: Story = {
               // Apply sorting if provided
               if (sortings) {
                 const field = sortings.field as keyof MockUser
-                const direction = sortings.direction
+                const direction = sortings.order
 
                 filteredUsers.sort((a, b) => {
                   const aValue = a[field]

--- a/lib/experimental/Collections/sortings.ts
+++ b/lib/experimental/Collections/sortings.ts
@@ -7,7 +7,7 @@ export type SortingsDefinition = Record<
 
 export type SortingsState<Definition extends SortingsDefinition> = {
   field: keyof Definition
-  direction: "asc" | "desc"
+  order: "asc" | "desc"
 } | null
 
 /**

--- a/lib/experimental/OneTable/index.stories.tsx
+++ b/lib/experimental/OneTable/index.stories.tsx
@@ -228,18 +228,18 @@ export const Sortable: Story = {
   render: () => {
     const [sortConfig, setSortConfig] = React.useState<{
       column: SortColumn | null
-      direction: SortState
+      order: SortState
     }>({
       column: "name",
-      direction: "asc",
+      order: "asc",
     })
 
     const handleSort = (column: SortColumn) => {
       setSortConfig((current) => ({
         column,
-        direction:
+        order:
           current.column === column
-            ? current.direction === "asc"
+            ? current.order === "asc"
               ? "desc"
               : "asc"
             : "asc",
@@ -253,7 +253,7 @@ export const Sortable: Story = {
         const aValue = a[sortConfig.column!]
         const bValue = b[sortConfig.column!]
 
-        return sortConfig.direction === "asc"
+        return sortConfig.order === "asc"
           ? aValue.localeCompare(bValue)
           : bValue.localeCompare(aValue)
       })
@@ -266,7 +266,7 @@ export const Sortable: Story = {
             <TableHead
               onSortClick={() => handleSort("name")}
               sortState={
-                sortConfig.column === "name" ? sortConfig.direction : undefined
+                sortConfig.column === "name" ? sortConfig.order : undefined
               }
             >
               Name
@@ -274,7 +274,7 @@ export const Sortable: Story = {
             <TableHead
               onSortClick={() => handleSort("email")}
               sortState={
-                sortConfig.column === "email" ? sortConfig.direction : undefined
+                sortConfig.column === "email" ? sortConfig.order : undefined
               }
             >
               Email
@@ -282,7 +282,7 @@ export const Sortable: Story = {
             <TableHead
               onSortClick={() => handleSort("role")}
               sortState={
-                sortConfig.column === "role" ? sortConfig.direction : undefined
+                sortConfig.column === "role" ? sortConfig.order : undefined
               }
             >
               Status


### PR DESCRIPTION
## Description

This changes the interface's key `order` for `direction` in order for it to match 1:1 with the backend. It's not a necessary change, but it's convenient.

## Screenshots (if applicable)

*None*

### Figma Link

*None*

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other
