### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.105.2",
+  "packages/react": "1.105.3",
   "packages/react-native": "0.16.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.105.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.2...factorial-one-react-v1.105.3) (2025-06-25)
+
+
+### Bug Fixes
+
+* pressed state for collection actions ([#2130](https://github.com/factorialco/factorial-one/issues/2130)) ([2b63d49](https://github.com/factorialco/factorial-one/commit/2b63d4973bf3778745f71af56ee35ce857cdefc5))
+
 ## [1.105.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.1...factorial-one-react-v1.105.2) (2025-06-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.105.2",
+  "version": "1.105.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.105.3</summary>

## [1.105.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.2...factorial-one-react-v1.105.3) (2025-06-25)


### Bug Fixes

* pressed state for collection actions ([#2130](https://github.com/factorialco/factorial-one/issues/2130)) ([2b63d49](https://github.com/factorialco/factorial-one/commit/2b63d4973bf3778745f71af56ee35ce857cdefc5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).