### PR TITLE
fix: Added whitespace prewrap in the pre tag to enable wrapping 

### DIFF
--- a/packages/react/src/experimental/RichText/index.css
+++ b/packages/react/src/experimental/RichText/index.css
@@ -98,7 +98,7 @@
 
 .ProseMirror pre,
 .rich-text-display-container pre {
-  @apply relative mx-0 overflow-x-auto rounded-md bg-f1-background-secondary p-2;
+  @apply relative mx-0 overflow-x-auto whitespace-pre-wrap rounded-md bg-f1-background-secondary p-2;
 }
 
 .ProseMirror code,


### PR DESCRIPTION
## Description

Resolved layout-breaking issue caused by pre code tags not wrapping content properly. Now long code lines wrap correctly to maintain layout integrity.

## Screenshots

Without
<img width="756" alt="Screenshot 2025-06-10 at 23 24 20" src="https://github.com/user-attachments/assets/8d594b56-35f9-4a60-ad31-be280672ce68" />

With

<img width="658" alt="Screenshot 2025-06-10 at 23 24 54" src="https://github.com/user-attachments/assets/a899a891-0267-48cf-9b61-a4a15a5c05a2" />

## Implementation details

Just added whitespace-pre-wrap to pre style.