### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.53.1",
+  "packages/react": "1.53.2",
   "packages/react-native": "0.4.0",
   "packages/core": "1.8.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.53.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.53.1...factorial-one-react-v1.53.2) (2025-05-14)
+
+
+### Bug Fixes
+
+* **Sidebar:** Truncate long user names + small visual fixes ([#1817](https://github.com/factorialco/factorial-one/issues/1817)) ([8d702d3](https://github.com/factorialco/factorial-one/commit/8d702d3453d62b29e84fd292feb71ba66bfc5d7c))
+
 ## [1.53.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.53.0...factorial-one-react-v1.53.1) (2025-05-14)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.53.1",
+  "version": "1.53.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.53.2</summary>

## [1.53.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.53.1...factorial-one-react-v1.53.2) (2025-05-14)


### Bug Fixes

* **Sidebar:** Truncate long user names + small visual fixes ([#1817](https://github.com/factorialco/factorial-one/issues/1817)) ([8d702d3](https://github.com/factorialco/factorial-one/commit/8d702d3453d62b29e84fd292feb71ba66bfc5d7c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).