### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.327.0",
+  "packages/react": "1.327.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.327.1](https://github.com/factorialco/f0/compare/f0-react-v1.327.0...f0-react-v1.327.1) (2026-01-16)
+
+
+### Bug Fixes
+
+* dialog in mobile not showing up correctly ([#3244](https://github.com/factorialco/f0/issues/3244)) ([c0f903a](https://github.com/factorialco/f0/commit/c0f903ab8357eb26b62c4080483689334813c222))
+
 ## [1.327.0](https://github.com/factorialco/f0/compare/f0-react-v1.326.0...f0-react-v1.327.0) (2026-01-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.327.0",
+  "version": "1.327.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.327.1</summary>

## [1.327.1](https://github.com/factorialco/f0/compare/f0-react-v1.327.0...f0-react-v1.327.1) (2026-01-16)


### Bug Fixes

* dialog in mobile not showing up correctly ([#3244](https://github.com/factorialco/f0/issues/3244)) ([c0f903a](https://github.com/factorialco/f0/commit/c0f903ab8357eb26b62c4080483689334813c222))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes `@factorialco/f0-react` v1.327.1 with a mobile dialog visibility bug fix.
> 
> - Update `packages/react` version to `1.327.1` in `package.json` and `.release-please-manifest.json`
> - Add changelog entry noting fix for dialog not showing correctly on mobile
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a05fe2c35cca5475160dab8e6b8c1bc14ada805. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->