### PR TITLE
Update product modal component

### DIFF
--- a/packages/react/src/components/UpsellingKit/ProductBlankslate/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductBlankslate/index.tsx
@@ -4,6 +4,7 @@ import { ModuleAvatar } from "@/experimental/Information/ModuleAvatar"
 import { CheckCircle } from "@/icons/app"
 import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
+import { RawTag } from "@factorialco/factorial-one-react-native";
 
 type ProductBlankslateProps = {
   title: string
@@ -14,6 +15,10 @@ type ProductBlankslateProps = {
   withShadow?: boolean
   icon?: IconType
   moduleName?: string
+  tag?: {
+    label: string
+    icon: IconType
+  }
 }
 
 const Benefits = ({ benefits }: { benefits: string[] }) => (
@@ -40,7 +45,7 @@ export const ProductBlankslate = forwardRef<
   ProductBlankslateProps
 >(
   (
-    { title, image, benefits, actions, withShadow = true, icon, moduleName },
+    { title, image, benefits, actions, withShadow = true, icon, moduleName, tag },
     ref
   ) => {
     return (
@@ -72,6 +77,11 @@ export const ProductBlankslate = forwardRef<
                   </p>
                 )}
               </div>
+              {tag && (
+                <div className="mb-2">
+                  <RawTag icon={tag.icon} text={tag.label} />
+                </div>
+              )}
               <h2 className="font-bold text-xl text-f1-foreground">{title}</h2>
             </div>
             <Benefits benefits={benefits} />

--- a/packages/react/src/components/UpsellingKit/ProductBlankslate/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductBlankslate/index.tsx
@@ -1,10 +1,10 @@
 // packages/react/src/experimental/ProductBlankslate/index.tsx
 import { Icon, IconType } from "@/components/Utilities/Icon"
+import { F0TagRaw } from "@/experimental"
 import { ModuleAvatar } from "@/experimental/Information/ModuleAvatar"
 import { CheckCircle } from "@/icons/app"
 import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
-import { RawTag } from "@factorialco/factorial-one-react-native";
 
 type ProductBlankslateProps = {
   title: string
@@ -45,7 +45,16 @@ export const ProductBlankslate = forwardRef<
   ProductBlankslateProps
 >(
   (
-    { title, image, benefits, actions, withShadow = true, icon, moduleName, tag },
+    {
+      title,
+      image,
+      benefits,
+      actions,
+      withShadow = true,
+      icon,
+      moduleName,
+      tag,
+    },
     ref
   ) => {
     return (
@@ -78,8 +87,8 @@ export const ProductBlankslate = forwardRef<
                 )}
               </div>
               {tag && (
-                <div className="mb-2">
-                  <RawTag icon={tag.icon} text={tag.label} />
+                <div className="flex justify-start">
+                  <F0TagRaw icon={tag.icon} text={tag.label} />
                 </div>
               )}
               <h2 className="font-bold text-xl text-f1-foreground">{title}</h2>

--- a/packages/react/src/components/UpsellingKit/ProductModal/ProductModal.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductModal/ProductModal.stories.tsx
@@ -86,6 +86,10 @@ const meta = {
       control: "text",
       description: "Label of the close modal",
     },
+    tag: {
+      control: "object",
+      description: "Tag of the modal",
+    },
   },
 } satisfies Meta<typeof ProductModal>
 
@@ -149,6 +153,10 @@ export const Default: Story = {
           text: "Demo to answer all your questions",
         },
       ],
+    },
+    tag: {
+      label: "Upgrade",
+      icon: UpsellIcon,
     },
     closeLabel: "Close",
   },

--- a/packages/react/src/components/UpsellingKit/ProductModal/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductModal/index.tsx
@@ -27,14 +27,18 @@ type ProductModalProps = {
   loadingState: {
     label: string
   }
-  nextSteps: {
+  closeLabel: string
+  nextSteps?: {
     title: string
     items: {
       text: string
       isCompleted?: boolean
     }[]
   }
-  closeLabel: string
+  tag?: {
+    label: string
+    icon: IconType
+  }
   primaryAction?: Action
   secondaryAction?: Action
   portalContainer?: HTMLElement | null
@@ -66,6 +70,7 @@ export function ProductModal({
   modalIcon,
   secondaryAction,
   portalContainer,
+  tag
 }: ProductModalProps) {
   const [isModalOpen, setIsOpen] = useState(isOpen)
   const [responseStatus, setResponseStatus] = useState<ResponseStatus>(null)
@@ -108,6 +113,7 @@ export function ProductModal({
             image={image}
             benefits={benefits}
             withShadow={false}
+            tag={tag}
             actions={
               <div className="flex gap-3">
                 {primaryAction && (

--- a/packages/react/src/components/UpsellingKit/ProductModal/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductModal/index.tsx
@@ -21,8 +21,8 @@ type ProductModalProps = {
   successMessage: {
     title: string
     description: string
-    buttonLabel: string
-    buttonOnClick: () => void
+    buttonLabel?: string
+    buttonOnClick?: () => void
   }
   loadingState: {
     label: string
@@ -70,7 +70,7 @@ export function ProductModal({
   modalIcon,
   secondaryAction,
   portalContainer,
-  tag
+  tag,
 }: ProductModalProps) {
   const [isModalOpen, setIsOpen] = useState(isOpen)
   const [responseStatus, setResponseStatus] = useState<ResponseStatus>(null)

--- a/packages/react/src/components/UpsellingKit/UpsellRequestResponseDialog/index.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellRequestResponseDialog/index.tsx
@@ -19,7 +19,7 @@ interface UpsellRequestResponseDialogProps {
   success: boolean
   errorMessage: ErrorMessageProps
   successMessage: SuccessMessageProps
-  nextSteps: NextStepsProps
+  nextSteps?: NextStepsProps
   closeLabel: string
   portalContainer?: HTMLElement | null
 }
@@ -32,8 +32,8 @@ export interface ErrorMessageProps {
 export interface SuccessMessageProps {
   title: string
   description: string
-  buttonLabel: string
-  buttonOnClick: () => void
+  buttonLabel?: string
+  buttonOnClick?: () => void
 }
 
 export interface StepItemProps {
@@ -92,10 +92,12 @@ const DialogActions = ({
 }: {
   onClose?: () => void
   success: boolean
-  successButtonOnClick: () => void
-  successButtonLabel: string
+  successButtonOnClick?: () => void
+  successButtonLabel?: string
   closeLabel: string
 }) => {
+  const showSecondButton = success && successButtonLabel && successButtonOnClick
+
   const renderButtons = (isSmallScreen = false) => (
     <>
       <Button
@@ -104,7 +106,7 @@ const DialogActions = ({
         onClick={onClose}
         size={isSmallScreen ? "lg" : undefined}
       />
-      {success && (
+      {showSecondButton && (
         <Button
           variant="promote"
           label={successButtonLabel}

--- a/packages/react/src/components/UpsellingKit/UpsellRequestResponseDialog/index.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellRequestResponseDialog/index.tsx
@@ -186,7 +186,7 @@ const UpsellRequestResponseDialog = forwardRef<
               </DialogDescription>
             </div>
           </DialogHeader>
-          {success ? (
+          {success && nextSteps ? (
             <>
               <Separator />
               <NextSteps title={nextSteps.title} items={nextSteps.items} />


### PR DESCRIPTION
## Description

We’re enhancing the `ProductModal` component to streamline the upsell and self-upsell experience.

## Screenshots (if applicable)

<img width="450" alt="Screenshot 2025-08-28 at 16 33 26" src="https://github.com/user-attachments/assets/226736cf-ac80-411e-80a7-ce41428e56a2" />

## Implementation details

- Add `tag` prop to `ProductModal` and `ProductBlankslate`.
- Make `nextStep` prop optional because is not always needed.
