### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.57.1",
+  "packages/react": "1.57.2",
   "packages/react-native": "0.4.0",
   "packages/core": "1.8.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.57.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.57.1...factorial-one-react-v1.57.2) (2025-05-16)
+
+
+### Bug Fixes
+
+* pageHeader prev next button reload page ([#1835](https://github.com/factorialco/factorial-one/issues/1835)) ([9f24d46](https://github.com/factorialco/factorial-one/commit/9f24d4674a441dbbef66c3daa2d70edb6f7b8a01))
+
 ## [1.57.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.57.0...factorial-one-react-v1.57.1) (2025-05-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.57.1",
+  "version": "1.57.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.57.2</summary>

## [1.57.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.57.1...factorial-one-react-v1.57.2) (2025-05-16)


### Bug Fixes

* pageHeader prev next button reload page ([#1835](https://github.com/factorialco/factorial-one/issues/1835)) ([9f24d46](https://github.com/factorialco/factorial-one/commit/9f24d4674a441dbbef66c3daa2d70edb6f7b8a01))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).