### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.169.1",
+  "packages/react": "1.170.0",
   "packages/react-native": "0.18.1",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.170.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.169.1...factorial-one-react-v1.170.0) (2025-09-02)
+
+
+### Features
+
+* **One:** trigger button ([#2498](https://github.com/factorialco/factorial-one/issues/2498)) ([9574eaf](https://github.com/factorialco/factorial-one/commit/9574eaf68e54857266fd944c561fb5e100e871e6))
+
 ## [1.169.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.169.0...factorial-one-react-v1.169.1) (2025-09-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.169.1",
+  "version": "1.170.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.170.0</summary>

## [1.170.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.169.1...factorial-one-react-v1.170.0) (2025-09-02)


### Features

* **One:** trigger button ([#2498](https://github.com/factorialco/factorial-one/issues/2498)) ([9574eaf](https://github.com/factorialco/factorial-one/commit/9574eaf68e54857266fd944c561fb5e100e871e6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).