### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.180.1",
+  "packages/react": "1.181.0",
   "packages/react-native": "0.19.1",
   "packages/core": "1.25.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.181.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.180.1...factorial-one-react-v1.181.0) (2025-09-11)
+
+
+### Features
+
+* **dataCollection:** add new LongText cell type ([#2568](https://github.com/factorialco/factorial-one/issues/2568)) ([ae9f885](https://github.com/factorialco/factorial-one/commit/ae9f885d9b6afdbefb6f426a5b74787aa48238ce))
+
 ## [1.180.1](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.180.0...factorial-one-react-v1.180.1) (2025-09-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/factorial-one-react",
-  "version": "1.180.1",
+  "version": "1.181.0",
   "main": "dist/factorial-one.js",
   "typings": "dist/factorial-one.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 Factorial-one React package stable release 🚀
---


<details><summary>factorial-one-react: 1.181.0</summary>

## [1.181.0](https://github.com/factorialco/factorial-one/compare/factorial-one-react-v1.180.1...factorial-one-react-v1.181.0) (2025-09-11)


### Features

* **dataCollection:** add new LongText cell type ([#2568](https://github.com/factorialco/factorial-one/issues/2568)) ([ae9f885](https://github.com/factorialco/factorial-one/commit/ae9f885d9b6afdbefb6f426a5b74787aa48238ce))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).