### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.338.1",
+  "packages/react": "1.338.2",
   "packages/react-native": "0.22.0",
   "packages/core": "1.42.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.338.2](https://github.com/factorialco/f0/compare/f0-react-v1.338.1...f0-react-v1.338.2) (2026-01-28)
+
+
+### Bug Fixes
+
+* get rid of Alert and rename OneAlert to F0Alert ([#3307](https://github.com/factorialco/f0/issues/3307)) ([c792592](https://github.com/factorialco/f0/commit/c792592d41cc129cc4f591edd0b44b49b94522e0))
+
 ## [1.338.1](https://github.com/factorialco/f0/compare/f0-react-v1.338.0...f0-react-v1.338.1) (2026-01-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.338.1",
+  "version": "1.338.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.338.2</summary>

## [1.338.2](https://github.com/factorialco/f0/compare/f0-react-v1.338.1...f0-react-v1.338.2) (2026-01-28)


### Bug Fixes

* get rid of Alert and rename OneAlert to F0Alert ([#3307](https://github.com/factorialco/f0/issues/3307)) ([c792592](https://github.com/factorialco/f0/commit/c792592d41cc129cc4f591edd0b44b49b94522e0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases `@factorialco/f0-react` 1.338.2.
> 
> - Bumps version in `package.json` and manifest
> - Changelog: bug fix removing `Alert` and renaming `OneAlert` to `F0Alert`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb5d0d87df78b0d72b25c965cdd58508144e88db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->