### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.201.8",
+  "packages/react": "1.202.0",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.202.0](https://github.com/factorialco/f0/compare/f0-react-v1.201.8...f0-react-v1.202.0) (2025-09-25)
+
+
+### Features
+
+* improve InputLabel and used in EntitySelector ([#2558](https://github.com/factorialco/f0/issues/2558)) ([bd8d974](https://github.com/factorialco/f0/commit/bd8d974c8904df72dc38fda7fd85a3d891c6f4e4))
+
 ## [1.201.8](https://github.com/factorialco/f0/compare/f0-react-v1.201.7...f0-react-v1.201.8) (2025-09-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.201.8",
+  "version": "1.202.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.202.0</summary>

## [1.202.0](https://github.com/factorialco/f0/compare/f0-react-v1.201.8...f0-react-v1.202.0) (2025-09-25)


### Features

* improve InputLabel and used in EntitySelector ([#2558](https://github.com/factorialco/f0/issues/2558)) ([bd8d974](https://github.com/factorialco/f0/commit/bd8d974c8904df72dc38fda7fd85a3d891c6f4e4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).