### PR TITLE
feat(PageHeader): add cross-selling feature to ProductUpdates component

### DIFF
--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -201,7 +201,6 @@ export const WithProductUpdate: Story = {
       isVisible: true,
       hasUnread: true,
       label: "Latest from Projects",
-      moreUpdatesLabel: "More updates",
       updatesPageUrl: "https://factorialmakers.atlassian.net/browse/FCT-24580",
       emptyScreen: {
         title: "There aren’t updates for Projects yet",

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -261,6 +261,21 @@ export const WithProductUpdate: Story = {
         alert("onHeaderClick")
       },
       currentModule: defaultModule.name,
+      crossSelling: {
+        isVisible: true,
+        type: "callout",
+        sectionTitle: "Discover other products",
+        title: "Benefits",
+        description:
+          "Improve your team’s salary without impacting your budget through flexible compensation.",
+        buttonText: "Learn more",
+        onClick: () => {
+          alert("onClick")
+        },
+        onClose: () => {
+          alert("onClose")
+        },
+      },
     },
   },
 }

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -247,6 +247,19 @@ export const WithProductUpdate: Story = {
                   updated: "2 mar 2025",
                   href: "https://factorialmakers.atlassian.net/browse/FCT-24580",
                 },
+                {
+                  title: "New Client section",
+                  mediaUrl: "https://placecats.com/neo/300/200",
+                  updated: "3 mar 2025",
+                  href: "https://factorialmakers.atlassian.net/browse/FCT-24580",
+                  unread: true,
+                },
+                {
+                  title: "Spending tab in projects",
+                  mediaUrl: "https://placecats.com/neo/300/200",
+                  updated: "2 mar 2025",
+                  href: "https://factorialmakers.atlassian.net/browse/FCT-24580",
+                },
               ]),
             1000
           )

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -280,6 +280,9 @@ export const WithProductUpdate: Story = {
             },
             icon: Briefcase,
             dismissable: false,
+            trackVisibility: (open) => {
+              console.log("trackOpenChange", open)
+            },
           },
           {
             title: "Projects",
@@ -293,6 +296,9 @@ export const WithProductUpdate: Story = {
             },
             icon: Briefcase,
             dismissable: false,
+            trackVisibility: (open) => {
+              console.log("trackOpenChange", open)
+            },
           },
         ],
       },

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -264,18 +264,37 @@ export const WithProductUpdate: Story = {
       crossSelling: {
         isVisible: true,
         sectionTitle: "Discover other products",
-        title: "Benefits",
-        description:
-          "Improve your team’s salary without impacting your budget through flexible compensation.",
-        buttonText: "Learn more",
-        onClick: () => {
-          alert("onClick")
-        },
         onClose: () => {
           alert("onClose")
         },
-        icon: Briefcase,
-        variant: "outline",
+        products: [
+          {
+            title: "Benefits",
+            description:
+              "Improve your team’s salary without impacting your budget through flexible compensation.",
+            onClick: () => {
+              alert("onClick")
+            },
+            onClose: () => {
+              alert("onClose")
+            },
+            icon: Briefcase,
+            dismissable: false,
+          },
+          {
+            title: "Projects",
+            description:
+              "Improve your team’s salary without impacting your budget through flexible compensation.",
+            onClick: () => {
+              alert("onClick")
+            },
+            onClose: () => {
+              alert("onClose")
+            },
+            icon: Briefcase,
+            dismissable: false,
+          },
+        ],
       },
     },
   },

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -286,8 +286,7 @@ export const WithProductUpdate: Story = {
           },
           {
             title: "Projects",
-            description:
-              "Improve your team’s salary without impacting your budget through flexible compensation.",
+            description: "Improve your.",
             onClick: () => {
               alert("onClick")
             },

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -263,7 +263,6 @@ export const WithProductUpdate: Story = {
       currentModule: defaultModule.name,
       crossSelling: {
         isVisible: true,
-        type: "callout",
         sectionTitle: "Discover other products",
         title: "Benefits",
         description:
@@ -275,6 +274,8 @@ export const WithProductUpdate: Story = {
         onClose: () => {
           alert("onClose")
         },
+        icon: Briefcase,
+        variant: "outline",
       },
     },
   },

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -59,7 +59,7 @@ type ProductUpdatesProp = {
   }
   crossSelling: {
     isVisible: boolean
-    type: "callout"
+    type: string
     sectionTitle: string
     title: string
     description: string

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -131,7 +131,8 @@ const ProductUpdates = ({
           collisionPadding={20}
           align="end"
           hideWhenDetached
-          className="min-w-96 max-w-md overflow-y-auto"
+          className="max-h-[90vh min-h-[600px] min-w-96 max-w-md overflow-y-auto"
+          style={{ maxHeight: "min(90vh, 760px)", minHeight: 600 }}
         >
           <Header title={label} url={updatesPageUrl} onClick={onHeaderClick} />
           {state === "fetching" && <ProductUpdatesSkeleton />}

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -65,6 +65,7 @@ type ProductUpdatesProp = {
     description: string
     buttonText: string
     onClick: () => void
+    onClose: () => void
   }
 }
 
@@ -428,7 +429,6 @@ const CrossSelling = ({
   description,
   buttonText,
   onClick,
-  imageUrl,
   onClose,
   isVisible,
   type,
@@ -449,21 +449,20 @@ const CrossSelling = ({
               <p className="font-medium">{title}</p>
               <p className="text-f1-foreground-secondary">{description}</p>
             </div>
+            <div className="mt-3 w-[100px]">
+              <Button variant="outline" label={buttonText} onClick={onClick} />
+            </div>
+          </div>
+          <div className="h-6 w-6">
             <Button
-              variant="outline"
-              label={buttonText}
-              className="mt-3 w-[100px]"
-              onClick={onClick}
+              variant="ghost"
+              icon={CrossIcon}
+              size="sm"
+              hideLabel
+              onClick={onClose}
+              label=""
             />
           </div>
-          <Button
-            variant="ghost"
-            icon={CrossIcon}
-            size="sm"
-            className="h-6 w-6"
-            hideLabel
-            onClick={onClose}
-          />
         </div>
       </div>
     </div>

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -138,8 +138,8 @@ const ProductUpdates = ({
           collisionPadding={20}
           align="end"
           hideWhenDetached
-          className="flex max-h-[90vh] min-h-[562px] min-w-96 max-w-md flex-col"
-          style={{ maxHeight: "min(90vh, 760px)", minHeight: 562 }}
+          className="min-h-auto flex max-h-[90vh] min-w-96 max-w-md flex-col"
+          style={{ maxHeight: "min(90vh, 760px)" }}
         >
           <Header title={label} url={updatesPageUrl} onClick={onHeaderClick} />
           {state === "fetching" && <ProductUpdatesSkeleton />}

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -2,7 +2,9 @@ import { Button } from "@/components/Actions/Button"
 import { ButtonInternal } from "@/components/Actions/Button/internal"
 import { Icon } from "@/components/Utilities/Icon"
 import AlertCircle from "@/icons/app/AlertCircle"
+import BellIcon from "@/icons/app/Bell"
 import ChevronRight from "@/icons/app/ChevronRight"
+import CrossIcon from "@/icons/app/Cross"
 import Megaphone from "@/icons/app/Megaphone"
 import { Image } from "@/lib/imageHandler"
 import { Link } from "@/lib/linkHandler"
@@ -24,6 +26,7 @@ import {
   useEffect,
   useState,
 } from "react"
+import { ModuleAvatar } from "../../../Information/ModuleAvatar"
 
 type ProductUpdate = {
   title: string
@@ -54,6 +57,15 @@ type ProductUpdatesProp = {
     description: string
     buttonText: string
   }
+  crossSelling: {
+    isVisible: boolean
+    type: "callout"
+    sectionTitle: string
+    title: string
+    description: string
+    buttonText: string
+    onClick: () => void
+  }
 }
 
 const ProductUpdates = ({
@@ -68,11 +80,11 @@ const ProductUpdates = ({
   onHeaderClick = () => {},
   onItemClick = () => {},
   hasUnread = false,
+  crossSelling,
 }: ProductUpdatesProp) => {
   const [state, setState] = useState<"idle" | "fetching" | "error">("idle")
   const [updates, setUpdates] = useState<Array<ProductUpdate> | null>(null)
   const [featuredUpdate, ...restUpdates] = updates ?? []
-
   useEffect(() => {
     setUpdates(null)
     setState("idle")
@@ -118,7 +130,7 @@ const ProductUpdates = ({
           collisionPadding={20}
           align="end"
           hideWhenDetached
-          className="max-h-[600px] min-w-96 max-w-md overflow-y-auto"
+          className="min-w-96 max-w-md overflow-y-auto"
         >
           <Header title={label} url={updatesPageUrl} onClick={onHeaderClick} />
           {state === "fetching" && <ProductUpdatesSkeleton />}
@@ -154,6 +166,17 @@ const ProductUpdates = ({
                   </>
                 )}
               </div>
+              {crossSelling.isVisible && (
+                <>
+                  <DropdownMenuSeparator />
+                  <div className="px-1">
+                    <CrossSelling
+                      {...crossSelling}
+                      onClose={crossSelling.onClose}
+                    />
+                  </div>
+                </>
+              )}
             </>
           )}
           {state === "error" && (
@@ -398,5 +421,52 @@ const UnreadDot = ({ className = "" }: { className?: string }) => (
     className={cn("size-2 rounded bg-f1-background-selected-bold", className)}
   />
 )
+
+const CrossSelling = ({
+  sectionTitle,
+  title,
+  description,
+  buttonText,
+  onClick,
+  imageUrl,
+  onClose,
+  isVisible,
+  type,
+}: {
+  onClose: () => void
+} & ProductUpdatesProp["crossSelling"]) =>
+  isVisible &&
+  type === "callout" && (
+    <div>
+      <p className="text-balance px-3 pb-2 pt-3 text-sm font-medium text-f1-foreground-secondary">
+        {sectionTitle}
+      </p>
+      <div className="p-2">
+        <div className="flex flex-row gap-2 rounded-md border border-solid border-f1-border p-3 text-f1-foreground">
+          <ModuleAvatar icon={BellIcon} size="md" />
+          <div className="flex flex-1 flex-col justify-center">
+            <div>
+              <p className="font-medium">{title}</p>
+              <p className="text-f1-foreground-secondary">{description}</p>
+            </div>
+            <Button
+              variant="outline"
+              label={buttonText}
+              className="mt-3 w-[100px]"
+              onClick={onClick}
+            />
+          </div>
+          <Button
+            variant="ghost"
+            icon={CrossIcon}
+            size="sm"
+            className="h-6 w-6"
+            hideLabel
+            onClick={onClose}
+          />
+        </div>
+      </div>
+    </div>
+  )
 
 export { ProductUpdates, type ProductUpdate, type ProductUpdatesProp }

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -472,7 +472,7 @@ const DiscoverMoreProducts = ({
             showArrows={false}
           >
             {crossSelling.products.map((product) => (
-              <ProductCard {...product} isVisible={true} />
+              <ProductCard key={product.title} {...product} isVisible={true} />
             ))}
           </Carousel>
         </div>

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -1,10 +1,9 @@
 import { Button } from "@/components/Actions/Button"
 import { ButtonInternal } from "@/components/Actions/Button/internal"
-import { Icon } from "@/components/Utilities/Icon"
+import { Icon, IconType } from "@/components/Utilities/Icon"
+import ProductCard from "@/experimental/ProductCard"
 import AlertCircle from "@/icons/app/AlertCircle"
-import BellIcon from "@/icons/app/Bell"
 import ChevronRight from "@/icons/app/ChevronRight"
-import CrossIcon from "@/icons/app/Cross"
 import Megaphone from "@/icons/app/Megaphone"
 import { Image } from "@/lib/imageHandler"
 import { Link } from "@/lib/linkHandler"
@@ -26,7 +25,6 @@ import {
   useEffect,
   useState,
 } from "react"
-import { ModuleAvatar } from "../../../Information/ModuleAvatar"
 
 type ProductUpdate = {
   title: string
@@ -59,13 +57,14 @@ type ProductUpdatesProp = {
   }
   crossSelling: {
     isVisible: boolean
-    type: string
+    variant: "outline" | "promote"
     sectionTitle: string
     title: string
     description: string
     buttonText: string
     onClick: () => void
     onClose: () => void
+    icon: IconType
   }
 }
 
@@ -150,6 +149,21 @@ const ProductUpdates = ({
                   {...featuredUpdate}
                   onClick={onItemClick}
                 />
+                {crossSelling.isVisible && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <div className="px-1">
+                      <p className="text-balance px-3 pb-2 pt-3 text-sm font-medium text-f1-foreground-secondary">
+                        {crossSelling.sectionTitle}
+                      </p>
+                      <ProductCard
+                        {...crossSelling}
+                        icon={crossSelling.icon}
+                        onClose={crossSelling.onClose}
+                      />
+                    </div>
+                  </>
+                )}
                 {updates.length > 1 && (
                   <>
                     <div className="pb-1">
@@ -168,17 +182,6 @@ const ProductUpdates = ({
                   </>
                 )}
               </div>
-              {crossSelling.isVisible && (
-                <>
-                  <DropdownMenuSeparator />
-                  <div className="px-1">
-                    <CrossSelling
-                      {...crossSelling}
-                      onClose={crossSelling.onClose}
-                    />
-                  </div>
-                </>
-              )}
             </>
           )}
           {state === "error" && (
@@ -423,50 +426,5 @@ const UnreadDot = ({ className = "" }: { className?: string }) => (
     className={cn("size-2 rounded bg-f1-background-selected-bold", className)}
   />
 )
-
-const CrossSelling = ({
-  sectionTitle,
-  title,
-  description,
-  buttonText,
-  onClick,
-  onClose,
-  isVisible,
-  type,
-}: {
-  onClose: () => void
-} & ProductUpdatesProp["crossSelling"]) =>
-  isVisible &&
-  type === "callout" && (
-    <div>
-      <p className="text-balance px-3 pb-2 pt-3 text-sm font-medium text-f1-foreground-secondary">
-        {sectionTitle}
-      </p>
-      <div className="p-2">
-        <div className="flex flex-row gap-2 rounded-md border border-solid border-f1-border p-3 text-f1-foreground">
-          <ModuleAvatar icon={BellIcon} size="md" />
-          <div className="flex flex-1 flex-col justify-center">
-            <div>
-              <p className="font-medium">{title}</p>
-              <p className="text-f1-foreground-secondary">{description}</p>
-            </div>
-            <div className="mt-3 w-[100px]">
-              <Button variant="outline" label={buttonText} onClick={onClick} />
-            </div>
-          </div>
-          <div className="h-6 w-6">
-            <Button
-              variant="ghost"
-              icon={CrossIcon}
-              size="sm"
-              hideLabel
-              onClick={onClose}
-              label=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  )
 
 export { ProductUpdates, type ProductUpdate, type ProductUpdatesProp }

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -156,10 +156,6 @@ const ProductUpdates = ({
                 {updates.length > 1 && (
                   <>
                     <div className="pb-1">
-                      <DropdownMenuSeparator />
-                      <p className="text-balance px-3 pb-2 pt-3 text-sm font-medium text-f1-foreground-secondary">
-                        {moreUpdatesLabel}
-                      </p>
                       {restUpdates.map((update, index) => (
                         <DropdownItem
                           key={index}
@@ -212,7 +208,7 @@ const FeaturedDropdownItem = ({
     <DropdownMenuPrimitive.Item
       onClick={onClick}
       asChild
-      className="relative mb-2 flex cursor-default select-none items-center rounded-md px-1 text-base font-medium outline-none transition-colors after:absolute after:inset-x-1 after:inset-y-0 after:h-full after:rounded after:bg-f1-background-hover after:opacity-0 after:transition-opacity after:duration-75 after:content-[''] hover:cursor-pointer hover:after:opacity-100 focus:after:opacity-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+      className="relative flex cursor-default select-none items-center rounded-md px-1 text-base font-medium outline-none transition-colors after:absolute after:inset-x-1 after:inset-y-0 after:h-full after:rounded after:bg-f1-background-hover after:opacity-0 after:transition-opacity after:duration-75 after:content-[''] hover:cursor-pointer hover:after:opacity-100 focus:after:opacity-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
     >
       <Link
         href={href}
@@ -448,8 +444,8 @@ const DiscoverMoreProducts = ({
       <>
         <DropdownMenuSeparator />
         <div className="px-1 pb-2">
-          <div className="flex flex-row items-center justify-between">
-            <p className="text-balance px-3 pb-2 pt-2 text-sm font-medium text-f1-foreground-secondary">
+          <div className="flex flex-row items-center justify-between px-3">
+            <p className="text-balance pb-2 pt-2 text-sm font-medium text-f1-foreground-secondary">
               {crossSelling?.sectionTitle}
             </p>
 

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -40,7 +40,6 @@ type ProductUpdate = {
 
 type ProductUpdatesProp = {
   label: string
-  moreUpdatesLabel: string
   updatesPageUrl: string
   getUpdates: () => Promise<Array<ProductUpdate>>
   hasUnread?: boolean
@@ -77,7 +76,6 @@ type ProductUpdatesProp = {
 const ProductUpdates = ({
   currentModule,
   label,
-  moreUpdatesLabel,
   getUpdates,
   updatesPageUrl,
   emptyScreen,

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -69,6 +69,7 @@ type ProductUpdatesProp = {
       icon: IconType
       dismissable: boolean
       onClose?: () => void
+      trackVisibility?: (open: boolean) => void
     }>
   }
 }
@@ -472,7 +473,12 @@ const DiscoverMoreProducts = ({
             showArrows={false}
           >
             {crossSelling.products.map((product) => (
-              <ProductCard key={product.title} {...product} isVisible={true} />
+              <ProductCard
+                key={product.title}
+                {...product}
+                isVisible={true}
+                trackVisibility={product.trackVisibility}
+              />
             ))}
           </Carousel>
         </div>

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -89,6 +89,8 @@ const ProductUpdates = ({
   const [state, setState] = useState<"idle" | "fetching" | "error">("idle")
   const [updates, setUpdates] = useState<Array<ProductUpdate> | null>(null)
   const [featuredUpdate, ...restUpdates] = updates ?? []
+  const [open, setOpen] = useState(false)
+
   useEffect(() => {
     setUpdates(null)
     setState("idle")
@@ -107,11 +109,13 @@ const ProductUpdates = ({
 
   return (
     <DropdownMenu
-      onOpenChange={async (open) => {
-        if (open && updates === null) {
+      open={open}
+      onOpenChange={async (isOpen) => {
+        setOpen(isOpen)
+        if (isOpen && updates === null) {
           invokeGetUpdates()
         }
-        onOpenChange(open)
+        onOpenChange(isOpen)
       }}
     >
       <DropdownMenuTrigger asChild>
@@ -182,6 +186,7 @@ const ProductUpdates = ({
               isVisible={crossSelling.isVisible}
               onClose={crossSelling.onClose}
               crossSelling={crossSelling}
+              onDropdownClose={() => setOpen(false)}
             />
           )}
         </DropdownMenuContent>
@@ -419,10 +424,12 @@ const DiscoverMoreProducts = ({
   isVisible,
   onClose,
   crossSelling,
+  onDropdownClose,
 }: {
   isVisible: boolean
   onClose?: () => void
   crossSelling: ProductUpdatesProp["crossSelling"]
+  onDropdownClose: () => void
 }) => {
   const [open, setOpen] = useState(isVisible)
 
@@ -434,6 +441,14 @@ const DiscoverMoreProducts = ({
     setOpen(false)
     if (onClose) {
       onClose()
+    }
+  }
+
+  const handleProductClick = (onClick: () => void) => {
+    setOpen(false)
+    onDropdownClose()
+    if (onClick) {
+      onClick()
     }
   }
 
@@ -472,6 +487,7 @@ const DiscoverMoreProducts = ({
                 {...product}
                 isVisible={true}
                 trackVisibility={product.trackVisibility}
+                onClick={() => handleProductClick(product.onClick)}
               />
             ))}
           </Carousel>

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -58,7 +58,7 @@ type ProductUpdatesProp = {
     description: string
     buttonText: string
   }
-  crossSelling: {
+  crossSelling?: {
     isVisible: boolean
     sectionTitle: string
     onClose?: () => void
@@ -183,7 +183,7 @@ const ProductUpdates = ({
               </div>
             )}
           </div>
-          {state === "idle" && crossSelling.isVisible && (
+          {state === "idle" && crossSelling && crossSelling.isVisible && (
             <DiscoverMoreProducts
               isVisible={crossSelling.isVisible}
               onClose={crossSelling.onClose}
@@ -450,7 +450,7 @@ const DiscoverMoreProducts = ({
         <div className="px-1 pb-2">
           <div className="flex flex-row items-center justify-between">
             <p className="text-balance px-3 pb-2 pt-2 text-sm font-medium text-f1-foreground-secondary">
-              {crossSelling.sectionTitle}
+              {crossSelling?.sectionTitle}
             </p>
 
             <div className="relative z-10 h-6 w-6">
@@ -472,7 +472,7 @@ const DiscoverMoreProducts = ({
             showDots
             showArrows={false}
           >
-            {crossSelling.products.map((product) => (
+            {crossSelling?.products.map((product) => (
               <ProductCard
                 key={product.title}
                 {...product}

--- a/packages/react/src/experimental/ProductCard/index.stories.tsx
+++ b/packages/react/src/experimental/ProductCard/index.stories.tsx
@@ -23,7 +23,6 @@ export const Default: Story = {
     title: "Benefits",
     description:
       "Improve your team’s salary without impacting your budget through flexible compensation.",
-    buttonText: "Learn more",
     onClick: () => {
       alert("onClick")
     },
@@ -31,13 +30,13 @@ export const Default: Story = {
       alert("onClose")
     },
     icon: Megaphone,
-    variant: "outline",
+    dismissable: false,
   },
 }
 
-export const Promote: Story = {
+export const Dismissable: Story = {
   args: {
     ...Default.args,
-    variant: "promote",
+    dismissable: true,
   },
 }

--- a/packages/react/src/experimental/ProductCard/index.stories.tsx
+++ b/packages/react/src/experimental/ProductCard/index.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import ProductCard from "./index"
+
+import Megaphone from "@/icons/app/Megaphone"
+import { ComponentProps } from "react"
+
+const meta: Meta<typeof ProductCard> = {
+  title: "ProductCard",
+  component: ProductCard,
+  tags: ["autodocs", "experimental"],
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [(Story) => <Story />],
+}
+
+export default meta
+type Story = StoryObj<ComponentProps<typeof ProductCard>>
+
+export const Default: Story = {
+  args: {
+    isVisible: true,
+    title: "Benefits",
+    description:
+      "Improve your team’s salary without impacting your budget through flexible compensation.",
+    buttonText: "Learn more",
+    onClick: () => {
+      alert("onClick")
+    },
+    onClose: () => {
+      alert("onClose")
+    },
+    icon: Megaphone,
+    variant: "outline",
+  },
+}
+
+export const Promote: Story = {
+  args: {
+    ...Default.args,
+    variant: "promote",
+  },
+}

--- a/packages/react/src/experimental/ProductCard/index.tsx
+++ b/packages/react/src/experimental/ProductCard/index.tsx
@@ -54,7 +54,7 @@ const ProductCard = ({
               size="sm"
               hideLabel
               onClick={onClose}
-              label=""
+              label="Close"
             />
           </div>
         </div>

--- a/packages/react/src/experimental/ProductCard/index.tsx
+++ b/packages/react/src/experimental/ProductCard/index.tsx
@@ -11,6 +11,7 @@ export type ProductCardProps = {
   isVisible: boolean
   icon: IconType
   dismissable?: boolean
+  trackVisibility?: (open: boolean) => void
 }
 
 const ProductCard = ({
@@ -21,12 +22,16 @@ const ProductCard = ({
   isVisible,
   icon,
   dismissable = false,
+  trackVisibility,
 }: ProductCardProps) => {
   const [open, setOpen] = useState(isVisible)
 
   useEffect(() => {
     setOpen(isVisible)
-  }, [isVisible])
+    if (trackVisibility) {
+      trackVisibility(isVisible)
+    }
+  }, [isVisible, trackVisibility])
 
   const handleClose = () => {
     setOpen(false)

--- a/packages/react/src/experimental/ProductCard/index.tsx
+++ b/packages/react/src/experimental/ProductCard/index.tsx
@@ -45,7 +45,7 @@ const ProductCard = ({
       <div>
         <div className="p-2">
           <div
-            className="flex cursor-pointer flex-row gap-2 rounded-md border-f1-border p-3 text-f1-foreground shadow-md hover:bg-f1-background-secondary"
+            className="flex h-[90px] cursor-pointer flex-row gap-2 rounded-md border-f1-border p-3 text-f1-foreground shadow-md hover:bg-f1-background-secondary"
             onClick={onClick}
           >
             <ModuleAvatar icon={icon} size="md" />

--- a/packages/react/src/experimental/ProductCard/index.tsx
+++ b/packages/react/src/experimental/ProductCard/index.tsx
@@ -48,10 +48,10 @@ const ProductCard = ({
             className="flex h-[90px] cursor-pointer flex-row gap-2 rounded-md border-f1-border p-3 text-f1-foreground shadow-md hover:bg-f1-background-secondary"
             onClick={onClick}
           >
-            <ModuleAvatar icon={icon} size="md" />
-            <div className="flex flex-1 flex-col justify-center">
+            <ModuleAvatar icon={icon} size="lg" />
+            <div className="flex flex-1 flex-col">
               <div>
-                <p className="font-medium">{title}</p>
+                <h3 className="text-lg font-medium">{title}</h3>
                 <p className="text-f1-foreground-secondary">{description}</p>
               </div>
             </div>

--- a/packages/react/src/experimental/ProductCard/index.tsx
+++ b/packages/react/src/experimental/ProductCard/index.tsx
@@ -1,65 +1,71 @@
 import { Button, IconType } from "@/factorial-one"
 import CrossIcon from "@/icons/app/Cross"
-import { cn } from "@/lib/utils"
+import { useEffect, useState } from "react"
 import { ModuleAvatar } from "../Information/ModuleAvatar"
-type ProductCardProps = {
+
+export type ProductCardProps = {
   title: string
   description: string
-  buttonText: string
   onClick: () => void
-  onClose: () => void
+  onClose?: () => void
   isVisible: boolean
   icon: IconType
-  variant: "outline" | "promote"
-}
-
-const variants = {
-  outline: "border-f1-border",
-  promote: "border-f1-border-promote bg-f1-background-promote",
+  dismissable?: boolean
 }
 
 const ProductCard = ({
   title,
   description,
-  buttonText,
   onClick,
   onClose,
   isVisible,
   icon,
-  variant,
-}: ProductCardProps) =>
-  isVisible && (
-    <div>
-      <div className="p-2">
-        <div
-          className={cn(
-            "flex flex-row gap-2 rounded-md border border-solid p-3 text-f1-foreground",
-            variants[variant]
-          )}
-        >
-          <ModuleAvatar icon={icon} size="md" />
-          <div className="flex flex-1 flex-col justify-center">
-            <div>
-              <p className="font-medium">{title}</p>
-              <p className="text-f1-foreground-secondary">{description}</p>
+  dismissable = false,
+}: ProductCardProps) => {
+  const [open, setOpen] = useState(isVisible)
+
+  useEffect(() => {
+    setOpen(isVisible)
+  }, [isVisible])
+
+  const handleClose = () => {
+    setOpen(false)
+    if (onClose) {
+      onClose()
+    }
+  }
+
+  return (
+    open && (
+      <div>
+        <div className="p-2">
+          <div
+            className="flex cursor-pointer flex-row gap-2 rounded-md border-f1-border p-3 text-f1-foreground shadow-md hover:bg-f1-background-secondary"
+            onClick={onClick}
+          >
+            <ModuleAvatar icon={icon} size="md" />
+            <div className="flex flex-1 flex-col justify-center">
+              <div>
+                <p className="font-medium">{title}</p>
+                <p className="text-f1-foreground-secondary">{description}</p>
+              </div>
             </div>
-            <div className="mt-3 w-[100px]">
-              <Button variant="outline" label={buttonText} onClick={onClick} />
-            </div>
-          </div>
-          <div className="h-6 w-6">
-            <Button
-              variant="ghost"
-              icon={CrossIcon}
-              size="sm"
-              hideLabel
-              onClick={onClose}
-              label="Close"
-            />
+            {dismissable && (
+              <div className="h-6 w-6">
+                <Button
+                  variant="ghost"
+                  icon={CrossIcon}
+                  size="sm"
+                  hideLabel
+                  onClick={handleClose}
+                  label="Close"
+                />
+              </div>
+            )}
           </div>
         </div>
       </div>
-    </div>
+    )
   )
-
+}
 export default ProductCard

--- a/packages/react/src/experimental/ProductCard/index.tsx
+++ b/packages/react/src/experimental/ProductCard/index.tsx
@@ -1,0 +1,65 @@
+import { Button, IconType } from "@/factorial-one"
+import CrossIcon from "@/icons/app/Cross"
+import { cn } from "@/lib/utils"
+import { ModuleAvatar } from "../Information/ModuleAvatar"
+type ProductCardProps = {
+  title: string
+  description: string
+  buttonText: string
+  onClick: () => void
+  onClose: () => void
+  isVisible: boolean
+  icon: IconType
+  variant: "outline" | "promote"
+}
+
+const variants = {
+  outline: "border-f1-border",
+  promote: "border-f1-border-promote bg-f1-background-promote",
+}
+
+const ProductCard = ({
+  title,
+  description,
+  buttonText,
+  onClick,
+  onClose,
+  isVisible,
+  icon,
+  variant,
+}: ProductCardProps) =>
+  isVisible && (
+    <div>
+      <div className="p-2">
+        <div
+          className={cn(
+            "flex flex-row gap-2 rounded-md border border-solid p-3 text-f1-foreground",
+            variants[variant]
+          )}
+        >
+          <ModuleAvatar icon={icon} size="md" />
+          <div className="flex flex-1 flex-col justify-center">
+            <div>
+              <p className="font-medium">{title}</p>
+              <p className="text-f1-foreground-secondary">{description}</p>
+            </div>
+            <div className="mt-3 w-[100px]">
+              <Button variant="outline" label={buttonText} onClick={onClick} />
+            </div>
+          </div>
+          <div className="h-6 w-6">
+            <Button
+              variant="ghost"
+              icon={CrossIcon}
+              size="sm"
+              hideLabel
+              onClick={onClose}
+              label=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+
+export default ProductCard


### PR DESCRIPTION
## Description

This PR enhances the productUpdates dropdown to support cross-selling opportunities by introducing a carousel that displays additional content items.

Changes Included:
Implemented a new reusable ProductCard component to showcase individual products or content.

Added a new carousel inside the productUpdates dropdown to display multiple ProductCard items in a scrollable layout.

This update enables dynamic promotion of related products and content directly within the dropdown.


[More context](https://www.notion.so/factorialco/Benefits-banner-in-Product-Updates-dropdown-1cf5e6e051ee80a4be78f6961561e258?pvs=4)

## Screenshots (if applicable)
![Screenshot 2025-05-06 at 3 04 20 PM](https://github.com/user-attachments/assets/b818e55a-7463-46b2-96f9-1856dcdb8c67)
<img width="1124" alt="Screenshot 2025-05-06 at 3 04 54 PM" src="https://github.com/user-attachments/assets/cf064285-d95c-4505-9064-0a6019e17de6" />

### Figma Link

[Link to Figma Design](https://www.figma.com/design/h9EH3SIN6nXY2CFHGRotGB/Recommended-section-on-Discover-dropdown---25Q2?node-id=13310-6270&p=f&t=TP4YR7cqDb8qZmio-0)

---

## Type of Change

- [x] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other


