### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.143.0",
+  "packages/react": "1.144.0",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.144.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.143.0...factorial-one-react-v1.144.0) (2025-07-31)
+
+
+### Features
+
+* **Card:** internal card with private props ([#2336](https://github.com/factorialco/factorial-one/issues/2336)) ([365e76d](https://github.com/factorialco/factorial-one/commit/365e76d9a6c7f751a8f13a886a684f178fac19bd))
+
 ## [1.143.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.142.0...factorial-one-react-v1.143.0) (2025-07-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.143.0",
+  "version": "1.144.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.144.0</summary>

## [1.144.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.143.0...factorial-one-react-v1.144.0) (2025-07-31)


### Features

* **Card:** internal card with private props ([#2336](https://github.com/factorialco/factorial-one/issues/2336)) ([365e76d](https://github.com/factorialco/factorial-one/commit/365e76d9a6c7f751a8f13a886a684f178fac19bd))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).