### PR TITLE
Update Filters component

### DIFF
--- a/packages/react/src/experimental/Collections/Filters/Components/FilterContent.tsx
+++ b/packages/react/src/experimental/Collections/Filters/Components/FilterContent.tsx
@@ -148,6 +148,12 @@ export function FilterContent<Definition extends FiltersDefinition>({
     }
   }
 
+  const handleClear = () => {
+    if (selectedFilterKey) {
+      onFilterChange(selectedFilterKey, filter.type === "in" ? [] : "")
+    }
+  }
+
   // Create a modified filter with filtered options for the InFilter component
   const getModifiedFilter = (originalFilter: InFilterDefinition<unknown>) => {
     if (deferredSearchTerm && loadedOptions.length > 0) {
@@ -161,7 +167,7 @@ export function FilterContent<Definition extends FiltersDefinition>({
   return (
     <div className="relative flex w-full flex-col gap-1">
       <div className="relative flex h-full flex-col justify-between overflow-y-auto">
-        <div className="flex flex-col gap-2 p-2">
+        <div className="relative flex flex-col gap-2 p-2">
           {showSearch && (
             <div className="flex gap-3">
               <Input
@@ -174,12 +180,6 @@ export function FilterContent<Definition extends FiltersDefinition>({
                 className="h-8 rounded"
                 icon={Search}
                 clearable
-              />
-              <Button
-                variant="outline"
-                label="Select all"
-                onClick={handleSelectAll}
-                disabled={filteredOptions.length === 0}
               />
             </div>
           )}
@@ -198,6 +198,30 @@ export function FilterContent<Definition extends FiltersDefinition>({
             />
           )}
         </div>
+        {filter.type === "in" && filteredOptions.length > 0 && (
+          <div className="sticky bottom-0 left-0 right-0 flex items-center justify-between gap-2 border border-solid border-transparent border-t-f1-border-secondary bg-f1-background/80 p-2 backdrop-blur-[8px]">
+            <Button
+              variant="outline"
+              label="Select all"
+              onClick={handleSelectAll}
+              disabled={
+                filteredOptions.length === 0 ||
+                (Array.isArray(currentValue) &&
+                  currentValue.length === filteredOptions.length)
+              }
+              size="sm"
+            />
+            <Button
+              variant="ghost"
+              label="Clear"
+              onClick={handleClear}
+              disabled={
+                !Array.isArray(currentValue) || currentValue.length === 0
+              }
+              size="sm"
+            />
+          </div>
+        )}
       </div>
     </div>
   )

--- a/packages/react/src/experimental/Collections/Filters/Components/FilterList.tsx
+++ b/packages/react/src/experimental/Collections/Filters/Components/FilterList.tsx
@@ -1,7 +1,5 @@
-import { Button } from "../../../../components/Actions/Button"
-import { Reset } from "../../../../icons/app"
-import { cn, focusRing } from "../../../../lib/utils"
 import { AnimatePresence, motion } from "framer-motion"
+import { cn, focusRing } from "../../../../lib/utils"
 import type { FiltersDefinition, FiltersState } from "../types"
 
 /**
@@ -17,18 +15,15 @@ interface FilterListProps<Definition extends FiltersDefinition> {
   selectedFilterKey: keyof Definition | null
   /** Callback fired when a filter is selected from the list */
   onFilterSelect: (key: keyof Definition) => void
-  /** Callback fired when a filter is cleared */
-  onFilterClear: (key: keyof Definition) => void
 }
 
 /**
- * Displays a vertical list of available filters with selection and clear functionality.
+ * Displays a vertical list of available filters with selection functionality.
  *
  * Features:
  * - Shows all available filters from the definition
  * - Indicates active filters with a visual indicator
  * - Allows selecting a filter to configure
- * - Provides a reset button for clearing individual filters
  * - Handles animation for status indicators
  *
  * This component renders the left sidebar in the filters popover interface.
@@ -40,7 +35,6 @@ export function FilterList<Definition extends FiltersDefinition>({
   tempFilters,
   selectedFilterKey,
   onFilterSelect,
-  onFilterClear,
 }: FilterListProps<Definition>) {
   return (
     <div className="w-[224px] shrink-0 border border-solid border-transparent border-r-f1-border-secondary">
@@ -63,7 +57,7 @@ export function FilterList<Definition extends FiltersDefinition>({
               )}
               onClick={() => onFilterSelect(key as keyof Definition)}
             >
-              <div className="flex items-center justify-start gap-2.5 pr-6">
+              <div className="flex items-center justify-start gap-2.5">
                 <span className="line-clamp-1 w-fit text-left">
                   {filter.label}
                 </span>
@@ -78,18 +72,6 @@ export function FilterList<Definition extends FiltersDefinition>({
                   )}
                 </AnimatePresence>
               </div>
-              {hasValue && (
-                <div className="absolute right-1 top-1 flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-visible:opacity-100">
-                  <Button
-                    label="Reset"
-                    variant="ghost"
-                    hideLabel
-                    size="sm"
-                    icon={Reset}
-                    onClick={() => onFilterClear(key as keyof Definition)}
-                  />
-                </div>
-              )}
             </button>
           )
         })}

--- a/packages/react/src/experimental/Collections/Filters/index.tsx
+++ b/packages/react/src/experimental/Collections/Filters/index.tsx
@@ -1,3 +1,4 @@
+import { Icon } from "@/components/Utilities/Icon"
 import { OverflowList } from "@/ui/OverflowList"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 import { AnimatePresence } from "framer-motion"
@@ -120,14 +121,6 @@ export function Filters<Definition extends FiltersDefinition>({
     onChange(newValue)
   }
 
-  const handleClearFilter = (key: keyof Definition) => {
-    setTempFilters((current) => {
-      const newFilters = { ...current }
-      delete newFilters[key]
-      return newFilters
-    })
-  }
-
   const handleFilterChange = (key: keyof Definition, newValue: unknown) => {
     setTempFilters((current) => ({
       ...current,
@@ -190,12 +183,16 @@ export function Filters<Definition extends FiltersDefinition>({
       <div className="flex items-center gap-2">
         <Popover open={isOpen} onOpenChange={handleOpenChange}>
           <PopoverTrigger asChild>
-            <Button
-              icon={Filter}
-              variant="outline"
-              hideLabel
-              label={i18n.filters.label}
-            />
+            <button
+              className={cn(
+                "flex h-8 w-8 items-center justify-center rounded border border-solid border-f1-border bg-f1-background-inverse-secondary text-f1-foreground hover:border-f1-border-hover",
+                isOpen && "border-f1-border-hover",
+                focusRing()
+              )}
+            >
+              <Icon icon={Filter} />
+              <span className="sr-only">{i18n.filters.label}</span>
+            </button>
           </PopoverTrigger>
           <PopoverContent
             className="w-[544px] rounded-xl border border-solid border-f1-border-secondary p-0 shadow-md"
@@ -209,7 +206,6 @@ export function Filters<Definition extends FiltersDefinition>({
                   tempFilters={tempFilters}
                   selectedFilterKey={selectedFilterKey}
                   onFilterSelect={setSelectedFilterKey}
-                  onFilterClear={handleClearFilter}
                 />
                 {selectedFilterKey && (
                   <FilterContent

--- a/packages/react/src/experimental/Collections/Filters/index.tsx
+++ b/packages/react/src/experimental/Collections/Filters/index.tsx
@@ -189,6 +189,7 @@ export function Filters<Definition extends FiltersDefinition>({
                 isOpen && "border-f1-border-hover",
                 focusRing()
               )}
+              title={i18n.filters.label}
             >
               <Icon icon={Filter} />
               <span className="sr-only">{i18n.filters.label}</span>


### PR DESCRIPTION
## Description

The design in Figma for the filter component in DataCollection was changed a week or two ago to make it look seamless with other selectors. This PR updates the design in the component itself.

- "Select all" and "Clear" actions are together in a fixed bar in the list.
- Button stays focused when the filters popover is opened.
- Removed the "Clear" icon action from the left list of filter categories.

## Screenshots

https://github.com/user-attachments/assets/67d31e1d-14fa-43ae-9b13-1b16941c7920

### Figma Link

[Link to Figma Design](https://www.figma.com/design/RBKhrXjevsqIHcLWAvhV3I/Internal-Patterns?node-id=4931-153800&t=WrMueYSxZznjcMuu-4)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
