### PR TITLE
fix(ResourceHeader): Action button fixes

### DIFF
--- a/packages/react/src/components/Actions/OneDropdownButton/OneDropdownButton.tsx
+++ b/packages/react/src/components/Actions/OneDropdownButton/OneDropdownButton.tsx
@@ -65,6 +65,7 @@ const OneDropdownButton = ({
           icon={selectedItem.icon}
           label={selectedItem.label}
           data-testid="button-main"
+          className="flex-1"
           {...props}
           appendButton={
             <DropdownInternal

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -187,7 +187,7 @@ export function BaseHeader({
                 onClick={primaryAction.onClick}
                 variant="default"
                 value={primaryAction.value}
-                size="md"
+                size="lg"
                 disabled={primaryAction.disabled}
                 tooltip={primaryAction.tooltip}
               />
@@ -196,7 +196,7 @@ export function BaseHeader({
 
           {visibleSecondaryActions.map((action) => (
             <Fragment key={action.label}>
-              <div className="w-full md:hidden [&>*]:w-full">
+              <div className="w-full md:hidden [&>*]:w-full [&>span]:block [&>span_div]:w-full">
                 <ButtonWithTooltip
                   label={action.label}
                   onClick={action.onClick}
@@ -211,7 +211,7 @@ export function BaseHeader({
           ))}
 
           {visibleOtherActions.length > 0 && (
-            <div className="w-full [&>*]:w-full">
+            <div className="w-full [&>*]:w-full [&_button]:w-full">
               <MobileDropdown items={visibleOtherActions} />
             </div>
           )}

--- a/packages/react/src/experimental/Navigation/Dropdown/index.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/index.tsx
@@ -40,6 +40,7 @@ export const Dropdown = (props: DropdownProps) => {
       {...publicProps}
       open={open}
       onOpenChange={onOpenChange}
+      align="end"
     />
   )
 }
@@ -58,6 +59,7 @@ export const MobileDropdown = ({ items, children }: DropdownProps) => {
             icon={EllipsisHorizontal}
             variant="outline"
             size="lg"
+            pressed={open}
           />
         )}
       </DrawerTrigger>

--- a/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu"
+import React, { useState } from "react"
 import { Button, ButtonProps } from "../../../components/Actions/Button"
 import { IconType } from "../../../components/Utilities/Icon"
 import { EllipsisHorizontal } from "../../../icons/app"
@@ -80,10 +81,17 @@ export function DropdownInternal({
   align = "start",
   size,
   children,
-  open,
-  onOpenChange,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
   ...rest
 }: DropdownInternalProps) {
+  const [internalOpen, setInternalOpen] = useState(false)
+
+  const isControlled =
+    controlledOpen !== undefined && controlledOnOpenChange !== undefined
+  const open = isControlled ? controlledOpen : internalOpen
+  const onOpenChange = isControlled ? controlledOnOpenChange : setInternalOpen
+
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
@@ -96,6 +104,7 @@ export function DropdownInternal({
             label="..."
             round
             variant="outline"
+            pressed={open}
           />
         )}
       </DropdownMenuTrigger>


### PR DESCRIPTION
## Description

There are some issues with ResourceHeader action buttons. This PR fixes them.

- Dropdown button not in full width in mobile.
- Wrong size for dropdown button in mobile.
- Disabled button not full width in mobile.
- Other actions (dropdown) does not set pressed state while open.
- Other actions aligned to the left.
- Other actions button in mobile trigger was not the whole button, just the label.

## Screenshots

### Disabled action

#### Before

<img width="366" alt="image" src="https://github.com/user-attachments/assets/79a88ee6-494f-4df0-ba9a-354509036ede" />

#### After

<img width="367" alt="Screenshot 2025-06-22 at 19 51 11" src="https://github.com/user-attachments/assets/5a8ce24e-fece-4d72-a438-f2ab0bd5a4f7" />

---

### Dropdown button

#### Before

<img width="357" alt="image" src="https://github.com/user-attachments/assets/e48e05b5-4aab-43d3-942f-651a2ea48fc6" />

#### After

<img width="363" alt="Screenshot 2025-06-22 at 19 51 21" src="https://github.com/user-attachments/assets/ee235432-524e-427f-bbf4-daefa871e837" />
