### PR TITLE
feat(DropdownButton): use internal Action component as base

### DIFF
--- a/packages/react/src/components/Actions/OneDropdownButton/OneDropdownButton.tsx
+++ b/packages/react/src/components/Actions/OneDropdownButton/OneDropdownButton.tsx
@@ -2,8 +2,10 @@ import { useI18n } from "@/lib/providers/i18n"
 import { useMemo, useState } from "react"
 import { DropdownInternal } from "../../../experimental/Navigation/Dropdown/internal"
 import { ChevronDown } from "../../../icons/app"
-import { IconType } from "../../Utilities/Icon"
-import { ButtonInternal, ButtonInternalProps } from "../Button/internal"
+import { cn, focusRing } from "../../../lib/utils"
+import { Action } from "../../../ui/Action"
+import { actionVariants, buttonSizeVariants } from "../../../ui/Action/variants"
+import { Icon, IconType } from "../../Utilities/Icon"
 import { OneDropdownButtonSize, OneDropdownButtonVariant } from "./types.ts"
 
 export type OneDropdownButtonItem<T = string> = {
@@ -13,13 +15,13 @@ export type OneDropdownButtonItem<T = string> = {
   critical?: boolean
 }
 
-export type OneDropdownButtonProps<T = string> = Partial<
-  Pick<ButtonInternalProps, "disabled" | "loading">
-> & {
+export type OneDropdownButtonProps<T = string> = {
   size?: OneDropdownButtonSize
   items: OneDropdownButtonItem<T>[]
   variant?: OneDropdownButtonVariant
   value?: T
+  disabled?: boolean
+  loading?: boolean
   onClick: (value: T, item: OneDropdownButtonItem<T>) => void
 }
 
@@ -57,36 +59,63 @@ const OneDropdownButton = ({
     [items, localValue, onClick]
   )
 
+  const dropdownSize =
+    props.size === "sm"
+      ? "[&_.main]:w-6"
+      : props.size === "lg"
+        ? "[&_.main]:w-10"
+        : "[&_.main]:w-8"
+
   return (
     selectedItem && (
-      <div className="flex items-center">
-        <ButtonInternal
-          onClick={handleClick}
-          icon={selectedItem.icon}
-          label={selectedItem.label}
-          data-testid="button-main"
-          className="flex-1"
-          {...props}
-          appendButton={
-            <DropdownInternal
-              items={dropdownItems}
-              align="end"
-              open={isOpen}
-              onOpenChange={setIsOpen}
+      <Action
+        onClick={handleClick}
+        variant={props.variant}
+        size={props.size}
+        disabled={props.disabled}
+        loading={props.loading}
+        data-testid="button-main"
+        prepend={selectedItem.icon && <Icon icon={selectedItem.icon} />}
+        appendOutside={true}
+        className="rounded-r-none after:rounded-r-none"
+        append={
+          <DropdownInternal
+            items={dropdownItems}
+            align="end"
+            open={isOpen && !props.disabled}
+            onOpenChange={(open) => {
+              if (props.disabled) return
+              setIsOpen(open)
+            }}
+          >
+            <button
+              className={cn(
+                actionVariants({
+                  variant: props.variant,
+                  pressed: isOpen && !props.disabled,
+                }),
+                buttonSizeVariants({ size: props.size }),
+                "-translate-x-px rounded-l-none px-0 after:rounded-l-none",
+                dropdownSize,
+                focusRing()
+              )}
+              disabled={props.disabled}
+              data-testid="button-menu"
+              data-pressed={isOpen && !props.disabled}
             >
-              <ButtonInternal
-                variant={props.variant}
-                size={props.size}
-                label={t.actions.more}
-                icon={ChevronDown}
-                hideLabel
-                data-testid="button-menu"
-                pressed={isOpen}
-              />
-            </DropdownInternal>
-          }
-        />
-      </div>
+              <div className="main flex items-center justify-center gap-1">
+                <span className="sr-only">{t.actions.more}</span>
+                <Icon
+                  icon={ChevronDown}
+                  size={props.size === "sm" ? "sm" : "md"}
+                />
+              </div>
+            </button>
+          </DropdownInternal>
+        }
+      >
+        {selectedItem.label}
+      </Action>
     )
   )
 }


### PR DESCRIPTION
## Description

[Action](https://github.com/factorialco/factorial-one/pull/2200) is an internal component to handles buttons and links. This PR makes the DropdownButton use the Action component, without changing the API.

It also improves a few small details about the component, like the chevron size depending on the button size.

## Screenshots

<img width="257" height="200" alt="image" src="https://github.com/user-attachments/assets/e9b8e27d-e304-4182-beaf-680b73c45905" />

