### PR TITLE
feat: show ratios in vertical bar chart

### DIFF
--- a/packages/react/src/components/Charts/VerticalBarChart/index.stories.tsx
+++ b/packages/react/src/components/Charts/VerticalBarChart/index.stories.tsx
@@ -18,6 +18,13 @@ const meta: Meta<typeof VerticalBarChart<typeof dataConfig>> = {
       </div>
     ),
   ],
+  argTypes: {
+    showRatio: {
+      control: {
+        type: "boolean",
+      },
+    },
+  },
   args: {
     dataConfig,
     data: [
@@ -28,9 +35,7 @@ const meta: Meta<typeof VerticalBarChart<typeof dataConfig>> = {
       { label: "Recruitment Efficiency", values: { value: 100 } },
     ],
     yAxis: {
-      width: 80,
-      tickFormatter: (value: string) =>
-        `${Number.isNaN(parseFloat(value)) ? value : (parseFloat(value) / 100).toFixed(2) + "€"}`,
+      width: 100,
     },
   },
 }
@@ -60,5 +65,25 @@ export const MultipleValues: Meta<
       { label: "April", values: { mobile: 1500, desktop: 8000 } },
       { label: "May", values: { mobile: 2000, desktop: 6000 } },
     ],
+    xAxis: {
+      hide: false,
+      tickFormatter: (value: string) =>
+        `${Number.isNaN(parseFloat(value)) ? value : (parseFloat(value) / 100).toFixed(2) + "€"}`,
+    },
+    valueFormatter: (value: string | number | undefined) =>
+      `${Number.isNaN(Number(value)) ? value : (Number(value) / 100).toFixed(2) + "€"}`,
+  },
+}
+
+export const WithRatios: Meta<typeof VerticalBarChart<typeof dataConfig>> = {
+  args: {
+    dataConfig: dataConfig,
+    data: [
+      { label: "Yes", values: { value: 140 } },
+      { label: "No", values: { value: 60 } },
+    ],
+    label: true,
+    showRatio: true,
+    valueFormatter: (value: string | number | undefined) => `${value} pers.`,
   },
 }


### PR DESCRIPTION
## Description

In Surveys we want to show not only the value of the bar, but also the ratio.

## Screenshots (if applicable)

Single group:
<img width="950" height="217" alt="image" src="https://github.com/user-attachments/assets/818c2d23-b290-48f8-8a4c-9c04d9dedf72" />

Multiple groups:
<img width="837" height="231" alt="image" src="https://github.com/user-attachments/assets/477724cf-096c-4523-8306-5580feae71bf" />

[Link to Figma design](https://www.figma.com/design/zEzrsNcGNKYj9JXTQa3moF/%F0%9F%93%8B-Engagement-Surveys-Q3?node-id=2296-74692&t=1OxhVRtgjX0oyuxt-0)

## Implementation details

Since Recharts doesn't allow to have multiple labels, I've had to create that part of the SVG manually.
