### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.31.3",
+  "packages/react": "1.32.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.32.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.31.3...factorial-one-react-v1.32.0) (2025-04-15)
+
+
+### Features
+
+* add support to pass tracked minutes to ClockInControls and ClockInGraph component ([#1624](https://github.com/factorialco/factorial-one/issues/1624)) ([f5215f7](https://github.com/factorialco/factorial-one/commit/f5215f7845fded5a0cc189b9ff106d6687ff7863))
+
 ## [1.31.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.31.2...factorial-one-react-v1.31.3) (2025-04-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.31.3",
+  "version": "1.32.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.32.0</summary>

## [1.32.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.31.3...factorial-one-react-v1.32.0) (2025-04-15)


### Features

* add support to pass tracked minutes to ClockInControls and ClockInGraph component ([#1624](https://github.com/factorialco/factorial-one/issues/1624)) ([f5215f7](https://github.com/factorialco/factorial-one/commit/f5215f7845fded5a0cc189b9ff106d6687ff7863))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).