### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.29.3",
+  "packages/react": "1.29.4",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.29.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.29.3...factorial-one-react-v1.29.4) (2025-04-14)
+
+
+### Bug Fixes
+
+* start break when the amount of break types is only one ([#1602](https://github.com/factorialco/factorial-one/issues/1602)) ([f59cc36](https://github.com/factorialco/factorial-one/commit/f59cc36934154499a17082614eb5e9cf3e94e626))
+
 ## [1.29.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.29.2...factorial-one-react-v1.29.3) (2025-04-14)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.29.3",
+  "version": "1.29.4",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,
@@ -167,8 +167,8 @@
   },
   "dependencies": {
     "@radix-ui/react-hover-card": "^1.1.6",
-    "@tanstack/react-virtual": "^3.13.6",
     "@radix-ui/react-switch": "^1.1.4",
+    "@tanstack/react-virtual": "^3.13.2",
     "@tiptap/extension-bubble-menu": "^2.11.5",
     "@tiptap/extension-character-count": "^2.11.5",
     "@tiptap/extension-color": "^2.11.5",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.29.4</summary>

## [1.29.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.29.3...factorial-one-react-v1.29.4) (2025-04-14)


### Bug Fixes

* start break when the amount of break types is only one ([#1602](https://github.com/factorialco/factorial-one/issues/1602)) ([f59cc36](https://github.com/factorialco/factorial-one/commit/f59cc36934154499a17082614eb5e9cf3e94e626))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).