### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.77.0",
+  "packages/react": "1.77.1",
   "packages/react-native": "0.8.2",
   "packages/core": "1.12.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.77.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.77.0...factorial-one-react-v1.77.1) (2025-05-30)
+
+
+### Bug Fixes
+
+* spacing issues datacollection ([#1949](https://github.com/factorialco/factorial-one/issues/1949)) ([61f3229](https://github.com/factorialco/factorial-one/commit/61f32293867b76f3388673c969e8a97bf59890f8))
+
 ## [1.77.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.76.1...factorial-one-react-v1.77.0) (2025-05-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.77.0",
+  "version": "1.77.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.77.1</summary>

## [1.77.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.77.0...factorial-one-react-v1.77.1) (2025-05-30)


### Bug Fixes

* spacing issues datacollection ([#1949](https://github.com/factorialco/factorial-one/issues/1949)) ([61f3229](https://github.com/factorialco/factorial-one/commit/61f32293867b76f3388673c969e8a97bf59890f8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).