### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.57.2",
+  "packages/react": "1.58.0",
   "packages/react-native": "0.4.0",
-  "packages/core": "1.8.0"
+  "packages/core": "1.9.0"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.9.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.8.0...factorial-one-core-v1.9.0) (2025-05-19)
+
+
+### Features
+
+* icons for meetings ([55b38e3](https://github.com/factorialco/factorial-one/commit/55b38e3faee0aa36513be485b07a72d889a6183d))
+
 ## [1.8.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.7.3...factorial-one-core-v1.8.0) (2025-05-13)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.58.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.57.2...factorial-one-react-v1.58.0) (2025-05-19)
+
+
+### Features
+
+* icons for meetings ([55b38e3](https://github.com/factorialco/factorial-one/commit/55b38e3faee0aa36513be485b07a72d889a6183d))
+
 ## [1.57.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.57.1...factorial-one-react-v1.57.2) (2025-05-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.57.2",
+  "version": "1.58.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.58.0</summary>

## [1.58.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.57.2...factorial-one-react-v1.58.0) (2025-05-19)


### Features

* icons for meetings ([55b38e3](https://github.com/factorialco/factorial-one/commit/55b38e3faee0aa36513be485b07a72d889a6183d))
</details>

<details><summary>factorial-one-core: 1.9.0</summary>

## [1.9.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.8.0...factorial-one-core-v1.9.0) (2025-05-19)


### Features

* icons for meetings ([55b38e3](https://github.com/factorialco/factorial-one/commit/55b38e3faee0aa36513be485b07a72d889a6183d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).