### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.116.0",
+  "packages/react": "1.116.1",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.116.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.116.0...factorial-one-react-v1.116.1) (2025-06-30)
+
+
+### Bug Fixes
+
+* **datacollection:** click over group header in table. Card and list group header paddings ([#2192](https://github.com/factorialco/factorial-one/issues/2192)) ([05b8e5c](https://github.com/factorialco/factorial-one/commit/05b8e5ca9cbebde9cc0fdf532529d764c6fcc3ef))
+
 ## [1.116.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.115.0...factorial-one-react-v1.116.0) (2025-06-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.116.0",
+  "version": "1.116.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.116.1</summary>

## [1.116.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.116.0...factorial-one-react-v1.116.1) (2025-06-30)


### Bug Fixes

* **datacollection:** click over group header in table. Card and list group header paddings ([#2192](https://github.com/factorialco/factorial-one/issues/2192)) ([05b8e5c](https://github.com/factorialco/factorial-one/commit/05b8e5ca9cbebde9cc0fdf532529d764c6fcc3ef))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).