### PR TITLE
fix(PageHeader): currentModule to check if the module changes and cle…

### DIFF
--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -259,6 +259,7 @@ export const WithProductUpdate: Story = {
       onHeaderClick: () => {
         alert("onHeaderClick")
       },
+      currentModule: defaultModule.name,
     },
   },
 }

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -242,7 +242,7 @@ export function PageHeader({
         )}
         {hasProductUpdates && (
           <div className="items-right flex gap-2">
-            <ProductUpdates {...productUpdates} />
+            <ProductUpdates {...productUpdates} currentModule={module.name} />
           </div>
         )}
         {hasActions && (

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -15,7 +15,13 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu"
 import { Skeleton } from "@/ui/skeleton"
-import { ComponentProps, ReactElement, useCallback, useState } from "react"
+import {
+  ComponentProps,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useState,
+} from "react"
 
 type ProductUpdate = {
   title: string
@@ -32,6 +38,7 @@ type ProductUpdatesProp = {
   updatesPageUrl: string
   getUpdates: () => Promise<Array<ProductUpdate>>
   hasUnread?: boolean
+  currentModule: string
   onOpenChange?: ComponentProps<typeof DropdownMenu>["onOpenChange"]
   onHeaderClick?: ComponentProps<typeof DropdownMenuTrigger>["onClick"]
   onItemClick?: ComponentProps<typeof DropdownMenuItem>["onClick"]
@@ -48,6 +55,7 @@ type ProductUpdatesProp = {
 }
 
 const ProductUpdates = ({
+  currentModule,
   label,
   moreUpdatesLabel,
   getUpdates,
@@ -62,6 +70,12 @@ const ProductUpdates = ({
   const [state, setState] = useState<"idle" | "fetching" | "error">("idle")
   const [updates, setUpdates] = useState<Array<ProductUpdate> | null>(null)
   const [featuredUpdate, ...restUpdates] = updates ?? []
+
+  useEffect(() => {
+    setUpdates(null)
+    setState("idle")
+  }, [currentModule])
+
   const invokeGetUpdates = useCallback(async () => {
     try {
       setState("fetching")


### PR DESCRIPTION
Adding `currentModule` property to PageHeader Product Updates, to check if the module changes, if it does the updates state is cleaned to avoid caching updates not related to the module.
