### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.29.1",
+  "packages/react": "1.29.2",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.29.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.29.1...factorial-one-react-v1.29.2) (2025-04-13)
+
+
+### Bug Fixes
+
+* set proper HighlightBanner button ([#1597](https://github.com/factorialco/factorial-one/issues/1597)) ([71010d3](https://github.com/factorialco/factorial-one/commit/71010d35a550a44a99ec383c07d0fe755e653a49))
+
 ## [1.29.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.29.0...factorial-one-react-v1.29.1) (2025-04-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.29.2</summary>

## [1.29.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.29.1...factorial-one-react-v1.29.2) (2025-04-13)


### Bug Fixes

* set proper HighlightBanner button ([#1597](https://github.com/factorialco/factorial-one/issues/1597)) ([71010d3](https://github.com/factorialco/factorial-one/commit/71010d35a550a44a99ec383c07d0fe755e653a49))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).