### PR TITLE
Make title optional in OneModal.Header

### DIFF
--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -127,7 +127,7 @@ export function BaseHeader({
   }
 
   return (
-    <div className="flex flex-col gap-3 px-6 pb-5 pt-3">
+    <div className="resource-header flex-col gap-3 px-6 pb-5 pt-3">
       <div
         className={cn(
           "flex flex-col items-start justify-start gap-4 md:flex-row",

--- a/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
@@ -1,4 +1,6 @@
 import { ButtonInternal } from "@/components/Actions/Button/internal"
+import { ResourceHeader } from "@/experimental/Information/Headers/ResourceHeader"
+import { Default as ResourceHeaderDefault } from "@/experimental/Information/Headers/ResourceHeader/index.stories"
 import {
   OnePersonListItem,
   OnePersonListItemProps,
@@ -160,6 +162,33 @@ export const WithModule: Story = {
         />
         <OneModal.Content tabs={TABS}>
           <ExamplePersonList />
+        </OneModal.Content>
+      </>
+    ),
+  },
+}
+
+export const WithResourceHeader: Story = {
+  args: {
+    ...Default.args,
+    position: "right",
+    children: (
+      <>
+        <OneModal.Header
+          module={{
+            id: "timeoff",
+            label: "Time Off",
+            href: "/timeoff",
+          }}
+        />
+        <OneModal.Content withPadding>
+          <ResourceHeader
+            {...(ResourceHeaderDefault.args as ComponentProps<
+              typeof ResourceHeader
+            >)}
+            primaryAction={undefined}
+            secondaryActions={undefined}
+          />
         </OneModal.Content>
       </>
     ),

--- a/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
@@ -188,6 +188,7 @@ export const WithResourceHeader: Story = {
             >)}
             primaryAction={undefined}
             secondaryActions={undefined}
+            otherActions={undefined}
           />
         </OneModal.Content>
       </>

--- a/packages/react/src/experimental/Modals/OneModal/OneModalContent/OneModalContent.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalContent/OneModalContent.tsx
@@ -6,12 +6,14 @@ import { useIsSmallScreen } from "../utils"
 
 export type OneModalContentProps = {
   children: React.ReactNode
+  withPadding?: boolean
 } & Partial<Pick<TabsProps, "tabs" | "activeTabId" | "setActiveTabId">>
 
 export const OneModalContent = ({
   tabs,
   activeTabId,
   setActiveTabId,
+  withPadding = false,
   children,
 }: OneModalContentProps) => {
   const { position: modalPosition } = useOneModal()
@@ -32,6 +34,8 @@ export const OneModalContent = ({
       <ScrollArea
         className={cn(
           "[*[data-state=visible]_div]:bg-f1-background flex flex-1 flex-col",
+          "[&_.resource-header]:p-0 [&_.resource-header]:pr-1",
+          withPadding && "px-5 py-3",
           !isSmallScreen && modalPosition === "center" && "max-h-[512px]"
         )}
       >

--- a/packages/react/src/experimental/Modals/OneModal/OneModalFooter/OneModalFooter.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalFooter/OneModalFooter.tsx
@@ -4,7 +4,7 @@ export type OneModalFooterProps = {
 
 export const OneModalFooter = ({ children }: OneModalFooterProps) => {
   return (
-    <div className="flex min-h-18 flex-row items-center justify-between border-x-0 border-b-0 border-t border-solid border-f1-border-secondary bg-f1-background p-4">
+    <div className="flex min-h-18 flex-row items-center justify-between border-x-0 border-b-0 border-t border-solid border-f1-border-secondary bg-f1-background p-5">
       {children}
     </div>
   )

--- a/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
@@ -12,7 +12,7 @@ import { DrawerTitle } from "@/ui/drawer"
 import { useOneModal } from "../OneModalProvider"
 
 export type OneModalHeaderProps = {
-  title: string
+  title?: string
   /**
    * Module configuration for the header. Only works when modal position is set to "right".
    * Displays module icon and name in the header.
@@ -86,7 +86,7 @@ export const OneModalHeader = ({
 
   if (modalPosition === "right" && !shownBottomSheet) {
     return (
-      <div className="flex flex-col gap-3 bg-f1-background p-4">
+      <div className="flex flex-col gap-3 bg-f1-background p-5 pb-3">
         <div className="flex flex-row justify-between">
           {module ? <Module /> : <Actions />}
           <div className="flex flex-row gap-2">
@@ -105,18 +105,22 @@ export const OneModalHeader = ({
             />
           </div>
         </div>
-        <DialogTitle className={cn(dialogClassName, "text-2xl")}>
-          {title}
-        </DialogTitle>
+        {!!title && (
+          <DialogTitle className={cn(dialogClassName, "text-2xl")}>
+            {title}
+          </DialogTitle>
+        )}
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col gap-3 bg-f1-background p-4">
+    <div className="flex flex-col gap-3 bg-f1-background p-5 pb-3">
       <div className="flex flex-row items-center justify-between">
         {!shownBottomSheet ? (
-          <DialogTitle className={dialogClassName}>{title}</DialogTitle>
+          !!title && (
+            <DialogTitle className={dialogClassName}>{title}</DialogTitle>
+          )
         ) : (
           <>
             {module ? (
@@ -138,7 +142,9 @@ export const OneModalHeader = ({
           />
         </div>
       </div>
-      {module && <DrawerTitle className={dialogClassName}>{title}</DrawerTitle>}
+      {module && !!title && (
+        <DrawerTitle className={dialogClassName}>{title}</DrawerTitle>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Description

We don't always want to show a title in our modals. As an example, sometimes we will just want to include this title by adding the resource header as part of the content.

## Screenshots

<img width="548" alt="Screenshot 2025-06-05 at 17 00 52" src="https://github.com/user-attachments/assets/cbc0744c-aa62-4dd6-9e20-777fd414c186" />

[Link to Figma Design](https://www.figma.com/design/wPNJScnPBVHxkli1CdCYKV/Inbox--Tasks---Notifications?node-id=2164-140848&m=dev)
