### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.113.1",
+  "packages/react": "1.113.2",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.113.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.1...factorial-one-react-v1.113.2) (2025-06-26)
+
+
+### Bug Fixes
+
+* refactor infinite scroll loading and add sticky summary row ([#2172](https://github.com/factorialco/factorial-one/issues/2172)) ([2036c30](https://github.com/factorialco/factorial-one/commit/2036c30aa1b3df429e5580548ef48bb11450da36))
+
 ## [1.113.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.0...factorial-one-react-v1.113.1) (2025-06-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.113.1",
+  "version": "1.113.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.113.2</summary>

## [1.113.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.1...factorial-one-react-v1.113.2) (2025-06-26)


### Bug Fixes

* refactor infinite scroll loading and add sticky summary row ([#2172](https://github.com/factorialco/factorial-one/issues/2172)) ([2036c30](https://github.com/factorialco/factorial-one/commit/2036c30aa1b3df429e5580548ef48bb11450da36))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).