### PR TITLE
fix: resolve useSelectable issues

### DIFF
--- a/packages/react/src/components/F0Select/components/ItemsCounter.tsx
+++ b/packages/react/src/components/F0Select/components/ItemsCounter.tsx
@@ -1,7 +1,5 @@
 import { F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Icon } from "@/components/F0Icon"
-import { F0TagRaw } from "@/components/tags/F0TagRaw"
-import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/ui/hover-card"
 import { ScrollArea, ScrollBar } from "@/ui/scrollarea"
 import { AnimatePresence, motion } from "motion/react"
@@ -26,11 +24,7 @@ const ItemContent = ({ item }: { item: F0SelectItemObject<string> }) => (
 /**
  * Counter component with optional hover card showing remaining items
  */
-export const ItemsCounter = ({
-  count,
-  items,
-  prefix = "+",
-}: ItemsCounterProps) => {
+export const ItemsCounter = ({ count, items }: ItemsCounterProps) => {
   const counter = (
     <AnimatePresence mode="popLayout">
       <motion.div
@@ -40,7 +34,7 @@ export const ItemsCounter = ({
         exit={{ opacity: 0, y: 8, scale: 0.9 }}
         transition={{ type: "spring", duration: 0.3, bounce: 0.2 }}
       >
-        <F0TagRaw text={`${prefix}${count}`} />
+        +{count}
       </motion.div>
     </AnimatePresence>
   )
@@ -76,13 +70,7 @@ export const ItemsCounter = ({
                 key={item.value ?? index}
                 className="flex w-[220px] min-w-0 items-center gap-1.5 px-2 py-1 [&:first-child]:pt-2 [&:last-child]:pb-2"
               >
-                {item.description ? (
-                  <Tooltip label={item.description}>
-                    <ItemContent item={item} />
-                  </Tooltip>
-                ) : (
-                  <ItemContent item={item} />
-                )}
+                <ItemContent item={item} />
               </div>
             ))}
             <ScrollBar

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -48,8 +48,6 @@ export function useSelectable<
 
   /**
    * Get the item by id from the local selected state or the data records
-   * @param id
-   * @returns
    */
   const getItemById = (id: SelectionId) => {
     const item =
@@ -714,20 +712,6 @@ export function useSelectable<
     isGrouped,
     groupsState,
   ])
-
-  // Control the allSelectedCheck state
-  // If all items are selected, we need to set the allSelectedCheck state to true
-  // If there are no selected items, we need to set the allSelectedCheck state to false
-  // If some items are selected, we need to keep the state as is to know if we will need to check the next page items
-  // IMPORTANT: Don't auto-trigger allSelectedCheck during search, because visible items
-  // are a filtered subset and selecting all of them shouldn't mean "select all"
-  useEffect(() => {
-    if (areAllKnownItemsSelected && !isSearchActive) {
-      setAllSelectedCheck(true)
-      // This is auto-detection, not explicit user action
-      // wasExplicitSelectAll remains false
-    }
-  }, [areAllKnownItemsSelected, isSearchActive])
 
   useEffect(() => {
     if (checkedCount === 0) {


### PR DESCRIPTION
## Description

Fix issues in `useSelectable` hook and `ItemsCounter` component by removing unnecessary auto-selection logic and simplifying the counter display.

## Implementation details

**useSelectable hook:**
- Removed automatic `allSelectedCheck` state management that was triggering unexpectedly
- Cleaned up redundant JSDoc comments

**ItemsCounter component:**
- Simplified counter display by removing `F0TagRaw` dependency and using plain text rendering
- Removed unused `prefix` prop (defaulted to "+")
- Removed tooltip wrapper for item descriptions to reduce component complexity
- Cleaned up unnecessary imports