### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.168.4",
+  "packages/react": "1.168.5",
   "packages/react-native": "0.18.1",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.168.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.168.4...factorial-one-react-v1.168.5) (2025-09-01)
+
+
+### Bug Fixes
+
+* set correct tag raw import ([#2491](https://github.com/factorialco/factorial-one/issues/2491)) ([5af9fe1](https://github.com/factorialco/factorial-one/commit/5af9fe16c7300a624f6e8cd637867cde0eedafb5))
+
 ## [1.168.4](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.168.3...factorial-one-react-v1.168.4) (2025-09-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.168.4",
+  "version": "1.168.5",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.168.5</summary>

## [1.168.5](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.168.4...factorial-one-react-v1.168.5) (2025-09-01)


### Bug Fixes

* set correct tag raw import ([#2491](https://github.com/factorialco/factorial-one/issues/2491)) ([5af9fe1](https://github.com/factorialco/factorial-one/commit/5af9fe16c7300a624f6e8cd637867cde0eedafb5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).