### PR TITLE
fix: get rid of wrong selected count on data collection

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/useSelectable.ts
+++ b/packages/react/src/experimental/OneDataCollection/useSelectable.ts
@@ -380,10 +380,6 @@ export function useSelectable<
 
   useEffect(() => {
     // Notify the parent component about the selected items
-    const totalItems = paginationInfo?.total ?? (data.records?.length || 0)
-
-    const selectedItemsCount = totalItems - unselectedCount
-
     onSelectItems?.(
       {
         allSelected:
@@ -400,7 +396,7 @@ export function useSelectable<
           ])
         ),
         filters: source.currentFilters,
-        selectedCount: selectedItemsCount,
+        selectedCount,
       },
       clearSelectedItems
     )


### PR DESCRIPTION
## Description

We were showing an incorrect number of elements selected in the data collection under some circumstances.

https://github.com/user-attachments/assets/ad8ce4eb-4e7e-4915-bae8-f981788c9036
