### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.57.0",
+  "packages/react": "1.57.1",
   "packages/react-native": "0.4.0",
   "packages/core": "1.8.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.57.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.57.0...factorial-one-react-v1.57.1) (2025-05-16)
+
+
+### Bug Fixes
+
+* add support to show activity item skeletons when loading more items on list ([#1832](https://github.com/factorialco/factorial-one/issues/1832)) ([745f21d](https://github.com/factorialco/factorial-one/commit/745f21dc5d45361d087da6f39fe520c99aba61c5))
+
 ## [1.57.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.56.1...factorial-one-react-v1.57.0) (2025-05-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.57.1</summary>

## [1.57.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.57.0...factorial-one-react-v1.57.1) (2025-05-16)


### Bug Fixes

* add support to show activity item skeletons when loading more items on list ([#1832](https://github.com/factorialco/factorial-one/issues/1832)) ([745f21d](https://github.com/factorialco/factorial-one/commit/745f21dc5d45361d087da6f39fe520c99aba61c5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).