### PR TITLE
feat(Calendar): Quarter and Half-year views

### DIFF
--- a/packages/react/src/experimental/OneCalendar/OneCalendar.stories.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.stories.tsx
@@ -292,3 +292,92 @@ export const Week: Story = {
     )
   },
 }
+
+export const QuarterSingle: Story = {
+  args: {
+    mode: "single",
+    view: "quarter",
+  },
+  render: (args) => {
+    const [selectedDate, setSelectedDate] = useState<Date | null>(() => {
+      const now = new Date()
+      const quarterStartMonth = Math.floor(now.getMonth() / 3) * 3
+      return new Date(now.getFullYear(), quarterStartMonth, 1)
+    })
+
+    const handleSelect = (date: Date | DateRange | null) => {
+      if (!date) {
+        setSelectedDate(null)
+        return
+      }
+      if (date instanceof Date) {
+        setSelectedDate(date)
+      }
+    }
+
+    const displayRange = selectedDate
+      ? {
+          from: selectedDate,
+          to: new Date(
+            selectedDate.getFullYear(),
+            Math.floor(selectedDate.getMonth() / 3) * 3 + 3,
+            0
+          ),
+        }
+      : null
+
+    return (
+      <div className="mx-auto max-w-80">
+        <OneCalendar
+          {...args}
+          defaultSelected={selectedDate}
+          onSelect={handleSelect}
+        />
+        {displayRange && <SelectedDateDisplay range={displayRange} />}
+      </div>
+    )
+  },
+}
+
+export const QuarterRange: Story = {
+  args: {
+    mode: "range",
+    view: "quarter",
+  },
+  render: (args) => {
+    const [selectedRange, setSelectedRange] = useState<DateRange | null>(() => {
+      const now = new Date()
+      const currentQuarter = Math.floor(now.getMonth() / 3)
+      const currentQuarterStartMonth = currentQuarter * 3
+      const nextQuarter = (currentQuarter + 1) % 4
+      const nextQuarterStartMonth = nextQuarter * 3
+      const nextQuarterYear = now.getFullYear() + (currentQuarter === 3 ? 1 : 0)
+
+      return {
+        from: new Date(now.getFullYear(), currentQuarterStartMonth, 1),
+        to: new Date(nextQuarterYear, nextQuarterStartMonth + 3, 0),
+      }
+    })
+
+    const handleSelect = (date: Date | DateRange | null) => {
+      if (!date) {
+        setSelectedRange(null)
+        return
+      }
+      if (!(date instanceof Date)) {
+        setSelectedRange(date)
+      }
+    }
+
+    return (
+      <div className="mx-auto max-w-80">
+        <OneCalendar
+          {...args}
+          defaultSelected={selectedRange}
+          onSelect={handleSelect}
+        />
+        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+      </div>
+    )
+  },
+}

--- a/packages/react/src/experimental/OneCalendar/OneCalendar.stories.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.stories.tsx
@@ -381,3 +381,91 @@ export const QuarterRange: Story = {
     )
   },
 }
+
+export const HalfYearSingle: Story = {
+  args: {
+    mode: "single",
+    view: "halfyear",
+  },
+  render: (args) => {
+    const [selectedDate, setSelectedDate] = useState<Date | null>(() => {
+      const now = new Date()
+      const halfYearStartMonth = Math.floor(now.getMonth() / 6) * 6
+      return new Date(now.getFullYear(), halfYearStartMonth, 1)
+    })
+
+    const handleSelect = (date: Date | DateRange | null) => {
+      if (!date) {
+        setSelectedDate(null)
+        return
+      }
+      if (date instanceof Date) {
+        setSelectedDate(date)
+      }
+    }
+
+    const displayRange = selectedDate
+      ? {
+          from: selectedDate,
+          to: new Date(
+            selectedDate.getFullYear(),
+            Math.floor(selectedDate.getMonth() / 6) * 6 + 6,
+            0
+          ),
+        }
+      : null
+
+    return (
+      <div className="mx-auto max-w-80">
+        <OneCalendar
+          {...args}
+          defaultSelected={selectedDate}
+          onSelect={handleSelect}
+        />
+        {displayRange && <SelectedDateDisplay range={displayRange} />}
+      </div>
+    )
+  },
+}
+
+export const HalfYearRange: Story = {
+  args: {
+    mode: "range",
+    view: "halfyear",
+  },
+  render: (args) => {
+    const [selectedRange, setSelectedRange] = useState<DateRange | null>(() => {
+      const now = new Date()
+      const currentHalfYear = Math.floor(now.getMonth() / 6)
+      const currentHalfYearStartMonth = currentHalfYear * 6
+      const endYear = now.getFullYear() + Math.floor((currentHalfYear + 2) / 2)
+      const endMonth = ((currentHalfYear + 2) % 2) * 6
+
+      return {
+        from: new Date(now.getFullYear(), currentHalfYearStartMonth, 1),
+        to: new Date(endYear, endMonth + 6, 0),
+      }
+    })
+
+    const handleSelect = (date: Date | DateRange | null) => {
+      if (!date) {
+        setSelectedRange(null)
+        return
+      }
+      if (!(date instanceof Date)) {
+        setSelectedRange(date)
+      }
+    }
+
+    return (
+      <div className="mx-auto max-w-80">
+        <OneCalendar
+          {...args}
+          defaultSelected={selectedRange}
+          onSelect={handleSelect}
+        />
+        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+      </div>
+    )
+  },
+}

--- a/packages/react/src/experimental/OneCalendar/OneCalendar.stories.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.stories.tsx
@@ -349,7 +349,7 @@ export const QuarterRange: Story = {
       const now = new Date()
       const currentQuarter = Math.floor(now.getMonth() / 3)
       const currentQuarterStartMonth = currentQuarter * 3
-      const nextQuarter = (currentQuarter + 1) % 4
+      const nextQuarter = (currentQuarter + 2) % 4
       const nextQuarterStartMonth = nextQuarter * 3
       const nextQuarterYear = now.getFullYear() + (currentQuarter === 3 ? 1 : 0)
 

--- a/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
@@ -48,6 +48,10 @@ export function OneCalendar({
       newDate.setFullYear(newDate.getFullYear() + direction)
     }
 
+    if (view === "quarter") {
+      newDate.setFullYear(newDate.getFullYear() + direction * 5)
+    }
+
     if (view === "year") {
       newDate.setFullYear(newDate.getFullYear() + direction * 10)
     }
@@ -78,6 +82,12 @@ export function OneCalendar({
           value={viewDate.getFullYear()}
         />
       )
+    }
+
+    if (view === "quarter") {
+      const baseYear = Math.floor(viewDate.getFullYear() / 5) * 5
+      const endYear = baseYear + 4
+      return `${baseYear}  -  ${endYear}`
     }
 
     if (view === "year") {

--- a/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
@@ -6,6 +6,7 @@ import { useI18n } from "../../lib/providers/i18n"
 import { CalendarMode, CalendarView, DateRange } from "./types"
 import { DayView } from "./views/day"
 import { MonthView } from "./views/month"
+import { QuarterView } from "./views/quarter"
 import { WeekView } from "./views/week"
 import { YearView } from "./views/year"
 
@@ -142,6 +143,16 @@ export function OneCalendar({
             onSelect={handleSelect}
             month={viewDate}
             onMonthChange={setViewDate}
+            motionDirection={motionDirection}
+          />
+        )}
+
+        {view === "quarter" && (
+          <QuarterView
+            mode={mode}
+            year={viewDate.getFullYear()}
+            selected={selected}
+            onSelect={handleSelect}
             motionDirection={motionDirection}
           />
         )}

--- a/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
@@ -5,11 +5,11 @@ import { Button } from "../../components/Actions/Button"
 import { useI18n } from "../../lib/providers/i18n"
 import { CalendarMode, CalendarView, DateRange } from "./types"
 import { DayView } from "./views/day"
+import { HalfYearView } from "./views/halfyear"
 import { MonthView } from "./views/month"
 import { QuarterView } from "./views/quarter"
 import { WeekView } from "./views/week"
 import { YearView } from "./views/year"
-
 export interface OneCalendarProps {
   mode: CalendarMode
   view: CalendarView
@@ -52,6 +52,10 @@ export function OneCalendar({
       newDate.setFullYear(newDate.getFullYear() + direction * 5)
     }
 
+    if (view === "halfyear") {
+      newDate.setFullYear(newDate.getFullYear() + direction * 5)
+    }
+
     if (view === "year") {
       newDate.setFullYear(newDate.getFullYear() + direction * 10)
     }
@@ -85,6 +89,12 @@ export function OneCalendar({
     }
 
     if (view === "quarter") {
+      const baseYear = Math.floor(viewDate.getFullYear() / 5) * 5
+      const endYear = baseYear + 4
+      return `${baseYear}  -  ${endYear}`
+    }
+
+    if (view === "halfyear") {
       const baseYear = Math.floor(viewDate.getFullYear() / 5) * 5
       const endYear = baseYear + 4
       return `${baseYear}  -  ${endYear}`
@@ -157,6 +167,16 @@ export function OneCalendar({
           />
         )}
 
+        {view === "month" && (
+          <MonthView
+            mode={mode}
+            year={viewDate.getFullYear()}
+            selected={selected}
+            onSelect={handleSelect}
+            motionDirection={motionDirection}
+          />
+        )}
+
         {view === "quarter" && (
           <QuarterView
             mode={mode}
@@ -167,8 +187,8 @@ export function OneCalendar({
           />
         )}
 
-        {view === "month" && (
-          <MonthView
+        {view === "halfyear" && (
+          <HalfYearView
             mode={mode}
             year={viewDate.getFullYear()}
             selected={selected}

--- a/packages/react/src/experimental/OneCalendar/types.ts
+++ b/packages/react/src/experimental/OneCalendar/types.ts
@@ -1,4 +1,10 @@
-export type CalendarView = "day" | "month" | "year" | "week" | "quarter"
+export type CalendarView =
+  | "day"
+  | "month"
+  | "year"
+  | "week"
+  | "quarter"
+  | "halfyear"
 
 export type CalendarMode = "single" | "range"
 

--- a/packages/react/src/experimental/OneCalendar/types.ts
+++ b/packages/react/src/experimental/OneCalendar/types.ts
@@ -1,4 +1,4 @@
-export type CalendarView = "day" | "month" | "year" | "week"
+export type CalendarView = "day" | "month" | "year" | "week" | "quarter"
 
 export type CalendarMode = "single" | "range"
 

--- a/packages/react/src/experimental/OneCalendar/views/halfyear.tsx
+++ b/packages/react/src/experimental/OneCalendar/views/halfyear.tsx
@@ -1,0 +1,249 @@
+import { cn, focusRing } from "@/lib/utils"
+import { isAfter, isBefore, isWithinInterval } from "date-fns"
+import { AnimatePresence, motion } from "framer-motion"
+import { CalendarMode, DateRange } from "../types"
+
+export const getHalfYearFromMonth = (month: number): number =>
+  month < 6 ? 1 : 2
+
+export const getHalfYearRange = (halfYear: number, year: number): DateRange => {
+  const firstMonth = halfYear === 1 ? 0 : 6 // Jan for H1, Jul for H2
+  const lastMonth = halfYear === 1 ? 5 : 11 // Jun for H1, Dec for H2
+
+  const from = new Date(year, firstMonth, 1)
+  const to = new Date(year, lastMonth + 1, 0) // Last day of the last month
+
+  return { from, to }
+}
+
+interface HalfYearViewProps {
+  mode: CalendarMode
+  selected: Date | DateRange | null
+  onSelect: (date: Date | DateRange) => void
+  year: number
+  motionDirection?: number
+}
+
+export const HalfYearView = ({
+  mode,
+  selected,
+  onSelect,
+  year,
+  motionDirection = 1,
+}: HalfYearViewProps) => {
+  const halfYears = [1, 2]
+  const today = new Date()
+  const currentYear = today.getFullYear()
+  const currentHalfYear = getHalfYearFromMonth(today.getMonth())
+  const baseYear = Math.floor(year / 5) * 5
+  const years = Array.from({ length: 5 }, (_, i) => baseYear + i)
+
+  // Check if a value is a DateRange
+  const isDateRange = (value: unknown): value is DateRange => {
+    return Boolean(
+      value && typeof value === "object" && ("from" in value || "to" in value)
+    )
+  }
+
+  // Handle click on a half year
+  const handleHalfYearClick = (halfYear: number, year: number) => {
+    const halfYearRange = getHalfYearRange(halfYear, year)
+
+    if (mode === "single") {
+      // For single selection, use the first day of the half-year
+      onSelect?.(halfYearRange.from)
+    } else if (mode === "range") {
+      if (!selected || !isDateRange(selected)) {
+        // Start of range
+        onSelect?.({
+          from: halfYearRange.from,
+          to: undefined,
+        })
+      } else if (selected && selected.from && !selected.to) {
+        // Complete the range
+        const fromDate = selected.from
+        const fromHalfYear = getHalfYearFromMonth(fromDate.getMonth())
+        const fromYear = fromDate.getFullYear()
+
+        if (fromHalfYear === halfYear && fromYear === year) {
+          // If clicking the same half-year, select just that half-year
+          onSelect?.({
+            from: halfYearRange.from,
+            to: halfYearRange.to,
+          })
+        } else {
+          // Create a range between the two half-years
+          const fromHalfYearRange = getHalfYearRange(fromHalfYear, fromYear)
+
+          const start = isBefore(fromHalfYearRange.from, halfYearRange.from)
+            ? fromHalfYearRange.from
+            : halfYearRange.from
+
+          const end = isAfter(fromHalfYearRange.to!, halfYearRange.to!)
+            ? fromHalfYearRange.to
+            : halfYearRange.to
+
+          onSelect?.({
+            from: start,
+            to: end,
+          })
+        }
+      } else {
+        // Start a new range
+        onSelect?.({
+          from: halfYearRange.from,
+          to: undefined,
+        })
+      }
+    }
+  }
+
+  // Check if a half-year is selected
+  const isHalfYearSelected = (halfYear: number, year: number): boolean => {
+    if (!selected) return false
+
+    const halfYearRange = getHalfYearRange(halfYear, year)
+
+    if (!isDateRange(selected)) {
+      // Single date selection
+      const selectedMonth = selected.getMonth()
+      const selectedHalfYear = getHalfYearFromMonth(selectedMonth)
+      return selectedHalfYear === halfYear && selected.getFullYear() === year
+    } else {
+      // Range selection
+      const from = selected.from
+      const to = selected.to
+
+      if (from && to) {
+        // Check if any part of the half-year is within the selected range
+        const isWithinRange =
+          isWithinInterval(halfYearRange.from, { start: from, end: to }) ||
+          (!!halfYearRange.to &&
+            isWithinInterval(halfYearRange.to, { start: from, end: to })) ||
+          (isBefore(halfYearRange.from, from) &&
+            !!halfYearRange.to &&
+            isAfter(halfYearRange.to, to))
+
+        return isWithinRange
+      } else if (from) {
+        // Check if the from date is in this half-year
+        const fromHalfYear = getHalfYearFromMonth(from.getMonth())
+        return fromHalfYear === halfYear && from.getFullYear() === year
+      }
+    }
+
+    return false
+  }
+
+  // Check if a half-year is the current half-year
+  const isCurrentHalfYear = (halfYear: number, year: number): boolean => {
+    return halfYear === currentHalfYear && year === currentYear
+  }
+
+  // Check if a half-year is the start of a range
+  const isRangeStart = (halfYear: number, year: number): boolean => {
+    if (!selected || !isDateRange(selected) || !selected.from) return false
+
+    const from = selected.from
+    const fromHalfYear = getHalfYearFromMonth(from.getMonth())
+    return fromHalfYear === halfYear && from.getFullYear() === year
+  }
+
+  // Check if a half-year is the end of a range
+  const isRangeEnd = (halfYear: number, year: number): boolean => {
+    if (!selected || !isDateRange(selected) || !selected.to) return false
+
+    const to = selected.to
+    const toHalfYear = getHalfYearFromMonth(to.getMonth())
+    return toHalfYear === halfYear && to.getFullYear() === year
+  }
+
+  const motionVariants = {
+    hidden: (direction: number) => ({
+      opacity: 0,
+      x: direction === 1 ? 40 : -40,
+    }),
+    visible: { opacity: 1, x: 0 },
+    exit: (direction: number) => ({
+      opacity: 0,
+      x: direction === 1 ? -40 : 40,
+    }),
+  }
+
+  return (
+    <AnimatePresence mode="popLayout" initial={false} custom={motionDirection}>
+      <motion.div
+        key={year}
+        className="flex flex-col gap-4"
+        custom={motionDirection}
+        variants={motionVariants}
+        initial="hidden"
+        animate="visible"
+        exit="exit"
+        transition={{ duration: 0.15, ease: [0.455, 0.03, 0.515, 0.955] }}
+      >
+        {years.map((yearValue) => (
+          <div
+            key={yearValue}
+            className="flex items-center justify-center gap-3 pl-1.5"
+          >
+            <div className="text-medium text-right text-sm tabular-nums text-f1-foreground-secondary">
+              {yearValue}
+            </div>
+            <div className="flex flex-1">
+              {halfYears.map((halfYear) => {
+                const isSelected = isHalfYearSelected(halfYear, yearValue)
+                const isCurrent = isCurrentHalfYear(halfYear, yearValue)
+                const isStart = isRangeStart(halfYear, yearValue)
+                const isEnd = isRangeEnd(halfYear, yearValue)
+
+                return (
+                  <button
+                    key={`${yearValue}-H${halfYear}`}
+                    onClick={() => handleHalfYearClick(halfYear, yearValue)}
+                    className={cn(
+                      "relative isolate flex h-10 flex-1 items-center justify-center rounded-md p-2 tabular-nums",
+                      "after:absolute after:inset-x-1 after:inset-y-0 after:z-0 after:rounded-md after:ring-1 after:ring-inset after:ring-f1-border-secondary after:transition-all after:duration-100 after:content-['']",
+                      "hover:after:bg-f1-background-hover",
+                      focusRing(),
+                      (isStart || isEnd) && "after:inset-x-0",
+                      isSelected &&
+                        "after:bg-f1-background-selected-bold after:ring-0 hover:after:bg-f1-background-selected-bold-hover [&>span]:text-f1-foreground-inverse",
+                      isSelected &&
+                        !isStart &&
+                        !isEnd &&
+                        mode === "range" &&
+                        "rounded-none bg-f1-background-selected after:opacity-0 after:transition-none first:rounded-l-md last:rounded-r-md hover:bg-f1-background-selected [&>span]:text-f1-foreground-selected"
+                    )}
+                  >
+                    {isStart && (
+                      <div className="absolute inset-y-0 right-0 z-0 w-1/2 bg-f1-background-selected" />
+                    )}
+                    {isEnd && (
+                      <div className="absolute inset-y-0 left-0 z-0 w-1/2 bg-f1-background-selected" />
+                    )}
+                    <span className="z-10 font-medium">H{halfYear}</span>
+                    {isCurrent && (
+                      <div
+                        className={cn(
+                          "absolute inset-x-0 bottom-1 z-20 mx-auto h-0.5 w-1.5 rounded-full bg-f1-background-selected-bold transition-colors duration-100",
+                          isSelected && mode === "single" && "bg-f1-background",
+                          (isStart || isEnd) && "bg-f1-background",
+                          !isStart &&
+                            !isEnd &&
+                            isSelected &&
+                            mode === "range" &&
+                            "bg-f1-background-selected-bold"
+                        )}
+                      />
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        ))}
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/packages/react/src/experimental/OneCalendar/views/quarter.tsx
+++ b/packages/react/src/experimental/OneCalendar/views/quarter.tsx
@@ -1,0 +1,211 @@
+import { cn, focusRing } from "@/lib/utils"
+import { isAfter, isBefore, isWithinInterval } from "date-fns"
+import { AnimatePresence, motion } from "framer-motion"
+import { CalendarMode, DateRange } from "../types"
+
+const getQuarterFromMonth = (month: number): number => {
+  return Math.floor(month / 3) + 1
+}
+
+const getQuarterMonths = (quarter: number): number[] =>
+  quarter >= 1 && quarter <= 4
+    ? [0, 1, 2].map((n) => n + (quarter - 1) * 3)
+    : []
+
+const getQuarterRange = (quarter: number, year: number): DateRange => {
+  const months = getQuarterMonths(quarter)
+  const firstMonth = months[0]
+  const lastMonth = months[months.length - 1]
+
+  const from = new Date(year, firstMonth, 1)
+  const to = new Date(year, lastMonth + 1, 0)
+
+  return { from, to }
+}
+
+interface QuarterViewProps {
+  mode: CalendarMode
+  selected: Date | DateRange | null
+  onSelect?: (date: Date | DateRange) => void
+  year: number
+  fromDate?: Date
+  toDate?: Date
+  motionDirection?: number
+}
+
+export const QuarterView = ({
+  mode,
+  selected,
+  onSelect,
+  year,
+  fromDate,
+  toDate,
+  motionDirection = 1,
+}: QuarterViewProps) => {
+  const quarters = [1, 2, 3, 4]
+  const today = new Date()
+  const currentYear = today.getFullYear()
+  const currentQuarter = getQuarterFromMonth(today.getMonth())
+
+  // Check if a value is a DateRange
+  const isDateRange = (value: unknown): value is DateRange => {
+    return Boolean(
+      value && typeof value === "object" && ("from" in value || "to" in value)
+    )
+  }
+
+  // Handle click on a quarter
+  const handleQuarterClick = (quarter: number) => {
+    const quarterRange = getQuarterRange(quarter, year)
+
+    if (mode === "single") {
+      onSelect?.(quarterRange.from)
+    } else if (mode === "range") {
+      if (!selected || !isDateRange(selected)) {
+        onSelect?.({
+          from: quarterRange.from,
+          to: undefined,
+        })
+      } else if (selected && selected.from && !selected.to) {
+        const fromDate = selected.from
+        const fromQuarter = getQuarterFromMonth(fromDate.getMonth())
+        const fromYear = fromDate.getFullYear()
+
+        if (fromQuarter === quarter && fromYear === year) {
+          onSelect?.({
+            from: quarterRange.from,
+            to: quarterRange.to,
+          })
+        } else {
+          const fromQuarterRange = getQuarterRange(fromQuarter, fromYear)
+
+          const start = isBefore(fromQuarterRange.from, quarterRange.from)
+            ? quarterRange.from
+            : fromQuarterRange.from
+
+          const end = isAfter(fromQuarterRange.to!, quarterRange.to!)
+            ? fromQuarterRange.to
+            : quarterRange.to
+
+          onSelect?.({
+            from: start,
+            to: end,
+          })
+        }
+      } else {
+        onSelect?.({
+          from: quarterRange.from,
+          to: undefined,
+        })
+      }
+    }
+  }
+
+  // Check if a quarter is selected
+  const isQuarterSelected = (quarter: number): boolean => {
+    if (!selected) return false
+
+    const quarterRange = getQuarterRange(quarter, year)
+
+    if (!isDateRange(selected)) {
+      // Single date selection
+      const selectedMonth = selected.getMonth()
+      const selectedQuarter = getQuarterFromMonth(selectedMonth)
+
+      return selectedQuarter === quarter && selected.getFullYear() === year
+    } else {
+      // Range selection
+      const from = selected.from
+      const to = selected.to
+
+      if (from && to) {
+        // Check if any part of the quarter is within the selected range
+        return (
+          isWithinInterval(quarterRange.from, { start: from, end: to }) ||
+          isWithinInterval(quarterRange.to!, { start: from, end: to }) ||
+          (isBefore(quarterRange.from, from) && isAfter(quarterRange.to!, to))
+        )
+      } else if (from) {
+        // Check if the from date is in this quarter
+        const fromQuarter = getQuarterFromMonth(from.getMonth())
+        return fromQuarter === quarter && from.getFullYear() === year
+      }
+    }
+
+    return false
+  }
+
+  // Check if a quarter is the current quarter
+  const isCurrentQuarter = (quarter: number): boolean => {
+    return quarter === currentQuarter && year === currentYear
+  }
+
+  // Check if a quarter is the start of a range
+  const isRangeStart = (quarter: number): boolean => {
+    if (!selected || !isDateRange(selected) || !selected.from) return false
+
+    const from = selected.from
+    const fromQuarter = getQuarterFromMonth(from.getMonth())
+    return fromQuarter === quarter && from.getFullYear() === year
+  }
+
+  // Check if a quarter is the end of a range
+  const isRangeEnd = (quarter: number): boolean => {
+    if (!selected || !isDateRange(selected) || !selected.to) return false
+
+    const to = selected.to
+    const toQuarter = getQuarterFromMonth(to.getMonth())
+    return toQuarter === quarter && to.getFullYear() === year
+  }
+
+  const motionVariants = {
+    hidden: (direction: number) => ({
+      opacity: 0,
+      x: direction === 1 ? 40 : -40,
+    }),
+    visible: { opacity: 1, x: 0 },
+    exit: (direction: number) => ({
+      opacity: 0,
+      x: direction === 1 ? -40 : 40,
+    }),
+  }
+
+  return (
+    <AnimatePresence mode="popLayout" initial={false} custom={motionDirection}>
+      <motion.div
+        key={year}
+        className="grid grid-cols-2 gap-3"
+        custom={motionDirection}
+        variants={motionVariants}
+        initial="hidden"
+        animate="visible"
+        exit="exit"
+        transition={{ duration: 0.15, ease: [0.455, 0.03, 0.515, 0.955] }}
+      >
+        {quarters.map((quarter) => {
+          const isSelected = isQuarterSelected(quarter)
+          const isCurrent = isCurrentQuarter(quarter)
+          const isStart = isRangeStart(quarter)
+          const isEnd = isRangeEnd(quarter)
+
+          return (
+            <button
+              key={quarter}
+              onClick={() => handleQuarterClick(quarter)}
+              className={cn(
+                "relative isolate flex h-10 items-center justify-center rounded-md p-2",
+                focusRing(),
+                isSelected && "bg-f1-background-selected-bold",
+                //isCurrent && "bg-f1-background-current",
+                isStart && "bg-f1-background-selected-bold",
+                isEnd && "bg-f1-background-selected-bold"
+              )}
+            >
+              Q{quarter}
+            </button>
+          )
+        })}
+      </motion.div>
+    </AnimatePresence>
+  )
+}


### PR DESCRIPTION
## Description

This PR introduces two new calendar views: Quarter, which shows a list of five years and lets users choose quarters, and Half-year, with a similar approach where users can select half-year periods. Both support single and range selections.

## Screenshots

https://github.com/user-attachments/assets/156a3147-0b47-440e-9fff-f0928f31858a

### Figma Link

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Components?node-id=9890-206657&t=6qWFKuMSb68j6HXP-4)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other