### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.37.2",
+  "packages/react": "1.37.3",
   "packages/react-native": "0.2.4"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.37.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.2...factorial-one-react-v1.37.3) (2025-04-30)
+
+
+### Bug Fixes
+
+* add support to be more selective on double column breakpoints in carousel ([#1714](https://github.com/factorialco/factorial-one/issues/1714)) ([56c6f33](https://github.com/factorialco/factorial-one/commit/56c6f3361b9e06ea74fe598907d9a31d764233e3))
+
 ## [1.37.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.1...factorial-one-react-v1.37.2) (2025-04-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.37.2",
+  "version": "1.37.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.37.3</summary>

## [1.37.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.2...factorial-one-react-v1.37.3) (2025-04-30)


### Bug Fixes

* add support to be more selective on double column breakpoints in carousel ([#1714](https://github.com/factorialco/factorial-one/issues/1714)) ([56c6f33](https://github.com/factorialco/factorial-one/commit/56c6f3361b9e06ea74fe598907d9a31d764233e3))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).