### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.180.0",
+  "packages/react": "1.180.1",
   "packages/react-native": "0.19.0",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.180.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.180.0...factorial-one-react-v1.180.1) (2025-09-09)
+
+
+### Bug Fixes
+
+* adjust paddings and margins on entity selector ([#2552](https://github.com/factorialco/factorial-one/issues/2552)) ([52200b9](https://github.com/factorialco/factorial-one/commit/52200b98aadbdb69348b16293a05751676f3ea85))
+
 ## [1.180.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.179.2...factorial-one-react-v1.180.0) (2025-09-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.180.0",
+  "version": "1.180.1",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.180.1</summary>

## [1.180.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.180.0...factorial-one-react-v1.180.1) (2025-09-09)


### Bug Fixes

* adjust paddings and margins on entity selector ([#2552](https://github.com/factorialco/factorial-one/issues/2552)) ([52200b9](https://github.com/factorialco/factorial-one/commit/52200b98aadbdb69348b16293a05751676f3ea85))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).