### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.247.1",
+  "packages/react": "1.247.2",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.247.2](https://github.com/factorialco/f0/compare/f0-react-v1.247.1...f0-react-v1.247.2) (2025-10-30)
+
+
+### Bug Fixes
+
+* set proper size for non compact calendar ([#2896](https://github.com/factorialco/f0/issues/2896)) ([47804b2](https://github.com/factorialco/f0/commit/47804b2d54cb2225d58282bfa19fb38af87d6db0))
+
 ## [1.247.1](https://github.com/factorialco/f0/compare/f0-react-v1.247.0...f0-react-v1.247.1) (2025-10-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.247.1",
+  "version": "1.247.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.247.2</summary>

## [1.247.2](https://github.com/factorialco/f0/compare/f0-react-v1.247.1...f0-react-v1.247.2) (2025-10-30)


### Bug Fixes

* set proper size for non compact calendar ([#2896](https://github.com/factorialco/f0/issues/2896)) ([47804b2](https://github.com/factorialco/f0/commit/47804b2d54cb2225d58282bfa19fb38af87d6db0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).