### PR TITLE
feat: use oneellipsis component for the text

### DIFF
--- a/packages/react/src/experimental/Forms/EntitySelect/Trigger/index.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/Trigger/index.tsx
@@ -1,3 +1,4 @@
+import { OneEllipsis } from "@/components/OneEllipsis"
 import { Arrow } from "@/experimental/Forms/Fields/Select/components/Arrow"
 import { cn } from "@/lib/utils"
 import { InputField, InputFieldProps } from "@/ui/InputField"
@@ -140,11 +141,13 @@ export const Trigger = ({
             : "pl-2"
         )}
       >
-        {flattenedList.length === 0
-          ? placeholder
-          : flattenedList.length === 1
-            ? flattenedList[0].subItem.subName
-            : flattenedList.length + " " + selected}
+        <OneEllipsis tag="span">
+          {flattenedList.length === 0
+            ? (placeholder ?? "")
+            : flattenedList.length === 1
+              ? flattenedList[0].subItem.subName
+              : `${flattenedList.length} ${selected}`}
+        </OneEllipsis>
       </span>
     </InputField>
   )


### PR DESCRIPTION
## Description

We want to add ellipsis in the EntitySelector component "placeholder" or "value" so we prevent strings breaking the boxs. Right now ellipsis is applied to the elements in the dropdown, but not in its value, this is breaking some UI scenarios that have to be fixed

## Screenshots (if applicable)

<img width="318" height="115" alt="add ellipsis to entity select component" src="https://github.com/user-attachments/assets/e34a7e59-4bd0-4a9f-92f9-c41a9be7a4a0" />


## Implementation details

Used the `<OneEllipsis />` using the text as a child instead of using the text directly
