### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.44.1",
+  "packages/react": "1.44.2",
   "packages/react-native": "0.3.0",
   "packages/core": "1.4.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.44.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.44.1...factorial-one-react-v1.44.2) (2025-05-07)
+
+
+### Bug Fixes
+
+* date type infer ([#1761](https://github.com/factorialco/factorial-one/issues/1761)) ([59eee12](https://github.com/factorialco/factorial-one/commit/59eee12bac50130331081c00c17eeb4ddf41f460))
+
 ## [1.44.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.44.0...factorial-one-react-v1.44.1) (2025-05-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.44.1",
+  "version": "1.44.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.44.2</summary>

## [1.44.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.44.1...factorial-one-react-v1.44.2) (2025-05-07)


### Bug Fixes

* date type infer ([#1761](https://github.com/factorialco/factorial-one/issues/1761)) ([59eee12](https://github.com/factorialco/factorial-one/commit/59eee12bac50130331081c00c17eeb4ddf41f460))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).