### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.30.2",
+  "packages/react": "1.30.3",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.30.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.30.2...factorial-one-react-v1.30.3) (2025-04-14)
+
+
+### Bug Fixes
+
+* make author url optional in CommunityPost component ([#1610](https://github.com/factorialco/factorial-one/issues/1610)) ([4fcc998](https://github.com/factorialco/factorial-one/commit/4fcc9989aa722cbf1f62ae7fba89388431d2ed35))
+
 ## [1.30.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.30.1...factorial-one-react-v1.30.2) (2025-04-14)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.30.3</summary>

## [1.30.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.30.2...factorial-one-react-v1.30.3) (2025-04-14)


### Bug Fixes

* make author url optional in CommunityPost component ([#1610](https://github.com/factorialco/factorial-one/issues/1610)) ([4fcc998](https://github.com/factorialco/factorial-one/commit/4fcc9989aa722cbf1f62ae7fba89388431d2ed35))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).