### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.95.0",
+  "packages/react": "1.95.1",
   "packages/react-native": "0.14.0",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.95.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.95.0...factorial-one-react-v1.95.1) (2025-06-13)
+
+
+### Bug Fixes
+
+* add support to know number of visible items in WidgetItemList component ([#2079](https://github.com/factorialco/factorial-one/issues/2079)) ([487b17e](https://github.com/factorialco/factorial-one/commit/487b17e1d0650cb05692b63084de8ad3ecc34469))
+
 ## [1.95.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.94.0...factorial-one-react-v1.95.0) (2025-06-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.95.0",
+  "version": "1.95.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.95.1</summary>

## [1.95.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.95.0...factorial-one-react-v1.95.1) (2025-06-13)


### Bug Fixes

* add support to know number of visible items in WidgetItemList component ([#2079](https://github.com/factorialco/factorial-one/issues/2079)) ([487b17e](https://github.com/factorialco/factorial-one/commit/487b17e1d0650cb05692b63084de8ad3ecc34469))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).