### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.246.0",
+  "packages/react": "1.247.0",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.247.0](https://github.com/factorialco/f0/compare/f0-react-v1.246.0...f0-react-v1.247.0) (2025-10-30)
+
+
+### Features
+
+* **forms:** add autocomplete attribute to inputs ([#2890](https://github.com/factorialco/f0/issues/2890)) ([09493fc](https://github.com/factorialco/f0/commit/09493fce992a6979a954b3bcb5020d4c35f8fad9))
+
 ## [1.246.0](https://github.com/factorialco/f0/compare/f0-react-v1.245.0...f0-react-v1.246.0) (2025-10-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.246.0",
+  "version": "1.247.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.247.0</summary>

## [1.247.0](https://github.com/factorialco/f0/compare/f0-react-v1.246.0...f0-react-v1.247.0) (2025-10-30)


### Features

* **forms:** add autocomplete attribute to inputs ([#2890](https://github.com/factorialco/f0/issues/2890)) ([09493fc](https://github.com/factorialco/f0/commit/09493fce992a6979a954b3bcb5020d4c35f8fad9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).