### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.107.2",
+  "packages/react": "1.108.0",
   "packages/react-native": "0.16.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.108.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.107.2...factorial-one-react-v1.108.0) (2025-06-25)
+
+
+### Features
+
+* **datacollections:** allow to define default selected items ([#2057](https://github.com/factorialco/factorial-one/issues/2057)) ([c2dc25e](https://github.com/factorialco/factorial-one/commit/c2dc25e8fab1efead5bf83fb4eadf5dfcf100f56))
+
 ## [1.107.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.107.1...factorial-one-react-v1.107.2) (2025-06-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.107.2",
+  "version": "1.108.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.108.0</summary>

## [1.108.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.107.2...factorial-one-react-v1.108.0) (2025-06-25)


### Features

* **datacollections:** allow to define default selected items ([#2057](https://github.com/factorialco/factorial-one/issues/2057)) ([c2dc25e](https://github.com/factorialco/factorial-one/commit/c2dc25e8fab1efead5bf83fb4eadf5dfcf100f56))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).