### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.338.2",
+  "packages/react": "1.339.0",
   "packages/react-native": "0.22.0",
-  "packages/core": "1.42.1"
+  "packages/core": "1.43.0"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.43.0](https://github.com/factorialco/f0/compare/f0-core-v1.42.1...f0-core-v1.43.0) (2026-01-28)
+
+
+### Features
+
+* add PushPin and PushPinSolid icons ([#3313](https://github.com/factorialco/f0/issues/3313)) ([cb03a06](https://github.com/factorialco/f0/commit/cb03a066371b9db579838c237cf39b75a7491c82))
+
 ## [1.42.1](https://github.com/factorialco/f0/compare/f0-core-v1.42.0...f0-core-v1.42.1) (2025-12-11)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-core",
-  "version": "1.42.1",
+  "version": "1.43.0",
   "description": "Core tokens and utilities for F0 Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.339.0](https://github.com/factorialco/f0/compare/f0-react-v1.338.2...f0-react-v1.339.0) (2026-01-28)
+
+
+### Features
+
+* add PushPin and PushPinSolid icons ([#3313](https://github.com/factorialco/f0/issues/3313)) ([cb03a06](https://github.com/factorialco/f0/commit/cb03a066371b9db579838c237cf39b75a7491c82))
+
 ## [1.338.2](https://github.com/factorialco/f0/compare/f0-react-v1.338.1...f0-react-v1.338.2) (2026-01-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.338.2",
+  "version": "1.339.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.339.0</summary>

## [1.339.0](https://github.com/factorialco/f0/compare/f0-react-v1.338.2...f0-react-v1.339.0) (2026-01-28)


### Features

* add PushPin and PushPinSolid icons ([#3313](https://github.com/factorialco/f0/issues/3313)) ([cb03a06](https://github.com/factorialco/f0/commit/cb03a066371b9db579838c237cf39b75a7491c82))
</details>

<details><summary>f0-core: 1.43.0</summary>

## [1.43.0](https://github.com/factorialco/f0/compare/f0-core-v1.42.1...f0-core-v1.43.0) (2026-01-28)


### Features

* add PushPin and PushPinSolid icons ([#3313](https://github.com/factorialco/f0/issues/3313)) ([cb03a06](https://github.com/factorialco/f0/commit/cb03a066371b9db579838c237cf39b75a7491c82))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases new versions of `@factorialco/f0-react` and `@factorialco/f0-core`.
> 
> - Adds `PushPin` and `PushPinSolid` icons in both React and Core packages
> - Bumps versions: `react` to `1.339.0`, `core` to `1.43.0`; updates `.release-please-manifest.json` and package changelogs accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7543e069116546ea30497f8b8f29bf0c377923b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->