### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.229.0",
-  "packages/react-native": "0.20.0",
+  "packages/react-native": "0.20.1",
   "packages/core": "1.29.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.20.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.20.0...f0-react-native-v0.20.1) (2025-10-09)
+
+
+### Bug Fixes
+
+* **react-native:** fix exports and improve package compatibility ([#2784](https://github.com/factorialco/f0/issues/2784)) ([d80bbec](https://github.com/factorialco/f0/commit/d80bbecc30e8e7c3b42cd9de1489867e123bb791))
+
 ## [0.20.0](https://github.com/factorialco/factorial-one/compare/f0-react-native-v0.19.1...f0-react-native-v0.20.0) (2025-09-11)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "src/index.ts",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.20.1</summary>

## [0.20.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.20.0...f0-react-native-v0.20.1) (2025-10-09)


### Bug Fixes

* **react-native:** fix exports and improve package compatibility ([#2784](https://github.com/factorialco/f0/issues/2784)) ([d80bbec](https://github.com/factorialco/f0/commit/d80bbecc30e8e7c3b42cd9de1489867e123bb791))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).