### PR TITLE
fix: set correct responsive for OneModal component with side position

### DIFF
--- a/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
@@ -82,7 +82,7 @@ export const OneModal: React.FC<OneModalProps> = ({
   if (isSidePosition) {
     contentClassName = cn(
       "w-full overflow-x-hidden flex flex-col absolute top-3 bottom-3 translate-y-0 translate-x-0 max-w-[539px] rounded-md border border-solid border-f1-border-secondary",
-      position === "left" && "left-3 right-8",
+      position === "left" && "left-3",
       position === "right" && "left-auto right-3"
     )
   }

--- a/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
@@ -1,4 +1,3 @@
-import { useSidebar } from "@/experimental/exports"
 import { TabsProps } from "@/experimental/Navigation/Tabs"
 import { cn } from "@/lib/utils"
 import { Dialog, DialogContent } from "@/ui/dialog"
@@ -37,7 +36,6 @@ export const OneModal: React.FC<OneModalProps> = ({
   isOpen,
   children,
 }) => {
-  const { sidebarState } = useSidebar()
   const [open, setOpen] = useState(isOpen)
 
   useEffect(() => {
@@ -83,9 +81,8 @@ export const OneModal: React.FC<OneModalProps> = ({
 
   if (isSidePosition) {
     contentClassName = cn(
-      "overflow-x-hidden flex flex-col fixed top-3 bottom-3 translate-y-0 translate-x-0 max-w-[539px] rounded-md border border-solid border-f1-border-secondary",
-      position === "left" &&
-        (sidebarState === "locked" ? "left-[248px]" : "left-3"),
+      "w-full overflow-x-hidden flex flex-col absolute top-3 bottom-3 translate-y-0 translate-x-0 max-w-[539px] rounded-md border border-solid border-f1-border-secondary",
+      position === "left" && "left-3 right-8",
       position === "right" && "left-auto right-3"
     )
   }

--- a/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
@@ -7,6 +7,7 @@ import {
 import { BreadcrumbItem } from "@/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem"
 import CrossIcon from "@/icons/app/Cross"
 import { cn } from "@/lib/utils"
+import { BreadcrumbList } from "@/ui/breadcrumb"
 import { DialogTitle } from "@/ui/dialog"
 import { DrawerTitle } from "@/ui/drawer"
 import { useOneModal } from "../OneModalProvider"
@@ -71,16 +72,18 @@ export const OneModalHeader = ({
     if (!module) return null
 
     return (
-      <BreadcrumbItem
-        item={{
-          id: module.id,
-          label: module.label,
-          href: module.href,
-          module: module.id,
-        }}
-        isLast={false}
-        isFirst={true}
-      />
+      <BreadcrumbList>
+        <BreadcrumbItem
+          item={{
+            id: module.id,
+            label: module.label,
+            href: module.href,
+            module: module.id,
+          }}
+          isLast={false}
+          isFirst={true}
+        />
+      </BreadcrumbList>
     )
   }
 

--- a/packages/react/src/experimental/Modals/OneModal/utils.ts
+++ b/packages/react/src/experimental/Modals/OneModal/utils.ts
@@ -1,6 +1,6 @@
 import { useMediaQuery } from "usehooks-ts"
 
 export const useIsSmallScreen = () =>
-  useMediaQuery("(max-width: 440px)", {
+  useMediaQuery("(max-width: 560px)", {
     initializeWithValue: false,
   })

--- a/packages/react/src/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/packages/react/src/experimental/Navigation/ApplicationFrame/index.tsx
@@ -94,7 +94,7 @@ function ApplicationFrameContent({
             <motion.main
               id="content"
               className={cn(
-                "flex max-w-full flex-1 overflow-auto xs:py-1 xs:pr-1",
+                "relative flex max-w-full flex-1 overflow-auto xs:py-1 xs:pr-1",
                 sidebarState === "locked" ? "pl-0" : "xs:pl-1"
               )}
               layout

--- a/packages/react/src/ui/dialog.tsx
+++ b/packages/react/src/ui/dialog.tsx
@@ -3,6 +3,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import * as React from "react"
 
+import { useEffect, useState } from "react"
 import { cn } from "../lib/utils"
 
 const Dialog = DialogPrimitive.Root
@@ -33,23 +34,32 @@ const DialogContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     withTraslateAnimation?: boolean
   }
->(({ className, children, withTraslateAnimation = true, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-[90%] translate-x-[-50%] translate-y-[-50%] rounded-xl border bg-f1-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-        withTraslateAnimation &&
-          "data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
+>(({ className, children, withTraslateAnimation = true, ...props }, ref) => {
+  const [container, setContainer] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    setContainer(document.getElementById("content"))
+  }, [])
+
+  return (
+    <DialogPortal container={container}>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-[90%] translate-x-[-50%] translate-y-[-50%] rounded-xl border bg-f1-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          withTraslateAnimation &&
+            "data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+})
+
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({

--- a/packages/react/src/ui/scrollarea.tsx
+++ b/packages/react/src/ui/scrollarea.tsx
@@ -20,6 +20,7 @@ const ScrollArea = React.forwardRef<
     <ScrollAreaPrimitive.Viewport
       ref={viewportRef}
       className="size-full rounded-[inherit] [&>div]:!block"
+      tabIndex={0}
       data-scroll-container
     >
       {children}

--- a/packages/react/src/ui/scrollarea.tsx
+++ b/packages/react/src/ui/scrollarea.tsx
@@ -19,7 +19,7 @@ const ScrollArea = React.forwardRef<
   >
     <ScrollAreaPrimitive.Viewport
       ref={viewportRef}
-      className="h-full w-full rounded-[inherit]"
+      className="size-full rounded-[inherit] [&>div]:!block"
       data-scroll-container
     >
       {children}


### PR DESCRIPTION
## Description

We could see some issues related to the OneModal component in the implementation of the Notifications activity item list in production:

- An unwanted horizontal scroll on the list showed up.
- When collapsing the sidebar the modal kept floating on the middle of the screen instead of sticking to the left edge.

## Screenshots

In this screenshot we can summarize these two issues that we're solving in this PR:

<img width="951" alt="Screenshot 2025-06-23 at 17 14 24" src="https://github.com/user-attachments/assets/43e2ab3b-b1ad-47e3-90d7-7ee16c5ba23c" />
