### PR TITLE
fix(DataCollection): let users define avatar type in `AvatarList` cell type

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
@@ -293,6 +293,7 @@ Renders a list of avatars
 type value = {
     avatarList: AvatarVariant[]
     max?: number // Max avatars to render
+    type?: "person" | "team" | "company"
 }
 ```
 

--- a/packages/react/src/experimental/OneDataCollection/visualizations/property/types/avatarList.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/property/types/avatarList.tsx
@@ -8,9 +8,15 @@ import { AvatarList } from "@/experimental/Information/Avatars/AvatarList"
 interface AvatarListValue {
   avatarList: AvatarVariant[]
   max?: number
+  type?: "person" | "team" | "company"
 }
 export type AvatarListCellValue = AvatarListValue
 
 export const AvatarListCell = (args: AvatarListCellValue) => (
-  <AvatarList avatars={args.avatarList} size="xsmall" max={args.max} />
+  <AvatarList
+    avatars={args.avatarList}
+    size="xsmall"
+    max={args.max}
+    type={args.type ?? "person"}
+  />
 )


### PR DESCRIPTION
## Description

`avatarList` is one of the cell types available in DataCollection. The base AvatarList component lets the user define the type of avatars: person, company or team, but we weren't passing that to the cell type.

This PR adds the option so teams can have avatar lists of different things than the person one.

## Screenshots

<img width="814" height="464" alt="Screenshot 2025-08-12 at 16 20 49" src="https://github.com/user-attachments/assets/6135003e-ea57-41bc-b085-69475b6ac0b4" />
