### PR TITLE
chore: only send slack notification when publish was done

### DIFF
--- a/.github/actions/publish-to-npmjs/action.yaml
+++ b/.github/actions/publish-to-npmjs/action.yaml
@@ -7,6 +7,12 @@ inputs:
   registry_token:
     description: "Registry token"
     required: true
+
+outputs:
+  published:
+    description: "Published packages"
+    value: ${{ steps.publish.outputs.published }}
+
 runs:
   using: "composite"
   steps:
@@ -21,6 +27,16 @@ runs:
 
     - name: Publish to registry
       shell: bash
-      run: pnpm --filter ${{ inputs.workspace }} publish --no-git-checks --access=public
+      id: publish
+      run: |
+        result=$(pnpm --filter ${{ inputs.workspace }} publish --no-git-checks --access=public)
+        if [[ $result == "There are no new packages that should be published" ]]
+        then
+          echo "No new packages to publish"
+          echo "published=false" >> $GITHUB_OUTPUT
+        else
+          echo "Packages published"
+          echo "published=true" >> $GITHUB_OUTPUT
+        fi
       env:
         NODE_AUTH_TOKEN: ${{ inputs.registry_token }}

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -35,13 +35,16 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag || github.sha }} # Checkout the tagged release
       - uses: ./.github/actions/publish-to-npmjs
+        id: publish
         with:
           workspace: "@factorialco/factorial-one-react"
           registry_token: ${{ secrets.NPMJS_TOKEN }}
       - name: Notify Slack
         run: |
-          curl -X POST -H "Content-Type: application/json" -d '{ "content": "⚛️ A new version of @factorialco/factorial-one-react was released.\n
-          \n\n ${{github.event.release.body}}\n\nhttps://www.npmjs.com/package/@factorialco/factorial-one-react?activeTab=versions"}' ${{ secrets.SLACK_WEBHOOK_URL }}
+          if [ ${{ steps.publish.outputs.published }} == "true" ]; then
+            curl -X POST -H "Content-Type: application/json" -d '{ "content": "⚛️ A new version of @factorialco/factorial-one-react was released.\n
+            \n\n ${{github.event.release.body}}\n\nhttps://www.npmjs.com/package/@factorialco/factorial-one-react?activeTab=versions"}' ${{ secrets.SLACK_WEBHOOK_URL }}
+          fi
 
   publish-react-native:
     name: "[📱 REACT NATIVE] Publish to npm"
@@ -62,10 +65,13 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag || github.sha }} # Checkout the tagged release
       - uses: ./.github/actions/publish-to-npmjs
+        id: publish
         with:
           workspace: "@factorialco/factorial-one-react-native"
           registry_token: ${{ secrets.NPMJS_TOKEN }}
       - name: Notify Slack
         run: |
-          curl -X POST -H "Content-Type: application/json" -d '{ "content": "📱 A new version of @factorialco/factorial-one-react-native was released.\n
-          \n\n ${{github.event.release.body}}\n\nhttps://www.npmjs.com/package/@factorialco/factorial-one-react-native?activeTab=versions"}' ${{ secrets.SLACK_WEBHOOK_URL }}
+          if [ ${{ steps.publish.outputs.published }} == "true" ]; then
+            curl -X POST -H "Content-Type: application/json" -d '{ "content": "📱 A new version of @factorialco/factorial-one-react-native was released.\n
+            \n\n ${{github.event.release.body}}\n\nhttps://www.npmjs.com/package/@factorialco/factorial-one-react-native?activeTab=versions"}' ${{ secrets.SLACK_WEBHOOK_URL }}
+          fi


### PR DESCRIPTION
## Description

Fixes the publish to npm action to only send the slack notification if the packages was published

