### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.90.4",
+  "packages/react": "1.91.0",
   "packages/react-native": "0.13.1",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.91.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.4...factorial-one-react-v1.91.0) (2025-06-11)
+
+
+### Features
+
+* add on click to dropdown footer sidebar ([#2052](https://github.com/factorialco/factorial-one/issues/2052)) ([205ea79](https://github.com/factorialco/factorial-one/commit/205ea799ecfc6a44a7daf614e7b1b15cf8e56e17))
+
 ## [1.90.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.3...factorial-one-react-v1.90.4) (2025-06-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.90.4",
+  "version": "1.91.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.91.0</summary>

## [1.91.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.4...factorial-one-react-v1.91.0) (2025-06-11)


### Features

* add on click to dropdown footer sidebar ([#2052](https://github.com/factorialco/factorial-one/issues/2052)) ([205ea79](https://github.com/factorialco/factorial-one/commit/205ea799ecfc6a44a7daf614e7b1b15cf8e56e17))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).