### PR TITLE
feat(Charts): visible label for Bar, Area and Line

### DIFF
--- a/packages/react/src/components/Charts/F0Chart/__stories__/line.stories.tsx
+++ b/packages/react/src/components/Charts/F0Chart/__stories__/line.stories.tsx
@@ -39,7 +39,7 @@ export const LineChart: Story = {
         {
           name: "Time to hire",
           type: "line",
-          data: [24, 17, 25, 30, 10, 26],
+          data: [24, 17, 25, 27, 10, 26],
           smooth: false,
         },
       ],

--- a/packages/react/src/components/Charts/F0Chart/themes/f0.light.ts
+++ b/packages/react/src/components/Charts/F0Chart/themes/f0.light.ts
@@ -258,7 +258,7 @@ export const theme = {
       show: true,
       color: chartColor(baseColors.grey[50]),
       fontSize: 12,
-      fontWeight: "regular",
+      fontWeight: "bold",
       position: "top",
     },
   },


### PR DESCRIPTION
## Description

Let's make Miguel happy. Visible labels outside for Area, Line and Bar charts.

## Screenshots

<img width="693" height="436" alt="image" src="https://github.com/user-attachments/assets/d968ad76-3011-409f-ac35-4ccbaf5a600a" />

<img width="715" height="439" alt="image" src="https://github.com/user-attachments/assets/817fc43c-ab75-4b89-9ef3-d5322e503484" />

<img width="706" height="441" alt="image" src="https://github.com/user-attachments/assets/dbc86553-9dc7-4030-8205-28f712e383f9" />
