### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.149.0",
+  "packages/react": "1.150.0",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.150.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.149.0...factorial-one-react-v1.150.0) (2025-08-07)
+
+
+### Features
+
+* **ModuleAvatar:** add new icon for my_surveys module ([#2381](https://github.com/factorialco/factorial-one/issues/2381)) ([134a01f](https://github.com/factorialco/factorial-one/commit/134a01fd30b063f11e56c8fdbd17a72d64d5752e))
+
 ## [1.149.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.148.0...factorial-one-react-v1.149.0) (2025-08-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.149.0",
+  "version": "1.150.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.150.0</summary>

## [1.150.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.149.0...factorial-one-react-v1.150.0) (2025-08-07)


### Features

* **ModuleAvatar:** add new icon for my_surveys module ([#2381](https://github.com/factorialco/factorial-one/issues/2381)) ([134a01f](https://github.com/factorialco/factorial-one/commit/134a01fd30b063f11e56c8fdbd17a72d64d5752e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).