### PR TITLE
feat: do not use dark mode as a classname to avoid wrong behaviour in…

### DIFF
--- a/packages/react-native/tailwind.config.ts
+++ b/packages/react-native/tailwind.config.ts
@@ -6,6 +6,7 @@ module.exports = {
   ...baseConfig,
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   presets: [require("nativewind/preset")],
+  darkMode: "false",
   theme: {
     ...baseConfig.theme,
     extend: {


### PR DESCRIPTION
## 🚪 Why?

There was a bug related to the dark mode and light mode in the Bottom Tab bar which is affected to Android devices.  We are gong to remove the dark mode support on NativeWind to avoid those unwanted behaviors in the app.

## 🔑 What?

There was a bug related to the bottom tab bar navigation and the dark mode / light mode. The app is not supported  this functionality:
![image011 (2)](https://github.com/user-attachments/assets/15eb353c-fbf0-44d8-9d2e-f6654d94f9b2)


## 🏡 Context

- [💼 Jira](_jira_link_)
