### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "packages/react": "1.36.2",
-  "packages/react-native": "0.2.1"
+  "packages/react-native": "0.2.2"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.1...factorial-one-react-native-v0.2.2) (2025-04-29)
+
+
+### Bug Fixes
+
+* update README ([#1696](https://github.com/factorialco/factorial-one/issues/1696)) ([cd2baca](https://github.com/factorialco/factorial-one/commit/cd2baca1e73eec23c1a28f3dcf7a0d3df24aa11a))
+
 ## [0.2.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.0...factorial-one-react-native-v0.2.1) (2025-04-29)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.2.2</summary>

## [0.2.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.1...factorial-one-react-native-v0.2.2) (2025-04-29)


### Bug Fixes

* update README ([#1696](https://github.com/factorialco/factorial-one/issues/1696)) ([cd2baca](https://github.com/factorialco/factorial-one/commit/cd2baca1e73eec23c1a28f3dcf7a0d3df24aa11a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).