### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.77.2",
+  "packages/react": "1.77.3",
   "packages/react-native": "0.8.2",
   "packages/core": "1.12.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.77.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.77.2...factorial-one-react-v1.77.3) (2025-05-30)
+
+
+### Bug Fixes
+
+* onepagination adapt large numbers ([#1953](https://github.com/factorialco/factorial-one/issues/1953)) ([901486b](https://github.com/factorialco/factorial-one/commit/901486b0255fe8d7f894310cb1f415032196d4cc))
+
 ## [1.77.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.77.1...factorial-one-react-v1.77.2) (2025-05-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.77.2",
+  "version": "1.77.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.77.3</summary>

## [1.77.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.77.2...factorial-one-react-v1.77.3) (2025-05-30)


### Bug Fixes

* onepagination adapt large numbers ([#1953](https://github.com/factorialco/factorial-one/issues/1953)) ([901486b](https://github.com/factorialco/factorial-one/commit/901486b0255fe8d7f894310cb1f415032196d4cc))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).