### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.214.2",
+  "packages/react": "1.214.3",
   "packages/react-native": "0.20.0",
   "packages/core": "1.29.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.214.3](https://github.com/factorialco/f0/compare/f0-react-v1.214.2...f0-react-v1.214.3) (2025-10-01)
+
+
+### Bug Fixes
+
+* **Home:** pulse avatar size ([#2729](https://github.com/factorialco/f0/issues/2729)) ([248f590](https://github.com/factorialco/f0/commit/248f590605bf57a8316d8d3b6a153e3480bc22b0))
+
 ## [1.214.2](https://github.com/factorialco/f0/compare/f0-react-v1.214.1...f0-react-v1.214.2) (2025-09-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.214.2",
+  "version": "1.214.3",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.214.3</summary>

## [1.214.3](https://github.com/factorialco/f0/compare/f0-react-v1.214.2...f0-react-v1.214.3) (2025-10-01)


### Bug Fixes

* **Home:** pulse avatar size ([#2729](https://github.com/factorialco/f0/issues/2729)) ([248f590](https://github.com/factorialco/f0/commit/248f590605bf57a8316d8d3b6a153e3480bc22b0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).