### PR TITLE
fix(OnePagination): better spacing between elements

### DIFF
--- a/packages/react/src/experimental/OnePagination/index.tsx
+++ b/packages/react/src/experimental/OnePagination/index.tsx
@@ -147,11 +147,12 @@ export function OnePagination({
             <PaginationPrevious
               aria-disabled={currentPage === 1 || disabled}
               tabIndex={currentPage === 1 ? -1 : 0}
-              className={
+              className={cn(
+                !isIndeterminate && "mr-1",
                 currentPage === 1 || disabled
                   ? "pointer-events-none opacity-50"
                   : ""
-              }
+              )}
               onClick={() => handlePageChange(currentPage - 1)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
@@ -209,13 +210,14 @@ export function OnePagination({
                     ? -1
                     : 0
               }
-              className={
+              className={cn(
+                !isIndeterminate && "ml-1",
                 (!isIndeterminate && currentPage === totalPages) ||
-                (!hasNextPage && isIndeterminate) ||
-                disabled
+                  (!hasNextPage && isIndeterminate) ||
+                  disabled
                   ? "pointer-events-none opacity-50"
                   : ""
-              }
+              )}
               onClick={() => handlePageChange(currentPage + 1)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {


### PR DESCRIPTION
## Description

- Changes the spacing between the previous/next arrows with the list of pages, to give them a bit more space.
- Use `cn` instead of regular conditionals for consistency and dynamic class management.

## Screenshots

<img width="359" alt="image" src="https://github.com/user-attachments/assets/d7cde3d1-90e6-405a-ad6a-2402dd645a29" />

_Not easy to notice, but there is more space between the previous button and the first page, and between the last page and the next button._

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other