### PR TITLE
fix(Card): options dropdown not visible

### DIFF
--- a/packages/react/src/experimental/OneCard/components/CardOptions.tsx
+++ b/packages/react/src/experimental/OneCard/components/CardOptions.tsx
@@ -57,9 +57,8 @@ export function CardOptions({
   return (
     <div
       className={cn(
-        "flex flex-row gap-1 opacity-100 transition-opacity focus-within:opacity-100 group-hover:opacity-100 sm:opacity-0 [&>div]:z-[1]",
-        isOpen && "opacity-100",
-        selected && "opacity-100",
+        "flex flex-row gap-1 opacity-100 transition-opacity delay-150 duration-150 focus-within:delay-0 group-hover:delay-0 sm:opacity-0 focus-within:sm:opacity-100 group-hover:sm:opacity-100 [&>div]:z-[1]",
+        (isOpen || selected) && "delay-0 sm:opacity-100",
         overlay &&
           "absolute right-2 top-2 rounded-sm bg-f1-background/60 p-1 shadow-md backdrop-blur-sm"
       )}


### PR DESCRIPTION
## Description

When adding the responsive behavior in #2315, the opacity of the top-right options got bugged. This PR fixes it, also adding a bit of delay so there's no opacity flash when a dropdown option is clicked.

## Screenshots

### Before

https://github.com/user-attachments/assets/a7c6ea58-483b-4dfd-b161-17fa6abaf7c8


### After

https://github.com/user-attachments/assets/7439a778-2864-48b8-9c69-545c8d763b31
