### PR TITLE
feat: expose hideMaxLength prop in experimental Input component

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Input/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Input/index.tsx
@@ -24,6 +24,7 @@ export type InputProps<T extends string> = Pick<
     | "placeholder"
     | "clearable"
     | "maxLength"
+    | "hideMaxLength"
     | "label"
     | "labelIcon"
     | "icon"


### PR DESCRIPTION
## Implementation details

<!-- What have you changed? Why? -->

Adds hideMaxLength to the InputProps type to allow hiding the character counter when maxLength is set. This prop was already supported in the base Input component but not exposed in the experimental wrapper.

