### PR TITLE
feat(Card): make Emoji avatar available

### DIFF
--- a/packages/react/src/experimental/OneCard/CardMetadata.tsx
+++ b/packages/react/src/experimental/OneCard/CardMetadata.tsx
@@ -16,7 +16,7 @@ interface CardMetadataProps {
 export function CardMetadata({ metadata }: CardMetadataProps) {
   return (
     <div className="flex h-8 items-center gap-1.5 font-medium">
-      <Icon icon={metadata.icon} className="text-f1-icon" size="md" />
+      <Icon icon={metadata.icon} color="default" size="md" />
 
       {metadata.type === "text" && (
         <div className="text-f1-foreground">{metadata.title}</div>

--- a/packages/react/src/experimental/OneCard/OneCard.stories.tsx
+++ b/packages/react/src/experimental/OneCard/OneCard.stories.tsx
@@ -147,3 +147,13 @@ export const WithChildren: Story = {
     ),
   },
 }
+
+export const WithEmoji: Story = {
+  args: {
+    ...Default.args,
+    avatar: {
+      type: "emoji",
+      emoji: "🐱",
+    },
+  },
+}

--- a/packages/react/src/experimental/OneCard/OneCard.tsx
+++ b/packages/react/src/experimental/OneCard/OneCard.tsx
@@ -6,6 +6,7 @@ import {
   Avatar,
   AvatarVariant,
 } from "@/experimental/Information/Avatars/Avatar"
+import { EmojiAvatar } from "@/experimental/Information/Avatars/EmojiAvatar"
 import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { EllipsisHorizontal } from "@/icons/app"
 import { cn, focusRing } from "@/lib/utils"
@@ -21,11 +22,15 @@ import { useState, type ReactNode } from "react"
 import { CardMetadata } from "./CardMetadata"
 import { type Metadata } from "./types"
 
+type CardAvatar =
+  | AvatarVariant
+  | { type: "emoji"; emoji: string; size?: "sm" | "md" | "lg" }
+
 interface OneCardProps {
   /**
    * The avatar to display in the card
    */
-  avatar?: AvatarVariant
+  avatar?: CardAvatar
 
   /**
    * The title of the card
@@ -148,7 +153,14 @@ export function OneCard({
           <CardHeader className="flex-col gap-0.5 p-0">
             {avatar && (
               <div className="mb-1.5 flex h-fit w-fit">
-                <Avatar avatar={avatar} size="medium" />
+                {avatar.type === "emoji" ? (
+                  <EmojiAvatar
+                    emoji={avatar.emoji}
+                    size={avatar.size || "md"}
+                  />
+                ) : (
+                  <Avatar avatar={avatar} size="medium" />
+                )}
               </div>
             )}
             <CardTitle className="flex flex-row justify-between gap-1 text-lg font-semibold text-f1-foreground">


### PR DESCRIPTION
## Description

Adds the option to use an `EmojiAvatar` as the avatar of the `Card` component. We're using it in a few designs, but it is not available yet in the code component.

## Screenshots

<img width="206" height="174" alt="image" src="https://github.com/user-attachments/assets/8b01c07a-d851-4c88-bfb6-edfe2ffafb48" />
