### PR TITLE
fix(DataCollection): conditionally display the total item summary skeleton + style fixes

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/index.tsx
@@ -358,12 +358,7 @@ export const OneDataCollection = <
     <div
       className={cn("flex flex-col gap-4", layout === "standard" && "-mx-6")}
     >
-      {((isLoading &&
-        totalItems !== undefined &&
-        totalItemSummary(totalItems)) ||
-        (!isLoading &&
-          totalItems !== undefined &&
-          totalItemSummary(totalItems)) ||
+      {((totalItems !== undefined && totalItemSummary(totalItems)) ||
         navigationFilters) && (
         <div className="border-f1-border-primary flex gap-4 px-6">
           <div className="flex flex-1 flex-shrink gap-4 text-lg font-semibold">

--- a/packages/react/src/experimental/OneDataCollection/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/index.tsx
@@ -358,34 +358,42 @@ export const OneDataCollection = <
     <div
       className={cn("flex flex-col gap-4", layout === "standard" && "-mx-6")}
     >
-      <div className="border-f1-border-primary flex gap-4 px-6">
-        <div className="flex flex-1 flex-shrink gap-4 text-lg font-semibold">
-          {isLoading &&
-            totalItems !== undefined &&
-            totalItemSummary(totalItems) && <Skeleton className="h-5 w-24" />}
-          {!isLoading && totalItems !== undefined && (
-            <div className="flex h-5 items-center">
-              {totalItemSummary(totalItems)}
-            </div>
-          )}
+      {((isLoading &&
+        totalItems !== undefined &&
+        totalItemSummary(totalItems)) ||
+        (!isLoading &&
+          totalItems !== undefined &&
+          totalItemSummary(totalItems)) ||
+        navigationFilters) && (
+        <div className="border-f1-border-primary flex gap-4 px-6">
+          <div className="flex flex-1 flex-shrink gap-4 text-lg font-semibold">
+            {isLoading &&
+              totalItems !== undefined &&
+              totalItemSummary(totalItems) && <Skeleton className="h-5 w-24" />}
+            {!isLoading && totalItems !== undefined && (
+              <div className="flex h-5 items-center">
+                {totalItemSummary(totalItems)}
+              </div>
+            )}
+          </div>
+          <div className="flex flex-1 flex-shrink justify-end">
+            {navigationFilters &&
+              Object.entries(navigationFilters).map(([key, filter]) => {
+                const filterDef = navigationFilterTypes[filter.type]
+                return filterDef.render({
+                  filter: filter,
+                  value: currentNavigationFilters[key]!,
+                  onChange: (value) => {
+                    setCurrentNavigationFilters({
+                      ...currentNavigationFilters,
+                      [key]: value,
+                    })
+                  },
+                })
+              })}
+          </div>
         </div>
-        <div className="flex flex-1 flex-shrink justify-end">
-          {navigationFilters &&
-            Object.entries(navigationFilters).map(([key, filter]) => {
-              const filterDef = navigationFilterTypes[filter.type]
-              return filterDef.render({
-                filter: filter,
-                value: currentNavigationFilters[key]!,
-                onChange: (value) => {
-                  setCurrentNavigationFilters({
-                    ...currentNavigationFilters,
-                    [key]: value,
-                  })
-                },
-              })
-            })}
-        </div>
-      </div>
+      )}
       <div className={cn("flex flex-col gap-4 px-6")}>
         <Filters.Root
           schema={filters}

--- a/packages/react/src/experimental/OneDataCollection/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/index.tsx
@@ -358,10 +358,16 @@ export const OneDataCollection = <
     <div
       className={cn("flex flex-col gap-4", layout === "standard" && "-mx-6")}
     >
-      <div className={cn("border-f1-border-primary mb-3 flex gap-4 px-6")}>
-        <div className="flex flex-1 flex-shrink gap-4">
-          {isLoading && <Skeleton className="h-5 w-24" />}
-          {!isLoading && !!totalItems && totalItemSummary(totalItems)}
+      <div className="border-f1-border-primary flex gap-4 px-6">
+        <div className="flex flex-1 flex-shrink gap-4 text-lg font-semibold">
+          {isLoading &&
+            totalItems !== undefined &&
+            totalItemSummary(totalItems) && <Skeleton className="h-5 w-24" />}
+          {!isLoading && totalItems !== undefined && (
+            <div className="flex h-5 items-center">
+              {totalItemSummary(totalItems)}
+            </div>
+          )}
         </div>
         <div className="flex flex-1 flex-shrink justify-end">
           {navigationFilters &&


### PR DESCRIPTION
## Description

The skeleton from the total item summary is being displayed every time, even if no summary has been defined. This makes the DataCollection jumps when loading:

https://github.com/user-attachments/assets/83e0e566-dcff-4389-a27c-0b05a013b3a2

This PR fixes this conditionally displaying the skeleton only if a total summary has been defined. Also, the entire container for this title and the date navigator is conditionally displayed only if any of those are present.

https://github.com/user-attachments/assets/e1760fb2-f10d-4acb-bb90-65917b4a29da


---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other