### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.107.1",
+  "packages/react": "1.107.2",
   "packages/react-native": "0.16.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.107.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.107.1...factorial-one-react-v1.107.2) (2025-06-25)
+
+
+### Bug Fixes
+
+* remove upselling kit stories from sidebar ([#2136](https://github.com/factorialco/factorial-one/issues/2136)) ([8952b49](https://github.com/factorialco/factorial-one/commit/8952b49cf21b594cfea5797037f68b868d5d4647))
+
 ## [1.107.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.107.0...factorial-one-react-v1.107.1) (2025-06-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.107.1",
+  "version": "1.107.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.107.2</summary>

## [1.107.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.107.1...factorial-one-react-v1.107.2) (2025-06-25)


### Bug Fixes

* remove upselling kit stories from sidebar ([#2136](https://github.com/factorialco/factorial-one/issues/2136)) ([8952b49](https://github.com/factorialco/factorial-one/commit/8952b49cf21b594cfea5797037f68b868d5d4647))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).