### PR TITLE
feat: applying colors on search or select in EntitySelector

### DIFF
--- a/packages/react/src/experimental/Forms/EntitySelect/Content/MainContent/Searcher.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/Content/MainContent/Searcher.tsx
@@ -40,7 +40,7 @@ export const Searcher = ({
         disabled={disabled}
         onKeyDown={handleKeyDown}
         type="text"
-        className="w-full border-none bg-transparent text-f1-foreground-secondary focus:outline-none"
+        className="w-full border-none bg-transparent focus:outline-none"
         placeholder={searchPlaceholder}
         value={search}
         onChange={(e) => onSearch(e.target.value)}

--- a/packages/react/src/experimental/Forms/EntitySelect/Content/MainContent/index.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/Content/MainContent/index.tsx
@@ -402,7 +402,10 @@ export const MainContent = ({
               onChange={onGroupChange}
               options={groups}
               value={selectedGroup}
-              className="h-8 rounded-[10px] bg-transparent py-[5px] text-f1-foreground-secondary"
+              className={cn(
+                "h-8 rounded-[10px] bg-transparent py-[5px]",
+                selectedGroup === "all" ? "text-f1-foreground-secondary" : ""
+              )}
             />
           </div>
         )}


### PR DESCRIPTION
## Description

We've removed the placeholder colors when the user introduced a search or selects a new group in the Entity Selector

## Screenshots (if applicable)

BEFORE

![Captura de pantalla 2025-05-13 a las 18 33 19](https://github.com/user-attachments/assets/f2e6446f-6eea-405f-b7d9-c5ba65c5f452)


NOW

![Captura de pantalla 2025-05-13 a las 18 35 56](https://github.com/user-attachments/assets/528cccd2-aebd-4c8f-8066-eadeffdf3459)


---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other

