### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.53.2",
+  "packages/react": "1.54.0",
   "packages/react-native": "0.4.0",
   "packages/core": "1.8.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.54.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.53.2...factorial-one-react-v1.54.0) (2025-05-14)
+
+
+### Features
+
+* **DataCollection:** support multiple dotTags ([#1729](https://github.com/factorialco/factorial-one/issues/1729)) ([eee963c](https://github.com/factorialco/factorial-one/commit/eee963c2560c07b42aafbba04c9d09d6597f977f))
+
 ## [1.53.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.53.1...factorial-one-react-v1.53.2) (2025-05-14)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.53.2",
+  "version": "1.54.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.54.0</summary>

## [1.54.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.53.2...factorial-one-react-v1.54.0) (2025-05-14)


### Features

* **DataCollection:** support multiple dotTags ([#1729](https://github.com/factorialco/factorial-one/issues/1729)) ([eee963c](https://github.com/factorialco/factorial-one/commit/eee963c2560c07b42aafbba04c9d09d6597f977f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).