### PR TITLE
fix: datacollection pagination is mixing some top padding

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -207,7 +207,7 @@ export const CardCollection = <
             })}
       </div>
       {paginationInfo && (
-        <div className="flex w-full items-center justify-between px-6">
+        <div className="flex w-full items-center justify-between px-6 pt-4">
           <span className="shrink-0 text-f1-foreground-secondary">
             {`${(paginationInfo.currentPage - 1) * paginationInfo.perPage + 1}-${Math.min(
               paginationInfo.currentPage * paginationInfo.perPage,

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
@@ -335,7 +335,7 @@ export const TableCollection = <
         </TableBody>
       </OneTable>
       {paginationInfo && (
-        <div className="flex w-full items-center justify-between px-6">
+        <div className="flex w-full items-center justify-between px-6 pt-4">
           <span className="shrink-0 text-f1-foreground-secondary">
             {paginationInfo.total > 0 &&
               `${(paginationInfo.currentPage - 1) * paginationInfo.perPage + 1}-${Math.min(


### PR DESCRIPTION
## Description

The Data Collection component pagination is missing some top padding, added it. Feel free to reject this PR if you consider that should be approached differently. Just trying to help 😊

## Screenshots (if applicable)

<img width="1470" alt="Screenshot 2025-06-05 at 23 41 32" src="https://github.com/user-attachments/assets/1f6bced6-945c-43c4-aa23-499f5ede8748" />

## Implementation details

Checked the separation between the elements on top of the datacollection and added similar padding to the pagination. 
