### PR TITLE
feat(Card): responsive design

### DIFF
--- a/packages/react/src/experimental/OneCard/CardActions.tsx
+++ b/packages/react/src/experimental/OneCard/CardActions.tsx
@@ -41,45 +41,81 @@ export function CardActions({
   return (
     <CardFooter
       className={cn(
-        "justify-between gap-2 [&>div]:z-[1]",
+        "flex-col gap-2 sm:flex-row sm:justify-between [&>div]:z-[1]",
         "relative -mx-4 mt-4 border-0 border-t border-solid border-t-f1-border-secondary px-4 pt-4",
         compact && "pt-3"
       )}
     >
       {secondaryActions && (
-        <div className="flex gap-2">
-          {Array.isArray(secondaryActions) ? (
-            secondaryActions.map((action, index) => (
-              <Button
-                key={index}
-                label={action.label}
-                icon={action.icon}
-                hideLabel={index > 0}
-                round={index > 0}
-                variant="outline"
-                onClick={action.onClick}
-                size={compact ? "sm" : "md"}
-              />
-            ))
-          ) : (
-            <Link
-              href={secondaryActions.href}
-              target={secondaryActions.target}
-              disabled={secondaryActions.disabled}
-            >
-              {secondaryActions.label}
-            </Link>
-          )}
-        </div>
+        <>
+          <div className="flex w-full flex-col gap-2 sm:hidden [&_a]:justify-center [&_button]:w-full [&_div]:w-full [&_div]:justify-center">
+            {Array.isArray(secondaryActions) ? (
+              secondaryActions.map((action, index) => (
+                <Button
+                  key={index}
+                  label={action.label}
+                  icon={action.icon}
+                  variant="outline"
+                  onClick={action.onClick}
+                  size="lg"
+                />
+              ))
+            ) : (
+              <Link
+                href={secondaryActions.href}
+                target={secondaryActions.target}
+                disabled={secondaryActions.disabled}
+              >
+                {secondaryActions.label}
+              </Link>
+            )}
+          </div>
+          <div className="hidden gap-2 sm:flex">
+            {Array.isArray(secondaryActions) ? (
+              secondaryActions.map((action, index) => (
+                <Button
+                  key={index}
+                  label={action.label}
+                  icon={action.icon}
+                  hideLabel={index > 0}
+                  round={index > 0}
+                  variant="outline"
+                  onClick={action.onClick}
+                  size={compact ? "sm" : "md"}
+                />
+              ))
+            ) : (
+              <Link
+                href={secondaryActions.href}
+                target={secondaryActions.target}
+                disabled={secondaryActions.disabled}
+              >
+                {secondaryActions.label}
+              </Link>
+            )}
+          </div>
+        </>
       )}
 
       {primaryAction && (
-        <Button
-          label={primaryAction.label}
-          icon={primaryAction.icon}
-          onClick={primaryAction.onClick}
-          size={compact ? "sm" : "md"}
-        />
+        <>
+          <div className="flex w-full sm:hidden [&_button]:w-full [&_div]:w-full [&_div]:justify-center">
+            <Button
+              label={primaryAction.label}
+              icon={primaryAction.icon}
+              onClick={primaryAction.onClick}
+              size="lg"
+            />
+          </div>
+          <div className="hidden w-fit sm:flex [&_button]:w-fit [&_div]:w-full [&_div]:justify-center">
+            <Button
+              label={primaryAction.label}
+              icon={primaryAction.icon}
+              onClick={primaryAction.onClick}
+              size={compact ? "sm" : "md"}
+            />
+          </div>
+        </>
       )}
     </CardFooter>
   )

--- a/packages/react/src/experimental/OneCard/CardOptions.tsx
+++ b/packages/react/src/experimental/OneCard/CardOptions.tsx
@@ -57,7 +57,7 @@ export function CardOptions({
   return (
     <div
       className={cn(
-        "flex flex-row gap-2 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 [&>div]:z-[1]",
+        "flex flex-row gap-2 opacity-100 transition-opacity focus-within:opacity-100 group-hover:opacity-100 sm:opacity-0 [&>div]:z-[1]",
         isOpen && "opacity-100",
         selected && "opacity-100",
         overlay &&


### PR DESCRIPTION
## Description

Adapts the Card component to smaller screens, with bigger buttons that are easier to tap. Options (top-right dropdown and checkbox) are always present, instead of only appearing on hover (since you can't easily hover on mobile).

The rule is that, regardless of the Card's layout (compact or not), buttons will be displayed in large size on mobile to make them easier to tap.

## Screenshots

<img width="418" height="398" alt="image" src="https://github.com/user-attachments/assets/22fbadc8-8e92-4773-bad3-0a29a52d4fca" />

_Card on smaller screens_

---

<img width="463" height="309" alt="image" src="https://github.com/user-attachments/assets/b348c718-88f7-4490-b776-8293cd73f2a6" />

_Regular card, for comparison_
