### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.99.0",
+  "packages/react": "1.99.1",
   "packages/react-native": "0.14.0",
   "packages/core": "1.15.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.99.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.99.0...factorial-one-react-v1.99.1) (2025-06-18)
+
+
+### Bug Fixes
+
+* add card view horizontal padding ([#2103](https://github.com/factorialco/factorial-one/issues/2103)) ([3c195da](https://github.com/factorialco/factorial-one/commit/3c195da15e1a1eed667b9801f498a329be966536))
+
 ## [1.99.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.98.0...factorial-one-react-v1.99.0) (2025-06-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.99.0",
+  "version": "1.99.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.99.1</summary>

## [1.99.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.99.0...factorial-one-react-v1.99.1) (2025-06-18)


### Bug Fixes

* add card view horizontal padding ([#2103](https://github.com/factorialco/factorial-one/issues/2103)) ([3c195da](https://github.com/factorialco/factorial-one/commit/3c195da15e1a1eed667b9801f498a329be966536))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).