### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.241.0",
+  "packages/react": "1.241.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.32.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.241.1](https://github.com/factorialco/f0/compare/f0-react-v1.241.0...f0-react-v1.241.1) (2025-10-23)
+
+
+### Bug Fixes
+
+* improve select component arrows ([#2867](https://github.com/factorialco/f0/issues/2867)) ([0ec6a35](https://github.com/factorialco/f0/commit/0ec6a35580c508d9ccdc72d1ae73b0d859750574))
+
 ## [1.241.0](https://github.com/factorialco/f0/compare/f0-react-v1.240.3...f0-react-v1.241.0) (2025-10-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.241.0",
+  "version": "1.241.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.241.1</summary>

## [1.241.1](https://github.com/factorialco/f0/compare/f0-react-v1.241.0...f0-react-v1.241.1) (2025-10-23)


### Bug Fixes

* improve select component arrows ([#2867](https://github.com/factorialco/f0/issues/2867)) ([0ec6a35](https://github.com/factorialco/f0/commit/0ec6a35580c508d9ccdc72d1ae73b0d859750574))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).