### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.279.0",
+  "packages/react": "1.279.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.35.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.279.1](https://github.com/factorialco/f0/compare/f0-react-v1.279.0...f0-react-v1.279.1) (2025-11-24)
+
+
+### Bug Fixes
+
+* add support to get selected label from datasource options ([#3019](https://github.com/factorialco/f0/issues/3019)) ([584f67f](https://github.com/factorialco/f0/commit/584f67f7c80dfcf35a7708b3ce9f857b8200ca20))
+
 ## [1.279.0](https://github.com/factorialco/f0/compare/f0-react-v1.278.0...f0-react-v1.279.0) (2025-11-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.279.0",
+  "version": "1.279.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.279.1</summary>

## [1.279.1](https://github.com/factorialco/f0/compare/f0-react-v1.279.0...f0-react-v1.279.1) (2025-11-24)


### Bug Fixes

* add support to get selected label from datasource options ([#3019](https://github.com/factorialco/f0/issues/3019)) ([584f67f](https://github.com/factorialco/f0/commit/584f67f7c80dfcf35a7708b3ce9f857b8200ca20))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).