### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "packages/react": "1.36.2",
-  "packages/react-native": "0.2.2"
+  "packages/react-native": "0.2.3"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.2...factorial-one-react-native-v0.2.3) (2025-04-29)
+
+
+### Bug Fixes
+
+* include src folder to the build ([#1698](https://github.com/factorialco/factorial-one/issues/1698)) ([9506ce8](https://github.com/factorialco/factorial-one/commit/9506ce8f57399f511e4672b1796d3f45d9dc4aba))
+
 ## [0.2.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.1...factorial-one-react-native-v0.2.2) (2025-04-29)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.2.3</summary>

## [0.2.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.2...factorial-one-react-native-v0.2.3) (2025-04-29)


### Bug Fixes

* include src folder to the build ([#1698](https://github.com/factorialco/factorial-one/issues/1698)) ([9506ce8](https://github.com/factorialco/factorial-one/commit/9506ce8f57399f511e4672b1796d3f45d9dc4aba))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).