### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.276.2",
+  "packages/react": "1.276.3",
   "packages/react-native": "0.20.1",
   "packages/core": "1.34.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.276.3](https://github.com/factorialco/f0/compare/f0-react-v1.276.2...f0-react-v1.276.3) (2025-11-21)
+
+
+### Bug Fixes
+
+* typing issue for multiple employee filters ([#3006](https://github.com/factorialco/f0/issues/3006)) ([77aca10](https://github.com/factorialco/f0/commit/77aca10c5ba67b3bfed44362d0c73650af88bcfb))
+
 ## [1.276.2](https://github.com/factorialco/f0/compare/f0-react-v1.276.1...f0-react-v1.276.2) (2025-11-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.276.2",
+  "version": "1.276.3",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.276.3</summary>

## [1.276.3](https://github.com/factorialco/f0/compare/f0-react-v1.276.2...f0-react-v1.276.3) (2025-11-21)


### Bug Fixes

* typing issue for multiple employee filters ([#3006](https://github.com/factorialco/f0/issues/3006)) ([77aca10](https://github.com/factorialco/f0/commit/77aca10c5ba67b3bfed44362d0c73650af88bcfb))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).