### PR TITLE
Fix column hiding/ordering on first render

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -90,10 +90,7 @@ export const TableCollection = <
   const { columns } = useColumns(
     originalColumns,
     frozenColumns,
-    settings.visualization?.table ?? {
-      order: [],
-      hidden: [],
-    },
+    settings.visualization?.table,
     allowColumnReordering,
     allowColumnHiding
   )

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/__tests__/Table.spec.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/__tests__/Table.spec.tsx
@@ -861,6 +861,62 @@ describe("TableCollection", () => {
     })
   })
 
+  describe("column visibility", () => {
+    it("hides columns with hidden: true on first render", async () => {
+      const columnsWithHidden = [
+        {
+          label: "Visible Column",
+          render: (item: Person) => item.name,
+        },
+        {
+          label: "Hidden Column",
+          hidden: true,
+          render: (item: Person) => item.email,
+        },
+      ]
+
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={columnsWithHidden}
+          source={createTestSource()}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+          allowColumnHiding={true}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      // Verify visible column header is present
+      const headers = screen.getAllByRole("columnheader")
+      expect(
+        headers.some((h) => h.textContent?.includes("Visible Column"))
+      ).toBe(true)
+
+      // Verify hidden column header is NOT present
+      expect(
+        headers.some((h) => h.textContent?.includes("Hidden Column"))
+      ).toBe(false)
+
+      // Verify data from visible column is shown
+      expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+
+      // Verify data from hidden column is NOT shown
+      expect(screen.queryByText(testData[0].email)).not.toBeInTheDocument()
+    })
+  })
+
   describe("Item Actions", () => {
     const testPersonWithActions = {
       id: 1,


### PR DESCRIPTION
## Description

Fix bug where columns with `hidden: true` property were always visible on first render in OneDataCollection tables. The issue was caused by an incorrect fallback value that prevented column definitions from being read.

## Screenshots (if applicable)

N/A - Bug fix for existing functionality

## Implementation details

### The Bug
When no stored settings existed, the code provided a fallback object:
```typescript
settings.visualization?.table ?? { order: [], hidden: [] }
```

The empty arrays `[]` are truthy in JavaScript, causing the nullish coalescing operator in `useColumns` to never call `getColsHiddenFromDefinition()` which reads the `hidden: true` property from column definitions.

### The Fix
**File: `Table.tsx` (Line 93-96)**

Removed the fallback object:
```diff
- settings.visualization?.table ?? { order: [], hidden: [] }
+ settings.visualization?.table
```

Now when settings are undefined, the hook correctly calls `getColsHiddenFromDefinition()` and `getColsOrderFromDefinition()` to read column definitions.

**File: `Table.spec.tsx`**

Added integration test to verify columns with `hidden: true` are correctly hidden on first render.

### Impact
- ✅ Columns with `hidden: true` now work on first render
- ✅ Columns with `order: number` now work on first render (bonus fix)
- ✅ Backward compatible - existing user preferences still respected
- ✅ Essential for version bumping strategy (e.g., `v1` → `v2`) to work correctly