### PR TITLE
fix(Card): metadata in regular weight

### DIFF
--- a/packages/react/src/components/F0Card/components/CardMetadata.tsx
+++ b/packages/react/src/components/F0Card/components/CardMetadata.tsx
@@ -34,7 +34,7 @@ export function CardMetadata({ metadata }: CardMetadataProps) {
 
   if (!renderer) {
     return (
-      <div className="flex h-8 items-center gap-1.5 font-medium">
+      <div className="flex h-8 items-center gap-1.5">
         {"icon" in metadata && (
           <F0Icon icon={metadata.icon} color="default" size="md" />
         )}
@@ -49,7 +49,7 @@ export function CardMetadata({ metadata }: CardMetadataProps) {
   ) => React.ReactNode
 
   return (
-    <div className="flex h-8 items-center gap-1.5 font-medium">
+    <div className="flex h-8 items-center gap-1.5">
       {"icon" in metadata && (
         <F0Icon icon={metadata.icon} color="default" size="md" />
       )}


### PR DESCRIPTION
## Description

- Changes the font weight for Card's metadata from medium to regular, as we have in Figma.

## Screenshots

#### Before

<img width="419" height="301" alt="image" src="https://github.com/user-attachments/assets/c84fe0aa-d1d5-4d87-a0e4-990d7a7534ee" />

#### After

<img width="422" height="314" alt="image" src="https://github.com/user-attachments/assets/20328d89-18f7-4bc4-b2cf-81a81075b09f" />

