### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.116.2",
+  "packages/react": "1.116.3",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.116.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.116.2...factorial-one-react-v1.116.3) (2025-07-01)
+
+
+### Bug Fixes
+
+* **datacollection:** empty state recover visualizacion on dataFetch observable emits next ([#2197](https://github.com/factorialco/factorial-one/issues/2197)) ([d21687b](https://github.com/factorialco/factorial-one/commit/d21687b4f413ba41a81c0f838449d8d9c80717a6))
+
 ## [1.116.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.116.1...factorial-one-react-v1.116.2) (2025-06-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.116.2",
+  "version": "1.116.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.116.3</summary>

## [1.116.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.116.2...factorial-one-react-v1.116.3) (2025-07-01)


### Bug Fixes

* **datacollection:** empty state recover visualizacion on dataFetch observable emits next ([#2197](https://github.com/factorialco/factorial-one/issues/2197)) ([d21687b](https://github.com/factorialco/factorial-one/commit/d21687b4f413ba41a81c0f838449d8d9c80717a6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).