### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.66.0",
+  "packages/react": "1.66.1",
   "packages/react-native": "0.7.0",
   "packages/core": "1.12.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.66.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.66.0...factorial-one-react-v1.66.1) (2025-05-26)
+
+
+### Bug Fixes
+
+* add missing exports ([#1882](https://github.com/factorialco/factorial-one/issues/1882)) ([349af34](https://github.com/factorialco/factorial-one/commit/349af349e3670d91c0bfb2ae3ad603840af24b1a))
+
 ## [1.66.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.65.1...factorial-one-react-v1.66.0) (2025-05-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.66.1</summary>

## [1.66.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.66.0...factorial-one-react-v1.66.1) (2025-05-26)


### Bug Fixes

* add missing exports ([#1882](https://github.com/factorialco/factorial-one/issues/1882)) ([349af34](https://github.com/factorialco/factorial-one/commit/349af349e3670d91c0bfb2ae3ad603840af24b1a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).