### PR TITLE
Hide comment button until hovering post component

### DIFF
--- a/packages/react/src/experimental/Information/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/experimental/Information/Communities/Post/CommunityPost/index.tsx
@@ -75,7 +75,6 @@ export const BaseCommunityPost = ({
   const ago = getAgo(createdAt)
 
   const handleClick = () => {
-    console.log("clicked")
     onClick(id)
   }
 

--- a/packages/react/src/experimental/Information/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/experimental/Information/Communities/Post/CommunityPost/index.tsx
@@ -75,6 +75,7 @@ export const BaseCommunityPost = ({
   const ago = getAgo(createdAt)
 
   const handleClick = () => {
+    console.log("clicked")
     onClick(id)
   }
 
@@ -86,7 +87,7 @@ export const BaseCommunityPost = ({
 
   return (
     <div
-      className="flex w-full cursor-pointer flex-row gap-3 rounded-xl border border-solid border-transparent p-3 pt-2 hover:bg-f1-background-hover focus:border-f1-border-secondary focus:outline focus:outline-1 focus:outline-offset-1 focus:outline-f1-border-selected-bold md:pb-4 md:pt-3"
+      className="group flex w-full cursor-pointer flex-row gap-3 rounded-xl border border-solid border-transparent p-3 pt-2 hover:bg-f1-background-hover focus:border-f1-border-secondary focus:outline focus:outline-1 focus:outline-offset-1 focus:outline-f1-border-selected-bold md:pb-4 md:pt-3"
       onClick={handleClick}
     >
       <div className="hidden md:block">
@@ -142,13 +143,14 @@ export const BaseCommunityPost = ({
 
             <div className="flex flex-row gap-2">
               <div className="hidden flex-row gap-2 md:flex">
-                <Link
-                  onClick={comment.onClick}
-                  title={comment.label}
-                  stopPropagation
-                >
-                  <Button label={comment.label} size="sm" variant="outline" />
-                </Link>
+                <div className="opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                  <Button
+                    label={comment.label}
+                    size="sm"
+                    variant="outline"
+                    onClick={comment.onClick}
+                  />
+                </div>
                 {dropdownItems?.length && (
                   <Dropdown
                     items={dropdownItems}

--- a/packages/react/src/experimental/Widgets/Content/CalendarEventList/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/CalendarEventList/index.tsx
@@ -4,7 +4,6 @@ import { CalendarEvent, CalendarEventProps } from "../CalendarEvent"
 
 export interface CalendarEventListProps {
   events: CalendarEventProps[]
-  limit?: 1 | 2 | 3 | 4 | 5
   gap?: number
   showAllItems?: boolean
   minSize?: number


### PR DESCRIPTION
## Description

The comment button in the Community Post component is rather redundant when listing this component, we should hide it until the user hovers the component.