### PR TITLE
feat(Card): Image prop

### DIFF
--- a/packages/react/src/experimental/OneCard/CardAvatar.tsx
+++ b/packages/react/src/experimental/OneCard/CardAvatar.tsx
@@ -1,0 +1,45 @@
+import {
+  Avatar,
+  AvatarVariant,
+} from "@/experimental/Information/Avatars/Avatar"
+import { EmojiAvatar } from "@/experimental/Information/Avatars/EmojiAvatar"
+import { cn } from "@/lib/utils"
+
+type CardAvatarType =
+  | AvatarVariant
+  | { type: "emoji"; emoji: string; size?: "sm" | "md" | "lg" }
+
+interface CardAvatarProps {
+  /**
+   * The avatar to display
+   */
+  avatar: CardAvatarType
+
+  /**
+   * Whether the avatar is displayed with an overlay
+   */
+  overlay?: boolean
+}
+
+export function CardAvatar({ avatar, overlay = false }: CardAvatarProps) {
+  const isRounded = avatar.type === "person"
+
+  return (
+    <div
+      className={cn(
+        "mb-1.5 flex h-fit w-fit",
+        overlay &&
+          "absolute -top-9 left-0 rounded-md ring-[3px] ring-f1-background",
+        overlay && isRounded && "rounded-full"
+      )}
+    >
+      {avatar.type === "emoji" ? (
+        <EmojiAvatar emoji={avatar.emoji} size={avatar.size || "md"} />
+      ) : (
+        <Avatar avatar={avatar} size="medium" />
+      )}
+    </div>
+  )
+}
+
+export type { CardAvatarType }

--- a/packages/react/src/experimental/OneCard/CardOptions.tsx
+++ b/packages/react/src/experimental/OneCard/CardOptions.tsx
@@ -1,0 +1,95 @@
+import { Button } from "@/components/Actions/Button"
+import { Checkbox } from "@/experimental/Forms/Fields/Checkbox"
+import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
+import { EllipsisHorizontal } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+import { useState } from "react"
+
+interface CardOptionsProps {
+  /**
+   * Actions to display in the dropdown menu
+   */
+  otherActions?: DropdownItem[]
+
+  /**
+   * Whether the card is selectable
+   */
+  selectable?: boolean
+
+  /**
+   * Whether the card is selected
+   */
+  selected?: boolean
+
+  /**
+   * The callback to handle the selection of the card
+   */
+  onSelect?: (selected: boolean) => void
+
+  /**
+   * Title for accessibility
+   */
+  title?: string
+
+  /**
+   * Whether the options are displayed with an overlay (displayed with the image)
+   */
+  overlay?: boolean
+}
+
+export function CardOptions({
+  otherActions,
+  selectable = false,
+  selected = false,
+  onSelect,
+  title,
+  overlay = false,
+}: CardOptionsProps) {
+  const translations = useI18n()
+  const hasOtherActions = otherActions && otherActions.length > 0
+  const [isOpen, setIsOpen] = useState(false)
+
+  if (!hasOtherActions && !selectable) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex flex-row gap-2 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 [&>div]:z-[1]",
+        isOpen && "opacity-100",
+        selected && "opacity-100",
+        overlay &&
+          "absolute right-2 top-2 rounded-sm bg-f1-background/60 p-1 shadow-md backdrop-blur-sm",
+        overlay && selectable && "pr-1.5"
+      )}
+    >
+      {hasOtherActions && (
+        <div className="flex items-center justify-center">
+          <Dropdown items={otherActions} open={isOpen} onOpenChange={setIsOpen}>
+            <Button
+              label={translations.actions.other}
+              icon={EllipsisHorizontal}
+              variant="ghost"
+              size="sm"
+              round
+              hideLabel
+              pressed={isOpen}
+            />
+          </Dropdown>
+        </div>
+      )}
+      {selectable && (
+        <div className="flex items-center justify-center">
+          <Checkbox
+            title={title}
+            checked={selected}
+            onCheckedChange={onSelect}
+            hideLabel
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/react/src/experimental/OneCard/OneCard.stories.tsx
+++ b/packages/react/src/experimental/OneCard/OneCard.stories.tsx
@@ -46,6 +46,7 @@ export const Default: Story = {
       lastName: "Moreno",
     },
     title: "Daniel Moreno",
+    description: "This is a cool description",
     metadata: [
       {
         icon: Briefcase,
@@ -169,5 +170,17 @@ export const WithEmoji: Story = {
       type: "emoji",
       emoji: "🐱",
     },
+  },
+}
+
+export const WithImage: Story = {
+  args: {
+    ...Default.args,
+    selectable: true,
+    image: cat,
+  },
+  render: (args) => {
+    const [selected, setSelected] = useState(false)
+    return <OneCard {...args} selected={selected} onSelect={setSelected} />
   },
 }

--- a/packages/react/src/experimental/OneCard/OneCard.tsx
+++ b/packages/react/src/experimental/OneCard/OneCard.tsx
@@ -1,14 +1,8 @@
 import { Button } from "@/components/Actions/Button"
 import { Link } from "@/components/Actions/Link"
-import { Icon, IconType } from "@/components/Utilities/Icon"
-import { Checkbox } from "@/experimental/Forms/Fields/Checkbox"
-import {
-  Avatar,
-  AvatarVariant,
-} from "@/experimental/Information/Avatars/Avatar"
-import { EmojiAvatar } from "@/experimental/Information/Avatars/EmojiAvatar"
-import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
-import { EllipsisHorizontal } from "@/icons/app"
+import { IconType } from "@/components/Utilities/Icon"
+import { Image } from "@/components/Utilities/Image"
+import { DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { cn, focusRing } from "@/lib/utils"
 import {
   Card,
@@ -18,19 +12,22 @@ import {
   CardSubtitle,
   CardTitle,
 } from "@/ui/Card"
-import { useState, type ReactNode } from "react"
+import { type ReactNode } from "react"
+import { CardAvatar, type CardAvatarType } from "./CardAvatar"
 import { CardMetadata } from "./CardMetadata"
+import { CardOptions } from "./CardOptions"
 import { type CardMetadata as CardMetadataType } from "./types"
-
-type CardAvatar =
-  | AvatarVariant
-  | { type: "emoji"; emoji: string; size?: "sm" | "md" | "lg" }
 
 interface OneCardProps {
   /**
    * The avatar to display in the card
    */
-  avatar?: CardAvatar
+  avatar?: CardAvatarType
+
+  /**
+   * Whether the card has an image
+   */
+  image?: string
 
   /**
    * The title of the card
@@ -105,6 +102,7 @@ interface OneCardProps {
 
 export function OneCard({
   avatar,
+  image,
   title,
   description,
   metadata,
@@ -120,14 +118,12 @@ export function OneCard({
 }: OneCardProps) {
   const hasActions =
     primaryAction || (secondaryActions && secondaryActions?.length > 0)
-  const hasOtherActions = otherActions && otherActions.length > 0
-  const [isOpen, setIsOpen] = useState(false)
 
   return (
     <Card
       className={cn(
         "group relative bg-f1-background shadow-none transition-all",
-        (selectable || hasOtherActions) &&
+        (selectable || (otherActions && otherActions.length > 0)) &&
           !selected &&
           "hover:border-f1-border",
         link &&
@@ -148,22 +144,34 @@ export function OneCard({
         />
       )}
 
-      <div className="flex flex-col gap-2.5">
+      {image && (
+        <div className="relative -mx-3 -mt-3 mb-4 h-32 overflow-hidden rounded-md">
+          <Image
+            src={image}
+            alt={title}
+            className="h-full w-full object-cover"
+          />
+          <CardOptions
+            otherActions={otherActions}
+            selectable={selectable}
+            selected={selected}
+            onSelect={onSelect}
+            title={title}
+            overlay
+          />
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
         <div className="flex flex-row items-start justify-between gap-1">
-          <CardHeader className="flex-col gap-0.5 p-0">
-            {avatar && (
-              <div className="mb-1.5 flex h-fit w-fit">
-                {avatar.type === "emoji" ? (
-                  <EmojiAvatar
-                    emoji={avatar.emoji}
-                    size={avatar.size || "md"}
-                  />
-                ) : (
-                  <Avatar avatar={avatar} size="medium" />
-                )}
-              </div>
-            )}
-            <CardTitle className="flex flex-row justify-between gap-1 text-lg font-semibold text-f1-foreground">
+          <CardHeader className="relative flex-col gap-0.5 p-0">
+            {avatar && <CardAvatar avatar={avatar} overlay={!!image} />}
+            <CardTitle
+              className={cn(
+                "flex flex-row justify-between gap-1 text-lg font-semibold text-f1-foreground",
+                image && "mt-1"
+              )}
+            >
               {title}
             </CardTitle>
             {description && (
@@ -172,52 +180,14 @@ export function OneCard({
               </CardSubtitle>
             )}
           </CardHeader>
-          {(hasOtherActions || selectable) && (
-            <div className={cn("flex flex-row gap-2 [&>div]:z-[1]")}>
-              {hasOtherActions && (
-                <div
-                  className={cn(
-                    "flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100",
-                    "focus-within:opacity-100",
-                    isOpen && "opacity-100"
-                  )}
-                >
-                  <Dropdown
-                    items={otherActions}
-                    open={isOpen}
-                    onOpenChange={setIsOpen}
-                  >
-                    <button
-                      className={cn(
-                        "flex h-6 w-6 items-center justify-center rounded-sm transition-colors hover:bg-f1-background-secondary",
-                        isOpen && "bg-f1-background-secondary",
-                        focusRing()
-                      )}
-                      aria-label="Other actions"
-                    >
-                      <Icon icon={EllipsisHorizontal} size="sm" />
-                    </button>
-                  </Dropdown>
-                </div>
-              )}
-              {selectable && (
-                <div
-                  className={cn(
-                    "flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100",
-                    "focus-within:opacity-100",
-                    selected && "opacity-100",
-                    isOpen && "opacity-100"
-                  )}
-                >
-                  <Checkbox
-                    title={title}
-                    checked={selected}
-                    onCheckedChange={onSelect}
-                    hideLabel
-                  />
-                </div>
-              )}
-            </div>
+          {!image && (
+            <CardOptions
+              otherActions={otherActions}
+              selectable={selectable}
+              selected={selected}
+              onSelect={onSelect}
+              title={title}
+            />
           )}
         </div>
         <CardContent>

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -33,6 +33,7 @@ export const defaultTranslations = {
     more: "More",
     moveUp: "Move up",
     moveDown: "Move down",
+    other: "Other actions",
   },
   status: {
     selected: {

--- a/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
+++ b/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
@@ -29,6 +29,7 @@ describe("I18nProvider", () => {
         more: "Más",
         moveUp: "Mover arriba",
         moveDown: "Mover abajo",
+        other: "Otras acciones",
       },
     }
 


### PR DESCRIPTION
## Description

Added an image prop for the Card component. Also two minor changes:

- Structured some parts in different, separated components for more clarity in the main code.
- Replaced a native button with custom styling with our Button component, also adding a missing translation line.

## Screenshots

<img width="422" height="370" alt="image" src="https://github.com/user-attachments/assets/8881bd6f-c070-4dc5-9fcb-19c4d5e7d91b" />

_Card with image_


<img width="461" height="310" alt="image" src="https://github.com/user-attachments/assets/6019eecc-9977-4d77-9b2e-fe4d4df22424" />

_Card without image_

---

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Components?node-id=4598-75751&t=lcMQxWtKJJYxryWJ-4)
