### PR TITLE
fix(Popover): add container prop to fix rendering inside dialogs

### DIFF
--- a/packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx
@@ -1,11 +1,12 @@
 import { F0Button } from "@/components/F0Button"
 import { ButtonInternal } from "@/components/F0Button/internal"
+import { F0DialogContext } from "@/components/F0Dialog"
 import { FilterPickerInternal } from "@/components/F0FilterPickerContent/internal"
 import { Filter } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 import { AnimatePresence, motion } from "motion/react"
-import { useEffect, useId, useMemo, useState } from "react"
+import { useContext, useEffect, useId, useMemo, useState } from "react"
 import { ArrowLeft } from "../../../icons/app"
 import { getFilterType } from "../filterTypes"
 import { FilterTypeContext, FilterTypeSchema } from "../filterTypes/types"
@@ -40,6 +41,16 @@ export function FiltersControls<Filters extends FiltersDefinition>({
   >(null)
   const [internalIsOpen, setInternalIsOpen] = useState(false)
   const i18n = useI18n()
+
+  // Auto-detect if we're inside a dialog and use its portal container
+  const dialogContext = useContext(F0DialogContext)
+  const shouldUseDialogContainer =
+    dialogContext.portalContainer &&
+    (dialogContext.position === "center" ||
+      dialogContext.position === "fullscreen")
+  const portalContainer = shouldUseDialogContainer
+    ? dialogContext.portalContainer
+    : undefined
 
   const isOpen = controlledIsOpen ?? internalIsOpen
   const onOpenChange = controlledOnOpenChange ?? setInternalIsOpen
@@ -265,6 +276,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
           align="start"
           side="bottom"
           aria-id={id}
+          container={portalContainer}
         >
           <FilterPickerInternal
             filters={filters}

--- a/packages/react/src/ui/popover.tsx
+++ b/packages/react/src/ui/popover.tsx
@@ -6,25 +6,36 @@ const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
 
+type PopoverContentProps = React.ComponentPropsWithoutRef<
+  typeof PopoverPrimitive.Content
+> & {
+  container?: HTMLElement | null
+}
+
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      asChild={props.asChild}
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-72 rounded-xs border bg-f1-background p-4 text-f1-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        "origin-[var(--radix-popover-content-transform-origin)]",
-        className
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-))
+  PopoverContentProps
+>(
+  (
+    { className, align = "center", sideOffset = 4, container, ...props },
+    ref
+  ) => (
+    <PopoverPrimitive.Portal container={container}>
+      <PopoverPrimitive.Content
+        asChild={props.asChild}
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 rounded-xs border bg-f1-background p-4 text-f1-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "origin-[var(--radix-popover-content-transform-origin)]",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+)
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
 export { Popover, PopoverContent, PopoverTrigger }


### PR DESCRIPTION
## Description

Fix portal container issue in FiltersControls popover when used inside dialogs. The popover component now supports a `container` prop that allows rendering the portal content into a specific container element, preventing clipping and z-index issues when the component is used within F0Dialog components.

When FiltersControls with its popover was used inside F0Dialog components, the popover would render in the default body portal. This caused z-index stacking issues and potential clipping problems, especially in center and fullscreen dialogs that have focus traps. By detecting the dialog context and using its portal container, the popover now renders correctly within the dialog's scope, maintaining proper layering and preventing visual issues.

## Screenshots (if applicable)
Before:
https://github.com/user-attachments/assets/9984224f-88d4-49e6-8457-97ef28acf60b

After:
https://github.com/user-attachments/assets/08fe3109-1e4d-4f5f-a46e-12e1d812e106
