### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.179.1",
+  "packages/react": "1.179.2",
   "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.179.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.179.1...factorial-one-react-v1.179.2) (2025-09-09)
+
+
+### Bug Fixes
+
+* export hook and remove create button form chat header ([#2550](https://github.com/factorialco/factorial-one/issues/2550)) ([84d58b1](https://github.com/factorialco/factorial-one/commit/84d58b18ee9ff41d0d4285acfdbdd43731536798))
+
 ## [1.179.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.179.0...factorial-one-react-v1.179.1) (2025-09-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.179.1",
+  "version": "1.179.2",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.179.2</summary>

## [1.179.2](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.179.1...factorial-one-react-v1.179.2) (2025-09-09)


### Bug Fixes

* export hook and remove create button form chat header ([#2550](https://github.com/factorialco/factorial-one/issues/2550)) ([84d58b1](https://github.com/factorialco/factorial-one/commit/84d58b18ee9ff41d0d4285acfdbdd43731536798))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).