### PR TITLE
fix(OneFilterPicker): prevent double toggle when closing open popover

### DIFF
--- a/packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx
@@ -1,3 +1,4 @@
+import { useControllableState } from "@radix-ui/react-use-controllable-state"
 import { AnimatePresence, motion } from "motion/react"
 import { useContext, useEffect, useId, useMemo, useRef, useState } from "react"
 
@@ -42,7 +43,6 @@ export function FiltersControls<Filters extends FiltersDefinition>({
   const [selectedFilterKey, setSelectedFilterKey] = useState<
     keyof Filters | null
   >(null)
-  const [internalIsOpen, setInternalIsOpen] = useState(false)
   const i18n = useI18n()
 
   // Auto-detect if we're inside a dialog and use its portal container
@@ -55,7 +55,11 @@ export function FiltersControls<Filters extends FiltersDefinition>({
     ? dialogContext.portalContainer
     : undefined
 
-  const isOpen = controlledIsOpen ?? internalIsOpen
+  const [isOpen, setIsOpen] = useControllableState({
+    prop: controlledIsOpen,
+    defaultProp: false,
+    onChange: controlledOnOpenChange,
+  })
 
   const isOpenRef = useRef(isOpen)
   useEffect(() => {
@@ -72,12 +76,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
 
     if (currentIsOpen) {
       isClosingRef.current = true
-
-      if (controlledOnOpenChange) {
-        controlledOnOpenChange(false)
-      } else {
-        setInternalIsOpen(false)
-      }
+      setIsOpen(false)
 
       setTimeout(() => {
         isClosingRef.current = false
@@ -86,11 +85,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
       return
     }
 
-    if (controlledOnOpenChange) {
-      controlledOnOpenChange(open)
-    } else {
-      setInternalIsOpen(open)
-    }
+    setIsOpen(open)
   }
 
   const onOpenChange = handleOpenChange


### PR DESCRIPTION
## Description

Fix double-toggle issue in `OneFilterPicker` where clicking the filter icon while the popover is already open would cause it to close and immediately reopen. This PR intercepts the `onOpenChange` callback to properly handle the close action when the popover is open, preventing Radix UI from reopening it.

## Screenshots 

**Before**
When clicking the filter icon while the popover is open, it would close and immediately reopen, requiring multiple clicks to actually close it.

https://github.com/user-attachments/assets/5ddd7737-9801-4dd8-a4e1-e0ef202403b8

**After**
Clicking the filter icon while the popover is open now closes it in a single click and keeps it closed.

https://github.com/user-attachments/assets/cce3f4fc-e351-4dc8-992c-a1ee3b1faf97

## Implementation details

The issue was caused by Radix UI's `PopoverTrigger` calling `onOpenChange` multiple times when using `modal={true}` - first with `false` (to close) and then immediately with `true` (to reopen).

**Changes made:**
- Refactored to use `useControllableState` from `@radix-ui/react-use-controllable-state` to handle controlled/uncontrolled state management, simplifying the code
- Added `isOpenRef` to track the current open state using a ref, avoiding stale closure issues in event handlers
- Created `handleOpenChange` function that intercepts all `onOpenChange` calls from Radix UI
- When the popover is open and any change is requested (user clicked trigger), the handler immediately closes it
- Added `isClosingRef` flag to prevent re-entry - blocks subsequent `onOpenChange` calls for 150ms after closing, preventing Radix UI from reopening the popover
- Normal open/close behavior is preserved when the popover is closed


**Files modified:**
- `packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx`

### Context
[Jira](https://factorialmakers.atlassian.net/browse/FCT-46891)

