### PR TITLE
feat/avatars overflowlist performance

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
@@ -3,6 +3,7 @@ import { OverflowList } from "@/ui/OverflowList"
 import { AvatarVariant, F0Avatar } from "../F0Avatar"
 import { MaxCounter } from "./components/MaxCounter"
 
+import { useMemo } from "react"
 import { AvatarListSize, avatarListSizes, F0AvatarListProps } from "./types"
 import { getAvatarDisplayName } from "./utils"
 
@@ -47,11 +48,21 @@ export const F0AvatarList = ({
   } satisfies Record<AvatarListSize, number>
   const gap = gaps[size] ?? 0
 
+  const itemWidth = useMemo(() => {
+    const sizeWidth = {
+      xs: 20,
+      sm: 24,
+      md: 32,
+    } satisfies Record<AvatarListSize, number>
+    return sizeWidth[size]
+  }, [size])
+
   return (
     <OverflowList
       max={max}
       items={avatars.map((avatar) => ({ type, ...avatar }) as AvatarVariant)}
       gap={gap}
+      itemsWidth={itemWidth}
       className="flex items-center"
       renderListItem={(avatar, index) => {
         const displayName = getAvatarDisplayName(type, avatar)

--- a/packages/react/src/components/avatars/F0AvatarList/__storybook__/F0AvatarList.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/__storybook__/F0AvatarList.stories.tsx
@@ -63,6 +63,46 @@ const dummyFiles = [
   { file: { name: "image.jpg", type: "image/jpeg" } },
 ]
 
+function getDummyAvatar<
+  T extends "person" | "company" | "team" | "file" = "person",
+>(
+  type: T,
+  index: number
+): T extends "person"
+  ? PersonAvatarVariant
+  : T extends "company"
+    ? CompanyAvatarVariant
+    : T extends "team"
+      ? TeamAvatarVariant
+      : T extends "file"
+        ? FileAvatarVariant
+        : never {
+  const sourceData = {
+    person: dummyPeople,
+    company: dummyCompanies,
+    team: dummyTeams,
+    file: dummyFiles,
+  }
+
+  const mockItem = sourceData[type][index % sourceData[type].length]
+
+  return {
+    ...mockItem,
+    src:
+      "src" in mockItem && mockItem.src
+        ? mockItem.src + "?t=" + index
+        : undefined,
+  } as T extends "person"
+    ? PersonAvatarVariant
+    : T extends "company"
+      ? CompanyAvatarVariant
+      : T extends "team"
+        ? TeamAvatarVariant
+        : T extends "file"
+          ? FileAvatarVariant
+          : never
+}
+
 function getDummyAvatars<
   T extends "person" | "company" | "team" | "file" = "person",
 >(
@@ -77,18 +117,11 @@ function getDummyAvatars<
       : T extends "file"
         ? FileAvatarVariant[]
         : never {
-  const sourceData = {
-    person: dummyPeople,
-    company: dummyCompanies,
-    team: dummyTeams,
-    file: dummyFiles,
-  }[type]
+  const mockList = Array.from({ length: count }, (_, index) =>
+    getDummyAvatar(type, index)
+  )
 
-  const mockList = Array.from({ length: count }, (_, index) => ({
-    ...sourceData[index % sourceData.length],
-  }))
-
-  return mockList as T extends "person"
+  return mockList as unknown as T extends "person"
     ? PersonAvatarVariant[]
     : T extends "company"
       ? CompanyAvatarVariant[]

--- a/packages/react/src/components/avatars/F0AvatarList/__storybook__/F0AvatarList.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/__storybook__/F0AvatarList.stories.tsx
@@ -26,6 +26,16 @@ const dummyPeople = [
     firstName: "Saúl",
     lastName: "Domínguez",
   },
+  {
+    firstName: "Dani",
+    lastName: "Moreno",
+    src: "/avatars/person03.jpg",
+  },
+  {
+    firstName: "Hellen",
+    lastName: "Fernández",
+    src: "/avatars/person04.jpg",
+  },
 ]
 
 const dummyCompanies = [
@@ -74,9 +84,18 @@ function getDummyAvatars<
     file: dummyFiles,
   }[type]
 
-  return Array.from({ length: count }, (_, index) => ({
+  const mockList = Array.from({ length: count }, (_, index) => ({
     ...sourceData[index % sourceData.length],
-  })) as T extends "person"
+  }))
+
+  if (type === "person") {
+    return mockList.map((item, index) => ({
+      ...item,
+      src: item.src ? item.src + "?t=" + index : undefined,
+    })) as PersonAvatarVariant[]
+  }
+
+  return mockList as T extends "person"
     ? PersonAvatarVariant[]
     : T extends "company"
       ? CompanyAvatarVariant[]

--- a/packages/react/src/components/avatars/F0AvatarList/__storybook__/F0AvatarList.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/__storybook__/F0AvatarList.stories.tsx
@@ -88,13 +88,6 @@ function getDummyAvatars<
     ...sourceData[index % sourceData.length],
   }))
 
-  if (type === "person") {
-    return mockList.map((item, index) => ({
-      ...item,
-      src: item.src ? item.src + "?t=" + index : undefined,
-    })) as PersonAvatarVariant[]
-  }
-
   return mockList as T extends "person"
     ? PersonAvatarVariant[]
     : T extends "company"

--- a/packages/react/src/lib/imageHandler.tsx
+++ b/packages/react/src/lib/imageHandler.tsx
@@ -40,7 +40,6 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(
 
     if (!src) return <img ref={ref} {...props} />
     const extraProps = src(props)
-
     return <img ref={ref} {...props} {...extraProps} />
   }
 )

--- a/packages/react/src/ui/Avatar/Avatar.tsx
+++ b/packages/react/src/ui/Avatar/Avatar.tsx
@@ -3,7 +3,7 @@
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
 import { cva } from "cva"
 import * as React from "react"
-import { Image } from "../../lib/imageHandler"
+import { useImageContext } from "../../lib/imageHandler"
 import { cn } from "../../lib/utils"
 import {
   internalAvatarColors,
@@ -71,16 +71,22 @@ Avatar.displayName = AvatarPrimitive.Root.displayName
 const AvatarImage = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Image>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
->(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image
-    ref={ref}
-    className={cn("aspect-square h-full w-full object-cover", className)}
-    {...props}
-    asChild
-  >
-    <Image loading="lazy" />
-  </AvatarPrimitive.Image>
-))
+>(({ className, ...props }, ref) => {
+  const { src: imageSrcContext } = useImageContext()
+
+  const extraProps =
+    props.src && imageSrcContext ? imageSrcContext(props) : props
+
+  return (
+    <AvatarPrimitive.Image
+      ref={ref}
+      className={cn("aspect-square h-full w-full object-cover", className)}
+      {...props}
+      {...extraProps}
+      loading="lazy"
+    ></AvatarPrimitive.Image>
+  )
+})
 AvatarImage.displayName = AvatarPrimitive.Image.displayName
 
 const AvatarFallback = React.forwardRef<

--- a/packages/react/src/ui/Avatar/Avatar.tsx
+++ b/packages/react/src/ui/Avatar/Avatar.tsx
@@ -78,7 +78,7 @@ const AvatarImage = React.forwardRef<
     {...props}
     asChild
   >
-    <Image />
+    <Image loading="lazy" />
   </AvatarPrimitive.Image>
 ))
 AvatarImage.displayName = AvatarPrimitive.Image.displayName

--- a/packages/react/src/ui/OverflowList/index.mdx
+++ b/packages/react/src/ui/OverflowList/index.mdx
@@ -26,6 +26,11 @@ props.
 The `renderListItem` prop is used to render items outside of the overflow list,
 and the `renderDropdownItem` prop is used for items inside of the dropdown.
 
+# Fixed Size
+
+For those lists where the width of the items is known, you can set the value to
+avoid calculating the width of the items in runtime
+
 ### Overflow Indicator
 
 The overflow indicator is the UI piece used to indicate that there are more

--- a/packages/react/src/ui/OverflowList/index.tsx
+++ b/packages/react/src/ui/OverflowList/index.tsx
@@ -63,7 +63,7 @@ interface OverflowListProps<T> {
    * This value is used to avoid calculating the width of the items in runtime
    * @default undefined (means auto)
    **/
-  itemWidth?: number | number[]
+  itemsWidth?: number | number[]
 }
 
 const OverflowList = function OverflowList<T>({
@@ -76,7 +76,7 @@ const OverflowList = function OverflowList<T>({
   className = "",
   gap = 8,
   max,
-  itemWidth,
+  itemsWidth,
 }: OverflowListProps<T>) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -92,7 +92,10 @@ const OverflowList = function OverflowList<T>({
     visibleItems,
     overflowItems,
     isInitialized,
-  } = useOverflowCalculation(items, gap, max)
+  } = useOverflowCalculation(items, gap, {
+    max,
+    itemsWidth,
+  })
 
   const DefaultOverflowIndicator = useMemo(
     () => (
@@ -125,7 +128,7 @@ const OverflowList = function OverflowList<T>({
         marginLeft: gap < 0 ? `${-gap}px` : undefined,
       }}
     >
-      {!itemWidth && (
+      {!itemsWidth && (
         <div
           ref={measurementContainerRef}
           aria-hidden="true"

--- a/packages/react/src/ui/OverflowList/index.tsx
+++ b/packages/react/src/ui/OverflowList/index.tsx
@@ -57,6 +57,13 @@ interface OverflowListProps<T> {
    * @default undefined (means auto)
    */
   max?: number
+
+  /**
+   * The widths of the items in pixels
+   * This value is used to avoid calculating the width of the items in runtime
+   * @default undefined (means auto)
+   **/
+  itemWidth?: number | number[]
 }
 
 const OverflowList = function OverflowList<T>({
@@ -69,6 +76,7 @@ const OverflowList = function OverflowList<T>({
   className = "",
   gap = 8,
   max,
+  itemWidth,
 }: OverflowListProps<T>) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -117,23 +125,25 @@ const OverflowList = function OverflowList<T>({
         marginLeft: gap < 0 ? `${-gap}px` : undefined,
       }}
     >
-      <div
-        ref={measurementContainerRef}
-        aria-hidden="true"
-        className="pointer-events-none invisible absolute left-0 top-0 flex opacity-0"
-        style={{ gap: gap > 0 ? `${gap}px` : undefined }}
-        data-testid="overflow-measurement-container"
-      >
-        {items.map((item, index) => (
-          <div
-            key={`measure-${index}`}
-            data-testid="overflow-measurement-item"
-            style={{ marginLeft: gap < 0 ? `${gap}px` : undefined }}
-          >
-            {renderListItem(item, index, false)}
-          </div>
-        ))}
-      </div>
+      {!itemWidth && (
+        <div
+          ref={measurementContainerRef}
+          aria-hidden="true"
+          className="pointer-events-none invisible absolute left-0 top-0 flex opacity-0"
+          style={{ gap: gap > 0 ? `${gap}px` : undefined }}
+          data-testid="overflow-measurement-container"
+        >
+          {items.map((item, index) => (
+            <div
+              key={`measure-${index}`}
+              data-testid="overflow-measurement-item"
+              style={{ marginLeft: gap < 0 ? `${gap}px` : undefined }}
+            >
+              {renderListItem(item, index, false)}
+            </div>
+          ))}
+        </div>
+      )}
 
       <div
         className="flex items-center whitespace-nowrap"

--- a/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
+++ b/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
@@ -69,7 +69,7 @@ export function useOverflowCalculation<T>(
     }
 
     return widths
-  }, [])
+  }, [options?.itemsWidth, items.length])
 
   // Calculate how many items can fit in the available width
   const calculateVisibleItemCount = useCallback(

--- a/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
+++ b/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
@@ -52,8 +52,8 @@ export function useOverflowCalculation<T>(
   const measureItemWidths = useCallback(() => {
     if (options?.itemsWidth) {
       return Array.isArray(options.itemsWidth)
-        ? options.itemsWidth.reduce((acc, width) => acc + width, 0)
-        : options.itemsWidth * items.length
+        ? options.itemsWidth
+        : Array(items.length).fill(options.itemsWidth)
     }
 
     if (!measurementContainerRef.current) {
@@ -87,9 +87,9 @@ export function useOverflowCalculation<T>(
       }
 
       // Return the actual count without enforcing a minimum of 1
-      return Math.min(visibleCount, max ?? items.length)
+      return Math.min(visibleCount, options?.max ?? items.length)
     },
-    [max, items.length]
+    [options?.max, items.length]
   )
 
   // Calculate which items should be visible and which should overflow

--- a/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
+++ b/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
@@ -18,7 +18,10 @@ type CalculateVisibleItemCountParams = {
 export function useOverflowCalculation<T>(
   items: T[],
   gap: number,
-  max?: number
+  options?: {
+    max?: number
+    itemsWidth?: number | number[]
+  }
 ) {
   const containerRef = useRef<HTMLDivElement>(null)
   const overflowButtonRef = useRef<HTMLButtonElement>(null)
@@ -47,7 +50,15 @@ export function useOverflowCalculation<T>(
 
   // Measure all items in a hidden container
   const measureItemWidths = useCallback(() => {
-    if (!measurementContainerRef.current) return []
+    if (options?.itemsWidth) {
+      return Array.isArray(options.itemsWidth)
+        ? options.itemsWidth.reduce((acc, width) => acc + width, 0)
+        : options.itemsWidth * items.length
+    }
+
+    if (!measurementContainerRef.current) {
+      return []
+    }
 
     const itemElements = measurementContainerRef.current.children
     const widths: number[] = []


### PR DESCRIPTION
## Description

Avoid to load all images in avatar list

## Implementation details

- Overflowlist:
   - support to define the itemsWidth (can be a single value or an array) this allows us to avoid need to render the invisilbe items list to calculate the itemsWidth. I will be useful in the avatarlist case as the avatars have a fixed width
- AvatarList
   - Use the fixed itemswidth to avoid loading all the avatars
- Avatar:
   - fix: image duplication 
   - feat: add loading="lazy"  
