### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.36.3",
+  "packages/react": "1.36.4",
   "packages/react-native": "0.2.3"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.36.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.3...factorial-one-react-v1.36.4) (2025-04-30)
+
+
+### Bug Fixes
+
+* consider reduced animation preference ([#1703](https://github.com/factorialco/factorial-one/issues/1703)) ([8d9390c](https://github.com/factorialco/factorial-one/commit/8d9390c33c4e1397ee0e54998c635b0824499e60))
+
 ## [1.36.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.2...factorial-one-react-v1.36.3) (2025-04-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.36.3",
+  "version": "1.36.4",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.36.4</summary>

## [1.36.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.3...factorial-one-react-v1.36.4) (2025-04-30)


### Bug Fixes

* consider reduced animation preference ([#1703](https://github.com/factorialco/factorial-one/issues/1703)) ([8d9390c](https://github.com/factorialco/factorial-one/commit/8d9390c33c4e1397ee0e54998c635b0824499e60))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).