### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.92.0",
+  "packages/react": "1.92.1",
   "packages/react-native": "0.13.1",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.92.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.92.0...factorial-one-react-v1.92.1) (2025-06-11)
+
+
+### Bug Fixes
+
+* update modules to icon map ([#2050](https://github.com/factorialco/factorial-one/issues/2050)) ([aa8bdf9](https://github.com/factorialco/factorial-one/commit/aa8bdf96e701bab4bdd337c5a5d7b5abcfcc31c1))
+
 ## [1.92.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.91.0...factorial-one-react-v1.92.0) (2025-06-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.92.0",
+  "version": "1.92.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.92.1</summary>

## [1.92.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.92.0...factorial-one-react-v1.92.1) (2025-06-11)


### Bug Fixes

* update modules to icon map ([#2050](https://github.com/factorialco/factorial-one/issues/2050)) ([aa8bdf9](https://github.com/factorialco/factorial-one/commit/aa8bdf96e701bab4bdd337c5a5d7b5abcfcc31c1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).