### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.84.0",
+  "packages/react": "1.84.1",
   "packages/react-native": "0.9.0",
   "packages/core": "1.12.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.84.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.84.0...factorial-one-react-v1.84.1) (2025-06-04)
+
+
+### Bug Fixes
+
+* datacollection standard layout spacing ([#1980](https://github.com/factorialco/factorial-one/issues/1980)) ([8cde481](https://github.com/factorialco/factorial-one/commit/8cde481b07ed4d05ea80d799e09ffdf8875e464d))
+
 ## [1.84.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.83.0...factorial-one-react-v1.84.0) (2025-06-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.84.0",
+  "version": "1.84.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.84.1</summary>

## [1.84.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.84.0...factorial-one-react-v1.84.1) (2025-06-04)


### Bug Fixes

* datacollection standard layout spacing ([#1980](https://github.com/factorialco/factorial-one/issues/1980)) ([8cde481](https://github.com/factorialco/factorial-one/commit/8cde481b07ed4d05ea80d799e09ffdf8875e464d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).