### PR TITLE
feat: add support for AlertTag cell type in data collection

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.stories.tsx
@@ -408,6 +408,22 @@ export const TagType: Story = {
   },
 }
 
+export const AlertTagType: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Alert Tag",
+      render: () => ({
+        type: "alertTag",
+        value: {
+          level: "critical",
+          label: "Critical",
+        },
+      }),
+    },
+  },
+}
+
 export const DotTagType: Story = {
   args: {
     item: mockItem,

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/index.tsx
@@ -1,4 +1,5 @@
 import { PropertyRenderer } from "./types.ts"
+import { AlertTagCell } from "./types/alertTag.tsx"
 import { AmountCell } from "./types/amount.tsx"
 import { AvatarListCell } from "./types/avatarList.tsx"
 import { CompanyCell } from "./types/company.tsx"
@@ -26,6 +27,7 @@ export const propertyRenderers = {
   amount: AmountCell,
   avatarList: AvatarListCell,
   status: StatusCell,
+  alertTag: AlertTagCell,
   person: PersonCell,
   company: CompanyCell,
   team: TeamCell,

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/types/alertTag.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/types/alertTag.tsx
@@ -1,0 +1,16 @@
+/**
+ * Alert tag cell type for displaying alert indicators with labels.
+ * Used for showing alerts on items in data collections.
+ */
+import { AlertTag } from "@/experimental/Information/Tags/exports"
+import { ComponentProps } from "react"
+
+interface AlertTagValue {
+  level: ComponentProps<typeof AlertTag>["level"]
+  label: string
+}
+export type AlertTagCellValue = AlertTagValue
+
+export const AlertTagCell = (args: AlertTagCellValue) => (
+  <AlertTag level={args.level} text={args.label} />
+)


### PR DESCRIPTION
## Description

We need this new alert tag cell type in data collection to show due dates in the inbox. At the moment we were using status cell type for that but we should have this new type instead.

## Screenshots

<img width="825" alt="Screenshot 2025-06-27 at 17 59 48" src="https://github.com/user-attachments/assets/660abf3e-d20f-4f8f-967e-fc304d5bd339" />
