### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.147.4",
+  "packages/react": "1.147.5",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.147.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.4...factorial-one-react-v1.147.5) (2025-08-05)
+
+
+### Bug Fixes
+
+* get rid of wrong selected count on data collection ([#2371](https://github.com/factorialco/factorial-one/issues/2371)) ([2ecbbf1](https://github.com/factorialco/factorial-one/commit/2ecbbf1af9254763650a4f8dac3c15089a2859a7))
+
 ## [1.147.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.3...factorial-one-react-v1.147.4) (2025-08-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.147.4",
+  "version": "1.147.5",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.147.5</summary>

## [1.147.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.4...factorial-one-react-v1.147.5) (2025-08-05)


### Bug Fixes

* get rid of wrong selected count on data collection ([#2371](https://github.com/factorialco/factorial-one/issues/2371)) ([2ecbbf1](https://github.com/factorialco/factorial-one/commit/2ecbbf1af9254763650a4f8dac3c15089a2859a7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).