### PR TITLE
fix(DataCollection): close filter chip

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/Filters/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/index.tsx
@@ -119,11 +119,10 @@ const FiltersRoot = <Definition extends FiltersDefinition>({
   const [localFiltersValue, setLocalFiltersValue] = useState(filters)
 
   const removeFilterValue = (key: keyof Definition) => {
-    setLocalFiltersValue((prev) => {
-      const { [key]: _, ...rest } = prev
-      return rest as FiltersState<Definition>
-    })
-    props.onChange(localFiltersValue)
+    const newFilters = { ...localFiltersValue }
+    delete newFilters[key]
+    setLocalFiltersValue(newFilters as FiltersState<Definition>)
+    props.onChange(newFilters as FiltersState<Definition>)
   }
 
   const setFiltersValue = (filters: FiltersState<Definition>) => {


### PR DESCRIPTION
## Description

Fixed an issue where closing a filter chip didn't refresh the data collection. The removeFilterValue function was passing the old filter state to onChange instead of the updated state. Now properly creates and passes a new filter object that excludes the removed filter, ensuring data refreshes correctly when removing filters.


## Screenshots (if applicable)

before: 

https://github.com/user-attachments/assets/b7eb0186-c1b6-47c0-aa13-e398b03175fd


after:

https://github.com/user-attachments/assets/69abc1c1-a74f-4d7d-b0c5-c2a1d164ca91


---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other