### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.321.0",
+  "packages/react": "1.321.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.321.1](https://github.com/factorialco/f0/compare/f0-react-v1.321.0...f0-react-v1.321.1) (2026-01-13)
+
+
+### Bug Fixes
+
+* only allow dragging items in co-creation when long pressing handlers ([#3219](https://github.com/factorialco/f0/issues/3219)) ([78ec14a](https://github.com/factorialco/f0/commit/78ec14a1c5a9dc830f12f384bd9679fbbd2daa0e))
+
 ## [1.321.0](https://github.com/factorialco/f0/compare/f0-react-v1.320.1...f0-react-v1.321.0) (2026-01-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.321.0",
+  "version": "1.321.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.321.1</summary>

## [1.321.1](https://github.com/factorialco/f0/compare/f0-react-v1.321.0...f0-react-v1.321.1) (2026-01-13)


### Bug Fixes

* only allow dragging items in co-creation when long pressing handlers ([#3219](https://github.com/factorialco/f0/issues/3219)) ([78ec14a](https://github.com/factorialco/f0/commit/78ec14a1c5a9dc830f12f384bd9679fbbd2daa0e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes a patch release for `@factorialco/f0-react`.
> 
> - Bumps package version to `1.321.1` in `packages/react/package.json` and updates `.release-please-manifest.json`
> - Updates `packages/react/CHANGELOG.md` with bug fix: only allow dragging items in co-creation when long pressing handlers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea73502a654df55e7fb4ef16dc05962f4a65c06f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->