### PR TITLE
fix: cards link unstyled and clikck thought header

### DIFF
--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -142,6 +142,15 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
     ref
   ) {
     const linkRef = useRef<HTMLAnchorElement>(null)
+
+    const emulateLinkClick = (
+      e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
+    ) => {
+      linkRef?.current?.click()
+      onClick?.()
+      e.preventDefault()
+      e.stopPropagation()
+    }
     return (
       <Card
         className={cn(
@@ -198,13 +207,15 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
         <div className="flex grow flex-col gap-2">
           <div className="flex flex-row items-start justify-between gap-1">
             <CardHeader
-              {...(disableOverlayLink
+              {...(!disableOverlayLink
                 ? {
                     onClick: (e) => {
-                      linkRef?.current?.click()
-                      onClick?.()
-                      e.preventDefault()
-                      e.stopPropagation()
+                      emulateLinkClick(e)
+                    },
+                    onKeyDown: (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        emulateLinkClick(e)
+                      }
                     },
                     role: "button",
                     "aria-label": title,

--- a/packages/react/src/experimental/Forms/Fields/Input/components/PasswordVisibilityToggle.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Input/components/PasswordVisibilityToggle.tsx
@@ -1,0 +1,24 @@
+import { F0ButtonToggle } from "@/components/F0ButtonToggle"
+import { EyeInvisible, EyeVisible } from "@/icons/app"
+
+export type PasswordVisibilityToggleProps = {
+  value: boolean
+  onChange?: (value: boolean) => void
+}
+
+export const PasswordVisibilityToggle = ({
+  value,
+  onChange,
+}: PasswordVisibilityToggleProps) => {
+  return (
+    <F0ButtonToggle
+      label="Toggle password visibility"
+      icon={[EyeInvisible, EyeVisible]}
+      selected={value}
+      size="sm"
+      onSelectedChange={(value) => {
+        onChange?.(Boolean(value))
+      }}
+    />
+  )
+}


### PR DESCRIPTION
## Description

-fix: Card to use unstyted link to avoid render an underline
-fix: Card header emits clicks and link link

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
