### PR TITLE
feat(DataCollection): enable onClick in rows

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/index.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react"
 import { DownloadIcon, Mail, Tag, UploadIcon } from "lucide-react"
+import { useState } from "react"
 import { Observable } from "zen-observable-ts"
 import {
   Ai,
@@ -12,6 +13,7 @@ import {
   Star,
 } from "../../icons/app"
 import { PromiseState } from "../../lib/promise-to-observable"
+import { Dialog } from "../Overlays/Dialog"
 import { StandardLayout } from "../PageLayouts/StandardLayout"
 import { FilterDefinition, FiltersState } from "./Filters/types"
 import { OneDataCollection, useDataSource } from "./index"
@@ -2347,4 +2349,152 @@ export const InLayout: Story = {
       <ExampleComponent frozenColumns={1} />
     </StandardLayout>
   ),
+}
+
+export const WithOnClick: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false)
+    const [item, setItem] = useState<string | undefined>(undefined)
+
+    const dataSource = useDataSource({
+      filters,
+      presets: filterPresets,
+      itemOnClick: (item) => () => {
+        setIsOpen(true)
+        setItem(item.name)
+      },
+      sortings: {
+        name: {
+          label: "Name",
+        },
+        email: {
+          label: "Email",
+        },
+        role: {
+          label: "Role",
+        },
+        department: {
+          label: "Department",
+        },
+        salary: {
+          label: "Salary",
+        },
+      },
+      dataAdapter: {
+        fetchData: createPromiseDataFetch(),
+      },
+      itemActions: (item) => [
+        {
+          label: "Edit",
+          icon: Pencil,
+          onClick: () => console.log(`Editing ${item.name}`),
+          description: "Modify user information",
+        },
+        {
+          label: "View Profile",
+          icon: Ai,
+          onClick: () => console.log(`Viewing ${item.name}'s profile`),
+        },
+        { type: "separator" },
+        {
+          label: item.isStarred ? "Remove Star" : "Star User",
+          icon: Star,
+          onClick: () => console.log(`Toggling star for ${item.name}`),
+          description: item.isStarred
+            ? "Remove from favorites"
+            : "Add to favorites",
+        },
+        {
+          label: "Delete",
+          icon: Delete,
+          onClick: () => console.log(`Deleting ${item.name}`),
+          critical: true,
+          description: "Permanently remove user",
+          enabled:
+            item.department === "Engineering" && item.status === "active",
+        },
+      ],
+    })
+
+    return (
+      <>
+        <Dialog
+          open={isOpen}
+          onClose={() => setIsOpen(false)}
+          header={{
+            title: `Viewing ${item}`,
+            description: `You clicked on the ${item} row`,
+            type: "info",
+          }}
+          actions={{
+            primary: {
+              label: "Ok",
+              variant: "default",
+              onClick: () => {
+                setIsOpen(false)
+              },
+            },
+            secondary: {
+              label: "Cancel",
+              onClick: () => setIsOpen(false),
+            },
+          }}
+        />
+        <div className="space-y-4">
+          <OneDataCollection
+            source={dataSource}
+            visualizations={[
+              {
+                type: "table",
+                options: {
+                  columns: [
+                    {
+                      label: "Name",
+                      render: (item) => item.name,
+                      sorting: "name",
+                    },
+                    {
+                      label: "Email",
+                      render: (item) => item.email,
+                      sorting: "email",
+                    },
+                    {
+                      label: "Role",
+                      render: (item) => item.role,
+                      sorting: "role",
+                    },
+                    {
+                      label: "Department",
+                      render: (item) => item.department,
+                      sorting: "department",
+                    },
+                  ],
+                },
+              },
+              {
+                type: "card",
+                options: {
+                  title: (item) => item.name,
+                  cardProperties: [
+                    {
+                      label: "Email",
+                      render: (item) => item.email,
+                    },
+                    {
+                      label: "Role",
+                      render: (item) => item.role,
+                    },
+                    {
+                      label: "Department",
+                      render: (item) => item.department,
+                    },
+                  ],
+                },
+              },
+            ]}
+          />
+        </div>
+      </>
+    )
+  },
 }

--- a/packages/react/src/experimental/OneDataCollection/types.ts
+++ b/packages/react/src/experimental/OneDataCollection/types.ts
@@ -25,6 +25,8 @@ export type DataSourceDefinition<
   presets?: Presets<Filters>
   /** URL for a single item in the collection */
   itemUrl?: (item: Record) => string | undefined
+  /** Click handler for a single item in the collection */
+  itemOnClick?: (item: Record) => () => void
   /** Available actions that can be performed on records */
   itemActions?: ItemActions
   /** Available primary actions that can be performed on the collection */

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
@@ -236,6 +236,9 @@ export const TableCollection = <
         <TableBody>
           {data.map((item, index) => {
             const itemHref = source.itemUrl ? source.itemUrl(item) : undefined
+            const itemOnClick = source.itemOnClick
+              ? source.itemOnClick(item)
+              : undefined
             const id = source.selectable ? source.selectable(item) : undefined
             return (
               <TableRow key={`row-${index}`}>
@@ -260,6 +263,7 @@ export const TableCollection = <
                     key={String(column.label)}
                     firstCell={cellIndex === 0}
                     href={itemHref}
+                    onClick={itemOnClick}
                     width={column.width}
                     sticky={
                       cellIndex < frozenColumnsLeft
@@ -292,6 +296,7 @@ export const TableCollection = <
                       right: 0,
                     }}
                     href={itemHref}
+                    onClick={itemOnClick}
                   >
                     <ActionsDropdown item={item} actions={source.itemActions} />
                   </TableCell>

--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -15,6 +15,11 @@ interface TableCellProps {
   href?: string
 
   /**
+   * The onClick handler for the cell
+   */
+  onClick?: () => void
+
+  /**
    * Defines if the cell is the first cell in the row
    * @default false
    */
@@ -35,6 +40,7 @@ interface TableCellProps {
 export function TableCell({
   children,
   href,
+  onClick,
   width = "auto",
   firstCell = false,
   sticky,
@@ -105,6 +111,26 @@ export function TableCell({
         >
           <span className="sr-only">{actions.view}</span>
         </Link>
+      )}
+      {onClick && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onClick()
+          }}
+          data-testid="table-cell-action-button"
+          className="table-cell-action-button absolute inset-0 !z-0 block"
+          tabIndex={firstCell ? undefined : -1}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault()
+              onClick()
+            }
+          }}
+        >
+          <span className="sr-only">{actions.view}</span>
+        </button>
       )}
     </TableCellRoot>
   )

--- a/packages/react/src/experimental/OneTable/TableRow/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableRow/index.tsx
@@ -14,7 +14,9 @@ export function TableRow({ children, selected, className }: TableRowProps) {
       className={cn(
         selected && "bg-f1-background-selected hover:bg-f1-background-selected",
         className,
-        "relative before:pointer-events-none before:absolute before:inset-0 before:z-10 before:content-[''] [&:has(a:focus)]:before:rounded-sm [&:has(a:focus)]:before:ring-1 [&:has(a:focus)]:before:ring-inset [&:has(a:focus)]:before:ring-f1-ring"
+        "relative before:pointer-events-none before:absolute before:inset-0 before:z-10 before:content-['']",
+        "[&:has(.table-cell-action-button:focus)]:before:rounded-sm [&:has(.table-cell-action-button:focus)]:before:ring-1 [&:has(.table-cell-action-button:focus)]:before:ring-inset [&:has(.table-cell-action-button:focus)]:before:ring-f1-ring",
+        "[&:has(a:focus)]:before:rounded-sm [&:has(a:focus)]:before:ring-1 [&:has(a:focus)]:before:ring-inset [&:has(a:focus)]:before:ring-f1-ring"
       )}
     >
       {children}

--- a/packages/react/src/experimental/OneTable/index.stories.tsx
+++ b/packages/react/src/experimental/OneTable/index.stories.tsx
@@ -741,3 +741,89 @@ export const Loading: Story = {
     )
   },
 }
+
+export const WithOnClick: Story = {
+  render: () => {
+    function action() {
+      alert("action clicked")
+    }
+
+    return (
+      <OneTable>
+        <TableHeader>
+          <TableRow>
+            <TableHead width="fit">
+              <Checkbox checked={false} title="Select all" hideLabel />
+            </TableHead>
+            <TableHead>Name</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Role</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead width="fit" hidden>
+              Actions
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sampleData.map((row) => (
+            <TableRow key={row.id}>
+              <TableCell firstCell onClick={action}>
+                <Checkbox checked={false} title="Select" hideLabel />
+              </TableCell>
+              <TableCell onClick={action}>
+                <div className="flex items-center gap-2">
+                  <PersonAvatar
+                    firstName={row.name.split(" ")[0]}
+                    lastName={row.name.split(" ")[1]}
+                    size="small"
+                  />
+                  <span className="font-medium">{row.name}</span>
+                </div>
+              </TableCell>
+              <TableCell onClick={action}>{row.email}</TableCell>
+              <TableCell onClick={action}>
+                <div className="w-fit">
+                  <RawTag text={row.role} />
+                </div>
+              </TableCell>
+              <TableCell onClick={action}>
+                <div className="w-fit">
+                  <StatusTag
+                    text={row.status.label}
+                    variant={row.status.variant}
+                  />
+                </div>
+              </TableCell>
+              <TableCell onClick={action}>
+                <Dropdown
+                  items={[
+                    {
+                      label: "Edit",
+                      icon: Pencil,
+                      onClick: () => {},
+                    },
+                    {
+                      label: "Delete",
+                      icon: Delete,
+                      onClick: () => {},
+                      critical: true,
+                    },
+                  ]}
+                >
+                  <Button
+                    hideLabel
+                    variant="ghost"
+                    icon={Ellipsis}
+                    onClick={() => {}}
+                    round
+                    label="Actions"
+                  />
+                </Dropdown>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </OneTable>
+    )
+  },
+}


### PR DESCRIPTION
## Description

Some use cases for the DataCollection require opening a sidepanel or modal instead of a link. This PR adds the option to define an onClick for each row in the table visualisation, so each team can define whatever they need when the row is clicked.

## Screenshots

https://github.com/user-attachments/assets/b5a3d64d-9719-40a1-b4e6-5496d38e9fca

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
