### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.152.1",
+  "packages/react": "1.152.2",
   "packages/react-native": "0.17.1",
   "packages/core": "1.22.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.152.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.152.1...factorial-one-react-v1.152.2) (2025-08-08)
+
+
+### Bug Fixes
+
+* **aiChat:** vertical scroll resize observer trigger ([#2400](https://github.com/factorialco/factorial-one/issues/2400)) ([49e0a67](https://github.com/factorialco/factorial-one/commit/49e0a6761440287f357608e71d2c530b77f0b81a))
+
 ## [1.152.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.152.0...factorial-one-react-v1.152.1) (2025-08-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.152.1",
+  "version": "1.152.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.152.2</summary>

## [1.152.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.152.1...factorial-one-react-v1.152.2) (2025-08-08)


### Bug Fixes

* **aiChat:** vertical scroll resize observer trigger ([#2400](https://github.com/factorialco/factorial-one/issues/2400)) ([49e0a67](https://github.com/factorialco/factorial-one/commit/49e0a6761440287f357608e71d2c530b77f0b81a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).