### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.168.6",
+  "packages/react": "1.169.0",
   "packages/react-native": "0.18.1",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.169.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.168.6...factorial-one-react-v1.169.0) (2025-09-02)
+
+
+### Features
+
+* add support to show file avatar in data collection ([#2497](https://github.com/factorialco/factorial-one/issues/2497)) ([ff54cc0](https://github.com/factorialco/factorial-one/commit/ff54cc006fe894c18a3bdf9e47811bfdc32887c0))
+
 ## [1.168.6](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.168.5...factorial-one-react-v1.168.6) (2025-09-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.168.6",
+  "version": "1.169.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.169.0</summary>

## [1.169.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.168.6...factorial-one-react-v1.169.0) (2025-09-02)


### Features

* add support to show file avatar in data collection ([#2497](https://github.com/factorialco/factorial-one/issues/2497)) ([ff54cc0](https://github.com/factorialco/factorial-one/commit/ff54cc006fe894c18a3bdf9e47811bfdc32887c0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).