### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.74.1",
+  "packages/react": "1.75.0",
   "packages/react-native": "0.8.2",
   "packages/core": "1.12.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.75.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.74.1...factorial-one-react-v1.75.0) (2025-05-30)
+
+
+### Features
+
+* add optional action button to Entity Select ([#1947](https://github.com/factorialco/factorial-one/issues/1947)) ([1ffe40a](https://github.com/factorialco/factorial-one/commit/1ffe40a5d16a2c893ed7c43b0ae9959be36807d4))
+
+
+### Bug Fixes
+
+* ellipsis on entity selector ([#1956](https://github.com/factorialco/factorial-one/issues/1956)) ([8c57d66](https://github.com/factorialco/factorial-one/commit/8c57d666af477a069c80b0b016720118173fa6f2))
+
 ## [1.74.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.74.0...factorial-one-react-v1.74.1) (2025-05-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.74.1",
+  "version": "1.75.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.75.0</summary>

## [1.75.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.74.1...factorial-one-react-v1.75.0) (2025-05-30)


### Features

* add optional action button to Entity Select ([#1947](https://github.com/factorialco/factorial-one/issues/1947)) ([1ffe40a](https://github.com/factorialco/factorial-one/commit/1ffe40a5d16a2c893ed7c43b0ae9959be36807d4))


### Bug Fixes

* ellipsis on entity selector ([#1956](https://github.com/factorialco/factorial-one/issues/1956)) ([8c57d66](https://github.com/factorialco/factorial-one/commit/8c57d666af477a069c80b0b016720118173fa6f2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).