### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.60.0",
+  "packages/react": "1.61.0",
   "packages/react-native": "0.5.0",
   "packages/core": "1.9.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.61.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.60.0...factorial-one-react-v1.61.0) (2025-05-21)
+
+
+### Features
+
+* show less than 2 actions in modal header without dropdown ([#1853](https://github.com/factorialco/factorial-one/issues/1853)) ([5967a6d](https://github.com/factorialco/factorial-one/commit/5967a6ded7ee5f218b5a6c71a24acf44802fb3ba))
+
 ## [1.60.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.59.1...factorial-one-react-v1.60.0) (2025-05-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.61.0</summary>

## [1.61.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.60.0...factorial-one-react-v1.61.0) (2025-05-21)


### Features

* show less than 2 actions in modal header without dropdown ([#1853](https://github.com/factorialco/factorial-one/issues/1853)) ([5967a6d](https://github.com/factorialco/factorial-one/commit/5967a6ded7ee5f218b5a6c71a24acf44802fb3ba))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).