### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.146.1",
+  "packages/react": "1.147.0",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.147.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.146.1...factorial-one-react-v1.147.0) (2025-08-04)
+
+
+### Features
+
+* export F0Checkbox component ([#2332](https://github.com/factorialco/factorial-one/issues/2332)) ([e78b12c](https://github.com/factorialco/factorial-one/commit/e78b12c3adb0538956c51d5d231323b7c54de5bd))
+
 ## [1.146.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.146.0...factorial-one-react-v1.146.1) (2025-08-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.146.1",
+  "version": "1.147.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.147.0</summary>

## [1.147.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.146.1...factorial-one-react-v1.147.0) (2025-08-04)


### Features

* export F0Checkbox component ([#2332](https://github.com/factorialco/factorial-one/issues/2332)) ([e78b12c](https://github.com/factorialco/factorial-one/commit/e78b12c3adb0538956c51d5d231323b7c54de5bd))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).