### PR TITLE
fix: promote factorial-one-core to dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -95,7 +95,6 @@
     "@eslint/compat": "^1.2.9",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.27.0",
-    "@factorialco/factorial-one-core": "workspace:*",
     "@microsoft/api-extractor": "7.52.2",
     "@playwright/test": "^1.52.0",
     "@storybook/addon-a11y": "^8.6.14",
@@ -166,6 +165,7 @@
     "@rollup/rollup-linux-x64-gnu": "^4.34"
   },
   "dependencies": {
+    "@factorialco/factorial-one-core": "workspace:*",
     "@radix-ui/react-hover-card": "^1.1.6",
     "@radix-ui/react-switch": "^1.2.2",
     "@tanstack/react-virtual": "^3.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
 
   packages/react:
     dependencies:
+      '@factorialco/factorial-one-core':
+        specifier: workspace:*
+        version: link:../core
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.10.0(react-hook-form@7.54.2(react@18.3.1))
@@ -296,9 +299,6 @@ importers:
       '@eslint/js':
         specifier: ^9.27.0
         version: 9.27.0
-      '@factorialco/factorial-one-core':
-        specifier: workspace:*
-        version: link:../core
       '@microsoft/api-extractor':
         specifier: 7.52.2
         version: 7.52.2(@types/node@22.13.9)


### PR DESCRIPTION
## Description

`factorial-one-react` components (e.g. `DotTag`) import token types. In production those imports throw errors because transitive dev dependencies aren't installed

## Media

A bit more details in the video (sound on 🔊):

https://github.com/user-attachments/assets/4c0a7345-d8a4-475b-917c-0db0caf91613

