### PR TITLE
fix: bubble menu editor

### DIFF
--- a/packages/react/src/experimental/RichText/NotesTextEditor/index.tsx
+++ b/packages/react/src/experimental/RichText/NotesTextEditor/index.tsx
@@ -320,7 +320,7 @@ const NotesTextEditorComponent = forwardRef<
           disableButtons={false}
           toolbarLabels={toolbarLabels}
           isToolbarOpen={!showBubbleMenu}
-          isFullscreen
+          isFullscreen={false}
           plainHtmlMode={false}
         />
       )}


### PR DESCRIPTION
## Description

When isFullscreen is true, the BubbleMenu creates a popup that lives in document.body (outside the editor container) and the menu hides before the style command runs. 

## Implementation details

I changed isFullscreen to isFullscreen={false} and the popup stays inside the editor container, so clicking buttons works correctly.
