### PR TITLE
fix(OneModal): fix state management

### DIFF
--- a/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
+++ b/packages/react/src/experimental/Modals/OneModal/OneModal.tsx
@@ -2,7 +2,7 @@ import { TabsProps } from "@/experimental/Navigation/Tabs"
 import { cn } from "@/lib/utils"
 import { Dialog, DialogContent } from "@/ui/dialog"
 import { Drawer, DrawerContent, DrawerOverlay } from "@/ui/drawer"
-import React, { ComponentProps, useEffect, useMemo, useState } from "react"
+import { ComponentProps, FC, ReactElement, useMemo } from "react"
 import { OneModalContent } from "./OneModalContent/OneModalContent"
 import { OneModalHeader } from "./OneModalHeader/OneModalHeader"
 import { OneModalProvider } from "./OneModalProvider"
@@ -21,17 +21,17 @@ export type OneModalProps = {
   position?: ModalPosition
   /** Custom content to render in the modal. Only accepts OneModal.Header and OneModal.Content components */
   children:
-    | React.ReactElement<
+    | ReactElement<
         | ComponentProps<typeof OneModalHeader>
         | ComponentProps<typeof OneModalContent>
       >
-    | React.ReactElement<
+    | ReactElement<
         | ComponentProps<typeof OneModalHeader>
         | ComponentProps<typeof OneModalContent>
       >[]
 } & Partial<Pick<TabsProps, "tabs" | "activeTabId" | "setActiveTabId">>
 
-export const OneModal: React.FC<OneModalProps> = ({
+export const OneModal: FC<OneModalProps> = ({
   asBottomSheetInMobile = true,
   position = "center",
   onClose,
@@ -39,22 +39,10 @@ export const OneModal: React.FC<OneModalProps> = ({
   contentPadding = "md",
   children,
 }) => {
-  const [open, setOpen] = useState(isOpen)
-
-  useEffect(() => {
-    setOpen(isOpen)
-  }, [isOpen])
-
   const handleOpenChange = (open: boolean) => {
-    setOpen(open)
     if (!open) {
       onClose()
     }
-  }
-
-  const handleClose = () => {
-    setOpen(false)
-    onClose()
   }
 
   const isSmallScreen = useIsSmallScreen()
@@ -84,13 +72,13 @@ export const OneModal: React.FC<OneModalProps> = ({
   if (isSmallScreen && asBottomSheetInMobile) {
     return (
       <OneModalProvider
-        isOpen={open}
-        onClose={handleClose}
+        isOpen={isOpen}
+        onClose={onClose}
         position={position}
         contentPadding={contentPadding}
         shownBottomSheet
       >
-        <Drawer open={open} onOpenChange={handleOpenChange}>
+        <Drawer open={isOpen} onOpenChange={handleOpenChange}>
           <DrawerOverlay className="bg-f1-background-overlay" />
           <DrawerContent className={contentClassName}>{children}</DrawerContent>
         </Drawer>
@@ -100,14 +88,14 @@ export const OneModal: React.FC<OneModalProps> = ({
 
   return (
     <OneModalProvider
-      isOpen={open}
-      onClose={handleClose}
+      isOpen={isOpen}
+      onClose={onClose}
       position={position}
       contentPadding={contentPadding}
     >
       <Dialog
-        open={open}
-        onOpenChange={onClose}
+        open={isOpen}
+        onOpenChange={handleOpenChange}
         modal={position === "center" || position === "fullscreen"}
       >
         <DialogContent


### PR DESCRIPTION
## Description

The current modal component manages the `isOpen` state in two different ways:
- The consumer can pass the `isOpen` prop manually.
- When the close button is clicked:
  - `onClose` is executed.
  - `isOpen` is automatically set to `false`.

This mixed approach leads to several issues — especially when the consumer wants to:
- Confirm before closing the modal.
- Fully control the behavior of the close button.
- Handle custom logic before updating the `isOpen` value.

### What Changed?

This PR delegates **100% control of the `isOpen` state to the consumer**:
- The component no longer updates its internal `isOpen` state.
- It stays fully synchronized with the `isOpen` prop passed by the consumer.
- The consumer is now responsible for setting `isOpen = false` inside the `onClose` function.

### Why?

This change:
- Enforces a predictable, controlled component pattern.
- Avoids race conditions and inconsistent UI behavior.
- Makes the dialog easier to integrate with confirmation flows and external state managers


## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
