### PR TITLE
fix: double click on dropdown

### DIFF
--- a/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
@@ -52,14 +52,7 @@ const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
   )
 
   return (
-    <DropdownMenuItem
-      asChild
-      onClick={(e) => {
-        e.stopPropagation()
-        item.onClick?.()
-      }}
-      className={itemClass}
-    >
+    <DropdownMenuItem asChild className={itemClass}>
       {href ? (
         <Link
           href={href}


### PR DESCRIPTION
## Description

Clicking on the items results in two calls on the onClick method, because all the props are passed to the children, that execute the onClick again.



## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
