### PR TITLE
fix: apply in text-f1-foreground color in body

### DIFF
--- a/packages/core/base.css
+++ b/packages/core/base.css
@@ -169,5 +169,5 @@
 }
 
 body {
-  @apply text-f1-foreground font-sans text-base antialiased;
+  @apply !text-f1-foreground font-sans text-base antialiased;
 }


### PR DESCRIPTION
## Description

We had to manually add `text-f1-foreground` to our texts everywhere because in our production frontend there was another color being applied though the body the same way we're doing here. With this change we impose this default color unless another one is specified, this way we're not going to be confused seeing this foreground color applied in Factorial One but not in production.

## Screenshots

A good example of this happening is the new holidays widget, it was looking perfect in Factorial One, but not in production:

<img width="800" alt="Screenshot 2025-05-09 at 14 00 03" src="https://github.com/user-attachments/assets/1bcba41d-2a54-4e6e-8c37-19fa7b7d36f3" />

After this change we'll be like this:

<img width="866" alt="Screenshot 2025-05-09 at 14 00 32" src="https://github.com/user-attachments/assets/b26abab6-60ab-4502-97fd-207382de4ed5" />


