### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.16.0",
+  "packages/react": "1.16.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.16.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.16.0...factorial-one-react-v1.16.1) (2025-03-31)
+
+
+### Bug Fixes
+
+* **PageHeader:** restrict height of description block ([#1499](https://github.com/factorialco/factorial-one/issues/1499)) ([da9323f](https://github.com/factorialco/factorial-one/commit/da9323fb42c8dac340b50915e7f4791f3499db5a))
+
 ## [1.16.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.15.0...factorial-one-react-v1.16.0) (2025-03-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.16.1</summary>

## [1.16.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.16.0...factorial-one-react-v1.16.1) (2025-03-31)


### Bug Fixes

* **PageHeader:** restrict height of description block ([#1499](https://github.com/factorialco/factorial-one/issues/1499)) ([da9323f](https://github.com/factorialco/factorial-one/commit/da9323fb42c8dac340b50915e7f4791f3499db5a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).