### PR TITLE
chore(main): Core release 1.4.4

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/react": "1.4.3"
+  "packages/react": "1.4.4"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.4.4](https://github.com/factorialco/factorial-one/compare/v1.4.3...v1.4.4) (2025-03-21)
+
+
+### Bug Fixes
+
+* release test ([#1445](https://github.com/factorialco/factorial-one/issues/1445)) ([b5bb2b2](https://github.com/factorialco/factorial-one/commit/b5bb2b2498259374ceb5cd323e32e171b07e0e9f))
+
 ## [1.4.3](https://github.com/factorialco/factorial-one/compare/v1.4.2...v1.4.3) (2025-03-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
Factorial-one core stable release 🚀
---


## [1.4.4](https://github.com/factorialco/factorial-one/compare/v1.4.3...v1.4.4) (2025-03-21)


### Bug Fixes

* release test ([#1445](https://github.com/factorialco/factorial-one/issues/1445)) ([b5bb2b2](https://github.com/factorialco/factorial-one/commit/b5bb2b2498259374ceb5cd323e32e171b07e0e9f))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).