### PR TITLE
chore(main): Core release 1.4.3

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/react": "1.4.2"
+  "packages/react": "1.4.3"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.4.3](https://github.com/factorialco/factorial-one/compare/v1.4.2...v1.4.3) (2025-03-21)
+
+
+### Bug Fixes
+
+* release test ([#1442](https://github.com/factorialco/factorial-one/issues/1442)) ([411319c](https://github.com/factorialco/factorial-one/commit/411319c8a465c7ce138d9261c0a00dcdbe6b1421))
+* release test ([#1443](https://github.com/factorialco/factorial-one/issues/1443)) ([08dca66](https://github.com/factorialco/factorial-one/commit/08dca663d6826aa2f8497b69b6ad5e9525b9e968))
+
 ## [1.4.2](https://github.com/factorialco/factorial-one/compare/v1.4.1...v1.4.2) (2025-03-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.3.0",
+  "version": "1.4.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
Factorial-one core stable release 🚀
---


## [1.4.3](https://github.com/factorialco/factorial-one/compare/v1.4.2...v1.4.3) (2025-03-21)


### Bug Fixes

* release test ([#1442](https://github.com/factorialco/factorial-one/issues/1442)) ([411319c](https://github.com/factorialco/factorial-one/commit/411319c8a465c7ce138d9261c0a00dcdbe6b1421))
* release test ([#1443](https://github.com/factorialco/factorial-one/issues/1443)) ([08dca66](https://github.com/factorialco/factorial-one/commit/08dca663d6826aa2f8497b69b6ad5e9525b9e968))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).