### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.195.1",
+  "packages/react": "1.196.0",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.196.0](https://github.com/factorialco/f0/compare/f0-react-v1.195.1...f0-react-v1.196.0) (2025-09-18)
+
+
+### Features
+
+* **RichText:** enhance NotesTextEditor with new tag type and icon support ([#2571](https://github.com/factorialco/f0/issues/2571)) ([0a5f316](https://github.com/factorialco/f0/commit/0a5f316feeff12b57fb3c7a18362884abc21aebe))
+
 ## [1.195.1](https://github.com/factorialco/f0/compare/f0-react-v1.195.0...f0-react-v1.195.1) (2025-09-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.195.1",
+  "version": "1.196.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.196.0</summary>

## [1.196.0](https://github.com/factorialco/f0/compare/f0-react-v1.195.1...f0-react-v1.196.0) (2025-09-18)


### Features

* **RichText:** enhance NotesTextEditor with new tag type and icon support ([#2571](https://github.com/factorialco/f0/issues/2571)) ([0a5f316](https://github.com/factorialco/f0/commit/0a5f316feeff12b57fb3c7a18362884abc21aebe))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).