### PR TITLE
fix: append with merge in data collection

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/useData.ts
+++ b/packages/react/src/experimental/OneDataCollection/useData.ts
@@ -315,7 +315,35 @@ export function useData<
         setTotalItems?.(result.length)
       }
 
-      setRawData(appendMode ? (prevData) => [...prevData, ...records] : records)
+      setRawData(
+        appendMode
+          ? (prevData) => {
+              const merged = [...prevData]
+              const idMap = new Map(
+                prevData
+                  .filter((item) => "id" in item && !!item.id)
+                  .map((item) => [item.id, item])
+              )
+
+              for (const record of records) {
+                if ("id" in record && !!record.id && idMap.has(record.id)) {
+                  const index = merged.findIndex(
+                    (item) => item.id === record.id
+                  )
+                  if (index !== -1) {
+                    merged[index] = record // Overwrite existing item
+                  } else {
+                    merged.push(record) // Fallback
+                  }
+                } else {
+                  merged.push(record) // New item
+                }
+              }
+
+              return merged
+            }
+          : records
+      )
       setError(null)
       setIsInitialLoading(false)
       setIsLoading(false)


### PR DESCRIPTION
## Description

When we're using infinite pagination we can receive the last page repeated when an item updates, we need to handle that case by overriding existing items instead of appending them at the end.
