### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.35.4",
+  "packages/react": "1.35.5",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.35.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.4...factorial-one-react-v1.35.5) (2025-04-23)
+
+
+### Bug Fixes
+
+* **PageHeader:** use Button component ([#1664](https://github.com/factorialco/factorial-one/issues/1664)) ([063f470](https://github.com/factorialco/factorial-one/commit/063f470eccbbca131131f81e3a6084459158722f))
+
 ## [1.35.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.3...factorial-one-react-v1.35.4) (2025-04-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.35.4",
+  "version": "1.35.5",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.35.5</summary>

## [1.35.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.4...factorial-one-react-v1.35.5) (2025-04-23)


### Bug Fixes

* **PageHeader:** use Button component ([#1664](https://github.com/factorialco/factorial-one/issues/1664)) ([063f470](https://github.com/factorialco/factorial-one/commit/063f470eccbbca131131f81e3a6084459158722f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).