### PR TITLE
fix: add missing moduleIcon

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarModule/modules.ts
+++ b/packages/react/src/components/avatars/F0AvatarModule/modules.ts
@@ -52,6 +52,7 @@ export const modules = {
   profile: ModuleIcons.Profile,
   project_management: ModuleIcons.Projects,
   reports: ModuleIcons.Reports,
+  salary_advance: ModuleIcons.SalaryAdvance,
   settings: ModuleIcons.Settings,
   personal_settings: ModuleIcons.Settings,
   shift_management: ModuleIcons.Shifts,


### PR DESCRIPTION
## Description

Add `salary_advance` module support to `F0AvatarModule` component.

The `salary_advance` module ID was missing from the module-to-icon mapping, causing a console warning when the Factorial frontend tried to render a ModuleAvatar for this module. The SVG icon and React component already existed in the codebase but weren't connected to the module mapping.

**Error fixed:**
```
ModuleAvatar: The module salary_advance is not supported.
```

## Implementation details

Added the missing module mapping in `packages/react/src/components/avatars/F0AvatarModule/modules.ts`:

```typescript
salary_advance: ModuleIcons.SalaryAdvance,
```

**Files changed:**
- `packages/react/src/components/avatars/F0AvatarModule/modules.ts` - Added `salary_advance` to the modules object

**No new files created** - The icon assets already existed:
- ✅ `packages/core/assets/icons/modules/SalaryAdvance.svg`
- ✅ `packages/react/src/icons/modules/SalaryAdvance.tsx`
- ✅ `packages/react/src/icons/modules/index.ts` (already exported)

The `ModuleId` type is automatically updated since it's derived from `keyof typeof modules`.