### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.256.0",
+  "packages/react": "1.257.0",
   "packages/react-native": "0.20.1",
   "packages/core": "1.34.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.257.0](https://github.com/factorialco/f0/compare/f0-react-v1.256.0...f0-react-v1.257.0) (2025-11-07)
+
+
+### Features
+
+* use oneellipsis component for the text ([#2921](https://github.com/factorialco/f0/issues/2921)) ([25c7548](https://github.com/factorialco/f0/commit/25c75487421c0793323c677003638e5c2f91e91c))
+
 ## [1.256.0](https://github.com/factorialco/f0/compare/f0-react-v1.255.1...f0-react-v1.256.0) (2025-11-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.256.0",
+  "version": "1.257.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.257.0</summary>

## [1.257.0](https://github.com/factorialco/f0/compare/f0-react-v1.256.0...f0-react-v1.257.0) (2025-11-07)


### Features

* use oneellipsis component for the text ([#2921](https://github.com/factorialco/f0/issues/2921)) ([25c7548](https://github.com/factorialco/f0/commit/25c75487421c0793323c677003638e5c2f91e91c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).