### PR TITLE
feat: adding clearSearch icon on EntitySelector

### DIFF
--- a/packages/react/src/experimental/Forms/EntitySelect/Content/MainContent/Searcher.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/Content/MainContent/Searcher.tsx
@@ -1,3 +1,4 @@
+import { CrossedCircle } from "@/icons/app"
 import { Search } from "lucide-react"
 import { Icon } from "../../../../../components/Utilities/Icon"
 import { focusNextFocusable, focusPreviousFocusable } from "../../ListItem"
@@ -44,6 +45,14 @@ export const Searcher = ({
         value={search}
         onChange={(e) => onSearch(e.target.value)}
       />
+      {search && (
+        <Icon
+          icon={CrossedCircle}
+          size="md"
+          onClick={() => onSearch("")}
+          className="cursor-pointer text-f1-icon-secondary"
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Description

We've implemented a new icon in order to be able to clear the search in the Entity Selector

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/a0d91680-da5d-4fa3-a6de-bf1de612f259)


## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other


