### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "packages/react": "1.36.2",
-  "packages/react-native": "0.2.0"
+  "packages/react-native": "0.2.1"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.0...factorial-one-react-native-v0.2.1) (2025-04-29)
+
+
+### Bug Fixes
+
+* trigger release ([#1692](https://github.com/factorialco/factorial-one/issues/1692)) ([dcf1555](https://github.com/factorialco/factorial-one/commit/dcf1555f8e54d9a2145d63bffd8684c3366d7b46))
+
 ## [0.2.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.1.0...factorial-one-react-native-v0.2.0) (2025-04-29)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.2.1</summary>

## [0.2.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.0...factorial-one-react-native-v0.2.1) (2025-04-29)


### Bug Fixes

* trigger release ([#1692](https://github.com/factorialco/factorial-one/issues/1692)) ([dcf1555](https://github.com/factorialco/factorial-one/commit/dcf1555f8e54d9a2145d63bffd8684c3366d7b46))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).