### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.334.0",
+  "packages/react": "1.335.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.335.0](https://github.com/factorialco/f0/compare/f0-react-v1.334.0...f0-react-v1.335.0) (2026-01-26)
+
+
+### Features
+
+* modify TableOfContentPopover exports ([#3291](https://github.com/factorialco/f0/issues/3291)) ([8517896](https://github.com/factorialco/f0/commit/8517896f90e81a34671a845b82ff3ec326a92c19))
+
 ## [1.334.0](https://github.com/factorialco/f0/compare/f0-react-v1.333.2...f0-react-v1.334.0) (2026-01-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.334.0",
+  "version": "1.335.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.335.0</summary>

## [1.335.0](https://github.com/factorialco/f0/compare/f0-react-v1.334.0...f0-react-v1.335.0) (2026-01-26)


### Features

* modify TableOfContentPopover exports ([#3291](https://github.com/factorialco/f0/issues/3291)) ([8517896](https://github.com/factorialco/f0/commit/8517896f90e81a34671a845b82ff3ec326a92c19))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release:** `@factorialco/f0-react` 1.335.0
> 
> - Bumps package version and manifest to `1.335.0`
> - Adds changelog entry noting a feature: modified `TableOfContentPopover` exports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6783a2eed9c4629fcabad6f1be4e79fcc6324348. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->