### PR TITLE
feat: copy One sidepanel and remove ai dependencies

### DIFF
--- a/packages/react/src/experimental/AiPromotionChat/OneIcon.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/OneIcon.tsx
@@ -1,0 +1,199 @@
+import { cn } from "@/lib/utils"
+import { cva } from "cva"
+import { motion } from "motion/react"
+import type { SVGProps } from "react"
+import { Ref, forwardRef, useId } from "react"
+
+interface OneIconProps extends SVGProps<SVGSVGElement> {
+  spin?: boolean
+  hover?: boolean
+  background?: string
+  size?: "sm" | "md" | "lg"
+}
+
+const sizeVariants = cva({
+  variants: {
+    size: {
+      sm: "h-[1.375rem] w-[1.375rem]",
+      md: "h-8 w-8",
+      lg: "h-10 w-10",
+    },
+  },
+  defaultVariants: { size: "md" },
+})
+
+const pieces = [
+  {
+    id: "bottom",
+    delay: 2.6,
+    transformOrigin: "center 89%",
+    rotateAxis: "1, 0, 0",
+    path: "M15.9939 24.8399C19.6511 24.8399 23.2335 26.0603 26.0525 28.4219C23.2335 30.7072 19.651 32.001 15.9939 32.001C12.1849 32.0009 8.67993 30.6307 5.93728 28.4219C8.75621 26.1365 12.3369 24.84 15.9939 24.8399Z",
+  },
+  {
+    id: "left",
+    delay: 2.2,
+    transformOrigin: "11% center",
+    rotateAxis: "0, 1, 0",
+    path: "M3.57986 5.94142C5.86509 8.76031 7.1608 12.3412 7.16092 15.9981C7.16092 19.6551 5.94136 23.2376 3.57986 26.0567C1.29443 23.2376 -0.000215909 19.6552 -0.00021553 15.9981C-0.000100728 12.1889 1.37091 8.6841 3.57986 5.94142Z",
+  },
+  {
+    id: "right",
+    delay: 2.4,
+    transformOrigin: "88.5% center",
+    rotateAxis: "0, 1, 0",
+    path: "M28.4236 5.94142C30.7088 8.76031 32.0046 12.3412 32.0047 15.9981C32.0047 19.6551 30.7851 23.2376 28.4236 26.0567C26.1382 23.2376 24.8435 19.6552 24.8435 15.9981C24.8436 12.1889 26.2147 8.6841 28.4236 5.94142Z",
+  },
+  {
+    id: "top",
+    delay: 2,
+    transformOrigin: "center 11%",
+    rotateAxis: "1, 0, 0",
+    path: "M15.9939 1.33514e-05C19.6511 1.37386e-05 23.2335 1.22043 26.0525 3.58204C23.2335 5.86737 19.651 7.16115 15.9939 7.16115C12.1849 7.16103 8.67993 5.79089 5.93728 3.58204C8.75621 1.29671 12.3369 0.000125175 15.9939 1.33514e-05Z",
+  },
+]
+
+const OneIcon = (
+  {
+    spin = false,
+    size = "md",
+    background,
+    hover = false,
+    ...svgProps
+  }: OneIconProps,
+  ref: Ref<SVGSVGElement>
+) => {
+  const clipPathId = useId()
+  const {
+    onAnimationStart: _onAnimationStart,
+    onAnimationEnd: _onAnimationEnd,
+    onDragStart: _onDragStart,
+    onDragEnd: _onDragEnd,
+    onDrag: _onDrag,
+    className,
+    ...safeSvgProps
+  } = svgProps
+
+  return (
+    <div
+      className={cn(sizeVariants({ size }), className)}
+      style={{
+        background: "transparent",
+        perspective: spin ? "10px" : undefined,
+        transformStyle: spin ? "preserve-3d" : undefined,
+      }}
+    >
+      <motion.svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 32 32"
+        xmlns="http://www.w3.org/2000/svg"
+        ref={ref}
+        animate={{
+          "--gradient-angle": ["0deg", "360deg"],
+        }}
+        transition={
+          !background
+            ? {
+                "--gradient-angle": {
+                  duration: 6,
+                  ease: "linear",
+                  repeat: Infinity,
+                },
+              }
+            : undefined
+        }
+        style={
+          {
+            "--gradient-angle": "0deg",
+            ...safeSvgProps.style,
+          } as React.CSSProperties
+        }
+        {...(({ style: _style, ...rest }) => rest)(safeSvgProps)}
+      >
+        <defs>
+          <clipPath id={`${clipPathId}-circle`}>
+            <circle cx="16" cy="16" r="16" />
+          </clipPath>
+          {pieces.map((piece) => (
+            <clipPath key={piece.id} id={`${clipPathId}-${piece.id}`}>
+              <path d={piece.path} />
+            </clipPath>
+          ))}
+        </defs>
+
+        <g clipPath={`url(#${clipPathId}-circle)`}>
+          {pieces.map((piece) => (
+            <motion.foreignObject
+              key={piece.id}
+              x="0"
+              y="0"
+              width="32"
+              height="32"
+              clipPath={`url(#${clipPathId}-${piece.id})`}
+              animate={{
+                "--rotate3d-angle": ["0deg", "180deg", "180deg", "360deg"],
+                "--scale": hover ? 8 : 1,
+                "--rotate": hover ? "90deg" : "0deg",
+                opacity: hover ? (piece.id === "left" ? 1 : 0) : 1,
+                filter: spin
+                  ? ["blur(0px)", "blur(8px)", "blur(0px)"]
+                  : undefined,
+              }}
+              transition={{
+                "--rotate3d-angle": {
+                  delay: spin ? piece.delay : 0,
+                  duration: 1.8,
+                  ease: [0.65, 0, 0.35, 1],
+                  times: [0, 0.99, 0.9999, 1],
+                },
+                "--scale": {
+                  duration: hover ? 0.6 : 0.35,
+                  ease: [0.55, 0, 0.1, 1],
+                },
+                "--rotate": {
+                  duration: 0.35,
+                  ease: "easeInOut",
+                },
+                opacity: {
+                  duration: hover ? 0.8 : 0.1,
+                  ease: "easeInOut",
+                },
+                filter: {
+                  delay: spin ? piece.delay : 0,
+                  duration: 1.8,
+                  ease: [0.65, 0, 0.35, 1],
+                  times: [0, 0.5, 1],
+                },
+              }}
+              style={
+                {
+                  "--rotate3d-angle": "0deg",
+                  "--scale": 1,
+                  "--rotate": "0deg",
+                  transform: spin
+                    ? `rotate3d(${piece.rotateAxis}, var(--rotate3d-angle))`
+                    : `scale(var(--scale)) rotate(var(--rotate))`,
+                  transformOrigin: piece.transformOrigin,
+                  willChange: "transform",
+                } as React.CSSProperties
+              }
+            >
+              <div
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  background:
+                    background ??
+                    `conic-gradient(from var(--gradient-angle) at 50% 50%, #E55619 0%, #A1ADE5 33%, #E51943 66%, #E55619 100%)`,
+                }}
+              />
+            </motion.foreignObject>
+          ))}
+        </g>
+      </motion.svg>
+    </div>
+  )
+}
+const ForwardRef = forwardRef<SVGSVGElement, OneIconProps>(OneIcon)
+export default ForwardRef

--- a/packages/react/src/experimental/AiPromotionChat/OneSwitch.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/OneSwitch.tsx
@@ -1,0 +1,95 @@
+import { useI18n } from "@/lib/providers/i18n"
+import { cn, focusRing } from "@/lib/utils"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/ui/tooltip"
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+import { motion } from "motion/react"
+import { useState } from "react"
+import OneIcon from "./OneIcon"
+import { useAiPromotionChat } from "./providers/AiChatStateProvider"
+
+export const OneSwitch = ({
+  className,
+  disabled,
+}: React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>) => {
+  const { setOpen, open } = useAiPromotionChat()
+  const translations = useI18n()
+  const [isHover, setIsHover] = useState(false)
+
+  return (
+    <div className="flex items-center">
+      <TooltipProvider>
+        <Tooltip delayDuration={850} disableHoverableContent>
+          <TooltipTrigger asChild>
+            <motion.div
+              animate={{
+                "--gradient-angle": ["0deg", "360deg"],
+              }}
+              transition={{
+                default: {
+                  duration: 8,
+                  ease: "linear",
+                  repeat: Infinity,
+                },
+              }}
+              style={
+                {
+                  "--gradient-angle": "180deg",
+                } as React.CSSProperties
+              }
+            >
+              <SwitchPrimitive.Root
+                onCheckedChange={(val) => {
+                  setOpen(val)
+                }}
+                checked={open}
+                aria-label={
+                  open ? translations.ai.closeChat : translations.ai.openChat
+                }
+                className={cn(
+                  "group relative h-8 w-12 rounded-full border-none bg-f1-background-inverse-secondary transition-all hover:bg-f1-background-hover",
+                  "shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_0_4px_rgba(13,22,37,.04)] data-[state=checked]:shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_0_4px_rgba(13,22,37,.6)]",
+                  "after:pointer-events-none after:absolute after:inset-0 after:rounded-full after:ring-1 after:ring-inset after:ring-f1-border after:transition-all after:content-[''] data-[state=checked]:after:ring-f1-border-inverse",
+                  "before:absolute before:inset-0 before:rounded-full before:bg-[conic-gradient(from_var(--gradient-angle),hsla(229,57%,76%,0.7),hsla(348,80%,50%,0.7),hsla(348,80%,50%,0.7),hsla(18,80%,50%,0.7),hsla(229,57%,76%,0.7),hsla(229,57%,76%,0.7))] before:opacity-0 before:transition-all before:duration-300 before:content-[''] data-[state=checked]:before:opacity-100",
+                  disabled && "cursor-not-allowed opacity-50",
+                  focusRing(),
+                  className
+                )}
+                disabled={disabled}
+                onMouseEnter={() => setIsHover(true)}
+                onMouseLeave={() => setIsHover(false)}
+              >
+                <SwitchPrimitive.Thumb
+                  className={cn(
+                    "block h-[1.375rem] w-[1.375rem] translate-x-[0.3125rem] rounded-full transition-transform duration-300 data-[state=checked]:translate-x-[1.3125rem]"
+                  )}
+                  style={{
+                    transitionTimingFunction:
+                      "cubic-bezier(0.175,0.885,0.32,1.5)",
+                  }}
+                >
+                  <div>
+                    <OneIcon
+                      size="sm"
+                      background={open ? "white" : undefined}
+                      hover={isHover}
+                    />
+                  </div>
+                </SwitchPrimitive.Thumb>
+              </SwitchPrimitive.Root>
+            </motion.div>
+          </TooltipTrigger>
+          {!open && (
+            <TooltipContent side="left" className="font-medium">
+              {translations.ai.welcome}
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  )
+}

--- a/packages/react/src/experimental/AiPromotionChat/components/ChatButton.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/components/ChatButton.tsx
@@ -1,0 +1,4 @@
+export const ChatButton = () => {
+  // Return null to hide CopilotKit's default chat button
+  return null
+}

--- a/packages/react/src/experimental/AiPromotionChat/components/ChatHeader.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/components/ChatHeader.tsx
@@ -1,0 +1,35 @@
+import { ButtonInternal } from "@/components/Actions/Button/internal"
+import Cross from "@/icons/app/Cross"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+import { useChatContext, type HeaderProps } from "@copilotkit/react-ui"
+import { motion } from "motion/react"
+import { useAiPromotionChat } from "../providers/AiChatStateProvider"
+
+export const ChatHeader = (props: HeaderProps) => {
+  const { labels } = useChatContext()
+  const { setOpen } = useAiPromotionChat()
+  const translations = useI18n()
+  const hasDefaultTitle = labels.title === "CopilotKit"
+
+  return (
+    <header
+      className={cn(
+        "flex justify-between border-0 border-solid border-f1-border-secondary p-3"
+      )}
+    >
+      <h2 className="text-f1-foreground">
+        {hasDefaultTitle ? "" : labels.title}
+      </h2>
+      <motion.div layout className="flex items-center gap-x-2" {...props}>
+        <ButtonInternal
+          variant="ghost"
+          hideLabel
+          label={translations.ai.closeChat}
+          icon={Cross}
+          onClick={() => setOpen(false)}
+        />
+      </motion.div>
+    </header>
+  )
+}

--- a/packages/react/src/experimental/AiPromotionChat/components/ChatTextarea.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/components/ChatTextarea.tsx
@@ -1,0 +1,147 @@
+import { ButtonInternal } from "@/components/Actions/Button/internal"
+import { ArrowUp, SolidStop } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+import { type InputProps } from "@copilotkit/react-ui"
+import { AnimatePresence, motion } from "motion/react"
+import { useEffect, useRef, useState } from "react"
+
+export const ChatTextarea = ({ inProgress, onSend, onStop }: InputProps) => {
+  const [inputValue, setInputValue] = useState("")
+  const [hasScrollbar, setHasScrollbar] = useState(false)
+  const formRef = useRef<HTMLFormElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const translation = useI18n()
+
+  const hasDataToSend = inputValue.trim().length > 0
+
+  useEffect(() => {
+    if (textareaRef.current && inputValue.length > 0) {
+      const { scrollHeight, clientHeight } = textareaRef.current
+      setHasScrollbar(scrollHeight > clientHeight)
+    } else {
+      setHasScrollbar(false)
+    }
+  }, [inputValue])
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (inProgress) {
+      onStop?.()
+    } else if (hasDataToSend) {
+      onSend(inputValue.trim())
+      setInputValue("")
+    }
+
+    textareaRef.current?.focus()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      if (!inProgress) {
+        formRef.current?.requestSubmit()
+      }
+    }
+  }
+
+  return (
+    <motion.form
+      layout
+      aria-busy={inProgress}
+      ref={formRef}
+      className={cn(
+        "relative isolate m-3 mt-2 flex flex-col gap-3 rounded-lg border border-solid border-f1-border hover:cursor-text",
+        "after:pointer-events-none after:absolute after:inset-0.5 after:z-[-2] after:rounded-[inherit] after:bg-f1-foreground-secondary after:opacity-0 after:blur-[5px] after:content-['']",
+        "from-[#E55619] via-[#A1ADE5] to-[#E51943] after:scale-90 after:bg-[conic-gradient(from_var(--gradient-angle),var(--tw-gradient-stops))]",
+        "after:transition-all after:delay-200 after:duration-300 has-[textarea:focus]:after:scale-100 has-[textarea:focus]:after:opacity-100",
+        "before:pointer-events-none before:absolute before:inset-0 before:z-[-1] before:rounded-[inherit] before:bg-f1-background before:content-['']"
+      )}
+      animate={{
+        "--gradient-angle": ["0deg", "360deg"],
+      }}
+      transition={{
+        default: {
+          duration: 6,
+          ease: "linear",
+          repeat: Infinity,
+        },
+        layout: {
+          duration: 0.3,
+        },
+      }}
+      style={
+        {
+          "--gradient-angle": "180deg",
+        } as React.CSSProperties
+      }
+      onClick={() => {
+        textareaRef.current?.focus()
+      }}
+      onSubmit={handleSubmit}
+    >
+      <div className="grid grid-cols-1 grid-rows-1">
+        <div
+          aria-hidden={true}
+          className="pointer-events-none invisible col-start-1 row-start-1 mx-3 mb-0 mt-3 max-h-36 whitespace-pre-wrap"
+        >
+          {inputValue.endsWith("\n") ? inputValue + "_" : inputValue}
+        </div>
+        <AnimatePresence>
+          {hasScrollbar && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 0.5 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+              className={cn(
+                "pointer-events-none absolute inset-x-0 z-10 h-3 rounded-t-xl after:absolute after:inset-x-0 after:h-px after:bg-f1-background-inverse after:opacity-[0.04] after:content-['']",
+                "-top-px bg-gradient-to-b from-f1-background-selected to-transparent after:-top-px"
+              )}
+            />
+          )}
+        </AnimatePresence>
+        <textarea
+          autoFocus={true}
+          name="one-ai-input"
+          ref={textareaRef}
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value)
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={translation.ai.inputPlaceholder}
+          className={cn(
+            "col-start-1 row-start-1",
+            "mx-3 mb-0 max-h-36 flex-1 resize-none overflow-y-scroll outline-none transition-all",
+            "bg-f1-background text-f1-foreground placeholder:text-f1-foreground-secondary",
+            !hasScrollbar && "mt-3"
+          )}
+        />
+      </div>
+
+      <div className="flex flex-row-reverse p-3 pt-0">
+        {inProgress ? (
+          <ButtonInternal
+            type="submit"
+            variant="neutral"
+            label={translation.ai.stopAnswerGeneration}
+            icon={SolidStop}
+            hideLabel
+            round
+          />
+        ) : (
+          <ButtonInternal
+            type="submit"
+            disabled={!hasDataToSend}
+            variant={hasDataToSend ? "default" : "neutral"}
+            label={translation.ai.sendMessage}
+            icon={ArrowUp}
+            hideLabel
+            round
+          />
+        )}
+      </div>
+    </motion.form>
+  )
+}

--- a/packages/react/src/experimental/AiPromotionChat/components/ChatWindow.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/components/ChatWindow.tsx
@@ -1,0 +1,48 @@
+import { type WindowProps } from "@copilotkit/react-ui"
+import { AnimatePresence, motion } from "motion/react"
+import { useAiPromotionChat } from "../providers/AiChatStateProvider"
+
+export const SidebarWindow = ({ children }: WindowProps) => {
+  const { open, shouldPlayEntranceAnimation, setShouldPlayEntranceAnimation } =
+    useAiPromotionChat()
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          key="chat-window"
+          aria-hidden={!open}
+          className="relative flex h-full max-w-[360px] flex-col overflow-hidden border border-solid border-f1-border-secondary bg-f1-special-page shadow xs:rounded-xl"
+          initial={
+            shouldPlayEntranceAnimation ? { opacity: 0, width: 0 } : false
+          }
+          animate={{ opacity: 1, width: 360 }}
+          exit={{ opacity: 0, width: 0 }}
+          transition={{
+            duration: 0.3,
+            ease: [0, 0, 0.1, 1],
+          }}
+          onAnimationComplete={() => {
+            if (shouldPlayEntranceAnimation) {
+              setShouldPlayEntranceAnimation(false)
+            }
+          }}
+        >
+          <motion.div
+            className="relative flex h-full w-[360px] flex-col overflow-x-hidden"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{
+              duration: shouldPlayEntranceAnimation ? 0.3 : 0.05,
+              ease: "easeOut",
+              delay: shouldPlayEntranceAnimation ? 0.2 : 0,
+            }}
+          >
+            {children}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/packages/react/src/experimental/AiPromotionChat/components/MessagesContainer.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/components/MessagesContainer.tsx
@@ -1,0 +1,399 @@
+import { ButtonInternal } from "@/components/Actions/Button/internal"
+import { ArrowDown } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+import { useCopilotChatInternal as useCopilotChat } from "@copilotkit/react-core"
+import { type MessagesProps } from "@copilotkit/react-ui"
+import { type Message } from "@copilotkit/shared"
+import { AnimatePresence, motion } from "motion/react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useEventListener, useResizeObserver } from "usehooks-ts"
+import { isAgentStateMessage } from "../messageTypes"
+import OneIcon from "../OneIcon"
+import { useAiPromotionChat } from "../providers/AiChatStateProvider"
+
+type Turn = Array<Message | Array<Message>>
+
+export const MessagesContainer = ({
+  inProgress,
+  children,
+  RenderMessage,
+  AssistantMessage,
+  UserMessage,
+  ImageRenderer,
+  onRegenerate,
+  onCopy,
+  onThumbsUp,
+  onThumbsDown,
+  markdownTagRenderers,
+}: MessagesProps) => {
+  const turnsContainerRef = useRef<HTMLDivElement>(null)
+  const { messages, interrupt } = useCopilotChat()
+
+  const translations = useI18n()
+  const { greeting, initialMessage } = useAiPromotionChat()
+  const [longestTurnHeight, setLongestTurnHeight] = useState<number>(0)
+  const initialMessages = useMemo(
+    () =>
+      makeInitialMessages(
+        initialMessage || translations.ai.defaultInitialMessage
+      ),
+    [initialMessage, translations.ai.defaultInitialMessage]
+  )
+  const showWelcomeBlock =
+    messages.length == 0 && (greeting || initialMessages.length > 0)
+
+  const {
+    messagesContainerRef,
+    messagesEndRef,
+    showScrollToBottom,
+    scrollToBottom,
+  } = useScrollToBottom()
+  const { height: containerHeight = 0 } = useResizeObserver({
+    ref: messagesContainerRef,
+    box: "border-box",
+  })
+  useEffect(() => {
+    if (!turnsContainerRef.current) {
+      return
+    }
+    const turnElements = turnsContainerRef.current.children
+    if (turnElements.length === 0) {
+      return
+    }
+
+    const lastTurnElement = turnElements[turnElements.length - 1]
+    const height = lastTurnElement.scrollHeight
+    setLongestTurnHeight((prev) => (prev >= height ? prev : height))
+  }, [messages.length, initialMessages.length])
+  const turns = useMemo(() => {
+    return convertMessagesToTurns(messages)
+  }, [messages])
+
+  // the scroll container's height is manually controlled by the size of the biggest turn (see `motion.div` below)
+  // However the initial height is dynamic and set via `flex-1` class.
+  // This way the scroll container takes all available vertical space in the chat window.
+  // When we measure it's size in the effect and start manipulating the hight manually. The flex is reset to initial.
+  return (
+    <motion.div
+      layout
+      className={cn(
+        "scrollbar-macos relative isolate flex-1 px-4 pt-3",
+        "overflow-y-scroll"
+      )}
+      ref={messagesContainerRef}
+      style={{
+        height: containerHeight
+          ? Math.max(containerHeight, longestTurnHeight)
+          : undefined,
+        flex: containerHeight ? "initial" : undefined,
+      }}
+    >
+      <motion.div layout="position" ref={turnsContainerRef}>
+        <AnimatePresence mode="popLayout">
+          {showWelcomeBlock && (
+            <motion.div
+              key="welcome"
+              className="absolute top-1/2 flex translate-y-[-50%] flex-col px-2"
+              initial={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+            >
+              <motion.div
+                className="flex w-fit justify-center"
+                initial={{ opacity: 0, scale: 0.8, filter: "blur(6px)" }}
+                animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+                exit={{ opacity: 0, scale: 0.8, filter: "blur(6px)" }}
+                transition={{
+                  opacity: { duration: 0.2, ease: "easeOut", delay: 0.4 },
+                  scale: { duration: 0.3, ease: [0.25, 0.46, 0.45, 1.94] },
+                  filter: { duration: 0.2, ease: "easeOut", delay: 0.4 },
+                }}
+              >
+                <OneIcon spin size="lg" className="my-4" />
+              </motion.div>
+              {greeting && (
+                <motion.p
+                  className="text-lg font-medium text-f1-foreground-secondary"
+                  initial={{ opacity: 0, filter: "blur(2px)", translateY: -8 }}
+                  animate={{ opacity: 1, filter: "blur(0px)", translateY: 0 }}
+                  exit={{ opacity: 0, filter: "blur(2px)", translateY: -8 }}
+                  transition={{
+                    opacity: { duration: 0.2, ease: "easeOut", delay: 0.5 },
+                    filter: { duration: 0.2, ease: "easeOut", delay: 0.5 },
+                    translateY: {
+                      duration: 0.2,
+                      ease: [0.25, 0.46, 0.45, 1.94],
+                      delay: 0.5,
+                    },
+                  }}
+                >
+                  {greeting}
+                </motion.p>
+              )}
+              {initialMessages.map((message) => (
+                <motion.p
+                  className="text-2xl font-semibold text-f1-foreground"
+                  key={message.id}
+                  initial={{ opacity: 0, filter: "blur(2px)", translateY: -8 }}
+                  animate={{ opacity: 1, filter: "blur(0px)", translateY: 0 }}
+                  exit={{ opacity: 0, filter: "blur(2px)", translateY: -8 }}
+                  transition={{
+                    opacity: { duration: 0.2, ease: "easeOut", delay: 0.7 },
+                    filter: { duration: 0.2, ease: "easeOut", delay: 0.7 },
+                    translateY: {
+                      duration: 0.2,
+                      ease: [0.25, 0.46, 0.45, 1.94],
+                      delay: 0.7,
+                    },
+                  }}
+                >
+                  {message.content}
+                </motion.p>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+        {turns.map((turnMessages, turnIndex) => {
+          const isCurrentTurn = turnIndex === turns.length - 1
+
+          return (
+            <div
+              className="flex flex-col items-start justify-start gap-2"
+              key={`turn-${turnIndex}`}
+              style={{
+                minHeight: isCurrentTurn
+                  ? // "scroll" the current turn up in the view to make space for the assistant response,
+                    // but leave 20% of the container height on the top to show part of the previous dialog
+                    containerHeight * 0.8
+                  : undefined,
+              }}
+            >
+              {turnMessages.map((message, index) => {
+                const isCurrentMessage =
+                  turnIndex === turns.length - 1 &&
+                  index === turnMessages.length - 1
+
+                return (
+                  <RenderMessage
+                    key={`${turnIndex}-${index}`}
+                    message={
+                      Array.isArray(message)
+                        ? message[message.length - 1] // show last thought when the thinking is ongoing
+                        : message
+                    }
+                    inProgress={inProgress}
+                    index={index}
+                    isCurrentMessage={isCurrentMessage}
+                    AssistantMessage={AssistantMessage}
+                    UserMessage={UserMessage}
+                    ImageRenderer={ImageRenderer}
+                    onRegenerate={onRegenerate}
+                    onCopy={onCopy}
+                    onThumbsUp={onThumbsUp}
+                    onThumbsDown={onThumbsDown}
+                    markdownTagRenderers={markdownTagRenderers}
+                  />
+                )
+              })}
+            </div>
+          )
+        })}
+        {interrupt}
+      </motion.div>
+      <footer className="copilotKitMessagesFooter" ref={messagesEndRef}>
+        {children}
+      </footer>
+      <AnimatePresence>
+        {showScrollToBottom && (
+          <motion.div
+            className="sticky bottom-2 z-10 flex justify-center"
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+            transition={{ duration: 0.2 }}
+          >
+            <div className="rounded bg-f1-background">
+              <ButtonInternal
+                onClick={() => scrollToBottom()}
+                label={translations.ai.scrollToBottom}
+                variant="neutral"
+                icon={ArrowDown}
+                hideLabel
+              />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  )
+}
+
+function makeInitialMessages(initial?: string | string[]): Message[] {
+  const initialArray: string[] = []
+  if (initial) {
+    if (Array.isArray(initial)) {
+      initialArray.push(...initial)
+    } else {
+      initialArray.push(initial)
+    }
+  }
+
+  return initialArray.map((message) => ({
+    id: message,
+    role: "assistant",
+    content: message,
+  }))
+}
+
+export function useScrollToBottom() {
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const messagesContainerRef = useRef<HTMLDivElement | null>(null)
+  const isProgrammaticScrollRef = useRef(false)
+  const isUserScrollUpRef = useRef(false)
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false)
+
+  const scrollToBottom = (behavior: ScrollBehavior = "smooth") => {
+    if (messagesContainerRef.current && messagesEndRef.current) {
+      setShowScrollToBottom(false)
+      isProgrammaticScrollRef.current = true
+      messagesEndRef.current.scrollIntoView({ behavior })
+    }
+  }
+
+  const checkIsScrollingUp = () => {
+    if (messagesContainerRef.current) {
+      const { scrollTop, scrollHeight, clientHeight } =
+        messagesContainerRef.current
+      const PRECISION = 20
+
+      isUserScrollUpRef.current =
+        scrollTop + clientHeight + PRECISION < scrollHeight
+    } else {
+      isUserScrollUpRef.current = false
+    }
+  }
+
+  const checkScrollToBottomButtonVisibility = () => {
+    if (!messagesContainerRef.current) {
+      setShowScrollToBottom(false)
+      return
+    }
+
+    const { scrollTop, scrollHeight, clientHeight } =
+      messagesContainerRef.current
+
+    const isScrolledFarUp = scrollTop < scrollHeight - 3 * clientHeight
+    setShowScrollToBottom(isScrolledFarUp)
+  }
+
+  const handleScroll = useCallback(() => {
+    if (isProgrammaticScrollRef.current) {
+      isProgrammaticScrollRef.current = false
+      return
+    }
+
+    checkIsScrollingUp()
+    checkScrollToBottomButtonVisibility()
+  }, [])
+
+  useEventListener("scroll", handleScroll, messagesContainerRef)
+
+  useEffect(() => {
+    const container = messagesContainerRef.current
+    if (!container) {
+      return
+    }
+
+    scrollToBottom("instant")
+
+    const mutationObserver = new MutationObserver(() => {
+      checkScrollToBottomButtonVisibility()
+    })
+
+    mutationObserver.observe(container, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    })
+
+    return () => {
+      mutationObserver.disconnect()
+    }
+  }, [])
+
+  return {
+    messagesEndRef,
+    messagesContainerRef,
+    showScrollToBottom,
+    scrollToBottom,
+  }
+}
+
+export function convertMessagesToTurns(messages: Message[]): Turn[] {
+  if (messages.length === 0) {
+    return []
+  }
+
+  console.assert(
+    messages[0].role === "user",
+    "Invariant violation! Assistant message received before user message"
+  )
+
+  const turns: Turn[] = []
+
+  for (const [i, message] of messages.entries()) {
+    if (message.role === "user") {
+      // create new turn
+      turns.push([message])
+      continue
+    }
+
+    const currentTurn = turns[turns.length - 1]
+
+    // Handle agent state messages that arrive during thinking message grouping
+    if (
+      isAgentStateMessage(message) &&
+      isCurrentlyGroupingThinking(currentTurn)
+    ) {
+      // we want to ignore the last agent state message
+      // to avoid rerenders of thinking components and play extra animations
+      if (i !== messages.length - 1) {
+        const thinkingGroup = currentTurn.pop() as Message[]
+        currentTurn.push(message, thinkingGroup)
+      }
+      continue
+    }
+
+    // Handle thinking messages
+    if (isThinkingMessage(message)) {
+      if (isCurrentlyGroupingThinking(currentTurn)) {
+        // Continue grouping: add to existing thinking group
+        const thinkingGroup = currentTurn.at(-1) as Message[]
+        thinkingGroup.push(message)
+      } else {
+        // Start grouping: create new thinking group
+        currentTurn.push([message])
+      }
+      continue
+    }
+
+    currentTurn.push(message)
+  }
+
+  return turns
+}
+
+function isThinkingMessage(message: Message): boolean {
+  return (
+    message.role === "assistant" &&
+    message.toolCalls?.some(
+      (call) => call.function.name === "orchestratorThinking"
+    ) === true
+  )
+}
+
+function isCurrentlyGroupingThinking(turn: Turn): boolean {
+  const lastMessage = turn.at(-1)
+  return Array.isArray(lastMessage)
+}

--- a/packages/react/src/experimental/AiPromotionChat/components/UserMessage.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/components/UserMessage.tsx
@@ -1,0 +1,38 @@
+import { type UserMessageProps } from "@copilotkit/react-ui"
+import { useEffect, useRef } from "react"
+
+export const UserMessage = ({ message, ImageRenderer }: UserMessageProps) => {
+  const isImageMessage = message && "image" in message && message.image
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!ref.current) return
+
+    ref.current.scrollIntoView({
+      behavior: "smooth",
+    })
+  }, [])
+
+  // Image message
+  if (isImageMessage) {
+    const imageMessage = message
+
+    return (
+      <div className="copilotKitMessage copilotKitUserMessage">
+        <ImageRenderer
+          image={imageMessage.image!}
+          content={imageMessage.content}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="my-4 w-fit max-w-[min(90%,330px)] self-end whitespace-pre-wrap rounded-2xl border border-solid border-f1-border-secondary bg-f1-background-tertiary px-4 py-3 first:mt-0 last:mb-0"
+    >
+      {message?.content}
+    </div>
+  )
+}

--- a/packages/react/src/experimental/AiPromotionChat/components/index.ts
+++ b/packages/react/src/experimental/AiPromotionChat/components/index.ts
@@ -1,0 +1,6 @@
+export { ChatButton } from "./ChatButton"
+export { ChatHeader } from "./ChatHeader"
+export { ChatTextarea } from "./ChatTextarea"
+export { SidebarWindow as ChatWindow } from "./ChatWindow"
+export { MessagesContainer } from "./MessagesContainer"
+export { UserMessage } from "./UserMessage"

--- a/packages/react/src/experimental/AiPromotionChat/exports.ts
+++ b/packages/react/src/experimental/AiPromotionChat/exports.ts
@@ -1,0 +1,2 @@
+export { AiPromotionChat } from "./index"
+export { useAiPromotionChat } from "./providers/AiChatStateProvider"

--- a/packages/react/src/experimental/AiPromotionChat/index.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/index.tsx
@@ -1,0 +1,24 @@
+import { ChatWindow } from "./components"
+import { AiChatStateProvider } from "./providers/AiChatStateProvider"
+
+const AiPromotionChatWrapper = () => {
+  return (
+    <ChatWindow
+      clickOutsideToClose={false}
+      hitEscapeToClose={false}
+      shortcut={""}
+    >
+      <div>
+        <h1>Ai Promotion Chat</h1>
+      </div>
+    </ChatWindow>
+  )
+}
+
+export const AiPromotionChat = () => {
+  return (
+    <AiChatStateProvider>
+      <AiPromotionChatWrapper />
+    </AiChatStateProvider>
+  )
+}

--- a/packages/react/src/experimental/AiPromotionChat/markdownRenderers.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/markdownRenderers.tsx
@@ -1,0 +1,195 @@
+import { Button } from "@/components/Actions/Button"
+import { Link } from "@/components/Actions/Link/OneLink"
+import DownloadIcon from "@/icons/app/Download"
+import { cn } from "@/lib/utils"
+import { type AssistantMessageProps } from "@copilotkit/react-ui"
+
+export const markdownRenderers: NonNullable<
+  AssistantMessageProps["markdownTagRenderers"]
+> = {
+  p: ({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p {...props} className={cn("text-base font-normal", props.className)}>
+      {children}
+    </p>
+  ),
+  h1: ({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h1
+      {...props}
+      className={cn(
+        "mb-2.5 mt-4 text-2xl font-medium first:mt-0 last:mb-0",
+        props.className
+      )}
+    >
+      {children}
+    </h1>
+  ),
+  h2: ({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h2
+      {...props}
+      className={cn(
+        "mb-2.5 mt-4 text-lg font-medium leading-6 first:mt-0 last:mb-0",
+        props.className
+      )}
+    >
+      {children}
+    </h2>
+  ),
+  h3: ({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h3
+      {...props}
+      className={cn(
+        "mb-2 mt-3.5 text-base font-semibold first:mt-0 last:mb-0",
+        props.className
+      )}
+    >
+      {children}
+    </h3>
+  ),
+  a: ({
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <Link {...props} variant="link">
+      {children}
+    </Link>
+  ),
+  strong: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
+    <strong {...props} className={cn("font-semibold", props.className)}>
+      {children}
+    </strong>
+  ),
+  em: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
+    <em {...props} className={cn("italic", props.className)}>
+      {children}
+    </em>
+  ),
+  li: ({ children, ...props }: React.HTMLAttributes<HTMLLIElement>) => (
+    <li {...props} className={cn("mb-2", props.className)}>
+      {children}
+    </li>
+  ),
+  pre: ({ children, ...props }: React.HTMLAttributes<HTMLPreElement>) => (
+    <pre
+      {...props}
+      className={cn(
+        "relative mx-0 my-4 overflow-x-auto whitespace-pre-wrap rounded-md bg-f1-background-secondary p-2",
+        props.className
+      )}
+    >
+      {children}
+    </pre>
+  ),
+  blockquote: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLQuoteElement>) => (
+    <blockquote
+      {...props}
+      className={cn(
+        "m-0 mb-2.5 border-0 border-l-4 border-solid border-f1-border pl-4",
+        props.className
+      )}
+    >
+      {children}
+    </blockquote>
+  ),
+  hr: ({ ...props }: React.HTMLAttributes<HTMLHRElement>) => (
+    <hr
+      {...props}
+      className={cn("my-3 border-0 border-t border-f1-border", props.className)}
+    />
+  ),
+  ul: ({ children, ...props }: React.HTMLAttributes<HTMLUListElement>) => (
+    <ul
+      {...props}
+      className={cn(
+        "list-disc pl-5 [&>li>ol]:mt-2 [&>li>ul]:mt-2",
+        props.className
+      )}
+    >
+      {children}
+    </ul>
+  ),
+  ol: ({ children, ...props }: React.HTMLAttributes<HTMLOListElement>) => (
+    <ol
+      {...props}
+      className={cn(
+        "list-decimal pl-5 [&>li>ol]:mt-2 [&>li>ul]:mt-2",
+        props.className
+      )}
+    >
+      {children}
+    </ol>
+  ),
+  table: ({ children, ...props }: React.HTMLAttributes<HTMLTableElement>) => (
+    <table
+      {...props}
+      className={cn(
+        "mb-2 w-full border-separate border-spacing-0 overflow-hidden rounded-md border border-solid border-f1-border-secondary",
+        props.className
+      )}
+    >
+      {children}
+    </table>
+  ),
+  th: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLTableHeaderCellElement>) => (
+    <th
+      {...props}
+      className={cn(
+        "border-0 border-b border-solid border-f1-border-secondary px-3 py-2 text-left font-medium text-f1-foreground-secondary",
+        props.className
+      )}
+    >
+      {children}
+    </th>
+  ),
+  td: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLTableDataCellElement>) => (
+    <td
+      {...props}
+      className={cn(
+        "border-0 border-b border-solid border-f1-border-secondary px-3 py-2",
+        props.className
+      )}
+    >
+      {children}
+    </td>
+  ),
+  img: ({ src, alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    const handleDownload = () => {
+      if (src) {
+        const link = document.createElement("a")
+        link.href = src
+        link.download = alt || "image"
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+      }
+    }
+
+    return (
+      <div className="relative w-fit">
+        <img
+          {...props}
+          src={src}
+          alt={alt}
+          className={cn("max-w-full rounded-md", props.className)}
+        />
+        <div className="absolute right-2 top-2 rounded bg-f1-background-inverse-secondary">
+          <Button
+            variant="neutral"
+            label={"t.actions.save"}
+            hideLabel
+            icon={DownloadIcon}
+            onClick={handleDownload}
+          />
+        </div>
+      </div>
+    )
+  },
+}

--- a/packages/react/src/experimental/AiPromotionChat/messageTypes.ts
+++ b/packages/react/src/experimental/AiPromotionChat/messageTypes.ts
@@ -1,0 +1,9 @@
+import { type AIMessage, type Message } from "@copilotkit/shared"
+
+export function isAiMessage(message: Message): message is AIMessage {
+  return message.role === "assistant"
+}
+
+export function isAgentStateMessage(message: Message): boolean {
+  return message.role === "assistant" && message.agentName !== undefined
+}

--- a/packages/react/src/experimental/AiPromotionChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/providers/AiChatStateProvider.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import {
+  createContext,
+  FC,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useState,
+} from "react"
+
+const AiChatStateContext = createContext<AiChatProviderReturnValue | null>(null)
+
+type AiChatProviderReturnValue = {
+  open: boolean
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
+  shouldPlayEntranceAnimation: boolean
+  setShouldPlayEntranceAnimation: React.Dispatch<React.SetStateAction<boolean>>
+
+  initialMessage?: string | string[]
+}
+
+export const AiChatStateProvider: FC<PropsWithChildren> = ({
+  children,
+  ...rest
+}) => {
+  const [open, setOpen] = useState(false)
+  const [shouldPlayEntranceAnimation, setShouldPlayEntranceAnimation] =
+    useState(true)
+
+  useEffect(() => {
+    if (!open) {
+      const prefersReducedMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)"
+      ).matches
+      setShouldPlayEntranceAnimation(!prefersReducedMotion)
+    }
+  }, [open])
+
+  return (
+    <AiChatStateContext.Provider
+      value={{
+        ...rest,
+        open,
+        setOpen,
+        shouldPlayEntranceAnimation,
+        setShouldPlayEntranceAnimation,
+      }}
+    >
+      {children}
+    </AiChatStateContext.Provider>
+  )
+}
+
+const noopFn = () => {}
+
+export function useAiPromotionChat(): AiChatProviderReturnValue {
+  const context = useContext(AiChatStateContext)
+  if (context === null) {
+    return {
+      open: false,
+      setOpen: noopFn,
+      shouldPlayEntranceAnimation: true,
+      setShouldPlayEntranceAnimation: noopFn,
+    }
+  }
+
+  return context
+}

--- a/packages/react/src/experimental/Navigation/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/ApplicationFrame/index.stories.tsx
@@ -20,9 +20,10 @@ const meta: Meta<typeof ApplicationFrame> = {
       agent: "one-workflow",
       credentials: "include",
       showDevConsole: false,
-      enabled: true,
+      enabled: false,
       greeting: "Hello, John",
     },
+    aiPromotion: true,
     sidebar: <Sidebar {...SidebarStories.default.args} />,
     children: <Page {...PageStories.Default.args} />,
   } satisfies ComponentProps<typeof ApplicationFrame>,
@@ -38,6 +39,7 @@ const DefaultStoryComponent = (
   return (
     <ApplicationFrame
       ai={args.ai}
+      aiPromotion={args.aiPromotion}
       sidebar={<Sidebar {...SidebarStories.default.args} />}
     >
       <Page {...PageStories.Default.args} />

--- a/packages/react/src/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/packages/react/src/experimental/Navigation/ApplicationFrame/index.tsx
@@ -9,6 +9,7 @@ import { cn, focusRing } from "../../../lib/utils"
 import { useReducedMotion } from "../../../lib/a11y"
 import { useI18n } from "../../../lib/providers/i18n"
 
+import { AiPromotionChat } from "@/experimental/AiPromotionChat"
 import { breakpoints } from "@factorialco/f0-core"
 import { Fragment, useEffect, useRef } from "react"
 import { useMediaQuery } from "usehooks-ts"
@@ -18,6 +19,7 @@ import { FrameProvider, SidebarState, useSidebar } from "./FrameProvider"
 
 interface ApplicationFrameProps {
   ai?: Omit<AiChatProviderProps, "children">
+  aiPromotion?: boolean
   banner?: React.ReactNode
   sidebar: React.ReactNode
   children: React.ReactNode
@@ -28,12 +30,19 @@ export function ApplicationFrame({
   sidebar,
   banner,
   ai,
+  aiPromotion,
 }: ApplicationFrameProps) {
-  const AiProvider = ai ? AiChatProvider : Fragment
+  const AiProvider = ai?.enabled ? AiChatProvider : Fragment
+  const providerProps = ai?.enabled ? { ...ai } : undefined
   return (
     <FrameProvider>
-      <AiProvider {...ai}>
-        <ApplicationFrameContent ai={ai} sidebar={sidebar} banner={banner}>
+      <AiProvider {...providerProps}>
+        <ApplicationFrameContent
+          ai={ai}
+          aiPromotion={aiPromotion}
+          sidebar={sidebar}
+          banner={banner}
+        >
           {children}
         </ApplicationFrameContent>
       </AiProvider>
@@ -101,6 +110,7 @@ function useAutoCloseSidebar(
 
 function ApplicationFrameContent({
   ai,
+  aiPromotion,
   children,
   sidebar,
   banner,
@@ -192,6 +202,7 @@ function ApplicationFrameContent({
                 </motion.div>
               </motion.main>
               {ai && ai.enabled && <AiChat />}
+              {aiPromotion && <AiPromotionChat />}
             </div>
           </LayoutGroup>
         </div>

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -14,6 +14,8 @@ import { AnimatePresence, motion } from "motion/react"
 import { ReactElement, useRef, useState } from "react"
 
 import { OneSwitch } from "@/experimental/AiChat/OneSwitch"
+import { OneSwitch as OneSwitchPromotion } from "@/experimental/AiPromotionChat/OneSwitch"
+
 import { Breadcrumbs, BreadcrumbsProps } from "../Breadcrumbs"
 import { FavoriteButton } from "../Favorites"
 import { ProductUpdates, ProductUpdatesProp } from "../ProductUpdates"
@@ -291,6 +293,7 @@ export function PageHeader({
         )}
         <div>
           <OneSwitch />
+          <OneSwitchPromotion />
         </div>
       </div>
     </div>

--- a/packages/react/src/experimental/exports.ts
+++ b/packages/react/src/experimental/exports.ts
@@ -3,6 +3,7 @@ import { ScrollArea as ScrollAreaComponent } from "./Utilities/ScrollArea"
 
 export * from "./Actions/exports"
 export * from "./AiChat/exports"
+export * from "./AiPromotionChat/exports"
 export * from "./Banners/exports"
 export * from "./Charts/exports"
 export * from "./Forms/exports"


### PR DESCRIPTION
## Description

We’re introducing a version of the current AI chat interface to display a waitlist promotion for users who don’t have access to the feature. This allows us to promote One directly in-app without enabling any AI-related functionality.

🎨 [Figma](https://www.figma.com/design/6Zg3LO7NxYpDDpJlLgVFXW/One-GTM---25Q3?node-id=6325-27268&t=04uVjCOXFATThvkX-0)

## Implementation details

- Duplicate existing sidepanel component to display promotional content only.
- Remove AI logic and dependencies to avoid unnecessary requests when the feature is inactive.

This approach was chosen as a temporary solution, copying the component is faster and safer than refactoring the existing chat logic, which could introduce regressions.

The promotional component will be removed once the waitlist campaign ends.
