### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.247.2",
+  "packages/react": "1.247.3",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.247.3](https://github.com/factorialco/f0/compare/f0-react-v1.247.2...f0-react-v1.247.3) (2025-10-31)
+
+
+### Bug Fixes
+
+* f0button empty label warn ([#2898](https://github.com/factorialco/f0/issues/2898)) ([3ffb376](https://github.com/factorialco/f0/commit/3ffb3767827a42c7eb105993c1751dcd3ca4229e))
+
 ## [1.247.2](https://github.com/factorialco/f0/compare/f0-react-v1.247.1...f0-react-v1.247.2) (2025-10-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.247.2",
+  "version": "1.247.3",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.247.3</summary>

## [1.247.3](https://github.com/factorialco/f0/compare/f0-react-v1.247.2...f0-react-v1.247.3) (2025-10-31)


### Bug Fixes

* f0button empty label warn ([#2898](https://github.com/factorialco/f0/issues/2898)) ([3ffb376](https://github.com/factorialco/f0/commit/3ffb3767827a42c7eb105993c1751dcd3ca4229e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).