### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.64.1",
-  "packages/react-native": "0.5.0",
+  "packages/react-native": "0.6.0",
   "packages/core": "1.11.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.5.0...factorial-one-react-native-v0.6.0) (2025-05-22)
+
+
+### Features
+
+* new f1 react native buttons ([#1854](https://github.com/factorialco/factorial-one/issues/1854)) ([3f1ad8e](https://github.com/factorialco/factorial-one/commit/3f1ad8ea127ce1629a86a7706d99cc9cba019886))
+
 ## [0.5.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.4.0...factorial-one-react-native-v0.5.0) (2025-05-21)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.6.0</summary>

## [0.6.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.5.0...factorial-one-react-native-v0.6.0) (2025-05-22)


### Features

* new f1 react native buttons ([#1854](https://github.com/factorialco/factorial-one/issues/1854)) ([3f1ad8e](https://github.com/factorialco/factorial-one/commit/3f1ad8ea127ce1629a86a7706d99cc9cba019886))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).