### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.126.0",
+  "packages/react": "1.126.1",
   "packages/react-native": "0.17.0",
   "packages/core": "1.20.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.126.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.126.0...factorial-one-react-v1.126.1) (2025-07-15)
+
+
+### Bug Fixes
+
+* table pagination padding ([#2252](https://github.com/factorialco/factorial-one/issues/2252)) ([1b17da3](https://github.com/factorialco/factorial-one/commit/1b17da350b7e8f51389b6fdb6014c03568ee9290))
+
 ## [1.126.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.125.0...factorial-one-react-v1.126.0) (2025-07-14)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.126.0",
+  "version": "1.126.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.126.1</summary>

## [1.126.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.126.0...factorial-one-react-v1.126.1) (2025-07-15)


### Bug Fixes

* table pagination padding ([#2252](https://github.com/factorialco/factorial-one/issues/2252)) ([1b17da3](https://github.com/factorialco/factorial-one/commit/1b17da350b7e8f51389b6fdb6014c03568ee9290))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).