### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.247.4",
+  "packages/react": "1.248.0",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.248.0](https://github.com/factorialco/f0/compare/f0-react-v1.247.4...f0-react-v1.248.0) (2025-10-31)
+
+
+### Features
+
+* add support for source prop for "in" filter ([#2884](https://github.com/factorialco/f0/issues/2884)) ([72a4f5c](https://github.com/factorialco/f0/commit/72a4f5cfb0a138d54f377f88436ab857ddb41438))
+
 ## [1.247.4](https://github.com/factorialco/f0/compare/f0-react-v1.247.3...f0-react-v1.247.4) (2025-10-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.247.4",
+  "version": "1.248.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.248.0</summary>

## [1.248.0](https://github.com/factorialco/f0/compare/f0-react-v1.247.4...f0-react-v1.248.0) (2025-10-31)


### Features

* add support for source prop for "in" filter ([#2884](https://github.com/factorialco/f0/issues/2884)) ([72a4f5c](https://github.com/factorialco/f0/commit/72a4f5cfb0a138d54f377f88436ab857ddb41438))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).