### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.171.2",
+  "packages/react": "1.171.3",
   "packages/react-native": "0.18.1",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.171.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.171.2...factorial-one-react-v1.171.3) (2025-09-03)
+
+
+### Bug Fixes
+
+* show presets itemCount when value is 0 ([#2484](https://github.com/factorialco/factorial-one/issues/2484)) ([7b2779c](https://github.com/factorialco/factorial-one/commit/7b2779cf40d7f165e8493eb38247da68a9eeea47))
+
 ## [1.171.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.171.1...factorial-one-react-v1.171.2) (2025-09-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.171.2",
+  "version": "1.171.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.171.3</summary>

## [1.171.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.171.2...factorial-one-react-v1.171.3) (2025-09-03)


### Bug Fixes

* show presets itemCount when value is 0 ([#2484](https://github.com/factorialco/factorial-one/issues/2484)) ([7b2779c](https://github.com/factorialco/factorial-one/commit/7b2779cf40d7f165e8493eb38247da68a9eeea47))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).