### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.44.2",
+  "packages/react": "1.44.3",
   "packages/react-native": "0.3.0",
   "packages/core": "1.4.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.44.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.44.2...factorial-one-react-v1.44.3) (2025-05-07)
+
+
+### Bug Fixes
+
+* expose useFormSchema ([#1766](https://github.com/factorialco/factorial-one/issues/1766)) ([b7ab162](https://github.com/factorialco/factorial-one/commit/b7ab1624483a906a5b852c6c9396c47841b57e85))
+
 ## [1.44.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.44.1...factorial-one-react-v1.44.2) (2025-05-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.44.2",
+  "version": "1.44.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.44.3</summary>

## [1.44.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.44.2...factorial-one-react-v1.44.3) (2025-05-07)


### Bug Fixes

* expose useFormSchema ([#1766](https://github.com/factorialco/factorial-one/issues/1766)) ([b7ab162](https://github.com/factorialco/factorial-one/commit/b7ab1624483a906a5b852c6c9396c47841b57e85))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).