### PR TITLE
fix: add card view horizontal padding

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -46,7 +46,7 @@ const findNextMultiple = (n: number): number => {
 
 const CardGrid = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+    <div className="grid grid-cols-1 gap-4 px-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {children}
     </div>
   )


### PR DESCRIPTION
## Description
Since latest updates, the card's view is lacking some padding. When rendering on pages, cards are touching the side, not at all aligned with the collection filters etc

## Screenshots (if applicable)
### How it is
<img width="928" alt="Screenshot 2025-06-18 at 12 50 40" src="https://github.com/user-attachments/assets/406eed65-f54e-4f13-9b5e-c0b2313954e6" />


### How it gets
<img width="928" alt="Screenshot 2025-06-18 at 12 51 48" src="https://github.com/user-attachments/assets/a823789c-e7f6-4dad-9e54-999562433b1c" />


[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
