### PR TITLE
fix(RichTextDisplay): add 'class' to allowed attributes

### DIFF
--- a/packages/react/src/experimental/RichText/RichTextDisplay/index.tsx
+++ b/packages/react/src/experimental/RichText/RichTextDisplay/index.tsx
@@ -35,7 +35,7 @@ const RichTextDisplay = forwardRef<RichTextDisplayHandle, RichTextDisplayProps>(
             : content,
           {
             ADD_ATTR: ["target"],
-            ALLOWED_ATTR: ["href", "target", "rel"],
+            ALLOWED_ATTR: ["href", "target", "rel", "class"],
           }
         ),
       [format, content]


### PR DESCRIPTION
## Description

- Added `class` to DOMPurify's `ALLOWED_ATTR` to preserve CSS classes in sanitized HTML content

### Why it's safe
- CSS class names cannot execute code
- DOMPurify still blocks dangerous attributes (onclick, onerror, etc.)

### Use case
```tsx
<RichTextDisplay content='<p class="font-bold">Styled text</p>' />
```

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
