### PR TITLE
fix: input type extends string

### DIFF
--- a/packages/core/src/tokens/colors.ts
+++ b/packages/core/src/tokens/colors.ts
@@ -111,7 +111,7 @@ export const baseColors = {
   special: {
     highlight: "348 80% 50%",
   },
-}
+} as const
 
 export const f1Colors = {
   foreground: {
@@ -232,4 +232,4 @@ export const f1Colors = {
   link: "hsl(var(--link))",
   page: "hsl(var(--page))",
   "special-highlight": "hsl(var(--special-highlight))",
-}
+} as const

--- a/packages/react/src/experimental/Forms/Fields/Input/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Input/index.tsx
@@ -2,7 +2,7 @@ import { Input as ShadcnInput } from "@/ui/input"
 import { InputFieldProps } from "@/ui/InputField"
 import { ComponentProps, HTMLInputTypeAttribute } from "react"
 
-export type InputProps<T extends string | number> = Pick<
+export type InputProps<T extends string> = Pick<
   ComponentProps<typeof ShadcnInput>,
   "ref"
 > &
@@ -24,7 +24,13 @@ export type InputProps<T extends string | number> = Pick<
     type?: Exclude<HTMLInputTypeAttribute, "number">
   }
 
-const Input: React.FC<InputProps<string | number>> =
-  ShadcnInput as unknown as React.FC<InputProps<string | number>>
+const Input = <T extends string = string>(props: InputProps<T>) => {
+  return (
+    <ShadcnInput
+      {...props}
+      onChange={(value) => props.onChange?.(value as T)}
+    />
+  )
+}
 
 export { Input }

--- a/packages/react/src/experimental/Forms/Fields/TextArea/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/TextArea/index.tsx
@@ -18,6 +18,8 @@ export type TextareaProps = Pick<
   | "hideLabel"
   | "maxLength"
   | "clearable"
+  | "onBlur"
+  | "onFocus"
 >
 
 const Textarea: React.FC<TextareaProps> = Component(

--- a/packages/react/src/ui/textarea.tsx
+++ b/packages/react/src/ui/textarea.tsx
@@ -3,24 +3,27 @@ import * as React from "react"
 import { cn } from "../lib/utils"
 import { InputField, InputFieldProps } from "./InputField"
 
-export type TextareaProps =
-  React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
-    value?: string
-  } & Pick<
-      InputFieldProps<string>,
-      | "label"
-      | "labelIcon"
-      | "icon"
-      | "error"
-      | "hideLabel"
-      | "maxLength"
-      | "clearable"
-      | "placeholder"
-      | "onChange"
-      | "onClear"
-      | "onFocus"
-      | "onBlur"
-    >
+export type TextareaProps = Omit<
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  "onChange" | "value" | "onFocus" | "onBlur"
+> & {
+  value?: string
+} & Pick<
+    InputFieldProps<string>,
+    | "label"
+    | "labelIcon"
+    | "icon"
+    | "error"
+    | "hideLabel"
+    | "maxLength"
+    | "clearable"
+    | "placeholder"
+    | "onChange"
+    | "value"
+    | "onClear"
+    | "onFocus"
+    | "onBlur"
+  >
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   (


### PR DESCRIPTION
## Description

Input should always extend string as is the native type, this removes the union type with number to avoid misleadings
