### PR TITLE
fix: add no response option to Product Modal

### DIFF
--- a/packages/react/src/components/UpsellingKit/ProductModal/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductModal/index.tsx
@@ -43,6 +43,7 @@ type ProductModalProps = {
   primaryAction?: Action
   secondaryAction?: Action
   portalContainer?: HTMLElement | null
+  showResponseDialog?: boolean
 }
 
 type Action = {
@@ -72,6 +73,7 @@ export function ProductModal({
   secondaryAction,
   portalContainer,
   tag,
+  showResponseDialog = true,
 }: ProductModalProps) {
   const [isModalOpen, setIsOpen] = useState(isOpen)
   const [responseStatus, setResponseStatus] = useState<ResponseStatus>(null)
@@ -83,9 +85,13 @@ export function ProductModal({
       try {
         await primaryAction.onClick()
         setIsOpen(false)
-        setResponseStatus("success")
+        if (showResponseDialog) {
+          setResponseStatus("success")
+        }
       } catch {
-        setResponseStatus("error")
+        if (showResponseDialog) {
+          setResponseStatus("error")
+        }
       } finally {
         setInternalLoading(false)
       }
@@ -142,7 +148,7 @@ export function ProductModal({
         </div>
       </CustomModal>
 
-      {responseStatus && (
+      {responseStatus && showResponseDialog && (
         <UpsellRequestResponseDialog
           open={true}
           onClose={() => {


### PR DESCRIPTION
## Description

Problem happening in Factorial APP.

https://github.com/user-attachments/assets/06d71cd1-6e77-490b-9549-00078d12dd84

## Implementation details

We add a prop to avoid response dialog component.
