### PR TITLE
refactor: use motion.create instead of motion

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/index.tsx
@@ -124,7 +124,7 @@ export const useDataSource = <
   }
 }
 
-const MotionIcon = motion(Icon)
+const MotionIcon = motion.create(Icon)
 
 /**
  * A component that renders a collection of data with filtering and visualization capabilities.

--- a/packages/react/src/ui/OverflowList/index.tsx
+++ b/packages/react/src/ui/OverflowList/index.tsx
@@ -15,7 +15,7 @@ import { cn, focusRing } from "../../lib/utils"
 import { Popover, PopoverContent, PopoverTrigger } from "../popover"
 import { Skeleton } from "../skeleton"
 
-const IconMotion = motion(Icon)
+const IconMotion = motion.create(Icon)
 
 /**
  * Custom hook for overflow calculations


### PR DESCRIPTION
## Description

The motion function is deprecated in favor of using motion.create. This updates some components that were using the old version.

## Screenshots (if applicable)

N/A

### Figma Link

N/A

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
