### PR TITLE
feat: add useBubbleMenu prop to NotesTextEditor

### DIFF
--- a/packages/react/src/experimental/RichText/NotesTextEditor/index.tsx
+++ b/packages/react/src/experimental/RichText/NotesTextEditor/index.tsx
@@ -1,6 +1,10 @@
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Icon } from "@/components/F0Icon"
-import { Toolbar, ToolbarLabels } from "@/experimental/RichText/CoreEditor"
+import {
+  EditorBubbleMenu,
+  Toolbar,
+  ToolbarLabels,
+} from "@/experimental/RichText/CoreEditor"
 import { SlashCommandGroupLabels } from "@/experimental/RichText/CoreEditor/Extensions/SlashCommand"
 import { Handle, Plus } from "@/icons/app"
 import { ScrollArea } from "@/ui/scrollarea"
@@ -52,6 +56,7 @@ interface NotesTextEditorProps {
   secondaryActions?: secondaryActionsType[]
   metadata?: MetadataItemValue[]
   withPadding?: boolean
+  showBubbleMenu?: boolean
 }
 
 const NotesTextEditorComponent = forwardRef<
@@ -69,7 +74,8 @@ const NotesTextEditorComponent = forwardRef<
     actions,
     secondaryActions,
     metadata,
-    withPadding: _withPadding = false,
+    withPadding = true,
+    showBubbleMenu = false,
   },
   ref
 ) {
@@ -81,7 +87,6 @@ const NotesTextEditorComponent = forwardRef<
     liveCompanionLabels,
     transcriptLabels,
   } = labels
-
   const containerRef = useRef<HTMLDivElement>(null)
   const hoveredRef = useRef<{ pos: number; nodeSize: number } | null>(null)
   const editorId = useId()
@@ -244,7 +249,7 @@ const NotesTextEditorComponent = forwardRef<
           secondaryActions={secondaryActions}
         />
       )}
-      {!readonly && (
+      {!readonly && !showBubbleMenu && (
         <div className="absolute bottom-8 left-1/2 z-50 max-w-[calc(100%-48px)] -translate-x-1/2 rounded-lg bg-f1-background p-2 shadow-md">
           <Toolbar
             labels={toolbarLabels}
@@ -257,7 +262,9 @@ const NotesTextEditorComponent = forwardRef<
       )}
       <ScrollArea className="h-full gap-6">
         {showTitle && (
-          <div className="mx-auto flex w-full max-w-[824px] flex-col px-14 pb-4 pt-5 transition-all duration-300">
+          <div
+            className={`mx-auto flex w-full max-w-[824px] flex-col pb-4 pt-5 transition-all duration-300 ${withPadding ? "px-14" : "pl-12"}`}
+          >
             <input
               disabled={!onTitleChange || readonly}
               value={title}
@@ -302,10 +309,21 @@ const NotesTextEditorComponent = forwardRef<
 
           <EditorContent
             editor={editor}
-            className="pb-28 [&>div]:mx-auto [&>div]:w-full [&>div]:max-w-[824px] [&>div]:px-14 [&>div]:transition-[padding] [&>div]:duration-300"
+            className={`pb-28 [&>div]:mx-auto [&>div]:w-full [&>div]:max-w-[824px] [&>div]:transition-[padding] [&>div]:duration-300 ${withPadding ? "[&>div]:px-14" : "[&>div]:pl-12"}`}
           />
         </div>
       </ScrollArea>
+      {!readonly && (
+        <EditorBubbleMenu
+          editorId={editorId}
+          editor={editor}
+          disableButtons={false}
+          toolbarLabels={toolbarLabels}
+          isToolbarOpen={!showBubbleMenu}
+          isFullscreen
+          plainHtmlMode={false}
+        />
+      )}
     </div>
   )
 })


### PR DESCRIPTION
## Description

For the LMS we introduced the NotesTextEditor for blocks type pages. This component includes a <ThumbnailComponent> + <TitleComponent> + <NotesTextEditor>. For editing the styles my original plan was to use the same toolbar sticky that meetings has, but I decided to use EditorBubbleMenu here because the fixed toolbar (position: absolute) doesn't work in nested layouts. Seems that in Meetings, the editor fills the entire screen and scrolls internally, so the toolbar stays visible. In Trainings, the NotesTextEditor is inside Builder which handles the scroll, causing the toolbar to scroll out of view. The bubble menu solves this by floating on text selection and follows a Notion Style which I like it.

## Screenshots (if applicable)

<img width="989" height="824" alt="Screenshot 2025-12-18 at 17 04 05" src="https://github.com/user-attachments/assets/4cf8a70c-8dbb-4878-9b0d-3aaee1eeedfc" />

## Implementation details

- I've added a new prop to decide if we show the Toolbar or the BublbeMenu.
- For any reason, I need to set the fullScreen prop to true in order to not cut the popover visualization