### PR TITLE
feat: outline promote button variant

### DIFF
--- a/packages/react/src/components/Actions/Button/index.stories.tsx
+++ b/packages/react/src/components/Actions/Button/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { expect, within } from "@storybook/test"
-import { Add, Archive, Delete, Save } from "../../../icons/app"
+import { Add, Archive, Delete, Save, Upsell } from "../../../icons/app"
 import { Button } from "./index"
 
 const meta = {
@@ -33,6 +33,7 @@ const meta = {
         "ghost",
         "outline",
         "promote",
+        "outlinePromote",
       ],
       description: "Visual style variant of the button",
     },
@@ -94,6 +95,7 @@ export const Variants: Story = {
         <Button {...args} variant="ghost" label="Ghost" />
         <Button {...args} variant="outline" label="Outline" />
         <Button {...args} variant="promote" label="Promote" />
+        <Button {...args} variant="outlinePromote" label="Outline Promote" />
       </div>
       <h3 className="mt-4">With icon</h3>
       <div className="flex gap-2">
@@ -103,6 +105,12 @@ export const Variants: Story = {
         <Button {...args} variant="ghost" label="Ghost" icon={Save} />
         <Button {...args} variant="outline" label="Outline" icon={Add} />
         <Button {...args} variant="promote" label="Promote" icon={Add} />
+        <Button
+          {...args}
+          variant="outlinePromote"
+          label="Outline Promote"
+          icon={Upsell}
+        />
       </div>
       <h3 className="mt-4">Only icon</h3>
       <div className="flex gap-2">
@@ -151,6 +159,14 @@ export const Variants: Story = {
           variant="promote"
           label="Promote"
           icon={Add}
+          hideLabel
+          round
+        />
+        <Button
+          {...args}
+          variant="outlinePromote"
+          label="Outline Promote"
+          icon={Upsell}
           hideLabel
           round
         />

--- a/packages/react/src/components/Actions/Button/internal.tsx
+++ b/packages/react/src/components/Actions/Button/internal.tsx
@@ -35,6 +35,7 @@ const iconVariants = cva({
         "text-f1-icon-critical-bold group-hover:text-f1-icon-inverse group-active:text-f1-icon-inverse group-data-[pressed=true]:text-f1-icon-inverse dark:group-hover:text-f1-icon-bold/80 dark:group-active:text-f1-icon-bold/80 dark:group-data-[pressed=true]:text-f1-icon-bold/80",
       ghost: "text-f1-icon",
       promote: "text-f1-icon-promote",
+      outlinePromote: "text-f1-icon-promote",
     },
   },
   defaultVariants: {
@@ -52,7 +53,8 @@ export const iconOnlyVariants = cva({
       critical:
         "text-f1-icon-critical-bold group-hover:text-f1-icon-inverse group-active:text-f1-icon-inverse group-data-[pressed=true]:text-f1-icon-inverse dark:group-hover:text-f1-icon-bold dark:group-active:text-f1-icon-bold dark:group-data-[pressed=true]:text-f1-icon-bold",
       ghost: "text-f1-icon-bold",
-      promote: "text-f1-icon-bold",
+      promote: "text-f1-icon-promote",
+      outlinePromote: "text-f1-icon-promote",
     },
   },
   defaultVariants: {

--- a/packages/react/src/components/UpsellingKit/UpsellingButton/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellingButton/index.stories.tsx
@@ -116,6 +116,9 @@ export const OutlinePromote: Story = {
     variant: "outlinePromote",
     label: "Request Information",
   },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 }
 
 export const Sizes: Story = {

--- a/packages/react/src/components/UpsellingKit/UpsellingButton/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellingButton/index.stories.tsx
@@ -111,6 +111,13 @@ export const Disabled: Story = {
   },
 }
 
+export const OutlinePromote: Story = {
+  args: {
+    variant: "outlinePromote",
+    label: "Request Information",
+  },
+}
+
 export const Sizes: Story = {
   render: (args) => (
     <div className="flex items-center gap-4">

--- a/packages/react/src/components/UpsellingKit/UpsellingButton/index.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellingButton/index.tsx
@@ -13,8 +13,8 @@ export interface LoadingStateProps {
   label: string
 }
 
-export interface UpsellingButtonProps
-  extends Omit<ButtonProps, "variant" | "icon"> {
+export interface UpsellingButtonProps extends Omit<ButtonProps, "icon"> {
+  variant?: "promote" | "outlinePromote"
   /**
    * The text to be displayed in the button
    */
@@ -66,6 +66,7 @@ export function UpsellingButton({
   loadingState,
   nextSteps,
   closeLabel,
+  variant = "promote",
   ...props
 }: UpsellingButtonProps) {
   const [responseStatus, setResponseStatus] = useState<ResponseStatus>(null)
@@ -93,7 +94,7 @@ export function UpsellingButton({
   return (
     <>
       <Button
-        variant="promote"
+        variant={variant}
         label={buttonLabel}
         icon={showIcon ? UpsellIcon : undefined}
         onClick={handleClick}

--- a/packages/react/src/experimental/Information/utils.tsx
+++ b/packages/react/src/experimental/Information/utils.tsx
@@ -19,5 +19,5 @@ export interface PrimaryDropdownAction<T> extends PrimaryAction {
 }
 
 export interface SecondaryAction extends PrimaryActionButton {
-  variant?: "outline" | "critical"
+  variant?: "outline" | "critical" | "outlinePromote" | "promote"
 }

--- a/packages/react/src/ui/button.tsx
+++ b/packages/react/src/ui/button.tsx
@@ -11,6 +11,7 @@ export const variants = [
   "neutral",
   "ghost",
   "promote",
+  "outlinePromote",
 ] as const
 export type ButtonVariant = (typeof variants)[number]
 
@@ -60,6 +61,11 @@ const buttonVariants = cva({
         "bg-f1-background-promote text-f1-foreground shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(245,165,28,.15)] after:pointer-events-none after:absolute after:inset-0 after:rounded after:ring-1 after:ring-inset after:ring-f1-border-promote after:transition-all after:content-[''] hover:bg-f1-background-promote-hover dark:shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(13,22,37,.30)]",
         "active:shadow-[inset_0_2px_4px_0_rgba(206,139,24,.5)]",
         "data-[pressed=true]:shadow-[inset_0_2px_4px_0_rgba(206,139,24,.5)]"
+      ),
+      outlinePromote: cn(
+        "bg-f1-background-inverse-secondary text-f1-foreground after:pointer-events-none after:absolute after:inset-0 after:rounded after:ring-1 after:ring-inset after:ring-f1-border after:transition-all after:content-[''] hover:bg-f1-background-tertiary hover:after:opacity-70 hover:after:ring-f1-border-hover",
+        "active:bg-f1-background-tertiary active:shadow-[inset_0_2px_6px_0_rgba(13,22,37,.15)] active:after:opacity-70 active:after:ring-f1-border-hover",
+        "data-[pressed=true]:bg-f1-background-tertiary data-[pressed=true]:shadow-[inset_0_2px_6px_0_rgba(13,22,37,.15)] data-[pressed=true]:after:opacity-70 data-[pressed=true]:after:ring-f1-border-hover"
       ),
     } satisfies Record<ButtonVariant, string>,
     size: {


### PR DESCRIPTION
## Description

Adding a new button variant, `outlinePromote` to match the other upselling button design

## Screenshots (if applicable)
<img width="303" alt="Screenshot 2025-06-03 at 12 41 14 PM" src="https://github.com/user-attachments/assets/a739efd5-2a99-4639-9778-9300f58d937c" />

<img width="322" alt="Screenshot 2025-06-03 at 12 41 23 PM" src="https://github.com/user-attachments/assets/7590ab51-d6ba-4706-87a8-f440947d5c14" />


## Implementation details

Adding a new button variant, `outlinePromote` to match the other upselling button design
