### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.105.3",
+  "packages/react": "1.105.4",
   "packages/react-native": "0.16.0",
   "packages/core": "1.17.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.105.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.3...factorial-one-react-v1.105.4) (2025-06-25)
+
+
+### Bug Fixes
+
+* resourceheader button fixes ([#2128](https://github.com/factorialco/factorial-one/issues/2128)) ([4568382](https://github.com/factorialco/factorial-one/commit/4568382fe7ab8cf4b0e8ef6445068cf1c95041e7))
+
 ## [1.105.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.2...factorial-one-react-v1.105.3) (2025-06-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.105.3",
+  "version": "1.105.4",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.105.3</summary>

## [1.105.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.2...factorial-one-react-v1.105.3) (2025-06-25)


### Bug Fixes

* pressed state for collection actions ([#2130](https://github.com/factorialco/factorial-one/issues/2130)) ([2b63d49](https://github.com/factorialco/factorial-one/commit/2b63d4973bf3778745f71af56ee35ce857cdefc5))
* resourceheader button fixes ([#2128](https://github.com/factorialco/factorial-one/issues/2128)) ([4568382](https://github.com/factorialco/factorial-one/commit/4568382fe7ab8cf4b0e8ef6445068cf1c95041e7))
* use button for item actions ([#2129](https://github.com/factorialco/factorial-one/issues/2129)) ([c09c144](https://github.com/factorialco/factorial-one/commit/c09c144f24e086dec6278b4d99c8e3c5e47c7bcc))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).