### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.76.0",
   "packages/react-native": "0.8.2",
-  "packages/core": "1.12.1"
+  "packages/core": "1.12.2"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.12.2](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.12.1...factorial-one-core-v1.12.2) (2025-05-30)
+
+
+### Bug Fixes
+
+* change upsell icon color ([#1943](https://github.com/factorialco/factorial-one/issues/1943)) ([0d5a1b1](https://github.com/factorialco/factorial-one/commit/0d5a1b17b894281a9118b68a658361c9c71f11cf))
+
 ## [1.12.1](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.12.0...factorial-one-core-v1.12.1) (2025-05-29)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-core: 1.12.2</summary>

## [1.12.2](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.12.1...factorial-one-core-v1.12.2) (2025-05-30)


### Bug Fixes

* change upsell icon color ([#1943](https://github.com/factorialco/factorial-one/issues/1943)) ([0d5a1b1](https://github.com/factorialco/factorial-one/commit/0d5a1b17b894281a9118b68a658361c9c71f11cf))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).