### PR TITLE
feat(collections): improve data fetching with recursive `ref`

### DIFF
--- a/lib/experimental/Collections/Card/index.spec.tsx
+++ b/lib/experimental/Collections/Card/index.spec.tsx
@@ -53,9 +53,9 @@ const createTestSource = (
   isLoading: false,
   setIsLoading: vi.fn(),
   dataAdapter: {
-    fetchData: async ({ filters: _filters }) => {
+    fetchData: ({ filters: _filters }) => {
       if (error) throw error
-      return data
+      return { result: Promise.resolve(data) }
     },
   },
 })
@@ -281,12 +281,14 @@ describe("CardCollection", () => {
         dataAdapter: {
           paginationType: "pages" as const,
           perPage: 10,
-          fetchData: async () => ({
-            records: largeDataSet.slice(0, 12),
-            pagesCount: Math.ceil(largeDataSet.length / 12),
-            currentPage: 1,
-            perPage: 12,
-            total: largeDataSet.length,
+          fetchData: () => ({
+            result: Promise.resolve({
+              records: largeDataSet.slice(0, 12),
+              pagesCount: Math.ceil(largeDataSet.length / 12),
+              currentPage: 1,
+              perPage: 12,
+              total: largeDataSet.length,
+            }),
           }),
         },
       }
@@ -334,12 +336,14 @@ describe("CardCollection", () => {
         setIsLoading: vi.fn(),
         dataAdapter: {
           paginationType: "pages" as const,
-          fetchData: async () => ({
-            records: largeDataSet.slice(0, 24),
-            pagesCount: Math.ceil(largeDataSet.length / 24),
-            currentPage: 1,
-            perPage: 24,
-            total: largeDataSet.length,
+          fetchData: () => ({
+            result: Promise.resolve({
+              records: largeDataSet.slice(0, 24),
+              pagesCount: Math.ceil(largeDataSet.length / 24),
+              currentPage: 1,
+              perPage: 24,
+              total: largeDataSet.length,
+            }),
           }),
         },
       }

--- a/lib/experimental/Collections/Table/index.spec.tsx
+++ b/lib/experimental/Collections/Table/index.spec.tsx
@@ -65,9 +65,9 @@ const createTestSource = (
   isLoading: false,
   setIsLoading: vi.fn(),
   dataAdapter: {
-    fetchData: async ({ filters: _filters }) => {
+    fetchData: ({ filters: _filters }) => {
       if (error) throw error
-      return data
+      return { result: data }
     },
   },
 })
@@ -262,7 +262,7 @@ describe("TableCollection", () => {
       dataAdapter: {
         paginationType: "pages",
         perPage: itemsPerPage,
-        fetchData: async ({ pagination }) => {
+        fetchData: ({ pagination }) => {
           const { currentPage = 1 } = pagination || {}
           const pagesCount = Math.ceil(totalItems / itemsPerPage)
           const startIndex = (currentPage - 1) * itemsPerPage
@@ -275,11 +275,13 @@ describe("TableCollection", () => {
           })).slice(startIndex, endIndex)
 
           return {
-            records: paginatedData,
-            total: totalItems,
-            currentPage,
-            perPage: itemsPerPage,
-            pagesCount,
+            result: {
+              records: paginatedData,
+              total: totalItems,
+              currentPage,
+              perPage: itemsPerPage,
+              pagesCount,
+            },
           }
         },
       },

--- a/lib/experimental/Collections/actions.stories.tsx
+++ b/lib/experimental/Collections/actions.stories.tsx
@@ -172,7 +172,7 @@ export const BasicActionsExample: Story = {
   render: () => {
     const dataSource = useDataSource({
       dataAdapter: {
-        fetchData: () => Promise.resolve(mockUsers),
+        fetchData: () => ({ result: Promise.resolve(mockUsers) }),
       },
       actions: createUserActions(),
     })
@@ -228,7 +228,7 @@ export const CardActionsExample: Story = {
   render: () => {
     const dataSource = useDataSource({
       dataAdapter: {
-        fetchData: () => Promise.resolve(mockUsers),
+        fetchData: () => ({ result: Promise.resolve(mockUsers) }),
       },
       actions: createUserActions(),
     })

--- a/lib/experimental/Collections/types.ts
+++ b/lib/experimental/Collections/types.ts
@@ -127,12 +127,16 @@ export type BaseDataAdapter<
    * @param options - The filter options to apply when fetching data
    * @returns Array of records, promise of records, or observable of records
    */
-  fetchData: (
-    options: BaseFetchOptions<Filters, Sortings>
-  ) =>
-    | BaseResponse<Record>
-    | Promise<BaseResponse<Record>>
-    | Observable<PromiseState<BaseResponse<Record>>>
+  fetchData: <T>(
+    options: BaseFetchOptions<Filters, Sortings>,
+    ref?: T
+  ) => {
+    result:
+      | BaseResponse<Record>
+      | Promise<BaseResponse<Record>>
+      | Observable<PromiseState<BaseResponse<Record>>>
+    ref?: T
+  }
 }
 
 /**
@@ -154,12 +158,17 @@ export type PaginatedDataAdapter<
    * @param options - The filter and pagination options to apply when fetching data
    * @returns Paginated response with records and pagination info
    */
-  fetchData: (
-    options: PaginatedFetchOptions<Filters, Sortings>
-  ) =>
-    | PaginatedResponse<Record>
-    | Promise<PaginatedResponse<Record>>
-    | Observable<PromiseState<PaginatedResponse<Record>>>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fetchData: <T = any>(
+    options: PaginatedFetchOptions<Filters, Sortings>,
+    ref?: T
+  ) => {
+    result:
+      | PaginatedResponse<Record>
+      | Promise<PaginatedResponse<Record>>
+      | Observable<PromiseState<PaginatedResponse<Record>>>
+    ref?: T
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

Data fetching sometimes needs to keep an object across calls: be it a cache, or an original reference to an observable, etc. This allows sending it so subsequent calls will receive it.

So, basically, you can now do stuff like:

```ts
fetchData: ({ filters }, cache = {}: Cache) => {
  const users = fetchUsers({ filters })
  cache.users = users

  return {
    result: users, 
    cache
  }
}
```

## Screenshots (if applicable)

*None*

### Figma Link

*None*

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other
