### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.124.0",
+  "packages/react": "1.125.0",
   "packages/react-native": "0.17.0",
   "packages/core": "1.20.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.125.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.124.0...factorial-one-react-v1.125.0) (2025-07-14)
+
+
+### Features
+
+* datacollection grouping on nested values ([#2240](https://github.com/factorialco/factorial-one/issues/2240)) ([6855042](https://github.com/factorialco/factorial-one/commit/6855042efd4fff42ae3ae1201400a13f5aba83b6))
+
 ## [1.124.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.123.0...factorial-one-react-v1.124.0) (2025-07-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.124.0",
+  "version": "1.125.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.125.0</summary>

## [1.125.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.124.0...factorial-one-react-v1.125.0) (2025-07-14)


### Features

* datacollection grouping on nested values ([#2240](https://github.com/factorialco/factorial-one/issues/2240)) ([6855042](https://github.com/factorialco/factorial-one/commit/6855042efd4fff42ae3ae1201400a13f5aba83b6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).