### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.131.2",
+  "packages/react": "1.132.0",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.132.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.131.2...factorial-one-react-v1.132.0) (2025-07-24)
+
+
+### Features
+
+* **Avatar:** new `large` size ([#2288](https://github.com/factorialco/factorial-one/issues/2288)) ([fdb72d7](https://github.com/factorialco/factorial-one/commit/fdb72d764945cd9c92ae84ff0670a5ac089ee955))
+
 ## [1.131.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.131.1...factorial-one-react-v1.131.2) (2025-07-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.131.2",
+  "version": "1.132.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.132.0</summary>

## [1.132.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.131.2...factorial-one-react-v1.132.0) (2025-07-24)


### Features

* **Avatar:** new `large` size ([#2288](https://github.com/factorialco/factorial-one/issues/2288)) ([fdb72d7](https://github.com/factorialco/factorial-one/commit/fdb72d764945cd9c92ae84ff0670a5ac089ee955))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).