### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.66.3",
+  "packages/react": "1.66.4",
   "packages/react-native": "0.7.0",
   "packages/core": "1.12.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.66.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.66.3...factorial-one-react-v1.66.4) (2025-05-26)
+
+
+### Bug Fixes
+
+* do not allow user to click page header navigation button when it's disabled ([#1894](https://github.com/factorialco/factorial-one/issues/1894)) ([3e32ffe](https://github.com/factorialco/factorial-one/commit/3e32ffe138732ecac141a767feefae3e1f40439e))
+
 ## [1.66.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.66.2...factorial-one-react-v1.66.3) (2025-05-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.66.3",
+  "version": "1.66.4",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.66.4</summary>

## [1.66.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.66.3...factorial-one-react-v1.66.4) (2025-05-26)


### Bug Fixes

* do not allow user to click page header navigation button when it's disabled ([#1894](https://github.com/factorialco/factorial-one/issues/1894)) ([3e32ffe](https://github.com/factorialco/factorial-one/commit/3e32ffe138732ecac141a767feefae3e1f40439e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).