### PR TITLE
fix(tooltip): add pointer-events-none to prevent tooltip interference

### DIFF
--- a/packages/react/src/experimental/Overlays/Tooltip/index.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.tsx
@@ -37,7 +37,9 @@ export function TooltipInternal({
           <TooltipTrigger asChild className="pointer-events-auto">
             {children}
           </TooltipTrigger>
-          <TooltipContent className={cn("max-w-xs", shortcut && "pr-1.5")}>
+          <TooltipContent
+            className={cn("pointer-events-none max-w-xs", shortcut && "pr-1.5")}
+          >
             <div className="flex flex-col gap-0.5">
               <div className="flex items-center gap-2">
                 {label && <p className="font-semibold">{label}</p>}


### PR DESCRIPTION
## Changes

This PR adds `pointer-events-none` to the `TooltipContent` component to prevent tooltips from being selectable and interfering with mouse interactions.

## Problem

When tooltips are displayed near other interactive elements (especially when positioned vertically), they can interfere with navigation between elements. This is particularly noticeable when navigating from bottom to top through icons with tooltips.


https://github.com/user-attachments/assets/1b2081e2-cbc7-47cf-ac99-057f046d5265



## Solution

Adding `pointer-events-none` to the tooltip content ensures that:
- Tooltips are not selectable
- Users can smoothly iterate between icons with tooltips
- No interference occurs when hovering over adjacent elements, especially in vertical layouts

## Testing

- ✅ Tooltips are displayed correctly
- ✅ Users can navigate between icons with tooltips without interference
- ✅ Vertical navigation (bottom to top) works smoothly