### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.55.0",
+  "packages/react": "1.56.0",
   "packages/react-native": "0.4.0",
   "packages/core": "1.8.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.56.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.55.0...factorial-one-react-v1.56.0) (2025-05-16)
+
+
+### Features
+
+* internal component select asList mode ([#1809](https://github.com/factorialco/factorial-one/issues/1809)) ([73f721c](https://github.com/factorialco/factorial-one/commit/73f721c9dba0b945e4eeb6f52cef4808f11d1adf))
+
 ## [1.55.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.54.0...factorial-one-react-v1.55.0) (2025-05-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.56.0</summary>

## [1.56.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.55.0...factorial-one-react-v1.56.0) (2025-05-16)


### Features

* internal component select asList mode ([#1809](https://github.com/factorialco/factorial-one/issues/1809)) ([73f721c](https://github.com/factorialco/factorial-one/commit/73f721c9dba0b945e4eeb6f52cef4808f11d1adf))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).