### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.203.2",
+  "packages/react": "1.203.3",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.203.3](https://github.com/factorialco/f0/compare/f0-react-v1.203.2...f0-react-v1.203.3) (2025-09-25)
+
+
+### Bug Fixes
+
+* add total in kanban view + fix move problem ([#2679](https://github.com/factorialco/f0/issues/2679)) ([c8b72b7](https://github.com/factorialco/f0/commit/c8b72b779f9f936591255b9c25a9848a43203a21))
+
 ## [1.203.2](https://github.com/factorialco/f0/compare/f0-react-v1.203.1...f0-react-v1.203.2) (2025-09-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.203.3</summary>

## [1.203.3](https://github.com/factorialco/f0/compare/f0-react-v1.203.2...f0-react-v1.203.3) (2025-09-25)


### Bug Fixes

* add total in kanban view + fix move problem ([#2679](https://github.com/factorialco/f0/issues/2679)) ([c8b72b7](https://github.com/factorialco/f0/commit/c8b72b779f9f936591255b9c25a9848a43203a21))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).