### PR TITLE
fix(OneCalendar): use year-start reference date for ISO week parsing

### DIFF
--- a/packages/react/src/experimental/OneCalendar/granularities/week/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/week/index.tsx
@@ -149,7 +149,7 @@ export const weekGranularity: GranularityDefinition = {
       const year = isNaN(Number(yearStr)) ? new Date().getFullYear() : +yearStr
 
       const week = Number(weekStr.replace(/[wW\s]/g, ""))
-      return parse(`${week}`, "I", new Date().setFullYear(year))
+      return parse(`${week}`, "I", new Date(year, 0, 1))
     }
 
     return toWeekGranularityDateRange({


### PR DESCRIPTION
Fix week parsing ambiguity when parsing ISO week strings (e.g., "W3 2024") near year boundaries. The previous implementation used `new Date().setFullYear(year)` which had an issue:

Using today's date (Dec 31, 2025) as base and setting year to 2024 creates Dec 31, 2024 as reference. Since ISO weeks can span calendar year boundaries, Dec 31, 2024 belongs to ISO week 1 of 2025, causing `parse()` to interpret "week 3" as week 3 of 2025 instead of 2024.

The fix uses `new Date(year, 0, 1)` to create an explicit reference date at January 1st of the target year, ensuring consistent and correct week parsing regardless of the current date.

Resources:
- ISO 8601 Week Dates: https://en.wikipedia.org/wiki/ISO_8601#Week_dates
- date-fns parse() docs: https://date-fns.org/docs/parse

Fixes failing tests for week parsing when run on Dec 31, 2025.
