### PR TITLE
fix(weekdays): remove key collisions

### DIFF
--- a/packages/react/src/experimental/Widgets/Content/Weekdays/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/Weekdays/index.tsx
@@ -36,7 +36,7 @@ export const Weekdays = forwardRef<HTMLDivElement, WeekdaysProps>(
         {daysOfTheWeek.map((day, index) => (
           <ToggleGroupItem
             aria-label={day}
-            key={day}
+            key={index}
             value={`${index}-${day}`}
             className="h-6 w-6 shrink-0 grow-0 basis-6 p-0 text-sm font-medium disabled:select-none disabled:bg-f1-background-tertiary disabled:text-f1-foreground-secondary disabled:opacity-100 disabled:data-[state=on]:border disabled:data-[state=on]:border-solid disabled:data-[state=on]:border-f1-border-selected disabled:data-[state=on]:bg-f1-background-selected disabled:data-[state=on]:text-f1-foreground-selected"
           >


### PR DESCRIPTION
When one letter day values passed, we have key collisions. Use index instead of values to ensure unique keys 
