### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.247.0",
+  "packages/react": "1.247.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.247.1](https://github.com/factorialco/f0/compare/f0-react-v1.247.0...f0-react-v1.247.1) (2025-10-30)
+
+
+### Bug Fixes
+
+* **select:** constrain dropdown width within parent container ([#2889](https://github.com/factorialco/f0/issues/2889)) ([6bc6d28](https://github.com/factorialco/f0/commit/6bc6d286d691f67a9a6bf969da9ebb558415d287))
+
 ## [1.247.0](https://github.com/factorialco/f0/compare/f0-react-v1.246.0...f0-react-v1.247.0) (2025-10-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.247.0",
+  "version": "1.247.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.247.1</summary>

## [1.247.1](https://github.com/factorialco/f0/compare/f0-react-v1.247.0...f0-react-v1.247.1) (2025-10-30)


### Bug Fixes

* **select:** constrain dropdown width within parent container ([#2889](https://github.com/factorialco/f0/issues/2889)) ([6bc6d28](https://github.com/factorialco/f0/commit/6bc6d286d691f67a9a6bf969da9ebb558415d287))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).