### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.33.0",
+  "packages/react": "1.34.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.34.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.33.0...factorial-one-react-v1.34.0) (2025-04-22)
+
+
+### Features
+
+* add support for info popover in widgets ([#1651](https://github.com/factorialco/factorial-one/issues/1651)) ([922f288](https://github.com/factorialco/factorial-one/commit/922f288d9d2f30acb417cca14319d1c6267cf226))
+
 ## [1.33.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.32.3...factorial-one-react-v1.33.0) (2025-04-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.34.0</summary>

## [1.34.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.33.0...factorial-one-react-v1.34.0) (2025-04-22)


### Features

* add support for info popover in widgets ([#1651](https://github.com/factorialco/factorial-one/issues/1651)) ([922f288](https://github.com/factorialco/factorial-one/commit/922f288d9d2f30acb417cca14319d1c6267cf226))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).