### PR TITLE
fix: add support to get isThinking from useAiChat hook

### DIFF
--- a/packages/react/src/experimental/AiChat/OneSwitch.tsx
+++ b/packages/react/src/experimental/AiChat/OneSwitch.tsx
@@ -10,13 +10,13 @@ import * as SwitchPrimitive from "@radix-ui/react-switch"
 import { motion } from "motion/react"
 import { useState } from "react"
 import OneIcon from "./OneIcon"
-import { useAiChat } from "./providers/AiChatStateProvider"
+import { useAiChatInternal } from "./providers/AiChatStateProvider"
 
 export const OneSwitch = ({
   className,
   disabled,
 }: React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>) => {
-  const { enabled, setOpen, open } = useAiChat()
+  const { enabled, setOpen, open } = useAiChatInternal()
   const translations = useI18n()
   const [isHover, setIsHover] = useState(false)
 

--- a/packages/react/src/experimental/AiChat/components/ChatHeader.tsx
+++ b/packages/react/src/experimental/AiChat/components/ChatHeader.tsx
@@ -6,12 +6,12 @@ import { cn } from "@/lib/utils"
 import { useCopilotChatInternal } from "@copilotkit/react-core"
 import { useChatContext, type HeaderProps } from "@copilotkit/react-ui"
 import { motion } from "motion/react"
-import { useAiChat } from "../providers/AiChatStateProvider"
+import { useAiChatInternal } from "../providers/AiChatStateProvider"
 
 export const ChatHeader = (props: HeaderProps) => {
   const { labels } = useChatContext()
   const { messages } = useCopilotChatInternal()
-  const { setOpen, clear } = useAiChat()
+  const { setOpen, clear } = useAiChatInternal()
   const translations = useI18n()
   const hasDefaultTitle = labels.title === "CopilotKit"
   const hasMessages = messages.length > 0

--- a/packages/react/src/experimental/AiChat/components/ChatTextarea.stories.tsx
+++ b/packages/react/src/experimental/AiChat/components/ChatTextarea.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
 import { useEffect, useRef, useState } from "react"
 import { AiChatProvider } from ".."
-import { useAiChat } from "../providers/AiChatStateProvider"
+import { useAiChatInternal } from "../providers/AiChatStateProvider"
 import { ChatTextarea } from "./ChatTextarea"
 
 // Wrapper component to manage state
@@ -10,7 +10,7 @@ const ChatTextareaWrapper = ({ placeholders }: { placeholders?: string[] }) => {
   const [isProcessing, setIsProcessing] = useState(false)
   const abortControllerRef = useRef<AbortController | null>(null)
 
-  const { setPlaceholders } = useAiChat()
+  const { setPlaceholders } = useAiChatInternal()
 
   useEffect(() => {
     if (placeholders) {

--- a/packages/react/src/experimental/AiChat/components/ChatTextarea.tsx
+++ b/packages/react/src/experimental/AiChat/components/ChatTextarea.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils"
 import { type InputProps } from "@copilotkit/react-ui"
 import { AnimatePresence, motion } from "motion/react"
 import { useEffect, useRef, useState } from "react"
-import { useAiChat } from "../providers/AiChatStateProvider"
+import { useAiChatInternal } from "../providers/AiChatStateProvider"
 
 interface TypewriterPlaceholderProps {
   placeholders: string[]
@@ -145,7 +145,7 @@ export const ChatTextarea = ({ inProgress, onSend, onStop }: InputProps) => {
   const formRef = useRef<HTMLFormElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const translation = useI18n()
-  const { placeholders } = useAiChat()
+  const { placeholders } = useAiChatInternal()
 
   const hasDataToSend = inputValue.trim().length > 0
 

--- a/packages/react/src/experimental/AiChat/components/ChatWindow.tsx
+++ b/packages/react/src/experimental/AiChat/components/ChatWindow.tsx
@@ -2,7 +2,7 @@ import { useCopilotChatInternal } from "@copilotkit/react-core"
 import { type WindowProps } from "@copilotkit/react-ui"
 import { AnimatePresence, motion } from "motion/react"
 import { useAutoClear } from "../hooks/useAutoClear"
-import { useAiChat } from "../providers/AiChatStateProvider"
+import { useAiChatInternal } from "../providers/AiChatStateProvider"
 
 export const SidebarWindow = ({ children }: WindowProps) => {
   const {
@@ -10,7 +10,7 @@ export const SidebarWindow = ({ children }: WindowProps) => {
     shouldPlayEntranceAnimation,
     setShouldPlayEntranceAnimation,
     autoClearMinutes,
-  } = useAiChat()
+  } = useAiChatInternal()
   const { reset } = useCopilotChatInternal()
   useAutoClear({
     reset,

--- a/packages/react/src/experimental/AiChat/components/MessagesContainer.tsx
+++ b/packages/react/src/experimental/AiChat/components/MessagesContainer.tsx
@@ -12,7 +12,7 @@ import { AnimatePresence, motion } from "motion/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useEventListener, useResizeObserver } from "usehooks-ts"
 import { isAgentStateMessage } from "../messageTypes"
-import { useAiChat } from "../providers/AiChatStateProvider"
+import { useAiChatInternal } from "../providers/AiChatStateProvider"
 import { FeedbackModal } from "./FeedbackModal"
 import { FeedbackModalProvider, useFeedbackModal } from "./FeedbackProvider"
 import { Thinking } from "./Thinking"
@@ -56,7 +56,7 @@ const Messages = ({
     welcomeScreenSuggestions,
     onThumbsUp,
     onThumbsDown,
-  } = useAiChat()
+  } = useAiChatInternal()
   const initialMessages = useMemo(
     () =>
       makeInitialMessages(

--- a/packages/react/src/experimental/Navigation/ApplicationFrame/index.tsx
+++ b/packages/react/src/experimental/Navigation/ApplicationFrame/index.tsx
@@ -19,7 +19,7 @@ import { breakpoints } from "@factorialco/f0-core"
 import { Fragment, useEffect, useRef } from "react"
 import { useMediaQuery } from "usehooks-ts"
 import { AiChat, AiChatProvider, AiChatProviderProps } from "../../AiChat"
-import { useAiChat } from "../../AiChat/providers/AiChatStateProvider"
+import { useAiChatInternal } from "../../AiChat/providers/AiChatStateProvider"
 import { FrameProvider, SidebarState, useSidebar } from "./FrameProvider"
 
 export interface ApplicationFrameProps {
@@ -132,7 +132,7 @@ function ApplicationFrameContent({
   const { sidebarState, toggleSidebar, isSmallScreen, setForceFloat } =
     useSidebar()
   const shouldReduceMotion = useReducedMotion()
-  const { open: isAiChatOpen } = useAiChat()
+  const { open: isAiChatOpen } = useAiChatInternal()
   const { open: isAiPromotionChatOpen } = useAiPromotionChat()
   const shouldAutoCloseSidebar = useMediaQuery(
     `(max-width: ${breakpoints.xl}px)`,


### PR DESCRIPTION
## Description

In order to be able to show the ["applying changes" state](https://github.com/factorialco/f0/pull/3106) in the co-creation form in the frontend we need to be able to know when One is thinking, we need to get that exposed in `useAiChat` hook. It could be something useful for other initiatives as well.
