### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.316.3",
+  "packages/react": "1.316.4",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.316.4](https://github.com/factorialco/f0/compare/f0-react-v1.316.3...f0-react-v1.316.4) (2025-12-31)
+
+
+### Bug Fixes
+
+* **OneCalendar:** use year-start reference date for ISO week parsing ([#3184](https://github.com/factorialco/f0/issues/3184)) ([197bd0b](https://github.com/factorialco/f0/commit/197bd0be1c3422fffe1ef70e829f4ed181f4be39))
+
 ## [1.316.3](https://github.com/factorialco/f0/compare/f0-react-v1.316.2...f0-react-v1.316.3) (2025-12-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.316.3",
+  "version": "1.316.4",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.316.4</summary>

## [1.316.4](https://github.com/factorialco/f0/compare/f0-react-v1.316.3...f0-react-v1.316.4) (2025-12-31)


### Bug Fixes

* **OneCalendar:** use year-start reference date for ISO week parsing ([#3184](https://github.com/factorialco/f0/issues/3184)) ([197bd0b](https://github.com/factorialco/f0/commit/197bd0be1c3422fffe1ef70e829f4ed181f4be39))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).