### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.259.0",
+  "packages/react": "1.259.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.34.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.259.1](https://github.com/factorialco/f0/compare/f0-react-v1.259.0...f0-react-v1.259.1) (2025-11-10)
+
+
+### Bug Fixes
+
+* **sidebar:** company selector ([#2946](https://github.com/factorialco/f0/issues/2946)) ([4c255e7](https://github.com/factorialco/f0/commit/4c255e71e44ca0eab156259e0e4794e4e2ee2fe9))
+
 ## [1.259.0](https://github.com/factorialco/f0/compare/f0-react-v1.258.0...f0-react-v1.259.0) (2025-11-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.259.0",
+  "version": "1.259.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.259.1</summary>

## [1.259.1](https://github.com/factorialco/f0/compare/f0-react-v1.259.0...f0-react-v1.259.1) (2025-11-10)


### Bug Fixes

* **sidebar:** company selector ([#2946](https://github.com/factorialco/f0/issues/2946)) ([4c255e7](https://github.com/factorialco/f0/commit/4c255e71e44ca0eab156259e0e4794e4e2ee2fe9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).