### PR TITLE
feat(Table): enhance row rendering with nested children support and u…

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -73,6 +73,31 @@ export const TableColumnOrderingAndHiddenNoPersistentStorage: Story = {
   },
 }
 
+export const TableWithNestedRecords: Story = {
+  render: () => {
+    const mockVisualizations = getMockVisualizations({
+      table: {
+        noSorting: true,
+        allowColumnHiding: true,
+        allowColumnReordering: true,
+      },
+    })
+
+    return (
+      <ExampleComponent
+        frozenColumns={2}
+        tableAllowColumnReordering
+        tableAllowColumnHiding
+        noSorting
+        storage={false}
+        visualizations={[mockVisualizations.table]}
+        id="employees/v1"
+        nestedRecords
+      />
+    )
+  },
+}
+
 export const TableColumnOrdering: Story = {
   render: () => (
     <ExampleComponent frozenColumns={2} tableAllowColumnReordering />

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -230,6 +230,10 @@ export const TableCollection = <
     !!source.selectable
   )
 
+  const tableWithChildren = data?.records.some((item) =>
+    source.itemsWithChildren?.(item)
+  )
+
   /*
    * Initial loading
    */
@@ -403,6 +407,7 @@ export const TableCollection = <
                   columns={columns}
                   frozenColumnsLeft={frozenColumnsLeft}
                   checkColumnWidth={checkColumnWidth}
+                  tableWithChildren={tableWithChildren}
                 />
               )
             })}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -1,0 +1,252 @@
+import { forwardRef, useRef, useState } from "react"
+
+import { FiltersDefinition } from "@/components/OneFilterPicker/types"
+import { DataCollectionSource } from "@/experimental/OneDataCollection/hooks/useDataCollectionSource/types"
+import { ItemActionsDefinition } from "@/experimental/OneDataCollection/item-actions"
+import { NavigationFiltersDefinition } from "@/experimental/OneDataCollection/navigationFilters/types"
+import { SummariesDefinition } from "@/experimental/OneDataCollection/summary"
+import {
+  GroupingDefinition,
+  RecordType,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+import { useLoadChildren } from "../hooks/useLoadChildren"
+import { TableColumnDefinition } from "../types"
+import { Row } from "./Row"
+import { RowLoading } from "./RowLoading"
+
+export type RowProps<
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Summaries extends SummariesDefinition,
+  ItemActions extends ItemActionsDefinition<R>,
+  NavigationFilters extends NavigationFiltersDefinition,
+  Grouping extends GroupingDefinition<R>,
+> = {
+  source: DataCollectionSource<
+    R,
+    Filters,
+    Sortings,
+    Summaries,
+    ItemActions,
+    NavigationFilters,
+    Grouping
+  >
+  item: R
+  index: number
+  groupIndex: number
+  onCheckedChange: (checked: boolean) => void
+  selectedItems: Map<string | number, R>
+  columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>
+  frozenColumnsLeft: number
+  checkColumnWidth: number
+  tableWithChildren: boolean
+  depth?: number
+  onChildrenExpand?: (count: number, isExpanding: boolean) => void
+  isLastOfRoot?: boolean
+  expandedLevels?: number
+  onExpand?: () => void
+}
+
+const NestedRowComponentInner = <
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Summaries extends SummariesDefinition,
+  ItemActions extends ItemActionsDefinition<R>,
+  NavigationFilters extends NavigationFiltersDefinition,
+  Grouping extends GroupingDefinition<R>,
+>({
+  source,
+  item,
+  onCheckedChange,
+  selectedItems,
+  columns,
+  frozenColumnsLeft,
+  checkColumnWidth,
+  index,
+  groupIndex,
+  tableWithChildren,
+  depth = 0,
+  onChildrenExpand,
+  isLastOfRoot = false,
+}: RowProps<
+  R,
+  Filters,
+  Sortings,
+  Summaries,
+  ItemActions,
+  NavigationFilters,
+  Grouping
+>) => {
+  const [expandedChildrenCount, setExpandedChildrenCount] = useState(0)
+  const [totalExpandedCount, setTotalExpandedCount] = useState(0)
+  const [open, setOpen] = useState(false)
+  const rowRef = useRef<HTMLTableRowElement>(null)
+
+  const { children, loadChildren, isLoading } = useLoadChildren({
+    item,
+    filters: source.currentFilters,
+    fetchChildren: source.fetchChildren,
+  })
+
+  const updateCounts = (
+    visualDelta: number,
+    totalDelta: number = visualDelta
+  ) => {
+    setExpandedChildrenCount((prev) => Math.max(0, prev + visualDelta))
+    setTotalExpandedCount((prev) => Math.max(0, prev + totalDelta))
+  }
+
+  const handleChildExpand =
+    (childIndex: number) => (count: number, isExpanding: boolean) => {
+      const isLastChild = childIndex === children.length - 1
+      const delta = isExpanding ? count : -count
+
+      // Last child: only update total (not visual), still propagate up
+      updateCounts(isLastChild ? 0 : delta, delta)
+      onChildrenExpand?.(count, isExpanding)
+    }
+
+  const handleExpand = () => {
+    const isExpanding = !open
+    setOpen(isExpanding)
+
+    if (isExpanding) {
+      const loadingRowsCount = 3
+
+      onChildrenExpand?.(loadingRowsCount, true)
+
+      loadChildren().then((loadedChildren) => {
+        const childrenCount = loadedChildren?.length || 0
+
+        const delta = childrenCount - loadingRowsCount
+        updateCounts(childrenCount, childrenCount)
+        onChildrenExpand?.(delta, delta !== 0)
+      })
+    } else {
+      onChildrenExpand?.(totalExpandedCount, false)
+      updateCounts(-expandedChildrenCount, -totalExpandedCount)
+    }
+  }
+
+  return (
+    <>
+      <Row
+        source={source}
+        item={item}
+        index={index}
+        groupIndex={groupIndex}
+        onCheckedChange={onCheckedChange}
+        selectedItems={selectedItems}
+        columns={columns}
+        frozenColumnsLeft={frozenColumnsLeft}
+        checkColumnWidth={checkColumnWidth}
+        tableWithChildren={tableWithChildren}
+        depth={depth}
+        hasLoadedChildren={false}
+        noBorder={open || depth > 0}
+        expandedLevels={expandedChildrenCount}
+        onExpand={handleExpand}
+        ref={rowRef}
+      />
+
+      {open && isLoading && (
+        <RowLoading
+          source={source}
+          item={item}
+          index={index}
+          groupIndex={groupIndex}
+          onCheckedChange={onCheckedChange}
+          selectedItems={selectedItems}
+          columns={columns}
+          checkColumnWidth={checkColumnWidth}
+          tableWithChildren={tableWithChildren}
+          depth={depth}
+          frozenColumnsLeft={frozenColumnsLeft}
+          rowRef={rowRef}
+        />
+      )}
+
+      {open && !isLoading && (
+        <>
+          {children.map((child, childIndex) => {
+            const childItem = child as R
+            const childHasChildren = source.itemsWithChildren?.(childItem)
+            const isLastChild = childIndex === children.length - 1
+            // Mark as last of root if parent is already last of root OR this is the last expandable child
+            // This ensures the entire subtree blocks notifications to grandparent
+            const childIsLastOfRoot =
+              isLastOfRoot || (isLastChild && childHasChildren)
+
+            if (childHasChildren) {
+              return (
+                <>
+                  <NestedRow
+                    key={`nested-row-${groupIndex}-${index}-${childIndex}`}
+                    source={source}
+                    item={childItem}
+                    index={childIndex}
+                    groupIndex={groupIndex}
+                    onCheckedChange={onCheckedChange}
+                    selectedItems={selectedItems}
+                    columns={columns}
+                    frozenColumnsLeft={frozenColumnsLeft}
+                    checkColumnWidth={checkColumnWidth}
+                    tableWithChildren={tableWithChildren}
+                    depth={depth + 1}
+                    onChildrenExpand={handleChildExpand(childIndex)}
+                    isLastOfRoot={childIsLastOfRoot}
+                    onExpand={handleExpand}
+                  />
+                </>
+              )
+            } else {
+              return (
+                <Row
+                  key={`row-${groupIndex}-${index}-${childIndex}`}
+                  source={source}
+                  item={childItem}
+                  index={childIndex}
+                  groupIndex={groupIndex}
+                  onCheckedChange={onCheckedChange}
+                  selectedItems={selectedItems}
+                  columns={columns}
+                  frozenColumnsLeft={frozenColumnsLeft}
+                  checkColumnWidth={checkColumnWidth}
+                  tableWithChildren={tableWithChildren}
+                  depth={depth + 1}
+                  noBorder
+                  onExpand={handleExpand}
+                />
+              )
+            }
+          })}
+        </>
+      )}
+    </>
+  )
+}
+
+const NestedRow = forwardRef(NestedRowComponentInner) as <
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Summaries extends SummariesDefinition,
+  ItemActions extends ItemActionsDefinition<R>,
+  NavigationFilters extends NavigationFiltersDefinition,
+  Grouping extends GroupingDefinition<R>,
+>(
+  props: RowProps<
+    R,
+    Filters,
+    Sortings,
+    Summaries,
+    ItemActions,
+    NavigationFilters,
+    Grouping
+  > & { ref?: React.ForwardedRef<HTMLTableRowElement> }
+) => ReturnType<typeof NestedRowComponentInner>
+
+export { NestedRow }

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
@@ -1,0 +1,122 @@
+import { DataCollectionSource } from "@/experimental/OneDataCollection/hooks/useDataCollectionSource"
+import { ItemActionsDefinition } from "@/experimental/OneDataCollection/item-actions"
+import { NavigationFiltersDefinition } from "@/experimental/OneDataCollection/navigationFilters/types"
+import { SummariesDefinition } from "@/experimental/OneDataCollection/summary"
+import {
+  FiltersDefinition,
+  GroupingDefinition,
+  RecordType,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+import { useLayoutEffect, useRef } from "react"
+import { Row, RowProps } from "../Row"
+
+const DEFAULT_LOADING_ROWS_COUNT = 3
+
+const SingleLoadingRow = <
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Summaries extends SummariesDefinition,
+  ItemActions extends ItemActionsDefinition<R>,
+  NavigationFilters extends NavigationFiltersDefinition,
+  Grouping extends GroupingDefinition<R>,
+>({
+  rowRef,
+  rowIndex,
+  source,
+  item,
+  columns,
+  frozenColumnsLeft,
+  depth,
+  groupIndex,
+  onCheckedChange,
+  selectedItems,
+  checkColumnWidth,
+  tableWithChildren,
+}: RowProps<
+  R,
+  Filters,
+  Sortings,
+  Summaries,
+  ItemActions,
+  NavigationFilters,
+  Grouping
+> & {
+  rowRef: React.RefObject<HTMLTableRowElement>
+  rowIndex: number
+}) => {
+  const loadingRowRef = useRef<HTMLTableRowElement>(null)
+  const rowRefCurrent = rowRef?.current
+
+  useLayoutEffect(() => {
+    if (loadingRowRef.current && rowRefCurrent) {
+      const height = rowRef.current.getBoundingClientRect().height
+      loadingRowRef.current.style.height = `${height}px`
+    }
+  }, [rowRefCurrent, rowRef])
+
+  return (
+    <Row
+      source={source}
+      item={item}
+      key={`row-loading-${rowIndex}`}
+      index={rowIndex}
+      frozenColumnsLeft={frozenColumnsLeft}
+      depth={depth}
+      columns={columns}
+      hasLoadedChildren={false}
+      noBorder
+      groupIndex={groupIndex}
+      onCheckedChange={onCheckedChange}
+      selectedItems={selectedItems}
+      checkColumnWidth={checkColumnWidth}
+      tableWithChildren={tableWithChildren}
+      loading
+      ref={loadingRowRef}
+    />
+  )
+}
+
+export const RowLoading = <
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Summaries extends SummariesDefinition,
+  ItemActions extends ItemActionsDefinition<R>,
+  NavigationFilters extends NavigationFiltersDefinition,
+  Grouping extends GroupingDefinition<R>,
+>({
+  rowRef,
+  ...props
+}: RowProps<
+  R,
+  Filters,
+  Sortings,
+  Summaries,
+  ItemActions,
+  NavigationFilters,
+  Grouping
+> & {
+  rowRef: React.RefObject<HTMLTableRowElement>
+  source: DataCollectionSource<
+    R,
+    Filters,
+    Sortings,
+    Summaries,
+    ItemActions,
+    NavigationFilters,
+    Grouping
+  >
+}) => {
+  const loadingRowsCount =
+    props.source.childrenCount?.(props.item) ?? DEFAULT_LOADING_ROWS_COUNT
+  return Array.from({ length: loadingRowsCount }).map((_, rowIndex) => (
+    <SingleLoadingRow
+      key={`row-loading-${rowIndex}`}
+      rowRef={rowRef}
+      rowIndex={rowIndex}
+      {...props}
+    />
+  ))
+}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/hooks/useLoadChildren.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/hooks/useLoadChildren.ts
@@ -1,0 +1,41 @@
+import {
+  BaseResponse,
+  FiltersDefinition,
+  FiltersState,
+  RecordType,
+} from "@/hooks/datasource"
+import { useCallback, useState } from "react"
+
+interface UseLoadChildrenProps<R extends RecordType> {
+  item: R
+  filters?: FiltersState<FiltersDefinition>
+  fetchChildren?: (
+    item: R,
+    filters?: FiltersState<FiltersDefinition>
+  ) => Promise<BaseResponse<R> | R[]> | R[]
+}
+
+export const useLoadChildren = <R extends RecordType>({
+  item,
+  filters,
+  fetchChildren,
+}: UseLoadChildrenProps<R>) => {
+  const [children, setChildren] = useState<R[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  const loadChildren = useCallback(async () => {
+    if (children.length > 0) return children
+
+    setIsLoading(true)
+
+    const data = await fetchChildren?.(item, filters)
+    const loadedChildren = Array.isArray(data) ? data : []
+
+    setChildren(loadedChildren)
+    setIsLoading(false)
+
+    return loadedChildren
+  }, [children, item, filters, fetchChildren])
+
+  return { children, loadChildren, isLoading }
+}

--- a/packages/react/src/experimental/OneTable/TableCell/NestedCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/NestedCell/index.tsx
@@ -1,0 +1,108 @@
+import { cn } from "@/lib/utils"
+import { ChevronDown, ChevronRight } from "lucide-react"
+import {
+  CHEVRON_SIZE,
+  getNestedMarginLeft,
+  isFirstCellWithChildren,
+  isFirstCellWithDepth,
+  isFirstCellWithNoChildrenAndTableChildren,
+  SPACING_FACTOR,
+} from "../utils/nested"
+
+interface NestedCellProps {
+  width?: number | "auto"
+  linkRef: React.RefObject<HTMLAnchorElement>
+  hasChildren: boolean
+  firstCell: boolean
+  depth: number
+  expandedLevels: number
+  children: React.ReactNode
+  tableWithChildren?: boolean
+  onClick?: () => void
+  onExpand?: () => void
+}
+
+export const NestedCell = ({
+  width,
+  linkRef,
+  hasChildren,
+  firstCell,
+  depth,
+  expandedLevels,
+  children,
+  tableWithChildren = false,
+  onClick,
+  onExpand,
+}: NestedCellProps) => {
+  const firstCellWithChildren = isFirstCellWithChildren(firstCell, hasChildren)
+  const firstCellWithDepth = isFirstCellWithDepth(firstCell, depth)
+  const firstCellWithNoChildrenAndTableChildren =
+    isFirstCellWithNoChildrenAndTableChildren(
+      firstCell,
+      hasChildren,
+      tableWithChildren
+    )
+
+  const marginLeft = firstCellWithDepth ? getNestedMarginLeft(depth) : undefined
+
+  return (
+    <div
+      className={cn(
+        width !== "auto" && "overflow-hidden",
+        "relative z-[1]",
+        firstCellWithChildren && "flex items-center gap-2"
+      )}
+      style={{ marginLeft }}
+      onClick={() => {
+        // Force the link to be clicked even if the element pointer-events: auto
+        linkRef.current?.click()
+        onClick?.()
+      }}
+    >
+      <div
+        className={cn(
+          "h-[var(--chevron-size)] w-[var(--chevron-size)]",
+          firstCellWithChildren &&
+            "pointer-events-auto cursor-pointer rounded-2xs hover:bg-f1-foreground-disabled"
+        )}
+        style={
+          {
+            ...{
+              "--chevron-size": `${CHEVRON_SIZE}px`,
+              "--spacing-factor": `${SPACING_FACTOR}px`,
+            },
+          } as React.CSSProperties
+        }
+        onClick={(e) => {
+          if (firstCellWithChildren) {
+            e.stopPropagation()
+            onExpand?.()
+          }
+        }}
+      >
+        {firstCellWithChildren &&
+          (expandedLevels > 0 ? (
+            <ChevronDown
+              className="pointer-events-none shrink-0"
+              size={CHEVRON_SIZE}
+            />
+          ) : (
+            <ChevronRight
+              className="pointer-events-none shrink-0"
+              size={CHEVRON_SIZE}
+            />
+          ))}
+      </div>
+      <div
+        className={cn(
+          firstCellWithChildren && "min-w-0",
+          firstCellWithNoChildrenAndTableChildren &&
+            "pl-[var(--spacing-factor)]",
+          "relative"
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/experimental/OneTable/TableCell/TreeConnector/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/TreeConnector/index.tsx
@@ -1,0 +1,76 @@
+import { cn } from "@/lib/utils"
+import {
+  CHEVRON_SIZE,
+  getNestedMarginLeft,
+  isFirstCellExpanded,
+  isFirstCellWithDepth,
+  LINE_WIDTH,
+  SPACING_FACTOR,
+} from "../utils/nested"
+
+interface TreeConnectorProps {
+  firstCell: boolean
+  hasChildren: boolean
+  depth: number
+  expandedLevels: number
+}
+
+export const connectorVariables = (expandedLevels: number) => {
+  return {
+    "--line-left": `-${2 * CHEVRON_SIZE}px`,
+    "--line-width": LINE_WIDTH,
+    "--horizontal-offset": `${CHEVRON_SIZE / 2}px`,
+    "--horizontal-height": `${SPACING_FACTOR / 2}px`,
+    "--line-top": `-${2 * CHEVRON_SIZE}px`,
+    "--line-height": `calc(${expandedLevels} * 100% - ${SPACING_FACTOR}px)`,
+  }
+}
+
+export const verticalConnectorStyles =
+  "h-full overflow-visible " +
+  "before:absolute " +
+  "before:-left-[var(--line-left)] " +
+  "before:-top-[var(--line-top)] " +
+  "before:h-[var(--line-height)] " +
+  "before:w-[var(--line-width)] " +
+  "before:bg-f1-foreground-disabled " +
+  "before:content-['']"
+
+export const horizontalConnectorStyles =
+  "after:absolute " +
+  "after:left-[var(--horizontal-offset)] " +
+  "after:top-[var(--horizontal-offset)] " +
+  "after:h-[var(--horizontal-height)] " +
+  "after:w-4 " +
+  "after:rounded-bl-[var(--horizontal-height)] " +
+  "after:content-[''] " +
+  "after:shadow-[inset_1px_-1px_0_0_hsl(var(--neutral-30))]"
+
+export const TreeConnector = ({
+  firstCell,
+  hasChildren,
+  depth,
+  expandedLevels,
+}: TreeConnectorProps) => {
+  const firstCellWithDepth = isFirstCellWithDepth(firstCell, depth)
+  const firstCellExpanded = isFirstCellExpanded(expandedLevels, firstCell)
+
+  if (!firstCellExpanded && !firstCellWithDepth && !hasChildren) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        "absolute inset-0 h-full",
+        firstCellExpanded && verticalConnectorStyles,
+        firstCellWithDepth && horizontalConnectorStyles,
+        firstCellWithDepth && !hasChildren && "after:w-8"
+      )}
+      style={{
+        marginLeft: firstCellWithDepth ? getNestedMarginLeft(depth) : undefined,
+        ...connectorVariables(expandedLevels),
+      }}
+    />
+  )
+}

--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from "@/ui/skeleton"
 import { TableCell as TableCellRoot } from "@/ui/table"
 import { AnimatePresence, motion } from "motion/react"
 import { useRef } from "react"
@@ -6,6 +7,12 @@ import { useI18n } from "../../../lib/providers/i18n"
 import { cn } from "../../../lib/utils"
 import { useTable } from "../utils/TableContext"
 import { getColWidth } from "../utils/colWidth"
+import { NestedCell } from "./NestedCell"
+import { TreeConnector } from "./TreeConnector"
+import {
+  isFirstCellWithChildren,
+  isFirstCellWithTableChildren,
+} from "./utils/nested"
 
 interface TableCellProps {
   children: React.ReactNode
@@ -46,6 +53,41 @@ interface TableCellProps {
    * The class name of the cell
    */
   className?: string
+
+  /**
+   * Defines if the cell has children
+   * @default false
+   */
+  hasChildren?: boolean
+
+  /**
+   * Defines if the cell is a table with children
+   * @default false
+   */
+  tableWithChildren?: boolean
+
+  /**
+   * The depth level of nested children (used for indentation)
+   * @default 0
+   */
+  depth?: number
+
+  /**
+   * The number of expanded levels of nested children
+   * @default 0
+   */
+  expandedLevels?: number
+
+  /**
+   * The onExpand handler for the cell
+   */
+  onExpand?: () => void
+
+  /**
+   * Defines if the cell is loading
+   * @default false
+   */
+  loading?: boolean
 }
 
 export function TableCell({
@@ -57,6 +99,12 @@ export function TableCell({
   sticky,
   colSpan,
   className,
+  hasChildren = false,
+  tableWithChildren = false,
+  depth = 0,
+  expandedLevels = 0,
+  onExpand,
+  loading = false,
 }: TableCellProps) {
   const { isScrolled, isScrolledRight } = useTable()
   const { actions } = useI18n()
@@ -70,11 +118,18 @@ export function TableCell({
   const colWidth = getColWidth(width)
 
   const linkRef = useRef<HTMLAnchorElement>(null)
+  const firstCellMarginLeft = isFirstCellWithTableChildren(
+    firstCell,
+    tableWithChildren
+  ) && {
+    marginLeft: `${(depth + 1) * 24}px`,
+  }
 
   return (
     <TableCellRoot
       colSpan={colSpan}
       className={cn(
+        "h-full",
         firstCell && "peer font-medium",
         isSticky &&
           isScrolled &&
@@ -110,56 +165,93 @@ export function TableCell({
           />
         )}
       </AnimatePresence>
-      <div
-        className={cn(
-          "[&:has([role=checkbox])]:relative [&:has([role=checkbox])]:z-[1]",
-          "[&:has([type=button])]:relative [&:has([type=button])]:z-[1]",
-          "[&:has(a)]:relative [&:has(a)]:z-[1]",
-          "pointer-events-none"
-        )}
-      >
-        <div
-          className={
-            (cn(width !== "auto" && "overflow-hidden"), "relative z-[1]")
-          }
-          onClick={() => {
-            // Force the link to be clicked even if the element pointer-events: auto
-            linkRef.current?.click()
-            onClick?.()
-          }}
-        >
-          {children}
+      {loading && (
+        <div style={{ ...firstCellMarginLeft }}>
+          <Skeleton className="h-4 w-full" />
         </div>
-      </div>
-      {href && (
-        <Link
-          ref={linkRef}
-          href={href}
-          className="pointer-events-auto absolute inset-0 !z-0 block"
-          tabIndex={firstCell ? undefined : -1}
-        >
-          <span className="sr-only">{actions.view}</span>
-        </Link>
       )}
-      {onClick && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            onClick()
-          }}
-          data-testid="table-cell-action-button"
-          className="table-cell-action-button absolute inset-0 !z-0 block"
-          tabIndex={firstCell ? undefined : -1}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault()
-              onClick()
-            }
-          }}
-        >
-          <span className="sr-only">{actions.view}</span>
-        </button>
+      {!loading && (
+        <>
+          <div
+            className={cn(
+              "[&:has([role=checkbox])]:relative [&:has([role=checkbox])]:z-[1]",
+              "[&:has([type=button])]:relative [&:has([type=button])]:z-[1]",
+              "[&:has(a)]:relative [&:has(a)]:z-[1]",
+              "pointer-events-none h-full items-start"
+            )}
+          >
+            {firstCell && (
+              <TreeConnector
+                firstCell={firstCell}
+                hasChildren={hasChildren}
+                depth={depth}
+                expandedLevels={expandedLevels}
+              />
+            )}
+
+            {isFirstCellWithChildren(firstCell, hasChildren) ? (
+              <NestedCell
+                linkRef={linkRef}
+                hasChildren={hasChildren}
+                firstCell={firstCell}
+                depth={depth}
+                expandedLevels={expandedLevels}
+                tableWithChildren={tableWithChildren}
+                onClick={onClick}
+                onExpand={onExpand}
+              >
+                {children}
+              </NestedCell>
+            ) : (
+              <div
+                className={cn(
+                  width !== "auto" && "overflow-hidden",
+                  "relative z-[1]"
+                )}
+                style={{
+                  ...firstCellMarginLeft,
+                }}
+                onClick={() => {
+                  // Force the link to be clicked even if the element pointer-events: auto
+                  linkRef.current?.click()
+                  onClick?.()
+                }}
+              >
+                {children}
+              </div>
+            )}
+          </div>
+          {href && (
+            <Link
+              ref={linkRef}
+              href={href}
+              className="pointer-events-auto absolute inset-0 !z-0 block"
+              tabIndex={firstCell ? undefined : -1}
+            >
+              <span className="sr-only">{actions.view}</span>
+            </Link>
+          )}
+          {onClick && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onClick()
+              }}
+              data-testid="table-cell-action-button"
+              className="table-cell-action-button absolute inset-0 !z-0 block"
+              tabIndex={firstCell ? undefined : -1}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault()
+                  onClick()
+                }
+              }}
+            >
+              <span className="sr-only">{actions.view}</span>
+            </button>
+          )}
+        </>
       )}
     </TableCellRoot>
   )

--- a/packages/react/src/experimental/OneTable/TableCell/utils/nested.ts
+++ b/packages/react/src/experimental/OneTable/TableCell/utils/nested.ts
@@ -1,0 +1,42 @@
+export const SPACING_FACTOR = 24
+export const CHEVRON_SIZE = 16
+export const LINE_WIDTH = "1px"
+
+export const getNestedMarginLeft = (depth: number, padding: number = 0) => {
+  return `${depth * SPACING_FACTOR + padding}px`
+}
+
+export const isFirstCellWithDepth = (firstCell: boolean, depth: number) => {
+  return firstCell && depth > 0
+}
+
+export const isFirstCellWithChildren = (
+  firstCell: boolean,
+  hasChildren: boolean
+) => {
+  return firstCell && hasChildren
+}
+
+export const isFirstCellExpanded = (
+  expandedLevels: number,
+  firstCell: boolean
+) => {
+  return expandedLevels > 0 && firstCell
+}
+
+export const isFirstCellWithTableChildren = (
+  firstCell: boolean,
+  tableWithChildren: boolean
+) => {
+  return firstCell && tableWithChildren
+}
+
+export const isFirstCellWithNoChildrenAndTableChildren = (
+  firstCell: boolean,
+  hasChildren: boolean,
+  tableWithChildren: boolean
+) => {
+  return (
+    !hasChildren && isFirstCellWithTableChildren(firstCell, tableWithChildren)
+  )
+}

--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -5,6 +5,7 @@ import {
 } from "@/components/OneFilterPicker/types"
 import { DataAdapter } from "./fetch.typings"
 import { GroupingDefinition, GroupingState } from "./grouping.typings"
+import { ChildrenResponse } from "./nested.typings"
 import { RecordType } from "./records.typings"
 import { SearchOptions } from "./search.typings"
 import { SelectedItemsState } from "./selection.typings"
@@ -72,6 +73,16 @@ export type DataSourceDefinition<
   /** Current state of applied grouping */
   currentGrouping?: GroupingState<R, Grouping>
   /*******************************************************/
+
+  /***** NESTED RECORDS ***************************************************/
+  fetchChildren?: (
+    item: R,
+    filters?: FiltersState<FiltersDefinition>
+  ) => Promise<ChildrenResponse<R>>
+  /** Function to determine if an item has children */
+  itemsWithChildren?: (item: R) => boolean
+  /** Function to get the number of children for an item */
+  childrenCount?: (item: R) => number | undefined
 }
 
 /**

--- a/packages/react/src/hooks/datasource/types/nested.typings.ts
+++ b/packages/react/src/hooks/datasource/types/nested.typings.ts
@@ -1,0 +1,9 @@
+import { BaseResponse } from "./fetch.typings"
+import { RecordType } from "./records.typings"
+
+type ChildrenResponseType = "basic" | "detailed"
+
+export type ChildrenResponse<R extends RecordType> =
+  | BaseResponse<R>
+  | R[]
+  | { records: R[] & { type?: ChildrenResponseType } }

--- a/packages/react/src/mocks/index.ts
+++ b/packages/react/src/mocks/index.ts
@@ -220,6 +220,7 @@ export type MockUser = {
     write?: boolean
     delete: boolean
   }
+  children?: MockUser[]
 }
 
 export const generateMockUsers = (count: number): MockUser[] => {


### PR DESCRIPTION
# feat(Table): Enhance row rendering with nested children support

## Overview

This PR introduces comprehensive support for nested/hierarchical data structures in the Table component, enabling users to expand and collapse rows to reveal child items with proper visual feedback and loading states.


https://github.com/user-attachments/assets/0c71e080-139e-4fa6-a9dc-275d935a86d3



## Changes

### Core Features

#### 1. **Nested Row Support**
- Added `NestedRow` component (`NestedRow.tsx`) that handles expandable rows with children
- Implements expand/collapse functionality with proper state management
- Supports recursive nesting with unlimited depth levels
- Tracks expanded children count for proper row height calculations

#### 2. **Loading States**
- New `RowLoading` component that displays skeleton rows while fetching children
- Automatically matches parent row height for smooth transitions
- Shows 3 loading placeholder rows during data fetch

#### 3. **Visual Enhancements**
- **Tree Connectors** (`TreeConnector/index.tsx`): Visual lines connecting parent and child rows
- **Nested Cell** (`NestedCell/index.tsx`): First column gets chevron icon and proper indentation
- Chevron icons (expand/collapse) with hover states
- Proper indentation based on nesting depth (24px per level)

#### DataCollectionSourceDefinition
Added three new optional properties:

```
{
  /** Function to fetch children for an item */
  fetchChildren?: (
    item: R,
    filters?: FiltersState<FiltersDefinition>
  ) => Promise<ChildrenResponse<R>>
  
  /** Function to determine if an item has children */
  itemsWithChildren?: (item: R) => boolean
}
```

### Performance
- Lazy loading: children fetched only when expanded
- Efficient state management to avoid unnecessary re-renders
- Proper height calculations prevent layout shifts

## Example Usage

```
<OneDataCollection
  source={{
    // ... other config
    itemsWithChildren: (item) => !!item?.children?.length,
    fetchChildren: async (item) => {
      await new Promise((resolve) => setTimeout(resolve, 1000))
      return item.children ?? []
    },
  }}
/>
```