### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.24.0",
+  "packages/react": "1.24.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.24.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.24.0...factorial-one-react-v1.24.1) (2025-04-10)
+
+
+### Bug Fixes
+
+* Button & DropdownButton visuals  ([#1571](https://github.com/factorialco/factorial-one/issues/1571)) ([9a6c4db](https://github.com/factorialco/factorial-one/commit/9a6c4db45f93c93abe93f62130b9f3e27c0e8997))
+
 ## [1.24.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.23.2...factorial-one-react-v1.24.0) (2025-04-08)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.24.1</summary>

## [1.24.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.24.0...factorial-one-react-v1.24.1) (2025-04-10)


### Bug Fixes

* Button & DropdownButton visuals  ([#1571](https://github.com/factorialco/factorial-one/issues/1571)) ([9a6c4db](https://github.com/factorialco/factorial-one/commit/9a6c4db45f93c93abe93f62130b9f3e27c0e8997))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).