### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.321.1",
+  "packages/react": "1.322.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.322.0](https://github.com/factorialco/f0/compare/f0-react-v1.321.1...f0-react-v1.322.0) (2026-01-14)
+
+
+### Features
+
+* manage new mode type to decide wether to display or not labels ([#3228](https://github.com/factorialco/f0/issues/3228)) ([af2c688](https://github.com/factorialco/f0/commit/af2c68825b0fa33b8a5602ef4e0754e6da5f761e))
+
 ## [1.321.1](https://github.com/factorialco/f0/compare/f0-react-v1.321.0...f0-react-v1.321.1) (2026-01-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.321.1",
+  "version": "1.322.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.322.0</summary>

## [1.322.0](https://github.com/factorialco/f0/compare/f0-react-v1.321.1...f0-react-v1.322.0) (2026-01-14)


### Features

* manage new mode type to decide wether to display or not labels ([#3228](https://github.com/factorialco/f0/issues/3228)) ([af2c688](https://github.com/factorialco/f0/commit/af2c68825b0fa33b8a5602ef4e0754e6da5f761e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases `@factorialco/f0-react` 1.322.0 with a small feature and version bumps.
> 
> - Adds a new mode type to control whether labels are displayed (documented in `CHANGELOG.md`)
> - Bumps `packages/react` version to `1.322.0` in `package.json` and `.release-please-manifest.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 642683ad639986decf15d6bcbf9419a9f0b56bed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->