### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.20.2",
+  "packages/react": "1.21.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.21.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.20.2...factorial-one-react-v1.21.0) (2025-04-03)
+
+
+### Features
+
+* **DataCollection:** enable onClick in rows ([#1539](https://github.com/factorialco/factorial-one/issues/1539)) ([084bfe1](https://github.com/factorialco/factorial-one/commit/084bfe1cfe6b224739994bc5d2a6ab8401407db2))
+
 ## [1.20.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.20.1...factorial-one-react-v1.20.2) (2025-04-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.21.0</summary>

## [1.21.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.20.2...factorial-one-react-v1.21.0) (2025-04-03)


### Features

* **DataCollection:** enable onClick in rows ([#1539](https://github.com/factorialco/factorial-one/issues/1539)) ([084bfe1](https://github.com/factorialco/factorial-one/commit/084bfe1cfe6b224739994bc5d2a6ab8401407db2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).