### PR TITLE
fix: datacolletion secondary actions dropdown aligment when no primary actions

### DIFF
--- a/packages/react/src/experimental/Navigation/Dropdown/index.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/index.tsx
@@ -18,7 +18,7 @@ import {
   DropdownItemObject,
 } from "./internal"
 
-const privateProps = ["align"] as const
+const privateProps = [] as const
 
 type DropdownProps = Omit<
   DropdownInternalProps,

--- a/packages/react/src/experimental/OneDataCollection/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/experimental/OneDataCollection/CollectionActions/CollectionActions.tsx
@@ -19,6 +19,8 @@ export const CollectionActions = ({
 
   if (buttonActions.length === 0 && dropdownActions.length === 0) return null
 
+  const align = buttonActions.length > 0 ? "start" : "end"
+
   return (
     <div className="flex flex-row-reverse items-center gap-2">
       {buttonActions.map((action) => (
@@ -33,12 +35,10 @@ export const CollectionActions = ({
       ))}
 
       {dropdownActions.length > 0 && (
-        <Dropdown items={dropdownActions}>
+        <Dropdown items={dropdownActions} align={align}>
           <Button variant="outline" icon={Ellipsis} label="Actions" hideLabel />
         </Dropdown>
       )}
-
-      <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
     </div>
   )
 }

--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
@@ -2572,3 +2572,82 @@ export const TableWithNoFilters: Story = {
     )
   },
 }
+
+export const TableWithSecondaryActions: Story = {
+  render: () => {
+    const dataSource = useDataSource({
+      sortings: {
+        name: { label: "Name" },
+        email: { label: "Email" },
+        role: { label: "Role" },
+        department: { label: "Department" },
+      },
+      secondaryActions: () => [
+        {
+          label: "View Profile",
+          icon: Ai,
+          onClick: () => console.log(`Viewing profile`),
+        },
+      ],
+      dataAdapter: {
+        fetchData: ({ search }) => {
+          let filteredUsers = [...mockUsers]
+
+          if (search) {
+            const searchLower = search.toLowerCase()
+            filteredUsers = filteredUsers.filter(
+              (user) =>
+                user.name.toLowerCase().includes(searchLower) ||
+                user.email.toLowerCase().includes(searchLower) ||
+                user.role.toLowerCase().includes(searchLower) ||
+                user.department.toLowerCase().includes(searchLower)
+            )
+          }
+
+          return Promise.resolve(filteredUsers)
+        },
+      },
+    })
+
+    return (
+      <OneDataCollection
+        source={dataSource}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              columns: [
+                {
+                  label: "Name",
+                  render: (item) => ({
+                    type: "person",
+                    value: {
+                      firstName: item.name.split(" ")[0],
+                      lastName: item.name.split(" ")[1],
+                    },
+                  }),
+                  sorting: "name",
+                },
+                {
+                  label: "Email",
+                  render: (item) => item.email,
+                  sorting: "email",
+                },
+                {
+                  label: "Role",
+                  render: (item) => item.role,
+                  sorting: "role",
+                },
+                {
+                  label: "Department",
+                  render: (item) => item.department,
+                  sorting: "department",
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+  },
+}

--- a/packages/react/src/experimental/OneDataCollection/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/index.tsx
@@ -255,6 +255,14 @@ export const OneDataCollection = <
     })
   }
 
+  const elementsRightActions = useMemo(() => {
+    return [
+      isLoading,
+      search?.enabled,
+      visualizations && visualizations.length > 1,
+    ].some(Boolean)
+  }, [search, isLoading, visualizations])
+
   return (
     <div
       className={cn("flex flex-col gap-4", layout === "standard" && "-mx-6")}
@@ -307,11 +315,17 @@ export const OneDataCollection = <
                     onVisualizationChange={setCurrentVisualization}
                   />
                 )}
+
                 {(primaryActionItem || secondaryActionsItems) && (
-                  <CollectionActions
-                    primaryActions={primaryActionItem}
-                    secondaryActions={secondaryActionsItems}
-                  />
+                  <>
+                    {elementsRightActions && (
+                      <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
+                    )}
+                    <CollectionActions
+                      primaryActions={primaryActionItem}
+                      secondaryActions={secondaryActionsItems}
+                    />
+                  </>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Description

-fix: Data collection secondary actions dropdown when no primary actions

## Screenshots (if applicable)

Before: 
![image](https://github.com/user-attachments/assets/b0437f44-a61e-4be6-8fc9-612340d957e5)

After:
![image](https://github.com/user-attachments/assets/26f952d2-1517-4a6a-a4c0-29da228ce585)

![image](https://github.com/user-attachments/assets/db76db1b-bf7a-4cd6-ba68-a86a5516bae6)


