### PR TITLE
fix: select when search

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Select/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Select/index.tsx
@@ -341,8 +341,14 @@ const SelectComponent = forwardRef(function Select<
   useEffect(() => {
     const foundOption = findOption(localValue)
 
-    onChangeSelectedOption?.(foundOption)
-    setSelectedOption(foundOption)
+    if (foundOption) {
+      onChangeSelectedOption?.(foundOption)
+      setSelectedOption(foundOption)
+    }
+    if (!localValue) {
+      onChangeSelectedOption?.(undefined)
+      setSelectedOption(undefined)
+    }
   }, [
     data.records,
     localValue,


### PR DESCRIPTION
## Description

Fix: in the selector, in async mode, when the user select an item, and then use the search the selected option disappears from the trigger


## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

he issue was caused by how the selectect item is "calculated", if tries to find the option that matches the value, but the hook also depends on the data.records, so when the user search the hook tried to calculate again the option, but in this case it could not exists in the records.

The fix, only sets a new selected option when this hook is able to find the option in the list, if not it keeps the previous one. To avoid show an incorrect option when the user clears the selection, if localValue is empty we un set the selectedOption
