### PR TITLE
feat(ValueDisplay): add percentage cell type

### DIFF
--- a/packages/react/src/components/value-display/__stories__/ValueDisplay.mdx
+++ b/packages/react/src/components/value-display/__stories__/ValueDisplay.mdx
@@ -736,3 +736,79 @@ render: (item) => ({
 `,
   }}
 />
+
+### percentage
+
+Renders a percentage with a chart
+
+#### Value type
+
+```
+type value = number | undefined
+// or
+type value = {
+    percentage: number | undefined
+}
+```
+
+#### PercentageInputAsObject
+
+<Canvas
+  of={ValueDisplayStories.PercentageInputAsObject}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'percentage',
+    value: 42
+})
+`,
+  }}
+/>
+
+#### PercentageValueInputAsObject
+
+<Canvas
+  of={ValueDisplayStories.PercentageValueInputAsObject}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'percentage'
+    value: {
+      percentage: 42
+    }
+})
+`,
+  }}
+/>
+
+#### With label
+
+<Canvas
+  of={ValueDisplayStories.PercentageWithLabel}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'percentage'
+    value: {
+      percentage: 75,
+      label: '324 out of 432'
+    }
+})`,
+  }}
+/>
+
+#### With placeholder
+
+<Canvas
+  of={ValueDisplayStories.PercentageWithPlaceholder}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'percentage'
+    value: {
+      percentage: undefined,
+      placeholder: 'There is no data yet'
+    }
+})`,
+  }}
+/>

--- a/packages/react/src/components/value-display/__stories__/ValueDisplay.stories.tsx
+++ b/packages/react/src/components/value-display/__stories__/ValueDisplay.stories.tsx
@@ -568,3 +568,61 @@ export const FolderType: Story = {
     },
   },
 }
+
+export const PercentageInputAsObject: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Percentage",
+      render: () => ({
+        type: "percentage",
+        value: 42,
+      }),
+    },
+  },
+}
+
+export const PercentageValueInputAsObject: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Percentage",
+      render: () => ({
+        type: "percentage",
+        value: { percentage: 50 },
+      }),
+    },
+  },
+}
+
+export const PercentageWithLabel: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Percentage",
+      render: () => ({
+        type: "percentage",
+        value: {
+          percentage: 75,
+          label: "324 out of 432",
+        },
+      }),
+    },
+  },
+}
+
+export const PercentageWithPlaceholder: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Percentage",
+      render: () => ({
+        type: "percentage",
+        value: {
+          percentage: undefined,
+          placeholder: "There is no data yet",
+        },
+      }),
+    },
+  },
+}

--- a/packages/react/src/components/value-display/renderers.tsx
+++ b/packages/react/src/components/value-display/renderers.tsx
@@ -10,6 +10,7 @@ import { FileCell } from "./types/file.tsx"
 import { FolderCell } from "./types/folder.tsx"
 import { IconCell } from "./types/icon.tsx"
 import { NumberCell } from "./types/number.tsx"
+import { PercentageCell } from "./types/percentage.tsx"
 import { PersonCell } from "./types/person.tsx"
 import { StatusCell } from "./types/status.tsx"
 import { TagCell } from "./types/tag.tsx"
@@ -40,6 +41,7 @@ export const valueDisplayRenderers = {
   status: StatusCell,
   alertTag: AlertTagCell,
   person: PersonCell,
+  percentage: PercentageCell,
   company: CompanyCell,
   team: TeamCell,
   tag: TagCell,

--- a/packages/react/src/components/value-display/types/percentage.tsx
+++ b/packages/react/src/components/value-display/types/percentage.tsx
@@ -1,0 +1,78 @@
+/**
+ * Percentage cell type for displaying percentage values in data collections.
+ * Supports both direct values and objects with placeholder states, it also supports a label.
+ */
+import { cn } from "@/lib/utils"
+import { isShowingPlaceholder, resolveValue } from "../utils"
+import { WithPlaceholder } from "./types"
+
+const VIEWBOX_SIZE = 100
+const STROKE_WIDTH = 12
+const PATH_GAP = 12
+
+export interface PercentageValue extends WithPlaceholder {
+  percentage: number | undefined
+  label?: string
+}
+
+export type PercentageCellValue = number | undefined | PercentageValue
+
+export const PercentageCell = (args: PercentageCellValue) => {
+  const value = resolveValue<number>(args, "percentage")
+  const isPlaceholder = isShowingPlaceholder(args, "percentage")
+
+  if (value === undefined) {
+    return null
+  }
+
+  if (isPlaceholder) {
+    return (
+      <span
+        className={cn(
+          "text-f1-foreground",
+          isPlaceholder && "text-f1-foreground-secondary"
+        )}
+      >
+        {value}
+      </span>
+    )
+  }
+
+  const center = VIEWBOX_SIZE / 2
+  const radius = center - STROKE_WIDTH / 2
+  const innerRadius = radius - PATH_GAP
+  const circumference = 2 * Math.PI * innerRadius
+  const progressOffset =
+    ((100 - Math.min(Number(value), 100)) / 100) * circumference
+  const hasLabel = typeof args === "object" && "label" in args
+
+  return (
+    <div className="flex items-center gap-2">
+      <svg
+        viewBox={`0 0 ${VIEWBOX_SIZE} ${VIEWBOX_SIZE}`}
+        className="h-7 w-7 -rotate-90 transform"
+      >
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          className="fill-f1-background-positive"
+        />
+        <circle
+          cx={center}
+          cy={center}
+          r={innerRadius}
+          className="stroke-f1-background-positive-bold"
+          fill="none"
+          strokeWidth={STROKE_WIDTH}
+          strokeDasharray={circumference}
+          strokeDashoffset={progressOffset}
+          strokeLinecap="round"
+        />
+      </svg>
+      <span className="text-f1-foreground">
+        {hasLabel ? args.label : `${value}%`}
+      </span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

In Talent Engagement we want to show the survey participation rate in the data collection. To do so we are showing the amount of people and a percentage chart:

<img width="1429" height="361" alt="image" src="https://github.com/user-attachments/assets/899441a2-4933-4403-a682-7342dbf9e1bc" />

## Screenshots (if applicable)

| With value | With custom label | Placeholder |
|--------|--------|--------|
| <img width="81" height="48" alt="image" src="https://github.com/user-attachments/assets/ae3c6ec8-f6a3-4fff-b1be-89f71053e5b9" /> | <img width="151" height="47" alt="image" src="https://github.com/user-attachments/assets/2dc8a239-05f8-4fa5-a53a-87ab134d2943" /> | <img width="168" height="52" alt="image" src="https://github.com/user-attachments/assets/27345e53-a7c9-401f-935b-31e08c1c639b" /> |

[Link to Figma Design](https://www.figma.com/design/zEzrsNcGNKYj9JXTQa3moF/%F0%9F%93%8B-Engagement-Surveys-Q3?node-id=2875-178568&t=CoAk6TjzAth4FHYr-0)

## Implementation details

I'd loved to reuse the `RadialProgressChart` but to achieve this design we'd need to:

- Allow a background
- Allow to hide the "empty" path (the grey one)
- Allow to change the path size, since when making it smaller (`28px`) it looked too skinny. 

I decided to go forward with a new implementation because I can see a future where we add different status colors to this percentage chart, for example a chart with a low amount could be shown as red so signify there is something wrong, and the background, etc, helps with that.
