### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.155.0",
+  "packages/react": "1.156.0",
   "packages/react-native": "0.18.1",
   "packages/core": "1.23.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.156.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.155.0...factorial-one-react-v1.156.0) (2025-08-18)
+
+
+### Features
+
+* file and folder cell types ([#2313](https://github.com/factorialco/factorial-one/issues/2313)) ([5fe083f](https://github.com/factorialco/factorial-one/commit/5fe083f58b8cde747ec22d167fb1ef6714d588e6))
+
 ## [1.155.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.154.0...factorial-one-react-v1.155.0) (2025-08-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.155.0",
+  "version": "1.156.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.156.0</summary>

## [1.156.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.155.0...factorial-one-react-v1.156.0) (2025-08-18)


### Features

* file and folder cell types ([#2313](https://github.com/factorialco/factorial-one/issues/2313)) ([5fe083f](https://github.com/factorialco/factorial-one/commit/5fe083f58b8cde747ec22d167fb1ef6714d588e6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).