### PR TITLE
fix(DataCollection): header separators visual fixes

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/experimental/OneDataCollection/CollectionActions/CollectionActions.tsx
@@ -38,7 +38,7 @@ export const CollectionActions = ({
         </Dropdown>
       )}
 
-      <div className="mx-1 h-4 w-px bg-f1-border-secondary" />
+      <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
     </div>
   )
 }

--- a/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersPresets.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersPresets.tsx
@@ -65,7 +65,9 @@ export const FiltersPresets = ({
     presets &&
     presets.length > 0 && (
       <>
-        <div className="mx-1 h-4 w-px bg-f1-border-secondary" />
+        <div className="flex items-center">
+          <div className="mx-2 h-4 w-px bg-f1-background-secondary-hover" />
+        </div>
         <OverflowList
           items={presets}
           renderListItem={renderListPresetItem}


### PR DESCRIPTION
## Description

Small tweaks for the header separators in the DataCollection component:

- Changed the color to use the same one as we do in ResourceHeader.
- Fixed the position and spacing of the separator after the filters.

## Screenshots

#### Before

<img width="210" alt="image" src="https://github.com/user-attachments/assets/e8e95049-5518-40a7-9486-9113e29c591d" />

#### After

<img width="250" alt="image" src="https://github.com/user-attachments/assets/5a2f5183-1afb-49f5-a97e-ef74c53e6a1d" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other