### PR TITLE
feat/numberfield append

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Checkbox/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Checkbox/index.tsx
@@ -56,6 +56,11 @@ interface CheckboxProps extends DataAttributes {
    * @default false
    */
   stopPropagation?: boolean
+
+  /**
+   * The name of the checkbox
+   */
+  name?: string
 }
 
 export function Checkbox({
@@ -69,6 +74,7 @@ export function Checkbox({
   hideLabel = false,
   presentational = false,
   stopPropagation = false,
+  name,
   ...rest
 }: CheckboxProps) {
   return (
@@ -80,6 +86,7 @@ export function Checkbox({
       indeterminate={indeterminate}
       checked={checked}
       value={value}
+      name={name}
       hideLabel={hideLabel}
       tabIndex={presentational ? -1 : undefined}
       onClick={(e) => stopPropagation && e.stopPropagation()}

--- a/packages/react/src/experimental/Forms/Fields/F1SearchBox/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F1SearchBox/index.tsx
@@ -11,7 +11,7 @@ type F1SearchBoxProps = {
   onChange?: (value: string) => void
 } & Pick<
   InputFieldProps<string>,
-  "size" | "loading" | "clearable" | "placeholder" | "disabled"
+  "size" | "loading" | "clearable" | "placeholder" | "disabled" | "name"
 >
 
 const F1SearchBox = forwardRef<HTMLInputElement, F1SearchBoxProps>(
@@ -63,6 +63,7 @@ const F1SearchBox = forwardRef<HTMLInputElement, F1SearchBoxProps>(
         size={size}
         autoFocus={props.autoFocus}
         clearable={clearable}
+        name={props.name}
       />
     )
   }

--- a/packages/react/src/experimental/Forms/Fields/Input/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Input/index.tsx
@@ -20,6 +20,7 @@ export type InputProps<T extends string> = Pick<
     | "icon"
     | "error"
     | "hideLabel"
+    | "name"
   > & {
     type?: Exclude<HTMLInputTypeAttribute, "number">
   }

--- a/packages/react/src/experimental/Forms/Fields/NumberInput/index.stories.tsx
+++ b/packages/react/src/experimental/Forms/Fields/NumberInput/index.stories.tsx
@@ -25,6 +25,10 @@ const meta = {
     maxDecimals: {
       control: { type: "number" },
     },
+    units: {
+      description: "Units to append to the value",
+      control: { type: "text" },
+    },
   },
   parameters: {
     jsx: {
@@ -52,10 +56,18 @@ export const WithStep: Story = {
     min: 1,
     max: 5,
     step: 1,
+    units: "EUR",
   },
   render: (props) => {
     const [value, setValue] = useState<number | null>(props.value ?? 1)
-    return <NumberInput {...props} value={value} onChange={setValue} />
+    return (
+      <NumberInput
+        {...props}
+        value={value}
+        onChange={setValue}
+        units={props.units}
+      />
+    )
   },
 }
 
@@ -134,5 +146,15 @@ export const Clearable: Story = {
   args: {
     label: "Label text here",
     clearable: true,
+  },
+}
+
+export const WithUnits: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    label: "Insert amount",
+    units: "EUR",
   },
 }

--- a/packages/react/src/experimental/Forms/Fields/NumberInput/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/NumberInput/index.tsx
@@ -11,7 +11,7 @@ const formatValue = (value: number, locale: string, maxDecimals?: number) =>
     useGrouping: false,
   }).format(value)
 
-type NumberInputProps = Omit<
+export type NumberInputProps = Omit<
   InputProps<string>,
   "value" | "type" | "onChange"
 > & {
@@ -22,11 +22,12 @@ type NumberInputProps = Omit<
   max?: number
   maxDecimals?: number
   onChange?: (value: number | null) => void
+  units?: string
 }
 
 export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
   function NumberInput(
-    { locale, value, maxDecimals, step, min, max, onChange, ...props },
+    { locale, value, maxDecimals, step, min, max, onChange, units, ...props },
     ref
   ) {
     const [fieldValue, setFieldValue] = useState<string>(() =>
@@ -102,6 +103,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
           inputMode="decimal"
           onChange={handleChange}
           {...props}
+          appendTag={units}
           append={<Arrows />}
         />
       </div>

--- a/packages/react/src/experimental/Forms/Fields/Select/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Select/index.tsx
@@ -45,6 +45,7 @@ export type SelectProps<T, R = any> = {
   className?: string
   selectContentClassName?: string
   actions?: Action[]
+  name?: string
 } & Pick<
   InputFieldProps<T>,
   | "loading"
@@ -127,6 +128,7 @@ const SelectComponent = forwardRef(function Select<T extends string, R>(
     labelIcon,
     clearable,
     loading,
+    name,
     ...props
   }: SelectProps<T, R>,
   ref: React.ForwardedRef<HTMLButtonElement>
@@ -248,6 +250,7 @@ const SelectComponent = forwardRef(function Select<T extends string, R>(
             clearable={clearable}
             size={size}
             loading={loading}
+            name={name}
             onClickContent={() => {
               handleChangeOpenLocal(!openLocal)
             }}

--- a/packages/react/src/experimental/Forms/Fields/TextArea/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/TextArea/index.tsx
@@ -20,6 +20,7 @@ export type TextareaProps = Pick<
   | "clearable"
   | "onBlur"
   | "onFocus"
+  | "name"
 >
 
 const Textarea: React.FC<TextareaProps> = Component(

--- a/packages/react/src/ui/InputField/AppendTag.tsx
+++ b/packages/react/src/ui/InputField/AppendTag.tsx
@@ -1,0 +1,14 @@
+import { OneEllipsis } from "@/components/OneEllipsis"
+import { cn } from "@/lib/utils"
+
+export const AppendTag = ({ text }: { text: string; disabled?: boolean }) => {
+  return (
+    <div
+      className={cn(
+        "shadow-sm flex max-w-20 items-center gap-2 rounded-sm border border-solid border-f1-border px-2 py-1 font-medium text-f1-foreground"
+      )}
+    >
+      <OneEllipsis tag="span">{text}</OneEllipsis>
+    </div>
+  )
+}

--- a/packages/react/src/ui/InputField/InputField.tsx
+++ b/packages/react/src/ui/InputField/InputField.tsx
@@ -12,6 +12,7 @@ import {
   useId,
   useState,
 } from "react"
+import { AppendTag } from "./AppendTag"
 import { InputMessages } from "./components/InputMessages"
 import { Label } from "./components/Label"
 export const INPUTFIELD_SIZES = ["sm", "md"] as const
@@ -131,6 +132,7 @@ export type InputFieldProps<T> = {
   maxLength?: number
   hideMaxLength?: boolean
   append?: React.ReactNode
+  appendTag?: string
   lengthProvider?: (value: T | undefined) => number
   loading?: boolean
 }
@@ -166,6 +168,7 @@ const InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
       onClickContent,
       name,
       role,
+      appendTag,
       "aria-controls": ariaControls,
       "aria-expanded": ariaExpanded,
       ...props
@@ -372,6 +375,7 @@ const InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
           {append && (
             <div className={cn("flex gap-2", inputElementVariants({ size }))}>
               {append}
+              {appendTag && <AppendTag text={appendTag} />}
             </div>
           )}
         </div>

--- a/packages/react/src/ui/InputField/InputField.tsx
+++ b/packages/react/src/ui/InputField/InputField.tsx
@@ -96,6 +96,7 @@ export type InputFieldProps<T> = {
   labelIcon?: IconType
   hideLabel?: boolean
   hidePlaceholder?: boolean
+  name?: string
   onClickPlaceholder?: () => void
   onClickChildren?: () => void
   onClickContent?: () => void
@@ -163,6 +164,7 @@ const InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
       onClickPlaceholder,
       onClickChildren,
       onClickContent,
+      name,
       role,
       "aria-controls": ariaControls,
       "aria-expanded": ariaExpanded,
@@ -317,6 +319,7 @@ const InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
                 "aria-label": label || placeholder,
                 "aria-busy": loading,
                 "aria-disabled": noEdit,
+                name,
                 className: cn(
                   "h-full w-full shrink flex-1 min-w-0",
                   "[&::-webkit-search-cancel-button]:hidden",

--- a/packages/react/src/ui/InputField/__stories__/InputField.stories.tsx
+++ b/packages/react/src/ui/InputField/__stories__/InputField.stories.tsx
@@ -95,6 +95,10 @@ const meta = {
     hideMaxLength: {
       description: "Whether to hide the max length indicator",
     },
+    appendTag: {
+      description: "Text to display in the append tag",
+      control: "text",
+    },
   },
   tags: ["autodocs", "internal"],
 } satisfies Meta<typeof InputField>
@@ -252,5 +256,13 @@ export const WithAppend: Story = {
         Tag
       </div>
     ),
+  },
+}
+
+export const WithAppendTag: Story = {
+  args: {
+    ...Default.args,
+    clearable: true,
+    appendTag: "Label",
   },
 }

--- a/packages/react/src/ui/checkbox.tsx
+++ b/packages/react/src/ui/checkbox.tsx
@@ -23,7 +23,7 @@ const Checkbox = React.forwardRef<
         {...props}
         ref={ref}
         id={checkboxId}
-        name={checkboxId}
+        name={props.name || checkboxId}
         aria-label={props.title}
         className={cn(
           "h-5 w-5 shrink-0 rounded-xs border border-solid border-f1-border text-f1-foreground-selected transition-[background-color,border-color] hover:border-f1-border-hover data-[state=checked]:bg-f1-background-selected-bold data-[state=checked]:text-f1-foreground-inverse hover:data-[state=checked]:border-transparent",

--- a/packages/react/src/ui/input.tsx
+++ b/packages/react/src/ui/input.tsx
@@ -55,6 +55,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       lengthProvider,
       onClickContent,
       hideLabel,
+      name,
       ...props
     },
     ref
@@ -84,6 +85,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         hideLabel={hideLabel}
         onChange={onChange}
         onClickContent={onClickContent}
+        name={name}
       >
         <input
           type={type}

--- a/packages/react/src/ui/input.tsx
+++ b/packages/react/src/ui/input.tsx
@@ -27,6 +27,7 @@ export type InputProps = Omit<
     | "onChange"
     | "role"
     | "onClickContent"
+    | "appendTag"
   >
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
@@ -52,6 +53,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       append,
       onChange,
       role,
+      appendTag,
       lengthProvider,
       onClickContent,
       hideLabel,
@@ -86,6 +88,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         onChange={onChange}
         onClickContent={onClickContent}
         name={name}
+        appendTag={appendTag}
       >
         <input
           type={type}


### PR DESCRIPTION
## Description

Add the append tag in the inputfield
-feat: use it to provide units props in number input


## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
