### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.319.3",
+  "packages/react": "1.320.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.320.0](https://github.com/factorialco/f0/compare/f0-react-v1.319.3...f0-react-v1.320.0) (2026-01-13)
+
+
+### Features
+
+* **F0Select:** add onDeselect functionality to F0Select preview ([#3213](https://github.com/factorialco/f0/issues/3213)) ([fd20f62](https://github.com/factorialco/f0/commit/fd20f629c6626bd5c6cfb69944e405bee8e371f0))
+
 ## [1.319.3](https://github.com/factorialco/f0/compare/f0-react-v1.319.2...f0-react-v1.319.3) (2026-01-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.319.3",
+  "version": "1.320.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.320.0</summary>

## [1.320.0](https://github.com/factorialco/f0/compare/f0-react-v1.319.3...f0-react-v1.320.0) (2026-01-13)


### Features

* **F0Select:** add onDeselect functionality to F0Select preview ([#3213](https://github.com/factorialco/f0/issues/3213)) ([fd20f62](https://github.com/factorialco/f0/commit/fd20f629c6626bd5c6cfb69944e405bee8e371f0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes `@factorialco/f0-react` 1.320.0 with a small feature addition.
> 
> - Adds `onDeselect` support to `F0Select` preview (CHANGELOG)
> - Bumps versions in `packages/react/package.json` and `.release-please-manifest.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aac0c0b51ff8c51264763a279704dcaed02a7ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->