### PR TITLE
feat: add support to pass tracked minutes to ClockInControls and ClockInGraph component

### DIFF
--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/helpers.spec.ts
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/helpers.spec.ts
@@ -29,6 +29,7 @@ describe("ClockInControls helpers", () => {
     it("should return clocked-out status when no data provided", () => {
       const result = getInfo({
         data: [],
+        trackedMinutes: 0,
         labels: mockLabels,
         remainingMinutes: undefined,
       })
@@ -46,6 +47,7 @@ describe("ClockInControls helpers", () => {
 
       const result = getInfo({
         data: mockData,
+        trackedMinutes: 0,
         labels: mockLabels,
         remainingMinutes: undefined,
       })
@@ -65,6 +67,7 @@ describe("ClockInControls helpers", () => {
         data: mockData,
         labels: mockLabels,
         remainingMinutes: undefined,
+        trackedMinutes: 0,
       })
 
       expect(result).toEqual({
@@ -80,6 +83,7 @@ describe("ClockInControls helpers", () => {
         data: [],
         labels: mockLabels,
         remainingMinutes: 90, // 1 hour 30 minutes
+        trackedMinutes: 0,
       })
 
       expect(result.subtitle).toBe("Remaining: 01:30")
@@ -102,6 +106,7 @@ describe("ClockInControls helpers", () => {
         ],
         labels: mockLabels,
         remainingMinutes: -45, // 45 minutes overtime
+        trackedMinutes: 45,
       })
 
       expect(result.subtitle).toBe("Overtime: 00:45")
@@ -113,6 +118,7 @@ describe("ClockInControls helpers", () => {
         data: [],
         labels: mockLabels,
         remainingMinutes: 0,
+        trackedMinutes: 0,
       })
 
       expect(result.subtitle).toBe("Remaining: 00:00")
@@ -126,6 +132,7 @@ describe("ClockInControls helpers", () => {
         data: mockData,
         labels: mockLabels,
         remainingMinutes: undefined,
+        trackedMinutes: 0,
       })
 
       expect(result.status).toBe("break")
@@ -140,6 +147,7 @@ describe("ClockInControls helpers", () => {
         data: mockData,
         labels: mockLabels,
         remainingMinutes: undefined,
+        trackedMinutes: 0,
       })
 
       expect(result.subtitle).toBeUndefined()
@@ -150,6 +158,7 @@ describe("ClockInControls helpers", () => {
         data: [],
         labels: mockLabels,
         remainingMinutes: 120, // 2 hours
+        trackedMinutes: 0,
       })
 
       expect(result).toEqual({

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/helpers.ts
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/helpers.ts
@@ -3,22 +3,12 @@ import { ClockInControlsProps } from "./index"
 
 // to prevent having an overtime greater that the total time that we're showing
 export const getNormalizedRemainingMinutes = (
-  data: ClockInControlsProps["data"],
+  trackedMinutes: ClockInControlsProps["trackedMinutes"],
   remainingMinutes: ClockInControlsProps["remainingMinutes"]
 ) => {
-  const totalMinutesWithoutRemainingTime =
-    (data?.reduce(
-      (acc, entry) =>
-        acc +
-        (entry.variant === "clocked-in"
-          ? (entry.to.getTime() - entry.from.getTime()) / 1000
-          : 0),
-      0
-    ) ?? 0) / 60
-
   const res =
-    (remainingMinutes ?? 0) < -1 * (totalMinutesWithoutRemainingTime ?? 0)
-      ? -1 * totalMinutesWithoutRemainingTime
+    (remainingMinutes ?? 0) < -1 * (trackedMinutes ?? 0)
+      ? -1 * trackedMinutes
       : remainingMinutes
 
   return res ?? 0
@@ -27,11 +17,16 @@ export const getNormalizedRemainingMinutes = (
 export const getInfo = ({
   data = [],
   labels,
+  trackedMinutes,
   remainingMinutes,
   canSeeRemainingTime = true,
 }: Pick<
   ClockInControlsProps,
-  "data" | "labels" | "remainingMinutes" | "canSeeRemainingTime"
+  | "data"
+  | "labels"
+  | "trackedMinutes"
+  | "remainingMinutes"
+  | "canSeeRemainingTime"
 >) => {
   const lastEntry = data[data.length - 1]
   const status = lastEntry?.variant || "clocked-out"
@@ -48,7 +43,7 @@ export const getInfo = ({
     if (remainingMinutes === undefined) return
 
     const normalizedRemainingMinutes = getNormalizedRemainingMinutes(
-      data,
+      trackedMinutes,
       remainingMinutes
     )
 

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.spec.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.spec.tsx
@@ -23,6 +23,7 @@ describe("ClockInControls", () => {
     render(
       <ClockInControls
         data={[]}
+        trackedMinutes={0}
         labels={defaultLabels}
         locations={[]}
         onChangeLocationId={() => {}}
@@ -36,6 +37,7 @@ describe("ClockInControls", () => {
     render(
       <ClockInControls
         labels={defaultLabels}
+        trackedMinutes={0}
         data={[
           {
             from: new Date(),
@@ -54,6 +56,7 @@ describe("ClockInControls", () => {
     render(
       <ClockInControls
         labels={defaultLabels}
+        trackedMinutes={0}
         data={[
           {
             from: new Date(),
@@ -73,6 +76,7 @@ describe("ClockInControls", () => {
     render(
       <ClockInControls
         labels={defaultLabels}
+        trackedMinutes={0}
         remainingMinutes={4 * 60 + 39}
         data={[
           {
@@ -94,6 +98,7 @@ describe("ClockInControls", () => {
     render(
       <ClockInControls
         labels={defaultLabels}
+        trackedMinutes={17}
         remainingMinutes={-17}
         data={[
           {
@@ -117,6 +122,7 @@ describe("ClockInControls", () => {
       <ClockInControls
         data={[]}
         labels={defaultLabels}
+        trackedMinutes={0}
         onClockIn={onClockIn}
         locations={[]}
         onChangeLocationId={() => {}}

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.stories.tsx
@@ -66,6 +66,7 @@ export const ClockedOut: Story = {
 
 export const ClockedIn: Story = {
   args: {
+    trackedMinutes: 4 * 60 + 21,
     remainingMinutes: 4 * 60 + 39,
     data: [
       {
@@ -106,6 +107,7 @@ export const OnBreak: Story = {
 
 export const WithOvertime: Story = {
   args: {
+    trackedMinutes: 4 * 60 + 21,
     remainingMinutes: -17,
     data: [
       {
@@ -130,6 +132,7 @@ export const WithOvertime: Story = {
 export const OvertimeOnly: Story = {
   args: {
     ...WithOvertime.args,
+    trackedMinutes: 6 * 60 + 21,
     remainingMinutes: -9 * 60,
   },
 }
@@ -144,6 +147,7 @@ export const Collapsed: Story = {
 
 export const WithNoLocationOrProject: Story = {
   args: {
+    trackedMinutes: 4 * 60 + 21,
     remainingMinutes: 4 * 60 + 39,
     data: [
       {
@@ -158,6 +162,7 @@ export const WithNoLocationOrProject: Story = {
 
 export const ClockedOutWithSomeTime: Story = {
   args: {
+    trackedMinutes: 2 * 60 + 40,
     remainingMinutes: 320,
     data: [
       {

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInControls/index.tsx
@@ -22,6 +22,8 @@ export interface ClockInControlsProps {
   remainingMinutes?: number
   /** Clock in entries data */
   data: ClockInGraphProps["data"]
+  /** Tracked minutes */
+  trackedMinutes: number
   /** Labels for all text content */
   labels: {
     clockedOut: string
@@ -64,6 +66,7 @@ export interface ClockInControlsProps {
 }
 
 export function ClockInControls({
+  trackedMinutes,
   remainingMinutes,
   data = [],
   labels,
@@ -88,6 +91,7 @@ export function ClockInControls({
   const { status, statusText, subtitle, statusColor } = getInfo({
     data,
     labels,
+    trackedMinutes,
     remainingMinutes,
     canSeeRemainingTime,
   })
@@ -258,6 +262,7 @@ export function ClockInControls({
           {canSeeGraph && (
             <ClockInGraph
               data={data}
+              trackedMinutes={trackedMinutes}
               remainingMinutes={canSeeRemainingTime ? remainingMinutes : 0}
             />
           )}

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/helpers.spec.ts
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/helpers.spec.ts
@@ -5,7 +5,7 @@ import { CLOCK_IN_COLORS, ClockInStatus } from "./index"
 describe("ClockInGraph helpers", () => {
   describe("normalizeData", () => {
     it("should return array with empty entry when no data provided", () => {
-      const result = normalizeData()
+      const result = normalizeData({ data: [], trackedMinutes: 0 })
       expect(result).toEqual([
         {
           value: 1,
@@ -15,7 +15,11 @@ describe("ClockInGraph helpers", () => {
     })
 
     it("should handle remaining minutes > 0", () => {
-      const result = normalizeData([], 30)
+      const result = normalizeData({
+        data: [],
+        trackedMinutes: 0,
+        remainingMinutes: 30,
+      })
       expect(result).toEqual([
         {
           value: 1,
@@ -25,7 +29,11 @@ describe("ClockInGraph helpers", () => {
     })
 
     it("should handle overtime (remaining minutes < 0)", () => {
-      const result = normalizeData([], -30)
+      const result = normalizeData({
+        data: [],
+        trackedMinutes: 0,
+        remainingMinutes: -30,
+      })
       expect(result).toEqual([
         {
           value: 1,
@@ -35,16 +43,17 @@ describe("ClockInGraph helpers", () => {
     })
 
     it("should calculate correct duration for clock entries", () => {
-      const result = normalizeData(
-        [
+      const result = normalizeData({
+        data: [
           {
             from: new Date("2024-03-20T09:00:00"),
             to: new Date("2024-03-20T10:30:00"),
             variant: "clocked-in" satisfies ClockInStatus,
           },
         ],
-        30
-      )
+        trackedMinutes: 90,
+        remainingMinutes: 30,
+      })
       expect(result).toEqual([
         {
           value: 0.75, // 90 minutes difference
@@ -84,7 +93,7 @@ describe("ClockInGraph helpers", () => {
         createMockEntry("12:00", "12:30", "clocked-out"),
       ]
 
-      const result = getLabels({ data: mockData })
+      const result = getLabels({ data: mockData, trackedMinutes: 3 * 60 })
       expect(result).toEqual({
         primaryLabel: "09:00",
         secondaryLabel: "--:--",
@@ -98,7 +107,7 @@ describe("ClockInGraph helpers", () => {
         createMockEntry("13:00", "15:00", "clocked-in"),
       ]
 
-      const result = getLabels({ data: mockData })
+      const result = getLabels({ data: mockData, trackedMinutes: 5 * 60 })
       expect(result).toEqual({
         primaryLabel: "09:00",
         secondaryLabel: "--:--",
@@ -112,6 +121,7 @@ describe("ClockInGraph helpers", () => {
       const result = getLabels({
         data: mockData,
         remainingMinutes: -30,
+        trackedMinutes: 8 * 60,
       })
 
       expect(result).toEqual({
@@ -127,7 +137,11 @@ describe("ClockInGraph helpers", () => {
         createMockEntry("12:00", "12:00", "clocked-out"),
       ]
 
-      const result = getLabels({ data: mockData, remainingMinutes: 0 })
+      const result = getLabels({
+        data: mockData,
+        remainingMinutes: 0,
+        trackedMinutes: 3 * 60,
+      })
 
       expect(result).toEqual({
         primaryLabel: "09:00",
@@ -142,7 +156,11 @@ describe("ClockInGraph helpers", () => {
         createMockEntry("12:00", "12:00", "clocked-out"),
       ]
 
-      const result = getLabels({ data: mockData, remainingMinutes: 30 })
+      const result = getLabels({
+        data: mockData,
+        remainingMinutes: 30,
+        trackedMinutes: 3 * 60,
+      })
 
       expect(result).toEqual({
         primaryLabel: "09:00",

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/helpers.ts
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/helpers.ts
@@ -111,6 +111,13 @@ export const normalizeData = ({
 
   res = res.filter((entry) => entry.value > 0)
 
+  if (!res.length) {
+    res.push({
+      value: 1,
+      color: CLOCK_IN_COLORS.empty,
+    })
+  }
+
   return res
 }
 

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/helpers.ts
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/helpers.ts
@@ -20,13 +20,20 @@ const getLeftEntry = (remainingMinutes: number, totalSeconds: number) => {
   }
 }
 
-export const normalizeData = (
-  data: ClockInGraphProps["data"] = [],
-  remainingMinutes?: number,
-  overtimeOnly?: boolean
-) => {
+export const normalizeData = ({
+  data = [],
+  trackedMinutes,
+  remainingMinutes = 0,
+}: {
+  data: ClockInGraphProps["data"]
+  trackedMinutes: number
+  remainingMinutes?: number
+}) => {
+  const overtimeOnly =
+    remainingMinutes < 0 && remainingMinutes < -1 * trackedMinutes
+
   const normalizedRemainingMinutes = getNormalizedRemainingMinutes(
-    data,
+    trackedMinutes,
     remainingMinutes
   )
 
@@ -110,6 +117,7 @@ export const normalizeData = (
 export const getLabels = ({
   data = [],
   remainingMinutes,
+  trackedMinutes = 0,
 }: ClockInGraphProps) => {
   const clockedInAt = data.find((entry) => entry.variant === "clocked-in")?.from
 
@@ -129,12 +137,7 @@ export const getLabels = ({
   const isLastEntryBreak = lastEntry?.variant === "break"
 
   const totalTime = !isLastEntryBreak
-    ? data.reduce((acc, entry) => {
-        if (entry.variant === "clocked-in") {
-          return acc + (entry.to.getTime() - entry.from.getTime())
-        }
-        return acc
-      }, 0)
+    ? trackedMinutes * 60 * 1000
     : lastEntry?.to.getTime() - lastEntry?.from.getTime() || 0
 
   const hours = Math.floor(totalTime / (1000 * 60 * 60))

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/index.spec.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/index.spec.tsx
@@ -16,7 +16,8 @@ describe("ClockInGraph", () => {
         variant: "clocked-in",
       },
     ]
-    render(<ClockInGraph data={data} />)
-    expect(screen.getByText("09:00")).toBeInTheDocument()
+    const hours = 9
+    render(<ClockInGraph data={data} trackedMinutes={hours * 60} />)
+    expect(screen.getByText(`${hours}:00`)).toBeInTheDocument()
   })
 })

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/index.spec.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/index.spec.tsx
@@ -16,8 +16,8 @@ describe("ClockInGraph", () => {
         variant: "clocked-in",
       },
     ]
-    const hours = 9
+    const hours = 8
     render(<ClockInGraph data={data} trackedMinutes={hours * 60} />)
-    expect(screen.getByText(`${hours}:00`)).toBeInTheDocument()
+    expect(screen.getByText(`0${hours}:00`)).toBeInTheDocument()
   })
 })

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/index.stories.tsx
@@ -6,6 +6,7 @@ const meta: Meta<typeof ClockInGraph> = {
   component: ClockInGraph,
   tags: ["autodocs", "experimental"],
   args: {
+    trackedMinutes: 60 * 2 + 21,
     remainingMinutes: 60 * 4 + 39,
     data: [],
   },
@@ -14,10 +15,16 @@ const meta: Meta<typeof ClockInGraph> = {
 export default meta
 type Story = StoryObj<typeof ClockInGraph>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    trackedMinutes: 0,
+  },
+}
 
 export const Empty: Story = {
-  args: {},
+  args: {
+    trackedMinutes: 0,
+  },
 }
 
 export const WithSomeProgress: Story = {
@@ -88,6 +95,7 @@ export const WithAlternatingEntries: Story = {
 
 export const WithAlternatingEntriesAndFinalClockedIn: Story = {
   args: {
+    trackedMinutes: 120,
     data: [
       {
         from: new Date("2024-03-20T09:00:00"),
@@ -120,6 +128,7 @@ export const WithAlternatingEntriesAndFinalClockedIn: Story = {
 
 export const WithoutRemainingMinutes: Story = {
   args: {
+    trackedMinutes: 120,
     remainingMinutes: undefined,
     data: [
       {
@@ -143,6 +152,7 @@ export const WithoutRemainingMinutes: Story = {
 
 export const WithOvertime: Story = {
   args: {
+    trackedMinutes: 8 * 60 + 12,
     remainingMinutes: -17,
     data: [
       {

--- a/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ClockIn/ClockInGraph/index.tsx
@@ -4,13 +4,13 @@ import { getLabels, normalizeData } from "./helpers"
 export type ClockInStatus = "clocked-in" | "break" | "clocked-out"
 
 export interface ClockInGraphProps {
+  trackedMinutes?: number
   data?: {
     from: Date
     to: Date
     variant: ClockInStatus
   }[]
   remainingMinutes?: number
-  overtimeOnly?: boolean
 }
 
 export const CLOCK_IN_COLORS = {
@@ -23,13 +23,18 @@ export const CLOCK_IN_COLORS = {
 
 export function ClockInGraph({
   data = [],
+  trackedMinutes = 0,
   remainingMinutes,
-  overtimeOnly = false,
 }: ClockInGraphProps) {
-  const normalizedData = normalizeData(data, remainingMinutes, overtimeOnly)
+  const normalizedData = normalizeData({
+    data,
+    trackedMinutes,
+    remainingMinutes,
+  })
 
   const { primaryLabel, secondaryLabel, time } = getLabels({
     data,
+    trackedMinutes,
     remainingMinutes,
   })
 


### PR DESCRIPTION
## Description

We need to be able to display the tracked minutes that our frontend calculates and determines due to the amount of edge cases that we can have.