### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.177.2",
+  "packages/react": "1.177.3",
   "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.177.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.177.2...factorial-one-react-v1.177.3) (2025-09-05)
+
+
+### Bug Fixes
+
+* change mobile actions label ([#2537](https://github.com/factorialco/factorial-one/issues/2537)) ([3b3ef8b](https://github.com/factorialco/factorial-one/commit/3b3ef8bc6fbfcceeafe2b51478378401ffba8b84))
+
 ## [1.177.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.177.1...factorial-one-react-v1.177.2) (2025-09-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.177.2",
+  "version": "1.177.3",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.177.3</summary>

## [1.177.3](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.177.2...factorial-one-react-v1.177.3) (2025-09-05)


### Bug Fixes

* change mobile actions label ([#2537](https://github.com/factorialco/factorial-one/issues/2537)) ([3b3ef8b](https://github.com/factorialco/factorial-one/commit/3b3ef8bc6fbfcceeafe2b51478378401ffba8b84))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).