### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.329.0",
+  "packages/react": "1.329.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.329.1](https://github.com/factorialco/f0/compare/f0-react-v1.329.0...f0-react-v1.329.1) (2026-01-20)
+
+
+### Bug Fixes
+
+* **datacollection:** cols in settings reacts to changes ([#3265](https://github.com/factorialco/f0/issues/3265)) ([d5b89a8](https://github.com/factorialco/f0/commit/d5b89a8786862c2421fd2e6c71f6809288a4292d))
+
 ## [1.329.0](https://github.com/factorialco/f0/compare/f0-react-v1.328.0...f0-react-v1.329.0) (2026-01-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.329.0",
+  "version": "1.329.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.329.1</summary>

## [1.329.1](https://github.com/factorialco/f0/compare/f0-react-v1.329.0...f0-react-v1.329.1) (2026-01-20)


### Bug Fixes

* **datacollection:** cols in settings reacts to changes ([#3265](https://github.com/factorialco/f0/issues/3265)) ([d5b89a8](https://github.com/factorialco/f0/commit/d5b89a8786862c2421fd2e6c71f6809288a4292d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes `@factorialco/f0-react` 1.329.1 with a small bug fix and version bumps.
> 
> - **Bug fix:** `datacollection` settings columns now react to changes (see `packages/react/CHANGELOG.md`)
> - Bumps version to `1.329.1` in `packages/react/package.json` and updates `.release-please-manifest.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0261e812f336b5ca06b61d39c6f99feacc859b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->