### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.26.0",
+  "packages/react": "1.26.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.26.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.26.0...factorial-one-react-v1.26.1) (2025-04-11)
+
+
+### Bug Fixes
+
+* make widgets more transparent ([#1570](https://github.com/factorialco/factorial-one/issues/1570)) ([b02386c](https://github.com/factorialco/factorial-one/commit/b02386c8e32b54bd77e1f2af916bc4a2d23f5618))
+
 ## [1.26.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.25.0...factorial-one-react-v1.26.0) (2025-04-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.26.1</summary>

## [1.26.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.26.0...factorial-one-react-v1.26.1) (2025-04-11)


### Bug Fixes

* make widgets more transparent ([#1570](https://github.com/factorialco/factorial-one/issues/1570)) ([b02386c](https://github.com/factorialco/factorial-one/commit/b02386c8e32b54bd77e1f2af916bc4a2d23f5618))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).