### PR TITLE
chore(metadata): uses fixed date on metadata component stories to avoid flakiness

### DIFF
--- a/lib/experimental/Information/Headers/Metadata/index.stories.tsx
+++ b/lib/experimental/Information/Headers/Metadata/index.stories.tsx
@@ -109,7 +109,7 @@ export const Default: Story = {
         label: "Created",
         value: {
           type: "date",
-          formattedDate: new Date().toLocaleDateString(),
+          formattedDate: "January 15, 2023",
           icon: "warning",
         },
       },
@@ -140,7 +140,7 @@ export const WithActions: Story = {
         label: "Created",
         value: {
           type: "date",
-          formattedDate: new Date().toLocaleDateString(),
+          formattedDate: "January 15, 2023",
           icon: "critical",
         },
         actions: [


### PR DESCRIPTION
## Description

The metadata component's stories were using `today` to show dates, which resulted in a different story every day.

## Screenshots (if applicable)

*None*

### Figma Link

*None*

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other
