### PR TITLE
fix: solve issue with Select used inside modal

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Select/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Select/index.tsx
@@ -70,7 +70,7 @@ export type SelectProps<T extends string, R = unknown> = {
   className?: string
   selectContentClassName?: string
   actions?: Action[]
-  disablePortal?: boolean
+  portalContainer?: HTMLElement | null
 } & (
   | {
       source: DataSourceDefinition<
@@ -206,7 +206,7 @@ const SelectComponent = forwardRef(function Select<
     status,
     hint,
     required,
-    disablePortal,
+    portalContainer,
     ...props
   }: SelectProps<T, R>,
   ref: React.ForwardedRef<HTMLButtonElement>
@@ -533,7 +533,7 @@ const SelectComponent = forwardRef(function Select<
             isLoadingMore={isLoadingMore}
             isLoading={isLoading || loading}
             showLoadingIndicator={!!children}
-            disablePortal={disablePortal}
+            portalContainer={portalContainer}
           />
         )}
       </SelectPrimitive>

--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -64,7 +64,7 @@ type SelectContentProps = (
   forceMinHeight?: boolean
   scrollMargin?: number
   taller?: boolean
-  disablePortal?: boolean
+  portalContainer?: HTMLElement | null
 }
 const SelectContent = forwardRef<
   ElementRef<typeof SelectPrimitive.Content>,
@@ -86,7 +86,7 @@ const SelectContent = forwardRef<
       forceMinHeight,
       showLoadingIndicator,
       asChild,
-      disablePortal = false,
+      portalContainer,
       ...props
     },
     ref
@@ -287,14 +287,10 @@ const SelectContent = forwardRef<
       </SelectPrimitive.Content>
     )
 
-    // If asList is true or portal is disabled, render without portal
-    if (asList || disablePortal) {
-      return content
-    }
-
-    // Otherwise, render with portal
-    return (
-      <SelectPrimitive.Portal>
+    return asList ? (
+      content
+    ) : (
+      <SelectPrimitive.Portal container={portalContainer}>
         <>
           {/* Overlay to prevent clicks on the content */}
           {open && (


### PR DESCRIPTION
## Description

When placing a Select inside a gamma modal we are experiencing the search input not working at all. This is occurring because the gamma uses a portal and the Select component is using a different one. With these changes we can pass the portal container element that we want to use via prop. This is a pattern I have already seen used in some other components that we already have.

✅ I could also verify via alpha build that this change actually solves the issue that we want to tackle.