### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.178.0",
+  "packages/react": "1.178.1",
   "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.178.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.178.0...factorial-one-react-v1.178.1) (2025-09-05)
+
+
+### Bug Fixes
+
+* allow selecting group by clicking on group header when collapsing is not enabled ([#2533](https://github.com/factorialco/factorial-one/issues/2533)) ([e5708ca](https://github.com/factorialco/factorial-one/commit/e5708ca924db02c598d309131fb925662340838b))
+
 ## [1.178.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.177.3...factorial-one-react-v1.178.0) (2025-09-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.178.0",
+  "version": "1.178.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.178.1</summary>

## [1.178.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.178.0...factorial-one-react-v1.178.1) (2025-09-05)


### Bug Fixes

* allow selecting group by clicking on group header when collapsing is not enabled ([#2533](https://github.com/factorialco/factorial-one/issues/2533)) ([e5708ca](https://github.com/factorialco/factorial-one/commit/e5708ca924db02c598d309131fb925662340838b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).