### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.337.2",
+  "packages/react": "1.338.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.338.0](https://github.com/factorialco/f0/compare/f0-react-v1.337.2...f0-react-v1.338.0) (2026-01-27)
+
+
+### Features
+
+* **CardSelectable:** add new card selection component ([#3299](https://github.com/factorialco/f0/issues/3299)) ([1f3a45b](https://github.com/factorialco/f0/commit/1f3a45b762b0c031bc2d8db6428b08aea299bb3c))
+
 ## [1.337.2](https://github.com/factorialco/f0/compare/f0-react-v1.337.1...f0-react-v1.337.2) (2026-01-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.337.2",
+  "version": "1.338.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.338.0</summary>

## [1.338.0](https://github.com/factorialco/f0/compare/f0-react-v1.337.2...f0-react-v1.338.0) (2026-01-27)


### Features

* **CardSelectable:** add new card selection component ([#3299](https://github.com/factorialco/f0/issues/3299)) ([1f3a45b](https://github.com/factorialco/f0/commit/1f3a45b762b0c031bc2d8db6428b08aea299bb3c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release: `@factorialco/f0-react` v1.338.0**
> 
> - Adds new `CardSelectable` component
> - Bumps version in `packages/react/package.json` and updates `.release-please-manifest.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f616157dfccf2901692918349fea34c72244b759. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->