### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.26.1",
+  "packages/react": "1.27.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.27.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.26.1...factorial-one-react-v1.27.0) (2025-04-11)
+
+
+### Features
+
+* create WidgetAvatarsListItem with alert ([#1585](https://github.com/factorialco/factorial-one/issues/1585)) ([4ee8a76](https://github.com/factorialco/factorial-one/commit/4ee8a76745e3456a513a735e646b6e6ba5256dae))
+
 ## [1.26.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.26.0...factorial-one-react-v1.26.1) (2025-04-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.26.1",
+  "version": "1.27.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.27.0</summary>

## [1.27.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.26.1...factorial-one-react-v1.27.0) (2025-04-11)


### Features

* create WidgetAvatarsListItem with alert ([#1585](https://github.com/factorialco/factorial-one/issues/1585)) ([4ee8a76](https://github.com/factorialco/factorial-one/commit/4ee8a76745e3456a513a735e646b6e6ba5256dae))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).