### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.88.0",
-  "packages/react-native": "0.12.0",
+  "packages/react-native": "0.13.0",
   "packages/core": "1.15.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.13.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.12.0...factorial-one-react-native-v0.13.0) (2025-06-06)
+
+
+### Features
+
+* new inbox module components and new page header component ([#2031](https://github.com/factorialco/factorial-one/issues/2031)) ([3474fc0](https://github.com/factorialco/factorial-one/commit/3474fc056ac11ea2414a3ee017763c14f44e1123))
+
 ## [0.12.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.11.0...factorial-one-react-native-v0.12.0) (2025-06-06)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.13.0</summary>

## [0.13.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.12.0...factorial-one-react-native-v0.13.0) (2025-06-06)


### Features

* new inbox module components and new page header component ([#2031](https://github.com/factorialco/factorial-one/issues/2031)) ([3474fc0](https://github.com/factorialco/factorial-one/commit/3474fc056ac11ea2414a3ee017763c14f44e1123))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).