### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.19.1",
+  "packages/react": "1.19.2",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.19.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.19.1...factorial-one-react-v1.19.2) (2025-04-02)
+
+
+### Bug Fixes
+
+* card link navigation on widget ([#1531](https://github.com/factorialco/factorial-one/issues/1531)) ([92a866e](https://github.com/factorialco/factorial-one/commit/92a866e8436166a5ace846191c16c0b2f26d146a))
+
 ## [1.19.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.19.0...factorial-one-react-v1.19.1) (2025-04-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.19.2</summary>

## [1.19.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.19.1...factorial-one-react-v1.19.2) (2025-04-02)


### Bug Fixes

* card link navigation on widget ([#1531](https://github.com/factorialco/factorial-one/issues/1531)) ([92a866e](https://github.com/factorialco/factorial-one/commit/92a866e8436166a5ace846191c16c0b2f26d146a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).