### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.171.3",
+  "packages/react": "1.172.0",
   "packages/react-native": "0.18.1",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.172.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.171.3...factorial-one-react-v1.172.0) (2025-09-03)
+
+
+### Features
+
+* hide filter chips if the filter matches a preset ([#2485](https://github.com/factorialco/factorial-one/issues/2485)) ([586ab4e](https://github.com/factorialco/factorial-one/commit/586ab4e095742fe0a88267e131dcbd4462c38bc6))
+* long format in week granularity ([#2479](https://github.com/factorialco/factorial-one/issues/2479)) ([6f01a18](https://github.com/factorialco/factorial-one/commit/6f01a18557b1ca0f7928b4485cd98a76fdc57964))
+
 ## [1.171.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.171.2...factorial-one-react-v1.171.3) (2025-09-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.171.3",
+  "version": "1.172.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.172.0</summary>

## [1.172.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.171.3...factorial-one-react-v1.172.0) (2025-09-03)


### Features

* hide filter chips if the filter matches a preset ([#2485](https://github.com/factorialco/factorial-one/issues/2485)) ([586ab4e](https://github.com/factorialco/factorial-one/commit/586ab4e095742fe0a88267e131dcbd4462c38bc6))
* long format in week granularity ([#2479](https://github.com/factorialco/factorial-one/issues/2479)) ([6f01a18](https://github.com/factorialco/factorial-one/commit/6f01a18557b1ca0f7928b4485cd98a76fdc57964))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).