### PR TITLE
Set origin-aware animations for dropdown and popover

### DIFF
--- a/lib/ui/dropdown-menu.tsx
+++ b/lib/ui/dropdown-menu.tsx
@@ -65,6 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         "z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border border-solid border-f1-border-secondary bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "origin-[var(--radix-dropdown-menu-content-transform-origin)]",
         className
       )}
       {...props}

--- a/lib/ui/popover.tsx
+++ b/lib/ui/popover.tsx
@@ -17,6 +17,7 @@ const PopoverContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         "z-50 w-72 rounded-xs border bg-f1-background p-4 text-f1-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "origin-[var(--radix-popover-content-transform-origin)]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Description

Based on [this thread](https://x.com/kianbazza/status/1897696705274925056), this PR adds origin-aware animations to the popover and dropdown components. This helps the user understands that the element comes from the trigger (and is related to it), instead of just randomly appear on screen).

## Screenshots (if applicable)

#### Before

https://github.com/user-attachments/assets/46928fba-e191-416e-a83c-547c413457cb


----

#### After

https://github.com/user-attachments/assets/a578b0a6-3355-4148-b0a2-6a641fb709cb

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other