### PR TITLE
fix(datacollection): list click area

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -322,6 +322,36 @@ export const getMockVisualizations = (options?: {
           sorting: "role",
         },
         {
+          label: "Teammates",
+          render: (item) => ({
+            type: "avatarList",
+            value: {
+              max: 1,
+              avatarList: [
+                {
+                  type: "person",
+                  firstName: item.name,
+                  lastName: "Doe",
+                  src: "/avatars/person01.jpg",
+                },
+                {
+                  type: "person",
+                  firstName: "Dani",
+                  lastName: "Moreno",
+                  src: "/avatars/person04.jpg",
+                },
+                {
+                  type: "person",
+                  firstName: "Sergio",
+                  lastName: "Carracedo",
+                  src: "/avatars/person05.jpg",
+                },
+              ],
+            },
+          }),
+          sorting: "role",
+        },
+        {
           label: "Email 2",
           render: (item) => item.email,
           sorting: "email",
@@ -342,6 +372,7 @@ export const getMockVisualizations = (options?: {
           }),
           hide: (item) => item.name.startsWith("D"),
         },
+
         {
           label: "Department",
           render: (item) => ({

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -101,10 +101,15 @@ export const Row = <
         "group after:absolute after:inset-y-0 after:-right-px after:z-10 after:hidden after:h-full after:w-10 after:bg-gradient-to-r after:from-transparent after:via-f1-background after:via-75% after:to-f1-background after:transition-all after:content-[''] hover:after:via-[#F5F6F8] hover:after:to-[#F5F6F8] dark:hover:after:via-[#192231] dark:hover:after:to-[#192231] md:after:block hover:md:bg-f1-background-hover"
       )}
     >
-      <div className="flex flex-1 flex-row items-center gap-2">
+      {/* This div is a click capture layer get the clicks in the row */}
+      <div
+        onClick={itemOnClick}
+        className="pointer-events-auto absolute inset-0"
+      ></div>
+      <div className="pointer-events-none flex flex-1 flex-row items-center gap-2">
         {source.selectable && id !== undefined && (
           // z-10 is needed here to prevent the checkbox from not being selectable when itemHref is provided
-          <div className="z-10 hidden items-center justify-end md:flex">
+          <div className="pointer-events-auto z-10 hidden items-center justify-end md:flex">
             <F0Checkbox
               checked={selectedItems.has(id)}
               onCheckedChange={(checked) =>
@@ -116,7 +121,13 @@ export const Row = <
           </div>
         )}
         {itemHref && (
-          <Link href={itemHref} className="absolute inset-0 block" tabIndex={0}>
+          <Link
+            href={itemHref}
+            className="pointer-events-auto absolute inset-0 block"
+            tabIndex={0}
+            // onClick is needed here as the click event is not propagate to the fake click layer
+            onClick={itemOnClick}
+          >
             <span className="sr-only">{actions.view}</span>
           </Link>
         )}
@@ -130,7 +141,7 @@ export const Row = <
         {(fields || [])
           .filter((field) => !field.hide?.(item))
           .map((field) => (
-            <div key={String(field.label)} onClick={itemOnClick}>
+            <div key={String(field.label)}>
               <div className="flex items-center justify-center px-0 py-1 md:p-3 [&>span]:whitespace-nowrap">
                 {renderCell(item, field)}
               </div>
@@ -141,7 +152,7 @@ export const Row = <
         <>
           <ItemActionsRowContainer
             dropDownOpen={dropDownOpen}
-            className="hidden md:flex"
+            className="pointer-events-auto hidden md:flex"
           >
             <ItemActionsRow
               primaryItemActions={primaryItemActions}
@@ -160,7 +171,7 @@ export const Row = <
       {source.selectable && id !== undefined && (
         <div
           className={cn(
-            "absolute right-3 top-3 flex h-8 w-8 items-center justify-center md:hidden",
+            "pointer-events-auto absolute right-3 top-3 flex h-8 w-8 items-center justify-center md:hidden",
             source.itemActions && "right-12"
           )}
         >


### PR DESCRIPTION
## Description

-fix: datacollection list view row click area, before the click event was captured in each value-display, so not all the row were clickable. Now: added a fake div to capture the click in all the row using css pointer events (auto and none) to manage the propagation

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
