### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.141.0",
+  "packages/react": "1.141.1",
   "packages/react-native": "0.17.1",
   "packages/core": "1.21.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.141.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.141.0...factorial-one-react-v1.141.1) (2025-07-30)
+
+
+### Bug Fixes
+
+* **Card:** options dropdown not visible ([#2329](https://github.com/factorialco/factorial-one/issues/2329)) ([11706fa](https://github.com/factorialco/factorial-one/commit/11706fad37a26620a18b05d91c742a411750353c))
+
 ## [1.141.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.140.0...factorial-one-react-v1.141.0) (2025-07-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.141.0",
+  "version": "1.141.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.141.1</summary>

## [1.141.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.141.0...factorial-one-react-v1.141.1) (2025-07-30)


### Bug Fixes

* **Card:** options dropdown not visible ([#2329](https://github.com/factorialco/factorial-one/issues/2329)) ([11706fa](https://github.com/factorialco/factorial-one/commit/11706fad37a26620a18b05d91c742a411750353c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).