### PR TITLE
feat(Table): implement detailed nested row support and enhance data f…

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -242,13 +242,16 @@ export const getMockVisualizations = (options?: {
         {
           label: "Name",
           width: 140,
-          render: (item) => ({
-            type: "person",
-            value: {
-              firstName: item.name.split(" ")[0],
-              lastName: item.name.split(" ")[1],
-            },
-          }),
+          render: (item) =>
+            !item.children && item.detailed
+              ? item.name
+              : {
+                  type: "person",
+                  value: {
+                    firstName: item.name.split(" ")[0],
+                    lastName: item.name.split(" ")[1],
+                  },
+                },
           id: "name",
           sorting: options?.table?.noSorting ? undefined : "name",
           hidden: options?.table?.allowColumnHiding ? true : undefined,
@@ -884,7 +887,31 @@ export const createPromiseDataFetch = (
             ...user,
             children:
               index % 2 === 0 && nestedRecords
-                ? [{ ...user }, { ...user }]
+                ? [
+                    {
+                      ...user,
+                      children: [
+                        { ...user },
+                        {
+                          ...user,
+                          detailed: index === 0,
+                          children: [
+                            { ...user, detailed: index === 0 },
+                            { ...user, detailed: index === 0 },
+                          ],
+                        },
+                        { ...user },
+                      ],
+                    },
+                    {
+                      ...user,
+                      detailed: index === 0,
+                      children: [
+                        { ...user, detailed: index === 0 },
+                        { ...user, detailed: index === 0 },
+                      ],
+                    },
+                  ]
                 : undefined,
           })),
           summaries: summaries as unknown as (typeof mockUsers)[number],
@@ -1104,7 +1131,13 @@ export const ExampleComponent = ({
       childrenCount: (item) => item?.children?.length,
       fetchChildren: async (item) => {
         await new Promise((resolve) => setTimeout(resolve, 1000))
-        return item.children ?? []
+
+        return item.children
+          ? {
+              records: item.children,
+              type: item.detailed ? "detailed" : "basic",
+            }
+          : []
       },
       lanes: [
         { id: "eng", filters: { department: ["Engineering"] } },

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -13,7 +13,7 @@ import {
 import { useLoadChildren } from "../hooks/useLoadChildren"
 import { TableColumnDefinition } from "../types"
 import { Row } from "./Row"
-import { RowLoading } from "./RowLoading"
+import { DEFAULT_LOADING_ROWS_COUNT, RowLoading } from "./RowLoading"
 
 export type RowProps<
   R extends RecordType,
@@ -85,11 +85,13 @@ const NestedRowComponentInner = <
   const [open, setOpen] = useState(false)
   const rowRef = useRef<HTMLTableRowElement>(null)
 
-  const { children, loadChildren, isLoading } = useLoadChildren({
+  const { children, loadChildren, isLoading, childrenType } = useLoadChildren({
     item,
     filters: source.currentFilters,
     fetchChildren: source.fetchChildren,
   })
+
+  const typeDetailed = childrenType === "detailed"
 
   const updateCounts = (
     visualDelta: number,
@@ -114,7 +116,8 @@ const NestedRowComponentInner = <
     setOpen(isExpanding)
 
     if (isExpanding) {
-      const loadingRowsCount = 3
+      const loadingRowsCount =
+        source.childrenCount?.(item) || DEFAULT_LOADING_ROWS_COUNT
 
       onChildrenExpand?.(loadingRowsCount, true)
 
@@ -150,6 +153,7 @@ const NestedRowComponentInner = <
         expandedLevels={expandedChildrenCount}
         onExpand={handleExpand}
         ref={rowRef}
+        nestedVariant={childrenType}
       />
 
       {open && isLoading && (
@@ -216,9 +220,10 @@ const NestedRowComponentInner = <
                   frozenColumnsLeft={frozenColumnsLeft}
                   checkColumnWidth={checkColumnWidth}
                   tableWithChildren={tableWithChildren}
-                  depth={depth + 1}
+                  depth={typeDetailed ? depth : depth + 1}
                   noBorder
                   onExpand={handleExpand}
+                  nestedVariant={childrenType}
                 />
               )
             }

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -15,6 +15,7 @@ import {
   RecordType,
   SortingsDefinition,
 } from "@/hooks/datasource"
+import { NestedVariant } from "@/hooks/datasource/types/nested.typings"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { Checkbox } from "@/ui/checkbox"
@@ -56,6 +57,7 @@ export type RowProps<
   expandedLevels?: number
   onExpand?: () => void
   loading?: boolean
+  nestedVariant?: NestedVariant
 }
 
 const RowComponentInner = <
@@ -84,6 +86,7 @@ const RowComponentInner = <
     expandedLevels = 0,
     onExpand,
     loading = false,
+    nestedVariant = "basic",
   }: RowProps<
     R,
     Filters,
@@ -189,6 +192,7 @@ const RowComponentInner = <
           expandedLevels={expandedLevels}
           onExpand={onExpand}
           loading={loading}
+          type={nestedVariant}
         >
           <div
             className={cn(

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
@@ -11,7 +11,7 @@ import {
 import { useLayoutEffect, useRef } from "react"
 import { Row, RowProps } from "../Row"
 
-const DEFAULT_LOADING_ROWS_COUNT = 3
+export const DEFAULT_LOADING_ROWS_COUNT = 3
 
 const SingleLoadingRow = <
   R extends RecordType,

--- a/packages/react/src/experimental/OneTable/TableCell/TreeConnector/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/TreeConnector/index.tsx
@@ -1,3 +1,4 @@
+import { NestedVariant } from "@/hooks/datasource/types/nested.typings"
 import { cn } from "@/lib/utils"
 import {
   CHEVRON_SIZE,
@@ -13,16 +14,25 @@ interface TreeConnectorProps {
   hasChildren: boolean
   depth: number
   expandedLevels: number
+  type?: NestedVariant
 }
 
-export const connectorVariables = (expandedLevels: number) => {
+export const connectorVariables = (
+  expandedLevels: number,
+  type: NestedVariant
+) => {
+  const height =
+    type === "detailed"
+      ? `calc(${expandedLevels + 1} * 100% - ${SPACING_FACTOR + CHEVRON_SIZE / 2}px)`
+      : `calc(${expandedLevels} * 100% - ${SPACING_FACTOR}px)`
+
   return {
     "--line-left": `-${2 * CHEVRON_SIZE}px`,
     "--line-width": LINE_WIDTH,
     "--horizontal-offset": `${CHEVRON_SIZE / 2}px`,
     "--horizontal-height": `${SPACING_FACTOR / 2}px`,
     "--line-top": `-${2 * CHEVRON_SIZE}px`,
-    "--line-height": `calc(${expandedLevels} * 100% - ${SPACING_FACTOR}px)`,
+    "--line-height": height,
   }
 }
 
@@ -51,9 +61,14 @@ export const TreeConnector = ({
   hasChildren,
   depth,
   expandedLevels,
+  type = "basic",
 }: TreeConnectorProps) => {
   const firstCellWithDepth = isFirstCellWithDepth(firstCell, depth)
   const firstCellExpanded = isFirstCellExpanded(expandedLevels, firstCell)
+  const typeBasic = type === "basic"
+  const typeDetailed = type === "detailed"
+
+  const detailedWithChildren = typeDetailed && hasChildren
 
   if (!firstCellExpanded && !firstCellWithDepth && !hasChildren) {
     return null
@@ -64,12 +79,14 @@ export const TreeConnector = ({
       className={cn(
         "absolute inset-0 h-full",
         firstCellExpanded && verticalConnectorStyles,
-        firstCellWithDepth && horizontalConnectorStyles,
+        firstCellWithDepth &&
+          (typeBasic || detailedWithChildren) &&
+          horizontalConnectorStyles,
         firstCellWithDepth && !hasChildren && "after:w-8"
       )}
       style={{
         marginLeft: firstCellWithDepth ? getNestedMarginLeft(depth) : undefined,
-        ...connectorVariables(expandedLevels),
+        ...connectorVariables(expandedLevels, type),
       }}
     />
   )

--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -1,3 +1,4 @@
+import { NestedVariant } from "@/hooks/datasource/types/nested.typings"
 import { Skeleton } from "@/ui/skeleton"
 import { TableCell as TableCellRoot } from "@/ui/table"
 import { AnimatePresence, motion } from "motion/react"
@@ -88,6 +89,12 @@ interface TableCellProps {
    * @default false
    */
   loading?: boolean
+
+  /**
+   * The type of the cell
+   * @default "basic"
+   */
+  type?: NestedVariant
 }
 
 export function TableCell({
@@ -105,6 +112,7 @@ export function TableCell({
   expandedLevels = 0,
   onExpand,
   loading = false,
+  type = "basic",
 }: TableCellProps) {
   const { isScrolled, isScrolledRight } = useTable()
   const { actions } = useI18n()
@@ -186,6 +194,7 @@ export function TableCell({
                 hasChildren={hasChildren}
                 depth={depth}
                 expandedLevels={expandedLevels}
+                type={type}
               />
             )}
 

--- a/packages/react/src/hooks/datasource/types/nested.typings.ts
+++ b/packages/react/src/hooks/datasource/types/nested.typings.ts
@@ -1,9 +1,13 @@
 import { BaseResponse } from "./fetch.typings"
 import { RecordType } from "./records.typings"
 
-type ChildrenResponseType = "basic" | "detailed"
+export type NestedVariant = "basic" | "detailed"
+export type NestedResponseWithType<R extends RecordType> = {
+  records: R[]
+  type?: NestedVariant
+}
 
 export type ChildrenResponse<R extends RecordType> =
   | BaseResponse<R>
   | R[]
-  | { records: R[] & { type?: ChildrenResponseType } }
+  | NestedResponseWithType<R>

--- a/packages/react/src/mocks/index.ts
+++ b/packages/react/src/mocks/index.ts
@@ -221,6 +221,7 @@ export type MockUser = {
     delete: boolean
   }
   children?: MockUser[]
+  detailed?: boolean
 }
 
 export const generateMockUsers = (count: number): MockUser[] => {


### PR DESCRIPTION
## Implement Detailed Nested Row Support and Enhance Data Fetching Logic

### Summary

This PR introduces support for "detailed" nested rows in tables, which allows rows to expand and display their children in a flat structure at the same nesting level, rather than increasing the depth.

### Key Changes

#### 1. **New Nested Variant Type System**
- Added `NestedVariant` type (`"basic" | "detailed"`) to define how nested rows behave
- Updated `NestedResponseWithType<R>` interface to support typed responses from `fetchChildren`
- Modified `ChildrenResponse` type to properly handle the new response structure

#### 2. **Tree Connector Visual Improvements**
- Updated `connectorVariables` to calculate proper heights for detailed rows
- Modified connector rendering logic to handle detailed rows with children differently
- Fixed horizontal connector display for detailed nested items

#### 3. **Row Component Updates**
- Added `nestedVariant` prop throughout the row hierarchy (`Row`, `NestedRow`, `TableCell`)
- Conditional depth incrementation: detailed rows maintain parent depth level
- Proper propagation of nested variant through the component tree

#### 4. **Loading State Enhancements**
- Exported `DEFAULT_LOADING_ROWS_COUNT` constant for reusability
- Updated loading row count to use `source.childrenCount?.()` when available

#### 5. **Type Definitions**
- Added `detailed?: boolean` property to `MockUser` type for testing purposes

### Technical Details

**Detailed vs Basic Nesting:**
- **Basic**: Each level increases depth → visual indentation increases
- **Detailed**: Children render at same depth → flat expansion for detail views

https://github.com/user-attachments/assets/881b2903-5346-47b2-a7af-3b35dca71c5e

