### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.97.1",
+  "packages/react": "1.97.2",
   "packages/react-native": "0.14.0",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.97.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.97.1...factorial-one-react-v1.97.2) (2025-06-17)
+
+
+### Bug Fixes
+
+* allow presets to be hidden ([#2093](https://github.com/factorialco/factorial-one/issues/2093)) ([7c145bf](https://github.com/factorialco/factorial-one/commit/7c145bf9aa24314601765506ea7e8930a5c7d87b))
+
 ## [1.97.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.97.0...factorial-one-react-v1.97.1) (2025-06-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.97.1",
+  "version": "1.97.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.97.2</summary>

## [1.97.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.97.1...factorial-one-react-v1.97.2) (2025-06-17)


### Bug Fixes

* allow presets to be hidden ([#2093](https://github.com/factorialco/factorial-one/issues/2093)) ([7c145bf](https://github.com/factorialco/factorial-one/commit/7c145bf9aa24314601765506ea7e8930a5c7d87b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).