### PR TITLE
feat: module tag

### DIFF
--- a/packages/react/src/experimental/Information/Tags/ModuleTag/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Tags/ModuleTag/index.stories.tsx
@@ -1,0 +1,84 @@
+import { IconType } from "@/components/Utilities/Icon"
+import * as ModuleIcons from "@/icons/modules"
+import type { Meta, StoryObj } from "@storybook/react"
+import { ModuleTag } from "./index"
+
+// Crear un objeto con los módulos y sus propiedades
+const modules = Object.entries(ModuleIcons).reduce(
+  (acc, [key, icon]) => {
+    const formattedName = key.replace(/([A-Z])/g, " $1").trim()
+    return {
+      ...acc,
+      [key]: {
+        name: formattedName,
+        icon,
+      },
+    }
+  },
+  {} as Record<string, { name: string; icon: IconType }>
+)
+
+type StoryProps = {
+  selectedModule: string
+  onClick?: () => void
+}
+
+const meta = {
+  component: ModuleTag,
+  title: "Tag/ModuleTag",
+  tags: ["autodocs", "experimental"],
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    selectedModule: {
+      control: "select",
+      options: Object.keys(modules),
+      description: "Select a module",
+    },
+  },
+  args: {
+    selectedModule: "Home",
+    onClick: () => {},
+  },
+} satisfies Meta<StoryProps>
+
+export default meta
+type Story = StoryObj<StoryProps>
+
+export const Default: Story = {
+  args: {
+    selectedModule: "Home",
+  },
+  render: ({ selectedModule }) => {
+    const module = modules[selectedModule]
+    return (
+      <ModuleTag
+        moduleName={module.name}
+        icon={module.icon}
+        onClick={() => console.log(`clicked ${module.name}`)}
+      />
+    )
+  },
+}
+
+export const AllModules: Story = {
+  args: {
+    selectedModule: "Home",
+  },
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      {Object.entries(modules).map(([key, module]) => (
+        <ModuleTag
+          key={key}
+          moduleName={module.name}
+          icon={module.icon}
+          onClick={() => console.log(`clicked ${module.name}`)}
+        />
+      ))}
+    </div>
+  ),
+}

--- a/packages/react/src/experimental/Information/Tags/ModuleTag/index.tsx
+++ b/packages/react/src/experimental/Information/Tags/ModuleTag/index.tsx
@@ -1,0 +1,35 @@
+import { IconType } from "@/components/Utilities/Icon"
+import { Home } from "@/icons/modules"
+import { useTextFormatEnforcer } from "@/lib/text"
+import { cn } from "@/lib/utils"
+import { forwardRef } from "react"
+import { ModuleAvatar } from "../../ModuleAvatar"
+import { BaseTag } from "../BaseTag"
+
+type Props = {
+  moduleName: string
+  icon?: IconType
+  onClick?: () => void
+  className?: string
+}
+
+export const ModuleTag = forwardRef<HTMLDivElement, Props>(
+  ({ moduleName, icon = Home, onClick, className }, ref) => {
+    useTextFormatEnforcer(moduleName, { disallowEmpty: true })
+
+    return (
+      <BaseTag
+        ref={ref}
+        className={cn(
+          "gap-1 rounded-[8px] border-[1px] border-solid border-f1-border-secondary py-[1px] pl-[1px]",
+          className
+        )}
+        left={<ModuleAvatar icon={icon} size="sm" />}
+        text={moduleName}
+        onClick={onClick}
+      />
+    )
+  }
+)
+
+ModuleTag.displayName = "ModuleTag"


### PR DESCRIPTION
## Description

I've created a reusable ModuleTag component to display module names or labels inside banners and other cross-selling / upselling components. This is an experimental addition aimed at testing potential uses and making my first contribution to the repository :3

## Screenshots (if applicable)
![Captura de pantalla 2025-05-09 a las 9 14 43](https://github.com/user-attachments/assets/744e504e-d3c6-426e-8c25-27fa07e8b97e)
![Captura de pantalla 2025-05-09 a las 9 17 07](https://github.com/user-attachments/assets/8453a3b4-8766-4667-bfea-b0253d437e1c)


## Type of Change

- [x] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [x] Component added to `experimental` folder
- [x] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
