### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.35.5",
+  "packages/react": "1.35.6",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.35.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.5...factorial-one-react-v1.35.6) (2025-04-23)
+
+
+### Bug Fixes
+
+* show comment icon button next to reactions in CommunityPost component ([#1663](https://github.com/factorialco/factorial-one/issues/1663)) ([e4edf83](https://github.com/factorialco/factorial-one/commit/e4edf83f594f8fd9749a9ffa4dc057bea96d9d38))
+
 ## [1.35.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.4...factorial-one-react-v1.35.5) (2025-04-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.35.5",
+  "version": "1.35.6",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.35.6</summary>

## [1.35.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.5...factorial-one-react-v1.35.6) (2025-04-23)


### Bug Fixes

* show comment icon button next to reactions in CommunityPost component ([#1663](https://github.com/factorialco/factorial-one/issues/1663)) ([e4edf83](https://github.com/factorialco/factorial-one/commit/e4edf83f594f8fd9749a9ffa4dc057bea96d9d38))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).