### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.316.1",
+  "packages/react": "1.316.2",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.316.2](https://github.com/factorialco/f0/compare/f0-react-v1.316.1...f0-react-v1.316.2) (2025-12-30)
+
+
+### Bug Fixes
+
+* bubble menu editor ([#3179](https://github.com/factorialco/f0/issues/3179)) ([a0d80b9](https://github.com/factorialco/f0/commit/a0d80b9af77e1fe51dc967bb907a02550731b490))
+
 ## [1.316.1](https://github.com/factorialco/f0/compare/f0-react-v1.316.0...f0-react-v1.316.1) (2025-12-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.316.1",
+  "version": "1.316.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.316.2</summary>

## [1.316.2](https://github.com/factorialco/f0/compare/f0-react-v1.316.1...f0-react-v1.316.2) (2025-12-30)


### Bug Fixes

* bubble menu editor ([#3179](https://github.com/factorialco/f0/issues/3179)) ([a0d80b9](https://github.com/factorialco/f0/commit/a0d80b9af77e1fe51dc967bb907a02550731b490))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).