### PR TITLE
refactor: Reorder between levels f0 table content

### DIFF
--- a/packages/react/src/experimental/Navigation/F0TableOfContent/DragContext/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/DragContext/index.tsx
@@ -5,6 +5,10 @@ interface DragContextType {
   setIsDragging: (isDragging: boolean) => void
   draggedItemId: string | null
   setDraggedItemId: (id: string | null) => void
+  dragOverItemId: string | null
+  setDragOverItemId: (id: string | null) => void
+  dragOverPosition: "before" | "after" | "inside" | null
+  setDragOverPosition: (position: "before" | "after" | "inside" | null) => void
 }
 
 const DragContext = createContext<DragContextType | undefined>(undefined)
@@ -12,9 +16,22 @@ const DragContext = createContext<DragContextType | undefined>(undefined)
 export function DragProvider({ children }: { children: ReactNode }) {
   const [isDragging, setIsDragging] = useState(false)
   const [draggedItemId, setDraggedItemId] = useState<string | null>(null)
+  const [dragOverItemId, setDragOverItemId] = useState<string | null>(null)
+  const [dragOverPosition, setDragOverPosition] = useState<
+    "before" | "after" | "inside" | null
+  >(null)
   return (
     <DragContext.Provider
-      value={{ isDragging, setIsDragging, draggedItemId, setDraggedItemId }}
+      value={{
+        isDragging,
+        setIsDragging,
+        draggedItemId,
+        setDraggedItemId,
+        dragOverItemId,
+        setDragOverItemId,
+        dragOverPosition,
+        setDragOverPosition,
+      }}
     >
       {children}
     </DragContext.Provider>

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/Item/PrimitiveItem.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/Item/PrimitiveItem.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence, DragControls, motion } from "motion/react"
+import { AnimatePresence, motion } from "motion/react"
 import { ReactNode } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
@@ -20,7 +20,6 @@ interface PrimitiveItemProps {
   collapsible?: boolean
   isExpanded?: boolean
   onToggleExpanded?: (id: string) => void
-  dragControls: DragControls
   children?: ReactNode
   open: boolean
   setOpen: (open: boolean) => void
@@ -36,7 +35,6 @@ export function PrimitiveItem({
   collapsible = false,
   isExpanded = false,
   onToggleExpanded = () => {},
-  dragControls,
   children,
   open,
   setOpen,
@@ -104,11 +102,6 @@ export function PrimitiveItem({
                 >
                   <div
                     className="flex flex-shrink-0 cursor-grab items-center justify-center text-f1-icon active:cursor-grabbing"
-                    onPointerDown={(e) => {
-                      e.preventDefault()
-                      e.stopPropagation()
-                      dragControls?.start(e)
-                    }}
                     aria-label="Drag to reorder"
                   >
                     <F0Icon icon={Handle} size="xs" />

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/Item/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/Item/index.tsx
@@ -1,5 +1,13 @@
-import { Reorder, useDragControls } from "motion/react"
-import { ReactNode, useState } from "react"
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge"
+import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter"
+import { motion } from "motion/react"
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react"
+
+import { useDraggable } from "@/lib/dnd/hooks"
+import { cn } from "@/lib/utils"
 
 import { TOCItem } from "../types"
 import { PrimitiveItem } from "./PrimitiveItem"
@@ -13,6 +21,13 @@ interface TOCItemProps {
   isExpanded?: boolean
   onToggleExpanded?: (id: string) => void
   children?: ReactNode
+  onDragOver?: (itemId: string, position: "before" | "after" | "inside") => void
+  onDragLeave?: () => void
+  onDrop?: (itemId: string, position: "before" | "after" | "inside") => void
+  canDropInside?: boolean
+  currentParentId?: string | null
+  draggedItemId?: string | null
+  justDropped?: boolean
 }
 
 export function Item({
@@ -24,63 +39,225 @@ export function Item({
   onToggleExpanded = () => {},
   sortable,
   children,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  canDropInside = false,
+  currentParentId = null,
+  justDropped = false,
 }: TOCItemProps) {
-  const dragControls = useDragControls()
   const [open, setOpen] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
+  const itemRef = useRef<HTMLDivElement>(null)
+  const [overEdge, setOverEdge] = useState<"top" | "bottom" | null>(null)
+  const [isOverInside, setIsOverInside] = useState(false)
+  // Track last reported state to prevent unnecessary callbacks
+  const lastReportedStateRef = useRef<{
+    edge: "top" | "bottom" | null
+    isInside: boolean
+    lastReportTime?: number
+  } | null>(null)
 
-  if (sortable) {
-    return (
-      <Reorder.Item
-        as="div"
-        key={item.id}
-        value={item}
-        dragControls={dragControls}
-        dragListener={false}
-        whileDrag={{
-          scale: 1.02,
-          opacity: 0.9,
-          zIndex: 50,
-          cursor: "grabbing",
-        }}
-        transition={{ type: "spring", bounce: 0.2, duration: 0.3 }}
-      >
-        <PrimitiveItem
-          item={item}
-          counter={counter}
-          isActive={isActive}
-          sortable={sortable}
-          collapsible={collapsible}
-          isExpanded={isExpanded}
-          onToggleExpanded={onToggleExpanded}
-          dragControls={dragControls}
-          open={open}
-          setOpen={setOpen}
-          isHovered={isHovered}
-          setIsHovered={setIsHovered}
-        >
-          {children}
-        </PrimitiveItem>
-      </Reorder.Item>
-    )
-  }
+  // Memoize payload to prevent unnecessary re-registrations
+  // Include currentParentId so payload changes when item moves
+  const payload = useMemo(
+    () => ({
+      kind: "toc-item",
+      id: item.id,
+      data: { item, currentParentId },
+    }),
+    [item.id, currentParentId, item]
+  )
+
+  // Make item draggable
+  useDraggable({
+    ref: itemRef as React.RefObject<HTMLElement>,
+    payload,
+    disabled: !sortable,
+  })
+
+  // Set up drop target
+  useEffect(() => {
+    if (!itemRef.current || !sortable) {
+      return
+    }
+
+    return dropTargetForElements({
+      element: itemRef.current,
+      canDrop: ({ source }) => {
+        // Only accept drops from toc-item kind
+        const sourceData = source.data as { kind?: string; id?: string }
+        return sourceData.kind === "toc-item" && sourceData.id !== item.id
+      },
+      getData: ({ input, element }) => {
+        const rect = element.getBoundingClientRect()
+        const y = input.clientY
+        const relativeY = y - rect.top
+        const height = rect.height
+        const bottomThreshold = height * 0.6 // Bottom 40% = inside
+
+        // Check if we should allow "inside" drop
+        if (canDropInside && relativeY > bottomThreshold) {
+          return { type: "toc-item-target", id: item.id, position: "inside" }
+        }
+
+        // Otherwise use closest edge (top/bottom)
+        return attachClosestEdge(
+          { type: "toc-item-target", id: item.id },
+          {
+            input,
+            element,
+            allowedEdges: ["top", "bottom"],
+          }
+        )
+      },
+      onDragEnter: ({ source }) => {
+        const sourceData = source.data as { kind?: string; id?: string }
+        // Only handle self-drag case, let onDrag handle all other updates
+        if (sourceData.id === item.id) {
+          setOverEdge(null)
+          setIsOverInside(false)
+          lastReportedStateRef.current = null
+          return
+        }
+      },
+      onDrag: ({ self, source }) => {
+        const sourceData = source.data as { kind?: string; id?: string }
+
+        if (sourceData.id === item.id) {
+          setOverEdge(null)
+          setIsOverInside(false)
+          lastReportedStateRef.current = null
+          return
+        }
+
+        const data = self.data as { position?: string }
+        const edge = extractClosestEdge(self.data as Record<string, unknown>)
+
+        if (data.position === "inside") {
+          const lastState = lastReportedStateRef.current
+          if (!lastState || !lastState.isInside || lastState.edge !== null) {
+            setIsOverInside(true)
+            setOverEdge(null)
+            lastReportedStateRef.current = { edge: null, isInside: true }
+            onDragOver?.(item.id, "inside")
+          }
+        } else if (edge && (edge === "top" || edge === "bottom")) {
+          const position = edge === "top" ? "before" : "after"
+          const lastState = lastReportedStateRef.current
+          const stateChanged =
+            !lastState ||
+            lastState.edge !== edge ||
+            lastState.isInside !== false
+
+          if (stateChanged) {
+            setOverEdge(edge)
+            setIsOverInside(false)
+            lastReportedStateRef.current = {
+              edge,
+              isInside: false,
+              lastReportTime: Date.now(),
+            }
+            onDragOver?.(item.id, position)
+          } else {
+            // Keep parent updated every 50ms to maintain placeholder visibility
+            const timeSinceLastReport =
+              Date.now() - (lastState.lastReportTime || 0)
+            if (timeSinceLastReport > 50) {
+              onDragOver?.(item.id, position)
+              lastReportedStateRef.current = {
+                ...lastState,
+                lastReportTime: Date.now(),
+              }
+            }
+          }
+        } else if (!edge) {
+          // Edge detection failed - use last known position
+          const lastState = lastReportedStateRef.current
+          if (lastState?.edge) {
+            const position = lastState.edge === "top" ? "before" : "after"
+            const timeSinceLastReport =
+              Date.now() - (lastState.lastReportTime || 0)
+            if (timeSinceLastReport > 50) {
+              onDragOver?.(item.id, position)
+              lastReportedStateRef.current = {
+                ...lastState,
+                lastReportTime: Date.now(),
+              }
+            }
+          }
+        }
+      },
+      onDragLeave: () => {
+        onDragLeave?.()
+      },
+      onDrop: ({ self }) => {
+        const data = self.data as { position?: string }
+        let position: "before" | "after" | "inside" = "after"
+
+        if (data.position === "inside") {
+          position = "inside"
+        } else {
+          const edge = extractClosestEdge(self.data as Record<string, unknown>)
+          position = edge === "top" ? "before" : "after"
+        }
+
+        setOverEdge(null)
+        setIsOverInside(false)
+
+        if (onDrop) {
+          onDrop(item.id, position)
+        }
+      },
+    })
+  }, [item.id, sortable, canDropInside, onDragOver, onDragLeave, onDrop])
 
   return (
-    <PrimitiveItem
-      item={item}
-      counter={counter}
-      isActive={isActive}
-      sortable={sortable}
-      collapsible={collapsible}
-      isExpanded={isExpanded}
-      onToggleExpanded={onToggleExpanded}
-      dragControls={dragControls}
-      open={open}
-      setOpen={setOpen}
-      isHovered={isHovered}
-      setIsHovered={setIsHovered}
+    <motion.div
+      ref={itemRef}
+      className={cn(
+        "relative rounded-lg transition-colors",
+        sortable && "cursor-grab active:cursor-grabbing",
+        // Show subtle indicator bars (less prominent since we have placeholders)
+        overEdge === "top" &&
+          "before:bg-f1-border-focus before:absolute before:left-0 before:right-0 before:top-0 before:z-10 before:h-0.5",
+        overEdge === "bottom" &&
+          "after:bg-f1-border-focus after:absolute after:bottom-0 after:left-0 after:right-0 after:z-10 after:h-0.5",
+        isOverInside && canDropInside && "bg-f1-background-hover/30",
+        justDropped && "bg-f1-background-hover/50 shadow-lg"
+      )}
+      animate={
+        justDropped
+          ? {
+              scale: [1, 1.05, 1],
+              y: [0, -2, 0],
+            }
+          : {}
+      }
+      transition={
+        justDropped
+          ? {
+              duration: 0.8,
+              ease: [0.34, 1.56, 0.64, 1], // Bouncy ease for more evident effect
+            }
+          : {}
+      }
     >
-      {children}
-    </PrimitiveItem>
+      <PrimitiveItem
+        item={item}
+        counter={counter}
+        isActive={isActive}
+        sortable={sortable}
+        collapsible={collapsible}
+        isExpanded={isExpanded}
+        onToggleExpanded={onToggleExpanded}
+        open={open}
+        setOpen={setOpen}
+        isHovered={isHovered}
+        setIsHovered={setIsHovered}
+      >
+        {children}
+      </PrimitiveItem>
+    </motion.div>
   )
 }

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/ItemSectionHeader/CollapsibleItemSectionHeader.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/ItemSectionHeader/CollapsibleItemSectionHeader.tsx
@@ -15,6 +15,14 @@ interface CollapsibleItemSectionHeaderProps {
   onToggleExpanded?: (id: string) => void
   sortable: boolean
   hideChildrenCounter?: boolean
+  isDragOver?: boolean
+  dragOverPosition?: "before" | "after" | "inside" | null
+  canDropInside?: boolean
+  onDragOver?: (itemId: string, position: "before" | "after" | "inside") => void
+  onDragLeave?: () => void
+  onDrop?: (itemId: string, position: "before" | "after" | "inside") => void
+  currentParentId?: string | null
+  draggedItemId?: string | null
 }
 
 export function CollapsibleItemSectionHeader({
@@ -25,6 +33,12 @@ export function CollapsibleItemSectionHeader({
   onToggleExpanded,
   sortable,
   hideChildrenCounter,
+  canDropInside = false,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  currentParentId,
+  draggedItemId,
 }: CollapsibleItemSectionHeaderProps) {
   const shouldReduceMotion = useReducedMotion()
 
@@ -45,6 +59,12 @@ export function CollapsibleItemSectionHeader({
         isExpanded={isExpanded}
         onToggleExpanded={onToggleExpanded}
         sortable={sortable}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        canDropInside={canDropInside}
+        currentParentId={currentParentId}
+        draggedItemId={draggedItemId}
       />
       <CollapsibleContent forceMount className="flex flex-col gap-1">
         <motion.div

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/ItemSectionHeader/StaticItemSectionHeader.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/ItemSectionHeader/StaticItemSectionHeader.tsx
@@ -9,6 +9,14 @@ interface StaticItemSectionHeaderProps {
   isActive?: boolean
   sortable: boolean
   hideChildrenCounter?: boolean
+  isDragOver?: boolean
+  dragOverPosition?: "before" | "after" | "inside" | null
+  canDropInside?: boolean
+  onDragOver?: (itemId: string, position: "before" | "after" | "inside") => void
+  onDragLeave?: () => void
+  onDrop?: (itemId: string, position: "before" | "after" | "inside") => void
+  currentParentId?: string | null
+  draggedItemId?: string | null
 }
 
 export function StaticItemSectionHeader({
@@ -17,6 +25,12 @@ export function StaticItemSectionHeader({
   isActive,
   sortable,
   hideChildrenCounter,
+  canDropInside = false,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  currentParentId,
+  draggedItemId,
 }: StaticItemSectionHeaderProps) {
   return (
     <>
@@ -28,6 +42,12 @@ export function StaticItemSectionHeader({
         isExpanded={undefined}
         onToggleExpanded={undefined}
         sortable={sortable}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        canDropInside={canDropInside}
+        currentParentId={currentParentId}
+        draggedItemId={draggedItemId}
       />
       {children && (
         <div className="ml-[18px] min-w-0 border-0 border-l border-solid border-f1-border-secondary pl-4">

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/ItemSectionHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/ItemSectionHeader/index.tsx
@@ -13,6 +13,12 @@ interface TOCItemSectionHeaderProps {
   onToggleExpanded?: (id: string) => void
   sortable: boolean
   hideChildrenCounter?: boolean
+  canDropInside?: boolean
+  onDragOver?: (itemId: string, position: "before" | "after" | "inside") => void
+  onDragLeave?: () => void
+  onDrop?: (itemId: string, position: "before" | "after" | "inside") => void
+  currentParentId?: string | null
+  draggedItemId?: string | null
 }
 
 export function ItemSectionHeader({
@@ -24,6 +30,12 @@ export function ItemSectionHeader({
   onToggleExpanded,
   sortable,
   hideChildrenCounter,
+  canDropInside = false,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  currentParentId,
+  draggedItemId,
 }: TOCItemSectionHeaderProps) {
   if (collapsible) {
     return (
@@ -34,6 +46,12 @@ export function ItemSectionHeader({
         onToggleExpanded={onToggleExpanded}
         sortable={sortable}
         hideChildrenCounter={hideChildrenCounter}
+        canDropInside={canDropInside}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        currentParentId={currentParentId}
+        draggedItemId={draggedItemId}
       >
         {children}
       </CollapsibleItemSectionHeader>
@@ -46,6 +64,12 @@ export function ItemSectionHeader({
       isActive={isActive}
       sortable={sortable}
       hideChildrenCounter={hideChildrenCounter}
+      canDropInside={canDropInside}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      currentParentId={currentParentId}
+      draggedItemId={draggedItemId}
     >
       {children}
     </StaticItemSectionHeader>

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/index.tsx
@@ -1,4 +1,4 @@
-import { LayoutGroup, Reorder } from "motion/react"
+import { AnimatePresence, motion } from "motion/react"
 import {
   ReactElement,
   useCallback,
@@ -10,14 +10,27 @@ import {
 
 import { OneEllipsis } from "@/components/OneEllipsis/OneEllipsis"
 import { F1SearchBox } from "@/experimental/Forms/Fields/F1SearchBox"
+import { createAtlaskitDriver } from "@/lib/dnd/atlaskitDriver"
+import { DndProvider } from "@/lib/dnd/context"
+import { useDndEvents } from "@/lib/dnd/hooks"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
+import { ScrollArea } from "@/ui/scrollarea"
 
-import { DragProvider } from "./DragContext"
 import { Item } from "./Item"
 import { ItemSectionHeader } from "./ItemSectionHeader"
-import { IdStructure, TOCItem, TOCItemAction, TOCProps } from "./types"
-import { filterTree, findExpandedPath } from "./utils"
+import { TOCItem, TOCItemAction, TOCProps } from "./types"
+import {
+  calculateAdjustedIndex,
+  convertToIds,
+  filterTree,
+  findExpandedPath,
+  findItemInTree,
+  insertItemInTree,
+  removeItemFromTree,
+  updateItemInTree,
+  wouldCreateCycle,
+} from "./utils"
 
 function renderTOCItem(
   item: TOCItem,
@@ -28,69 +41,180 @@ function renderTOCItem(
   hideChildrenCounter?: boolean,
   expandedItems?: Set<string>,
   onToggleExpanded?: (id: string) => void,
-  onUpdateItem?: (itemId: string, updatedItem: TOCItem) => void
+  onMoveItem?: (
+    itemId: string,
+    targetParentId: string | null,
+    targetIndex: number
+  ) => void,
+  allItems?: TOCItem[],
+  draggedItemId?: string | null,
+  dragOverItemId?: string | null,
+  dragOverPosition?: "before" | "after" | "inside" | null,
+  onChildrenReorder?: (parentId: string) => (newOrder: TOCItem[]) => void,
+  currentParentId?: string | null,
+  onDragOver?: (
+    itemId: string,
+    position: "before" | "after" | "inside"
+  ) => void,
+  onDragLeave?: () => void,
+  onDrop?: (itemId: string, position: "before" | "after" | "inside") => void,
+  justDroppedItemId?: string | null
 ): ReactElement {
   const Component = item.children ? ItemSectionHeader : Item
   const isExpanded = expandedItems?.has(item.id) ?? true
 
-  const handleChildrenReorder = (newOrder: TOCItem[]) => {
-    if (onUpdateItem) {
-      const updatedItem = { ...item, children: newOrder }
-      onUpdateItem(item.id, updatedItem)
+  const isDragOver = dragOverItemId === item.id
+  // Only allow dropping inside if the item has children (is a section header)
+  const canDropInside = Boolean(
+    draggedItemId &&
+    draggedItemId !== item.id &&
+    allItems &&
+    item.children !== undefined && // Item must have children property (is a section)
+    !wouldCreateCycle(allItems, draggedItemId, item.id)
+  )
+
+  // Show placeholder for both same-level and cross-level moves
+  // This creates a visual gap similar to motion/react's automatic placeholder
+  const showPlaceholderBefore = Boolean(
+    draggedItemId &&
+    draggedItemId !== item.id &&
+    isDragOver &&
+    dragOverPosition === "before"
+  )
+  const showPlaceholderAfter = Boolean(
+    draggedItemId &&
+    draggedItemId !== item.id &&
+    isDragOver &&
+    dragOverPosition === "after"
+  )
+
+  // Check if this is the first item in its parent (for adjusting placeholder margins)
+  const isFirstItem = (() => {
+    if (currentParentId === null) {
+      return allItems?.[0]?.id === item.id
     }
-  }
+    if (!allItems || !currentParentId) return false
+    const parent = findItemInTree(allItems, currentParentId)
+    return parent?.item.children?.[0]?.id === item.id
+  })()
 
   return (
-    <Component
-      key={item.id}
-      item={item}
-      isActive={activeItem === item.id}
-      collapsible={collapsible && item.children && item.children.length > 0}
-      isExpanded={isExpanded}
-      onToggleExpanded={onToggleExpanded}
-      sortable={sortable}
-      hideChildrenCounter={hideChildrenCounter}
-    >
-      {item.children &&
-        (Component === ItemSectionHeader || isExpanded) &&
-        (sortable ? (
-          <Reorder.Group
-            as="div"
-            values={item.children}
-            onReorder={handleChildrenReorder}
-            axis="y"
-            className="flex flex-col"
-          >
-            {item.children.map((child) =>
-              renderTOCItem(
-                child,
-                sortable,
-                depth + 1,
-                activeItem,
-                collapsible,
-                hideChildrenCounter,
-                expandedItems,
-                onToggleExpanded,
-                onUpdateItem
-              )
-            )}
-          </Reorder.Group>
-        ) : (
-          item.children.map((child) =>
-            renderTOCItem(
-              child,
-              sortable,
-              depth + 1,
-              activeItem,
-              collapsible,
-              hideChildrenCounter,
-              expandedItems,
-              onToggleExpanded,
-              onUpdateItem
-            )
-          )
-        ))}
-    </Component>
+    <>
+      {/* Placeholder before item - creates visual gap like motion/react */}
+      <AnimatePresence>
+        {showPlaceholderBefore && (
+          <motion.div
+            key="placeholder-before"
+            initial={{ opacity: 0, height: 0, marginTop: 0, marginBottom: 0 }}
+            animate={{
+              opacity: 1,
+              height: 40,
+              marginTop: isFirstItem ? 0 : 2,
+              marginBottom: 2,
+            }}
+            exit={{ opacity: 0, height: 0, marginTop: 0, marginBottom: 0 }}
+            transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+            className="rounded-[10px] border-2 border-dashed border-f1-border-secondary bg-f1-background-hover/40"
+          />
+        )}
+      </AnimatePresence>
+      {Component === Item ? (
+        <Item
+          key={item.id}
+          item={item}
+          isActive={activeItem === item.id}
+          sortable={sortable}
+          collapsible={false}
+          isExpanded={false}
+          onToggleExpanded={onToggleExpanded}
+          onDragOver={onDragOver}
+          onDragLeave={onDragLeave}
+          onDrop={onDrop}
+          canDropInside={false}
+          currentParentId={currentParentId}
+          draggedItemId={draggedItemId}
+          justDropped={justDroppedItemId === item.id}
+        />
+      ) : (
+        <Component
+          key={item.id}
+          item={item}
+          isActive={activeItem === item.id}
+          collapsible={collapsible && item.children && item.children.length > 0}
+          isExpanded={isExpanded}
+          onToggleExpanded={onToggleExpanded}
+          sortable={sortable}
+          hideChildrenCounter={hideChildrenCounter}
+          canDropInside={canDropInside}
+          onDragOver={Component === ItemSectionHeader ? onDragOver : undefined}
+          onDragLeave={
+            Component === ItemSectionHeader ? onDragLeave : undefined
+          }
+          onDrop={Component === ItemSectionHeader ? onDrop : undefined}
+          currentParentId={currentParentId}
+          draggedItemId={draggedItemId}
+        >
+          {item.children && (Component === ItemSectionHeader || isExpanded) && (
+            <div
+              className={cn(
+                "flex flex-col",
+                // Show placeholder background when dragging inside this section
+                isDragOver &&
+                  dragOverPosition === "inside" &&
+                  canDropInside &&
+                  "rounded-md bg-f1-background-hover/20 p-1"
+              )}
+            >
+              {item.children.map((child) => {
+                return renderTOCItem(
+                  child,
+                  sortable,
+                  depth + 1,
+                  activeItem,
+                  collapsible,
+                  hideChildrenCounter,
+                  expandedItems,
+                  onToggleExpanded,
+                  onMoveItem,
+                  allItems,
+                  draggedItemId,
+                  dragOverItemId,
+                  dragOverPosition,
+                  sortable ? onChildrenReorder : undefined,
+                  item.id,
+                  onDragOver,
+                  onDragLeave,
+                  onDrop,
+                  justDroppedItemId
+                )
+              })}
+              {/* Placeholder when dragging inside and section is empty or collapsed */}
+              {isDragOver &&
+                dragOverPosition === "inside" &&
+                canDropInside &&
+                (!isExpanded || item.children.length === 0) && (
+                  <div className="flex h-9 items-center justify-center rounded-md bg-f1-background-hover/30 text-xs text-f1-foreground-secondary">
+                    Drop here
+                  </div>
+                )}
+            </div>
+          )}
+        </Component>
+      )}
+      {/* Placeholder after item - creates visual gap like motion/react */}
+      <AnimatePresence>
+        {showPlaceholderAfter && (
+          <motion.div
+            key="placeholder-after"
+            initial={{ opacity: 0, height: 0, marginTop: 0, marginBottom: 0 }}
+            animate={{ opacity: 1, height: 40, marginTop: 2, marginBottom: 2 }}
+            exit={{ opacity: 0, height: 0, marginTop: 0, marginBottom: 0 }}
+            transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+            className="rounded-[10px] border-2 border-dashed border-f1-border-secondary bg-f1-background-hover/40"
+          />
+        )}
+      </AnimatePresence>
+    </>
   )
 }
 
@@ -130,13 +254,6 @@ function TOCContent({
 
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const convertToIds = useCallback((items: TOCItem[]): IdStructure[] => {
-    return items.map((item) => ({
-      id: item.id,
-      ...(item.children && { children: convertToIds(item.children) }),
-    }))
-  }, [])
-
   const handleToggleExpanded = useCallback(
     (id: string) => {
       setExpandedItems((prev) => {
@@ -152,32 +269,81 @@ function TOCContent({
     [setExpandedItems]
   )
 
-  const handleSort = useCallback(
-    (newOrder: TOCItem[]) => {
-      setSortableItems(newOrder)
-      if (onReorder) {
-        onReorder(convertToIds(newOrder))
-      }
-    },
-    [onReorder, convertToIds]
-  )
-
   const handleUpdateItem = useCallback(
     (itemId: string, updatedItem: TOCItem) => {
-      const updateItemInTree = (items: TOCItem[]): TOCItem[] => {
-        return items.map((item) => {
-          if (item.id === itemId) {
-            return updatedItem
+      const updatedItems = updateItemInTree(sortableItems, itemId, updatedItem)
+      setSortableItems(updatedItems)
+
+      // Notify parent with hierarchical IDs structure
+      if (onReorder) {
+        onReorder(convertToIds(updatedItems))
+      }
+    },
+    [sortableItems, onReorder]
+  )
+
+  const handleChildrenReorder = useCallback(
+    (parentId: string) => (newOrder: TOCItem[]) => {
+      // Update the parent item with the new order
+      const parentItem = findItemInTree(sortableItems, parentId)
+      if (parentItem) {
+        const updatedItem = { ...parentItem.item, children: newOrder }
+        handleUpdateItem(parentId, updatedItem)
+      } else {
+        // If parentId is null, it means we're reordering root items
+        if (parentId === null || parentId === undefined) {
+          setSortableItems(newOrder)
+          if (onReorder) {
+            onReorder(convertToIds(newOrder))
           }
-          if (item.children) {
-            return { ...item, children: updateItemInTree(item.children) }
-          }
-          return item
-        })
+        }
+      }
+    },
+    [sortableItems, handleUpdateItem, onReorder, convertToIds]
+  )
+
+  const handleMoveItem = useCallback(
+    (itemId: string, targetParentId: string | null, targetIndex: number) => {
+      // Prevent cycles
+      if (wouldCreateCycle(sortableItems, itemId, targetParentId)) {
+        return
       }
 
-      const updatedItems = updateItemInTree(sortableItems)
+      // Find the item to move
+      const itemData = findItemInTree(sortableItems, itemId)
+      if (!itemData) return
+
+      const itemToMove = itemData.item
+
+      // Remove item from current location
+      let updatedItems = removeItemFromTree(sortableItems, itemId)
+
+      // Calculate the correct index after removal
+      const adjustedIndex = calculateAdjustedIndex(
+        sortableItems,
+        itemId,
+        targetParentId,
+        targetIndex
+      )
+
+      // Insert item at new location
+      updatedItems = insertItemInTree(
+        updatedItems,
+        itemToMove,
+        targetParentId,
+        adjustedIndex
+      )
+
       setSortableItems(updatedItems)
+
+      // Expand target parent if moving into it
+      if (targetParentId !== null) {
+        setExpandedItems((prev) => {
+          const newSet = new Set(prev)
+          newSet.add(targetParentId)
+          return newSet
+        })
+      }
 
       // Notify parent with hierarchical IDs structure
       if (onReorder) {
@@ -190,6 +356,497 @@ function TOCContent({
   const filteredSortableItems = useMemo(() => {
     return filterTree(sortableItems, searchValue)
   }, [sortableItems, searchValue])
+
+  // State for drag and drop
+  const [draggedItemId, setDraggedItemId] = useState<string | null>(null)
+  const [dragOverItemId, setDragOverItemId] = useState<string | null>(null)
+  const [dragOverPosition, setDragOverPosition] = useState<
+    "before" | "after" | "inside" | null
+  >(null)
+  const [justDroppedItemId, setJustDroppedItemId] = useState<string | null>(
+    null
+  )
+
+  // Use ref to store draggedItemId so handleDrop can access it even after state is cleared
+  const draggedItemIdRef = useRef<string | null>(null)
+  // Flag to track if handleDrop has been called (to prevent safety timeout from clearing state)
+  const handleDropCalledRef = useRef<boolean>(false)
+  // Use refs to access current dragOver state in useDndEvents callback
+  const dragOverItemIdRef = useRef<string | null>(null)
+  const dragOverPositionRef = useRef<"before" | "after" | "inside" | null>(null)
+
+  // Use refs to stabilize drag over updates and prevent flickering
+  const dragOverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const lastDragOverRef = useRef<{
+    itemId: string
+    position: "before" | "after" | "inside"
+  } | null>(null)
+  const lastItemIndexRef = useRef<number | null>(null)
+  // Track when the current state was set to add persistence
+  const currentStateSetTimeRef = useRef<number>(0)
+  // Track last time handleDragOver was called to detect active dragging
+  const lastDragOverCallTimeRef = useRef<number>(0)
+  // Track if placeholder is "locked" for first item (should not disappear)
+  const isPlaceholderLockedRef = useRef<boolean>(false)
+  // Store safety timeout ID so we can cancel it when handleDrop fires
+  const safetyTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Handle drag over from Item component with debounce
+  const handleDragOver = useCallback(
+    (itemId: string, position: "before" | "after" | "inside") => {
+      // Cancel any pending timeout
+      if (dragOverTimeoutRef.current) {
+        clearTimeout(dragOverTimeoutRef.current)
+        dragOverTimeoutRef.current = null
+      }
+
+      // Find the index of the current item to detect drag direction
+      const items = sortable ? filteredSortableItems : filteredItems
+      const currentItemIndex = items.findIndex((item) => item.id === itemId)
+      const isMovingUp =
+        lastItemIndexRef.current !== null &&
+        currentItemIndex < lastItemIndexRef.current
+      lastItemIndexRef.current = currentItemIndex
+
+      // Create a key for this drag over state
+      const dragOverKey = `${itemId}-${position}`
+      const currentStateKey =
+        dragOverItemId && dragOverPosition
+          ? `${dragOverItemId}-${dragOverPosition}`
+          : null
+
+      // Skip if same as current state
+      if (dragOverKey === currentStateKey) {
+        return
+      }
+
+      // Store the pending update
+      lastDragOverRef.current = { itemId, position }
+
+      // Debounce delay - shorter when moving up to prevent glitchy behavior
+      const debounceDelay = isMovingUp ? 50 : 30
+
+      // Debounce the update to prevent rapid state changes
+      dragOverTimeoutRef.current = setTimeout(() => {
+        const pending = lastDragOverRef.current
+        if (pending) {
+          setDragOverItemId(pending.itemId)
+          setDragOverPosition(pending.position)
+          dragOverItemIdRef.current = pending.itemId
+          dragOverPositionRef.current = pending.position
+          const now = Date.now()
+          currentStateSetTimeRef.current = now
+          lastDragOverCallTimeRef.current = now
+
+          // Lock placeholder if this is the first item with "before" position
+          const items = sortable ? filteredSortableItems : filteredItems
+          const firstItem = items[0]
+          if (
+            pending.itemId === firstItem?.id &&
+            pending.position === "before"
+          ) {
+            isPlaceholderLockedRef.current = true
+          }
+        }
+        dragOverTimeoutRef.current = null
+      }, debounceDelay)
+    },
+    [
+      dragOverItemId,
+      dragOverPosition,
+      sortable,
+      filteredSortableItems,
+      filteredItems,
+    ]
+  )
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (dragOverTimeoutRef.current) {
+        clearTimeout(dragOverTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  // Handle drag leave with debounce to prevent premature clearing
+  const handleDragLeave = useCallback(() => {
+    // Don't clear if handleDrop has been called or is about to be called
+    // This prevents clearing state during the drop process
+    if (handleDropCalledRef.current) {
+      return
+    }
+
+    // Don't clear immediately - wait a bit to see if drag over fires again
+    // This prevents flickering when cursor is at edge boundaries
+    // Use a longer timeout to give onDrop time to execute
+    if (dragOverTimeoutRef.current) {
+      clearTimeout(dragOverTimeoutRef.current)
+    }
+
+    // Use a longer timeout to give onDrop time to execute
+    // onDrop typically fires within 100-200ms of the drop event
+    // Use even longer timeout when placeholder is locked (first item) to ensure drop can execute
+    // But also use a reasonable timeout for all positions to prevent premature clearing
+    const leaveTimeout = isPlaceholderLockedRef.current ? 1000 : 800
+    dragOverTimeoutRef.current = setTimeout(() => {
+      // Check again if handleDrop was called during the timeout
+      if (handleDropCalledRef.current) {
+        dragOverTimeoutRef.current = null
+        return
+      }
+
+      const now = Date.now()
+      const timeSinceLastState = now - currentStateSetTimeRef.current
+      const timeSinceLastDragOverCall = now - lastDragOverCallTimeRef.current
+
+      // Check if handleDragOver was called recently
+      // Use longer timeout when placeholder is locked to give more time for drop
+      // But also use reasonable timeout for all positions
+      const minTimeSinceLastCall = isPlaceholderLockedRef.current ? 800 : 500
+      if (timeSinceLastDragOverCall < minTimeSinceLastCall) {
+        // Cancelled (handleDragOver called recently - still dragging over)
+        dragOverTimeoutRef.current = null
+        return
+      }
+
+      // Also check if state was set recently
+      const minTimeSinceLastState = isPlaceholderLockedRef.current ? 800 : 500
+      if (timeSinceLastState < minTimeSinceLastState) {
+        // Cancelled (state updated recently)
+        dragOverTimeoutRef.current = null
+        return
+      }
+
+      // Check if placeholder is locked (first item) - don't clear if locked
+      if (isPlaceholderLockedRef.current) {
+        const items = sortable ? filteredSortableItems : filteredItems
+        const firstItem = items[0]
+        const isFirstItem =
+          dragOverItemId === firstItem?.id && dragOverPosition === "before"
+
+        if (isFirstItem) {
+          // For locked first item placeholder, be very persistent
+          // Only clear if handleDragOver hasn't been called for a very long time (2 seconds)
+          // This ensures the placeholder stays visible even if onDrag doesn't fire for a moment
+          if (timeSinceLastDragOverCall < 2000) {
+            // Cancelled (first item placeholder locked)
+            dragOverTimeoutRef.current = null
+            return
+          }
+          // Only unlock if we really left (no drag over calls for 2 seconds)
+          isPlaceholderLockedRef.current = false
+        } else {
+          // If we moved to a different item, unlock and allow clearing
+          // Unlocking (moved to different item)
+          isPlaceholderLockedRef.current = false
+        }
+      }
+
+      // Normal clearing
+      // DON'T clear lastDragOverRef here - keep it for potential fallback in drop
+      // It will be cleared when a new drag starts
+      lastItemIndexRef.current = null
+      currentStateSetTimeRef.current = 0
+      setDragOverItemId(null)
+      setDragOverPosition(null)
+      dragOverItemIdRef.current = null
+      dragOverPositionRef.current = null
+      dragOverTimeoutRef.current = null
+    }, leaveTimeout) // Use longer timeout when placeholder is locked to give drop time to execute
+  }, [
+    dragOverItemId,
+    dragOverPosition,
+    sortable,
+    filteredSortableItems,
+    filteredItems,
+  ])
+
+  // Handle drop from Item component
+  const handleDrop = useCallback(
+    (targetItemId: string, position: "before" | "after" | "inside") => {
+      // Mark that handleDrop has been called to prevent safety timeout from clearing state
+      handleDropCalledRef.current = true
+
+      // Use ref to get draggedItemId in case state was already cleared
+      const currentDraggedItemId = draggedItemIdRef.current
+
+      // Always unlock placeholder on drop
+      isPlaceholderLockedRef.current = false
+
+      // IMMEDIATELY clear drag over state to remove placeholder
+      setDragOverItemId(null)
+      setDragOverPosition(null)
+      dragOverItemIdRef.current = null
+      dragOverPositionRef.current = null
+
+      // Cancel any pending drag over timeout
+      if (dragOverTimeoutRef.current) {
+        clearTimeout(dragOverTimeoutRef.current)
+        dragOverTimeoutRef.current = null
+      }
+
+      if (!currentDraggedItemId || currentDraggedItemId === targetItemId) {
+        draggedItemIdRef.current = null
+        setDraggedItemId(null)
+        setDragOverItemId(null)
+        setDragOverPosition(null)
+        return
+      }
+
+      // Calculate target index and parent
+      const targetItem = findItemInTree(sortableItems, targetItemId)
+      const draggedItem = findItemInTree(sortableItems, currentDraggedItemId)
+
+      if (targetItem && draggedItem) {
+        let targetParentId: string | null = null
+        let targetIndex = 0
+
+        if (position === "inside") {
+          // Moving inside the target item (as a child)
+          targetParentId = targetItemId
+          targetIndex = targetItem.item.children?.length ?? 0
+        } else if (position === "before") {
+          // Moving before the target item
+          if (targetItem.parentPath.length > 0) {
+            targetParentId =
+              targetItem.parentPath[targetItem.parentPath.length - 1]
+          } else {
+            targetParentId = null // Root level
+          }
+          // Find the index of the target item in its parent
+          if (targetParentId === null) {
+            targetIndex = sortableItems.findIndex((i) => i.id === targetItemId)
+          } else {
+            const parent = findItemInTree(sortableItems, targetParentId)
+            if (parent) {
+              targetIndex =
+                parent.item.children?.findIndex((c) => c.id === targetItemId) ??
+                0
+            }
+          }
+        } else if (position === "after") {
+          // Moving after the target item
+          if (targetItem.parentPath.length > 0) {
+            targetParentId =
+              targetItem.parentPath[targetItem.parentPath.length - 1]
+          } else {
+            targetParentId = null // Root level
+          }
+          // Find the index of the target item in its parent and add 1
+          if (targetParentId === null) {
+            targetIndex =
+              sortableItems.findIndex((i) => i.id === targetItemId) + 1
+          } else {
+            const parent = findItemInTree(sortableItems, targetParentId)
+            if (parent) {
+              targetIndex =
+                (parent.item.children?.findIndex(
+                  (c) => c.id === targetItemId
+                ) ?? 0) + 1
+            }
+          }
+        }
+
+        // Only move if it's a cross-level move, different parent, or different index in same parent
+        const draggedParentId =
+          draggedItem.parentPath.length > 0
+            ? draggedItem.parentPath[draggedItem.parentPath.length - 1]
+            : null
+
+        // Calculate current index of dragged item
+        let currentIndex = -1
+        if (draggedParentId === null) {
+          currentIndex = sortableItems.findIndex(
+            (i) => i.id === currentDraggedItemId
+          )
+        } else {
+          const draggedParent = findItemInTree(sortableItems, draggedParentId)
+          if (draggedParent) {
+            currentIndex =
+              draggedParent.item.children?.findIndex(
+                (c) => c.id === currentDraggedItemId
+              ) ?? -1
+          }
+        }
+
+        // Move if: different parent, or same parent but different index
+        if (
+          targetParentId !== draggedParentId ||
+          (targetParentId === draggedParentId && currentIndex !== targetIndex)
+        ) {
+          // Trigger drop animation effect IMMEDIATELY before moving
+          // This ensures the animation starts right away
+          setJustDroppedItemId(currentDraggedItemId)
+
+          handleMoveItem(currentDraggedItemId, targetParentId, targetIndex)
+
+          // Clear animation state after animation completes
+          setTimeout(() => {
+            setJustDroppedItemId(null)
+          }, 800) // Match animation duration
+        }
+      }
+
+      // Clear drag state - always unlock and clear
+      isPlaceholderLockedRef.current = false
+      draggedItemIdRef.current = null
+      handleDropCalledRef.current = true // Mark as called BEFORE clearing state
+      // DON'T clear lastDragOverRef here - keep it for potential fallback in next drag
+      // It will be cleared when a new drag starts
+      lastItemIndexRef.current = null
+      currentStateSetTimeRef.current = 0
+      lastDragOverCallTimeRef.current = 0
+
+      // Cancel safety timeout since handleDrop has fired
+      if (safetyTimeoutRef.current) {
+        clearTimeout(safetyTimeoutRef.current)
+        safetyTimeoutRef.current = null
+      }
+
+      // Clear dragged item state
+      setDraggedItemId(null)
+
+      // Reset flag after safety timeout duration to ensure it's checked
+      // Safety timeout is 500ms, so reset after 600ms to be safe
+      setTimeout(() => {
+        handleDropCalledRef.current = false
+      }, 600)
+    },
+    [sortableItems, handleMoveItem]
+  )
+
+  // Monitor drag start/end using useDndEvents
+  useDndEvents(
+    useCallback(
+      (e: {
+        phase: "start" | "over" | "drop" | "cancel"
+        source: { kind: string; id: string; data?: unknown }
+      }) => {
+        if (e.phase === "start" && e.source.kind === "toc-item") {
+          // Cancel any pending timeouts from previous drag
+          if (dragOverTimeoutRef.current) {
+            clearTimeout(dragOverTimeoutRef.current)
+            dragOverTimeoutRef.current = null
+          }
+          if (safetyTimeoutRef.current) {
+            clearTimeout(safetyTimeoutRef.current)
+            safetyTimeoutRef.current = null
+          }
+
+          draggedItemIdRef.current = e.source.id
+          handleDropCalledRef.current = false // Reset flag for new drag
+          // Clear lastDragOverRef when starting a new drag
+          lastDragOverRef.current = null
+          setDraggedItemId(e.source.id)
+        } else if (e.phase === "cancel") {
+          // For cancel, clear everything immediately
+          isPlaceholderLockedRef.current = false
+          handleDropCalledRef.current = false
+          lastDragOverRef.current = null
+          lastItemIndexRef.current = null
+          currentStateSetTimeRef.current = 0
+          lastDragOverCallTimeRef.current = 0
+          if (dragOverTimeoutRef.current) {
+            clearTimeout(dragOverTimeoutRef.current)
+            dragOverTimeoutRef.current = null
+          }
+          if (safetyTimeoutRef.current) {
+            clearTimeout(safetyTimeoutRef.current)
+            safetyTimeoutRef.current = null
+          }
+          setDragOverItemId(null)
+          setDragOverPosition(null)
+          dragOverItemIdRef.current = null
+          dragOverPositionRef.current = null
+          setDraggedItemId(null)
+          draggedItemIdRef.current = null
+        } else if (e.phase === "drop") {
+          // For drop, DON'T clear visual state immediately
+          // The dropTargetForElements onDrop handler needs the state to process the drop
+          // We'll clear it in handleDrop after processing, or with a safety timeout
+
+          // CRITICAL: Cancel any pending handleDragLeave timeout
+          // This prevents handleDragLeave from clearing state before onDrop executes
+          if (dragOverTimeoutRef.current) {
+            clearTimeout(dragOverTimeoutRef.current)
+            dragOverTimeoutRef.current = null
+          }
+
+          // Only clear timeouts and refs, but keep visual state for handleDrop
+          isPlaceholderLockedRef.current = false
+
+          // If we have a valid dragOverItemId and dragOverPosition, and handleDrop hasn't been called yet,
+          // try to execute handleDrop directly in case the drop was on the placeholder
+          // This is a fallback in case onDrop from Item doesn't fire (e.g., drop on placeholder)
+          // Also check lastDragOverRef as fallback in case handleDragLeave cleared the state
+          const currentDragOverItemId =
+            dragOverItemIdRef.current || lastDragOverRef.current?.itemId
+          const currentDragOverPosition =
+            dragOverPositionRef.current || lastDragOverRef.current?.position
+          if (
+            !handleDropCalledRef.current &&
+            currentDragOverItemId &&
+            currentDragOverPosition &&
+            draggedItemIdRef.current &&
+            draggedItemIdRef.current !== currentDragOverItemId
+          ) {
+            // Use requestAnimationFrame to execute in the next frame
+            // This gives onDrop from Item a chance to fire first, but is faster than setTimeout
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
+                if (!handleDropCalledRef.current) {
+                  // Check refs first, then lastDragOverRef as fallback
+                  const finalItemId =
+                    dragOverItemIdRef.current || lastDragOverRef.current?.itemId
+                  const finalPosition =
+                    dragOverPositionRef.current ||
+                    lastDragOverRef.current?.position
+                  if (finalItemId && finalPosition) {
+                    handleDrop(finalItemId, finalPosition)
+                  }
+                }
+              })
+            })
+          }
+
+          // DON'T reset the flag here - handleDrop will set it to true when it executes
+          // The flag will be reset when a new drag starts (in "start" phase)
+
+          // Cancel any existing safety timeout
+          if (safetyTimeoutRef.current) {
+            clearTimeout(safetyTimeoutRef.current)
+            safetyTimeoutRef.current = null
+          }
+
+          // Set a safety timeout to clear state if handleDrop doesn't fire
+          // This prevents the placeholder from staying visible forever if something goes wrong
+          // Note: handleDrop may execute before or after this event, so we check the flag
+          const timeoutId = setTimeout(() => {
+            // Double-check the flag - handleDrop may have executed between scheduling and execution
+            if (!handleDropCalledRef.current) {
+              lastDragOverRef.current = null
+              lastItemIndexRef.current = null
+              currentStateSetTimeRef.current = 0
+              lastDragOverCallTimeRef.current = 0
+              setDragOverItemId(null)
+              setDragOverPosition(null)
+              dragOverItemIdRef.current = null
+              dragOverPositionRef.current = null
+              setDraggedItemId(null)
+              draggedItemIdRef.current = null
+            }
+            // Only clear the ref if this is still the active timeout
+            if (safetyTimeoutRef.current === timeoutId) {
+              safetyTimeoutRef.current = null
+            }
+          }, 500) // 500ms should be enough for handleDrop to fire
+          safetyTimeoutRef.current = timeoutId
+        }
+      },
+      [handleDrop]
+    )
+  )
 
   return (
     <nav
@@ -230,18 +887,11 @@ function TOCContent({
           )}
         </div>
       )}
-
-      <div className="px-3 pb-2">
-        {sortable ? (
-          <Reorder.Group
-            as="div"
-            values={sortableItems}
-            onReorder={handleSort}
-            axis="y"
-            className="flex flex-col gap-0.5"
-            dragConstraints={containerRef}
-          >
-            {filteredSortableItems.map((item) =>
+      <ScrollArea className="h-full min-h-0">
+        <div className="px-3 pb-2">
+          <div className="flex flex-col gap-0.5">
+            {/* Removed duplicate placeholder - renderTOCItem handles it */}
+            {(sortable ? filteredSortableItems : filteredItems).map((item) =>
               renderTOCItem(
                 item,
                 sortable,
@@ -251,37 +901,37 @@ function TOCContent({
                 hideChildrenCounter,
                 expandedItems,
                 handleToggleExpanded,
-                handleUpdateItem
+                handleMoveItem,
+                sortableItems,
+                draggedItemId,
+                dragOverItemId,
+                dragOverPosition,
+                sortable ? handleChildrenReorder : undefined,
+                null,
+                handleDragOver,
+                handleDragLeave,
+                handleDrop,
+                justDroppedItemId
               )
             )}
-          </Reorder.Group>
-        ) : (
-          filteredItems.map((item) =>
-            renderTOCItem(
-              item,
-              sortable,
-              0,
-              activeItem,
-              collapsible,
-              hideChildrenCounter,
-              expandedItems,
-              handleToggleExpanded,
-              handleUpdateItem
-            )
-          )
-        )}
-      </div>
+          </div>
+        </div>
+      </ScrollArea>
     </nav>
   )
 }
 
 export function F0TableOfContent(props: TOCProps) {
+  // Create a unique instance ID for each component instance
+  const instanceIdRef = useRef(Symbol("f0-table-of-contents"))
+  const driver = useMemo(() => {
+    return createAtlaskitDriver(instanceIdRef.current)
+  }, [])
+
   return (
-    <DragProvider>
-      <LayoutGroup id="table-of-contents">
-        <TOCContent {...props} />
-      </LayoutGroup>
-    </DragProvider>
+    <DndProvider driver={driver}>
+      <TOCContent {...props} />
+    </DndProvider>
   )
 }
 

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/utils.ts
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/utils.ts
@@ -1,4 +1,4 @@
-import { TOCItem } from "./types"
+import { IdStructure, TOCItem } from "./types"
 
 export function findExpandedPath(
   items: TOCItem[],
@@ -71,4 +71,235 @@ export function filterTree(items: TOCItem[], searchQuery: string): TOCItem[] {
   }
 
   return items.map(filterItem).filter(Boolean) as TOCItem[]
+}
+
+/**
+ * Find an item in the tree by ID and return its path
+ */
+export function findItemInTree(
+  items: TOCItem[],
+  itemId: string
+): { item: TOCItem; parentPath: string[] } | null {
+  function search(
+    items: TOCItem[],
+    targetId: string,
+    parentPath: string[] = []
+  ): { item: TOCItem; parentPath: string[] } | null {
+    for (const item of items) {
+      if (item.id === targetId) {
+        return { item, parentPath }
+      }
+
+      if (item.children) {
+        const result = search(item.children, targetId, [...parentPath, item.id])
+        if (result) return result
+      }
+    }
+    return null
+  }
+
+  return search(items, itemId)
+}
+
+/**
+ * Remove an item from the tree by ID
+ */
+export function removeItemFromTree(
+  items: TOCItem[],
+  itemId: string
+): TOCItem[] {
+  return items
+    .map((item) => {
+      if (item.id === itemId) {
+        return null
+      }
+
+      if (item.children) {
+        const filteredChildren = removeItemFromTree(item.children, itemId)
+        return {
+          ...item,
+          children: filteredChildren.length > 0 ? filteredChildren : undefined,
+        }
+      }
+
+      return item
+    })
+    .filter(Boolean) as TOCItem[]
+}
+
+/**
+ * Insert an item into the tree at a specific location
+ */
+export function insertItemInTree(
+  items: TOCItem[],
+  item: TOCItem,
+  targetParentId: string | null,
+  targetIndex: number
+): TOCItem[] {
+  // If targetParentId is null, insert at root level
+  if (targetParentId === null) {
+    const newItems = [...items]
+    newItems.splice(targetIndex, 0, item)
+    return newItems
+  }
+
+  // Find the parent and insert the item
+  function insert(
+    items: TOCItem[],
+    parentId: string | null,
+    targetIndex: number
+  ): TOCItem[] {
+    return items.map((currentItem) => {
+      if (currentItem.id === parentId) {
+        const children = currentItem.children || []
+        const newChildren = [...children]
+        newChildren.splice(targetIndex, 0, item)
+        return {
+          ...currentItem,
+          children: newChildren,
+        }
+      }
+
+      if (currentItem.children) {
+        return {
+          ...currentItem,
+          children: insert(currentItem.children, parentId, targetIndex),
+        }
+      }
+
+      return currentItem
+    })
+  }
+
+  return insert(items, targetParentId, targetIndex)
+}
+
+/**
+ * Check if moving an item to a target location would create a cycle
+ * (e.g., moving a parent into its own child)
+ */
+export function wouldCreateCycle(
+  items: TOCItem[],
+  itemId: string,
+  targetParentId: string | null
+): boolean {
+  // If target is root level, no cycle possible
+  if (targetParentId === null) return false
+
+  // If target is the item itself, cycle
+  if (targetParentId === itemId) return true
+
+  // Check if targetParentId is a descendant of itemId
+  const itemData = findItemInTree(items, itemId)
+  if (!itemData) return false
+
+  function isDescendant(
+    items: TOCItem[],
+    ancestorId: string,
+    descendantId: string
+  ): boolean {
+    for (const item of items) {
+      if (item.id === descendantId) {
+        return true
+      }
+      if (item.children) {
+        if (isDescendant(item.children, ancestorId, descendantId)) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+
+  // Check if targetParentId is a descendant of itemId
+  const itemWithChildren = findItemInTree(items, itemId)
+  if (itemWithChildren?.item.children) {
+    return isDescendant(itemWithChildren.item.children, itemId, targetParentId)
+  }
+
+  return false
+}
+
+/**
+ * Convert TOCItem tree to IdStructure tree (only IDs, no data)
+ */
+export function convertToIds(items: TOCItem[]): IdStructure[] {
+  return items.map((item) => ({
+    id: item.id,
+    ...(item.children && { children: convertToIds(item.children) }),
+  }))
+}
+
+/**
+ * Update an item in the tree by ID
+ */
+export function updateItemInTree(
+  items: TOCItem[],
+  itemId: string,
+  updatedItem: TOCItem
+): TOCItem[] {
+  return items.map((item) => {
+    if (item.id === itemId) {
+      return updatedItem
+    }
+    if (item.children) {
+      return {
+        ...item,
+        children: updateItemInTree(item.children, itemId, updatedItem),
+      }
+    }
+    return item
+  })
+}
+
+/**
+ * Calculate the adjusted target index when moving an item within the same parent
+ * This accounts for the fact that removing an item shifts indices
+ */
+export function calculateAdjustedIndex(
+  items: TOCItem[],
+  itemId: string,
+  targetParentId: string | null,
+  targetIndex: number
+): number {
+  const itemData = findItemInTree(items, itemId)
+  if (!itemData) return targetIndex
+
+  let adjustedIndex = targetIndex
+
+  if (targetParentId !== null) {
+    const targetParent = findItemInTree(items, targetParentId)
+    if (targetParent) {
+      const sourceParentPath = itemData.parentPath
+      if (
+        sourceParentPath.length > 0 &&
+        sourceParentPath[sourceParentPath.length - 1] === targetParentId
+      ) {
+        const sourceParent = findItemInTree(
+          items,
+          sourceParentPath[sourceParentPath.length - 1]
+        )
+        if (sourceParent) {
+          const originalIndex = sourceParent.item.children?.findIndex(
+            (c) => c.id === itemId
+          )
+          if (originalIndex !== undefined && originalIndex < targetIndex) {
+            adjustedIndex = targetIndex - 1
+          }
+        }
+      }
+    }
+  } else {
+    // Moving to root level
+    const sourceParentPath = itemData.parentPath
+    if (sourceParentPath.length === 0) {
+      // Already at root, just reordering
+      const originalIndex = items.findIndex((i) => i.id === itemId)
+      if (originalIndex < targetIndex) {
+        adjustedIndex = targetIndex - 1
+      }
+    }
+  }
+
+  return adjustedIndex
 }

--- a/packages/react/src/lib/dnd/atlaskitDriver.ts
+++ b/packages/react/src/lib/dnd/atlaskitDriver.ts
@@ -43,7 +43,9 @@ export function createAtlaskitDriver(instanceId: symbol): DndDriver {
       if (disabled) return () => {}
       return draggable({
         element: el,
-        getInitialData: () => ({ ...payload, instanceId }),
+        getInitialData: () => {
+          return { ...payload, instanceId }
+        },
         dragHandle: handle ?? undefined,
       })
     },

--- a/packages/react/src/lib/dnd/hooks.ts
+++ b/packages/react/src/lib/dnd/hooks.ts
@@ -13,15 +13,21 @@ export function useDraggable<T = unknown>(args: {
   const ctx = useDndContextOptional()
   const { ref, payload, disabled, handleRef } = args
 
+  // Create a key that includes both id and currentParentId to detect moves
+  // This ensures we re-register when an item moves to a different parent
+  const payloadData = payload.data as { currentParentId?: string | null }
+  const payloadKey = payload.id + "|" + (payloadData?.currentParentId ?? "null")
+
   useEffect(() => {
     if (!ref.current) return
     if (!ctx || disabled) return
+
     return ctx.driver.registerDraggable(ref.current, {
       payload,
       disabled,
       handle: handleRef?.current ?? null,
     })
-  }, [ctx, ref, payload, disabled, handleRef])
+  }, [ctx, ref, payloadKey, disabled, handleRef, payload])
 }
 
 export function useDroppableList(args?: {


### PR DESCRIPTION
## Description

This PR refactors the `F0TableOfContent` component to use `@atlaskit/pragmatic-drag-and-drop` instead of `motion/react`'s `Reorder` component. The implementation includes visual placeholders during drag operations, improved drop detection, and smooth drop animations.

## Implementation Details

### Major Changes

- **Drag and Drop System**: Migrated from `motion/react`'s `Reorder.Item` to `@atlaskit/pragmatic-drag-and-drop`
- **Visual Placeholders**: Added animated placeholders that appear before/after items during drag operations
- **Drop Animations**: Implemented bounce animation when items are dropped
- **Sticky Header**: Added optional sticky header with search box when scrolling (`scrollable` prop)
- **Utility Functions**: Moved helper functions (`convertToIds`, `updateItemInTree`, `calculateAdjustedIndex`) to `utils.ts`

### Technical Improvements

- Better state management with refs for stable drag tracking
- Debounced drag over updates to prevent flickering
- Improved handling of edge cases (first item position, placeholder drops)
- Enhanced DnD driver to support payload updates during drag

### Breaking Changes

- Removed dependency on `motion/react`'s `Reorder` component
- `Item` component no longer accepts `dragControls` prop
