### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.131.1",
+  "packages/react": "1.131.2",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.131.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.131.1...factorial-one-react-v1.131.2) (2025-07-24)
+
+
+### Bug Fixes
+
+* select icon classes ([f55d9ec](https://github.com/factorialco/factorial-one/commit/f55d9ecd9fc026381e84b4911997ec3266cba90a))
+
 ## [1.131.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.131.0...factorial-one-react-v1.131.1) (2025-07-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.131.1",
+  "version": "1.131.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.131.2</summary>

## [1.131.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.131.1...factorial-one-react-v1.131.2) (2025-07-24)


### Bug Fixes

* select icon classes ([f55d9ec](https://github.com/factorialco/factorial-one/commit/f55d9ecd9fc026381e84b4911997ec3266cba90a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).