### PR TITLE
fix: set correct GroupHeader padding for list view

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/index.tsx
@@ -203,7 +203,7 @@ export const ListCollection = <
                 >
                   <GroupHeader
                     key={`group-header-${group.key}`}
-                    className="cursor-pointer select-none rounded-md px-6 py-3 transition-colors hover:bg-f1-background-hover"
+                    className="cursor-pointer select-none rounded-md px-3.5 py-3 transition-colors hover:bg-f1-background-hover"
                     selectable={!!source.selectable}
                     select={
                       groupAllSelectedStatus[group.key]?.checked


### PR DESCRIPTION
## Description

Set correct GroupHeader padding for list view.

## Screenshots

### Before

<img width="866" height="342" alt="Screenshot 2025-08-05 at 12 13 41" src="https://github.com/user-attachments/assets/d0a6d4d1-8692-4a03-98ad-7d61c6353eb0" />

### After

<img width="866" height="342" alt="Screenshot 2025-08-05 at 12 12 46" src="https://github.com/user-attachments/assets/f683d90a-0da0-4dc7-b3da-f70820e8924e" />
