### PR TITLE
fix(avatar): add no translate attribute for avatars

### DIFF
--- a/packages/react/src/experimental/Information/Avatars/BaseAvatar/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/BaseAvatar/index.tsx
@@ -120,6 +120,7 @@ export const BaseAvatar = forwardRef<HTMLDivElement, Props>(
               aria-hidden={!hasAria}
               aria-label={ariaLabel}
               aria-labelledby={ariaLabelledby}
+              translate="no"
               data-a11y-color-contrast-ignore
               className={
                 src

--- a/packages/react/src/ui/avatar.tsx
+++ b/packages/react/src/ui/avatar.tsx
@@ -101,6 +101,7 @@ const AvatarFallback = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Fallback
     ref={ref}
+    translate="no"
     className={cn(
       "flex h-full w-full items-center justify-center text-f1-foreground-inverse/90",
       className


### PR DESCRIPTION
## Description

We had issues when abbreviations were translated as medical conditions

## Implementation details

set [`translate` attribute](https://html.spec.whatwg.org/multipage/dom.html#dom-translate) that prohibits translation of the content
