### PR TITLE
fix: ModuleAvatar small size

### DIFF
--- a/packages/react-native/src/components/Avatars/ModuleAvatar/index.tsx
+++ b/packages/react-native/src/components/Avatars/ModuleAvatar/index.tsx
@@ -8,7 +8,7 @@ const moduleAvatarVariants = cva({
   base: "relative flex shrink-0 items-center justify-center",
   variants: {
     size: {
-      sm: "h-5 w-5",
+      sm: "h-4 w-4",
       md: "h-6 w-6",
       lg: "h-8 w-8",
       xl: "h-10 w-10",
@@ -23,7 +23,7 @@ const iconContainerVariants = cva({
   base: "absolute inset-0 items-center justify-center z-10",
   variants: {
     size: {
-      sm: "h-5 w-5",
+      sm: "h-4 w-4",
       md: "h-6 w-6",
       lg: "h-8 w-8",
       xl: "h-10 w-10",


### PR DESCRIPTION
## Description

Checking Figma we should set properly the small size for this

## Screenshots (if applicable)


<img width="1179" height="2556" alt="simulator_screenshot_9598BD2F-7674-4A18-A25E-7BA69F99DAAE" src="https://github.com/user-attachments/assets/a0f5debb-e02a-4ac8-a04d-84ae1064318b" />
