### PR TITLE
feat: sort dropdown items alphabetically between separators

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.92.2",
+  "packages/react": "1.92.3",
   "packages/react-native": "0.13.1",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.92.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.92.2...factorial-one-react-v1.92.3) (2025-06-11)
+
+
+### Bug Fixes
+
+* whitespace prewrap added to add wrapping and avoid issues when pre code block is added ([#2053](https://github.com/factorialco/factorial-one/issues/2053)) ([3099da6](https://github.com/factorialco/factorial-one/commit/3099da62c880efacb5a564ce847454a4bdb2732f))
+
 ## [1.92.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.92.1...factorial-one-react-v1.92.2) (2025-06-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.92.2",
+  "version": "1.92.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,

--- a/packages/react/src/experimental/Navigation/Dropdown/index.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/index.tsx
@@ -17,6 +17,7 @@ import {
   DropdownItem,
   DropdownItemObject,
 } from "./internal"
+import { sortDropdownItems } from "./utils"
 
 const privateProps = [] as const
 
@@ -64,7 +65,7 @@ export const MobileDropdown = ({ items, children }: DropdownProps) => {
       <DrawerOverlay className="bg-f1-background-overlay" />
       <DrawerContent className="bg-f1-background">
         <div className="flex flex-col px-2 pb-3 pt-2">
-          {items.map((item, index) =>
+          {sortDropdownItems(items).map((item, index) =>
             item.type === "separator" ? (
               <div
                 key={`separator-${index}`}

--- a/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
@@ -13,6 +13,7 @@ import { cn } from "../../../lib/utils"
 import { AvatarVariant } from "../../Information/Avatars/Avatar"
 import { NavigationItem } from "../utils"
 import { DropdownItemContent } from "./DropdownItem"
+import { sortDropdownItems } from "./utils"
 
 export type DropdownItemSeparator = { type: "separator" }
 export type DropdownItem = DropdownItemObject | DropdownItemSeparator
@@ -100,7 +101,7 @@ export function DropdownInternal({
         )}
       </DropdownMenuTrigger>
       <DropdownMenuContent align={align}>
-        {items.map((item, index) =>
+        {sortDropdownItems(items).map((item, index) =>
           item.type === "separator" ? (
             <DropdownMenuSeparator key={index} />
           ) : (

--- a/packages/react/src/experimental/Navigation/Dropdown/utils.ts
+++ b/packages/react/src/experimental/Navigation/Dropdown/utils.ts
@@ -1,0 +1,24 @@
+export function sortDropdownItems(items: DropdownItem[]): DropdownItem[] {
+  const sortedItems: DropdownItem[] = []
+  let currentGroup: DropdownItemObject[] = []
+
+  for (const item of items) {
+    if (item.type === "separator") {
+      // Sort the current group and add to sortedItems
+      currentGroup.sort((a, b) => a.label.localeCompare(b.label))
+      sortedItems.push(...currentGroup)
+      sortedItems.push(item) // Add the separator
+      currentGroup = [] // Reset for the next group
+    } else {
+      currentGroup.push(item)
+    }
+  }
+
+  // Add any remaining items in the last group
+  if (currentGroup.length > 0) {
+    currentGroup.sort((a, b) => a.label.localeCompare(b.label))
+    sortedItems.push(...currentGroup)
+  }
+
+  return sortedItems
+}


### PR DESCRIPTION
## Description
We've received some feedback from users that they wanted their dropdown alphabetically sorted. Sound crazy first, but I guess it's a nice little detail for the more detail oriented/OCD haver people (like me). 

## Screenshots (if applicable)
Before
<img width="1912" alt="Screenshot 2025-06-12 at 13 44 03" src="https://github.com/user-attachments/assets/dfa5a317-2e32-42a0-b75a-d21c20f15856" />

After
<img width="1912" alt="Screenshot 2025-06-12 at 13 43 44" src="https://github.com/user-attachments/assets/6b55a82f-beef-45a6-843d-aa66e8821382" />


## Implementation details
Sorts items within each separator
