### PR TITLE
chore: release main

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 * **UpsellingKit:** new product widget ([#1845](https://github.com/factorialco/factorial-one/issues/1845)) ([023b8e4](https://github.com/factorialco/factorial-one/commit/023b8e40466d161c0a7e46d5c762ce353b49ccff))
 
+
+### Bug Fixes
+
+* companySelector ellipsis ([#1849](https://github.com/factorialco/factorial-one/issues/1849)) ([71667f5](https://github.com/factorialco/factorial-one/commit/71667f5fd47847f200db1d5b899b07fc1a669fd4))
+
 ## [1.59.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.59.0...factorial-one-react-v1.59.1) (2025-05-20)
 
 


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.60.0</summary>

## [1.60.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.59.1...factorial-one-react-v1.60.0) (2025-05-20)


### Features

* **UpsellingKit:** new product widget ([#1845](https://github.com/factorialco/factorial-one/issues/1845)) ([023b8e4](https://github.com/factorialco/factorial-one/commit/023b8e40466d161c0a7e46d5c762ce353b49ccff))


### Bug Fixes

* companySelector ellipsis ([#1849](https://github.com/factorialco/factorial-one/issues/1849)) ([71667f5](https://github.com/factorialco/factorial-one/commit/71667f5fd47847f200db1d5b899b07fc1a669fd4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).