### PR TITLE
Support icon avatar type in `F0Card`

### DIFF
--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -6,6 +6,7 @@ import {
   Delete,
   Envelope,
   ExternalLink,
+  Lightbulb,
   Office,
   Star,
 } from "@/icons/app"
@@ -195,6 +196,16 @@ export const WithEmoji: Story = {
     avatar: {
       type: "emoji",
       emoji: "🐱",
+    },
+  },
+}
+
+export const WithIcon: Story = {
+  args: {
+    ...Default.args,
+    avatar: {
+      type: "icon",
+      icon: Lightbulb,
     },
   },
 }

--- a/packages/react/src/components/F0Card/components/CardAvatar.tsx
+++ b/packages/react/src/components/F0Card/components/CardAvatar.tsx
@@ -1,12 +1,15 @@
 import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0AvatarEmoji } from "@/components/avatars/F0AvatarEmoji"
 import { F0AvatarFile } from "@/components/avatars/F0AvatarFile"
+import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
+import { IconType } from "@/components/Utilities/Icon"
 import { cn } from "@/lib/utils"
 
 type CardAvatarVariant =
   | AvatarVariant
   | { type: "emoji"; emoji: string }
   | { type: "file"; file: File }
+  | { type: "icon"; icon: IconType }
 
 interface CardAvatarProps {
   /**
@@ -41,6 +44,9 @@ const AvatarRender = ({
     return (
       <F0AvatarFile file={avatar.file} size={compact ? "small" : "large"} />
     )
+  }
+  if (avatar.type === "icon") {
+    return <F0AvatarIcon icon={avatar.icon} size={compact ? "sm" : "lg"} />
   }
   return <F0Avatar avatar={avatar} size={compact ? "small" : "large"} />
 }


### PR DESCRIPTION
## Description

We add support for icon avatars in the `F0Card` component, which up until now only supported files, images, company, etc.

## Screenshots (if applicable)

<img width="559" height="275" alt="image" src="https://github.com/user-attachments/assets/82766b5c-7245-4f4a-8f61-40034c02697b" />

## Implementation details

We've simply reused existing facilities and added support for this.
