### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.36.1",
+  "packages/react": "1.36.2",
   "packages/react-native": "0.0.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.36.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.1...factorial-one-react-v1.36.2) (2025-04-28)
+
+
+### Bug Fixes
+
+* update localValue when value or items are changed on re-render ([#1679](https://github.com/factorialco/factorial-one/issues/1679)) ([d6fd9a4](https://github.com/factorialco/factorial-one/commit/d6fd9a44d2138e570f6f20d5ed2e9cb845108785))
+
 ## [1.36.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.0...factorial-one-react-v1.36.1) (2025-04-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.36.2</summary>

## [1.36.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.1...factorial-one-react-v1.36.2) (2025-04-28)


### Bug Fixes

* update localValue when value or items are changed on re-render ([#1679](https://github.com/factorialco/factorial-one/issues/1679)) ([d6fd9a4](https://github.com/factorialco/factorial-one/commit/d6fd9a44d2138e570f6f20d5ed2e9cb845108785))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).