### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.102.1",
+  "packages/react": "1.102.2",
   "packages/react-native": "0.15.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.102.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.1...factorial-one-react-v1.102.2) (2025-06-20)
+
+
+### Bug Fixes
+
+* **datenavigator:** export ([#2102](https://github.com/factorialco/factorial-one/issues/2102)) ([c3e95c8](https://github.com/factorialco/factorial-one/commit/c3e95c809c869709a4894a0ac76331ad2f408841))
+
 ## [1.102.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.0...factorial-one-react-v1.102.1) (2025-06-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.102.1",
+  "version": "1.102.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.102.2</summary>

## [1.102.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.1...factorial-one-react-v1.102.2) (2025-06-20)


### Bug Fixes

* **datenavigator:** export ([#2102](https://github.com/factorialco/factorial-one/issues/2102)) ([c3e95c8](https://github.com/factorialco/factorial-one/commit/c3e95c809c869709a4894a0ac76331ad2f408841))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).