### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.104.1",
+  "packages/react": "1.104.2",
   "packages/react-native": "0.16.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.104.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.104.1...factorial-one-react-v1.104.2) (2025-06-23)
+
+
+### Bug Fixes
+
+* set correct spacing and flex for data collection list item description ([#2123](https://github.com/factorialco/factorial-one/issues/2123)) ([38f5d58](https://github.com/factorialco/factorial-one/commit/38f5d58d97b989cb09d70568b29b9e27aac02aba))
+
 ## [1.104.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.104.0...factorial-one-react-v1.104.1) (2025-06-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.104.1",
+  "version": "1.104.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.104.2</summary>

## [1.104.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.104.1...factorial-one-react-v1.104.2) (2025-06-23)


### Bug Fixes

* set correct spacing and flex for data collection list item description ([#2123](https://github.com/factorialco/factorial-one/issues/2123)) ([38f5d58](https://github.com/factorialco/factorial-one/commit/38f5d58d97b989cb09d70568b29b9e27aac02aba))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).