### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.302.0",
+  "packages/react": "1.302.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.42.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.302.1](https://github.com/factorialco/f0/compare/f0-react-v1.302.0...f0-react-v1.302.1) (2025-12-04)
+
+
+### Bug Fixes
+
+* improve empty state layout in SelectContent component ([#3092](https://github.com/factorialco/f0/issues/3092)) ([ff1f8f9](https://github.com/factorialco/f0/commit/ff1f8f94e3cadad7728f5871f28b98986057aebe))
+
 ## [1.302.0](https://github.com/factorialco/f0/compare/f0-react-v1.301.0...f0-react-v1.302.0) (2025-12-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.302.0",
+  "version": "1.302.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.302.1</summary>

## [1.302.1](https://github.com/factorialco/f0/compare/f0-react-v1.302.0...f0-react-v1.302.1) (2025-12-04)


### Bug Fixes

* improve empty state layout in SelectContent component ([#3092](https://github.com/factorialco/f0/issues/3092)) ([ff1f8f9](https://github.com/factorialco/f0/commit/ff1f8f94e3cadad7728f5871f28b98986057aebe))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).