### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.164.0",
+  "packages/react": "1.165.0",
   "packages/react-native": "0.18.1",
   "packages/core": "1.25.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.165.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.164.0...factorial-one-react-v1.165.0) (2025-08-28)
+
+
+### Features
+
+* upgrade copilot kit 1.10.2 ([#2465](https://github.com/factorialco/factorial-one/issues/2465)) ([b99b73d](https://github.com/factorialco/factorial-one/commit/b99b73deef240962c63072e1b8978dda75d0e611))
+
 ## [1.164.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.163.2...factorial-one-react-v1.164.0) (2025-08-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.164.0",
+  "version": "1.165.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.165.0</summary>

## [1.165.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.164.0...factorial-one-react-v1.165.0) (2025-08-28)


### Features

* upgrade copilot kit 1.10.2 ([#2465](https://github.com/factorialco/factorial-one/issues/2465)) ([b99b73d](https://github.com/factorialco/factorial-one/commit/b99b73deef240962c63072e1b8978dda75d0e611))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).