### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.136.0",
+  "packages/react": "1.136.1",
   "packages/react-native": "0.17.1",
   "packages/core": "1.20.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.136.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.136.0...factorial-one-react-v1.136.1) (2025-07-28)
+
+
+### Bug Fixes
+
+* **Checkbox:** ensure size is a11y compliant ([#2314](https://github.com/factorialco/factorial-one/issues/2314)) ([7ae4e48](https://github.com/factorialco/factorial-one/commit/7ae4e48f234e08abb1849ff86bc63a3e6eee515e))
+
 ## [1.136.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.135.0...factorial-one-react-v1.136.0) (2025-07-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.136.0",
+  "version": "1.136.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.136.1</summary>

## [1.136.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.136.0...factorial-one-react-v1.136.1) (2025-07-28)


### Bug Fixes

* **Checkbox:** ensure size is a11y compliant ([#2314](https://github.com/factorialco/factorial-one/issues/2314)) ([7ae4e48](https://github.com/factorialco/factorial-one/commit/7ae4e48f234e08abb1849ff86bc63a3e6eee515e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).