### PR TITLE
fix: add support for widget skeleton to be full height

### DIFF
--- a/packages/react/src/experimental/Widgets/Widget/Skeleton.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/Skeleton.stories.tsx
@@ -39,3 +39,17 @@ export const WithSubtitle: Story = {
     },
   },
 }
+
+export const FullHeight: Story = {
+  decorators: [
+    (Story) => (
+      <div className="h-[350px] w-full min-w-72 max-w-96">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    ...meta.args,
+    height: "full",
+  },
+}

--- a/packages/react/src/experimental/Widgets/Widget/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.stories.tsx
@@ -136,3 +136,17 @@ export const Full: Story = {
     ],
   },
 }
+
+export const FullHeight: Story = {
+  decorators: [
+    (Story) => (
+      <div className="h-[350px] w-full min-w-72 max-w-96">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    ...meta.args,
+    fullHeight: true,
+  },
+}

--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -234,13 +234,21 @@ export type WidgetSkeletonProps = {
     title?: string
     subtitle?: string
   }
-} & VariantProps<typeof skeletonVariants>
+} & (
+  | VariantProps<typeof skeletonVariants>
+  | {
+      height: "full"
+    }
+)
 
 const Skeleton = forwardRef<HTMLDivElement, WidgetSkeletonProps>(
   function Skeleton({ header, height }, ref) {
     return (
       <Card
-        className="flex gap-4 border-f1-border-secondary"
+        className={cn(
+          "flex gap-4 border-f1-border-secondary",
+          height === "full" && "h-full"
+        )}
         ref={ref}
         aria-live="polite"
         aria-busy={true}
@@ -260,7 +268,7 @@ const Skeleton = forwardRef<HTMLDivElement, WidgetSkeletonProps>(
         </CardHeader>
         <CardContent
           aria-hidden={true}
-          className={cn(skeletonVariants({ height }))}
+          className={cn(height !== "full" && skeletonVariants({ height }))}
         >
           {[...Array(4)].map((_, i) => (
             <SkeletonPrimitive


### PR DESCRIPTION
## Description

We need to have support for widget skeletons to be full height depending on parent height. We need it for the holidays widget we are creating for the home, where this widget height depends entirely on its parent.
