### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.270.0",
+  "packages/react": "1.270.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.34.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.270.1](https://github.com/factorialco/f0/compare/f0-react-v1.270.0...f0-react-v1.270.1) (2025-11-17)
+
+
+### Bug Fixes
+
+* number filter range ([#2978](https://github.com/factorialco/f0/issues/2978)) ([4e13663](https://github.com/factorialco/f0/commit/4e13663315f3f245ce34d17d0a31a426fed2b6a3))
+
 ## [1.270.0](https://github.com/factorialco/f0/compare/f0-react-v1.269.0...f0-react-v1.270.0) (2025-11-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.270.0",
+  "version": "1.270.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.270.1</summary>

## [1.270.1](https://github.com/factorialco/f0/compare/f0-react-v1.270.0...f0-react-v1.270.1) (2025-11-17)


### Bug Fixes

* number filter range ([#2978](https://github.com/factorialco/f0/issues/2978)) ([4e13663](https://github.com/factorialco/f0/commit/4e13663315f3f245ce34d17d0a31a426fed2b6a3))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).