### PR TITLE
chore(main): Core release 1.4.5

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/react": "1.4.4"
+  "packages/react": "1.4.5"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.4.5](https://github.com/factorialco/factorial-one/compare/v1.4.4...v1.4.5) (2025-03-21)
+
+
+### Bug Fixes
+
+* when one element of employeeSelector is removed all get removed ([#1451](https://github.com/factorialco/factorial-one/issues/1451)) ([c080544](https://github.com/factorialco/factorial-one/commit/c080544dd0d5e428a3b13217708f3ecb83edf391))
+
 ## [1.4.4](https://github.com/factorialco/factorial-one/compare/v1.4.3...v1.4.4) (2025-03-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
Factorial-one core stable release 🚀
---


## [1.4.5](https://github.com/factorialco/factorial-one/compare/v1.4.4...v1.4.5) (2025-03-21)


### Bug Fixes

* when one element of employeeSelector is removed all get removed ([#1451](https://github.com/factorialco/factorial-one/issues/1451)) ([c080544](https://github.com/factorialco/factorial-one/commit/c080544dd0d5e428a3b13217708f3ecb83edf391))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).