### PR TITLE
fix: Prevent null/undefined errors in FiltersPresets during initial load

### DIFF
--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -201,45 +201,26 @@ export function useSelectable<
     return { itemsStatus, selectedIds }
   }, [localSelectedState.items])
 
-  const groupsStatus = useMemo(() => {
-    try {
-      return (
-        Object.fromEntries(
-          Array.from(groupsState.values())
-            .filter(({ group }) => group && group.key)
-            .map(({ group, checked }) => [group!.key, !!checked])
-        ) || {}
-      )
-    } catch {
-      return {}
-    }
-  }, [groupsState])
+  const groupsStatus = useMemo(
+    () =>
+      Object.fromEntries(
+        Array.from(groupsState.values()).map(({ group, checked }) => [
+          group.key,
+          !!checked,
+        ])
+      ),
+    [groupsState]
+  )
 
   const selectionStatus = useMemo((): SelectionStatus<R, Filters> => {
-    // Ensure filters is always a valid object, never null or undefined
-    const filters =
-      source.currentFilters != null &&
-      typeof source.currentFilters === "object" &&
-      !Array.isArray(source.currentFilters)
-        ? source.currentFilters
-        : {}
-
-    // Ensure groupsStatus is always a valid object, never null or undefined
-    const safeGroupsStatus =
-      groupsStatus != null &&
-      typeof groupsStatus === "object" &&
-      !Array.isArray(groupsStatus)
-        ? groupsStatus
-        : {}
-
     return {
       allChecked: allSelectedState,
       itemsStatus,
       selectedIds,
       checkedItems: Array.from(checkedItems.values()),
       uncheckedItems: Array.from(uncheckedItems.values()),
-      groupsStatus: safeGroupsStatus,
-      filters,
+      groupsStatus,
+      filters: source.currentFilters || {},
       selectedCount: selectedItemsCount,
       totalKnownItemsCount,
     }
@@ -713,29 +694,13 @@ export function useSelectable<
     }
     previousSelectionState.current = stateKey
 
-    // Ensure filters is always a valid object, never null or undefined
-    const filters =
-      source.currentFilters != null &&
-      typeof source.currentFilters === "object" &&
-      !Array.isArray(source.currentFilters)
-        ? source.currentFilters
-        : {}
-
-    // Ensure groupsStatus is always a valid object, never null or undefined
-    const safeGroupsStatus =
-      groupsStatus != null &&
-      typeof groupsStatus === "object" &&
-      !Array.isArray(groupsStatus)
-        ? groupsStatus
-        : {}
-
     onSelectItems?.(
       {
         allSelected: allSelectedState,
         itemsStatus,
         selectedIds,
-        groupsStatus: safeGroupsStatus,
-        filters,
+        groupsStatus,
+        filters: source.currentFilters || {},
         selectedCount: selectedItemsCount,
       },
       clearSelectedItems


### PR DESCRIPTION
## Description

We have a "Cannot convert undefined or null to object" error in `FiltersPresets` component when filters or preset data haven't loaded yet.

## Changes
- Added `safeValue` memoization to ensure `value` prop is always a valid object
- Added validation for `preset.filter` before using `Object.entries()` and `Object.keys()`
- Filter out presets with invalid filters before rendering
- Added null checks in Counter component to prevent errors when `preset.filter` is invalid

All object operations now validate that values are valid objects before use, defaulting to empty objects when needed.

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
