### PR TITLE
chore: fix alpha release

### DIFF
--- a/.github/actions/publish-release-branch/action.yaml
+++ b/.github/actions/publish-release-branch/action.yaml
@@ -17,7 +17,32 @@ runs:
         git config user.name 'github-actions[bot]'
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+        # Get the current commit SHA
+        SHA=$(git rev-parse --short HEAD)
+
+        # Update package.json dependencies
+        cd ${{ inputs.directory }}
+
+        # Replace workspace:* dependencies with latest
+        sed -i 's/"workspace:\*"/"latest"/g' package.json
+
+        # # Get current version from package.json
+        # CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+        # # Update version to include alpha and SHA
+        # npm version --no-git-tag-version "${CURRENT_VERSION}-alpha.${SHA}"
+
+        cd -
+
+        git add -A
+        git commit -m "chore: update dependencies"
+
+
         # Publish alpha version
         pnpx sergiocarracedo/git-publish#npm/feat/directory-support -b '${{ inputs.branch-name }}' --directory ${{ inputs.directory }}
+
+        # Get the latest commit SHA from the branch
         LAST=$(git log -n 1 'origin/${{ inputs.branch-name }}' --pretty=format:"%H")
+
+        # Print the message
         echo "::notice title='Package published'::Use pnpm i github:factorialco/factorial-one#${{ inputs.branch-name }} to install the package (or pnpm i github:factorialco/factorial-one#${LAST} to install this specific commit)"

--- a/packages/react/src/lib/imageHandler.tsx
+++ b/packages/react/src/lib/imageHandler.tsx
@@ -22,7 +22,6 @@ export const ImageProvider: React.FC<
 
 export const useImageContext = () => {
   const context = useContext(ImageContext)
-
   return {
     ...context,
   }


### PR DESCRIPTION
## Description

After moving factorial-one-core as dependency (not devDependency) in factorial-one-react the alpha build starts to fail because they tried to get the dependency from 'workspace'. Changed workspace:* to latest in alpha releases

## Implementation details

<!-- What have you changed? Why? -->
