### PR TITLE
fix: show proper titles in Storybook

### DIFF
--- a/packages/react/src/components/tags/F0TagAlert/__storybook__/TagAlert.stories.tsx
+++ b/packages/react/src/components/tags/F0TagAlert/__storybook__/TagAlert.stories.tsx
@@ -4,7 +4,7 @@ import { F0TagAlert } from "../"
 
 const meta: Meta = {
   component: F0TagAlert,
-  title: "Tag/F0TagAlert",
+  title: "Tag/TagAlert",
   tags: ["autodocs"],
   parameters: {
     layout: "centered",

--- a/packages/react/src/components/tags/F0TagBalance/__storybook__/TagBalance.stories.tsx
+++ b/packages/react/src/components/tags/F0TagBalance/__storybook__/TagBalance.stories.tsx
@@ -4,7 +4,7 @@ import { F0TagBalance } from "../"
 
 const meta: Meta = {
   component: F0TagBalance,
-  title: "Tag/F0TagBalance",
+  title: "Tag/TagBalance",
   tags: ["autodocs"],
   parameters: {
     layout: "centered",

--- a/packages/react/src/components/tags/F0TagCompany/__storybook__/TagCompany.stories.tsx
+++ b/packages/react/src/components/tags/F0TagCompany/__storybook__/TagCompany.stories.tsx
@@ -4,7 +4,7 @@ import { F0TagCompany } from "../"
 
 const meta: Meta = {
   component: F0TagCompany,
-  title: "Tag/F0TagCompany",
+  title: "Tag/TagCompany",
   tags: ["autodocs"],
   parameters: {
     layout: "centered",

--- a/packages/react/src/components/tags/F0TagDot/__storybook__/TagDot.stories.tsx
+++ b/packages/react/src/components/tags/F0TagDot/__storybook__/TagDot.stories.tsx
@@ -4,7 +4,7 @@ import { F0TagDot } from "../"
 
 const meta: Meta = {
   component: F0TagDot,
-  title: "Tag/F0TagDot",
+  title: "Tag/TagDot",
   tags: ["autodocs"],
   parameters: {
     layout: "centered",

--- a/packages/react/src/components/tags/F0TagList/__storybook__/TagList.stories.tsx
+++ b/packages/react/src/components/tags/F0TagList/__storybook__/TagList.stories.tsx
@@ -152,7 +152,7 @@ const rawTags = [
  * relevant to that specific tag type.
  */
 const meta = {
-  title: "Tag/F0TagList",
+  title: "Tag/TagList",
   component: F0TagList,
   parameters: {
     layout: "centered",

--- a/packages/react/src/components/tags/F0TagPerson/__storybook__/TagPerson.stories.tsx
+++ b/packages/react/src/components/tags/F0TagPerson/__storybook__/TagPerson.stories.tsx
@@ -4,7 +4,7 @@ import { F0TagPerson } from "../"
 
 const meta: Meta = {
   component: F0TagPerson,
-  title: "Tag/F0TagPerson",
+  title: "Tag/TagPerson",
   tags: ["autodocs"],
   parameters: {
     layout: "centered",

--- a/packages/react/src/components/tags/F0TagRaw/__storybook__/TagRaw.stories.tsx
+++ b/packages/react/src/components/tags/F0TagRaw/__storybook__/TagRaw.stories.tsx
@@ -5,7 +5,7 @@ import { F0TagRaw } from "../"
 
 const meta: Meta = {
   component: F0TagRaw,
-  title: "Tag/F0TagRaw",
+  title: "Tag/TagRaw",
   tags: ["autodocs"],
   parameters: {
     layout: "centered",

--- a/packages/react/src/components/tags/F0TagStatus/__storybook__/TagStatus.stories.tsx
+++ b/packages/react/src/components/tags/F0TagStatus/__storybook__/TagStatus.stories.tsx
@@ -4,7 +4,7 @@ import { F0TagStatus } from "../"
 
 const meta: Meta = {
   component: F0TagStatus,
-  title: "Tag/F0TagStatus",
+  title: "Tag/TagStatus",
   tags: ["autodocs"],
   parameters: {
     layout: "centered",

--- a/packages/react/src/components/tags/F0TagTeam/__storybook__/TagTeam.stories.tsx
+++ b/packages/react/src/components/tags/F0TagTeam/__storybook__/TagTeam.stories.tsx
@@ -4,7 +4,7 @@ import { F0TagTeam } from "../"
 
 const meta: Meta = {
   component: F0TagTeam,
-  title: "Tag/F0TagTeam",
+  title: "Tag/TagTeam",
   tags: ["autodocs"],
   parameters: {
     layout: "centered",


### PR DESCRIPTION
Not so fancy:
<img width="287" height="304" alt="image" src="https://github.com/user-attachments/assets/4fecfe6c-0334-4439-91b7-c54cbf63954d" />
