### PR TITLE
feat: enhance F0Select component with item caching

### DIFF
--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -625,8 +625,16 @@ export function useSelectable<
         }
       }
     } else {
-      // Use the ref value to avoid dependency on isAllSelected
-      handleSelectItemChangeInternal(recordIds, isAllSelectedRef.current, true)
+      // Only apply selection state to new records in multi-selection mode
+      // In single selection mode, don't auto-select items when data changes
+      if (isMultiSelection) {
+        // Use the ref value to avoid dependency on isAllSelected
+        handleSelectItemChangeInternal(
+          recordIds,
+          isAllSelectedRef.current,
+          true
+        )
+      }
     }
 
     // Also update items that have checked=true but item=undefined


### PR DESCRIPTION
## Description

Fix F0Select component issues with item caching and selection handling.

### Changes

- **Item Caching**: Added cache to preserve selected items that are not in the current data (e.g., when paginating or searching)
- **Selection Fix**: Fixed auto-selection bug in single-select mode - new data no longer triggers unwanted selections
- **Search UX**: Search field now stays populated in multi-select mode while selecting items
- **Cleanup**: Clear cache when clearing all selections

### Why

Selected items were disappearing when not present in current paginated data, and single-select mode was auto-selecting items on data changes.


<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
