### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.145.0",
+  "packages/react": "1.145.1",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.145.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.145.0...factorial-one-react-v1.145.1) (2025-07-31)
+
+
+### Bug Fixes
+
+* **Card:** avoid multiple actions rendering ([#2349](https://github.com/factorialco/factorial-one/issues/2349)) ([9caa59e](https://github.com/factorialco/factorial-one/commit/9caa59e34d9cc235c781a981c4cb683146959b8a))
+
 ## [1.145.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.144.1...factorial-one-react-v1.145.0) (2025-07-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.145.0",
+  "version": "1.145.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.145.1</summary>

## [1.145.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.145.0...factorial-one-react-v1.145.1) (2025-07-31)


### Bug Fixes

* **Card:** avoid multiple actions rendering ([#2349](https://github.com/factorialco/factorial-one/issues/2349)) ([9caa59e](https://github.com/factorialco/factorial-one/commit/9caa59e34d9cc235c781a981c4cb683146959b8a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).