### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.316.4",
+  "packages/react": "1.317.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.317.0](https://github.com/factorialco/f0/compare/f0-react-v1.316.4...f0-react-v1.317.0) (2025-12-31)
+
+
+### Features
+
+* image fit options for card view ([#3168](https://github.com/factorialco/f0/issues/3168)) ([cfca155](https://github.com/factorialco/f0/commit/cfca15551bbe91f1d32ab8dac18eeaeec41f8cad))
+
 ## [1.316.4](https://github.com/factorialco/f0/compare/f0-react-v1.316.3...f0-react-v1.316.4) (2025-12-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.316.4",
+  "version": "1.317.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.317.0</summary>

## [1.317.0](https://github.com/factorialco/f0/compare/f0-react-v1.316.4...f0-react-v1.317.0) (2025-12-31)


### Features

* image fit options for card view ([#3168](https://github.com/factorialco/f0/issues/3168)) ([cfca155](https://github.com/factorialco/f0/commit/cfca15551bbe91f1d32ab8dac18eeaeec41f8cad))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).