### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.319.0",
+  "packages/react": "1.319.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.319.1](https://github.com/factorialco/f0/compare/f0-react-v1.319.0...f0-react-v1.319.1) (2026-01-12)
+
+
+### Bug Fixes
+
+* change syncing icon and do not rotate pending one (syncStatus) ([#3205](https://github.com/factorialco/f0/issues/3205)) ([7cc7d61](https://github.com/factorialco/f0/commit/7cc7d61ca9d0331f9beb270ae6a185e387388090))
+
 ## [1.319.0](https://github.com/factorialco/f0/compare/f0-react-v1.318.1...f0-react-v1.319.0) (2026-01-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.319.0",
+  "version": "1.319.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.319.1</summary>

## [1.319.1](https://github.com/factorialco/f0/compare/f0-react-v1.319.0...f0-react-v1.319.1) (2026-01-12)


### Bug Fixes

* change syncing icon and do not rotate pending one (syncStatus) ([#3205](https://github.com/factorialco/f0/issues/3205)) ([7cc7d61](https://github.com/factorialco/f0/commit/7cc7d61ca9d0331f9beb270ae6a185e387388090))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes a patch of `@factorialco/f0-react` with a small UI bug fix.
> 
> - Fix: update syncing icon and stop rotating the pending state in `syncStatus`
> - Bump version to `1.319.1` in `packages/react/package.json` and `.release-please-manifest.json`
> - Add corresponding entry to `packages/react/CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71ee6d56adc7426b11ae47525560f98b57402bbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->