### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.46.3",
   "packages/react-native": "0.4.0",
-  "packages/core": "1.7.2"
+  "packages/core": "1.7.3"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.7.3](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.7.2...factorial-one-core-v1.7.3) (2025-05-12)
+
+
+### Bug Fixes
+
+* apply in text-f1-foreground color in body ([#1787](https://github.com/factorialco/factorial-one/issues/1787)) ([9e3aa61](https://github.com/factorialco/factorial-one/commit/9e3aa61136f7b75205fdb79bb8a2bad518842da8))
+
 ## [1.7.2](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.7.1...factorial-one-core-v1.7.2) (2025-05-09)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-core: 1.7.3</summary>

## [1.7.3](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.7.2...factorial-one-core-v1.7.3) (2025-05-12)


### Bug Fixes

* apply in text-f1-foreground color in body ([#1787](https://github.com/factorialco/factorial-one/issues/1787)) ([9e3aa61](https://github.com/factorialco/factorial-one/commit/9e3aa61136f7b75205fdb79bb8a2bad518842da8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).