### PR TITLE
Add support to show emoji in widget highlight items

### DIFF
--- a/packages/react/src/experimental/Widgets/Content/IndicatorsList/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/IndicatorsList/index.tsx
@@ -12,12 +12,13 @@ export const IndicatorsList = forwardRef<HTMLDivElement, IndicatorsListProps>(
         ref={ref}
         className="grid auto-cols-fr grid-flow-col items-end gap-x-3"
       >
-        {items.map(({ label, content, icon, color }) => (
+        {items.map(({ label, content, icon, emoji, color }) => (
           <Indicator
             key={`${label}-${content}`}
             label={label}
             content={content}
             icon={icon}
+            emoji={emoji}
             color={color}
           />
         ))}

--- a/packages/react/src/experimental/Widgets/Content/IndicatorsList/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/IndicatorsList/index.tsx
@@ -12,14 +12,13 @@ export const IndicatorsList = forwardRef<HTMLDivElement, IndicatorsListProps>(
         ref={ref}
         className="grid auto-cols-fr grid-flow-col items-end gap-x-3"
       >
-        {items.map(({ label, content, icon, emoji, color }) => (
+        {items.map(({ label, content, color, ...item }) => (
           <Indicator
             key={`${label}-${content}`}
             label={label}
             content={content}
-            icon={icon}
-            emoji={emoji}
             color={color}
+            {...item}
           />
         ))}
       </div>

--- a/packages/react/src/ui/indicator.tsx
+++ b/packages/react/src/ui/indicator.tsx
@@ -1,3 +1,4 @@
+import { EmojiImage } from "@/lib/emojis"
 import { forwardRef } from "react"
 import { Icon, IconType } from "../components/Utilities/Icon"
 import { cn } from "../lib/utils"
@@ -7,12 +8,13 @@ interface IndicatorProps {
   label: string
   color?: string
   icon?: IconType
+  emoji?: string
 }
 
 export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
-  function Indicator({ content, label, icon, color }, ref) {
+  function Indicator({ content, label, icon, emoji, color }, ref) {
     return (
-      <div key={label} className="grid-row-2 col-span-1 grid" ref={ref}>
+      <div key={label} className="flex flex-col gap-1" ref={ref}>
         <p className="text-3xl font-semibold">{content}</p>
         <div className="flex items-center gap-1">
           <p
@@ -21,11 +23,12 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
           >
             {label}
           </p>
-          {icon && (
+          {icon && !emoji && (
             <span className={cn("flex", color)}>
               <Icon icon={icon} />
             </span>
           )}
+          {emoji && !icon && <EmojiImage emoji={emoji} size="md" />}
         </div>
       </div>
     )

--- a/packages/react/src/ui/indicator.tsx
+++ b/packages/react/src/ui/indicator.tsx
@@ -3,16 +3,14 @@ import { forwardRef } from "react"
 import { Icon, IconType } from "../components/Utilities/Icon"
 import { cn } from "../lib/utils"
 
-interface IndicatorProps {
+type IndicatorProps = {
   content: string
   label: string
   color?: string
-  icon?: IconType
-  emoji?: string
-}
+} & ({ icon?: IconType } | { emoji?: string })
 
 export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
-  function Indicator({ content, label, icon, emoji, color }, ref) {
+  function Indicator({ content, label, color, ...props }, ref) {
     return (
       <div key={label} className="flex flex-col gap-1" ref={ref}>
         <p className="text-3xl font-semibold">{content}</p>
@@ -23,12 +21,16 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
           >
             {label}
           </p>
-          {icon && !emoji && (
+          {"icon" in props && props.icon && (
             <span className={cn("flex", color)}>
-              <Icon icon={icon} />
+              <Icon icon={props.icon} />
             </span>
           )}
-          {emoji && !icon && <EmojiImage emoji={emoji} size="md" />}
+          {"emoji" in props && props.emoji && (
+            <span className={cn("flex", color)}>
+              <EmojiImage emoji={props.emoji} size="md" />
+            </span>
+          )}
         </div>
       </div>
     )


### PR DESCRIPTION
## Description

We need to support showing an emoji in widget highlight items for one new widget that we'll be creating.

<img width="578" alt="Screenshot 2025-04-29 at 09 51 23" src="https://github.com/user-attachments/assets/3e89752b-0415-4501-b8a0-d7ae3392c47d" />

## Screenshots

<img width="510" alt="Screenshot 2025-04-29 at 10 22 49" src="https://github.com/user-attachments/assets/a5558ac8-f914-45ac-8d5b-503a7ac8b692" />

