### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.177.0",
+  "packages/react": "1.177.1",
   "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.177.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.177.0...factorial-one-react-v1.177.1) (2025-09-05)
+
+
+### Bug Fixes
+
+* allow deselecting a preset by clicking on it again ([#2531](https://github.com/factorialco/factorial-one/issues/2531)) ([f7cc87e](https://github.com/factorialco/factorial-one/commit/f7cc87ef463dcd44bfd7d9ac698e820689247ce7))
+
 ## [1.177.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.176.0...factorial-one-react-v1.177.0) (2025-09-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.177.0",
+  "version": "1.177.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.177.1</summary>

## [1.177.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.177.0...factorial-one-react-v1.177.1) (2025-09-05)


### Bug Fixes

* allow deselecting a preset by clicking on it again ([#2531](https://github.com/factorialco/factorial-one/issues/2531)) ([f7cc87e](https://github.com/factorialco/factorial-one/commit/f7cc87ef463dcd44bfd7d9ac698e820689247ce7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).