### PR TITLE
fix: data collection defaultOpenGroups as true

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/grouping.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/grouping.mdx
@@ -37,7 +37,7 @@ const { source, currentGrouping, setCurrentGrouping } = useDataCollection({
   grouping={{
     mandatory: true, // If true, the grouping is mandatory and the data will be grouped by the grouping field, if false, the grouping is optional and the use can choose not grouping the data
     collapsible: true, // If true, the grouping is collapsible and the user can collapse the grouping, if false, the grouping is non collapsible and the user cannot collapse the grouping
-    initialOpenGroups: true, // If true, the grouping is open by default, if false, the grouping is closed by default, if an array, the grouping will be open only for the groups in the array
+    defaultOpenGroups: true, // If true, the grouping is open by default, if false, the grouping is closed by default, if an array, the grouping will be open only for the groups in the array
     groupBy: {
         // This is the field to group the data by
         department: {

--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/list.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/list.stories.tsx
@@ -62,6 +62,36 @@ export const ListVisualizationWithGrouping: Story = {
   },
 }
 
+export const ListVisualizationWithGroupingAndAllGroupsOpenByDefault: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: () => {
+    const mockVisualizations = getMockVisualizations()
+    return (
+      <ExampleComponent
+        visualizations={[mockVisualizations.list]}
+        grouping={{
+          collapsible: true,
+          mandatory: true,
+          defaultOpenGroups: true,
+          groupBy: {
+            department: {
+              name: "Department",
+              label: (groupId) => groupId,
+              itemCount: async (groupId) => {
+                await new Promise((resolve) => setTimeout(resolve, 1000))
+                return mockUsers.filter((user) => user.department === groupId)
+                  .length
+              },
+            },
+          },
+        }}
+      />
+    )
+  },
+}
+
 export const ListVisualizationWithInfiniteScrollPagination: Story = {
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/packages/react/src/experimental/OneDataCollection/useGroups.ts
+++ b/packages/react/src/experimental/OneDataCollection/useGroups.ts
@@ -19,7 +19,7 @@ export const useGroups = <R extends RecordType>(
       },
       {} as Record<string, boolean>
     )
-    if (Object.values(defaultOpenGroups).length > 0) {
+    if (Object.values(defaultValue).length > 0) {
       setOpenGroups(defaultValue)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on deep changes


### PR DESCRIPTION
## Description

When we were passing `defaultOpenGroups: true` to our data collection it wasn't opening all groups by default as expected.
