### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.37.5",
+  "packages/react": "1.37.6",
   "packages/react-native": "0.2.4",
   "packages/core": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.37.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.5...factorial-one-react-v1.37.6) (2025-04-30)
+
+
+### Bug Fixes
+
+* tooltips in AvatarList component with layout fill ([#1723](https://github.com/factorialco/factorial-one/issues/1723)) ([70b358e](https://github.com/factorialco/factorial-one/commit/70b358e36b6f52a6168923401bc75e33e4738d50))
+
 ## [1.37.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.4...factorial-one-react-v1.37.5) (2025-04-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.37.5",
+  "version": "1.37.6",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.37.6</summary>

## [1.37.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.5...factorial-one-react-v1.37.6) (2025-04-30)


### Bug Fixes

* tooltips in AvatarList component with layout fill ([#1723](https://github.com/factorialco/factorial-one/issues/1723)) ([70b358e](https://github.com/factorialco/factorial-one/commit/70b358e36b6f52a6168923401bc75e33e4738d50))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).