### PR TITLE
fix: add CoreEditor types export to RichText module

### DIFF
--- a/packages/react/src/experimental/RichText/CoreEditor/types.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/types.tsx
@@ -1,0 +1,2 @@
+export * from "./Extensions/Mention/types"
+export * from "./Toolbar/types"

--- a/packages/react/src/experimental/RichText/exports.tsx
+++ b/packages/react/src/experimental/RichText/exports.tsx
@@ -1,4 +1,5 @@
 export * from "./BlankTextEditor"
+export * from "./CoreEditor/types"
 export * from "./FileItem"
 export * from "./RichTextDisplay"
 export * from "./RichTextEditor"


### PR DESCRIPTION
## Description

This change adds missing type exports for the Core Editor, ensuring that all necessary type definitions are available for downstream consumers.

## Implementation Details

- Created a new `types.tsx` file under `packages/react/src/experimental/RichText/CoreEditor/` that re-exports:
  - `Extensions/Mention/types`
  - `Toolbar/types`
- Updated `packages/react/src/experimental/RichText/exports.tsx` to include the new `CoreEditor/types` export, making these types accessible from the top‐level RichText package.
