### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.43.0",
+  "packages/react": "1.43.1",
   "packages/react-native": "0.2.6",
   "packages/core": "1.4.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.43.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.43.0...factorial-one-react-v1.43.1) (2025-05-06)
+
+
+### Bug Fixes
+
+* add missing case in CommunityPost with no author ([#1757](https://github.com/factorialco/factorial-one/issues/1757)) ([55144de](https://github.com/factorialco/factorial-one/commit/55144dec779511f5e26ab4a5894c60a1ed5cc44c))
+
 ## [1.43.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.42.0...factorial-one-react-v1.43.0) (2025-05-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.43.0",
+  "version": "1.43.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.43.1</summary>

## [1.43.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.43.0...factorial-one-react-v1.43.1) (2025-05-06)


### Bug Fixes

* add missing case in CommunityPost with no author ([#1757](https://github.com/factorialco/factorial-one/issues/1757)) ([55144de](https://github.com/factorialco/factorial-one/commit/55144dec779511f5e26ab4a5894c60a1ed5cc44c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).