### PR TITLE
feat: improve one-card to can do the kanban-view

### DIFF
--- a/packages/react/src/experimental/OneCard/OneCard.tsx
+++ b/packages/react/src/experimental/OneCard/OneCard.tsx
@@ -175,7 +175,13 @@ export function OneCard({
             )}
           >
             {avatar && (
-              <CardAvatar avatar={avatar} overlay={!!image} compact={compact} />
+              <CardAvatar
+                avatar={avatar}
+                overlay={!!image}
+                compact={compact}
+                title={title}
+                description={description}
+              />
             )}
             <div className="flex flex-col gap-0">
               <CardTitle
@@ -186,7 +192,7 @@ export function OneCard({
               >
                 {title}
               </CardTitle>
-              {description && (
+              {description && title && (
                 <CardSubtitle className="line-clamp-3 text-base text-f1-foreground-secondary">
                   {description}
                 </CardSubtitle>

--- a/packages/react/src/experimental/OneCard/__stories__/OneCard.stories.tsx
+++ b/packages/react/src/experimental/OneCard/__stories__/OneCard.stories.tsx
@@ -65,6 +65,7 @@ export const Default: Story = {
       },
       {
         icon: CalendarArrowRight,
+        tooltip: "Hired",
         property: {
           type: "text",
           value: "3 years ago",
@@ -126,6 +127,7 @@ export const WithActions: Story = {
     metadata: [
       {
         icon: Office,
+        tooltip: "Location",
         property: {
           type: "tag",
           value: {
@@ -135,6 +137,7 @@ export const WithActions: Story = {
       },
       {
         icon: Calendar,
+        tooltip: "Hired",
         property: {
           type: "text",
           value: "10 months ago",
@@ -202,30 +205,64 @@ export const WithEmoji: Story = {
   },
 }
 
-export const WithImage: Story = {
-  args: {
-    ...Default.args,
-    selectable: true,
-    image: image,
-  },
-  render: (args) => {
-    const [selected, setSelected] = useState(false)
-    return <OneCard {...args} selected={selected} onSelect={setSelected} />
-  },
-}
-
 export const WithFileAvatar: Story = {
   parameters: {
     chromatic: { disableSnapshot: true },
   },
   args: {
-    ...WithImage.args,
-    selectable: true,
-    image: image,
+    ...Default.args,
     avatar: {
       type: "file",
       file: new File([""], "document.pdf", { type: "application/pdf" }),
     },
+  },
+}
+
+export const WithPersonAvatar: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    ...Default.args,
+    avatar: {
+      type: "person",
+      firstName: "Daniel",
+      lastName: "Moreno",
+    },
+  },
+}
+
+export const WithTeamAvatar: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    ...Default.args,
+    avatar: {
+      type: "team",
+      name: "Design Team",
+    },
+  },
+}
+
+export const WithCompanyAvatar: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    ...Default.args,
+    avatar: {
+      type: "company",
+      name: "Test de verdad",
+    },
+  },
+}
+
+export const WithImage: Story = {
+  args: {
+    ...Default.args,
+    selectable: true,
+    image: image,
   },
   render: (args) => {
     const [selected, setSelected] = useState(false)

--- a/packages/react/src/experimental/OneCard/components/CardAvatar.tsx
+++ b/packages/react/src/experimental/OneCard/components/CardAvatar.tsx
@@ -26,22 +26,66 @@ interface CardAvatarProps {
    * Whether the avatar is displayed in a compact layout
    */
   compact?: boolean
+
+  /**
+   * The title to display
+   */
+  title?: string
+
+  /**
+   * The description to display
+   */
+  description?: string
 }
 
-const AvatarRender = ({ avatar }: { avatar: CardAvatarType }) => {
+const AvatarRender = ({
+  avatar,
+  title = "",
+  description = "",
+}: {
+  avatar: CardAvatarType
+  title?: string
+  description?: string
+}) => {
+  let avatarElement = null
+  let titleElement = title
   if (avatar.type === "emoji") {
-    return <EmojiAvatar emoji={avatar.emoji} size="lg" />
+    avatarElement = <EmojiAvatar emoji={avatar.emoji} size={"lg"} />
+  } else if (avatar.type === "file") {
+    avatarElement = <FileAvatar file={avatar.file} size={"large"} />
+  } else {
+    avatarElement = (
+      <Avatar avatar={avatar} size={description ? "large" : "small"} />
+    )
+    if (avatar.type === "person") {
+      titleElement = `${avatar.firstName} ${avatar.lastName}`
+    } else {
+      titleElement = avatar.name
+    }
   }
-  if (avatar.type === "file") {
-    return <FileAvatar file={avatar.file} size="large" />
-  }
-  return <Avatar avatar={avatar} size="large" />
+  return !title ? (
+    <div className="flex flex-row items-center gap-2">
+      {avatarElement}
+      <div className="flex flex-col gap-0">
+        <span className="text-lg font-semibold text-f1-foreground">
+          {titleElement}
+        </span>
+        <span className="line-clamp-1 text-base text-f1-foreground-secondary">
+          {description}
+        </span>
+      </div>
+    </div>
+  ) : (
+    avatarElement
+  )
 }
 
 export function CardAvatar({
   avatar,
   overlay = false,
   compact = false,
+  description = "",
+  title = "",
 }: CardAvatarProps) {
   const isRounded = avatar.type === "person"
 
@@ -57,7 +101,7 @@ export function CardAvatar({
       )}
       data-testid="card-avatar"
     >
-      <AvatarRender avatar={avatar} />
+      <AvatarRender avatar={avatar} title={title} description={description} />
     </div>
   )
 }

--- a/packages/react/src/experimental/OneCard/components/CardMetadata.tsx
+++ b/packages/react/src/experimental/OneCard/components/CardMetadata.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@/components/Utilities/Icon"
+import { Tooltip } from "@/experimental"
 import { propertyRenderers } from "@/experimental/OneDataCollection/visualizations/property"
 import React from "react"
 import { CardMetadata as CardMetadataType } from "../types"
@@ -30,10 +31,18 @@ export function CardMetadata({ metadata }: CardMetadataProps) {
 
   const renderer = cardPropertyRenderers[type as CardPropertyType]
 
+  const iconWithTooltip = metadata.tooltip ? (
+    <Tooltip description={metadata.tooltip}>
+      <Icon icon={metadata.icon} color="default" size="md" />
+    </Tooltip>
+  ) : (
+    <Icon icon={metadata.icon} color="default" size="md" />
+  )
+
   if (!renderer) {
     return (
       <div className="flex h-8 items-center gap-1.5 font-medium">
-        <Icon icon={metadata.icon} color="default" size="md" />
+        {iconWithTooltip}
         <span>Unsupported property type: {type}</span>
       </div>
     )
@@ -46,7 +55,7 @@ export function CardMetadata({ metadata }: CardMetadataProps) {
 
   return (
     <div className="flex h-8 items-center gap-1.5 font-medium">
-      <Icon icon={metadata.icon} color="default" size="md" />
+      {iconWithTooltip}
       {typedRenderer(value, { visualization: "card" })}
     </div>
   )

--- a/packages/react/src/experimental/OneCard/types.ts
+++ b/packages/react/src/experimental/OneCard/types.ts
@@ -15,5 +15,6 @@ export type CardMetadataProperty = {
 
 export type CardMetadata = {
   icon: IconType
+  tooltip?: string
   property: CardMetadataProperty
 }


### PR DESCRIPTION
## Description

First step to achieve the kanban view. This PR focus on prepare the OneCard to can be used in the kanban view.

## Screenshots (if applicable)

[Link to Figma Design](https://www.figma.com/design/LHwRuF7PZBAMhi98O9jtY7/05-03-2025---Kanban?node-id=5-3562&p=f&t=oQybjpFtSN6O3slo-0)

## Implementation details


https://github.com/user-attachments/assets/dca4af39-bf88-4793-8b4d-66b0f336c924


