### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.99.1",
+  "packages/react": "1.100.0",
   "packages/react-native": "0.14.0",
-  "packages/core": "1.15.0"
+  "packages/core": "1.16.0"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.16.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.15.0...factorial-one-core-v1.16.0) (2025-06-19)
+
+
+### Features
+
+* add ClockBack icon ([#2106](https://github.com/factorialco/factorial-one/issues/2106)) ([77a7c30](https://github.com/factorialco/factorial-one/commit/77a7c30adbb789e174a1f2f8dac3ca94b5a09f98))
+
 ## [1.15.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.14.0...factorial-one-core-v1.15.0) (2025-06-05)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.100.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.99.1...factorial-one-react-v1.100.0) (2025-06-19)
+
+
+### Features
+
+* add ClockBack icon ([#2106](https://github.com/factorialco/factorial-one/issues/2106)) ([77a7c30](https://github.com/factorialco/factorial-one/commit/77a7c30adbb789e174a1f2f8dac3ca94b5a09f98))
+
 ## [1.99.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.99.0...factorial-one-react-v1.99.1) (2025-06-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.99.1",
+  "version": "1.100.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.100.0</summary>

## [1.100.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.99.1...factorial-one-react-v1.100.0) (2025-06-19)


### Features

* add ClockBack icon ([#2106](https://github.com/factorialco/factorial-one/issues/2106)) ([77a7c30](https://github.com/factorialco/factorial-one/commit/77a7c30adbb789e174a1f2f8dac3ca94b5a09f98))
</details>

<details><summary>factorial-one-core: 1.16.0</summary>

## [1.16.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.15.0...factorial-one-core-v1.16.0) (2025-06-19)


### Features

* add ClockBack icon ([#2106](https://github.com/factorialco/factorial-one/issues/2106)) ([77a7c30](https://github.com/factorialco/factorial-one/commit/77a7c30adbb789e174a1f2f8dac3ca94b5a09f98))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).