### PR TITLE
AiChat: export hook and remove create button form chat header

### DIFF
--- a/packages/react/src/experimental/AiChat/components/ChatHeader.tsx
+++ b/packages/react/src/experimental/AiChat/components/ChatHeader.tsx
@@ -1,12 +1,10 @@
 import { ButtonInternal } from "@/components/Actions/Button/internal"
-import Add from "@/icons/app/Add"
 import Cross from "@/icons/app/Cross"
 import Maximize from "@/icons/app/Maximize"
 import Minimize from "@/icons/app/Minimize"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { DialogDescription, DialogHeader, DialogTitle } from "@/ui/dialog"
-import { useCopilotChatInternal } from "@copilotkit/react-core"
 import { useChatContext, type HeaderProps } from "@copilotkit/react-ui"
 import { motion } from "motion/react"
 import { ElementType } from "react"
@@ -48,7 +46,6 @@ const ChatHeader = ({
   ...rest
 }: ChatHeaderProps) => {
   const { setOpen, labels } = useChatContext()
-  const { messages, reset } = useCopilotChatInternal()
   const { messageContainerScrollTop } = useChatWindowContext()
   const translations = useI18n()
   const { mode, setMode } = useAiChat()
@@ -70,16 +67,6 @@ const ChatHeader = ({
         {translations.ai.description}
       </DescriptionComponent>
       <motion.div layout className="flex items-center gap-x-2" {...rest}>
-        {messages.length > 0 && (
-          <ButtonInternal
-            variant="outline"
-            hideLabel
-            label={translations.ai.newChat}
-            icon={Add}
-            size="sm"
-            onClick={() => reset()}
-          />
-        )}
         <ButtonInternal
           variant="outline"
           hideLabel

--- a/packages/react/src/experimental/AiChat/exports.ts
+++ b/packages/react/src/experimental/AiChat/exports.ts
@@ -1,8 +1,8 @@
-export { AiChat, AiChatProvider, type AiChatProviderProps } from "./index"
-
 export {
   HILActionConfirmation,
   type HILActionConfirmationProps,
 } from "./HILActionConfirmation"
+export { AiChat, AiChatProvider, type AiChatProviderProps } from "./index"
+export { useAiChat } from "./providers/AiChatStateProvider"
 
 export { ActionItem, type ActionItemProps } from "./ActionItem"

--- a/packages/react/src/experimental/AiChat/index.stories.tsx
+++ b/packages/react/src/experimental/AiChat/index.stories.tsx
@@ -13,8 +13,11 @@ const meta = {
       return (
         <div className="h-full w-full bg-[hsl(0,0,98)]">
           <AiChatProvider
+            enabled
             runtimeUrl="https://mastra.local.factorial.dev/copilotkit"
             agent="one-workflow"
+            credentials="include"
+            showDevConsole={false}
           >
             <Story />
           </AiChatProvider>
@@ -27,14 +30,4 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
-  args: {
-    labels: {
-      greeting: "Hey Adam,",
-      initial: ["How can I help you today?"],
-    },
-    children: (
-      <div className="rounded border p-4">Your app content goes here</div>
-    ),
-  },
-}
+export const Default: Story = {}

--- a/packages/react/src/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/packages/react/src/experimental/Navigation/ApplicationFrame/index.tsx
@@ -9,6 +9,7 @@ import { cn, focusRing } from "../../../lib/utils"
 import { useReducedMotion } from "../../../lib/a11y"
 import { useI18n } from "../../../lib/providers/i18n"
 
+import { Fragment } from "react"
 import { AiChat, AiChatProvider, AiChatProviderProps } from "../../AiChat"
 import { useAiChat } from "../../AiChat/providers/AiChatStateProvider"
 import { FrameProvider, useSidebar } from "./FrameProvider"
@@ -26,13 +27,14 @@ export function ApplicationFrame({
   banner,
   ai,
 }: ApplicationFrameProps) {
+  const AiProvider = ai ? AiChatProvider : Fragment
   return (
     <FrameProvider>
-      <AiChatProvider {...ai}>
+      <AiProvider {...ai}>
         <ApplicationFrameContent sidebar={sidebar} banner={banner}>
           {children}
         </ApplicationFrameContent>
-      </AiChatProvider>
+      </AiProvider>
     </FrameProvider>
   )
 }

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -179,7 +179,6 @@ export const defaultTranslations = {
     description: "Chat with AI",
     expandChat: "Expand chat",
     minimizeChat: "Minimize chat window",
-    newChat: "New Chat",
     openChat: "Open Chat",
     scrollToBottom: "Scroll to bottom",
     welcome: "I'm One. Ask or make anything.",


### PR DESCRIPTION
## Description

A small batch of changes:
- add missing export of `useAiChat` hook
- removes "newChat" button from the header
- fixes AiChat story
- skips render of AiChatProvider if no config is passed

