### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.316.0",
+  "packages/react": "1.316.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.316.1](https://github.com/factorialco/f0/compare/f0-react-v1.316.0...f0-react-v1.316.1) (2025-12-29)
+
+
+### Bug Fixes
+
+* Prevent null/undefined errors in FiltersPresets during initial load ([#3177](https://github.com/factorialco/f0/issues/3177)) ([ca93c03](https://github.com/factorialco/f0/commit/ca93c0307317e227b6497ad80e2d7535d61cb79e))
+
 ## [1.316.0](https://github.com/factorialco/f0/compare/f0-react-v1.315.0...f0-react-v1.316.0) (2025-12-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.316.0",
+  "version": "1.316.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.316.1</summary>

## [1.316.1](https://github.com/factorialco/f0/compare/f0-react-v1.316.0...f0-react-v1.316.1) (2025-12-29)


### Bug Fixes

* Prevent null/undefined errors in FiltersPresets during initial load ([#3177](https://github.com/factorialco/f0/issues/3177)) ([ca93c03](https://github.com/factorialco/f0/commit/ca93c0307317e227b6497ad80e2d7535d61cb79e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).