### PR TITLE
chore(main): Core release 1.6.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/react": "1.5.1"
+  "packages/react": "1.6.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.6.0](https://github.com/factorialco/factorial-one/compare/v1.5.1...v1.6.0) (2025-03-25)
+
+
+### Features
+
+* **PageHeader:** allow videos in product updates dropdown ([#1463](https://github.com/factorialco/factorial-one/issues/1463)) ([3d99c43](https://github.com/factorialco/factorial-one/commit/3d99c439569410803ceed4352e46e885a0b031c1))
+
 ## [1.5.1](https://github.com/factorialco/factorial-one/compare/v1.5.0...v1.5.1) (2025-03-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
Factorial-one core stable release 🚀
---


## [1.6.0](https://github.com/factorialco/factorial-one/compare/v1.5.1...v1.6.0) (2025-03-25)


### Features

* **PageHeader:** allow videos in product updates dropdown ([#1463](https://github.com/factorialco/factorial-one/issues/1463)) ([3d99c43](https://github.com/factorialco/factorial-one/commit/3d99c439569410803ceed4352e46e885a0b031c1))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).