### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.309.0",
+  "packages/react": "1.309.1",
   "packages/react-native": "0.20.1",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.309.1](https://github.com/factorialco/f0/compare/f0-react-v1.309.0...f0-react-v1.309.1) (2025-12-17)
+
+
+### Bug Fixes
+
+* resolve useSelectable issues ([#3147](https://github.com/factorialco/f0/issues/3147)) ([b8da623](https://github.com/factorialco/f0/commit/b8da6233586c50682cc1b7e8a11315a932ec7420))
+
 ## [1.309.0](https://github.com/factorialco/f0/compare/f0-react-v1.308.1...f0-react-v1.309.0) (2025-12-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.309.0",
+  "version": "1.309.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.309.1</summary>

## [1.309.1](https://github.com/factorialco/f0/compare/f0-react-v1.309.0...f0-react-v1.309.1) (2025-12-17)


### Bug Fixes

* resolve useSelectable issues ([#3147](https://github.com/factorialco/f0/issues/3147)) ([b8da623](https://github.com/factorialco/f0/commit/b8da6233586c50682cc1b7e8a11315a932ec7420))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).