### PR TITLE
Fix: Add missing 'required' prop in input and select

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Input/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Input/index.tsx
@@ -8,6 +8,7 @@ export type InputProps<T extends string> = Pick<
 > &
   Pick<
     InputFieldProps<T>,
+    | "required"
     | "disabled"
     | "size"
     | "onChange"

--- a/packages/react/src/experimental/Forms/Fields/Select/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Select/index.tsx
@@ -103,6 +103,7 @@ export type SelectProps<T extends string, R = unknown> = {
 ) &
   Pick<
     InputFieldProps<T>,
+    | "required"
     | "loading"
     | "hideLabel"
     | "clearable"
@@ -117,7 +118,6 @@ export type SelectProps<T extends string, R = unknown> = {
     | "status"
     | "hint"
   >
-
 const SelectItem = <T extends string, R>({
   item,
 }: {
@@ -207,6 +207,7 @@ const SelectComponent = forwardRef(function Select<
     error,
     status,
     hint,
+    required,
     ...props
   }: SelectProps<T, R>,
   ref: React.ForwardedRef<HTMLButtonElement>
@@ -509,6 +510,7 @@ const SelectComponent = forwardRef(function Select<
             <InputField
               label={label}
               error={error}
+              required={required}
               status={status}
               hint={hint}
               icon={icon}


### PR DESCRIPTION
## Description

Add the missing `required` prop in select and input components

 
## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
