### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.74.0",
+  "packages/react": "1.74.1",
   "packages/react-native": "0.8.1",
   "packages/core": "1.12.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.74.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.74.0...factorial-one-react-v1.74.1) (2025-05-29)
+
+
+### Bug Fixes
+
+* update internal favorites value when prop changes ([#1941](https://github.com/factorialco/factorial-one/issues/1941)) ([bad23d7](https://github.com/factorialco/factorial-one/commit/bad23d75c3386943b95be9de9033f4b4b46a193f))
+
 ## [1.74.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.73.2...factorial-one-react-v1.74.0) (2025-05-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.74.0",
+  "version": "1.74.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.74.1</summary>

## [1.74.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.74.0...factorial-one-react-v1.74.1) (2025-05-29)


### Bug Fixes

* update internal favorites value when prop changes ([#1941](https://github.com/factorialco/factorial-one/issues/1941)) ([bad23d7](https://github.com/factorialco/factorial-one/commit/bad23d75c3386943b95be9de9033f4b4b46a193f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).