### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.66.0",
-  "packages/react-native": "0.6.0",
+  "packages/react-native": "0.7.0",
   "packages/core": "1.12.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.6.0...factorial-one-react-native-v0.7.0) (2025-05-26)
+
+
+### Features
+
+* improve icon button colors ([#1884](https://github.com/factorialco/factorial-one/issues/1884)) ([e778a22](https://github.com/factorialco/factorial-one/commit/e778a227cc5e44d0d3680f7388b008707b1bc73d))
+
 ## [0.6.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.5.0...factorial-one-react-native-v0.6.0) (2025-05-22)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.7.0</summary>

## [0.7.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.6.0...factorial-one-react-native-v0.7.0) (2025-05-26)


### Features

* improve icon button colors ([#1884](https://github.com/factorialco/factorial-one/issues/1884)) ([e778a22](https://github.com/factorialco/factorial-one/commit/e778a227cc5e44d0d3680f7388b008707b1bc73d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).