### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.37.0",
+  "packages/react": "1.37.1",
   "packages/react-native": "0.2.4"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.37.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.0...factorial-one-react-v1.37.1) (2025-04-30)
+
+
+### Bug Fixes
+
+* double click on dropdown ([#1708](https://github.com/factorialco/factorial-one/issues/1708)) ([a7b6796](https://github.com/factorialco/factorial-one/commit/a7b6796a888095a76c251e16c9e881c7c0afa91b))
+
 ## [1.37.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.36.4...factorial-one-react-v1.37.0) (2025-04-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.37.1</summary>

## [1.37.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.0...factorial-one-react-v1.37.1) (2025-04-30)


### Bug Fixes

* double click on dropdown ([#1708](https://github.com/factorialco/factorial-one/issues/1708)) ([a7b6796](https://github.com/factorialco/factorial-one/commit/a7b6796a888095a76c251e16c9e881c7c0afa91b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).