### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.34.0",
+  "packages/react": "1.35.0",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.35.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.34.0...factorial-one-react-v1.35.0) (2025-04-22)
+
+
+### Features
+
+* add stable layout components ([#1643](https://github.com/factorialco/factorial-one/issues/1643)) ([5cf5390](https://github.com/factorialco/factorial-one/commit/5cf5390b5eef055b88868c6035bad58e47da74c5))
+
 ## [1.34.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.33.0...factorial-one-react-v1.34.0) (2025-04-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.35.0</summary>

## [1.35.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.34.0...factorial-one-react-v1.35.0) (2025-04-22)


### Features

* add stable layout components ([#1643](https://github.com/factorialco/factorial-one/issues/1643)) ([5cf5390](https://github.com/factorialco/factorial-one/commit/5cf5390b5eef055b88868c6035bad58e47da74c5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).