### PR TITLE
fix(One): dialog origin position

### DIFF
--- a/packages/react/src/experimental/AiChat/components/ChatWindow.tsx
+++ b/packages/react/src/experimental/AiChat/components/ChatWindow.tsx
@@ -100,7 +100,7 @@ export const ChatWindow = ({ children, ...rest }: WindowProps) => {
         <DialogPrimitive.Content
           onPointerDownOutside={(e) => e.preventDefault()}
           className={cn(
-            "fixed bottom-4 right-4 isolate z-50 w-[90%] rounded-xl border bg-f1-background shadow-lg",
+            "fixed bottom-4 right-4 isolate z-50 w-[90%] origin-bottom-right rounded-xl border bg-f1-background shadow-lg",
             "duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
             "flex max-h-[min(680px,calc(100%-16px))] min-h-[416px] max-w-[464px] flex-col overflow-hidden rounded-xl border-solid border-f1-border shadow"
           )}


### PR DESCRIPTION
## Description

Sets the animation origin for the chat to the bottom right. If you look closely in the video, you'll notice the dialog grows from that point instead of the center, making it look like it grows from the trigger.

## Screenshots

https://github.com/user-attachments/assets/ec05222e-b8f0-49d4-b51f-bfa3ef5a6aa5


