### PR TITLE
fix: add min height for data collection list view rows

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -97,7 +97,7 @@ export const Row = <
   return (
     <div
       className={cn(
-        "relative flex w-full flex-col justify-between gap-4 p-3 transition-colors md:flex-row md:p-2 md:pl-3 md:pr-4",
+        "relative flex min-h-[64px] w-full flex-col justify-between gap-4 p-3 transition-colors md:flex-row md:p-2 md:pl-3 md:pr-4",
         "group after:absolute after:inset-y-0 after:-right-px after:z-10 after:hidden after:h-full after:w-10 after:bg-gradient-to-r after:from-transparent after:via-f1-background after:via-75% after:to-f1-background after:transition-all after:content-[''] hover:after:via-[#F5F6F8] hover:after:to-[#F5F6F8] dark:hover:after:via-[#192231] dark:hover:after:to-[#192231] md:after:block hover:md:bg-f1-background-hover"
       )}
     >


### PR DESCRIPTION
## Description

Add min-height for data collection list view rows as we have some visual inconsistency in the list when showing items that have no description and extra fields.

<img width="964" height="536" alt="Screenshot 2025-10-20 at 13 10 17" src="https://github.com/user-attachments/assets/e686f453-ec27-48f4-9da5-ef0f46055738" />

Because of this, I thought it would be more convenient to establish a base height for items of 64px which is the height used already normally.
