### PR TITLE
fix: dialog in mobile not showing up correctly

### DIFF
--- a/packages/react/src/components/F0Dialog/F0DialogInternal.tsx
+++ b/packages/react/src/components/F0Dialog/F0DialogInternal.tsx
@@ -104,11 +104,11 @@ export const F0DialogInternal: FC<F0DialogInternalProps> = ({
   const isSidePosition = position === "left" || position === "right"
 
   const variant = useMemo(() => {
-    if (position === "fullscreen") {
-      return "fullscreen"
-    }
     if (isSmallScreen && asBottomSheetInMobile) {
       return "bottomSheet"
+    }
+    if (position === "fullscreen") {
+      return "fullscreen"
     }
     if (isSidePosition) {
       return "sidePosition"


### PR DESCRIPTION
## Description

Dialog in mobile devices were showing up transparent without correct styles.

## Screenshots

### Before

<img width="564" height="770" alt="Screenshot 2026-01-16 at 11 33 38" src="https://github.com/user-attachments/assets/9340ca15-fd3b-4741-8161-6e4c3074c5c6" />

### After

<img width="564" height="770" alt="Screenshot 2026-01-16 at 11 32 35" src="https://github.com/user-attachments/assets/16b9eeac-c18c-477f-94ce-9e6b87861f1b" />
