### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.85.4",
-  "packages/react-native": "0.10.0",
-  "packages/core": "1.13.0"
+  "packages/react-native": "0.11.0",
+  "packages/core": "1.14.0"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.14.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.13.0...factorial-one-core-v1.14.0) (2025-06-05)
+
+
+### Features
+
+* create new  Chip & RawTag component for mobile ([#2005](https://github.com/factorialco/factorial-one/issues/2005)) ([3c60e51](https://github.com/factorialco/factorial-one/commit/3c60e5181cbc46db31488dd5755abab45071f008))
+
 ## [1.13.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.12.2...factorial-one-core-v1.13.0) (2025-06-04)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.11.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.10.0...factorial-one-react-native-v0.11.0) (2025-06-05)
+
+
+### Features
+
+* create new  Chip & RawTag component for mobile ([#2005](https://github.com/factorialco/factorial-one/issues/2005)) ([3c60e51](https://github.com/factorialco/factorial-one/commit/3c60e5181cbc46db31488dd5755abab45071f008))
+
 ## [0.10.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.9.0...factorial-one-react-native-v0.10.0) (2025-06-04)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.11.0</summary>

## [0.11.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.10.0...factorial-one-react-native-v0.11.0) (2025-06-05)


### Features

* create new  Chip & RawTag component for mobile ([#2005](https://github.com/factorialco/factorial-one/issues/2005)) ([3c60e51](https://github.com/factorialco/factorial-one/commit/3c60e5181cbc46db31488dd5755abab45071f008))
</details>

<details><summary>factorial-one-core: 1.14.0</summary>

## [1.14.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.13.0...factorial-one-core-v1.14.0) (2025-06-05)


### Features

* create new  Chip & RawTag component for mobile ([#2005](https://github.com/factorialco/factorial-one/issues/2005)) ([3c60e51](https://github.com/factorialco/factorial-one/commit/3c60e5181cbc46db31488dd5755abab45071f008))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).