### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.36.2",
+  "packages/react": "1.36.3",
   "packages/react-native": "0.2.3"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.36.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.2...factorial-one-react-v1.36.3) (2025-04-29)
+
+
+### Bug Fixes
+
+* avoid links to be cut-off in widget ([#1701](https://github.com/factorialco/factorial-one/issues/1701)) ([da902d2](https://github.com/factorialco/factorial-one/commit/da902d259fb157cad26f8bf18880d675b350a458))
+
 ## [1.36.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.1...factorial-one-react-v1.36.2) (2025-04-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.36.2",
+  "version": "1.36.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.36.3</summary>

## [1.36.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.2...factorial-one-react-v1.36.3) (2025-04-29)


### Bug Fixes

* avoid links to be cut-off in widget ([#1701](https://github.com/factorialco/factorial-one/issues/1701)) ([da902d2](https://github.com/factorialco/factorial-one/commit/da902d259fb157cad26f8bf18880d675b350a458))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).