### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.38.1",
+  "packages/react": "1.39.0",
   "packages/react-native": "0.2.5",
   "packages/core": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.39.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.38.1...factorial-one-react-v1.39.0) (2025-05-05)
+
+
+### Features
+
+* add new banner component ([#1628](https://github.com/factorialco/factorial-one/issues/1628)) ([a1eaab0](https://github.com/factorialco/factorial-one/commit/a1eaab072ef096a1d5ef89b2a3d21119ec4b369a))
+
 ## [1.38.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.38.0...factorial-one-react-v1.38.1) (2025-05-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.38.1",
+  "version": "1.39.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.39.0</summary>

## [1.39.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.38.1...factorial-one-react-v1.39.0) (2025-05-05)


### Features

* add new banner component ([#1628](https://github.com/factorialco/factorial-one/issues/1628)) ([a1eaab0](https://github.com/factorialco/factorial-one/commit/a1eaab072ef096a1d5ef89b2a3d21119ec4b369a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).