### PR TITLE
fix(DataCollection): Fix layout spacing

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/index.tsx
@@ -442,7 +442,7 @@ export const OneDataCollection = <
           </div>
         </div>
       )}
-      <div className={cn("flex flex-col gap-4 px-6")}>
+      <div className="flex flex-col gap-4 px-6">
         <Filters.Root
           schema={filters}
           filters={currentFilters}
@@ -502,7 +502,9 @@ export const OneDataCollection = <
           </div>
           <Filters.ChipsList />
         </Filters.Root>
+      </div>
 
+      <div>
         {emptyState ? (
           <div className="flex flex-col items-center justify-center">
             <OneEmptyState


### PR DESCRIPTION
## Description

The visualization (table or cards) is inside a container with padding, making it not reach the borders of the Page, even with the layout check, leading to this:

<img width="439" alt="image" src="https://github.com/user-attachments/assets/5caca124-ea65-4899-a68c-b7422f4ba04e" />

This PR moves the visualization outside of that container.

---

## Type of Change

- [ ] New experimental component
- [ ] Promote component from experimental to stable
- [x] Maintenance / Bug Fix / Other
