### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.336.1",
+  "packages/react": "1.337.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.337.0](https://github.com/factorialco/f0/compare/f0-react-v1.336.1...f0-react-v1.337.0) (2026-01-27)
+
+
+### Features
+
+* update docs for nested tables in Data Collection ([#3296](https://github.com/factorialco/f0/issues/3296)) ([b595b8b](https://github.com/factorialco/f0/commit/b595b8b72ab48b1201cc8c9ec5efe8028726c824))
+
 ## [1.336.1](https://github.com/factorialco/f0/compare/f0-react-v1.336.0...f0-react-v1.336.1) (2026-01-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.336.1",
+  "version": "1.337.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.337.0</summary>

## [1.337.0](https://github.com/factorialco/f0/compare/f0-react-v1.336.1...f0-react-v1.337.0) (2026-01-27)


### Features

* update docs for nested tables in Data Collection ([#3296](https://github.com/factorialco/f0/issues/3296)) ([b595b8b](https://github.com/factorialco/f0/commit/b595b8b72ab48b1201cc8c9ec5efe8028726c824))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release `@factorialco/f0-react` 1.337.0**
> 
> - Bumps `packages/react` version to `1.337.0` in `package.json` and `.release-please-manifest.json`
> - Updates `CHANGELOG.md` with a feature: docs update for nested tables in Data Collection
> 
> *No runtime code changes; release/versioning and docs only.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eef8e9a603303e1ffa44388ec1e957947417c851. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->