### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.106.0",
+  "packages/react": "1.107.0",
   "packages/react-native": "0.16.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.107.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.106.0...factorial-one-react-v1.107.0) (2025-06-25)
+
+
+### Features
+
+* **avatars:** add badge tooltip ([#2148](https://github.com/factorialco/factorial-one/issues/2148)) ([a01bd70](https://github.com/factorialco/factorial-one/commit/a01bd700723d46a613145e207aa1d1391b1a5b1d))
+
 ## [1.106.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.105.4...factorial-one-react-v1.106.0) (2025-06-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.106.0",
+  "version": "1.107.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.107.0</summary>

## [1.107.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.106.0...factorial-one-react-v1.107.0) (2025-06-25)


### Features

* **avatars:** add badge tooltip ([#2148](https://github.com/factorialco/factorial-one/issues/2148)) ([a01bd70](https://github.com/factorialco/factorial-one/commit/a01bd700723d46a613145e207aa1d1391b1a5b1d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).