### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.40.0",
-  "packages/react-native": "0.2.5",
-  "packages/core": "1.2.5"
+  "packages/react-native": "0.2.6",
+  "packages/core": "1.3.0"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.3.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.2.5...factorial-one-core-v1.3.0) (2025-05-05)
+
+
+### Features
+
+* create WidgetAvatarsListItem with alert ([#1585](https://github.com/factorialco/factorial-one/issues/1585)) ([4ee8a76](https://github.com/factorialco/factorial-one/commit/4ee8a76745e3456a513a735e646b6e6ba5256dae))
+
+
+### Bug Fixes
+
+* **core:** add missing peer dependencies ([c6145ad](https://github.com/factorialco/factorial-one/commit/c6145add828bd3d5d9ab7e598c69cc64792f7e25))
+* **core:** include src to the package ([b62fb0e](https://github.com/factorialco/factorial-one/commit/b62fb0ecc46c4517e8a80280d4d4679578a1e610))
+* regenerated icons ([ce283f6](https://github.com/factorialco/factorial-one/commit/ce283f6ccea32b8033b32a532cbc2261a034c783))
+* **Tokens:** fixed selected colors ([60b719c](https://github.com/factorialco/factorial-one/commit/60b719c15c42295c09bca2016c57b686d40786c9))
+* update peer dependency for factorial-one-core in package.json ([#1744](https://github.com/factorialco/factorial-one/issues/1744)) ([8efe621](https://github.com/factorialco/factorial-one/commit/8efe6214e15f2c6ff492620ac6820f8aa32c0b5f))
+
 ## 1.0.0 (2025-04-30)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.5...factorial-one-react-native-v0.2.6) (2025-05-05)
+
+
+### Bug Fixes
+
+* update peer dependency for factorial-one-core in package.json ([#1744](https://github.com/factorialco/factorial-one/issues/1744)) ([8efe621](https://github.com/factorialco/factorial-one/commit/8efe6214e15f2c6ff492620ac6820f8aa32c0b5f))
+
 ## [0.2.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.4...factorial-one-react-native-v0.2.5) (2025-05-02)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.2.6</summary>

## [0.2.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.5...factorial-one-react-native-v0.2.6) (2025-05-05)


### Bug Fixes

* update peer dependency for factorial-one-core in package.json ([#1744](https://github.com/factorialco/factorial-one/issues/1744)) ([8efe621](https://github.com/factorialco/factorial-one/commit/8efe6214e15f2c6ff492620ac6820f8aa32c0b5f))
</details>

<details><summary>factorial-one-core: 1.3.0</summary>

## [1.3.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.2.5...factorial-one-core-v1.3.0) (2025-05-05)


### Features

* create WidgetAvatarsListItem with alert ([#1585](https://github.com/factorialco/factorial-one/issues/1585)) ([4ee8a76](https://github.com/factorialco/factorial-one/commit/4ee8a76745e3456a513a735e646b6e6ba5256dae))


### Bug Fixes

* **core:** add missing peer dependencies ([c6145ad](https://github.com/factorialco/factorial-one/commit/c6145add828bd3d5d9ab7e598c69cc64792f7e25))
* **core:** include src to the package ([b62fb0e](https://github.com/factorialco/factorial-one/commit/b62fb0ecc46c4517e8a80280d4d4679578a1e610))
* regenerated icons ([ce283f6](https://github.com/factorialco/factorial-one/commit/ce283f6ccea32b8033b32a532cbc2261a034c783))
* **Tokens:** fixed selected colors ([60b719c](https://github.com/factorialco/factorial-one/commit/60b719c15c42295c09bca2016c57b686d40786c9))
* update peer dependency for factorial-one-core in package.json ([#1744](https://github.com/factorialco/factorial-one/issues/1744)) ([8efe621](https://github.com/factorialco/factorial-one/commit/8efe6214e15f2c6ff492620ac6820f8aa32c0b5f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).