### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.68.0",
+  "packages/react": "1.69.0",
   "packages/react-native": "0.8.0",
   "packages/core": "1.12.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.69.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.68.0...factorial-one-react-v1.69.0) (2025-05-27)
+
+
+### Features
+
+* Use `OneEmptyState` in widgets empty state ([#1895](https://github.com/factorialco/factorial-one/issues/1895)) ([99d91d3](https://github.com/factorialco/factorial-one/commit/99d91d3ece208c02538f38975522c9fff99f3ab7))
+
 ## [1.68.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.67.0...factorial-one-react-v1.68.0) (2025-05-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.69.0</summary>

## [1.69.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.68.0...factorial-one-react-v1.69.0) (2025-05-27)


### Features

* Use `OneEmptyState` in widgets empty state ([#1895](https://github.com/factorialco/factorial-one/issues/1895)) ([99d91d3](https://github.com/factorialco/factorial-one/commit/99d91d3ece208c02538f38975522c9fff99f3ab7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).