### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.174.0",
+  "packages/react": "1.175.0",
   "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.175.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.174.0...factorial-one-react-v1.175.0) (2025-09-04)
+
+
+### Features
+
+* **ValueDisplay:** add percentage cell type ([#2516](https://github.com/factorialco/factorial-one/issues/2516)) ([a03c006](https://github.com/factorialco/factorial-one/commit/a03c006de5bc365d90d8471ee8aa23aefe220921))
+
 ## [1.174.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.173.0...factorial-one-react-v1.174.0) (2025-09-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.174.0",
+  "version": "1.175.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.175.0</summary>

## [1.175.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.174.0...factorial-one-react-v1.175.0) (2025-09-04)


### Features

* **ValueDisplay:** add percentage cell type ([#2516](https://github.com/factorialco/factorial-one/issues/2516)) ([a03c006](https://github.com/factorialco/factorial-one/commit/a03c006de5bc365d90d8471ee8aa23aefe220921))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).