### PR TITLE
fix: allow presets to be hidden

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersPresets.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Filters/Components/FiltersPresets.tsx
@@ -72,7 +72,7 @@ export const FiltersPresets = <Filters extends FiltersDefinition>({
           items={presets}
           renderListItem={renderListPresetItem}
           renderDropdownItem={renderDropdownPresetItem}
-          className="flex-1"
+          className="min-w-0 flex-1"
         />
       </>
     )

--- a/packages/react/src/experimental/OneDataCollection/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/index.tsx
@@ -501,12 +501,12 @@ export const OneDataCollection = <
         >
           <div
             className={cn(
-              "flex items-center justify-between",
+              "flex items-center justify-between gap-4",
               !filters && "justify-end"
             )}
           >
             {filters && (
-              <div className="flex flex-1 gap-1">
+              <div className="flex min-w-0 flex-1 gap-1">
                 <Filters.Controls />
                 <Filters.Presets />
               </div>


### PR DESCRIPTION
## Description

Allow datacollections all presets to be hidden if not enough space

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/0fb827ee-c48d-4f3b-8aae-09c03f279cfb)


https://github.com/user-attachments/assets/0cfae62c-bb9c-4022-b97d-4daa4a3e461a





## Implementation details

<!-- What have you changed? Why? -->
