### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.310.0",
-  "packages/react-native": "0.21.0",
+  "packages/react": "1.311.0",
+  "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.22.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.21.0...f0-react-native-v0.22.0) (2025-12-17)
+
+
+### Features
+
+* add f0bignumber component ([#3144](https://github.com/factorialco/f0/issues/3144)) ([cc289d7](https://github.com/factorialco/f0/commit/cc289d7b187e04af2b8a962cb0385a4ce068fde8))
+
 ## [0.21.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.20.1...f0-react-native-v0.21.0) (2025-12-17)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "src/index.ts",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.311.0](https://github.com/factorialco/f0/compare/f0-react-v1.310.0...f0-react-v1.311.0) (2025-12-17)
+
+
+### Features
+
+* add f0bignumber component ([#3144](https://github.com/factorialco/f0/issues/3144)) ([cc289d7](https://github.com/factorialco/f0/commit/cc289d7b187e04af2b8a962cb0385a4ce068fde8))
+
 ## [1.310.0](https://github.com/factorialco/f0/compare/f0-react-v1.309.1...f0-react-v1.310.0) (2025-12-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.310.0",
+  "version": "1.311.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.311.0</summary>

## [1.311.0](https://github.com/factorialco/f0/compare/f0-react-v1.310.0...f0-react-v1.311.0) (2025-12-17)


### Features

* add f0bignumber component ([#3144](https://github.com/factorialco/f0/issues/3144)) ([cc289d7](https://github.com/factorialco/f0/commit/cc289d7b187e04af2b8a962cb0385a4ce068fde8))
</details>

<details><summary>f0-react-native: 0.22.0</summary>

## [0.22.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.21.0...f0-react-native-v0.22.0) (2025-12-17)


### Features

* add f0bignumber component ([#3144](https://github.com/factorialco/f0/issues/3144)) ([cc289d7](https://github.com/factorialco/f0/commit/cc289d7b187e04af2b8a962cb0385a4ce068fde8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).