### PR TITLE
refactor(BasicTextEditor): remove EditorBubbleMenu

### DIFF
--- a/packages/react/src/experimental/RichText/BasicTextEditor/index.tsx
+++ b/packages/react/src/experimental/RichText/BasicTextEditor/index.tsx
@@ -1,9 +1,5 @@
 import { Icon } from "@/components/Utilities/Icon"
-import {
-  EditorBubbleMenu,
-  Toolbar,
-  ToolbarLabels,
-} from "@/experimental/RichText/CoreEditor"
+import { Toolbar, ToolbarLabels } from "@/experimental/RichText/CoreEditor"
 import { SlashCommandGroupLabels } from "@/experimental/RichText/CoreEditor/Extensions/SlashCommand"
 import { Handle, Plus } from "@/icons/app"
 import { Button } from "@/ui/button"
@@ -278,15 +274,6 @@ const BasicTextEditorComponent = forwardRef<
         <EditorContent
           editor={editor}
           className="[&>div]:w-full [&>div]:px-16"
-        />
-
-        <EditorBubbleMenu
-          editor={editor}
-          toolbarLabels={toolbarLabels}
-          disableButtons={false}
-          isToolbarOpen={false}
-          isFullscreen={false}
-          editorId={editorId}
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

Now that we have the toolbar at the top of the editor we made the decision to remove the bubble menu as they as at the end of the day the same component with very similar behavior 
