### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.157.0",
+  "packages/react": "1.157.1",
   "packages/react-native": "0.18.1",
   "packages/core": "1.23.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.157.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.157.0...factorial-one-react-v1.157.1) (2025-08-19)
+
+
+### Bug Fixes
+
+* **DataCollection:** let users define avatar type in `AvatarList` cell type ([#2411](https://github.com/factorialco/factorial-one/issues/2411)) ([3480303](https://github.com/factorialco/factorial-one/commit/3480303d816e94fe6dbf6ee2a6c457c2242e89ea))
+
 ## [1.157.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.156.0...factorial-one-react-v1.157.0) (2025-08-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.157.0",
+  "version": "1.157.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.157.1</summary>

## [1.157.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.157.0...factorial-one-react-v1.157.1) (2025-08-19)


### Bug Fixes

* **DataCollection:** let users define avatar type in `AvatarList` cell type ([#2411](https://github.com/factorialco/factorial-one/issues/2411)) ([3480303](https://github.com/factorialco/factorial-one/commit/3480303d816e94fe6dbf6ee2a6c457c2242e89ea))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).