### PR TITLE
feat(OneAlert): enhance responsiveness

### DIFF
--- a/packages/core/src/tokens/breakpoints.ts
+++ b/packages/core/src/tokens/breakpoints.ts
@@ -1,5 +1,4 @@
 export const breakpoints = {
-  sm: 600,
   md: 900,
   lg: 1200,
   xl: 1440,

--- a/packages/core/tailwind.ts
+++ b/packages/core/tailwind.ts
@@ -133,6 +133,7 @@ export const baseConfig: Omit<Config, "content"> = {
         autofill: "autofill 0s both",
       },
       containers: {
+        sm: "40rem",
         "8xl": "96rem",
         "9xl": "120rem",
         "10xl": "152rem",

--- a/packages/react/src/experimental/OneAlert/index.stories.tsx
+++ b/packages/react/src/experimental/OneAlert/index.stories.tsx
@@ -55,7 +55,7 @@ export const Default: Story = {
     variant: "info",
   },
   render: (args) => (
-    <div className="w-[600px]">
+    <div className="w-[640px]">
       <OneAlert {...args} />
     </div>
   ),

--- a/packages/react/src/experimental/OneAlert/index.tsx
+++ b/packages/react/src/experimental/OneAlert/index.tsx
@@ -5,9 +5,8 @@ import type { IconType } from "@/components/F0Icon"
 import { F0Link } from "@/components/F0Link"
 import { Placeholder } from "@/icons/app"
 import { cn } from "@/lib/utils"
-import { breakpoints } from "@factorialco/f0-core"
 import { cva, type VariantProps } from "cva"
-import { useEffect, useRef, useState } from "react"
+import { useRef } from "react"
 
 type AlertVariant = "info" | "warning" | "critical" | "neutral" | "positive"
 
@@ -67,33 +66,13 @@ export const OneAlert = ({
   variant = "neutral",
 }: AlertProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
-  const [isNarrow, setIsNarrow] = useState(false)
-
-  useEffect(() => {
-    const container = containerRef.current
-    if (!container) return
-
-    const resizeObserver = new ResizeObserver((entries) => {
-      const width = entries[0].contentRect.width
-      setIsNarrow(width < breakpoints.sm)
-    })
-
-    resizeObserver.observe(container)
-
-    return () => {
-      resizeObserver.disconnect()
-    }
-  }, [])
 
   return (
-    <div ref={containerRef}>
+    <div ref={containerRef} className="@container">
       <div className={alertVariants({ variant })}>
         <div
           className={cn(
-            "flex gap-3",
-            isNarrow
-              ? "flex-col items-start"
-              : "flex-row items-center justify-between"
+            "flex flex-col items-start gap-3 @sm:flex-row @sm:items-center @sm:justify-between"
           )}
         >
           <div className="flex flex-row gap-2">
@@ -114,8 +93,7 @@ export const OneAlert = ({
           {(action || link) && (
             <div
               className={cn(
-                "flex flex-shrink-0 flex-row items-center gap-3",
-                isNarrow && "pl-8"
+                "flex flex-shrink-0 flex-row items-center gap-3 pl-8 @sm:pl-0"
               )}
             >
               {link && (


### PR DESCRIPTION
## Description

Because when the parent container is very narrow the alert looks strange since the actions appear very cramped, I've made it so that when it's less than 640px (when Tailwind changes to sm size) the actions move below the alert description

## Screenshots (if applicable)
<img width="772" height="269" alt="Captura de pantalla 2025-11-18 a las 10 05 41" src="https://github.com/user-attachments/assets/9e0dd63e-d056-42ef-ab19-de26ecc30036" />

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](https://www.figma.com/design/H9TOvI7je1FIDqicC5nOHR/Freemium---trial?node-id=534-42256&t=Mkm0bDm6ocBvVzUm-0)
