### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.97.0",
+  "packages/react": "1.97.1",
   "packages/react-native": "0.14.0",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.97.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.97.0...factorial-one-react-v1.97.1) (2025-06-16)
+
+
+### Bug Fixes
+
+* **RichTextEditor:** addresing some editor errors ([#2067](https://github.com/factorialco/factorial-one/issues/2067)) ([ae47adf](https://github.com/factorialco/factorial-one/commit/ae47adf66a360f19c85d8afcd9e5c6ab768b6694))
+
 ## [1.97.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.96.1...factorial-one-react-v1.97.0) (2025-06-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.97.0",
+  "version": "1.97.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.97.1</summary>

## [1.97.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.97.0...factorial-one-react-v1.97.1) (2025-06-16)


### Bug Fixes

* **RichTextEditor:** addresing some editor errors ([#2067](https://github.com/factorialco/factorial-one/issues/2067)) ([ae47adf](https://github.com/factorialco/factorial-one/commit/ae47adf66a360f19c85d8afcd9e5c6ab768b6694))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).