### PR TITLE
Fix: Outline promote variant in product widget

### DIFF
--- a/packages/react/src/components/UpsellingKit/ProductWidget/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductWidget/index.stories.tsx
@@ -84,6 +84,7 @@ export const WithUpsellingButton: Story = {
     actions: [
       {
         type: "upsell",
+        variant: "promote",
         label: "Request Information",
         errorMessage: {
           title: "Request failed",

--- a/packages/react/src/components/UpsellingKit/ProductWidget/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductWidget/index.tsx
@@ -19,6 +19,7 @@ type BaseAction = {
 
 type UpsellAction = BaseAction & {
   type: "upsell"
+  variant: "promote" | "outlinePromote"
   errorMessage: ErrorMessageProps
   successMessage: SuccessMessageProps
   loadingState: LoadingStateProps
@@ -131,6 +132,7 @@ export function ProductWidget({
                     nextSteps={action.nextSteps}
                     closeLabel={action.closeLabel}
                     showConfirmation={action.showConfirmation}
+                    variant={action.variant}
                   />
                 ) : (
                   <Button


### PR DESCRIPTION
## Description
Adding variant prop  to product widget

## Screenshots (if applicable)
<img width="763" alt="Screenshot 2025-06-03 at 2 47 03 PM" src="https://github.com/user-attachments/assets/a1553df1-3fe3-49f9-bbb4-2cc97ced7da7" />
<img width="530" alt="Screenshot 2025-06-03 at 2 47 16 PM" src="https://github.com/user-attachments/assets/01044e05-95d6-482f-a82e-ad7883d1dd7d" />