### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.133.0",
+  "packages/react": "1.133.1",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.133.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.133.0...factorial-one-react-v1.133.1) (2025-07-28)
+
+
+### Bug Fixes
+
+* select icon classes and docs ([#2297](https://github.com/factorialco/factorial-one/issues/2297)) ([907ef4a](https://github.com/factorialco/factorial-one/commit/907ef4a4d402403276872eaaa8a37c2f72431516))
+
 ## [1.133.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.132.1...factorial-one-react-v1.133.0) (2025-07-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.133.0",
+  "version": "1.133.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.133.1</summary>

## [1.133.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.133.0...factorial-one-react-v1.133.1) (2025-07-28)


### Bug Fixes

* select icon classes and docs ([#2297](https://github.com/factorialco/factorial-one/issues/2297)) ([907ef4a](https://github.com/factorialco/factorial-one/commit/907ef4a4d402403276872eaaa8a37c2f72431516))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).