### PR TITLE
fix(CommunityPost): fix comment button growing unexpectedly

### DIFF
--- a/packages/react/src/experimental/Information/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/experimental/Information/Communities/Post/CommunityPost/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/components/Actions/Button"
 import { Link } from "@/components/Actions/Link"
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
@@ -228,22 +227,19 @@ export const BaseCommunityPost = ({
           </div>
         )}
         <p className="text-f1-foreground-secondary">{countersDisplay}</p>
-        <div className="flex flex-row gap-2.5">
-          {!noReactionsButton && (
-            <Button
-              label={comment.label}
-              onClick={comment.onClick}
-              variant="outline"
-              icon={CommentIcon}
-              round
-              hideLabel
-            />
-          )}
-          <Reactions
-            items={reactions?.items ?? []}
-            onInteraction={reactions?.onInteraction}
-          />
-        </div>
+        <Reactions
+          items={reactions?.items ?? []}
+          onInteraction={reactions?.onInteraction}
+          action={
+            !noReactionsButton
+              ? {
+                  label: comment.label,
+                  onClick: comment.onClick,
+                  icon: CommentIcon,
+                }
+              : undefined
+          }
+        />
       </div>
     </div>
   )

--- a/packages/react/src/experimental/Information/Reactions/index.tsx
+++ b/packages/react/src/experimental/Information/Reactions/index.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@/components/Actions/Button"
+import { IconType } from "@/components/F0Icon"
 import { Picker } from "./Picker"
 import { Reaction, ReactionProps } from "./reaction"
 
@@ -5,11 +7,31 @@ export interface ReactionsProps {
   items: ReactionProps[]
   onInteraction?: (emoji: string) => void
   locale?: string
+  action?: {
+    label: string
+    icon: IconType
+    onClick: () => void
+  }
 }
 
-export function Reactions({ items, onInteraction, locale }: ReactionsProps) {
+export function Reactions({
+  items,
+  onInteraction,
+  locale,
+  action,
+}: ReactionsProps) {
   return (
     <div className="flex flex-wrap gap-2">
+      {action && (
+        <Button
+          label={action.label}
+          icon={action.icon}
+          onClick={action.onClick}
+          variant="outline"
+          round
+          hideLabel
+        />
+      )}
       <Picker onSelect={onInteraction} locale={locale} />
       {items.map((item) => (
         <Reaction


### PR DESCRIPTION
## Description

The comment button in a community post grows when there's more than one line of reactions. The button and reactions are built separately, so in this PR I'm moving the action button into the Reactions component, making it easier to wrap the content as expected.

## Screenshots

### Before

<img width="635" height="156" alt="image" src="https://github.com/user-attachments/assets/51098d02-8eb3-4eee-b667-4974354de3d0" />

### After

<img width="385" height="162" alt="image" src="https://github.com/user-attachments/assets/a27ba49f-d417-432f-ad6a-dbfa20e5c20e" />
