### PR TITLE
feat(tooltip): add instant prop for immediate tooltip interaction

### DIFF
--- a/packages/react/src/components/F0Icon/F0Icon.tsx
+++ b/packages/react/src/components/F0Icon/F0Icon.tsx
@@ -67,7 +67,11 @@ const TooltipWrapper: React.FC<{
   children: React.ReactNode
 }> = ({ tooltip, children }) => {
   if (tooltip) {
-    return <TooltipInternal label={tooltip}>{children}</TooltipInternal>
+    return (
+      <TooltipInternal label={tooltip} instant>
+        {children}
+      </TooltipInternal>
+    )
   }
   return children
 }

--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -594,9 +594,17 @@ export const getMockVisualizations = (options?: {
           tooltip: "Email",
           property: { type: "text", value: u.email },
         },
-        { icon: Building, property: { type: "text", value: u.department } },
-        { icon: Briefcase, property: { type: "text", value: u.role } },
-        { icon: Star, property: { type: "text", value: u.id } },
+        {
+          icon: Building,
+          tooltip: "Department",
+          property: { type: "text", value: u.department },
+        },
+        {
+          icon: Briefcase,
+          tooltip: "Role",
+          property: { type: "text", value: u.role },
+        },
+        { icon: Star, tooltip: "ID", property: { type: "text", value: u.id } },
       ],
       onMove: options?.cache
         ? async (

--- a/packages/react/src/experimental/Overlays/Tooltip/index.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.tsx
@@ -12,6 +12,7 @@ type TooltipInternalProps = {
   children: React.ReactNode
   shortcut?: ComponentProps<typeof Shortcut>["keys"]
   delay?: number
+  instant?: boolean
 } & (
   | {
       label: string
@@ -28,17 +29,25 @@ export function TooltipInternal({
   description,
   children,
   shortcut,
+  instant = false,
   delay = 700,
 }: TooltipInternalProps) {
   return (
     <>
-      <TooltipProvider delayDuration={delay}>
+      <TooltipProvider
+        delayDuration={instant ? 100 : delay}
+        disableHoverableContent={instant}
+      >
         <TooltipPrimitive>
           <TooltipTrigger asChild className="pointer-events-auto">
             {children}
           </TooltipTrigger>
           <TooltipContent
-            className={cn("pointer-events-none max-w-xs", shortcut && "pr-1.5")}
+            className={cn(
+              "max-w-xs",
+              shortcut && "pr-1.5",
+              instant && "pointer-events-none"
+            )}
           >
             <div className="flex flex-col gap-0.5">
               <div className="flex items-center gap-2">


### PR DESCRIPTION
## Context

PR #2979 attempted to fix tooltip interference by adding `pointer-events-none` globally to the tooltip content. However, this approach didn't work as expected because **TooltipProvider already manages hover interactions natively**, and the global `pointer-events-none` conflicted with its internal behavior.

## Problem

When tooltips are displayed near other interactive elements (especially in vertical layouts), they can interfere with mouse navigation. The issue is particularly noticeable when:
- Navigating from bottom to top through icons with tooltips
- Hovering quickly between adjacent interactive elements
- The tooltip content blocks interaction with nearby elements

## Solution

This PR introduces an `instant` prop that leverages TooltipProvider's native capabilities:


https://github.com/user-attachments/assets/9e198813-89f7-4782-adb5-018904d72916



### Changes

1. **New `instant` prop**: Boolean flag to enable instant tooltip mode
2. **Native hover management**: Uses `disableHoverableContent` prop from TooltipProvider
3. **Reduced delay**: Sets `delayDuration` to 100ms for faster appearance
4. **Conditional pointer-events**: Applies `pointer-events-none` only when instant mode is active

### Implementation

```tsx
<TooltipProvider
  delayDuration={instant ? 100 : delay}
  disableHoverableContent={instant}
>
  <TooltipContent
    className={cn(
      "max-w-xs",
      instant && "pointer-events-none"
    )}
  >
```

### Usage

Applied to F0Icon component for immediate, non-interfering tooltips:

```tsx
<TooltipInternal label={tooltip} instant>
  {children}
</TooltipInternal>
```

## Testing

- ✅ Tooltips appear instantly without interfering with navigation
- ✅ Users can smoothly iterate between icons with tooltips
- ✅ Vertical navigation (bottom to top) works without interference
- ✅ TooltipProvider's native behavior is properly utilized
- ✅ Backward compatible - instant prop is optional (defaults to false)

## Why This Works

The key is `disableHoverableContent`, which tells TooltipProvider to not keep the tooltip open when hovering over the tooltip content itself. Combined with `pointer-events-none`, this ensures tooltips never interfere with mouse interactions while maintaining proper behavior.