### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.18.1",
+  "packages/react": "1.18.2",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.18.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.18.1...factorial-one-react-v1.18.2) (2025-04-01)
+
+
+### Bug Fixes
+
+* **SectionHeader:** adjust separator based on the layout ([#1519](https://github.com/factorialco/factorial-one/issues/1519)) ([4fbfe85](https://github.com/factorialco/factorial-one/commit/4fbfe85e36c7bb4f4d7b3964c2a94941f8d98f26))
+
 ## [1.18.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.18.0...factorial-one-react-v1.18.1) (2025-04-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.18.2</summary>

## [1.18.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.18.1...factorial-one-react-v1.18.2) (2025-04-01)


### Bug Fixes

* **SectionHeader:** adjust separator based on the layout ([#1519](https://github.com/factorialco/factorial-one/issues/1519)) ([4fbfe85](https://github.com/factorialco/factorial-one/commit/4fbfe85e36c7bb4f4d7b3964c2a94941f8d98f26))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).