### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.151.0",
+  "packages/react": "1.151.1",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.151.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.151.0...factorial-one-react-v1.151.1) (2025-08-07)
+
+
+### Bug Fixes
+
+* not hiding filters when no filters to show in data collection ([#2387](https://github.com/factorialco/factorial-one/issues/2387)) ([a1a5f30](https://github.com/factorialco/factorial-one/commit/a1a5f304eec9f151e14a70f45052f12fd5a923ca))
+
 ## [1.151.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.150.1...factorial-one-react-v1.151.0) (2025-08-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.151.0",
+  "version": "1.151.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.151.1</summary>

## [1.151.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.151.0...factorial-one-react-v1.151.1) (2025-08-07)


### Bug Fixes

* not hiding filters when no filters to show in data collection ([#2387](https://github.com/factorialco/factorial-one/issues/2387)) ([a1a5f30](https://github.com/factorialco/factorial-one/commit/a1a5f304eec9f151e14a70f45052f12fd5a923ca))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).