### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.113.2",
+  "packages/react": "1.113.3",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.113.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.2...factorial-one-react-v1.113.3) (2025-06-27)
+
+
+### Bug Fixes
+
+* export provider defaults ([#2175](https://github.com/factorialco/factorial-one/issues/2175)) ([12cdef2](https://github.com/factorialco/factorial-one/commit/12cdef268b1c6d9bd50b1d5a9f1b8109092121a1))
+
 ## [1.113.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.1...factorial-one-react-v1.113.2) (2025-06-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.113.2",
+  "version": "1.113.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.113.3</summary>

## [1.113.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.2...factorial-one-react-v1.113.3) (2025-06-27)


### Bug Fixes

* export provider defaults ([#2175](https://github.com/factorialco/factorial-one/issues/2175)) ([12cdef2](https://github.com/factorialco/factorial-one/commit/12cdef268b1c6d9bd50b1d5a9f1b8109092121a1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).