### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.147.0",
+  "packages/react": "1.147.1",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.147.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.0...factorial-one-react-v1.147.1) (2025-08-05)
+
+
+### Bug Fixes
+
+* **DetailsList:** copy action animation ([#2363](https://github.com/factorialco/factorial-one/issues/2363)) ([a33cbc8](https://github.com/factorialco/factorial-one/commit/a33cbc8f6cc0215feed0758e69cb97c8ea6613b2))
+
 ## [1.147.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.146.1...factorial-one-react-v1.147.0) (2025-08-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.147.0",
+  "version": "1.147.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.147.1</summary>

## [1.147.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.0...factorial-one-react-v1.147.1) (2025-08-05)


### Bug Fixes

* **DetailsList:** copy action animation ([#2363](https://github.com/factorialco/factorial-one/issues/2363)) ([a33cbc8](https://github.com/factorialco/factorial-one/commit/a33cbc8f6cc0215feed0758e69cb97c8ea6613b2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).