### PR TITLE
fix: take into account overflowButtonWidth just when there is overflow

### DIFF
--- a/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
+++ b/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
@@ -108,13 +108,22 @@ export function useOverflowCalculation<T>(
     const itemWidths = measureItemWidths()
     const itemWidthsWithGap = itemWidths.map((width) => width + gap)
 
-    // Calculate how many items fit with an overflow button
-    const availableWidth = currentContainerWidth - overflowButtonWidth - gap
-
-    const visibleCount = calculateVisibleItemCount({
+    const availableWidthWithoutOverflow = currentContainerWidth
+    const visibleCountWithoutOverflow = calculateVisibleItemCount({
       itemWidths: itemWidthsWithGap,
-      availableWidth,
+      availableWidth: availableWidthWithoutOverflow,
     })
+
+    const fitsWithoutOverflow =
+      visibleCountWithoutOverflow >= items.length &&
+      (options?.max === undefined || items.length <= options.max)
+
+    const visibleCount = fitsWithoutOverflow
+      ? visibleCountWithoutOverflow
+      : calculateVisibleItemCount({
+          itemWidths: itemWidthsWithGap,
+          availableWidth: currentContainerWidth - overflowButtonWidth - gap,
+        })
 
     let visibleItems = visibleCount === 0 ? [] : items.slice(0, visibleCount)
     let overflowItems = visibleCount === 0 ? items : items.slice(visibleCount)
@@ -132,7 +141,7 @@ export function useOverflowCalculation<T>(
       visibleItems,
       overflowItems,
     })
-  }, [items, gap, measureItemWidths, calculateVisibleItemCount])
+  }, [items, gap, measureItemWidths, calculateVisibleItemCount, options?.max])
 
   // Initial calculation and initialization
   useEffect(() => {


### PR DESCRIPTION
> [!WARNING]  
> This OverflowList component is used in multiple components. I've manually tested them in storybook and they seem work fine. These components are:
> 1. F0ChipList
> 2. FiltersPresets
> 3. F0AvatarList
> 3. F0TagList

## Description
Fix overflow list sizing so short avatar lists (≤ max) render all visible avatars instead of overflowing when there’s enough space. This prevents single‑ and small‑count lists from appearing only in the popover due to reserved overflow indicator width.

## Screenshots (if applicable)
| Before  | After |
| ------------- | ------------- |
| <img width="320" height="137" alt="image" src="https://github.com/user-attachments/assets/8b0abbf7-cb0b-4382-a60e-9862622da897" />  | <img width="262" height="117" alt="image" src="https://github.com/user-attachments/assets/22c0b33a-d453-4e71-9f89-e80e5d7b27eb" />  |
| <img width="302" height="134" alt="image" src="https://github.com/user-attachments/assets/9a9bbc64-6037-4deb-bdf1-04c9eee5fea1" />  | <img width="249" height="122" alt="image" src="https://github.com/user-attachments/assets/121005c0-e66d-4fe0-a320-f3d41e343b41" />  |
| <img width="332" height="142" alt="image" src="https://github.com/user-attachments/assets/76fb8735-852d-40c9-969d-c37cb59a7544" />  | <img width="261" height="121" alt="image" src="https://github.com/user-attachments/assets/affd652f-57fe-41b6-a8bd-7e86ef138d6b" />  |

And it keeps working for more than max (3)
<img width="359" height="132" alt="image" src="https://github.com/user-attachments/assets/d739a206-e7e4-4b42-a830-02c9430e6c56" /> 

[Link to Figma Design](https://www.figma.com/design/GMCxqNWVOzvwxtkIuqwihB/%F0%9F%91%AB--Communities?node-id=6499-46766&t=ib4Wpc5ndF6VWrLz-4)

## Implementation details
- Updated overflow calculation to first check fit without reserving overflow-indicator width.
- Only subtracts overflow indicator width when overflow is actually needed.
- Preserves overflow behavior when the container is too small.