### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.336.0",
+  "packages/react": "1.336.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.336.1](https://github.com/factorialco/f0/compare/f0-react-v1.336.0...f0-react-v1.336.1) (2026-01-27)
+
+
+### Bug Fixes
+
+* add support to edit emojis in rating questions ([#3298](https://github.com/factorialco/f0/issues/3298)) ([ccd3845](https://github.com/factorialco/f0/commit/ccd3845ae900de0d47cde1d3d0b78a963543058e))
+
 ## [1.336.0](https://github.com/factorialco/f0/compare/f0-react-v1.335.0...f0-react-v1.336.0) (2026-01-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.336.0",
+  "version": "1.336.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.336.1</summary>

## [1.336.1](https://github.com/factorialco/f0/compare/f0-react-v1.336.0...f0-react-v1.336.1) (2026-01-27)


### Bug Fixes

* add support to edit emojis in rating questions ([#3298](https://github.com/factorialco/f0/issues/3298)) ([ccd3845](https://github.com/factorialco/f0/commit/ccd3845ae900de0d47cde1d3d0b78a963543058e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release:** *f0-react 1.336.1*
> 
> - Bumps `packages/react` version to `1.336.1` and updates `.release-please-manifest.json`
> - Adds CHANGELOG entry for a bug fix: support editing emojis in rating questions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78d4c5af740c5f5fb92951a20486480c3f60d521. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->