### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.338.0",
+  "packages/react": "1.338.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.338.1](https://github.com/factorialco/f0/compare/f0-react-v1.338.0...f0-react-v1.338.1) (2026-01-27)
+
+
+### Bug Fixes
+
+* **popover:** height and overflow ([#3271](https://github.com/factorialco/f0/issues/3271)) ([c888c94](https://github.com/factorialco/f0/commit/c888c94eb8501a0ef8544bf9f9d39fb975047121))
+
 ## [1.338.0](https://github.com/factorialco/f0/compare/f0-react-v1.337.2...f0-react-v1.338.0) (2026-01-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.338.0",
+  "version": "1.338.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,
@@ -50,7 +50,6 @@
     "vitest:ci": "pnpm run vitest --project=unit --reporter=dot",
     "cycle-deps:delta": "tsx --tsconfig tsconfig.node.json .scripts/check-cycle-dependencies.ts"
   },
-  
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.7.4",
     "@atlaskit/pragmatic-drag-and-drop-flourish": "^2.0.4",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.338.1</summary>

## [1.338.1](https://github.com/factorialco/f0/compare/f0-react-v1.338.0...f0-react-v1.338.1) (2026-01-27)


### Bug Fixes

* **popover:** height and overflow ([#3271](https://github.com/factorialco/f0/issues/3271)) ([c888c94](https://github.com/factorialco/f0/commit/c888c94eb8501a0ef8544bf9f9d39fb975047121))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release:** *@factorialco/f0-react* v1.338.1
> 
> - Bumps `packages/react` version to `1.338.1` and updates `.release-please-manifest.json`
> - Adds changelog entry for a popover bug fix (height/overflow)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bd42065b4ea932e1a4ebf475a7fcd343a2b3411. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->