### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.127.0",
+  "packages/react": "1.127.1",
   "packages/react-native": "0.17.1",
-  "packages/core": "1.20.0"
+  "packages/core": "1.20.1"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.20.1](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.20.0...factorial-one-core-v1.20.1) (2025-07-17)
+
+
+### Bug Fixes
+
+* input type extends string ([#2265](https://github.com/factorialco/factorial-one/issues/2265)) ([ff995c6](https://github.com/factorialco/factorial-one/commit/ff995c6f847c5fa172874fdcffb72e697353a5e8))
+
 ## [1.20.0](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.19.0...factorial-one-core-v1.20.0) (2025-07-10)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.127.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.127.0...factorial-one-react-v1.127.1) (2025-07-17)
+
+
+### Bug Fixes
+
+* input type extends string ([#2265](https://github.com/factorialco/factorial-one/issues/2265)) ([ff995c6](https://github.com/factorialco/factorial-one/commit/ff995c6f847c5fa172874fdcffb72e697353a5e8))
+
 ## [1.127.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.126.3...factorial-one-react-v1.127.0) (2025-07-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.127.0",
+  "version": "1.127.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.127.1</summary>

## [1.127.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.127.0...factorial-one-react-v1.127.1) (2025-07-17)


### Bug Fixes

* input type extends string ([#2265](https://github.com/factorialco/factorial-one/issues/2265)) ([ff995c6](https://github.com/factorialco/factorial-one/commit/ff995c6f847c5fa172874fdcffb72e697353a5e8))
</details>

<details><summary>factorial-one-core: 1.20.1</summary>

## [1.20.1](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.20.0...factorial-one-core-v1.20.1) (2025-07-17)


### Bug Fixes

* input type extends string ([#2265](https://github.com/factorialco/factorial-one/issues/2265)) ([ff995c6](https://github.com/factorialco/factorial-one/commit/ff995c6f847c5fa172874fdcffb72e697353a5e8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).