### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.158.0",
+  "packages/react": "1.158.1",
   "packages/react-native": "0.18.1",
   "packages/core": "1.24.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.158.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.158.0...factorial-one-react-v1.158.1) (2025-08-21)
+
+
+### Bug Fixes
+
+* empty value when no sorting ([#2430](https://github.com/factorialco/factorial-one/issues/2430)) ([1ac7052](https://github.com/factorialco/factorial-one/commit/1ac7052fe8365e048dc89407cb37fbd6d204aaf3))
+
 ## [1.158.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.157.1...factorial-one-react-v1.158.0) (2025-08-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.158.0",
+  "version": "1.158.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.158.1</summary>

## [1.158.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.158.0...factorial-one-react-v1.158.1) (2025-08-21)


### Bug Fixes

* empty value when no sorting ([#2430](https://github.com/factorialco/factorial-one/issues/2430)) ([1ac7052](https://github.com/factorialco/factorial-one/commit/1ac7052fe8365e048dc89407cb37fbd6d204aaf3))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).