### PR TITLE
fix: include src folder to the react-native build

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -21,7 +21,7 @@
     "./tailwind.config": "./tailwind.config.js"
   },
   "files": [
-    "dist",
+    "src",
     "tailwind.config.js"
   ],
   "scripts": {


### PR DESCRIPTION
We publish a package of two files now, missing all the react components