### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.23.0",
+  "packages/react": "1.23.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.23.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.23.0...factorial-one-react-v1.23.1) (2025-04-04)
+
+
+### Bug Fixes
+
+* exports widgets components ([#1562](https://github.com/factorialco/factorial-one/issues/1562)) ([fe912c0](https://github.com/factorialco/factorial-one/commit/fe912c0107107e5d9676f7f814eff3bf715dc251))
+
 ## [1.23.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.22.2...factorial-one-react-v1.23.0) (2025-04-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.23.1</summary>

## [1.23.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.23.0...factorial-one-react-v1.23.1) (2025-04-04)


### Bug Fixes

* exports widgets components ([#1562](https://github.com/factorialco/factorial-one/issues/1562)) ([fe912c0](https://github.com/factorialco/factorial-one/commit/fe912c0107107e5d9676f7f814eff3bf715dc251))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).