### PR TITLE
fix: do not allow user to click page header navigation button when it's disabled

### DIFF
--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -98,6 +98,7 @@ function PageNavigationLink({
         disabled={disabled}
         onClick={(e) => {
           e.preventDefault()
+          if (disabled) return
           ref.current?.click()
         }}
       />


### PR DESCRIPTION
## Description

On our frontend we were opening the link specified in `PageNavigationLink` even though it was marked as disabled. 