### PR TITLE
feat: Tokens for spacing between elements

### DIFF
--- a/packages/core/src/tokens/spacing.ts
+++ b/packages/core/src/tokens/spacing.ts
@@ -87,3 +87,15 @@ export const relativeSpacing: ThemeConfig["spacing"] = {
   80: "20rem",
   96: "24rem",
 }
+
+/*
+ * Spacing between elements
+ * This special scale is used for the gap between common elements.
+ * Docs: https://zeroheight.com/6cc527675/p/94c391-spacing/t/3409209197
+ */
+export const betweenSpacing: ThemeConfig["spacing"] = {
+  sm: relativeSpacing[1],
+  md: relativeSpacing[2],
+  lg: relativeSpacing[3],
+  xl: relativeSpacing[4],
+}

--- a/packages/core/tailwind.ts
+++ b/packages/core/tailwind.ts
@@ -1,7 +1,11 @@
 import type { Config } from "tailwindcss"
 import { borderRadius } from "./src/tokens/borderRadius"
 import { baseColors, f1Colors } from "./src/tokens/colors"
-import { absoluteSpacing, relativeSpacing } from "./src/tokens/spacing"
+import {
+  absoluteSpacing,
+  betweenSpacing,
+  relativeSpacing,
+} from "./src/tokens/spacing"
 
 export const baseConfig: Omit<Config, "content"> = {
   darkMode: "class",
@@ -101,6 +105,8 @@ export const baseConfig: Omit<Config, "content"> = {
       minWidth: relativeSpacing,
       textIndent: relativeSpacing,
       width: relativeSpacing,
+      gap: betweenSpacing,
+      space: betweenSpacing,
       colors: {
         f1: f1Colors,
       },

--- a/packages/react/src/components/F0Card/components/CardActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardActions.tsx
@@ -49,7 +49,7 @@ export function CardActions({
       )}
     >
       {secondaryActions && (
-        <div className="flex w-full flex-col gap-2 sm:flex-row [&_a]:justify-center sm:[&_a]:justify-start [&_button]:w-full sm:[&_button]:w-fit [&_div]:w-full [&_div]:justify-center sm:[&_div]:w-fit">
+        <div className="flex w-full flex-col gap-md sm:flex-row [&_a]:justify-center sm:[&_a]:justify-start [&_button]:w-full sm:[&_button]:w-fit [&_div]:w-full [&_div]:justify-center sm:[&_div]:w-fit">
           {Array.isArray(secondaryActions) ? (
             secondaryActions.map((action, index) => (
               <Button


### PR DESCRIPTION
## Description

Adds new spacing tokens for `gap` and `space`, with a simpler list of options (`sm`, `md`, `lg` and `xl`), documented [here](https://zeroheight.com/6cc527675/p/94c391-spacing/t/3409209197).

Each token is aimed at different combination of elements.

## Why?

After interviewing a few designers, it's clear they're not sure how to use the spacing tokens. This is part of an effort to reduce decision fatigue and cognitive overload.

The idea is to have tokens on top of the _foundational_ ones (which are tailwind spacings), specific for different use cases and synced with Figma:

<img width="598" height="828" alt="image" src="https://github.com/user-attachments/assets/4f91ebcc-0d3b-4e44-86a4-e947717e2fa2" />

Also, reducing the options available, we ensure more consistency and meaning in our spacing usage.

So, instead of writing `gap-2` or `space-y-4`, you'd write `gap-sm` and `space-y-md`. Numbers confuse designers (since they think of 2 as 2px, not as a spacing unit), and we shorten the list of options, making it easier to avoid mistakes.

## Let's apply this to every component!

Quieto parao 😔✋ Let me try out how this works and iterate on it before launching. But having the tokens ready and making new things with them is fine.

## Next steps

1. Try them, get some designers feedback.
2. Replace current gaps and spaces with these tokens.
3. Make these the only available options for gap and space. For now, the foundational tokens are also available (so you can keep using gap-2).