### PR TITLE
fix(Checkbox): ensure size is a11y compliant

### DIFF
--- a/packages/react/src/experimental/Forms/EntitySelect/ListItem/index.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/ListItem/index.tsx
@@ -142,13 +142,9 @@ export const ListItemSingleContent = ({
           onClick={handleLabelClick}
           onKeyDown={handleKeyDown}
           className={cn(
-            "pointer-events-none ml-auto h-[20px] w-[20px] rounded-xs border-[1px] data-[state=checked]:text-f1-foreground-inverse",
+            "pointer-events-none ml-auto",
             singleSelector ? "opacity-0" : ""
           )}
-          style={{
-            backgroundColor: selected ? "hsl(var(--selected-50))" : undefined,
-            borderColor: selected ? "hsl(var(--selected-50))" : undefined,
-          }}
         />
 
         {singleSelector && selected && (
@@ -300,20 +296,7 @@ const EntitySelectListItem = ({
               setPressingLabel(false)
             }}
             data-avatarname-navigator-element="true"
-            className={cn(
-              "ml-auto h-[20px] w-[20px] rounded-xs border-[1px] data-[state=checked]:text-f1-foreground-inverse",
-              singleSelector ? "opacity-0" : ""
-            )}
-            style={{
-              backgroundColor: selected
-                ? "hsl(var(--selected-50))"
-                : "hsl(var(--background))",
-              color:
-                !selected && partialSelected
-                  ? "hsl(var(--selected-50))"
-                  : undefined,
-              borderColor: checked ? "hsl(var(--selected-50))" : undefined,
-            }}
+            className={cn("ml-auto", singleSelector ? "opacity-0" : "")}
           />
         </label>
       </div>

--- a/packages/react/src/experimental/OneCard/CardOptions.tsx
+++ b/packages/react/src/experimental/OneCard/CardOptions.tsx
@@ -57,12 +57,11 @@ export function CardOptions({
   return (
     <div
       className={cn(
-        "flex flex-row gap-2 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 [&>div]:z-[1]",
+        "flex flex-row gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 [&>div]:z-[1]",
         isOpen && "opacity-100",
         selected && "opacity-100",
         overlay &&
-          "absolute right-2 top-2 rounded-sm bg-f1-background/60 p-1 shadow-md backdrop-blur-sm",
-        overlay && selectable && "pr-1.5"
+          "absolute right-2 top-2 rounded-sm bg-f1-background/60 p-1 shadow-md backdrop-blur-sm"
       )}
     >
       {hasOtherActions && (

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
@@ -368,7 +368,7 @@ export const TableCollection = <
                       }
                     >
                       <GroupHeader
-                        className="px-4"
+                        className="px-3"
                         selectable={!!source.selectable}
                         select={statusToChecked(
                           groupAllSelectedStatus[group.key]

--- a/packages/react/src/ui/checkbox.tsx
+++ b/packages/react/src/ui/checkbox.tsx
@@ -1,5 +1,5 @@
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { AnimatePresence, motion } from "motion/react"
+import { AnimatePresence } from "motion/react"
 import * as React from "react"
 import { useId } from "react"
 import { Icon } from "../components/Utilities/Icon"
@@ -26,10 +26,10 @@ const Checkbox = React.forwardRef<
         name={checkboxId}
         aria-label={props.title}
         className={cn(
-          "h-5 w-5 shrink-0 rounded-xs border border-solid border-f1-border text-f1-foreground-selected transition-[background-color,border-color] hover:border-f1-border-hover data-[state=checked]:bg-f1-background-selected-bold data-[state=checked]:text-f1-foreground-inverse hover:data-[state=checked]:border-transparent",
+          "relative h-6 w-6 shrink-0 text-f1-foreground-selected data-[state=checked]:text-f1-foreground-inverse",
+          "after:absolute after:left-0.5 after:top-0.5 after:z-[1] after:h-5 after:w-5 after:rounded-xs after:border after:border-solid after:border-f1-border after:transition-[background-color,border-color] after:content-[''] hover:after:border-f1-border-hover data-[state=checked]:after:bg-f1-background-selected-bold hover:data-[state=checked]:after:border-transparent",
           disabled && "cursor-not-allowed opacity-50 hover:border-f1-border",
-          indeterminate &&
-            "data-[state=checked]:bg-f1-background data-[state=checked]:text-f1-foreground-selected hover:data-[state=checked]:border-f1-border-hover",
+          indeterminate && "data-[state=checked]:text-f1-foreground-inverse",
           props.checked &&
             disabled &&
             "data-[state=checked]:bg-f1-background-secondary data-[state=checked]:text-f1-foreground-secondary",
@@ -41,23 +41,12 @@ const Checkbox = React.forwardRef<
         disabled={disabled}
       >
         <AnimatePresence>
-          <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current transition-none">
-            <motion.div
-              initial={{ opacity: 0, scale: 0.6 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.6 }}
-              transition={{
-                ease: [0.175, 0.885, 0.32, 1.275],
-                duration: 0.4,
-              }}
-              className="flex items-center justify-center"
-            >
-              {indeterminate ? (
-                <Icon icon={Minus} size="sm" />
-              ) : (
-                <Icon icon={Check} size="sm" />
-              )}
-            </motion.div>
+          <CheckboxPrimitive.Indicator className="absolute inset-0 z-[2] flex items-center justify-center text-current transition-none">
+            {indeterminate ? (
+              <Icon icon={Minus} size="sm" />
+            ) : (
+              <Icon icon={Check} size="sm" />
+            )}
           </CheckboxPrimitive.Indicator>
         </AnimatePresence>
       </CheckboxPrimitive.Root>

--- a/packages/react/src/ui/table.tsx
+++ b/packages/react/src/ui/table.tsx
@@ -82,7 +82,7 @@ const TableHead = React.forwardRef<
     className={cn(
       "relative px-3 py-2.5 text-left align-middle font-medium text-f1-foreground-secondary first:pl-6 last:pr-6",
       "after:pointer-events-none after:absolute after:inset-x-0 after:inset-y-1 after:rounded after:bg-transparent after:transition-colors after:content-[''] first:after:left-3 last:after:right-3 hover:after:bg-f1-background-hover",
-      "[&:has([role=checkbox])]:px-2 [&:has([role=checkbox])]:hover:after:bg-transparent",
+      "[&:has([role=checkbox])]:px-2 [&:has([role=checkbox])]:py-2 [&:has([role=checkbox])]:hover:after:bg-transparent",
       className
     )}
     {...props}


### PR DESCRIPTION
## Description

Our current `Checkbox` target area does not meet [WCAG 2.2 minimum size](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).

This PR changes the checkbox to have a bigger target area (24 x 24px, which is the minimum), while keeping the visual size the same (20 x 20 px).

There are a few changes in how the Checkbox is used in several places to accommodate this size change.

## Screenshots

https://github.com/user-attachments/assets/f80e65f2-a2c2-4619-b99b-35dbccceaaf0
