### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.249.1",
+  "packages/react": "1.250.0",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.250.0](https://github.com/factorialco/f0/compare/f0-react-v1.249.1...f0-react-v1.250.0) (2025-11-03)
+
+
+### Features
+
+* add promoTag to product modal component ([#2906](https://github.com/factorialco/f0/issues/2906)) ([bdc2c42](https://github.com/factorialco/f0/commit/bdc2c428d5cc01185ad81300731148bd210e8680))
+
 ## [1.249.1](https://github.com/factorialco/f0/compare/f0-react-v1.249.0...f0-react-v1.249.1) (2025-11-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.249.1",
+  "version": "1.250.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.250.0</summary>

## [1.250.0](https://github.com/factorialco/f0/compare/f0-react-v1.249.1...f0-react-v1.250.0) (2025-11-03)


### Features

* add promoTag to product modal component ([#2906](https://github.com/factorialco/f0/issues/2906)) ([bdc2c42](https://github.com/factorialco/f0/commit/bdc2c428d5cc01185ad81300731148bd210e8680))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).