### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.113.3",
+  "packages/react": "1.113.4",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.113.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.3...factorial-one-react-v1.113.4) (2025-06-27)
+
+
+### Bug Fixes
+
+* append with merge in data collection ([#2177](https://github.com/factorialco/factorial-one/issues/2177)) ([19843d4](https://github.com/factorialco/factorial-one/commit/19843d4d1e97f594218416813e49b1ccb1a4b27e))
+
 ## [1.113.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.2...factorial-one-react-v1.113.3) (2025-06-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.113.3",
+  "version": "1.113.4",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.113.4</summary>

## [1.113.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.3...factorial-one-react-v1.113.4) (2025-06-27)


### Bug Fixes

* append with merge in data collection ([#2177](https://github.com/factorialco/factorial-one/issues/2177)) ([19843d4](https://github.com/factorialco/factorial-one/commit/19843d4d1e97f594218416813e49b1ccb1a4b27e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).