### PR TITLE
feat(BarChart): allow to have a different color per bar

### DIFF
--- a/packages/react/src/components/Charts/BarChart/index.stories.tsx
+++ b/packages/react/src/components/Charts/BarChart/index.stories.tsx
@@ -123,3 +123,47 @@ export const FinancialValues: Meta<
     },
   },
 }
+
+export const ColoredBars: Meta<typeof BarChart> = {
+  args: {
+    dataConfig: {
+      pulse: {
+        label: "Pulse",
+      },
+    },
+    data: [
+      {
+        label: "Struggling",
+        color: "hsl(var(--mood-super-negative))",
+        values: { pulse: 4000 },
+      },
+      {
+        label: "Not great",
+        color: "hsl(var(--mood-negative))",
+        values: { pulse: 3000 },
+      },
+      {
+        label: "Ok",
+        color: "hsl(var(--mood-neutral))",
+        values: { pulse: 2000 },
+      },
+      {
+        label: "Good",
+        color: "hsl(var(--mood-positive))",
+        values: { pulse: 1500 },
+      },
+      {
+        label: "Great",
+        color: "hsl(var(--mood-super-positive))",
+        values: { pulse: 2000 },
+      },
+    ],
+    xAxis: {
+      hide: false,
+      tickFormatter: (value: string) => value,
+    },
+    onClick: (data) => {
+      console.log("Bar clicked", data)
+    },
+  },
+}

--- a/packages/react/src/components/Charts/BarChart/index.tsx
+++ b/packages/react/src/components/Charts/BarChart/index.tsx
@@ -79,8 +79,16 @@ const _BarChart = <K extends ChartConfig>(
       }
     }
 
+    if (item.color) {
+      return {
+        ...item,
+        fill: item.color,
+      }
+    }
+
     return item
   })
+
   const maxLabelWidth = Math.max(
     ...preparedData.flatMap((el) =>
       bars.map((key) =>
@@ -185,7 +193,6 @@ const _BarChart = <K extends ChartConfig>(
               : undefined
           }
         />
-
         {bars.map((key, index) => (
           <Bar
             key={`bar-${key}`}
@@ -196,11 +203,7 @@ const _BarChart = <K extends ChartConfig>(
                 ? "stack"
                 : undefined
             }
-            fill={
-              highlightLastBar
-                ? (((data: { fill: string }) => data.fill) as unknown as string)
-                : (dataConfig[key].color ?? autoColor(index))
-            }
+            fill={dataConfig[key].color ?? autoColor(index)}
             radius={type === "stacked-by-sign" ? [4, 4, 0, 0] : 4}
             maxBarSize={32}
           >

--- a/packages/react/src/components/Charts/VerticalBarChart/index.tsx
+++ b/packages/react/src/components/Charts/VerticalBarChart/index.tsx
@@ -11,7 +11,6 @@ import {
   YAxis,
   YAxisProps,
 } from "recharts"
-import { prepareData } from "../utils/bar"
 import { autoColor } from "../utils/colors"
 import {
   cartesianGridProps,
@@ -20,6 +19,7 @@ import {
   yAxisProps as yAxisConfigureProps,
 } from "../utils/elements"
 import { fixedForwardRef } from "../utils/forwardRef"
+import { prepareData } from "../utils/muncher"
 import { ChartConfig, ChartPropsBase } from "../utils/types"
 
 const getMaxValueByKey = (

--- a/packages/react/src/components/Charts/utils/bar.ts
+++ b/packages/react/src/components/Charts/utils/bar.ts
@@ -1,5 +1,0 @@
-import { ChartConfig, ChartItem } from "./types"
-
-export function prepareData<K extends ChartConfig>(data: ChartItem<K>[]) {
-  return data.map((item) => ({ x: item.label, ...item.values }))
-}

--- a/packages/react/src/components/Charts/utils/muncher.ts
+++ b/packages/react/src/components/Charts/utils/muncher.ts
@@ -1,5 +1,9 @@
 import { ChartConfig, ChartItem } from "./types"
 
 export function prepareData<K extends ChartConfig>(data: ChartItem<K>[]) {
-  return data.map((item) => ({ x: item.label, ...item.values }))
+  return data.map((item) => ({
+    x: item.label,
+    color: item.color,
+    ...item.values,
+  }))
 }

--- a/packages/react/src/components/Charts/utils/types.ts
+++ b/packages/react/src/components/Charts/utils/types.ts
@@ -7,6 +7,7 @@ import { ComponentProps } from "react"
 
 export type ChartItem<K extends ChartConfig> = {
   label: string
+  color?: string
   values: {
     [key in keyof K]: number
   }


### PR DESCRIPTION
## Description

There are different parts of Factorial where we need to be able to color each BarChart bar independently, for example:

<details><summary>Performance</summary>
<img width="956" height="423" alt="image" src="https://github.com/user-attachments/assets/62859825-a7da-497c-928e-901cf5b4caf2" />
</details> 

<details><summary>Employee pulse</summary>
<img width="950" height="418" alt="image" src="https://github.com/user-attachments/assets/89bbcc26-8a66-4bef-b138-b0ec8022f5c5" />
</details> 

This is currently not supported, so those parts of the product still use Nivo Charts and are using a custom implementation. If want to migrate to factorial-~one~zero we need to be able to achieve this.

## Screenshots (if applicable)

<img width="1047" height="382" alt="image" src="https://github.com/user-attachments/assets/dd5d0fcb-fea7-494b-9b9c-2f1577d22e0f" />

## Implementation details

This PR allows developers to add a `color` to each `data` and it will be used if present.