### PR TITLE
feat(Collections): "Clear" button in filters

### DIFF
--- a/packages/react/src/experimental/Collections/Filters/Components/FiltersChipsList.tsx
+++ b/packages/react/src/experimental/Collections/Filters/Components/FiltersChipsList.tsx
@@ -1,0 +1,53 @@
+import { Button } from "@/components/Actions/Button"
+import { AnimatePresence } from "framer-motion"
+import { useI18n } from "../../../../lib/i18n-provider"
+import type { FiltersDefinition, FiltersState } from "../types"
+import { FilterButton } from "./FilterButton"
+
+interface FiltersChipsListProps<Filters extends FiltersDefinition> {
+  filters: Filters
+  currentFilters: FiltersState<Filters>
+  onFilterSelect: (key: keyof Filters) => void
+  onFilterRemove: (key: keyof Filters) => void
+  onClearAll: () => void
+}
+
+export function FiltersChipsList<Filters extends FiltersDefinition>({
+  filters,
+  currentFilters,
+  onFilterSelect,
+  onFilterRemove,
+  onClearAll,
+}: FiltersChipsListProps<Filters>) {
+  const i18n = useI18n()
+  if (Object.keys(currentFilters).length === 0) return null
+
+  return (
+    <div className="flex items-start justify-between gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <AnimatePresence presenceAffectsLayout initial={false}>
+          {(Object.keys(currentFilters) as Array<keyof Filters>).map((key) => {
+            const filter = filters[key]
+            if (!currentFilters[key]) return null
+
+            return (
+              <FilterButton
+                key={String(key)}
+                filter={filter}
+                value={currentFilters[key]}
+                onSelect={() => onFilterSelect(key)}
+                onRemove={() => onFilterRemove(key)}
+              />
+            )
+          })}
+        </AnimatePresence>
+      </div>
+      <Button
+        variant="ghost"
+        label={i18n.actions.clear}
+        size="sm"
+        onClick={onClearAll}
+      />
+    </div>
+  )
+}

--- a/packages/react/src/experimental/Collections/Filters/Components/FiltersControls.tsx
+++ b/packages/react/src/experimental/Collections/Filters/Components/FiltersControls.tsx
@@ -21,6 +21,8 @@ interface FiltersControlsProps<Filters extends FiltersDefinition> {
     filter: FiltersState<Filters>
   }>
   onPresetsChange?: (filter: FiltersState<Filters>) => void
+  isOpen?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 export function FiltersControls<Filters extends FiltersDefinition>({
@@ -29,15 +31,20 @@ export function FiltersControls<Filters extends FiltersDefinition>({
   onFilterChange,
   presets,
   onPresetsChange,
+  isOpen: controlledIsOpen,
+  onOpenChange: controlledOnOpenChange,
 }: FiltersControlsProps<Filters>) {
   const [selectedFilterKey, setSelectedFilterKey] = useState<
     keyof Filters | null
   >(null)
-  const [isOpen, setIsOpen] = useState(false)
+  const [internalIsOpen, setInternalIsOpen] = useState(false)
   const i18n = useI18n()
 
+  const isOpen = controlledIsOpen ?? internalIsOpen
+  const onOpenChange = controlledOnOpenChange ?? setInternalIsOpen
+
   const handleApplyFilters = () => {
-    setIsOpen(false)
+    onOpenChange(false)
   }
 
   const renderListPresetItem = (
@@ -87,7 +94,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
 
   return (
     <div className="flex items-center gap-2">
-      <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <Popover open={isOpen} onOpenChange={onOpenChange}>
         <PopoverTrigger asChild>
           <button
             className={cn(

--- a/packages/react/src/experimental/Collections/Filters/Components/FiltersControls.tsx
+++ b/packages/react/src/experimental/Collections/Filters/Components/FiltersControls.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react"
+import { Button } from "../../../../components/Actions/Button"
+import { Icon } from "../../../../components/Utilities/Icon"
+import { Filter } from "../../../../icons/app"
+import { useI18n } from "../../../../lib/i18n-provider"
+import { cn, focusRing } from "../../../../lib/utils"
+import { OverflowList } from "../../../../ui/OverflowList"
+import { Popover, PopoverContent, PopoverTrigger } from "../../../../ui/popover"
+import { Counter } from "../../../Information/Counter"
+import { Preset } from "../../../OnePreset"
+import type { FiltersDefinition, FiltersState } from "../types"
+import { FilterContent } from "./FilterContent"
+import { FilterList } from "./FilterList"
+
+interface FiltersControlsProps<Filters extends FiltersDefinition> {
+  filters: Filters
+  currentFilters: FiltersState<Filters>
+  onFilterChange: (key: keyof Filters, value: unknown) => void
+  presets?: Array<{
+    label: string
+    filter: FiltersState<Filters>
+  }>
+  onPresetsChange?: (filter: FiltersState<Filters>) => void
+}
+
+export function FiltersControls<Filters extends FiltersDefinition>({
+  filters,
+  currentFilters,
+  onFilterChange,
+  presets,
+  onPresetsChange,
+}: FiltersControlsProps<Filters>) {
+  const [selectedFilterKey, setSelectedFilterKey] = useState<
+    keyof Filters | null
+  >(null)
+  const [isOpen, setIsOpen] = useState(false)
+  const i18n = useI18n()
+
+  const handleApplyFilters = () => {
+    setIsOpen(false)
+  }
+
+  const renderListPresetItem = (
+    preset: NonNullable<typeof presets>[number],
+    index: number,
+    isVisible = true
+  ) => {
+    const isSelected =
+      JSON.stringify(preset.filter) === JSON.stringify(currentFilters)
+    return (
+      <Preset
+        key={index}
+        label={preset.label}
+        selected={isSelected}
+        onClick={() => onPresetsChange?.(preset.filter)}
+        data-visible={isVisible}
+      />
+    )
+  }
+
+  const renderDropdownPresetItem = (
+    preset: NonNullable<typeof presets>[number],
+    index: number
+  ) => {
+    const isSelected =
+      JSON.stringify(preset.filter) === JSON.stringify(currentFilters)
+    return (
+      <button
+        key={index}
+        className={cn(
+          "flex w-full cursor-pointer items-center justify-between rounded-sm p-2 text-left font-medium text-f1-foreground hover:bg-f1-background-secondary",
+          isSelected &&
+            "bg-f1-background-selected hover:bg-f1-background-selected",
+          focusRing()
+        )}
+        onClick={() => onPresetsChange?.(preset.filter)}
+        data-visible={true}
+      >
+        {preset.label}
+        <Counter
+          value={Object.keys(preset.filter).length}
+          type={isSelected ? "selected" : "default"}
+        />
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild>
+          <button
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded border border-solid border-f1-border bg-f1-background-inverse-secondary text-f1-foreground hover:border-f1-border-hover",
+              isOpen && "border-f1-border-hover",
+              focusRing()
+            )}
+            title={i18n.filters.label}
+          >
+            <Icon icon={Filter} />
+            <span className="sr-only">{i18n.filters.label}</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-[544px] rounded-xl border border-solid border-f1-border-secondary p-0 shadow-md"
+          align="start"
+          side="bottom"
+        >
+          <div className="flex h-[min(448px,80vh)] flex-col">
+            <div className="flex min-h-0 flex-1">
+              <FilterList
+                definition={filters}
+                tempFilters={currentFilters}
+                selectedFilterKey={selectedFilterKey}
+                onFilterSelect={(key: keyof Filters) =>
+                  setSelectedFilterKey(key)
+                }
+              />
+              {selectedFilterKey && (
+                <FilterContent
+                  selectedFilterKey={selectedFilterKey}
+                  definition={filters}
+                  tempFilters={currentFilters}
+                  onFilterChange={onFilterChange}
+                />
+              )}
+            </div>
+
+            <div className="flex items-center justify-end gap-2 border-solid border-transparent border-t-f1-border-secondary px-3 py-2">
+              <Button
+                onClick={handleApplyFilters}
+                label={i18n.filters.applyFilters}
+              />
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {presets && presets.length > 0 && (
+        <OverflowList
+          items={presets}
+          renderListItem={renderListPresetItem}
+          renderDropdownItem={renderDropdownPresetItem}
+          className="flex-1"
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/react/src/experimental/Collections/index.tsx
+++ b/packages/react/src/experimental/Collections/index.tsx
@@ -1,10 +1,11 @@
-import { AnimatePresence, motion } from "framer-motion"
+import { motion } from "framer-motion"
 import { useEffect, useMemo, useState } from "react"
 import { useDebounceValue } from "usehooks-ts"
 import { Icon } from "../../components/Utilities/Icon"
 import { Spinner } from "../../icons/app"
 import { CollectionActions } from "./CollectionActions/ColletionActions"
-import { Filters } from "./Filters"
+import { FiltersChipsList } from "./Filters/Components/FiltersChipsList"
+import { FiltersControls } from "./Filters/Components/FiltersControls"
 import type { FiltersDefinition, FiltersState } from "./Filters/types"
 import { ItemActionsDefinition } from "./item-actions"
 import { Search } from "./search"
@@ -163,6 +164,7 @@ export const DataCollection = <
     isLoading,
     primaryActions,
     secondaryActions,
+    presets,
   } = source
   const [currentVisualization, setCurrentVisualization] = useState(0)
 
@@ -176,33 +178,49 @@ export const DataCollection = <
     [secondaryActions]
   )
 
+  const handleFilterChange = (key: keyof Filters, value: unknown) => {
+    setCurrentFilters((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const handleFilterRemove = (key: keyof Filters) => {
+    setCurrentFilters((prev) => ({ ...prev, [key]: undefined }))
+  }
+
+  const handleFilterSelect = (key: keyof Filters) => {
+    // This will be handled by the FiltersControls component
+  }
+
+  const handleClearAll = () => {
+    setCurrentFilters({})
+  }
+
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-start justify-between">
+      <div className="flex items-center justify-between">
         {filters && (
-          <Filters
-            schema={filters}
-            filters={currentFilters}
-            presets={source.presets}
-            onChange={setCurrentFilters}
-          />
+          <div className="flex-1">
+            <FiltersControls
+              filters={filters}
+              currentFilters={currentFilters}
+              onFilterChange={handleFilterChange}
+              presets={presets}
+              onPresetsChange={setCurrentFilters}
+            />
+          </div>
         )}
-        <div className="shrink-1 grow-1 flex"></div>
         <div className="flex shrink-0 items-center gap-2">
-          <AnimatePresence initial={false}>
-            {isLoading && (
-              <MotionIcon
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{
-                  opacity: 0,
-                }}
-                size="lg"
-                icon={Spinner}
-                className="animate-spin"
-              />
-            )}
-          </AnimatePresence>
+          {isLoading && (
+            <MotionIcon
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{
+                opacity: 0,
+              }}
+              size="lg"
+              icon={Spinner}
+              className="animate-spin"
+            />
+          )}
           {search && (
             <Search onChange={setCurrentSearch} value={currentSearch} />
           )}
@@ -221,6 +239,15 @@ export const DataCollection = <
           )}
         </div>
       </div>
+      {filters && (
+        <FiltersChipsList
+          filters={filters}
+          currentFilters={currentFilters}
+          onFilterSelect={handleFilterSelect}
+          onFilterRemove={handleFilterRemove}
+          onClearAll={handleClearAll}
+        />
+      )}
       <VisualizationRenderer
         visualization={visualizations[currentVisualization]}
         source={source}

--- a/packages/react/src/experimental/Collections/index.tsx
+++ b/packages/react/src/experimental/Collections/index.tsx
@@ -167,6 +167,7 @@ export const DataCollection = <
     presets,
   } = source
   const [currentVisualization, setCurrentVisualization] = useState(0)
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false)
 
   const primaryActionItem = useMemo(
     () => primaryActions && primaryActions(),
@@ -186,8 +187,8 @@ export const DataCollection = <
     setCurrentFilters((prev) => ({ ...prev, [key]: undefined }))
   }
 
-  const handleFilterSelect = (key: keyof Filters) => {
-    // This will be handled by the FiltersControls component
+  const handleFilterSelect = () => {
+    setIsFiltersOpen(true)
   }
 
   const handleClearAll = () => {
@@ -205,9 +206,12 @@ export const DataCollection = <
               onFilterChange={handleFilterChange}
               presets={presets}
               onPresetsChange={setCurrentFilters}
+              isOpen={isFiltersOpen}
+              onOpenChange={setIsFiltersOpen}
             />
           </div>
         )}
+        <div className="shrink-1 grow-1 flex"></div>
         <div className="flex shrink-0 items-center gap-2">
           {isLoading && (
             <MotionIcon


### PR DESCRIPTION
## Description

Adds a "Clear" button in the active filters list, that clear all the filters applied. To do so, I've split the Filters component into two: one for the filters button and presets, and the other one for the filters chip list.

## Screenshots

<img width="717" alt="image" src="https://github.com/user-attachments/assets/465529aa-7f22-4493-9848-7c5d7adb2b7f" />

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](https://www.figma.com/design/Drd7hhxgof79A7zeftSYMo/Patterns?node-id=105-50264&t=fL0eOflaYmBWQWki-4)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other