### PR TITLE
feat: add support for icon color and background color to (F0Card)

### DIFF
--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -206,8 +206,6 @@ export const WithIconAndImage: Story = {
     avatar: {
       type: "icon",
       icon: Lightbulb,
-      color: "#877FED",
-      backgroundColor: "#E9E0FD",
     },
     image: image,
   },

--- a/packages/react/src/components/F0Card/components/CardAvatar.tsx
+++ b/packages/react/src/components/F0Card/components/CardAvatar.tsx
@@ -9,12 +9,7 @@ type CardAvatarVariant =
   | AvatarVariant
   | { type: "emoji"; emoji: string }
   | { type: "file"; file: File }
-  | {
-      type: "icon"
-      icon: IconType
-      color?: `#${string}`
-      backgroundColor?: `#${string}`
-    }
+  | { type: "icon"; icon: IconType }
 
 interface CardAvatarProps {
   /**
@@ -47,14 +42,7 @@ const AvatarRender = ({
     return <F0AvatarFile file={avatar.file} size={compact ? "sm" : "lg"} />
   }
   if (avatar.type === "icon") {
-    return (
-      <F0AvatarIcon
-        icon={avatar.icon}
-        size={compact ? "sm" : "lg"}
-        color={avatar.color}
-        backgroundColor={avatar.backgroundColor}
-      />
-    )
+    return <F0AvatarIcon icon={avatar.icon} size={compact ? "sm" : "lg"} />
   }
   return <F0Avatar avatar={avatar} size={compact ? "sm" : "lg"} />
 }

--- a/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
@@ -7,8 +7,6 @@ export const avatarIconSizes = ["sm", "md", "lg"] as const
 export type F0AvatarIconProps = {
   icon: IconType
   size?: (typeof avatarIconSizes)[number]
-  color?: `#${string}`
-  backgroundColor?: `#${string}`
 } & Partial<Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">>
 
 const sizes = {
@@ -22,17 +20,12 @@ export const F0AvatarIcon = ({
   size = "md",
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
-  color,
-  backgroundColor,
 }: F0AvatarIconProps) => {
-  const backgroundCSS =
-    backgroundColor !== undefined && `bg-[${backgroundColor}]`
   return (
     <div
       className={cn(
         "flex aspect-square items-center justify-center border border-solid border-f1-border-secondary bg-f1-background dark:bg-f1-background-inverse-secondary",
-        sizes[size],
-        backgroundColor && `${backgroundCSS} dark:${backgroundCSS}`
+        sizes[size]
       )}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
@@ -40,7 +33,6 @@ export const F0AvatarIcon = ({
       <F0Icon
         icon={icon}
         size={size}
-        {...(color !== undefined ? { color } : {})}
         className="text-f1-foreground-secondary"
       />
     </div>


### PR DESCRIPTION
## Description

Fix icon avatar with transparent background combined with card image

## Screenshots (if applicable)
icon avatar with transparent background combined with card image
<img width="396" height="421" alt="image" src="https://github.com/user-attachments/assets/2be36e6e-ce13-4514-8b46-997d1883664f" />

F0Card with icon avatar with non transparent background as other avatar types (emoji, file...)
<img width="549" height="403" alt="image" src="https://github.com/user-attachments/assets/afaa6e36-3471-4e3c-ba2f-bee09d1aee3b" />

## Implementation details
Added `bg-f1-background dark:bg-f1-background-inverse-secondary` classes to F0Icon wrapper
