### PR TITLE
fix: remove default sidebar activity button shortcut

### DIFF
--- a/packages/react/src/experimental/Navigation/Sidebar/Footer/index.tsx
+++ b/packages/react/src/experimental/Navigation/Sidebar/Footer/index.tsx
@@ -24,7 +24,7 @@ export function SidebarFooter({
   user,
   options,
   showActivityButton = false,
-  activityButtonShortcut = ["cmd", "B"],
+  activityButtonShortcut,
   onActivityButtonClick,
   hasActivityUpdates,
 }: SidebarFooterProps) {


### PR DESCRIPTION
## Description

We need to remove this shortcut for now in our frontend as it's overlapping with other shortcut in the app.