### PR TITLE
Snapshot review for `Button` and `Link` components

### DIFF
--- a/packages/react/src/components/Actions/Button/index.stories.tsx
+++ b/packages/react/src/components/Actions/Button/index.stories.tsx
@@ -1,3 +1,4 @@
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import React from "react"
 import { expect, within } from "storybook/test"
@@ -106,6 +107,7 @@ export const Default: Story = {
 }
 
 export const Variants: Story = {
+  ...withSnapshot({}),
   render: (args) => (
     <div className="flex gap-2">
       <Button {...args} variant="default" label="Default" />
@@ -120,6 +122,7 @@ export const Variants: Story = {
 }
 
 export const IconVariants: Story = {
+  ...withSnapshot({}),
   render: (args) => (
     <div className="flex flex-col gap-6">
       <div>
@@ -205,6 +208,7 @@ export const IconVariants: Story = {
 
 // Size Variants
 export const Sizes: Story = {
+  ...withSnapshot({}),
   render: (args) => (
     <div className="flex items-center gap-4">
       <Button {...args} size="lg" label="Large" />
@@ -214,7 +218,6 @@ export const Sizes: Story = {
   ),
 }
 
-// States
 export const Disabled: Story = {
   args: {
     disabled: true,
@@ -246,6 +249,7 @@ export const AsyncAction: Story = {
 }
 
 export const IconButtonGroup: Story = {
+  ...withSnapshot({}),
   render: () => (
     <div className="flex items-center gap-2">
       <Button variant="ghost" icon={Add} hideLabel round label="Add" />
@@ -265,6 +269,7 @@ export const OnlyEmoji: Story = {
 }
 
 export const States: Story = {
+  ...withSnapshot({}),
   render: (args) => {
     const [asyncLoading, setAsyncLoading] = React.useState(false)
     return (

--- a/packages/react/src/components/Actions/Link/__stories__/index.stories.tsx
+++ b/packages/react/src/components/Actions/Link/__stories__/index.stories.tsx
@@ -1,3 +1,4 @@
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { ComponentProps } from "react"
@@ -42,6 +43,7 @@ export const Default: Story = {
 }
 
 export const Variants: Story = {
+  ...withSnapshot({}),
   render: (args) => (
     <div className="[&>h3]:mt-5 [&>h3]:pb-2">
       <h3 className="!m-0">Basic usage</h3>
@@ -57,6 +59,7 @@ export const Variants: Story = {
 }
 
 export const States: Story = {
+  ...withSnapshot({}),
   render: (args) => (
     <div className="flex flex-row items-center justify-center space-x-6">
       <Link {...args} variant="link">

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -110,9 +110,6 @@ export const Default: Story = {
 }
 
 export const WithActions: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     title: "Product designer",
     description:
@@ -167,9 +164,6 @@ export const WithActionsAndLink: Story = {
 }
 
 export const WithLink: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     ...Default.args,
     link: "/",
@@ -177,9 +171,6 @@ export const WithLink: Story = {
 }
 
 export const Selectable: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     ...Default.args,
     selectable: true,
@@ -191,9 +182,6 @@ export const Selectable: Story = {
 }
 
 export const WithChildren: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     title: "Card with children",
     children: <SlotComponent />,
@@ -201,9 +189,6 @@ export const WithChildren: Story = {
 }
 
 export const WithEmoji: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     ...Default.args,
     avatar: {
@@ -226,9 +211,6 @@ export const WithImage: Story = {
 }
 
 export const WithFileAvatar: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     ...WithImage.args,
     selectable: true,
@@ -252,18 +234,12 @@ export const Compact: Story = {
 }
 
 export const Skeleton: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => {
     return <F0Card.Skeleton />
   },
 }
 
 export const SkeletonCompact: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => {
     return <F0Card.Skeleton compact />
   },
@@ -271,7 +247,6 @@ export const SkeletonCompact: Story = {
 
 export const IntentsShowcase: Story = {
   parameters: {
-    chromatic: { disableSnapshot: true },
     docs: {
       story: { inline: false, height: "420px" },
     },

--- a/packages/react/src/components/UpsellingKit/UpsellingButton/index.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellingButton/index.stories.tsx
@@ -116,9 +116,6 @@ export const OutlinePromote: Story = {
     variant: "outlinePromote",
     label: "Request Information",
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }
 
 export const Sizes: Story = {

--- a/packages/react/src/experimental/Forms/Fields/Input/index.stories.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Input/index.stories.tsx
@@ -83,18 +83,12 @@ export const Disabled: Story = {
 }
 
 export const WithLabel: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
   },
 }
 
 export const WithHiddenLabel: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     hideLabel: true,
@@ -102,9 +96,6 @@ export const WithHiddenLabel: Story = {
 }
 
 export const WithLabelIcon: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     labelIcon: Placeholder,
@@ -112,9 +103,6 @@ export const WithLabelIcon: Story = {
 }
 
 export const WithIcon: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     icon: Placeholder,
@@ -122,9 +110,6 @@ export const WithIcon: Story = {
 }
 
 export const WithError: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     error: "Error message here",
@@ -132,9 +117,6 @@ export const WithError: Story = {
 }
 
 export const WithWarning: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     status: {
@@ -145,9 +127,6 @@ export const WithWarning: Story = {
 }
 
 export const WithInfo: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     status: {
@@ -158,9 +137,6 @@ export const WithInfo: Story = {
 }
 
 export const WithHint: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     hint: "Hint message",
@@ -168,9 +144,6 @@ export const WithHint: Story = {
 }
 
 export const WithMaxLength: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     maxLength: 10,
@@ -178,9 +151,6 @@ export const WithMaxLength: Story = {
 }
 
 export const Clearable: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     maxLength: 10,

--- a/packages/react/src/experimental/Forms/Fields/NumberInput/index.stories.tsx
+++ b/packages/react/src/experimental/Forms/Fields/NumberInput/index.stories.tsx
@@ -81,18 +81,12 @@ export const Disabled: Story = {
 }
 
 export const WithLabel: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
   },
 }
 
 export const WithHiddenLabel: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     hideLabel: true,
@@ -100,9 +94,6 @@ export const WithHiddenLabel: Story = {
 }
 
 export const WithLabelIcon: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     labelIcon: Placeholder,
@@ -110,9 +101,6 @@ export const WithLabelIcon: Story = {
 }
 
 export const WithIcon: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     icon: Placeholder,
@@ -120,9 +108,6 @@ export const WithIcon: Story = {
 }
 
 export const WithError: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     error: "Error message here",
@@ -130,9 +115,6 @@ export const WithError: Story = {
 }
 
 export const WithMaxLength: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     maxLength: 10,
@@ -140,9 +122,6 @@ export const WithMaxLength: Story = {
 }
 
 export const Clearable: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     clearable: true,
@@ -150,9 +129,6 @@ export const Clearable: Story = {
 }
 
 export const WithUnits: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Insert amount",
     units: "EUR",

--- a/packages/react/src/experimental/Forms/Fields/Select/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Select/__stories__/index.stories.tsx
@@ -224,9 +224,6 @@ export const Default: Story = {
 }
 
 export const WithPreselectedValue: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     value: "dark",
@@ -234,9 +231,6 @@ export const WithPreselectedValue: Story = {
 }
 
 export const WithPlaceholder: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     placeholder: "Select a theme",
@@ -245,9 +239,6 @@ export const WithPlaceholder: Story = {
 }
 
 export const WithHiddenLabel: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     hideLabel: true,
@@ -255,9 +246,6 @@ export const WithHiddenLabel: Story = {
 }
 
 export const WithIcon: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     icon: Desktop,
@@ -265,9 +253,6 @@ export const WithIcon: Story = {
 }
 
 export const WithLabelIcon: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     labelIcon: Circle,
@@ -275,9 +260,6 @@ export const WithLabelIcon: Story = {
 }
 
 export const SizeMd: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     icon: Desktop,
@@ -286,9 +268,6 @@ export const SizeMd: Story = {
 }
 
 export const WithError: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     error: "Error message",
@@ -296,9 +275,6 @@ export const WithError: Story = {
 }
 
 export const WithWarning: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     status: {
@@ -309,9 +285,6 @@ export const WithWarning: Story = {
 }
 
 export const WithInfo: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     status: {
@@ -322,9 +295,6 @@ export const WithInfo: Story = {
 }
 
 export const WithHint: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     hint: "Hint message",
@@ -332,9 +302,6 @@ export const WithHint: Story = {
 }
 
 export const Clearable: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Select a theme",
     clearable: true,

--- a/packages/react/src/experimental/Forms/Fields/TextArea/index.stories.tsx
+++ b/packages/react/src/experimental/Forms/Fields/TextArea/index.stories.tsx
@@ -31,18 +31,12 @@ export const Disabled: Story = {
 }
 
 export const WithLabel: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
   },
 }
 
 export const WithHiddenLabel: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     hideLabel: true,
@@ -50,9 +44,6 @@ export const WithHiddenLabel: Story = {
 }
 
 export const WithLabelIcon: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     labelIcon: Placeholder,
@@ -60,9 +51,6 @@ export const WithLabelIcon: Story = {
 }
 
 export const WithIcon: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     icon: Placeholder,
@@ -70,9 +58,6 @@ export const WithIcon: Story = {
 }
 
 export const WithError: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     error: "Error message here",
@@ -80,9 +65,6 @@ export const WithError: Story = {
 }
 
 export const WithWarning: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     status: {
@@ -93,9 +75,6 @@ export const WithWarning: Story = {
 }
 
 export const WithInfo: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     status: {
@@ -106,9 +85,6 @@ export const WithInfo: Story = {
 }
 
 export const WithHint: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     hint: "Hint message",
@@ -116,9 +92,6 @@ export const WithHint: Story = {
 }
 
 export const WithMaxLength: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     maxLength: 10,
@@ -126,9 +99,6 @@ export const WithMaxLength: Story = {
 }
 
 export const Clearable: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     label: "Label text here",
     clearable: true,

--- a/packages/react/src/experimental/Information/Avatars/CompanyAvatar/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Avatars/CompanyAvatar/index.stories.tsx
@@ -26,18 +26,12 @@ type Story = StoryObj<typeof CompanyAvatar>
 export const Default: Story = {}
 
 export const WithImage: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     src: "/avatars/factorial.png",
   },
 }
 
 export const WithModuleBadge: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     src: "/avatars/factorial.png",
     badge: {

--- a/packages/react/src/experimental/Information/Avatars/FileAvatar/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Avatars/FileAvatar/index.stories.tsx
@@ -24,9 +24,6 @@ export const Default: Story = {
     file: new File([""], "document.pdf", { type: "application/pdf" }),
     size: "medium",
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }
 
 export const AllFileTypes: Story = {

--- a/packages/react/src/experimental/Information/Avatars/IconAvatar/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Avatars/IconAvatar/index.stories.tsx
@@ -27,7 +27,6 @@ const meta: Meta<typeof IconAvatar> = {
         ],
       },
     },
-    chromatic: { disableSnapshot: true },
   },
 }
 

--- a/packages/react/src/experimental/Navigation/Dropdown/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/index.stories.tsx
@@ -50,7 +50,6 @@ export const Default: Story = {
 
 export const PlayTest: Story = {
   parameters: {
-    chromatic: { disableSnapshot: true },
     a11y: {
       skipCi: true,
       disable: true, // as the play test uses body storybook container, it will be marked as an issues

--- a/packages/react/src/experimental/OneCalendar/OneCalendar.stories.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.stories.tsx
@@ -453,9 +453,6 @@ export const HalfYearRange: Story = {
     mode: "range",
     view: "halfyear",
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: (args) => {
     const [selectedRange, setSelectedRange] = useState<DateRange | null>(() => {
       const now = mockDate
@@ -499,9 +496,6 @@ export const DayRangeWithInput: Story = {
     view: "day",
     showInput: true,
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }
 
 export const MonthRangeWithInput: Story = {
@@ -509,9 +503,6 @@ export const MonthRangeWithInput: Story = {
     mode: "range",
     view: "month",
     showInput: true,
-  },
-  parameters: {
-    chromatic: { disableSnapshot: true },
   },
 }
 
@@ -521,9 +512,6 @@ export const QuarterRangeWithInput: Story = {
     view: "quarter",
     showInput: true,
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }
 
 export const HalfYearRangeWithInput: Story = {
@@ -532,9 +520,6 @@ export const HalfYearRangeWithInput: Story = {
     view: "halfyear",
     showInput: true,
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }
 
 export const YearRangeWithInput: Story = {
@@ -542,9 +527,6 @@ export const YearRangeWithInput: Story = {
     mode: "range",
     view: "year",
     showInput: true,
-  },
-  parameters: {
-    chromatic: { disableSnapshot: true },
   },
 }
 

--- a/packages/react/src/experimental/OneDataCollection/__stories__/collection-actions.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/collection-actions.stories.tsx
@@ -225,7 +225,6 @@ export const CardActionsExample: Story = {
     a11y: {
       skipCi: true,
     },
-    chromatic: { disableSnapshot: true },
   },
   render: () => {
     const dataSource = useDataSource({

--- a/packages/react/src/experimental/OneDataCollection/__stories__/full-height.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/full-height.stories.tsx
@@ -33,9 +33,6 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Basic: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => (
     <ExampleComponent
       frozenColumns={2}

--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
@@ -718,9 +718,6 @@ export const WithSelectableAndDefaultSelectedItems: Story = {
       }}
     />
   ),
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }
 export const WithSelectableAndDefaultSelectedGroups: Story = {
   render: () => (
@@ -747,9 +744,6 @@ export const WithSelectableAndDefaultSelectedGroups: Story = {
       }}
     />
   ),
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }
 
 const JsonVisualization = ({

--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/list.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/list.stories.tsx
@@ -24,9 +24,6 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const BasicListVisualization: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => {
     const mockVisualizations = getMockVisualizations()
     return <ExampleComponent visualizations={[mockVisualizations.list]} />
@@ -34,9 +31,6 @@ export const BasicListVisualization: Story = {
 }
 
 export const ListVisualizationWithGrouping: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => {
     const mockVisualizations = getMockVisualizations()
     return (
@@ -63,9 +57,6 @@ export const ListVisualizationWithGrouping: Story = {
 }
 
 export const ListVisualizationWithGroupingAndAllGroupsOpenByDefault: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => {
     const mockVisualizations = getMockVisualizations()
     return (
@@ -93,9 +84,6 @@ export const ListVisualizationWithGroupingAndAllGroupsOpenByDefault: Story = {
 }
 
 export const ListVisualizationWithInfiniteScrollPagination: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => {
     const mockVisualizations = getMockVisualizations()
     return (
@@ -113,9 +101,6 @@ export const ListVisualizationWithInfiniteScrollPagination: Story = {
 }
 
 export const ListVisualizationWithRegularPagination: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => {
     const mockVisualizations = getMockVisualizations()
     return (

--- a/packages/react/src/experimental/OneDateNavigator/__stories__/OneDateNavigator.stories.tsx
+++ b/packages/react/src/experimental/OneDateNavigator/__stories__/OneDateNavigator.stories.tsx
@@ -236,7 +236,4 @@ export const WithCompareTo: Story = {
       ],
     },
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }

--- a/packages/react/src/experimental/OneDatePicker/__stories__/OneDatePicker.stories.tsx
+++ b/packages/react/src/experimental/OneDatePicker/__stories__/OneDatePicker.stories.tsx
@@ -66,9 +66,6 @@ export const Simple: Story = {
       granularity: "day",
     } as DatePickerValue,
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }
 
 export const WithCustomRange: Story = {
@@ -79,9 +76,6 @@ export const WithCustomRange: Story = {
       granularity: "month",
     } as DatePickerValue,
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }
 
 export const HideGoToCurrent: Story = {
@@ -89,9 +83,6 @@ export const HideGoToCurrent: Story = {
     label: "Date",
     placeholder: "Select a date",
     hideGoToCurrent: true,
-  },
-  parameters: {
-    chromatic: { disableSnapshot: true },
   },
 }
 
@@ -105,9 +96,6 @@ export const WithDefaultDate: Story = {
       granularity: "day",
     } as DatePickerValue,
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 }
 
 export const WithPresets: Story = {
@@ -119,9 +107,6 @@ export const WithPresets: Story = {
     } as DatePickerValue,
     granularities: ["day", "week", "month", "quarter"],
     presets,
-  },
-  parameters: {
-    chromatic: { disableSnapshot: true },
   },
 }
 
@@ -135,8 +120,5 @@ export const WithMinMaxDates: Story = {
     granularities: ["day", "week", "month"],
     minDate: subDays(today, 30), // Can't select dates before 30 days ago
     maxDate: today, // Can't select dates after today
-  },
-  parameters: {
-    chromatic: { disableSnapshot: true },
   },
 }

--- a/packages/react/src/experimental/Widgets/Content/ListItems/WidgetInboxListItem/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ListItems/WidgetInboxListItem/index.stories.tsx
@@ -31,9 +31,6 @@ export const Default: Story = {
 }
 
 export const DefaultModule: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   args: {
     id: "1",
     title: "Title",

--- a/packages/react/src/lib/storybook-utils/parameters.ts
+++ b/packages/react/src/lib/storybook-utils/parameters.ts
@@ -1,0 +1,12 @@
+interface ChromaticOptions {
+  disableSnapshot?: boolean
+  diffThreshold?: number
+  forceColors: string
+}
+
+export const withSnapshot = (
+  parameters: Record<string, unknown>,
+  options?: ChromaticOptions
+) => {
+  return { ...parameters, chromatic: { disableSnapshot: false, ...options } }
+}

--- a/packages/react/src/ui/Action/__stories__/Action.stories.tsx
+++ b/packages/react/src/ui/Action/__stories__/Action.stories.tsx
@@ -6,9 +6,6 @@ import { Action } from "../Action"
 const meta: Meta<typeof Action> = {
   title: "Components/Action",
   component: Action,
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   tags: ["autodocs"],
   argTypes: {
     variant: {

--- a/packages/react/src/ui/Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/ui/Card/__stories__/Card.stories.tsx
@@ -15,9 +15,6 @@ import {
 const meta: Meta<typeof Card> = {
   title: "Components/Card",
   component: Card,
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   tags: ["autodocs"],
 }
 
@@ -25,9 +22,6 @@ export default meta
 type Story = StoryObj<typeof Card>
 
 export const Basic: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => (
     <Card>
       <CardHeader>
@@ -41,9 +35,6 @@ export const Basic: Story = {
 }
 
 export const WithSubtitle: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => (
     <Card>
       <CardHeader>
@@ -58,9 +49,6 @@ export const WithSubtitle: Story = {
 }
 
 export const WithInfo: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => (
     <Card>
       <CardHeader>
@@ -75,9 +63,6 @@ export const WithInfo: Story = {
 }
 
 export const WithFooter: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => (
     <Card>
       <CardHeader>
@@ -94,9 +79,6 @@ export const WithFooter: Story = {
 }
 
 export const WithComment: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => (
     <Card>
       <CardHeader>
@@ -111,9 +93,6 @@ export const WithComment: Story = {
 }
 
 export const Clickable: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => (
     <Card onClick={() => alert("Card clicked!")}>
       <CardHeader>
@@ -127,9 +106,6 @@ export const Clickable: Story = {
 }
 
 export const Disabled: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => (
     <Card disabled>
       <CardHeader>
@@ -143,9 +119,6 @@ export const Disabled: Story = {
 }
 
 export const Complete: Story = {
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: () => (
     <Card>
       <CardHeader>

--- a/packages/react/src/ui/ChevronToggle/__stories__/ChevronToggle.stories.tsx
+++ b/packages/react/src/ui/ChevronToggle/__stories__/ChevronToggle.stories.tsx
@@ -7,7 +7,6 @@ const meta = {
   component: ChevronToggle,
   parameters: {
     layout: "centered",
-    chromatic: { disableSnapshot: true },
   },
   tags: ["autodocs", "internal"],
 } satisfies Meta<typeof ChevronToggle>

--- a/packages/react/src/ui/Lane/__stories__/Lane.stories.tsx
+++ b/packages/react/src/ui/Lane/__stories__/Lane.stories.tsx
@@ -347,7 +347,6 @@ export const WithImages: Story = {
 
 export const TwoLanesDnD: Story = {
   parameters: {
-    chromatic: { disableSnapshot: true },
     docs: { story: { inline: false, height: "560px" } },
     containerHeight: "800px",
     containerMaxWidth: "900px",


### PR DESCRIPTION
## Description

Enables snapshot tests for important stories in `Button` and `Link` components

## Implementation details

- I created a parameter decorator `withSnapshot` to enable tests quickly and used it in button and link stories 
- I removed `disableSnapshot: true` in individual stories because snapshots are disabled by default
