### PR TITLE
feat: banner

### DIFF
--- a/packages/react/src/experimental/Banner/index.stories.tsx
+++ b/packages/react/src/experimental/Banner/index.stories.tsx
@@ -1,0 +1,80 @@
+// packages/react/src/experimental/Banner/Banner.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react"
+import { Banner } from "."
+
+const meta: Meta<typeof Banner> = {
+  title: "Banner",
+  component: Banner,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "promote"],
+      description: "Banner purpose (activation or upselling)",
+    },
+    primaryAction: {
+      control: "object",
+      description: "Banner primary action",
+    },
+    secondaryAction: {
+      control: "object",
+      description: "Banner secondary actionr",
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Banner>
+
+export const Default: Story = {
+  args: {
+    title: "Complete your financial picture",
+    subtitle:
+      "Without expenses, you're missing half the story. Add them to gain clarity and make better decisions.",
+    image: "https://placehold.co/400x225", // 16:9 ratio
+    variant: "default",
+    primaryAction: {
+      label: "Start now",
+      onClick: () => alert("Request information"),
+    },
+    secondaryAction: {
+      label: "Learn more",
+      onClick: () => alert("Read more"),
+    },
+    onClose: () => alert("Closed"),
+  },
+}
+
+export const Promote: Story = {
+  args: {
+    title: "Try our new feature!",
+    subtitle: "Experience the new dashboard with enhanced analytics.",
+    image: "https://placehold.co/400x225",
+    variant: "promote",
+    primaryAction: {
+      label: "Request information",
+      onClick: () => alert("Try now"),
+    },
+    secondaryAction: {
+      label: "Learn more",
+      onClick: () => alert("Learn more"),
+    },
+    onClose: () => alert("Closed"),
+  },
+}
+
+export const OnlyPrimary: Story = {
+  args: {
+    title: "Upgrade your plan",
+    subtitle: "Access more features and better support.",
+    image: "https://placehold.co/400x225",
+    primaryAction: {
+      label: "Start now",
+      onClick: () => alert("Upgrade"),
+    },
+    onClose: () => alert("Closed"),
+  },
+}

--- a/packages/react/src/experimental/Banner/index.tsx
+++ b/packages/react/src/experimental/Banner/index.tsx
@@ -1,0 +1,91 @@
+// packages/react/src/experimental/Banner/index.tsx
+import { Button } from "@/components/Actions/Button"
+import { X } from "lucide-react"
+import { forwardRef } from "react"
+
+type BannerProps = {
+  title: string
+  subtitle?: string
+  image: string
+  variant?: "default" | "promote"
+  primaryAction?: {
+    label: string
+    icon?: React.ReactNode
+    onClick: () => void
+  }
+  secondaryAction?: {
+    label: string
+    onClick: () => void
+  }
+  onClose?: () => void
+}
+
+export const Banner = forwardRef<HTMLDivElement, BannerProps>(
+  (
+    {
+      title,
+      subtitle,
+      image,
+      variant = "default",
+      primaryAction,
+      secondaryAction,
+      onClose,
+    },
+    ref
+  ) => (
+    <div
+      ref={ref}
+      className="bg-white relative flex w-full flex-col gap-4 rounded-xl border border-f1-border-secondary shadow-md sm:flex-row sm:gap-5"
+    >
+      {/* Imagen 16:9 */}
+      <div className="aspect-video w-full flex-shrink-0 overflow-hidden rounded-xl px-1 pb-0 pt-1 sm:max-w-80 sm:py-1 sm:pl-1">
+        <img
+          src={image}
+          alt=""
+          className="h-full w-full rounded-lg object-cover"
+        />
+      </div>
+
+      {/* Contenido */}
+      <div className="flex flex-col justify-center gap-5 px-3 pb-3 sm:py-3 sm:pl-0 sm:pr-3">
+        <div className="flex w-full flex-col gap-1 sm:max-w-lg">
+          <h3 className="font-bold text-xl text-f1-foreground">{title}</h3>
+          {subtitle && (
+            <p className="text-base text-f1-foreground-secondary">{subtitle}</p>
+          )}
+        </div>
+        <div className="flex gap-3">
+          {primaryAction && (
+            <Button
+              onClick={primaryAction.onClick}
+              label={primaryAction.label}
+              variant={variant}
+              size="md"
+            />
+          )}
+          {secondaryAction && (
+            <Button
+              onClick={secondaryAction.onClick}
+              label={secondaryAction.label}
+              variant="outline"
+              size="md"
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Botón de cerrar */}
+      {onClose && (
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 text-f1-foreground-secondary hover:text-f1-foreground"
+          aria-label="Close"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      )}
+    </div>
+  )
+)
+
+Banner.displayName = "Banner"


### PR DESCRIPTION
## Description

First version of a banner component for activation and upselling. Supports custom content and an optional image. Still early and likely to evolve.

## Screenshots (if applicable)
<img width="910" alt="Captura de pantalla 2025-05-13 a las 8 49 59" src="https://github.com/user-attachments/assets/83086614-5d2a-4667-a700-162e6e996662" />

### Figma Link

🚧 [LINK](https://www.figma.com/design/ByqArcQkGBk6qmWqivXF5Y/28-03-2025---Upselling-Kit?node-id=4311-73546)

---

## Type of Change

- [x] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [x] Component added to `experimental` folder
- [x] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [x] **Responsiveness**

  - [x] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
