### PR TITLE
feat: show less than 2 actions in modal header without dropdown

### DIFF
--- a/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
@@ -25,6 +25,36 @@ export const OneModalHeader = ({
     modalPosition === "center" ? "text-lg" : "text-xl"
   )
 
+  const Divider = () => {
+    return <div className="h-4 w-px self-center bg-f1-background-secondary" />
+  }
+
+  const otherActionItems =
+    otherActions?.filter((action) => action.type !== "separator") ?? []
+
+  const Actions = () => {
+    if (!otherActionItems.length || !otherActions) return null
+
+    if (otherActionItems.length <= 2) {
+      return (
+        <div className="flex flex-row gap-2">
+          {otherActionItems.map((action) => (
+            <ButtonInternal
+              key={action.label}
+              variant="outline"
+              icon={action.icon}
+              onClick={action.onClick}
+              label={action.label}
+              hideLabel
+            />
+          ))}
+        </div>
+      )
+    }
+
+    return <DropdownInternal items={otherActions} />
+  }
+
   if (modalPosition === "right" && !shownBottomSheet) {
     return (
       <div className="flex flex-col gap-3 px-4 py-4">
@@ -36,7 +66,7 @@ export const OneModalHeader = ({
             label="Close modal"
             hideLabel
           />
-          {!!otherActions?.length && <DropdownInternal items={otherActions} />}
+          <Actions />
         </div>
         <DialogTitle className={cn(dialogClassName, "text-2xl")}>
           {title}
@@ -53,7 +83,8 @@ export const OneModalHeader = ({
         <DrawerTitle className={dialogClassName}>{title}</DrawerTitle>
       )}
       <div className="flex flex-row gap-2">
-        {!!otherActions?.length && <DropdownInternal items={otherActions} />}
+        <Actions />
+        {otherActions && <Divider />}
         <ButtonInternal
           variant="outline"
           icon={CrossIcon}


### PR DESCRIPTION
## Description

When `otherActions` prop passed to `OneModal.Header` has 2 items at most it will show up without a dropdown. That will allow us to put the settings button visible as required by design in our upcoming notifications modal in frontend.

## Screenshots

<img width="797" alt="Screenshot 2025-05-21 at 08 45 03" src="https://github.com/user-attachments/assets/3b9672df-28f4-45aa-9ee5-c024fa760fc7" />
