### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.122.0",
+  "packages/react": "1.122.1",
   "packages/react-native": "0.17.0",
   "packages/core": "1.20.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.122.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.122.0...factorial-one-react-v1.122.1) (2025-07-10)
+
+
+### Bug Fixes
+
+* **datacollection:** filters form width and custo height by type ([#2160](https://github.com/factorialco/factorial-one/issues/2160)) ([6c067f2](https://github.com/factorialco/factorial-one/commit/6c067f21b04f0d24f8b2cf8f73c01bb219b19788))
+
 ## [1.122.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.121.1...factorial-one-react-v1.122.0) (2025-07-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.122.0",
+  "version": "1.122.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.122.1</summary>

## [1.122.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.122.0...factorial-one-react-v1.122.1) (2025-07-10)


### Bug Fixes

* **datacollection:** filters form width and custo height by type ([#2160](https://github.com/factorialco/factorial-one/issues/2160)) ([6c067f2](https://github.com/factorialco/factorial-one/commit/6c067f21b04f0d24f8b2cf8f73c01bb219b19788))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).