### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.104.2",
+  "packages/react": "1.105.0",
   "packages/react-native": "0.16.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.105.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.104.2...factorial-one-react-v1.105.0) (2025-06-24)
+
+
+### Features
+
+* add summary stories and docs for OneDataCollection WIP ([#2075](https://github.com/factorialco/factorial-one/issues/2075)) ([844474d](https://github.com/factorialco/factorial-one/commit/844474d1bcda1f4da1b13bef30749988ea6e14e1))
+
 ## [1.104.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.104.1...factorial-one-react-v1.104.2) (2025-06-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.104.2",
+  "version": "1.105.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.105.0</summary>

## [1.105.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.104.2...factorial-one-react-v1.105.0) (2025-06-24)


### Features

* add summary stories and docs for OneDataCollection WIP ([#2075](https://github.com/factorialco/factorial-one/issues/2075)) ([844474d](https://github.com/factorialco/factorial-one/commit/844474d1bcda1f4da1b13bef30749988ea6e14e1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).