### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.85.4",
+  "packages/react": "1.85.5",
   "packages/react-native": "0.11.0",
   "packages/core": "1.14.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.85.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.85.4...factorial-one-react-v1.85.5) (2025-06-05)
+
+
+### Bug Fixes
+
+* **datacollection:** no cache infilters render loop ([#2019](https://github.com/factorialco/factorial-one/issues/2019)) ([546ab14](https://github.com/factorialco/factorial-one/commit/546ab14a9d0826f351bc17b0d7b58aa32e8a5c80))
+
 ## [1.85.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.85.3...factorial-one-react-v1.85.4) (2025-06-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.85.4",
+  "version": "1.85.5",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.85.5</summary>

## [1.85.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.85.4...factorial-one-react-v1.85.5) (2025-06-05)


### Bug Fixes

* **datacollection:** no cache infilters render loop ([#2019](https://github.com/factorialco/factorial-one/issues/2019)) ([546ab14](https://github.com/factorialco/factorial-one/commit/546ab14a9d0826f351bc17b0d7b58aa32e8a5c80))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).