### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.21.3",
+  "packages/react": "1.22.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.22.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.21.3...factorial-one-react-v1.22.0) (2025-04-04)
+
+
+### Features
+
+* add support to show break type name in ClockInControls ([#1553](https://github.com/factorialco/factorial-one/issues/1553)) ([e41f813](https://github.com/factorialco/factorial-one/commit/e41f813e2dd0c82a67f6b1ca3cefd494781a4fe2))
+
 ## [1.21.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.21.2...factorial-one-react-v1.21.3) (2025-04-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.21.3",
+  "version": "1.22.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.22.0</summary>

## [1.22.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.21.3...factorial-one-react-v1.22.0) (2025-04-04)


### Features

* add support to show break type name in ClockInControls ([#1553](https://github.com/factorialco/factorial-one/issues/1553)) ([e41f813](https://github.com/factorialco/factorial-one/commit/e41f813e2dd0c82a67f6b1ca3cefd494781a4fe2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).