### PR TITLE
feat(ResourceHeader): add tooltip to metadata

### DIFF
--- a/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
@@ -52,7 +52,12 @@ interface MetadataItem {
   value: MetadataItemValue
   actions?: (MetadataAction | MetadataCopyAction)[]
   hideLabel?: boolean
-  tooltip?: {
+
+  /**
+   * Optional info text. When provided, displays an info icon next to the label
+   * that shows this text in a tooltip when hovered.
+   */
+  info?: {
     title: string
     description?: string
   }
@@ -118,11 +123,11 @@ function MetadataItem({ item }: { item: MetadataItem }) {
         )}
       >
         {item.label}
-        {item.tooltip && (
+        {item.info && (
           <div className="flex h-4 w-4 items-center text-f1-foreground-tertiary hover:cursor-help">
             <Tooltip
-              label={item.tooltip.title}
-              description={item.tooltip.description}
+              label={item.info.title}
+              description={item.info.description}
             >
               <Icon icon={InfoCircleLine} size="sm" />
             </Tooltip>

--- a/packages/react/src/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -148,7 +148,7 @@ export const Metadata: Story = {
     metadata: [
       {
         label: "Created",
-        tooltip: {
+        info: {
           title: "Date of creation",
           description: "When the job was created",
         },


### PR DESCRIPTION
## Description

Add the option to define a tooltip in any metadata to show some additional help info. This tooltip is optional, and when defined, the label will display an info icon that will show this tooltip on hover.

## Screenshots

https://github.com/user-attachments/assets/a15b6d2c-41cd-4511-b9fa-85aa0fff17a4

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
