### PR TITLE
chore(main): Core release 1.5.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/react": "1.4.6"
+  "packages/react": "1.5.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.0](https://github.com/factorialco/factorial-one/compare/v1.4.6...v1.5.0) (2025-03-24)
+
+
+### Features
+
+* **PageHeader:** add product update dropdown ([#1429](https://github.com/factorialco/factorial-one/issues/1429)) ([20be94d](https://github.com/factorialco/factorial-one/commit/20be94d5c35b481a1e2bf4af69b826f00aa61230))
+
 ## [1.4.6](https://github.com/factorialco/factorial-one/compare/v1.4.5...v1.4.6) (2025-03-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one",
-  "version": "1.4.6",
+  "version": "1.5.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
Factorial-one core stable release 🚀
---


## [1.5.0](https://github.com/factorialco/factorial-one/compare/v1.4.6...v1.5.0) (2025-03-24)


### Features

* **PageHeader:** add product update dropdown ([#1429](https://github.com/factorialco/factorial-one/issues/1429)) ([20be94d](https://github.com/factorialco/factorial-one/commit/20be94d5c35b481a1e2bf4af69b826f00aa61230))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).