### PR TITLE
fix: adjust paddings and margins on entity selector

### DIFF
--- a/packages/react/src/experimental/Forms/EntitySelect/Content/MainContent/index.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/Content/MainContent/index.tsx
@@ -320,7 +320,7 @@ export const MainContent: React.FC<MainContentProps> = ({
             singleSelector={singleSelector}
             goToFirst={goToFirst}
             goToLast={goToLast}
-            hideLine={vi.index === flattenedList.length - 1}
+            hideLine={index === flattenedList.length - 1}
             disabled={disabled}
             hiddenAvatar={hiddenAvatar}
           />

--- a/packages/react/src/experimental/Forms/EntitySelect/ListItem/index.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/ListItem/index.tsx
@@ -109,7 +109,7 @@ export const ListItemSingleContent = ({
         aria-label={entity.name}
         className={cn(
           marginLeft,
-          "flex flex-row flex-wrap items-center gap-2 rounded-[10px] border p-2 hover:cursor-pointer",
+          "flex flex-row flex-wrap items-center gap-2 rounded-[10px] border px-2 py-1.5 hover:cursor-pointer",
           "focus-within:outline focus-within:outline-1 focus-within:-outline-offset-1 focus-within:outline-f1-border-selected-bold hover:bg-f1-background-hover",
           selected && singleSelector
             ? "bg-f1-background-selected-bold/10 transition-colors dark:bg-f1-background-selected-bold/20"
@@ -252,7 +252,7 @@ const EntitySelectListItem = ({
   const checked = selected || partialSelected
   return (
     <>
-      <div className="flex w-full flex-row flex-wrap items-center gap-0 rounded-md border pl-1 pr-1">
+      <div className="flex w-full flex-row flex-wrap items-center gap-0 rounded-md border pl-2.5 pr-1">
         <Button
           round
           hideLabel
@@ -268,7 +268,7 @@ const EntitySelectListItem = ({
           onPointerDown={() => {
             setPressingLabel(true)
           }}
-          className="flex flex-1 flex-row items-center gap-2 rounded-[10px] border p-2 focus-within:outline focus-within:outline-1 focus-within:-outline-offset-1 focus-within:outline-f1-border-selected-bold hover:cursor-pointer hover:bg-f1-background-hover"
+          className="flex flex-1 flex-row items-center gap-2 rounded-[10px] border px-2 py-1.5 focus-within:outline focus-within:outline-1 focus-within:-outline-offset-1 focus-within:outline-f1-border-selected-bold hover:cursor-pointer hover:bg-f1-background-hover"
         >
           {showGroupIcon && (
             <F0Icon


### PR DESCRIPTION
## Description

Fix some pixel problems

## Screenshots (if applicable)

### Before:

<img width="642" height="620" alt="Screenshot 2025-09-09 at 16 18 29" src="https://github.com/user-attachments/assets/edd34367-d72e-40f1-960c-10855994cf8f" />

### After:

<img width="606" height="633" alt="Screenshot 2025-09-09 at 16 54 35" src="https://github.com/user-attachments/assets/627432f4-85ff-4385-aa55-bbb188a86619" />
<img width="571" height="601" alt="Screenshot 2025-09-09 at 16 55 08" src="https://github.com/user-attachments/assets/ff589f7f-27a6-490f-a2da-b64b644abaf2" />
