### PR TITLE
chore(RichTextEditor): remove '@tiptap/extension-image'

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -173,7 +173,6 @@
     "@tiptap/extension-character-count": "^2.11.5",
     "@tiptap/extension-color": "^2.11.5",
     "@tiptap/extension-highlight": "^2.11.5",
-    "@tiptap/extension-image": "^2.11.5",
     "@tiptap/extension-link": "^2.11.5",
     "@tiptap/extension-mention": "^2.11.5",
     "@tiptap/extension-placeholder": "^2.11.5",

--- a/packages/react/src/experimental/RichText/RichTextDisplay/index.stories.tsx
+++ b/packages/react/src/experimental/RichText/RichTextDisplay/index.stories.tsx
@@ -65,9 +65,6 @@ const htmlContent = `<p>
 <pre>
   <code>Good luck guys </code>
 </pre>
-<p></p>
-<img src="https://bmicalculator.mes.fm/img/memes/homer-after-one-day-at-the-gym.jpg" alt="Homer After One Day At the Gym | Memes | BMI Calculator">
-
 `
 
 export const Default: Story = {

--- a/packages/react/src/experimental/RichText/RichTextEditor/utils/extensions/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/utils/extensions/index.tsx
@@ -1,7 +1,6 @@
 import CharacterCount from "@tiptap/extension-character-count"
 import Color from "@tiptap/extension-color"
 import Highlight from "@tiptap/extension-highlight"
-import Image from "@tiptap/extension-image"
 import Link from "@tiptap/extension-link"
 import Placeholder from "@tiptap/extension-placeholder"
 import TaskList from "@tiptap/extension-task-list"
@@ -48,7 +47,6 @@ const ExtensionsConfiguration = ({
     Underline,
     TextStyle,
     Color,
-    Image,
     Typography,
     Highlight,
     TaskList.configure({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,9 +150,6 @@ importers:
       '@tiptap/extension-highlight':
         specifier: ^2.11.5
         version: 2.11.7(@tiptap/core@2.11.7(@tiptap/pm@2.11.7))
-      '@tiptap/extension-image':
-        specifier: ^2.11.5
-        version: 2.11.7(@tiptap/core@2.11.7(@tiptap/pm@2.11.7))
       '@tiptap/extension-link':
         specifier: ^2.11.5
         version: 2.11.7(@tiptap/core@2.11.7(@tiptap/pm@2.11.7))(@tiptap/pm@2.11.7)
@@ -4441,11 +4438,6 @@ packages:
     peerDependencies:
       '@tiptap/core': ^2.7.0
       '@tiptap/pm': ^2.7.0
-
-  '@tiptap/extension-image@2.11.7':
-    resolution: {integrity: sha512-YvCmTDB7Oo+A56tR4S/gcNaYpqU4DDlSQcRp5IQvmQV5EekSe0lnEazGDoqOCwsit9qQhj4MPQJhKrnaWrJUrg==}
-    peerDependencies:
-      '@tiptap/core': ^2.7.0
 
   '@tiptap/extension-italic@2.11.7':
     resolution: {integrity: sha512-r985bkQfG0HMpmCU0X0p/Xe7U1qgRm2mxvcp6iPCuts2FqxaCoyfNZ8YnMsgVK1mRhM7+CQ5SEg2NOmQNtHvPw==}
@@ -15388,10 +15380,6 @@ snapshots:
     dependencies:
       '@tiptap/core': 2.11.7(@tiptap/pm@2.11.7)
       '@tiptap/pm': 2.11.7
-
-  '@tiptap/extension-image@2.11.7(@tiptap/core@2.11.7(@tiptap/pm@2.11.7))':
-    dependencies:
-      '@tiptap/core': 2.11.7(@tiptap/pm@2.11.7)
 
   '@tiptap/extension-italic@2.11.7(@tiptap/core@2.11.7(@tiptap/pm@2.11.7))':
     dependencies:


### PR DESCRIPTION
Deleted image capability from the editor

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [ ] Component added to `experimental` folder
- [ ] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
