### PR TITLE
Fix: card link navigation on widget

### DIFF
--- a/packages/react/src/ui/card.tsx
+++ b/packages/react/src/ui/card.tsx
@@ -111,7 +111,6 @@ const CardLink = React.forwardRef<
       )}
       aria-label={title}
       {...props}
-      role="link"
     >
       <Icon size="sm" icon={icon} className="text-f1-icon-bold" />
     </Link>

--- a/packages/react/src/ui/card.tsx
+++ b/packages/react/src/ui/card.tsx
@@ -7,7 +7,6 @@ import InfoCircleLine from "../icons/app/InfoCircleLine"
 
 import { Icon, IconType } from "@/components/Utilities/Icon"
 import { Link } from "@/lib/linkHandler"
-import { Button } from "../components/Actions/Button"
 import {
   Tooltip,
   TooltipContent,
@@ -101,14 +100,20 @@ const CardLink = React.forwardRef<
   React.ComponentPropsWithoutRef<"a"> & { icon?: IconType }
 >(({ className, title, icon = ChevronRight, ...props }, ref) => {
   return (
-    <Link ref={ref} className={className} aria-label={title} {...props}>
-      <Button
-        icon={icon}
-        label={title ?? ""}
-        variant="outline"
-        size="sm"
-        hideLabel
-      />
+    <Link
+      ref={ref}
+      className={cn(
+        "group inline-flex aspect-square h-6 items-center justify-center gap-1", //layout
+        "rounded-sm border border-solid border-f1-border bg-f1-background-inverse-secondary", //appearance
+        "whitespace-nowrap px-0 text-base font-medium text-f1-foreground", //typography
+        "cursor-pointer transition-colors hover:border-f1-border-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-ring focus-visible:ring-offset-1", //interaction
+        className
+      )}
+      aria-label={title}
+      {...props}
+      role="link"
+    >
+      <Icon size="sm" icon={icon} className="text-f1-icon-bold" />
     </Link>
   )
 })


### PR DESCRIPTION
## Description

Fixed navigation of CardLink on Widget component. The component was rendering a `<Button>` inside `<Link>`, causing a full-page reload instead of internal navigation.  I'm proposing to use an `<Icon>` instead of a `<Button>`:

- Simplify event handling
- The previous approach is against W3C [recommendation](https://html.spec.whatwg.org/#the-a-element) of not having interactive elements nested on a Link

## Screenshots

![image](https://github.com/user-attachments/assets/62225786-acb0-430c-aaa1-f08ed28ce049)

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other