### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.311.2",
+  "packages/react": "1.311.3",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.311.3](https://github.com/factorialco/f0/compare/f0-react-v1.311.2...f0-react-v1.311.3) (2025-12-17)
+
+
+### Bug Fixes
+
+* remove selection on filter or grouping change ([#3148](https://github.com/factorialco/f0/issues/3148)) ([5b04d1d](https://github.com/factorialco/f0/commit/5b04d1df94714a1b3b2b793039b29254c3e9b362))
+
 ## [1.311.2](https://github.com/factorialco/f0/compare/f0-react-v1.311.1...f0-react-v1.311.2) (2025-12-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.311.2",
+  "version": "1.311.3",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.311.3</summary>

## [1.311.3](https://github.com/factorialco/f0/compare/f0-react-v1.311.2...f0-react-v1.311.3) (2025-12-17)


### Bug Fixes

* remove selection on filter or grouping change ([#3148](https://github.com/factorialco/f0/issues/3148)) ([5b04d1d](https://github.com/factorialco/f0/commit/5b04d1df94714a1b3b2b793039b29254c3e9b362))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).