### PR TITLE
feat: add support for full-screen on OneModal

### DIFF
--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -23,7 +23,7 @@ import { Metadata, MetadataAction, MetadataProps } from "../Metadata"
 import { Description } from "./Description"
 
 interface BaseHeaderProps {
-  title: string
+  title?: string
   avatar?:
     | {
         type: "generic"
@@ -128,146 +128,154 @@ export function BaseHeader({
 
   return (
     <div className="resource-header flex flex-col gap-3 px-6 pb-5 pt-3">
-      <div
-        className={cn(
-          "flex flex-col items-start justify-start gap-4 md:flex-row",
-          !description && "md:items-center"
-        )}
-      >
+      {(avatar || !!title || !!description) && (
         <div
           className={cn(
-            "flex grow flex-col items-start justify-start gap-3 md:flex-row md:items-start",
+            "flex flex-col items-start justify-start gap-4 md:flex-row",
             !description && "md:items-center"
           )}
         >
-          {avatar && (
-            <div className="flex items-start">
-              <Avatar
-                avatar={{
-                  ...(avatar.type === "generic"
-                    ? { ...avatar, type: "company" }
-                    : avatar),
-                }}
-                size="large"
-              />
-            </div>
-          )}
-          <div className="flex flex-col gap-1">
-            <span className="text-2xl font-semibold text-f1-foreground">
-              {title}
-            </span>
-            {description && <Description description={description} />}
-          </div>
-        </div>
-
-        {allMetadata.length > 0 && (
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
-            <Metadata items={allMetadata} />
-          </div>
-        )}
-
-        <div className="flex w-full shrink-0 flex-col gap-x-2 gap-y-3 md:hidden">
-          {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
-            <div className="w-full md:hidden [&>*]:w-full">
-              <ButtonWithTooltip
-                label={primaryAction.label}
-                onClick={primaryAction.onClick}
-                variant="default"
-                icon={primaryAction.icon}
-                size="lg"
-                disabled={primaryAction.disabled}
-                tooltip={primaryAction.tooltip}
-              />
-            </div>
-          )}
-          {isPrimaryActionVisible && isPrimaryDropdownAction(primaryAction) && (
-            <div className="w-full md:hidden [&>*]:w-full">
-              <DropdownButtonWithTooltip
-                items={primaryAction.items}
-                onClick={primaryAction.onClick}
-                variant="default"
-                value={primaryAction.value}
-                size="lg"
-                disabled={primaryAction.disabled}
-                tooltip={primaryAction.tooltip}
-              />
-            </div>
-          )}
-
-          {visibleSecondaryActions.map((action) => (
-            <Fragment key={action.label}>
-              <div className="w-full md:hidden [&>*]:w-full [&>span]:block [&>span_div]:w-full">
-                <ButtonWithTooltip
-                  label={action.label}
-                  onClick={action.onClick}
-                  variant={action.variant ?? "outline"}
-                  icon={action.icon}
-                  size="lg"
-                  disabled={action.disabled}
-                  tooltip={action.tooltip}
+          <div
+            className={cn(
+              "flex grow flex-col items-start justify-start gap-3 md:flex-row md:items-start",
+              !description && "md:items-center"
+            )}
+          >
+            {avatar && (
+              <div className="flex items-start">
+                <Avatar
+                  avatar={{
+                    ...(avatar.type === "generic"
+                      ? { ...avatar, type: "company" }
+                      : avatar),
+                  }}
+                  size="large"
                 />
               </div>
-            </Fragment>
-          ))}
+            )}
+            {(!!title || !!description) && (
+              <div className="flex flex-col gap-1">
+                {!!title && (
+                  <span className="text-2xl font-semibold text-f1-foreground">
+                    {title}
+                  </span>
+                )}
+                {description && <Description description={description} />}
+              </div>
+            )}
+          </div>
 
-          {visibleOtherActions.length > 0 && (
-            <div className="w-full [&>*]:w-full [&_button]:w-full">
-              <MobileDropdown items={visibleOtherActions} />
+          {allMetadata.length > 0 && (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
+              <Metadata items={allMetadata} />
             </div>
           )}
-        </div>
 
-        <div className="-m-1 hidden w-fit shrink-0 flex-wrap items-center gap-x-2 gap-y-2 p-1 md:flex md:overflow-x-auto">
-          {visibleOtherActions.length > 0 && (
-            <div>
-              <Dropdown items={visibleOtherActions} />
-            </div>
-          )}
-          {visibleSecondaryActions.map((action) => (
-            <Fragment key={action.label}>
+          <div className="flex w-full shrink-0 flex-col gap-x-2 gap-y-3 md:hidden">
+            {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
+              <div className="w-full md:hidden [&>*]:w-full">
+                <ButtonWithTooltip
+                  label={primaryAction.label}
+                  onClick={primaryAction.onClick}
+                  variant="default"
+                  icon={primaryAction.icon}
+                  size="lg"
+                  disabled={primaryAction.disabled}
+                  tooltip={primaryAction.tooltip}
+                />
+              </div>
+            )}
+            {isPrimaryActionVisible &&
+              isPrimaryDropdownAction(primaryAction) && (
+                <div className="w-full md:hidden [&>*]:w-full">
+                  <DropdownButtonWithTooltip
+                    items={primaryAction.items}
+                    onClick={primaryAction.onClick}
+                    variant="default"
+                    value={primaryAction.value}
+                    size="lg"
+                    disabled={primaryAction.disabled}
+                    tooltip={primaryAction.tooltip}
+                  />
+                </div>
+              )}
+
+            {visibleSecondaryActions.map((action) => (
+              <Fragment key={action.label}>
+                <div className="w-full md:hidden [&>*]:w-full [&>span]:block [&>span_div]:w-full">
+                  <ButtonWithTooltip
+                    label={action.label}
+                    onClick={action.onClick}
+                    variant={action.variant ?? "outline"}
+                    icon={action.icon}
+                    size="lg"
+                    disabled={action.disabled}
+                    tooltip={action.tooltip}
+                  />
+                </div>
+              </Fragment>
+            ))}
+
+            {visibleOtherActions.length > 0 && (
+              <div className="w-full [&>*]:w-full [&_button]:w-full">
+                <MobileDropdown items={visibleOtherActions} />
+              </div>
+            )}
+          </div>
+
+          <div className="-m-1 hidden w-fit shrink-0 flex-wrap items-center gap-x-2 gap-y-2 p-1 md:flex md:overflow-x-auto">
+            {visibleOtherActions.length > 0 && (
+              <div>
+                <Dropdown items={visibleOtherActions} />
+              </div>
+            )}
+            {visibleSecondaryActions.map((action) => (
+              <Fragment key={action.label}>
+                <div className="hidden md:block">
+                  <ButtonWithTooltip
+                    label={action.label}
+                    onClick={action.onClick}
+                    variant={action.variant ?? "outline"}
+                    icon={action.icon}
+                    disabled={action.disabled}
+                    tooltip={action.tooltip}
+                  />
+                </div>
+              </Fragment>
+            ))}
+            {isPrimaryActionVisible &&
+              (hasSecondaryActions || hasOtherActions) && (
+                <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
+              )}
+            {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
               <div className="hidden md:block">
                 <ButtonWithTooltip
-                  label={action.label}
-                  onClick={action.onClick}
-                  variant={action.variant ?? "outline"}
-                  icon={action.icon}
-                  disabled={action.disabled}
-                  tooltip={action.tooltip}
+                  label={primaryAction.label}
+                  onClick={primaryAction.onClick}
+                  variant="default"
+                  icon={primaryAction.icon}
+                  disabled={primaryAction.disabled}
+                  tooltip={primaryAction.tooltip}
                 />
               </div>
-            </Fragment>
-          ))}
-          {isPrimaryActionVisible &&
-            (hasSecondaryActions || hasOtherActions) && (
-              <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
             )}
-          {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
-            <div className="hidden md:block">
-              <ButtonWithTooltip
-                label={primaryAction.label}
-                onClick={primaryAction.onClick}
-                variant="default"
-                icon={primaryAction.icon}
-                disabled={primaryAction.disabled}
-                tooltip={primaryAction.tooltip}
-              />
-            </div>
-          )}
-          {isPrimaryActionVisible && isPrimaryDropdownAction(primaryAction) && (
-            <div className="hidden md:block">
-              <DropdownButtonWithTooltip
-                items={primaryAction.items}
-                onClick={primaryAction.onClick}
-                variant="default"
-                value={primaryAction.value}
-                size="md"
-                disabled={primaryAction.disabled}
-                tooltip={primaryAction.tooltip}
-              />
-            </div>
-          )}
+            {isPrimaryActionVisible &&
+              isPrimaryDropdownAction(primaryAction) && (
+                <div className="hidden md:block">
+                  <DropdownButtonWithTooltip
+                    items={primaryAction.items}
+                    onClick={primaryAction.onClick}
+                    variant="default"
+                    value={primaryAction.value}
+                    size="md"
+                    disabled={primaryAction.disabled}
+                    tooltip={primaryAction.tooltip}
+                  />
+                </div>
+              )}
+          </div>
         </div>
-      </div>
+      )}
       {allMetadata.length > 0 && (
         <div className="hidden flex-wrap items-center gap-x-3 gap-y-1 md:block">
           <Metadata items={allMetadata} />

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -23,7 +23,7 @@ import { Metadata, MetadataAction, MetadataProps } from "../Metadata"
 import { Description } from "./Description"
 
 interface BaseHeaderProps {
-  title?: string
+  title: string
   avatar?:
     | {
         type: "generic"
@@ -128,154 +128,146 @@ export function BaseHeader({
 
   return (
     <div className="resource-header flex flex-col gap-3 px-6 pb-5 pt-3">
-      {(avatar || !!title || !!description) && (
+      <div
+        className={cn(
+          "flex flex-col items-start justify-start gap-4 md:flex-row",
+          !description && "md:items-center"
+        )}
+      >
         <div
           className={cn(
-            "flex flex-col items-start justify-start gap-4 md:flex-row",
+            "flex grow flex-col items-start justify-start gap-3 md:flex-row md:items-start",
             !description && "md:items-center"
           )}
         >
-          <div
-            className={cn(
-              "flex grow flex-col items-start justify-start gap-3 md:flex-row md:items-start",
-              !description && "md:items-center"
-            )}
-          >
-            {avatar && (
-              <div className="flex items-start">
-                <Avatar
-                  avatar={{
-                    ...(avatar.type === "generic"
-                      ? { ...avatar, type: "company" }
-                      : avatar),
-                  }}
-                  size="large"
-                />
-              </div>
-            )}
-            {(!!title || !!description) && (
-              <div className="flex flex-col gap-1">
-                {!!title && (
-                  <span className="text-2xl font-semibold text-f1-foreground">
-                    {title}
-                  </span>
-                )}
-                {description && <Description description={description} />}
-              </div>
-            )}
+          {avatar && (
+            <div className="flex items-start">
+              <Avatar
+                avatar={{
+                  ...(avatar.type === "generic"
+                    ? { ...avatar, type: "company" }
+                    : avatar),
+                }}
+                size="large"
+              />
+            </div>
+          )}
+          <div className="flex flex-col gap-1">
+            <span className="text-2xl font-semibold text-f1-foreground">
+              {title}
+            </span>
+            {description && <Description description={description} />}
           </div>
+        </div>
 
-          {allMetadata.length > 0 && (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
-              <Metadata items={allMetadata} />
+        {allMetadata.length > 0 && (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
+            <Metadata items={allMetadata} />
+          </div>
+        )}
+
+        <div className="flex w-full shrink-0 flex-col gap-x-2 gap-y-3 md:hidden">
+          {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
+            <div className="w-full md:hidden [&>*]:w-full">
+              <ButtonWithTooltip
+                label={primaryAction.label}
+                onClick={primaryAction.onClick}
+                variant="default"
+                icon={primaryAction.icon}
+                size="lg"
+                disabled={primaryAction.disabled}
+                tooltip={primaryAction.tooltip}
+              />
+            </div>
+          )}
+          {isPrimaryActionVisible && isPrimaryDropdownAction(primaryAction) && (
+            <div className="w-full md:hidden [&>*]:w-full">
+              <DropdownButtonWithTooltip
+                items={primaryAction.items}
+                onClick={primaryAction.onClick}
+                variant="default"
+                value={primaryAction.value}
+                size="lg"
+                disabled={primaryAction.disabled}
+                tooltip={primaryAction.tooltip}
+              />
             </div>
           )}
 
-          <div className="flex w-full shrink-0 flex-col gap-x-2 gap-y-3 md:hidden">
-            {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
-              <div className="w-full md:hidden [&>*]:w-full">
+          {visibleSecondaryActions.map((action) => (
+            <Fragment key={action.label}>
+              <div className="w-full md:hidden [&>*]:w-full [&>span]:block [&>span_div]:w-full">
                 <ButtonWithTooltip
-                  label={primaryAction.label}
-                  onClick={primaryAction.onClick}
-                  variant="default"
-                  icon={primaryAction.icon}
+                  label={action.label}
+                  onClick={action.onClick}
+                  variant={action.variant ?? "outline"}
+                  icon={action.icon}
                   size="lg"
-                  disabled={primaryAction.disabled}
-                  tooltip={primaryAction.tooltip}
+                  disabled={action.disabled}
+                  tooltip={action.tooltip}
                 />
               </div>
-            )}
-            {isPrimaryActionVisible &&
-              isPrimaryDropdownAction(primaryAction) && (
-                <div className="w-full md:hidden [&>*]:w-full">
-                  <DropdownButtonWithTooltip
-                    items={primaryAction.items}
-                    onClick={primaryAction.onClick}
-                    variant="default"
-                    value={primaryAction.value}
-                    size="lg"
-                    disabled={primaryAction.disabled}
-                    tooltip={primaryAction.tooltip}
-                  />
-                </div>
-              )}
+            </Fragment>
+          ))}
 
-            {visibleSecondaryActions.map((action) => (
-              <Fragment key={action.label}>
-                <div className="w-full md:hidden [&>*]:w-full [&>span]:block [&>span_div]:w-full">
-                  <ButtonWithTooltip
-                    label={action.label}
-                    onClick={action.onClick}
-                    variant={action.variant ?? "outline"}
-                    icon={action.icon}
-                    size="lg"
-                    disabled={action.disabled}
-                    tooltip={action.tooltip}
-                  />
-                </div>
-              </Fragment>
-            ))}
+          {visibleOtherActions.length > 0 && (
+            <div className="w-full [&>*]:w-full [&_button]:w-full">
+              <MobileDropdown items={visibleOtherActions} />
+            </div>
+          )}
+        </div>
 
-            {visibleOtherActions.length > 0 && (
-              <div className="w-full [&>*]:w-full [&_button]:w-full">
-                <MobileDropdown items={visibleOtherActions} />
-              </div>
-            )}
-          </div>
-
-          <div className="-m-1 hidden w-fit shrink-0 flex-wrap items-center gap-x-2 gap-y-2 p-1 md:flex md:overflow-x-auto">
-            {visibleOtherActions.length > 0 && (
-              <div>
-                <Dropdown items={visibleOtherActions} />
-              </div>
-            )}
-            {visibleSecondaryActions.map((action) => (
-              <Fragment key={action.label}>
-                <div className="hidden md:block">
-                  <ButtonWithTooltip
-                    label={action.label}
-                    onClick={action.onClick}
-                    variant={action.variant ?? "outline"}
-                    icon={action.icon}
-                    disabled={action.disabled}
-                    tooltip={action.tooltip}
-                  />
-                </div>
-              </Fragment>
-            ))}
-            {isPrimaryActionVisible &&
-              (hasSecondaryActions || hasOtherActions) && (
-                <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
-              )}
-            {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
+        <div className="-m-1 hidden w-fit shrink-0 flex-wrap items-center gap-x-2 gap-y-2 p-1 md:flex md:overflow-x-auto">
+          {visibleOtherActions.length > 0 && (
+            <div>
+              <Dropdown items={visibleOtherActions} />
+            </div>
+          )}
+          {visibleSecondaryActions.map((action) => (
+            <Fragment key={action.label}>
               <div className="hidden md:block">
                 <ButtonWithTooltip
-                  label={primaryAction.label}
-                  onClick={primaryAction.onClick}
-                  variant="default"
-                  icon={primaryAction.icon}
-                  disabled={primaryAction.disabled}
-                  tooltip={primaryAction.tooltip}
+                  label={action.label}
+                  onClick={action.onClick}
+                  variant={action.variant ?? "outline"}
+                  icon={action.icon}
+                  disabled={action.disabled}
+                  tooltip={action.tooltip}
                 />
               </div>
+            </Fragment>
+          ))}
+          {isPrimaryActionVisible &&
+            (hasSecondaryActions || hasOtherActions) && (
+              <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
             )}
-            {isPrimaryActionVisible &&
-              isPrimaryDropdownAction(primaryAction) && (
-                <div className="hidden md:block">
-                  <DropdownButtonWithTooltip
-                    items={primaryAction.items}
-                    onClick={primaryAction.onClick}
-                    variant="default"
-                    value={primaryAction.value}
-                    size="md"
-                    disabled={primaryAction.disabled}
-                    tooltip={primaryAction.tooltip}
-                  />
-                </div>
-              )}
-          </div>
+          {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
+            <div className="hidden md:block">
+              <ButtonWithTooltip
+                label={primaryAction.label}
+                onClick={primaryAction.onClick}
+                variant="default"
+                icon={primaryAction.icon}
+                disabled={primaryAction.disabled}
+                tooltip={primaryAction.tooltip}
+              />
+            </div>
+          )}
+          {isPrimaryActionVisible && isPrimaryDropdownAction(primaryAction) && (
+            <div className="hidden md:block">
+              <DropdownButtonWithTooltip
+                items={primaryAction.items}
+                onClick={primaryAction.onClick}
+                variant="default"
+                value={primaryAction.value}
+                size="md"
+                disabled={primaryAction.disabled}
+                tooltip={primaryAction.tooltip}
+              />
+            </div>
+          )}
         </div>
-      )}
+      </div>
       {allMetadata.length > 0 && (
         <div className="hidden flex-wrap items-center gap-x-3 gap-y-1 md:block">
           <Metadata items={allMetadata} />

--- a/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
@@ -159,6 +159,13 @@ export const WithRightPosition: Story = {
   },
 }
 
+export const WithFullscreenPosition: Story = {
+  args: {
+    ...Default.args,
+    position: "fullscreen",
+  },
+}
+
 export const WithModule: Story = {
   args: {
     ...Default.args,
@@ -182,6 +189,13 @@ export const WithModule: Story = {
   },
 }
 
+export const WithModuleAndFullscreenPosition: Story = {
+  args: {
+    ...WithModule.args,
+    position: "fullscreen",
+  },
+}
+
 export const WithResourceHeader: Story = {
   args: {
     ...Default.args,
@@ -200,6 +214,43 @@ export const WithResourceHeader: Story = {
             {...(ResourceHeaderDefault.args as ComponentProps<
               typeof ResourceHeader
             >)}
+            primaryAction={undefined}
+            secondaryActions={undefined}
+            otherActions={undefined}
+          />
+        </OneModal.Content>
+      </>
+    ),
+  },
+}
+
+export const WithResourceHeaderAndFullscreenPosition: Story = {
+  args: {
+    ...WithResourceHeader.args,
+    position: "fullscreen",
+  },
+}
+
+export const WithResourceHeaderWithOnlyMetadata: Story = {
+  args: {
+    ...Default.args,
+    position: "fullscreen",
+    children: (
+      <>
+        <OneModal.Header
+          module={{
+            id: "timeoff",
+            label: "Time Off",
+            href: "/timeoff",
+          }}
+        />
+        <OneModal.Content withPadding>
+          <ResourceHeader
+            {...(ResourceHeaderDefault.args as ComponentProps<
+              typeof ResourceHeader
+            >)}
+            title=""
+            description={undefined}
             primaryAction={undefined}
             secondaryActions={undefined}
             otherActions={undefined}

--- a/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.stories.tsx
@@ -231,36 +231,6 @@ export const WithResourceHeaderAndFullscreenPosition: Story = {
   },
 }
 
-export const WithResourceHeaderWithOnlyMetadata: Story = {
-  args: {
-    ...Default.args,
-    position: "fullscreen",
-    children: (
-      <>
-        <OneModal.Header
-          module={{
-            id: "timeoff",
-            label: "Time Off",
-            href: "/timeoff",
-          }}
-        />
-        <OneModal.Content withPadding>
-          <ResourceHeader
-            {...(ResourceHeaderDefault.args as ComponentProps<
-              typeof ResourceHeader
-            >)}
-            title=""
-            description={undefined}
-            primaryAction={undefined}
-            secondaryActions={undefined}
-            otherActions={undefined}
-          />
-        </OneModal.Content>
-      </>
-    ),
-  },
-}
-
 export const WithFewItems: Story = {
   args: {
     ...Default.args,

--- a/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
@@ -2,7 +2,7 @@ import { TabsProps } from "@/experimental/Navigation/Tabs"
 import { cn } from "@/lib/utils"
 import { Dialog, DialogContent } from "@/ui/dialog"
 import { Drawer, DrawerContent, DrawerOverlay } from "@/ui/drawer"
-import React, { ComponentProps, useEffect, useState } from "react"
+import React, { ComponentProps, useEffect, useMemo, useState } from "react"
 import { OneModalContent } from "./OneModalContent/OneModalContent"
 import { OneModalHeader } from "./OneModalHeader/OneModalHeader"
 import { OneModalProvider } from "./OneModalProvider"
@@ -56,6 +56,28 @@ export const OneModal: React.FC<OneModalProps> = ({
 
   const isSmallScreen = useIsSmallScreen()
 
+  const isSidePosition = position === "left" || position === "right"
+
+  const contentClassName = useMemo(() => {
+    if (isSmallScreen && asBottomSheetInMobile) {
+      return "max-h-[95vh] bg-f1-background"
+    }
+
+    if (isSidePosition) {
+      return cn(
+        "w-full overflow-x-hidden flex flex-col absolute top-3 bottom-3 translate-y-0 translate-x-0 max-w-[539px] rounded-md border border-solid border-f1-border-secondary",
+        position === "left" && "left-3",
+        position === "right" && "left-auto right-3"
+      )
+    }
+
+    if (position === "fullscreen") {
+      return "w-[calc(100%-48px)] h-[calc(100%-48px)] overflow-x-hidden"
+    }
+
+    return "flex flex-col max-h-[620px] max-w-[680px] overflow-hidden"
+  }, [position, isSmallScreen, asBottomSheetInMobile, isSidePosition])
+
   if (isSmallScreen && asBottomSheetInMobile) {
     return (
       <OneModalProvider
@@ -66,30 +88,19 @@ export const OneModal: React.FC<OneModalProps> = ({
       >
         <Drawer open={open} onOpenChange={handleOpenChange}>
           <DrawerOverlay className="bg-f1-background-overlay" />
-          <DrawerContent className="max-h-[95vh] bg-f1-background">
-            {children}
-          </DrawerContent>
+          <DrawerContent className={contentClassName}>{children}</DrawerContent>
         </Drawer>
       </OneModalProvider>
     )
   }
 
-  let contentClassName =
-    "flex flex-col max-h-[620px] max-w-[680px] overflow-hidden"
-
-  const isSidePosition = position === "left" || position === "right"
-
-  if (isSidePosition) {
-    contentClassName = cn(
-      "w-full overflow-x-hidden flex flex-col absolute top-3 bottom-3 translate-y-0 translate-x-0 max-w-[539px] rounded-md border border-solid border-f1-border-secondary",
-      position === "left" && "left-3",
-      position === "right" && "left-auto right-3"
-    )
-  }
-
   return (
     <OneModalProvider isOpen={open} onClose={handleClose} position={position}>
-      <Dialog open={open} onOpenChange={onClose} modal={position === "center"}>
+      <Dialog
+        open={open}
+        onOpenChange={onClose}
+        modal={position === "center" || position === "fullscreen"}
+      >
         <DialogContent
           withTraslateAnimation={!isSidePosition}
           className={contentClassName}

--- a/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModalHeader/OneModalHeader.tsx
@@ -87,9 +87,11 @@ export const OneModalHeader = ({
     )
   }
 
-  if (modalPosition === "right" && !shownBottomSheet) {
+  const containerClassName = "flex flex-col gap-3 bg-f1-background p-5 pb-3"
+
+  if (module && !shownBottomSheet) {
     return (
-      <div className="flex flex-col gap-3 bg-f1-background p-5 pb-3">
+      <div className={containerClassName}>
         <div className="flex flex-row justify-between">
           {module ? <Module /> : <Actions />}
           <div className="flex flex-row gap-2">
@@ -118,7 +120,7 @@ export const OneModalHeader = ({
   }
 
   return (
-    <div className="flex flex-col gap-3 bg-f1-background p-5 pb-3">
+    <div className={containerClassName}>
       <div className="flex flex-row items-center justify-between">
         {!shownBottomSheet ? (
           !!title && (

--- a/packages/react/src/experimental/Modals/OneModal/types.ts
+++ b/packages/react/src/experimental/Modals/OneModal/types.ts
@@ -1,1 +1,1 @@
-export type ModalPosition = "center" | "left" | "right"
+export type ModalPosition = "center" | "left" | "right" | "fullscreen"

--- a/packages/react/src/ui/dialog.tsx
+++ b/packages/react/src/ui/dialog.tsx
@@ -64,7 +64,7 @@ const DialogContent = React.forwardRef<
         <DialogPrimitive.Content
           ref={ref}
           className={cn(
-            "fixed left-[50%] top-[50%] z-50 grid w-[90%] translate-x-[-50%] translate-y-[-50%] rounded-xl border bg-f1-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+            "fixed left-[50%] top-[50%] z-50 w-[90%] translate-x-[-50%] translate-y-[-50%] rounded-xl border bg-f1-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
             withTraslateAnimation &&
               "data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
             className


### PR DESCRIPTION
## Description

We need to provide a new full-screen visualization for our OneModal component as many teams have been requesting this recently for their use cases.

## Screenshots

<img width="1263" height="347" alt="Screenshot 2025-07-23 at 17 08 08" src="https://github.com/user-attachments/assets/f91e168a-aa0c-45e5-9100-be81c64ebe36" />

<img width="1263" height="347" alt="Screenshot 2025-07-23 at 17 08 29" src="https://github.com/user-attachments/assets/eec70440-bdd2-4d08-980a-300bc673303d" />

<img width="1263" height="347" alt="Screenshot 2025-07-23 at 17 08 41" src="https://github.com/user-attachments/assets/42496ed1-4fe4-4df2-8f4e-65820e7f077f" />
