### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.29.0",
+  "packages/react": "1.29.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.29.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.29.0...factorial-one-react-v1.29.1) (2025-04-13)
+
+
+### Bug Fixes
+
+* change positive badge color ([#1595](https://github.com/factorialco/factorial-one/issues/1595)) ([0fad991](https://github.com/factorialco/factorial-one/commit/0fad991f88eec4251f7b9e5b9115d97dda9f1f2c))
+
 ## [1.29.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.28.0...factorial-one-react-v1.29.0) (2025-04-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.29.1</summary>

## [1.29.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.29.0...factorial-one-react-v1.29.1) (2025-04-13)


### Bug Fixes

* change positive badge color ([#1595](https://github.com/factorialco/factorial-one/issues/1595)) ([0fad991](https://github.com/factorialco/factorial-one/commit/0fad991f88eec4251f7b9e5b9115d97dda9f1f2c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).