### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.91.0",
+  "packages/react": "1.92.0",
   "packages/react-native": "0.13.1",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.92.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.91.0...factorial-one-react-v1.92.0) (2025-06-11)
+
+
+### Features
+
+* disable drag and drop in sidebar on touch screens ([#2048](https://github.com/factorialco/factorial-one/issues/2048)) ([6ddf3e3](https://github.com/factorialco/factorial-one/commit/6ddf3e329e2c9fa131841df3d80c76ec7e7b909d))
+
 ## [1.91.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.90.4...factorial-one-react-v1.91.0) (2025-06-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.91.0",
+  "version": "1.92.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.92.0</summary>

## [1.92.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.91.0...factorial-one-react-v1.92.0) (2025-06-11)


### Features

* disable drag and drop in sidebar on touch screens ([#2048](https://github.com/factorialco/factorial-one/issues/2048)) ([6ddf3e3](https://github.com/factorialco/factorial-one/commit/6ddf3e329e2c9fa131841df3d80c76ec7e7b909d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).