### PR TITLE
feat: add promoTag to product modal component

### DIFF
--- a/packages/react/src/components/UpsellingKit/ProductBlankslate/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductBlankslate/index.tsx
@@ -2,6 +2,7 @@
 import { F0AvatarModule, ModuleId } from "@/components/avatars/F0AvatarModule"
 import { F0Icon, IconType } from "@/components/F0Icon"
 import { F0TagRaw } from "@/components/tags/F0TagRaw"
+import { F0TagStatus, Variant } from "@/components/tags/F0TagStatus"
 import { CheckCircle } from "@/icons/app"
 import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
@@ -18,6 +19,10 @@ type ProductBlankslateProps = {
   tag?: {
     label: string
     icon: IconType
+  }
+  promoTag?: {
+    label: string
+    variant?: Variant
   }
 }
 
@@ -54,6 +59,7 @@ export const ProductBlankslate = forwardRef<
       module,
       moduleName,
       tag,
+      promoTag,
     },
     ref
   ) => {
@@ -86,9 +92,15 @@ export const ProductBlankslate = forwardRef<
                   </p>
                 )}
               </div>
-              {tag && (
-                <div className="flex justify-start">
-                  <F0TagRaw icon={tag.icon} text={tag.label} />
+              {(tag || promoTag) && (
+                <div className="flex justify-start gap-2">
+                  {tag && <F0TagRaw icon={tag.icon} text={tag.label} />}
+                  {promoTag && (
+                    <F0TagStatus
+                      variant={promoTag.variant || "positive"}
+                      text={promoTag.label}
+                    />
+                  )}
                 </div>
               )}
               <h2 className="font-bold text-xl text-f1-foreground">{title}</h2>

--- a/packages/react/src/components/UpsellingKit/ProductModal/ProductModal.stories.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductModal/ProductModal.stories.tsx
@@ -153,6 +153,10 @@ export const Default: Story = {
       label: "Upgrade",
       icon: UpsellIcon,
     },
+    promoTag: {
+      label: "50% off",
+      variant: "warning",
+    },
     closeLabel: "Close",
   },
   render: (args) => <ProductModal {...args} />,

--- a/packages/react/src/components/UpsellingKit/ProductModal/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductModal/index.tsx
@@ -1,6 +1,7 @@
 import { ButtonVariant, F0Button } from "@/components/F0Button"
 import { IconType } from "@/components/F0Icon"
 import { ModuleId } from "@/components/avatars/F0AvatarModule"
+import { Variant } from "@/components/tags/F0TagStatus"
 import { useState } from "react"
 import { ProductBlankslate } from "../ProductBlankslate"
 import { UpsellRequestResponseDialog } from "../UpsellRequestResponseDialog"
@@ -39,6 +40,10 @@ type ProductModalProps = {
     label: string
     icon: IconType
   }
+  promoTag?: {
+    label: string
+    variant?: Variant
+  }
   primaryAction?: Action
   secondaryAction?: Action
   portalContainer?: HTMLElement | null
@@ -72,6 +77,7 @@ export function ProductModal({
   secondaryAction,
   portalContainer,
   tag,
+  promoTag,
   showResponseDialog = true,
 }: ProductModalProps) {
   const [isModalOpen, setIsOpen] = useState(isOpen)
@@ -120,6 +126,7 @@ export function ProductModal({
             benefits={benefits}
             withShadow={false}
             tag={tag}
+            promoTag={promoTag}
             actions={
               <div className="flex gap-3">
                 {primaryAction && (

--- a/packages/react/src/components/UpsellingKit/UpsellRequestResponseDialog/index.tsx
+++ b/packages/react/src/components/UpsellingKit/UpsellRequestResponseDialog/index.tsx
@@ -184,7 +184,7 @@ const UpsellRequestResponseDialog = forwardRef<
               </DialogDescription>
             </div>
           </DialogHeader>
-          {success && nextSteps ? (
+          {success && nextSteps && nextSteps.items?.length > 0 ? (
             <>
               <Separator />
               <NextSteps title={nextSteps.title} items={nextSteps.items} />


### PR DESCRIPTION
## Description

Adapt `ProductModal` component to show a promotional Tag when needed.

## Screenshots

- 🎨 [Figma](https://www.figma.com/design/gPEMn0sBimXbqnFrCbv52y/Campaigns-Q4---25Q4?node-id=9052-90162&t=5Z1DKi3metDpYmUk-0)


<img width="400" alt="Screenshot 2025-11-03 at 10 28 43" src="https://github.com/user-attachments/assets/501b50f6-71d0-4ffa-ae07-c7c134fee9ec" />


