### PR TITLE
fix(RichTextEditor): deleted dark styles

### DIFF
--- a/packages/react/src/experimental/RichText/RichTextEditor/Toolbar/ToolbarButton/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/Toolbar/ToolbarButton/index.tsx
@@ -59,13 +59,7 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
       >
         <Icon
           icon={icon}
-          className={
-            active
-              ? "text-f1-icon-selected"
-              : mode === "dark"
-                ? "text-f1-foreground-inverse"
-                : "text-f1-foreground"
-          }
+          className={active ? "text-f1-icon-selected" : "text-f1-foreground"}
         />
         {showLabel && (
           <span

--- a/packages/react/src/experimental/RichText/RichTextEditor/Toolbar/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/Toolbar/index.tsx
@@ -38,17 +38,11 @@ interface ToolbarDividerProps {
   mode?: "light" | "dark"
 }
 
-const ToolbarDivider = ({
-  hidden = false,
-  mode = "light",
-}: ToolbarDividerProps) => (
+const ToolbarDivider = ({ hidden = false }: ToolbarDividerProps) => (
   <div
     className={cn(
-      "mx-1 h-4 w-[1px] flex-shrink-0",
-      hidden && "hidden",
-      mode === "dark"
-        ? "bg-f1-foreground-inverse opacity-50"
-        : "bg-f1-foreground-disabled"
+      "mx-1 h-4 w-[1px] flex-shrink-0 bg-f1-foreground-disabled",
+      hidden && "hidden"
     )}
   />
 )
@@ -365,7 +359,7 @@ const Toolbar = ({
             : "overflow-hidden"
         )}
       >
-        {intersperse(groups, <ToolbarDivider mode={mode} />)}
+        {intersperse(groups, <ToolbarDivider />)}
       </div>
     </div>
   )


### PR DESCRIPTION
## Description
I deleted dark classes from the buttons as they were giving some errors

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [ ] Component added to `experimental` folder
- [ ] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
