### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.77.3",
-  "packages/react-native": "0.8.2",
+  "packages/react-native": "0.9.0",
   "packages/core": "1.12.2"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.9.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.8.2...factorial-one-react-native-v0.9.0) (2025-05-30)
+
+
+### Features
+
+* disable activity item press effect ([#1955](https://github.com/factorialco/factorial-one/issues/1955)) ([499d38c](https://github.com/factorialco/factorial-one/commit/499d38cc4392f88f578335c3d1453bd2a8b44e60))
+
 ## [0.8.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.8.1...factorial-one-react-native-v0.8.2) (2025-05-29)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.9.0</summary>

## [0.9.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.8.2...factorial-one-react-native-v0.9.0) (2025-05-30)


### Features

* disable activity item press effect ([#1955](https://github.com/factorialco/factorial-one/issues/1955)) ([499d38c](https://github.com/factorialco/factorial-one/commit/499d38cc4392f88f578335c3d1453bd2a8b44e60))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).