### PR TITLE
feat: add ModuleAvatar component with size variants and icon support

### DIFF
--- a/packages/react-native-playground/components/ModuleAvatar/ModuleAvatar.mdx
+++ b/packages/react-native-playground/components/ModuleAvatar/ModuleAvatar.mdx
@@ -1,0 +1,62 @@
+import { Meta, Primary, Controls, Story, Canvas } from "@storybook/blocks";
+import * as ModuleAvatarStories from "./ModuleAvatar.stories";
+
+<Meta of={ModuleAvatarStories} />
+
+# ModuleAvatar
+
+The ModuleAvatar component is used to display a module icon with a consistent background shape and styling.
+It's commonly used in navigation and module identification throughout the application.
+
+## Features
+
+- Three size variants: small (sm), medium (md), and large (lg)
+- Consistent squircle background shape with gradient
+- Supports all module icons from the design system
+- Accessible with proper ARIA roles
+
+## Usage
+
+```tsx
+import {
+  ModuleAvatar,
+  ModuleIcons,
+} from "@factorialco/factorial-one-react-native";
+
+function MyComponent() {
+  return <ModuleAvatar icon={ModuleIcons.Home} size="md" />;
+}
+```
+
+## Examples
+
+### Default
+
+The default ModuleAvatar uses the medium size and requires an icon prop.
+
+<Canvas of={ModuleAvatarStories.Default} />
+<Controls of={ModuleAvatarStories.Default} />
+
+### Size Variants
+
+ModuleAvatar comes in three sizes to accommodate different use cases:
+
+<Canvas of={ModuleAvatarStories.SizeVariants} />
+
+### All Available Modules
+
+Here's a showcase of all available module icons that can be used with ModuleAvatar:
+
+<Canvas of={ModuleAvatarStories.AllModules} />
+
+## Props
+
+- `icon` (required): A module icon from the ModuleIcons collection
+- `size` (optional): "sm" | "md" | "lg" (defaults to "md")
+
+## Accessibility
+
+The component includes proper accessibility attributes:
+
+- Uses accessibilityRole="image"
+- Maintains good color contrast for icon visibility

--- a/packages/react-native-playground/components/ModuleAvatar/ModuleAvatar.stories.tsx
+++ b/packages/react-native-playground/components/ModuleAvatar/ModuleAvatar.stories.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { ScrollView } from "react-native";
+import { View } from "react-native";
+import { Text } from "react-native";
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  ModuleAvatar,
+  ModuleIcons,
+} from "@factorialco/factorial-one-react-native";
+
+const meta = {
+  title: "Components/ModuleAvatar",
+  component: ModuleAvatar,
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+    },
+  },
+  args: {
+    size: "md",
+    icon: ModuleIcons.Home,
+  },
+  decorators: [
+    (Story) => (
+      <View className="flex-1 p-4">
+        <Story />
+      </View>
+    ),
+  ],
+} satisfies Meta<typeof ModuleAvatar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+interface SizeVariantProps {
+  icon: any;
+  name: string;
+  size: "sm" | "md" | "lg";
+}
+
+interface IconDisplayProps {
+  icon: any;
+  name: string;
+}
+
+const SizeVariant = ({ icon, name, size }: SizeVariantProps) => (
+  <View className="items-center justify-center">
+    <ModuleAvatar icon={icon} size={size} />
+    <Text className="text-xs mt-2 text-center">{name}</Text>
+  </View>
+);
+
+const IconDisplay = ({ icon, name }: IconDisplayProps) => (
+  <View className="items-center w-24 mb-4 p-2">
+    <ModuleAvatar icon={icon} size="lg" />
+    <Text className="text-xs mt-2 text-center text-f1-foreground">{name}</Text>
+  </View>
+);
+
+export const Default: Story = {
+  args: {
+    icon: ModuleIcons.Home,
+    size: "md",
+  },
+};
+
+export const SizeVariants: Story = {
+  args: {
+    icon: ModuleIcons.Home,
+  },
+  render: () => (
+    <ScrollView>
+      <Text className="text-lg font-bold mb-4 mt-6">Size Variants</Text>
+      <View className="flex-row justify-around mb-8 p-4 bg-gray-100 rounded-lg">
+        <SizeVariant icon={ModuleIcons.Home} name="sm" size="sm" />
+        <SizeVariant icon={ModuleIcons.Home} name="md" size="md" />
+        <SizeVariant icon={ModuleIcons.Home} name="lg" size="lg" />
+      </View>
+
+      <View className="flex-row justify-around mb-8 p-4 bg-gray-100 rounded-lg">
+        <SizeVariant icon={ModuleIcons.TimeTracking} name="sm" size="sm" />
+        <SizeVariant icon={ModuleIcons.TimeTracking} name="md" size="md" />
+        <SizeVariant icon={ModuleIcons.TimeTracking} name="lg" size="lg" />
+      </View>
+
+      <View className="flex-row justify-around p-4 bg-gray-100 rounded-lg">
+        <SizeVariant icon={ModuleIcons.Documents} name="sm" size="sm" />
+        <SizeVariant icon={ModuleIcons.Documents} name="md" size="md" />
+        <SizeVariant icon={ModuleIcons.Documents} name="lg" size="lg" />
+      </View>
+    </ScrollView>
+  ),
+};
+
+export const AllModules: Story = {
+  render: () => {
+    const moduleEntries = Object.entries(ModuleIcons);
+
+    return (
+      <ScrollView>
+        <Text className="text-lg font-bold mb-4">All Module Icons</Text>
+        <View className="flex-row flex-wrap justify-start">
+          {moduleEntries.map(([name, icon]) => (
+            <IconDisplay key={name} icon={icon} name={name} />
+          ))}
+        </View>
+      </ScrollView>
+    );
+  },
+};

--- a/packages/react-native/src/components/Icon/index.tsx
+++ b/packages/react-native/src/components/Icon/index.tsx
@@ -42,7 +42,7 @@ export type IconType = ForwardRefExoticComponent<
 const interopAppliedIcons = new WeakSet();
 
 // Function to apply NativeWind interop to an icon component
-function applyIconInterop(icon: IconType) {
+export function applyIconInterop(icon: IconType) {
   if (!interopAppliedIcons.has(icon)) {
     cssInterop(icon, {
       className: {

--- a/packages/react-native/src/components/Information/ModuleAvatar/index.tsx
+++ b/packages/react-native/src/components/Information/ModuleAvatar/index.tsx
@@ -1,0 +1,82 @@
+import { View } from "react-native";
+import { cva, type VariantProps } from "cva";
+import { IconType, applyIconInterop } from "../../Icon";
+import Svg, { Defs, LinearGradient, Stop, Path } from "react-native-svg";
+
+const moduleAvatarVariants = cva({
+  base: "relative flex shrink-0 items-center justify-center",
+  variants: {
+    size: {
+      sm: "h-5 w-5",
+      md: "h-6 w-6",
+      lg: "h-8 w-8",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+  },
+});
+
+const iconContainerVariants = cva({
+  base: "absolute inset-0 items-center justify-center z-10",
+  variants: {
+    size: {
+      sm: "h-5 w-5",
+      md: "h-6 w-6",
+      lg: "h-8 w-8",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+  },
+});
+
+const iconSizeVariants = cva({
+  base: "relative text-f1-foreground-inverse drop-shadow",
+  variants: {
+    size: {
+      sm: "h-[14px] w-[14px]",
+      md: "h-[18px] w-[18px]",
+      lg: "h-6 w-6",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+  },
+});
+
+export interface ModuleAvatarProps
+  extends VariantProps<typeof moduleAvatarVariants> {
+  icon: IconType;
+}
+
+const squirclePath =
+  "M50,0 C43,0 36,0 30,1 23,2 17,5 12,9 5,16 1,25 0,36 0,43 0,57 0,64 1,75 5,84 12,91 17,95 23,98 30,99 36,100 43,100 50,100 57,100 64,100 70,99 77,98 83,95 88,91 95,84 99,75 100,64 100,57 100,43 100,36 99,25 95,16 88,9 83,5 77,2 70,1 64,0 57,0 50,0";
+
+export function ModuleAvatar({ size = "md", icon }: ModuleAvatarProps) {
+  const IconComponent = applyIconInterop(icon);
+  const code = Math.random().toString(36).substring(2, 15);
+  const gradientId = `gradient-${code}`;
+
+  return (
+    <View className={moduleAvatarVariants({ size })} accessibilityRole="image">
+      <Svg
+        viewBox="0 0 100 100"
+        className="absolute h-full w-full"
+        preserveAspectRatio="none"
+      >
+        <Defs>
+          <LinearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+            <Stop offset="0%" stopColor="#FF355E" />
+            <Stop offset="44%" stopColor="#FF355E" />
+            <Stop offset="100%" stopColor="#D62D4F" />
+          </LinearGradient>
+        </Defs>
+        <Path d={squirclePath} fill={`url(#${gradientId})`} />
+      </Svg>
+      <View className={iconContainerVariants({ size })}>
+        <IconComponent className={iconSizeVariants({ size })} />
+      </View>
+    </View>
+  );
+}

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,6 +1,7 @@
 // Export components
 export * from "./components/ExampleComponent";
 export * from "./components/Icon";
+export { ModuleAvatar } from "./components/Information/ModuleAvatar";
 
 // Export icons
 export * from "./icons";


### PR DESCRIPTION
- Introduced the ModuleAvatar component to display module icons with a consistent squircle background and gradient.
- Added size variants (small, medium, large) for flexibility in usage.
- Implemented accessibility features with proper ARIA roles.
- Updated the index file to export the new ModuleAvatar component.
- Created stories and documentation for the ModuleAvatar component in Storybook.

## Demo

![Simulator Screenshot - iPhone 15 - 2025-05-02 at 14 06 46](https://github.com/user-attachments/assets/c115f6d1-f93e-4f4b-87db-ba91f355012c)
