### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.240.1",
+  "packages/react": "1.240.2",
   "packages/react-native": "0.20.1",
   "packages/core": "1.32.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.240.2](https://github.com/factorialco/f0/compare/f0-react-v1.240.1...f0-react-v1.240.2) (2025-10-22)
+
+
+### Bug Fixes
+
+* establish min height for select with filters ([#2856](https://github.com/factorialco/f0/issues/2856)) ([f3fda1a](https://github.com/factorialco/f0/commit/f3fda1ad7c0b76e87434a4da19f6165e17e7f7f5))
+
 ## [1.240.1](https://github.com/factorialco/f0/compare/f0-react-v1.240.0...f0-react-v1.240.1) (2025-10-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.240.1",
+  "version": "1.240.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.240.2</summary>

## [1.240.2](https://github.com/factorialco/f0/compare/f0-react-v1.240.1...f0-react-v1.240.2) (2025-10-22)


### Bug Fixes

* establish min height for select with filters ([#2856](https://github.com/factorialco/f0/issues/2856)) ([f3fda1a](https://github.com/factorialco/f0/commit/f3fda1ad7c0b76e87434a4da19f6165e17e7f7f5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).