### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.32.2",
+  "packages/react": "1.32.3",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.32.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.32.2...factorial-one-react-v1.32.3) (2025-04-16)
+
+
+### Bug Fixes
+
+* **RichTextEditor:** height config, streamline fullscreen behavior, and add imperative methods ([#1563](https://github.com/factorialco/factorial-one/issues/1563)) ([9650111](https://github.com/factorialco/factorial-one/commit/96501110bb780d3cea4fba8eba612f5a99e563d8))
+
 ## [1.32.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.32.1...factorial-one-react-v1.32.2) (2025-04-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.32.2",
+  "version": "1.32.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.32.3</summary>

## [1.32.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.32.2...factorial-one-react-v1.32.3) (2025-04-16)


### Bug Fixes

* **RichTextEditor:** height config, streamline fullscreen behavior, and add imperative methods ([#1563](https://github.com/factorialco/factorial-one/issues/1563)) ([9650111](https://github.com/factorialco/factorial-one/commit/96501110bb780d3cea4fba8eba612f5a99e563d8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).