### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.102.0",
+  "packages/react": "1.102.1",
   "packages/react-native": "0.15.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.102.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.0...factorial-one-react-v1.102.1) (2025-06-20)
+
+
+### Bug Fixes
+
+* **RichTextEditor:** change default plainHtmlMode to false and pass it to Footer component ([#2111](https://github.com/factorialco/factorial-one/issues/2111)) ([2b75ef9](https://github.com/factorialco/factorial-one/commit/2b75ef9bbcd3d33fd6173be1cd50795203e14770))
+
 ## [1.102.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.101.1...factorial-one-react-v1.102.0) (2025-06-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.102.0",
+  "version": "1.102.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.102.1</summary>

## [1.102.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.0...factorial-one-react-v1.102.1) (2025-06-20)


### Bug Fixes

* **RichTextEditor:** change default plainHtmlMode to false and pass it to Footer component ([#2111](https://github.com/factorialco/factorial-one/issues/2111)) ([2b75ef9](https://github.com/factorialco/factorial-one/commit/2b75ef9bbcd3d33fd6173be1cd50795203e14770))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).