### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.66.1",
+  "packages/react": "1.66.2",
   "packages/react-native": "0.7.0",
   "packages/core": "1.12.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.66.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.66.1...factorial-one-react-v1.66.2) (2025-05-26)
+
+
+### Bug Fixes
+
+* add support to hide reactions button in CommunityPost component via prop ([#1890](https://github.com/factorialco/factorial-one/issues/1890)) ([a3ede51](https://github.com/factorialco/factorial-one/commit/a3ede514ecaec6a3dc9dee32fc185878667f97bc))
+
 ## [1.66.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.66.0...factorial-one-react-v1.66.1) (2025-05-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.66.1",
+  "version": "1.66.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.66.2</summary>

## [1.66.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.66.1...factorial-one-react-v1.66.2) (2025-05-26)


### Bug Fixes

* add support to hide reactions button in CommunityPost component via prop ([#1890](https://github.com/factorialco/factorial-one/issues/1890)) ([a3ede51](https://github.com/factorialco/factorial-one/commit/a3ede514ecaec6a3dc9dee32fc185878667f97bc))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).