### PR TITLE
feat: add hover actions to table

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.spec.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.spec.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 import type { FiltersDefinition } from "../../../../../components/OneFilterPicker/types"
@@ -907,6 +908,110 @@ describe("TableCollection", () => {
 
       // Clean up mock
       consoleSpy.mockRestore()
+    })
+  })
+
+  describe("Item Actions", () => {
+    const testPersonWithActions = {
+      id: 1,
+      name: "John Doe",
+      email: "john@example.com",
+      displayName: "Dr. John Doe",
+    }
+
+    const createTestSourceWithActions = (
+      itemActions: ItemActionsDefinition<Person>
+    ): DataSource<
+      Person,
+      TestFilters,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Person>,
+      TestNavigationFilters,
+      GroupingDefinition<Person>
+    > => ({
+      ...createTestSource([testPersonWithActions]),
+      itemActions,
+    })
+
+    it("renders actions as buttons and dropdown", async () => {
+      const mockAction = vi.fn()
+
+      const itemActions: ItemActionsDefinition<Person> = (_item) => [
+        {
+          label: "Edit User",
+          type: "primary", // Required for button rendering
+          onClick: mockAction,
+        },
+        {
+          label: "View Profile",
+          type: "secondary", // Goes to dropdown
+          onClick: mockAction,
+        },
+      ]
+
+      render(
+        <TestWrapper>
+          <TableCollection
+            columns={testColumns}
+            source={createTestSourceWithActions(itemActions)}
+            onSelectItems={vi.fn()}
+            onLoadData={vi.fn()}
+            onLoadError={vi.fn()}
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("John Doe")).toBeInTheDocument()
+      })
+
+      // Verify primary action is rendered as button
+      expect(
+        screen.getByRole("button", { name: /edit user/i })
+      ).toBeInTheDocument()
+
+      // Secondary actions go to dropdown (just verify dropdown exists)
+      expect(
+        screen.getByRole("button", { name: /actions/i })
+      ).toBeInTheDocument()
+    })
+
+    it("calls onClick handlers when buttons are clicked", async () => {
+      const user = userEvent.setup()
+      const actionMock = vi.fn()
+
+      const itemActions: ItemActionsDefinition<Person> = (_item) => [
+        {
+          label: "Edit User",
+          type: "primary",
+          onClick: actionMock,
+        },
+      ]
+
+      render(
+        <TestWrapper>
+          <TableCollection
+            columns={testColumns}
+            source={createTestSourceWithActions(itemActions)}
+            onSelectItems={vi.fn()}
+            onLoadData={vi.fn()}
+            onLoadError={vi.fn()}
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("John Doe")).toBeInTheDocument()
+      })
+
+      const actionButton = screen.getByRole("button", {
+        name: /edit user/i,
+      })
+
+      await user.click(actionButton)
+
+      expect(actionMock).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
## Description

Following this [Figma](https://www.figma.com/design/v1YD01TajEDThOX2BKzXee/Time-tracking---Data-collections?node-id=4001-14459&t=XJjNaqcgOVnIWbuj-0) and this [thread](https://factorialteam.slack.com/archives/C099YVA8E1J/p1756194673826619) we are adding an on hover button to the `<Table/>` row similar to the `<List/>` component.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/14088faa-f17f-4c11-b0d9-823ec6c5bb87

[Link to Figma Design](https://www.figma.com/design/v1YD01TajEDThOX2BKzXee/Time-tracking---Data-collections?node-id=4001-14459&t=XJjNaqcgOVnIWbuj-0)

## Implementation details

Added on hover actions to the `<Table/>`
