### PR TITLE
fix(DataCollection): empty state types not recognized

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/empty-states.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/empty-states.stories.tsx
@@ -108,7 +108,7 @@ export const CustomMessagesAndActions: Story = {
       fetchData: createPromiseDataFetch(),
     }
 
-    const emptyStates = {
+    const emptyStates: CustomEmptyStates = {
       "no-data": {
         description: "This is a no data custom message",
         emoji: "🤷",

--- a/packages/react/src/experimental/OneDataCollection/useEmptyState.ts
+++ b/packages/react/src/experimental/OneDataCollection/useEmptyState.ts
@@ -9,7 +9,7 @@ export type EmptyState = {
   actions?: ActionProps[]
 }
 
-export const emptyStatesTypes = ["no-data", "no-results", "error"]
+export const emptyStatesTypes = ["no-data", "no-results", "error"] as const
 export type EmptyStateType = (typeof emptyStatesTypes)[number]
 
 export type CustomEmptyStates = Partial<


### PR DESCRIPTION
## Description

When implementing a `DataCollection` I realised that the `emptyState` keys were not typed properly.

## Screenshots (if applicable)

Before:
<img width="625" height="260" alt="image" src="https://github.com/user-attachments/assets/ec15beea-433e-4a26-90e7-03c467781930" />

After:
<img width="610" height="271" alt="image" src="https://github.com/user-attachments/assets/5f29b578-df48-48d2-bf9a-1f4dda1462cc" />

## Implementation details

This PR just adds `as const` to the types array so it's typed properly
