### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.32.0",
+  "packages/react": "1.32.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.32.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.32.0...factorial-one-react-v1.32.1) (2025-04-15)
+
+
+### Bug Fixes
+
+* **DataCollection:** Reported changes from teams ([#1575](https://github.com/factorialco/factorial-one/issues/1575)) ([378a3ec](https://github.com/factorialco/factorial-one/commit/378a3ec8c0a7fd79ad9238bc732a43214e7d158d))
+
 ## [1.32.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.31.3...factorial-one-react-v1.32.0) (2025-04-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.32.1</summary>

## [1.32.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.32.0...factorial-one-react-v1.32.1) (2025-04-15)


### Bug Fixes

* **DataCollection:** Reported changes from teams ([#1575](https://github.com/factorialco/factorial-one/issues/1575)) ([378a3ec](https://github.com/factorialco/factorial-one/commit/378a3ec8c0a7fd79ad9238bc732a43214e7d158d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).