### PR TITLE
feat(One): make the whole textarea clickable

### DIFF
--- a/packages/react/src/experimental/AiChat/components/ChatTextarea.tsx
+++ b/packages/react/src/experimental/AiChat/components/ChatTextarea.tsx
@@ -48,7 +48,7 @@ export const ChatTextarea = ({ inProgress, onSend, onStop }: InputProps) => {
       aria-busy={inProgress}
       ref={formRef}
       className={cn(
-        "relative isolate m-2 flex flex-col gap-3 rounded-lg border border-solid border-f1-border",
+        "relative isolate m-2 flex flex-col gap-3 rounded-lg border border-solid border-f1-border hover:cursor-text",
         "after:pointer-events-none after:absolute after:inset-0.5 after:z-[-2] after:rounded-[inherit] after:bg-f1-foreground-secondary after:opacity-0 after:blur-[5px] after:content-['']",
         "from-[#E55619] via-[#A1ADE5] to-[#E51943] after:scale-90 after:bg-[conic-gradient(from_var(--gradient-angle),var(--tw-gradient-stops))]",
         "after:transition-all after:delay-200 after:duration-300 has-[textarea:focus]:after:scale-100 has-[textarea:focus]:after:opacity-100",
@@ -67,6 +67,9 @@ export const ChatTextarea = ({ inProgress, onSend, onStop }: InputProps) => {
           "--gradient-angle": "180deg",
         } as React.CSSProperties
       }
+      onClick={() => {
+        textareaRef.current?.focus()
+      }}
       onSubmit={handleSubmit}
     >
       <div className="grid grid-cols-1 grid-rows-1">


### PR DESCRIPTION
## Description

Simple QoL improvement.

<img width="472" height="155" alt="image" src="https://github.com/user-attachments/assets/e2b3f7a4-ec15-406b-91e3-d1dd670aa057" />

The textarea is the element with the red border, and the rest is the form, which includes the button. But to the user, the entire form seems to be the textarea, since that's where we're drawing the glowing border. To focus the textarea, the user has to click in it, but they might click on the form (not the textarea), since it looks like it's all one element, but it does not get focused, making it seem like a bug.

This PR makes clicking the form focus the textarea. Buttons inside still work.

## Screenshots

### Before

https://github.com/user-attachments/assets/4c8c3748-67f2-4cb6-97ee-9a07763675bf

_Notice how clicking on the bottom part of the (what seems to be) the textarea does not focus it_

### After

https://github.com/user-attachments/assets/56fe8abc-9dd6-4ff4-b2b3-e2434808d066

---

Slack does the same trick:

https://github.com/user-attachments/assets/6e2381a1-e321-4bf8-85b6-d9dd5ec2b812