### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.151.2",
+  "packages/react": "1.151.3",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.151.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.151.2...factorial-one-react-v1.151.3) (2025-08-07)
+
+
+### Bug Fixes
+
+* resource header metadata icon color ([#2391](https://github.com/factorialco/factorial-one/issues/2391)) ([baf3998](https://github.com/factorialco/factorial-one/commit/baf3998c8972f45225aba31bdb631c4c4151251f))
+
 ## [1.151.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.151.1...factorial-one-react-v1.151.2) (2025-08-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.151.2",
+  "version": "1.151.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.151.3</summary>

## [1.151.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.151.2...factorial-one-react-v1.151.3) (2025-08-07)


### Bug Fixes

* resource header metadata icon color ([#2391](https://github.com/factorialco/factorial-one/issues/2391)) ([baf3998](https://github.com/factorialco/factorial-one/commit/baf3998c8972f45225aba31bdb631c4c4151251f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).