### PR TITLE
fix(Table): Head label truncate when not enough space

### DIFF
--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -76,7 +76,9 @@ export function TableHead({
           hasContent && "gap-1"
         )}
       >
-        {children}
+        <div className={cn("truncate", width !== "auto" && "overflow-hidden")}>
+          {children}
+        </div>
         {hasContent && (
           <div className="flex items-center">
             {info && (
@@ -187,18 +189,7 @@ export function TableHead({
           />
         )}
       </AnimatePresence>
-      {!hidden &&
-        (info ? (
-          <Tooltip label={info}>
-            <div className={cn(width !== "auto" && "overflow-hidden")}>
-              {content}
-            </div>
-          </Tooltip>
-        ) : (
-          <div className={cn(width !== "auto" && "overflow-hidden")}>
-            {content}
-          </div>
-        ))}
+      {!hidden && (info ? <Tooltip label={info}>{content}</Tooltip> : content)}
     </TableHeadRoot>
   )
 }


### PR DESCRIPTION
## Description

The table head label is now truncated if there is not enough space to display it.

PD: This is a quick fix to avoid weird behaviours, but we can improve this by displaying a tooltip to be able to read the entire label. But as we also have a `info` prop that displays a different tooltip, we need to check first how to do that design-wise.

## Screenshots

<img width="322" alt="Screenshot 2025-04-10 at 17 05 30" src="https://github.com/user-attachments/assets/11e55db1-3759-4e83-b6ba-4fa421943ead" />
<img width="347" alt="Screenshot 2025-04-10 at 17 05 55" src="https://github.com/user-attachments/assets/d00e0dc0-f082-4190-b3aa-664ef477c77f" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
