### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.90.1",
+  "packages/react": "1.90.2",
   "packages/react-native": "0.13.1",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.90.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.1...factorial-one-react-v1.90.2) (2025-06-10)
+
+
+### Bug Fixes
+
+* datacollection pagination is mixing some top padding ([#2030](https://github.com/factorialco/factorial-one/issues/2030)) ([453a095](https://github.com/factorialco/factorial-one/commit/453a0951910082b747eeb54e755f65b0d551e25f))
+
 ## [1.90.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.0...factorial-one-react-v1.90.1) (2025-06-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.90.1",
+  "version": "1.90.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.90.2</summary>

## [1.90.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.1...factorial-one-react-v1.90.2) (2025-06-10)


### Bug Fixes

* datacollection pagination is mixing some top padding ([#2030](https://github.com/factorialco/factorial-one/issues/2030)) ([453a095](https://github.com/factorialco/factorial-one/commit/453a0951910082b747eeb54e755f65b0d551e25f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).