### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.116.3",
+  "packages/react": "1.117.0",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.117.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.116.3...factorial-one-react-v1.117.0) (2025-07-01)
+
+
+### Features
+
+* **datacollection:** sticky group header in table ([#2185](https://github.com/factorialco/factorial-one/issues/2185)) ([d1b782f](https://github.com/factorialco/factorial-one/commit/d1b782f2d74d45e3be0fc135ed116575ec46254b))
+
 ## [1.116.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.116.2...factorial-one-react-v1.116.3) (2025-07-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.116.3",
+  "version": "1.117.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.117.0</summary>

## [1.117.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.116.3...factorial-one-react-v1.117.0) (2025-07-01)


### Features

* **datacollection:** sticky group header in table ([#2185](https://github.com/factorialco/factorial-one/issues/2185)) ([d1b782f](https://github.com/factorialco/factorial-one/commit/d1b782f2d74d45e3be0fc135ed116575ec46254b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).