### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.122.1",
+  "packages/react": "1.122.2",
   "packages/react-native": "0.17.0",
   "packages/core": "1.20.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.122.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.122.1...factorial-one-react-v1.122.2) (2025-07-10)
+
+
+### Bug Fixes
+
+* stop using module icon prop in breadcrumbs ([#2233](https://github.com/factorialco/factorial-one/issues/2233)) ([8c325f5](https://github.com/factorialco/factorial-one/commit/8c325f56ebf9c83d70e1e223906e805af57218bf))
+
 ## [1.122.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.122.0...factorial-one-react-v1.122.1) (2025-07-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.122.1",
+  "version": "1.122.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.122.2</summary>

## [1.122.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.122.1...factorial-one-react-v1.122.2) (2025-07-10)


### Bug Fixes

* stop using module icon prop in breadcrumbs ([#2233](https://github.com/factorialco/factorial-one/issues/2233)) ([8c325f5](https://github.com/factorialco/factorial-one/commit/8c325f56ebf9c83d70e1e223906e805af57218bf))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).