### PR TITLE
feat(RichTextEditor): add switch button as secondary action

### DIFF
--- a/packages/react/src/experimental/RichText/RichTextEditor/Footer/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/Footer/index.tsx
@@ -6,9 +6,9 @@ import { useEffect, useRef, useState } from "react"
 import { EnhanceActivator } from "../Enhance"
 import { Toolbar, ToolbarDivider } from "../Toolbar"
 import {
-  actionType,
   enhanceConfig,
   primaryActionType,
+  secondaryActionType,
   toolbarLabels,
 } from "../utils/types"
 import { ActionsMenu } from "./ActionsMenu"
@@ -16,7 +16,7 @@ import { ActionsMenu } from "./ActionsMenu"
 interface FooterProps {
   editor: Editor
   maxCharacters: number | undefined
-  secondaryAction: actionType | undefined
+  secondaryAction: secondaryActionType | undefined
   primaryAction: primaryActionType | undefined
   fileInputRef: React.RefObject<HTMLInputElement>
   canUseFiles: boolean

--- a/packages/react/src/experimental/RichText/RichTextEditor/index.stories.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/index.stories.tsx
@@ -1,4 +1,3 @@
-import { Calendar } from "@/icons/app"
 import type { Meta, StoryObj } from "@storybook/react"
 import { EnhancementOption, FILE_TYPES, resultType, RichTextEditor } from "."
 
@@ -218,7 +217,6 @@ export const Default: Story = {
         {
           label: "Add tomorrow",
           onClick: () => alert("Add tomorrow"),
-          icon: Calendar,
         },
         {
           label: "Add next week",
@@ -227,9 +225,11 @@ export const Default: Story = {
       ],
     },
     secondaryAction: {
+      type: "switch",
       label: "Cancel",
-      onClick: () => alert("Cancel"),
+      onClick: () => {},
       variant: "outline",
+      checked: true,
     },
     toolbarLabels: {
       bold: "Bold",

--- a/packages/react/src/experimental/RichText/RichTextEditor/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/index.tsx
@@ -30,7 +30,6 @@ import {
   setupContainerObservers,
 } from "./utils/helpers"
 import {
-  actionType,
   editorStateType,
   enhanceConfig,
   errorConfig,
@@ -41,6 +40,7 @@ import {
   mentionsConfig,
   primaryActionType,
   resultType,
+  secondaryActionType,
   toolbarLabels,
 } from "./utils/types"
 
@@ -48,7 +48,7 @@ interface RichTextEditorProps {
   mentionsConfig?: mentionsConfig
   enhanceConfig?: enhanceConfig
   filesConfig?: filesConfig
-  secondaryAction?: actionType
+  secondaryAction?: secondaryActionType
   primaryAction?: primaryActionType
   onChange: (result: resultType) => void
   maxCharacters?: number

--- a/packages/react/src/experimental/RichText/RichTextEditor/utils/types.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/utils/types.tsx
@@ -76,6 +76,18 @@ type actionType = {
   icon?: IconType
 }
 
+type toggleActionType = {
+  label: string
+  checked: boolean
+  onClick: (checked?: boolean) => void
+  disabled?: boolean
+  hideLabel?: boolean
+}
+
+type secondaryActionType = (actionType | toggleActionType) & {
+  type?: "button" | "switch"
+}
+
 type subActionType = {
   label: string
   onClick: () => void
@@ -157,6 +169,7 @@ export type {
   mentionsConfig,
   primaryActionType,
   resultType,
+  secondaryActionType,
   subActionType,
   toolbarLabels,
 }


### PR DESCRIPTION
## Description

Added support to switch button inside secondary actions

## Screenshots (if applicable)

![Captura de pantalla 2025-05-14 a las 13 38 00](https://github.com/user-attachments/assets/4cc642ec-6062-430a-93df-bbc2ba58ceac)

### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [ ] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [ ] Component added to `experimental` folder
- [ ] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [ ] **Testing**

  - [ ] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
