### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.35.0",
+  "packages/react": "1.35.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.35.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.0...factorial-one-react-v1.35.1) (2025-04-22)
+
+
+### Bug Fixes
+
+* export `DetailsItem` and `DetailsItemsList` ([#1655](https://github.com/factorialco/factorial-one/issues/1655)) ([bcd4901](https://github.com/factorialco/factorial-one/commit/bcd490161ac5b37955ddaa538d59486b26eef6da))
+
 ## [1.35.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.34.0...factorial-one-react-v1.35.0) (2025-04-22)
 
 ### Features

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.35.1</summary>

## [1.35.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.0...factorial-one-react-v1.35.1) (2025-04-22)


### Bug Fixes

* export `DetailsItem` and `DetailsItemsList` ([#1655](https://github.com/factorialco/factorial-one/issues/1655)) ([bcd4901](https://github.com/factorialco/factorial-one/commit/bcd490161ac5b37955ddaa538d59486b26eef6da))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).