### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.46.2",
+  "packages/react": "1.46.3",
   "packages/react-native": "0.4.0",
   "packages/core": "1.7.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.46.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.46.2...factorial-one-react-v1.46.3) (2025-05-09)
+
+
+### Bug Fixes
+
+* datacollection secondary actions dropdown alignment when no primary actions ([#1783](https://github.com/factorialco/factorial-one/issues/1783)) ([a1bf03d](https://github.com/factorialco/factorial-one/commit/a1bf03d897b954db2793722da1d604f65f5ad6a2))
+
 ## [1.46.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.46.1...factorial-one-react-v1.46.2) (2025-05-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.46.2",
+  "version": "1.46.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.46.3</summary>

## [1.46.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.46.2...factorial-one-react-v1.46.3) (2025-05-09)


### Bug Fixes

* datacollection secondary actions dropdown alignment when no primary actions ([#1783](https://github.com/factorialco/factorial-one/issues/1783)) ([a1bf03d](https://github.com/factorialco/factorial-one/commit/a1bf03d897b954db2793722da1d604f65f5ad6a2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).