### PR TITLE
chore: standardise properties across charts

### DIFF
--- a/packages/react/src/components/Charts/BarChart/index.tsx
+++ b/packages/react/src/components/Charts/BarChart/index.tsx
@@ -47,7 +47,6 @@ export type BarChartProps<K extends ChartConfig = ChartConfig> =
     showValueUnderLabel?: boolean
     highlightLastBar?: boolean
     onClick?: (data: ChartDataPoint<K>) => void
-    hideTooltip?: boolean
   }
 
 const _BarChart = <K extends ChartConfig>(
@@ -59,6 +58,7 @@ const _BarChart = <K extends ChartConfig>(
     label = false,
     type = "simple",
     hideTooltip = false,
+    hideGrid = false,
     aspect,
     legend,
     showValueUnderLabel = false,
@@ -122,7 +122,7 @@ const _BarChart = <K extends ChartConfig>(
           onClick(chartData)
         }}
       >
-        {hideTooltip && (
+        {!hideTooltip && (
           <ChartTooltip
             cursor
             content={
@@ -130,7 +130,7 @@ const _BarChart = <K extends ChartConfig>(
             }
           />
         )}
-        <CartesianGrid {...cartesianGridProps()} />
+        {!hideGrid && <CartesianGrid {...cartesianGridProps()} />}
         <YAxis
           {...yAxisProps(yAxis)}
           tick

--- a/packages/react/src/components/Charts/LineChart/index.tsx
+++ b/packages/react/src/components/Charts/LineChart/index.tsx
@@ -36,6 +36,8 @@ export const _LineChart = <K extends LineChartConfig>(
     yAxis = { hide: true },
     lineType = "natural",
     aspect,
+    hideTooltip = false,
+    hideGrid = false,
   }: LineChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
@@ -60,7 +62,7 @@ export const _LineChart = <K extends LineChartConfig>(
         data={preparedData}
         margin={{ left: yAxis && !yAxis.hide ? 0 : 12, right: 12 }}
       >
-        <CartesianGrid {...cartesianGridProps()} />
+        {!hideGrid && <CartesianGrid {...cartesianGridProps()} />}
         {!xAxis?.hide && <XAxis {...xAxisProps(xAxis)} />}
         {!yAxis?.hide && (
           <YAxis
@@ -68,12 +70,14 @@ export const _LineChart = <K extends LineChartConfig>(
             width={yAxis.width ?? maxLabelWidth + 20}
           />
         )}
-        <ChartTooltip
-          cursor
-          content={
-            <ChartTooltipContent yAxisFormatter={yAxis?.tickFormatter} />
-          }
-        />
+        {!hideTooltip && (
+          <ChartTooltip
+            cursor
+            content={
+              <ChartTooltipContent yAxisFormatter={yAxis?.tickFormatter} />
+            }
+          />
+        )}
         {lines.map((line, index) => (
           <Line
             key={line}

--- a/packages/react/src/components/Charts/VerticalBarChart/index.tsx
+++ b/packages/react/src/components/Charts/VerticalBarChart/index.tsx
@@ -59,6 +59,8 @@ const _VBarChart = <K extends ChartConfig>(
     yAxis,
     label = false,
     aspect,
+    hideTooltip = false,
+    hideGrid = false,
   }: VerticalBarChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
@@ -88,17 +90,21 @@ const _VBarChart = <K extends ChartConfig>(
         data={preparedData}
         margin={{ left: yAxis && !yAxis.hide ? 0 : 12, right: label ? 32 : 0 }}
       >
-        <ChartTooltip
-          cursor
-          content={
-            <ChartTooltipContent yAxisFormatter={yAxis?.tickFormatter} />
-          }
-        />
-        <CartesianGrid
-          {...cartesianGridProps()}
-          vertical={true}
-          horizontal={false}
-        />
+        {!hideTooltip && (
+          <ChartTooltip
+            cursor
+            content={
+              <ChartTooltipContent yAxisFormatter={yAxis?.tickFormatter} />
+            }
+          />
+        )}
+        {!hideGrid && (
+          <CartesianGrid
+            {...cartesianGridProps()}
+            vertical={true}
+            horizontal={false}
+          />
+        )}
         <XAxis {...xAxisProps} hide={xAxis?.hide} />
         <YAxis
           {...yAxisProps}

--- a/packages/react/src/components/Charts/utils/elements.tsx
+++ b/packages/react/src/components/Charts/utils/elements.tsx
@@ -19,9 +19,11 @@ export const xAxisProps = (
   config?: AxisConfig
 ): Partial<ComponentProps<typeof XAxis>> => ({
   dataKey: "x",
+  domain: config?.domain,
   tickLine: false,
   axisLine: false,
   tickMargin: 8,
+  ticks: config?.ticks,
   tickCount: config?.tickCount,
   tickFormatter: config?.tickFormatter,
 })
@@ -31,6 +33,7 @@ export const yAxisProps = (
 ): Partial<ComponentProps<typeof YAxis>> => ({
   tickLine: false,
   axisLine: false,
+  domain: config?.domain,
   tickMargin: 8,
   ticks: config?.ticks,
   tickCount: config?.tickCount,

--- a/packages/react/src/components/Charts/utils/types.ts
+++ b/packages/react/src/components/Charts/utils/types.ts
@@ -34,6 +34,8 @@ export type ChartPropsBase<
   xAxis?: AxisConfig
   yAxis?: AxisConfig
   aspect?: ComponentProps<typeof ChartContainer>["aspect"]
+  hideGrid?: boolean
+  hideTooltip?: boolean
 }
 
 export type LineChartPropsBase<K extends LineChartConfig = LineChartConfig> = {
@@ -42,4 +44,6 @@ export type LineChartPropsBase<K extends LineChartConfig = LineChartConfig> = {
   xAxis?: AxisConfig
   yAxis?: AxisConfig
   aspect?: ComponentProps<typeof ChartContainer>["aspect"]
+  hideGrid?: boolean
+  hideTooltip?: boolean
 }


### PR DESCRIPTION
We have varying different prop experiences across line, bar and vertical bar charts at the moment. There are also props that can be passed down into these components but have no impact on the component at all.

This commit standardises a number of things:

- Ensures all charts support the option to hide the tooltip
- Ensures all charts support the option to hide the grid
- Ensures all charts support the domain property in recharts (previously we supported passing this in the wrapper but it wasn't passed to recharts)
