### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.236.3",
+  "packages/react": "1.236.4",
   "packages/react-native": "0.20.1",
   "packages/core": "1.31.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.236.4](https://github.com/factorialco/f0/compare/f0-react-v1.236.3...f0-react-v1.236.4) (2025-10-16)
+
+
+### Bug Fixes
+
+* **RichTextDisplay:** add 'class' to allowed attributes for content rendering ([#2829](https://github.com/factorialco/f0/issues/2829)) ([13b9516](https://github.com/factorialco/f0/commit/13b9516449d153f086edd8c182751677cbd6bfba))
+
 ## [1.236.3](https://github.com/factorialco/f0/compare/f0-react-v1.236.2...f0-react-v1.236.3) (2025-10-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.236.3",
+  "version": "1.236.4",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.236.4</summary>

## [1.236.4](https://github.com/factorialco/f0/compare/f0-react-v1.236.3...f0-react-v1.236.4) (2025-10-16)


### Bug Fixes

* **RichTextDisplay:** add 'class' to allowed attributes for content rendering ([#2829](https://github.com/factorialco/f0/issues/2829)) ([13b9516](https://github.com/factorialco/f0/commit/13b9516449d153f086edd8c182751677cbd6bfba))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).