### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.195.0",
+  "packages/react": "1.195.1",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.195.1](https://github.com/factorialco/f0/compare/f0-react-v1.195.0...f0-react-v1.195.1) (2025-09-18)
+
+
+### Bug Fixes
+
+* **avatar:** use short size values for ([#2621](https://github.com/factorialco/f0/issues/2621)) ([fb4acee](https://github.com/factorialco/f0/commit/fb4acee493f94edc8ad36c042619fe3af8648ced))
+
 ## [1.195.0](https://github.com/factorialco/f0/compare/f0-react-v1.194.0...f0-react-v1.195.0) (2025-09-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.195.0",
+  "version": "1.195.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.195.1</summary>

## [1.195.1](https://github.com/factorialco/f0/compare/f0-react-v1.195.0...f0-react-v1.195.1) (2025-09-18)


### Bug Fixes

* **avatar:** use short size values for ([#2621](https://github.com/factorialco/f0/issues/2621)) ([fb4acee](https://github.com/factorialco/f0/commit/fb4acee493f94edc8ad36c042619fe3af8648ced))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).