### PR TITLE
feat: Use ellipsis in icon names in Icons documentation

### DIFF
--- a/packages/react/docs/components/IconGrid.tsx
+++ b/packages/react/docs/components/IconGrid.tsx
@@ -39,11 +39,8 @@ function IconCard({ name, icon: Icon }: IconEntry) {
       transition={{ duration: 0.1 }}
     >
       <IconComponent icon={Icon} size="lg" color="bold" />
-      <div className="w-full">
-        <OneEllipsis
-          tag="span"
-          className="text-center !text-sm text-f1-foreground-secondary"
-        >
+      <div className="w-full text-center text-f1-foreground-secondary">
+        <OneEllipsis tag="span" className="!text-sm">
           {name}
         </OneEllipsis>
       </div>

--- a/packages/react/docs/components/IconGrid.tsx
+++ b/packages/react/docs/components/IconGrid.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from "motion/react"
 import { useMemo, useState } from "react"
+import { OneEllipsis } from "../../src/components/OneEllipsis"
 import {
   Icon as IconComponent,
   IconType,
@@ -37,10 +38,15 @@ function IconCard({ name, icon: Icon }: IconEntry) {
       exit={{ opacity: 0, scale: 0.95 }}
       transition={{ duration: 0.1 }}
     >
-      <IconComponent icon={Icon} size="lg" className="text-f1-icon-bold" />
-      <span className="text-center !text-sm text-f1-foreground-secondary">
-        {name}
-      </span>
+      <IconComponent icon={Icon} size="lg" color="bold" />
+      <div className="w-full">
+        <OneEllipsis
+          tag="span"
+          className="text-center !text-sm text-f1-foreground-secondary"
+        >
+          {name}
+        </OneEllipsis>
+      </div>
       <motion.button
         onClick={copyToClipboard}
         className={cn(
@@ -102,14 +108,13 @@ export function IconGrid() {
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
         />
-        <IconComponent
-          icon={Icons.Search}
-          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 select-none text-f1-foreground-secondary"
-        />
+        <div className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 select-none">
+          <IconComponent icon={Icons.Search} color="secondary" />
+        </div>
       </div>
       <AnimatePresence>
         {filteredIcons.length > 0 ? (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
             {filteredIcons.map((iconEntry) => (
               <IconCard key={iconEntry.name} {...iconEntry} />
             ))}

--- a/packages/react/src/components/OneFilterPicker/__test__/index.test.tsx
+++ b/packages/react/src/components/OneFilterPicker/__test__/index.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event"
 import React from "react"
 import { describe, expect, it, vi } from "vitest"
 import { defaultTranslations, I18nProvider } from "../../../lib/providers/i18n"
-import { render, screen, waitFor, within } from "../../../test-utils"
+import { render, screen, waitFor } from "../../../test-utils"
 import { OneFilterPicker } from "../index"
 import type { FiltersDefinition } from "../types"
 
@@ -450,9 +450,7 @@ describe("Presets", () => {
     )
 
     // Apply a preset
-    const visibleContainer = screen.getByTestId("overflow-visible-container")
-    const engineeringOnlyPreset =
-      within(visibleContainer).getByText("Engineering Only")
+    const engineeringOnlyPreset = screen.getByText("Engineering Only")
     await user.click(engineeringOnlyPreset)
     expect(onChange).toHaveBeenCalledWith({ department: ["engineering"] })
 
@@ -514,9 +512,7 @@ describe("Presets", () => {
     )
 
     // Click on the preset
-    const visibleContainer = screen.getByTestId("overflow-visible-container")
-    const engineeringSearchPreset =
-      within(visibleContainer).getByText("Engineering Search")
+    const engineeringSearchPreset = screen.getByText("Engineering Search")
     await user.click(engineeringSearchPreset)
 
     // Verify both filters were applied


### PR DESCRIPTION
## Description

Icon names in the icon grid are not truncated and go beyond the container with longer names. This PR uses the `OneEllipsis` component to truncate them and display a tooltip with the complete name on hover.

Also, some small styling changes related to [recent changes](https://github.com/factorialco/factorial-one/pull/2239) to the Icon component.

## Screenshots

### Before
<img width="182" height="139" alt="image" src="https://github.com/user-attachments/assets/53339e40-91ab-4c95-98c3-a101c4378e10" />

### After
https://github.com/user-attachments/assets/f4adc47f-ee2c-4a1c-99b3-caa7d49091cd


