### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.152.0",
+  "packages/react": "1.152.1",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.152.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.152.0...factorial-one-react-v1.152.1) (2025-08-07)
+
+
+### Bug Fixes
+
+* **aiChat:** render subComponents when passed ([#2394](https://github.com/factorialco/factorial-one/issues/2394)) ([e2e444c](https://github.com/factorialco/factorial-one/commit/e2e444cd1a612a33cad845b3f1f35810955b2ebf))
+
 ## [1.152.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.151.3...factorial-one-react-v1.152.0) (2025-08-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.152.0",
+  "version": "1.152.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.152.1</summary>

## [1.152.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.152.0...factorial-one-react-v1.152.1) (2025-08-07)


### Bug Fixes

* **aiChat:** render subComponents when passed ([#2394](https://github.com/factorialco/factorial-one/issues/2394)) ([e2e444c](https://github.com/factorialco/factorial-one/commit/e2e444cd1a612a33cad845b3f1f35810955b2ebf))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).