### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.182.0",
+  "packages/react": "1.182.1",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.182.1](https://github.com/factorialco/f0/compare/f0-react-v1.182.0...f0-react-v1.182.1) (2025-09-12)
+
+
+### Bug Fixes
+
+* add missing bottom padding on list ([#2577](https://github.com/factorialco/f0/issues/2577)) ([568c0f4](https://github.com/factorialco/f0/commit/568c0f41203b275f26854077e29d27e242a914ad))
+
 ## [1.182.0](https://github.com/factorialco/factorial-one/compare/f0-react-v1.181.0...f0-react-v1.182.0) (2025-09-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.182.0",
+  "version": "1.182.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.182.1</summary>

## [1.182.1](https://github.com/factorialco/f0/compare/f0-react-v1.182.0...f0-react-v1.182.1) (2025-09-12)


### Bug Fixes

* add missing bottom padding on list ([#2577](https://github.com/factorialco/f0/issues/2577)) ([568c0f4](https://github.com/factorialco/f0/commit/568c0f41203b275f26854077e29d27e242a914ad))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).