### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.309.1",
-  "packages/react-native": "0.20.1",
+  "packages/react": "1.310.0",
+  "packages/react-native": "0.21.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.21.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.20.1...f0-react-native-v0.21.0) (2025-12-17)
+
+
+### Features
+
+* **react-native:** upgrade to Expo SDK 54, React 19, and React Nativ… ([#3132](https://github.com/factorialco/f0/issues/3132)) ([1877d24](https://github.com/factorialco/f0/commit/1877d2457b1ef76eb9b6e855f1e9a7289a7aec32))
+
 ## [0.20.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.20.0...f0-react-native-v0.20.1) (2025-10-09)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "src/index.ts",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.310.0](https://github.com/factorialco/f0/compare/f0-react-v1.309.1...f0-react-v1.310.0) (2025-12-17)
+
+
+### Features
+
+* **react-native:** upgrade to Expo SDK 54, React 19, and React Nativ… ([#3132](https://github.com/factorialco/f0/issues/3132)) ([1877d24](https://github.com/factorialco/f0/commit/1877d2457b1ef76eb9b6e855f1e9a7289a7aec32))
+
 ## [1.309.1](https://github.com/factorialco/f0/compare/f0-react-v1.309.0...f0-react-v1.309.1) (2025-12-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.309.1",
+  "version": "1.310.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.310.0</summary>

## [1.310.0](https://github.com/factorialco/f0/compare/f0-react-v1.309.1...f0-react-v1.310.0) (2025-12-17)


### Features

* **react-native:** upgrade to Expo SDK 54, React 19, and React Nativ… ([#3132](https://github.com/factorialco/f0/issues/3132)) ([1877d24](https://github.com/factorialco/f0/commit/1877d2457b1ef76eb9b6e855f1e9a7289a7aec32))
</details>

<details><summary>f0-react-native: 0.21.0</summary>

## [0.21.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.20.1...f0-react-native-v0.21.0) (2025-12-17)


### Features

* **react-native:** upgrade to Expo SDK 54, React 19, and React Nativ… ([#3132](https://github.com/factorialco/f0/issues/3132)) ([1877d24](https://github.com/factorialco/f0/commit/1877d2457b1ef76eb9b6e855f1e9a7289a7aec32))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).