### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.92.3",
+  "packages/react": "1.93.0",
   "packages/react-native": "0.13.1",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.93.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.92.3...factorial-one-react-v1.93.0) (2025-06-12)
+
+
+### Features
+
+* Onclick dropdown footer ([#2064](https://github.com/factorialco/factorial-one/issues/2064)) ([00f6b3f](https://github.com/factorialco/factorial-one/commit/00f6b3f40d0ca98429bb5a73d20136a63abcf466))
+
 ## [1.92.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.92.2...factorial-one-react-v1.92.3) (2025-06-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.92.3",
+  "version": "1.93.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.93.0</summary>

## [1.93.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.92.3...factorial-one-react-v1.93.0) (2025-06-12)


### Features

* Onclick dropdown footer ([#2064](https://github.com/factorialco/factorial-one/issues/2064)) ([00f6b3f](https://github.com/factorialco/factorial-one/commit/00f6b3f40d0ca98429bb5a73d20136a63abcf466))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).