### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.24.1",
+  "packages/react": "1.25.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.25.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.24.1...factorial-one-react-v1.25.0) (2025-04-11)
+
+
+### Features
+
+* define default items per page as 20 ([#1543](https://github.com/factorialco/factorial-one/issues/1543)) ([aca28fa](https://github.com/factorialco/factorial-one/commit/aca28fa9de1e0416eb1f37c85f6055b9d5c97e1d))
+
 ## [1.24.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.24.0...factorial-one-react-v1.24.1) (2025-04-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.25.0</summary>

## [1.25.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.24.1...factorial-one-react-v1.25.0) (2025-04-11)


### Features

* define default items per page as 20 ([#1543](https://github.com/factorialco/factorial-one/issues/1543)) ([aca28fa](https://github.com/factorialco/factorial-one/commit/aca28fa9de1e0416eb1f37c85f6055b9d5c97e1d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).