### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.240.2",
+  "packages/react": "1.240.3",
   "packages/react-native": "0.20.1",
   "packages/core": "1.32.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.240.3](https://github.com/factorialco/f0/compare/f0-react-v1.240.2...f0-react-v1.240.3) (2025-10-23)
+
+
+### Bug Fixes
+
+* select's  searchbox lose focus while typing ([fcbe8a0](https://github.com/factorialco/f0/commit/fcbe8a08955e6e55835cef625466d7b3369d142a))
+
 ## [1.240.2](https://github.com/factorialco/f0/compare/f0-react-v1.240.1...f0-react-v1.240.2) (2025-10-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.240.2",
+  "version": "1.240.3",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.240.3</summary>

## [1.240.3](https://github.com/factorialco/f0/compare/f0-react-v1.240.2...f0-react-v1.240.3) (2025-10-23)


### Bug Fixes

* select's  searchbox lose focus while typing ([fcbe8a0](https://github.com/factorialco/f0/commit/fcbe8a08955e6e55835cef625466d7b3369d142a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).