### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.113.4",
+  "packages/react": "1.113.5",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.113.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.4...factorial-one-react-v1.113.5) (2025-06-27)
+
+
+### Bug Fixes
+
+* update TableHead sticky row background layering ([#2179](https://github.com/factorialco/factorial-one/issues/2179)) ([3a96259](https://github.com/factorialco/factorial-one/commit/3a96259eff35d5418ad36fa338f81b806ccc9f73))
+
 ## [1.113.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.3...factorial-one-react-v1.113.4) (2025-06-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.113.4",
+  "version": "1.113.5",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.113.5</summary>

## [1.113.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.4...factorial-one-react-v1.113.5) (2025-06-27)


### Bug Fixes

* update TableHead sticky row background layering ([#2179](https://github.com/factorialco/factorial-one/issues/2179)) ([3a96259](https://github.com/factorialco/factorial-one/commit/3a96259eff35d5418ad36fa338f81b806ccc9f73))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).