### PR TITLE
Update internal state when favorites prop changes

### DIFF
--- a/packages/react/src/experimental/Navigation/Sidebar/Menu/index.tsx
+++ b/packages/react/src/experimental/Navigation/Sidebar/Menu/index.tsx
@@ -5,7 +5,14 @@ import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils"
 import { Collapsible, CollapsibleContent } from "@/ui/collapsible"
 import { LayoutGroup, motion, Reorder, useDragControls } from "framer-motion"
-import React, { useEffect, useRef, useState } from "react"
+import {
+  ReactNode,
+  RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import {
   ChevronDown,
   Delete,
@@ -109,7 +116,7 @@ const FavoriteItem = ({
   onMove,
 }: {
   item: FavoriteMenuItem
-  dragConstraints?: React.RefObject<HTMLElement>
+  dragConstraints?: RefObject<HTMLElement>
   onRemove?: (item: FavoriteMenuItem) => void
   index: number
   total: number
@@ -122,7 +129,7 @@ const FavoriteItem = ({
   const { isActive } = useNavigation()
   const active = isActive(item.href, { exact: item.exactMatch })
   const wasDragging = useRef(false)
-  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false)
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const isFirst = index === 0
   const isLast = index === total - 1
   const isOnly = total === 1
@@ -246,9 +253,9 @@ interface BaseCategoryProps {
   isOpen?: boolean
   isRoot?: boolean
   onCollapse?: (isOpen: boolean) => void
-  children?: React.ReactNode
+  children?: ReactNode
   isDragging?: boolean
-  wasDragging?: React.RefObject<boolean>
+  wasDragging?: RefObject<boolean>
 }
 
 const BaseCategory = ({
@@ -260,7 +267,7 @@ const BaseCategory = ({
   isDragging,
   wasDragging,
 }: BaseCategoryProps) => {
-  const [isOpen, setIsOpen] = React.useState(initialIsOpen)
+  const [isOpen, setIsOpen] = useState(initialIsOpen)
   const shouldReduceMotion = useReducedMotion()
 
   const handleClick = () => {
@@ -328,7 +335,7 @@ const BaseCategory = ({
 interface CategoryItemProps {
   category: MenuCategory
   isSortable?: boolean
-  dragConstraints?: React.RefObject<HTMLDivElement>
+  dragConstraints?: RefObject<HTMLDivElement>
   onCollapse?: (category: MenuCategory, isOpen: boolean) => void
   onDragEnd?: (categories: MenuCategory[]) => void
   currentOrder?: MenuCategory[]
@@ -442,16 +449,16 @@ export function Menu({
   const nonSortableItems = tree.filter(
     (category) => category.isSortable === false
   )
-  const [sortableItems, setSortableItems] = React.useState(
+  const [sortableItems, setSortableItems] = useState(
     tree.filter((category) => category.isSortable !== false)
   )
   const [forceUpdateKey, setForceUpdateKey] = useState(0)
 
-  const handleSort = React.useCallback((newOrder: MenuCategory[]) => {
+  const handleSort = useCallback((newOrder: MenuCategory[]) => {
     setSortableItems(newOrder)
   }, [])
 
-  const handleDragEnd = React.useCallback(
+  const handleDragEnd = useCallback(
     (newOrder: MenuCategory[]) => {
       onSort?.(newOrder)
     },
@@ -485,14 +492,14 @@ function MenuContent({
   containerRef,
   onCollapse,
   onDragEnd,
-  favorites,
+  favorites = [],
   onFavoritesChange,
   forceUpdate,
 }: {
   nonSortableItems: MenuCategory[]
   sortableItems: MenuCategory[]
   setSortableItems: (items: MenuCategory[]) => void
-  containerRef: React.RefObject<HTMLDivElement>
+  containerRef: RefObject<HTMLDivElement>
   onCollapse?: (category: MenuCategory, isOpen: boolean) => void
   onDragEnd?: (categories: MenuCategory[]) => void
   favorites?: FavoriteMenuItem[]
@@ -507,12 +514,15 @@ function MenuContent({
     nonSortableItems.filter((category) => !category.isRoot).length > 0
   const hasSortableItems = sortableItems.length > 0
   const favoritesRef = useRef<HTMLDivElement>(null)
-  const [currentFavorites, setCurrentFavorites] = React.useState<
-    FavoriteMenuItem[]
-  >(favorites || [])
-  const hasFavorites = (favorites || []).length > 0
+  const [currentFavorites, setCurrentFavorites] =
+    useState<FavoriteMenuItem[]>(favorites)
+  const hasFavorites = favorites.length > 0
 
-  const handleFavoritesReorder = React.useCallback(
+  useEffect(() => {
+    setCurrentFavorites(favorites)
+  }, [favorites])
+
+  const handleFavoritesReorder = useCallback(
     (newOrder: FavoriteMenuItem[]) => {
       setCurrentFavorites(newOrder)
       onFavoritesChange?.(newOrder)
@@ -520,7 +530,7 @@ function MenuContent({
     [onFavoritesChange]
   )
 
-  const handleRemoveFavorite = React.useCallback(
+  const handleRemoveFavorite = useCallback(
     (item: FavoriteMenuItem) => {
       const updated = currentFavorites.filter((fav) => fav.href !== item.href)
       setCurrentFavorites(updated)
@@ -529,7 +539,7 @@ function MenuContent({
     [currentFavorites, onFavoritesChange]
   )
 
-  const handleMoveFavorite = React.useCallback(
+  const handleMoveFavorite = useCallback(
     (from: number, to: number) => {
       if (to < 0 || to >= currentFavorites.length) return
       const updated = [...currentFavorites]
@@ -541,7 +551,7 @@ function MenuContent({
     [currentFavorites, onFavoritesChange]
   )
 
-  const [isInitialized, setIsInitialized] = React.useState(false)
+  const [isInitialized, setIsInitialized] = useState(false)
   const resizeTimeoutRef = useRef<number | null>(null)
 
   // Initialize once when component mounts
@@ -608,7 +618,7 @@ function MenuContent({
               >
                 {currentFavorites.map((item, idx) => (
                   <FavoriteItem
-                    key={item.href}
+                    key={`${item.href}-${item.label}`}
                     item={item}
                     dragConstraints={favoritesRef}
                     onRemove={handleRemoveFavorite}


### PR DESCRIPTION
## Description

Favorites items are uncontrolled. The component receives first passed favorite items to set the state and new favorites prop value is ignored.

## Solution

Adds a `useEffect` to sync props with state. I am not entirely sure whether or not we need a state here. It is definitely helps us to be optimistic, hiding items before we actually stored the change. At the same time it could be confusing in cases of error - the item will reappear on the next reload.