### PR TITLE
fix: no longer rendering 0 for empty actions on metadataitem

### DIFF
--- a/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
@@ -81,7 +81,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
   const isList =
     (item.value.type === "data-list" && item.value.data.length > 1) ||
     (item.value.type === "tag-list" && item.value.tags.length > 1)
-  const isAction = item.actions?.length
+  const isAction = Boolean(item.actions?.length)
   const hasHover = isAction || isList
 
   const getValueToCopy = (


### PR DESCRIPTION
## Description

In the Header Metadata, when actions are empty, it is rendering a "0", which becomes really weird when displayed next to the phone field 😅.

## Screenshots (if applicable)

<img width="637" alt="Screenshot 2025-06-05 at 23 30 32" src="https://github.com/user-attachments/assets/b71ac553-528d-45bb-8f5e-988ff947162e" />

## Implementation details

The item.actions?.length returns 0 when actions is an empty array so {0 && <MobileDropdown />} renders 0 instead of nothing, adding Boolean fixes it.
