### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.161.0",
+  "packages/react": "1.161.1",
   "packages/react-native": "0.18.1",
   "packages/core": "1.25.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.161.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.161.0...factorial-one-react-v1.161.1) (2025-08-27)
+
+
+### Bug Fixes
+
+* Rename tag variants to match name convention ([#2445](https://github.com/factorialco/factorial-one/issues/2445)) ([f8d0f18](https://github.com/factorialco/factorial-one/commit/f8d0f1834d2b16a29f70d1f99e4c981b46645a00))
+
 ## [1.161.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.160.1...factorial-one-react-v1.161.0) (2025-08-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.161.0",
+  "version": "1.161.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.161.1</summary>

## [1.161.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.161.0...factorial-one-react-v1.161.1) (2025-08-27)


### Bug Fixes

* Rename tag variants to match name convention ([#2445](https://github.com/factorialco/factorial-one/issues/2445)) ([f8d0f18](https://github.com/factorialco/factorial-one/commit/f8d0f1834d2b16a29f70d1f99e4c981b46645a00))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).