### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.330.0",
+  "packages/react": "1.330.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.330.1](https://github.com/factorialco/f0/compare/f0-react-v1.330.0...f0-react-v1.330.1) (2026-01-21)
+
+
+### Bug Fixes
+
+* placeholder ellipsis ([#3268](https://github.com/factorialco/f0/issues/3268)) ([28ca89c](https://github.com/factorialco/f0/commit/28ca89caa7c830983f60875d3dab66d6ca1fcff5))
+
 ## [1.330.0](https://github.com/factorialco/f0/compare/f0-react-v1.329.1...f0-react-v1.330.0) (2026-01-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.330.0",
+  "version": "1.330.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.330.1</summary>

## [1.330.1](https://github.com/factorialco/f0/compare/f0-react-v1.330.0...f0-react-v1.330.1) (2026-01-21)


### Bug Fixes

* placeholder ellipsis ([#3268](https://github.com/factorialco/f0/issues/3268)) ([28ca89c](https://github.com/factorialco/f0/commit/28ca89caa7c830983f60875d3dab66d6ca1fcff5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes a patch release of `@factorialco/f0-react` with a small bug fix.
> 
> - Bumps `packages/react` to `1.330.1` in `package.json` and `.release-please-manifest.json`
> - Updates `CHANGELOG.md` with a bug fix entry for placeholder ellipsis
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84a83276d9882c171b5a147e7d6821dfc1acb2b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->