### PR TITLE
fix(Checkbox): set rounded focus ring

### DIFF
--- a/packages/react/src/ui/checkbox.tsx
+++ b/packages/react/src/ui/checkbox.tsx
@@ -26,14 +26,14 @@ const Checkbox = React.forwardRef<
         name={props.name || checkboxId}
         aria-label={props.title}
         className={cn(
-          "relative h-6 w-6 shrink-0 text-f1-foreground-selected data-[state=checked]:text-f1-foreground-inverse",
+          "relative h-6 w-6 shrink-0 rounded-sm text-f1-foreground-selected data-[state=checked]:text-f1-foreground-inverse",
           "after:absolute after:left-0.5 after:top-0.5 after:z-[1] after:h-5 after:w-5 after:rounded-xs after:border after:border-solid after:border-f1-border after:transition-[background-color,border-color] after:content-[''] hover:after:border-f1-border-hover data-[state=checked]:after:bg-f1-background-selected-bold hover:data-[state=checked]:after:border-transparent",
           disabled && "cursor-not-allowed opacity-50 hover:border-f1-border",
           indeterminate && "data-[state=checked]:text-f1-foreground-inverse",
           props.checked &&
             disabled &&
             "data-[state=checked]:bg-f1-background-secondary data-[state=checked]:text-f1-foreground-secondary",
-          focusRing(),
+          focusRing("focus-visible:ring-offset-0"),
           className
         )}
         checked={props.checked}


### PR DESCRIPTION
## Description

The checkbox focus ring is square but should be rounded.

## Screenshots

#### Before

<img width="164" height="101" alt="image" src="https://github.com/user-attachments/assets/7b1174ca-8289-4ff1-a1c3-551a83ffc75a" />

#### After

<img width="177" height="127" alt="image" src="https://github.com/user-attachments/assets/c729613c-19c1-4513-bcf9-b0c9bdc25ba1" />
