### PR TITLE
feat: show deactivated employees

### DIFF
--- a/packages/react/src/components/value-display/types/person/__stories__/person.mdx
+++ b/packages/react/src/components/value-display/types/person/__stories__/person.mdx
@@ -50,7 +50,7 @@ render: (item) => ({
 **For deactivated person**
 
 <Canvas
-  of={PersonStories.PersonType}
+  of={PersonStories.DeactivatedPersonType}
   source={{
     code: `
 render: (item) => ({

--- a/packages/react/src/components/value-display/types/person/__stories__/person.stories.tsx
+++ b/packages/react/src/components/value-display/types/person/__stories__/person.stories.tsx
@@ -39,6 +39,24 @@ export const PersonType: Story = {
   },
 }
 
+export const DeactivatedPersonType: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Person",
+      render: (item) => ({
+        type: "person",
+        value: {
+          firstName: item.firstName,
+          lastName: item.lastName,
+          src: item.avatar,
+          deactivated: true,
+        },
+      }),
+    },
+  },
+}
+
 export const PersonTypeWithBadge: Story = {
   args: {
     item: mockItem,

--- a/packages/react/src/components/value-display/types/person/person.tsx
+++ b/packages/react/src/components/value-display/types/person/person.tsx
@@ -41,7 +41,13 @@ export const PersonCell = (
         }}
         size="xs"
       />
-      <OneEllipsis className="min-w-0 flex-1 text-f1-foreground" tag="span">
+      <OneEllipsis
+        className={cn(
+          "min-w-0 flex-1",
+          args.deactivated ? "text-f1-foreground/[0.61]" : "text-f1-foreground"
+        )}
+        tag="span"
+      >
         {fullName}
       </OneEllipsis>
     </div>

--- a/packages/react/src/experimental/Forms/EntitySelect/ListItem/index.stories.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/ListItem/index.stories.tsx
@@ -39,6 +39,12 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
+export const DefaultDeactivated: Story = {
+  args: {
+    entity: { ...famousEmployees[0], deactivated: true },
+  },
+}
+
 export const GroupViewSelected: Story = {
   args: {
     entity: teamsWithEmployees[0],

--- a/packages/react/src/experimental/Forms/EntitySelect/ListItem/index.tsx
+++ b/packages/react/src/experimental/Forms/EntitySelect/ListItem/index.tsx
@@ -122,11 +122,17 @@ export const ListItemSingleContent = ({
             firstName={firstName}
             lastName={lastName}
             size="xs"
+            deactivated={entity.deactivated}
           />
         )}
 
         <div className="flex flex-1 flex-col">
-          <div className="flex flex-1 flex-row items-center gap-2 break-all">
+          <div
+            className={cn(
+              "flex flex-1 flex-row items-center gap-2 break-all",
+              entity.deactivated ? "text-f1-foreground/[0.61]" : undefined
+            )}
+          >
             <HighlightText
               text={entity.name}
               search={search}

--- a/packages/react/src/experimental/Forms/EntitySelect/types.ts
+++ b/packages/react/src/experimental/Forms/EntitySelect/types.ts
@@ -15,6 +15,7 @@ export type EntitySelectEntity = {
   avatar?: string
   expanded?: boolean
   searchKeys?: string[]
+  deactivated?: boolean
   subItems?: EntitySelectSubEntity[]
 }
 

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -27,6 +27,7 @@ export type HeaderSecondaryAction = SecondaryAction & {
 }
 interface BaseHeaderProps {
   title: string
+  deactivated?: boolean
   avatar?:
     | {
         type: "generic"
@@ -54,6 +55,7 @@ const isVisible = (action: { isVisible?: boolean }) =>
 export function BaseHeader({
   title,
   avatar,
+  deactivated,
   description,
   primaryAction,
   secondaryActions = [],
@@ -120,7 +122,12 @@ export function BaseHeader({
             </div>
           )}
           <div className="flex flex-col gap-1">
-            <span className="text-2xl font-semibold text-f1-foreground">
+            <span
+              className={cn(
+                "text-2xl font-semibold",
+                deactivated ? "text-f1-foreground/[0.61]" : "text-f1-foreground"
+              )}
+            >
               {title}
             </span>
             {description && <Description description={description} />}

--- a/packages/react/src/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -560,6 +560,7 @@ export const DeactivatedEmployee: Story = {
   args: {
     ...PersonHeader.args,
     title: "John Doe",
+    deactivated: true,
     description: "Software Engineer",
     avatar: {
       type: "person",

--- a/packages/react/src/experimental/Information/Headers/ResourceHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/ResourceHeader/index.tsx
@@ -13,6 +13,7 @@ type Props = {} & Pick<
   | "otherActions"
   | "metadata"
   | "status"
+  | "deactivated"
 >
 
 export const ResourceHeader = ({
@@ -24,6 +25,7 @@ export const ResourceHeader = ({
   otherActions,
   status,
   metadata,
+  deactivated,
 }: Props) => {
   return (
     <BaseHeader
@@ -35,6 +37,7 @@ export const ResourceHeader = ({
       otherActions={otherActions}
       status={status}
       metadata={metadata}
+      deactivated={deactivated}
     />
   )
 }

--- a/packages/react/src/experimental/OneChip/index.mdx
+++ b/packages/react/src/experimental/OneChip/index.mdx
@@ -30,6 +30,13 @@ Chips can optionally display an avatar by setting the `avatar` prop.
 
 <Canvas of={ChipStories.WithAvatar} />
 
+### With deactivated avatar and label
+
+Chips can optionally display a deactivated avatar and label by setting the
+`deactivated` prop.
+
+<Canvas of={ChipStories.WithDeactivatedAvatarAndLabel} />
+
 ### With an icon
 
 Chips can optionally display an icon by setting the `icon` prop.

--- a/packages/react/src/experimental/OneChip/index.stories.tsx
+++ b/packages/react/src/experimental/OneChip/index.stories.tsx
@@ -111,6 +111,26 @@ export const WithAvatar: Story = {
   ),
 }
 
+export const WithDeactivatedAvatarAndLabel: Story = {
+  args: {
+    label: "Deactivated User",
+    variant: "default",
+    deactivated: true,
+    avatar: {
+      type: "person",
+      deactivated: true,
+      firstName: "Deactivated",
+      lastName: "User",
+      src: "/avatars/person01.jpg",
+    },
+  },
+  render: ({ icon: _icon, ...args }) => (
+    <div className="flex flex-wrap gap-2">
+      <Chip {...args} />
+    </div>
+  ),
+}
+
 export const WithIcon: Story = {
   args: {
     label: "Label",

--- a/packages/react/src/experimental/OneChip/index.tsx
+++ b/packages/react/src/experimental/OneChip/index.tsx
@@ -33,6 +33,8 @@ interface BaseChipProps extends VariantProps<typeof chipVariants> {
    * If defined, the close icon will be displayed and the chip will be clickable
    * */
   onClose?: () => void
+
+  deactivated?: boolean
 }
 
 type ChipVariants =
@@ -61,6 +63,7 @@ export type ChipProps = BaseChipProps &
   }
 
 export const Chip = ({
+  deactivated,
   label,
   variant,
   onClick,
@@ -90,7 +93,9 @@ export const Chip = ({
       {avatar && <F0Avatar avatar={avatar} size="xs" />}
       <div className="flex items-center gap-0.5">
         {icon && <F0Icon icon={icon} size="sm" className="text-f1-icon" />}
-        {label}
+        <span className={deactivated ? "text-f1-foreground/[0.61]" : undefined}>
+          {label}
+        </span>
       </div>
       {onClose && (
         <button


### PR DESCRIPTION
## Description
Allow the following components indicate that a user/employee is deactivated by display.
- `PersonCell`
- `ListItem`
- `ResourceHeader`
- `OneChip`

## Screenshots (if applicable)
<img width="1613" height="141" alt="Screenshot 2026-01-08 at 15 41 33" src="https://github.com/user-attachments/assets/aa486582-b2b8-4038-8c3e-ea68553f32ca" />
<img width="1297" height="195" alt="Screenshot 2026-01-08 at 15 35 08" src="https://github.com/user-attachments/assets/3dec056a-e06e-4b76-8743-d28c1cb641ca" />
<img width="1291" height="168" alt="Screenshot 2026-01-08 at 15 34 21" src="https://github.com/user-attachments/assets/f2a328ea-ebcf-4afd-bcca-4016556bad40" />
<img width="1297" height="158" alt="Screenshot 2026-01-08 at 15 38 54" src="https://github.com/user-attachments/assets/f5c573ef-7c72-42ec-8674-50365a753684" />


[Link to Figma Design](https://www.figma.com/design/xANtWNXpZPS0agcSgryKj1/Terminated-employees-27-07-2025?node-id=2121-2768&t=rVq9ds5jbh6BlHYK-0)

## Implementation details
Simply added the deactivated prop where necessary, pass it to the avatar and/or display text at 61% opacity when true.
