### PR TITLE
fix: improve connector height calculation in TreeConnector

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/hooks/useCalculateConectorHeight.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/hooks/useCalculateConectorHeight.ts
@@ -33,7 +33,7 @@ export const useCalculateConectorHeight = (nestedVariant: NestedVariant) => {
   useLayoutEffect(() => {
     const previousRow = firstRow?.previousElementSibling
 
-    if (!firstRow || !lastRow || !previousRow) {
+    if (!firstRow || !lastRow || firstRow === lastRow || !previousRow) {
       setCalculatedHeight(0)
       return
     }

--- a/packages/react/src/experimental/OneTable/TableCell/TreeConnector/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/TreeConnector/index.tsx
@@ -23,7 +23,7 @@ interface TreeConnectorProps {
 }
 
 export const connectorVariables = (
-  height: string,
+  height: number,
   nestedRowProps?: NestedRowProps & {
     rowWithChildren?: boolean
     tableWithChildren?: boolean
@@ -45,14 +45,18 @@ export const connectorVariables = (
         ? CONNECTOR_WIDTH - 6
         : CONNECTOR_WIDTH
 
+  const lineHeight =
+    height !== 0 &&
+    `calc(${height}px - ${CHEVRON_PARENT_SIZE + PADDING_TOP}px )`
+
   return {
     "--line-left": `-${2 * CHEVRON_SIZE}px`,
     "--line-width": LINE_WIDTH,
     "--horizontal-offset": `${horizontalOffset}px`,
     "--horizontal-left": `4px`,
     "--horizontal-height": `${SPACING_FACTOR / 2}px`,
-    "--line-height": `calc(${height} - ${CHEVRON_PARENT_SIZE + PADDING_TOP}px )`,
     "--connector-width": `${connectorWidth}px`,
+    ...(lineHeight ? { "--line-height": lineHeight } : {}),
   }
 }
 
@@ -102,9 +106,7 @@ export const TreeConnector = ({
         padding: 0,
       })
     : undefined
-  const connectorHeight = nestedRowProps?.connectorHeight
-    ? `${nestedRowProps?.connectorHeight}px`
-    : "0px"
+  const connectorHeight = nestedRowProps?.connectorHeight ?? 0
 
   if (
     !firstCellExpanded &&


### PR DESCRIPTION
Fixed a bug where tree connector heights were incorrectly calculated when a parent row had only one child. The logic now properly handles both single and multiple child scenarios, ensuring correct visual rendering of hierarchical relationships in the OneDataCollection table component.


https://github.com/user-attachments/assets/af5fcbfd-8354-44b2-b8cc-d782ad5549a1

