### PR TITLE
fix: prevent deselection in single select mode when not clearable

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -329,6 +329,7 @@ const F0SelectComponent = forwardRef(function Select<
     onSelectItems: onSelectItems,
     selectedState: initialSelectedState,
     disableSelectAll: disableSelectAll,
+    isSearchActive: !!currentSearch,
   })
 
   /**

--- a/packages/react/src/hooks/datasource/useSelectable/typings.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/typings.ts
@@ -53,6 +53,12 @@ export type UseSelectableProps<
    * When true, allSelected will always be false even if all items are checked.
    */
   disableSelectAll?: boolean
+  /**
+   * Indicates if search is currently active.
+   * When true, selecting all visible items won't trigger "all selected" state,
+   * because the visible items are a filtered subset.
+   */
+  isSearchActive?: boolean
 }
 
 export type SelectionMeta<R extends RecordType> = {


### PR DESCRIPTION
## Description

This fix prevents deselection when we have a select with single mode and clearable is not activated, so we force the user to select something

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
