### PR TITLE
fix: allow selecting group by clicking on group header when collapsing is not enabled

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/components/GroupHeader/GroupHeader.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/GroupHeader/GroupHeader.tsx
@@ -40,10 +40,18 @@ export const GroupHeader = ({
     onOpenChange?.(!isOpen)
   }
 
+  const handleGroupClick = () => {
+    if (showOpenChange) {
+      handleOpenChange()
+    } else if (selectable) {
+      onSelectChange?.(!select)
+    }
+  }
+
   return (
     <div
       className={cn("pointer-events-auto flex items-center gap-2", className)}
-      onClick={handleOpenChange}
+      onClick={handleGroupClick}
     >
       {selectable && (
         <F0Checkbox


### PR DESCRIPTION
## Description

When we have grouping enabled on a data collection but these groups are not meant to be collapsible, we should select/deselect the whole group of items when clicking on the header.

https://github.com/user-attachments/assets/aa102f11-c049-4a4e-81d7-98cbdb906bfa
