### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.129.2",
+  "packages/react": "1.129.3",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.129.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.129.2...factorial-one-react-v1.129.3) (2025-07-22)
+
+
+### Bug Fixes
+
+* **RichTextDisplay:** improve HTML content handling and line break support ([#2284](https://github.com/factorialco/factorial-one/issues/2284)) ([2fc7a2a](https://github.com/factorialco/factorial-one/commit/2fc7a2a9a5d74c7111507fd42d2a960730ac2aa1))
+
 ## [1.129.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.129.1...factorial-one-react-v1.129.2) (2025-07-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.129.2",
+  "version": "1.129.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.129.3</summary>

## [1.129.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.129.2...factorial-one-react-v1.129.3) (2025-07-22)


### Bug Fixes

* **RichTextDisplay:** improve HTML content handling and line break support ([#2284](https://github.com/factorialco/factorial-one/issues/2284)) ([2fc7a2a](https://github.com/factorialco/factorial-one/commit/2fc7a2a9a5d74c7111507fd42d2a960730ac2aa1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).