### PR TITLE
fix: deleted shadow from switch

### DIFF
--- a/packages/react/src/ui/switch.tsx
+++ b/packages/react/src/ui/switch.tsx
@@ -23,7 +23,7 @@ const Switch = React.forwardRef<
         name={switchId}
         aria-label={props.title ?? "Switch"}
         className={cn(
-          "relative h-5 w-[1.875rem] rounded-full bg-f1-border shadow-md hover:bg-f1-border-hover data-[state=checked]:bg-f1-background-selected-bold",
+          "relative h-5 w-[1.875rem] rounded-full bg-f1-border hover:bg-f1-border-hover data-[state=checked]:bg-f1-background-selected-bold",
           disabled && "cursor-not-allowed opacity-50",
           focusRing(),
           className
@@ -32,7 +32,7 @@ const Switch = React.forwardRef<
       >
         <SwitchPrimitive.Thumb
           className={cn(
-            "block h-4 w-4 translate-x-[0.125rem] rounded-full bg-f1-background shadow-md transition-transform duration-300 data-[state=checked]:translate-x-[0.75rem]"
+            "block h-4 w-4 translate-x-[0.125rem] rounded-full bg-f1-background transition-transform duration-300 data-[state=checked]:translate-x-[0.75rem]"
           )}
         />
       </SwitchPrimitive.Root>


### PR DESCRIPTION
## Description

I made a mistake an I added a shadow to the component

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [ ] Component added to `experimental` folder
- [ ] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
