### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.315.0",
+  "packages/react": "1.316.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.316.0](https://github.com/factorialco/f0/compare/f0-react-v1.315.0...f0-react-v1.316.0) (2025-12-29)
+
+
+### Features
+
+* add label prop and DropdownMenuLabel to dropdown  ([#3171](https://github.com/factorialco/f0/issues/3171)) ([5985b36](https://github.com/factorialco/f0/commit/5985b36d9485a27a8db15d3162c625c0cd2f0377))
+
 ## [1.315.0](https://github.com/factorialco/f0/compare/f0-react-v1.314.0...f0-react-v1.315.0) (2025-12-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.315.0",
+  "version": "1.316.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.316.0</summary>

## [1.316.0](https://github.com/factorialco/f0/compare/f0-react-v1.315.0...f0-react-v1.316.0) (2025-12-29)


### Features

* add label prop and DropdownMenuLabel to dropdown  ([#3171](https://github.com/factorialco/f0/issues/3171)) ([5985b36](https://github.com/factorialco/f0/commit/5985b36d9485a27a8db15d3162c625c0cd2f0377))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).