### PR TITLE
Add support to not show graph nor overtime

### DIFF
--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/helpers.ts
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/helpers.ts
@@ -1,11 +1,15 @@
-import { ClockInControlsProps } from "./index"
 import { CLOCK_IN_COLORS } from "../ClockInGraph"
+import { ClockInControlsProps } from "./index"
 
 export const getInfo = ({
   data = [],
   labels,
   remainingMinutes,
-}: Pick<ClockInControlsProps, "data" | "labels" | "remainingMinutes">) => {
+  canSeeRemainingTime = true,
+}: Pick<
+  ClockInControlsProps,
+  "data" | "labels" | "remainingMinutes" | "canSeeRemainingTime"
+>) => {
   const lastEntry = data[data.length - 1]
   const status = lastEntry?.variant || "clocked-out"
 
@@ -16,6 +20,8 @@ export const getInfo = ({
   }[status]
 
   const subtitle = (() => {
+    if (!canSeeRemainingTime) return
+
     if (remainingMinutes === undefined) return
 
     const absRemainingMinutes = Math.abs(remainingMinutes)

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
@@ -77,6 +77,14 @@ export const ClockedIn: Story = {
   },
 }
 
+export const NoGraphNorRemainingTime: Story = {
+  args: {
+    ...ClockedIn.args,
+    canSeeGraph: false,
+    canSeeRemainingTime: false,
+  },
+}
+
 export const OnBreak: Story = {
   args: {
     remainingMinutes: 4 * 60 + 39,

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
@@ -50,6 +50,8 @@ export interface ClockInControlsProps {
   canShowLocation?: boolean
   locationSelectorDisabled?: boolean
   canShowBreakButton?: boolean
+  canSeeGraph?: boolean
+  canSeeRemainingTime?: boolean
   /** Callback when Clock In button is clicked */
   onClockIn?: () => void
   /** Callback when Clock Out button is clicked */
@@ -74,6 +76,8 @@ export function ClockInControls({
   breakTypes,
   onChangeBreakTypeId,
   canShowBreakButton = true,
+  canSeeGraph = true,
+  canSeeRemainingTime = true,
   // onClickProjectSelector,
   onChangeLocationId,
   canShowProject = true,
@@ -83,6 +87,7 @@ export function ClockInControls({
     data,
     labels,
     remainingMinutes,
+    canSeeRemainingTime,
   })
 
   const showLocationAndProjectSelectors = status === "clocked-out"
@@ -242,7 +247,12 @@ export function ClockInControls({
               )}
             </div>
           </div>
-          <ClockInGraph data={data} remainingMinutes={remainingMinutes} />
+          {canSeeGraph && (
+            <ClockInGraph
+              data={data}
+              remainingMinutes={canSeeRemainingTime ? remainingMinutes : 0}
+            />
+          )}
         </div>
         <div className="mt-6 flex flex-row flex-wrap items-center justify-center gap-2 @xs:justify-start">
           {canSelectLocation ? (


### PR DESCRIPTION
## Description

We need to allow this component not to show the graph nor the remaining time as we have an use case that depending on permissions user won't be able to see them.

## Screenshots 

<img width="505" alt="Screenshot 2025-03-24 at 15 44 34" src="https://github.com/user-attachments/assets/5dfcbab3-ee97-4266-bba0-2101a9df2774" />

### Figma Link

https://www.figma.com/design/060q78tnGIGaRc1sxecTvV/Home-Web?node-id=2311-30888&t=MkJxnwBnaznMzBnY-4
