### PR TITLE
Make secondary options nillable so we dont render the footer when the…

### DIFF
--- a/packages/react/src/components/F0Card/components/CardActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardActions.tsx
@@ -34,7 +34,7 @@ export function CardActions({
   compact = false,
 }: CardActionsProps) {
   const isDesktop = useMediaQuery("(min-width: 640px)")
-  const hasActions = primaryAction || secondaryActions
+  const hasActions = primaryAction || (secondaryActions?.length)
 
   if (!hasActions) {
     return null

--- a/packages/react/src/components/F0Card/components/CardActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardActions.tsx
@@ -34,7 +34,7 @@ export function CardActions({
   compact = false,
 }: CardActionsProps) {
   const isDesktop = useMediaQuery("(min-width: 640px)")
-  const hasActions = primaryAction || (secondaryActions?.length)
+  const hasActions = primaryAction || hasSecondaryActions()
 
   if (!hasActions) {
     return null
@@ -89,4 +89,12 @@ export function CardActions({
       )}
     </CardFooter>
   )
+
+  function hasSecondaryActions(): boolean {
+    if (!secondaryActions) return false
+    if ("href" in secondaryActions) return true
+    if ("length" in secondaryActions) return secondaryActions.length > 0
+
+    return false
+  }
 }

--- a/packages/react/src/components/F0Card/components/CardMetadata.tsx
+++ b/packages/react/src/components/F0Card/components/CardMetadata.tsx
@@ -35,7 +35,9 @@ export function CardMetadata({ metadata }: CardMetadataProps) {
   if (!renderer) {
     return (
       <div className="flex h-8 items-center gap-1.5 font-medium">
-        <Icon icon={metadata.icon} color="default" size="md" />
+        {"icon" in metadata && (
+          <Icon icon={metadata.icon} color="default" size="md" />
+        )}
         <span>Unsupported property type: {type}</span>
       </div>
     )
@@ -48,7 +50,9 @@ export function CardMetadata({ metadata }: CardMetadataProps) {
 
   return (
     <div className="flex h-8 items-center gap-1.5 font-medium">
-      <Icon icon={metadata.icon} color="default" size="md" />
+      {"icon" in metadata && (
+        <Icon icon={metadata.icon} color="default" size="md" />
+      )}
       {typedRenderer(value, { visualization: "card" })}
     </div>
   )

--- a/packages/react/src/components/F0Card/types.ts
+++ b/packages/react/src/components/F0Card/types.ts
@@ -13,7 +13,11 @@ export type CardMetadataProperty = {
   }
 }[CardPropertyType]
 
-export type CardMetadata = {
-  icon: IconType
-  property: CardMetadataProperty
-}
+export type CardMetadata =
+  | {
+      icon: IconType
+      property: Exclude<CardMetadataProperty, { type: "file" }>
+    }
+  | {
+      property: Extract<CardMetadataProperty, { type: "file" }>
+    }

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -156,6 +156,9 @@ const GroupCards = <
 
         const cardProperty = convertToCardMetadataProperty(result)
         if (!cardProperty) return null
+        if (cardProperty.type === 'file') return {
+          property: cardProperty,
+        }
 
         return {
           icon: property.icon ?? Placeholder,
@@ -163,6 +166,7 @@ const GroupCards = <
         }
       })
       .filter((item): item is CardMetadata => item !== null)
+
   }
 
   function convertToCardMetadataProperty(

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -156,9 +156,10 @@ const GroupCards = <
 
         const cardProperty = convertToCardMetadataProperty(result)
         if (!cardProperty) return null
-        if (cardProperty.type === 'file') return {
-          property: cardProperty,
-        }
+        if (cardProperty.type === "file")
+          return {
+            property: cardProperty,
+          }
 
         return {
           icon: property.icon ?? Placeholder,
@@ -166,7 +167,6 @@ const GroupCards = <
         }
       })
       .filter((item): item is CardMetadata => item !== null)
-
   }
 
   function convertToCardMetadataProperty(


### PR DESCRIPTION
## Description
After some changes to the card collection, some cards started rendering strangely. 

The two main things is that now we force an icon, which makes file properties have two icons. 

The other is that the card footer is always displayed


## Screenshots (if applicable)

<img width="420" height="195" alt="Screenshot 2025-08-26 at 10 54 29" src="https://github.com/user-attachments/assets/2d0e3e36-5aca-4baf-93c0-e1ee8310bb6c" />


