### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.127.0",
-  "packages/react-native": "0.17.0",
+  "packages/react-native": "0.17.1",
   "packages/core": "1.20.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.17.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.17.0...factorial-one-react-native-v0.17.1) (2025-07-17)
+
+
+### Bug Fixes
+
+* change type ([#2264](https://github.com/factorialco/factorial-one/issues/2264)) ([2b5b3eb](https://github.com/factorialco/factorial-one/commit/2b5b3eb5c7800058602cceb7a2cfb2b36a1cc1af))
+
 ## [0.17.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.16.0...factorial-one-react-native-v0.17.0) (2025-06-25)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.17.1</summary>

## [0.17.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.17.0...factorial-one-react-native-v0.17.1) (2025-07-17)


### Bug Fixes

* change type ([#2264](https://github.com/factorialco/factorial-one/issues/2264)) ([2b5b3eb](https://github.com/factorialco/factorial-one/commit/2b5b3eb5c7800058602cceb7a2cfb2b36a1cc1af))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).