### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.44.0",
+  "packages/react": "1.44.1",
   "packages/react-native": "0.3.0",
   "packages/core": "1.4.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.44.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.44.0...factorial-one-react-v1.44.1) (2025-05-07)
+
+
+### Bug Fixes
+
+* Sidebar grouping position bug ([#1754](https://github.com/factorialco/factorial-one/issues/1754)) ([a7ffc0f](https://github.com/factorialco/factorial-one/commit/a7ffc0f2cde4fed75630b227e4c5278dc0dce8e8))
+
 ## [1.44.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.43.1...factorial-one-react-v1.44.0) (2025-05-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.44.1</summary>

## [1.44.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.44.0...factorial-one-react-v1.44.1) (2025-05-07)


### Bug Fixes

* Sidebar grouping position bug ([#1754](https://github.com/factorialco/factorial-one/issues/1754)) ([a7ffc0f](https://github.com/factorialco/factorial-one/commit/a7ffc0f2cde4fed75630b227e4c5278dc0dce8e8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).