### PR TITLE
feat: allow string id on Entity Selector

### DIFF
--- a/packages/react/src/experimental/Forms/EntitySelect/Content/MainContent/index.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/Content/MainContent/index.tsx
@@ -7,6 +7,7 @@ import { VirtualList } from "../../../../Navigation/VirtualList"
 import { Select } from "../../../Fields/Select"
 import { EntitySelectListItem } from "../../ListItem"
 import {
+  EntityId,
   EntitySelectEntity,
   EntitySelectNamedGroup,
   EntitySelectSubEntity,
@@ -332,7 +333,7 @@ export const MainContent = ({
     if (!entities.length) {
       return [false, false]
     }
-    const selectedMap = new Map<number, EntitySelectEntity>(
+    const selectedMap = new Map<EntityId, EntitySelectEntity>(
       (selectedEntities ?? []).map((se) => [se.id, se])
     )
 

--- a/packages/react/src/experimental/Forms/EntitySelect/Content/SecondaryContent/index.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/Content/SecondaryContent/index.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react"
 import { VirtualList } from "../../../../Navigation/VirtualList"
 import { ListTag } from "../../ListTag"
 import {
+  EntityId,
   EntitySelectEntity,
   EntitySelectSubEntity,
   FlattenedItem,
@@ -44,7 +45,7 @@ export const SecondaryContent = ({
           }))
         )
 
-    const seenIds = new Set<number>()
+    const seenIds = new Set<EntityId>()
     return rawFlattened.filter((item) => {
       const key = item.subItem.subId
       if (seenIds.has(key)) {

--- a/packages/react/src/experimental/Forms/EntitySelect/employee-selector.stories.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/employee-selector.stories.tsx
@@ -3,7 +3,7 @@ import { fn } from "@storybook/test"
 import { useState } from "react"
 import avatar from "../../../../storybook-assets/avatar.jpeg"
 import { EntitySelect } from "./index"
-import { EntitySelectEntity } from "./types"
+import { EntityId, EntitySelectEntity } from "./types"
 
 // --------------------------------------
 // EXAMPLE GRAPHQL COMMENT BLOCK
@@ -207,7 +207,7 @@ export const Default: Story = {
     const [loading, setLoading] = useState<boolean>(true)
     const [fetchEmployees, setFetchEmployees] = useState<FetchEmployee[]>([])
     const [selectedGroup, setSelectedGroup] = useState<string>("all")
-    const [expandedElements, setExpandedElements] = useState<number[]>([])
+    const [expandedElements, setExpandedElements] = useState<EntityId[]>([])
     const [selectedEmployees, setSelectedEmployees] = useState<
       EntitySelectEntity[]
     >([])
@@ -227,7 +227,7 @@ export const Default: Story = {
       setSelectedEmployees(Array.isArray(el) ? el : el ? [el] : [])
     }
 
-    const onItemExpandedChange = (id: number, expanded: boolean) => {
+    const onItemExpandedChange = (id: EntityId, expanded: boolean) => {
       if (expanded) {
         setExpandedElements([id].concat(expandedElements))
       } else {

--- a/packages/react/src/experimental/Forms/EntitySelect/groups-avatar-name.factory.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/groups-avatar-name.factory.tsx
@@ -4,24 +4,24 @@ import { EntitySelectEntity } from "./types"
 
 export const teamsWithEmployees: EntitySelectEntity[] = [
   {
-    id: 51,
+    id: "engineering_51",
     name: "Engineering",
     avatar: avatar,
     subItems: getEmployeesFromRange(0, 12),
   },
   {
-    id: 52,
+    id: "design_52",
     name: "Design",
     avatar: avatar,
     subItems: getEmployeesFromRange(10, 22),
   },
   {
-    id: 53,
+    id: "marketing_53",
     name: "Marketing",
     avatar: avatar,
   },
   {
-    id: 54,
+    id: "sales_54",
     name: "Sales",
     avatar: avatar,
     subItems: getEmployeesFromRange(20, 30),

--- a/packages/react/src/experimental/Forms/EntitySelect/index.stories.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/index.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from "./groups-avatar-name.factory"
 import { EntitySelect } from "./index"
 import {
+  EntityId,
   EntitySelectEntity,
   EntitySelectNamedGroup,
   EntitySelectProps,
@@ -92,7 +93,7 @@ export const Default = {
   args: defaultArgs,
   render: (props: ComponentProps<typeof EntitySelect>) => {
     const [loading, setLoading] = useState<boolean>(props.loading ?? true)
-    const [expandedElements, setExpandedElements] = useState<number[]>([])
+    const [expandedElements, setExpandedElements] = useState<EntityId[]>([])
     const [selected, setSelected] = useState<EntitySelectEntity[]>([
       {
         ...famousEmployees[0],
@@ -103,7 +104,7 @@ export const Default = {
       props.selectedGroup ?? "all"
     )
 
-    const onItemExpandedChange = (id: number, expanded: boolean) => {
+    const onItemExpandedChange = (id: EntityId, expanded: boolean) => {
       if (expanded) {
         setExpandedElements([id].concat(expandedElements))
       } else {
@@ -217,7 +218,7 @@ export const WithSelectedGroup = {
   } as EntitySelectProps,
   render: (props: ComponentProps<typeof EntitySelect>) => {
     const [loading, setLoading] = useState<boolean>(props.loading ?? true)
-    const [expandedElements, setExpandedElements] = useState<number[]>([])
+    const [expandedElements, setExpandedElements] = useState<EntityId[]>([])
     const [selected, setSelected] = useState<EntitySelectEntity[]>([
       {
         ...famousEmployees[0],
@@ -228,7 +229,7 @@ export const WithSelectedGroup = {
       props.selectedGroup ?? "all"
     )
 
-    const onItemExpandedChange = (id: number, expanded: boolean) => {
+    const onItemExpandedChange = (id: EntityId, expanded: boolean) => {
       if (expanded) {
         setExpandedElements([id].concat(expandedElements))
       } else {
@@ -275,12 +276,12 @@ export const SingleSelector = {
   render: (props: ComponentProps<typeof EntitySelect>) => {
     const [loading, setLoading] = useState<boolean>(props.loading ?? true)
     const [selected, setSelected] = useState<EntitySelectEntity | undefined>()
-    const [expandedElements, setExpandedElements] = useState<number[]>([])
+    const [expandedElements, setExpandedElements] = useState<EntityId[]>([])
     const [selectedGroup, setSelectedGroup] = useState<string>(
       props.selectedGroup ?? "all"
     )
 
-    const onItemExpandedChange = (id: number, expanded: boolean) => {
+    const onItemExpandedChange = (id: EntityId, expanded: boolean) => {
       if (expanded) {
         setExpandedElements([id].concat(expandedElements))
       } else {
@@ -335,7 +336,7 @@ export const AlwaysOpen = {
   } as EntitySelectProps,
   render: (props: ComponentProps<typeof EntitySelect>) => {
     const [loading, setLoading] = useState<boolean>(props.loading ?? true)
-    const [expandedElements, setExpandedElements] = useState<number[]>([])
+    const [expandedElements, setExpandedElements] = useState<EntityId[]>([])
     const [selected, setSelected] = useState<EntitySelectEntity[]>([
       {
         ...famousEmployees[0],
@@ -346,7 +347,7 @@ export const AlwaysOpen = {
       props.selectedGroup ?? "all"
     )
 
-    const onItemExpandedChange = (id: number, expanded: boolean) => {
+    const onItemExpandedChange = (id: EntityId, expanded: boolean) => {
       if (expanded) {
         setExpandedElements([id].concat(expandedElements))
       } else {
@@ -396,7 +397,7 @@ export const AlwaysOpenInForm = {
     alwaysOpen: true,
   } as EntitySelectProps,
   render: (props: ComponentProps<typeof EntitySelect>) => {
-    const [expandedElements, setExpandedElements] = useState<number[]>([])
+    const [expandedElements, setExpandedElements] = useState<EntityId[]>([])
     const [selected, setSelected] = useState<EntitySelectEntity[]>([
       {
         ...famousEmployees[0],
@@ -407,7 +408,7 @@ export const AlwaysOpenInForm = {
       props.selectedGroup ?? "all"
     )
 
-    const onItemExpandedChange = (id: number, expanded: boolean) => {
+    const onItemExpandedChange = (id: EntityId, expanded: boolean) => {
       if (expanded) {
         setExpandedElements([id].concat(expandedElements))
       } else {
@@ -450,7 +451,7 @@ export const WithCustomTrigger = {
   } as EntitySelectProps,
   render: (props: ComponentProps<typeof EntitySelect>) => {
     const [loading, setLoading] = useState<boolean>(props.loading ?? true)
-    const [expandedElements, setExpandedElements] = useState<number[]>([])
+    const [expandedElements, setExpandedElements] = useState<EntityId[]>([])
     const [selectedGroup, setSelectedGroup] = useState<string>(
       props.selectedGroup ?? "all"
     )
@@ -463,7 +464,7 @@ export const WithCustomTrigger = {
     const [numSelected, setNumSelected] = useState<number>(2)
     const [open, setOpen] = useState<boolean>(false)
 
-    const onItemExpandedChange = (id: number, expanded: boolean) => {
+    const onItemExpandedChange = (id: EntityId, expanded: boolean) => {
       if (expanded) {
         setExpandedElements([id].concat(expandedElements))
       } else {
@@ -611,7 +612,7 @@ export const HiddenAvatar = {
     hiddenAvatar: true,
   },
   render: (props: ComponentProps<typeof EntitySelect>) => {
-    const [expandedElements, setExpandedElements] = useState<number[]>([])
+    const [expandedElements, setExpandedElements] = useState<EntityId[]>([])
     const [selected, setSelected] = useState<EntitySelectEntity[]>([
       {
         ...famousEmployees[0],
@@ -622,7 +623,7 @@ export const HiddenAvatar = {
       props.selectedGroup ?? "all"
     )
 
-    const onItemExpandedChange = (id: number, expanded: boolean) => {
+    const onItemExpandedChange = (id: EntityId, expanded: boolean) => {
       if (expanded) {
         setExpandedElements([id].concat(expandedElements))
       } else {

--- a/packages/react/src/experimental/Forms/EntitySelect/index.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/index.tsx
@@ -5,6 +5,7 @@ import { cn } from "../../../lib/utils"
 import { Content } from "./Content"
 import { Trigger } from "./Trigger"
 import {
+  EntityId,
   EntitySelectEntity,
   EntitySelectProps,
   EntitySelectSubEntity,
@@ -45,7 +46,7 @@ export const EntitySelect = (
       (filteredEntity.subItems ?? []).map((s) => s.subId)
     )
 
-    const parentIdsToUpdate = new Set<number>([filteredEntity.id])
+    const parentIdsToUpdate = new Set<EntityId>([filteredEntity.id])
     filteredEntities.forEach((possibleParent) => {
       if (possibleParent.id !== filteredEntity.id) {
         const hasIntersection = (possibleParent.subItems ?? []).some((sub) =>
@@ -111,7 +112,7 @@ export const EntitySelect = (
     } else {
       const prevSelected = props.selectedEntities ?? []
       const selectedIds = new Set(prevSelected.map((sel) => sel.id))
-      const selectedSubItemsMap = new Map<number, EntitySelectSubEntity[]>(
+      const selectedSubItemsMap = new Map<EntityId, EntitySelectSubEntity[]>(
         prevSelected.map((sel) => [sel.id, sel.subItems ?? []])
       )
 
@@ -247,7 +248,7 @@ export const EntitySelect = (
     let newSelected: EntitySelectEntity[] = []
 
     if (groupView) {
-      const visibleSubIds = new Set<number>(
+      const visibleSubIds = new Set<EntityId>(
         filteredEntities.flatMap((ent) =>
           (ent.subItems ?? []).map((sub) => sub.subId)
         )
@@ -266,7 +267,9 @@ export const EntitySelect = (
         }
       }
     } else {
-      const visibleIds = new Set<number>(filteredEntities.map((ent) => ent.id))
+      const visibleIds = new Set<EntityId>(
+        filteredEntities.map((ent) => ent.id)
+      )
       newSelected = (prevSelected ?? []).filter((el) => !visibleIds.has(el.id))
     }
 

--- a/packages/react/src/experimental/Forms/EntitySelect/types.ts
+++ b/packages/react/src/experimental/Forms/EntitySelect/types.ts
@@ -1,14 +1,14 @@
 import { PopoverProps } from "@radix-ui/react-popover"
 
 export type EntitySelectSubEntity = {
-  subId: number
+  subId: EntityId
   subName: string
   subAvatar?: string
   subSearchKeys?: string[]
 }
 
 export type EntitySelectEntity = {
-  id: number
+  id: EntityId
   name: string
   avatar?: string
   expanded?: boolean
@@ -31,7 +31,7 @@ interface EntitySelectCommonProps
   triggerSelected: string
   notFoundTitle: string
   notFoundSubtitle: string
-  onItemExpandedChange: (id: number, expanded: boolean) => void
+  onItemExpandedChange: (id: EntityId, expanded: boolean) => void
   onGroupChange: (value: string | null) => void
   disabled?: boolean
   zIndex?: number
@@ -68,3 +68,5 @@ export interface EntitySelectMultipleProps extends EntitySelectCommonProps {
 export type EntitySelectProps =
   | EntitySelectSingleProps
   | EntitySelectMultipleProps
+
+export type EntityId = number | string


### PR DESCRIPTION
## Description

Allowing entities from Entity Selector to have string ids. This allow the selector to have custom groups on the selector, where the group is not an entity. Also, this will allow to subItems to be customizable too

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [X] Maintenance / Bug Fix / Other

