### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.252.2",
+  "packages/react": "1.252.3",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.252.3](https://github.com/factorialco/f0/compare/f0-react-v1.252.2...f0-react-v1.252.3) (2025-11-06)
+
+
+### Bug Fixes
+
+* onStageChange filter type ([#2930](https://github.com/factorialco/f0/issues/2930)) ([a2dc149](https://github.com/factorialco/f0/commit/a2dc149b564a8cd5ffe34cabaf61287e47e582ec))
+
 ## [1.252.2](https://github.com/factorialco/f0/compare/f0-react-v1.252.1...f0-react-v1.252.2) (2025-11-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.252.2",
+  "version": "1.252.3",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.252.3</summary>

## [1.252.3](https://github.com/factorialco/f0/compare/f0-react-v1.252.2...f0-react-v1.252.3) (2025-11-06)


### Bug Fixes

* onStageChange filter type ([#2930](https://github.com/factorialco/f0/issues/2930)) ([a2dc149](https://github.com/factorialco/f0/commit/a2dc149b564a8cd5ffe34cabaf61287e47e582ec))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).