### PR TITLE
chore: add icon? prop just to secondary tabs

### DIFF
--- a/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react"
 import { ComponentProps, forwardRef, PropsWithChildren } from "react"
 import { describe, expect, it, vi } from "vitest"
-import { Home, Upsell } from "../../../icons/app"
 import { BaseTabs, TabsSkeleton } from "./index"
 
 // Mock the linkHandler module
@@ -28,13 +27,13 @@ describe("Tabs", () => {
   ]
 
   const secondaryTabsWithUpsellIcons = [
-    { label: "Tab 1", href: "/active", icon: Upsell },
-    { label: "Tab 2", href: "/other", icon: Upsell },
+    { label: "Tab 1", href: "/active", showUpsellIcon: true },
+    { label: "Tab 2", href: "/other", showUpsellIcon: true },
   ]
 
-  const secondaryTabsWithNonUpsellIcons = [
-    { label: "Tab 1", href: "/active", icon: Home },
-    { label: "Tab 2", href: "/other", icon: Home },
+  const secondaryTabsWithoutUpsellIcons = [
+    { label: "Tab 1", href: "/active" },
+    { label: "Tab 2", href: "/other" },
   ]
 
   it("renders multiple tabs correctly", () => {
@@ -68,30 +67,30 @@ describe("Tabs", () => {
     expect(nav).toHaveAttribute("aria-label", "primary-navigation")
   })
 
-  it("renders Upsell icons in secondary tabs", () => {
+  it("renders Upsell icons in secondary tabs when showUpsellIcon is true", () => {
     render(<BaseTabs tabs={secondaryTabsWithUpsellIcons} secondary />)
 
     const icons = document.querySelectorAll("svg")
     expect(icons).toHaveLength(2)
   })
 
-  it("renders Upsell icons for primary tabs", () => {
+  it("renders Upsell icons for primary tabs when showUpsellIcon is true", () => {
     render(<BaseTabs tabs={secondaryTabsWithUpsellIcons} secondary={false} />)
 
     const icons = document.querySelectorAll("svg")
     expect(icons).toHaveLength(2)
   })
 
-  it("does not render non-Upsell icons in secondary tabs", () => {
-    render(<BaseTabs tabs={secondaryTabsWithNonUpsellIcons} secondary />)
+  it("does not render icons in secondary tabs when showUpsellIcon is false", () => {
+    render(<BaseTabs tabs={secondaryTabsWithoutUpsellIcons} secondary />)
 
     const icons = document.querySelectorAll("svg")
     expect(icons).toHaveLength(0)
   })
 
-  it("does not render non-Upsell icons in primary tabs", () => {
+  it("does not render icons in primary tabs when showUpsellIcon is false", () => {
     render(
-      <BaseTabs tabs={secondaryTabsWithNonUpsellIcons} secondary={false} />
+      <BaseTabs tabs={secondaryTabsWithoutUpsellIcons} secondary={false} />
     )
 
     const icons = document.querySelectorAll("svg")

--- a/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
@@ -68,8 +68,15 @@ describe("Tabs", () => {
     expect(nav).toHaveAttribute("aria-label", "primary-navigation")
   })
 
-  it("renders Upsell icons only for secondary tabs", () => {
+  it("renders Upsell icons in secondary tabs", () => {
     render(<BaseTabs tabs={secondaryTabsWithUpsellIcons} secondary />)
+
+    const icons = document.querySelectorAll("svg")
+    expect(icons).toHaveLength(2)
+  })
+
+  it("renders Upsell icons for primary tabs", () => {
+    render(<BaseTabs tabs={secondaryTabsWithUpsellIcons} secondary={false} />)
 
     const icons = document.querySelectorAll("svg")
     expect(icons).toHaveLength(2)
@@ -82,7 +89,7 @@ describe("Tabs", () => {
     expect(icons).toHaveLength(0)
   })
 
-  it("does not render any icons for primary tabs", () => {
+  it("does not render non-Upsell icons in primary tabs", () => {
     render(
       <BaseTabs tabs={secondaryTabsWithNonUpsellIcons} secondary={false} />
     )

--- a/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react"
 import { ComponentProps, forwardRef, PropsWithChildren } from "react"
 import { describe, expect, it, vi } from "vitest"
+import { Home } from "../../../icons/app"
 import { BaseTabs, TabsSkeleton } from "./index"
 
 // Mock the linkHandler module
@@ -26,6 +27,11 @@ describe("Tabs", () => {
     { label: "Tab 3", href: "/another" },
   ]
 
+  const secondaryTabsWithIcons = [
+    { label: "Tab 1", href: "/active", icon: Home },
+    { label: "Tab 2", href: "/other", icon: Home },
+  ]
+
   it("renders multiple tabs correctly", () => {
     render(<BaseTabs tabs={defaultTabs} />)
 
@@ -43,6 +49,20 @@ describe("Tabs", () => {
     expect(tab).toHaveClass("text-lg", "font-medium")
   })
 
+  it("renders a single secondary tab with icon", () => {
+    const singleTabWithIcon = [
+      { label: "Single Tab", href: "/single", icon: Home },
+    ]
+    render(<BaseTabs tabs={singleTabWithIcon} secondary />)
+
+    const tab = screen.getByText("Single Tab")
+    expect(tab.tagName).toBe("LI")
+    expect(tab).toHaveClass("text-lg", "font-medium")
+
+    const icon = tab.querySelector("svg")
+    expect(icon).toBeInTheDocument()
+  })
+
   it("applies active state to the correct tab", () => {
     render(<BaseTabs tabs={defaultTabs} />)
 
@@ -55,6 +75,20 @@ describe("Tabs", () => {
 
     const nav = screen.getByRole("navigation")
     expect(nav).toHaveAttribute("aria-label", "primary-navigation")
+  })
+
+  it("renders icons only for secondary tabs", () => {
+    render(<BaseTabs tabs={secondaryTabsWithIcons} secondary />)
+
+    const icons = screen.getAllByRole("img", { hidden: true })
+    expect(icons).toHaveLength(2)
+  })
+
+  it("does not render icons for primary tabs", () => {
+    render(<BaseTabs tabs={secondaryTabsWithIcons} secondary={false} />)
+
+    const icons = screen.queryAllByRole("img", { hidden: true })
+    expect(icons).toHaveLength(0)
   })
 
   describe("TabsSkeleton", () => {

--- a/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
@@ -66,7 +66,7 @@ describe("Tabs", () => {
   it("renders icons only for secondary tabs", () => {
     render(<BaseTabs tabs={secondaryTabsWithIcons} secondary />)
 
-    const icons = screen.getAllByRole("img", { hidden: true })
+    const icons = document.querySelectorAll("svg")
     expect(icons).toHaveLength(2)
   })
 

--- a/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
@@ -49,20 +49,6 @@ describe("Tabs", () => {
     expect(tab).toHaveClass("text-lg", "font-medium")
   })
 
-  it("renders a single secondary tab with icon", () => {
-    const singleTabWithIcon = [
-      { label: "Single Tab", href: "/single", icon: Home },
-    ]
-    render(<BaseTabs tabs={singleTabWithIcon} secondary />)
-
-    const tab = screen.getByText("Single Tab")
-    expect(tab.tagName).toBe("LI")
-    expect(tab).toHaveClass("text-lg", "font-medium")
-
-    const icon = tab.querySelector("svg")
-    expect(icon).toBeInTheDocument()
-  })
-
   it("applies active state to the correct tab", () => {
     render(<BaseTabs tabs={defaultTabs} />)
 

--- a/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react"
 import { ComponentProps, forwardRef, PropsWithChildren } from "react"
 import { describe, expect, it, vi } from "vitest"
-import { Home } from "../../../icons/app"
+import { Home, Upsell } from "../../../icons/app"
 import { BaseTabs, TabsSkeleton } from "./index"
 
 // Mock the linkHandler module
@@ -27,7 +27,12 @@ describe("Tabs", () => {
     { label: "Tab 3", href: "/another" },
   ]
 
-  const secondaryTabsWithIcons = [
+  const secondaryTabsWithUpsellIcons = [
+    { label: "Tab 1", href: "/active", icon: Upsell },
+    { label: "Tab 2", href: "/other", icon: Upsell },
+  ]
+
+  const secondaryTabsWithNonUpsellIcons = [
     { label: "Tab 1", href: "/active", icon: Home },
     { label: "Tab 2", href: "/other", icon: Home },
   ]
@@ -63,17 +68,26 @@ describe("Tabs", () => {
     expect(nav).toHaveAttribute("aria-label", "primary-navigation")
   })
 
-  it("renders icons only for secondary tabs", () => {
-    render(<BaseTabs tabs={secondaryTabsWithIcons} secondary />)
+  it("renders Upsell icons only for secondary tabs", () => {
+    render(<BaseTabs tabs={secondaryTabsWithUpsellIcons} secondary />)
 
     const icons = document.querySelectorAll("svg")
     expect(icons).toHaveLength(2)
   })
 
-  it("does not render icons for primary tabs", () => {
-    render(<BaseTabs tabs={secondaryTabsWithIcons} secondary={false} />)
+  it("does not render non-Upsell icons in secondary tabs", () => {
+    render(<BaseTabs tabs={secondaryTabsWithNonUpsellIcons} secondary />)
 
-    const icons = screen.queryAllByRole("img", { hidden: true })
+    const icons = document.querySelectorAll("svg")
+    expect(icons).toHaveLength(0)
+  })
+
+  it("does not render any icons for primary tabs", () => {
+    render(
+      <BaseTabs tabs={secondaryTabsWithNonUpsellIcons} secondary={false} />
+    )
+
+    const icons = document.querySelectorAll("svg")
     expect(icons).toHaveLength(0)
   })
 

--- a/packages/react/src/experimental/Navigation/Tabs/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.stories.tsx
@@ -24,14 +24,6 @@ const primaryTabItemsWithUpsellIcons: TabItem[] = [
   { label: "Requests", href: "/requests", "data-test": "foo" },
 ]
 
-const secondaryTabItemsWithIcons: TabItem[] = [
-  { label: "Overview", href: "/", index: true },
-  { label: "Courses", href: "/courses", showUpsellIcon: true },
-  { label: "Categories", href: "/categories" },
-  { label: "Catalog", href: "/catalog" },
-  { label: "Requests", href: "/requests", "data-test": "foo" },
-]
-
 const meta: Meta<typeof Tabs> = {
   title: "Navigation/Tabs",
   component: Tabs,
@@ -87,13 +79,6 @@ export const Piled: Story = {
 export const Secondary: Story = {
   args: {
     tabs: tabItems,
-    secondary: true,
-  },
-}
-
-export const SecondaryUpsell: Story = {
-  args: {
-    tabs: secondaryTabItemsWithIcons,
     secondary: true,
   },
 }

--- a/packages/react/src/experimental/Navigation/Tabs/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { expect, within } from "@storybook/test"
-import { BookOpen, Folders, Home, List, Messages } from "../../../icons/app"
+import { BookOpen, Home, List, Messages, Upsell } from "../../../icons/app"
 import { TabItem, Tabs } from "./index"
 
 const tabItems: TabItem[] = [
@@ -19,9 +19,9 @@ const secondaryTabItems = [
 
 const secondaryTabItemsWithIcons: TabItem[] = [
   { label: "Overview", href: "/", index: true, icon: Home },
-  { label: "Courses", href: "/courses", icon: BookOpen },
+  { label: "Courses", href: "/courses", icon: Upsell },
   { label: "Categories", href: "/categories", icon: List },
-  { label: "Catalog", href: "/catalog", icon: Folders },
+  { label: "Catalog", href: "/catalog", icon: BookOpen },
   { label: "Requests", href: "/requests", "data-test": "foo" },
 ]
 
@@ -122,7 +122,7 @@ const tabItemsWithIdsAndIcons: TabItem[] = [
   { label: "Overview", id: "overview", icon: Home, index: true },
   { label: "Courses", id: "courses", icon: BookOpen },
   { label: "Categories", id: "categories", icon: List },
-  { label: "Catalog", id: "catalog", icon: Folders },
+  { label: "Catalog", id: "catalog", icon: Upsell },
   { label: "Requests", id: "requests", icon: Messages, "data-test": "foo" },
 ]
 

--- a/packages/react/src/experimental/Navigation/Tabs/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { expect, within } from "@storybook/test"
+import { BookOpen, Folders, Home, List, Messages } from "../../../icons/app"
 import { TabItem, Tabs } from "./index"
 
 const tabItems: TabItem[] = [
@@ -14,6 +15,14 @@ const secondaryTabItems = [
   { label: "All", href: "/courses", index: true },
   { label: "Courses", href: "/courses/new" },
   { label: "Activity", href: "/courses/activity" },
+]
+
+const secondaryTabItemsWithIcons: TabItem[] = [
+  { label: "Overview", href: "/", index: true, icon: Home },
+  { label: "Courses", href: "/courses", icon: BookOpen },
+  { label: "Categories", href: "/categories", icon: List },
+  { label: "Catalog", href: "/catalog", icon: Folders },
+  { label: "Requests", href: "/requests", "data-test": "foo" },
 ]
 
 const meta: Meta<typeof Tabs> = {
@@ -68,6 +77,13 @@ export const Secondary: Story = {
   },
 }
 
+export const SecondaryWithIcons: Story = {
+  args: {
+    tabs: secondaryTabItemsWithIcons,
+    secondary: true,
+  },
+}
+
 export const Skeleton: Story = {
   args: {
     tabs: [],
@@ -102,9 +118,25 @@ const tabItemsWithIds: TabItem[] = [
   { label: "Requests", id: "requests", "data-test": "foo" },
 ]
 
+const tabItemsWithIdsAndIcons: TabItem[] = [
+  { label: "Overview", id: "overview", icon: Home, index: true },
+  { label: "Courses", id: "courses", icon: BookOpen },
+  { label: "Categories", id: "categories", icon: List },
+  { label: "Catalog", id: "catalog", icon: Folders },
+  { label: "Requests", id: "requests", icon: Messages, "data-test": "foo" },
+]
+
 export const WithIds: Story = {
   args: {
     tabs: tabItemsWithIds,
     activeTabId: "overview",
+  },
+}
+
+export const WithIdsAndIcons: Story = {
+  args: {
+    tabs: tabItemsWithIdsAndIcons,
+    activeTabId: "overview",
+    secondary: true,
   },
 }

--- a/packages/react/src/experimental/Navigation/Tabs/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { expect, within } from "@storybook/test"
-import { BookOpen, Home, List, Messages, Upsell } from "../../../icons/app"
 import { TabItem, Tabs } from "./index"
 
 const tabItems: TabItem[] = [
@@ -19,17 +18,17 @@ const secondaryTabItems = [
 
 const primaryTabItemsWithUpsellIcons: TabItem[] = [
   { label: "Overview", href: "/", index: true },
-  { label: "Courses", href: "/courses", icon: Upsell },
+  { label: "Courses", href: "/courses", showUpsellIcon: true },
   { label: "Categories", href: "/categories" },
-  { label: "Catalog", href: "/catalog", icon: Upsell },
+  { label: "Catalog", href: "/catalog", showUpsellIcon: true },
   { label: "Requests", href: "/requests", "data-test": "foo" },
 ]
 
 const secondaryTabItemsWithIcons: TabItem[] = [
-  { label: "Overview", href: "/", index: true, icon: Home },
-  { label: "Courses", href: "/courses", icon: Upsell },
-  { label: "Categories", href: "/categories", icon: List },
-  { label: "Catalog", href: "/catalog", icon: BookOpen },
+  { label: "Overview", href: "/", index: true },
+  { label: "Courses", href: "/courses", showUpsellIcon: true },
+  { label: "Categories", href: "/categories" },
+  { label: "Catalog", href: "/catalog" },
   { label: "Requests", href: "/requests", "data-test": "foo" },
 ]
 
@@ -133,12 +132,12 @@ const tabItemsWithIds: TabItem[] = [
   { label: "Requests", id: "requests", "data-test": "foo" },
 ]
 
-const tabItemsWithIdsAndIcons: TabItem[] = [
-  { label: "Overview", id: "overview", icon: Home, index: true },
-  { label: "Courses", id: "courses", icon: BookOpen },
-  { label: "Categories", id: "categories", icon: List },
-  { label: "Catalog", id: "catalog", icon: Upsell },
-  { label: "Requests", id: "requests", icon: Messages, "data-test": "foo" },
+const tabItemsWithIdsAndUpsell: TabItem[] = [
+  { label: "Overview", id: "overview", index: true },
+  { label: "Courses", id: "courses" },
+  { label: "Categories", id: "categories" },
+  { label: "Catalog", id: "catalog", showUpsellIcon: true },
+  { label: "Requests", id: "requests", "data-test": "foo" },
 ]
 
 export const WithIds: Story = {
@@ -148,9 +147,9 @@ export const WithIds: Story = {
   },
 }
 
-export const WithIdsAndIcons: Story = {
+export const WithIdsAndUpsell: Story = {
   args: {
-    tabs: tabItemsWithIdsAndIcons,
+    tabs: tabItemsWithIdsAndUpsell,
     activeTabId: "overview",
     secondary: true,
   },

--- a/packages/react/src/experimental/Navigation/Tabs/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.stories.tsx
@@ -17,6 +17,14 @@ const secondaryTabItems = [
   { label: "Activity", href: "/courses/activity" },
 ]
 
+const primaryTabItemsWithUpsellIcons: TabItem[] = [
+  { label: "Overview", href: "/", index: true },
+  { label: "Courses", href: "/courses", icon: Upsell },
+  { label: "Categories", href: "/categories" },
+  { label: "Catalog", href: "/catalog", icon: Upsell },
+  { label: "Requests", href: "/requests", "data-test": "foo" },
+]
+
 const secondaryTabItemsWithIcons: TabItem[] = [
   { label: "Overview", href: "/", index: true, icon: Home },
   { label: "Courses", href: "/courses", icon: Upsell },
@@ -55,6 +63,13 @@ export const Primary: Story = {
   },
 }
 
+export const PrimaryUpsell: Story = {
+  args: {
+    tabs: primaryTabItemsWithUpsellIcons,
+    secondary: false,
+  },
+}
+
 export const Piled: Story = {
   args: {
     tabs: [],
@@ -77,7 +92,7 @@ export const Secondary: Story = {
   },
 }
 
-export const SecondaryWithIcons: Story = {
+export const SecondaryUpsell: Story = {
   args: {
     tabs: secondaryTabItemsWithIcons,
     secondary: true,

--- a/packages/react/src/experimental/Navigation/Tabs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.tsx
@@ -1,7 +1,7 @@
 import { TabNavigation, TabNavigationLink } from "@/ui/tab-navigation"
 import { Dispatch, useEffect, useState } from "react"
 import { Icon } from "../../../components/Utilities/Icon"
-import { Pencil } from "../../../icons/app"
+import { Upsell } from "../../../icons/app"
 import { Link, useNavigation } from "../../../lib/linkHandler"
 import { withSkeleton } from "../../../lib/skeleton"
 
@@ -82,7 +82,7 @@ export const BaseTabs: React.FC<TabsProps> = ({
               <Link role="link" {...props}>
                 {props.showUpsellIcon && (
                   <Icon
-                    icon={Pencil}
+                    icon={Upsell}
                     size="md"
                     className="mr-1 text-[hsl(var(--promote-50))]"
                   />

--- a/packages/react/src/experimental/Navigation/Tabs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.tsx
@@ -1,6 +1,6 @@
 import { TabNavigation, TabNavigationLink } from "@/ui/tab-navigation"
 import { Dispatch, useEffect, useState } from "react"
-import { Icon, IconType } from "../../../components/Utilities/Icon"
+import { Icon } from "../../../components/Utilities/Icon"
 import { Upsell } from "../../../icons/app"
 import { Link, useNavigation } from "../../../lib/linkHandler"
 import { withSkeleton } from "../../../lib/skeleton"
@@ -8,7 +8,7 @@ import { withSkeleton } from "../../../lib/skeleton"
 export type TabItem = {
   label: string
   index?: boolean
-  icon?: IconType
+  showUpsellIcon?: boolean
 } & DataAttributes &
   ({ href: string } | { id: string })
 
@@ -60,7 +60,7 @@ export const BaseTabs: React.FC<TabsProps> = ({
           {visibleTabs[0].label}
         </li>
       ) : (
-        visibleTabs.map(({ label, icon, ...props }, index) => {
+        visibleTabs.map(({ label, showUpsellIcon, ...props }, index) => {
           const active =
             activeTab && "href" in activeTab && "href" in props
               ? activeTab.href === props.href
@@ -80,9 +80,9 @@ export const BaseTabs: React.FC<TabsProps> = ({
               asChild
             >
               <Link role="link" {...props}>
-                {icon && icon === Upsell && (
+                {showUpsellIcon && (
                   <Icon
-                    icon={icon}
+                    icon={Upsell}
                     size="md"
                     className="mr-1 text-[hsl(var(--promote-50))]"
                   />

--- a/packages/react/src/experimental/Navigation/Tabs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.tsx
@@ -80,11 +80,11 @@ export const BaseTabs: React.FC<TabsProps> = ({
               asChild
             >
               <Link role="link" {...props}>
-                {secondary && icon && icon === Upsell && (
+                {icon && icon === Upsell && (
                   <Icon
                     icon={icon}
                     size="md"
-                    className="text-[hsl(var(--promote-50))]"
+                    className="mr-1 text-[hsl(var(--promote-50))]"
                   />
                 )}
                 {label}

--- a/packages/react/src/experimental/Navigation/Tabs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.tsx
@@ -1,6 +1,7 @@
 import { TabNavigation, TabNavigationLink } from "@/ui/tab-navigation"
 import { Dispatch, useEffect, useState } from "react"
 import { Icon, IconType } from "../../../components/Utilities/Icon"
+import { Upsell } from "../../../icons/app"
 import { Link, useNavigation } from "../../../lib/linkHandler"
 import { withSkeleton } from "../../../lib/skeleton"
 
@@ -80,7 +81,11 @@ export const BaseTabs: React.FC<TabsProps> = ({
             >
               <Link role="link" {...props}>
                 {secondary && icon && (
-                  <Icon icon={icon} size="md" className="text-promote mr-1" />
+                  <Icon
+                    icon={icon}
+                    size="md"
+                    className={`mr-1 ${icon === Upsell ? "text-[hsl(var(--promote-50))]" : ""}`}
+                  />
                 )}
                 {label}
               </Link>

--- a/packages/react/src/experimental/Navigation/Tabs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.tsx
@@ -57,7 +57,11 @@ export const BaseTabs: React.FC<TabsProps> = ({
       {visibleTabs.length === 1 ? (
         <li className="flex h-8 items-center justify-center whitespace-nowrap text-lg font-medium text-f1-foreground">
           {secondary && visibleTabs[0].icon && (
-            <Icon icon={visibleTabs[0].icon} size="sm" className="mr-2" />
+            <Icon
+              icon={visibleTabs[0].icon}
+              size="sm"
+              className="promote mr-2"
+            />
           )}
           {visibleTabs[0].label}
         </li>

--- a/packages/react/src/experimental/Navigation/Tabs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.tsx
@@ -1,11 +1,13 @@
 import { TabNavigation, TabNavigationLink } from "@/ui/tab-navigation"
 import { Dispatch, useEffect, useState } from "react"
+import { Icon, IconType } from "../../../components/Utilities/Icon"
 import { Link, useNavigation } from "../../../lib/linkHandler"
 import { withSkeleton } from "../../../lib/skeleton"
 
 export type TabItem = {
   label: string
   index?: boolean
+  icon?: IconType
 } & DataAttributes &
   ({ href: string } | { id: string })
 
@@ -54,10 +56,13 @@ export const BaseTabs: React.FC<TabsProps> = ({
     >
       {visibleTabs.length === 1 ? (
         <li className="flex h-8 items-center justify-center whitespace-nowrap text-lg font-medium text-f1-foreground">
+          {secondary && visibleTabs[0].icon && (
+            <Icon icon={visibleTabs[0].icon} size="sm" className="mr-2" />
+          )}
           {visibleTabs[0].label}
         </li>
       ) : (
-        visibleTabs.map(({ label, ...props }, index) => {
+        visibleTabs.map(({ label, icon, ...props }, index) => {
           const active =
             activeTab && "href" in activeTab && "href" in props
               ? activeTab.href === props.href
@@ -77,6 +82,9 @@ export const BaseTabs: React.FC<TabsProps> = ({
               asChild
             >
               <Link role="link" {...props}>
+                {secondary && icon && (
+                  <Icon icon={icon} size="sm" className="mr-2" />
+                )}
                 {label}
               </Link>
             </TabNavigationLink>

--- a/packages/react/src/experimental/Navigation/Tabs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.tsx
@@ -1,7 +1,7 @@
 import { TabNavigation, TabNavigationLink } from "@/ui/tab-navigation"
 import { Dispatch, useEffect, useState } from "react"
 import { Icon } from "../../../components/Utilities/Icon"
-import { Upsell } from "../../../icons/app"
+import { Pencil } from "../../../icons/app"
 import { Link, useNavigation } from "../../../lib/linkHandler"
 import { withSkeleton } from "../../../lib/skeleton"
 
@@ -82,7 +82,7 @@ export const BaseTabs: React.FC<TabsProps> = ({
               <Link role="link" {...props}>
                 {props.showUpsellIcon && (
                   <Icon
-                    icon={Upsell}
+                    icon={Pencil}
                     size="md"
                     className="mr-1 text-[hsl(var(--promote-50))]"
                   />

--- a/packages/react/src/experimental/Navigation/Tabs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.tsx
@@ -60,7 +60,7 @@ export const BaseTabs: React.FC<TabsProps> = ({
           {visibleTabs[0].label}
         </li>
       ) : (
-        visibleTabs.map(({ label, showUpsellIcon, ...props }, index) => {
+        visibleTabs.map(({ label, ...props }, index) => {
           const active =
             activeTab && "href" in activeTab && "href" in props
               ? activeTab.href === props.href
@@ -80,7 +80,7 @@ export const BaseTabs: React.FC<TabsProps> = ({
               asChild
             >
               <Link role="link" {...props}>
-                {showUpsellIcon && (
+                {props.showUpsellIcon && (
                   <Icon
                     icon={Upsell}
                     size="md"

--- a/packages/react/src/experimental/Navigation/Tabs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.tsx
@@ -56,13 +56,6 @@ export const BaseTabs: React.FC<TabsProps> = ({
     >
       {visibleTabs.length === 1 ? (
         <li className="flex h-8 items-center justify-center whitespace-nowrap text-lg font-medium text-f1-foreground">
-          {secondary && visibleTabs[0].icon && (
-            <Icon
-              icon={visibleTabs[0].icon}
-              size="sm"
-              className="promote mr-2"
-            />
-          )}
           {visibleTabs[0].label}
         </li>
       ) : (
@@ -87,7 +80,7 @@ export const BaseTabs: React.FC<TabsProps> = ({
             >
               <Link role="link" {...props}>
                 {secondary && icon && (
-                  <Icon icon={icon} size="sm" className="mr-2" />
+                  <Icon icon={icon} size="md" className="text-promote mr-1" />
                 )}
                 {label}
               </Link>

--- a/packages/react/src/experimental/Navigation/Tabs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Tabs/index.tsx
@@ -80,11 +80,11 @@ export const BaseTabs: React.FC<TabsProps> = ({
               asChild
             >
               <Link role="link" {...props}>
-                {secondary && icon && (
+                {secondary && icon && icon === Upsell && (
                   <Icon
                     icon={icon}
                     size="md"
-                    className={`mr-1 ${icon === Upsell ? "text-[hsl(var(--promote-50))]" : ""}`}
+                    className="text-[hsl(var(--promote-50))]"
                   />
                 )}
                 {label}


### PR DESCRIPTION
## Description

Add Icon prop to Tab component.

## Screenshots (if applicable)

![Screenshot 2025-05-28 at 14 46 02](https://github.com/user-attachments/assets/40b3cd16-5b1e-4e1c-8290-e8317a6d4ce0)

![Screenshot 2025-05-28 at 13 28 03](https://github.com/user-attachments/assets/9f68d994-65d1-4b0a-8a77-63c5d8f249df)


### Figma Link

<!-- Add the Figma URL as the source of truth for this component -->

[Link to Figma Design](Figma URL here)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other

---

<!--
 **Note:** Delete sections that are not applicable to this PR.
 -->

## Experimental Component Checklist (if applicable)

- [ ] Component added to `experimental` folder
- [ ] Component is documented with basic stories
- [ ] Component added to the
      [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

## Promotion to Stable Checklist (if applicable)

- [ ] **Documentation**

  - [ ] The component has a dedicated documentation page
  - [ ] Includes description and clear use cases
  - [ ] Includes Storybook stories covering all variations
  - [ ] Component updated on the
        [Roadmap](https://www.notion.so/factorialco/9405cb75dd384c7488a6f565ed736577?v=d43fbf70913445e7881bb8ef67b12048&pvs=4)

- [ ] **Responsiveness**

  - [ ] Verified the component works across various screen sizes

- [X ] **Testing**

  - [ X] Component includes unit tests with sufficient coverage

- [ ] **Accessibility**
  - [ ] Accessibility standards meet at least AA level requirements
  - [ ] All interactive elements are keyboard-navigable and have focus states
  - [ ] Proper ARIA attributes are used where needed
