### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.249.0",
+  "packages/react": "1.249.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.249.1](https://github.com/factorialco/f0/compare/f0-react-v1.249.0...f0-react-v1.249.1) (2025-11-03)
+
+
+### Bug Fixes
+
+* show settings when table visualization can order or hide cols ([#2905](https://github.com/factorialco/f0/issues/2905)) ([b11b494](https://github.com/factorialco/f0/commit/b11b49436e0558b2d41c22f30c02b5f221bd6039))
+
 ## [1.249.0](https://github.com/factorialco/f0/compare/f0-react-v1.248.0...f0-react-v1.249.0) (2025-10-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.249.0",
+  "version": "1.249.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.249.1</summary>

## [1.249.1](https://github.com/factorialco/f0/compare/f0-react-v1.249.0...f0-react-v1.249.1) (2025-11-03)


### Bug Fixes

* show settings when table visualization can order or hide cols ([#2905](https://github.com/factorialco/f0/issues/2905)) ([b11b494](https://github.com/factorialco/f0/commit/b11b49436e0558b2d41c22f30c02b5f221bd6039))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).