### PR TITLE
fix: add icons to banner buttons

### DIFF
--- a/packages/react/src/components/UpsellingKit/UpsellingBanner/index.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellingBanner/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/Actions/Button"
+import { IconType } from "@/components/Utilities/Icon"
 import {
   BaseBanner,
   type BannerAction,
@@ -20,6 +21,7 @@ type PromoteAction = {
   closeLabel: UpsellingButtonProps["closeLabel"]
   showIcon?: boolean
   showConfirmation?: boolean
+  icon?: IconType
 }
 
 type UpsellingBannerProps = Omit<
@@ -61,6 +63,7 @@ export const UpsellingBanner = forwardRef<HTMLDivElement, UpsellingBannerProps>(
           label={action.label}
           variant={action.variant || "default"}
           size="md"
+          icon={action.icon}
         />
       )
     }

--- a/packages/react/src/experimental/Banners/BaseBanner/index.stories.tsx
+++ b/packages/react/src/experimental/Banners/BaseBanner/index.stories.tsx
@@ -1,3 +1,4 @@
+import { Download, Upsell } from "@/icons/app"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { BaseBanner } from "./index"
 
@@ -84,5 +85,27 @@ export const Loading: Story = {
     mediaUrl:
       "https://images.unsplash.com/photo-1551434678-e076c223a692?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80",
     isLoading: true,
+  },
+}
+
+export const WithIcons: Story = {
+  args: {
+    title: "Premium features available",
+    subtitle: "Upgrade your experience with our premium features and tools",
+    mediaUrl:
+      "https://images.unsplash.com/photo-1551434678-e076c223a692?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80",
+    primaryAction: {
+      label: "Upgrade Now",
+      onClick: () => alert("Upgrade clicked"),
+      variant: "outline",
+      icon: Upsell,
+    },
+    secondaryAction: {
+      label: "Download Guide",
+      onClick: () => alert("Download clicked"),
+      variant: "outline",
+      icon: Download,
+    },
+    onClose: () => alert("Banner closed"),
   },
 }

--- a/packages/react/src/experimental/Banners/BaseBanner/index.tsx
+++ b/packages/react/src/experimental/Banners/BaseBanner/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/Actions/Button"
+import { IconType } from "@/components/Utilities/Icon"
 import CrossIcon from "@/icons/app/Cross"
 import { withSkeleton } from "@/lib/skeleton"
 import { Skeleton } from "@/ui/skeleton"
@@ -8,6 +9,7 @@ export type BannerAction = {
   label: string
   onClick: () => void
   variant?: "default" | "outline" | "ghost"
+  icon?: IconType
 }
 
 export type BaseBannerProps = {
@@ -92,6 +94,7 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
                 label={primaryAction.label}
                 variant={primaryAction.variant || "default"}
                 size="md"
+                icon={primaryAction.icon}
               />
             )}
             {secondaryAction && (
@@ -100,6 +103,7 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
                 label={secondaryAction.label}
                 variant={secondaryAction.variant || "outline"}
                 size="md"
+                icon={secondaryAction.icon}
               />
             )}
             {children}


### PR DESCRIPTION
## Description

Banner buttons are not accepting icons. Added the possibility.

## Screenshots (if applicable)

<img width="862" height="354" alt="Screenshot 2025-08-07 at 12 08 55" src="https://github.com/user-attachments/assets/40e558a6-176e-442e-a794-03ac36d5fa6c" />

## Implementation details

Adapt component to accept icons in buttons.
Adapt stories to showcase it.
