### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.65.1",
+  "packages/react": "1.66.0",
   "packages/react-native": "0.6.0",
   "packages/core": "1.12.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.66.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.65.1...factorial-one-react-v1.66.0) (2025-05-23)
+
+
+### Features
+
+* **Button:** new pressed styles ([#1864](https://github.com/factorialco/factorial-one/issues/1864)) ([2df9128](https://github.com/factorialco/factorial-one/commit/2df9128c180358416a9263c55af0a3ad6d036801))
+
 ## [1.65.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.65.0...factorial-one-react-v1.65.1) (2025-05-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.65.1",
+  "version": "1.66.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.66.0</summary>

## [1.66.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.65.1...factorial-one-react-v1.66.0) (2025-05-23)


### Features

* **Button:** new pressed styles ([#1864](https://github.com/factorialco/factorial-one/issues/1864)) ([2df9128](https://github.com/factorialco/factorial-one/commit/2df9128c180358416a9263c55af0a3ad6d036801))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).