### PR TITLE
Update calendar weekly view

### DIFF
--- a/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
@@ -155,8 +155,14 @@ export function OneCalendar({
     const range = toDateRange(selected)
     if (granularity.calendarView === "week") {
       setInputValue({
-        from: granularity.toFormattedString(range?.from),
-        to: granularity.toFormattedString(range?.to),
+        from: granularity.toFormattedString(
+          i18n.date.granularities.week.range,
+          range?.from
+        ),
+        to: granularity.toFormattedString(
+          i18n.date.granularities.week.range,
+          range?.to
+        ),
       })
     } else {
       const { from, to } = granularity.toRangeString(

--- a/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
@@ -78,7 +78,6 @@ export function OneCalendar({
       setSelectedInternal(date)
 
       // Set the input value
-      setInputValue(granularity.toRangeString(date))
 
       const newViewDate = granularity.getViewDateFromDate(
         date instanceof Date ? date : date?.from || date?.to || new Date()
@@ -154,14 +153,20 @@ export function OneCalendar({
   }
   useEffect(() => {
     const range = toDateRange(selected)
-
-    const { from, to } = granularity.toRangeString(
-      range ? range : { from: new Date(), to: undefined }
-    )
-    setInputValue({
-      from: from || "",
-      to: to || "",
-    })
+    if (granularity.calendarView === "week") {
+      setInputValue({
+        from: granularity.toFormattedString(range?.from),
+        to: granularity.toFormattedString(range?.to),
+      })
+    } else {
+      const { from, to } = granularity.toRangeString(
+        range ? range : { from: new Date(), to: undefined }
+      )
+      setInputValue({
+        from: from || "",
+        to: to || "",
+      })
+    }
   }, [granularity, selected])
 
   const handleInputNavigate = (input: "from" | "to", direction: -1 | 1) => {

--- a/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
@@ -173,7 +173,7 @@ export function OneCalendar({
         to: to || "",
       })
     }
-  }, [granularity, selected])
+  }, [granularity, selected, i18n.date.granularities.week.range])
 
   const handleInputNavigate = (input: "from" | "to", direction: -1 | 1) => {
     const currentDate = inputValue[input]

--- a/packages/react/src/experimental/OneCalendar/granularities/types.ts
+++ b/packages/react/src/experimental/OneCalendar/granularities/types.ts
@@ -60,6 +60,7 @@ export interface GranularityDefinition {
     date: DateRange,
     options: DateNavigationOptions
   ): PrevNextDateNavigation
+  toFormattedString: (date: Date | DateRange | undefined | null) => string
 }
 
 export type GranularityDefinitionSimple = Pick<

--- a/packages/react/src/experimental/OneCalendar/granularities/types.ts
+++ b/packages/react/src/experimental/OneCalendar/granularities/types.ts
@@ -60,7 +60,10 @@ export interface GranularityDefinition {
     date: DateRange,
     options: DateNavigationOptions
   ): PrevNextDateNavigation
-  toFormattedString: (date: Date | DateRange | undefined | null) => string
+  toFormattedString: (
+    str: string,
+    date: Date | DateRange | undefined | null
+  ) => string
 }
 
 export type GranularityDefinitionSimple = Pick<

--- a/packages/react/src/experimental/OneCalendar/granularities/week/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/week/index.tsx
@@ -60,6 +60,9 @@ export const weekGranularity: GranularityDefinition = {
   toRangeString: (date) => formatDateRange(date, "'W'I yyyy"),
   toRange: (date) => toWeekGranularityDateRange(date),
   toString: (date) => formatDateToString(date, "'W'I yyyy"),
+  toFormattedString: (date) => {
+    return formatDateToString(date, "'Week of' MMM d")
+  },
   fromString: (dateStr) => {
     const dateRangeString = toDateRangeString(dateStr)
     if (!dateRangeString) {

--- a/packages/react/src/experimental/OneCalendar/granularities/week/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/week/index.tsx
@@ -60,8 +60,8 @@ export const weekGranularity: GranularityDefinition = {
   toRangeString: (date) => formatDateRange(date, "'W'I yyyy"),
   toRange: (date) => toWeekGranularityDateRange(date),
   toString: (date) => formatDateToString(date, "'W'I yyyy"),
-  toFormattedString: (date) => {
-    return formatDateToString(date, "'Week of' MMM d")
+  toFormattedString: (str, date) => {
+    return formatDateToString(date, `'${str}' MMM d`)
   },
   fromString: (dateStr) => {
     const dateRangeString = toDateRangeString(dateStr)

--- a/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
+++ b/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
@@ -59,7 +59,10 @@ const DateNavigatorTrigger = forwardRef<
       }
       const granularity = granularityDefinitions[value.granularity]
       if (value.granularity === "week") {
-        return granularity.toFormattedString(value.value)
+        return granularity.toFormattedString(
+          i18n.date.granularities.week.range,
+          value.value
+        )
       }
       return granularity.toString(value.value) ?? i18n.date.selectDate
     }, [value, i18n.date.selectDate])

--- a/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
+++ b/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
@@ -65,7 +65,7 @@ const DateNavigatorTrigger = forwardRef<
         )
       }
       return granularity.toString(value.value) ?? i18n.date.selectDate
-    }, [value, i18n.date.selectDate])
+    }, [value, i18n.date.selectDate, i18n.date.granularities.week.range])
 
     const handleNavigation = (date: DateRange | false) => {
       if (!date) {

--- a/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
+++ b/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
@@ -61,7 +61,7 @@ const DateNavigatorTrigger = forwardRef<
       if (value.granularity === "week") {
         return granularity.toFormattedString(
           i18n.date.granularities.week.range,
-          value.value
+          value.value.from
         )
       }
       return granularity.toString(value.value) ?? i18n.date.selectDate

--- a/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
+++ b/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
@@ -58,6 +58,9 @@ const DateNavigatorTrigger = forwardRef<
         return i18n.date.selectDate
       }
       const granularity = granularityDefinitions[value.granularity]
+      if (value.granularity === "week") {
+        return granularity.toFormattedString(value.value)
+      }
       return granularity.toString(value.value) ?? i18n.date.selectDate
     }, [value, i18n.date.selectDate])
 

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -132,7 +132,7 @@ export const defaultTranslations = {
       week: {
         currentDate: "This week",
         label: "Week",
-        range: "Week of {{date}}",
+        range: "Week of",
       },
       month: {
         currentDate: "This month",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -132,6 +132,7 @@ export const defaultTranslations = {
       week: {
         currentDate: "This week",
         label: "Week",
+        range: "Week of {{date}}",
       },
       month: {
         currentDate: "This month",


### PR DESCRIPTION
## Description

We want to add a new format string for "Weekly view" in Date navigator component. We want to change it from:
`W22 2025 `to `Week of Aug 2025`. 

## Screenshots (if applicable)
Now:

<img width="1274" height="1030" alt="image" src="https://github.com/user-attachments/assets/44c23512-5b3d-4126-b045-693855692878" />

Before:
<img width="554" height="467" alt="image" src="https://github.com/user-attachments/assets/ea354ff6-ac38-4971-b1ad-f23e9ce606d3" />




## Implementation details

To achieve this new behavior we add a new function in the granularities formatters, and use it when needed. In our case, as we only want to use it for week granularity we check the granularity type.

Also, we need to use translations for the "Week of" part, so we need to add a new key in the translation file for it.

<!-- What have you changed? Why? -->
