### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.77.1",
+  "packages/react": "1.77.2",
   "packages/react-native": "0.8.2",
   "packages/core": "1.12.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.77.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.77.1...factorial-one-react-v1.77.2) (2025-05-30)
+
+
+### Bug Fixes
+
+* datacollection item actions alignment ([#1952](https://github.com/factorialco/factorial-one/issues/1952)) ([c6c4cc4](https://github.com/factorialco/factorial-one/commit/c6c4cc42bb5c7a8f16ff4393977ee78ef718826c))
+
 ## [1.77.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.77.0...factorial-one-react-v1.77.1) (2025-05-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.77.1",
+  "version": "1.77.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.77.2</summary>

## [1.77.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.77.1...factorial-one-react-v1.77.2) (2025-05-30)


### Bug Fixes

* datacollection item actions alignment ([#1952](https://github.com/factorialco/factorial-one/issues/1952)) ([c6c4cc4](https://github.com/factorialco/factorial-one/commit/c6c4cc42bb5c7a8f16ff4393977ee78ef718826c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).