### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.21.0",
+  "packages/react": "1.21.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.21.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.21.0...factorial-one-react-v1.21.1) (2025-04-03)
+
+
+### Bug Fixes
+
+* figma errors and new functionalities for RichTextEditor ([#1541](https://github.com/factorialco/factorial-one/issues/1541)) ([0d03644](https://github.com/factorialco/factorial-one/commit/0d036441c10274a0b0d3df5399edff5d609846a3))
+
 ## [1.21.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.20.2...factorial-one-react-v1.21.0) (2025-04-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.21.1</summary>

## [1.21.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.21.0...factorial-one-react-v1.21.1) (2025-04-03)


### Bug Fixes

* figma errors and new functionalities for RichTextEditor ([#1541](https://github.com/factorialco/factorial-one/issues/1541)) ([0d03644](https://github.com/factorialco/factorial-one/commit/0d036441c10274a0b0d3df5399edff5d609846a3))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).