### PR TITLE
chore(main): Core release 1.5.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/react": "1.5.0"
+  "packages/react": "1.5.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.1](https://github.com/factorialco/factorial-one/compare/v1.5.0...v1.5.1) (2025-03-24)
+
+
+### Bug Fixes
+
+* **PageHeader:** currentModule to check if the module changes and clean its state ([#1460](https://github.com/factorialco/factorial-one/issues/1460)) ([e07f95c](https://github.com/factorialco/factorial-one/commit/e07f95ce22799801a16e4ace1bc83a8781ddfc59))
+
 ## [1.5.0](https://github.com/factorialco/factorial-one/compare/v1.4.6...v1.5.0) (2025-03-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
Factorial-one core stable release 🚀
---


## [1.5.1](https://github.com/factorialco/factorial-one/compare/v1.5.0...v1.5.1) (2025-03-24)


### Bug Fixes

* **PageHeader:** currentModule to check if the module changes and clean its state ([#1460](https://github.com/factorialco/factorial-one/issues/1460)) ([e07f95c](https://github.com/factorialco/factorial-one/commit/e07f95ce22799801a16e4ace1bc83a8781ddfc59))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).