### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.319.1",
+  "packages/react": "1.319.2",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.319.2](https://github.com/factorialco/f0/compare/f0-react-v1.319.1...f0-react-v1.319.2) (2026-01-12)
+
+
+### Bug Fixes
+
+* **F0Dialog:** add disableContentPadding prop and adjust dialog content ([#3214](https://github.com/factorialco/f0/issues/3214)) ([f9f4f07](https://github.com/factorialco/f0/commit/f9f4f075b4fa0d29696acb94644173d3a1269175))
+
 ## [1.319.1](https://github.com/factorialco/f0/compare/f0-react-v1.319.0...f0-react-v1.319.1) (2026-01-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.319.1",
+  "version": "1.319.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.319.2</summary>

## [1.319.2](https://github.com/factorialco/f0/compare/f0-react-v1.319.1...f0-react-v1.319.2) (2026-01-12)


### Bug Fixes

* **F0Dialog:** add disableContentPadding prop and adjust dialog content ([#3214](https://github.com/factorialco/f0/issues/3214)) ([f9f4f07](https://github.com/factorialco/f0/commit/f9f4f075b4fa0d29696acb94644173d3a1269175))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes a patch release of `@factorialco/f0-react` with a small dialog fix.
> 
> - Bumps `@factorialco/f0-react` to `1.319.2` and updates `.release-please-manifest.json`
> - Bug fix: `F0Dialog` adds `disableContentPadding` prop and adjusts dialog content
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b32de4e88d82491b07a3dc45eddb02bce1ab3c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->