### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.18.0",
+  "packages/react": "1.18.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.18.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.18.0...factorial-one-react-v1.18.1) (2025-04-01)
+
+
+### Bug Fixes
+
+* **PageHeader:** adding asChild Property ([#1516](https://github.com/factorialco/factorial-one/issues/1516)) ([e4ddcfa](https://github.com/factorialco/factorial-one/commit/e4ddcfa5cf95b841f19b56e5980f4772074141af))
+
 ## [1.18.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.17.0...factorial-one-react-v1.18.0) (2025-03-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.18.1</summary>

## [1.18.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.18.0...factorial-one-react-v1.18.1) (2025-04-01)


### Bug Fixes

* **PageHeader:** adding asChild Property ([#1516](https://github.com/factorialco/factorial-one/issues/1516)) ([e4ddcfa](https://github.com/factorialco/factorial-one/commit/e4ddcfa5cf95b841f19b56e5980f4772074141af))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).