### PR TITLE
feat: useSelectable add pageOnlySelection feature 

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -361,7 +361,7 @@ const F0SelectComponent = forwardRef(function Select<
     selectedState: initialSelectedState,
     disableSelectAll: disableSelectAll,
     isSearchActive: !!currentSearch,
-    pageOnlySelection: false,
+    allPagesSelection: true,
   })
 
   /**

--- a/packages/react/src/experimental/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/experimental/OneDataCollection/OneDatacollection.tsx
@@ -333,6 +333,16 @@ const OneDataCollectionComp = <
 
   const [selectedItemsCount, setSelectedItemsCount] = useState(0)
 
+  /**
+   * All-pages selection state tracking
+   */
+  const [isAllCurrentPageSelected, setIsAllCurrentPageSelected] =
+    useState(false)
+  const [isAllItemsSelected, setIsAllItemsSelected] = useState(false)
+  const [selectAllFunc, setSelectAllFunc] = useState<
+    ((checked: boolean) => void) | undefined
+  >(undefined)
+
   const i18n = useI18n()
 
   const totalItemSummaryFn = useMemo(() => {
@@ -347,9 +357,10 @@ const OneDataCollectionComp = <
 
   const onSelectItemsLocal: OnSelectItemsCallback<R, Filters> = (
     selectedItems,
-    clearSelectedItems
+    clearSelectedItems,
+    handleSelectAll
   ): void => {
-    onSelectItems?.(selectedItems, clearSelectedItems)
+    onSelectItems?.(selectedItems, clearSelectedItems, handleSelectAll)
 
     /**
      * Show action bar
@@ -368,6 +379,22 @@ const OneDataCollectionComp = <
      * Clear selected items function
      */
     setClearSelectedItemsFunc(() => clearSelectedItems)
+
+    /**
+     * Track all-pages selection state
+     */
+    if (handleSelectAll) {
+      setSelectAllFunc(() => handleSelectAll)
+    }
+
+    // Track whether all items on the current page are selected
+    const allOnPage =
+      selectedItems.itemsStatus.length > 0 &&
+      selectedItems.itemsStatus.every((item) => item.checked)
+    setIsAllCurrentPageSelected(allOnPage)
+
+    // Track whether all items across all pages are selected
+    setIsAllItemsSelected(selectedItems.allSelected === true)
 
     /**
      * Bulk actions for the action bar
@@ -775,6 +802,11 @@ const OneDataCollectionComp = <
                   : undefined
               }
               onUnselect={() => clearSelectedItemsFunc?.()}
+              allPagesSelection={!!source.allPagesSelection}
+              isAllCurrentPageSelected={isAllCurrentPageSelected}
+              isAllItemsSelected={isAllItemsSelected}
+              totalItems={totalItems}
+              onSelectAllItems={() => selectAllFunc?.(true)}
             />
           )}
         </>

--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
@@ -886,7 +886,7 @@ export const WithPageOnlySelection: Story = {
     return (
       <ExampleComponent
         selectable={(item) => item.id}
-        pageOnlySelection={true} // Default behavior - selection resets on page change
+        // Page-only selection is the default behavior - selection resets on page change
         dataAdapter={createDataAdapter({
           data: paginatedMockUsers,
           delay: 500,
@@ -914,7 +914,7 @@ export const WithCrossPageSelection: Story = {
     return (
       <ExampleComponent
         selectable={(item) => item.id}
-        pageOnlySelection={false} // Maintain selection across pages
+        allPagesSelection={true} // Maintain selection across pages
         dataAdapter={createDataAdapter({
           data: paginatedMockUsers,
           delay: 500,

--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -1047,7 +1047,7 @@ export const ExampleComponent = ({
   frozenColumns = 0,
   selectable,
   defaultSelectedItems,
-  pageOnlySelection,
+  allPagesSelection,
   bulkActions,
   currentGrouping,
   currentSortings,
@@ -1108,7 +1108,7 @@ export const ExampleComponent = ({
   >
   defaultSelectedItems?: SelectedItemsState<MockUser>
   selectable?: (item: MockUser) => string | number | undefined
-  pageOnlySelection?: boolean
+  allPagesSelection?: boolean
   bulkActions?: BulkActionsDefinition<MockUser, FiltersType>
   onSelectItems?: OnSelectItemsCallback<MockUser, FiltersType>
   onBulkAction?: OnBulkActionCallback<MockUser, FiltersType>
@@ -1234,7 +1234,7 @@ export const ExampleComponent = ({
       ],
       selectable,
       defaultSelectedItems,
-      pageOnlySelection,
+      allPagesSelection,
       bulkActions,
       totalItemSummary,
       search:

--- a/packages/react/src/experimental/OneDataCollection/__stories__/selectable-bulk-actions.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/selectable-bulk-actions.mdx
@@ -98,10 +98,9 @@ const { source, currentSelectable, setCurrentSelectable } = useDataCollection({
 })
 ```
 
-### pageOnlySelection
+### Selection scope (page-only vs all-pages)
 
-By default, the selection state is scoped to the current page only
-(`pageOnlySelection: true`). This means:
+By default, the selection state is scoped to the current page only. This means:
 
 - Selection state resets when navigating between pages
 - `itemsStatus` only includes items from the current page
@@ -109,18 +108,22 @@ By default, the selection state is scoped to the current page only
 - Useful for bulk actions that should only affect the current page
 
 If you need to maintain selection across all pages (like the backend manages the
-selection), you can set `pageOnlySelection: false` in your data source:
+selection), you can set `allPagesSelection: true` in your data source:
 
 ```tsx
 const { source } = useDataCollectionSource({
   ...
   selectable: (item) => item.id,
-  pageOnlySelection: false, // Maintain selection across all pages
+  allPagesSelection: true, // Maintain selection across all pages
   ...
 })
 ```
 
-**With pageOnlySelection (default behavior):**
+When `allPagesSelection` is enabled, the ActionBar will show a "Select all N items"
+link after selecting all items on the current page, following the Gmail-style pattern
+for cross-page selection.
+
+**Page-only selection (default behavior):**
 
 - Navigate to page 1, select 2 items
 - Navigate to page 2 → previous selections are cleared
@@ -132,12 +135,13 @@ const { source } = useDataCollectionSource({
   meta={DataCollectionStories}
 />
 
-**Without pageOnlySelection:**
+**All-pages selection (`allPagesSelection: true`):**
 
 - Navigate to page 1, select 2 items
 - Navigate to page 2 → previous selections are maintained
 - Select 3 items on page 2
 - All 5 items (2 from page 1 + 3 from page 2) are selected
+- When all items on a page are selected, a "Select all N items" banner appears
 - You need to manage the full selection state in your backend
 
 <Canvas

--- a/packages/react/src/experimental/OneDataCollection/components/ActionBar/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/ActionBar/index.tsx
@@ -90,6 +90,33 @@ interface ActionBarProps {
    * The warning message to show in the action bar
    */
   warningMessage?: string
+
+  /**
+   * Whether all-pages selection mode is active.
+   * When true, shows a banner to select all items across pages.
+   */
+  allPagesSelection?: boolean
+
+  /**
+   * Whether all items on the current page are selected.
+   * Used together with allPagesSelection to show the "select all items" banner.
+   */
+  isAllCurrentPageSelected?: boolean
+
+  /**
+   * Whether the user has opted to select ALL items across all pages.
+   */
+  isAllItemsSelected?: boolean
+
+  /**
+   * Total number of items across all pages.
+   */
+  totalItems?: number
+
+  /**
+   * Callback to select all items across all pages.
+   */
+  onSelectAllItems?: () => void
 }
 
 const Alert = ({ message }: { message: string }) => {
@@ -107,14 +134,34 @@ export const ActionBar = ({
   selectedNumber = undefined,
   onUnselect,
   warningMessage,
+  allPagesSelection = false,
+  isAllCurrentPageSelected = false,
+  isAllItemsSelected = false,
+  totalItems,
+  onSelectAllItems,
   ...props
 }: ActionBarProps) => {
-  const i18n = useI18n()
+  const { t, ...i18n } = useI18n()
 
   const selectedText =
     selectedNumber === 1
       ? i18n.status.selected.singular
       : i18n.status.selected.plural
+
+  // Show the "select all across pages" banner when:
+  // - all-pages selection mode is active
+  // - all items on the current page are selected
+  // - but NOT all items across all pages are selected yet
+  const showSelectAllBanner =
+    allPagesSelection &&
+    isAllCurrentPageSelected &&
+    !isAllItemsSelected &&
+    totalItems !== undefined &&
+    totalItems > 0
+
+  // Show "all items selected" confirmation when all items across pages are selected
+  const showAllItemsSelected =
+    allPagesSelection && isAllItemsSelected && totalItems !== undefined
 
   const visibleSecondaryActions = secondaryActions.slice(0, 2)
   const dropdownActions = secondaryActions.slice(2).map((action) => ({
@@ -179,22 +226,40 @@ export const ActionBar = ({
           )}
         >
           {selectedNumber && (
-            <div className="dark flex h-8 w-full items-center justify-between gap-2 px-2 sm:h-auto sm:w-fit sm:justify-start sm:pl-2 sm:pr-0">
-              <span className="font-medium tabular-nums">
-                <NumberFlow
-                  value={selectedNumber}
-                  spinTiming={{
-                    duration: 200,
-                    easing: "cubic-bezier(0.175, 0.885, 0.32, 1.275)",
-                  }}
+            <div className="dark flex h-8 w-full items-center justify-between gap-3 px-2 sm:h-auto sm:w-fit sm:justify-start sm:pl-2 sm:pr-0">
+              {showAllItemsSelected ? (
+                <span className="font-medium tabular-nums">
+                  {t("status.selected.allItemsSelected", {
+                    total: totalItems ?? 0,
+                  })}
+                </span>
+              ) : (
+                <span className="font-medium tabular-nums">
+                  <NumberFlow
+                    value={selectedNumber}
+                    spinTiming={{
+                      duration: 200,
+                      easing: "cubic-bezier(0.175, 0.885, 0.32, 1.275)",
+                    }}
+                  />
+                  <span> {selectedText}</span>
+                </span>
+              )}
+              {showSelectAllBanner && (
+                <F0Button
+                  variant="outline"
+                  size="sm"
+                  label={t("status.selected.selectAllItems", {
+                    total: totalItems ?? 0,
+                  })}
+                  onClick={onSelectAllItems}
                 />
-                <span> {selectedText}</span>
-              </span>
+              )}
               <F0Button
                 variant="outline"
-                size="sm"
                 label={i18n.actions.unselect}
                 onClick={onUnselect}
+                size="sm"
               />
             </div>
           )}
@@ -217,7 +282,6 @@ export const ActionBar = ({
                         const action = getActionByValue(value)
                         ;(action as ActionType)?.onClick?.()
                       }}
-                      size="lg"
                     />
                   ) : (
                     <F0Button
@@ -225,7 +289,6 @@ export const ActionBar = ({
                       icon={singlePrimaryAction.icon}
                       onClick={singlePrimaryAction.onClick}
                       disabled={singlePrimaryAction.disabled}
-                      size="lg"
                     />
                   )}
                 </Fragment>

--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -69,11 +69,15 @@ export type DataSourceDefinition<
   /** Default selected items */
   defaultSelectedItems?: SelectedItemsState<R>
   /**
-   * When true, selection state is scoped to the current page only.
+   * When true, selection spans across all pages (cross-page selection).
+   * - Selection state persists when navigating between pages
+   * - itemStatus includes items from all pages
+   *
+   * When false (default), selection is scoped to the current page only:
    * - Selection state resets when navigating between pages
    * - itemStatus only includes items from the current page
    */
-  pageOnlySelection?: boolean
+  allPagesSelection?: boolean
 
   /***** GROUPING ***************************************************/
   /** Grouping configuration */

--- a/packages/react/src/hooks/datasource/types/selection.typings.ts
+++ b/packages/react/src/hooks/datasource/types/selection.typings.ts
@@ -46,5 +46,6 @@ export type OnSelectItemsCallback<
   selectedItems: SelectedItemsDetailedStatus<R, Filters> & {
     byLane?: Record<string, SelectedItemsDetailedStatus<R, Filters>>
   },
-  clearSelectedItems: () => void
+  clearSelectedItems: () => void,
+  handleSelectAll?: (checked: boolean) => void
 ) => void

--- a/packages/react/src/hooks/datasource/useSelectable/typings.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/typings.ts
@@ -60,11 +60,15 @@ export type UseSelectableProps<
    */
   isSearchActive?: boolean
   /**
-   * When true, selection state is scoped to the current page only.
+   * When true, selection spans across all pages (cross-page selection).
+   * - Selection state persists when navigating between pages
+   * - itemStatus includes items from all pages
+   *
+   * When false (default), selection is scoped to the current page only:
    * - Selection state resets when navigating between pages
    * - itemStatus only includes items from the current page
    */
-  pageOnlySelection?: boolean
+  allPagesSelection?: boolean
 }
 
 export type SelectionMeta<R extends RecordType> = {

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -38,7 +38,7 @@ export function useSelectable<
   onSelectItems,
   disableSelectAll = false,
   isSearchActive = false,
-  pageOnlySelection,
+  allPagesSelection,
 }: UseSelectableProps<R, Filters, Sortings, Grouping>): UseSelectableReturn<
   R,
   Filters
@@ -47,9 +47,13 @@ export function useSelectable<
   const isGrouped = data.type === "grouped"
   const isMultiSelection = selectionMode === "multi"
   const getSelectable = source.selectable
-  // Use pageOnlySelection from props, falling back to source.pageOnlySelection, default true
-  const isPageOnlySelection =
-    pageOnlySelection ?? source.pageOnlySelection ?? true
+  // Use allPagesSelection from props, falling back to source.allPagesSelection, default false
+  // When allPagesSelection is false (default), selection is scoped to the current page only
+  const isPageOnlySelection = !(
+    allPagesSelection ??
+    source.allPagesSelection ??
+    false
+  )
 
   // State & Refs
 
@@ -74,7 +78,7 @@ export function useSelectable<
   const previousSelectionState = useRef<string>("")
   const isAllSelectedRef = useRef(false)
   const justClearedByFilterChange = useRef(false)
-  // Track current page/cursor for pageOnlySelection mode - initialized as undefined
+  // Track current page/cursor for page-only selection mode - initialized as undefined
   const previousPageIdentifierRef = useRef<string | number | null | undefined>(
     undefined
   )
@@ -82,7 +86,7 @@ export function useSelectable<
   // Computed Values
 
   const totalKnownItemsCount = useMemo(() => {
-    // In pageOnlySelection mode, only count items in current page
+    // In page-only selection mode, only count items in current page
     if (isPageOnlySelection) {
       return data.records?.length || 0
     }
@@ -218,7 +222,7 @@ export function useSelectable<
   const { itemsStatus, selectedIds } = useMemo(() => {
     const items = localSelectedState.items || new Map()
 
-    // In pageOnlySelection mode, only include items from current page
+    // In page-only selection mode, only include items from current page
     const currentPageItemIds = isPageOnlySelection
       ? new Set(
           data.records
@@ -230,7 +234,7 @@ export function useSelectable<
     const itemsStatus = Array.from(items.values())
       .filter((itemState) => {
         if (itemState.item === undefined) return false
-        // Filter to only current page items in pageOnlySelection mode
+        // Filter to only current page items in page-only selection mode
         if (isPageOnlySelection && currentPageItemIds) {
           return currentPageItemIds.has(itemState.id)
         }
@@ -241,7 +245,7 @@ export function useSelectable<
     const selectedIds = Array.from(items.entries())
       .filter(([id, itemState]) => {
         if (!itemState.checked) return false
-        // Filter to only current page items in pageOnlySelection mode
+        // Filter to only current page items in page-only selection mode
         if (isPageOnlySelection && currentPageItemIds) {
           return currentPageItemIds.has(id)
         }
@@ -648,7 +652,7 @@ export function useSelectable<
     }
   }, [source.currentFilters, clearSelectedItems, disableSelectAll])
 
-  // Clear selections when page changes in pageOnlySelection mode
+  // Clear selections when page changes in page-only selection mode
   useEffect(() => {
     if (!isPageOnlySelection) return
 
@@ -794,7 +798,8 @@ export function useSelectable<
         filters: source.currentFilters || {},
         selectedCount: selectedItemsCount,
       },
-      clearSelectedItems
+      clearSelectedItems,
+      handleSelectAll
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -66,6 +66,9 @@ export const defaultTranslations = {
       singular: "Selected",
       plural: "Selected",
       all: "All selected",
+      allOnPage: "All items on this page are selected",
+      selectAllItems: "Select all {{total}} items",
+      allItemsSelected: "All {{total}} items selected",
     },
   },
   syncStatus: {


### PR DESCRIPTION
## Description

Add `pageOnlySelection` feature to the `useSelectable` hook and OneDataCollection component to control selection behavior across paginated data. This enhancement allows developers to choose between two selection modes:

- **Page-only selection (default)**: Selection state resets when navigating between pages
- **Cross-page selection**: Selection state persists across all pages

This feature is particularly useful for bulk actions that should operate either on the current page only or across the entire dataset.

## Screenshots (if applicable)

[Link to Figma Design](Figma URL here)

## Implementation details

### What have you changed?

1. **Added `pageOnlySelection` property** to:
   - `DataSourceDefinition` type (`datasource.typings.ts`)
   - `UseSelectableProps` type (`useSelectable/typings.ts`)
   - Propagated through `ExampleComponent` and its props

2. **Enhanced `useSelectable` hook** (`useSelectable.ts`):
   - Added logic to track current page/cursor using `previousPageIdentifierRef`
   - Implemented `useEffect` hook that clears selections when page changes (only when `pageOnlySelection` is enabled)
   - Modified `itemsStatus` and `selectedIds` computations to filter items based on current page when in page-only mode
   - Updated `totalKnownItemsCount` to reflect current page count in page-only mode
   - Adjusted selection logic to respect the page-only constraint

3. **Added comprehensive documentation** (`selectable-bulk-actions.mdx`):
   - Explained both selection modes with clear examples
   - Documented the differences in behavior
   - Added usage examples with code snippets

4. **Created two Storybook stories** (`index.stories.tsx`):
   - `WithPageOnlySelection`: Demonstrates default behavior
   - `WithCrossPageSelection`: Demonstrates cross-page selection with `pageOnlySelection: false`

5. **Updated F0Select component** to use the default `pageOnlySelection: false` for backward compatibility