### PR TITLE
fix: truncate input value to maxLenght when the value is updated via prop

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Input/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Input/__stories__/index.stories.tsx
@@ -158,6 +158,7 @@ export const WithMaxLength: Story = {
   args: {
     label: "Label text here",
     maxLength: 10,
+    value: "longtext should be truncated",
   },
 }
 

--- a/packages/react/src/ui/InputField/InputField.tsx
+++ b/packages/react/src/ui/InputField/InputField.tsx
@@ -268,8 +268,12 @@ const InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
     }
 
     useEffect(() => {
-      setLocalValue(value)
-    }, [value])
+      setLocalValue(
+        maxLength && value && lengthProvider(value) > maxLength
+          ? value?.substring(0, maxLength)
+          : value
+      )
+    }, [value, lengthProvider, maxLength])
 
     const handleChange = (
       value: string | React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>

--- a/packages/react/src/ui/InputField/__stories__/InputField.stories.tsx
+++ b/packages/react/src/ui/InputField/__stories__/InputField.stories.tsx
@@ -165,6 +165,7 @@ export const WithMaxLength: Story = {
     ...Default.args,
     maxLength: 10,
     hideMaxLength: false,
+    value: "long text should be truncated",
   },
 }
 


### PR DESCRIPTION
## Description

The input field has the prop `maxLength` that should ensure the value introduced in the input is shorter than that number charts. When the value was set via `value` prop the length was not checked and the value was not truncated allowing to introduce longer strings


## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
