### PR TITLE
fix: change mobile actions label

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/components/itemActions/ItemActionsDropdown/ItemActionsDropdown.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/itemActions/ItemActionsDropdown/ItemActionsDropdown.tsx
@@ -6,6 +6,7 @@ import { useState } from "react"
 
 export type ItemActionsDropdownProps = {
   items: DropdownItem[]
+  label?: string
   onOpenChange?: (open: boolean) => void
   align?: "start" | "end"
   className?: string
@@ -15,6 +16,7 @@ export const ItemActionsDropdown = ({
   items,
   onOpenChange,
   align = "end",
+  label = "Actions",
   className,
 }: ItemActionsDropdownProps) => {
   const [open, setOpen] = useState(false)
@@ -44,7 +46,7 @@ export const ItemActionsDropdown = ({
       >
         <Button
           icon={Ellipsis}
-          label="Actions"
+          label={label}
           hideLabel
           round
           variant="ghost"

--- a/packages/react/src/experimental/OneDataCollection/components/itemActions/ItemActionsMobile/ItemActionsMobile.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/itemActions/ItemActionsMobile/ItemActionsMobile.tsx
@@ -16,6 +16,7 @@ export const ItemActionsMobile = ({
   return (
     <div className={cn(className)}>
       <ItemActionsDropdown
+        label="Mobile Actions"
         align="end"
         items={items}
         onOpenChange={onOpenChange}


### PR DESCRIPTION
## Description

We are having a [test failing](https://github.com/factorialco/factorial/actions/runs/17487465905/job/49669900524?pr=75873#step:15:13609) on frontend due to a new actions button with the same label as the regular actions button shown on desktop.
