### PR TITLE
feat: manage new mode type to decide wether to display or not labels

### DIFF
--- a/packages/react/src/components/OneFilterPicker/OneFilterPicker.tsx
+++ b/packages/react/src/components/OneFilterPicker/OneFilterPicker.tsx
@@ -193,7 +193,7 @@ const FiltersControls = () => {
         onChange={handleFilterChange}
         onOpenChange={setIsFiltersOpen}
         isOpen={isFiltersOpen}
-        hideLabel={!!presets}
+        hideLabel={!!presets || mode === "simple"}
         mode={mode}
       />
       {!!presets?.length && (

--- a/packages/react/src/components/OneFilterPicker/types.ts
+++ b/packages/react/src/components/OneFilterPicker/types.ts
@@ -49,7 +49,7 @@ export type FiltersState<Definition extends Record<string, FilterDefinition>> =
     [K in keyof Definition]?: FilterValue<Definition[K]>
   }
 
-export type FiltersMode = "default" | "compact"
+export type FiltersMode = "default" | "compact" | "simple"
 
 /**
  * Record of filter definitions for a collection.


### PR DESCRIPTION
## Description

In this pr we add a new type to `mode` current prop, so we can handle wether we want to display labels or not.


https://github.com/user-attachments/assets/8cf5c36e-c63f-4c6a-9d59-f8229ab0ffff


## Implementation details

I added a new type in the mode types that allows us to handle the display of the `FiltersChipsList` only without modifying the UI, and also the label of the button.
