### PR TITLE
feat: add spacing options to Split and Stack components

### DIFF
--- a/packages/react/src/experimental/Utilities/Layout/shared.ts
+++ b/packages/react/src/experimental/Utilities/Layout/shared.ts
@@ -1,7 +1,27 @@
 export const gaps = {
+  "0": "gap-0",
+  px: "gap-px",
+  "0.5": "gap-0.5",
+  "1": "gap-1",
+  "1.5": "gap-1.5",
   "2": "gap-2",
+  "2.5": "gap-2.5",
+  "3": "gap-3",
   "4": "gap-4",
+  "5": "gap-5",
+  "6": "gap-6",
+  "7": "gap-7",
   "8": "gap-8",
+  "9": "gap-9",
+  "10": "gap-10",
+  "11": "gap-11",
+  "12": "gap-12",
+  "14": "gap-14",
+  "16": "gap-16",
+  sm: "gap-1",
+  md: "gap-2",
+  lg: "gap-3",
+  xl: "gap-4",
 } as const
 
 export const flexItemVariants = {


### PR DESCRIPTION
## Description

Add all spacing options described in the documentation to the allowed list of values of the `gap` property of `Split` and `Stack` experimental components.

## Implementation details

Extended the `gaps` enum.
