### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.126.3",
+  "packages/react": "1.127.0",
   "packages/react-native": "0.17.0",
   "packages/core": "1.20.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.127.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.126.3...factorial-one-react-v1.127.0) (2025-07-16)
+
+
+### Features
+
+* **PageHeader:** add pressed state to product updates and actions dropdown ([#2260](https://github.com/factorialco/factorial-one/issues/2260)) ([b22a0a7](https://github.com/factorialco/factorial-one/commit/b22a0a7a61f1ec73d214949173a6f5630cc31c75))
+
 ## [1.126.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.126.2...factorial-one-react-v1.126.3) (2025-07-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.126.3",
+  "version": "1.127.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.127.0</summary>

## [1.127.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.126.3...factorial-one-react-v1.127.0) (2025-07-16)


### Features

* **PageHeader:** add pressed state to product updates and actions dropdown ([#2260](https://github.com/factorialco/factorial-one/issues/2260)) ([b22a0a7](https://github.com/factorialco/factorial-one/commit/b22a0a7a61f1ec73d214949173a6f5630cc31c75))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).