### PR TITLE
feat(DataCollection): Add Icon cell type

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
@@ -507,3 +507,29 @@ render: (item) => ({
 `,
   }}
 />
+
+### icon
+
+Renders an icon with a label
+
+#### Value type
+
+```
+type value = { icon: IconType, label: string }
+```
+
+<Canvas
+  of={CellTypesDataCollectionStories.IconType}
+  source={{
+    code: `
+// Example with dot tags
+render: (item) => ({
+    type: 'icon',
+    value: {
+        icon: Placeholder,
+        label: 'Icon'
+    }
+})
+`,
+  }}
+/>

--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.stories.tsx
@@ -1,5 +1,6 @@
 import { NewColor } from "@/experimental/Information/Tags/DotTag"
 import { Meta, StoryObj } from "@storybook/react"
+import { Placeholder } from "../../../icons/app"
 import { PropertyDefinition, renderProperty } from "../property-render"
 
 function Cell({
@@ -395,6 +396,22 @@ export const TagArrayType: Story = {
             color: skill.color,
           })),
           max: 3,
+        },
+      }),
+    },
+  },
+}
+
+export const IconType: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Icon",
+      render: () => ({
+        type: "icon",
+        value: {
+          icon: Placeholder,
+          label: "Icon",
         },
       }),
     },

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
@@ -1,4 +1,4 @@
-import { IconType } from "@/components/Utilities/Icon"
+import { Icon, IconType } from "@/components/Utilities/Icon"
 import { AvatarList } from "@/experimental/Information/Avatars/AvatarList"
 import {
   Avatar,
@@ -97,6 +97,12 @@ export interface TagListValue {
   type: TagType
 }
 export type TagListCellValue = TagListValue
+
+export interface IconValue {
+  icon: IconType
+  label: string
+}
+export type IconCellValue = IconValue
 
 /**
  * The renderer function to use for a property.
@@ -236,6 +242,12 @@ export const propertyRenderers = {
   ),
   tagList: (args: TagListCellValue) => (
     <TagList type={args.type} tags={args.tags as TagVariant[]} max={args.max} />
+  ),
+  icon: (args: IconCellValue) => (
+    <div className="flex items-center gap-2">
+      <Icon icon={args.icon} />
+      <span className="text-f1-foreground">{args.label}</span>
+    </div>
   ),
 } as const satisfies Record<string, PropertyRenderer<never>>
 


### PR DESCRIPTION
## Description

We are missing one of the cell types for the DataCollection: [Icon](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Components?node-id=7968-87096&t=0C2vYWnDhLZBy1r6-4). This PR adds it.

## Screenshots

<img width="676" alt="image" src="https://github.com/user-attachments/assets/bcc8e83a-b3e9-4963-9c62-3df15dd45d8f" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other