### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.172.0",
+  "packages/react": "1.173.0",
   "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.173.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.172.0...factorial-one-react-v1.173.0) (2025-09-04)
+
+
+### Features
+
+* add hover actions to table ([#2454](https://github.com/factorialco/factorial-one/issues/2454)) ([a0e13b0](https://github.com/factorialco/factorial-one/commit/a0e13b09d5aae7a9a004ad6fac4675da68ce9510))
+
 ## [1.172.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.171.3...factorial-one-react-v1.172.0) (2025-09-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.172.0",
+  "version": "1.173.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.173.0</summary>

## [1.173.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.172.0...factorial-one-react-v1.173.0) (2025-09-04)


### Features

* add hover actions to table ([#2454](https://github.com/factorialco/factorial-one/issues/2454)) ([a0e13b0](https://github.com/factorialco/factorial-one/commit/a0e13b09d5aae7a9a004ad6fac4675da68ce9510))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).