### PR TITLE
fix(OnePagination): Adapt item width to large numbers

### DIFF
--- a/packages/react/src/ui/pagination.tsx
+++ b/packages/react/src/ui/pagination.tsx
@@ -45,7 +45,7 @@ const PaginationLink = ({
   <a
     aria-current={isActive ? "page" : undefined}
     className={cn(
-      "flex h-8 w-8 select-none items-center justify-center rounded font-medium text-f1-foreground-secondary transition-all hover:cursor-pointer hover:bg-f1-background-secondary-hover",
+      "flex h-8 min-w-8 select-none items-center justify-center rounded px-1.5 font-medium text-f1-foreground-secondary transition-all hover:cursor-pointer hover:bg-f1-background-secondary-hover",
       isActive &&
         "bg-f1-background-selected-bold font-semibold text-f1-foreground-inverse hover:bg-f1-background-selected-bold-hover",
       focusRing(),


### PR DESCRIPTION
## Description

Items in `OnePagination` has a fixed width, making it look tight with large numbers. This PR fixes that adapting the item to the number, keeping a minimum width to make them seem seamless.

## Screenshots 

### Before

<img width="174" alt="image" src="https://github.com/user-attachments/assets/46589b97-30c4-48a6-8c0a-37428212d184" />

### After

<img width="177" alt="image" src="https://github.com/user-attachments/assets/227f94ec-7976-4471-ba26-505dd254ed47" />

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
