### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.107.0",
+  "packages/react": "1.107.1",
   "packages/react-native": "0.16.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.107.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.107.0...factorial-one-react-v1.107.1) (2025-06-25)
+
+
+### Bug Fixes
+
+* set correct responsive for OneModal component with side position ([#2139](https://github.com/factorialco/factorial-one/issues/2139)) ([15e2e38](https://github.com/factorialco/factorial-one/commit/15e2e3849de1702d8000f2beafad193880d29096))
+
 ## [1.107.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.106.0...factorial-one-react-v1.107.0) (2025-06-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.107.0",
+  "version": "1.107.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.107.1</summary>

## [1.107.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.107.0...factorial-one-react-v1.107.1) (2025-06-25)


### Bug Fixes

* set correct responsive for OneModal component with side position ([#2139](https://github.com/factorialco/factorial-one/issues/2139)) ([15e2e38](https://github.com/factorialco/factorial-one/commit/15e2e3849de1702d8000f2beafad193880d29096))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).