### PR TITLE
fix(button): focus trap

### DIFF
--- a/packages/react/src/ui/button.tsx
+++ b/packages/react/src/ui/button.tsx
@@ -130,8 +130,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             buttonRef.current?.click()
           }}
           onKeyDown={(e) => {
-            e.preventDefault()
             if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault()
               buttonRef.current?.click()
             }
           }}


### PR DESCRIPTION
## Description

After focusing a button with the keyboard, it was impossible to move to the next or previous one


## Implementation details

There was `preventDefault` call blocking the focus move
