### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.101.0",
+  "packages/react": "1.101.1",
   "packages/react-native": "0.15.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.101.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.101.0...factorial-one-react-v1.101.1) (2025-06-20)
+
+
+### Bug Fixes
+
+* export ModuleAvatar ([#2113](https://github.com/factorialco/factorial-one/issues/2113)) ([7150e5c](https://github.com/factorialco/factorial-one/commit/7150e5cd108e7c415e4097168d99ec1444c9a0e9))
+
 ## [1.101.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.100.0...factorial-one-react-v1.101.0) (2025-06-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.101.0",
+  "version": "1.101.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.101.1</summary>

## [1.101.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.101.0...factorial-one-react-v1.101.1) (2025-06-20)


### Bug Fixes

* export ModuleAvatar ([#2113](https://github.com/factorialco/factorial-one/issues/2113)) ([7150e5c](https://github.com/factorialco/factorial-one/commit/7150e5cd108e7c415e4097168d99ec1444c9a0e9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).