### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.236.1",
+  "packages/react": "1.236.2",
   "packages/react-native": "0.20.1",
   "packages/core": "1.31.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.236.2](https://github.com/factorialco/f0/compare/f0-react-v1.236.1...f0-react-v1.236.2) (2025-10-15)
+
+
+### Bug Fixes
+
+* **Dialog:** loading spinner size ([#2824](https://github.com/factorialco/f0/issues/2824)) ([84dd7ba](https://github.com/factorialco/f0/commit/84dd7bae1a509c1199d03e362fc6f37b0f49e913))
+
 ## [1.236.1](https://github.com/factorialco/f0/compare/f0-react-v1.236.0...f0-react-v1.236.1) (2025-10-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.236.1",
+  "version": "1.236.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.236.2</summary>

## [1.236.2](https://github.com/factorialco/f0/compare/f0-react-v1.236.1...f0-react-v1.236.2) (2025-10-15)


### Bug Fixes

* **Dialog:** loading spinner size ([#2824](https://github.com/factorialco/f0/issues/2824)) ([84dd7ba](https://github.com/factorialco/f0/commit/84dd7bae1a509c1199d03e362fc6f37b0f49e913))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).