### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.306.3",
+  "packages/react": "1.306.4",
   "packages/react-native": "0.20.1",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.306.4](https://github.com/factorialco/f0/compare/f0-react-v1.306.3...f0-react-v1.306.4) (2025-12-15)
+
+
+### Bug Fixes
+
+* get rid of chattextarea focus issue ([#3136](https://github.com/factorialco/f0/issues/3136)) ([e39aea6](https://github.com/factorialco/f0/commit/e39aea60880835e9a9f26e168e85900748c29d99))
+
 ## [1.306.3](https://github.com/factorialco/f0/compare/f0-react-v1.306.2...f0-react-v1.306.3) (2025-12-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.306.3",
+  "version": "1.306.4",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.306.4</summary>

## [1.306.4](https://github.com/factorialco/f0/compare/f0-react-v1.306.3...f0-react-v1.306.4) (2025-12-15)


### Bug Fixes

* get rid of chattextarea focus issue ([#3136](https://github.com/factorialco/f0/issues/3136)) ([e39aea6](https://github.com/factorialco/f0/commit/e39aea60880835e9a9f26e168e85900748c29d99))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).