### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.117.0",
+  "packages/react": "1.117.1",
   "packages/react-native": "0.17.0",
   "packages/core": "1.18.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.117.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.117.0...factorial-one-react-v1.117.1) (2025-07-01)
+
+
+### Bug Fixes
+
+* adding table row hover styles in onedatacollection footer ([#2199](https://github.com/factorialco/factorial-one/issues/2199)) ([2d0e5c2](https://github.com/factorialco/factorial-one/commit/2d0e5c236b1328e8e675e9a79f33fcfbbde46d80))
+
 ## [1.117.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.116.3...factorial-one-react-v1.117.0) (2025-07-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.117.0",
+  "version": "1.117.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.117.1</summary>

## [1.117.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.117.0...factorial-one-react-v1.117.1) (2025-07-01)


### Bug Fixes

* adding table row hover styles in onedatacollection footer ([#2199](https://github.com/factorialco/factorial-one/issues/2199)) ([2d0e5c2](https://github.com/factorialco/factorial-one/commit/2d0e5c236b1328e8e675e9a79f33fcfbbde46d80))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).