### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.242.0",
+  "packages/react": "1.242.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.32.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.242.1](https://github.com/factorialco/f0/compare/f0-react-v1.242.0...f0-react-v1.242.1) (2025-10-24)
+
+
+### Bug Fixes
+
+* export combochart ([#2876](https://github.com/factorialco/f0/issues/2876)) ([603a1d4](https://github.com/factorialco/f0/commit/603a1d4be22f43967a0e916bb8566b2692a6f9bb))
+
 ## [1.242.0](https://github.com/factorialco/f0/compare/f0-react-v1.241.2...f0-react-v1.242.0) (2025-10-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.242.0",
+  "version": "1.242.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.242.1</summary>

## [1.242.1](https://github.com/factorialco/f0/compare/f0-react-v1.242.0...f0-react-v1.242.1) (2025-10-24)


### Bug Fixes

* export combochart ([#2876](https://github.com/factorialco/f0/issues/2876)) ([603a1d4](https://github.com/factorialco/f0/commit/603a1d4be22f43967a0e916bb8566b2692a6f9bb))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).