### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.73.2",
+  "packages/react": "1.74.0",
   "packages/react-native": "0.8.1",
   "packages/core": "1.12.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.74.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.73.2...factorial-one-react-v1.74.0) (2025-05-29)
+
+
+### Features
+
+* close on select on single selection when grouping ([#1934](https://github.com/factorialco/factorial-one/issues/1934)) ([df460b3](https://github.com/factorialco/factorial-one/commit/df460b3621e1a40e6f74a14d825e40bd4c09366c))
+
 ## [1.73.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.73.1...factorial-one-react-v1.73.2) (2025-05-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.73.2",
+  "version": "1.74.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.74.0</summary>

## [1.74.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.73.2...factorial-one-react-v1.74.0) (2025-05-29)


### Features

* close on select on single selection when grouping ([#1934](https://github.com/factorialco/factorial-one/issues/1934)) ([df460b3](https://github.com/factorialco/factorial-one/commit/df460b3621e1a40e6f74a14d825e40bd4c09366c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).