### PR TITLE
Fix(DateNavigator): pass the right value to onCompareToChange

### DIFF
--- a/packages/react/src/ui/DatePickerPopup/OneDatePickerPopup.tsx
+++ b/packages/react/src/ui/DatePickerPopup/OneDatePickerPopup.tsx
@@ -160,7 +160,7 @@ export function OneDatePickerPopup({
 
       return {
         label: compare.label,
-        value: index.toString(),
+        value: (index + 1).toString(), // This leaves index 0 spot vacant for the 'none' option.
         description,
         dateValue: value,
       }
@@ -173,7 +173,7 @@ export function OneDatePickerPopup({
     return [
       {
         label: i18n.date.none,
-        value: "none",
+        value: "0",
         description: "",
         dateValue: undefined,
       },
@@ -183,7 +183,7 @@ export function OneDatePickerPopup({
   }, [compareTo, localValue, granularityDefinition, localGranularity])
 
   useEffect(() => {
-    setSelectedCompareTo("none")
+    setSelectedCompareTo("0")
   }, [localValue])
 
   const handleCompareToChange = (value: string) => {


### PR DESCRIPTION
## Description
This issue came up when trying to implement data comparisons for different dates in financial workspace. Upon using the DateNavigator component and passing relevant props to it, it turned out the `onCompareToChange` function prop was not getting the appropriate parameters passed in when called from within the component. See implementation in this PR.

## Screenshots (if applicable)
<img width="463" height="491" alt="Screenshot 2025-08-21 at 12 09 56" src="https://github.com/user-attachments/assets/dcfcc6a1-69d4-4b98-88ba-6e97ac2408ae" />

## Implementation details
```
const compareToOptions: ({
    label: string;
    value: string;
    description: string;
    dateValue: Required<DateRange> | Required<DateRange>[];
} | {
    label: string;
    value: string;
    description: string;
    dateValue: undefined;
})[]
```
The current implementation of compareToOptions  assumes value is a stringified number (e.g. "0", "1", etc.) that can be coerced into an array index using the unary +. When building the array of options, value is set to the index position of the option object. This however does not take into account that a default `none` option will later be placed in the first position as first option, thereby invalidating the value previously set for the other options.

This PR fixes this by incrementing the option values by 1 when building the options array. Thereby leaving the 0 index spot vacant for the default none option.


