### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.59.0",
+  "packages/react": "1.59.1",
   "packages/react-native": "0.4.0",
   "packages/core": "1.9.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.59.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.59.0...factorial-one-react-v1.59.1) (2025-05-20)
+
+
+### Bug Fixes
+
+* missing datacollection filterNavigatioln types exports ([#1846](https://github.com/factorialco/factorial-one/issues/1846)) ([b19aa76](https://github.com/factorialco/factorial-one/commit/b19aa760907141a107e899d2f895abf009f17004))
+
 ## [1.59.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.58.0...factorial-one-react-v1.59.0) (2025-05-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.59.1</summary>

## [1.59.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.59.0...factorial-one-react-v1.59.1) (2025-05-20)


### Bug Fixes

* missing datacollection filterNavigatioln types exports ([#1846](https://github.com/factorialco/factorial-one/issues/1846)) ([b19aa76](https://github.com/factorialco/factorial-one/commit/b19aa760907141a107e899d2f895abf009f17004))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).