### PR TITLE
fix: change type

### DIFF
--- a/packages/react-native/src/ui/avatar.tsx
+++ b/packages/react-native/src/ui/avatar.tsx
@@ -101,7 +101,7 @@ const AvatarFallback = ({
   className,
   size = "medium",
   ...props
-}: React.ComponentPropsWithoutRef<typeof View> & {
+}: React.ComponentPropsWithoutRef<typeof Text> & {
   size?: (typeof sizes)[number];
 }) => (
   <Text


### PR DESCRIPTION
## Description

We are having this error in our repo regarding to the Expo52 bump:

<img width="650" height="197" alt="Screenshot 2025-07-17 at 09 30 58" src="https://github.com/user-attachments/assets/5e490051-4419-486f-a524-d8a3d4490c4f" />

Reference [here](https://github.com/factorialco/factorial/actions/runs/16326050588/job/46116355766?pr=72310)

So we should change the ref type to Text instead of using a View
