### PR TITLE
fix(RichTextDisplay): enhance content processing to support line breaks

### DIFF
--- a/packages/react/src/experimental/RichText/RichTextDisplay/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextDisplay/index.tsx
@@ -12,11 +12,18 @@ type RichTextDisplayHandle = HTMLDivElement
 
 const RichTextDisplay = forwardRef<RichTextDisplayHandle, RichTextDisplayProps>(
   function RichTextDisplay({ content, className, ...props }, ref) {
+    // convert line breaks to <br> if no HTML tags are detected to be retro compatible with the old text
+    const processedContent = /<[^>]*>/.test(content)
+      ? content
+      : content.replace(/\n/g, "<br>")
+
     return (
       <div
         ref={ref}
         className={cn("rich-text-display-container", className)}
-        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
+        dangerouslySetInnerHTML={{
+          __html: DOMPurify.sanitize(processedContent),
+        }}
         {...props}
       />
     )


### PR DESCRIPTION
## Description

We need to support line-breaks if they provide us a plain text instead of an html content to be retro compatible with old content, for example: performance reviews 

