### PR TITLE
fix(DataCollection): display tooltip with info icon & custom icon

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
@@ -194,6 +194,7 @@ export const BasicTableView: Story = {
                     label: "Department",
                     render: (item) => item.department,
                     sorting: "department",
+                    info: "Team that the employee belongs to",
                   },
                   {
                     label: "Salary",

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
@@ -46,7 +46,10 @@ export type TableColumnDefinition<
   Record,
   Sortings extends SortingsDefinition,
 > = WithOptionalSorting<Record, Sortings> &
-  Pick<ComponentProps<typeof TableHead>, "hidden" | "info" | "sticky" | "width">
+  Pick<
+    ComponentProps<typeof TableHead>,
+    "hidden" | "info" | "infoIcon" | "sticky" | "width"
+  >
 
 export type TableVisualizationOptions<
   Record extends RecordType,

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -99,7 +99,15 @@ export function TableHead({
             {info && (
               <div className="flex h-6 w-6 items-center justify-center text-f1-foreground-secondary">
                 <Tooltip label={info}>
-                  <Icon icon={infoIcon} size="sm" />
+                  <div
+                    className={cn(
+                      "flex h-5 w-5 items-center justify-center rounded-xs",
+                      focusRing()
+                    )}
+                    tabIndex={0}
+                  >
+                    <Icon icon={infoIcon} size="sm" />
+                  </div>
                 </Tooltip>
               </div>
             )}

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -1,6 +1,6 @@
 import { TableHead as TableHeadRoot } from "@/ui/table"
 import { AnimatePresence, motion } from "framer-motion"
-import { Icon } from "../../../components/Utilities/Icon"
+import { Icon, IconType } from "../../../components/Utilities/Icon"
 import { ArrowDown, InfoCircleLine } from "../../../icons/app"
 import { cn, focusRing } from "../../../lib/utils"
 import { Tooltip } from "../../Overlays/Tooltip"
@@ -43,6 +43,12 @@ interface TableHeadProps {
   info?: string
 
   /**
+   * Icon to display when info is provided.
+   * @default InfoCircleLine
+   */
+  infoIcon?: IconType
+
+  /**
    * When true, the header cell will not be visible.
    * @default false
    */
@@ -61,6 +67,7 @@ export function TableHead({
   sortState = "none",
   onSortClick,
   info,
+  infoIcon = InfoCircleLine,
   sticky,
   hidden = false,
   align = "left",
@@ -91,7 +98,9 @@ export function TableHead({
           <div className="flex items-center">
             {info && (
               <div className="flex h-6 w-6 items-center justify-center text-f1-foreground-secondary">
-                <Icon icon={InfoCircleLine} size="sm" />
+                <Tooltip label={info}>
+                  <Icon icon={infoIcon} size="sm" />
+                </Tooltip>
               </div>
             )}
             {onSortClick && (
@@ -197,7 +206,7 @@ export function TableHead({
           />
         )}
       </AnimatePresence>
-      {!hidden && (info ? <Tooltip label={info}>{content}</Tooltip> : content)}
+      {!hidden && content}
     </TableHeadRoot>
   )
 }


### PR DESCRIPTION
## Description

The info prop for the table headers isn't working. Even though the icon is shown, no tooltip is displayed on hover. Also, some teams need to change the icon to depict something about the label without taking up much space, like this case of Compensations:

![image](https://github.com/user-attachments/assets/fe4b4b7c-4dfd-4e8c-a4fa-5ab05c6d2c91)

_PD: That's not the final design, but you get the idea, they need a different icon other than the info circle._

## Screenshots

![image](https://github.com/user-attachments/assets/542cf882-4352-49c4-be12-2681c0582427)

_Info icon with a working tooltip_

![image](https://github.com/user-attachments/assets/b7957efa-175d-444c-9721-aaf5d8a9db36)

_Custom icon_

## Implementation details

- Now, the tooltip is displayed only while hovering the icon. It was not working before as the tooltip was wrapping the entire header, and there are some interactive elements inside that was breaking the tooltip.
- Added a new prop to define a custom info icon.
