### PR TITLE
feat(RichTextEditor): multiple secondary actions

### DIFF
--- a/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/index.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/index.tsx
@@ -19,7 +19,7 @@ export const EditorBubbleMenu = ({
   toolbarLabels,
   isToolbarOpen,
   isFullscreen,
-  plainHtmlMode = true,
+  plainHtmlMode = false,
 }: EditorBubbleMenuProps) => {
   return (
     <BubbleMenu

--- a/packages/react/src/experimental/RichText/RichTextEditor/Footer/ActionsMenu/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/Footer/ActionsMenu/index.tsx
@@ -288,7 +288,7 @@ const ActionsMenu = ({
       isFullscreen)
 
   return (
-    <div className="scrollbar-macos flex items-center gap-2 overflow-x-auto">
+    <div className="scrollbar-macos flex items-center gap-2 overflow-x-auto overflow-y-hidden">
       <SecondaryActionsButtons
         secondaryActions={secondaryActions}
         useLittleMode={useLittleMode}

--- a/packages/react/src/experimental/RichText/RichTextEditor/Footer/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/Footer/index.tsx
@@ -12,14 +12,14 @@ import { EnhanceActivator } from "../Enhance"
 import {
   enhanceConfig,
   primaryActionType,
-  secondaryActionType,
+  secondaryActionsType,
 } from "../utils/types"
 import { ActionsMenu } from "./ActionsMenu"
 
 interface FooterProps {
   editor: Editor
   maxCharacters: number | undefined
-  secondaryAction: secondaryActionType | undefined
+  secondaryAction: secondaryActionsType | undefined
   primaryAction: primaryActionType | undefined
   fileInputRef: React.RefObject<HTMLInputElement>
   canUseFiles: boolean

--- a/packages/react/src/experimental/RichText/RichTextEditor/index.stories.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/index.stories.tsx
@@ -50,7 +50,7 @@ const meta = {
     secondaryAction: {
       control: "object",
       description:
-        "Configures the secondary action button (usually cancel or discard)",
+        "Configures the secondary action button (usually cancel or discard) or switch actions, you can also pass an array of actions",
     },
     maxCharacters: {
       control: "number",

--- a/packages/react/src/experimental/RichText/RichTextEditor/index.stories.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/index.stories.tsx
@@ -231,13 +231,21 @@ export const Default: Story = {
         },
       ],
     },
-    secondaryAction: {
-      type: "switch",
-      label: "Cancel",
-      onClick: () => {},
-      variant: "outline",
-      checked: true,
-    },
+    secondaryAction: [
+      {
+        type: "switch",
+        label: "Cancel",
+        onClick: () => {},
+        variant: "outline",
+        checked: true,
+      },
+      {
+        type: "button",
+        label: "Discard",
+        onClick: () => {},
+        variant: "outline",
+      },
+    ],
     toolbarLabels: {
       bold: "Bold",
       italic: "Italic",

--- a/packages/react/src/experimental/RichText/RichTextEditor/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/index.tsx
@@ -43,14 +43,14 @@ import {
   lastIntentType,
   primaryActionType,
   resultType,
-  secondaryActionType,
+  secondaryActionsType,
 } from "./utils/types"
 
 interface RichTextEditorProps {
   mentionsConfig?: MentionsConfig
   enhanceConfig?: enhanceConfig
   filesConfig?: filesConfig
-  secondaryAction?: secondaryActionType
+  secondaryAction?: secondaryActionsType
   primaryAction?: primaryActionType
   onChange: (result: resultType) => void
   maxCharacters?: number

--- a/packages/react/src/experimental/RichText/RichTextEditor/utils/types.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/utils/types.tsx
@@ -74,6 +74,8 @@ type secondaryActionType = (actionType | toggleActionType) & {
   type?: "button" | "switch"
 }
 
+type secondaryActionsType = secondaryActionType | secondaryActionType[]
+
 type subActionType = {
   label: string
   onClick: () => void
@@ -122,6 +124,7 @@ export type {
   lastIntentType,
   primaryActionType,
   resultType,
+  secondaryActionsType,
   secondaryActionType,
   subActionType,
 }


### PR DESCRIPTION
## Description

Now we can have multiple secondary actions inside the editor

## Screenshots (if applicable)

![Captura de pantalla 2025-06-18 a las 19 00 28](https://github.com/user-attachments/assets/78eca8f7-10aa-413c-9fb0-6a36b5e3031e)


## Implementation details

- The type now is an array of actions or a secondary action
- I also check the button types to hide them in responsive mode
