### PR TITLE
fix: become rem with inlineRem to be align with design

### DIFF
--- a/packages/react-native-playground/metro.config.js
+++ b/packages/react-native-playground/metro.config.js
@@ -8,7 +8,10 @@ const config = getDefaultConfig(__dirname);
 config.resolver.disableHierarchicalLookup = true;
 
 // First apply NativeWind
-const nativeWindConfig = withNativeWind(config, { input: "./global.css" });
+const nativeWindConfig = withNativeWind(config, {
+  input: "./global.css",
+  inlineRem: 16,
+});
 
 // Then wrap with Storybook
 module.exports = withStorybook(nativeWindConfig, {


### PR DESCRIPTION
## Description

Checking the design on Figma we did realize Nativewind was becoming size of Icons and components. So we have set properli the inlineRem value to keep the same size as we can see in Figma.

We should do the same action in the Factorial Mobile App

## Screenshots (if applicable)

<img width="854" alt="Screenshot 2025-05-28 at 09 24 15" src="https://github.com/user-attachments/assets/064ef495-5303-4d8f-b4fb-3d6c0d8de1a4" />
