### PR TITLE
feat: ellipsis in F0Buttons

### DIFF
--- a/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
@@ -260,6 +260,78 @@ export const Sizes: Story = {
   ),
 }
 
+export const Ellipsis: Story = {
+  parameters: withSnapshot({
+    docs: {
+      description: {
+        story:
+          "A button that will truncate the label if it is too long, to allow for better readability and usability.",
+      },
+    },
+  }),
+  render: (args) => (
+    <div
+      className="flex max-w-[120px] flex-col items-center gap-4 p-3"
+      style={{ border: "1px dotted #333" }}
+    >
+      <F0Button
+        {...args}
+        size="lg"
+        label="Large label that will be truncated"
+      />
+      <F0Button
+        {...args}
+        size="md"
+        label="Medium label that will be truncated"
+      />
+      <F0Button
+        {...args}
+        size="sm"
+        label="Small label that will be truncated"
+      />
+      <F0Button
+        icon={Add}
+        {...args}
+        size="lg"
+        label="Large label that will be truncated"
+      />
+      <F0Button
+        icon={Add}
+        {...args}
+        size="md"
+        label="Medium label that will be truncated"
+      />
+      <F0Button
+        icon={Add}
+        {...args}
+        size="sm"
+        label="Small label that will be truncated"
+      />
+      <F0Button
+        icon={Add}
+        {...args}
+        hideLabel
+        size="lg"
+        label="Large label that will be truncated"
+      />
+      <F0Button
+        icon={Add}
+        loading
+        {...args}
+        size="md"
+        label="Medium label that will be truncated"
+      />
+      <F0Button
+        hideLabel
+        icon={Add}
+        {...args}
+        size="sm"
+        label="Small label that will be truncated"
+      />
+    </div>
+  ),
+}
+
 export const Disabled: Story = {
   args: {
     disabled: true,

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils"
 import { Action } from "@/ui/Action"
 import { cva } from "cva"
 import { forwardRef, useState } from "react"
+import { OneEllipsis } from "../OneEllipsis"
 import { ButtonInternalProps } from "./internal-types"
 
 const iconVariants = cva({
@@ -109,7 +110,7 @@ const ButtonInternal = forwardRef<
       tooltip={tooltip ?? (!noAutoTooltip && hideLabel && label)}
       onClick={handleClick}
       loading={isLoading}
-      className={className}
+      className={cn("max-w-full", className)}
       mode={hideLabel ? "only" : "default"}
       aria-label={ariaLabel || props.title || label}
       title={
@@ -117,7 +118,12 @@ const ButtonInternal = forwardRef<
       }
       compact={!!shouldHideLabel}
     >
-      <div className={cn(isLoading && "invisible", "flex items-center gap-1")}>
+      <div
+        className={cn(
+          isLoading && "invisible",
+          "flex min-w-0 flex-1 items-center gap-1"
+        )}
+      >
         {icon && (
           <F0Icon
             size={size === "sm" ? "sm" : "md"}
@@ -136,7 +142,13 @@ const ButtonInternal = forwardRef<
             alt={""}
           />
         )}
-        <span className={cn(shouldHideLabel && "sr-only")}>{label}</span>
+        {!shouldHideLabel ? (
+          <OneEllipsis className={cn(shouldHideLabel && "sr-only")} tag="span">
+            {label.toString()}
+          </OneEllipsis>
+        ) : (
+          <span className="sr-only">{label.toString()}</span>
+        )}
         {append}
       </div>
     </Action>

--- a/packages/react/src/ui/Action/Action.tsx
+++ b/packages/react/src/ui/Action/Action.tsx
@@ -73,14 +73,14 @@ export const Action = React.forwardRef<
     <>
       <div
         className={cn(
-          "main flex items-center justify-center gap-1",
+          "main flex min-w-0 flex-1 items-center justify-center gap-1",
           compact && compactClasses({ size }),
           loading && "opacity-0",
           iconVariants({ variant: localVariant, mode })
         )}
       >
         {prepend}
-        <span className={cn("flex items-center justify-center")}>
+        <span className={cn("flex min-w-0 flex-1 items-center justify-center")}>
           {children}
         </span>
         {append}


### PR DESCRIPTION
## Description

Add ellipsis to buttons to allow then to fit in small containers without overflow
## Screenshots (if applicable)

<img width="579" height="588" alt="image" src="https://github.com/user-attachments/assets/48532cf4-0d37-4048-b7c2-eb195a74934f" />


## Implementation details

<!-- What have you changed? Why? -->
