### PR TITLE
fix(DataCollection): Ensure seamless row height in table view

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
@@ -23,6 +23,16 @@ import {
 import { CollectionProps, RecordType } from "../../../types"
 import { useData } from "../../../useData"
 import { useSelectable } from "../../../useSelectable"
+import { PropertyRendererType } from "../../../visualizations/property"
+
+// Define padding values for different property types
+const PROPERTY_TYPE_PADDINGS: Partial<Record<PropertyRendererType, number>> = {
+  avatarList: 8,
+  tag: 8,
+}
+
+// Default padding if not specified for a type
+const DEFAULT_CELL_PADDING = 12
 
 export type WithOptionalSorting<
   Record,
@@ -251,35 +261,47 @@ export const TableCollection = <
                     )}
                   </TableCell>
                 )}
-                {columns.map((column, cellIndex) => (
-                  <TableCell
-                    key={String(column.label)}
-                    firstCell={cellIndex === 0}
-                    href={itemHref}
-                    width={column.width}
-                    sticky={
-                      cellIndex < frozenColumnsLeft
-                        ? {
-                            left: columns
-                              .slice(0, Math.max(0, cellIndex))
-                              .reduce(
-                                (acc, column) => acc + (column.width ?? 0),
-                                checkColumnWidth
-                              ),
-                          }
-                        : undefined
-                    }
-                  >
-                    <div
-                      className={cn(
-                        column.align === "right" ? "justify-end" : "",
-                        "flex"
-                      )}
+                {columns.map((column, cellIndex) => {
+                  const renderedProperty = column.render(item)
+                  const propertyType =
+                    typeof renderedProperty === "object" &&
+                    renderedProperty !== null
+                      ? renderedProperty.type
+                      : "text"
+                  const padding =
+                    PROPERTY_TYPE_PADDINGS[propertyType] ?? DEFAULT_CELL_PADDING
+
+                  return (
+                    <TableCell
+                      key={String(column.label)}
+                      firstCell={cellIndex === 0}
+                      href={itemHref}
+                      width={column.width}
+                      padding={padding}
+                      sticky={
+                        cellIndex < frozenColumnsLeft
+                          ? {
+                              left: columns
+                                .slice(0, Math.max(0, cellIndex))
+                                .reduce(
+                                  (acc, column) => acc + (column.width ?? 0),
+                                  checkColumnWidth
+                                ),
+                            }
+                          : undefined
+                      }
                     >
-                      {renderCell(item, column)}
-                    </div>
-                  </TableCell>
-                ))}
+                      <div
+                        className={cn(
+                          column.align === "right" ? "justify-end" : "",
+                          "flex"
+                        )}
+                      >
+                        {renderCell(item, column)}
+                      </div>
+                    </TableCell>
+                  )
+                })}
                 {source.itemActions && (
                   <TableCell
                     key="actions"

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
@@ -68,7 +68,7 @@ export const propertyRenderers = {
         }}
         size="xsmall"
       />
-      <span className="text-sm font-medium">
+      <span>
         {args.firstName} {args.lastName}
       </span>
     </div>
@@ -83,7 +83,7 @@ export const propertyRenderers = {
         }}
         size="xsmall"
       />
-      <span className="text-sm font-medium">{args.name}</span>
+      <span>{args.name}</span>
     </div>
   ),
   team: (args: { name: string; src?: string }) => (
@@ -96,7 +96,7 @@ export const propertyRenderers = {
         }}
         size="xsmall"
       />
-      <span className="text-sm font-medium">{args.name}</span>
+      <span>{args.name}</span>
     </div>
   ),
   tag: (args: { label: string; icon?: IconType }) => (

--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -30,6 +30,12 @@ interface TableCellProps {
    * @default undefined
    */
   sticky?: { left?: number; right?: never } | { left?: never; right?: number }
+
+  /**
+   * The padding of the cell
+   * @default 12
+   */
+  padding?: number
 }
 
 export function TableCell({
@@ -38,6 +44,7 @@ export function TableCell({
   width = "auto",
   firstCell = false,
   sticky,
+  padding = 12,
 }: TableCellProps) {
   const { isScrolled, isScrolledRight } = useTable()
   const { actions } = useI18n()
@@ -66,6 +73,8 @@ export function TableCell({
         minWidth: colWidth,
         left: stickyLeft,
         right: stickyRight,
+        paddingTop: padding,
+        paddingBottom: padding,
       }}
     >
       <AnimatePresence>

--- a/packages/react/src/ui/table.tsx
+++ b/packages/react/src/ui/table.tsx
@@ -97,7 +97,7 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "relative whitespace-nowrap p-3 align-middle",
+      "relative min-h-12 whitespace-nowrap p-3 align-middle",
       "[&:has([role=checkbox])]:px-2",
       className
     )}


### PR DESCRIPTION
## Description

Different data types were making the row height inconsistent. While we want the height to grow if needed, we want to ensure a minimum of 48px. Some cell types were making this height larger, as the content inside made the cells grow.

To avoid this, the padding top and bottom of the cell now depends on the type of data in the table visualization, ensuring that larger elements like tags don't unnecessarily increase the row size.

## Screenshots

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/bd7f33c8-c5e6-43c2-a5ce-8a057ae3537c" />

### Figma Link

[Link to Figma Design](https://www.figma.com/design/RBKhrXjevsqIHcLWAvhV3I/Internal-Patterns?node-id=10388-167106&t=M80YbIZDpttoL3eg-4)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other