### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.129.3",
+  "packages/react": "1.130.0",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.130.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.129.3...factorial-one-react-v1.130.0) (2025-07-22)
+
+
+### Features
+
+* **Card:** use DataCollection's metadata ([#2272](https://github.com/factorialco/factorial-one/issues/2272)) ([71f75f2](https://github.com/factorialco/factorial-one/commit/71f75f24df1deb0b8d41c46010a322924dad6e33))
+
 ## [1.129.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.129.2...factorial-one-react-v1.129.3) (2025-07-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.129.3",
+  "version": "1.130.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.130.0</summary>

## [1.130.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.129.3...factorial-one-react-v1.130.0) (2025-07-22)


### Features

* **Card:** use DataCollection's metadata ([#2272](https://github.com/factorialco/factorial-one/issues/2272)) ([71f75f2](https://github.com/factorialco/factorial-one/commit/71f75f24df1deb0b8d41c46010a322924dad6e33))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).