### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.95.1",
+  "packages/react": "1.95.2",
   "packages/react-native": "0.14.0",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.95.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.95.1...factorial-one-react-v1.95.2) (2025-06-13)
+
+
+### Bug Fixes
+
+* update fallback cursor value to null in mock data ([#2081](https://github.com/factorialco/factorial-one/issues/2081)) ([015ecb0](https://github.com/factorialco/factorial-one/commit/015ecb0df5d86484651b8181390ce5ad3bdcf750))
+
 ## [1.95.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.95.0...factorial-one-react-v1.95.1) (2025-06-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.95.1",
+  "version": "1.95.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.95.2</summary>

## [1.95.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.95.1...factorial-one-react-v1.95.2) (2025-06-13)


### Bug Fixes

* update fallback cursor value to null in mock data ([#2081](https://github.com/factorialco/factorial-one/issues/2081)) ([015ecb0](https://github.com/factorialco/factorial-one/commit/015ecb0df5d86484651b8181390ce5ad3bdcf750))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).