### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.17.0",
+  "packages/react": "1.18.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.18.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.17.0...factorial-one-react-v1.18.0) (2025-03-31)
+
+
+### Features
+
+* datacolletion selectable rows ([#1489](https://github.com/factorialco/factorial-one/issues/1489)) ([e5b0ada](https://github.com/factorialco/factorial-one/commit/e5b0ada4fccda81a1c95104e3b9fb64edffe72ed))
+
 ## [1.17.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.16.1...factorial-one-react-v1.17.0) (2025-03-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.18.0</summary>

## [1.18.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.17.0...factorial-one-react-v1.18.0) (2025-03-31)


### Features

* datacolletion selectable rows ([#1489](https://github.com/factorialco/factorial-one/issues/1489)) ([e5b0ada](https://github.com/factorialco/factorial-one/commit/e5b0ada4fccda81a1c95104e3b9fb64edffe72ed))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).