### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.69.3",
+  "packages/react": "1.70.0",
   "packages/react-native": "0.8.1",
   "packages/core": "1.12.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.70.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.69.3...factorial-one-react-v1.70.0) (2025-05-28)
+
+
+### Features
+
+* datacollection visible secondary actions ([#1893](https://github.com/factorialco/factorial-one/issues/1893)) ([88efe58](https://github.com/factorialco/factorial-one/commit/88efe5876ea4dc45eac4b7e4fac5d4a774b5f2a0))
+
 ## [1.69.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.69.2...factorial-one-react-v1.69.3) (2025-05-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.69.3",
+  "version": "1.70.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.70.0</summary>

## [1.70.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.69.3...factorial-one-react-v1.70.0) (2025-05-28)


### Features

* datacollection visible secondary actions ([#1893](https://github.com/factorialco/factorial-one/issues/1893)) ([88efe58](https://github.com/factorialco/factorial-one/commit/88efe5876ea4dc45eac4b7e4fac5d4a774b5f2a0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).