### PR TITLE
feat(dataCollection): Data collection cells placeholder

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
@@ -47,11 +47,35 @@ type value = {
   of={CellTypesDataCollectionStories.TextType}
   source={{
     code: `
-render: (item) => 'my text'
-// or
+    render: (item) => 'John Doe'
+    `,
+  }}
+/>
+
+#### TextInputAsObject
+
+<Canvas
+  of={CellTypesDataCollectionStories.TextInputAsObject}
+  source={{
+    code: `
 render: (item) => ({
     type: 'text',
-    value: 'my text'
+    value: 'John Doe'
+})`,
+  }}
+/>
+
+#### TextValueInputAsObject
+
+<Canvas
+  of={CellTypesDataCollectionStories.TextValueInputAsObject}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'text',
+    value: {
+      text: 'John Doe'
+    }
 })`,
   }}
 />
@@ -80,15 +104,38 @@ Renders a number (right align on table visualizacion)
 
 ```
 type value = number | undefined
+// or
+type value = {
+    number: number | undefined
+    placeholder?: string
+}
 ```
 
+#### NumberInputAsObject
+
 <Canvas
-  of={CellTypesDataCollectionStories.NumberType}
+  of={CellTypesDataCollectionStories.NumberInputAsObject}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'number',
+    value: 1234
+})
+`,
+  }}
+/>
+
+#### NumberValueInputAsObject
+
+<Canvas
+  of={CellTypesDataCollectionStories.NumberValueInputAsObject}
   source={{
     code: `
 render: (item) => ({
     type: 'number'
-    value: 1234
+    value: {
+      number: 1234
+    }
 })
 `,
   }}
@@ -103,7 +150,7 @@ render: (item) => ({
 render: (item) => ({
     type: 'number'
     value: {
-      number: undefined
+      number: undefined,
       placeholder: 'Some placeholder'
     }
 })`,
@@ -118,15 +165,38 @@ Renders a date
 
 ```
 type value = Date | undefined
+// or
+type value = {
+    date: Date | undefined
+    placeholder?: string
+}
 ```
 
+#### DateInputAsObject
+
 <Canvas
-  of={CellTypesDataCollectionStories.DateType}
+  of={CellTypesDataCollectionStories.DateInputAsObject}
   source={{
     code: `
 render: (item) => ({
     type: 'date'
     value: new Date()
+})
+`,
+  }}
+/>
+
+#### DateValueInputAsObject
+
+<Canvas
+  of={CellTypesDataCollectionStories.DateValueInputAsObject}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'date'
+    value: {
+      date: new Date()
+    }
 })
 `,
   }}
@@ -156,15 +226,36 @@ Renders a monetary number (right align on table visualizacion)
 
 ```
 type value = number | undefined
+// or
+type value = {
+    amount: Date | undefined
+    placeholder?: string
+}
 ```
 
+#### AmountInputAsObject
+
 <Canvas
-  of={CellTypesDataCollectionStories.AmountType}
+  of={CellTypesDataCollectionStories.AmountInputAsObject}
   source={{
     code: `
 render: (item) => ({
     type: 'amount'
     value: 1234
+})
+`,
+  }}
+/>
+
+#### AmountValueInputAsObject
+
+<Canvas
+  of={CellTypesDataCollectionStories.AmountValueInputAsObject}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'amount'
+    value: { amount: 1234 },
 })
 `,
   }}

--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
@@ -35,7 +35,12 @@ Renders a text This type's render function can be used as a shortcut returning
 just a string.
 
 ```
-type value = string | undefined
+type value = string | number | undefined
+// or
+type value = {
+    text: string | number | undefined
+    placeholder?: string
+}
 ```
 
 <Canvas
@@ -45,8 +50,16 @@ type value = string | undefined
 render: (item) => 'my text'
 // or
 render: (item) => ({
-    type: 'text'
+    type: 'text',
     value: 'my text'
+})
+// or
+render: (item) => ({
+    type: 'text'
+    value: {
+      text: 'my text'
+      placeholder: 'Placeholder'
+    }
 })`,
   }}
 />

--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
@@ -52,13 +52,21 @@ render: (item) => 'my text'
 render: (item) => ({
     type: 'text',
     value: 'my text'
-})
-// or
+})`,
+  }}
+/>
+
+#### With placeholder
+
+<Canvas
+  of={CellTypesDataCollectionStories.TextWithPlaceholder}
+  source={{
+    code: `
 render: (item) => ({
     type: 'text'
     value: {
-      text: 'my text'
-      placeholder: 'Placeholder'
+      text: undefined
+      placeholder: 'Some placeholder'
     }
 })`,
   }}
@@ -86,6 +94,22 @@ render: (item) => ({
   }}
 />
 
+#### With placeholder
+
+<Canvas
+  of={CellTypesDataCollectionStories.NumberWithPlaceholder}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'number'
+    value: {
+      number: undefined
+      placeholder: 'Some placeholder'
+    }
+})`,
+  }}
+/>
+
 ### date
 
 Renders a date
@@ -108,6 +132,22 @@ render: (item) => ({
   }}
 />
 
+#### With placeholder
+
+<Canvas
+  of={CellTypesDataCollectionStories.DateWithPlaceholder}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'date'
+    value: {
+      date: undefined
+      placeholder: 'Some placeholder'
+    }
+})`,
+  }}
+/>
+
 ### amount
 
 Renders a monetary number (right align on table visualizacion)
@@ -127,6 +167,22 @@ render: (item) => ({
     value: 1234
 })
 `,
+  }}
+/>
+
+#### With placeholder
+
+<Canvas
+  of={CellTypesDataCollectionStories.AmountWithPlaceholder}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'text'
+    value: {
+      amount: undefined
+      placeholder: 'Some placeholder'
+    }
+})`,
   }}
 />
 

--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.stories.tsx
@@ -103,8 +103,22 @@ export const TextType: Story = {
         type: "text",
         value: {
           text: item.firstName + " " + item.lastName,
-          // TODO: another variant
-          // placeholder: 'Placeholder'
+        },
+      }),
+    },
+  },
+}
+
+export const TextWithPlaceholder: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Name",
+      render: () => ({
+        type: "text",
+        value: {
+          text: undefined,
+          placeholder: "Some placeholder",
         },
       }),
     },
@@ -124,6 +138,22 @@ export const NumberType: Story = {
   },
 }
 
+export const NumberWithPlaceholder: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Name",
+      render: () => ({
+        type: "number",
+        value: {
+          number: undefined,
+          placeholder: "Some placeholder",
+        },
+      }),
+    },
+  },
+}
+
 export const DateType: Story = {
   args: {
     item: mockItem,
@@ -137,6 +167,19 @@ export const DateType: Story = {
   },
 }
 
+export const DateWithPlaceholder: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Date",
+      render: () => ({
+        type: "date",
+        value: { date: undefined, placeholder: "Some placeholder" },
+      }),
+    },
+  },
+}
+
 export const AmountType: Story = {
   args: {
     item: mockItem,
@@ -145,6 +188,19 @@ export const AmountType: Story = {
       render: (item) => ({
         type: "amount",
         value: item.amount,
+      }),
+    },
+  },
+}
+
+export const AmountWithPlaceholder: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Amount",
+      render: () => ({
+        type: "amount",
+        value: { amount: undefined, placeholder: "Some placeholder" },
       }),
     },
   },

--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.stories.tsx
@@ -99,7 +99,14 @@ export const TextType: Story = {
     item: mockItem,
     property: {
       label: "Name",
-      render: (item) => item.firstName + " " + item.lastName,
+      render: (item) => ({
+        type: "text",
+        value: {
+          text: item.firstName + " " + item.lastName,
+          // TODO: another variant
+          // placeholder: 'Placeholder'
+        },
+      }),
     },
   },
 }

--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.stories.tsx
@@ -93,8 +93,30 @@ const mockItem = {
   ],
 }
 
-// Basic story showing all action types
 export const TextType: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Name",
+      render: (item) => item.firstName + " " + item.lastName,
+    },
+  },
+}
+
+export const TextInputAsObject: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Name",
+      render: (item) => ({
+        type: "text",
+        value: item.firstName + " " + item.lastName,
+      }),
+    },
+  },
+}
+
+export const TextValueInputAsObject: Story = {
   args: {
     item: mockItem,
     property: {
@@ -125,7 +147,7 @@ export const TextWithPlaceholder: Story = {
   },
 }
 
-export const NumberType: Story = {
+export const NumberInputAsObject: Story = {
   args: {
     item: mockItem,
     property: {
@@ -133,6 +155,19 @@ export const NumberType: Story = {
       render: (item) => ({
         type: "number",
         value: Number(item.id),
+      }),
+    },
+  },
+}
+
+export const NumberValueInputAsObject: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Employee ID",
+      render: (item) => ({
+        type: "number",
+        value: { number: Number(item.id) },
       }),
     },
   },
@@ -154,7 +189,7 @@ export const NumberWithPlaceholder: Story = {
   },
 }
 
-export const DateType: Story = {
+export const DateInputAsObject: Story = {
   args: {
     item: mockItem,
     property: {
@@ -162,6 +197,19 @@ export const DateType: Story = {
       render: (item) => ({
         type: "date",
         value: item.date,
+      }),
+    },
+  },
+}
+
+export const DateValueInputAsObject: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Date",
+      render: (item) => ({
+        type: "date",
+        value: { date: item.date },
       }),
     },
   },
@@ -180,7 +228,7 @@ export const DateWithPlaceholder: Story = {
   },
 }
 
-export const AmountType: Story = {
+export const AmountInputAsObject: Story = {
   args: {
     item: mockItem,
     property: {
@@ -188,6 +236,19 @@ export const AmountType: Story = {
       render: (item) => ({
         type: "amount",
         value: item.amount,
+      }),
+    },
+  },
+}
+
+export const AmountValueInputAsObject: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Amount",
+      render: (item) => ({
+        type: "amount",
+        value: { amount: item.amount },
       }),
     },
   },

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/index.test.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/index.test.tsx
@@ -105,7 +105,7 @@ describe("resolveValue", () => {
   it("should handle complex objects correctly", () => {
     const date = new Date()
     const obj = { date, placeholder: "No date" }
-    expect(resolveValue(obj, "date")).toBe(date)
+    expect(resolveValue(obj, "date")).toStrictEqual(date)
 
     const objWithUndefined = { date: undefined, placeholder: "No date" }
     expect(resolveValue(objWithUndefined, "date")).toBe("No date")

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/index.test.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/index.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest"
+import {
+  hasPlaceholder,
+  isShowingPlaceholder,
+  resolveValue,
+} from "./property-utils"
+
+describe("hasPlaceholder", () => {
+  it("should return true when object has placeholder property with string value", () => {
+    const obj = { placeholder: "Some placeholder" }
+    expect(hasPlaceholder(obj)).toBe(true)
+  })
+
+  it("should return false when object does not have placeholder property", () => {
+    const obj = { someOtherProp: "value" }
+    expect(hasPlaceholder(obj)).toBe(false)
+  })
+
+  it("should return false when placeholder property is not a string", () => {
+    const obj = { placeholder: 123 }
+    expect(hasPlaceholder(obj)).toBe(false)
+  })
+
+  it("should return false for null input", () => {
+    expect(hasPlaceholder(null)).toBe(false)
+  })
+
+  it("should return false for undefined input", () => {
+    expect(hasPlaceholder(undefined)).toBe(false)
+  })
+
+  it("should return false for primitive values", () => {
+    expect(hasPlaceholder(123)).toBe(false)
+    expect(hasPlaceholder("string")).toBe(false)
+    expect(hasPlaceholder(true)).toBe(false)
+  })
+})
+
+describe("isShowingPlaceholder", () => {
+  it("should return true when object has placeholder property and specified key with undefined value", () => {
+    const obj = { text: undefined, placeholder: "Some placeholder" }
+    expect(isShowingPlaceholder(obj, "text")).toBe(true)
+  })
+
+  it("should return false when object has placeholder but specified key has defined value", () => {
+    const obj = { text: "Hello", placeholder: "Some placeholder" }
+    expect(isShowingPlaceholder(obj, "text")).toBe(false)
+  })
+
+  it("should return false when object has no placeholder property", () => {
+    const obj = { text: undefined }
+    expect(isShowingPlaceholder(obj, "text")).toBe(false)
+  })
+
+  it("should return false when specified key doesn't exist in object", () => {
+    const obj = { placeholder: "Some placeholder" }
+    expect(isShowingPlaceholder(obj, "nonExistentKey")).toBe(true)
+  })
+
+  it("should return false for non-object values", () => {
+    expect(isShowingPlaceholder("string", "text")).toBe(false)
+    expect(isShowingPlaceholder(123, "text")).toBe(false)
+    expect(isShowingPlaceholder(null, "text")).toBe(false)
+    expect(isShowingPlaceholder(undefined, "text")).toBe(false)
+  })
+})
+
+describe("resolveValue", () => {
+  it("should return primitive value if args is a primitive", () => {
+    expect(resolveValue("hello", "text")).toBe("hello")
+    expect(resolveValue(123, "number")).toBe(123)
+    expect(resolveValue(true, "boolean")).toBe(true)
+  })
+
+  it("should return property value if it exists and is defined", () => {
+    const obj = { text: "Hello world" }
+    expect(resolveValue(obj, "text")).toBe("Hello world")
+  })
+
+  it("should return placeholder if property value is undefined", () => {
+    const obj = { text: undefined, placeholder: "Some placeholder" }
+    expect(resolveValue(obj, "text")).toBe("Some placeholder")
+  })
+
+  it("should return placeholder if property doesn't exist", () => {
+    const obj = { placeholder: "Some placeholder" }
+    expect(resolveValue(obj, "text")).toBe("Some placeholder")
+  })
+
+  it("should return undefined if property value is undefined and no placeholder", () => {
+    const obj = { text: undefined }
+    expect(resolveValue(obj, "text")).toBeUndefined()
+  })
+
+  it("should return undefined if property doesn't exist and no placeholder", () => {
+    const obj = { someOtherProp: "value" }
+    expect(resolveValue(obj, "text")).toBeUndefined()
+  })
+
+  it("should return undefined for null or undefined input", () => {
+    expect(resolveValue(null, "text")).toBeUndefined()
+    expect(resolveValue(undefined, "text")).toBeUndefined()
+  })
+
+  it("should handle complex objects correctly", () => {
+    const date = new Date()
+    const obj = { date, placeholder: "No date" }
+    expect(resolveValue(obj, "date")).toBe(date)
+
+    const objWithUndefined = { date: undefined, placeholder: "No date" }
+    expect(resolveValue(objWithUndefined, "date")).toBe("No date")
+  })
+})

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
@@ -17,7 +17,11 @@ import { cn } from "@/lib/utils"
 import { ReactNode } from "react"
 import { PropertyDefinition } from "../../property-render"
 import { VisualizationType } from "../../visualizations"
-import { isShowingPlaceholder, resolveValue } from "./property-utils.ts"
+import {
+  formatDateValue,
+  isShowingPlaceholder,
+  resolveValue,
+} from "./property-utils.ts"
 
 export interface WithPlaceholder {
   placeholder?: string
@@ -146,9 +150,9 @@ export const propertyRenderers = {
       </div>
     )
   },
-
   date: (args: DateCellValue) => {
-    const value = resolveValue<Date>(args, "date")
+    const formattedDate = formatDateValue(args)
+
     const shouldShowPlaceholderStyling = isShowingPlaceholder(args, "date")
 
     return (
@@ -158,11 +162,10 @@ export const propertyRenderers = {
           shouldShowPlaceholderStyling && "text-f1-foreground-secondary"
         )}
       >
-        {value instanceof Date ? value.toLocaleDateString() : value}
+        {formattedDate}
       </div>
     )
   },
-
   amount: (args: AmountCellValue, meta: PropertyRendererMetadata<never>) => {
     const value = resolveValue<number>(args, "amount")
     const shouldShowPlaceholderStyling = isShowingPlaceholder(args, "amount")

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
@@ -38,9 +38,30 @@ export type PropertyRendererMetadata<T> = {
  * @returns The rendered property value
  */
 export const propertyRenderers = {
-  text: (text: string | number | undefined) => (
-    <span className="text-f1-foreground">{text}</span>
-  ),
+  text: (
+    args:
+      | { text: string | number | undefined; placeholder?: string }
+      | string
+      | number
+      | undefined
+  ) => {
+    const textContent =
+      typeof args === "object" && args !== null ? args.text : args
+
+    const isPlaceholder =
+      typeof args === "object" && args !== null && args.placeholder
+
+    return (
+      <span
+        className={cn(
+          "text-f1-foreground",
+          isPlaceholder && "text-f1-foreground-secondary"
+        )}
+      >
+        {textContent}
+      </span>
+    )
+  },
   number: (
     number: number | undefined,
     meta: PropertyRendererMetadata<never>

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils"
 import { ReactNode } from "react"
 import { PropertyDefinition } from "../../property-render"
 import { VisualizationType } from "../../visualizations"
+import { extractValue, hasPlaceholder } from "./property-utils.ts"
 
 /**
  * The renderer function to use for a property.
@@ -45,11 +46,8 @@ export const propertyRenderers = {
       | number
       | undefined
   ) => {
-    const textContent =
-      typeof args === "object" && args !== null ? args.text : args
-
-    const isPlaceholder =
-      typeof args === "object" && args !== null && args.placeholder
+    const value = extractValue<string | number>(args)
+    const isPlaceholder = hasPlaceholder(args)
 
     return (
       <span
@@ -58,39 +56,71 @@ export const propertyRenderers = {
           isPlaceholder && "text-f1-foreground-secondary"
         )}
       >
-        {textContent}
+        {value}
       </span>
     )
   },
   number: (
-    number: number | undefined,
+    args:
+      | { number: number | undefined; placeholder?: string }
+      | number
+      | undefined,
     meta: PropertyRendererMetadata<never>
-  ) => (
-    <div
-      className={cn(
-        "text-f1-foreground",
-        meta.visualization === "table" && "text-right"
-      )}
-    >
-      {number}
-    </div>
-  ),
-  date: (date: Date | undefined) => (
-    <div className="text-f1-foreground">{date?.toLocaleDateString()}</div>
-  ),
+  ) => {
+    const value = extractValue<number>(args)
+    const isPlaceholder = hasPlaceholder(args)
+
+    return (
+      <div
+        className={cn(
+          "text-f1-foreground",
+          meta.visualization === "table" && "text-right",
+          isPlaceholder && "text-f1-foreground-secondary"
+        )}
+      >
+        {value}
+      </div>
+    )
+  },
+  date: (
+    args: { date: Date | undefined; placeholder?: string } | Date | undefined
+  ) => {
+    const value = extractValue<Date>(args)
+    const isPlaceholder = hasPlaceholder(args)
+
+    return (
+      <div
+        className={cn(
+          "text-f1-foreground",
+          isPlaceholder && "text-f1-foreground-secondary"
+        )}
+      >
+        {value?.toLocaleDateString()}
+      </div>
+    )
+  },
   amount: (
-    amount: number | undefined,
+    args:
+      | { amount: number | undefined; placeholder?: string }
+      | number
+      | undefined,
     meta: PropertyRendererMetadata<never>
-  ) => (
-    <div
-      className={cn(
-        "text-f1-foreground",
-        meta.visualization === "table" && "text-right"
-      )}
-    >
-      {amount}
-    </div>
-  ),
+  ) => {
+    const value = extractValue<number>(args)
+    const isPlaceholder = hasPlaceholder(args)
+
+    return (
+      <div
+        className={cn(
+          "text-f1-foreground",
+          meta.visualization === "table" && "text-right",
+          isPlaceholder && "text-f1-foreground-secondary"
+        )}
+      >
+        {value}
+      </div>
+    )
+  },
   avatarList: (args: { avatarList: AvatarVariant[]; max?: number }) => (
     <AvatarList avatars={args.avatarList} size="xsmall" max={args.max} />
   ),

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils"
 import { ReactNode } from "react"
 import { PropertyDefinition } from "../../property-render"
 import { VisualizationType } from "../../visualizations"
-import { hasPlaceholder } from "./property-utils.ts"
+import { isShowingPlaceholder, resolveValue } from "./property-utils.ts"
 
 export interface WithPlaceholder {
   placeholder?: string
@@ -115,17 +115,14 @@ export type PropertyRendererMetadata<T> = {
  */
 export const propertyRenderers = {
   text: (args: TextCellValue) => {
-    const isPlaceholder = hasPlaceholder(args)
-    const value =
-      typeof args === "object" && args !== null && "text" in args
-        ? args.text
-        : args
+    const value = resolveValue<string | number>(args, "text")
+    const shouldShowPlaceholderStyling = isShowingPlaceholder(args, "text")
 
     return (
       <span
         className={cn(
           "text-f1-foreground",
-          isPlaceholder && "text-f1-foreground-secondary"
+          shouldShowPlaceholderStyling && "text-f1-foreground-secondary"
         )}
       >
         {value}
@@ -134,18 +131,15 @@ export const propertyRenderers = {
   },
 
   number: (args: NumberCellValue, meta: PropertyRendererMetadata<never>) => {
-    const isPlaceholder = hasPlaceholder(args)
-    const value =
-      typeof args === "object" && args !== null && "number" in args
-        ? args.number
-        : args
+    const value = resolveValue<number>(args, "number")
+    const shouldShowPlaceholderStyling = isShowingPlaceholder(args, "number")
 
     return (
       <div
         className={cn(
           "text-f1-foreground",
           meta.visualization === "table" && "text-right",
-          isPlaceholder && "text-f1-foreground-secondary"
+          shouldShowPlaceholderStyling && "text-f1-foreground-secondary"
         )}
       >
         {value}
@@ -154,37 +148,31 @@ export const propertyRenderers = {
   },
 
   date: (args: DateCellValue) => {
-    const isPlaceholder = hasPlaceholder(args)
-    const value =
-      typeof args === "object" && args !== null && "date" in args
-        ? args.date
-        : args
+    const value = resolveValue<Date>(args, "date")
+    const shouldShowPlaceholderStyling = isShowingPlaceholder(args, "date")
 
     return (
       <div
         className={cn(
           "text-f1-foreground",
-          isPlaceholder && "text-f1-foreground-secondary"
+          shouldShowPlaceholderStyling && "text-f1-foreground-secondary"
         )}
       >
-        {value?.toLocaleDateString()}
+        {value instanceof Date ? value.toLocaleDateString() : value}
       </div>
     )
   },
 
   amount: (args: AmountCellValue, meta: PropertyRendererMetadata<never>) => {
-    const isPlaceholder = hasPlaceholder(args)
-    const value =
-      typeof args === "object" && args !== null && "amount" in args
-        ? args.amount
-        : args
+    const value = resolveValue<number>(args, "amount")
+    const shouldShowPlaceholderStyling = isShowingPlaceholder(args, "amount")
 
     return (
       <div
         className={cn(
           "text-f1-foreground",
           meta.visualization === "table" && "text-right",
-          isPlaceholder && "text-f1-foreground-secondary"
+          shouldShowPlaceholderStyling && "text-f1-foreground-secondary"
         )}
       >
         {value}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
@@ -17,7 +17,82 @@ import { cn } from "@/lib/utils"
 import { ReactNode } from "react"
 import { PropertyDefinition } from "../../property-render"
 import { VisualizationType } from "../../visualizations"
-import { extractValue, hasPlaceholder } from "./property-utils.ts"
+import { hasPlaceholder } from "./property-utils.ts"
+
+export interface WithPlaceholder {
+  placeholder?: string
+}
+
+export interface TextValue extends WithPlaceholder {
+  text: string | number | undefined
+}
+
+export interface NumberValue extends WithPlaceholder {
+  number: number | undefined
+}
+
+export interface DateValue extends WithPlaceholder {
+  date: Date | undefined
+}
+
+export interface AmountValue extends WithPlaceholder {
+  amount: number | undefined
+}
+
+export type TextCellValue = string | number | undefined | TextValue
+export type NumberCellValue = number | undefined | NumberValue
+export type DateCellValue = Date | undefined | DateValue
+export type AmountCellValue = number | undefined | AmountValue
+
+export interface AvatarListValue {
+  avatarList: AvatarVariant[]
+  max?: number
+}
+export type AvatarListCellValue = AvatarListValue
+
+export interface StatusValue {
+  status: StatusVariant
+  label: string
+}
+export type StatusCellValue = StatusValue
+
+export interface PersonValue {
+  firstName: string
+  lastName: string
+  src?: string
+}
+export type PersonCellValue = PersonValue
+
+export interface CompanyValue {
+  name: string
+  src?: string
+}
+export type CompanyCellValue = CompanyValue
+
+export interface TeamValue {
+  name: string
+  src?: string
+}
+export type TeamCellValue = TeamValue
+
+export interface TagValue {
+  label: string
+  icon?: IconType
+}
+export type TagCellValue = TagValue
+
+export interface DotTagValue {
+  label: string
+  color: NewColor
+}
+export type DotTagCellValue = DotTagValue
+
+export interface TagListValue {
+  tags: Array<Omit<TagVariant, "type">>
+  max?: number
+  type: TagType
+}
+export type TagListCellValue = TagListValue
 
 /**
  * The renderer function to use for a property.
@@ -39,15 +114,12 @@ export type PropertyRendererMetadata<T> = {
  * @returns The rendered property value
  */
 export const propertyRenderers = {
-  text: (
-    args:
-      | { text: string | number | undefined; placeholder?: string }
-      | string
-      | number
-      | undefined
-  ) => {
-    const value = extractValue<string | number>(args)
+  text: (args: TextCellValue) => {
     const isPlaceholder = hasPlaceholder(args)
+    const value =
+      typeof args === "object" && args !== null && "text" in args
+        ? args.text
+        : args
 
     return (
       <span
@@ -60,15 +132,13 @@ export const propertyRenderers = {
       </span>
     )
   },
-  number: (
-    args:
-      | { number: number | undefined; placeholder?: string }
-      | number
-      | undefined,
-    meta: PropertyRendererMetadata<never>
-  ) => {
-    const value = extractValue<number>(args)
+
+  number: (args: NumberCellValue, meta: PropertyRendererMetadata<never>) => {
     const isPlaceholder = hasPlaceholder(args)
+    const value =
+      typeof args === "object" && args !== null && "number" in args
+        ? args.number
+        : args
 
     return (
       <div
@@ -82,11 +152,13 @@ export const propertyRenderers = {
       </div>
     )
   },
-  date: (
-    args: { date: Date | undefined; placeholder?: string } | Date | undefined
-  ) => {
-    const value = extractValue<Date>(args)
+
+  date: (args: DateCellValue) => {
     const isPlaceholder = hasPlaceholder(args)
+    const value =
+      typeof args === "object" && args !== null && "date" in args
+        ? args.date
+        : args
 
     return (
       <div
@@ -99,15 +171,13 @@ export const propertyRenderers = {
       </div>
     )
   },
-  amount: (
-    args:
-      | { amount: number | undefined; placeholder?: string }
-      | number
-      | undefined,
-    meta: PropertyRendererMetadata<never>
-  ) => {
-    const value = extractValue<number>(args)
+
+  amount: (args: AmountCellValue, meta: PropertyRendererMetadata<never>) => {
     const isPlaceholder = hasPlaceholder(args)
+    const value =
+      typeof args === "object" && args !== null && "amount" in args
+        ? args.amount
+        : args
 
     return (
       <div
@@ -121,13 +191,13 @@ export const propertyRenderers = {
       </div>
     )
   },
-  avatarList: (args: { avatarList: AvatarVariant[]; max?: number }) => (
+  avatarList: (args: AvatarListCellValue) => (
     <AvatarList avatars={args.avatarList} size="xsmall" max={args.max} />
   ),
-  status: (args: { status: StatusVariant; label: string }) => (
+  status: (args: StatusCellValue) => (
     <StatusTag variant={args.status} text={args.label} />
   ),
-  person: (args: { firstName: string; lastName: string; src?: string }) => (
+  person: (args: PersonCellValue) => (
     <div className="flex items-center gap-2">
       <Avatar
         avatar={{
@@ -143,7 +213,7 @@ export const propertyRenderers = {
       </span>
     </div>
   ),
-  company: (args: { name: string; src?: string }) => (
+  company: (args: CompanyCellValue) => (
     <div className="flex items-center gap-2">
       <Avatar
         avatar={{
@@ -156,7 +226,7 @@ export const propertyRenderers = {
       <span className="text-f1-foreground">{args.name}</span>
     </div>
   ),
-  team: (args: { name: string; src?: string }) => (
+  team: (args: TeamCellValue) => (
     <div className="flex items-center gap-2">
       <Avatar
         avatar={{
@@ -169,17 +239,11 @@ export const propertyRenderers = {
       <span className="text-f1-foreground">{args.name}</span>
     </div>
   ),
-  tag: (args: { label: string; icon?: IconType }) => (
-    <RawTag text={args.label} icon={args.icon} />
-  ),
-  dotTag: (args: { label: string; color: NewColor }) => (
+  tag: (args: TagCellValue) => <RawTag text={args.label} icon={args.icon} />,
+  dotTag: (args: DotTagCellValue) => (
     <DotTag text={args.label} color={args.color} />
   ),
-  tagList: (args: {
-    tags: Array<Omit<TagVariant, "type">>
-    max?: number
-    type: TagType
-  }) => (
+  tagList: (args: TagListCellValue) => (
     <TagList type={args.type} tags={args.tags as TagVariant[]} max={args.max} />
   ),
 } as const satisfies Record<string, PropertyRenderer<never>>

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/property-utils.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/property-utils.ts
@@ -1,34 +1,22 @@
-function extractValue<T>(
-  args: T | Record<string, any> | undefined
-): T | undefined {
-  if (args === null || args === undefined) {
-    return undefined
-  }
+import {
+  AmountValue,
+  DateValue,
+  NumberValue,
+  TextValue,
+} from "@/experimental/OneDataCollection/visualizations/property"
 
-  if (typeof args !== "object") {
-    return args as T
-  }
+export type ValueKey = "text" | "number" | "date" | "amount"
 
-  const obj = args as Record<string, any>
+export type ValueObject = TextValue | NumberValue | DateValue | AmountValue
 
-  for (const key of ["text", "number", "date", "amount"]) {
-    if (key in obj) {
-      return obj[key]
-    }
-  }
-
-  return args as T
-}
-
-function hasPlaceholder(args: unknown): boolean {
-  if (args === null || args === undefined || typeof args !== "object") {
-    return false
-  }
-
+/**
+ * Checks if a value object has a placeholder property
+ */
+export function hasPlaceholder(args: unknown): args is { placeholder: string } {
   return (
-    "placeholder" in (args as Record<string, unknown>) &&
-    !!(args as Record<string, unknown>).placeholder
+    typeof args === "object" &&
+    args !== null &&
+    "placeholder" in args &&
+    typeof args.placeholder === "string"
   )
 }
-
-export { extractValue, hasPlaceholder }

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/property-utils.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/property-utils.ts
@@ -1,14 +1,3 @@
-import {
-  AmountValue,
-  DateValue,
-  NumberValue,
-  TextValue,
-} from "@/experimental/OneDataCollection/visualizations/property"
-
-export type ValueKey = "text" | "number" | "date" | "amount"
-
-export type ValueObject = TextValue | NumberValue | DateValue | AmountValue
-
 /**
  * Checks if a value object has a placeholder property
  */

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/property-utils.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/property-utils.ts
@@ -9,3 +9,70 @@ export function hasPlaceholder(args: unknown): args is { placeholder: string } {
     typeof args.placeholder === "string"
   )
 }
+
+/**
+ * Determines if we should show placeholder styling
+ * This happens when:
+ * 1. The args object has a placeholder property
+ * 2. The value for the specified key is undefined
+ */
+export function isShowingPlaceholder(args: unknown, valueKey: string): boolean {
+  if (!hasPlaceholder(args)) {
+    return false
+  }
+
+  // If args is an object with the valueKey
+  if (typeof args === "object" && args !== null && valueKey in args) {
+    const value = (args as any)[valueKey]
+    // Show placeholder styling if the value is undefined
+    return value === undefined
+  }
+
+  // If args is just an object with a placeholder (no valueKey)
+  return true
+}
+
+/**
+ * Resolves the display value from a cell value object
+ * Returns the actual value if present, the placeholder if defined, or undefined
+ */
+export function resolveValue<T>(
+  args: unknown,
+  valueKey: string
+): T | string | undefined {
+  // If args is a primitive value (not an object), return it directly
+  if (args !== undefined && typeof args !== "object") {
+    return args as any
+  }
+
+  // If args is null or not an object, return undefined
+  if (!args || typeof args !== "object") {
+    return undefined
+  }
+
+  // Get the value if the key exists in the object
+  const valueExists = valueKey in args
+  const value = valueExists ? (args as any)[valueKey] : undefined
+
+  // Check if there's a placeholder
+  const hasAPlaceholder = hasPlaceholder(args)
+  const placeholder = hasAPlaceholder ? args.placeholder : undefined
+
+  // Return logic with priority:
+  // 1. Return value if it's not undefined
+  // 2. Return placeholder if available
+  // 3. Return undefined otherwise
+
+  // If value is not undefined, return it
+  if (value !== undefined) {
+    return value
+  }
+
+  // If placeholder exists, return it (this will handle cases where text: undefined)
+  if (placeholder !== undefined) {
+    return placeholder
+  }
+
+  // Default case - return undefined
+  return undefined
+}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/property-utils.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/property-utils.ts
@@ -1,0 +1,34 @@
+function extractValue<T>(
+  args: T | Record<string, any> | undefined
+): T | undefined {
+  if (args === null || args === undefined) {
+    return undefined
+  }
+
+  if (typeof args !== "object") {
+    return args as T
+  }
+
+  const obj = args as Record<string, any>
+
+  for (const key of ["text", "number", "date", "amount"]) {
+    if (key in obj) {
+      return obj[key]
+    }
+  }
+
+  return args as T
+}
+
+function hasPlaceholder(args: unknown): boolean {
+  if (args === null || args === undefined || typeof args !== "object") {
+    return false
+  }
+
+  return (
+    "placeholder" in (args as Record<string, unknown>) &&
+    !!(args as Record<string, unknown>).placeholder
+  )
+}
+
+export { extractValue, hasPlaceholder }

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/property-utils.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/property-utils.ts
@@ -11,6 +11,13 @@ export function hasPlaceholder(args: unknown): args is { placeholder: string } {
 }
 
 /**
+ * Type for objects with a dynamic key
+ */
+interface DynamicArgObject {
+  [arg: string]: unknown
+}
+
+/**
  * Determines if we should show placeholder styling
  * This happens when:
  * 1. The args object has a placeholder property
@@ -21,14 +28,11 @@ export function isShowingPlaceholder(args: unknown, valueKey: string): boolean {
     return false
   }
 
-  // If args is an object with the valueKey
   if (typeof args === "object" && args !== null && valueKey in args) {
-    const value = (args as any)[valueKey]
-    // Show placeholder styling if the value is undefined
+    const value = (args as DynamicArgObject)[valueKey]
     return value === undefined
   }
 
-  // If args is just an object with a placeholder (no valueKey)
   return true
 }
 
@@ -40,39 +44,27 @@ export function resolveValue<T>(
   args: unknown,
   valueKey: string
 ): T | string | undefined {
-  // If args is a primitive value (not an object), return it directly
   if (args !== undefined && typeof args !== "object") {
-    return args as any
+    return args as T
   }
 
-  // If args is null or not an object, return undefined
   if (!args || typeof args !== "object") {
     return undefined
   }
 
-  // Get the value if the key exists in the object
   const valueExists = valueKey in args
-  const value = valueExists ? (args as any)[valueKey] : undefined
+  const value = valueExists ? (args as DynamicArgObject)[valueKey] : undefined
 
-  // Check if there's a placeholder
   const hasAPlaceholder = hasPlaceholder(args)
   const placeholder = hasAPlaceholder ? args.placeholder : undefined
 
-  // Return logic with priority:
-  // 1. Return value if it's not undefined
-  // 2. Return placeholder if available
-  // 3. Return undefined otherwise
-
-  // If value is not undefined, return it
   if (value !== undefined) {
-    return value
+    return value as T
   }
 
-  // If placeholder exists, return it (this will handle cases where text: undefined)
   if (placeholder !== undefined) {
     return placeholder
   }
 
-  // Default case - return undefined
   return undefined
 }


### PR DESCRIPTION
## Description

Enable placeholder behavior in data collection cells for primitive types (text, number, date, amount), similar to native <input> elements in browsers.

1. Unified Typing via WithPlaceholder Interface.
2. Renderer Extraction Logic.
3. Scope: Limited to Primitive Types Only.
4. Maintaining Backward Compatibility.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/b92d19d0-9019-487c-a4b9-4e6f5e16a957

### Figma Link

[Link to Figma Design](https://www.figma.com/design/Drd7hhxgof79A7zeftSYMo/Patterns?node-id=938-167513&t=zUWtStTTQxZYM4ex-0)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other

---

- [x] **Testing**

  - [x] Component includes unit tests with sufficient coverage

- [x] **Accessibility**

This implementation is already following best practices in terms of accessibility because:
1. The span doesn't need an additional role - it's properly contained within the table structure
2. You're using appropriate styling for different states (like placeholders)


