### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.171.1",
+  "packages/react": "1.171.2",
   "packages/react-native": "0.18.1",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.171.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.171.1...factorial-one-react-v1.171.2) (2025-09-03)
+
+
+### Bug Fixes
+
+* **One:** dialog origin position ([#2508](https://github.com/factorialco/factorial-one/issues/2508)) ([5c74417](https://github.com/factorialco/factorial-one/commit/5c74417dd8e301493380ffab9e57bd919694c384))
+
 ## [1.171.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.171.0...factorial-one-react-v1.171.1) (2025-09-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.171.1",
+  "version": "1.171.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.171.2</summary>

## [1.171.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.171.1...factorial-one-react-v1.171.2) (2025-09-03)


### Bug Fixes

* **One:** dialog origin position ([#2508](https://github.com/factorialco/factorial-one/issues/2508)) ([5c74417](https://github.com/factorialco/factorial-one/commit/5c74417dd8e301493380ffab9e57bd919694c384))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).