### PR TITLE
fix: allow deselecting a preset by clicking on it again

### DIFF
--- a/packages/react/src/components/OneFilterPicker/components/FiltersPresets.test.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersPresets.test.tsx
@@ -7,27 +7,7 @@ import type {
 } from "../types"
 import { FiltersPresets } from "./FiltersPresets"
 
-// Mock data for testing
-const mockFiltersDefinition: FiltersDefinition = {
-  department: {
-    type: "in",
-    label: "Department",
-    options: [
-      { value: "engineering", label: "Engineering" },
-      { value: "marketing", label: "Marketing" },
-    ],
-  },
-  status: {
-    type: "in",
-    label: "Status",
-    options: [
-      { value: "active", label: "Active" },
-      { value: "inactive", label: "Inactive" },
-    ],
-  },
-}
-
-const mockPresets: PresetsDefinition<typeof mockFiltersDefinition> = [
+const mockPresets: PresetsDefinition<FiltersDefinition> = [
   {
     label: "Engineering Active",
     filter: { department: ["engineering"], status: ["active"] },
@@ -42,7 +22,7 @@ describe("FiltersPresets", () => {
   it("should apply preset when clicked and not selected", async () => {
     const user = userEvent.setup()
     const mockOnPresetsChange = vi.fn()
-    const initialFilters: FiltersState<typeof mockFiltersDefinition> = {}
+    const initialFilters: FiltersState<FiltersDefinition> = {}
 
     const { getByText } = zeroRender(
       <FiltersPresets
@@ -65,7 +45,7 @@ describe("FiltersPresets", () => {
   it("should deselect preset when clicked and already selected", async () => {
     const user = userEvent.setup()
     const mockOnPresetsChange = vi.fn()
-    const selectedFilters: FiltersState<typeof mockFiltersDefinition> = {
+    const selectedFilters: FiltersState<FiltersDefinition> = {
       department: ["engineering"],
       status: ["active"],
     }
@@ -88,7 +68,7 @@ describe("FiltersPresets", () => {
   it("should toggle between different presets correctly", async () => {
     const user = userEvent.setup()
     const mockOnPresetsChange = vi.fn()
-    const initialFilters: FiltersState<typeof mockFiltersDefinition> = {}
+    const initialFilters: FiltersState<FiltersDefinition> = {}
 
     const { getByText } = zeroRender(
       <FiltersPresets
@@ -118,7 +98,7 @@ describe("FiltersPresets", () => {
   it("should work with dropdown preset items", async () => {
     const user = userEvent.setup()
     const mockOnPresetsChange = vi.fn()
-    const selectedFilters: FiltersState<typeof mockFiltersDefinition> = {
+    const selectedFilters: FiltersState<FiltersDefinition> = {
       department: ["marketing"],
     }
 

--- a/packages/react/src/components/OneFilterPicker/components/FiltersPresets.test.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersPresets.test.tsx
@@ -1,0 +1,139 @@
+import { userEvent, zeroRender } from "@/testing/test-utils"
+import { describe, expect, it, vi } from "vitest"
+import type {
+  FiltersDefinition,
+  FiltersState,
+  PresetsDefinition,
+} from "../types"
+import { FiltersPresets } from "./FiltersPresets"
+
+// Mock data for testing
+const mockFiltersDefinition: FiltersDefinition = {
+  department: {
+    type: "in",
+    label: "Department",
+    options: [
+      { value: "engineering", label: "Engineering" },
+      { value: "marketing", label: "Marketing" },
+    ],
+  },
+  status: {
+    type: "in",
+    label: "Status",
+    options: [
+      { value: "active", label: "Active" },
+      { value: "inactive", label: "Inactive" },
+    ],
+  },
+}
+
+const mockPresets: PresetsDefinition<typeof mockFiltersDefinition> = [
+  {
+    label: "Engineering Active",
+    filter: { department: ["engineering"], status: ["active"] },
+  },
+  {
+    label: "Marketing Only",
+    filter: { department: ["marketing"] },
+  },
+]
+
+describe("FiltersPresets", () => {
+  it("should apply preset when clicked and not selected", async () => {
+    const user = userEvent.setup()
+    const mockOnPresetsChange = vi.fn()
+    const initialFilters: FiltersState<typeof mockFiltersDefinition> = {}
+
+    const { getByText } = zeroRender(
+      <FiltersPresets
+        presets={mockPresets}
+        value={initialFilters}
+        onPresetsChange={mockOnPresetsChange}
+      />
+    )
+
+    // Click on the first preset
+    await user.click(getByText("Engineering Active"))
+
+    // Should call onPresetsChange with the preset's filter
+    expect(mockOnPresetsChange).toHaveBeenCalledWith({
+      department: ["engineering"],
+      status: ["active"],
+    })
+  })
+
+  it("should deselect preset when clicked and already selected", async () => {
+    const user = userEvent.setup()
+    const mockOnPresetsChange = vi.fn()
+    const selectedFilters: FiltersState<typeof mockFiltersDefinition> = {
+      department: ["engineering"],
+      status: ["active"],
+    }
+
+    const { getByText } = zeroRender(
+      <FiltersPresets
+        presets={mockPresets}
+        value={selectedFilters}
+        onPresetsChange={mockOnPresetsChange}
+      />
+    )
+
+    // Click on the already selected preset
+    await user.click(getByText("Engineering Active"))
+
+    // Should call onPresetsChange with empty filters to deselect
+    expect(mockOnPresetsChange).toHaveBeenCalledWith({})
+  })
+
+  it("should toggle between different presets correctly", async () => {
+    const user = userEvent.setup()
+    const mockOnPresetsChange = vi.fn()
+    const initialFilters: FiltersState<typeof mockFiltersDefinition> = {}
+
+    const { getByText } = zeroRender(
+      <FiltersPresets
+        presets={mockPresets}
+        value={initialFilters}
+        onPresetsChange={mockOnPresetsChange}
+      />
+    )
+
+    // Click on first preset
+    await user.click(getByText("Engineering Active"))
+    expect(mockOnPresetsChange).toHaveBeenCalledWith({
+      department: ["engineering"],
+      status: ["active"],
+    })
+
+    // Reset mock
+    mockOnPresetsChange.mockClear()
+
+    // Click on second preset
+    await user.click(getByText("Marketing Only"))
+    expect(mockOnPresetsChange).toHaveBeenCalledWith({
+      department: ["marketing"],
+    })
+  })
+
+  it("should work with dropdown preset items", async () => {
+    const user = userEvent.setup()
+    const mockOnPresetsChange = vi.fn()
+    const selectedFilters: FiltersState<typeof mockFiltersDefinition> = {
+      department: ["marketing"],
+    }
+
+    const { getByText } = zeroRender(
+      <FiltersPresets
+        presets={mockPresets}
+        value={selectedFilters}
+        onPresetsChange={mockOnPresetsChange}
+      />
+    )
+
+    // Click on the already selected preset in dropdown
+    await user.click(getByText("Marketing Only"))
+
+    // Should deselect the preset
+    expect(mockOnPresetsChange).toHaveBeenCalledWith({})
+  })
+})

--- a/packages/react/src/components/OneFilterPicker/components/FiltersPresets.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersPresets.tsx
@@ -27,7 +27,15 @@ export const FiltersPresets = <Filters extends FiltersDefinition>({
         key={index}
         label={preset.label}
         selected={isSelected}
-        onClick={() => onPresetsChange?.(preset.filter)}
+        onClick={() => {
+          if (isSelected) {
+            // If preset is already selected, deselect it by clearing filters
+            onPresetsChange?.({} as FiltersState<Filters>)
+          } else {
+            // If preset is not selected, apply the preset's filter
+            onPresetsChange?.(preset.filter)
+          }
+        }}
         data-visible={isVisible}
         number={preset.itemsCount?.(value) ?? undefined}
       />
@@ -48,7 +56,15 @@ export const FiltersPresets = <Filters extends FiltersDefinition>({
             "bg-f1-background-selected hover:bg-f1-background-selected",
           focusRing()
         )}
-        onClick={() => onPresetsChange?.(preset.filter)}
+        onClick={() => {
+          if (isSelected) {
+            // If preset is already selected, deselect it by clearing filters
+            onPresetsChange?.({} as FiltersState<Filters>)
+          } else {
+            // If preset is not selected, apply the preset's filter
+            onPresetsChange?.(preset.filter)
+          }
+        }}
         data-visible={true}
       >
         {preset.label}

--- a/packages/react/src/components/OneFilterPicker/components/FiltersPresets.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersPresets.tsx
@@ -27,15 +27,11 @@ export const FiltersPresets = <Filters extends FiltersDefinition>({
         key={index}
         label={preset.label}
         selected={isSelected}
-        onClick={() => {
-          if (isSelected) {
-            // If preset is already selected, deselect it by clearing filters
-            onPresetsChange?.({} as FiltersState<Filters>)
-          } else {
-            // If preset is not selected, apply the preset's filter
-            onPresetsChange?.(preset.filter)
-          }
-        }}
+        onClick={() =>
+          onPresetsChange?.(
+            isSelected ? ({} as FiltersState<Filters>) : preset.filter
+          )
+        }
         data-visible={isVisible}
         number={preset.itemsCount?.(value) ?? undefined}
       />
@@ -56,15 +52,11 @@ export const FiltersPresets = <Filters extends FiltersDefinition>({
             "bg-f1-background-selected hover:bg-f1-background-selected",
           focusRing()
         )}
-        onClick={() => {
-          if (isSelected) {
-            // If preset is already selected, deselect it by clearing filters
-            onPresetsChange?.({} as FiltersState<Filters>)
-          } else {
-            // If preset is not selected, apply the preset's filter
-            onPresetsChange?.(preset.filter)
-          }
-        }}
+        onClick={() =>
+          onPresetsChange?.(
+            isSelected ? ({} as FiltersState<Filters>) : preset.filter
+          )
+        }
         data-visible={true}
       >
         {preset.label}


### PR DESCRIPTION
## Description

It is not easy at all for the user to come back to the original list if we do not allow them to deselect the preset they just applied, with this change they should be able to undo it right by clicking on the same element.

https://github.com/user-attachments/assets/fd526263-7472-4d27-a61e-95974d80d79a

