### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.56.0",
+  "packages/react": "1.56.1",
   "packages/react-native": "0.4.0",
   "packages/core": "1.8.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.56.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.56.0...factorial-one-react-v1.56.1) (2025-05-16)
+
+
+### Bug Fixes
+
+* add support to know when user reaches end of ActivityItem list ([#1822](https://github.com/factorialco/factorial-one/issues/1822)) ([d773a33](https://github.com/factorialco/factorial-one/commit/d773a33c713bfe4976868064eb6359fa2d460cbd))
+
 ## [1.56.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.55.0...factorial-one-react-v1.56.0) (2025-05-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.56.1</summary>

## [1.56.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.56.0...factorial-one-react-v1.56.1) (2025-05-16)


### Bug Fixes

* add support to know when user reaches end of ActivityItem list ([#1822](https://github.com/factorialco/factorial-one/issues/1822)) ([d773a33](https://github.com/factorialco/factorial-one/commit/d773a33c713bfe4976868064eb6359fa2d460cbd))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).