### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.14.0",
+  "packages/react": "1.14.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.14.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.14.0...factorial-one-react-v1.14.1) (2025-03-28)
+
+
+### Bug Fixes
+
+* Fixes in Product Updates dropdown ([#1491](https://github.com/factorialco/factorial-one/issues/1491)) ([81f374f](https://github.com/factorialco/factorial-one/commit/81f374fe00d3e1b720f8ea11f1fd43dfa4ad37af))
+
 ## [1.14.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.13.0...factorial-one-react-v1.14.0) (2025-03-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.14.1</summary>

## [1.14.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.14.0...factorial-one-react-v1.14.1) (2025-03-28)


### Bug Fixes

* Fixes in Product Updates dropdown ([#1491](https://github.com/factorialco/factorial-one/issues/1491)) ([81f374f](https://github.com/factorialco/factorial-one/commit/81f374fe00d3e1b720f8ea11f1fd43dfa4ad37af))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).