### PR TITLE
fix(AvatarPerson): change icon size for sm size

### DIFF
--- a/packages/react/src/components/avatars/internal/BaseAvatar/BaseAvatar.tsx
+++ b/packages/react/src/components/avatars/internal/BaseAvatar/BaseAvatar.tsx
@@ -22,7 +22,7 @@ const DEFAULT_SIZE = "md"
 
 const iconSize: Record<AvatarSize, F0IconProps["size"]> = {
   xs: "xs",
-  sm: "xs",
+  sm: "sm",
   md: "md",
   lg: "md",
   xl: "lg",


### PR DESCRIPTION
## Description

Cata (PD Finance) raised a good point. The `AvatarPerson`, when deactivated, displays an icon. The icon size for the `sm` avatar is too small. It was a `xs` icon, while a `sm` icon fits better.

This is the avatar size we use in the DataCollection so it's pretty noticeable.

## Screenshots

#### Before

<img width="44" height="50" alt="image" src="https://github.com/user-attachments/assets/53885f98-6851-417a-89ec-9f3bf5484a47" />


#### After

<img width="47" height="45" alt="image" src="https://github.com/user-attachments/assets/abf57aa2-357a-45e4-b70a-8ee11f4b93eb" />

