### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.322.1",
+  "packages/react": "1.323.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.323.0](https://github.com/factorialco/f0/compare/f0-react-v1.322.1...f0-react-v1.323.0) (2026-01-15)
+
+
+### Features
+
+* **Table:** add disableHover prop and remove unused N/A ([#3232](https://github.com/factorialco/f0/issues/3232)) ([162b9cd](https://github.com/factorialco/f0/commit/162b9cd1721aa4dc863c5e568eeb445dd3b63835))
+
 ## [1.322.1](https://github.com/factorialco/f0/compare/f0-react-v1.322.0...f0-react-v1.322.1) (2026-01-14)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.322.1",
+  "version": "1.323.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.323.0</summary>

## [1.323.0](https://github.com/factorialco/f0/compare/f0-react-v1.322.1...f0-react-v1.323.0) (2026-01-15)


### Features

* **Table:** add disableHover prop and remove unused N/A ([#3232](https://github.com/factorialco/f0/issues/3232)) ([162b9cd](https://github.com/factorialco/f0/commit/162b9cd1721aa4dc863c5e568eeb445dd3b63835))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases `@factorialco/f0-react` 1.323.0 with a small Table enhancement.
> 
> - Adds `Table` `disableHover` prop and removes unused "N/A"
> - Bumps `packages/react` version to `1.323.0` in `package.json` and `.release-please-manifest.json`
> - Updates `CHANGELOG.md` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6022d965d0ed7d91973906465fe0f5df602bc02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->