### PR TITLE
fix: set correct spacing and flex for data collection list item description

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/ItemTeaser.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/ItemTeaser.tsx
@@ -26,7 +26,7 @@ export const ItemTeaser = ({ title, avatar, description }: ItemTeaserProps) => {
           {description && description.length > 0 && (
             <div className="flex w-full flex-col text-base font-normal text-f1-foreground-secondary md:flex-row md:gap-1">
               {description.map((item, index) => (
-                <div key={index} className="flex min-w-0 flex-row gap-1">
+                <div key={index} className="flex min-w-0 gap-1">
                   <OneEllipsis>{item}</OneEllipsis>
                   {index < description.length - 1 && (
                     <span className="hidden md:inline"> · </span>

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/ItemTeaser.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/ItemTeaser.tsx
@@ -14,7 +14,7 @@ export const ItemTeaser = ({ title, avatar, description }: ItemTeaserProps) => {
   return (
     <article className="flex w-[calc(100%-72px)] min-w-40 flex-col items-start gap-3 md:w-full md:flex-row md:items-center md:gap-2">
       {avatar && <Avatar avatar={avatar} size="medium" />}
-      <div className="flex flex-col gap-0.5 md:gap-1">
+      <div className="flex flex-1 flex-col gap-0.5 md:gap-1">
         <header>
           <h3>
             <OneEllipsis className="text-base font-medium text-f1-foreground">
@@ -26,7 +26,7 @@ export const ItemTeaser = ({ title, avatar, description }: ItemTeaserProps) => {
           {description && description.length > 0 && (
             <div className="flex w-full flex-col text-base font-normal text-f1-foreground-secondary md:flex-row md:gap-1">
               {description.map((item, index) => (
-                <div key={index} className="flex min-w-0 flex-1 flex-row gap-1">
+                <div key={index} className="flex min-w-0 flex-row gap-1">
                   <OneEllipsis>{item}</OneEllipsis>
                   {index < description.length - 1 && (
                     <span className="hidden md:inline"> · </span>

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -139,7 +139,7 @@ export const Row = <
         dropDownOpen && "md:bg-f1-background-hover"
       )}
     >
-      <div className="flex flex-row items-center gap-2">
+      <div className="flex flex-1 flex-row items-center gap-2">
         {source.selectable && id !== undefined && (
           <div className="hidden items-center justify-end md:flex">
             <Checkbox


### PR DESCRIPTION
## Description

The description in data collection list row items wasn't shown properly.

## Screenshots

<img width="498" alt="Screenshot 2025-06-20 at 12 47 53" src="https://github.com/user-attachments/assets/251df3d1-6e58-4cce-82d5-45d1c88f0137" />
