### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.172.0",
-  "packages/react-native": "0.18.1",
+  "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.19.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.18.1...factorial-one-react-native-v0.19.0) (2025-09-03)
+
+
+### Features
+
+* remove module inbox ([#2514](https://github.com/factorialco/factorial-one/issues/2514)) ([183c97c](https://github.com/factorialco/factorial-one/commit/183c97c8803792ef0312ec876b45a827af085574))
+
 ## [0.18.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.18.0...factorial-one-react-native-v0.18.1) (2025-08-13)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.19.0</summary>

## [0.19.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.18.1...factorial-one-react-native-v0.19.0) (2025-09-03)


### Features

* remove module inbox ([#2514](https://github.com/factorialco/factorial-one/issues/2514)) ([183c97c](https://github.com/factorialco/factorial-one/commit/183c97c8803792ef0312ec876b45a827af085574))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).