### PR TITLE
fix: remove upselling kit stories from sidebar

### DIFF
--- a/packages/react/src/components/UpsellingKit/ProductBlankslate/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductBlankslate/index.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof ProductBlankslate> = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "no-sidebar"],
   argTypes: {
     benefits: {
       control: { type: "object" },

--- a/packages/react/src/components/UpsellingKit/ProductCard/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductCard/index.stories.tsx
@@ -6,7 +6,7 @@ import { ComponentProps } from "react"
 const meta: Meta<typeof ProductCard> = {
   title: "UpsellingKit/ProductCard",
   component: ProductCard,
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "no-sidebar"],
   parameters: {
     layout: "fullscreen",
   },

--- a/packages/react/src/components/UpsellingKit/ProductModal/ProductModal.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductModal/ProductModal.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
       story: { inline: false, height: "720px" },
     },
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "no-sidebar"],
   decorators: [
     (Story) => (
       <ApplicationFrame

--- a/packages/react/src/components/UpsellingKit/ProductWidget/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductWidget/index.stories.tsx
@@ -33,7 +33,7 @@ export const Default: Story = {
       },
     ],
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "no-sidebar"],
   argTypes: {
     mediaUrl: {
       control: "text",
@@ -123,5 +123,5 @@ export const WithUpsellingButton: Story = {
       },
     ],
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "no-sidebar"],
 }

--- a/packages/react/src/components/UpsellingKit/UpsellRequestResponseDialog/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellRequestResponseDialog/index.stories.tsx
@@ -44,7 +44,7 @@ const meta = {
       story: { inline: false, height: "400px" },
     },
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "no-sidebar"],
 } satisfies Meta<typeof UpsellRequestResponseDialog>
 
 export default meta

--- a/packages/react/src/components/UpsellingKit/UpsellingBanner/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellingBanner/index.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof UpsellingBanner> = {
   parameters: {
     layout: "padded",
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "no-sidebar"],
   argTypes: {
     primaryAction: {
       control: "object",

--- a/packages/react/src/components/UpsellingKit/UpsellingButton/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellingButton/index.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
       url: "https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Web-components?node-id=41-1256&t=99GWQFvFLZtKW49N-4",
     },
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "no-sidebar"],
   args: {
     label: "Request Information",
     size: "md",

--- a/packages/react/src/components/UpsellingKit/UpsellingPopover/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellingPopover/index.stories.tsx
@@ -90,7 +90,7 @@ export const Default: Story = {
       },
     ],
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "no-sidebar"],
   render: (args) => {
     const [isOpen, setIsOpen] = useState(false)
 
@@ -168,7 +168,7 @@ export const WithUpsellingButton: Story = {
       },
     ],
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "no-sidebar"],
   render: (args) => {
     const [isOpen, setIsOpen] = useState(false)
 


### PR DESCRIPTION
## Description

We need to remove upselling kit components from storybook sidebar to promote the usage of them through factorial. No need to expose this components to devs 

