### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.147.6",
+  "packages/react": "1.147.7",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.147.7](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.6...factorial-one-react-v1.147.7) (2025-08-05)
+
+
+### Bug Fixes
+
+* set correct side spacing on listview when initial loading ([#2376](https://github.com/factorialco/factorial-one/issues/2376)) ([d5c8dde](https://github.com/factorialco/factorial-one/commit/d5c8dde9816117b8f0f578a45aae883b1bb2b704))
+
 ## [1.147.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.5...factorial-one-react-v1.147.6) (2025-08-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.147.6",
+  "version": "1.147.7",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.147.7</summary>

## [1.147.7](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.147.6...factorial-one-react-v1.147.7) (2025-08-05)


### Bug Fixes

* set correct side spacing on listview when initial loading ([#2376](https://github.com/factorialco/factorial-one/issues/2376)) ([d5c8dde](https://github.com/factorialco/factorial-one/commit/d5c8dde9816117b8f0f578a45aae883b1bb2b704))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).