### PR TITLE
fix(DataCollection): Spacing tweaks in Filters

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersControls.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersControls.tsx
@@ -113,7 +113,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
               )}
             </div>
 
-            <div className="flex items-center justify-end gap-2 border-solid border-transparent border-t-f1-border-secondary px-3 py-2">
+            <div className="flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary p-2">
               <Button
                 onClick={handleApplyFilters}
                 label={i18n.filters.applyFilters}

--- a/packages/react/src/experimental/OneDataCollection/Filters/FilterTypes/InFilter/InFilter.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/FilterTypes/InFilter/InFilter.tsx
@@ -155,12 +155,12 @@ export function InFilter<T extends string>({
 
   return (
     <div
-      className="flex min-h-full w-full flex-col gap-1"
+      className="flex min-h-full w-full flex-col"
       role="group"
       aria-label={schema.label}
     >
       {showSearch && (
-        <div className="sticky left-0 right-0 top-0 p-2 backdrop-blur-[8px]">
+        <div className="sticky left-0 right-0 top-0 rounded-tr-xl p-2 backdrop-blur-[8px]">
           <Input
             type="search"
             placeholder="Search..."
@@ -173,7 +173,7 @@ export function InFilter<T extends string>({
           />
         </div>
       )}
-      <div className="flex-1 overflow-y-auto px-3">
+      <div className="flex-1 overflow-y-auto px-2">
         {filteredOptions.map((option) => {
           const isSelected = value.includes(option.value)
           const optionId = `option-${String(option.value)}`


### PR DESCRIPTION
## Description

Fixes a few reported spacing issues:

- [Filter list should have 8px padding left, right, top](https://www.notion.so/factorialco/Filter-list-should-have-8px-padding-left-right-top-2025e6e051ee80ef8577cba543a34ee3?pvs=4)
- [Doble separator in filters](https://www.notion.so/factorialco/Doble-separator-in-filters-2025e6e051ee80d1b13cfa3a6fd94923?pvs=4)
- [Border radius is cropped](https://www.notion.so/factorialco/Border-radius-is-cropped-2025e6e051ee8019bc18d071e7968786?pvs=4)
- [Apply button spacing should be 8px, not 12px](https://www.notion.so/factorialco/Apply-button-spacing-should-be-8px-not-12px-2025e6e051ee80cd8334db7c11a02127?pvs=4)

## Screenshots

<img width="568" alt="image" src="https://github.com/user-attachments/assets/032f509b-9c06-4105-9491-358523fb0dc6" />

_Filters popover with these fixes_

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other