### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.313.0",
+  "packages/react": "1.314.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.314.0](https://github.com/factorialco/f0/compare/f0-react-v1.313.0...f0-react-v1.314.0) (2025-12-20)
+
+
+### Features
+
+* add useBubbleMenu prop to NotesTextEditor ([#3160](https://github.com/factorialco/f0/issues/3160)) ([c034259](https://github.com/factorialco/f0/commit/c0342593d187238ad5faa1a86dbd225155c32f28))
+
 ## [1.313.0](https://github.com/factorialco/f0/compare/f0-react-v1.312.0...f0-react-v1.313.0) (2025-12-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.313.0",
+  "version": "1.314.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.314.0</summary>

## [1.314.0](https://github.com/factorialco/f0/compare/f0-react-v1.313.0...f0-react-v1.314.0) (2025-12-20)


### Features

* add useBubbleMenu prop to NotesTextEditor ([#3160](https://github.com/factorialco/f0/issues/3160)) ([c034259](https://github.com/factorialco/f0/commit/c0342593d187238ad5faa1a86dbd225155c32f28))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).