### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.35.1",
+  "packages/react": "1.35.2",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.35.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.1...factorial-one-react-v1.35.2) (2025-04-22)
+
+
+### Bug Fixes
+
+* regenerated icons ([ce283f6](https://github.com/factorialco/factorial-one/commit/ce283f6ccea32b8033b32a532cbc2261a034c783))
+
 ## [1.35.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.0...factorial-one-react-v1.35.1) (2025-04-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.35.1",
+  "version": "1.35.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.35.2</summary>

## [1.35.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.1...factorial-one-react-v1.35.2) (2025-04-22)


### Bug Fixes

* regenerated icons ([ce283f6](https://github.com/factorialco/factorial-one/commit/ce283f6ccea32b8033b32a532cbc2261a034c783))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).