### PR TITLE
feat(ActionItem): add shine effect to executing status

### DIFF
--- a/packages/react/src/experimental/AiChat/ActionItem.tsx
+++ b/packages/react/src/experimental/AiChat/ActionItem.tsx
@@ -3,6 +3,7 @@ import OutlineCircle from "@/icons/animated/CheckCircleLine"
 import DottedCircle from "@/icons/app/DottedCircle"
 import { cn } from "@/lib/utils"
 import { ChatSpinner } from "./components/ChatSpinner"
+import "./styles.css"
 
 export interface ActionItemProps {
   title: string

--- a/packages/react/src/experimental/AiChat/styles.css
+++ b/packages/react/src/experimental/AiChat/styles.css
@@ -1,0 +1,22 @@
+@keyframes shine {
+  0% {
+    background-position: 200% center;
+  }
+  100% {
+    background-position: -200% center;
+  }
+}
+
+.shine-text {
+  background: linear-gradient(
+    110deg,
+    currentColor 30%,
+    rgba(255, 255, 255, 0.8) 50%,
+    currentColor 70%
+  );
+  background-size: 200% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: shine 3s linear infinite;
+}

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -40,26 +40,3 @@ div[role="dialog"] {
 .scrollbar-macos::-webkit-scrollbar-thumb:hover {
   background-color: var(--scrollbar-thumb-hover);
 }
-
-@keyframes shine {
-  0% {
-    background-position: 200% center;
-  }
-  100% {
-    background-position: -200% center;
-  }
-}
-
-.shine-text {
-  background: linear-gradient(
-    110deg,
-    currentColor 30%,
-    rgba(255, 255, 255, 0.8) 50%,
-    currentColor 70%
-  );
-  background-size: 200% 100%;
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: shine 3s linear infinite;
-}


### PR DESCRIPTION
## Description

To improve the loading and execution experience of the action item, we've added a shine effect to the text when it's in the "running" state. To do this, I created a styles file to create a custom class, since I wasn't able to achieve the desired effect with pure Tailwind and wanted to avoid installing new dependencies.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/69ba10e9-96fa-499f-966d-798892ca2fb6

## Implementation details

<!-- What have you changed? Why? -->
