### PR TITLE
feat(Nested Table): implement clearFetchedData functionality for filters changes

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -108,6 +108,7 @@ const NestedRowContent = <
       rowId: rowId,
       item: props.item,
       source: props.source,
+      onClearFetchedData: () => setOpen(false),
     })
 
   const shouldShowLoading = open && isLoading

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/hooks/useLoadChildren.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/hooks/useLoadChildren.ts
@@ -14,7 +14,7 @@ import {
   NestedResponseWithType,
   NestedVariant,
 } from "@/hooks/datasource/types/nested.typings"
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useNestedDataContext } from "../providers/NestedProvider"
 
 interface UseLoadChildrenProps<
@@ -37,6 +37,7 @@ interface UseLoadChildrenProps<
     NavigationFilters,
     Grouping
   >
+  onClearFetchedData: () => void
 }
 
 const isDetailed = <R extends RecordType>(
@@ -75,6 +76,7 @@ export const useLoadChildren = <
   rowId,
   item,
   source,
+  onClearFetchedData,
 }: UseLoadChildrenProps<
   R,
   Filters,
@@ -84,8 +86,11 @@ export const useLoadChildren = <
   NavigationFilters,
   Grouping
 >) => {
-  const { fetchedData: nestedFetchedData, updateFetchedData } =
-    useNestedDataContext<R>()
+  const {
+    fetchedData: nestedFetchedData,
+    updateFetchedData,
+    clearFetchedData,
+  } = useNestedDataContext<R>()
   const [children, setChildren] = useState<R[]>(
     getChildren(nestedFetchedData?.[rowId])
   )
@@ -96,6 +101,26 @@ export const useLoadChildren = <
   const [childrenType, setChildrenType] = useState<NestedVariant>(
     getChildrenType(nestedFetchedData?.[rowId])
   )
+
+  const previousFiltersRef = useRef(source.currentFilters)
+  const previousSortingsRef = useRef(source.currentSortings)
+
+  useEffect(() => {
+    const filtersChanged = previousFiltersRef.current !== source.currentFilters
+    const sortingsChanged =
+      previousSortingsRef.current !== source.currentSortings
+
+    if (filtersChanged || sortingsChanged) {
+      setChildren([])
+      setPaginationInfo(undefined)
+      setChildrenType("basic")
+      clearFetchedData()
+      onClearFetchedData()
+
+      previousFiltersRef.current = source.currentFilters
+      previousSortingsRef.current = source.currentSortings
+    }
+  }, [source.currentFilters, source.currentSortings, clearFetchedData])
 
   const loadChildren = useCallback(async () => {
     if (children.length > 0 && !paginationInfo?.hasMore) return children

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
@@ -1,10 +1,17 @@
 import { RecordType } from "@/hooks/datasource"
 import { ChildrenResponse } from "@/hooks/datasource/types/nested.typings"
-import { createContext, ReactNode, useContext, useState } from "react"
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react"
 
 interface NestedDataContextValue<R extends RecordType> {
   fetchedData: Record<string, ChildrenResponse<R>>
   updateFetchedData: (rowId: string, data: ChildrenResponse<R>) => void
+  clearFetchedData: () => void
 }
 
 const NestedDataContext = createContext<
@@ -20,17 +27,28 @@ export const NestedDataProvider = <R extends RecordType>({
     Record<string, ChildrenResponse<R>>
   >({})
 
-  const updateFetchedData = (rowId: string, data: ChildrenResponse<R>) => {
-    setFetchedData((prev) => ({
-      ...prev,
-      [rowId]: data,
-    }))
-  }
+  const updateFetchedData = useCallback(
+    (rowId: string, data: ChildrenResponse<R>) => {
+      setFetchedData((prev) => ({
+        ...prev,
+        [rowId]: data,
+      }))
+    },
+    []
+  )
+
+  const clearFetchedData = useCallback(() => {
+    setFetchedData({})
+  }, [])
 
   return (
     <NestedDataContext.Provider
       value={
-        { fetchedData, updateFetchedData } as NestedDataContextValue<RecordType>
+        {
+          fetchedData,
+          updateFetchedData,
+          clearFetchedData,
+        } as NestedDataContextValue<RecordType>
       }
     >
       {children}


### PR DESCRIPTION
## Clear nested children cache on filters or sortings change

### Summary

- Added `clearFetchedData` function to `NestedDataContext` to reset the cached nested rows
- Added detection for `currentFilters` and `currentSortings` changes in `useLoadChildren` hook
- When filters or sortings change, the hook now resets the data.
- Added `onClearFetchedData` callback prop to notify parent components when cache is cleared

### Why

Previously, nested children data was cached after the first fetch and never invalidated. This caused stale data to persist when users changed filters or sorting options, leading to incorrect results being displayed.