### PR TITLE
fix(Dialog): loading spinner size

### DIFF
--- a/packages/react/src/experimental/Overlays/Dialog/index.tsx
+++ b/packages/react/src/experimental/Overlays/Dialog/index.tsx
@@ -74,15 +74,15 @@ const OneDialog = forwardRef<HTMLDivElement, DialogProps>(
             </div>
           </DialogHeader>
           {actions && (
-            <DialogFooter className="px-4 pb-4 pt-2 [&_div]:w-full">
-              <div className="hidden sm:flex sm:flex-row sm:justify-between sm:gap-3">
+            <DialogFooter className="px-4 pb-4 pt-2">
+              <div className="hidden sm:flex sm:flex-row sm:justify-between sm:gap-3 [&>div]:w-full">
                 <Button variant="outline" {...actions.secondary} />
                 <Button
                   {...actions.primary}
                   variant={actions.primary.variant || "default"}
                 />
               </div>
-              <div className="flex flex-col-reverse gap-2 sm:hidden">
+              <div className="flex flex-col-reverse gap-2 sm:hidden [&>div]:w-full">
                 <Button variant="outline" {...actions.secondary} size="lg" />
                 <Button
                   {...actions.primary}


### PR DESCRIPTION
## Description

When the `Dialog` component has attached an async action the button shows a spinner. Since we're overriding the `Button` styles inside the `Dialog` to make them full size it was breaking the icon.

## Screenshots (if applicable)

Before:
![spinner before](https://github.com/user-attachments/assets/2654bfbb-e41f-4861-aa2d-314a677095ae)

After:
![spinner after](https://github.com/user-attachments/assets/8c250f6b-28d1-4ee0-8abb-2c6fcc7d20a7)

## Implementation details

I just changed the selector to target direct childs, and put it in the `div` previous to the `Button`.
