### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.145.2",
+  "packages/react": "1.146.0",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.146.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.145.2...factorial-one-react-v1.146.0) (2025-08-01)
+
+
+### Features
+
+* **Card:** add skeleton ([#2352](https://github.com/factorialco/factorial-one/issues/2352)) ([bbe3aba](https://github.com/factorialco/factorial-one/commit/bbe3abaa4752ad3edaf879f43ce08e0716a321d2))
+
 ## [1.145.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.145.1...factorial-one-react-v1.145.2) (2025-07-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.145.2",
+  "version": "1.146.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.146.0</summary>

## [1.146.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.145.2...factorial-one-react-v1.146.0) (2025-08-01)


### Features

* **Card:** add skeleton ([#2352](https://github.com/factorialco/factorial-one/issues/2352)) ([bbe3aba](https://github.com/factorialco/factorial-one/commit/bbe3abaa4752ad3edaf879f43ce08e0716a321d2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).