### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.39.1",
+  "packages/react": "1.40.0",
   "packages/react-native": "0.2.5",
   "packages/core": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.40.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.39.1...factorial-one-react-v1.40.0) (2025-05-05)
+
+
+### Features
+
+* add new copy action to metada ([#1734](https://github.com/factorialco/factorial-one/issues/1734)) ([445a2e4](https://github.com/factorialco/factorial-one/commit/445a2e495bb5990c8c61794ea923e59e8703d78d))
+
 ## [1.39.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.39.0...factorial-one-react-v1.39.1) (2025-05-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.40.0</summary>

## [1.40.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.39.1...factorial-one-react-v1.40.0) (2025-05-05)


### Features

* add new copy action to metada ([#1734](https://github.com/factorialco/factorial-one/issues/1734)) ([445a2e4](https://github.com/factorialco/factorial-one/commit/445a2e495bb5990c8c61794ea923e59e8703d78d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).