### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.13.0",
+  "packages/react": "1.14.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.14.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.13.0...factorial-one-react-v1.14.0) (2025-03-28)
+
+
+### Features
+
+* **Collections:** propagate loading state to Table visualization ([#1488](https://github.com/factorialco/factorial-one/issues/1488)) ([a2a488c](https://github.com/factorialco/factorial-one/commit/a2a488c27146618c1549e3457a42d8e032562a7b))
+
 ## [1.13.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.12.0...factorial-one-react-v1.13.0) (2025-03-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.14.0</summary>

## [1.14.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.13.0...factorial-one-react-v1.14.0) (2025-03-28)


### Features

* **Collections:** propagate loading state to Table visualization ([#1488](https://github.com/factorialco/factorial-one/issues/1488)) ([a2a488c](https://github.com/factorialco/factorial-one/commit/a2a488c27146618c1549e3457a42d8e032562a7b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).