### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.46.3",
+  "packages/react": "1.47.0",
   "packages/react-native": "0.4.0",
   "packages/core": "1.7.3"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.47.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.46.3...factorial-one-react-v1.47.0) (2025-05-12)
+
+
+### Features
+
+* **ResourceHeader:** add tooltip to metadata ([#1795](https://github.com/factorialco/factorial-one/issues/1795)) ([b74d5e6](https://github.com/factorialco/factorial-one/commit/b74d5e66d962eb88b40f9b8d5f6604ba7caabb98))
+
 ## [1.46.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.46.2...factorial-one-react-v1.46.3) (2025-05-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.46.3",
+  "version": "1.47.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.47.0</summary>

## [1.47.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.46.3...factorial-one-react-v1.47.0) (2025-05-12)


### Features

* **ResourceHeader:** add tooltip to metadata ([#1795](https://github.com/factorialco/factorial-one/issues/1795)) ([b74d5e6](https://github.com/factorialco/factorial-one/commit/b74d5e66d962eb88b40f9b8d5f6604ba7caabb98))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).