### PR TITLE
feat: add table view to DetailsItemsList component

### DIFF
--- a/packages/react/src/experimental/Lists/DataList/index.tsx
+++ b/packages/react/src/experimental/Lists/DataList/index.tsx
@@ -25,7 +25,7 @@ const _DataList = forwardRef<HTMLUListElement, DataListProps>(
       <div
         className={cn(
           isHorizontal
-            ? "flex flex-1 flex-col px-3 py-2 xs:flex-row"
+            ? "flex flex-1 flex-col px-3 py-1.5 xs:flex-row"
             : "min-w-32 max-w-72"
         )}
       >

--- a/packages/react/src/experimental/Lists/DataList/index.tsx
+++ b/packages/react/src/experimental/Lists/DataList/index.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, ReactElement } from "react"
 
+import { cn } from "@/lib/utils"
 import { IconType } from "../../../components/Utilities/Icon"
 import { CompanyAvatar } from "../../Information/Avatars/CompanyAvatar"
 import { PersonAvatar } from "../../Information/Avatars/PersonAvatar"
@@ -9,6 +10,7 @@ import { InternalActionType, ItemContainer } from "./ItemContainer"
 export type DataListProps = {
   children: ReactElement<Items>[] | ReactElement<Items>
   label?: string
+  isHorizontal?: boolean
 }
 
 type Items =
@@ -18,11 +20,24 @@ type Items =
   | typeof TeamItem
 
 const _DataList = forwardRef<HTMLUListElement, DataListProps>(
-  ({ children, label }, ref) => {
+  ({ children, label, isHorizontal = false }, ref) => {
     return (
-      <div className="min-w-32 max-w-72">
+      <div
+        className={cn(
+          isHorizontal
+            ? "flex flex-1 flex-col px-3 py-2 xs:flex-row"
+            : "min-w-32 max-w-72"
+        )}
+      >
         {label && (
-          <p className="mb-0.5 px-1.5 text-f1-foreground-secondary">{label}</p>
+          <p
+            className={cn(
+              "px-1.5 text-f1-foreground-secondary",
+              isHorizontal ? "mt-1.5 w-44 xs:px-0" : "mb-0.5"
+            )}
+          >
+            {label}
+          </p>
         )}
         <ul className="flex flex-col gap-0.5" ref={ref}>
           {children}

--- a/packages/react/src/experimental/Lists/DataList/index.tsx
+++ b/packages/react/src/experimental/Lists/DataList/index.tsx
@@ -25,7 +25,7 @@ const _DataList = forwardRef<HTMLUListElement, DataListProps>(
       <div
         className={cn(
           isHorizontal
-            ? "flex flex-1 flex-col px-3 py-1.5 xs:flex-row"
+            ? "flex flex-1 flex-col py-1.5 pl-3 pr-1.5 xs:flex-row"
             : "min-w-32 max-w-72"
         )}
       >

--- a/packages/react/src/experimental/Lists/DetailsItem/index.stories.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.stories.tsx
@@ -48,3 +48,14 @@ export const WithMoreLinesThanAllowed: Story = {
     },
   },
 }
+
+export const Horizontal: Story = {
+  args: {
+    title: "Address",
+    content: {
+      type: "item",
+      text: "Paseo Mara, 62, Bajos\nPáez del Vallès\nCeuta",
+    },
+    isHorizontal: true,
+  },
+}

--- a/packages/react/src/experimental/Lists/DetailsItem/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.tsx
@@ -23,6 +23,7 @@ type Content =
 export interface DetailsItemType {
   title: string
   content: Content | Content[]
+  isHorizontal?: boolean
   spacingAtTheBottom?: boolean
 }
 
@@ -41,15 +42,22 @@ const ItemContent: FC<{ content: Content }> = ({ content }) => (
 )
 
 export const DetailsItem = forwardRef<HTMLDivElement, DetailsItemType>(
-  function DetailsItem({ title, content, spacingAtTheBottom }, ref) {
+  function DetailsItem(
+    { title, content, isHorizontal = false, spacingAtTheBottom },
+    ref
+  ) {
     const contentArray = Array.isArray(content) ? content : [content]
 
     return (
       <div
         ref={ref}
-        className={cn("flex flex-col gap-0.5", spacingAtTheBottom && "pb-3")}
+        className={cn(
+          "flex flex-col gap-0.5",
+          spacingAtTheBottom && !isHorizontal && "pb-3",
+          isHorizontal && "[&_li>div]:p-0 [&_ul]:flex-1"
+        )}
       >
-        <DataList label={title}>
+        <DataList label={title} isHorizontal={isHorizontal}>
           {contentArray.map((c, i) => (
             <ItemContent key={i} content={c} />
           ))}

--- a/packages/react/src/experimental/Lists/DetailsItemsList/index.stories.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItemsList/index.stories.tsx
@@ -69,3 +69,10 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Primary: Story = {}
+
+export const TableView: Story = {
+  args: {
+    title: undefined,
+    tableView: true,
+  },
+}

--- a/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
@@ -1,15 +1,17 @@
-import { forwardRef } from "react"
+import { cn } from "@/lib/utils"
+import React, { forwardRef } from "react"
 import { DetailsItem, DetailsItemType } from "../DetailsItem"
 
 interface DetailsItemsListProps {
-  title: string
+  title?: string
+  tableView?: boolean
   details: DetailsItemType[]
 }
 
 export const DetailsItemsList = forwardRef<
   HTMLDivElement,
   DetailsItemsListProps
->(function DetailsItemList({ title, details }, ref) {
+>(function DetailsItemList({ title, tableView = false, details }, ref) {
   return (
     <div ref={ref} className="flex flex-col gap-4">
       {!!title && (
@@ -17,14 +19,27 @@ export const DetailsItemsList = forwardRef<
           {title.toLocaleUpperCase()}
         </p>
       )}
-      <div className="flex flex-col gap-3">
-        {details?.map((item) => (
-          <DetailsItem
-            title={item.title}
-            key={item.title}
-            content={item.content}
-            spacingAtTheBottom={item.spacingAtTheBottom}
-          />
+      <div
+        className={cn(
+          "flex flex-col",
+          tableView
+            ? "rounded-md border border-solid border-f1-border-secondary"
+            : "gap-3"
+        )}
+      >
+        {details?.map((item, index) => (
+          <React.Fragment key={item.title}>
+            <DetailsItem
+              title={item.title}
+              key={item.title}
+              content={item.content}
+              spacingAtTheBottom={item.spacingAtTheBottom}
+              isHorizontal={tableView}
+            />
+            {tableView && index !== details.length - 1 && (
+              <div className="h-[1px] w-full bg-f1-border-secondary" />
+            )}
+          </React.Fragment>
         ))}
       </div>
     </div>

--- a/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
@@ -23,7 +23,7 @@ export const DetailsItemsList = forwardRef<
         className={cn(
           "flex flex-col",
           tableView
-            ? "rounded-md border border-solid border-f1-border-secondary"
+            ? "max-w-[580px] rounded-md border border-solid border-f1-border-secondary"
             : "gap-3"
         )}
       >


### PR DESCRIPTION
## Description

Provide an alternative "table" kind of view for `DetailItemsList` component as a new need to show information in a wider container.

<img width="506" alt="Screenshot 2025-06-06 at 19 08 41" src="https://github.com/user-attachments/assets/2eea6a3f-cdab-4537-9081-63bda7e9c347" />

## Screenshots

<img width="670" alt="Screenshot 2025-06-06 at 19 28 02" src="https://github.com/user-attachments/assets/3f9d5721-ddb4-4e6c-80e7-baff5781cd5d" />

✨  Looking good as well in smaller screen sizes:

<img width="462" alt="Screenshot 2025-06-06 at 19 12 50" src="https://github.com/user-attachments/assets/472c6153-f046-4c94-91e2-6af750435999" />

[Link to Figma Design](https://www.figma.com/design/wPNJScnPBVHxkli1CdCYKV/Inbox--Tasks---Notifications?node-id=2164-140708&m=dev)
