### PR TITLE
fix(datacollection): click over group header in table. Card and list group header paddings

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/components/GroupHeader/GroupHeader.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/GroupHeader/GroupHeader.tsx
@@ -42,7 +42,7 @@ export const GroupHeader = ({
 
   return (
     <div
-      className={cn("flex items-center gap-2", className)}
+      className={cn("pointer-events-auto flex items-center gap-2", className)}
       onClick={handleOpenChange}
     >
       {selectable && (

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -359,9 +359,10 @@ export const CardCollection = <
                       onSelectChange={(checked) =>
                         handleSelectGroupChange(group, checked)
                       }
+                      className="px-6 pb-2 pt-4"
                     />
                     <AnimatePresence>
-                      {openGroups[group.key] && (
+                      {(!collapsible || openGroups[group.key]) && (
                         <GroupCards
                           key={group.key}
                           source={source}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/index.tsx
@@ -222,7 +222,7 @@ export const ListCollection = <
                     onOpenChange={(open) => setGroupOpen(group.key, open)}
                   />
                   <AnimatePresence>
-                    {openGroups[group.key] && (
+                    {(!collapsible || openGroups[group.key]) && (
                       <motion.div
                         initial={{ height: 0, opacity: 0 }}
                         animate={{ height: "auto", opacity: 1 }}


### PR DESCRIPTION
## Description

Fix the click on group header on table and add the correct paddings in cards and table view


## Implementation details

<!-- What have you changed? Why? -->
