### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.127.2",
+  "packages/react": "1.128.0",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.128.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.127.2...factorial-one-react-v1.128.0) (2025-07-17)
+
+
+### Features
+
+* Add internal Action component ([#2200](https://github.com/factorialco/factorial-one/issues/2200)) ([5de1af3](https://github.com/factorialco/factorial-one/commit/5de1af3b1824a1a863c6f3cba484cf61a30ad0d7))
+
 ## [1.127.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.127.1...factorial-one-react-v1.127.2) (2025-07-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.127.2",
+  "version": "1.128.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.128.0</summary>

## [1.128.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.127.2...factorial-one-react-v1.128.0) (2025-07-17)


### Features

* Add internal Action component ([#2200](https://github.com/factorialco/factorial-one/issues/2200)) ([5de1af3](https://github.com/factorialco/factorial-one/commit/5de1af3b1824a1a863c6f3cba484cf61a30ad0d7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).