### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.153.0",
+  "packages/react": "1.154.0",
   "packages/react-native": "0.17.1",
   "packages/core": "1.23.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.154.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.153.0...factorial-one-react-v1.154.0) (2025-08-11)
+
+
+### Features
+
+* support, new avatar variants, image and compact for DataCollection Cards ([9800f5f](https://github.com/factorialco/factorial-one/commit/9800f5fdde3f6c4c4bced27d782cc702c5646f3b))
+
 ## [1.153.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.152.2...factorial-one-react-v1.153.0) (2025-08-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.153.0",
+  "version": "1.154.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.154.0</summary>

## [1.154.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.153.0...factorial-one-react-v1.154.0) (2025-08-11)


### Features

* support, new avatar variants, image and compact for DataCollection Cards ([9800f5f](https://github.com/factorialco/factorial-one/commit/9800f5fdde3f6c4c4bced27d782cc702c5646f3b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).