### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.324.0",
+  "packages/react": "1.325.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.325.0](https://github.com/factorialco/f0/compare/f0-react-v1.324.0...f0-react-v1.325.0) (2026-01-15)
+
+
+### Features
+
+* **CollapsibleMenu:** new collapsible menu ([#3234](https://github.com/factorialco/f0/issues/3234)) ([121dcfa](https://github.com/factorialco/f0/commit/121dcfa7adb539c31dbc2a17ff60aaa499c63828))
+
 ## [1.324.0](https://github.com/factorialco/f0/compare/f0-react-v1.323.0...f0-react-v1.324.0) (2026-01-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.324.0",
+  "version": "1.325.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.325.0</summary>

## [1.325.0](https://github.com/factorialco/f0/compare/f0-react-v1.324.0...f0-react-v1.325.0) (2026-01-15)


### Features

* **CollapsibleMenu:** new collapsible menu ([#3234](https://github.com/factorialco/f0/issues/3234)) ([121dcfa](https://github.com/factorialco/f0/commit/121dcfa7adb539c31dbc2a17ff60aaa499c63828))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Release-only changes for `@factorialco/f0-react`.
> 
> - Bump `packages/react` to `1.325.0` and update `.release-please-manifest.json`
> - Update `CHANGELOG.md` to include new `CollapsibleMenu` feature
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecc8c13d755b3d2727f4d44b967db051752a4796. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->