### PR TITLE
fix(Card): avoid multiple actions rendering

### DIFF
--- a/packages/react/src/components/F0Card/__tests__/Card.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/Card.test.tsx
@@ -121,7 +121,7 @@ describe("F0Card Component", () => {
     const card = screen.getByTestId("card")
     expect(card).toBeInTheDocument()
 
-    const primaryButton = screen.getByTestId("primary-button-web")
+    const primaryButton = screen.getByTestId("primary-button")
     expect(primaryButton).toBeInTheDocument()
 
     await user.click(primaryButton)
@@ -146,7 +146,7 @@ describe("F0Card Component", () => {
     const card = screen.getByTestId("card")
     expect(card).toBeInTheDocument()
 
-    const primaryButton = screen.getByTestId("primary-button-mobile")
+    const primaryButton = screen.getByTestId("primary-button")
     expect(primaryButton).toBeInTheDocument()
 
     await user.click(primaryButton)
@@ -166,7 +166,7 @@ describe("F0Card Component", () => {
     const card = screen.getByTestId("card")
     expect(card).toBeInTheDocument()
 
-    const linkElement = screen.getByTestId("secondary-link-web")
+    const linkElement = screen.getByTestId("secondary-link")
     expect(linkElement).toBeInTheDocument()
     expect(linkElement).toHaveAttribute("href", "/test-page")
     expect(linkElement).toHaveAttribute("target", "_blank")

--- a/packages/react/src/components/F0Card/components/CardActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardActions.tsx
@@ -3,6 +3,7 @@ import { Link, type LinkProps } from "@/components/Actions/Link"
 import { IconType } from "@/components/Utilities/Icon"
 import { cn } from "@/lib/utils"
 import { CardFooter } from "@/ui/Card"
+import { useMediaQuery } from "usehooks-ts"
 
 export interface CardPrimaryAction {
   label: string
@@ -32,6 +33,7 @@ export function CardActions({
   secondaryActions,
   compact = false,
 }: CardActionsProps) {
+  const isDesktop = useMediaQuery("(min-width: 640px)")
   const hasActions = primaryAction || secondaryActions
 
   if (!hasActions) {
@@ -47,78 +49,43 @@ export function CardActions({
       )}
     >
       {secondaryActions && (
-        <>
-          <div className="flex w-full flex-col gap-2 sm:hidden [&_a]:justify-center [&_button]:w-full [&_div]:w-full [&_div]:justify-center">
-            {Array.isArray(secondaryActions) ? (
-              secondaryActions.map((action, index) => (
-                <Button
-                  key={index}
-                  label={action.label}
-                  icon={action.icon}
-                  variant="outline"
-                  onClick={action.onClick}
-                  size="lg"
-                />
-              ))
-            ) : (
-              <Link
-                href={secondaryActions.href}
-                target={secondaryActions.target}
-                disabled={secondaryActions.disabled}
-              >
-                {secondaryActions.label}
-              </Link>
-            )}
-          </div>
-          <div className="hidden gap-2 sm:flex">
-            {Array.isArray(secondaryActions) ? (
-              secondaryActions.map((action, index) => (
-                <Button
-                  key={index}
-                  label={action.label}
-                  icon={action.icon}
-                  hideLabel={index > 0}
-                  round={index > 0}
-                  variant="outline"
-                  onClick={action.onClick}
-                  size={compact ? "sm" : "md"}
-                />
-              ))
-            ) : (
-              <Link
-                href={secondaryActions.href}
-                target={secondaryActions.target}
-                disabled={secondaryActions.disabled}
-                data-testid="secondary-link-web"
-              >
-                {secondaryActions.label}
-              </Link>
-            )}
-          </div>
-        </>
+        <div className="flex w-full flex-col gap-2 sm:flex-row [&_a]:justify-center sm:[&_a]:justify-start [&_button]:w-full sm:[&_button]:w-fit [&_div]:w-full [&_div]:justify-center sm:[&_div]:w-fit">
+          {Array.isArray(secondaryActions) ? (
+            secondaryActions.map((action, index) => (
+              <Button
+                key={index}
+                label={action.label}
+                icon={action.icon}
+                variant="outline"
+                onClick={action.onClick}
+                hideLabel={isDesktop && index > 0}
+                round={isDesktop && index > 0}
+                size={isDesktop ? (compact ? "sm" : "md") : "lg"}
+              />
+            ))
+          ) : (
+            <Link
+              href={secondaryActions.href}
+              target={secondaryActions.target}
+              disabled={secondaryActions.disabled}
+              data-testid="secondary-link"
+            >
+              {secondaryActions.label}
+            </Link>
+          )}
+        </div>
       )}
 
       {primaryAction && (
-        <>
-          <div className="flex w-full sm:hidden [&_button]:w-full [&_div]:w-full [&_div]:justify-center">
-            <Button
-              label={primaryAction.label}
-              icon={primaryAction.icon}
-              onClick={primaryAction.onClick}
-              size="lg"
-              data-testid="primary-button-mobile"
-            />
-          </div>
-          <div className="hidden w-fit sm:flex [&_button]:w-fit [&_div]:w-full [&_div]:justify-center">
-            <Button
-              label={primaryAction.label}
-              icon={primaryAction.icon}
-              onClick={primaryAction.onClick}
-              size={compact ? "sm" : "md"}
-              data-testid="primary-button-web"
-            />
-          </div>
-        </>
+        <div className="w-full sm:w-fit [&_button]:w-full sm:[&_button]:w-fit [&_div]:w-full [&_div]:justify-center">
+          <Button
+            label={primaryAction.label}
+            icon={primaryAction.icon}
+            onClick={primaryAction.onClick}
+            size={isDesktop ? (compact ? "sm" : "md") : "lg"}
+            data-testid="primary-button"
+          />
+        </div>
       )}
     </CardFooter>
   )


### PR DESCRIPTION
## Description

I introduced some tweaks for the Card in #2315 regarding responsiveness. The idea was to make it work with pure CSS, but since the action buttons have some logic (like different sizes depending on screen size), I rendered multiple buttons and show/hide them based on the breakpoint.

This works, but the component ends up rendering the same button twice, which causes some tests to fail. That's why I'm fixing this using `useMediaQuery`, to keep the button logic, but only render one button.

## Screenshots

<img width="400" height="379" alt="image" src="https://github.com/user-attachments/assets/5f6c9433-fd06-4c72-b7df-d54e58a3cc4d" />

_Mobile layout Card_
