### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.128.0",
+  "packages/react": "1.128.1",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.128.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.128.0...factorial-one-react-v1.128.1) (2025-07-21)
+
+
+### Bug Fixes
+
+* add missing modules names ([#2276](https://github.com/factorialco/factorial-one/issues/2276)) ([8d3e275](https://github.com/factorialco/factorial-one/commit/8d3e275555edd418f54e5b9dcbde646d0186870b))
+
 ## [1.128.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.127.2...factorial-one-react-v1.128.0) (2025-07-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.128.0",
+  "version": "1.128.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.128.1</summary>

## [1.128.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.128.0...factorial-one-react-v1.128.1) (2025-07-21)


### Bug Fixes

* add missing modules names ([#2276](https://github.com/factorialco/factorial-one/issues/2276)) ([8d3e275](https://github.com/factorialco/factorial-one/commit/8d3e275555edd418f54e5b9dcbde646d0186870b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).