### PR TITLE
fix(DataCollection): Collection & item dropdown alignment

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/experimental/OneDataCollection/CollectionActions/CollectionActions.tsx
@@ -29,8 +29,6 @@ export const CollectionActions = ({
   )
     return null
 
-  const align = primaryActionsButton.length > 0 ? "start" : "end"
-
   return (
     <div className="flex flex-row-reverse items-center gap-2">
       {primaryActionsButton.map((action) => (
@@ -57,7 +55,7 @@ export const CollectionActions = ({
       ))}
 
       {dropdownActions.length > 0 && (
-        <Dropdown items={dropdownActions} align={align}>
+        <Dropdown items={dropdownActions} align="end">
           <Button variant="outline" icon={Ellipsis} label="Actions" hideLabel />
         </Dropdown>
       )}

--- a/packages/react/src/experimental/OneDataCollection/ItemActions/Dropdown.tsx
+++ b/packages/react/src/experimental/OneDataCollection/ItemActions/Dropdown.tsx
@@ -39,6 +39,7 @@ export const ActionsDropdown = <
       })}
       open={open}
       onOpenChange={setOpen}
+      align="end"
     >
       <button
         title="Actions"


### PR DESCRIPTION
## Description

We are aligning collection and item dropdowns to the 'end' point as they fall at the right corner of the screen, and aligning them to the 'start' point makes for a weird positioning.

## Screenshots

### Before

<img width="431" alt="image" src="https://github.com/user-attachments/assets/e7039c50-da3f-407b-8cc7-645535efbdd6" />

### After

<img width="503" alt="image" src="https://github.com/user-attachments/assets/d3346d60-2912-43af-b4b1-9b9f7267de34" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
