### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.11.0",
+  "packages/react": "1.12.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.12.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.11.0...factorial-one-react-v1.12.0) (2025-03-26)
+
+
+### Features
+
+* publish packages b ([#1484](https://github.com/factorialco/factorial-one/issues/1484)) ([afde2a7](https://github.com/factorialco/factorial-one/commit/afde2a710ffa9b9fc9fae114b52240fa3d613947))
+
 ## [1.11.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.10.0...factorial-one-react-v1.11.0) (2025-03-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.12.0</summary>

## [1.12.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.11.0...factorial-one-react-v1.12.0) (2025-03-26)


### Features

* publish packages b ([#1484](https://github.com/factorialco/factorial-one/issues/1484)) ([afde2a7](https://github.com/factorialco/factorial-one/commit/afde2a710ffa9b9fc9fae114b52240fa3d613947))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).