### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.199.0",
+  "packages/react": "1.199.1",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.199.1](https://github.com/factorialco/f0/compare/f0-react-v1.199.0...f0-react-v1.199.1) (2025-09-22)
+
+
+### Bug Fixes
+
+* adjust width of datacollection to cover 100% of the width ([#2639](https://github.com/factorialco/f0/issues/2639)) ([583cc82](https://github.com/factorialco/f0/commit/583cc8205a3f04ae22b57aa4477d58bad9895753))
+
 ## [1.199.0](https://github.com/factorialco/f0/compare/f0-react-v1.198.1...f0-react-v1.199.0) (2025-09-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.199.0",
+  "version": "1.199.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.199.1</summary>

## [1.199.1](https://github.com/factorialco/f0/compare/f0-react-v1.199.0...f0-react-v1.199.1) (2025-09-22)


### Bug Fixes

* adjust width of datacollection to cover 100% of the width ([#2639](https://github.com/factorialco/f0/issues/2639)) ([583cc82](https://github.com/factorialco/f0/commit/583cc8205a3f04ae22b57aa4477d58bad9895753))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).