### PR TITLE
fix: auto-select first filter by default when opening the filters picker

### DIFF
--- a/packages/react/src/components/OneFilterPicker/__test__/index.test.tsx
+++ b/packages/react/src/components/OneFilterPicker/__test__/index.test.tsx
@@ -143,6 +143,56 @@ describe("Filters", () => {
   })
 
   describe("Filter Operations", () => {
+    it("auto-selects the first filter when opening the popover with no active filters", async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(
+        <TestWrapper>
+          <OneFilterPicker
+            filters={definition}
+            value={{}}
+            onChange={onChange}
+          />
+        </TestWrapper>
+      )
+
+      // Open filter popover
+      await user.click(screen.getByRole("button", { name: /filters/i }))
+
+      // Wait for the popover to open and check that the first filter (Department) is selected
+      await waitFor(() => {
+        const departmentButton = screen
+          .getByText("Department")
+          .closest("button")
+        expect(departmentButton).toHaveClass("bg-f1-background-secondary")
+      })
+    })
+
+    it("auto-selects the first filter with a value when opening the popover with active filters", async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(
+        <TestWrapper>
+          <OneFilterPicker
+            filters={definition}
+            value={{ search: "test query" }}
+            onChange={onChange}
+          />
+        </TestWrapper>
+      )
+
+      // Open filter popover
+      await user.click(screen.getByRole("button", { name: /filters/i }))
+
+      // Wait for the popover to open and check that the first filter with a value (Search) is selected
+      await waitFor(() => {
+        const searchButton = screen.getByText("Search").closest("button")
+        expect(searchButton).toHaveClass("bg-f1-background-secondary")
+      })
+    })
+
     it("correctly removes a filter when handleRemoveFilter is called", () => {
       const onChange = vi.fn()
 

--- a/packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx
@@ -70,12 +70,10 @@ export function FiltersControls<Filters extends FiltersDefinition>({
     }
 
     if (isOpen) {
-      // First try to find a filter that has a value
       const firstFilterWithValue = getFirstFilterNotEmpty()
       if (firstFilterWithValue) {
         setSelectedFilterKey(firstFilterWithValue[0] as keyof Filters)
       } else {
-        // If no filter has a value, auto-select the first filter by default
         const firstFilterKey = Object.keys(filters)[0] as keyof Filters
         setSelectedFilterKey(firstFilterKey)
       }

--- a/packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx
@@ -70,7 +70,15 @@ export function FiltersControls<Filters extends FiltersDefinition>({
     }
 
     if (isOpen) {
-      setSelectedFilterKey(getFirstFilterNotEmpty()?.[0] as keyof Filters)
+      // First try to find a filter that has a value
+      const firstFilterWithValue = getFirstFilterNotEmpty()
+      if (firstFilterWithValue) {
+        setSelectedFilterKey(firstFilterWithValue[0] as keyof Filters)
+      } else {
+        // If no filter has a value, auto-select the first filter by default
+        const firstFilterKey = Object.keys(filters)[0] as keyof Filters
+        setSelectedFilterKey(firstFilterKey)
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- We only want to run this when the popover is opened
   }, [isOpen])


### PR DESCRIPTION
## Description

When the user opens the filters picker and there is no active filter applied before, we should auto-select the first one on the list, this way we save the user a click, and it is really handy when there is only a single filter there.

https://github.com/user-attachments/assets/75e4940f-e91f-481d-bca7-a37f5978594d
