### PR TITLE
fix: adding table row hover styles in onedatacollection footer

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
@@ -463,7 +463,7 @@ export const TableCollection = <
             <TableRow
               className={cn(
                 summaryData.sticky &&
-                  "sticky bottom-0 z-10 bg-f1-background shadow-[0_-1px_0_0_var(--f1-border-secondary)]",
+                  "sticky bottom-0 z-10 bg-f1-background shadow-[0_-1px_0_0_var(--f1-border-secondary)] hover:bg-f1-background",
                 "font-medium"
               )}
             >


### PR DESCRIPTION
## Description

## Screenshots (if applicable)

#### Before

<img width="718" alt="Screenshot 2025-06-30 at 16 03 11" src="https://github.com/user-attachments/assets/f17e12ee-7e0c-4f6c-a809-dc87458f2930" />
