### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.90.0",
+  "packages/react": "1.90.1",
   "packages/react-native": "0.13.1",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.90.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.0...factorial-one-react-v1.90.1) (2025-06-09)
+
+
+### Bug Fixes
+
+* no longer rendering 0 for empty actions on metadataitem ([#2029](https://github.com/factorialco/factorial-one/issues/2029)) ([9429aa1](https://github.com/factorialco/factorial-one/commit/9429aa1fa7676dbeb46b144f80a6b4e2d89153e7))
+
 ## [1.90.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.89.0...factorial-one-react-v1.90.0) (2025-06-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.90.0",
+  "version": "1.90.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.90.1</summary>

## [1.90.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.0...factorial-one-react-v1.90.1) (2025-06-09)


### Bug Fixes

* no longer rendering 0 for empty actions on metadataitem ([#2029](https://github.com/factorialco/factorial-one/issues/2029)) ([9429aa1](https://github.com/factorialco/factorial-one/commit/9429aa1fa7676dbeb46b144f80a6b4e2d89153e7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).