### PR TITLE
feat(FileItem): fileItem component with multiple action handling

### DIFF
--- a/packages/react/src/experimental/RichText/FileItem/index.stories.tsx
+++ b/packages/react/src/experimental/RichText/FileItem/index.stories.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, CrossedCircle } from "@/icons/app"
+import { CrossedCircle } from "@/icons/app"
 import type { Meta, StoryObj } from "@storybook/react"
 import { FileItem } from "."
 
@@ -14,25 +14,48 @@ export const Default: Story = {
   tags: ["experimental"],
   args: {
     file: new File(["test"], "test.txt", { type: "text/plain" }),
-    onAction: () => {
-      alert("file action")
-    },
-    actionIcon: CrossedCircle,
+    actions: [
+      {
+        label: "Delete file",
+        onClick: () => {
+          alert("file action")
+        },
+      },
+    ],
     disabled: false,
   },
 }
 
-export const WithCustomIcon: Story = {
+export const WithMultipleActions: Story = {
   args: {
-    ...Default.args,
-    actionIcon: ArrowRight,
+    file: new File(["test"], "test of a long file name.pdf", {
+      type: "application/pdf",
+    }),
+    actions: [
+      {
+        icon: CrossedCircle,
+        label: "Delete file",
+        onClick: () => {
+          alert("delete file")
+        },
+        critical: true,
+      },
+      {
+        label: "Forward file",
+        onClick: () => {
+          alert("forward file")
+        },
+      },
+    ],
   },
 }
 
-export const WithoutAction: Story = {
+export const WithoutActions: Story = {
   args: {
-    ...Default.args,
-    onAction: undefined,
+    file: new File(["test"], "test of a long file name.pdf", {
+      type: "application/pdf",
+    }),
+    actions: [],
   },
 }
 

--- a/packages/react/src/experimental/RichText/FileItem/index.tsx
+++ b/packages/react/src/experimental/RichText/FileItem/index.tsx
@@ -1,60 +1,77 @@
 import { Icon, IconType } from "@/components/Utilities/Icon"
 import { FileAvatar } from "@/experimental/exports"
+import {
+  DropdownInternal,
+  DropdownItem,
+} from "@/experimental/Navigation/Dropdown/internal"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { CrossedCircle } from "@/icons/app"
 import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
 
+interface FileAction {
+  icon?: IconType
+  label: string
+  onClick: () => void
+  critical?: boolean
+}
+
 interface FileItemProps extends React.HTMLAttributes<HTMLDivElement> {
   file: File
-  onAction?: () => void
-  actionIcon?: IconType
+  actions?: FileAction[]
   disabled?: boolean
 }
 
 const FileItem = forwardRef<HTMLDivElement, FileItemProps>(
-  (
-    {
-      file,
-      onAction,
-      actionIcon = CrossedCircle,
-      disabled = false,
-      className,
-      ...props
-    },
-    ref
-  ) => {
+  ({ file, actions = [], disabled = false, className, ...props }, ref) => {
+    const hasActions = actions.length > 0
+    const singleAction = actions.length === 1 ? actions[0] : null
+
+    const dropdownItems: DropdownItem[] = actions.map((action) => ({
+      label: action.label,
+      icon: action.icon,
+      critical: action.critical,
+      onClick: disabled ? undefined : action.onClick,
+    }))
+
     return (
-      <Tooltip label={file.name}>
-        <div
-          ref={ref}
-          className={cn(
-            "flex w-fit max-w-48 flex-row items-center gap-1.5 rounded-md bg-f1-background-tertiary p-0.5 pr-2",
-            className
-          )}
-          {...props}
-        >
-          <FileAvatar file={file} />
+      <div
+        ref={ref}
+        className={cn(
+          "flex w-fit max-w-40 flex-row items-center gap-2 overflow-hidden rounded-md bg-f1-background-tertiary p-0.5 pr-2",
+          className
+        )}
+        {...props}
+      >
+        <FileAvatar file={file} />
+        <Tooltip label={file.name}>
           <p
             title={file.name}
             className="text-neutral-1000 grow overflow-hidden truncate text-ellipsis text-sm font-medium"
           >
             {file.name}
           </p>
-
-          {onAction && (
+        </Tooltip>
+        {hasActions &&
+          (singleAction ? (
             <Icon
               size="md"
-              icon={actionIcon}
+              icon={singleAction.icon ?? CrossedCircle}
               className={cn(
                 "cursor-pointer text-f1-icon",
-                disabled ? "cursor-not-allowed" : "hover:text-f1-icon-bold"
+                disabled ? "cursor-not-allowed" : "hover:text-f1-icon-bold",
+                singleAction.critical && "text-f1-foreground-critical"
               )}
-              onClick={disabled ? undefined : onAction}
+              onClick={disabled ? undefined : singleAction.onClick}
             />
-          )}
-        </div>
-      </Tooltip>
+          ) : (
+            <DropdownInternal
+              items={dropdownItems}
+              size="sm"
+              {...(disabled ? { "data-disabled": "true" } : {})}
+            />
+          ))}
+      </div>
     )
   }
 )

--- a/packages/react/src/experimental/RichText/FileItem/index.tsx
+++ b/packages/react/src/experimental/RichText/FileItem/index.tsx
@@ -9,7 +9,7 @@ import { CrossedCircle } from "@/icons/app"
 import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
 
-interface FileAction {
+type FileAction = {
   icon?: IconType
   label: string
   onClick: () => void
@@ -78,3 +78,4 @@ const FileItem = forwardRef<HTMLDivElement, FileItemProps>(
 FileItem.displayName = "FileItem"
 
 export { FileItem }
+export type { FileAction }

--- a/packages/react/src/experimental/RichText/RichTextEditor/FileList/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/FileList/index.tsx
@@ -61,7 +61,7 @@ const FileList = ({
             exit={{ height: 0, opacity: 0, y: -20 }}
             transition={{ duration: 0.3 }}
           >
-            <div className="scrollbar-macos flex w-full items-end gap-2 overflow-x-auto py-2">
+            <div className="scrollbar-macos flex w-full items-end gap-2 overflow-x-auto pt-2">
               {files.map((file, index) => (
                 <FileItem
                   key={`${file.name}-${index}`}

--- a/packages/react/src/experimental/RichText/RichTextEditor/FileList/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/FileList/index.tsx
@@ -66,9 +66,13 @@ const FileList = ({
                 <FileItem
                   key={`${file.name}-${index}`}
                   file={file}
-                  onAction={() =>
-                    handleRemoveFile(index, files, filesConfig, setFiles)
-                  }
+                  actions={[
+                    {
+                      label: "Delete",
+                      onClick: () =>
+                        handleRemoveFile(index, files, filesConfig, setFiles),
+                    },
+                  ]}
                   disabled={disabled}
                 />
               ))}


### PR DESCRIPTION
## Description
Now you can have multiple actions in the file item, this is needed when you use the file item to handle download and delete at the same time

## Screenshots (if applicable)
![Captura de pantalla 2025-04-17 a las 11 10 31](https://github.com/user-attachments/assets/e59d4e09-acb4-434a-862e-23d65055b663)

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [ ] Component added to `experimental` folder
- [ ] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
