### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.18.2",
+  "packages/react": "1.19.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.19.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.18.2...factorial-one-react-v1.19.0) (2025-04-01)
+
+
+### Features
+
+* make a release ([#1526](https://github.com/factorialco/factorial-one/issues/1526)) ([e4c54cf](https://github.com/factorialco/factorial-one/commit/e4c54cf6fa037d24c44c67fe58255917e49407c0))
+
 ## [1.18.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.18.1...factorial-one-react-v1.18.2) (2025-04-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.18.2",
+  "version": "1.19.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.19.0</summary>

## [1.19.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.18.2...factorial-one-react-v1.19.0) (2025-04-01)


### Features

* make a release ([#1526](https://github.com/factorialco/factorial-one/issues/1526)) ([e4c54cf](https://github.com/factorialco/factorial-one/commit/e4c54cf6fa037d24c44c67fe58255917e49407c0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).