### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.131.0",
+  "packages/react": "1.131.1",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.131.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.131.0...factorial-one-react-v1.131.1) (2025-07-24)
+
+
+### Bug Fixes
+
+* fullHeight ([#2274](https://github.com/factorialco/factorial-one/issues/2274)) ([e237773](https://github.com/factorialco/factorial-one/commit/e2377736d4f19a75d7fca2d5fc4ac8e558085dc0))
+
 ## [1.131.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.130.1...factorial-one-react-v1.131.0) (2025-07-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.131.0",
+  "version": "1.131.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.131.1</summary>

## [1.131.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.131.0...factorial-one-react-v1.131.1) (2025-07-24)


### Bug Fixes

* fullHeight ([#2274](https://github.com/factorialco/factorial-one/issues/2274)) ([e237773](https://github.com/factorialco/factorial-one/commit/e2377736d4f19a75d7fca2d5fc4ac8e558085dc0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).