### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.250.0",
+  "packages/react": "1.251.0",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.251.0](https://github.com/factorialco/f0/compare/f0-react-v1.250.0...f0-react-v1.251.0) (2025-11-03)
+
+
+### Features
+
+* range filter ([#2907](https://github.com/factorialco/f0/issues/2907)) ([dfd3fc7](https://github.com/factorialco/f0/commit/dfd3fc7834c6a9524291221c4372b900caa8bd84))
+
 ## [1.250.0](https://github.com/factorialco/f0/compare/f0-react-v1.249.1...f0-react-v1.250.0) (2025-11-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.250.0",
+  "version": "1.251.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.251.0</summary>

## [1.251.0](https://github.com/factorialco/f0/compare/f0-react-v1.250.0...f0-react-v1.251.0) (2025-11-03)


### Features

* range filter ([#2907](https://github.com/factorialco/f0/issues/2907)) ([dfd3fc7](https://github.com/factorialco/f0/commit/dfd3fc7834c6a9524291221c4372b900caa8bd84))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).