### PR TITLE
fix: card other options click propagation

### DIFF
--- a/packages/react/src/components/F0Card/components/CardOptions.tsx
+++ b/packages/react/src/components/F0Card/components/CardOptions.tsx
@@ -75,6 +75,7 @@ export function CardOptions({
               pressed={isOpen}
               compact
               data-testid="card-options-dropdown"
+              onClick={(e) => e.stopPropagation()}
             />
           </Dropdown>
         </div>

--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -979,6 +979,7 @@ export const ExampleComponent = ({
       currentGrouping: currentGrouping,
       primaryActions,
       secondaryActions,
+      itemOnClick: (item) => () => console.log(`Clicking ${item.name}`),
       itemUrl: (item) => `/users/${item.id}`,
       itemActions: (item) => [
         {


### PR DESCRIPTION
## Description

Add stopprogation to card other options dropdown 

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
