### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.67.0",
+  "packages/react": "1.68.0",
   "packages/react-native": "0.8.0",
   "packages/core": "1.12.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.68.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.67.0...factorial-one-react-v1.68.0) (2025-05-27)
+
+
+### Features
+
+* **dataCollection:** Data collection cells placeholder ([#1886](https://github.com/factorialco/factorial-one/issues/1886)) ([00e1199](https://github.com/factorialco/factorial-one/commit/00e119991ae555549c7ae41a4ed617e965e450f9))
+
 ## [1.67.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.66.4...factorial-one-react-v1.67.0) (2025-05-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.67.0",
+  "version": "1.68.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.68.0</summary>

## [1.68.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.67.0...factorial-one-react-v1.68.0) (2025-05-27)


### Features

* **dataCollection:** Data collection cells placeholder ([#1886](https://github.com/factorialco/factorial-one/issues/1886)) ([00e1199](https://github.com/factorialco/factorial-one/commit/00e119991ae555549c7ae41a4ed617e965e450f9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).