### PR TITLE
feat(frame): remember sidebar state between loads

### DIFF
--- a/packages/react/src/experimental/Navigation/ApplicationFrame/FrameProvider.tsx
+++ b/packages/react/src/experimental/Navigation/ApplicationFrame/FrameProvider.tsx
@@ -10,6 +10,8 @@ import React, {
 import { useMediaQuery } from "usehooks-ts"
 import { useNavigation } from "../../../lib/linkHandler"
 
+const PREFERRED_INITIAL_STATE_KEY = "one_sidebar_locked"
+
 type SidebarState = "locked" | "unlocked" | "hidden"
 
 interface FrameContextType {
@@ -45,7 +47,11 @@ export function FrameProvider({ children }: FrameProviderProps) {
     initializeWithValue: true,
   })
 
-  const [locked, setLocked] = useState(true)
+  const [locked, setLocked] = useState<boolean>(() => {
+    const storedState = localStorage.getItem(PREFERRED_INITIAL_STATE_KEY)
+
+    return storedState !== null ? !!storedState : true
+  })
   const [visible, setVisible] = useState(false)
   const [prevSidebarState, setPrevSidebarState] = useState<SidebarState | null>(
     null
@@ -84,6 +90,10 @@ export function FrameProvider({ children }: FrameProviderProps) {
   useEffect(() => {
     setVisible(false)
   }, [currentPath])
+
+  useEffect(() => {
+    localStorage.setItem(PREFERRED_INITIAL_STATE_KEY, locked ? "1" : "")
+  }, [locked])
 
   useEffect(() => {
     return () => {

--- a/packages/react/src/experimental/Navigation/Header/Favorites/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Favorites/index.tsx
@@ -3,8 +3,18 @@ import Star from "@/icons/app/Star"
 import StarFilled from "@/icons/app/StarFilled"
 import { cn, focusRing } from "@/lib/utils"
 import { AnimatePresence, motion } from "motion/react"
+import { useState } from "react"
 
 const IconMotion = motion.create(Icon)
+
+const iconVariants = {
+  initial: { scale: 1 },
+  animate: { scale: 1 },
+  exit: { scale: 0.5 },
+  // Transition variants
+  enterFromUnfavorite: { scale: 0.5 },
+  enterFromFavorite: { scale: 0.8 },
+}
 
 interface FavoriteButtonProps {
   /**
@@ -23,6 +33,13 @@ export const FavoriteButton = ({
   onChange,
   label,
 }: FavoriteButtonProps) => {
+  const [hasTransitioned, setHasTransitioned] = useState(false)
+
+  const handleClick = () => {
+    setHasTransitioned(true)
+    onChange(!isMarked)
+  }
+
   return (
     <AnimatePresence mode="wait">
       <button
@@ -30,7 +47,7 @@ export const FavoriteButton = ({
           "flex h-6 w-6 items-center justify-center rounded",
           focusRing()
         )}
-        onClick={() => onChange(!isMarked)}
+        onClick={handleClick}
         aria-label={label}
       >
         {isMarked ? (
@@ -39,9 +56,10 @@ export const FavoriteButton = ({
             key="favorite"
             icon={StarFilled}
             className="text-[hsl(var(--promote-50))]"
-            initial={{ scale: 0.5 }}
-            animate={{ scale: 1 }}
-            exit={{ scale: 0.5 }}
+            variants={iconVariants}
+            initial={hasTransitioned ? "enterFromUnfavorite" : "initial"}
+            animate="animate"
+            exit="exit"
             transition={{
               ease: [0.175, 0.885, 0.27, 2],
             }}
@@ -50,10 +68,12 @@ export const FavoriteButton = ({
           <IconMotion
             size="sm"
             key="not-favorite"
+            whileTap={{ scale: 0.8 }}
             icon={Star}
-            initial={{ scale: 0.8 }}
-            animate={{ scale: 1 }}
-            exit={{ scale: 0.8 }}
+            variants={iconVariants}
+            initial={hasTransitioned ? "enterFromFavorite" : "initial"}
+            animate="animate"
+            exit="exit"
             transition={{
               ease: [0, 0, 0.58, 1],
             }}


### PR DESCRIPTION
## Description

The whole sidebar collapsed/uncollapsed state does not make any sense until we remember which one a user prefers

## Screenshots (if applicable)

https://github.com/user-attachments/assets/8eccaa0c-53bf-46a6-970f-fde99202300d


## Implementation details

I use Local Storage to save whether a user prefers attached or detached version of the sidebar. It works between tabs, but not between browsers. If a user changes from Chrome to Firefox, they get initial state of the sidebar (attached)
