### PR TITLE
refactor: pageHeader component to use f1 components

### DIFF
--- a/packages/react/src/components/Actions/Link/index.stories.tsx
+++ b/packages/react/src/components/Actions/Link/index.stories.tsx
@@ -47,3 +47,9 @@ export const AsText: Story = {
     variant: "text",
   },
 }
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}

--- a/packages/react/src/components/Actions/Link/index.tsx
+++ b/packages/react/src/components/Actions/Link/index.tsx
@@ -20,6 +20,10 @@ const linkVariants = cva({
       true: "",
       false: "",
     },
+    disabled: {
+      true: "cursor-not-allowed no-underline",
+      false: "",
+    },
   },
   defaultVariants: {
     variant: "link",
@@ -54,7 +58,11 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       {...props}
       onClick={handleClick}
       className={cn(
-        linkVariants({ variant, active: isActive(props.href) }),
+        linkVariants({
+          variant,
+          active: isActive(props.href),
+          disabled: props.disabled,
+        }),
         className
       )}
     >

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -1,21 +1,16 @@
+import { Button } from "@/components/Actions/Button"
+import { IconType } from "@/components/Utilities/Icon"
+import type { StatusVariant } from "@/experimental/Information/Tags/StatusTag"
+import { StatusTag } from "@/experimental/Information/Tags/StatusTag"
+import { useSidebar } from "@/experimental/Navigation/ApplicationFrame/FrameProvider"
+import { Dropdown } from "@/experimental/Navigation/Dropdown"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { ChevronDown, ChevronLeft, ChevronUp, Menu } from "@/icons/app"
+import { Link } from "@/lib/linkHandler"
+import { cn } from "@/lib/utils"
 import { Skeleton } from "@/ui/skeleton"
 import { AnimatePresence, motion } from "framer-motion"
 import { ReactElement } from "react"
-import { Button } from "../../../../components/Actions/Button"
-import { Icon, IconType } from "../../../../components/Utilities/Icon"
-import {
-  ChevronDown,
-  ChevronLeft,
-  ChevronUp,
-  Menu,
-} from "../../../../icons/app"
-import { Link } from "../../../../lib/linkHandler"
-import { cn } from "../../../../lib/utils"
-import type { StatusVariant } from "../../../Information/Tags/StatusTag"
-import { StatusTag } from "../../../Information/Tags/StatusTag"
-import { Tooltip } from "../../../Overlays/Tooltip"
-import { useSidebar } from "../../ApplicationFrame/FrameProvider"
-import { Dropdown } from "../../Dropdown"
 
 import Breadcrumbs, { type BreadcrumbItemType } from "../Breadcrumbs"
 import { ProductUpdates, ProductUpdatesProp } from "../ProductUpdates"
@@ -79,16 +74,16 @@ function PageNavigationLink({
   disabled?: boolean
 }) {
   return (
-    <Link
-      href={disabled ? "" : href}
-      title={label}
-      aria-label={label}
-      className={cn(
-        "inline-flex aspect-square h-6 items-center justify-center rounded-sm border border-solid border-f1-border bg-f1-background px-0 text-f1-foreground hover:border-f1-border-hover",
-        disabled && "pointer-events-none opacity-50"
-      )}
-    >
-      <Icon icon={icon} size="md" />
+    <Link href={href} title={label} aria-label={label} disabled={disabled}>
+      <Button
+        size="sm"
+        variant="outline"
+        round
+        label={label}
+        icon={icon}
+        hideLabel
+        disabled={disabled}
+      />
     </Link>
   )
 }
@@ -261,23 +256,26 @@ function PageAction({ action }: { action: PageAction }): ReactElement {
   if ("actions" in action) {
     return (
       <Dropdown items={action.actions}>
-        <button
-          title={action.label}
-          className="inline-flex aspect-square h-8 items-center justify-center rounded border border-solid border-f1-border bg-f1-background-inverse-secondary px-0 text-f1-foreground hover:border-f1-border-hover"
-        >
-          <Icon icon={action.icon} size="md" />
-        </button>
+        <Button
+          size="md"
+          variant="outline"
+          label={action.label}
+          icon={action.icon}
+          hideLabel
+        />
       </Dropdown>
     )
   }
 
   return (
-    <Link
-      href={action.href}
-      title={action.label}
-      className="inline-flex aspect-square h-8 items-center justify-center rounded border border-solid border-f1-border bg-f1-background-inverse-secondary px-0 text-f1-foreground hover:border-f1-border-hover"
-    >
-      <Icon icon={action.icon} size="md" />
+    <Link href={action.href} title={action.label} aria-label={action.label}>
+      <Button
+        size="md"
+        variant="outline"
+        label={action.label}
+        icon={action.icon}
+        hideLabel
+      />
     </Link>
   )
 }


### PR DESCRIPTION
## Description

-refactor: Use Factorial One Buttons in PageHeader instead of html buttons
-feat: add `disabled` property passthrough in Link component, and auto disabled if no href

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [ ] Component added to `experimental` folder
- [ ] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
