### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.85.0",
+  "packages/react": "1.85.1",
   "packages/react-native": "0.10.0",
   "packages/core": "1.13.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.85.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.85.0...factorial-one-react-v1.85.1) (2025-06-04)
+
+
+### Bug Fixes
+
+* adding variant to widget button ([#1999](https://github.com/factorialco/factorial-one/issues/1999)) ([13ee275](https://github.com/factorialco/factorial-one/commit/13ee275f5430c29113a932bd3f2cb8e7ec76988b))
+
 ## [1.85.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.84.1...factorial-one-react-v1.85.0) (2025-06-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.85.0",
+  "version": "1.85.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.85.1</summary>

## [1.85.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.85.0...factorial-one-react-v1.85.1) (2025-06-04)


### Bug Fixes

* adding variant to widget button ([#1999](https://github.com/factorialco/factorial-one/issues/1999)) ([13ee275](https://github.com/factorialco/factorial-one/commit/13ee275f5430c29113a932bd3f2cb8e7ec76988b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).