### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.59.1",
+  "packages/react": "1.60.0",
   "packages/react-native": "0.4.0",
   "packages/core": "1.9.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.60.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.59.1...factorial-one-react-v1.60.0) (2025-05-20)
+
+
+### Features
+
+* **UpsellingKit:** new product widget ([#1845](https://github.com/factorialco/factorial-one/issues/1845)) ([023b8e4](https://github.com/factorialco/factorial-one/commit/023b8e40466d161c0a7e46d5c762ce353b49ccff))
+
 ## [1.59.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.59.0...factorial-one-react-v1.59.1) (2025-05-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.59.1",
+  "version": "1.60.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.60.0</summary>

## [1.60.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.59.1...factorial-one-react-v1.60.0) (2025-05-20)


### Features

* **UpsellingKit:** new product widget ([#1845](https://github.com/factorialco/factorial-one/issues/1845)) ([023b8e4](https://github.com/factorialco/factorial-one/commit/023b8e40466d161c0a7e46d5c762ce353b49ccff))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).