### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.46.1",
+  "packages/react": "1.46.2",
   "packages/react-native": "0.4.0",
-  "packages/core": "1.7.1"
+  "packages/core": "1.7.2"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.7.2](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.7.1...factorial-one-core-v1.7.2) (2025-05-09)
+
+
+### Bug Fixes
+
+* pulse face icons updated ([54f503a](https://github.com/factorialco/factorial-one/commit/54f503aec4fe9f3a86adc1652cbae3e8d3c90622))
+
 ## [1.7.1](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.7.0...factorial-one-core-v1.7.1) (2025-05-09)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.46.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.46.1...factorial-one-react-v1.46.2) (2025-05-09)
+
+
+### Bug Fixes
+
+* pulse face icons updated ([54f503a](https://github.com/factorialco/factorial-one/commit/54f503aec4fe9f3a86adc1652cbae3e8d3c90622))
+
 ## [1.46.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.46.0...factorial-one-react-v1.46.1) (2025-05-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.46.1",
+  "version": "1.46.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.46.2</summary>

## [1.46.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.46.1...factorial-one-react-v1.46.2) (2025-05-09)


### Bug Fixes

* pulse face icons updated ([54f503a](https://github.com/factorialco/factorial-one/commit/54f503aec4fe9f3a86adc1652cbae3e8d3c90622))
</details>

<details><summary>factorial-one-core: 1.7.2</summary>

## [1.7.2](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.7.1...factorial-one-core-v1.7.2) (2025-05-09)


### Bug Fixes

* pulse face icons updated ([54f503a](https://github.com/factorialco/factorial-one/commit/54f503aec4fe9f3a86adc1652cbae3e8d3c90622))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).