### PR TITLE
feat(Card): set compact header

### DIFF
--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -178,23 +178,33 @@ export function CardInternal({
             className={cn(
               "relative flex-col gap-0 p-0",
               image && !compact && "pt-3",
-              compact && "flex-row items-center gap-2.5"
+              compact && "flex-row items-center gap-2"
             )}
           >
             {avatar && (
               <CardAvatar avatar={avatar} overlay={!!image} compact={compact} />
             )}
-            <div className="flex flex-col gap-0">
+            <div
+              className={cn(
+                "flex flex-col gap-0",
+                compact && "flex-row items-center gap-2"
+              )}
+            >
               <CardTitle
                 className={cn(
                   "flex flex-row justify-between gap-1 text-lg font-semibold text-f1-foreground",
-                  compact && "text-base"
+                  compact && "shrink-0 text-base"
                 )}
               >
                 {title}
               </CardTitle>
               {description && (
-                <CardSubtitle className="line-clamp-3 text-base text-f1-foreground-secondary">
+                <CardSubtitle
+                  className={cn(
+                    "line-clamp-3 text-base text-f1-foreground-secondary",
+                    compact && "line-clamp-1"
+                  )}
+                >
                   {description}
                 </CardSubtitle>
               )}

--- a/packages/react/src/components/F0Card/components/CardAvatar.tsx
+++ b/packages/react/src/components/F0Card/components/CardAvatar.tsx
@@ -28,14 +28,20 @@ interface CardAvatarProps {
   compact?: boolean
 }
 
-const AvatarRender = ({ avatar }: { avatar: CardAvatarType }) => {
+const AvatarRender = ({
+  avatar,
+  compact = false,
+}: {
+  avatar: CardAvatarType
+  compact?: boolean
+}) => {
   if (avatar.type === "emoji") {
-    return <EmojiAvatar emoji={avatar.emoji} size="lg" />
+    return <EmojiAvatar emoji={avatar.emoji} size={compact ? "sm" : "lg"} />
   }
   if (avatar.type === "file") {
-    return <FileAvatar file={avatar.file} size="large" />
+    return <FileAvatar file={avatar.file} size={compact ? "small" : "large"} />
   }
-  return <Avatar avatar={avatar} size="large" />
+  return <Avatar avatar={avatar} size={compact ? "small" : "large"} />
 }
 
 export function CardAvatar({
@@ -57,7 +63,7 @@ export function CardAvatar({
       )}
       data-testid="card-avatar"
     >
-      <AvatarRender avatar={avatar} />
+      <AvatarRender avatar={avatar} compact={compact} />
     </div>
   )
 }

--- a/packages/react/src/components/F0Card/components/CardAvatar.tsx
+++ b/packages/react/src/components/F0Card/components/CardAvatar.tsx
@@ -36,7 +36,9 @@ const AvatarRender = ({
   compact?: boolean
 }) => {
   if (avatar.type === "emoji") {
-    return <EmojiAvatar emoji={avatar.emoji} size={compact ? "sm" : "lg"} />
+    return (
+      <EmojiAvatar emoji={avatar.emoji} size={compact ? "small" : "large"} />
+    )
   }
   if (avatar.type === "file") {
     return <FileAvatar file={avatar.file} size={compact ? "small" : "large"} />

--- a/packages/react/src/experimental/Information/Avatars/EmojiAvatar/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Avatars/EmojiAvatar/index.stories.tsx
@@ -8,12 +8,12 @@ const meta: Meta<typeof EmojiAvatar> = {
   argTypes: {
     size: {
       control: "select",
-      options: ["sm", "md", "lg"],
+      options: ["small", "medium", "large"],
     },
   },
   args: {
     emoji: "🍑",
-    size: "md",
+    size: "medium",
   },
   parameters: {
     a11y: {

--- a/packages/react/src/experimental/Information/Avatars/EmojiAvatar/index.tsx
+++ b/packages/react/src/experimental/Information/Avatars/EmojiAvatar/index.tsx
@@ -3,22 +3,22 @@ import { cn } from "../../../../lib/utils"
 
 type Props = {
   emoji: string
-  size?: "sm" | "md" | "lg"
+  size?: "small" | "medium" | "large"
 }
 
 const sizes = {
-  sm: "w-6 h-6 rounded-sm",
-  md: "w-9 h-9 rounded",
-  lg: "w-10 h-10 rounded-md",
+  small: "w-6 h-6 rounded-sm",
+  medium: "w-9 h-9 rounded",
+  large: "w-10 h-10 rounded-md",
 }
 
 const imageSizes = {
-  sm: "xs",
-  md: "sm",
-  lg: "md",
+  small: "xs",
+  medium: "sm",
+  large: "md",
 } as const
 
-export const EmojiAvatar = ({ emoji, size = "md" }: Props) => {
+export const EmojiAvatar = ({ emoji, size = "medium" }: Props) => {
   // Check if emoji is a single emoji character using regex
   // \uFE0F is the variation selector that makes emojis display as colored graphics instead of black & white text
   const emojiRegex = /^\p{Emoji}\uFE0F?$/u

--- a/packages/react/src/experimental/OneEmptyState/OneEmptyState.tsx
+++ b/packages/react/src/experimental/OneEmptyState/OneEmptyState.tsx
@@ -13,7 +13,7 @@ export function OneEmptyState({
 }: Types.OneEmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center gap-5 p-8">
-      {variant === "default" && <EmojiAvatar emoji={emoji!} size="lg" />}
+      {variant === "default" && <EmojiAvatar emoji={emoji!} size="large" />}
       {variant !== "default" && <AlertAvatar type={variant} size="lg" />}
       <div className="flex flex-col items-center justify-center gap-0.5">
         <p className="text-center text-lg font-medium text-f1-foreground">


### PR DESCRIPTION
## Description

Changes the header (avatar + title and description) to fit the compact layout, displaying everything inline. Figma is already updated.

## Screenshots

<img width="430" height="170" alt="Screenshot 2025-07-31 at 15 16 46" src="https://github.com/user-attachments/assets/6dcdb553-bf1f-4272-bb05-cc7ca3750f65" />

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Components?node-id=14199-59953&t=XK5iIrWZx0EhylDS-4)
