### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "packages/react": "1.36.2",
-  "packages/react-native": "0.0.1"
+  "packages/react-native": "0.1.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.0.1...factorial-one-react-native-v0.1.0) (2025-04-29)
+
+
+### Features
+
+* update README to improve usage example and add icons section ([#1686](https://github.com/factorialco/factorial-one/issues/1686)) ([0009f34](https://github.com/factorialco/factorial-one/commit/0009f340289c76cd44c22ada37041bb38ca4637a))

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.1.0</summary>

## [0.1.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.0.1...factorial-one-react-native-v0.1.0) (2025-04-29)


### Features

* update README to improve usage example and add icons section ([#1686](https://github.com/factorialco/factorial-one/issues/1686)) ([0009f34](https://github.com/factorialco/factorial-one/commit/0009f340289c76cd44c22ada37041bb38ca4637a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).