### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.103.0",
+  "packages/react": "1.104.0",
   "packages/react-native": "0.16.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.104.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.103.0...factorial-one-react-v1.104.0) (2025-06-23)
+
+
+### Features
+
+* **RichtTextEditor:** mood tracker extension ([#2134](https://github.com/factorialco/factorial-one/issues/2134)) ([8476641](https://github.com/factorialco/factorial-one/commit/84766416d7a629c06768834f252661e01f562580))
+
 ## [1.103.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.102.3...factorial-one-react-v1.103.0) (2025-06-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.103.0",
+  "version": "1.104.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.104.0</summary>

## [1.104.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.103.0...factorial-one-react-v1.104.0) (2025-06-23)


### Features

* **RichtTextEditor:** mood tracker extension ([#2134](https://github.com/factorialco/factorial-one/issues/2134)) ([8476641](https://github.com/factorialco/factorial-one/commit/84766416d7a629c06768834f252661e01f562580))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).