### PR TITLE
fix: change syncing icon and do not rotate pending one (syncStatus)

### DIFF
--- a/packages/react/src/components/value-display/types/syncStatus/__stories__/syncStatus.mdx
+++ b/packages/react/src/components/value-display/types/syncStatus/__stories__/syncStatus.mdx
@@ -27,8 +27,8 @@ type value = {
 | Status            | Icon               | Color  | Animated | Default Tooltip                                       |
 | ----------------- | ------------------ | ------ | -------- | ----------------------------------------------------- |
 | `synced`          | CheckCircle        | Green  | No       | Sync completed successfully.                          |
-| `syncing`         | ArrowCycle         | Blue   | Yes      | Sync in progress.                                     |
-| `pending`         | DottedCircle       | Gray   | Yes      | Not yet started.                                      |
+| `syncing`         | Spinner            | Gray   | Yes      | Sync in progress.                                     |
+| `pending`         | DottedCircle       | Gray   | No       | Not yet started.                                      |
 | `partiallySynced` | PartiallyCompleted | Orange | No       | All aggregated data was synced but at least 1 failed. |
 | `outdated`        | Warning            | Orange | No       | Data might need to be synced again.                   |
 | `failed`          | CrossedCircle      | Red    | No       | Sync failed.                                          |

--- a/packages/react/src/components/value-display/types/syncStatus/syncStatus.tsx
+++ b/packages/react/src/components/value-display/types/syncStatus/syncStatus.tsx
@@ -4,7 +4,7 @@
  */
 import { F0Icon, IconType } from "@/components/F0Icon"
 import {
-  ArrowCycle,
+  Spinner,
   CheckCircle,
   CrossedCircle,
   DottedCircle,
@@ -37,14 +37,13 @@ const syncStatusConfig: Record<SyncStatusType, SyncStatusConfig> = {
     colorClass: "text-f1-icon-positive",
   },
   syncing: {
-    icon: ArrowCycle,
-    colorClass: "text-f1-icon-info",
+    icon: Spinner,
+    colorClass: "text-f1-icon-secondary",
     animated: true,
   },
   pending: {
     icon: DottedCircle,
     colorClass: "text-f1-icon-secondary",
-    animated: true,
   },
   partiallySynced: {
     icon: PartiallyCompleted,


### PR DESCRIPTION
## Description

- Changes `syncing` icon
- Makes `pending` one not rotate

Specification:

<img width="866" height="397" alt="image" src="https://github.com/user-attachments/assets/81b33b0c-1efa-4b5d-beca-8f5eb4569313" />
