### PR TITLE
fix: update localValue when value or items are changed on re-render

### DIFF
--- a/packages/react/src/components/Actions/OneDropdownButton/OneDropdownButton.tsx
+++ b/packages/react/src/components/Actions/OneDropdownButton/OneDropdownButton.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from "@/lib/providers/i18n"
-import { useMemo, useState } from "react"
+import { useMemo } from "react"
 import { DropdownInternal } from "../../../experimental/Navigation/Dropdown/internal"
 import { ChevronDown } from "../../../icons/app"
 import { IconType } from "../../Utilities/Icon"
@@ -30,7 +30,7 @@ const OneDropdownButton = ({
 }: OneDropdownButtonProps) => {
   const t = useI18n()
 
-  const [localValue] = useState(value || items[0].value)
+  const localValue = useMemo(() => value || items[0].value, [value, items])
 
   const selectedItem = useMemo(
     () => items.find((item) => item.value === localValue),


### PR DESCRIPTION
Right now, if we update the items or value properties on the button is not re-render properly unless the first value is still an option on the items list.

- Error before the change: https://factorialteam.slack.com/archives/C06QT46115K/p1745399269364049