### PR TITLE
fix: add support to show activity item skeletons when loading more items on list

### DIFF
--- a/packages/react/src/experimental/Information/Activity/ActivityItemList/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Activity/ActivityItemList/index.stories.tsx
@@ -62,6 +62,13 @@ export const Default: Story = {
   },
 }
 
+export const LoadingMoreItems: Story = {
+  args: {
+    items: ITEMS,
+    loadingMoreItems: true,
+  },
+}
+
 export const Skeleton: Story = {
   args: {},
   render: () => <ActivityItemList.Skeleton />,

--- a/packages/react/src/experimental/Information/Activity/ActivityItemList/index.tsx
+++ b/packages/react/src/experimental/Information/Activity/ActivityItemList/index.tsx
@@ -3,7 +3,10 @@ import { useI18n } from "@/lib/providers/i18n"
 import { withSkeleton } from "@/lib/skeleton"
 import throttle from "lodash/throttle"
 import React from "react"
+import { ActivityItem } from "../ActivityItem"
 import { Section, SectionProps } from "./Section"
+
+const MORE_ITEMS_LOADING_COUNT = 3
 
 export type ActivityItemListProps = Pick<
   SectionProps,
@@ -11,6 +14,7 @@ export type ActivityItemListProps = Pick<
 > & {
   onEndReached?: () => void
   onEndReachedItemsThreshold?: number
+  loadingMoreItems?: boolean
 }
 
 const Separator = () => (
@@ -19,6 +23,7 @@ const Separator = () => (
 
 export const BaseActivityItemList = ({
   items,
+  loadingMoreItems = false,
   onClickItem,
   onEndReached,
   onEndReachedItemsThreshold = 5,
@@ -38,25 +43,31 @@ export const BaseActivityItemList = ({
     }
   }, 1000)
 
+  const groups = Object.entries(categorizedItems).filter(
+    ([_, items]) => !!items.length
+  )
+
   return (
     <div className="flex flex-col gap-2 px-2">
-      {Object.entries(categorizedItems)
-        .filter(([_, items]) => !!items.length)
-        .map(([group, items]) => (
-          <React.Fragment key={group}>
-            <Section
-              title={
-                translations.date.groups[
-                  group as keyof typeof translations.date.groups
-                ]
-              }
-              items={items}
-              onClickItem={onClickItem}
-              onItemVisible={handleItemVisible}
-            />
-            <Separator />
-          </React.Fragment>
-        ))}
+      {groups.map(([group, items], index) => (
+        <React.Fragment key={group}>
+          <Section
+            title={
+              translations.date.groups[
+                group as keyof typeof translations.date.groups
+              ]
+            }
+            items={items}
+            onClickItem={onClickItem}
+            onItemVisible={handleItemVisible}
+          />
+          {index !== groups.length - 1 && <Separator />}
+        </React.Fragment>
+      ))}
+      {loadingMoreItems &&
+        new Array(MORE_ITEMS_LOADING_COUNT)
+          .fill(null)
+          .map((_, index) => <ActivityItem.Skeleton key={index} />)}
     </div>
   )
 }


### PR DESCRIPTION
<img width="476" alt="Screenshot 2025-05-16 at 15 20 44" src="https://github.com/user-attachments/assets/a2ede072-339e-4a04-9498-b0892ff1b74d" />
