### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.105.0",
+  "packages/react": "1.105.1",
   "packages/react-native": "0.16.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.105.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.0...factorial-one-react-v1.105.1) (2025-06-25)
+
+
+### Bug Fixes
+
+* refactor summary module imports for consistency ([#2143](https://github.com/factorialco/factorial-one/issues/2143)) ([c54a1ba](https://github.com/factorialco/factorial-one/commit/c54a1ba9f4e48bcb819fb7d0385556bcf94bf0e2))
+
 ## [1.105.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.104.2...factorial-one-react-v1.105.0) (2025-06-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.105.0",
+  "version": "1.105.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.105.1</summary>

## [1.105.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.0...factorial-one-react-v1.105.1) (2025-06-25)


### Bug Fixes

* refactor summary module imports for consistency ([#2143](https://github.com/factorialco/factorial-one/issues/2143)) ([c54a1ba](https://github.com/factorialco/factorial-one/commit/c54a1ba9f4e48bcb819fb7d0385556bcf94bf0e2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).