### PR TITLE
chore: create RestrictComponent in order to disallow usages of certain components in some routes

### DIFF
--- a/packages/react/src/lib/restrict-component/index.spec.tsx
+++ b/packages/react/src/lib/restrict-component/index.spec.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it } from "vitest"
+import { RestrictComponent } from "."
+
+// Mock window.location
+const mockLocation = (pathname: string) => {
+  Object.defineProperty(window, "location", {
+    value: { pathname },
+    writable: true,
+  })
+}
+
+describe("RestrictComponent", () => {
+  const TestContent = () => <div>Test Content</div>
+
+  beforeEach(() => {
+    // Reset window.location before each test
+    mockLocation("/")
+  })
+
+  it("renders children when no restrictions are provided", () => {
+    render(
+      <RestrictComponent identifier="test-component">
+        <TestContent />
+      </RestrictComponent>
+    )
+
+    expect(screen.getByText("Test Content")).toBeInTheDocument()
+  })
+
+  it("renders children when current path is in allowedRoutes", () => {
+    mockLocation("/allowed-path")
+
+    render(
+      <RestrictComponent
+        identifier="test-component"
+        allowedRoutes={["/allowed-path"]}
+      >
+        <TestContent />
+      </RestrictComponent>
+    )
+
+    expect(screen.getByText("Test Content")).toBeInTheDocument()
+  })
+
+  it("does not render children when current path is not in allowedRoutes", () => {
+    mockLocation("/not-allowed-path")
+
+    render(
+      <RestrictComponent
+        identifier="test-component"
+        allowedRoutes={["/allowed-path"]}
+      >
+        <TestContent />
+      </RestrictComponent>
+    )
+
+    expect(screen.queryByText("Test Content")).not.toBeInTheDocument()
+  })
+
+  it("renders children when current path is not in disallowedRoutes", () => {
+    mockLocation("/allowed-path")
+
+    render(
+      <RestrictComponent
+        identifier="test-component"
+        disallowedRoutes={["/disallowed-path"]}
+      >
+        <TestContent />
+      </RestrictComponent>
+    )
+
+    expect(screen.getByText("Test Content")).toBeInTheDocument()
+  })
+
+  it("does not render children when current path is in disallowedRoutes", () => {
+    mockLocation("/disallowed-path")
+
+    render(
+      <RestrictComponent
+        identifier="test-component"
+        disallowedRoutes={["/disallowed-path"]}
+      >
+        <TestContent />
+      </RestrictComponent>
+    )
+
+    expect(screen.queryByText("Test Content")).not.toBeInTheDocument()
+  })
+
+  it("prioritizes allowedRoutes over disallowedRoutes", () => {
+    mockLocation("/test-path")
+
+    render(
+      <RestrictComponent
+        identifier="test-component"
+        allowedRoutes={["/test-path"]}
+        disallowedRoutes={["/test-path"]}
+      >
+        <TestContent />
+      </RestrictComponent>
+    )
+
+    expect(screen.getByText("Test Content")).toBeInTheDocument()
+  })
+
+  it("handles empty arrays for both allowedRoutes and disallowedRoutes", () => {
+    mockLocation("/any-path")
+
+    render(
+      <RestrictComponent
+        identifier="test-component"
+        allowedRoutes={[]}
+        disallowedRoutes={[]}
+      >
+        <TestContent />
+      </RestrictComponent>
+    )
+
+    expect(screen.getByText("Test Content")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/lib/restrict-component/index.tsx
+++ b/packages/react/src/lib/restrict-component/index.tsx
@@ -1,0 +1,50 @@
+import { FC, useMemo } from "react"
+
+type RestrictComponentProps = {
+  identifier: string
+  allowedRoutes?: string[]
+  disallowedRoutes?: string[]
+  children: React.ReactNode
+}
+
+export const RestrictComponent: FC<RestrictComponentProps> = ({
+  identifier,
+  allowedRoutes,
+  disallowedRoutes,
+  children,
+}) => {
+  const pathname = window.location.pathname
+
+  const isAllowed = useMemo(() => {
+    if (allowedRoutes && allowedRoutes.length > 0) {
+      return allowedRoutes.includes(pathname)
+    }
+
+    if (disallowedRoutes && disallowedRoutes.length > 0) {
+      return !disallowedRoutes.includes(pathname)
+    }
+
+    return true
+  }, [pathname, allowedRoutes, disallowedRoutes])
+
+  const errorMessage = useMemo(() => {
+    let message = `The component ${identifier} is not allowed to be rendered in the current route.`
+
+    if (allowedRoutes && allowedRoutes.length > 0) {
+      message += ` Allowed routes: ${allowedRoutes.join(", ")}`
+    }
+
+    if (disallowedRoutes && disallowedRoutes.length > 0) {
+      message += ` Disallowed routes: ${disallowedRoutes.join(", ")}`
+    }
+
+    return message
+  }, [identifier, allowedRoutes, disallowedRoutes])
+
+  if (!isAllowed) {
+    console.error(errorMessage)
+    return null
+  }
+
+  return children
+}


### PR DESCRIPTION
## Description

We want to disallow the usage of certain components that are still experimental such as the `OneModal`, only explicitly allowing it to be used in the routes that we mark as "safe".