### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.102.2",
+  "packages/react": "1.102.3",
   "packages/react-native": "0.15.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.102.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.2...factorial-one-react-v1.102.3) (2025-06-20)
+
+
+### Bug Fixes
+
+* make list item row checkbox work when itemHref is present ([#2119](https://github.com/factorialco/factorial-one/issues/2119)) ([b56f613](https://github.com/factorialco/factorial-one/commit/b56f613b0bd6542ae5b0505656d0b8935e6754f7))
+
 ## [1.102.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.1...factorial-one-react-v1.102.2) (2025-06-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.102.2",
+  "version": "1.102.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.102.3</summary>

## [1.102.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.2...factorial-one-react-v1.102.3) (2025-06-20)


### Bug Fixes

* make list item row checkbox work when itemHref is present ([#2119](https://github.com/factorialco/factorial-one/issues/2119)) ([b56f613](https://github.com/factorialco/factorial-one/commit/b56f613b0bd6542ae5b0505656d0b8935e6754f7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).