### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.23.1",
+  "packages/react": "1.23.2",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.23.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.23.1...factorial-one-react-v1.23.2) (2025-04-07)
+
+
+### Bug Fixes
+
+* remove section header padding top ([#1565](https://github.com/factorialco/factorial-one/issues/1565)) ([b2d9cac](https://github.com/factorialco/factorial-one/commit/b2d9cac0e2b279cffb8fb4b8f8781b4fde76da65))
+
 ## [1.23.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.23.0...factorial-one-react-v1.23.1) (2025-04-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.23.2</summary>

## [1.23.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.23.1...factorial-one-react-v1.23.2) (2025-04-07)


### Bug Fixes

* remove section header padding top ([#1565](https://github.com/factorialco/factorial-one/issues/1565)) ([b2d9cac](https://github.com/factorialco/factorial-one/commit/b2d9cac0e2b279cffb8fb4b8f8781b4fde76da65))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).