### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.90.2",
+  "packages/react": "1.90.3",
   "packages/react-native": "0.13.1",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.90.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.2...factorial-one-react-v1.90.3) (2025-06-10)
+
+
+### Bug Fixes
+
+* swap import/export icons ([#2027](https://github.com/factorialco/factorial-one/issues/2027)) ([99f295d](https://github.com/factorialco/factorial-one/commit/99f295da24adca6ef55f751f58176d20c6f5bd5e))
+
 ## [1.90.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.1...factorial-one-react-v1.90.2) (2025-06-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.90.2",
+  "version": "1.90.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.90.3</summary>

## [1.90.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.2...factorial-one-react-v1.90.3) (2025-06-10)


### Bug Fixes

* swap import/export icons ([#2027](https://github.com/factorialco/factorial-one/issues/2027)) ([99f295d](https://github.com/factorialco/factorial-one/commit/99f295da24adca6ef55f751f58176d20c6f5bd5e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).