### PR TITLE
fix: spacings and alignment in grouping selector

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/Settings/Settings.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Settings/Settings.tsx
@@ -133,14 +133,19 @@ export const Settings = <
                 onVisualizationChange={handleVisualizationChange}
               />
             ),
-            hasGrouping && !grouping?.hideSelector && (
-              <GroupingSelector
-                key="grouping"
-                grouping={grouping}
-                currentGrouping={currentGrouping}
-                onGroupingChange={handleGroupingChange}
-              />
-            ),
+            hasGrouping &&
+              !grouping?.hideSelector &&
+              !(
+                !!grouping.mandatory &&
+                Object.entries(grouping.groupBy).length < 2
+              ) && (
+                <GroupingSelector
+                  key="grouping"
+                  grouping={grouping}
+                  currentGrouping={currentGrouping}
+                  onGroupingChange={handleGroupingChange}
+                />
+              ),
             hasSortings && (
               <SortingSelector
                 key="sorting"

--- a/packages/react/src/experimental/OneDataCollection/Settings/components/GroupingSelector.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Settings/components/GroupingSelector.tsx
@@ -62,8 +62,8 @@ export const GroupingSelector = <
   ]
 
   return (
-    <div className="flex flex-col gap-0">
-      <div className="flex items-center gap-2 px-3">
+    <div className="flex flex-col gap-0 py-3">
+      <div className="flex items-end gap-2 px-3">
         <div className="shrink grow [&_button]:h-8 [&_button]:rounded">
           <Select
             label={i18n.collections.grouping.groupBy}
@@ -83,20 +83,18 @@ export const GroupingSelector = <
           />
         </div>
         {currentGrouping?.field && (
-          <div className="pb-1">
-            <Button
-              hideLabel
-              label={i18n.collections.grouping.toggleDirection}
-              variant="outline"
-              icon={currentGrouping?.order === "asc" ? ArrowUp : ArrowDown}
-              onClick={() =>
-                onGroupingChange?.({
-                  field: currentGrouping.field,
-                  order: currentGrouping.order === "asc" ? "desc" : "asc",
-                })
-              }
-            />
-          </div>
+          <Button
+            hideLabel
+            label={i18n.collections.grouping.toggleDirection}
+            variant="outline"
+            icon={currentGrouping?.order === "asc" ? ArrowUp : ArrowDown}
+            onClick={() =>
+              onGroupingChange?.({
+                field: currentGrouping.field,
+                order: currentGrouping.order === "asc" ? "desc" : "asc",
+              })
+            }
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Description

We just noticed some spacing and alignments of button in the grouping selector being wrong.

## Screenshots

### Before

<img width="317" height="245" alt="Screenshot 2025-09-19 at 13 05 35" src="https://github.com/user-attachments/assets/3305d63a-8c5d-47a6-814a-08506d93e03d" />

### After

<img width="317" height="245" alt="Screenshot 2025-09-19 at 13 04 55" src="https://github.com/user-attachments/assets/99e38bca-f516-4dc4-b5ac-632a713bb378" />
