### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.252.3",
+  "packages/react": "1.253.0",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.253.0](https://github.com/factorialco/f0/compare/f0-react-v1.252.3...f0-react-v1.253.0) (2025-11-06)
+
+
+### Features
+
+* add spacing options to Split and Stack components ([#2931](https://github.com/factorialco/f0/issues/2931)) ([12bcb11](https://github.com/factorialco/f0/commit/12bcb11add73697fbc8e462eb7d6ccb15fce749f))
+
 ## [1.252.3](https://github.com/factorialco/f0/compare/f0-react-v1.252.2...f0-react-v1.252.3) (2025-11-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.252.3",
+  "version": "1.253.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.253.0</summary>

## [1.253.0](https://github.com/factorialco/f0/compare/f0-react-v1.252.3...f0-react-v1.253.0) (2025-11-06)


### Features

* add spacing options to Split and Stack components ([#2931](https://github.com/factorialco/f0/issues/2931)) ([12bcb11](https://github.com/factorialco/f0/commit/12bcb11add73697fbc8e462eb7d6ccb15fce749f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).