### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.147.2",
+  "packages/react": "1.147.3",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.147.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.2...factorial-one-react-v1.147.3) (2025-08-05)
+
+
+### Bug Fixes
+
+* set correct GroupHeader padding for list view ([#2369](https://github.com/factorialco/factorial-one/issues/2369)) ([da30ec1](https://github.com/factorialco/factorial-one/commit/da30ec12634fbff1efa6cc7a71a559ba525b1d9f))
+
 ## [1.147.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.1...factorial-one-react-v1.147.2) (2025-08-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.147.2",
+  "version": "1.147.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.147.3</summary>

## [1.147.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.2...factorial-one-react-v1.147.3) (2025-08-05)


### Bug Fixes

* set correct GroupHeader padding for list view ([#2369](https://github.com/factorialco/factorial-one/issues/2369)) ([da30ec1](https://github.com/factorialco/factorial-one/commit/da30ec12634fbff1efa6cc7a71a559ba525b1d9f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).