### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.111.0",
+  "packages/react": "1.112.0",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.112.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.111.0...factorial-one-react-v1.112.0) (2025-06-26)
+
+
+### Features
+
+* **RichTextEditor:** add AIBlock extension and integrate into Basic text editor ([#2145](https://github.com/factorialco/factorial-one/issues/2145)) ([9338520](https://github.com/factorialco/factorial-one/commit/93385209a520fca58045d36c66a002dc702b45c7))
+
 ## [1.111.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.110.0...factorial-one-react-v1.111.0) (2025-06-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.111.0",
+  "version": "1.112.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.112.0</summary>

## [1.112.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.111.0...factorial-one-react-v1.112.0) (2025-06-26)


### Features

* **RichTextEditor:** add AIBlock extension and integrate into Basic text editor ([#2145](https://github.com/factorialco/factorial-one/issues/2145)) ([9338520](https://github.com/factorialco/factorial-one/commit/93385209a520fca58045d36c66a002dc702b45c7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).