### PR TITLE
fix(l10n): make date optional in L10nContextValue

### DIFF
--- a/packages/react/src/lib/providers/l10n/types.ts
+++ b/packages/react/src/lib/providers/l10n/types.ts
@@ -2,7 +2,7 @@ import { WeekStartsOn } from "@/experimental/OneCalendar/types"
 
 export type L10nContextValue = {
   locale: string
-  date: {
+  date?: {
     weekStartsOn: WeekStartsOn
   }
 }


### PR DESCRIPTION
## Description

Make `date` optional in `L10nContextValue` so Factorial can use L10nProvider with only `{ locale }`. Apps that don't use calendar features were getting a TS error in CI when passing just the locale.

## Implementation details

- **What:** Make the `date` property optional in `L10nContextValue` (`packages/react/src/lib/providers/l10n/types.ts`).
- **Why:** Integrators were required to pass `date.weekStartsOn` even when not using calendar components. Consumers (OneCalendar, DatePickerPopup, etc.) already use `l10n.date?.weekStartsOn ?? default`, so no further changes were needed.