### PR TITLE
fix: nested tables - apply observables to useLoadChildren hook

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/hooks/useLoadChildren.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/hooks/useLoadChildren.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import { Observable } from "zen-observable-ts"
 
 import { DataCollectionSource } from "@/experimental/OneDataCollection/hooks/useDataCollectionSource/types"
 import { ItemActionsDefinition } from "@/experimental/OneDataCollection/item-actions"
@@ -16,6 +17,7 @@ import {
   NestedResponseWithType,
   NestedVariant,
 } from "@/hooks/datasource/types/nested.typings"
+import { promiseToObservable, PromiseState } from "@/lib/promise-to-observable"
 
 import { useNestedDataContext } from "../providers/NestedProvider"
 
@@ -134,35 +136,90 @@ export const useLoadChildren = <
     onClearFetchedData,
   ])
 
-  const loadChildren = useCallback(async () => {
+  const subscriptionRef = useRef<ZenObservable.Subscription | undefined>()
+
+  const processChildrenData = useCallback(
+    (data: ChildrenResponse<R> | undefined) => {
+      const loadedChildren = getChildren(data)
+      const updatedChildren = [...children, ...loadedChildren]
+      setChildren(updatedChildren)
+
+      const updatedData: ChildrenResponse<R> = {
+        records: updatedChildren,
+        type: data?.type,
+        paginationInfo: data?.paginationInfo,
+      }
+
+      updateFetchedData(rowId, updatedData)
+      setChildrenType(getChildrenType(data))
+      setPaginationInfo(data?.paginationInfo)
+
+      return loadedChildren
+    },
+    [children, rowId, updateFetchedData]
+  )
+
+  const loadChildren = useCallback(() => {
     if (children.length > 0 && !paginationInfo?.hasMore) return children
+
+    // Cancel any existing subscription
+    subscriptionRef.current?.unsubscribe()
 
     setIsLoading(true)
 
-    const data = await source.fetchChildren?.({
+    const result = source.fetchChildren?.({
       item,
       filters: source.currentFilters,
       pagination: paginationInfo,
       sortings: source.currentSortings,
     })
-    const loadedChildren = getChildren(data)
 
-    const updatedChildren = [...children, ...loadedChildren]
-    setChildren(updatedChildren)
-
-    const updatedData: ChildrenResponse<R> = {
-      records: updatedChildren,
-      type: data?.type,
-      paginationInfo: data?.paginationInfo,
+    // Handle undefined result
+    if (!result) {
+      setIsLoading(false)
+      return []
     }
 
-    updateFetchedData(rowId, updatedData)
-    setChildrenType(getChildrenType(data))
-    setPaginationInfo(data?.paginationInfo)
-    setIsLoading(false)
+    // Handle synchronous data (not a Promise or Observable)
+    if (!("then" in result) && !("subscribe" in result)) {
+      const loadedChildren = processChildrenData(result)
+      setIsLoading(false)
+      return loadedChildren
+    }
 
-    return loadedChildren
-  }, [children, item, source, rowId, updateFetchedData, paginationInfo])
+    // Convert Promise to Observable or use existing Observable
+    const observable: Observable<PromiseState<ChildrenResponse<R>>> =
+      "subscribe" in result ? result : promiseToObservable(result)
+
+    subscriptionRef.current = observable.subscribe({
+      next: (state) => {
+        if (state.loading) {
+          setIsLoading(true)
+        } else if (state.error) {
+          setIsLoading(false)
+        } else if (state.data) {
+          processChildrenData(state.data)
+          setIsLoading(false)
+        }
+      },
+      error: (error) => {
+        setIsLoading(false)
+        console.error("Error loading children:", error)
+      },
+      complete: () => {
+        subscriptionRef.current = undefined
+      },
+    })
+
+    return []
+  }, [children, item, source, paginationInfo, processChildrenData])
+
+  // Cleanup subscription on unmount
+  useEffect(() => {
+    return () => {
+      subscriptionRef.current?.unsubscribe()
+    }
+  }, [])
 
   return {
     children,

--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -1,8 +1,11 @@
+import { Observable } from "zen-observable-ts"
+
 import {
   FiltersDefinition,
   FiltersState,
   PresetsDefinition,
 } from "@/components/OneFilterPicker/types"
+import { PromiseState } from "@/lib/promise-to-observable"
 
 import { DataAdapter } from "./fetch.typings"
 import { GroupingDefinition, GroupingState } from "./grouping.typings"
@@ -86,7 +89,10 @@ export type DataSourceDefinition<
     filters?: FiltersState<Filters>
     pagination?: ChildrenPaginationInfo
     sortings?: SortingsState<Sortings>
-  }) => Promise<ChildrenResponse<R>>
+  }) =>
+    | ChildrenResponse<R>
+    | Promise<ChildrenResponse<R>>
+    | Observable<PromiseState<ChildrenResponse<R>>>
   /** Function to determine if an item has children */
   itemsWithChildren?: (item: R) => boolean
   /** Function to get the number of children for an item */

--- a/packages/react/src/icons/modules/Communities.tsx
+++ b/packages/react/src/icons/modules/Communities.tsx
@@ -1,4 +1,5 @@
 import type { SVGProps } from "react"
+
 import { Ref, forwardRef } from "react"
 const SvgCommunities = (
   props: SVGProps<SVGSVGElement>,


### PR DESCRIPTION
## Summary

Enhances `useLoadChildren` hook to support Observable-based data fetching, aligning with the pattern used in `useData.ts`.

### Changes

- **`fetchChildren` now accepts three return types:** sync data, Promise, or Observable
- **Refactored `loadChildren`:** replaced `async/await` with Observable subscription pattern
- **Added subscription cleanup** on unmount to prevent memory leaks