### PR TITLE
feat: set long label for consistency

### DIFF
--- a/packages/react/src/components/F0DatePicker/components/DateInput.tsx
+++ b/packages/react/src/components/F0DatePicker/components/DateInput.tsx
@@ -45,7 +45,7 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const i18n = useI18n()
 
     useEffect(() => {
-      setInputValue(granularity.toString(value?.value, i18n))
+      setInputValue(granularity.toString(value?.value, i18n, "long"))
     }, [value, granularity, i18n])
 
     const isValidDate = (date: Date | undefined | null) => {


### PR DESCRIPTION
## Description

We want to display label like "Week of 5 Jan 2025" in DatePicker component as we currently do in DateNavigator. This string is more clear and understandable to the users.

<img width="709" height="332" alt="image" src="https://github.com/user-attachments/assets/27f698e5-644e-4fe0-ba09-d373fa3f9b21" />



## Implementation details

Just set the format "long" in the `toString` format
