### PR TITLE
fix: prevent applying changes tag in co-creation form to disappear when scrolling

### DIFF
--- a/packages/react/src/experimental/CoCreationForm/ApplyingChangesTag/index.tsx
+++ b/packages/react/src/experimental/CoCreationForm/ApplyingChangesTag/index.tsx
@@ -9,7 +9,7 @@ const ApplyingChangesTag = () => {
   const i18n = useI18n()
 
   return (
-    <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-row items-center gap-1 rounded-full border border-solid border-f1-border-secondary bg-f1-background px-2 py-1.5 pr-2.5 shadow-md">
+    <div className="flex flex-row items-center gap-1 rounded-full border border-solid border-f1-border-secondary bg-f1-background px-2 py-1.5 pr-2.5 shadow-md">
       <IconMotion
         size="xs"
         animate={{

--- a/packages/react/src/experimental/CoCreationForm/Form/index.tsx
+++ b/packages/react/src/experimental/CoCreationForm/Form/index.tsx
@@ -183,12 +183,18 @@ export const CoCreationForm = ({
         </motion.div>
         {applyingChanges && (
           <motion.div
-            className="absolute left-0 top-0 h-full w-full"
+            className="fixed z-50 flex h-screen w-full items-center justify-center"
+            style={{
+              inset: 0,
+            }}
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.95 }}
           >
-            <ApplyingChangesTag />
+            {/* Needed offset to compensate the height of the header */}
+            <div className="translate-y-48">
+              <ApplyingChangesTag />
+            </div>
           </motion.div>
         )}
       </div>


### PR DESCRIPTION
## Description

When we scrolled down on the co-creation form while One was applying changes, this tag was getting hidden.
