### PR TITLE
feat: add support to open modal on left and right sides

### DIFF
--- a/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
@@ -1,13 +1,14 @@
-import { ApplicationFrame } from "@/experimental/exports"
 import {
   OnePersonListItem,
   OnePersonListItemProps,
 } from "@/experimental/Lists/OnePersonListItem"
 import { Default as OnePersonListItemDefault } from "@/experimental/Lists/OnePersonListItem/index.stories"
+import { ApplicationFrame } from "@/experimental/Navigation/ApplicationFrame"
+import ApplicationFrameStoryMeta from "@/experimental/Navigation/ApplicationFrame/index.stories"
 import DeleteIcon from "@/icons/app/Delete"
 import PencilIcon from "@/icons/app/Pencil"
 import type { Meta, StoryObj } from "@storybook/react"
-import { FC } from "react"
+import { ComponentProps, FC } from "react"
 import { OneModal } from "."
 
 const meta: Meta<typeof OneModal> = {
@@ -22,8 +23,14 @@ const meta: Meta<typeof OneModal> = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <ApplicationFrame sidebar={null}>
-        <Story />
+      <ApplicationFrame
+        {...(ApplicationFrameStoryMeta.args as ComponentProps<
+          typeof ApplicationFrame
+        >)}
+      >
+        <div className="flex-1 rounded-md border border-solid border-f1-border-secondary bg-f1-background">
+          <Story />
+        </div>
       </ApplicationFrame>
     ),
   ],
@@ -118,6 +125,21 @@ export const WithPersonListItems: Story = {
     ),
   },
 }
+
+export const WithLeftPosition: Story = {
+  args: {
+    ...Default.args,
+    position: "left",
+  },
+}
+
+export const WithRightPosition: Story = {
+  args: {
+    ...Default.args,
+    position: "right",
+  },
+}
+
 export const WithFewItems: Story = {
   args: {
     ...Default.args,

--- a/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
@@ -1,10 +1,13 @@
+import { useSidebar } from "@/experimental/exports"
 import { TabsProps } from "@/experimental/Navigation/Tabs"
+import { cn } from "@/lib/utils"
 import { Dialog, DialogContent } from "@/ui/dialog"
 import { Drawer, DrawerContent, DrawerOverlay } from "@/ui/drawer"
 import React, { ComponentProps, useEffect, useState } from "react"
 import { OneModalContent } from "./OneModalContent/OneModalContent"
 import { OneModalHeader } from "./OneModalHeader/OneModalHeader"
 import { OneModalProvider } from "./OneModalProvider"
+import { ModalPosition } from "./types"
 import { useIsSmallScreen } from "./utils"
 
 export type OneModalProps = {
@@ -14,6 +17,7 @@ export type OneModalProps = {
   onClose: () => void
   /** Whether to render the modal as a bottom sheet on mobile */
   asBottomSheetInMobile?: boolean
+  position?: ModalPosition
   /** Custom content to render in the modal. Only accepts OneModal.Header and OneModal.Content components */
   children:
     | React.ReactElement<
@@ -28,10 +32,12 @@ export type OneModalProps = {
 
 export const OneModal: React.FC<OneModalProps> = ({
   asBottomSheetInMobile = true,
+  position = "center",
   onClose,
   isOpen,
   children,
 }) => {
+  const { sidebarState } = useSidebar()
   const [open, setOpen] = useState(isOpen)
 
   useEffect(() => {
@@ -54,7 +60,12 @@ export const OneModal: React.FC<OneModalProps> = ({
 
   if (isSmallScreen && asBottomSheetInMobile) {
     return (
-      <OneModalProvider isOpen={open} onClose={handleClose} shownBottomSheet>
+      <OneModalProvider
+        isOpen={open}
+        onClose={handleClose}
+        position={position}
+        shownBottomSheet
+      >
         <Drawer open={open} onOpenChange={handleOpenChange}>
           <DrawerOverlay className="bg-f1-background-overlay" />
           <DrawerContent className="max-h-[95vh] bg-f1-background">
@@ -65,12 +76,24 @@ export const OneModal: React.FC<OneModalProps> = ({
     )
   }
 
+  let contentClassName =
+    "max-h-[620px] max-w-[680px] overflow-y-auto overflow-x-hidden data-[state=closed]:slide-out-to-top-[2%] data-[state=open]:slide-in-from-top-[2%] sm:top-[50%] sm:translate-y-[-50%] sm:data-[state=closed]:slide-out-to-top-[48%] sm:data-[state=open]:slide-in-from-top-[48%]"
+
+  const isSidePosition = position === "left" || position === "right"
+
+  if (isSidePosition) {
+    contentClassName = cn(
+      "overflow-x-hidden flex flex-col fixed top-3 bottom-3 translate-y-0 translate-x-0 max-w-[539px] rounded-md border border-solid border-f1-border-secondary data-[state=closed]:slide-out-to-top-0 data-[state=open]:slide-in-from-top-0 data-[state=open]:slide-in-from-left-0 data-[state=closed]:slide-out-to-left-0",
+      position === "left" &&
+        (sidebarState === "locked" ? "left-[248px]" : "left-3"),
+      position === "right" && "left-auto right-3"
+    )
+  }
+
   return (
-    <OneModalProvider isOpen={open} onClose={handleClose}>
-      <Dialog open={open} onOpenChange={onClose}>
-        <DialogContent className="max-h-[620px] max-w-[680px] overflow-y-auto overflow-x-hidden data-[state=closed]:slide-out-to-top-[2%] data-[state=open]:slide-in-from-top-[2%] sm:top-[50%] sm:translate-y-[-50%] sm:data-[state=closed]:slide-out-to-top-[48%] sm:data-[state=open]:slide-in-from-top-[48%]">
-          {children}
-        </DialogContent>
+    <OneModalProvider isOpen={open} onClose={handleClose} position={position}>
+      <Dialog open={open} onOpenChange={onClose} modal={position === "center"}>
+        <DialogContent className={contentClassName}>{children}</DialogContent>
       </Dialog>
     </OneModalProvider>
   )

--- a/packages/react/src/experimental/Modals/OneModal/OneModalContent/OneModalContent.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalContent/OneModalContent.tsx
@@ -1,6 +1,7 @@
 import { Tabs, TabsProps } from "@/experimental/Navigation/Tabs"
 import { cn } from "@/lib/utils"
 import { ScrollArea, ScrollBar } from "@/ui/scrollarea"
+import { useOneModal } from "../OneModalProvider"
 import { useIsSmallScreen } from "../utils"
 
 export type OneModalContentProps = {
@@ -13,6 +14,8 @@ export const OneModalContent = ({
   setActiveTabId,
   children,
 }: OneModalContentProps) => {
+  const { position: modalPosition } = useOneModal()
+
   const isSmallScreen = useIsSmallScreen()
 
   return (
@@ -29,7 +32,7 @@ export const OneModalContent = ({
       <ScrollArea
         className={cn(
           "[*[data-state=visible]_div]:bg-f1-background flex flex-col",
-          !isSmallScreen && "max-h-[512px]"
+          !isSmallScreen && modalPosition === "center" && "max-h-[512px]"
         )}
       >
         {children}

--- a/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
@@ -4,6 +4,7 @@ import {
   DropdownInternalProps,
 } from "@/experimental/Navigation/Dropdown/internal"
 import CrossIcon from "@/icons/app/Cross"
+import { cn } from "@/lib/utils"
 import { DialogTitle } from "@/ui/dialog"
 import { DrawerTitle } from "@/ui/drawer"
 import { useOneModal } from "../OneModalProvider"
@@ -17,12 +18,35 @@ export const OneModalHeader = ({
   title,
   otherActions,
 }: OneModalHeaderProps) => {
-  const { onClose, shownBottomSheet } = useOneModal()
+  const { onClose, shownBottomSheet, position: modalPosition } = useOneModal()
 
-  const dialogClassName = "text-lg font-semibold text-f1-foreground"
+  const dialogClassName = cn(
+    "font-semibold text-f1-foreground",
+    modalPosition === "center" ? "text-lg" : "text-xl"
+  )
+
+  if (modalPosition === "right" && !shownBottomSheet) {
+    return (
+      <div className="flex flex-col gap-3 px-4 py-4">
+        <div className="flex flex-row justify-between">
+          <ButtonInternal
+            variant="outline"
+            icon={CrossIcon}
+            onClick={onClose}
+            label="Close modal"
+            hideLabel
+          />
+          {!!otherActions?.length && <DropdownInternal items={otherActions} />}
+        </div>
+        <DialogTitle className={cn(dialogClassName, "text-2xl")}>
+          {title}
+        </DialogTitle>
+      </div>
+    )
+  }
 
   return (
-    <div className="flex flex-row items-center justify-between px-4 py-3">
+    <div className="flex flex-row items-center justify-between px-4 py-4">
       {!shownBottomSheet ? (
         <DialogTitle className={dialogClassName}>{title}</DialogTitle>
       ) : (

--- a/packages/react/src/experimental/Modals/OneModal/OneModalProvider.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalProvider.tsx
@@ -1,14 +1,17 @@
 import { createContext, useContext } from "react"
+import { ModalPosition } from "./types"
 
 type OneModalContextType = {
   open: boolean
   onClose: () => void
   shownBottomSheet: boolean
+  position: ModalPosition
 }
 
 export const OneModalContext = createContext<OneModalContextType>({
   open: false,
   onClose: () => {},
+  position: "center",
   shownBottomSheet: false,
 })
 
@@ -16,16 +19,18 @@ export const OneModalProvider = ({
   isOpen,
   onClose,
   shownBottomSheet = false,
+  position,
   children,
 }: {
   isOpen: boolean
   onClose: () => void
   shownBottomSheet?: boolean
+  position: ModalPosition
   children: React.ReactNode
 }) => {
   return (
     <OneModalContext.Provider
-      value={{ open: isOpen, onClose, shownBottomSheet }}
+      value={{ open: isOpen, onClose, position, shownBottomSheet }}
     >
       {children}
     </OneModalContext.Provider>

--- a/packages/react/src/experimental/Modals/OneModal/types.ts
+++ b/packages/react/src/experimental/Modals/OneModal/types.ts
@@ -1,0 +1,1 @@
+export type ModalPosition = "center" | "left" | "right"


### PR DESCRIPTION
## Description

We need to add support to open modals on the left and on the right.

## Screenshots

<img width="1499" alt="Screenshot 2025-05-05 at 15 50 53" src="https://github.com/user-attachments/assets/42abe050-7104-4228-a05e-17da0ac4645a" />

<img width="1499" alt="Screenshot 2025-05-05 at 15 51 09" src="https://github.com/user-attachments/assets/0f2b0e18-a442-49ab-bdcd-e7f00880f090" />
