### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.36.0",
+  "packages/react": "1.36.1",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.36.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.0...factorial-one-react-v1.36.1) (2025-04-28)
+
+
+### Bug Fixes
+
+* improve filter removal logic in Filters component ([#1665](https://github.com/factorialco/factorial-one/issues/1665)) ([cfda323](https://github.com/factorialco/factorial-one/commit/cfda3237ee6a2fda5e87d7f4a4b89d1434f3af69))
+
 ## [1.36.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.35.6...factorial-one-react-v1.36.0) (2025-04-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.36.1</summary>

## [1.36.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.0...factorial-one-react-v1.36.1) (2025-04-28)


### Bug Fixes

* improve filter removal logic in Filters component ([#1665](https://github.com/factorialco/factorial-one/issues/1665)) ([cfda323](https://github.com/factorialco/factorial-one/commit/cfda3237ee6a2fda5e87d7f4a4b89d1434f3af69))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).