### PR TITLE
feat: adding upsell option to empty state

### DIFF
--- a/packages/react/src/experimental/OneEmptyState/OneEmptyState.tsx
+++ b/packages/react/src/experimental/OneEmptyState/OneEmptyState.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@/components/Actions/Button"
+import { UpsellingButton } from "@/components/UpsellingKit/UpsellingButton"
 import { EmojiAvatar } from "@/experimental/Information/Avatars/EmojiAvatar"
 import { AlertAvatar } from "../Information/Avatars/AlertAvatar"
+import { ModuleAvatar } from "../Information/ModuleAvatar"
 import * as Types from "./types"
 
 export function OneEmptyState({
@@ -8,12 +10,16 @@ export function OneEmptyState({
   description,
   variant = "default",
   emoji,
+  icon,
   actions,
 }: Types.OneEmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center gap-5 p-8">
+      {variant === "upsell" && icon && <ModuleAvatar icon={icon} />}
       {variant === "default" && <EmojiAvatar emoji={emoji!} size="lg" />}
-      {variant !== "default" && <AlertAvatar type={variant} size="lg" />}
+      {variant !== "default" && variant !== "upsell" && (
+        <AlertAvatar type={variant} size="lg" />
+      )}
       <div className="flex flex-col items-center justify-center gap-0.5">
         <p className="text-center text-lg font-medium text-f1-foreground">
           {title}
@@ -26,9 +32,32 @@ export function OneEmptyState({
       </div>
       {actions && (
         <div className="flex w-full flex-col items-center justify-center gap-2 sm:w-fit sm:flex-row sm:gap-3 [&>div]:w-full">
-          {actions.map((action) => (
-            <Button key={action.label} {...action} />
-          ))}
+          {actions.map((action) => {
+            if (action.type === "upsell") {
+              return (
+                <UpsellingButton
+                  key={action.label}
+                  label={action.label}
+                  onRequest={() => Promise.resolve(action.onClick())}
+                  errorMessage={action.errorMessage}
+                  successMessage={action.successMessage}
+                  loadingState={action.loadingState}
+                  nextSteps={action.nextSteps}
+                  closeLabel={action.closeLabel}
+                />
+              )
+            } else {
+              return (
+                <Button
+                  key={action.label}
+                  label={action.label}
+                  variant={action.variant}
+                  onClick={action.onClick}
+                  icon={action.icon}
+                />
+              )
+            }
+          })}
         </div>
       )}
     </div>

--- a/packages/react/src/experimental/OneEmptyState/__stories__/OneEmptyState.stories.tsx
+++ b/packages/react/src/experimental/OneEmptyState/__stories__/OneEmptyState.stories.tsx
@@ -1,3 +1,4 @@
+import { Trainings } from "@/icons/modules"
 import type { Meta, StoryObj } from "@storybook/react"
 import { fn } from "@storybook/test"
 import { Plus } from "lucide-react"
@@ -42,5 +43,49 @@ export const WithAlert: Story = {
         <OneEmptyState variant="critical" title="Unauthorized" />
       </div>
     )
+  },
+}
+
+export const WithUpsell: Story = {
+  args: {
+    title: "Take your team’s skills to the next level",
+    description:
+      "Activate Trainings to create engaging sessions and track real progress!",
+    icon: Trainings,
+    variant: "upsell",
+    actions: [
+      {
+        label: "Learn more",
+        onClick: fn(),
+        variant: "outline",
+      },
+      {
+        label: "Request information",
+        onClick: fn(),
+        type: "upsell",
+        errorMessage: {
+          title: "Error",
+          description: "Something went wrong",
+        },
+        successMessage: {
+          title: "Success",
+          description: "Something went right",
+          buttonLabel: "Close",
+          buttonOnClick: fn(),
+        },
+        loadingState: {
+          label: "Loading...",
+        },
+        nextSteps: {
+          title: "Next steps",
+          items: [
+            {
+              text: "Step 1",
+            },
+          ],
+        },
+        closeLabel: "Close",
+      },
+    ],
   },
 }

--- a/packages/react/src/experimental/OneEmptyState/types.ts
+++ b/packages/react/src/experimental/OneEmptyState/types.ts
@@ -1,3 +1,9 @@
+import { LoadingStateProps } from "@/components/UpsellingKit/UpsellingButton"
+import {
+  ErrorMessageProps,
+  NextStepsProps,
+  SuccessMessageProps,
+} from "@/components/UpsellingKit/UpsellRequestResponseDialog"
 import { IconType } from "@/components/Utilities/Icon"
 import { AlertAvatarProps } from "@/experimental/Information/Avatars/AlertAvatar"
 
@@ -24,7 +30,43 @@ export type ActionProps = {
    * @optional
    */
   icon?: IconType
-}
+} & (
+  | {
+      /**
+       * The type of the action
+       */
+      type: "upsell"
+      /**
+       * The error message of the action
+       */
+      errorMessage: ErrorMessageProps
+      /**
+       * The success message of the action
+       */
+      successMessage: SuccessMessageProps
+
+      /**
+       * The loading state of the action
+       */
+      loadingState: LoadingStateProps
+
+      /**
+       * The next steps of the action
+       */
+      nextSteps: NextStepsProps
+
+      /**
+       * The next steps of the action
+       */
+      closeLabel: string
+    }
+  | {
+      /**
+       * The type of the action
+       */
+      type?: "default"
+    }
+)
 
 export type OneEmptyStateProps = {
   /**
@@ -45,26 +87,22 @@ export type OneEmptyStateProps = {
    * @optional
    */
   actions?: ActionProps[]
-} & (
-  | {
-      /**
-       * The variant of the empty state
-       * @optional
-       */
-      variant?: "default"
 
-      /**
-       * An icon will be displayed in the empty state.
-       * emoji string
-       */
-      emoji?: string
-    }
-  | {
-      /**
-       * The variant of the empty state
-       * @optional
-       */
-      variant: Exclude<AlertAvatarProps["type"], "positive">
-      emoji?: never
-    }
-)
+  /**
+   * The variant of the empty state
+   * @optional
+   */
+  variant?: "default" | "upsell" | Exclude<AlertAvatarProps["type"], "positive">
+
+  /**
+   * An icon will be displayed in the empty state
+   * @optional
+   */
+  icon?: IconType
+
+  /**
+   * An emoji will be displayed in the empty state
+   * @optional
+   */
+  emoji?: string
+}


### PR DESCRIPTION
## Description

Adding new variant to EmptyState to handle upsell

Recommended in this [PR](https://github.com/factorialco/factorial-one/pull/1931)



## Screenshots (if applicable)
![Screenshot 2025-05-30 at 11 41 06 AM](https://github.com/user-attachments/assets/c5849c8f-71a1-4bbb-ab96-9edb3d7342ae)


### Figma Link

[Link to Figma Design](https://www.figma.com/design/ByqArcQkGBk6qmWqivXF5Y/28-03-2025---Upselling-Kit?node-id=4827-68240&t=63QK5WWV6wS7RSJR-0)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
