### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.147.1",
+  "packages/react": "1.147.2",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.147.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.1...factorial-one-react-v1.147.2) (2025-08-05)
+
+
+### Bug Fixes
+
+* **upsell-kit:** allow portals to ensure overlay ([#2360](https://github.com/factorialco/factorial-one/issues/2360)) ([20e1048](https://github.com/factorialco/factorial-one/commit/20e1048158248254785e7a11c61285a3b5014231))
+
 ## [1.147.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.0...factorial-one-react-v1.147.1) (2025-08-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.147.1",
+  "version": "1.147.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.147.2</summary>

## [1.147.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.1...factorial-one-react-v1.147.2) (2025-08-05)


### Bug Fixes

* **upsell-kit:** allow portals to ensure overlay ([#2360](https://github.com/factorialco/factorial-one/issues/2360)) ([20e1048](https://github.com/factorialco/factorial-one/commit/20e1048158248254785e7a11c61285a3b5014231))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).