### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.36.4",
+  "packages/react": "1.37.0",
   "packages/react-native": "0.2.3"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.37.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.4...factorial-one-react-v1.37.0) (2025-04-30)
+
+
+### Features
+
+* add support to have double columns in carousel ([#1706](https://github.com/factorialco/factorial-one/issues/1706)) ([56be64e](https://github.com/factorialco/factorial-one/commit/56be64ed70a2315861b199f7663bf03b03434d8f))
+
 ## [1.36.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.3...factorial-one-react-v1.36.4) (2025-04-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.36.4",
+  "version": "1.37.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.37.0</summary>

## [1.37.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.4...factorial-one-react-v1.37.0) (2025-04-30)


### Features

* add support to have double columns in carousel ([#1706](https://github.com/factorialco/factorial-one/issues/1706)) ([56be64e](https://github.com/factorialco/factorial-one/commit/56be64ed70a2315861b199f7663bf03b03434d8f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).