### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.56.1",
+  "packages/react": "1.57.0",
   "packages/react-native": "0.4.0",
   "packages/core": "1.8.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.57.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.56.1...factorial-one-react-v1.57.0) (2025-05-16)
+
+
+### Features
+
+* **RichTextEditor:** enhance secondary action handling with toggle support ([#1819](https://github.com/factorialco/factorial-one/issues/1819)) ([aa7018e](https://github.com/factorialco/factorial-one/commit/aa7018e34b7fbade41f78a734a3453d567695e8e))
+
 ## [1.56.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.56.0...factorial-one-react-v1.56.1) (2025-05-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.56.1",
+  "version": "1.57.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.57.0</summary>

## [1.57.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.56.1...factorial-one-react-v1.57.0) (2025-05-16)


### Features

* **RichTextEditor:** enhance secondary action handling with toggle support ([#1819](https://github.com/factorialco/factorial-one/issues/1819)) ([aa7018e](https://github.com/factorialco/factorial-one/commit/aa7018e34b7fbade41f78a734a3453d567695e8e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).