### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.333.2",
+  "packages/react": "1.334.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.334.0](https://github.com/factorialco/f0/compare/f0-react-v1.333.2...f0-react-v1.334.0) (2026-01-26)
+
+
+### Features
+
+* **TableOfContentPopover:** rename and normalize table of content popover component ([#3289](https://github.com/factorialco/f0/issues/3289)) ([f48c2e8](https://github.com/factorialco/f0/commit/f48c2e8cd684f7ee50ffef3b4b9c24047e8f2489))
+
 ## [1.333.2](https://github.com/factorialco/f0/compare/f0-react-v1.333.1...f0-react-v1.333.2) (2026-01-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.333.2",
+  "version": "1.334.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.334.0</summary>

## [1.334.0](https://github.com/factorialco/f0/compare/f0-react-v1.333.2...f0-react-v1.334.0) (2026-01-26)


### Features

* **TableOfContentPopover:** rename and normalize table of content popover component ([#3289](https://github.com/factorialco/f0/issues/3289)) ([f48c2e8](https://github.com/factorialco/f0/commit/f48c2e8cd684f7ee50ffef3b4b9c24047e8f2489))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases `@factorialco/f0-react` v1.334.0 and updates release metadata.
> 
> - Updates `packages/react` version to `1.334.0` in `package.json` and `.release-please-manifest.json`
> - Changelog: feature to rename/normalize `TableOfContentPopover` component
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ca55e63dda12ef85b6cfd1365bd308b68da41d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->