### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.98.0",
+  "packages/react": "1.99.0",
   "packages/react-native": "0.14.0",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.99.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.98.0...factorial-one-react-v1.99.0) (2025-06-17)
+
+
+### Features
+
+* **frame:** remember sidebar state between loads ([#2083](https://github.com/factorialco/factorial-one/issues/2083)) ([0447afd](https://github.com/factorialco/factorial-one/commit/0447afd85995dfd64719d1ca8dcaf2b2801fc587))
+
 ## [1.98.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.97.2...factorial-one-react-v1.98.0) (2025-06-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.98.0",
+  "version": "1.99.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.99.0</summary>

## [1.99.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.98.0...factorial-one-react-v1.99.0) (2025-06-17)


### Features

* **frame:** remember sidebar state between loads ([#2083](https://github.com/factorialco/factorial-one/issues/2083)) ([0447afd](https://github.com/factorialco/factorial-one/commit/0447afd85995dfd64719d1ca8dcaf2b2801fc587))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).