### PR TITLE
fix: add reset to :focus-visible

### DIFF
--- a/packages/react/src/reset.css
+++ b/packages/react/src/reset.css
@@ -1,1 +1,8 @@
 @import "ress/dist/ress.min.css";
+
+/* Remove default outline for focus-visible on inputs and textareas */
+/* ress only handles :focus, but browsers now use :focus-visible in UA stylesheets */
+input:focus-visible,
+textarea:focus-visible {
+  outline: none;
+}


### PR DESCRIPTION
## Description

- Fix focus-visible css as was showing an incorrect outline



## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

It seems related to AU (browser) changes as no changes related to that in the last week in f0 repo

It was working well in the factorial's app a it reset the input:focus style for all the app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts global reset styles to align focus handling across browsers.
> 
> - Updates `reset.css` to remove default `:focus-visible` outlines on `input` and `textarea`, complementing `ress` which only resets `:focus`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83b388fd83fde530d72e2f13d12ee7065e89b2fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->