### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.113.0",
+  "packages/react": "1.113.1",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.113.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.0...factorial-one-react-v1.113.1) (2025-06-26)
+
+
+### Bug Fixes
+
+* **datacollection:** tooltip when link ([#2169](https://github.com/factorialco/factorial-one/issues/2169)) ([5602a08](https://github.com/factorialco/factorial-one/commit/5602a08cfa6f04a3617a376d030c8a03bc38ba17))
+
 ## [1.113.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.112.0...factorial-one-react-v1.113.0) (2025-06-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.113.0",
+  "version": "1.113.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.113.1</summary>

## [1.113.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.0...factorial-one-react-v1.113.1) (2025-06-26)


### Bug Fixes

* **datacollection:** tooltip when link ([#2169](https://github.com/factorialco/factorial-one/issues/2169)) ([5602a08](https://github.com/factorialco/factorial-one/commit/5602a08cfa6f04a3617a376d030c8a03bc38ba17))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).