### PR TITLE
feat: add support for ONE package in workflows and configuration

### DIFF
--- a/.github/workflows/_check-workspaces-changes.yaml
+++ b/.github/workflows/_check-workspaces-changes.yaml
@@ -2,6 +2,9 @@ name: "Check workspaces changes"
 on:
   workflow_call:
     outputs:
+      package_one:
+        description: "Changes in the one package"
+        value: ${{ jobs.changes.outputs.package_one }}
       package_react:
         description: "Changes in the react package"
         value: ${{ jobs.changes.outputs.package_react }}
@@ -18,6 +21,7 @@ jobs:
     name: Check for workspaces with changes
     runs-on: ubuntu-latest
     outputs:
+      package_one: ${{ steps.changes.outputs.package_one }}
       package_react: ${{ steps.changes.outputs.package_react }}
       package_react_native: ${{ steps.changes.outputs.package_react_native }}
       package_core: ${{ steps.changes.outputs.package_core }}
@@ -28,10 +32,14 @@ jobs:
         with:
           token: ${{ github.token }}
           filters: |
+            package_one: 
+              - "packages/one/**"
+              - "packages/core/**"
+              - "packages/react/**"
             package_react: 
-              - 'packages/react/**'
-              - 'packages/core/**'
+              - "packages/react/**"
+              - "packages/core/**"
             package_react_native: 
-              - 'packages/react-native/**'
+              - "packages/react-native/**"
             package_core: 
-              - 'packages/core/**'
+              - "packages/core/**"

--- a/.github/workflows/build-and-publish-alpha.yaml
+++ b/.github/workflows/build-and-publish-alpha.yaml
@@ -107,3 +107,37 @@ jobs:
         with:
           branch-name: npm/alpha-pr-${{ github.event.pull_request.number }}-core
           directory: packages/core
+
+  publish-alpha-one:
+    name: "[🔷 ONE] Build and Publish ALPHA"
+    needs: detect-changes
+    if: |
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.comment.body == 'build') ||
+      (github.event_name == 'pull_request' && 
+      needs.detect-changes.outputs.package_one == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/setup-node-pnpm
+        name: Setup Node and pnpm
+
+      - name: Build
+        run: |
+          pnpm --filter @factorialco/f0-core build
+          pnpm --filter @factorialco/f0-react build
+          pnpm --filter @factorialco/one build
+
+      - name: Publish to release branch npm/alpha-pr-${{ github.event.pull_request.number }}-one
+        uses: ./.github/actions/publish-release-branch
+        with:
+          branch-name: npm/alpha-pr-${{ github.event.pull_request.number }}-one
+          directory: packages/one

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -219,3 +219,77 @@ jobs:
           curl -X POST -H "Content-Type: application/json" \
               --data @/tmp/payload.json \
               "${{ secrets.SLACK_WEBHOOK_ZERO_UPDATER }}"
+
+  publish-one:
+    name: "[🔷 ONE] Publish to npm"
+    # Prevents running on the release-please branch
+    # For workflow_run trigger we need to check if the workflow_run was successful and if the new_version output was set to not run on it if no new version was released
+    if: |
+      contains(github.event.release.tag_name, 'one-v') &&
+      github.head_ref != 'release-please--branches--master' && !contains(github.event.pull_request.labels.*.name, 'autorelease') && 
+      github.event_name == 'workflow_dispatch' || github.event_name == 'release' || 
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.outputs.new_version)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag || github.sha }} # Checkout the tagged release
+      - uses: ./.github/actions/setup-node-pnpm
+        name: Setup Node and pnpm
+      - name: Build dependencies
+        run: |
+          pnpm --filter @factorialco/f0-core build
+          pnpm --filter @factorialco/f0-react build
+      - uses: ./.github/actions/publish-to-npmjs
+        id: publish
+        with:
+          workspace: "@factorialco/one"
+          registry_token: ${{ secrets.NPMJS_TOKEN }}
+      - name: Notify Slack
+        if: ${{ steps.publish.outputs.published == 'true' }}
+        env:
+          RELEASE_BODY_RAW: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          PACKAGE: "@factorialco/one"
+          NPM_URL: "https://www.npmjs.com/package/@factorialco/one?activeTab=versions"
+        run: |
+          # 1️⃣  Convert GitHub-style markdown ➜ Slack mrkdwn
+          RELEASE_BODY=$(echo "$RELEASE_BODY_RAW" | perl -pe '
+            s/^### (.+)$/*\1*/;           # h3 ➜ bold
+            s/^## (.+)$/*\1*/;            # h2 ➜ bold
+            s/^(\s*[-*])\s+/• /;          # bullets
+            s/\[([^\]]+)\]\(([^)]+)\)/<\2|\1>/g;  # links
+          ')
+
+          # 2️⃣  JSON-escape the body (newline-preserving)
+          BODY_JSON=$(printf "%s" "$RELEASE_BODY" | jq -Rs .)
+
+          # 3️⃣  Build Block-Kit payload with jq
+          jq -n --arg body "$RELEASE_BODY" \
+                --arg rel_url "$RELEASE_URL" \
+                --arg rel_name "$RELEASE_NAME" \
+                --arg npm "$NPM_URL" \
+                --arg pkg "$PACKAGE" '
+          {
+            blocks: [
+              { type: "header",
+                text: { type: "plain_text", text: "🔷 New version \($rel_name) released" } },
+              { type: "section",
+                text: { type: "mrkdwn", text: $body } },
+              { type: "context",
+                elements: [
+                  { type: "mrkdwn", text: "<\($npm)|npm package>" },
+                  { type: "mrkdwn", text: "<\($rel_url)|GitHub release>" }
+                ] }
+            ]
+          }' > /tmp/payload.json
+
+          # 4️⃣  Send
+          curl -X POST -H "Content-Type: application/json" \
+              --data @/tmp/payload.json \
+              "${{ secrets.SLACK_WEBHOOK_ZERO_UPDATER }}"

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -69,3 +69,44 @@ jobs:
         run: pnpm --filter @factorialco/f0-react-native run lint
       - name: Check typescript
         run: pnpm --filter @factorialco/f0-react-native exec tsc --noEmit
+  prettier-one:
+    needs: detect-changes
+    # Prevents running on the release-please branch
+    if: |
+      needs.detect-changes.outputs.package_one == 'true' &&
+      github.head_ref != 'release-please--branches--master' &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease')
+    name: "[🔷 ONE] Prettier"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Check formatting with Prettier
+        run: pnpm --filter @factorialco/one run prettier:check:ci
+  eslint-one:
+    needs: detect-changes
+    # Prevents running on the release-please branch
+    if: |
+      needs.detect-changes.outputs.package_one == 'true' &&
+      github.head_ref != 'release-please--branches--master' &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease')
+    name: "[🔷 ONE] Eslint"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: "22.x"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build core package
+        run: pnpm --filter @factorialco/f0-core build
+      - name: Build react package
+        run: pnpm --filter @factorialco/f0-react build
+      - name: Check linting with eslint
+        run: pnpm --filter @factorialco/one run lint
+      - name: Check typescript
+        run: pnpm --filter @factorialco/one exec tsc --noEmit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,3 +76,47 @@ jobs:
         run: pnpm --filter @factorialco/f0-core build
       - name: Run tests
         run: pnpm --filter @factorialco/f0-react-native run test
+
+  # ------------------------------------------------------------------------------
+
+  test-one:
+    needs: detect-changes
+    name: "[🔷 ONE] Unit Tests"
+    if: |
+      needs.detect-changes.outputs.package_one == 'true' &&
+      github.head_ref != 'release-please--branches--master' &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease')
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to checkout the code
+      contents: read
+      # Required to put a comment into the pull-request
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          ## Set repository to correctly checkout from forks
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: "22.x"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build core package
+        run: pnpm --filter @factorialco/f0-core build
+      - name: Build react package
+        run: pnpm --filter @factorialco/f0-react build
+      - name: Run type checking
+        run: pnpm --filter @factorialco/one run tsc
+      - name: Run tests
+        run: pnpm --filter @factorialco/one run vitest:ci --coverage.enabled true
+      - name: "Report Coverage"
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: packages/one

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,11 @@
       "pull-request-header": "🤖 F0 Core stable release 🚀",
       "pull-request-title-pattern": "chore${scope}: 🤖 Core 🎯 release${component} ${version}",
       "group-pull-request-title-pattern": "chore${scope}: 🤖 Core 🎯 release ${version}"
+    },
+    "packages/one": {
+      "pull-request-header": "🤖 ONE package stable release 🚀",
+      "pull-request-title-pattern": "chore${scope}: 🤖 ONE package release${component} ${version} 🚀",
+      "group-pull-request-title-pattern": "chore${scope}: 🤖 ONE package release ${version} 🚀"
     }
   }
 }


### PR DESCRIPTION
## Description

- Add packages/one to release-please-config.json with its own versioning

- Create GitHub workflow job in .github/workflows/npm-publish.yaml for @factorialco/one

- Configure release tag pattern (e.g., one-v*)

- Set up publish action similar to other packages
