### PR TITLE
fix(RichTextEditor): error in default mode

### DIFF
--- a/packages/react/src/experimental/RichText/RichTextEditor/Footer/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/Footer/index.tsx
@@ -40,6 +40,7 @@ interface FooterProps {
   toolbarLabels: ToolbarLabels
   setIsToolbarOpen: (isToolbarOpen: boolean) => void
   isToolbarOpen: boolean
+  plainHtmlMode: boolean
 }
 
 const Footer = ({
@@ -58,6 +59,7 @@ const Footer = ({
   disableButtons,
   setIsToolbarOpen,
   isToolbarOpen,
+  plainHtmlMode,
 }: FooterProps) => {
   const [toolbarAnimationComplete, setToolbarAnimationComplete] =
     useState(false)
@@ -104,6 +106,7 @@ const Footer = ({
               setToolbarAnimationComplete(false)
             }}
             animationComplete={toolbarAnimationComplete}
+            plainHtmlMode={plainHtmlMode}
           />
         </motion.div>
 

--- a/packages/react/src/experimental/RichText/RichTextEditor/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextEditor/index.tsx
@@ -92,7 +92,7 @@ const RichTextEditorComponent = forwardRef<
     title,
     errorConfig,
     height = "auto",
-    plainHtmlMode = true,
+    plainHtmlMode = false,
   },
   ref
 ) {
@@ -384,6 +384,7 @@ const RichTextEditorComponent = forwardRef<
           toolbarLabels={toolbarLabels}
           setIsToolbarOpen={setIsToolbarOpen}
           isToolbarOpen={isToolbarOpen}
+          plainHtmlMode={plainHtmlMode}
         />
 
         <EditorBubbleMenu


### PR DESCRIPTION
## Description

I made an error and put by default plainHtmlMode and didnt pass the prop to the footer

