### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.84.1",
-  "packages/react-native": "0.9.0",
+  "packages/react-native": "0.10.0",
   "packages/core": "1.12.2"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.10.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.9.0...factorial-one-react-native-v0.10.0) (2025-06-04)
+
+
+### Features
+
+* create new f1 components AlertTag for Mobile ([#1994](https://github.com/factorialco/factorial-one/issues/1994)) ([afe7df1](https://github.com/factorialco/factorial-one/commit/afe7df11e763712ca5f18e228702c5d09061523f))
+
 ## [0.9.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.8.2...factorial-one-react-native-v0.9.0) (2025-05-30)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.10.0</summary>

## [0.10.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.9.0...factorial-one-react-native-v0.10.0) (2025-06-04)


### Features

* create new f1 components AlertTag for Mobile ([#1994](https://github.com/factorialco/factorial-one/issues/1994)) ([afe7df1](https://github.com/factorialco/factorial-one/commit/afe7df11e763712ca5f18e228702c5d09061523f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).