### PR TITLE
fix: add support to know number of visible items in WidgetItemList component

### DIFF
--- a/packages/react/src/experimental/Widgets/Content/Lists/WidgetInboxList/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/Lists/WidgetInboxList/index.tsx
@@ -1,4 +1,5 @@
 import { VerticalOverflowList } from "@/ui/VerticalOverflowList"
+import { ComponentProps } from "react"
 import {
   WidgetInboxListItem,
   WidgetInboxListItemProps,
@@ -9,7 +10,7 @@ type Props<Id extends string | number = string | number> = {
   minSize?: number
   onClickItem?: (id: Id) => void
   showAllItems?: boolean
-}
+} & Pick<ComponentProps<typeof VerticalOverflowList>, "onVisibleItemsChange">
 
 export type WidgetInboxListProps = Props
 
@@ -18,6 +19,7 @@ export function WidgetInboxList({
   minSize = 184,
   onClickItem,
   showAllItems,
+  onVisibleItemsChange,
 }: Props) {
   if (showAllItems) {
     return (
@@ -36,6 +38,7 @@ export function WidgetInboxList({
       renderListItem={(item) => (
         <WidgetInboxListItem key={item.id} {...item} onClick={onClickItem} />
       )}
+      onVisibleItemsChange={onVisibleItemsChange}
       gap={8}
     />
   )

--- a/packages/react/src/ui/VerticalOverflowList/index.tsx
+++ b/packages/react/src/ui/VerticalOverflowList/index.tsx
@@ -99,10 +99,15 @@ function useOverflowCalculation<T>(items: T[], gap: number) {
         overflowItems: items,
       })
     } else {
-      setItemsState({
-        visibleItems: items.slice(0, visibleCount),
-        overflowItems: items.slice(visibleCount),
-      })
+      setItemsState((prev) =>
+        prev.visibleItems.length === visibleCount &&
+        prev.overflowItems.length === items.length - visibleCount
+          ? prev
+          : {
+              visibleItems: items.slice(0, visibleCount),
+              overflowItems: items.slice(visibleCount),
+            }
+      )
     }
   }, [items, measureItemSizes, calculateVisibleItemCount])
 
@@ -148,6 +153,12 @@ interface OverflowListProps<T> {
    * @default 0
    */
   minSize: number
+
+  /**
+   * Callback when the visible items change
+   * @param visibleItems - The visible items
+   */
+  onVisibleItemsChange?: (visibleItems: T[]) => void
 }
 
 const VerticalOverflowList = function VerticalOverflowList<T>({
@@ -156,9 +167,14 @@ const VerticalOverflowList = function VerticalOverflowList<T>({
   className,
   gap = 0,
   minSize,
+  onVisibleItemsChange,
 }: OverflowListProps<T>) {
   const { containerRef, measurementContainerRef, visibleItems } =
     useOverflowCalculation(items, gap)
+
+  useEffect(() => {
+    onVisibleItemsChange?.(visibleItems)
+  }, [onVisibleItemsChange, visibleItems])
 
   return (
     <div


### PR DESCRIPTION
## Description

We didn't have a way to know the number of visible items on `WidgetItemList` component and because of that we didn't have an accurate way to tell to the user "see x more items" or even if we should show to them a "see more" button below.
