### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.180.1",
-  "packages/react-native": "0.19.0",
+  "packages/react-native": "0.19.1",
   "packages/core": "1.25.1"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.19.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.19.0...factorial-one-react-native-v0.19.1) (2025-09-10)
+
+
+### Bug Fixes
+
+* add new props to adapt the design ([#2559](https://github.com/factorialco/factorial-one/issues/2559)) ([b0832c2](https://github.com/factorialco/factorial-one/commit/b0832c254265499d95485af2258cab026ad51b51))
+
 ## [0.19.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.18.1...factorial-one-react-native-v0.19.0) (2025-09-03)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react-native",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "type": "module",
   "description": "React Native components for Factorial One Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react-native: 0.19.1</summary>

## [0.19.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-native-v0.19.0...factorial-one-react-native-v0.19.1) (2025-09-10)


### Bug Fixes

* add new props to adapt the design ([#2559](https://github.com/factorialco/factorial-one/issues/2559)) ([b0832c2](https://github.com/factorialco/factorial-one/commit/b0832c254265499d95485af2258cab026ad51b51))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).