### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.156.0",
+  "packages/react": "1.157.0",
   "packages/react-native": "0.18.1",
   "packages/core": "1.23.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.157.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.156.0...factorial-one-react-v1.157.0) (2025-08-19)
+
+
+### Features
+
+* **DropdownButton:** use internal Action component as base ([#2412](https://github.com/factorialco/factorial-one/issues/2412)) ([c930e53](https://github.com/factorialco/factorial-one/commit/c930e53395573959b45e65815b1c0745be64a4d2))
+
 ## [1.156.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.155.0...factorial-one-react-v1.156.0) (2025-08-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.156.0",
+  "version": "1.157.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.157.0</summary>

## [1.157.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.156.0...factorial-one-react-v1.157.0) (2025-08-19)


### Features

* **DropdownButton:** use internal Action component as base ([#2412](https://github.com/factorialco/factorial-one/issues/2412)) ([c930e53](https://github.com/factorialco/factorial-one/commit/c930e53395573959b45e65815b1c0745be64a4d2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).