### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.308.0",
+  "packages/react": "1.308.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.308.1](https://github.com/factorialco/f0/compare/f0-react-v1.308.0...f0-react-v1.308.1) (2025-12-16)
+
+
+### Bug Fixes
+
+* add support to show video for event community post ([#3142](https://github.com/factorialco/f0/issues/3142)) ([2fb17f3](https://github.com/factorialco/f0/commit/2fb17f38a24dc941b1a9fa6c8c188586e7df0d42))
+
 ## [1.308.0](https://github.com/factorialco/f0/compare/f0-react-v1.307.0...f0-react-v1.308.0) (2025-12-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.308.0",
+  "version": "1.308.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.308.1</summary>

## [1.308.1](https://github.com/factorialco/f0/compare/f0-react-v1.308.0...f0-react-v1.308.1) (2025-12-16)


### Bug Fixes

* add support to show video for event community post ([#3142](https://github.com/factorialco/f0/issues/3142)) ([2fb17f3](https://github.com/factorialco/f0/commit/2fb17f38a24dc941b1a9fa6c8c188586e7df0d42))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).