### PR TITLE
fix: mood colours

### DIFF
--- a/packages/core/base.css
+++ b/packages/core/base.css
@@ -4,11 +4,11 @@
 
 @layer base {
   :root {
-    --mood-accent-super-negative: theme("colors.radical.50");
-    --mood-positive: theme("colors.army.50");
+    --mood-super-negative: theme("colors.radical.50");
+    --mood-negative: theme("colors.orange.50");
+    --mood-neutral: theme("colors.yellow.50");
+    --mood-positive: theme("colors.flubber.50");
     --mood-super-positive: theme("colors.grass.50");
-    --mood-negative: theme("colors.orange.60");
-    --mood-neutral: theme("colors.smoke.60");
 
     --neutral-0: theme("colors.white.100");
     --neutral-2: theme("colors.grey.0");

--- a/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
@@ -35,9 +35,9 @@ const iconStyle = cva({
   variants: {
     pulse: {
       superNegative: "text-[hsl(theme(colors.radical.50))]",
-      negative: "text-[hsl(theme(colors.orange.60))]",
-      neutral: "text-[hsl(theme(colors.smoke.60))]",
-      positive: "text-[hsl(theme(colors.army.50))]",
+      negative: "text-[hsl(theme(colors.orange.50))]",
+      neutral: "text-[hsl(theme(colors.yellow.50))]",
+      positive: "text-[hsl(theme(colors.flubber.50))]",
       superPositive: "text-[hsl(theme(colors.grass.50))]",
     },
   },


### PR DESCRIPTION
## Description

The current colours are based on an outdated Figma design, this PR amends this error by replacing the wrong ones by the correct ones 

## Screenshots (if applicable)

https://github.com/user-attachments/assets/361e771a-6b56-41cb-b40c-02e4ca367341

![Screenshot 2025-05-09 at 10 17 34](https://github.com/user-attachments/assets/771160d4-1def-4455-8cc6-13f74fb05bc1)

### Figma Link

https://www.figma.com/design/rNjUoMah0kY7NM4uU8njPM/Pulse?node-id=17-24754&t=w4tNlrZ7a9RhkAD5-0

