### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.330.1",
+  "packages/react": "1.330.2",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.330.2](https://github.com/factorialco/f0/compare/f0-react-v1.330.1...f0-react-v1.330.2) (2026-01-22)
+
+
+### Bug Fixes
+
+* **Popover:** add container prop to fix rendering inside dialogs ([#3255](https://github.com/factorialco/f0/issues/3255)) ([9138284](https://github.com/factorialco/f0/commit/9138284e4324f0bc7981e4309fbcd8eb43eb2087))
+
 ## [1.330.1](https://github.com/factorialco/f0/compare/f0-react-v1.330.0...f0-react-v1.330.1) (2026-01-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.330.1",
+  "version": "1.330.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.330.2</summary>

## [1.330.2](https://github.com/factorialco/f0/compare/f0-react-v1.330.1...f0-react-v1.330.2) (2026-01-22)


### Bug Fixes

* **Popover:** add container prop to fix rendering inside dialogs ([#3255](https://github.com/factorialco/f0/issues/3255)) ([9138284](https://github.com/factorialco/f0/commit/9138284e4324f0bc7981e4309fbcd8eb43eb2087))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release:** `packages/react` bumped to `1.330.2` with changelog update.
> 
> - Bug fix: `Popover` adds `container` prop to ensure proper rendering inside dialogs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 833474d7a5912c20b9cde6e1ff69b9744a625475. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->