### PR TITLE
fix: add support to be more selective on double column breakpoints in carousel

### DIFF
--- a/packages/react/src/experimental/Navigation/Carousel/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Carousel/index.stories.tsx
@@ -90,7 +90,16 @@ export const CustomColumns: Story = {
 export const DoubleColumns: Story = {
   args: {
     ...CustomColumns.args,
-    doubleColumnIndices: [0, 4],
+    doubleColumns: [
+      {
+        index: 0,
+        sizes: ["default", "lg"],
+      },
+      {
+        index: 4,
+        sizes: ["default", "lg"],
+      },
+    ],
   },
 }
 

--- a/packages/react/src/experimental/Navigation/Carousel/index.tsx
+++ b/packages/react/src/experimental/Navigation/Carousel/index.tsx
@@ -25,7 +25,10 @@ interface CarouselProps {
   delay?: number
   columns?: CarouselBreakpoints
   showPeek?: boolean
-  doubleColumnIndices?: number[]
+  doubleColumns?: {
+    index: number
+    sizes: (keyof CarouselBreakpoints)[]
+  }[]
 }
 
 function getVariantValue(
@@ -49,7 +52,7 @@ export const Carousel = ({
   autoplay = false,
   delay = 3000,
   showPeek = false,
-  doubleColumnIndices,
+  doubleColumns,
 }: CarouselProps) => {
   const childrenArray = React.Children.toArray(children)
 
@@ -90,20 +93,35 @@ export const Carousel = ({
         <div className="relative">
           <CarouselContent>
             {React.Children.map(childrenArray, (child, index) => {
-              const isDoubleColumn = doubleColumnIndices?.includes(index)
+              const doubleColumn = doubleColumns?.find(
+                (column) => column.index === index
+              )
+
               return (
                 <CarouselItem
                   key={index}
                   className={carouselItemVariants({
-                    default: getVariantValue(
-                      columns.default,
+                    default: getVariantValue(columns.default, showPeek),
+                    xs: getVariantValue(
+                      columns.xs,
                       showPeek,
-                      isDoubleColumn
+                      doubleColumn?.sizes?.includes("xs")
                     ),
-                    xs: getVariantValue(columns.xs, showPeek, isDoubleColumn),
-                    sm: getVariantValue(columns.sm, showPeek, isDoubleColumn),
-                    md: getVariantValue(columns.md, showPeek, isDoubleColumn),
-                    lg: getVariantValue(columns.lg, showPeek, isDoubleColumn),
+                    sm: getVariantValue(
+                      columns.sm,
+                      showPeek,
+                      doubleColumn?.sizes?.includes("sm")
+                    ),
+                    md: getVariantValue(
+                      columns.md,
+                      showPeek,
+                      doubleColumn?.sizes?.includes("md")
+                    ),
+                    lg: getVariantValue(
+                      columns.lg,
+                      showPeek,
+                      doubleColumn?.sizes?.includes("lg")
+                    ),
                     peek: showPeek,
                   })}
                 >


### PR DESCRIPTION
## Description

We need to allow to be more selective on the breakpoints in the carousel in which we want each item to be double in size. For the new holidays widget we will only want it to be double in size when we have a larger screen.