### PR TITLE
fix(Card): use `Button` for other actions

### DIFF
--- a/packages/react/src/experimental/OneCard/OneCard.tsx
+++ b/packages/react/src/experimental/OneCard/OneCard.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/Actions/Button"
 import { Link } from "@/components/Actions/Link"
-import { Icon, IconType } from "@/components/Utilities/Icon"
+import { IconType } from "@/components/Utilities/Icon"
 import { Checkbox } from "@/experimental/Forms/Fields/Checkbox"
 import {
   Avatar,
@@ -9,6 +9,7 @@ import {
 import { EmojiAvatar } from "@/experimental/Information/Avatars/EmojiAvatar"
 import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { EllipsisHorizontal } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import { cn, focusRing } from "@/lib/utils"
 import {
   Card,
@@ -118,6 +119,8 @@ export function OneCard({
   onSelect,
   onClick,
 }: OneCardProps) {
+  const translations = useI18n()
+
   const hasActions =
     primaryAction || (secondaryActions && secondaryActions?.length > 0)
   const hasOtherActions = otherActions && otherActions.length > 0
@@ -173,7 +176,7 @@ export function OneCard({
             )}
           </CardHeader>
           {(hasOtherActions || selectable) && (
-            <div className={cn("flex flex-row gap-2 [&>div]:z-[1]")}>
+            <div className="flex flex-row items-center gap-2 [&>div]:z-[1]">
               {hasOtherActions && (
                 <div
                   className={cn(
@@ -187,16 +190,15 @@ export function OneCard({
                     open={isOpen}
                     onOpenChange={setIsOpen}
                   >
-                    <button
-                      className={cn(
-                        "flex h-6 w-6 items-center justify-center rounded-sm transition-colors hover:bg-f1-background-secondary",
-                        isOpen && "bg-f1-background-secondary",
-                        focusRing()
-                      )}
-                      aria-label="Other actions"
-                    >
-                      <Icon icon={EllipsisHorizontal} size="sm" />
-                    </button>
+                    <Button
+                      label={translations.actions.other}
+                      icon={EllipsisHorizontal}
+                      variant="ghost"
+                      size="sm"
+                      round
+                      hideLabel
+                      pressed={isOpen}
+                    />
                   </Dropdown>
                 </div>
               )}

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -33,6 +33,7 @@ export const defaultTranslations = {
     more: "More",
     moveUp: "Move up",
     moveDown: "Move down",
+    other: "Other actions",
   },
   status: {
     selected: {

--- a/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
+++ b/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
@@ -29,6 +29,7 @@ describe("I18nProvider", () => {
         more: "Más",
         moveUp: "Mover arriba",
         moveDown: "Mover abajo",
+        other: "Otras acciones",
       },
     }
 


### PR DESCRIPTION
## Description

The 'Other actions' trigger in the Card component is using a native button with a styling similar to our Button component. This PR uses our actual Button component, also using the pressed prop to show when the dropdown is opened, and added a translation key for the action, which was previously hard-coded.

## Screenshots

https://github.com/user-attachments/assets/ced9d320-c858-46db-8fa0-38af69f96016
