### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.314.0",
+  "packages/react": "1.315.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.315.0](https://github.com/factorialco/f0/compare/f0-react-v1.314.0...f0-react-v1.315.0) (2025-12-22)
+
+
+### Features
+
+* refactor and document useSelectable ([#3150](https://github.com/factorialco/f0/issues/3150)) ([c4d1aa6](https://github.com/factorialco/f0/commit/c4d1aa6ad4504b9cbe7cd9ec241fff4220f030c8))
+
 ## [1.314.0](https://github.com/factorialco/f0/compare/f0-react-v1.313.0...f0-react-v1.314.0) (2025-12-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.314.0",
+  "version": "1.315.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.315.0</summary>

## [1.315.0](https://github.com/factorialco/f0/compare/f0-react-v1.314.0...f0-react-v1.315.0) (2025-12-22)


### Features

* refactor and document useSelectable ([#3150](https://github.com/factorialco/f0/issues/3150)) ([c4d1aa6](https://github.com/factorialco/f0/commit/c4d1aa6ad4504b9cbe7cd9ec241fff4220f030c8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).