### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.337.1",
+  "packages/react": "1.337.2",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.337.2](https://github.com/factorialco/f0/compare/f0-react-v1.337.1...f0-react-v1.337.2) (2026-01-27)
+
+
+### Bug Fixes
+
+* **l10n:** make date optional in L10nContextValue ([#3303](https://github.com/factorialco/f0/issues/3303)) ([17aefd3](https://github.com/factorialco/f0/commit/17aefd362890ac01a8a845569be60bc0aa3dc69c))
+
 ## [1.337.1](https://github.com/factorialco/f0/compare/f0-react-v1.337.0...f0-react-v1.337.1) (2026-01-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.337.1",
+  "version": "1.337.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.337.2</summary>

## [1.337.2](https://github.com/factorialco/f0/compare/f0-react-v1.337.1...f0-react-v1.337.2) (2026-01-27)


### Bug Fixes

* **l10n:** make date optional in L10nContextValue ([#3303](https://github.com/factorialco/f0/issues/3303)) ([17aefd3](https://github.com/factorialco/f0/commit/17aefd362890ac01a8a845569be60bc0aa3dc69c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes a patch release of `@factorialco/f0-react`.
> 
> - Fixes l10n type by making `date` optional in `L10nContextValue`
> - Bumps `packages/react` version to `1.337.2` in `package.json` and `.release-please-manifest.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c5e6a1fafa9954fcecf29efd4c5936b718e4aaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->