### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.105.1",
+  "packages/react": "1.105.2",
   "packages/react-native": "0.16.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.105.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.1...factorial-one-react-v1.105.2) (2025-06-25)
+
+
+### Bug Fixes
+
+* **favorites:** many small things ([#2141](https://github.com/factorialco/factorial-one/issues/2141)) ([29fe769](https://github.com/factorialco/factorial-one/commit/29fe7691ec9c277ee4ccf0fe0fbbaa3382402032))
+
 ## [1.105.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.0...factorial-one-react-v1.105.1) (2025-06-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.105.1",
+  "version": "1.105.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.105.2</summary>

## [1.105.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.1...factorial-one-react-v1.105.2) (2025-06-25)


### Bug Fixes

* **favorites:** many small things ([#2141](https://github.com/factorialco/factorial-one/issues/2141)) ([29fe769](https://github.com/factorialco/factorial-one/commit/29fe7691ec9c277ee4ccf0fe0fbbaa3382402032))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).