### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.132.0",
+  "packages/react": "1.132.1",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.132.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.132.0...factorial-one-react-v1.132.1) (2025-07-24)
+
+
+### Bug Fixes
+
+* **FileAvatar:** defined sizes & structured stories ([#2289](https://github.com/factorialco/factorial-one/issues/2289)) ([7172713](https://github.com/factorialco/factorial-one/commit/7172713e620f571b8089d7cae8d7c5b235d875c1))
+
 ## [1.132.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.131.2...factorial-one-react-v1.132.0) (2025-07-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.132.0",
+  "version": "1.132.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.132.1</summary>

## [1.132.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.132.0...factorial-one-react-v1.132.1) (2025-07-24)


### Bug Fixes

* **FileAvatar:** defined sizes & structured stories ([#2289](https://github.com/factorialco/factorial-one/issues/2289)) ([7172713](https://github.com/factorialco/factorial-one/commit/7172713e620f571b8089d7cae8d7c5b235d875c1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).