### PR TITLE
fix: update fallback cursor value to null in mock data

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -729,7 +729,7 @@ export function createDataAdapter<
     } else if (pagination && paginationType === "infinite-scroll") {
       const pageSize = pagination.perPage || perPage
 
-      const cursor = "cursor" in pagination ? pagination.cursor : 0
+      const cursor = "cursor" in pagination ? pagination.cursor : null
 
       const nextCursor = cursor ? Number(cursor) + pageSize : pageSize
 


### PR DESCRIPTION
## Description

Mock data fix

## Implementation details

Don't send zero as a cursor fallback since cursor is a string.
