### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.303.5",
+  "packages/react": "1.303.6",
   "packages/react-native": "0.20.1",
   "packages/core": "1.42.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.303.6](https://github.com/factorialco/f0/compare/f0-react-v1.303.5...f0-react-v1.303.6) (2025-12-10)
+
+
+### Bug Fixes
+
+* lock CoCreationForm while One is applying changes ([#3106](https://github.com/factorialco/f0/issues/3106)) ([ce30714](https://github.com/factorialco/f0/commit/ce30714ad1af5bb60ff288938281dab2a856bf61))
+
 ## [1.303.5](https://github.com/factorialco/f0/compare/f0-react-v1.303.4...f0-react-v1.303.5) (2025-12-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.303.5",
+  "version": "1.303.6",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.303.6</summary>

## [1.303.6](https://github.com/factorialco/f0/compare/f0-react-v1.303.5...f0-react-v1.303.6) (2025-12-10)


### Bug Fixes

* lock CoCreationForm while One is applying changes ([#3106](https://github.com/factorialco/f0/issues/3106)) ([ce30714](https://github.com/factorialco/f0/commit/ce30714ad1af5bb60ff288938281dab2a856bf61))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).