### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.252.0",
+  "packages/react": "1.252.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.252.1](https://github.com/factorialco/f0/compare/f0-react-v1.252.0...f0-react-v1.252.1) (2025-11-05)
+
+
+### Bug Fixes
+
+* **NotesTextEditor:** adjust styles ([#2916](https://github.com/factorialco/f0/issues/2916)) ([befb8af](https://github.com/factorialco/f0/commit/befb8af7372bd026d47625cca103d6b744eb6fc2))
+
 ## [1.252.0](https://github.com/factorialco/f0/compare/f0-react-v1.251.1...f0-react-v1.252.0) (2025-11-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.252.0",
+  "version": "1.252.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.252.1</summary>

## [1.252.1](https://github.com/factorialco/f0/compare/f0-react-v1.252.0...f0-react-v1.252.1) (2025-11-05)


### Bug Fixes

* **NotesTextEditor:** adjust styles ([#2916](https://github.com/factorialco/f0/issues/2916)) ([befb8af](https://github.com/factorialco/f0/commit/befb8af7372bd026d47625cca103d6b744eb6fc2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).