### PR TITLE
fix: card compact bug overflow

### DIFF
--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -245,7 +245,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
                 <div
                   className={cn(
                     "flex flex-col gap-0.5",
-                    compact && "flex-row flex-wrap gap-x-3 gap-y-0",
+                    compact && "gap-x-3 gap-y-0",
                     forceVerticalMetadata && "flex-col gap-y-0.5"
                   )}
                 >


### PR DESCRIPTION
## Description

Fix a bug with compact cards

## Screenshots

Before:

No compact:
<img width="517" height="376" alt="Screenshot 2025-10-20 at 14 14 23" src="https://github.com/user-attachments/assets/f4713ddc-685f-45f7-8d70-989a5c649243" />

compact:
<img width="958" height="361" alt="Screenshot 2025-10-20 at 14 14 28" src="https://github.com/user-attachments/assets/e16bb626-dcf8-496d-b4f9-9d520e507f2d" />


After compact:

<img width="429" height="259" alt="Screenshot 2025-10-20 at 14 17 20" src="https://github.com/user-attachments/assets/ad30f777-3dd4-4c79-9a58-e9182b42f0dc" />

