### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.19.2",
+  "packages/react": "1.20.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.20.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.19.2...factorial-one-react-v1.20.0) (2025-04-02)
+
+
+### Features
+
+* expose data attributes for interactive elements ([#1535](https://github.com/factorialco/factorial-one/issues/1535)) ([a59c4c4](https://github.com/factorialco/factorial-one/commit/a59c4c4f31b00ea8ae919b2df621aaa9d7b65380))
+
 ## [1.19.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.19.1...factorial-one-react-v1.19.2) (2025-04-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.20.0</summary>

## [1.20.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.19.2...factorial-one-react-v1.20.0) (2025-04-02)


### Features

* expose data attributes for interactive elements ([#1535](https://github.com/factorialco/factorial-one/issues/1535)) ([a59c4c4](https://github.com/factorialco/factorial-one/commit/a59c4c4f31b00ea8ae919b2df621aaa9d7b65380))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).