### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.102.3",
+  "packages/react": "1.103.0",
   "packages/react-native": "0.15.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.103.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.3...factorial-one-react-v1.103.0) (2025-06-20)
+
+
+### Features
+
+* select allow generic value ([#2121](https://github.com/factorialco/factorial-one/issues/2121)) ([300642d](https://github.com/factorialco/factorial-one/commit/300642d8313ba69c31194610f01af72d5d813360))
+
 ## [1.102.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.2...factorial-one-react-v1.102.3) (2025-06-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.102.3",
+  "version": "1.103.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.103.0</summary>

## [1.103.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.3...factorial-one-react-v1.103.0) (2025-06-20)


### Features

* select allow generic value ([#2121](https://github.com/factorialco/factorial-one/issues/2121)) ([300642d](https://github.com/factorialco/factorial-one/commit/300642d8313ba69c31194610f01af72d5d813360))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).