### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.74.1",
-  "packages/react-native": "0.8.1",
+  "packages/react-native": "0.8.2",
   "packages/core": "1.12.1"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.8.1...factorial-one-react-native-v0.8.2) (2025-05-29)
+
+
+### Bug Fixes
+
+* text size in activity item ([#1936](https://github.com/factorialco/factorial-one/issues/1936)) ([937955f](https://github.com/factorialco/factorial-one/commit/937955f0107f16274f5adb0f8a0f6bfe89f97d9d))
+
 ## [0.8.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.8.0...factorial-one-react-native-v0.8.1) (2025-05-27)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.8.2</summary>

## [0.8.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.8.1...factorial-one-react-native-v0.8.2) (2025-05-29)


### Bug Fixes

* text size in activity item ([#1936](https://github.com/factorialco/factorial-one/issues/1936)) ([937955f](https://github.com/factorialco/factorial-one/commit/937955f0107f16274f5adb0f8a0f6bfe89f97d9d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).