### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.239.4",
+  "packages/react": "1.240.0",
   "packages/react-native": "0.20.1",
   "packages/core": "1.32.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.240.0](https://github.com/factorialco/f0/compare/f0-react-v1.239.4...f0-react-v1.240.0) (2025-10-22)
+
+
+### Features
+
+* datenavigator value prop ([#2841](https://github.com/factorialco/f0/issues/2841)) ([ba8baf3](https://github.com/factorialco/f0/commit/ba8baf35d4c34fee4c091104d4bd3e85b5fad7aa))
+
 ## [1.239.4](https://github.com/factorialco/f0/compare/f0-react-v1.239.3...f0-react-v1.239.4) (2025-10-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.239.4",
+  "version": "1.240.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.240.0</summary>

## [1.240.0](https://github.com/factorialco/f0/compare/f0-react-v1.239.4...f0-react-v1.240.0) (2025-10-22)


### Features

* datenavigator value prop ([#2841](https://github.com/factorialco/f0/issues/2841)) ([ba8baf3](https://github.com/factorialco/f0/commit/ba8baf35d4c34fee4c091104d4bd3e85b5fad7aa))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).