### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.276.1",
+  "packages/react": "1.276.2",
   "packages/react-native": "0.20.1",
   "packages/core": "1.34.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.276.2](https://github.com/factorialco/f0/compare/f0-react-v1.276.1...f0-react-v1.276.2) (2025-11-21)
+
+
+### Bug Fixes
+
+* **AvatarPerson:** change icon size for sm size ([#3005](https://github.com/factorialco/f0/issues/3005)) ([2b85c06](https://github.com/factorialco/f0/commit/2b85c0625e7c70c6b91ecaa6dd7122309785976c))
+
 ## [1.276.1](https://github.com/factorialco/f0/compare/f0-react-v1.276.0...f0-react-v1.276.1) (2025-11-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.276.1",
+  "version": "1.276.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.276.2</summary>

## [1.276.2](https://github.com/factorialco/f0/compare/f0-react-v1.276.1...f0-react-v1.276.2) (2025-11-21)


### Bug Fixes

* **AvatarPerson:** change icon size for sm size ([#3005](https://github.com/factorialco/f0/issues/3005)) ([2b85c06](https://github.com/factorialco/f0/commit/2b85c0625e7c70c6b91ecaa6dd7122309785976c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).