### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.317.2",
+  "packages/react": "1.318.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.318.0](https://github.com/factorialco/f0/compare/f0-react-v1.317.2...f0-react-v1.318.0) (2026-01-07)
+
+
+### Features
+
+* **OneFilterPicker:** add and export FilterPickerContent for always-… ([#3124](https://github.com/factorialco/f0/issues/3124)) ([5d3a446](https://github.com/factorialco/f0/commit/5d3a446e8310411e52436f33beef526786ec7712))
+
 ## [1.317.2](https://github.com/factorialco/f0/compare/f0-react-v1.317.1...f0-react-v1.317.2) (2026-01-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.317.2",
+  "version": "1.318.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.318.0</summary>

## [1.318.0](https://github.com/factorialco/f0/compare/f0-react-v1.317.2...f0-react-v1.318.0) (2026-01-07)


### Features

* **OneFilterPicker:** add and export FilterPickerContent for always-… ([#3124](https://github.com/factorialco/f0/issues/3124)) ([5d3a446](https://github.com/factorialco/f0/commit/5d3a446e8310411e52436f33beef526786ec7712))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).