### PR TITLE
fix: start break when the amount of break types is only one

### DIFF
--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
@@ -206,8 +206,16 @@ export const WithBreakTypes: Story = {
 
 export const WithOneBreakType: Story = {
   args: {
-    ...WithBreakTypes.args,
-    breakTypes: WithBreakTypes.args.breakTypes.slice(0, 1),
+    ...ClockedIn.args,
+    breakTypes: [
+      {
+        id: "1",
+        name: "Break name",
+        duration: "1h",
+        description: "This is a description",
+        isPaid: true,
+      },
+    ],
   },
 }
 

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
@@ -204,6 +204,13 @@ export const WithBreakTypes: Story = {
   },
 }
 
+export const WithOneBreakType: Story = {
+  args: {
+    ...WithBreakTypes.args,
+    breakTypes: WithBreakTypes.args.breakTypes.slice(0, 1),
+  },
+}
+
 export const WithDisabledSelectors: Story = {
   args: {
     ...ClockedOut.args,

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
@@ -94,19 +94,20 @@ export function ClockInControls({
 
   const showLocationAndProjectSelectors = status === "clocked-out"
 
-  const breakTypeOptions = breakTypes?.map((breakType) => ({
-    value: breakType.id,
-    label: breakType.duration
-      ? `${breakType.name} · ${breakType.duration}`
-      : breakType.name,
-    description: breakType.description,
-    tag: breakType.isPaid ? labels.paid : labels.unpaid,
-  }))
+  const breakTypeOptions =
+    breakTypes?.map((breakType) => ({
+      value: breakType.id,
+      label: breakType.duration
+        ? `${breakType.name} · ${breakType.duration}`
+        : breakType.name,
+      description: breakType.description,
+      tag: breakType.isPaid ? labels.paid : labels.unpaid,
+    })) ?? []
 
   const [breakTypePickerOpen, setBreakTypePickerOpen] = useState(false)
 
   const handleClickBreakButton = () => {
-    if ((breakTypeOptions?.length ?? 0) > 1) {
+    if (breakTypeOptions.length > 1) {
       if (!breakTypePickerOpen) {
         setBreakTypePickerOpen(true)
       }
@@ -199,9 +200,7 @@ export function ClockInControls({
                 <>
                   {canShowBreakButton && (
                     <>
-                      {breakTypeOptions &&
-                      (breakTypeOptions?.length ?? 0) > 1 &&
-                      onChangeBreakTypeId ? (
+                      {breakTypeOptions.length > 1 && onChangeBreakTypeId ? (
                         <Select
                           value=""
                           options={breakTypeOptions}

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
@@ -106,10 +106,13 @@ export function ClockInControls({
   const [breakTypePickerOpen, setBreakTypePickerOpen] = useState(false)
 
   const handleClickBreakButton = () => {
-    if (breakTypeOptions?.length && !breakTypePickerOpen) {
-      setBreakTypePickerOpen(true)
-    } else if (!breakTypeOptions?.length) {
-      onBreak?.()
+    if ((breakTypeOptions?.length ?? 0) > 1) {
+      if (!breakTypePickerOpen) {
+        setBreakTypePickerOpen(true)
+      }
+    } else {
+      const firstBreakTypeValue = breakTypeOptions?.[0]?.value
+      onBreak?.(firstBreakTypeValue)
     }
   }
 
@@ -196,7 +199,9 @@ export function ClockInControls({
                 <>
                   {canShowBreakButton && (
                     <>
-                      {breakTypeOptions?.length && onChangeBreakTypeId ? (
+                      {breakTypeOptions &&
+                      (breakTypeOptions?.length ?? 0) > 1 &&
+                      onChangeBreakTypeId ? (
                         <Select
                           value=""
                           options={breakTypeOptions}
@@ -207,7 +212,6 @@ export function ClockInControls({
                         >
                           <div aria-label="Select break type">
                             <Button
-                              // onClick={handleClickBreakButton}
                               label={labels.break}
                               variant="neutral"
                               icon={SolidPause}


### PR DESCRIPTION
## Description

When we pass an array of break types it will probably be more usual to pass multiple of them, however, when we are passing only one break type we are also showing the picker when the user clicks on the break button, which is a little bit redundant.

## Screenshots

This is what we want to avoid:

<img width="384" alt="Screenshot 2025-04-14 at 10 08 54" src="https://github.com/user-attachments/assets/39e93aab-837a-48cc-bad2-2a28830aa8c1" />

Now, if only one break type is available, that one will be selected by default and the break will start automatically.