### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.112.0",
+  "packages/react": "1.113.0",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.113.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.112.0...factorial-one-react-v1.113.0) (2025-06-26)
+
+
+### Features
+
+* export tooltip ([#2167](https://github.com/factorialco/factorial-one/issues/2167)) ([9a70440](https://github.com/factorialco/factorial-one/commit/9a70440394bebf36a24341ce8f8052b21747d6d5))
+
 ## [1.112.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.111.0...factorial-one-react-v1.112.0) (2025-06-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.112.0",
+  "version": "1.113.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.113.0</summary>

## [1.113.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.112.0...factorial-one-react-v1.113.0) (2025-06-26)


### Features

* export tooltip ([#2167](https://github.com/factorialco/factorial-one/issues/2167)) ([9a70440](https://github.com/factorialco/factorial-one/commit/9a70440394bebf36a24341ce8f8052b21747d6d5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).