### PR TITLE
fix: update avatar pulse with the correct colours

### DIFF
--- a/packages/core/base.css
+++ b/packages/core/base.css
@@ -4,9 +4,11 @@
 
 @layer base {
   :root {
-    --army-50: theme("colors.army.50");
-
-    --grass-50: theme("colors.grass.50");
+    --mood-accent-super-negative: theme("colors.radical.50");
+    --mood-positive: theme("colors.army.50");
+    --mood-super-positive: theme("colors.grass.50");
+    --mood-negative: theme("colors.orange.60");
+    --mood-neutral: theme("colors.smoke.60");
 
     --neutral-0: theme("colors.white.100");
     --neutral-2: theme("colors.grey.0");
@@ -24,10 +26,6 @@
 
     --neutral-solid-40: theme("colors.grey.solid.40");
     --neutral-solid-50: theme("colors.grey.solid.50");
-
-    --orange-60: theme("colors.orange.60");
-
-    --smoke-60: theme("colors.smoke.60");
 
     --white-5: theme("colors.white.5");
     --white-10: theme("colors.white.10");

--- a/packages/core/base.css
+++ b/packages/core/base.css
@@ -4,6 +4,10 @@
 
 @layer base {
   :root {
+    --army-60: theme("colors.army.60");
+
+    --grass-50: theme("colors.grass.50");
+
     --neutral-0: theme("colors.white.100");
     --neutral-2: theme("colors.grey.0");
     --neutral-5: theme("colors.grey.5");
@@ -20,6 +24,10 @@
 
     --neutral-solid-40: theme("colors.grey.solid.40");
     --neutral-solid-50: theme("colors.grey.solid.50");
+
+    --orange-60: theme("colors.orange.60");
+
+    --smoke-60: theme("colors.smoke.60");
 
     --white-5: theme("colors.white.5");
     --white-10: theme("colors.white.10");

--- a/packages/core/base.css
+++ b/packages/core/base.css
@@ -4,7 +4,7 @@
 
 @layer base {
   :root {
-    --army-60: theme("colors.army.60");
+    --army-50: theme("colors.army.50");
 
     --grass-50: theme("colors.grass.50");
 

--- a/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
@@ -37,7 +37,7 @@ const iconStyle = cva({
       superNegative: "text-[hsl(theme(colors.radical.50))]",
       negative: "text-[hsl(theme(colors.orange.60))]",
       neutral: "text-[hsl(theme(colors.smoke.60))]",
-      positive: "text-[hsl(theme(colors.army.60))]",
+      positive: "text-[hsl(theme(colors.army.50))]",
       superPositive: "text-[hsl(theme(colors.grass.60))]",
     },
   },

--- a/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
@@ -34,11 +34,11 @@ const pulseIcon: Record<Pulse, IconType> = {
 const iconStyle = cva({
   variants: {
     pulse: {
-      superNegative: "text-[hsl(var(--accent-50))]",
-      negative: "text-[hsl(var(--orange-60))]",
-      neutral: "text-[hsl(var(--smoke-60))]",
-      positive: "text-[hsl(var(--army-60))]",
-      superPositive: "text-[hsl(var(--grass-50))]",
+      superNegative: "text-[hsl(theme(colors.radical.50))]",
+      negative: "text-[hsl(theme(colors.orange.60))]",
+      neutral: "text-[hsl(theme(colors.smoke.60))]",
+      positive: "text-[hsl(theme(colors.army.60))]",
+      superPositive: "text-[hsl(theme(colors.grass.60))]",
     },
   },
 })

--- a/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
@@ -34,11 +34,11 @@ const pulseIcon: Record<Pulse, IconType> = {
 const iconStyle = cva({
   variants: {
     pulse: {
-      superNegative: "text-[hsl(theme(colors.indigo.50))]",
-      negative: "text-[hsl(theme(colors.malibu.50))]",
-      neutral: "text-[hsl(theme(colors.smoke.50))]",
-      positive: "text-[hsl(theme(colors.flubber.50))]",
-      superPositive: "text-[hsl(theme(colors.grass.50))]",
+      superNegative: "text-[hsl(var(--accent-50))]",
+      negative: "text-[hsl(var(--orange-60))]",
+      neutral: "text-[hsl(var(--smoke-60))]",
+      positive: "text-[hsl(var(--army-60))]",
+      superPositive: "text-[hsl(var(--grass-50))]",
     },
   },
 })

--- a/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
@@ -38,7 +38,7 @@ const iconStyle = cva({
       negative: "text-[hsl(theme(colors.orange.60))]",
       neutral: "text-[hsl(theme(colors.smoke.60))]",
       positive: "text-[hsl(theme(colors.army.50))]",
-      superPositive: "text-[hsl(theme(colors.grass.60))]",
+      superPositive: "text-[hsl(theme(colors.grass.50))]",
     },
   },
 })


### PR DESCRIPTION
## Description

This PR updates the icons of the Avatar Pulse component with the colors applied in the latest version of Gamma. It also exposes the colors in the root so they can be used in Factorial and in the Pulse components that rely on this color palette.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/29390726-1780-43b0-bb55-e24f158fd1d0

### Figma Link

https://www.figma.com/design/rNjUoMah0kY7NM4uU8njPM/Pulse?node-id=17-24754&t=sQD7bvWswOgqsaEg-0

---