### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "packages/react": "1.37.0",
-  "packages/react-native": "0.2.3"
+  "packages/react-native": "0.2.4"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.3...factorial-one-react-native-v0.2.4) (2025-04-30)
+
+
+### Bug Fixes
+
+* icons typescript error ([#1710](https://github.com/factorialco/factorial-one/issues/1710)) ([02bf31f](https://github.com/factorialco/factorial-one/commit/02bf31fbdab9f382d870c71969aa586eb2636c5c))
+
 ## [0.2.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.2...factorial-one-react-native-v0.2.3) (2025-04-29)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.2.4</summary>

## [0.2.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.3...factorial-one-react-native-v0.2.4) (2025-04-30)


### Bug Fixes

* icons typescript error ([#1710](https://github.com/factorialco/factorial-one/issues/1710)) ([02bf31f](https://github.com/factorialco/factorial-one/commit/02bf31fbdab9f382d870c71969aa586eb2636c5c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).