### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.62.0",
+  "packages/react": "1.62.1",
   "packages/react-native": "0.5.0",
   "packages/core": "1.10.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.62.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.62.0...factorial-one-react-v1.62.1) (2025-05-22)
+
+
+### Bug Fixes
+
+* itemUrl and onClick in datacollection cards view ([#1830](https://github.com/factorialco/factorial-one/issues/1830)) ([5ce1121](https://github.com/factorialco/factorial-one/commit/5ce1121243ca568e21097d8efa3aff0d1b385829))
+
 ## [1.62.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.61.1...factorial-one-react-v1.62.0) (2025-05-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.62.0",
+  "version": "1.62.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.62.1</summary>

## [1.62.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.62.0...factorial-one-react-v1.62.1) (2025-05-22)


### Bug Fixes

* itemUrl and onClick in datacollection cards view ([#1830](https://github.com/factorialco/factorial-one/issues/1830)) ([5ce1121](https://github.com/factorialco/factorial-one/commit/5ce1121243ca568e21097d8efa3aff0d1b385829))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).