### PR TITLE
fix: datacollection filters async label

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/Filters/Components/FilterContent.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/Components/FilterContent.tsx
@@ -17,7 +17,7 @@ import type {
  * Props for the FilterContent component.
  * @template Definition - The type defining the structure of available filters
  */
-interface FilterContentProps<Definition extends FiltersDefinition> {
+type FilterContentProps<Definition extends FiltersDefinition> = {
   /** The currently selected filter key, if any */
   selectedFilterKey: keyof Definition | null
   /** The schema defining available filters and their configurations */
@@ -99,16 +99,15 @@ export function FilterContent<Definition extends FiltersDefinition>({
 
     const loadOptions = async () => {
       try {
-        if (Array.isArray(filter.options)) {
-          // Static options
-          setLoadedOptions(filter.options)
-          setFilteredOptions(filter.options)
-        } else if (typeof filter.options === "function") {
-          // Function options (sync or async)
-          setIsLoading(true)
-          const result = await filter.options()
-          setLoadedOptions(result)
-          setFilteredOptions(result)
+        setIsLoading(true)
+        const ops = await (typeof filter.options === "function"
+          ? filter.options()
+          : filter.options)
+        if (ops !== undefined) {
+          setLoadedOptions(ops)
+          setFilteredOptions(ops)
+        } else {
+          throw new Error("No options found")
         }
       } catch (error) {
         console.error("Error loading options:", error)

--- a/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersChipsList.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersChipsList.tsx
@@ -28,11 +28,13 @@ export function FiltersChipsList<Filters extends FiltersDefinition>({
         <AnimatePresence presenceAffectsLayout initial={false}>
           {(Object.keys(currentFilters) as Array<keyof Filters>).map((key) => {
             const filter = filters[key]
-            if (!currentFilters[key]) return null
+            if (!currentFilters[key]) {
+              return null
+            }
 
             return (
               <FilterButton
-                key={String(key)}
+                key={`filter-${String(key)}`}
                 filter={filter}
                 value={currentFilters[key]}
                 onSelect={() => onFilterSelect(key)}

--- a/packages/react/src/experimental/OneDataCollection/Filters/index.spec.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/index.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
-import { render, screen, within } from "../../../test-utils"
+import { render, screen, waitFor, within } from "../../../test-utils"
 import { Filters } from "./index"
 import type { FiltersDefinition } from "./types"
 
@@ -63,16 +63,18 @@ describe("Filters", () => {
       )
 
       // Check for active filters in the UI
-      const searchFilter = screen.getByText(/search:/i)
-      const departmentFilter = screen.getByText(/department:/i)
+      let searchFilter, departmentFilter
+      await waitFor(() => {
+        searchFilter = screen.getByText(/search:/i)
+        departmentFilter = screen.getByText(/department:/i)
 
-      // Verify both filters are visible in the UI
-      expect(searchFilter).toBeInTheDocument()
-      expect(departmentFilter).toBeInTheDocument()
+        // Verify both filters are visible in the UI
+        expect(searchFilter).toBeInTheDocument()
+        expect(departmentFilter).toBeInTheDocument()
 
-      // Simply verify both filters exist without checking order
-      // The order might be different in the current implementation
-      expect(screen.getAllByText(/search:|department:/i)).toHaveLength(2)
+        // Simply verify both filters exist without checking order
+        expect(screen.getAllByText(/search:|department:/i)).toHaveLength(2)
+      })
     })
 
     it("preserves filter order when reopening the filter panel", async () => {
@@ -84,6 +86,9 @@ describe("Filters", () => {
       // Open and configure filter
       await user.click(screen.getByRole("button", { name: /filters/i }))
       await user.click(screen.getByText("Department"))
+      await waitFor(() => {
+        expect(screen.getByText("Department")).toBeInTheDocument()
+      })
       await user.click(screen.getByText("Engineering"))
 
       // Apply the filter
@@ -226,8 +231,10 @@ describe("Filters", () => {
       )
 
       // Verify the UI shows the updated filter
-      expect(screen.getByText(/department:/i)).toBeInTheDocument()
-      expect(screen.getByText(/design/i)).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByText(/department:/i)).toBeInTheDocument()
+        expect(screen.getByText(/design/i)).toBeInTheDocument()
+      })
     })
   })
 })

--- a/packages/react/src/experimental/OneDataCollection/Filters/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react"
+import { fn } from "@storybook/test"
 import { useEffect, useState } from "react"
 import { Input } from "../../../ui/input"
 import { Label } from "../../../ui/label"
@@ -23,16 +24,19 @@ const sampleDefinition: FiltersDefinition = {
   department: {
     type: "in",
     label: "Department",
-    options: [
-      {
-        value: "engineering",
-        label: "Engineering",
-      },
-      { value: "marketing", label: "Marketing" },
-      { value: "sales", label: "Sales" },
-      { value: "hr", label: "Human Resources" },
-      { value: "finance", label: "Finance" },
-    ],
+    options: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      return [
+        {
+          value: "engineering",
+          label: "Engineering",
+        },
+        { value: "marketing", label: "Marketing" },
+        { value: "sales", label: "Sales" },
+        { value: "hr", label: "Human Resources" },
+        { value: "finance", label: "Finance" },
+      ]
+    },
   },
   name: {
     type: "search",
@@ -194,6 +198,7 @@ export const Default: Story = {
   args: {
     schema: sampleDefinition,
     filters: {},
+    onChange: fn(),
   },
 }
 
@@ -206,6 +211,7 @@ export const WithPresetsArgs: Story = {
     schema: sampleDefinition,
     filters: {},
     presets: samplePresets,
+    onChange: fn(),
   },
 }
 
@@ -335,7 +341,7 @@ export const WithAsyncOptions: Story = {
       department: {
         type: "in"
         label: string
-        options: Array<{ value: string; label: string }>
+        options: () => Promise<Array<{ value: string; label: string }>>
       }
       users: {
         type: "in"
@@ -361,12 +367,19 @@ export const WithAsyncOptions: Story = {
       department: {
         type: "in",
         label: "Department",
-        options: [
-          { value: "engineering", label: "Engineering" },
-          { value: "marketing", label: "Marketing" },
-          { value: "sales", label: "Sales" },
-          { value: "hr", label: "Human Resources" },
-        ],
+        options: async () => {
+          // Simulate API call with a delay
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              resolve([
+                { value: "engineering", label: "Engineering2" },
+                { value: "marketing", label: "Marketing" },
+                { value: "sales", label: "Sales" },
+                { value: "hr", label: "Human Resources" },
+              ])
+            }, 1500)
+          })
+        },
       },
       users: {
         type: "in",

--- a/packages/react/src/experimental/OneDataCollection/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/index.stories.tsx
@@ -35,10 +35,10 @@ const filters = {
     type: "search",
     label: "Search",
   },
-  department: {
+  departmentId: {
     type: "in",
     label: "Department",
-    options: DEPARTMENTS.map((value) => ({ value, label: value })),
+    options: DEPARTMENTS.map((value, i) => ({ value: i, label: value })),
   },
 } as const
 
@@ -47,25 +47,25 @@ const filterPresets: Presets<typeof filters> = [
   {
     label: "Engineering Team",
     filter: {
-      department: ["Engineering"],
+      departmentId: [0],
     },
   },
   {
     label: "Product Team",
     filter: {
-      department: ["Product"],
+      departmentId: [1],
     },
   },
   {
     label: "Design Team",
     filter: {
-      department: ["Design"],
+      departmentId: [2],
     },
   },
   {
     label: "Marketing Team",
     filter: {
-      department: ["Marketing"],
+      departmentId: [3],
     },
   },
 ]
@@ -76,6 +76,7 @@ const mockUsers: {
   name: string
   email: string
   role: string
+  departmentId: number
   department: (typeof DEPARTMENTS)[number]
   status: string
   isStarred: boolean
@@ -87,6 +88,7 @@ const mockUsers: {
     name: "John Doe",
     email: "john@example.com",
     role: "Senior Engineer",
+    departmentId: 0,
     department: DEPARTMENTS[0],
     status: "active",
     isStarred: true,
@@ -97,6 +99,7 @@ const mockUsers: {
     name: "Jane Smith",
     email: "jane@example.com",
     role: "Product Manager",
+    departmentId: 1,
     department: DEPARTMENTS[1],
     status: "active",
     isStarred: false,
@@ -107,6 +110,7 @@ const mockUsers: {
     name: "Bob Johnson",
     email: "bob@example.com",
     role: "Designer",
+    departmentId: 2,
     department: DEPARTMENTS[2],
     status: "inactive",
     isStarred: false,
@@ -117,6 +121,7 @@ const mockUsers: {
     name: "Alice Williams",
     email: "alice@example.com",
     role: "Marketing Lead",
+    departmentId: 3,
     department: DEPARTMENTS[3],
     status: "active",
     isStarred: true,
@@ -129,6 +134,7 @@ const filterUsers = <
   T extends RecordType & {
     name: string
     email: string
+    departmentId: number
     department: string
     salary: number | undefined
   },
@@ -191,13 +197,14 @@ const filterUsers = <
   }
 
   // Handle department filter
-  const departmentFilterValues = filterValues.department
+  const departmentFilterValues = filterValues.departmentId
+
   if (
     Array.isArray(departmentFilterValues) &&
     departmentFilterValues.length > 0
   ) {
     filteredUsers = filteredUsers.filter((user) =>
-      departmentFilterValues.some((d) => d === user.department)
+      departmentFilterValues.some((d) => d === user.departmentId)
     )
   }
 
@@ -316,7 +323,7 @@ const ExampleComponent = ({
         onClick: () => console.log(`Deleting ${item.name}`),
         critical: true,
         description: "Permanently remove user",
-        enabled: item.department === "Engineering" && item.status === "active",
+        enabled: item.departmentId === 0 && item.status === "active",
       },
     ],
     selectable,
@@ -540,8 +547,7 @@ export const BasicTableView: Story = {
           onClick: () => console.log(`Deleting ${item.name}`),
           critical: true,
           description: "Permanently remove user",
-          enabled:
-            item.department === "Engineering" && item.status === "active",
+          enabled: item.departmentId === 0 && item.status === "active",
         },
       ],
       primaryActions: () => ({
@@ -679,8 +685,7 @@ export const WithLinkedItems: Story = {
           onClick: () => console.log(`Deleting ${item.name}`),
           critical: true,
           description: "Permanently remove user",
-          enabled:
-            item.department === "Engineering" && item.status === "active",
+          enabled: item.departmentId === 0 && item.status === "active",
         },
       ],
     })
@@ -982,7 +987,7 @@ export const WithPreselectedFilters: Story = {
       sortings,
       presets: filterPresets,
       currentFilters: {
-        department: ["Engineering"],
+        departmentId: [0],
       },
       dataAdapter: {
         fetchData: createPromiseDataFetch(),
@@ -1242,12 +1247,14 @@ function createDataAdapter<
 
     // Apply department filter if provided
     if (
-      "department" in filters &&
-      Array.isArray(filters.department) &&
-      filters.department.length > 0
+      "departmentId" in filters &&
+      Array.isArray(filters.departmentId) &&
+      filters.departmentId.length > 0
     ) {
       filteredRecords = filteredRecords.filter((record) =>
-        (filters.department as string[]).includes(record.department)
+        (filters.departmentId as number[]).includes(
+          record.departmentId as number
+        )
       )
     }
 
@@ -1530,18 +1537,19 @@ export const WithMultipleVisualizations: Story = {
 // Fix the generateMockUsers function to use the correct department types
 const generateMockUsers = (count: number) => {
   return Array.from({ length: count }).map((_, index) => {
-    const department = DEPARTMENTS[index % DEPARTMENTS.length]
+    const departmentId = index % DEPARTMENTS.length
     return {
       id: `user-${index + 1}`,
       name: `User ${index + 1}`,
       email: `user${index + 1}@example.com`,
       role:
         index % 3 === 0 ? "Engineer" : index % 3 === 1 ? "Designer" : "Manager",
-      department,
+      department: DEPARTMENTS[departmentId],
+      departmentId: departmentId,
       status: index % 5 === 0 ? "inactive" : "active",
       isStarred: index % 3 === 0,
       href: `/users/user-${index + 1}`,
-      salary: department === "Marketing" ? 50000 + index * 1000 : undefined,
+      salary: departmentId === 2 ? 50000 + index * 1000 : undefined,
     }
   })
 }
@@ -1753,7 +1761,7 @@ export const WithAdvancedActions: Story = {
           },
           critical: true,
           description: "This action cannot be undone",
-          enabled: item.department === "Engineering",
+          enabled: item.departmentId === 0,
         },
         // Toggle action
         {
@@ -1833,6 +1841,7 @@ export const WithSyncSearch: Story = {
               email: "john@example.com",
               role: "Senior Engineer",
               department: DEPARTMENTS[0],
+              departmentId: 0,
               status: "active",
               isStarred: true,
             },
@@ -1842,6 +1851,7 @@ export const WithSyncSearch: Story = {
               email: "jane@example.com",
               role: "Product Manager",
               department: DEPARTMENTS[1],
+              departmentId: 1,
               status: "active",
               isStarred: false,
             },
@@ -1851,6 +1861,7 @@ export const WithSyncSearch: Story = {
               email: "alice@example.com",
               role: "UX Designer",
               department: DEPARTMENTS[2],
+              departmentId: 2,
               status: "active",
               isStarred: false,
             },
@@ -1860,6 +1871,7 @@ export const WithSyncSearch: Story = {
               email: "bob@example.com",
               role: "Developer",
               department: DEPARTMENTS[0],
+              departmentId: 0,
               status: "inactive",
               isStarred: true,
             },
@@ -1869,6 +1881,7 @@ export const WithSyncSearch: Story = {
               email: "emma@example.com",
               role: "Marketing Lead",
               department: DEPARTMENTS[3],
+              departmentId: 3,
               status: "active",
               isStarred: false,
             },
@@ -1892,10 +1905,10 @@ export const WithSyncSearch: Story = {
           }
 
           // Apply department filter if provided
-          const departmentFilter = filters.department as string[] | undefined
+          const departmentFilter = filters.departmentId as number[] | undefined
           if (departmentFilter && departmentFilter.length > 0) {
             filteredUsers = filteredUsers.filter((user) =>
-              departmentFilter.includes(user.department)
+              departmentFilter.includes(user.departmentId)
             )
           }
 
@@ -2037,7 +2050,7 @@ export const WithAsyncSearch: Story = {
               }
 
               // Apply department filter if provided
-              const departmentFilter = filters.department as
+              const departmentFilter = filters.departmentId as
                 | string[]
                 | undefined
               if (departmentFilter && departmentFilter.length > 0) {


### PR DESCRIPTION
## Description

- fix: Fixes an issue with the filters that loads the options async that didn't show the label in the chips
- feat: set a new way to load the options and caches the values to use in the selector and in the chips

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [ ] Component added to `experimental` folder
- [ ] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
