### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.37.3",
+  "packages/react": "1.37.4",
   "packages/react-native": "0.2.4",
   "packages/core": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.37.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.3...factorial-one-react-v1.37.4) (2025-04-30)
+
+
+### Bug Fixes
+
+* update avatar list remaining count depending on number of items shown ([#1720](https://github.com/factorialco/factorial-one/issues/1720)) ([783a290](https://github.com/factorialco/factorial-one/commit/783a29084868d46bd7da01aec846d4735e42e11d))
+
 ## [1.37.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.2...factorial-one-react-v1.37.3) (2025-04-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.37.3",
+  "version": "1.37.4",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.37.4</summary>

## [1.37.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.3...factorial-one-react-v1.37.4) (2025-04-30)


### Bug Fixes

* update avatar list remaining count depending on number of items shown ([#1720](https://github.com/factorialco/factorial-one/issues/1720)) ([783a290](https://github.com/factorialco/factorial-one/commit/783a29084868d46bd7da01aec846d4735e42e11d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).