### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.155.0",
-  "packages/react-native": "0.18.0",
+  "packages/react-native": "0.18.1",
   "packages/core": "1.23.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.18.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.18.0...factorial-one-react-native-v0.18.1) (2025-08-13)
+
+
+### Bug Fixes
+
+* size ([#2414](https://github.com/factorialco/factorial-one/issues/2414)) ([4c1f145](https://github.com/factorialco/factorial-one/commit/4c1f14515830bcbf7c2d88aa057213909163c49c))
+
 ## [0.18.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.17.1...factorial-one-react-native-v0.18.0) (2025-08-12)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.18.1</summary>

## [0.18.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.18.0...factorial-one-react-native-v0.18.1) (2025-08-13)


### Bug Fixes

* size ([#2414](https://github.com/factorialco/factorial-one/issues/2414)) ([4c1f145](https://github.com/factorialco/factorial-one/commit/4c1f14515830bcbf7c2d88aa057213909163c49c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).