### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.85.1",
+  "packages/react": "1.85.2",
   "packages/react-native": "0.10.0",
   "packages/core": "1.13.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.85.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.85.1...factorial-one-react-v1.85.2) (2025-06-04)
+
+
+### Bug Fixes
+
+* remove default sidebar activity button shortcut ([#2008](https://github.com/factorialco/factorial-one/issues/2008)) ([0d751af](https://github.com/factorialco/factorial-one/commit/0d751af870d8568d0464556163b3fa6420795457))
+
 ## [1.85.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.85.0...factorial-one-react-v1.85.1) (2025-06-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.85.1",
+  "version": "1.85.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.85.2</summary>

## [1.85.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.85.1...factorial-one-react-v1.85.2) (2025-06-04)


### Bug Fixes

* remove default sidebar activity button shortcut ([#2008](https://github.com/factorialco/factorial-one/issues/2008)) ([0d751af](https://github.com/factorialco/factorial-one/commit/0d751af870d8568d0464556163b3fa6420795457))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).