### PR TITLE
fix(Card): hide empty content

### DIFF
--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -239,22 +239,24 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
               />
             )}
           </div>
-          <CardContent>
-            {metadata && (
-              <div
-                className={cn(
-                  "flex flex-col gap-0.5",
-                  compact && "flex-row flex-wrap gap-x-3 gap-y-0",
-                  forceVerticalMetadata && "flex-col gap-y-0.5"
-                )}
-              >
-                {metadata.map((item, index) => (
-                  <CardMetadata key={index} metadata={item} />
-                ))}
-              </div>
-            )}
-            {children}
-          </CardContent>
+          {(metadata || children) && (
+            <CardContent>
+              {metadata && (
+                <div
+                  className={cn(
+                    "flex flex-col gap-0.5",
+                    compact && "flex-row flex-wrap gap-x-3 gap-y-0",
+                    forceVerticalMetadata && "flex-col gap-y-0.5"
+                  )}
+                >
+                  {metadata.map((item, index) => (
+                    <CardMetadata key={index} metadata={item} />
+                  ))}
+                </div>
+              )}
+              {children}
+            </CardContent>
+          )}
         </div>
         <CardActions
           primaryAction={primaryAction}


### PR DESCRIPTION
## Description

Fixes an error with the Card component. The div that contains the metadata and content of the Card, when is empty, is still displayed, making it look like there's more space to the bottom.

Slack: https://factorialteam.slack.com/archives/C082ZNKS403/p1759849355961809

## Screenshots

### Before

<img width="958" height="488" alt="image" src="https://github.com/user-attachments/assets/383acdb7-f4f1-4ef6-a457-991c65d81286" />


### After

<img width="310" height="74" alt="Screenshot 2025-10-07 at 19 37 49" src="https://github.com/user-attachments/assets/202cbf3f-e3a5-4e33-868e-0152e277753f" />

