### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.93.0",
+  "packages/react": "1.93.1",
   "packages/react-native": "0.13.1",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.93.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.93.0...factorial-one-react-v1.93.1) (2025-06-12)
+
+
+### Bug Fixes
+
+* **header:** stop playing favorite button animation on initial render ([#2071](https://github.com/factorialco/factorial-one/issues/2071)) ([675d8aa](https://github.com/factorialco/factorial-one/commit/675d8aa0e7c81d0e69595920fd7ef228a8b5e7a4))
+
 ## [1.93.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.92.3...factorial-one-react-v1.93.0) (2025-06-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.93.0",
+  "version": "1.93.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.93.1</summary>

## [1.93.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.93.0...factorial-one-react-v1.93.1) (2025-06-12)


### Bug Fixes

* **header:** stop playing favorite button animation on initial render ([#2071](https://github.com/factorialco/factorial-one/issues/2071)) ([675d8aa](https://github.com/factorialco/factorial-one/commit/675d8aa0e7c81d0e69595920fd7ef228a8b5e7a4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).