### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.179.0",
+  "packages/react": "1.179.1",
   "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.179.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.179.0...factorial-one-react-v1.179.1) (2025-09-09)
+
+
+### Bug Fixes
+
+* solve infinite scroll loading in data collection ([#2546](https://github.com/factorialco/factorial-one/issues/2546)) ([20496fe](https://github.com/factorialco/factorial-one/commit/20496fe3f7e1977f1c9df19879c15db63f15a977))
+
 ## [1.179.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.178.1...factorial-one-react-v1.179.0) (2025-09-08)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.179.0",
+  "version": "1.179.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.179.1</summary>

## [1.179.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.179.0...factorial-one-react-v1.179.1) (2025-09-09)


### Bug Fixes

* solve infinite scroll loading in data collection ([#2546](https://github.com/factorialco/factorial-one/issues/2546)) ([20496fe](https://github.com/factorialco/factorial-one/commit/20496fe3f7e1977f1c9df19879c15db63f15a977))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).