### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.38.0",
+  "packages/react": "1.38.1",
   "packages/react-native": "0.2.4",
   "packages/core": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.38.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.38.0...factorial-one-react-v1.38.1) (2025-05-02)
+
+
+### Bug Fixes
+
+* palce tooltips in body of the page ([#1730](https://github.com/factorialco/factorial-one/issues/1730)) ([dba64e9](https://github.com/factorialco/factorial-one/commit/dba64e9df208ad696fd806229a453366ca4c1ab9))
+
 ## [1.38.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.37.6...factorial-one-react-v1.38.0) (2025-05-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.38.1</summary>

## [1.38.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.38.0...factorial-one-react-v1.38.1) (2025-05-02)


### Bug Fixes

* palce tooltips in body of the page ([#1730](https://github.com/factorialco/factorial-one/issues/1730)) ([dba64e9](https://github.com/factorialco/factorial-one/commit/dba64e9df208ad696fd806229a453366ca4c1ab9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).