### PR TITLE
fix: CompanySelect doesn't open

### DIFF
--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -1,17 +1,27 @@
+import { useReducedMotion } from "@/lib/a11y"
+import { cn } from "@/lib/utils"
 import { ScrollArea } from "@/ui/scrollarea"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { useVirtualizer } from "@tanstack/react-virtual"
-import * as React from "react"
-import { ReactNode, useContext, useEffect, useMemo, useRef } from "react"
-import { cn } from "../../../lib/utils.ts"
+import {
+  ComponentPropsWithoutRef,
+  ElementRef,
+  forwardRef,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { VirtualItem } from "../index"
-import { SelectContext } from "../SelectContext.tsx"
+import { SelectContext } from "../SelectContext"
 
 /**
  * Select Content component
  */
 // Define two different prop types for the two mutually exclusive scenarios
-type SelectItemProps = React.ComponentPropsWithoutRef<
+type SelectItemProps = ComponentPropsWithoutRef<
   typeof SelectPrimitive.Content
 > & {
   top?: ReactNode
@@ -37,8 +47,8 @@ type SelectContentProps =
   | SelectContentWithItemsProps
   | SelectContentWithChildrenProps
 
-const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
+const SelectContent = forwardRef<
+  ElementRef<typeof SelectPrimitive.Content>,
   SelectContentProps
 >(
   (
@@ -64,10 +74,11 @@ const SelectContent = React.forwardRef<
       return !children
     }, [isVirtual, items, children])
 
+    const prefersReducedMotion = useReducedMotion()
     // State to check if the virtual list is ready and the scroll in the correct position
-    const [virtualReady, setVirtualReady] = React.useState(false)
+    const [virtualReady, setVirtualReady] = useState(prefersReducedMotion)
     // State to check if the radixui animation has started
-    const [animationStarted, setAnimationStarted] = React.useState(false)
+    const [animationStarted, setAnimationStarted] = useState(false)
 
     // Get the value and the open status from the select context
     const { value, open } = useContext(SelectContext)
@@ -81,7 +92,7 @@ const SelectContent = React.forwardRef<
       getScrollElement: () => parentRef.current,
       estimateSize: (i: number) => items?.[i]?.height || 0,
       overscan: 5,
-      enabled: animationStarted,
+      enabled: prefersReducedMotion || animationStarted,
     })
 
     useEffect(() => {


### PR DESCRIPTION
## Description

Several client reported a bug that the company selector does not expand when clicked

## Root cause

The issue happens when user has animations disabled on the OS level. It is a common practice for remote desktops since they have slower refresh rate and animations look junky.

## Solution

We relied solely on `onAnimationStart` callback to trigger virtual list creation. The fix uses `useReducedMotion` hook to get information whether or not animations are disabled and initializes the virtual list on render, when they are disabled.


https://github.com/user-attachments/assets/3bdf573b-a18f-48ea-b482-81e5f2d7f29c

