### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.327.1",
+  "packages/react": "1.327.2",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.327.2](https://github.com/factorialco/f0/compare/f0-react-v1.327.1...f0-react-v1.327.2) (2026-01-16)
+
+
+### Bug Fixes
+
+* add reset to :focus-visible ([#3246](https://github.com/factorialco/f0/issues/3246)) ([57ef687](https://github.com/factorialco/f0/commit/57ef687101ba7964331764b0e7bc0491adb2887e))
+
 ## [1.327.1](https://github.com/factorialco/f0/compare/f0-react-v1.327.0...f0-react-v1.327.1) (2026-01-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.327.1",
+  "version": "1.327.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.327.2</summary>

## [1.327.2](https://github.com/factorialco/f0/compare/f0-react-v1.327.1...f0-react-v1.327.2) (2026-01-16)


### Bug Fixes

* add reset to :focus-visible ([#3246](https://github.com/factorialco/f0/issues/3246)) ([57ef687](https://github.com/factorialco/f0/commit/57ef687101ba7964331764b0e7bc0491adb2887e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases `@factorialco/f0-react` v1.327.2.
> 
> - Updates `packages/react/package.json` and `.release-please-manifest.json` to 1.327.2
> - Adds changelog entry noting bug fix: reset for `:focus-visible`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 153a6e343c0190156f9e825ac3137548c59dcd84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->