### PR TITLE
fix(AvatarList): correct gap between avatars

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
@@ -42,9 +42,9 @@ export const F0AvatarList = ({
   }
 
   const gaps = {
-    xs: -0.5,
+    xs: -2,
     sm: -3,
-    md: -10,
+    md: -4,
   } satisfies Record<AvatarListSize, number>
   const gap = gaps[size] ?? 0
 
@@ -99,17 +99,22 @@ export const F0AvatarList = ({
       renderDropdownItem={() => null}
       forceShowingOverflowIndicator={initialRemainingCount !== undefined}
       renderOverflowIndicator={(count) => (
-        <MaxCounter
-          count={(initialRemainingCount ?? 0) + count}
-          size={size}
-          type={type === "person" ? "rounded" : "base"}
-          avatarType={type}
-          list={
-            initialRemainingCount
-              ? undefined
-              : avatars.slice(avatars.length - count)
-          }
-        />
+        <div
+          className="flex h-fit w-fit items-center"
+          style={{ marginLeft: gap }}
+        >
+          <MaxCounter
+            count={(initialRemainingCount ?? 0) + count}
+            size={size}
+            type={type === "person" ? "rounded" : "base"}
+            avatarType={type}
+            list={
+              initialRemainingCount
+                ? undefined
+                : avatars.slice(avatars.length - count)
+            }
+          />
+        </div>
       )}
       overflowIndicatorWithPopover={false}
     />


### PR DESCRIPTION
## Description

Fixes the gap between avatars (and counter) in the AvatarList component.

- Set correct gap values.
- MaxCounter wasn't affected by this gap value, making it look apart from the list.

## Screenshots

### Before

<img width="487" height="746" alt="image" src="https://github.com/user-attachments/assets/1d54acd6-c227-4f4a-9653-e184edec0c7c" />


### After

<img width="528" height="813" alt="image" src="https://github.com/user-attachments/assets/2792a094-7c56-4762-b5f8-354bbaafd457" />

