### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.113.6",
+  "packages/react": "1.114.0",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.114.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.6...factorial-one-react-v1.114.0) (2025-06-27)
+
+
+### Features
+
+* **RichTextEditor:** add LiveCompanion extension ([#2176](https://github.com/factorialco/factorial-one/issues/2176)) ([7242f65](https://github.com/factorialco/factorial-one/commit/7242f6563f99156d11bc0b06f0298726bd0724ac))
+
 ## [1.113.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.5...factorial-one-react-v1.113.6) (2025-06-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.113.6",
+  "version": "1.114.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.114.0</summary>

## [1.114.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.113.6...factorial-one-react-v1.114.0) (2025-06-27)


### Features

* **RichTextEditor:** add LiveCompanion extension ([#2176](https://github.com/factorialco/factorial-one/issues/2176)) ([7242f65](https://github.com/factorialco/factorial-one/commit/7242f6563f99156d11bc0b06f0298726bd0724ac))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).