### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.128.1",
+  "packages/react": "1.129.0",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.129.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.128.1...factorial-one-react-v1.129.0) (2025-07-21)
+
+
+### Features
+
+* **EmojiPicker:** use pressed prop in trigger ([#2271](https://github.com/factorialco/factorial-one/issues/2271)) ([65ee496](https://github.com/factorialco/factorial-one/commit/65ee496a83077d0362e2e193fe55deb109231fa4))
+
 ## [1.128.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.128.0...factorial-one-react-v1.128.1) (2025-07-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.128.1",
+  "version": "1.129.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.129.0</summary>

## [1.129.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.128.1...factorial-one-react-v1.129.0) (2025-07-21)


### Features

* **EmojiPicker:** use pressed prop in trigger ([#2271](https://github.com/factorialco/factorial-one/issues/2271)) ([65ee496](https://github.com/factorialco/factorial-one/commit/65ee496a83077d0362e2e193fe55deb109231fa4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).