### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.108.0",
+  "packages/react": "1.108.1",
   "packages/react-native": "0.16.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.108.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.108.0...factorial-one-react-v1.108.1) (2025-06-25)
+
+
+### Bug Fixes
+
+* add hidelable to upselling kit popover ([#2146](https://github.com/factorialco/factorial-one/issues/2146)) ([1b06366](https://github.com/factorialco/factorial-one/commit/1b06366ca790da5e286a1dfefe3b261b6d271094))
+
 ## [1.108.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.107.2...factorial-one-react-v1.108.0) (2025-06-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.108.0",
+  "version": "1.108.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.108.1</summary>

## [1.108.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.108.0...factorial-one-react-v1.108.1) (2025-06-25)


### Bug Fixes

* add hidelable to upselling kit popover ([#2146](https://github.com/factorialco/factorial-one/issues/2146)) ([1b06366](https://github.com/factorialco/factorial-one/commit/1b06366ca790da5e286a1dfefe3b261b6d271094))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).