### PR TITLE
fix(datacollection): tooltip when link

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/ItemActions/ItemActionsDropdown.tsx
+++ b/packages/react/src/experimental/OneDataCollection/ItemActions/ItemActionsDropdown.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils"
 import { useState } from "react"
 import { Button } from "../../../components/Actions/Button"
 import { Ellipsis } from "../../../icons/app"
@@ -7,12 +8,14 @@ export type ItemActionsDropdownProps = {
   items: DropdownItem[]
   onOpenChange?: (open: boolean) => void
   align?: "start" | "end"
+  className?: string
 }
 
 export const ItemActionsDropdown = ({
   items,
   onOpenChange,
   align = "end",
+  className,
 }: ItemActionsDropdownProps) => {
   const [open, setOpen] = useState(false)
 
@@ -21,31 +24,33 @@ export const ItemActionsDropdown = ({
   }
 
   return (
-    <Dropdown
-      align={align}
-      items={items.map((item) => {
-        if (item.type === "separator") {
-          return item
-        }
-        return {
-          ...item,
-          type: "item",
-        }
-      })}
-      open={open}
-      onOpenChange={(open) => {
-        setOpen(open)
-        onOpenChange?.(open)
-      }}
-    >
-      <Button
-        icon={Ellipsis}
-        label="Actions"
-        hideLabel
-        round
-        variant="ghost"
-        pressed={open}
-      />
-    </Dropdown>
+    <div className={cn("pointer-events-auto", className)}>
+      <Dropdown
+        align={align}
+        items={items.map((item) => {
+          if (item.type === "separator") {
+            return item
+          }
+          return {
+            ...item,
+            type: "item",
+          }
+        })}
+        open={open}
+        onOpenChange={(open) => {
+          setOpen(open)
+          onOpenChange?.(open)
+        }}
+      >
+        <Button
+          icon={Ellipsis}
+          label="Actions"
+          hideLabel
+          round
+          variant="ghost"
+          pressed={open}
+        />
+      </Dropdown>
+    </div>
   )
 }

--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
@@ -255,6 +255,7 @@ export const WithLinkedItems: Story = {
       dataAdapter: {
         fetchData: createPromiseDataFetch(),
       },
+      selectable: (item) => item.id,
       itemActions: (item) => [
         {
           label: "Edit",
@@ -301,7 +302,18 @@ export const WithLinkedItems: Story = {
                 columns: [
                   {
                     label: "Name",
-                    render: (item) => item.name,
+                    render: (item) => ({
+                      type: "person",
+                      value: {
+                        firstName: item.name.split(" ")[0],
+                        lastName: item.name.split(" ")[1],
+                        badge: {
+                          type: "module",
+                          module: "inbox",
+                          tooltip: "Inbox",
+                        },
+                      },
+                    }),
                     sorting: "name",
                   },
                   {

--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -361,6 +361,11 @@ export const getMockVisualizations = (options?: {
           type: "person",
           firstName: item.name.split(" ")[0],
           lastName: item.name.split(" ")[1],
+          badge: {
+            type: "module",
+            module: "inbox",
+            tooltip: "Inbox",
+          },
         },
       }),
       fields: [

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -314,7 +314,7 @@ export const CardCollection = <
   )
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4 border-solid border-[#f00]">
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
       <div className="overflow-auto">
         {isInitialLoading ? (
           <CardGrid>

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -99,7 +99,7 @@ const RowComponentInner = <
       {source.selectable && (
         <TableCell width={checkColumnWidth} sticky={{ left: 0 }}>
           {id !== undefined && (
-            <div className="flex items-center justify-end">
+            <div className="pointer-events-auto flex items-center justify-end">
               <Checkbox
                 checked={selectedItems.has(id)}
                 onCheckedChange={onCheckedChange}
@@ -150,7 +150,10 @@ const RowComponentInner = <
           href={itemHref}
           onClick={itemOnClick}
         >
-          <ItemActionsDropdown items={actionsToDropdownItems(itemActions)} />
+          <ItemActionsDropdown
+            items={actionsToDropdownItems(itemActions)}
+            className="pointer-events-auto"
+          />
         </TableCell>
       )}
     </TableRow>

--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -103,17 +103,22 @@ export function TableCell({
         className={cn(
           "[&:has([role=checkbox])]:relative [&:has([role=checkbox])]:z-[1]",
           "[&:has([type=button])]:relative [&:has([type=button])]:z-[1]",
-          "[&:has(a)]:relative [&:has(a)]:z-[1]"
+          "[&:has(a)]:relative [&:has(a)]:z-[1]",
+          "pointer-events-none"
         )}
       >
-        <div className={cn(width !== "auto" && "overflow-hidden")}>
+        <div
+          className={
+            (cn(width !== "auto" && "overflow-hidden"), "relative z-[1]")
+          }
+        >
           {children}
         </div>
       </div>
       {href && (
         <Link
           href={href}
-          className="absolute inset-0 block"
+          className="pointer-events-auto absolute inset-0 !z-0 block bg-[#00]"
           tabIndex={firstCell ? undefined : -1}
         >
           <span className="sr-only">{actions.view}</span>

--- a/packages/react/src/experimental/Overlays/Tooltip/index.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.tsx
@@ -32,7 +32,9 @@ export function Tooltip({
     <>
       <TooltipProvider>
         <TooltipPrimitive>
-          <TooltipTrigger asChild>{children}</TooltipTrigger>
+          <TooltipTrigger asChild className="pointer-events-auto">
+            {children}
+          </TooltipTrigger>
           <TooltipContent className={cn("max-w-xs", shortcut && "pr-1.5")}>
             <div className="flex flex-col gap-0.5">
               <div className="flex items-center gap-2">


### PR DESCRIPTION
## Description

Allow badge tooltips (and any tooltip) to work when the datacollection table row has a link

## Implementation details

Uses pointer-events-auto in the children elements to allow them to get pointer events at the same time the link works. (the cell  have pointer events none, pointer-events-auto is needed in the children need mouse events
