### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.103.0",
-  "packages/react-native": "0.15.0",
+  "packages/react-native": "0.16.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.16.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.15.0...factorial-one-react-native-v0.16.0) (2025-06-23)
+
+
+### Features
+
+* do not use dark mode as a classname to avoid wrong behaviour in the Mobile app ([#2126](https://github.com/factorialco/factorial-one/issues/2126)) ([77ace3d](https://github.com/factorialco/factorial-one/commit/77ace3d3b94cbcd469f24e86e88b6f1f5f8e52b9))
+
 ## [0.15.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.14.0...factorial-one-react-native-v0.15.0) (2025-06-20)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.16.0</summary>

## [0.16.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.15.0...factorial-one-react-native-v0.16.0) (2025-06-23)


### Features

* do not use dark mode as a classname to avoid wrong behaviour in the Mobile app ([#2126](https://github.com/factorialco/factorial-one/issues/2126)) ([77ace3d](https://github.com/factorialco/factorial-one/commit/77ace3d3b94cbcd469f24e86e88b6f1f5f8e52b9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).