### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.177.1",
+  "packages/react": "1.177.2",
   "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.177.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.177.1...factorial-one-react-v1.177.2) (2025-09-05)
+
+
+### Bug Fixes
+
+* auto-select first filter by default when opening the filters picker ([#2534](https://github.com/factorialco/factorial-one/issues/2534)) ([8c77cbc](https://github.com/factorialco/factorial-one/commit/8c77cbcddf3da5cc47b8b9f681ea46841e74ad33))
+
 ## [1.177.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.177.0...factorial-one-react-v1.177.1) (2025-09-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.177.1",
+  "version": "1.177.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.177.2</summary>

## [1.177.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.177.1...factorial-one-react-v1.177.2) (2025-09-05)


### Bug Fixes

* auto-select first filter by default when opening the filters picker ([#2534](https://github.com/factorialco/factorial-one/issues/2534)) ([8c77cbc](https://github.com/factorialco/factorial-one/commit/8c77cbcddf3da5cc47b8b9f681ea46841e74ad33))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).