### PR TITLE
fix(DataCollection): use `Button` for item actions

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/ItemActions/ItemActionsDropdown.tsx
+++ b/packages/react/src/experimental/OneDataCollection/ItemActions/ItemActionsDropdown.tsx
@@ -1,6 +1,5 @@
-import { cn, focusRing } from "@/lib/utils"
 import { useState } from "react"
-import { Icon } from "../../../components/Utilities/Icon"
+import { Button } from "../../../components/Actions/Button"
 import { Ellipsis } from "../../../icons/app"
 import { Dropdown, DropdownItem } from "../../Navigation/Dropdown"
 
@@ -39,17 +38,14 @@ export const ItemActionsDropdown = ({
         onOpenChange?.(open)
       }}
     >
-      <button
-        title="Actions"
-        className={cn(
-          "flex h-8 w-8 items-center justify-center rounded text-f1-icon-bold hover:bg-f1-background-secondary",
-          open && "bg-f1-background-secondary",
-          focusRing("focus-visible:ring-inset")
-        )}
-      >
-        <Icon icon={Ellipsis} />
-        <label className="sr-only">Actions</label>
-      </button>
+      <Button
+        icon={Ellipsis}
+        label="Actions"
+        hideLabel
+        round
+        variant="ghost"
+        pressed={open}
+      />
     </Dropdown>
   )
 }


### PR DESCRIPTION
## Description

Item actions in DataCollection is using a native button with custom styling, mimicking our Button. This made the button outdated once we upated styles.

This PR changes this, so it uses the our Button component.

## Screenshots

#### Before

<img width="236" alt="image" src="https://github.com/user-attachments/assets/b449c30e-2e67-4d40-8fe6-fcf3f95ea0f3" />

#### After

<img width="244" alt="image" src="https://github.com/user-attachments/assets/090777e4-784e-4ea8-8249-3a43bf70e0ad" />

