### PR TITLE
fix: make widgets more transparent

### DIFF
--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -93,6 +93,9 @@ const Container = forwardRef<
         fullHeight ? "h-full" : "",
         "relative flex gap-3 border-f1-border-secondary"
       )}
+      style={{
+        backgroundColor: "hsl(var(--white-40))",
+      }}
       ref={ref}
     >
       {header && (


### PR DESCRIPTION
## Description

According to our final Figma designs, widgets background opacity should be 0.4 instead of 0.6.

<img width="1047" alt="Screenshot 2025-04-09 at 17 18 30" src="https://github.com/user-attachments/assets/9ccd5333-4145-4154-9181-7e2f833ae26c" />
