### PR TITLE
Enable declaration maps for better IDE support

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,15 +8,9 @@
     "declaration": true,
     "outDir": "dist",
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "declarationMap": true
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "**/*.test.ts",
-    "**/*.spec.ts"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -13,7 +13,8 @@
     "paths": {
       "@factorialco/f0-core": ["../core/src"]
     },
-    "types": ["nativewind/types", "jest"]
+    "types": ["nativewind/types", "jest"],
+    "declarationMap": true
   },
   "include": ["src", "nativewind-env.d.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -24,7 +24,9 @@
     "paths": {
       "@/*": ["./src/*"],
       "~/*": ["./*"]
-    }
+    },
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["src", ".storybook", "src/tokens"],
   "exclude": [


### PR DESCRIPTION
[Declaration maps](https://www.typescriptlang.org/es/tsconfig/#declarationMap) allow better tooling in client projects by enabling developers to jump to the original source when `Ctrl+Click`ing a symbol. If a declaration map is present, instead of jumping to the type declaration `.d.ts` file, the IDE can use them to show the actual code declaring that symbol.

We enable them in all our packages to improve the developer experience.