### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.272.1",
+  "packages/react": "1.273.0",
   "packages/react-native": "0.20.1",
   "packages/core": "1.34.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.273.0](https://github.com/factorialco/f0/compare/f0-react-v1.272.1...f0-react-v1.273.0) (2025-11-19)
+
+
+### Features
+
+* **Charts:** visible label for Bar, Area and Line ([#2992](https://github.com/factorialco/f0/issues/2992)) ([1286fb2](https://github.com/factorialco/f0/commit/1286fb2e22f24ec160c260c9da23ad653b3b74cd))
+
 ## [1.272.1](https://github.com/factorialco/f0/compare/f0-react-v1.272.0...f0-react-v1.272.1) (2025-11-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.272.1",
+  "version": "1.273.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.273.0</summary>

## [1.273.0](https://github.com/factorialco/f0/compare/f0-react-v1.272.1...f0-react-v1.273.0) (2025-11-19)


### Features

* **Charts:** visible label for Bar, Area and Line ([#2992](https://github.com/factorialco/f0/issues/2992)) ([1286fb2](https://github.com/factorialco/f0/commit/1286fb2e22f24ec160c260c9da23ad653b3b74cd))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).