### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.244.1",
+  "packages/react": "1.245.0",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.245.0](https://github.com/factorialco/f0/compare/f0-react-v1.244.1...f0-react-v1.245.0) (2025-10-28)
+
+
+### Features
+
+* rename buttons ([daccd92](https://github.com/factorialco/f0/commit/daccd928375d32055ab244b4ac45d0bc916e2d60))
+* stabilize F0Button, F0ButtonDropdown, F0ButtonToggle and F0Link components ([daccd92](https://github.com/factorialco/f0/commit/daccd928375d32055ab244b4ac45d0bc916e2d60))
+
 ## [1.244.1](https://github.com/factorialco/f0/compare/f0-react-v1.244.0...f0-react-v1.244.1) (2025-10-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.244.1",
+  "version": "1.245.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.245.0</summary>

## [1.245.0](https://github.com/factorialco/f0/compare/f0-react-v1.244.1...f0-react-v1.245.0) (2025-10-28)


### Features

* rename buttons ([daccd92](https://github.com/factorialco/f0/commit/daccd928375d32055ab244b4ac45d0bc916e2d60))
* stabilize F0Button, F0ButtonDropdown, F0ButtonToggle and F0Link components ([daccd92](https://github.com/factorialco/f0/commit/daccd928375d32055ab244b4ac45d0bc916e2d60))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).