### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.44.0",
-  "packages/react-native": "0.2.6",
+  "packages/react-native": "0.3.0",
   "packages/core": "1.4.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.6...factorial-one-react-native-v0.3.0) (2025-05-07)
+
+
+### Features
+
+* add ModuleAvatar component with size variants and icon support ([#1733](https://github.com/factorialco/factorial-one/issues/1733)) ([027f976](https://github.com/factorialco/factorial-one/commit/027f976ccad9286970b58130fc7296f88e852429))
+
 ## [0.2.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.5...factorial-one-react-native-v0.2.6) (2025-05-05)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.3.0</summary>

## [0.3.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.2.6...factorial-one-react-native-v0.3.0) (2025-05-07)


### Features

* add ModuleAvatar component with size variants and icon support ([#1733](https://github.com/factorialco/factorial-one/issues/1733)) ([027f976](https://github.com/factorialco/factorial-one/commit/027f976ccad9286970b58130fc7296f88e852429))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).