### PR TITLE
fix(RichTextEditor): implement unique editor IDs

### DIFF
--- a/packages/react/src/experimental/RichText/RichTextEditor/BubbleMenu/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/BubbleMenu/index.tsx
@@ -8,9 +8,11 @@ interface EditorBubbleMenuProps {
   toolbarLabels: toolbarLabels
   isToolbarOpen: boolean
   isFullscreen: boolean
+  editorId: string
 }
 
 const EditorBubbleMenu = ({
+  editorId,
   editor,
   disableButtons,
   toolbarLabels,
@@ -26,8 +28,7 @@ const EditorBubbleMenu = ({
         appendTo: () =>
           isFullscreen
             ? document.body
-            : document.getElementById("rich-text-editor-container") ||
-              document.body,
+            : document.getElementById(editorId) || document.body,
         zIndex: 9999,
       }}
       editor={editor}

--- a/packages/react/src/experimental/RichText/RichTextEditor/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/index.tsx
@@ -6,6 +6,7 @@ import { AnimatePresence, motion } from "framer-motion"
 import {
   forwardRef,
   useEffect,
+  useId,
   useImperativeHandle,
   useRef,
   useState,
@@ -91,8 +92,7 @@ const RichTextEditorComponent = forwardRef<
   },
   ref
 ) {
-  // Unique id for the editor to render popovers correctly if there are more than 1 editor on the page
-  const editorId = Math.random().toString(36).substring(2, 15)
+  const editorId = useId()
 
   const fileInputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -252,11 +252,12 @@ const RichTextEditorComponent = forwardRef<
     <div
       ref={containerRef}
       id={editorId}
-      className={
+      className={cn(
+        "rich-text-editor-container flex flex-col bg-f1-background",
         isFullscreen
-          ? "rich-text-editor-container fixed inset-0 z-50 flex flex-col bg-f1-background"
-          : "relative flex w-full flex-col rounded-xl border border-solid border-f1-border bg-f1-background"
-      }
+          ? "fixed inset-0 z-50"
+          : "relative w-full rounded-xl border border-solid border-f1-border"
+      )}
     >
       <Head
         isFullscreen={isFullscreen}

--- a/packages/react/src/experimental/RichText/RichTextEditor/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/index.tsx
@@ -91,6 +91,9 @@ const RichTextEditorComponent = forwardRef<
   },
   ref
 ) {
+  // Unique id for the editor to render popovers correctly if there are more than 1 editor on the page
+  const editorId = Math.random().toString(36).substring(2, 15)
+
   const fileInputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const editorContentContainerRef = useRef<HTMLDivElement>(null)
@@ -248,10 +251,10 @@ const RichTextEditorComponent = forwardRef<
   const editorContent = (
     <div
       ref={containerRef}
-      id="rich-text-editor-container"
+      id={editorId}
       className={
         isFullscreen
-          ? "fixed inset-0 z-50 flex flex-col bg-f1-background"
+          ? "rich-text-editor-container fixed inset-0 z-50 flex flex-col bg-f1-background"
           : "relative flex w-full flex-col rounded-xl border border-solid border-f1-border bg-f1-background"
       }
     >
@@ -378,6 +381,7 @@ const RichTextEditorComponent = forwardRef<
         />
 
         <EditorBubbleMenu
+          editorId={editorId}
           editor={editor}
           disableButtons={disableAllButtons}
           toolbarLabels={toolbarLabels}

--- a/packages/react/src/experimental/RichText/index.css
+++ b/packages/react/src/experimental/RichText/index.css
@@ -12,11 +12,11 @@
 }
 
 /* Make all selections transparent */
-#rich-text-editor-container *::selection {
+.rich-text-editor-container *::selection {
   background-color: transparent !important;
 }
 
-#rich-text-editor-container::selection {
+.rich-text-editor-container::selection {
   background-color: transparent !important;
 }
 


### PR DESCRIPTION
## Description

Now each editor has a unique container ID, which is used to render its bubble menu.
Previously, when multiple editors were present on the same page, they shared the same ID, causing the bubble menu to render incorrectly. This has now been fixed.

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [ ] Component added to `experimental` folder
- [ ] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
