### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.75.0",
+  "packages/react": "1.76.0",
   "packages/react-native": "0.8.2",
   "packages/core": "1.12.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.76.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.75.0...factorial-one-react-v1.76.0) (2025-05-30)
+
+
+### Features
+
+* adding upsell popover and generating story descriptions  ([#1950](https://github.com/factorialco/factorial-one/issues/1950)) ([8babbd5](https://github.com/factorialco/factorial-one/commit/8babbd5382d645aee855baeffb884c521daec6de))
+
 ## [1.75.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.74.1...factorial-one-react-v1.75.0) (2025-05-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.76.0</summary>

## [1.76.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.75.0...factorial-one-react-v1.76.0) (2025-05-30)


### Features

* adding upsell popover and generating story descriptions  ([#1950](https://github.com/factorialco/factorial-one/issues/1950)) ([8babbd5](https://github.com/factorialco/factorial-one/commit/8babbd5382d645aee855baeffb884c521daec6de))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).