### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.311.1",
+  "packages/react": "1.311.2",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.311.2](https://github.com/factorialco/f0/compare/f0-react-v1.311.1...f0-react-v1.311.2) (2025-12-17)
+
+
+### Bug Fixes
+
+* remove isdev from useFormatterEnforcer ([#3155](https://github.com/factorialco/f0/issues/3155)) ([22ec60c](https://github.com/factorialco/f0/commit/22ec60cc3fd74a6630c6afabeff079eac1fbf2f9))
+
 ## [1.311.1](https://github.com/factorialco/f0/compare/f0-react-v1.311.0...f0-react-v1.311.1) (2025-12-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.311.1",
+  "version": "1.311.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.311.2</summary>

## [1.311.2](https://github.com/factorialco/f0/compare/f0-react-v1.311.1...f0-react-v1.311.2) (2025-12-17)


### Bug Fixes

* remove isdev from useFormatterEnforcer ([#3155](https://github.com/factorialco/f0/issues/3155)) ([22ec60c](https://github.com/factorialco/f0/commit/22ec60cc3fd74a6630c6afabeff079eac1fbf2f9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).