### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.119.3",
+  "packages/react": "1.120.0",
   "packages/react-native": "0.17.0",
   "packages/core": "1.19.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.120.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.119.3...factorial-one-react-v1.120.0) (2025-07-10)
+
+
+### Features
+
+* Extract datacollection filters to OneFilterPicker component ([#2226](https://github.com/factorialco/factorial-one/issues/2226)) ([#2232](https://github.com/factorialco/factorial-one/issues/2232)) ([0fbf916](https://github.com/factorialco/factorial-one/commit/0fbf9163f4fb71cb0f11bb58ce67180d75bf3004))
+
 ## [1.119.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.119.2...factorial-one-react-v1.119.3) (2025-07-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.119.3",
+  "version": "1.120.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.120.0</summary>

## [1.120.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.119.3...factorial-one-react-v1.120.0) (2025-07-10)


### Features

* Extract datacollection filters to OneFilterPicker component ([#2226](https://github.com/factorialco/factorial-one/issues/2226)) ([#2232](https://github.com/factorialco/factorial-one/issues/2232)) ([0fbf916](https://github.com/factorialco/factorial-one/commit/0fbf9163f4fb71cb0f11bb58ce67180d75bf3004))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).