### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.240.0",
+  "packages/react": "1.240.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.32.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.240.1](https://github.com/factorialco/f0/compare/f0-react-v1.240.0...f0-react-v1.240.1) (2025-10-22)
+
+
+### Bug Fixes
+
+* add no response option to Product Modal ([#2859](https://github.com/factorialco/f0/issues/2859)) ([d0264ad](https://github.com/factorialco/f0/commit/d0264adbe6c12a2fc0e005b003e5b237812b01fe))
+
 ## [1.240.0](https://github.com/factorialco/f0/compare/f0-react-v1.239.4...f0-react-v1.240.0) (2025-10-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.240.0",
+  "version": "1.240.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.240.1</summary>

## [1.240.1](https://github.com/factorialco/f0/compare/f0-react-v1.240.0...f0-react-v1.240.1) (2025-10-22)


### Bug Fixes

* add no response option to Product Modal ([#2859](https://github.com/factorialco/f0/issues/2859)) ([d0264ad](https://github.com/factorialco/f0/commit/d0264adbe6c12a2fc0e005b003e5b237812b01fe))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).