### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.122.2",
+  "packages/react": "1.123.0",
   "packages/react-native": "0.17.0",
   "packages/core": "1.20.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.123.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.122.2...factorial-one-react-v1.123.0) (2025-07-11)
+
+
+### Features
+
+* Use ellipsis in icon names in Icons documentation ([#2246](https://github.com/factorialco/factorial-one/issues/2246)) ([d3aaa89](https://github.com/factorialco/factorial-one/commit/d3aaa89b612ecbbf21d10f81500fcb02d08827af))
+
 ## [1.122.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.122.1...factorial-one-react-v1.122.2) (2025-07-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.122.2",
+  "version": "1.123.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.123.0</summary>

## [1.123.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.122.2...factorial-one-react-v1.123.0) (2025-07-11)


### Features

* Use ellipsis in icon names in Icons documentation ([#2246](https://github.com/factorialco/factorial-one/issues/2246)) ([d3aaa89](https://github.com/factorialco/factorial-one/commit/d3aaa89b612ecbbf21d10f81500fcb02d08827af))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).