### PR TITLE
fix: placeholder ellipsis

### DIFF
--- a/packages/react/src/ui/InputField/InputField.tsx
+++ b/packages/react/src/ui/InputField/InputField.tsx
@@ -501,7 +501,7 @@ const InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
             {!noEdit && (
               <div
                 className={cn(
-                  "pointer-events-none absolute bottom-0 left-0 top-[1px] z-10 flex flex-1 justify-start px-3 text-f1-foreground-secondary transition-opacity",
+                  "pointer-events-none absolute bottom-0 left-0 top-[1px] z-10 flex flex-1 justify-start px-3 text-f1-foreground-secondary transition-opacity line-clamp-1",
                   (icon || avatar) && "pl-8",
                   (icon || avatar) && size === "md" && "pl-9",
                   inputElementVariants({ size }),
@@ -514,6 +514,7 @@ const InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
                 )}
                 onClick={handleClickPlaceholder}
                 aria-hidden="true"
+                title={placeholder}
               >
                 {placeholder}
               </div>

--- a/packages/react/src/ui/InputField/__stories__/InputField.stories.tsx
+++ b/packages/react/src/ui/InputField/__stories__/InputField.stories.tsx
@@ -1,7 +1,8 @@
 import * as icons from "@/icons/app"
-import { Search } from "@/icons/app"
+import { Placeholder, Search } from "@/icons/app"
 import type { Meta, StoryObj } from "@storybook/react-vite"
-import { InputField } from "../"
+import { InputField, INPUTFIELD_SIZES } from "../"
+import { withSkipA11y, withSnapshot } from "@/lib/storybook-utils/parameters"
 
 const meta = {
   title: "Components/InputField",
@@ -289,5 +290,89 @@ export const WithAppendTag: Story = {
     ...Default.args,
     clearable: true,
     appendTag: "Label",
+  },
+}
+
+export const LongPlaceholder: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-96">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    ...Default.args,
+    placeholder:
+      "This is a very long placeholder that should be truncated and show an ellipsis",
+  },
+}
+
+export const Snapshot: Story = {
+  parameters: withSkipA11y(withSnapshot({})),
+  args: Default.args,
+  render: () => {
+    const base = {
+      clearable: true,
+      icon: Placeholder,
+      labelIcon: Placeholder,
+      label: "Label text here",
+      children: <input type="text" className="w-full" />,
+    }
+    const snapshotVariants = [
+      { ...base },
+      { ...base, value: "Value" },
+      { ...base, disabled: true },
+      { ...base, readonly: true },
+      { ...base, required: true },
+      { ...base, maxLength: 10, value: "Value" },
+      { ...base, hideLabel: true },
+      { ...base, error: true },
+      { ...base, icon: Placeholder },
+      {
+        ...base,
+        children: <input type="password" className="w-full" />,
+      },
+      { ...base, status: { type: "error" as const, message: "Error message" } },
+      {
+        ...base,
+        status: { type: "warning" as const, message: "Warning message" },
+      },
+      { ...base, status: { type: "info" as const, message: "Info message" } },
+      { ...base, hint: "Hint message" },
+      { ...base, loading: true },
+      {
+        ...base,
+        appendTag: "Label",
+      },
+      {
+        ...base,
+        append: (
+          <div className="rounded-sm bg-f1-background-secondary px-2 py-0.5 text-f1-foreground-secondary">
+            Tag
+          </div>
+        ),
+      },
+      { ...base },
+    ]
+    return (
+      <div className="flex flex-col gap-4">
+        {INPUTFIELD_SIZES.map((size) => (
+          <section key={size}>
+            <h4 className="mb-3 text-lg font-semibold">Size: {size}</h4>
+            <div className="flex flex-col gap-4">
+              <InputField
+                size={size}
+                label="Label text here"
+                children={<input type="text" className="w-full" />}
+              />
+              {snapshotVariants.map((variant, index) => (
+                <InputField key={`${size}-${index}`} size={size} {...variant} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    )
   },
 }


### PR DESCRIPTION
## Description

Add ellipsis in inputfield placeholder


## Screenshots (if applicable)

Before: 
<img width="360" height="102" alt="image" src="https://github.com/user-attachments/assets/0261006b-2975-4b92-b70b-f47cf9d719e7" />

After:
<img width="427" height="102" alt="image" src="https://github.com/user-attachments/assets/4e61a0f3-87e2-46a7-9118-06709bd9745d" />


[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a46f1461f255f0b73c02a8612350cd95686f8955. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->