### PR TITLE
fix(PulseAvatar): icons not showing the right color

### DIFF
--- a/packages/core/src/tokens/colors.ts
+++ b/packages/core/src/tokens/colors.ts
@@ -113,9 +113,7 @@ export const baseColors = {
   },
 } as const
 
-
 export type BaseColor = keyof typeof baseColors
-
 
 export const f1Colors = {
   foreground: {
@@ -231,6 +229,13 @@ export const f1Colors = {
       DEFAULT: "hsl(var(--selected-50))",
       hover: "hsl(var(--selected-60))",
     },
+    mood: {
+      "super-negative": "hsl(var(--mood-super-negative))",
+      negative: "hsl(var(--mood-negative))",
+      neutral: "hsl(var(--mood-neutral))",
+      positive: "hsl(var(--mood-positive))",
+      "super-positive": "hsl(var(--mood-super-positive))",
+    },
   },
   ring: "hsl(var(--ring))",
   link: "hsl(var(--link))",
@@ -238,6 +243,4 @@ export const f1Colors = {
   "special-highlight": "hsl(var(--special-highlight))",
 } as const
 
-
 export type F1Color = keyof typeof f1Colors
-

--- a/packages/react/src/components/Utilities/Icon/index.tsx
+++ b/packages/react/src/components/Utilities/Icon/index.tsx
@@ -23,12 +23,33 @@ const iconVariants = cva({
   },
 })
 
+/**
+ * Utility type to extract all possible paths from nested object.
+ * Generates hyphenated paths from nested object structure
+ * Only includes parent key if it has a DEFAULT property
+ */
+type NestedKeyOf<T> = {
+  [K in keyof T & string]: T[K] extends object
+    ? K extends "DEFAULT"
+      ? never
+      : T[K] extends { DEFAULT: string }
+        ? `${K}` | `${K}-${NestedKeyOf<T[K]>}`
+        : `${K}-${NestedKeyOf<T[K]>}`
+    : K extends "DEFAULT"
+      ? never
+      : `${K}`
+}[keyof T & string]
+
 export interface IconProps
   extends SVGProps<SVGSVGElement>,
     VariantProps<typeof iconVariants> {
   icon: IconType
   state?: "normal" | "animate"
-  color?: Lowercase<keyof typeof f1Colors.icon> | `#${string}` | "currentColor"
+  color?:
+    | "default"
+    | "currentColor"
+    | `#${string}`
+    | Lowercase<NestedKeyOf<typeof f1Colors.icon>>
 }
 
 export type IconType = ForwardRefExoticComponent<

--- a/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/PulseAvatar/index.tsx
@@ -1,5 +1,5 @@
 import { Button as ActionButton } from "@/components/Actions/Button"
-import { Icon, IconType } from "@/components/Utilities/Icon"
+import { Icon, IconProps, IconType } from "@/components/Utilities/Icon"
 import {
   FaceNegative,
   FaceNeutral,
@@ -10,7 +10,6 @@ import {
 } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { Button } from "@/ui/button"
-import { cva } from "cva"
 import { AnimatePresence, motion } from "motion/react"
 import { ComponentProps, useState } from "react"
 import { EmojiImage } from "../../../../lib/emojis"
@@ -31,17 +30,13 @@ export const pulseIcon: Record<Pulse, IconType> = {
   superPositive: FaceSuperPositive,
 }
 
-export const pulseIconStyle = cva({
-  variants: {
-    pulse: {
-      superNegative: "text-[hsl(theme(colors.radical.50))]",
-      negative: "text-[hsl(theme(colors.orange.50))]",
-      neutral: "text-[hsl(theme(colors.yellow.50))]",
-      positive: "text-[hsl(theme(colors.flubber.50))]",
-      superPositive: "text-[hsl(theme(colors.grass.50))]",
-    },
-  },
-})
+export const pulseIconColor: Record<Pulse, IconProps["color"]> = {
+  superNegative: "mood-super-negative",
+  negative: "mood-negative",
+  neutral: "mood-neutral",
+  positive: "mood-positive",
+  superPositive: "mood-super-positive",
+}
 
 type BaseAvatarProps = ComponentProps<typeof BaseAvatar>
 
@@ -152,10 +147,7 @@ export const PulseAvatar = ({
                   round
                   aria-label={translations.actions.edit}
                 >
-                  <Icon
-                    icon={pulseIcon[pulse]}
-                    className={pulseIconStyle({ pulse })}
-                  />
+                  <Icon icon={pulseIcon[pulse]} color={pulseIconColor[pulse]} />
                 </Button>
               </div>
             ) : (

--- a/packages/react/src/experimental/RichText/CoreEditor/Extensions/MoodTracker/index.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/Extensions/MoodTracker/index.tsx
@@ -3,7 +3,7 @@ import { Icon } from "@/components/Utilities/Icon"
 import {
   Pulse,
   pulseIcon,
-  pulseIconStyle,
+  pulseIconColor,
 } from "@/experimental/Information/Avatars/PulseAvatar"
 import { Dropdown } from "@/experimental/Navigation/Dropdown"
 import { ChevronDown, ChevronUp, Delete } from "@/icons/app"
@@ -113,7 +113,7 @@ export const MoodTrackerView: React.FC<NodeViewProps> = ({
                       <Icon
                         icon={pulseIcon[day.mood]}
                         size="lg"
-                        className={pulseIconStyle({ pulse: day.mood })}
+                        color={pulseIconColor[day.mood]}
                       />
                     </div>
                   ))}
@@ -205,7 +205,7 @@ export const MoodTrackerView: React.FC<NodeViewProps> = ({
                         <Icon
                           icon={pulseIcon[day.mood]}
                           size="lg"
-                          className={pulseIconStyle({ pulse: day.mood })}
+                          color={pulseIconColor[day.mood]}
                         />
                       </div>
                       <p className="text-f1-text-primary text-md font-normal">


### PR DESCRIPTION
## Description

Currently, in the [factorial-one(soon-to-be-zero)]() storybook, the `PulseAvatar` icons are broken, this PR fixes them.

I have also fixed a problem with the `color` prop in the `Icon` component. When we introduced it in https://github.com/factorialco/factorial-one/pull/2239 the type only took into account the first level keys in the object, while the icon colors had nested keys (critical, critical-bold)

## Screenshots (if applicable)

Icons before:
<img width="606" height="211" alt="image" src="https://github.com/user-attachments/assets/c75e5d3c-b641-43ad-9779-686cef25ea5d" />

Icons after:
<img width="611" height="218" alt="image" src="https://github.com/user-attachments/assets/44cdf11d-ff04-4bee-a081-99712825fb3a" />

Icon color autocomplete before:
<img width="617" height="404" alt="image" src="https://github.com/user-attachments/assets/f60ece49-c9ac-44a9-afdc-a07fbeba3fac" />

Icon color autocomplete after:
<img width="616" height="401" alt="image" src="https://github.com/user-attachments/assets/6ae6530f-7120-4c85-818d-e7ee3c634a5b" />

## Implementation details

To be honest I'm not sure about adding "mood" related colors to the icon colors, feels to coupled to a feature, we could _almost_ reuse the colors we already had, but we are missing one for the "mood-positive", which uses `colors.flubber.50`, maybe we can come up with a name for it and add it.
