### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.48.0",
+  "packages/react": "1.49.0",
   "packages/react-native": "0.4.0",
   "packages/core": "1.7.3"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.49.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.48.0...factorial-one-react-v1.49.0) (2025-05-12)
+
+
+### Features
+
+* **PageHeader:** add cross-selling feature to ProductUpdates component ([#1736](https://github.com/factorialco/factorial-one/issues/1736)) ([f658f16](https://github.com/factorialco/factorial-one/commit/f658f166888683b56f6da1509c1321756551b587))
+
 ## [1.48.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.47.1...factorial-one-react-v1.48.0) (2025-05-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.49.0</summary>

## [1.49.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.48.0...factorial-one-react-v1.49.0) (2025-05-12)


### Features

* **PageHeader:** add cross-selling feature to ProductUpdates component ([#1736](https://github.com/factorialco/factorial-one/issues/1736)) ([f658f16](https://github.com/factorialco/factorial-one/commit/f658f166888683b56f6da1509c1321756551b587))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).