### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.121.0",
+  "packages/react": "1.121.1",
   "packages/react-native": "0.17.0",
   "packages/core": "1.20.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.121.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.121.0...factorial-one-react-v1.121.1) (2025-07-10)
+
+
+### Bug Fixes
+
+* proper overflow calculation to avoid overflows ([#2238](https://github.com/factorialco/factorial-one/issues/2238)) ([2c86bc5](https://github.com/factorialco/factorial-one/commit/2c86bc5107d400faf6826c7f22d4c6f6a7c68c9a))
+
 ## [1.121.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.120.0...factorial-one-react-v1.121.0) (2025-07-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.121.0",
+  "version": "1.121.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.121.1</summary>

## [1.121.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.121.0...factorial-one-react-v1.121.1) (2025-07-10)


### Bug Fixes

* proper overflow calculation to avoid overflows ([#2238](https://github.com/factorialco/factorial-one/issues/2238)) ([2c86bc5](https://github.com/factorialco/factorial-one/commit/2c86bc5107d400faf6826c7f22d4c6f6a7c68c9a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).