### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.69.0",
-  "packages/react-native": "0.8.0",
+  "packages/react-native": "0.8.1",
   "packages/core": "1.12.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.8.0...factorial-one-react-native-v0.8.1) (2025-05-27)
+
+
+### Bug Fixes
+
+* sort css classnem ([#1900](https://github.com/factorialco/factorial-one/issues/1900)) ([a9e2b59](https://github.com/factorialco/factorial-one/commit/a9e2b59554a83d164e1e32b88890886c6f5fa43b))
+
 ## [0.8.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.7.0...factorial-one-react-native-v0.8.0) (2025-05-27)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.8.1</summary>

## [0.8.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.8.0...factorial-one-react-native-v0.8.1) (2025-05-27)


### Bug Fixes

* sort css classnem ([#1900](https://github.com/factorialco/factorial-one/issues/1900)) ([a9e2b59](https://github.com/factorialco/factorial-one/commit/a9e2b59554a83d164e1e32b88890886c6f5fa43b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).