### PR TITLE
Add support to fill container with AvatarList component

### DIFF
--- a/packages/react/src/experimental/Information/Avatars/AvatarList/MaxCounter.tsx
+++ b/packages/react/src/experimental/Information/Avatars/AvatarList/MaxCounter.tsx
@@ -64,7 +64,9 @@ export const MaxCounter = ({
   list,
 }: Props) => {
   const counter = (
-    <div className={cn("font-medium", sizeVariants({ size, type }))}>
+    <div
+      className={cn("cursor-default font-medium", sizeVariants({ size, type }))}
+    >
       {size === "xsmall" ? (
         <Icon icon={EllipsisHorizontal} size="xs" />
       ) : (

--- a/packages/react/src/experimental/Information/Avatars/AvatarList/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Avatars/AvatarList/index.stories.tsx
@@ -71,6 +71,13 @@ const meta: Meta<typeof AvatarList> = {
   parameters: {
     layout: "centered",
   },
+  decorators: [
+    (Story) => (
+      <div className="w-[270px]">
+        <Story />
+      </div>
+    ),
+  ],
 } satisfies Meta<typeof AvatarList>
 
 export default meta
@@ -100,6 +107,14 @@ export const WithMaxAvatars: Story = {
     ...Default.args,
     avatars: getDummyAvatars(50, "person"),
     max: 3,
+  },
+}
+
+export const FillContainer: Story = {
+  args: {
+    ...Default.args,
+    avatars: getDummyAvatars(50, "person"),
+    fillContainer: true,
   },
 }
 

--- a/packages/react/src/experimental/Information/Avatars/AvatarList/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Avatars/AvatarList/index.stories.tsx
@@ -114,7 +114,7 @@ export const FillContainer: Story = {
   args: {
     ...Default.args,
     avatars: getDummyAvatars(50, "person"),
-    fillContainer: true,
+    layout: "fill",
   },
 }
 

--- a/packages/react/src/experimental/Information/Avatars/AvatarList/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/AvatarList/index.tsx
@@ -76,10 +76,10 @@ type Props = {
   remainingCount?: number
 
   /**
-   * Whether to fill the container with avatars.
-   * @default false
+   * The layout of the avatar list.
+   * @default "compact"
    */
-  fillContainer?: boolean
+  layout?: "fill" | "compact"
 }
 
 export const AvatarList = ({
@@ -89,9 +89,9 @@ export const AvatarList = ({
   noTooltip = false,
   remainingCount: initialRemainingCount,
   max = 3,
-  fillContainer = false,
+  layout = "compact",
 }: Props) => {
-  if (fillContainer) {
+  if (layout === "fill") {
     return (
       <OverflowList
         items={avatars}

--- a/packages/react/src/experimental/Information/Avatars/AvatarList/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/AvatarList/index.tsx
@@ -77,6 +77,8 @@ type Props = {
 
   /**
    * The layout of the avatar list.
+   * - "fill" - Avatars will expand to fill the available width, with overflow items shown in a counter
+   * - "compact" - Avatars will be stacked tightly together up to the max limit, with remaining shown in counter
    * @default "compact"
    */
   layout?: "fill" | "compact"

--- a/packages/react/src/experimental/Information/Avatars/AvatarList/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/AvatarList/index.tsx
@@ -110,10 +110,14 @@ export const AvatarList = ({
         renderDropdownItem={() => null}
         renderOverflowIndicator={(count) => (
           <MaxCounter
-            count={count}
+            count={initialRemainingCount ?? count}
             size={size}
             type={type === "person" ? "rounded" : "base"}
-            list={avatars.slice(avatars.length - count)}
+            list={
+              initialRemainingCount
+                ? undefined
+                : avatars.slice(avatars.length - count)
+            }
           />
         )}
         overflowIndicatorWithPopover={false}

--- a/packages/react/src/experimental/Information/Avatars/AvatarList/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/AvatarList/index.tsx
@@ -1,4 +1,5 @@
 import { sizes } from "@/ui/avatar"
+import { OverflowList } from "@/ui/OverflowList"
 import { cva } from "cva"
 import { Tooltip } from "../../../Overlays/Tooltip"
 import { Avatar, AvatarVariant } from "../Avatar"
@@ -73,6 +74,12 @@ type Props = {
    * The remaining number to display.
    */
   remainingCount?: number
+
+  /**
+   * Whether to fill the container with avatars.
+   * @default false
+   */
+  fillContainer?: boolean
 }
 
 export const AvatarList = ({
@@ -82,7 +89,39 @@ export const AvatarList = ({
   noTooltip = false,
   remainingCount: initialRemainingCount,
   max = 3,
+  fillContainer = false,
 }: Props) => {
+  if (fillContainer) {
+    return (
+      <OverflowList
+        items={avatars}
+        renderListItem={(avatar) => {
+          const displayName =
+            avatar.type === "person"
+              ? `${avatar.firstName} ${avatar.lastName}`
+              : avatar.name
+
+          return (
+            <Tooltip label={displayName}>
+              <Avatar avatar={avatar} size={size} />
+            </Tooltip>
+          )
+        }}
+        renderDropdownItem={() => null}
+        renderOverflowIndicator={(count) => (
+          <MaxCounter
+            count={count}
+            size={size}
+            type={type === "person" ? "rounded" : "base"}
+            list={avatars.slice(avatars.length - count)}
+          />
+        )}
+        overflowIndicatorWithPopover={false}
+        className="flex-1"
+      />
+    )
+  }
+
   const visibleAvatars = avatars.slice(0, max)
   const remainingAvatars = avatars.slice(max)
   const remainingCount = initialRemainingCount ?? avatars.length - max

--- a/packages/react/src/ui/OverflowList/OverflowIndicator/index.tsx
+++ b/packages/react/src/ui/OverflowList/OverflowIndicator/index.tsx
@@ -1,0 +1,49 @@
+import { Icon } from "@/components/Utilities/Icon"
+import { ChevronDown } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+import { motion } from "framer-motion"
+import { FC } from "react"
+
+const IconMotion = motion.create(Icon)
+
+interface OverflowIndicatorProps {
+  totalItemsCount: number
+  isOpen: boolean
+  count: number
+}
+
+const OverflowIndicator: FC<OverflowIndicatorProps> = ({
+  count,
+  totalItemsCount,
+  isOpen,
+}) => {
+  const i18n = useI18n()
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 rounded py-1.5 pl-3 pr-2 text-base font-medium text-f1-foreground transition-colors hover:bg-f1-background-secondary",
+        isOpen && "bg-f1-background-secondary"
+      )}
+    >
+      <span>
+        {count < totalItemsCount && "+"}
+        {count}
+      </span>
+      <span>{i18n.actions.more}</span>
+      <div className="flex h-5 w-5 items-center justify-center after:absolute after:h-4 after:w-4 after:rounded-xs after:bg-f1-background-secondary after:content-['']">
+        <IconMotion
+          icon={ChevronDown}
+          initial={{ rotate: 0 }}
+          animate={{ rotate: isOpen ? 180 : 0 }}
+          size="xs"
+        />
+      </div>
+    </div>
+  )
+}
+
+OverflowIndicator.displayName = "OverflowIndicator"
+
+export { OverflowIndicator }

--- a/packages/react/src/ui/OverflowList/index.tsx
+++ b/packages/react/src/ui/OverflowList/index.tsx
@@ -201,6 +201,12 @@ interface OverflowListProps<T> {
    */
   renderOverflowIndicator?: (count: number, isOpen: boolean) => ReactNode
 
+  /**
+   * Whether to render the overflow indicator with a popover
+   * @default false
+   */
+  overflowIndicatorWithPopover?: boolean
+
   // Component styling
   /**
    * Additional styling for the container
@@ -218,6 +224,7 @@ const OverflowList = function OverflowList<T>({
   items,
   renderListItem,
   renderDropdownItem,
+  overflowIndicatorWithPopover = true,
   renderOverflowIndicator,
   className = "",
   gap = 8,
@@ -277,6 +284,8 @@ const OverflowList = function OverflowList<T>({
 
   const showOverflowDropdown = overflowItems.length > 0
 
+  console.log({ overflowItems: overflowItems.length })
+
   return (
     <div
       ref={containerRef}
@@ -316,7 +325,11 @@ const OverflowList = function OverflowList<T>({
         {placeholderElements}
       </div>
 
-      {showOverflowDropdown && (
+      {showOverflowDropdown &&
+        !overflowIndicatorWithPopover &&
+        (renderOverflowIndicator?.(overflowItems.length, false) ??
+          defaultOverflowIndicator(overflowItems.length, false))}
+      {showOverflowDropdown && overflowIndicatorWithPopover && (
         <Popover open={isOpen} onOpenChange={handleOpenChange}>
           <PopoverTrigger asChild>
             <button

--- a/packages/react/src/ui/OverflowList/index.tsx
+++ b/packages/react/src/ui/OverflowList/index.tsx
@@ -1,183 +1,9 @@
-import { motion } from "framer-motion"
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
-import { useResizeObserver } from "usehooks-ts"
-import { Icon } from "../../components/Utilities/Icon"
-import { ChevronDown } from "../../icons/app"
-import { useI18n } from "../../lib/providers/i18n"
+import { type ReactNode, useCallback, useMemo, useState } from "react"
 import { cn, focusRing } from "../../lib/utils"
 import { Popover, PopoverContent, PopoverTrigger } from "../popover"
 import { Skeleton } from "../skeleton"
-
-const IconMotion = motion.create(Icon)
-
-/**
- * Custom hook for overflow calculations
- *
- * This hook dynamically determines which items should be visible in the main list and which should be placed in an overflow dropdown based on available space.
- *
- * @param items - The items to display
- * @param gap - The gap between items
- * @returns The overflow calculation state
- */
-function useOverflowCalculation<T>(items: T[], gap: number) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const overflowButtonRef = useRef<HTMLButtonElement>(null)
-  const measurementContainerRef = useRef<HTMLDivElement>(null)
-
-  // Combined state for visible and overflow items
-  const [itemsState, setItemsState] = useState<{
-    visibleItems: T[]
-    overflowItems: T[]
-  }>({
-    visibleItems: [],
-    overflowItems: [],
-  })
-
-  // Track initialization
-  const [isInitialized, setIsInitialized] = useState(false)
-
-  // Watch for container size changes
-  useResizeObserver({
-    ref: containerRef,
-    onResize: () => {
-      calculateVisibleItems()
-    },
-  })
-
-  // Helper function to add gap between items
-  const addGapBetweenItems = useCallback(
-    (totalWidth: number, itemIndex: number, itemsCount: number) => {
-      return itemIndex < itemsCount - 1 ? totalWidth + gap : totalWidth
-    },
-    [gap]
-  )
-
-  // Measure all items in a hidden container
-  const measureItemWidths = useCallback(() => {
-    if (!measurementContainerRef.current) return []
-
-    const itemElements = measurementContainerRef.current.children
-    const widths: number[] = []
-
-    for (let i = 0; i < itemElements.length; i++) {
-      const itemWidth = itemElements[i].getBoundingClientRect().width
-      widths.push(itemWidth)
-    }
-
-    return widths
-  }, [])
-
-  // Calculate the total width of all items including gaps
-  const calculateTotalItemsWidth = useCallback(
-    (itemWidths: number[]) => {
-      let totalWidth = 0
-
-      for (let i = 0; i < itemWidths.length; i++) {
-        totalWidth += itemWidths[i]
-        totalWidth = addGapBetweenItems(totalWidth, i, itemWidths.length)
-      }
-
-      return totalWidth
-    },
-    [addGapBetweenItems]
-  )
-
-  // Calculate how many items can fit in the available width
-  const calculateVisibleItemCount = useCallback(
-    (itemWidths: number[], availableWidth: number) => {
-      let visibleCount = 0
-      let accumulatedWidth = 0
-
-      for (let i = 0; i < itemWidths.length; i++) {
-        const newWidth = accumulatedWidth + itemWidths[i]
-
-        if (newWidth > availableWidth) break
-
-        accumulatedWidth = newWidth
-        accumulatedWidth = addGapBetweenItems(
-          accumulatedWidth,
-          i,
-          itemWidths.length
-        )
-        visibleCount++
-      }
-
-      // Return the actual count without enforcing a minimum of 1
-      return visibleCount
-    },
-    [addGapBetweenItems]
-  )
-
-  // Calculate which items should be visible and which should overflow
-  const calculateVisibleItems = useCallback(() => {
-    if (!containerRef.current || items.length === 0) return
-
-    const currentContainerWidth = containerRef.current.clientWidth
-    const overflowButtonWidth = overflowButtonRef.current?.offsetWidth || 60
-    const itemWidths = measureItemWidths()
-
-    // Check if all items can fit without an overflow button
-    const totalItemsWidth = calculateTotalItemsWidth(itemWidths)
-    const allItemsFit = totalItemsWidth <= currentContainerWidth
-
-    if (allItemsFit) {
-      setItemsState({
-        visibleItems: items,
-        overflowItems: [],
-      })
-      return
-    }
-
-    // Calculate how many items fit with an overflow button
-    const availableWidth = currentContainerWidth - overflowButtonWidth - gap
-    const visibleCount = calculateVisibleItemCount(itemWidths, availableWidth)
-
-    // If no items can fit, put all items in the overflow
-    if (visibleCount === 0) {
-      setItemsState({
-        visibleItems: [],
-        overflowItems: items,
-      })
-    } else {
-      setItemsState({
-        visibleItems: items.slice(0, visibleCount),
-        overflowItems: items.slice(visibleCount),
-      })
-    }
-  }, [
-    items,
-    gap,
-    measureItemWidths,
-    calculateTotalItemsWidth,
-    calculateVisibleItemCount,
-  ])
-
-  // Initial calculation and initialization
-  useEffect(() => {
-    calculateVisibleItems()
-  }, [calculateVisibleItems])
-
-  useEffect(() => {
-    setIsInitialized(true)
-  }, [])
-
-  return {
-    containerRef,
-    overflowButtonRef,
-    measurementContainerRef,
-    visibleItems: itemsState.visibleItems,
-    overflowItems: itemsState.overflowItems,
-    isInitialized,
-  }
-}
-
+import { OverflowIndicator } from "./OverflowIndicator"
+import { useOverflowCalculation } from "./useOverflowCalculation"
 interface OverflowListProps<T> {
   items: T[]
 
@@ -230,7 +56,6 @@ const OverflowList = function OverflowList<T>({
   gap = 8,
 }: OverflowListProps<T>) {
   const [isOpen, setIsOpen] = useState(false)
-  const i18n = useI18n()
 
   const handleOpenChange = useCallback((open: boolean) => {
     setIsOpen(open)
@@ -245,33 +70,16 @@ const OverflowList = function OverflowList<T>({
     isInitialized,
   } = useOverflowCalculation(items, gap)
 
-  // Default overflow indicator
-  const defaultOverflowIndicator = useMemo(() => {
-    const OverflowIndicator = (count: number, isOpen: boolean) => (
-      <div
-        className={cn(
-          "flex items-center gap-1 rounded py-1.5 pl-3 pr-2 text-base font-medium text-f1-foreground transition-colors hover:bg-f1-background-secondary",
-          isOpen && "bg-f1-background-secondary"
-        )}
-      >
-        <span>
-          {count < items.length && "+"}
-          {count}
-        </span>
-        <span>{i18n.actions.more}</span>
-        <div className="flex h-5 w-5 items-center justify-center after:absolute after:h-4 after:w-4 after:rounded-xs after:bg-f1-background-secondary after:content-['']">
-          <IconMotion
-            icon={ChevronDown}
-            initial={{ rotate: 0 }}
-            animate={{ rotate: isOpen ? 180 : 0 }}
-            size="xs"
-          />
-        </div>
-      </div>
-    )
-    OverflowIndicator.displayName = "OverflowIndicator"
-    return OverflowIndicator
-  }, [items.length, i18n.actions.more])
+  const DefaultOverflowIndicator = useMemo(
+    () => (
+      <OverflowIndicator
+        totalItemsCount={items.length}
+        isOpen={isOpen}
+        count={overflowItems.length}
+      />
+    ),
+    [items.length, isOpen, overflowItems.length]
+  )
 
   // Placeholder elements for initialization
   const placeholderElements = useMemo(() => {
@@ -282,9 +90,7 @@ const OverflowList = function OverflowList<T>({
     ))
   }, [items, isInitialized])
 
-  const showOverflowDropdown = overflowItems.length > 0
-
-  console.log({ overflowItems: overflowItems.length })
+  const showOverflow = overflowItems.length > 0
 
   return (
     <div
@@ -325,38 +131,40 @@ const OverflowList = function OverflowList<T>({
         {placeholderElements}
       </div>
 
-      {showOverflowDropdown &&
-        !overflowIndicatorWithPopover &&
-        (renderOverflowIndicator?.(overflowItems.length, false) ??
-          defaultOverflowIndicator(overflowItems.length, false))}
-      {showOverflowDropdown && overflowIndicatorWithPopover && (
-        <Popover open={isOpen} onOpenChange={handleOpenChange}>
-          <PopoverTrigger asChild>
-            <button
-              ref={overflowButtonRef}
-              className={cn(
-                "inline-flex flex-shrink-0 items-center",
-                focusRing()
-              )}
-            >
-              {renderOverflowIndicator
-                ? renderOverflowIndicator(overflowItems.length, isOpen)
-                : defaultOverflowIndicator(overflowItems.length, isOpen)}
-            </button>
-          </PopoverTrigger>
-          <PopoverContent
-            className="rounded-md border border-solid border-f1-border-secondary p-1 shadow-md"
-            align="end"
-          >
-            <div className="flex flex-col">
-              {overflowItems.map((item, index) => (
-                <div key={`overflow-item-${index}`}>
-                  {renderDropdownItem(item, index)}
+      {showOverflow && (
+        <>
+          {overflowIndicatorWithPopover ? (
+            <Popover open={isOpen} onOpenChange={handleOpenChange}>
+              <PopoverTrigger asChild>
+                <button
+                  ref={overflowButtonRef}
+                  className={cn(
+                    "inline-flex flex-shrink-0 items-center",
+                    focusRing()
+                  )}
+                >
+                  {renderOverflowIndicator?.(overflowItems.length, isOpen) ??
+                    DefaultOverflowIndicator}
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="rounded-md border border-solid border-f1-border-secondary p-1 shadow-md"
+                align="end"
+              >
+                <div className="flex flex-col">
+                  {overflowItems.map((item, index) => (
+                    <div key={`overflow-item-${index}`}>
+                      {renderDropdownItem(item, index)}
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </PopoverContent>
-        </Popover>
+              </PopoverContent>
+            </Popover>
+          ) : (
+            (renderOverflowIndicator?.(overflowItems.length, false) ??
+            DefaultOverflowIndicator)
+          )}
+        </>
       )}
     </div>
   )

--- a/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
+++ b/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useResizeObserver } from "usehooks-ts"
+
+/**
+ * Custom hook for overflow calculations
+ *
+ * This hook dynamically determines which items should be visible in the main list and which should be placed in an overflow dropdown based on available space.
+ *
+ * @param items - The items to display
+ * @param gap - The gap between items
+ * @returns The overflow calculation state
+ */
+export function useOverflowCalculation<T>(items: T[], gap: number) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const overflowButtonRef = useRef<HTMLButtonElement>(null)
+  const measurementContainerRef = useRef<HTMLDivElement>(null)
+
+  // Combined state for visible and overflow items
+  const [itemsState, setItemsState] = useState<{
+    visibleItems: T[]
+    overflowItems: T[]
+  }>({
+    visibleItems: [],
+    overflowItems: [],
+  })
+
+  // Track initialization
+  const [isInitialized, setIsInitialized] = useState(false)
+
+  // Watch for container size changes
+  useResizeObserver({
+    ref: containerRef,
+    onResize: () => {
+      calculateVisibleItems()
+    },
+  })
+
+  // Helper function to add gap between items
+  const addGapBetweenItems = useCallback(
+    (totalWidth: number, itemIndex: number, itemsCount: number) => {
+      return itemIndex < itemsCount - 1 ? totalWidth + gap : totalWidth
+    },
+    [gap]
+  )
+
+  // Measure all items in a hidden container
+  const measureItemWidths = useCallback(() => {
+    if (!measurementContainerRef.current) return []
+
+    const itemElements = measurementContainerRef.current.children
+    const widths: number[] = []
+
+    for (let i = 0; i < itemElements.length; i++) {
+      const itemWidth = itemElements[i].getBoundingClientRect().width
+      widths.push(itemWidth)
+    }
+
+    return widths
+  }, [])
+
+  // Calculate the total width of all items including gaps
+  const calculateTotalItemsWidth = useCallback(
+    (itemWidths: number[]) => {
+      let totalWidth = 0
+
+      for (let i = 0; i < itemWidths.length; i++) {
+        totalWidth += itemWidths[i]
+        totalWidth = addGapBetweenItems(totalWidth, i, itemWidths.length)
+      }
+
+      return totalWidth
+    },
+    [addGapBetweenItems]
+  )
+
+  // Calculate how many items can fit in the available width
+  const calculateVisibleItemCount = useCallback(
+    (itemWidths: number[], availableWidth: number) => {
+      let visibleCount = 0
+      let accumulatedWidth = 0
+
+      for (let i = 0; i < itemWidths.length; i++) {
+        const newWidth = accumulatedWidth + itemWidths[i]
+
+        if (newWidth > availableWidth) break
+
+        accumulatedWidth = newWidth
+        accumulatedWidth = addGapBetweenItems(
+          accumulatedWidth,
+          i,
+          itemWidths.length
+        )
+        visibleCount++
+      }
+
+      // Return the actual count without enforcing a minimum of 1
+      return visibleCount
+    },
+    [addGapBetweenItems]
+  )
+
+  // Calculate which items should be visible and which should overflow
+  const calculateVisibleItems = useCallback(() => {
+    if (!containerRef.current || items.length === 0) return
+
+    const currentContainerWidth = containerRef.current.clientWidth
+    const overflowButtonWidth = overflowButtonRef.current?.offsetWidth || 60
+    const itemWidths = measureItemWidths()
+
+    // Check if all items can fit without an overflow button
+    const totalItemsWidth = calculateTotalItemsWidth(itemWidths)
+    const allItemsFit = totalItemsWidth <= currentContainerWidth
+
+    if (allItemsFit) {
+      setItemsState({
+        visibleItems: items,
+        overflowItems: [],
+      })
+      return
+    }
+
+    // Calculate how many items fit with an overflow button
+    const availableWidth = currentContainerWidth - overflowButtonWidth - gap
+    const visibleCount = calculateVisibleItemCount(itemWidths, availableWidth)
+
+    // If no items can fit, put all items in the overflow
+    if (visibleCount === 0) {
+      setItemsState({
+        visibleItems: [],
+        overflowItems: items,
+      })
+    } else {
+      setItemsState({
+        visibleItems: items.slice(0, visibleCount),
+        overflowItems: items.slice(visibleCount),
+      })
+    }
+  }, [
+    items,
+    gap,
+    measureItemWidths,
+    calculateTotalItemsWidth,
+    calculateVisibleItemCount,
+  ])
+
+  // Initial calculation and initialization
+  useEffect(() => {
+    calculateVisibleItems()
+  }, [calculateVisibleItems])
+
+  useEffect(() => {
+    setIsInitialized(true)
+  }, [])
+
+  return {
+    containerRef,
+    overflowButtonRef,
+    measurementContainerRef,
+    visibleItems: itemsState.visibleItems,
+    overflowItems: itemsState.overflowItems,
+    isInitialized,
+  }
+}


### PR DESCRIPTION
## Description

We need to support an alternative way of visualizing a list of avatars that consists of the entire parent container to be filled with avatars. We need it for this widget that we're about to create:

<img width="578" alt="Screenshot 2025-04-29 at 09 51 23" src="https://github.com/user-attachments/assets/3e89752b-0415-4501-b8a0-d7ae3392c47d" />

## Screenshots

<img width="276" alt="Screenshot 2025-04-29 at 09 51 50" src="https://github.com/user-attachments/assets/f174798a-a266-4618-9eae-fb0ebb0d76c0" />
