### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.37.6",
+  "packages/react": "1.38.0",
   "packages/react-native": "0.2.4",
   "packages/core": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.38.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.6...factorial-one-react-v1.38.0) (2025-05-02)
+
+
+### Features
+
+* **Calendar:** show week number & styles ([#1704](https://github.com/factorialco/factorial-one/issues/1704)) ([f373513](https://github.com/factorialco/factorial-one/commit/f373513a8348830cb1eec1a685a19d42bc1b8a68))
+
 ## [1.37.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.5...factorial-one-react-v1.37.6) (2025-04-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.37.6",
+  "version": "1.38.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.38.0</summary>

## [1.38.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.6...factorial-one-react-v1.38.0) (2025-05-02)


### Features

* **Calendar:** show week number & styles ([#1704](https://github.com/factorialco/factorial-one/issues/1704)) ([f373513](https://github.com/factorialco/factorial-one/commit/f373513a8348830cb1eec1a685a19d42bc1b8a68))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).