### PR TITLE
fix(DataCollection): check active filters to display the 'Clear' button

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersChipsList.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersChipsList.tsx
@@ -20,18 +20,21 @@ export function FiltersChipsList<Filters extends FiltersDefinition>({
   onClearAll,
 }: FiltersChipsListProps<Filters>) {
   const i18n = useI18n()
-  if (Object.keys(currentFilters).length === 0) return null
+
+  const activeFilterKeys = Object.keys(currentFilters).filter((key) => {
+    const value = currentFilters[key as keyof Filters]
+    const filter = filters[key as keyof Filters]
+    return filter.type === "in" && Array.isArray(value) && value.length > 0
+  }) as Array<keyof Filters>
+
+  if (activeFilterKeys.length === 0) return null
 
   return (
     <div className="flex items-start justify-between gap-2 px-6">
       <div className="flex flex-wrap items-center gap-2">
         <AnimatePresence presenceAffectsLayout initial={false}>
-          {(Object.keys(currentFilters) as Array<keyof Filters>).map((key) => {
+          {activeFilterKeys.map((key) => {
             const filter = filters[key]
-            if (!currentFilters[key]) {
-              return null
-            }
-
             return (
               <FilterButton
                 key={`filter-${String(key)}`}


### PR DESCRIPTION
## Description

The 'Clear' button in the filters chips list was being displayed even if no active filters were applied. This PR fixes that checking for active filters in the filters chip list component.

## Screenshots

### Before

https://github.com/user-attachments/assets/418cf697-aa25-4465-a096-0d72baffea93

### After

https://github.com/user-attachments/assets/085ff601-72ab-43ee-a089-9b956117ab76

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other