### PR TITLE
chore(main): Core release 1.4.6

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/react": "1.4.5"
+  "packages/react": "1.4.6"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.4.6](https://github.com/factorialco/factorial-one/compare/v1.4.5...v1.4.6) (2025-03-24)
+
+
+### Bug Fixes
+
+* move basecolors to ahve it in the dist ([#1453](https://github.com/factorialco/factorial-one/issues/1453)) ([72f91bb](https://github.com/factorialco/factorial-one/commit/72f91bb1c260aba797a22852ee4f1eb3964e5335))
+
 ## [1.4.5](https://github.com/factorialco/factorial-one/compare/v1.4.4...v1.4.5) (2025-03-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
Factorial-one core stable release 🚀
---


## [1.4.6](https://github.com/factorialco/factorial-one/compare/v1.4.5...v1.4.6) (2025-03-24)


### Bug Fixes

* move basecolors to ahve it in the dist ([#1453](https://github.com/factorialco/factorial-one/issues/1453)) ([72f91bb](https://github.com/factorialco/factorial-one/commit/72f91bb1c260aba797a22852ee4f1eb3964e5335))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).