### PR TITLE
fix(Table): add isLastChild prop to NestedRow for improved border logic

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -61,6 +61,7 @@ export type NestedRowProps = {
   depth?: number
   expanded?: boolean
   hasLoadedChildren?: boolean
+  isLastChild?: boolean
   nestedVariant?: NestedVariant
   parentHasChildren?: boolean
   onExpand?: () => void

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
@@ -36,6 +36,7 @@ const SingleLoadingRowInner = <
     selectedItems,
     checkColumnWidth,
     tableWithChildren,
+    shouldHideBorder,
   }: RowProps<
     R,
     Filters,
@@ -47,6 +48,7 @@ const SingleLoadingRowInner = <
   > & {
     rowRef: React.RefObject<HTMLTableRowElement>
     rowIndex: number
+    shouldHideBorder?: boolean
   },
   ref:
     | ((element: HTMLTableRowElement | null) => void)
@@ -84,7 +86,7 @@ const SingleLoadingRowInner = <
       index={rowIndex}
       frozenColumnsLeft={frozenColumnsLeft}
       columns={columns}
-      noBorder
+      noBorder={shouldHideBorder ?? false}
       groupIndex={groupIndex}
       onCheckedChange={onCheckedChange}
       selectedItems={selectedItems}
@@ -122,6 +124,7 @@ const SingleLoadingRow = forwardRef(SingleLoadingRowInner) as <
   > & {
     rowRef: React.RefObject<HTMLTableRowElement>
     rowIndex: number
+    shouldHideBorder?: boolean
   } & {
     ref?:
       | ((element: HTMLTableRowElement | null) => void)
@@ -162,6 +165,7 @@ const RowLoadingInner = <
       Grouping
     >
     paginationInfo?: ChildrenPaginationInfo
+    shouldHideBorder?: boolean
   },
   ref:
     | ((element: HTMLTableRowElement | null) => void)
@@ -188,15 +192,22 @@ const RowLoadingInner = <
 
   return (
     <>
-      {Array.from({ length: loadingRowsCount }).map((_, rowIndex) => (
-        <SingleLoadingRow
-          key={`row-loading-${rowIndex}`}
-          ref={ref}
-          rowRef={rowRef}
-          rowIndex={rowIndex}
-          {...props}
-        />
-      ))}
+      {Array.from({ length: loadingRowsCount }).map((_, rowIndex) => {
+        const isLastLoadingRow = rowIndex === loadingRowsCount - 1
+        // Only show border on the last loading row if parent is isLastChild
+        const rowShouldHideBorder = !isLastLoadingRow || props.shouldHideBorder
+
+        return (
+          <SingleLoadingRow
+            key={`row-loading-${rowIndex}`}
+            ref={ref}
+            rowRef={rowRef}
+            rowIndex={rowIndex}
+            {...props}
+            shouldHideBorder={rowShouldHideBorder}
+          />
+        )
+      })}
     </>
   )
 }
@@ -235,5 +246,6 @@ export const RowLoading = forwardRef(RowLoadingInner) as <
       | ((element: HTMLTableRowElement | null) => void)
       | React.RefObject<HTMLTableRowElement>
       | null
+    shouldHideBorder?: boolean
   }
 ) => JSX.Element


### PR DESCRIPTION
Fixes border rendering in nested table rows. The bottom border now only appears on the last visible element in the tree hierarchy.

https://github.com/user-attachments/assets/bf0aa9e9-a434-4fe1-9c3a-34f4ef23aa18

