### PR TITLE
fix: add portal props to upselling kit modal

### DIFF
--- a/packages/react/src/components/UpsellingKit/ProductModal/components/CustomModal.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductModal/components/CustomModal.tsx
@@ -12,6 +12,7 @@ type CustomModalProps = {
   title: string
   children: React.ReactNode
   icon?: IconType
+  portalContainer?: HTMLElement | null
 }
 
 export function CustomModal({
@@ -20,6 +21,7 @@ export function CustomModal({
   title,
   children,
   icon,
+  portalContainer,
 }: CustomModalProps) {
   const [open, setOpen] = useState(isOpen)
 
@@ -36,7 +38,10 @@ export function CustomModal({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange} modal>
-      <DialogContent className="max-h-[620px] w-[760px] overflow-y-auto overflow-x-hidden bg-f1-background">
+      <DialogContent
+        className="max-h-[620px] w-[760px] overflow-y-auto overflow-x-hidden bg-f1-background"
+        container={portalContainer}
+      >
         <div className="flex flex-row items-center justify-between px-4 py-4">
           <DialogTitle className="flex flex-row items-center gap-2 text-lg font-semibold text-f1-foreground">
             {icon && <ModuleAvatar icon={icon} size="lg" />}

--- a/packages/react/src/components/UpsellingKit/ProductModal/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductModal/index.tsx
@@ -100,6 +100,7 @@ export function ProductModal({
         onClose={handleClose}
         title={modalTitle}
         icon={modalIcon}
+        portalContainer={portalContainer}
       >
         <div className="pb-4 pl-4">
           <ProductBlankslate


### PR DESCRIPTION
## Description

Modal is shown behind Sidebar from main app even if both zIndex logic have correct values.

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
