### PR TITLE
fix: button when label is undefined

### DIFF
--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -4,7 +4,7 @@ import { useTextFormatEnforcer } from "@/lib/text"
 import { cn } from "@/lib/utils"
 import { Action } from "@/ui/Action"
 import { cva } from "cva"
-import { forwardRef, useMemo, useState } from "react"
+import { forwardRef, useState } from "react"
 import { OneEllipsis } from "../OneEllipsis"
 import { ButtonInternalProps } from "./internal-types"
 
@@ -100,9 +100,8 @@ const ButtonInternal = forwardRef<
   const isLoading = forceLoading || loading
   const shouldHideLabel = hideLabel || emoji
 
-  const buttonLabel = useMemo(() => {
-    return (label ?? "").toString()
-  }, [label])
+  const buttonLabel = (label ?? "").toString()
+
   return (
     <Action
       variant={variant}


### PR DESCRIPTION
## Description

Avoid error when label is undefined (it should not be, but there are some legacy cases)


## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
