### PR TITLE
fix: align elements inside button

### DIFF
--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -114,7 +114,7 @@ const ButtonInternal = forwardRef<
         <div
           className={cn(
             isLoading && "invisible",
-            "flex min-w-0 flex-1 items-center gap-1",
+            "flex min-w-0 flex-1 items-center justify-center gap-1",
             icon && !hideLabel && "-ml-[3px]"
           )}
         >


### PR DESCRIPTION
## Description

Recently we found that the text rendered inside the calendar component was not centered, this is due to a missing `justify-center` in the internal button. 

### Before:
<img width="387" height="62" alt="not aligned" src="https://github.com/user-attachments/assets/d42a4944-cce3-454f-b9ed-d96bb2b63946" />

### Now:
<img width="295" height="46" alt="aligned" src="https://github.com/user-attachments/assets/852f1a1c-5ee1-4a6d-93b8-d2430e706b69" />

I just added a `justify-center` attribute so the labels inside the internal button are centered.
