### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.188.0",
+  "packages/react": "1.188.1",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.188.1](https://github.com/factorialco/f0/compare/f0-react-v1.188.0...f0-react-v1.188.1) (2025-09-16)
+
+
+### Bug Fixes
+
+* add missing export for event catcher provider ([#2601](https://github.com/factorialco/f0/issues/2601)) ([3f3ee2a](https://github.com/factorialco/f0/commit/3f3ee2a75b012badfa18ef0035cfc87b39cb30b5))
+
 ## [1.188.0](https://github.com/factorialco/f0/compare/f0-react-v1.187.1...f0-react-v1.188.0) (2025-09-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.188.0",
+  "version": "1.188.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.188.1</summary>

## [1.188.1](https://github.com/factorialco/f0/compare/f0-react-v1.188.0...f0-react-v1.188.1) (2025-09-16)


### Bug Fixes

* add missing export for event catcher provider ([#2601](https://github.com/factorialco/f0/issues/2601)) ([3f3ee2a](https://github.com/factorialco/f0/commit/3f3ee2a75b012badfa18ef0035cfc87b39cb30b5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).