### PR TITLE
feat: adding defaultOpen prop to EntitySelector

### DIFF
--- a/packages/react/src/experimental/Forms/EntitySelect/index.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/index.tsx
@@ -365,6 +365,12 @@ export const EntitySelect = (
     props.onOpenChange?.(open)
   }
 
+  useEffect(() => {
+    if (props.defaultOpen) {
+      props.onOpenChange?.(true)
+    }
+  }, [props])
+
   const containerRef = useRef<HTMLDivElement>(null)
   const [containerWidth, setContainerWidth] = useState(0)
 

--- a/packages/react/src/experimental/Forms/EntitySelect/types.ts
+++ b/packages/react/src/experimental/Forms/EntitySelect/types.ts
@@ -42,6 +42,7 @@ interface EntitySelectCommonProps
   selectedLabel?: string
   selectedEntities?: EntitySelectEntity[]
   alwaysOpen?: boolean
+  defaultOpen?: boolean
   width?: number
   hiddenAvatar?: boolean
 }


### PR DESCRIPTION
## Description

We've introduced the `defaultOpen` prop to EntitySelector to allows the component be opened by default

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other

