### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.331.0",
+  "packages/react": "1.332.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.332.0](https://github.com/factorialco/f0/compare/f0-react-v1.331.0...f0-react-v1.332.0) (2026-01-22)
+
+
+### Features
+
+* add communities module icon ([#3276](https://github.com/factorialco/f0/issues/3276)) ([46deaf9](https://github.com/factorialco/f0/commit/46deaf9fa82ff06c85ddcda593c63f842cd21a47))
+
 ## [1.331.0](https://github.com/factorialco/f0/compare/f0-react-v1.330.2...f0-react-v1.331.0) (2026-01-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.331.0",
+  "version": "1.332.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.332.0</summary>

## [1.332.0](https://github.com/factorialco/f0/compare/f0-react-v1.331.0...f0-react-v1.332.0) (2026-01-22)


### Features

* add communities module icon ([#3276](https://github.com/factorialco/f0/issues/3276)) ([46deaf9](https://github.com/factorialco/f0/commit/46deaf9fa82ff06c85ddcda593c63f842cd21a47))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases `@factorialco/f0-react` 1.332.0.
> 
> - Version bump in `packages/react` manifest and `package.json`
> - Changelog adds feature: add communities module icon
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bf6c918d391d009e2a7cdd74cbddc65e5ac056c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->