### PR TITLE
feat(EmojiPicker): use pressed prop in trigger

### DIFF
--- a/packages/react/src/experimental/Information/Reactions/Picker/index.tsx
+++ b/packages/react/src/experimental/Information/Reactions/Picker/index.tsx
@@ -38,6 +38,7 @@ export function Picker({
           size={size}
           icon={lastEmojiReaction ? undefined : Reaction}
           emoji={lastEmojiReaction}
+          pressed={isOpen}
           onClick={(event) => {
             event.preventDefault()
             event.stopPropagation()
@@ -49,7 +50,7 @@ export function Picker({
       <PopoverContent
         side="bottom"
         align="start"
-        className="w-fit border-none bg-transparent p-2 shadow-none"
+        className="w-fit -translate-x-2 border-none bg-transparent p-2 shadow-none"
         onClick={(event) => {
           event.preventDefault()
           event.stopPropagation()


### PR DESCRIPTION
## Description

Use the `pressed` prop in the emoji picker button to leave it pressed when the picker is opened. Also tweaked the position of the popover, which was misplaced.

## Screenshots

https://github.com/user-attachments/assets/1f9048f6-1878-4885-bb00-c13142738af1
