### PR TITLE
fix: select remove option on clear

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Select/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Select/index.tsx
@@ -62,7 +62,7 @@ export type SelectProps<T extends string, R = unknown> = {
     option?: SelectItemObject<T, ResolvedRecordType<R>>
   ) => void
   onChangeSelectedOption?: (
-    option: SelectItemObject<T, ResolvedRecordType<R>>
+    option: SelectItemObject<T, ResolvedRecordType<R>> | undefined
   ) => void
   value?: T
   defaultItem?: SelectItemObject<T, ResolvedRecordType<R>>
@@ -329,10 +329,8 @@ const SelectComponent = forwardRef(function Select<
   useEffect(() => {
     const foundOption = findOption(localValue)
 
-    if (foundOption) {
-      onChangeSelectedOption?.(foundOption)
-      setSelectedOption(foundOption)
-    }
+    onChangeSelectedOption?.(foundOption)
+    setSelectedOption(foundOption)
   }, [
     data.records,
     localValue,
@@ -359,11 +357,10 @@ const SelectComponent = forwardRef(function Select<
     // Resets the search value when the option is selected
     setCurrentSearch(undefined)
     setLocalValue(changedValue as T)
+
     const foundOption = findOption(changedValue)
 
-    if (foundOption) {
-      onChange?.(foundOption.value, foundOption.item, foundOption)
-    }
+    onChange?.(changedValue as T, foundOption?.item, foundOption)
   }
 
   const handleChangeOpenLocal = (open: boolean) => {

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbSelect/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbSelect/index.tsx
@@ -37,9 +37,9 @@ export function BreadcrumbSelect<T extends string, R = unknown>({
   }
 
   const handleChangeSelectedOption = (
-    option: SelectItemObject<T, ResolvedRecordType<R>>
+    option: SelectItemObject<T, ResolvedRecordType<R>> | undefined
   ) => {
-    setSelectedLabel(option.label)
+    setSelectedLabel(option?.label || "")
   }
 
   return (

--- a/packages/react/src/ui/InputField/InputField.tsx
+++ b/packages/react/src/ui/InputField/InputField.tsx
@@ -3,7 +3,7 @@ import { AvatarVariant } from "@/components/avatars/F0Avatar/types"
 import { F0Icon, IconType } from "@/components/F0Icon"
 import { Spinner } from "@/experimental/Information/Spinner"
 import { CrossedCircle } from "@/icons/app"
-import { cn } from "@/lib/utils.ts"
+import { cn, focusRing } from "@/lib/utils.ts"
 import { cva } from "cva"
 import { AnimatePresence, motion } from "motion/react"
 import {
@@ -453,16 +453,24 @@ const InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
                 {clearable && !noEdit && (
                   <AnimatePresence initial={!isEmpty(localValue)}>
                     {!isEmpty(localValue) && (
-                      <motion.div
+                      <motion.button
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
                         exit={{ opacity: 0 }}
                         transition={{ duration: 0.2 }}
-                        className="mr-px mt-px flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center"
-                        onClick={handleClear}
+                        className={cn(
+                          "mt-pxflex mr-px h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-full p-0",
+                          focusRing()
+                        )}
+                        tabIndex={0}
+                        data-testid="clear-button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleClear()
+                        }}
                       >
                         <F0Icon icon={CrossedCircle} color="bold" size="md" />
-                      </motion.div>
+                      </motion.button>
                     )}
                   </AnimatePresence>
                 )}

--- a/packages/react/src/ui/Select/select.stories.tsx
+++ b/packages/react/src/ui/Select/select.stories.tsx
@@ -49,7 +49,6 @@ const meta = {
     a11y: {
       skipCi: true, // Todo add aria labels
     },
-    //layout: "centered",
     docs: {
       description: {
         component:


### PR DESCRIPTION
## Description

- fix(select): remove selected option when the the clear button is used to set the value (to '')
- feat(inputfield): clear button as button a focusable. Stops propagation
- chore(select): add clear test

## Screenshots (if applicable)

<img width="245" height="108" alt="image" src="https://github.com/user-attachments/assets/497f715c-bd1e-42d4-bcc5-0fd21b011389" />


https://github.com/user-attachments/assets/85eb82ba-f54d-4e1c-9eee-f664230c2359



## Implementation details

<!-- What have you changed? Why? -->
