### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.318.0",
+  "packages/react": "1.318.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.318.1](https://github.com/factorialco/f0/compare/f0-react-v1.318.0...f0-react-v1.318.1) (2026-01-07)
+
+
+### Bug Fixes
+
+* remove unnecessary motion ([#3116](https://github.com/factorialco/f0/issues/3116)) ([b6b18a0](https://github.com/factorialco/f0/commit/b6b18a00cc19117b1e0522ceb9d20adb3d22221d))
+
 ## [1.318.0](https://github.com/factorialco/f0/compare/f0-react-v1.317.2...f0-react-v1.318.0) (2026-01-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.318.0",
+  "version": "1.318.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.318.1</summary>

## [1.318.1](https://github.com/factorialco/f0/compare/f0-react-v1.318.0...f0-react-v1.318.1) (2026-01-07)


### Bug Fixes

* remove unnecessary motion ([#3116](https://github.com/factorialco/f0/issues/3116)) ([b6b18a0](https://github.com/factorialco/f0/commit/b6b18a00cc19117b1e0522ceb9d20adb3d22221d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).