### PR TITLE
feat(forms): add autocomplete attribute to inputs

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Input/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Input/index.tsx
@@ -25,6 +25,7 @@ export type InputProps<T extends string> = Pick<
     | "error"
     | "status"
     | "hint"
+    | "autocomplete"
   > & {
     type?: Exclude<HTMLInputTypeAttribute, "number">
     onPressEnter?: () => void

--- a/packages/react/src/ui/InputField/InputField.tsx
+++ b/packages/react/src/ui/InputField/InputField.tsx
@@ -15,6 +15,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type AutoFill,
 } from "react"
 import { AppendTag } from "./AppendTag"
 import { InputMessages } from "./components/InputMessages"
@@ -162,6 +163,7 @@ export type InputFieldProps<T> = {
   readonly?: boolean
   clearable?: boolean
   role?: string
+  autocomplete?: AutoFill
   inputRef?: React.Ref<unknown>
   "aria-controls"?: AriaAttributes["aria-controls"]
   "aria-expanded"?: AriaAttributes["aria-expanded"]

--- a/packages/react/src/ui/input.tsx
+++ b/packages/react/src/ui/input.tsx
@@ -34,6 +34,7 @@ export type InputProps = Omit<
     | "onBlur"
     | "onClear"
     | "readonly"
+    | "autocomplete"
   >
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of the changes (e.g., "Add new Button component to experimental" or "Promote Card component to stable"). Describe what this PR does and why it's needed -->

Adds the `autocomplete` prop to the Input component to support use cases such as login, signup, setting new passwords or filling any other kind of forms with autocompletable data.

## Implementation details

- Adds `autocomplete` to the type of the input props
- `Input` was already passing all its props to the underlying native input, so no actual changes are needed.
- The chosen static type is React's `Autofill`, which models the _de facto_ well known use-cases across the most widely used user-agents and password managers. This was chosen over `HTMLInputAutoCompleteAttribute` because the later is actually just `string` with extra steps.
	- ... which is correct since the DOM accepts any string in there and is up to the user-agent to decide what to do with it, but that's not very useful as static type and downstream users can always just pass a string if they really want to anyway.
