### PR TITLE
chore: adapt new feedback buttons to new design  

### DIFF
--- a/packages/react/src/experimental/AiChat/components/AssistantMessage.tsx
+++ b/packages/react/src/experimental/AiChat/components/AssistantMessage.tsx
@@ -1,4 +1,4 @@
-import { F0Button } from "@/components/F0Button"
+import { F0Icon } from "@/components/F0Icon"
 import {
   ThumbsDown,
   ThumbsDownFilled,
@@ -6,10 +6,10 @@ import {
   ThumbsUpFilled,
 } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
-import { cn } from "@/lib/utils"
+import { Action } from "@/ui/Action"
 import { ButtonCopy } from "@/ui/ButtonCopy"
 import { Markdown, type AssistantMessageProps } from "@copilotkit/react-ui"
-import { useCallback, useRef, useState } from "react"
+import { useState } from "react"
 import { ActionItem } from "../ActionItem"
 import { markdownRenderers as f0MarkdownRenderers } from "../MarkdownRenderers"
 import { useFeedbackModal, UserReaction } from "./FeedbackProvider"
@@ -39,35 +39,13 @@ export const AssistantMessage = ({
   const translations = useI18n()
   const { open: openFeedbackModal } = useFeedbackModal()
   const [reactionValue, setReactionValue] = useState<UserReaction | null>(null)
-  const [isHovered, setIsHovered] = useState(false)
-  const timeoutRef = useRef<NodeJS.Timeout>()
-
-  const handleMouseEnter = useCallback(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-    }
-
-    if (!isLoading && !isGenerating && !subComponent) {
-      setIsHovered(true)
-    }
-  }, [isGenerating, isLoading, subComponent])
-
-  const handleMouseLeave = useCallback(() => {
-    timeoutRef.current = setTimeout(() => {
-      setIsHovered(false)
-    }, 150)
-  }, [])
 
   if (!isLoading && !isGenerating && isEmptyMessage) {
     return null
   }
 
   return (
-    <div
-      className="relative isolate flex w-full flex-col items-start justify-center"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
+    <div className="relative isolate flex w-full flex-col items-start justify-center gap-1">
       {isLoading && !subComponent && (
         <ActionItem title={translations.ai.thinking} status="executing" />
       )}
@@ -80,69 +58,70 @@ export const AssistantMessage = ({
             />
           </div>
 
-          <div
-            className={cn(
-              // add paddings to make the area bigger and avoid flickering when the mouse is over the actions
-              "invisible absolute left-0 top-full py-1 pr-4 focus-within:visible",
-              isHovered && !isGenerating && "visible"
-            )}
-            onMouseEnter={handleMouseEnter}
-            // no onMouseLeave attached because the div is part of the upper container with the handler attached
-          >
-            <div className="flex gap-1">
-              <div>
-                <ButtonCopy
-                  variant="ghost"
-                  valueToCopy={content}
-                  disabled={isGenerating}
-                  onCopy={(e) => {
-                    e.currentTarget.blur()
-                    onCopy?.(content)
-                  }}
-                />
-              </div>
-
-              <div>
-                <F0Button
-                  variant="ghost"
-                  size="sm"
-                  label={translations.actions.thumbsUp}
-                  icon={reactionValue === "like" ? ThumbsUpFilled : ThumbsUp}
-                  hideLabel
-                  disabled={isGenerating}
-                  onClick={(e) => {
-                    const newValue = reactionValue === "like" ? null : "like"
-                    if (newValue) {
-                      openFeedbackModal(newValue, message)
-                    }
-                    setReactionValue(newValue)
-                    e.currentTarget.blur()
-                  }}
-                />
-              </div>
-              <div>
-                <F0Button
-                  variant="ghost"
-                  size="sm"
-                  label={translations.actions.thumbsDown}
-                  icon={
-                    reactionValue === "dislike" ? ThumbsDownFilled : ThumbsDown
+          {!isGenerating && !isLoading && !!content && (
+            <div className="flex">
+              <ButtonCopy
+                size="md"
+                variant="ghost"
+                valueToCopy={content}
+                disabled={isGenerating}
+                onCopy={(e) => {
+                  e.currentTarget.blur()
+                  onCopy?.(content)
+                }}
+              />
+              <Action
+                onClick={(e) => {
+                  const newValue = reactionValue === "like" ? null : "like"
+                  if (newValue) {
+                    openFeedbackModal(newValue, message)
                   }
-                  hideLabel
-                  disabled={isGenerating}
-                  onClick={(e) => {
-                    const newValue =
-                      reactionValue === "dislike" ? null : "dislike"
-                    if (newValue) {
-                      openFeedbackModal(newValue, message)
+                  setReactionValue(newValue)
+                  e.currentTarget.blur()
+                }}
+                compact={true}
+                mode="only"
+                variant="ghost"
+                aria-label={translations.actions.thumbsUp}
+              >
+                <div className="flex min-w-0 flex-1 items-center justify-center gap-1">
+                  <F0Icon
+                    size="md"
+                    icon={reactionValue === "like" ? ThumbsUpFilled : ThumbsUp}
+                    color="default"
+                  />
+                </div>
+              </Action>
+
+              <Action
+                onClick={(e) => {
+                  const newValue =
+                    reactionValue === "dislike" ? null : "dislike"
+                  if (newValue) {
+                    openFeedbackModal(newValue, message)
+                  }
+                  setReactionValue(newValue)
+                  e.currentTarget.blur()
+                }}
+                compact={true}
+                mode="only"
+                variant="ghost"
+                aria-label={translations.actions.thumbsDown}
+              >
+                <div className="flex min-w-0 flex-1 items-center justify-center gap-1">
+                  <F0Icon
+                    size="md"
+                    icon={
+                      reactionValue === "dislike"
+                        ? ThumbsDownFilled
+                        : ThumbsDown
                     }
-                    setReactionValue(newValue)
-                    e.currentTarget.blur()
-                  }}
-                />
-              </div>
+                    color="default"
+                  />
+                </div>
+              </Action>
             </div>
-          </div>
+          )}
         </>
       )}
       {!!subComponent && <div className="w-full">{subComponent}</div>}


### PR DESCRIPTION
## Description
Now they are always visible

## Screenshots (if applicable)
<img width="375" height="232" alt="Captura de pantalla 2025-12-18 a las 18 52 49" src="https://github.com/user-attachments/assets/fcef9c53-23ba-4545-b506-cc3d046c2230" />

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](https://www.figma.com/design/VTVKWL9OGmnTJDPOmQmVhI/AI-Kit?node-id=3203-8240&t=KqDDzgvQ3wCQ63Wl-0)

## Implementation details

[jira](https://factorialmakers.atlassian.net/browse/FCT-44868)
<!-- What have you changed? Why? -->
