### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.176.0",
+  "packages/react": "1.177.0",
   "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.177.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.176.0...factorial-one-react-v1.177.0) (2025-09-04)
+
+
+### Features
+
+* stabilize avatar components ([#2524](https://github.com/factorialco/factorial-one/issues/2524)) ([3b9b4f3](https://github.com/factorialco/factorial-one/commit/3b9b4f3c1284c9cac4171cee60ada903b066c031))
+
 ## [1.176.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.175.1...factorial-one-react-v1.176.0) (2025-09-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.176.0",
+  "version": "1.177.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.177.0</summary>

## [1.177.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.176.0...factorial-one-react-v1.177.0) (2025-09-04)


### Features

* stabilize avatar components ([#2524](https://github.com/factorialco/factorial-one/issues/2524)) ([3b9b4f3](https://github.com/factorialco/factorial-one/commit/3b9b4f3c1284c9cac4171cee60ada903b066c031))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).