### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.76.0",
+  "packages/react": "1.76.1",
   "packages/react-native": "0.8.2",
   "packages/core": "1.12.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.76.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.76.0...factorial-one-react-v1.76.1) (2025-05-30)
+
+
+### Bug Fixes
+
+* **DataCollection:** conditionally display the total item summary skeleton + style fixes ([#1932](https://github.com/factorialco/factorial-one/issues/1932)) ([268cfc6](https://github.com/factorialco/factorial-one/commit/268cfc6c5d7f6f60978be7ac5d8a5e6a1c5f04d0))
+
 ## [1.76.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.75.0...factorial-one-react-v1.76.0) (2025-05-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.76.0",
+  "version": "1.76.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.76.1</summary>

## [1.76.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.76.0...factorial-one-react-v1.76.1) (2025-05-30)


### Bug Fixes

* **DataCollection:** conditionally display the total item summary skeleton + style fixes ([#1932](https://github.com/factorialco/factorial-one/issues/1932)) ([268cfc6](https://github.com/factorialco/factorial-one/commit/268cfc6c5d7f6f60978be7ac5d8a5e6a1c5f04d0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).