### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.8.0",
+  "packages/react": "1.9.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.9.0](https://github.com/factorialco/factorial-one/compare/factorial-one-v1.8.0...factorial-one-v1.9.0) (2025-03-26)
+
+
+### Features
+
+* publish packages test a ([#1477](https://github.com/factorialco/factorial-one/issues/1477)) ([7769055](https://github.com/factorialco/factorial-one/commit/776905592a12b2084a1e0dd1e820296dd271a361))
+
 ## [1.8.0](https://github.com/factorialco/factorial-one/compare/factorial-one-v1.7.0...factorial-one-v1.8.0) (2025-03-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one: 1.9.0</summary>

## [1.9.0](https://github.com/factorialco/factorial-one/compare/factorial-one-v1.8.0...factorial-one-v1.9.0) (2025-03-26)


### Features

* publish packages test a ([#1477](https://github.com/factorialco/factorial-one/issues/1477)) ([7769055](https://github.com/factorialco/factorial-one/commit/776905592a12b2084a1e0dd1e820296dd271a361))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).