### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.93.1",
-  "packages/react-native": "0.13.1",
+  "packages/react-native": "0.14.0",
   "packages/core": "1.15.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.14.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.13.1...factorial-one-react-native-v0.14.0) (2025-06-12)
+
+
+### Features
+
+* remove unused separator ([#2073](https://github.com/factorialco/factorial-one/issues/2073)) ([af53065](https://github.com/factorialco/factorial-one/commit/af5306513a91e927a478d9299a333a5bc7849646))
+
 ## [0.13.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.13.0...factorial-one-react-native-v0.13.1) (2025-06-06)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.14.0</summary>

## [0.14.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.13.1...factorial-one-react-native-v0.14.0) (2025-06-12)


### Features

* remove unused separator ([#2073](https://github.com/factorialco/factorial-one/issues/2073)) ([af53065](https://github.com/factorialco/factorial-one/commit/af5306513a91e927a478d9299a333a5bc7849646))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).