### PR TITLE
feat: add support to show file avatar in data collection

### DIFF
--- a/packages/react/src/components/avatars/F0Avatar/F0Avatar.tsx
+++ b/packages/react/src/components/avatars/F0Avatar/F0Avatar.tsx
@@ -1,24 +1,16 @@
-import { sizes } from "@/ui/avatar"
 import { ComponentProps, ReactNode } from "react"
 import { F0AvatarCompany } from "../F0AvatarCompany"
+import { F0AvatarFile } from "../F0AvatarFile"
 import { F0AvatarPerson } from "../F0AvatarPerson"
 import { F0AvatarTeam } from "../F0AvatarTeam"
-
-type PersonAvatarProps = ComponentProps<typeof F0AvatarPerson>
-type TeamAvatarProps = ComponentProps<typeof F0AvatarTeam>
-type CompanyAvatarProps = ComponentProps<typeof F0AvatarCompany>
-
-export type AvatarVariant =
-  | ({ type: "person" } & Omit<PersonAvatarProps, "size">)
-  | ({ type: "team" } & Omit<TeamAvatarProps, "size">)
-  | ({ type: "company" } & Omit<CompanyAvatarProps, "size">)
+import { AvatarVariant, AvatarVariantWithSize } from "./types"
 
 export const F0Avatar = ({
   avatar,
-  size = "xsmall",
+  size = "small",
 }: {
   avatar: AvatarVariant
-  size?: (typeof sizes)[number]
+  size?: AvatarVariantWithSize["size"]
 }): ReactNode => {
   switch (avatar.type) {
     case "person":
@@ -51,6 +43,16 @@ export const F0Avatar = ({
           src={avatar.src}
           badge={avatar.badge}
           size={size}
+          aria-label={avatar["aria-label"]}
+          aria-labelledby={avatar["aria-labelledby"]}
+        />
+      )
+    case "file":
+      return (
+        <F0AvatarFile
+          file={avatar.file}
+          size={size as ComponentProps<typeof F0AvatarFile>["size"]}
+          badge={avatar.badge}
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}
         />

--- a/packages/react/src/components/avatars/F0Avatar/types.ts
+++ b/packages/react/src/components/avatars/F0Avatar/types.ts
@@ -2,6 +2,7 @@ import { BadgeProps } from "@/experimental/Information/Badge"
 import { ModuleId } from "@/experimental/Information/ModuleAvatar"
 import { ComponentProps } from "react"
 import { F0AvatarCompany } from "../F0AvatarCompany"
+import { F0AvatarFile } from "../F0AvatarFile"
 import { F0AvatarPerson } from "../F0AvatarPerson"
 import { F0AvatarTeam } from "../F0AvatarTeam"
 
@@ -21,8 +22,16 @@ export type AvatarBadge = (
 type PersonAvatarProps = ComponentProps<typeof F0AvatarPerson>
 type TeamAvatarProps = ComponentProps<typeof F0AvatarTeam>
 type CompanyAvatarProps = ComponentProps<typeof F0AvatarCompany>
+type FileAvatarProps = ComponentProps<typeof F0AvatarFile>
 
-export type AvatarVariant =
-  | ({ type: "person" } & Omit<PersonAvatarProps, "size">)
-  | ({ type: "team" } & Omit<TeamAvatarProps, "size">)
-  | ({ type: "company" } & Omit<CompanyAvatarProps, "size">)
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never
+
+export type AvatarVariantWithSize =
+  | ({ type: "person" } & PersonAvatarProps)
+  | ({ type: "team" } & TeamAvatarProps)
+  | ({ type: "company" } & CompanyAvatarProps)
+  | ({ type: "file" } & FileAvatarProps)
+
+export type AvatarVariant = DistributiveOmit<AvatarVariantWithSize, "size">

--- a/packages/react/src/components/avatars/F0AvatarFile/F0AvatarFile.tsx
+++ b/packages/react/src/components/avatars/F0AvatarFile/F0AvatarFile.tsx
@@ -1,6 +1,13 @@
+import { Badge, BadgeProps } from "@/experimental/Information/Badge"
+import {
+  ModuleAvatar,
+  ModuleAvatarProps,
+} from "@/experimental/Information/ModuleAvatar"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { cn } from "@/lib/utils"
 import { Avatar, AvatarFallback, sizes } from "@/ui/avatar"
-import { ElementRef, forwardRef } from "react"
+import { ElementRef, forwardRef, useMemo } from "react"
+import { AvatarBadge } from "../F0Avatar/types"
 import { FileDef } from "./types"
 import { getFileTypeInfo } from "./utils"
 
@@ -9,27 +16,83 @@ type F0AvatarFileSize = Extract<
   "small" | "medium" | "large"
 >
 
+const getBadgeSize = (
+  size?: F0AvatarFileSize
+): BadgeProps["size"] | undefined => {
+  const sizeMap: Partial<
+    Record<Exclude<F0AvatarFileSize, undefined>, BadgeProps["size"]>
+  > = {
+    large: "sm",
+    small: "sm",
+  } as const
+
+  return size && sizeMap[size] ? sizeMap[size] : sizeMap.small
+}
+
+const getAvatarSize = (
+  size?: F0AvatarFileSize
+): ModuleAvatarProps["size"] | undefined => {
+  const sizeMap: Partial<
+    Record<Exclude<F0AvatarFileSize, undefined>, ModuleAvatarProps["size"]>
+  > = {
+    large: "xs",
+    small: "xs",
+  } as const
+
+  return size && sizeMap[size] ? sizeMap[size] : sizeMap.small
+}
+
 export type F0AvatarFileProps = Omit<
   React.ComponentPropsWithoutRef<typeof Avatar>,
   "type"
 > & {
   file: FileDef
   size?: F0AvatarFileSize
+  badge?: AvatarBadge
 }
 
 const F0AvatarFile = forwardRef<ElementRef<typeof Avatar>, F0AvatarFileProps>(
-  ({ file, className, ...props }, ref) => {
+  ({ file, badge, className, ...props }, ref) => {
     const { type: fileType, color: fileColor } = getFileTypeInfo(file)
+
+    const badgeSize = getBadgeSize(props.size)
+    const moduleAvatarSize = getAvatarSize(props.size)
+
+    const badgeContent = useMemo(
+      () =>
+        badge ? (
+          <>
+            {badge.type === "module" && (
+              <ModuleAvatar module={badge.module} size={moduleAvatarSize} />
+            )}
+            {badge.type !== "module" && (
+              <Badge type={badge.type} icon={badge.icon} size={badgeSize} />
+            )}
+          </>
+        ) : null,
+      [badge, badgeSize, moduleAvatarSize]
+    )
 
     return (
       <Avatar
         ref={ref}
-        className={cn("bg-f1-background", className)}
+        className={cn("overflow-visible bg-f1-background", className)}
         {...props}
       >
         <AvatarFallback className={cn("text-xs font-semibold", fileColor)}>
           {fileType}
         </AvatarFallback>
+        {badge && (
+          <div className="absolute -bottom-0.5 -right-0.5">
+            {badge.tooltip ? (
+              <Tooltip description={badge.tooltip}>
+                <div className="cursor-help">{badgeContent}</div>
+              </Tooltip>
+            ) : (
+              badgeContent
+            )}
+          </div>
+        )}
       </Avatar>
     )
   }

--- a/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
@@ -1,10 +1,11 @@
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { OverflowList } from "@/ui/OverflowList"
 import { cva } from "cva"
-import { AvatarVariant, F0Avatar } from "../F0Avatar"
+import { F0Avatar } from "../F0Avatar"
 import { MaxCounter } from "./components/MaxCounter"
 
 import { AvatarListSize, F0AvatarListProps } from "./types"
+import { getAvatarDisplayName } from "./utils"
 
 const avatarListVariants = cva({
   base: "flex items-center",
@@ -39,21 +40,6 @@ const CLIP_MASK: Record<"base" | "rounded", Record<AvatarListSize, string>> = {
   },
 }
 
-const getDisplayName = (avatar: AvatarVariant) => {
-  switch (avatar.type) {
-    case "person":
-      return `${avatar.firstName} ${avatar.lastName}`
-    case "team":
-      return avatar.name
-    case "company":
-      return avatar.name
-    case "file":
-      return avatar.file.name
-    default:
-      return ""
-  }
-}
-
 export const F0AvatarList = ({
   avatars,
   size = "medium",
@@ -68,7 +54,7 @@ export const F0AvatarList = ({
       <OverflowList
         items={avatars}
         renderListItem={(avatar) => {
-          const displayName = getDisplayName(avatar)
+          const displayName = getAvatarDisplayName(avatar)
 
           return (
             <Tooltip label={displayName}>
@@ -106,7 +92,7 @@ export const F0AvatarList = ({
   return (
     <div className={avatarListVariants({ size })}>
       {visibleAvatars.map((avatar, index) => {
-        const displayName = getDisplayName(avatar)
+        const displayName = getAvatarDisplayName(avatar)
 
         const clippedAvatar = (
           <div

--- a/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { OverflowList } from "@/ui/OverflowList"
 import { cva } from "cva"
-import { F0Avatar } from "../F0Avatar"
+import { AvatarVariant, F0Avatar } from "../F0Avatar"
 import { MaxCounter } from "./components/MaxCounter"
 
 import { AvatarListSize, F0AvatarListProps } from "./types"
@@ -39,6 +39,21 @@ const CLIP_MASK: Record<"base" | "rounded", Record<AvatarListSize, string>> = {
   },
 }
 
+const getDisplayName = (avatar: AvatarVariant) => {
+  switch (avatar.type) {
+    case "person":
+      return `${avatar.firstName} ${avatar.lastName}`
+    case "team":
+      return avatar.name
+    case "company":
+      return avatar.name
+    case "file":
+      return avatar.file.name
+    default:
+      return ""
+  }
+}
+
 export const F0AvatarList = ({
   avatars,
   size = "medium",
@@ -53,10 +68,7 @@ export const F0AvatarList = ({
       <OverflowList
         items={avatars}
         renderListItem={(avatar) => {
-          const displayName =
-            avatar.type === "person"
-              ? `${avatar.firstName} ${avatar.lastName}`
-              : avatar.name
+          const displayName = getDisplayName(avatar)
 
           return (
             <Tooltip label={displayName}>
@@ -94,10 +106,7 @@ export const F0AvatarList = ({
   return (
     <div className={avatarListVariants({ size })}>
       {visibleAvatars.map((avatar, index) => {
-        const displayName =
-          avatar.type === "person"
-            ? `${avatar.firstName} ${avatar.lastName}`
-            : avatar.name
+        const displayName = getDisplayName(avatar)
 
         const clippedAvatar = (
           <div

--- a/packages/react/src/components/avatars/F0AvatarList/components/MaxCounter.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/components/MaxCounter.tsx
@@ -7,6 +7,7 @@ import { ScrollArea, ScrollBar } from "@/ui/scrollarea"
 import { cva } from "cva"
 import { AvatarVariant, F0Avatar } from "../../F0Avatar"
 import { type AvatarListSize } from "../types"
+import { getAvatarDisplayName } from "../utils"
 
 const sizeVariants = cva({
   base: "flex shrink-0 items-center justify-center bg-f1-background-secondary font-medium text-f1-foreground-secondary",
@@ -80,9 +81,7 @@ export const MaxCounter = ({
                 <F0Avatar avatar={avatar} size="small" />
               </div>
               <div className="min-w-0 flex-1 truncate font-semibold">
-                {avatar.type === "person"
-                  ? `${avatar.firstName} ${avatar.lastName}`
-                  : avatar.name}
+                {getAvatarDisplayName(avatar)}
               </div>
             </div>
           ))}

--- a/packages/react/src/components/avatars/F0AvatarList/utils.ts
+++ b/packages/react/src/components/avatars/F0AvatarList/utils.ts
@@ -1,0 +1,16 @@
+import { AvatarVariant } from "../F0Avatar"
+
+export const getAvatarDisplayName = (avatar: AvatarVariant) => {
+  switch (avatar.type) {
+    case "person":
+      return `${avatar.firstName} ${avatar.lastName}`
+    case "team":
+      return avatar.name
+    case "company":
+      return avatar.name
+    case "file":
+      return avatar.file.name
+    default:
+      return ""
+  }
+}


### PR DESCRIPTION
## Description

We need to support the data collection to also show file avatars in order to show document-related tasks there.

## Screenshots

<img width="929" height="388" alt="Screenshot 2025-09-02 at 13 48 24" src="https://github.com/user-attachments/assets/bbed85cb-ede0-47f4-978a-7e42e963e217" />
