### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.333.1",
+  "packages/react": "1.333.2",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.333.2](https://github.com/factorialco/f0/compare/f0-react-v1.333.1...f0-react-v1.333.2) (2026-01-23)
+
+
+### Bug Fixes
+
+* nested tables - apply observables to useLoadChildren hook ([#3281](https://github.com/factorialco/f0/issues/3281)) ([d210f78](https://github.com/factorialco/f0/commit/d210f781add32b630e9b64bb47d5616f5b72e45a))
+
 ## [1.333.1](https://github.com/factorialco/f0/compare/f0-react-v1.333.0...f0-react-v1.333.1) (2026-01-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.333.1",
+  "version": "1.333.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.333.2</summary>

## [1.333.2](https://github.com/factorialco/f0/compare/f0-react-v1.333.1...f0-react-v1.333.2) (2026-01-23)


### Bug Fixes

* nested tables - apply observables to useLoadChildren hook ([#3281](https://github.com/factorialco/f0/issues/3281)) ([d210f78](https://github.com/factorialco/f0/commit/d210f781add32b630e9b64bb47d5616f5b72e45a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release `@factorialco/f0-react` 1.333.2**
> 
> - Bumps `packages/react` version to `1.333.2` in `package.json` and manifest
> - Changelog adds bug fix: apply observables to `useLoadChildren` for nested tables
> 
> *No code changes beyond versioning and changelog updates*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de5cd0514bd353a74be248100d46c1d07e4110db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->