### PR TITLE
feat: add fullwith to buttons

### DIFF
--- a/packages/react-native/src/components/Button/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-native/src/components/Button/__snapshots__/index.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Snapshot - critical variant 1`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button"
@@ -49,7 +49,7 @@ exports[`Button Snapshot - critical variant 1`] = `
 
 exports[`Button Snapshot - default button 1`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button"
@@ -96,7 +96,7 @@ exports[`Button Snapshot - default button 1`] = `
 
 exports[`Button Snapshot - different sizes 1`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button"
@@ -143,7 +143,7 @@ exports[`Button Snapshot - different sizes 1`] = `
 
 exports[`Button Snapshot - different sizes 2`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button"
@@ -190,7 +190,7 @@ exports[`Button Snapshot - different sizes 2`] = `
 
 exports[`Button Snapshot - different sizes 3`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button"
@@ -237,7 +237,7 @@ exports[`Button Snapshot - different sizes 3`] = `
 
 exports[`Button Snapshot - disabled state 1`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button, disabled"
@@ -284,7 +284,7 @@ exports[`Button Snapshot - disabled state 1`] = `
 
 exports[`Button Snapshot - loading state 1`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button, disabled, loading"
@@ -331,7 +331,7 @@ exports[`Button Snapshot - loading state 1`] = `
 
 exports[`Button Snapshot - outline variant 1`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button"
@@ -378,7 +378,7 @@ exports[`Button Snapshot - outline variant 1`] = `
 
 exports[`Button Snapshot - round button with hidden label 1`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button"
@@ -419,7 +419,7 @@ exports[`Button Snapshot - round button with hidden label 1`] = `
 
 exports[`Button Snapshot - with emoji 1`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button"
@@ -471,7 +471,7 @@ exports[`Button Snapshot - with emoji 1`] = `
 
 exports[`Button Snapshot - with icon 1`] = `
 <View
-  className="flex items-start"
+  className="flex item-start"
 >
   <View
     accessibilityLabel="Test Button"

--- a/packages/react-native/src/components/Button/index.tsx
+++ b/packages/react-native/src/components/Button/index.tsx
@@ -119,6 +119,7 @@ export interface ButtonProps extends VariantProps<typeof buttonVariants> {
   className?: string;
   accessibilityHint?: string;
   showBadge?: boolean;
+  fullWidth?: boolean;
 }
 
 export const Button = forwardRef<View, ButtonProps>(function Button(
@@ -136,6 +137,7 @@ export const Button = forwardRef<View, ButtonProps>(function Button(
     className,
     accessibilityHint,
     showBadge = false,
+    fullWidth = false,
   },
   ref,
 ) {
@@ -162,7 +164,7 @@ export const Button = forwardRef<View, ButtonProps>(function Button(
   const shouldShowPressed = isPressed && !isDisabled;
 
   return (
-    <View className="flex items-start">
+    <View className={`flex ${fullWidth ? "flex-1" : "item-start"}`}>
       <Pressable
         ref={ref}
         disabled={isDisabled}


### PR DESCRIPTION
## Description

We should have support for fullwidth in some cases in buttons for instance:

## Screenshots (if applicable)
<img width="445" alt="Screenshot 2025-06-25 at 15 48 21" src="https://github.com/user-attachments/assets/96583a97-f64f-4af2-a1e9-9e36ffae9af7" />
