### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.147.5",
+  "packages/react": "1.147.6",
   "packages/react-native": "0.17.1",
-  "packages/core": "1.22.1"
+  "packages/core": "1.22.2"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.22.2](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.22.1...factorial-one-core-v1.22.2) (2025-08-05)
+
+
+### Bug Fixes
+
+* **Colors:** Color tokens audit ([#2366](https://github.com/factorialco/factorial-one/issues/2366)) ([74c90df](https://github.com/factorialco/factorial-one/commit/74c90df7d88cb776b313a3766fb0553b5ba48a79))
+
 ## [1.22.1](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.22.0...factorial-one-core-v1.22.1) (2025-08-05)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-core",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Core tokens and utilities for Factorial One Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.147.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.5...factorial-one-react-v1.147.6) (2025-08-05)
+
+
+### Bug Fixes
+
+* **Colors:** Color tokens audit ([#2366](https://github.com/factorialco/factorial-one/issues/2366)) ([74c90df](https://github.com/factorialco/factorial-one/commit/74c90df7d88cb776b313a3766fb0553b5ba48a79))
+
 ## [1.147.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.4...factorial-one-react-v1.147.5) (2025-08-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.147.5",
+  "version": "1.147.6",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.147.6</summary>

## [1.147.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.5...factorial-one-react-v1.147.6) (2025-08-05)


### Bug Fixes

* **Colors:** Color tokens audit ([#2366](https://github.com/factorialco/factorial-one/issues/2366)) ([74c90df](https://github.com/factorialco/factorial-one/commit/74c90df7d88cb776b313a3766fb0553b5ba48a79))
</details>

<details><summary>factorial-one-core: 1.22.2</summary>

## [1.22.2](https://github.com/factorialco/factorial-one/compare/factorial-one-core-v1.22.1...factorial-one-core-v1.22.2) (2025-08-05)


### Bug Fixes

* **Colors:** Color tokens audit ([#2366](https://github.com/factorialco/factorial-one/issues/2366)) ([74c90df](https://github.com/factorialco/factorial-one/commit/74c90df7d88cb776b313a3766fb0553b5ba48a79))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).