### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.255.0",
+  "packages/react": "1.255.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.33.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.255.1](https://github.com/factorialco/f0/compare/f0-react-v1.255.0...f0-react-v1.255.1) (2025-11-06)
+
+
+### Bug Fixes
+
+* cards link unstyled and click thought header ([#2934](https://github.com/factorialco/f0/issues/2934)) ([7f08d64](https://github.com/factorialco/f0/commit/7f08d6447e58fcff941f5ca4d24e9f8736ab0796))
+
 ## [1.255.0](https://github.com/factorialco/f0/compare/f0-react-v1.254.0...f0-react-v1.255.0) (2025-11-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.255.0",
+  "version": "1.255.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.255.1</summary>

## [1.255.1](https://github.com/factorialco/f0/compare/f0-react-v1.255.0...f0-react-v1.255.1) (2025-11-06)


### Bug Fixes

* cards link unstyled and click thought header ([#2934](https://github.com/factorialco/f0/issues/2934)) ([7f08d64](https://github.com/factorialco/f0/commit/7f08d6447e58fcff941f5ca4d24e9f8736ab0796))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).