### PR TITLE
fix: return search from useDataCollectionData

### DIFF
--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -84,6 +84,8 @@ export type WithGroupId<RecordType> = RecordType & {
  */
 export interface UseDataReturn<R extends RecordType> {
   data: Data<R>
+  search: string | undefined
+  setSearch: (search: string | undefined) => void
   isInitialLoading: boolean
   isLoading: boolean
   isLoadingMore: boolean
@@ -245,6 +247,7 @@ export function useData<
     currentSortings,
     search,
     currentSearch,
+    setCurrentSearch,
     isLoading,
     setIsLoading,
     currentGrouping,
@@ -767,6 +770,8 @@ export function useData<
 
   return {
     data,
+    search: currentSearch,
+    setSearch: setCurrentSearch,
     isInitialLoading,
     isLoading,
     isLoadingMore,


### PR DESCRIPTION
## Description

We need to have this search from `useDataCollectionData` for the calendar view in Factorial so that we perform it on the backend and not client-wise.

## Screenshots

We have a OneFilterPicker in the calendar but the search input doesn't come from F0 and it is not inside any data collection and we need to be able to set the `useDataCollectionData` search value.

<img width="1244" height="649" alt="Screenshot 2025-12-04 at 17 20 26" src="https://github.com/user-attachments/assets/8991eea2-ebbf-4fba-b8a2-1f1f04a0c545" />

