### PR TITLE
fix: no reactions prop was not hidding the reactions, only comments

### DIFF
--- a/packages/react/src/experimental/Information/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/experimental/Information/Communities/Post/CommunityPost/index.tsx
@@ -227,19 +227,17 @@ export const BaseCommunityPost = ({
           </div>
         )}
         <p className="text-f1-foreground-secondary">{countersDisplay}</p>
-        <Reactions
-          items={reactions?.items ?? []}
-          onInteraction={reactions?.onInteraction}
-          action={
-            !noReactionsButton
-              ? {
-                  label: comment.label,
-                  onClick: comment.onClick,
-                  icon: CommentIcon,
-                }
-              : undefined
-          }
-        />
+        {!noReactionsButton && (
+          <Reactions
+            items={reactions?.items ?? []}
+            onInteraction={reactions?.onInteraction}
+            action={{
+              label: comment.label,
+              onClick: comment.onClick,
+              icon: CommentIcon,
+            }}
+          />
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Description

noReactionsButton prop was not hidding the reactions, only the comments option, when it should do both.

## Screenshots (if applicable)

<img width="1150" height="390" alt="image" src="https://github.com/user-attachments/assets/a85c9654-959f-4f51-9842-bf94e45b3d69" />

## Implementation details

Make sure reactions are not shown if noReactionsButton is true
