### PR TITLE
fix: card no pointer events none if no link

### DIFF
--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -207,7 +207,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
         <div className="flex grow flex-col gap-2">
           <div className="flex flex-row items-start justify-between gap-1">
             <CardHeader
-              {...(!disableOverlayLink
+              {...(!disableOverlayLink && link
                 ? {
                     onClick: (e) => {
                       emulateLinkClick(e)
@@ -265,7 +265,11 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
             )}
           </div>
           {(metadata || children) && (
-            <CardContent className="pointer-events-none">
+            <CardContent
+              className={cn(
+                (disableOverlayLink || link) && "pointer-events-none"
+              )}
+            >
               {metadata && (
                 <div
                   className={cn(

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -1,3 +1,4 @@
+import { F0Button } from "@/components/F0Button"
 import {
   Add,
   Briefcase,
@@ -27,7 +28,16 @@ import { DropLaneReorder } from "./DropLaneReorder"
 const SlotComponent = () => {
   return (
     <div className="w-full rounded border-2 border-dashed border-f1-border-info bg-f1-background-info p-5 text-center font-medium text-f1-foreground-info">
-      This is a slot (children)
+      <p>This is a slot (children)</p>
+      <F0Button
+        onClick={(e) => {
+          console.log("button clicked", e)
+          e.preventDefault()
+          e.stopPropagation()
+        }}
+        label="Click me"
+        size="sm"
+      />
     </div>
   )
 }
@@ -38,6 +48,24 @@ const meta = {
   parameters: {
     docs: {
       story: { inline: false, height: "320px" },
+      description: {
+        component: [
+          "A card component that displays a title, description, and actions.",
+          "The card can use value display and also have children that are displayed inside the card.",
+        ]
+          .map((line) => `<p>${line}</p>`)
+          .join("\n"),
+      },
+    },
+  },
+  argTypes: {
+    link: {
+      control: "text",
+      description:
+        "The link to navigate to when the card is clicked. (href). NOTE: When the card has a link, the elements inside the card will have `pointer-events: none` so will not be clickable.",
+    },
+    onClick: {
+      description: "The function to trigger when the card is clicked.",
     },
   },
   tags: ["autodocs", "stable"],
@@ -196,6 +224,19 @@ export const Selectable: Story = {
 export const WithChildren: Story = {
   args: {
     title: "Card with children",
+    children: <SlotComponent />,
+  },
+}
+
+export const WithChildrenAndLink: Story = {
+  args: {
+    ...WithChildren.args,
+    link: "/test-link",
+    primaryAction: {
+      label: "Click me",
+      icon: Envelope,
+      onClick: fn(),
+    },
     children: <SlotComponent />,
   },
 }


### PR DESCRIPTION
## Description

Removes the `pointer-events: none` from the card when no link to allow click on children elements

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
