### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.49.0",
+  "packages/react": "1.50.0",
   "packages/react-native": "0.4.0",
   "packages/core": "1.7.3"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.50.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.49.0...factorial-one-react-v1.50.0) (2025-05-13)
+
+
+### Features
+
+* adding defaultOpen prop to EntitySelector ([#1805](https://github.com/factorialco/factorial-one/issues/1805)) ([d98ecac](https://github.com/factorialco/factorial-one/commit/d98ecaced23d1e80ae1c3147e998c51d79824430))
+
 ## [1.49.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.48.0...factorial-one-react-v1.49.0) (2025-05-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.50.0</summary>

## [1.50.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.49.0...factorial-one-react-v1.50.0) (2025-05-13)


### Features

* adding defaultOpen prop to EntitySelector ([#1805](https://github.com/factorialco/factorial-one/issues/1805)) ([d98ecac](https://github.com/factorialco/factorial-one/commit/d98ecaced23d1e80ae1c3147e998c51d79824430))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).