### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.108.1",
+  "packages/react": "1.109.0",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.109.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.108.1...factorial-one-react-v1.109.0) (2025-06-25)
+
+
+### Features
+
+* **datenavigator:** dateNavigation compareTo ([#2041](https://github.com/factorialco/factorial-one/issues/2041)) ([4971127](https://github.com/factorialco/factorial-one/commit/4971127d07c48c49912d02d133458b1bd0653ae9))
+
 ## [1.108.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.108.0...factorial-one-react-v1.108.1) (2025-06-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.108.1",
+  "version": "1.109.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.109.0</summary>

## [1.109.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.108.1...factorial-one-react-v1.109.0) (2025-06-25)


### Features

* **datenavigator:** dateNavigation compareTo ([#2041](https://github.com/factorialco/factorial-one/issues/2041)) ([4971127](https://github.com/factorialco/factorial-one/commit/4971127d07c48c49912d02d133458b1bd0653ae9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).