### PR TITLE
fix: make list item row checkbox work when itemHref is present

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -141,7 +141,8 @@ export const Row = <
     >
       <div className="flex flex-row items-center gap-2">
         {source.selectable && id !== undefined && (
-          <div className="hidden items-center justify-end md:flex">
+          // z-10 is needed here to prevent the checkbox from not being selectable when itemHref is provided
+          <div className="z-10 hidden items-center justify-end md:flex">
             <Checkbox
               checked={selectedItems.has(id)}
               onCheckedChange={(checked) =>


### PR DESCRIPTION
## Description

When `itemHref` was present, the checkbox wasn't working at all.

## 📹 Video

https://github.com/user-attachments/assets/cc7570f1-1e0f-4f95-a845-d5e906eceb26
