### PR TITLE
fix: allow no actions on dialogs

### DIFF
--- a/packages/react/src/experimental/Overlays/Dialog/index.tsx
+++ b/packages/react/src/experimental/Overlays/Dialog/index.tsx
@@ -27,7 +27,7 @@ type DialogProps = {
     title: string
     description: string
   }
-  actions: {
+  actions?: {
     primary: PrimaryAction
     secondary: SecondaryAction
   }


### PR DESCRIPTION
## Description

Allow to not pass `actions` prop on `Dialog` component.