### PR TITLE
feat: add support for info popover in widgets

### DIFF
--- a/packages/react/src/experimental/Widgets/Widget/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.stories.tsx
@@ -57,6 +57,17 @@ export const WithLinkAndCustomIcon: Story = {
   },
 }
 
+export const WithInfo: Story = {
+  args: {
+    ...meta.args,
+    header: {
+      title: "Insight title",
+      subtitle: "Subtitle",
+      info: "This is a tooltip",
+    },
+  },
+}
+
 export const WithAction: Story = {
   args: {
     ...meta.args,

--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -1,13 +1,14 @@
 import { Button, type ButtonProps } from "@/components/Actions/Button"
-import { IconType } from "@/components/Utilities/Icon"
+import { Icon, IconType } from "@/components/Utilities/Icon"
 import { Counter } from "@/experimental/Information/Counter"
 import { AlertTag } from "@/experimental/Information/Tags/AlertTag"
 import {
   StatusTag,
   StatusVariant,
 } from "@/experimental/Information/Tags/StatusTag"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { PrivateBox } from "@/experimental/Utilities/PrivateBox"
-import { EyeInvisible, EyeVisible } from "@/icons/app"
+import { EyeInvisible, EyeVisible, InfoCircleLine } from "@/icons/app"
 import { usePrivacyMode } from "@/lib/privacyMode"
 import { withSkeleton } from "@/lib/skeleton"
 import { cn } from "@/lib/utils"
@@ -31,6 +32,7 @@ export interface WidgetProps {
     title?: string
     subtitle?: string
     comment?: string
+    info?: string
     canBeBlurred?: boolean
     link?: {
       title: string
@@ -118,6 +120,15 @@ const Container = forwardRef<
                       {header.subtitle}
                     </CardSubtitle>
                   </div>
+                )}
+                {header.info && (
+                  <Tooltip label={header.info}>
+                    <Icon
+                      icon={InfoCircleLine}
+                      size="sm"
+                      className="text-f1-icon-secondary"
+                    />
+                  </Tooltip>
                 )}
                 {header.count && (
                   <div className="ml-0.5">


### PR DESCRIPTION
<img width="444" alt="Screenshot 2025-04-22 at 10 50 06" src="https://github.com/user-attachments/assets/85d768e6-eefe-4ff6-a99f-a5d9a316b040" />
