### PR TITLE
Fix(Sidebar): Truncate long user names + small visual fixes

### DIFF
--- a/packages/react/src/experimental/Navigation/Sidebar/Footer/index.tsx
+++ b/packages/react/src/experimental/Navigation/Sidebar/Footer/index.tsx
@@ -31,7 +31,7 @@ export function SidebarFooter({
   const i18n = useI18n()
 
   return (
-    <div className="flex flex-row items-center justify-between gap-3 p-3">
+    <div className="flex flex-row items-center justify-between gap-1 p-3">
       <div className="flex-1">
         <Dropdown items={options}>
           <button
@@ -46,7 +46,7 @@ export function SidebarFooter({
               lastName={user.lastName}
               size="xsmall"
             />
-            <span className="min-w-0 truncate text-f1-foreground">
+            <span className="line-clamp-1 flex-1 text-left text-f1-foreground">
               {user.firstName} {user.lastName}
             </span>
           </button>

--- a/packages/react/src/experimental/Navigation/Sidebar/Menu/index.tsx
+++ b/packages/react/src/experimental/Navigation/Sidebar/Menu/index.tsx
@@ -422,8 +422,9 @@ const CategoryItem = ({
         scale: 1.04,
         cursor: "grabbing",
         zIndex: 50,
+        backdropFilter: "blur(4px)",
       }}
-      className="relative backdrop-blur-sm"
+      className="relative"
     >
       {content}
     </Reorder.Item>

--- a/packages/react/src/experimental/Navigation/Sidebar/Sidebar.tsx
+++ b/packages/react/src/experimental/Navigation/Sidebar/Sidebar.tsx
@@ -72,7 +72,7 @@ export function Sidebar({ header, body, footer }: SidebarProps) {
         sidebarState === "locked"
           ? "h-full"
           : cn(
-              "border-solid border-f1-border-secondary shadow-lg backdrop-blur-2xl",
+              "shadow-lg ring-1 ring-f1-border-secondary backdrop-blur-2xl",
               isSmallScreen
                 ? "h-full border-y-transparent border-l-transparent bg-f1-background/90"
                 : "h-[calc(100%-16px)] bg-f1-background/60"


### PR DESCRIPTION
## Description

- Truncate long user names (reported [here](https://factorialteam.slack.com/archives/C082ZNKS403/p1747214357509499))
- Changed floating sidebar border from 2px to 1px (using `ring` now so the border does not takes space)
- Fixed categories background

## Screenshots

<img width="270" alt="Screenshot 2025-05-14 at 12 19 38" src="https://github.com/user-attachments/assets/2fb5e629-0a5c-4662-ba42-e5abd6dba7d7" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other