### PR TITLE
feat(Card): add skeleton

### DIFF
--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -9,6 +9,7 @@ import {
   CardSubtitle,
   CardTitle,
 } from "@/ui/Card"
+import { Skeleton } from "@/ui/skeleton"
 import { type ReactNode } from "react"
 import {
   CardActions,
@@ -242,6 +243,51 @@ export function CardInternal({
         secondaryActions={secondaryActions}
         compact={compact}
       />
+    </Card>
+  )
+}
+
+export const CardSkeleton = ({ compact = false }: { compact?: boolean }) => {
+  return (
+    <Card
+      className={cn(
+        "group relative flex flex-col gap-2 bg-f1-background p-4 shadow-none",
+        compact && "p-3"
+      )}
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <CardHeader
+        className={cn(
+          "flex flex-col gap-2.5 p-0",
+          compact && "flex-row items-center gap-2"
+        )}
+      >
+        <Skeleton
+          className={cn("h-10 w-10 rounded-full", compact && "h-6 w-6")}
+        />
+        <div
+          className={cn(
+            "flex flex-col gap-0",
+            compact && "flex-row items-center gap-1.5"
+          )}
+        >
+          <CardTitle className="flex h-6 items-center">
+            <Skeleton className={cn("h-4 w-20 rounded-md", compact && "h-3")} />
+          </CardTitle>
+          <CardSubtitle className="flex h-5 items-center">
+            <Skeleton className="h-3 w-12 rounded-md" />
+          </CardSubtitle>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-0">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex h-6 items-center gap-1.5">
+            <Skeleton className="h-4 w-4 rounded-full" />
+            <Skeleton className="h-3 w-full max-w-20 rounded-md" />
+          </div>
+        ))}
+      </CardContent>
     </Card>
   )
 }

--- a/packages/react/src/components/F0Card/F0Card.tsx
+++ b/packages/react/src/components/F0Card/F0Card.tsx
@@ -1,11 +1,12 @@
+import { withSkeleton } from "@/lib/skeleton"
 import { forwardRef } from "react"
-import { CardInternal, CardInternalProps } from "./CardInternal"
+import { CardInternal, CardInternalProps, CardSkeleton } from "./CardInternal"
 
 const privateProps = ["forceVerticalMetadata"] as const
 
 export type F0CardProps = Omit<CardInternalProps, (typeof privateProps)[number]>
 
-const F0Card = forwardRef<HTMLDivElement, F0CardProps>((props) => {
+const F0CardBase = forwardRef<HTMLDivElement, F0CardProps>((props) => {
   const publicProps = privateProps.reduce((acc, key) => {
     const { [key]: _, ...rest } = acc
     return rest
@@ -14,5 +15,10 @@ const F0Card = forwardRef<HTMLDivElement, F0CardProps>((props) => {
   return <CardInternal {...publicProps} />
 })
 
-F0Card.displayName = "F0Card"
-export { F0Card }
+const F0CardSkeleton = ({ compact = false }: { compact?: boolean }) => {
+  return <CardSkeleton compact={compact} />
+}
+
+F0CardBase.displayName = "F0Card"
+
+export const F0Card = withSkeleton(F0CardBase, F0CardSkeleton)

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -239,3 +239,21 @@ export const Compact: Story = {
     compact: true,
   },
 }
+
+export const Skeleton: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: () => {
+    return <F0Card.Skeleton />
+  },
+}
+
+export const SkeletonCompact: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: () => {
+    return <F0Card.Skeleton compact />
+  },
+}


### PR DESCRIPTION
## Description

Adds a skeleton version for the Card component, for loading states. It's usage is as simple as:

`<F0Card.Skeleton />`

Or you can also use a compact version of it:

`<F0Card.Skeleton compact />`

## Screenshots

<img width="448" height="273" alt="image" src="https://github.com/user-attachments/assets/bcb16030-0530-440b-86d9-9d4c056b197b" />

_Card default skeleton version_

<img width="432" height="182" alt="image" src="https://github.com/user-attachments/assets/f1555b18-96cc-46f5-8a3e-d023ef88591d" />

_Compact_