### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.38.1",
-  "packages/react-native": "0.2.4",
+  "packages/react-native": "0.2.5",
   "packages/core": "1.0.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.4...factorial-one-react-native-v0.2.5) (2025-05-02)
+
+
+### Bug Fixes
+
+* tailwind native extensions ([34b7426](https://github.com/factorialco/factorial-one/commit/34b7426c823bb0db095a7193190004b5226e3ec9))
+
 ## [0.2.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.3...factorial-one-react-native-v0.2.4) (2025-04-30)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.2.5</summary>

## [0.2.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.4...factorial-one-react-native-v0.2.5) (2025-05-02)


### Bug Fixes

* tailwind native extensions ([34b7426](https://github.com/factorialco/factorial-one/commit/34b7426c823bb0db095a7193190004b5226e3ec9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).