### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.317.0",
+  "packages/react": "1.317.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.317.1](https://github.com/factorialco/f0/compare/f0-react-v1.317.0...f0-react-v1.317.1) (2026-01-07)
+
+
+### Bug Fixes
+
+* prevent applying changes tag in co-creation form to disappear when scrolling ([#3187](https://github.com/factorialco/f0/issues/3187)) ([1b3397e](https://github.com/factorialco/f0/commit/1b3397e4aca3757a64f5eae54fe1c08fbfe24099))
+
 ## [1.317.0](https://github.com/factorialco/f0/compare/f0-react-v1.316.4...f0-react-v1.317.0) (2025-12-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.317.0",
+  "version": "1.317.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.317.1</summary>

## [1.317.1](https://github.com/factorialco/f0/compare/f0-react-v1.317.0...f0-react-v1.317.1) (2026-01-07)


### Bug Fixes

* prevent applying changes tag in co-creation form to disappear when scrolling ([#3187](https://github.com/factorialco/f0/issues/3187)) ([1b3397e](https://github.com/factorialco/f0/commit/1b3397e4aca3757a64f5eae54fe1c08fbfe24099))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).