### PR TITLE
fix(OneCard): same key error

### DIFF
--- a/packages/react/src/experimental/OneCard/OneCard.tsx
+++ b/packages/react/src/experimental/OneCard/OneCard.tsx
@@ -198,8 +198,8 @@ export function OneCard({
         </div>
         {metadata && (
           <div className="flex flex-col gap-0.5">
-            {metadata.map((item) => (
-              <CardMetadata key={item.type} metadata={item} />
+            {metadata.map((item, index) => (
+              <CardMetadata key={index} metadata={item} />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Description

I noticed that using the same type for multiple metadata entries causes an error because the type is being used as a key

## Screenshots (if applicable)
![Captura de pantalla 2025-05-09 a las 18 12 36](https://github.com/user-attachments/assets/1fe3c36b-f513-422b-bab1-3fbfab1ced67)


### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [ ] Component added to `experimental` folder
- [ ] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
