### PR TITLE
feat(dataCollection): implement single select functionality in inFilter

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/Filters/FilterTypes/InFilter/InFilter.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/FilterTypes/InFilter/InFilter.stories.tsx
@@ -343,3 +343,49 @@ export const SyncFunctionOptions: Story = {
     onChange: () => {},
   },
 }
+
+// Single select example
+const SingleSelectExample = () => {
+  const [selectedValues, setSelectedValues] = useState<string[]>([
+    "engineering",
+  ])
+
+  const handleChange = (value: string[]) => {
+    setSelectedValues(value)
+  }
+
+  return (
+    <InFilter<string>
+      schema={{
+        label: "Department",
+        options: {
+          options: [
+            {
+              label: "Admin",
+              value: "admin",
+            },
+            {
+              label: "User",
+              value: "user",
+            },
+            {
+              label: "Editor",
+              value: "editor",
+            },
+            {
+              label: "Viewer",
+              value: "viewer",
+            },
+          ],
+          singleSelect: true,
+        },
+      }}
+      value={selectedValues}
+      onChange={handleChange}
+    />
+  )
+}
+
+export const SingleSelect: Story = {
+  render: () => <SingleSelectExample />,
+}

--- a/packages/react/src/experimental/OneDataCollection/Filters/FilterTypes/InFilter/InFilter.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/FilterTypes/InFilter/InFilter.tsx
@@ -46,6 +46,7 @@ type InFilterComponentProps<T = unknown> = FilterTypeComponentProps<
  *         { value: "active", label: "Active" },
  *         { value: "inactive", label: "Inactive" }
  *       ]
+ *       singleSelect: false,
  *     }
  *   }}
  *   value={["active"]}
@@ -136,6 +137,11 @@ export function InFilter<T extends string>({
   const showSearch = options.length > 0 && !isLoading
 
   const handleSelectAll = () => {
+    if (schema.options.singleSelect) {
+      // if is single select skip the select all button
+      return
+    }
+
     const allValues = filteredOptions.map((option) => option.value)
     const currentValues = value ?? []
     const newValues = [...currentValues]
@@ -186,11 +192,17 @@ export function InFilter<T extends string>({
                 focusRing()
               )}
               onClick={() => {
-                onChange(
-                  isSelected
-                    ? value.filter((v) => v !== option.value)
-                    : [...value, option.value]
-                )
+                if (schema.options.singleSelect) {
+                  // If singleSelect is true, replace the entire array with just this value
+                  onChange(isSelected ? [] : [option.value])
+                } else {
+                  // Normal multi-select behavior
+                  onChange(
+                    isSelected
+                      ? value.filter((v) => v !== option.value)
+                      : [...value, option.value]
+                  )
+                }
               }}
             >
               <span className="line-clamp-1 w-fit text-left">
@@ -207,17 +219,24 @@ export function InFilter<T extends string>({
           )
         })}
       </div>
-      <div className="sticky bottom-0 left-0 right-0 flex items-center justify-between gap-2 border border-solid border-transparent border-t-f1-border-secondary bg-f1-background/80 p-2 backdrop-blur-[8px]">
-        <Button
-          variant="outline"
-          label="Select all"
-          onClick={handleSelectAll}
-          disabled={
-            filteredOptions.length === 0 ||
-            (Array.isArray(value) && value.length === filteredOptions.length)
-          }
-          size="sm"
-        />
+      <div
+        className={cn(
+          "sticky bottom-0 left-0 right-0 flex items-center justify-between gap-2 border border-solid border-transparent border-t-f1-border-secondary bg-f1-background/80 p-2 backdrop-blur-[8px]",
+          schema.options.singleSelect ? "justify-end" : "justify-between"
+        )}
+      >
+        {!schema.options.singleSelect && (
+          <Button
+            variant="outline"
+            label="Select all"
+            onClick={handleSelectAll}
+            disabled={
+              filteredOptions.length === 0 ||
+              (Array.isArray(value) && value.length === filteredOptions.length)
+            }
+            size="sm"
+          />
+        )}
         <Button
           variant="ghost"
           label="Clear"

--- a/packages/react/src/experimental/OneDataCollection/Filters/FilterTypes/InFilter/types.ts
+++ b/packages/react/src/experimental/OneDataCollection/Filters/FilterTypes/InFilter/types.ts
@@ -22,6 +22,11 @@ export type InFilterOptions<T> = {
     | (() =>
         | Array<InFilterOptionItem<T>>
         | Promise<Array<InFilterOptionItem<T>>>)
+  /**
+   * When true, only one option can be selected at a time
+   * @default false
+   */
+  singleSelect?: boolean
 }
 
 /**

--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
@@ -32,7 +32,7 @@ import { useData } from "../useData"
 
 const DEPARTMENTS = ["Engineering", "Product", "Design", "Marketing"] as const
 const ROLES = [
-  "Engineer",
+  "Senior Engineer",
   "Product Manager",
   "Designer",
   "Marketing Lead",
@@ -56,6 +56,7 @@ const filters = {
     label: "Role",
     options: {
       options: () => ROLES.map((value) => ({ value, label: value })),
+      singleSelect: true,
     },
   },
   date: {
@@ -108,7 +109,7 @@ const mockUsers: {
     id: "user-1",
     name: "John Doe",
     email: "john@example.com",
-    role: "Senior Engineer",
+    role: ROLES[0],
     department: DEPARTMENTS[0],
     status: "active",
     isStarred: true,
@@ -118,7 +119,7 @@ const mockUsers: {
     id: "user-2",
     name: "Jane Smith",
     email: "jane@example.com",
-    role: "Product Manager",
+    role: ROLES[1],
     department: DEPARTMENTS[1],
     status: "active",
     isStarred: false,
@@ -128,7 +129,7 @@ const mockUsers: {
     id: "user-3",
     name: "Bob Johnson",
     email: "bob@example.com",
-    role: "Designer",
+    role: ROLES[2],
     department: DEPARTMENTS[2],
     status: "inactive",
     isStarred: false,
@@ -138,7 +139,7 @@ const mockUsers: {
     id: "user-4",
     name: "Alice Williams",
     email: "alice@example.com",
-    role: "Marketing Lead",
+    role: ROLES[3],
     department: DEPARTMENTS[3],
     status: "active",
     isStarred: true,
@@ -220,6 +221,14 @@ const filterUsers = <
   ) {
     filteredUsers = filteredUsers.filter((user) =>
       departmentFilterValues.some((d) => d === user.department)
+    )
+  }
+
+  // Handle role filter
+  const roleFilterValues = filterValues.role
+  if (Array.isArray(roleFilterValues) && roleFilterValues.length > 0) {
+    filteredUsers = filteredUsers.filter((user) =>
+      roleFilterValues.some((r) => r === user.role)
     )
   }
 
@@ -1294,6 +1303,17 @@ function createDataAdapter<
       )
     }
 
+    // Apply role filter if provided
+    if (
+      "role" in filters &&
+      Array.isArray(filters.role) &&
+      filters.role.length > 0
+    ) {
+      filteredRecords = filteredRecords.filter((record) =>
+        (filters.role as string[]).includes(record.role as string)
+      )
+    }
+
     // Apply sorting if available
     if (sortingsState) {
       const sortField = sortingsState.field as keyof TRecord
@@ -1940,6 +1960,14 @@ export const WithSyncSearch: Story = {
             )
           }
 
+          // Apply role filter if provided
+          const roleFilter = filters.role as string[] | undefined
+          if (roleFilter && roleFilter.length > 0) {
+            filteredUsers = filteredUsers.filter((user) =>
+              roleFilter.includes(user.role)
+            )
+          }
+
           // Apply sorting if provided
           if (sortings) {
             const field = sortings.field as keyof (typeof mockUserData)[0]
@@ -2084,6 +2112,14 @@ export const WithAsyncSearch: Story = {
               if (departmentFilter && departmentFilter.length > 0) {
                 filteredUsers = filteredUsers.filter((user) =>
                   departmentFilter.includes(user.department)
+                )
+              }
+
+              // Apply role filter if provided
+              const roleFilter = filters.role as string[] | undefined
+              if (roleFilter && roleFilter.length > 0) {
+                filteredUsers = filteredUsers.filter((user) =>
+                  roleFilter.includes(user.role)
                 )
               }
 


### PR DESCRIPTION
## Description

### Added a singleSelect property to the InFilterOptions interface that restricts users to selecting only one option at a time
Modified the InFilter component to:
- Handle single selection behavior (deselecting previous choice when a new one is selected)
- Disable the "Select all" button when in single-select mode
- Updated the role filter in the stories to use this new single-select functionality

## Screenshots (if applicable)

https://github.com/user-attachments/assets/c55e9ebe-955f-4d03-9c64-9817ef01ef48


https://github.com/user-attachments/assets/613bcf01-e767-4914-af03-c9722e3f1d46


<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other


