### PR TITLE
feat(DataCollection): Show label in Filters button when no presets

### DIFF
--- a/packages/react/src/components/Actions/Button/index.stories.tsx
+++ b/packages/react/src/components/Actions/Button/index.stories.tsx
@@ -58,6 +58,10 @@ const meta = {
       control: "boolean",
       description: "Hide label and show only icon",
     },
+    pressed: {
+      control: "boolean",
+      description: "Force the button to be pressed",
+    },
   },
 } satisfies Meta<typeof Button>
 

--- a/packages/react/src/components/Actions/Button/internal.tsx
+++ b/packages/react/src/components/Actions/Button/internal.tsx
@@ -7,7 +7,7 @@ import { Icon, IconType } from "../../Utilities/Icon"
 
 export type ButtonInternalProps = Pick<
   ComponentProps<typeof ShadcnButton>,
-  "variant" | "size" | "disabled" | "type" | "round" | "className"
+  "variant" | "size" | "disabled" | "type" | "round" | "className" | "pressed"
 > &
   DataAttributes & {
     onClick?: (
@@ -31,7 +31,7 @@ const iconVariants = cva({
       outline: "text-f1-icon",
       neutral: "text-f1-icon",
       critical:
-        "text-f1-icon-critical-bold group-hover:text-f1-icon-inverse group-active:text-f1-icon-inverse dark:group-hover:text-f1-icon-bold/80 dark:group-active:text-f1-icon-bold/80",
+        "text-f1-icon-critical-bold group-hover:text-f1-icon-inverse group-active:text-f1-icon-inverse group-data-[pressed=true]:text-f1-icon-inverse dark:group-hover:text-f1-icon-bold/80 dark:group-active:text-f1-icon-bold/80 dark:group-data-[pressed=true]:text-f1-icon-bold/80",
       ghost: "text-f1-icon",
       promote: "text-f1-icon-promote",
     },
@@ -49,7 +49,7 @@ export const iconOnlyVariants = cva({
       outline: "text-f1-icon-bold",
       neutral: "text-f1-icon-bold",
       critical:
-        "text-f1-icon-critical-bold group-hover:text-f1-icon-inverse group-active:text-f1-icon-inverse dark:group-hover:text-f1-icon-bold dark:group-active:text-f1-icon-bold",
+        "text-f1-icon-critical-bold group-hover:text-f1-icon-inverse group-active:text-f1-icon-inverse group-data-[pressed=true]:text-f1-icon-inverse dark:group-hover:text-f1-icon-bold dark:group-active:text-f1-icon-bold dark:group-data-[pressed=true]:text-f1-icon-bold",
       ghost: "text-f1-icon-bold",
       promote: "text-f1-icon-bold",
     },

--- a/packages/react/src/components/Actions/OneDropdownButton/OneDropdownButton.tsx
+++ b/packages/react/src/components/Actions/OneDropdownButton/OneDropdownButton.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from "@/lib/providers/i18n"
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { DropdownInternal } from "../../../experimental/Navigation/Dropdown/internal"
 import { ChevronDown } from "../../../icons/app"
 import { IconType } from "../../Utilities/Icon"
@@ -30,6 +30,7 @@ const OneDropdownButton = ({
   ...props
 }: OneDropdownButtonProps) => {
   const t = useI18n()
+  const [isOpen, setIsOpen] = useState(false)
 
   const localValue = useMemo(() => value || items[0].value, [value, items])
 
@@ -50,6 +51,7 @@ const OneDropdownButton = ({
           ...item,
           onClick: () => {
             onClick(item.value, item)
+            setIsOpen(false)
           },
         })),
     [items, localValue, onClick]
@@ -65,7 +67,12 @@ const OneDropdownButton = ({
           data-testid="button-main"
           {...props}
           appendButton={
-            <DropdownInternal items={dropdownItems} align="end">
+            <DropdownInternal
+              items={dropdownItems}
+              align="end"
+              open={isOpen}
+              onOpenChange={setIsOpen}
+            >
               <ButtonInternal
                 variant={props.variant}
                 size={props.size}
@@ -73,6 +80,7 @@ const OneDropdownButton = ({
                 icon={ChevronDown}
                 hideLabel
                 data-testid="button-menu"
+                pressed={isOpen}
               />
             </DropdownInternal>
           }

--- a/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersControls.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersControls.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useState } from "react"
 import { Button } from "../../../../components/Actions/Button"
-import { Icon } from "../../../../components/Utilities/Icon"
 import { Filter } from "../../../../icons/app"
 import { useI18n } from "../../../../lib/providers/i18n"
-import { cn, focusRing } from "../../../../lib/utils"
 import { Popover, PopoverContent, PopoverTrigger } from "../../../../ui/popover"
 import { getFilterType } from "../FilterTypes"
 import { FilterTypeContext, FilterTypeSchema } from "../FilterTypes/types"
@@ -17,6 +15,7 @@ interface FiltersControlsProps<Filters extends FiltersDefinition> {
   onChange: (value: FiltersState<Filters>) => void
   isOpen?: boolean
   onOpenChange?: (open: boolean) => void
+  hideLabel?: boolean
 }
 
 export function FiltersControls<Filters extends FiltersDefinition>({
@@ -25,6 +24,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
   onChange,
   isOpen: controlledIsOpen,
   onOpenChange: controlledOnOpenChange,
+  hideLabel,
 }: FiltersControlsProps<Filters>) {
   const [selectedFilterKey, setSelectedFilterKey] = useState<
     keyof Filters | null
@@ -76,17 +76,15 @@ export function FiltersControls<Filters extends FiltersDefinition>({
     <div className="flex items-center gap-2">
       <Popover open={isOpen} onOpenChange={onOpenChange}>
         <PopoverTrigger asChild>
-          <button
-            className={cn(
-              "flex h-8 w-8 items-center justify-center rounded border border-solid border-f1-border bg-f1-background-inverse-secondary text-f1-foreground hover:border-f1-border-hover",
-              isOpen && "border-f1-border-hover",
-              focusRing()
-            )}
-            title={i18n.filters.label}
-          >
-            <Icon icon={Filter} />
-            <span className="sr-only">{i18n.filters.label}</span>
-          </button>
+          <Button
+            variant="outline"
+            label={i18n.filters.label}
+            icon={Filter}
+            pressed={isOpen}
+            onClick={() => onOpenChange(!isOpen)}
+            hideLabel={hideLabel}
+            round={hideLabel}
+          />
         </PopoverTrigger>
         <PopoverContent
           className="w-[544px] rounded-xl border border-solid border-f1-border-secondary p-0 shadow-md"

--- a/packages/react/src/experimental/OneDataCollection/Filters/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/index.tsx
@@ -153,8 +153,14 @@ FiltersRoot.displayName = "Filters.Root"
  * Filter controls
  */
 const FiltersControls = () => {
-  const { schema, filters, isFiltersOpen, setIsFiltersOpen, setFiltersValue } =
-    useContext(FiltersContext)
+  const {
+    schema,
+    filters,
+    isFiltersOpen,
+    setIsFiltersOpen,
+    setFiltersValue,
+    presets,
+  } = useContext(FiltersContext)
 
   return (
     schema && (
@@ -164,6 +170,7 @@ const FiltersControls = () => {
         onChange={setFiltersValue}
         onOpenChange={setIsFiltersOpen}
         isOpen={isFiltersOpen}
+        hideLabel={!!presets}
       />
     )
   )

--- a/packages/react/src/ui/button.tsx
+++ b/packages/react/src/ui/button.tsx
@@ -26,19 +26,41 @@ const buttonVariants = cva({
       true: "pointer-events-none opacity-50",
       false: cn("cursor-pointer", focusRing()),
     },
+    pressed: {
+      true: "[&_button]:translate-y-px",
+      false: "",
+    },
     variant: {
-      default:
-        "bg-f1-background-accent-bold text-f1-foreground-inverse shadow-[0_2px_6px_-1px_rgba(13,22,37,.10),inset_0_-2px_4px_rgba(13,22,37,.08)] after:pointer-events-none after:absolute after:inset-0 after:rounded after:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.25)] after:content-[''] hover:bg-f1-background-accent-bold-hover active:bg-f1-background-accent-bold-hover active:shadow-[0_-2px_6px_-1px_rgba(13,22,37,.10)] active:after:shadow-[inset_0_3px_6px_0_rgba(13,22,37,.2)]",
-      outline:
-        "bg-f1-background-inverse-secondary text-f1-foreground after:pointer-events-none after:absolute after:inset-0 after:rounded after:ring-1 after:ring-inset after:ring-f1-border after:transition-all after:content-[''] hover:bg-f1-background-tertiary hover:after:opacity-70 hover:after:ring-f1-border-hover active:bg-f1-background-tertiary active:shadow-[inset_0_2px_6px_0_rgba(13,22,37,.15)] active:after:opacity-70 active:after:ring-f1-border-hover",
-      neutral:
-        "bg-f1-background-secondary text-f1-foreground hover:bg-f1-background-secondary-hover active:bg-f1-background-secondary-hover active:shadow-[inset_0_2px_8px_0_rgba(13,22,37,.16)]",
-      critical:
-        "bg-f1-background-secondary text-f1-foreground-critical after:pointer-events-none after:absolute after:inset-0 after:rounded after:ring-1 after:ring-inset after:ring-f1-border after:transition-all after:content-[''] hover:bg-f1-background-critical-bold hover:text-f1-foreground-inverse hover:after:ring-transparent active:bg-f1-background-critical-bold active:text-f1-foreground-inverse active:after:shadow-[inset_0_3px_6px_0_rgba(13,22,37,.2)] active:after:ring-transparent dark:bg-transparent dark:hover:bg-f1-background-critical-bold",
-      ghost:
-        "bg-transparent text-f1-foreground shadow-none hover:bg-f1-background-secondary-hover hover:shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(13,22,37,.04)] active:bg-f1-background-secondary-hover active:shadow-[inset_0_2px_4px_0_rgba(13,22,37,.1)]",
-      promote:
-        "bg-f1-background-promote text-f1-foreground shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(245,165,28,.15)] after:pointer-events-none after:absolute after:inset-0 after:rounded after:ring-1 after:ring-inset after:ring-f1-border-promote after:transition-all after:content-[''] hover:bg-f1-background-promote-hover active:shadow-[inset_0_2px_4px_0_rgba(206,139,24,.5)] dark:shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(13,22,37,.30)]",
+      default: cn(
+        "bg-f1-background-accent-bold text-f1-foreground-inverse shadow-[0_2px_6px_-1px_rgba(13,22,37,.10),inset_0_-2px_4px_rgba(13,22,37,.08)] after:pointer-events-none after:absolute after:inset-0 after:rounded after:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.25)] after:content-[''] hover:bg-f1-background-accent-bold-hover",
+        "active:bg-f1-background-accent-bold-hover active:shadow-[0_-2px_6px_-1px_rgba(13,22,37,.10)] active:after:shadow-[inset_0_3px_6px_0_rgba(13,22,37,.2)]",
+        "data-[pressed=true]:bg-f1-background-accent-bold-hover data-[pressed=true]:shadow-[0_-2px_6px_-1px_rgba(13,22,37,.10)] data-[pressed=true]:after:shadow-[inset_0_3px_6px_0_rgba(13,22,37,.2)]"
+      ),
+      outline: cn(
+        "bg-f1-background-inverse-secondary text-f1-foreground after:pointer-events-none after:absolute after:inset-0 after:rounded after:ring-1 after:ring-inset after:ring-f1-border after:transition-all after:content-[''] hover:bg-f1-background-tertiary hover:after:opacity-70 hover:after:ring-f1-border-hover",
+        "active:bg-f1-background-tertiary active:shadow-[inset_0_2px_6px_0_rgba(13,22,37,.15)] active:after:opacity-70 active:after:ring-f1-border-hover",
+        "data-[pressed=true]:bg-f1-background-tertiary data-[pressed=true]:shadow-[inset_0_2px_6px_0_rgba(13,22,37,.15)] data-[pressed=true]:after:opacity-70 data-[pressed=true]:after:ring-f1-border-hover"
+      ),
+      neutral: cn(
+        "bg-f1-background-secondary text-f1-foreground hover:bg-f1-background-secondary-hover",
+        "active:bg-f1-background-secondary-hover active:shadow-[inset_0_2px_8px_0_rgba(13,22,37,.16)]",
+        "data-[pressed=true]:bg-f1-background-secondary-hover data-[pressed=true]:shadow-[inset_0_2px_8px_0_rgba(13,22,37,.16)]"
+      ),
+      critical: cn(
+        "bg-f1-background-secondary text-f1-foreground-critical after:pointer-events-none after:absolute after:inset-0 after:rounded after:ring-1 after:ring-inset after:ring-f1-border after:transition-all after:content-[''] hover:bg-f1-background-critical-bold hover:text-f1-foreground-inverse hover:after:ring-transparent dark:bg-transparent dark:hover:bg-f1-background-critical-bold",
+        "active:bg-f1-background-critical-bold active:text-f1-foreground-inverse active:after:shadow-[inset_0_3px_6px_0_rgba(13,22,37,.2)] active:after:ring-transparent",
+        "data-[pressed=true]:bg-f1-background-critical-bold data-[pressed=true]:text-f1-foreground-inverse data-[pressed=true]:after:shadow-[inset_0_3px_6px_0_rgba(13,22,37,.2)] data-[pressed=true]:after:ring-transparent"
+      ),
+      ghost: cn(
+        "bg-transparent text-f1-foreground shadow-none hover:bg-f1-background-secondary-hover hover:shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(13,22,37,.04)]",
+        "active:bg-f1-background-secondary-hover active:shadow-[inset_0_2px_4px_0_rgba(13,22,37,.1)]",
+        "data-[pressed=true]:bg-f1-background-secondary-hover data-[pressed=true]:shadow-[inset_0_2px_4px_0_rgba(13,22,37,.1)]"
+      ),
+      promote: cn(
+        "bg-f1-background-promote text-f1-foreground shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(245,165,28,.15)] after:pointer-events-none after:absolute after:inset-0 after:rounded after:ring-1 after:ring-inset after:ring-f1-border-promote after:transition-all after:content-[''] hover:bg-f1-background-promote-hover dark:shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(13,22,37,.30)]",
+        "active:shadow-[inset_0_2px_4px_0_rgba(206,139,24,.5)]",
+        "data-[pressed=true]:shadow-[inset_0_2px_4px_0_rgba(206,139,24,.5)]"
+      ),
     } satisfies Record<ButtonVariant, string>,
     size: {
       sm: "rounded-sm after:rounded-sm",
@@ -49,6 +71,7 @@ const buttonVariants = cva({
   defaultVariants: {
     variant: "default",
     size: "md",
+    pressed: false,
   },
 })
 
@@ -60,6 +83,7 @@ export interface ButtonProps
   size?: ButtonSize
   variant?: ButtonVariant
   appendButton?: React.ReactNode
+  pressed?: boolean
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -72,6 +96,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       size,
       asChild = false,
       appendButton,
+      pressed,
       children,
       ...props
     },
@@ -86,11 +111,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <>
         <Comp
           className={cn(
-            buttonVariants({ variant, size, disabled: !!disabled }),
+            buttonVariants({ variant, size, disabled: !!disabled, pressed }),
             appendButton &&
               "rounded-r-none after:rounded-r-none [&>button]:rounded-r-none",
             className
           )}
+          data-pressed={pressed}
           aria-disabled={disabled}
           tabIndex={disabled ? -1 : 0}
           onClick={(e) => {


### PR DESCRIPTION
## Description

Replaces the custom button used for filters in `DataCollection` with our `Button` component, and displays the "Filters" label when there are no presets defined.

## Screenshots

https://github.com/user-attachments/assets/1b2b39d6-b7e3-4f81-8d0f-efee085fe7c6

### Figma Link

[Link to Figma Design](https://www.figma.com/design/RBKhrXjevsqIHcLWAvhV3I/Workspace?node-id=11184-346113&t=LCJm165TIf6Px88U-4)

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other