### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.339.0",
+  "packages/react": "1.339.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.339.1](https://github.com/factorialco/f0/compare/f0-react-v1.339.0...f0-react-v1.339.1) (2026-01-28)
+
+
+### Bug Fixes
+
+* resource header not rendering because Metadata component was wrapped in memo ([#3315](https://github.com/factorialco/f0/issues/3315)) ([0e7b2f4](https://github.com/factorialco/f0/commit/0e7b2f45abd95f7afd78107f2acc0c784c9e3d5a))
+
 ## [1.339.0](https://github.com/factorialco/f0/compare/f0-react-v1.338.2...f0-react-v1.339.0) (2026-01-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.339.0",
+  "version": "1.339.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.339.1</summary>

## [1.339.1](https://github.com/factorialco/f0/compare/f0-react-v1.339.0...f0-react-v1.339.1) (2026-01-28)


### Bug Fixes

* resource header not rendering because Metadata component was wrapped in memo ([#3315](https://github.com/factorialco/f0/issues/3315)) ([0e7b2f4](https://github.com/factorialco/f0/commit/0e7b2f45abd95f7afd78107f2acc0c784c9e3d5a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes a patch release for `@factorialco/f0-react`.
> 
> - Bumps version to `1.339.1` in `package.json` and `.release-please-manifest.json`
> - Updates `CHANGELOG.md` with a bug fix: resource header not rendering due to `Metadata` being wrapped in `memo`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61950504adcfd38ceec666cb1051580af44cf62b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->