### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.258.0",
+  "packages/react": "1.259.0",
   "packages/react-native": "0.20.1",
   "packages/core": "1.34.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.259.0](https://github.com/factorialco/f0/compare/f0-react-v1.258.0...f0-react-v1.259.0) (2025-11-10)
+
+
+### Features
+
+* input password visibility ([#2936](https://github.com/factorialco/f0/issues/2936)) ([be2c4fc](https://github.com/factorialco/f0/commit/be2c4fc955f5be1cb738960ed7b8133e4a825322))
+
 ## [1.258.0](https://github.com/factorialco/f0/compare/f0-react-v1.257.0...f0-react-v1.258.0) (2025-11-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.258.0",
+  "version": "1.259.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.259.0</summary>

## [1.259.0](https://github.com/factorialco/f0/compare/f0-react-v1.258.0...f0-react-v1.259.0) (2025-11-10)


### Features

* input password visibility ([#2936](https://github.com/factorialco/f0/issues/2936)) ([be2c4fc](https://github.com/factorialco/f0/commit/be2c4fc955f5be1cb738960ed7b8133e4a825322))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).