### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.163.2",
+  "packages/react": "1.164.0",
   "packages/react-native": "0.18.1",
   "packages/core": "1.25.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.164.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.163.2...factorial-one-react-v1.164.0) (2025-08-28)
+
+
+### Features
+
+* **ai-chat:** add effects to header ([#2461](https://github.com/factorialco/factorial-one/issues/2461)) ([76c2027](https://github.com/factorialco/factorial-one/commit/76c2027a349844f0abc15a5c4d6148fcf3215f19))
+
 ## [1.163.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.163.1...factorial-one-react-v1.163.2) (2025-08-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.163.2",
+  "version": "1.164.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.164.0</summary>

## [1.164.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.163.2...factorial-one-react-v1.164.0) (2025-08-28)


### Features

* **ai-chat:** add effects to header ([#2461](https://github.com/factorialco/factorial-one/issues/2461)) ([76c2027](https://github.com/factorialco/factorial-one/commit/76c2027a349844f0abc15a5c4d6148fcf3215f19))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).