### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.88.0",
-  "packages/react-native": "0.11.0",
+  "packages/react-native": "0.12.0",
   "packages/core": "1.15.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.12.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.11.0...factorial-one-react-native-v0.12.0) (2025-06-06)
+
+
+### Features
+
+* create new component avatar for mobile ([#2026](https://github.com/factorialco/factorial-one/issues/2026)) ([b6da3c6](https://github.com/factorialco/factorial-one/commit/b6da3c60fa98d4d4be048b684cfd6ae81e427948))
+
 ## [0.11.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.10.0...factorial-one-react-native-v0.11.0) (2025-06-05)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.12.0</summary>

## [0.12.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.11.0...factorial-one-react-native-v0.12.0) (2025-06-06)


### Features

* create new component avatar for mobile ([#2026](https://github.com/factorialco/factorial-one/issues/2026)) ([b6da3c6](https://github.com/factorialco/factorial-one/commit/b6da3c60fa98d4d4be048b684cfd6ae81e427948))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).