### PR TITLE
fix: dialog position

### DIFF
--- a/packages/react/src/experimental/Overlays/Dialog/index.stories.tsx
+++ b/packages/react/src/experimental/Overlays/Dialog/index.stories.tsx
@@ -35,6 +35,47 @@ const meta = {
     open: true,
   },
   tags: ["autodocs", "experimental"],
+  decorators: [
+    (Story, { args }) => {
+      const [isOpen, setIsOpen] = useState(true)
+
+      return (
+        <div className="flex h-full w-full items-center justify-center">
+          <F0Button
+            variant="critical"
+            icon={Delete}
+            label="Open dialog"
+            onClick={() => setIsOpen(true)}
+          />
+          <Story
+            args={{
+              ...args,
+              open: isOpen,
+              onClose: () => setIsOpen(false),
+              actions: {
+                primary: {
+                  ...args.actions?.primary,
+                  label: args.actions?.primary?.label || "",
+                  onClick: (e) => {
+                    args.actions?.primary?.onClick?.(e)
+                    setIsOpen(false)
+                  },
+                },
+                secondary: {
+                  ...args.actions?.secondary,
+                  label: args.actions?.secondary?.label || "",
+                  onClick: (e) => {
+                    args.actions?.secondary?.onClick?.(e)
+                    setIsOpen(false)
+                  },
+                },
+              },
+            }}
+          />
+        </div>
+      )
+    },
+  ],
 } satisfies Meta<typeof Dialog>
 
 export default meta

--- a/packages/react/src/experimental/Overlays/Dialog/index.tsx
+++ b/packages/react/src/experimental/Overlays/Dialog/index.tsx
@@ -58,10 +58,7 @@ const OneDialog = forwardRef<HTMLDivElement, DialogProps>(
         open={open && !closing}
         onOpenChange={(open) => !open && handleClose?.()}
       >
-        <DialogContent
-          ref={ref}
-          className="bottom-3 top-auto max-w-[400px] translate-y-0 sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%]"
-        >
+        <DialogContent ref={ref} className="bottom-3 top-auto max-w-[400px]">
           <DialogHeader className="flex flex-col gap-4 px-4 py-5">
             <F0AvatarAlert type={header.type} size="lg" />
             <div className="flex flex-col gap-0.5">


### PR DESCRIPTION
## Description

-fix: dialog position after ui dialog refactor

## Screenshots (if applicable)

Before:
<img width="720" height="359" alt="image" src="https://github.com/user-attachments/assets/ad2710da-1aa2-4257-9929-1a002fed0999" />


After:
<img width="1250" height="592" alt="image" src="https://github.com/user-attachments/assets/e1f6b9cd-fc88-4431-aed8-e8df7bde296c" />


## Implementation details

Remove translation in dialog as ui/dialog provides the position