### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.108.1",
-  "packages/react-native": "0.16.0",
+  "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.17.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.16.0...factorial-one-react-native-v0.17.0) (2025-06-25)
+
+
+### Features
+
+* add fullwith to buttons ([#2161](https://github.com/factorialco/factorial-one/issues/2161)) ([3b85e82](https://github.com/factorialco/factorial-one/commit/3b85e8237b98200375a703ac835462f513313c09))
+
 ## [0.16.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.15.0...factorial-one-react-native-v0.16.0) (2025-06-23)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.17.0</summary>

## [0.17.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.16.0...factorial-one-react-native-v0.17.0) (2025-06-25)


### Features

* add fullwith to buttons ([#2161](https://github.com/factorialco/factorial-one/issues/2161)) ([3b85e82](https://github.com/factorialco/factorial-one/commit/3b85e8237b98200375a703ac835462f513313c09))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).