### PR TITLE
f0-public-flaticon

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -34,9 +34,7 @@ const config: StorybookConfig = {
   ],
   managerHead: (head) => {
     return `${head}
-      <link rel="icon" href="/${
-        process.env.STORYBOOK_PUBLIC_BUILD ? "favicon.svg" : "favicon-dev.svg"
-      }" type="image/svg+xml" />
+      <link rel="icon" href="/favicon-dev.svg" type="image/svg+xml" />
   `
   },
   staticDirs: ["../public", "./static"],


### PR DESCRIPTION
## Description

With the Zeroheight flaticon update, Storybook and Zeroheight looked the same. This causes confusion and doesn't help you know which tool you're going to access from the browser tabs. Let's use the dev version of the logo for Storybook so that it's clear it's an internal workspace, and the more official black one for Zeroheight.

## Screenshots
<img width="55" height="32" alt="Screenshot 2025-08-25 at 09 43 31" src="https://github.com/user-attachments/assets/dff8c8d5-d5ba-42fc-960a-36f5466ad14b" />

On the left is the Storybook flaticon, and on the right is the Zeroheight one.
