### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.311.3",
+  "packages/react": "1.312.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.312.0](https://github.com/factorialco/f0/compare/f0-react-v1.311.3...f0-react-v1.312.0) (2025-12-17)
+
+
+### Features
+
+* sync status value-display ([#3157](https://github.com/factorialco/f0/issues/3157)) ([d16626f](https://github.com/factorialco/f0/commit/d16626ff56aed2ababd1869e7b23e33cff5943aa))
+
 ## [1.311.3](https://github.com/factorialco/f0/compare/f0-react-v1.311.2...f0-react-v1.311.3) (2025-12-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.311.3",
+  "version": "1.312.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.312.0</summary>

## [1.312.0](https://github.com/factorialco/f0/compare/f0-react-v1.311.3...f0-react-v1.312.0) (2025-12-17)


### Features

* sync status value-display ([#3157](https://github.com/factorialco/f0/issues/3157)) ([d16626f](https://github.com/factorialco/f0/commit/d16626ff56aed2ababd1869e7b23e33cff5943aa))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).