### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.129.1",
+  "packages/react": "1.129.2",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.129.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.129.1...factorial-one-react-v1.129.2) (2025-07-22)
+
+
+### Bug Fixes
+
+* **RichTextDisplay:** enhance content processing to support line breaks ([#2280](https://github.com/factorialco/factorial-one/issues/2280)) ([17da146](https://github.com/factorialco/factorial-one/commit/17da146147a52ac5cf1812ea611b31ffb4240875))
+
 ## [1.129.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.129.0...factorial-one-react-v1.129.1) (2025-07-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.129.1",
+  "version": "1.129.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.129.2</summary>

## [1.129.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.129.1...factorial-one-react-v1.129.2) (2025-07-22)


### Bug Fixes

* **RichTextDisplay:** enhance content processing to support line breaks ([#2280](https://github.com/factorialco/factorial-one/issues/2280)) ([17da146](https://github.com/factorialco/factorial-one/commit/17da146147a52ac5cf1812ea611b31ffb4240875))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).