### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.43.0",
   "packages/react-native": "0.2.6",
-  "packages/core": "1.3.0"
+  "packages/core": "1.4.0"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.4.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.3.0...factorial-one-core-v1.4.0) (2025-05-06)
+
+
+### Features
+
+* add new hub icon ([#1755](https://github.com/factorialco/factorial-one/issues/1755)) ([83b6068](https://github.com/factorialco/factorial-one/commit/83b6068693e5b7f41a51d0cf4316c7cb89408d24))
+
 ## [1.3.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.2.5...factorial-one-core-v1.3.0) (2025-05-05)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-core: 1.4.0</summary>

## [1.4.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.3.0...factorial-one-core-v1.4.0) (2025-05-06)


### Features

* add new hub icon ([#1755](https://github.com/factorialco/factorial-one/issues/1755)) ([83b6068](https://github.com/factorialco/factorial-one/commit/83b6068693e5b7f41a51d0cf4316c7cb89408d24))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).