### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.160.0",
+  "packages/react": "1.160.1",
   "packages/react-native": "0.18.1",
   "packages/core": "1.25.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.160.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.160.0...factorial-one-react-v1.160.1) (2025-08-21)
+
+
+### Bug Fixes
+
+* **DateNavigator:** pass the right value to onCompareToChange ([#2434](https://github.com/factorialco/factorial-one/issues/2434)) ([38ae18e](https://github.com/factorialco/factorial-one/commit/38ae18ea4be729b8b1bf5698a88395288fda260c))
+
 ## [1.160.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.159.0...factorial-one-react-v1.160.0) (2025-08-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.160.0",
+  "version": "1.160.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.160.1</summary>

## [1.160.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.160.0...factorial-one-react-v1.160.1) (2025-08-21)


### Bug Fixes

* **DateNavigator:** pass the right value to onCompareToChange ([#2434](https://github.com/factorialco/factorial-one/issues/2434)) ([38ae18e](https://github.com/factorialco/factorial-one/commit/38ae18ea4be729b8b1bf5698a88395288fda260c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).