### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.327.3",
+  "packages/react": "1.328.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.328.0](https://github.com/factorialco/f0/compare/f0-react-v1.327.3...f0-react-v1.328.0) (2026-01-16)
+
+
+### Features
+
+* card border color ([#3252](https://github.com/factorialco/f0/issues/3252)) ([18f3964](https://github.com/factorialco/f0/commit/18f39640a6b02c952cff2c0ce85ca078b00858c1))
+
 ## [1.327.3](https://github.com/factorialco/f0/compare/f0-react-v1.327.2...f0-react-v1.327.3) (2026-01-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.327.3",
+  "version": "1.328.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.328.0</summary>

## [1.328.0](https://github.com/factorialco/f0/compare/f0-react-v1.327.3...f0-react-v1.328.0) (2026-01-16)


### Features

* card border color ([#3252](https://github.com/factorialco/f0/issues/3252)) ([18f3964](https://github.com/factorialco/f0/commit/18f39640a6b02c952cff2c0ce85ca078b00858c1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release `@factorialco/f0-react` 1.328.0**
> 
> - Adds card border color feature
> - Bumps version in `packages/react/package.json` and `.release-please-manifest.json`; updates `packages/react/CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0975efb9d3761d17be4298147e43f3828e6a793b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->