### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.330.2",
+  "packages/react": "1.331.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.331.0](https://github.com/factorialco/f0/compare/f0-react-v1.330.2...f0-react-v1.331.0) (2026-01-22)
+
+
+### Features
+
+* add image extension to NotesTextEditor ([#3250](https://github.com/factorialco/f0/issues/3250)) ([08207e5](https://github.com/factorialco/f0/commit/08207e5fe3bc681586ef80875b6a8c374fbd98fd))
+
 ## [1.330.2](https://github.com/factorialco/f0/compare/f0-react-v1.330.1...f0-react-v1.330.2) (2026-01-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.330.2",
+  "version": "1.331.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.331.0</summary>

## [1.331.0](https://github.com/factorialco/f0/compare/f0-react-v1.330.2...f0-react-v1.331.0) (2026-01-22)


### Features

* add image extension to NotesTextEditor ([#3250](https://github.com/factorialco/f0/issues/3250)) ([08207e5](https://github.com/factorialco/f0/commit/08207e5fe3bc681586ef80875b6a8c374fbd98fd))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release f0-react 1.331.0**
> 
> - Adds image extension support to `NotesTextEditor` (documented in `CHANGELOG.md`)
> - Bumps `@factorialco/f0-react` version to `1.331.0` in `package.json` and updates `.release-please-manifest.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cfb3c1837d2436c7e9bb7f82a7d309ace853349. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->