### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.42.0",
+  "packages/react": "1.43.0",
   "packages/react-native": "0.2.6",
   "packages/core": "1.3.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.43.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.42.0...factorial-one-react-v1.43.0) (2025-05-06)
+
+
+### Features
+
+* **Calendar:** Quarter and Half-year views ([#1728](https://github.com/factorialco/factorial-one/issues/1728)) ([0f6c950](https://github.com/factorialco/factorial-one/commit/0f6c950f9779302739d9ee68aee1595dfa3bdd8c))
+
 ## [1.42.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.41.0...factorial-one-react-v1.42.0) (2025-05-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.43.0</summary>

## [1.43.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.42.0...factorial-one-react-v1.43.0) (2025-05-06)


### Features

* **Calendar:** Quarter and Half-year views ([#1728](https://github.com/factorialco/factorial-one/issues/1728)) ([0f6c950](https://github.com/factorialco/factorial-one/commit/0f6c950f9779302739d9ee68aee1595dfa3bdd8c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).