### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.7.0",
+  "packages/react": "1.8.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.8.0](https://github.com/factorialco/factorial-one/compare/factorial-one-v1.7.0...factorial-one-v1.8.0) (2025-03-26)
+
+
+### Features
+
+* publish packages ([#1473](https://github.com/factorialco/factorial-one/issues/1473)) ([aa7c997](https://github.com/factorialco/factorial-one/commit/aa7c997c37d3ac43e2f9fcf34b3197d1c44b8b9e))
+
 ## [1.7.0](https://github.com/factorialco/factorial-one/compare/factorial-one-v1.6.0...factorial-one-v1.7.0) (2025-03-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one: 1.8.0</summary>

## [1.8.0](https://github.com/factorialco/factorial-one/compare/factorial-one-v1.7.0...factorial-one-v1.8.0) (2025-03-26)


### Features

* publish packages ([#1473](https://github.com/factorialco/factorial-one/issues/1473)) ([aa7c997](https://github.com/factorialco/factorial-one/commit/aa7c997c37d3ac43e2f9fcf34b3197d1c44b8b9e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).