### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.61.1",
+  "packages/react": "1.62.0",
   "packages/react-native": "0.5.0",
-  "packages/core": "1.9.0"
+  "packages/core": "1.10.0"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.10.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.9.0...factorial-one-core-v1.10.0) (2025-05-21)
+
+
+### Features
+
+* videorecorder and microphone icons ([420c16f](https://github.com/factorialco/factorial-one/commit/420c16f1d27417e1d271c68bd1a59c571945903c))
+
 ## [1.9.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.8.0...factorial-one-core-v1.9.0) (2025-05-19)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.62.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.61.1...factorial-one-react-v1.62.0) (2025-05-21)
+
+
+### Features
+
+* videorecorder and microphone icons ([420c16f](https://github.com/factorialco/factorial-one/commit/420c16f1d27417e1d271c68bd1a59c571945903c))
+
 ## [1.61.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.61.0...factorial-one-react-v1.61.1) (2025-05-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.61.1",
+  "version": "1.62.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.62.0</summary>

## [1.62.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.61.1...factorial-one-react-v1.62.0) (2025-05-21)


### Features

* videorecorder and microphone icons ([420c16f](https://github.com/factorialco/factorial-one/commit/420c16f1d27417e1d271c68bd1a59c571945903c))
</details>

<details><summary>factorial-one-core: 1.10.0</summary>

## [1.10.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.9.0...factorial-one-core-v1.10.0) (2025-05-21)


### Features

* videorecorder and microphone icons ([420c16f](https://github.com/factorialco/factorial-one/commit/420c16f1d27417e1d271c68bd1a59c571945903c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).