### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.115.0",
+  "packages/react": "1.116.0",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.116.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.115.0...factorial-one-react-v1.116.0) (2025-06-30)
+
+
+### Features
+
+* **RichTextEditor:** add Transcript and details extension ([#2189](https://github.com/factorialco/factorial-one/issues/2189)) ([bd8033d](https://github.com/factorialco/factorial-one/commit/bd8033df537c79bba08ddf4d00354169068d856c))
+
 ## [1.115.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.114.0...factorial-one-react-v1.115.0) (2025-06-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.115.0",
+  "version": "1.116.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.116.0</summary>

## [1.116.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.115.0...factorial-one-react-v1.116.0) (2025-06-30)


### Features

* **RichTextEditor:** add Transcript and details extension ([#2189](https://github.com/factorialco/factorial-one/issues/2189)) ([bd8033d](https://github.com/factorialco/factorial-one/commit/bd8033df537c79bba08ddf4d00354169068d856c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).