### PR TITLE
fix: allow to truncate tags

### DIFF
--- a/packages/react/src/components/tags/BaseTag/index.tsx
+++ b/packages/react/src/components/tags/BaseTag/index.tsx
@@ -37,7 +37,7 @@ export const BaseTag = forwardRef<HTMLDivElement, Props>(
     >
       {left}
       {!!text && (
-        <span title={text} className="line-clamp-1">
+        <span title={text} className="line-clamp-1 truncate">
           {text}
         </span>
       )}

--- a/packages/react/src/components/tags/F0TagDot/F0TagDot.tsx
+++ b/packages/react/src/components/tags/F0TagDot/F0TagDot.tsx
@@ -23,7 +23,7 @@ export const F0TagDot = forwardRef<HTMLDivElement, Props>(
         className="border-[1px] border-solid border-f1-border-secondary"
         left={
           <div
-            className="m-1 aspect-square w-2 rounded-full"
+            className="m-1 aspect-square h-2 w-2 rounded-full"
             style={{
               backgroundColor,
             }}

--- a/packages/react/src/components/tags/F0TagList/components/TagCounter.tsx
+++ b/packages/react/src/components/tags/F0TagList/components/TagCounter.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const TagCounter = ({ count, list }: Props) => {
   const [isOpen, setIsOpen] = useState(false)
 
-  const counter = <F0TagRaw text={`+${count}`} />
+  const counter = <F0TagRaw text={`+${count}`} className="w-fit" />
 
   if (!list?.length) return counter
 
@@ -24,7 +24,10 @@ export const TagCounter = ({ count, list }: Props) => {
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
         <button
-          className={cn("inline-flex flex-shrink-0 items-center", focusRing())}
+          className={cn(
+            "inline-flex w-fit flex-shrink-0 items-center",
+            focusRing()
+          )}
         >
           {counter}
         </button>

--- a/packages/react/src/components/value-display/types/tagList.tsx
+++ b/packages/react/src/components/value-display/types/tagList.tsx
@@ -13,5 +13,10 @@ interface TagListValue {
 export type TagListCellValue = TagListValue
 
 export const TagListCell = (args: TagListCellValue) => (
-  <F0TagList type={args.type} tags={args.tags as TagVariant[]} max={args.max} />
+  <F0TagList
+    layout="fill"
+    type={args.type}
+    tags={args.tags as TagVariant[]}
+    max={args.max}
+  />
 )

--- a/packages/react/src/ui/OverflowList/index.tsx
+++ b/packages/react/src/ui/OverflowList/index.tsx
@@ -149,7 +149,7 @@ const OverflowList = function OverflowList<T>({
       )}
 
       <div
-        className="flex items-center whitespace-nowrap"
+        className="flex min-w-0 items-center whitespace-nowrap"
         style={{ gap: gap > 0 ? `${gap}px` : undefined }}
         data-testid="overflow-visible-container"
       >
@@ -157,7 +157,7 @@ const OverflowList = function OverflowList<T>({
           visibleItems.map((item, index) => (
             <div
               key={`item-${index}`}
-              className="transition-all duration-150"
+              className="overflow-hidden transition-all duration-150"
               data-testid="overflow-visible-item"
               style={{ marginLeft: gap < 0 ? `${gap}px` : undefined }}
             >
@@ -176,7 +176,7 @@ const OverflowList = function OverflowList<T>({
                 <button
                   ref={overflowButtonRef}
                   className={cn(
-                    "inline-flex flex-shrink-0 items-center",
+                    "inline-flex w-fit flex-shrink-0 items-center",
                     focusRing()
                   )}
                 >

--- a/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
+++ b/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
@@ -86,8 +86,9 @@ export function useOverflowCalculation<T>(
         visibleCount++
       }
 
-      // Return the actual count without enforcing a minimum of 1
-      return Math.min(visibleCount, options?.max ?? items.length)
+      // Ensure we always show at least 1 item; it should be truncated to fit
+      const capped = Math.min(visibleCount, options?.max ?? items.length)
+      return items.length > 0 ? Math.max(1, capped) : 0
     },
     [options?.max, items.length]
   )


### PR DESCRIPTION
## Description

We've got a report about a data table showing information that overlaps and makes it impossible to read, you can see it here:

<img width="1311" height="613" alt="image" src="https://github.com/user-attachments/assets/7a689f6d-8379-40b0-a661-4c1b31396fd0" />

## Screenshots (if applicable)
I've wrapped the `OverflowList` component in a `300px` `div` with a red border so we can see the overflow.

Before:
<img width="960" height="56" alt="image" src="https://github.com/user-attachments/assets/fc4ebb76-9f6d-4a54-a9f5-309256e14687" />

After:
<img width="347" height="60" alt="image" src="https://github.com/user-attachments/assets/13cd1d8d-78c0-4ec7-8944-9f12ea2090f6" />


## Implementation details

The were a few problems. The first one is that the `ValueDisplay` renderer for `tagList` is not using the `fill` prop, so any tags inside it won't try and fit the available content.

The second problem was that in the `calculateVisibleItemCount`, we were allowing to return no visible elements, but we don't want that, we want to show at least one of them, and that item should be truncated.

Then we needed to make the `BaseTag` truncate the text, and add a `min-w-0` to avoid the overflowing.
