### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.89.0",
+  "packages/react": "1.90.0",
   "packages/react-native": "0.13.1",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.90.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.89.0...factorial-one-react-v1.90.0) (2025-06-09)
+
+
+### Features
+
+* add dot tag item to details item list component ([#2042](https://github.com/factorialco/factorial-one/issues/2042)) ([a89ab32](https://github.com/factorialco/factorial-one/commit/a89ab329703e9151b8d52a084f6f06c7f1e6ea7e))
+
 ## [1.89.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.88.1...factorial-one-react-v1.89.0) (2025-06-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.90.0</summary>

## [1.90.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.89.0...factorial-one-react-v1.90.0) (2025-06-09)


### Features

* add dot tag item to details item list component ([#2042](https://github.com/factorialco/factorial-one/issues/2042)) ([a89ab32](https://github.com/factorialco/factorial-one/commit/a89ab329703e9151b8d52a084f6f06c7f1e6ea7e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).