### PR TITLE
fix: support Select component as list with scroll

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Select/__stories__/Select.stories.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Select/__stories__/Select.stories.tsx
@@ -46,7 +46,7 @@ const SelectWithHooks = (props: SelectProps<string>) => {
   }
 
   return (
-    <div className="w-48">
+    <div className="w-[450px]">
       <Select
         label={label ?? "The label"}
         {...restProps}
@@ -486,6 +486,7 @@ export const WithDataSourcePaginated: Story = {
     showSearchBox: true,
     onChange: fn(),
     value: "option-2",
+    as: "list-with-scroll",
     source: createDataSourceDefinition<MockItem>({
       filters: {
         status: {

--- a/packages/react/src/experimental/Forms/Fields/Select/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Select/index.tsx
@@ -58,6 +58,7 @@ export type SelectProps<T extends string, R = unknown> = {
     option: SelectItemObject<T, ResolvedRecordType<R>> | undefined
   ) => void
   value?: T
+  as?: "list" | "list-with-scroll"
   defaultItem?: SelectItemObject<T, ResolvedRecordType<R>>
   children?: React.ReactNode
   open?: boolean
@@ -211,7 +212,9 @@ const SelectComponent = forwardRef(function Select<
 ) {
   type ActualRecordType = ResolvedRecordType<R>
 
-  const [openLocal, setOpenLocal] = useState(open)
+  const [openLocal, setOpenLocal] = useState(
+    open || props.as === "list" || props.as === "list-with-scroll"
+  )
 
   const [localValue, setLocalValue] = useState(
     value || props.defaultItem?.value

--- a/packages/react/src/ui/Select/SelectContext.tsx
+++ b/packages/react/src/ui/Select/SelectContext.tsx
@@ -2,13 +2,14 @@ import { createContext, useContext } from "react"
 
 export type SelectContextType = {
   open?: boolean
-  as?: "list"
+  as?: "list" | "list-with-scroll"
   multiple?: boolean
   value: string[] | string
 }
 export const SelectContext = createContext<SelectContextType>({
   value: "",
   open: false,
+  as: undefined,
   multiple: false,
 })
 

--- a/packages/react/src/ui/Select/components/Select.tsx
+++ b/packages/react/src/ui/Select/components/Select.tsx
@@ -9,7 +9,7 @@ type SelectOption = {
 }
 
 export type SelectProps<T extends string = string> = SelectPrimitiveProps<T> & {
-  as?: "list"
+  as?: "list" | "list-with-scroll"
   placeholder?: string
   options?: SelectOption[]
 }
@@ -20,16 +20,22 @@ export type SelectProps<T extends string = string> = SelectPrimitiveProps<T> & {
 
 const Select = <T extends string = string>(props: SelectProps<T>) => {
   type Value = NonNullable<typeof props.value>
-  const [internalOpen, setInternalOpen] = useState(!!(props.as === "list"))
+  const [internalOpen, setInternalOpen] = useState(
+    props.as === "list" || props.as === "list-with-scroll"
+  )
 
   const isOpen =
-    props.as === "list"
+    props.as === "list" || props.as === "list-with-scroll"
       ? true
       : props.open !== undefined
         ? props.open
         : internalOpen
 
   const handleOpenChange = (open: boolean) => {
+    if (props.as === "list" || props.as === "list-with-scroll") {
+      return
+    }
+
     // Update internal state if we're not in controlled mode
     if (props.open === undefined) {
       setInternalOpen(open)

--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -110,7 +110,9 @@ const SelectContent = forwardRef<
     // Get the value and the open status from the select context
     const { value, open, as: asSelectProp } = useContext(SelectContext)
 
-    const asList = asSelectProp === "list"
+    const asList =
+      asSelectProp === "list" || asSelectProp === "list-with-scroll"
+    const asListWithScroll = asSelectProp === "list-with-scroll"
 
     const valueArray = useMemo(
       () =>
@@ -250,7 +252,7 @@ const SelectContent = forwardRef<
               viewportRef={parentRef}
               className={cn(
                 "flex flex-col overflow-y-auto",
-                asList
+                asList && !asListWithScroll
                   ? "max-h-full"
                   : taller
                     ? "max-h-[440px]"

--- a/packages/react/src/ui/Select/components/SelectTrigger.tsx
+++ b/packages/react/src/ui/Select/components/SelectTrigger.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils.ts"
 import * as React from "react"
+import { SelectContext } from "../SelectContext"
 import * as SelectPrimitive from "./radix-ui"
 
 /**
@@ -9,7 +10,10 @@ const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => {
-  return (
+  const { as: asSelectProp } = React.useContext(SelectContext)
+
+  return asSelectProp === "list" ||
+    asSelectProp === "list-with-scroll" ? null : (
     <SelectPrimitive.Trigger ref={ref} className={cn(className)} {...props}>
       {children}
     </SelectPrimitive.Trigger>


### PR DESCRIPTION
## Description

We need to support the `Select` component to be rendered without its input, being always open and scrollable.

https://github.com/user-attachments/assets/9fd136be-1a36-4bb2-834a-d70f1f00f03f
