### PR TITLE
fix: rich text missing ul, ol, h4 styles

### DIFF
--- a/packages/react/src/experimental/RichText/index.css
+++ b/packages/react/src/experimental/RichText/index.css
@@ -51,6 +51,22 @@
   @apply m-0 mb-2.5 p-0 text-lg font-medium;
 }
 
+.ProseMirror h4,
+.rich-text-display-container h4 {
+  @apply m-0 mb-2.5 p-0 text-lg font-medium;
+}
+
+.ProseMirror ul,
+.rich-text-display-container ul {
+  @apply m-0 mb-2.5;
+  list-style: disc;
+}
+
+.ProseMirror ol,
+.rich-text-display-container ol {
+  @apply m-0 mb-2.5 list-decimal;
+}
+
 .ProseMirror a,
 .rich-text-display-container a {
   @apply cursor-pointer font-medium text-f1-foreground-accent no-underline;


### PR DESCRIPTION
## Description

Add missing styles for ul, ol, and h4 (in storybook the ul and ol were rendered as they were using the browser defaults

