### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.337.0",
+  "packages/react": "1.337.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.337.1](https://github.com/factorialco/f0/compare/f0-react-v1.337.0...f0-react-v1.337.1) (2026-01-27)
+
+
+### Bug Fixes
+
+* take into account overflowButtonWidth just when there is overflow ([#3294](https://github.com/factorialco/f0/issues/3294)) ([807b341](https://github.com/factorialco/f0/commit/807b3418afc99261dc103ea8dc7bc0855bf83e36))
+
 ## [1.337.0](https://github.com/factorialco/f0/compare/f0-react-v1.336.1...f0-react-v1.337.0) (2026-01-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.337.0",
+  "version": "1.337.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.337.1</summary>

## [1.337.1](https://github.com/factorialco/f0/compare/f0-react-v1.337.0...f0-react-v1.337.1) (2026-01-27)


### Bug Fixes

* take into account overflowButtonWidth just when there is overflow ([#3294](https://github.com/factorialco/f0/issues/3294)) ([807b341](https://github.com/factorialco/f0/commit/807b3418afc99261dc103ea8dc7bc0855bf83e36))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Patch release for `@factorialco/f0-react`**
> 
> - Bumps `packages/react` to `1.337.1`; updates `package.json` and `.release-please-manifest.json`
> - Adds CHANGELOG entry noting bug fix: consider `overflowButtonWidth` only when there is overflow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2eb3d47246c05380d8fcb4e50e6395c1213d125c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->