### PR TITLE
fix: add missing OneModal footer component

### DIFF
--- a/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
@@ -1,3 +1,4 @@
+import { ButtonInternal } from "@/components/Actions/Button/internal"
 import {
   OnePersonListItem,
   OnePersonListItemProps,
@@ -5,6 +6,8 @@ import {
 import { Default as OnePersonListItemDefault } from "@/experimental/Lists/OnePersonListItem/index.stories"
 import { ApplicationFrame } from "@/experimental/Navigation/ApplicationFrame"
 import ApplicationFrameStoryMeta from "@/experimental/Navigation/ApplicationFrame/index.stories"
+import CheckDoubleIcon from "@/icons/app/CheckDouble"
+import CrossIcon from "@/icons/app/Cross"
 import DeleteIcon from "@/icons/app/Delete"
 import PencilIcon from "@/icons/app/Pencil"
 import type { Meta, StoryObj } from "@storybook/react"
@@ -143,12 +146,28 @@ export const WithRightPosition: Story = {
 export const WithFewItems: Story = {
   args: {
     ...Default.args,
+    position: "right",
     children: (
       <>
         <OneModal.Header title="Team Status" otherActions={OTHER_ACTIONS} />
         <OneModal.Content tabs={TABS}>
           <ExamplePersonList numberOfItems={3} />
         </OneModal.Content>
+        <OneModal.Footer>
+          <div className="flex flex-1 flex-row gap-3">
+            <ButtonInternal
+              label="Approve"
+              icon={CheckDoubleIcon}
+              onClick={() => {}}
+            />
+            <ButtonInternal
+              label="Reject"
+              icon={CrossIcon}
+              variant="critical"
+              onClick={() => {}}
+            />
+          </div>
+        </OneModal.Footer>
       </>
     ),
   },

--- a/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
@@ -77,7 +77,7 @@ export const OneModal: React.FC<OneModalProps> = ({
   }
 
   let contentClassName =
-    "max-h-[620px] max-w-[680px] overflow-y-auto overflow-x-hidden"
+    "flex flex-col max-h-[620px] max-w-[680px] overflow-hidden"
 
   const isSidePosition = position === "left" || position === "right"
 

--- a/packages/react/src/experimental/Modals/OneModal/OneModalContent/OneModalContent.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalContent/OneModalContent.tsx
@@ -31,7 +31,7 @@ export const OneModalContent = ({
       )}
       <ScrollArea
         className={cn(
-          "[*[data-state=visible]_div]:bg-f1-background flex flex-col",
+          "[*[data-state=visible]_div]:bg-f1-background flex flex-1 flex-col",
           !isSmallScreen && modalPosition === "center" && "max-h-[512px]"
         )}
       >

--- a/packages/react/src/experimental/Modals/OneModal/OneModalFooter/OneModalFooter.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalFooter/OneModalFooter.tsx
@@ -1,0 +1,11 @@
+export type OneModalFooterProps = {
+  children: React.ReactNode
+}
+
+export const OneModalFooter = ({ children }: OneModalFooterProps) => {
+  return (
+    <div className="flex min-h-18 flex-row items-center justify-between border-x-0 border-b-0 border-t border-solid border-f1-border-secondary bg-f1-background p-4">
+      {children}
+    </div>
+  )
+}

--- a/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
@@ -57,7 +57,7 @@ export const OneModalHeader = ({
 
   if (modalPosition === "right" && !shownBottomSheet) {
     return (
-      <div className="flex flex-col gap-3 px-4 py-4">
+      <div className="flex flex-col gap-3 bg-f1-background p-4">
         <div className="flex flex-row justify-between">
           <ButtonInternal
             variant="outline"
@@ -76,7 +76,7 @@ export const OneModalHeader = ({
   }
 
   return (
-    <div className="flex flex-row items-center justify-between px-4 py-4">
+    <div className="flex flex-row items-center justify-between bg-f1-background p-4">
       {!shownBottomSheet ? (
         <DialogTitle className={dialogClassName}>{title}</DialogTitle>
       ) : (

--- a/packages/react/src/experimental/Modals/OneModal/index.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/index.tsx
@@ -1,15 +1,18 @@
 import { OneModal } from "./OneModal"
 import { OneModalContent } from "./OneModalContent/OneModalContent"
+import { OneModalFooter } from "./OneModalFooter/OneModalFooter"
 import { OneModalHeader } from "./OneModalHeader/OneModalHeader"
 
 type OneModalComponent = typeof OneModal & {
   Header: typeof OneModalHeader
   Content: typeof OneModalContent
+  Footer: typeof OneModalFooter
 }
 
 const ComposedOneModal = OneModal as OneModalComponent
 
 ComposedOneModal.Header = OneModalHeader
 ComposedOneModal.Content = OneModalContent
+ComposedOneModal.Footer = OneModalFooter
 
 export { ComposedOneModal as OneModal }


### PR DESCRIPTION
## Description

We were missing the `OneModal.Footer` component that will allow to us to put extra content such as buttons at the bottom of our modals.

## Screenshots

<img width="594" alt="Screenshot 2025-05-23 at 16 22 45" src="https://github.com/user-attachments/assets/e9591c45-dc9d-4557-bf6a-552e4cc08daa" />
