### PR TITLE
feat: add testId prop to components for testing support

### DIFF
--- a/packages/react/src/components/Charts/AreaChart/index.tsx
+++ b/packages/react/src/components/Charts/AreaChart/index.tsx
@@ -108,7 +108,12 @@ export const BaseAreaChart = <K extends LineChartConfig>(
   const showTooltip = !canBeBlurred || !privacyModeEnabled
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect} data-testid={testId}>
+    <ChartContainer
+      config={dataConfig}
+      ref={ref}
+      aspect={aspect}
+      data-testid={testId}
+    >
       <AreaChartPrimitive
         accessibilityLayer
         data={preparedData}

--- a/packages/react/src/components/Charts/AreaChart/index.tsx
+++ b/packages/react/src/components/Charts/AreaChart/index.tsx
@@ -78,6 +78,7 @@ export const BaseAreaChart = <K extends LineChartConfig>(
     canBeBlurred,
     blurArea,
     lineType = "monotoneX",
+    testId,
     aspect,
     marginTop = 0,
   }: AreaChartProps<K>,
@@ -107,7 +108,7 @@ export const BaseAreaChart = <K extends LineChartConfig>(
   const showTooltip = !canBeBlurred || !privacyModeEnabled
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
+    <ChartContainer config={dataConfig} ref={ref} aspect={aspect} data-testid={testId}>
       <AreaChartPrimitive
         accessibilityLayer
         data={preparedData}

--- a/packages/react/src/components/Charts/BarChart/index.tsx
+++ b/packages/react/src/components/Charts/BarChart/index.tsx
@@ -97,7 +97,12 @@ const _BarChart = <K extends ChartConfig>(
   )
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect} data-testid={testId}>
+    <ChartContainer
+      config={dataConfig}
+      ref={ref}
+      aspect={aspect}
+      data-testid={testId}
+    >
       <BarChartPrimitive
         accessibilityLayer
         data={preparedData}

--- a/packages/react/src/components/Charts/BarChart/index.tsx
+++ b/packages/react/src/components/Charts/BarChart/index.tsx
@@ -66,6 +66,7 @@ const _BarChart = <K extends ChartConfig>(
     showValueUnderLabel = false,
     highlightLastBar = false,
     onClick,
+    testId,
   }: BarChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
@@ -96,7 +97,7 @@ const _BarChart = <K extends ChartConfig>(
   )
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
+    <ChartContainer config={dataConfig} ref={ref} aspect={aspect} data-testid={testId}>
       <BarChartPrimitive
         accessibilityLayer
         data={preparedData}

--- a/packages/react/src/components/Charts/CategoryBarChart/index.tsx
+++ b/packages/react/src/components/Charts/CategoryBarChart/index.tsx
@@ -1,5 +1,6 @@
 import { ForwardedRef } from "react"
 
+import type { TestableProps } from "@/global.types"
 import {
   Tooltip,
   TooltipContent,
@@ -10,7 +11,7 @@ import {
 import { getCategoricalColor, getColor } from "../utils/colors"
 import { fixedForwardRef } from "../utils/forwardRef"
 
-export interface CategoryBarProps {
+export interface CategoryBarProps extends TestableProps {
   data: {
     name: string
     value: number
@@ -21,14 +22,14 @@ export interface CategoryBarProps {
 }
 
 const _CategoryBarChart = (
-  { data, legend = true, hideTooltip = false }: CategoryBarProps,
+  { data, legend = true, hideTooltip = false, testId }: CategoryBarProps,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const total = data.reduce((sum, category) => sum + category.value, 0)
 
   return (
     <TooltipProvider>
-      <div className="w-full" ref={ref}>
+      <div className="w-full" ref={ref} data-testid={testId}>
         <div className="flex h-2 gap-1 overflow-hidden">
           {data.map((category, index) => {
             const percentage = (category.value / total) * 100

--- a/packages/react/src/components/Charts/ComboChart/index.tsx
+++ b/packages/react/src/components/Charts/ComboChart/index.tsx
@@ -130,6 +130,7 @@ const _ComboChart = <K extends ChartConfig>(
     line,
     scatter,
     onClick,
+    testId,
   }: ComboChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
@@ -176,7 +177,7 @@ const _ComboChart = <K extends ChartConfig>(
   )
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
+    <ChartContainer config={dataConfig} ref={ref} aspect={aspect} data-testid={testId}>
       <ComposedChart
         accessibilityLayer
         data={preparedData}

--- a/packages/react/src/components/Charts/ComboChart/index.tsx
+++ b/packages/react/src/components/Charts/ComboChart/index.tsx
@@ -177,7 +177,12 @@ const _ComboChart = <K extends ChartConfig>(
   )
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect} data-testid={testId}>
+    <ChartContainer
+      config={dataConfig}
+      ref={ref}
+      aspect={aspect}
+      data-testid={testId}
+    >
       <ComposedChart
         accessibilityLayer
         data={preparedData}

--- a/packages/react/src/components/Charts/LineChart/index.tsx
+++ b/packages/react/src/components/Charts/LineChart/index.tsx
@@ -41,6 +41,7 @@ export const _LineChart = <K extends LineChartConfig>(
     aspect,
     hideTooltip = false,
     hideGrid = false,
+    testId,
   }: LineChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
@@ -59,7 +60,7 @@ export const _LineChart = <K extends LineChartConfig>(
   )
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
+    <ChartContainer config={dataConfig} ref={ref} aspect={aspect} data-testid={testId}>
       <LineChartPrimitive
         accessibilityLayer
         data={preparedData}

--- a/packages/react/src/components/Charts/LineChart/index.tsx
+++ b/packages/react/src/components/Charts/LineChart/index.tsx
@@ -60,7 +60,12 @@ export const _LineChart = <K extends LineChartConfig>(
   )
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect} data-testid={testId}>
+    <ChartContainer
+      config={dataConfig}
+      ref={ref}
+      aspect={aspect}
+      data-testid={testId}
+    >
       <LineChartPrimitive
         accessibilityLayer
         data={preparedData}

--- a/packages/react/src/components/Charts/PieChart/index.tsx
+++ b/packages/react/src/components/Charts/PieChart/index.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps, ForwardedRef } from "react"
 import { Cell, Label, Pie, PieChart as PieChartPrimitive } from "recharts"
 
+import type { TestableProps } from "@/global.types"
 import {
   ChartContainer,
   ChartLegend,
@@ -19,7 +20,7 @@ export type PieChartItem = {
   color?: string
 }
 
-export type PieChartProps = {
+export type PieChartProps = TestableProps & {
   dataConfig: ChartConfig
   data: PieChartItem[]
   tickFormatter?: (value: string) => string
@@ -28,7 +29,7 @@ export type PieChartProps = {
 }
 
 export const _PieChart = (
-  { data, dataConfig, overview, aspect, tickFormatter }: PieChartProps,
+  { data, dataConfig, overview, aspect, tickFormatter, testId }: PieChartProps,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const preparedData = data.map((item, index) => ({
@@ -57,6 +58,7 @@ export const _PieChart = (
       aspect={aspect}
       data-chromatic="ignore"
       style={{ height: 380 }}
+      data-testid={testId}
     >
       <PieChartPrimitive accessibilityLayer margin={{ left: 0, right: 0 }}>
         {sum !== 0 && (

--- a/packages/react/src/components/Charts/ProgressChart/index.tsx
+++ b/packages/react/src/components/Charts/ProgressChart/index.tsx
@@ -22,7 +22,11 @@ const _ProgressBar = <K extends ChartConfig>(
   const percentage = (value / max) * 100
 
   return (
-    <div className="flex items-center space-x-2" aria-live="polite" data-testid={testId}>
+    <div
+      className="flex items-center space-x-2"
+      aria-live="polite"
+      data-testid={testId}
+    >
       <div className="flex-grow">
         <Progress
           color={barColor}

--- a/packages/react/src/components/Charts/ProgressChart/index.tsx
+++ b/packages/react/src/components/Charts/ProgressChart/index.tsx
@@ -15,14 +15,14 @@ export type ProgressBarProps<K extends ChartConfig = ChartConfig> =
   }
 
 const _ProgressBar = <K extends ChartConfig>(
-  { value, max = 100, label, color }: ProgressBarProps<K>,
+  { value, max = 100, label, color, testId }: ProgressBarProps<K>,
   _ref: ForwardedRef<HTMLDivElement>
 ) => {
   const barColor = color ? getColor(color) : getColor("categorical-1")
   const percentage = (value / max) * 100
 
   return (
-    <div className="flex items-center space-x-2" aria-live="polite">
+    <div className="flex items-center space-x-2" aria-live="polite" data-testid={testId}>
       <div className="flex-grow">
         <Progress
           color={barColor}

--- a/packages/react/src/components/Charts/RadarChart/index.tsx
+++ b/packages/react/src/components/Charts/RadarChart/index.tsx
@@ -7,6 +7,7 @@ import {
   RadarChart as RadarChartPrimitive,
 } from "recharts"
 
+import type { TestableProps } from "@/global.types"
 import {
   ChartContainer,
   ChartLegend,
@@ -18,7 +19,7 @@ import { getCategoricalColor, getColor } from "../utils/colors"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { ChartConfig, ChartItem } from "../utils/types"
 
-export type RadarChartProps<K extends ChartConfig> = {
+export type RadarChartProps<K extends ChartConfig> = TestableProps & {
   dataConfig: K
   data: ChartItem<K>[]
   scaleMin?: number

--- a/packages/react/src/components/Charts/RadarChart/index.tsx
+++ b/packages/react/src/components/Charts/RadarChart/index.tsx
@@ -27,7 +27,7 @@ export type RadarChartProps<K extends ChartConfig> = {
 }
 
 export const _RadarChart = <K extends ChartConfig>(
-  { data, dataConfig, scaleMin, scaleMax, aspect }: RadarChartProps<K>,
+  { data, dataConfig, scaleMin, scaleMax, aspect, testId }: RadarChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const items = Object.keys(dataConfig)
@@ -42,6 +42,7 @@ export const _RadarChart = <K extends ChartConfig>(
       ref={ref}
       aspect={aspect}
       data-chromatic="ignore"
+      data-testid={testId}
     >
       <RadarChartPrimitive accessibilityLayer data={preparedData}>
         <ChartTooltip

--- a/packages/react/src/components/Charts/RadialProgressChart/index.tsx
+++ b/packages/react/src/components/Charts/RadialProgressChart/index.tsx
@@ -1,6 +1,8 @@
+import type { TestableProps } from "@/global.types"
+
 import { getColor } from "../utils/colors"
 
-export interface RadialProgressProps {
+export interface RadialProgressProps extends TestableProps {
   value: number
   max?: number
   color?: string
@@ -12,6 +14,7 @@ export function RadialProgressChart({
   max = 100,
   color,
   overview,
+  testId,
 }: RadialProgressProps) {
   const strokeWidth = 12
   const size = 100
@@ -22,7 +25,10 @@ export function RadialProgressChart({
   const strokeColor = color ? getColor(color) : getColor("categorical-1")
 
   return (
-    <div className="relative inline-flex aspect-auto h-full w-full items-center justify-center overflow-hidden">
+    <div
+      className="relative inline-flex aspect-auto h-full w-full items-center justify-center overflow-hidden"
+      data-testid={testId}
+    >
       <svg
         viewBox={`0 0 ${size} ${size}`}
         className="h-full w-full -rotate-90 transform"

--- a/packages/react/src/components/Charts/VerticalBarChart/index.tsx
+++ b/packages/react/src/components/Charts/VerticalBarChart/index.tsx
@@ -106,7 +106,12 @@ const _VBarChart = <K extends ChartConfig>(
   }
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect} data-testid={testId}>
+    <ChartContainer
+      config={dataConfig}
+      ref={ref}
+      aspect={aspect}
+      data-testid={testId}
+    >
       <BarChartPrimitive
         layout="vertical"
         accessibilityLayer

--- a/packages/react/src/components/Charts/VerticalBarChart/index.tsx
+++ b/packages/react/src/components/Charts/VerticalBarChart/index.tsx
@@ -73,6 +73,7 @@ const _VBarChart = <K extends ChartConfig>(
     hideGrid = false,
     showRatio = false,
     valueFormatter,
+    testId,
   }: VerticalBarChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
@@ -105,7 +106,7 @@ const _VBarChart = <K extends ChartConfig>(
   }
 
   return (
-    <ChartContainer config={dataConfig} ref={ref} aspect={aspect}>
+    <ChartContainer config={dataConfig} ref={ref} aspect={aspect} data-testid={testId}>
       <BarChartPrimitive
         layout="vertical"
         accessibilityLayer

--- a/packages/react/src/components/Charts/utils/types.ts
+++ b/packages/react/src/components/Charts/utils/types.ts
@@ -1,5 +1,6 @@
 import { ComponentProps } from "react"
 
+import type { TestableProps } from "@/global.types"
 import type {
   ChartContainer,
   LineChartConfig,
@@ -29,7 +30,7 @@ export type ChartConfig = Record<
 
 export type ChartPropsBase<
   K extends OriginalChartConfig = OriginalChartConfig,
-> = {
+> = TestableProps & {
   dataConfig: K
   data: ChartItem<K>[]
   xAxis?: AxisConfig
@@ -39,12 +40,13 @@ export type ChartPropsBase<
   hideTooltip?: boolean
 }
 
-export type LineChartPropsBase<K extends LineChartConfig = LineChartConfig> = {
-  dataConfig: K
-  data: ChartItem<K>[]
-  xAxis?: AxisConfig
-  yAxis?: AxisConfig
-  aspect?: ComponentProps<typeof ChartContainer>["aspect"]
-  hideGrid?: boolean
-  hideTooltip?: boolean
-}
+export type LineChartPropsBase<K extends LineChartConfig = LineChartConfig> =
+  TestableProps & {
+    dataConfig: K
+    data: ChartItem<K>[]
+    xAxis?: AxisConfig
+    yAxis?: AxisConfig
+    aspect?: ComponentProps<typeof ChartContainer>["aspect"]
+    hideGrid?: boolean
+    hideTooltip?: boolean
+  }

--- a/packages/react/src/components/F0Alert/F0Alert.tsx
+++ b/packages/react/src/components/F0Alert/F0Alert.tsx
@@ -49,11 +49,12 @@ export const F0Alert = ({
   link,
   icon,
   variant = "neutral",
+  testId,
 }: F0AlertProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
 
   return (
-    <div ref={containerRef} className="@container">
+    <div ref={containerRef} className="@container" data-testid={testId}>
       <div className={alertVariants({ variant })}>
         <div
           className={cn(

--- a/packages/react/src/components/F0Alert/__stories__/F0Alert.stories.tsx
+++ b/packages/react/src/components/F0Alert/__stories__/F0Alert.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { fn } from "storybook/test"
+import { expect, fn, within } from "storybook/test"
 
 import { F0Alert } from "../F0Alert"
 
@@ -83,4 +83,23 @@ export const Narrow: Story = {
       <F0Alert {...args} />
     </div>
   ),
+}
+
+export const WithTestId: Story = {
+  args: {
+    title: "Important notification",
+    description: "This alert has a testId for testing purposes.",
+    variant: "info",
+    testId: "important-alert",
+  },
+  render: (args) => (
+    <div className="w-[640px]">
+      <F0Alert {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const alert = canvas.getByTestId("important-alert")
+    await expect(alert).toBeInTheDocument()
+  },
 }

--- a/packages/react/src/components/F0Alert/types.ts
+++ b/packages/react/src/components/F0Alert/types.ts
@@ -1,4 +1,5 @@
 import type { IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 
 export type AlertVariant =
   | "info"
@@ -7,7 +8,7 @@ export type AlertVariant =
   | "neutral"
   | "positive"
 
-export interface F0AlertProps {
+export interface F0AlertProps extends TestableProps {
   title: string
   description: string
   action?: {

--- a/packages/react/src/components/F0BigNumber/F0BigNumber.tsx
+++ b/packages/react/src/components/F0BigNumber/F0BigNumber.tsx
@@ -26,7 +26,7 @@ const normalizeTrend = (
   }
 }
 
-const F0BigNumberCmp = ({ label, ...props }: BigNumberProps) => {
+const F0BigNumberCmp = ({ label, testId, ...props }: BigNumberProps) => {
   const normalizeValueWithFormatter = useNormalizeValueWithFormatter()
 
   const value = normalizeValueWithFormatter(props.value, {
@@ -58,7 +58,7 @@ const F0BigNumberCmp = ({ label, ...props }: BigNumberProps) => {
   }, [valueValue, comparisonValue, trendConfig.show])
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2" data-testid={testId}>
       {label && <div>{label}</div>}
       <div className="flex flex-row flex-wrap items-center gap-2">
         <span className="font-bold text-2xl">{formattedValue}</span>

--- a/packages/react/src/components/F0BigNumber/types.ts
+++ b/packages/react/src/components/F0BigNumber/types.ts
@@ -1,3 +1,4 @@
+import type { TestableProps } from "@/global.types"
 import { Numeric, NumericWithFormatter } from "@/lib/numeric"
 
 export type NumberWithFormatter = NumericWithFormatter & {
@@ -9,7 +10,7 @@ export type TrendConfig = {
   invertStatus?: boolean
 }
 
-export type BigNumberProps = {
+export type BigNumberProps = TestableProps & {
   value: Numeric | NumberWithFormatter | number
   label?: string
   trend?: boolean | TrendConfig

--- a/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
@@ -427,3 +427,25 @@ export const AsyncLoading: Story = {
     )
   },
 }
+
+export const WithTestId: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates using the `testId` prop to add a `data-testid` attribute for testing purposes. This allows selecting the element in tests using `getByTestId`.",
+      },
+    },
+  },
+  args: {
+    variant: "default",
+    label: "Submit Form",
+    testId: "submit-button",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const button = canvas.getByTestId("submit-button")
+    await expect(button).toBeInTheDocument()
+  },
+}

--- a/packages/react/src/components/F0Button/internal-types.ts
+++ b/packages/react/src/components/F0Button/internal-types.ts
@@ -1,4 +1,5 @@
 import { IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 import {
   ActionButtonVariant,
   ActionProps,
@@ -20,7 +21,8 @@ export type ButtonInternalProps = Pick<
   | "tooltip"
   | "fontSize"
 > &
-  DataAttributes & {
+  DataAttributes &
+  TestableProps & {
     /**
      * The aria-label of the button if not provided title or label will be used.
      */

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -38,6 +38,7 @@ const ButtonInternal = forwardRef<
     noAutoTooltip,
     noTitle,
     iconRotate = false,
+    testId,
     ...props
   },
   ref
@@ -115,6 +116,7 @@ const ButtonInternal = forwardRef<
         compact={!!shouldHideLabel}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
+        data-testid={testId}
       >
         <div
           className={cn(

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -39,6 +39,7 @@ const ButtonInternal = forwardRef<
     noTitle,
     iconRotate = false,
     testId,
+    "data-testid": dataTestId,
     ...props
   },
   ref
@@ -116,7 +117,7 @@ const ButtonInternal = forwardRef<
         compact={!!shouldHideLabel}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
-        data-testid={testId}
+        data-testid={testId ?? dataTestId}
       >
         <div
           className={cn(

--- a/packages/react/src/components/F0ButtonDropdown/F0ButtonDropdown.tsx
+++ b/packages/react/src/components/F0ButtonDropdown/F0ButtonDropdown.tsx
@@ -65,6 +65,7 @@ function isButtonDropdownItem<T = string>(
 const F0ButtonDropdown = ({
   onClick,
   value,
+  testId,
   ...props
 }: F0ButtonDropdownProps) => {
   const t = useI18n()
@@ -139,7 +140,7 @@ const F0ButtonDropdown = ({
         size={props.size}
         disabled={props.disabled}
         loading={props.loading}
-        data-testid="button-main"
+        data-testid={testId}
         aria-label={selectedItem.label}
         prepend={selectedItem.icon && <F0Icon icon={selectedItem.icon} />}
         className="rounded-r-none after:rounded-r-none"

--- a/packages/react/src/components/F0ButtonDropdown/F0ButtonDropdown.tsx
+++ b/packages/react/src/components/F0ButtonDropdown/F0ButtonDropdown.tsx
@@ -140,7 +140,7 @@ const F0ButtonDropdown = ({
         size={props.size}
         disabled={props.disabled}
         loading={props.loading}
-        data-testid={testId}
+        data-testid={testId ?? "button-main"}
         aria-label={selectedItem.label}
         prepend={selectedItem.icon && <F0Icon icon={selectedItem.icon} />}
         className="rounded-r-none after:rounded-r-none"

--- a/packages/react/src/components/F0ButtonDropdown/types.ts
+++ b/packages/react/src/components/F0ButtonDropdown/types.ts
@@ -1,4 +1,5 @@
 import { IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 import { actionSizes } from "@/ui/Action"
 
 export const buttonDropdownVariants = ["default", "outline", "neutral"] as const
@@ -35,7 +36,7 @@ export type ButtonDropdownGroup<T = string> = {
   items: ButtonDropdownItem<T>[]
 }
 
-export type F0ButtonDropdownProps<T = string> = {
+export type F0ButtonDropdownProps<T = string> = TestableProps & {
   /**
    * The size of the button.
    * @default "md"

--- a/packages/react/src/components/F0ButtonToggle/internal/F0ButtonToggle.internal.tsx
+++ b/packages/react/src/components/F0ButtonToggle/internal/F0ButtonToggle.internal.tsx
@@ -75,6 +75,7 @@ export const F0ButtonToggleInternal = forwardRef<
       variant = "compact",
       withBorder = false,
       defaultSelected = false,
+      testId,
       ...props
     },
     ref
@@ -129,6 +130,7 @@ export const F0ButtonToggleInternal = forwardRef<
         disabled={disabled}
         aria-label={localLabel}
         title={localLabel}
+        data-testid={testId}
         className={cn(
           "aspect-square px-0",
           "flex flex-col items-center justify-center gap-2",

--- a/packages/react/src/components/F0ButtonToggle/internal/types.internal.ts
+++ b/packages/react/src/components/F0ButtonToggle/internal/types.internal.ts
@@ -1,8 +1,9 @@
 import { IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 
 import { ButtonToggleSize, ButtonToggleVariant } from "../types"
 
-export type F0ButtonToggleInternalProps = {
+export type F0ButtonToggleInternalProps = TestableProps & {
   /**
    * The accessible label for the button.
    */

--- a/packages/react/src/components/F0ButtonToggle/internal/types.internal.ts
+++ b/packages/react/src/components/F0ButtonToggle/internal/types.internal.ts
@@ -36,14 +36,14 @@ export type F0ButtonToggleInternalProps = TestableProps & {
    */
   withBorder?: boolean
 } & (
-  | {
-      selected: boolean
-      onSelectedChange: (selected: boolean) => void
-      defaultSelected?: undefined
-    }
-  | {
-      defaultSelected?: boolean
-      selected?: undefined
-      onSelectedChange?: undefined
-    }
-)
+    | {
+        selected: boolean
+        onSelectedChange: (selected: boolean) => void
+        defaultSelected?: undefined
+      }
+    | {
+        defaultSelected?: boolean
+        selected?: undefined
+        onSelectedChange?: undefined
+      }
+  )

--- a/packages/react/src/components/F0ButtonToggleGroup/F0ButtonToggleGroup.tsx
+++ b/packages/react/src/components/F0ButtonToggleGroup/F0ButtonToggleGroup.tsx
@@ -16,6 +16,7 @@ export const F0ButtonToggleGroup = (props: F0ButtonToggleGroupProps) => {
     onChange,
     variant,
     disabled,
+    testId,
   } = props
 
   const [localValue, setLocalValue] = useState(value)
@@ -70,6 +71,7 @@ export const F0ButtonToggleGroup = (props: F0ButtonToggleGroupProps) => {
       onValueChange={handleChange}
       disabled={disabled}
       className={cn("flex flex-wrap items-center justify-center gap-1")}
+      data-testid={testId}
     >
       {localItems.map((item) => (
         <ToggleGroupItem

--- a/packages/react/src/components/F0ButtonToggleGroup/types.ts
+++ b/packages/react/src/components/F0ButtonToggleGroup/types.ts
@@ -1,3 +1,5 @@
+import type { TestableProps } from "@/global.types"
+
 import { ButtonToggleVariant, F0ButtonToggleProps } from "../F0ButtonToggle"
 
 export type F0ButtonToggleGroupItem = Pick<
@@ -10,7 +12,7 @@ export type F0ButtonToggleGroupItem = Pick<
 export const buttonToggleGroupSizes = ["sm", "md"] as const
 export type ButtonToggleGroupSize = (typeof buttonToggleGroupSizes)[number]
 
-export type F0ButtonToggleGroupProps = {
+export type F0ButtonToggleGroupProps = TestableProps & {
   items: F0ButtonToggleGroupItem[]
   /**
    * The size of the buttons.

--- a/packages/react/src/components/F0ButtonToggleGroup/types.ts
+++ b/packages/react/src/components/F0ButtonToggleGroup/types.ts
@@ -45,14 +45,14 @@ export type F0ButtonToggleGroupProps = TestableProps & {
    */
   disabled?: boolean
 } & (
-  | {
-      multiple: true
-      value?: string[]
-      onChange?: (value: string[]) => void
-    }
-  | {
-      multiple?: false
-      value?: string
-      onChange?: (value: string) => void
-    }
-)
+    | {
+        multiple: true
+        value?: string[]
+        onChange?: (value: string[]) => void
+      }
+    | {
+        multiple?: false
+        value?: string
+        onChange?: (value: string) => void
+      }
+  )

--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, forwardRef, useRef } from "react"
 import { F0Link } from "@/components/F0Link"
 import { Image } from "@/components/Utilities/Image"
 import { DropdownItem } from "@/experimental/Navigation/Dropdown"
+import type { TestableProps } from "@/global.types"
 import { cn, focusRing } from "@/lib/utils"
 import {
   Card,
@@ -47,7 +48,7 @@ const imageSizeClassMap: Record<CardImageSize, string> = {
   xl: "h-64",
 }
 
-export interface CardInternalProps {
+export interface CardInternalProps extends TestableProps {
   /**
    * Whether the card has a compact layout
    */
@@ -198,6 +199,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
       forceVerticalMetadata = false,
       fullHeight = false,
       disableOverlayLink = false,
+      testId,
     },
     ref
   ) {
@@ -226,7 +228,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
             "border-f1-border-selected bg-f1-background-selected-secondary"
         )}
         onClick={onClick}
-        data-testid="card"
+        data-testid={testId}
         ref={ref}
       >
         {link && !disableOverlayLink && (

--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -228,7 +228,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
             "border-f1-border-selected bg-f1-background-selected-secondary"
         )}
         onClick={onClick}
-        data-testid={testId}
+        data-testid={testId ?? "card"}
         ref={ref}
       >
         {link && !disableOverlayLink && (

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import image from "@storybook-static/avatars/person04.jpg"
 import { useState } from "react"
-import { fn } from "storybook/test"
+import { expect, fn, within } from "storybook/test"
 
 import {
   Add,
@@ -615,4 +615,16 @@ export const Snapshot: Story = {
       <F0Card {...WithProgressBarCustomColor.args} />
     </div>
   ),
+}
+
+export const WithTestId: Story = {
+  args: {
+    ...Default.args,
+    testId: "user-profile-card",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const card = canvas.getByTestId("user-profile-card")
+    await expect(card).toBeInTheDocument()
+  },
 }

--- a/packages/react/src/components/F0Checkbox/F0Checkbox.tsx
+++ b/packages/react/src/components/F0Checkbox/F0Checkbox.tsx
@@ -1,8 +1,8 @@
-import { DataAttributes } from "@/global.types"
+import { DataAttributes, TestableProps } from "@/global.types"
 import { experimentalComponent } from "@/lib/experimental"
 import { Checkbox as CheckboxRoot } from "@/ui/checkbox"
 
-interface CheckboxProps extends DataAttributes {
+interface CheckboxProps extends DataAttributes, TestableProps {
   /**
    * The title of the checkbox
    */
@@ -77,6 +77,7 @@ function _F0Checkbox({
   presentational = false,
   stopPropagation = false,
   name,
+  testId,
   ...rest
 }: CheckboxProps) {
   return (
@@ -92,6 +93,7 @@ function _F0Checkbox({
       hideLabel={hideLabel}
       tabIndex={presentational ? -1 : undefined}
       onClick={(e) => stopPropagation && e.stopPropagation()}
+      data-testid={testId}
       {...rest}
     />
   )

--- a/packages/react/src/components/F0ChipList/index.tsx
+++ b/packages/react/src/components/F0ChipList/index.tsx
@@ -1,10 +1,11 @@
+import type { TestableProps } from "@/global.types"
 import { experimentalComponent } from "@/lib/experimental"
 import { OverflowList } from "@/ui/OverflowList"
 
 import { Chip, type ChipProps } from "../../experimental/OneChip"
 import { ChipCounter } from "./ChipCounter"
 
-type Props = {
+type Props = TestableProps & {
   /**
    * Array of chips to display.
    */
@@ -35,10 +36,12 @@ const _F0ChipList = ({
   max = 4,
   remainingCount: initialRemainingCount,
   layout = "compact",
+  testId,
 }: Props) => {
   if (layout === "fill") {
     return (
       <OverflowList
+        data-testid={testId}
         items={chips}
         renderListItem={(chip) => <Chip {...chip} />}
         renderDropdownItem={() => null}
@@ -65,7 +68,7 @@ const _F0ChipList = ({
   const showCounter = remainingCount > 0
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2" data-testid={testId}>
       {visibleChips.map((chip, index) => {
         return <Chip key={index} {...chip} />
       })}

--- a/packages/react/src/components/F0DatePicker/F0DatePicker.tsx
+++ b/packages/react/src/components/F0DatePicker/F0DatePicker.tsx
@@ -18,6 +18,7 @@ export function F0DatePicker({
   minDate,
   maxDate,
   open = false,
+  testId,
   ...inputProps
 }: F0DatePickerProps) {
   const [localValue, setLocalValue] = useState<DatePickerValue | undefined>()
@@ -141,6 +142,7 @@ export function F0DatePicker({
       open={isOpen}
       onOpenChange={handlePickerOpenChange}
       asChild
+      data-testid={testId}
     >
       <DateInput
         ref={inputRef}

--- a/packages/react/src/components/F0DatePicker/types.ts
+++ b/packages/react/src/components/F0DatePicker/types.ts
@@ -1,3 +1,4 @@
+import type { TestableProps } from "@/global.types"
 import {
   DatePickerPopupProps,
   DatePickerValue as DatePickerPopupValue,
@@ -13,12 +14,13 @@ export type DatePickerValue = DatePickerPopupValue
 export type F0DatePickerProps = Pick<
   DatePickerPopupProps,
   "granularities" | "minDate" | "maxDate" | "presets" | "open" | "onOpenChange"
-> & {
-  onChange?: (
-    value: DatePickerValue | undefined,
-    stringValue: string | undefined
-  ) => void
-  value?: DatePickerValue
-} & Pick<InputFieldProps<string>, InputFieldInheritedProps>
+> &
+  TestableProps & {
+    onChange?: (
+      value: DatePickerValue | undefined,
+      stringValue: string | undefined
+    ) => void
+    value?: DatePickerValue
+  } & Pick<InputFieldProps<string>, InputFieldInheritedProps>
 
 export const datepickerSizes = INPUTFIELD_SIZES

--- a/packages/react/src/components/F0Dialog/F0DialogInternal.tsx
+++ b/packages/react/src/components/F0Dialog/F0DialogInternal.tsx
@@ -162,7 +162,11 @@ export const F0DialogInternal: FC<F0DialogInternalProps> = ({
       >
         <Drawer open={isOpen} onOpenChange={handleOpenChange}>
           <DrawerOverlay className="bg-f1-background-overlay" />
-          <DrawerContent ref={setContentRef} className={contentClassName} data-testid={testId}>
+          <DrawerContent
+            ref={setContentRef}
+            className={contentClassName}
+            data-testid={testId}
+          >
             <F0DialogHeader {...headerProps} />
             <F0DialogContent disableContentPadding={disableContentPadding}>
               {children}

--- a/packages/react/src/components/F0Dialog/F0DialogInternal.tsx
+++ b/packages/react/src/components/F0Dialog/F0DialogInternal.tsx
@@ -82,6 +82,7 @@ export const F0DialogInternal: FC<F0DialogInternalProps> = ({
   activeTabId,
   setActiveTabId,
   disableContentPadding,
+  testId,
 }) => {
   // Use state to store the container element so we can trigger re-renders
   // when it's set. This ensures child components like F0Select get the
@@ -161,7 +162,7 @@ export const F0DialogInternal: FC<F0DialogInternalProps> = ({
       >
         <Drawer open={isOpen} onOpenChange={handleOpenChange}>
           <DrawerOverlay className="bg-f1-background-overlay" />
-          <DrawerContent ref={setContentRef} className={contentClassName}>
+          <DrawerContent ref={setContentRef} className={contentClassName} data-testid={testId}>
             <F0DialogHeader {...headerProps} />
             <F0DialogContent disableContentPadding={disableContentPadding}>
               {children}
@@ -197,6 +198,7 @@ export const F0DialogInternal: FC<F0DialogInternalProps> = ({
           })}
           className={contentClassName}
           onOpenAutoFocus={(e) => e.preventDefault()}
+          data-testid={testId}
         >
           <F0DialogHeader {...headerProps} />
           <F0DialogContent disableContentPadding={disableContentPadding}>

--- a/packages/react/src/components/F0Dialog/internal-types.ts
+++ b/packages/react/src/components/F0Dialog/internal-types.ts
@@ -2,6 +2,7 @@ import { ReactNode } from "react"
 
 import { ModuleId } from "@/components/avatars/F0AvatarModule"
 import { DropdownInternalProps } from "@/experimental/Navigation/Dropdown/internal"
+import type { TestableProps } from "@/global.types"
 import { TabsProps } from "@/experimental/Navigation/Tabs"
 
 import {
@@ -45,7 +46,7 @@ export type F0DialogProviderProps = {
   portalContainer: HTMLDivElement | null
 }
 
-export type F0DialogInternalProps = {
+export type F0DialogInternalProps = TestableProps & {
   // Whether the dialog is open
   isOpen: boolean
   // Callback when dialog is closed

--- a/packages/react/src/components/F0Heading/F0Heading.tsx
+++ b/packages/react/src/components/F0Heading/F0Heading.tsx
@@ -1,17 +1,19 @@
 import { forwardRef } from "react"
 
+import type { TestableProps } from "@/global.types"
 import { Text, TextProps, type HeadingTags } from "@/ui/Text"
 
 const _allowedVariants = ["heading", "heading-large"] as const
 
-export type F0HeadingProps = Omit<TextProps, "className" | "variant" | "as"> & {
-  variant?: (typeof _allowedVariants)[number]
-  as?: HeadingTags
-}
+export type F0HeadingProps = Omit<TextProps, "className" | "variant" | "as"> &
+  TestableProps & {
+    variant?: (typeof _allowedVariants)[number]
+    as?: HeadingTags
+  }
 
 export const F0Heading = forwardRef<HTMLElement, F0HeadingProps>(
-  (props, ref) => {
-    return <Text ref={ref} variant="heading" {...props} />
+  ({ testId, ...props }, ref) => {
+    return <Text ref={ref} variant="heading" data-testid={testId} {...props} />
   }
 )
 

--- a/packages/react/src/components/F0Icon/F0Icon.tsx
+++ b/packages/react/src/components/F0Icon/F0Icon.tsx
@@ -7,6 +7,7 @@ import {
   SVGProps,
 } from "react"
 
+import type { TestableProps } from "@/global.types"
 import { cn } from "@/lib/utils"
 
 const iconVariants = cva({
@@ -42,7 +43,9 @@ type NestedKeyOf<T> = {
 }[keyof T & string]
 
 export interface F0IconProps
-  extends SVGProps<SVGSVGElement>, VariantProps<typeof iconVariants> {
+  extends SVGProps<SVGSVGElement>,
+    VariantProps<typeof iconVariants>,
+    TestableProps {
   icon: IconType
   size?: "lg" | "md" | "sm" | "xs"
   state?: "normal" | "animate"
@@ -60,7 +63,7 @@ export type IconType = ForwardRefExoticComponent<
     }
 >
 export const F0Icon = forwardRef<SVGSVGElement, F0IconProps>(function F0Icon(
-  { size, icon, state = "normal", color = "currentColor", ...props },
+  { size, icon, state = "normal", color = "currentColor", testId, ...props },
   ref
 ) {
   if (!icon) return null
@@ -88,6 +91,7 @@ export const F0Icon = forwardRef<SVGSVGElement, F0IconProps>(function F0Icon(
         className={cn(iconVariants({ size }), "select-none", colorClass)}
         style={colorStyle}
         data-has-color={color !== "currentColor" ? "true" : undefined}
+        data-testid={testId}
       />
     )
   }
@@ -99,6 +103,7 @@ export const F0Icon = forwardRef<SVGSVGElement, F0IconProps>(function F0Icon(
       className={cn("aspect-square", iconVariants({ size }), colorClass)}
       style={colorStyle}
       data-has-color={color !== "currentColor" ? "true" : undefined}
+      data-testid={testId}
     />
   )
 })

--- a/packages/react/src/components/F0Icon/F0Icon.tsx
+++ b/packages/react/src/components/F0Icon/F0Icon.tsx
@@ -43,7 +43,8 @@ type NestedKeyOf<T> = {
 }[keyof T & string]
 
 export interface F0IconProps
-  extends SVGProps<SVGSVGElement>,
+  extends
+    SVGProps<SVGSVGElement>,
     VariantProps<typeof iconVariants>,
     TestableProps {
   icon: IconType

--- a/packages/react/src/components/F0Link/F0Link.tsx
+++ b/packages/react/src/components/F0Link/F0Link.tsx
@@ -21,6 +21,7 @@ export const F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
     "aria-label": ariaLabel,
     href,
     testId,
+    "data-testid": dataTestId,
     ...props
   },
   ref
@@ -44,7 +45,7 @@ export const F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
       rel={external ? "noopener noreferrer" : undefined}
       aria-label={ariaLabel || props.title}
       className={className}
-      data-testid={testId}
+      data-testid={testId ?? dataTestId}
     >
       <span>{children}</span>
       {external && <F0Icon icon={ExternalLink} size="sm" />}

--- a/packages/react/src/components/F0Link/F0Link.tsx
+++ b/packages/react/src/components/F0Link/F0Link.tsx
@@ -1,15 +1,17 @@
 import { forwardRef } from "react"
 
+import type { TestableProps } from "@/global.types"
 import ExternalLink from "@/icons/app/ExternalLink"
 import { Action, ActionLinkProps, ActionLinkVariant } from "@/ui/Action"
 
 import { F0Icon } from "../F0Icon"
 
-export type F0LinkProps = Omit<ActionLinkProps, "variant" | "href"> & {
-  variant?: ActionLinkVariant
-  stopPropagation?: boolean
-  href?: string
-}
+export type F0LinkProps = Omit<ActionLinkProps, "variant" | "href"> &
+  TestableProps & {
+    variant?: ActionLinkVariant
+    stopPropagation?: boolean
+    href?: string
+  }
 
 export const F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
   {
@@ -18,6 +20,7 @@ export const F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
     stopPropagation = false,
     "aria-label": ariaLabel,
     href,
+    testId,
     ...props
   },
   ref
@@ -41,6 +44,7 @@ export const F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
       rel={external ? "noopener noreferrer" : undefined}
       aria-label={ariaLabel || props.title}
       className={className}
+      data-testid={testId}
     >
       <span>{children}</span>
       {external && <F0Icon icon={ExternalLink} size="sm" />}

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -121,6 +121,7 @@ const F0SelectComponent = forwardRef(function Select<
     multiple,
     portalContainer,
     asList = false,
+    testId,
     ...props
   }: F0SelectProps<T, R>,
   ref: React.ForwardedRef<HTMLButtonElement>
@@ -696,6 +697,7 @@ const F0SelectComponent = forwardRef(function Select<
           "flex w-full max-h-full flex-col gap-2",
           disabled && "cursor-not-allowed opacity-50"
         )}
+        data-testid={testId}
       >
         {label && !hideLabel && (
           <Label
@@ -726,7 +728,7 @@ const F0SelectComponent = forwardRef(function Select<
   }
 
   return (
-    <>
+    <div data-testid={testId}>
       <SelectPrimitive {...selectPrimitiveProps}>
         <SelectTrigger ref={ref} asChild>
           {children ? (
@@ -827,7 +829,7 @@ const F0SelectComponent = forwardRef(function Select<
         </SelectTrigger>
         {openLocal && selectContent}
       </SelectPrimitive>
-    </>
+    </div>
   )
 })
 

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -1,5 +1,6 @@
 import type { AvatarVariant } from "@/components/avatars/F0Avatar"
 import type { IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 import type {
   DataSourceDefinition,
   FiltersDefinition,
@@ -26,7 +27,7 @@ export type { FiltersState, OnSelectItemsCallback, SelectedItemsState }
 /**
  * Base props shared across all F0Select variants
  */
-type F0SelectBaseProps<T extends string, R = unknown> = {
+type F0SelectBaseProps<T extends string, R = unknown> = TestableProps & {
   onChangeSelectedOption?: (
     option: F0SelectItemObject<T, ResolvedRecordType<R>> | undefined,
     checked: boolean

--- a/packages/react/src/components/F0Text/F0Text.tsx
+++ b/packages/react/src/components/F0Text/F0Text.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from "react"
 
+import type { TestableProps } from "@/global.types"
 import { Text, TextProps, type TextTags } from "@/ui/Text"
 
 const _allowedVariants = [
@@ -11,14 +12,24 @@ const _allowedVariants = [
   "label",
 ] as const
 
-export type F0TextProps = Omit<TextProps, "className" | "variant" | "as"> & {
-  variant?: (typeof _allowedVariants)[number]
-  as?: TextTags
-  markdown?: boolean
-}
+export type F0TextProps = Omit<TextProps, "className" | "variant" | "as"> &
+  TestableProps & {
+    variant?: (typeof _allowedVariants)[number]
+    as?: TextTags
+    markdown?: boolean
+  }
 
-export const F0Text = forwardRef<HTMLElement, F0TextProps>((props, ref) => {
-  return <Text ref={ref} markdown={props.markdown ?? true} {...props} />
-})
+export const F0Text = forwardRef<HTMLElement, F0TextProps>(
+  ({ testId, ...props }, ref) => {
+    return (
+      <Text
+        ref={ref}
+        markdown={props.markdown ?? true}
+        data-testid={testId}
+        {...props}
+      />
+    )
+  }
+)
 
 F0Text.displayName = "F0Text"

--- a/packages/react/src/components/F0Widget/F0Widget.tsx
+++ b/packages/react/src/components/F0Widget/F0Widget.tsx
@@ -4,10 +4,8 @@ import { useEffect, useState, type ReactNode } from "react"
 import { AIButton as AIButtonComponent } from "@/components/AIButton"
 import { F0Icon } from "@/components/F0Icon"
 import { F0Text } from "@/components/F0Text"
-import {
-  DropdownInternal,
-  DropdownItem,
-} from "@/experimental/Navigation/Dropdown/internal.tsx"
+import { DropdownInternal, DropdownItem } from "@/experimental/Navigation/Dropdown/internal.tsx"
+import type { TestableProps } from "@/global.types"
 import { One as OneIcon } from "@/icons/ai"
 import { Ellipsis, Handle } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
@@ -17,7 +15,7 @@ import { Skeleton } from "@/ui/skeleton"
 
 import { ButtonInternal } from "../F0Button/internal"
 
-export interface WidgetProps {
+export interface WidgetProps extends TestableProps {
   title: string
   draggable?: boolean
   onDragStart?: () => void
@@ -39,6 +37,7 @@ const F0WidgetBase = ({
   actions,
   children,
   selected = false,
+  testId,
 }: WidgetProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
@@ -79,6 +78,7 @@ const F0WidgetBase = ({
       )}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      data-testid={testId}
     >
       <div className="flex h-12 w-full items-center justify-between gap-3">
         <div

--- a/packages/react/src/components/F0Widget/F0Widget.tsx
+++ b/packages/react/src/components/F0Widget/F0Widget.tsx
@@ -4,7 +4,10 @@ import { useEffect, useState, type ReactNode } from "react"
 import { AIButton as AIButtonComponent } from "@/components/AIButton"
 import { F0Icon } from "@/components/F0Icon"
 import { F0Text } from "@/components/F0Text"
-import { DropdownInternal, DropdownItem } from "@/experimental/Navigation/Dropdown/internal.tsx"
+import {
+  DropdownInternal,
+  DropdownItem,
+} from "@/experimental/Navigation/Dropdown/internal.tsx"
 import type { TestableProps } from "@/global.types"
 import { One as OneIcon } from "@/icons/ai"
 import { Ellipsis, Handle } from "@/icons/app"

--- a/packages/react/src/components/OneEllipsis/OneEllipsis.tsx
+++ b/packages/react/src/components/OneEllipsis/OneEllipsis.tsx
@@ -199,7 +199,7 @@ const OneEllipsis = forwardRef<HTMLElement, OneEllipsisProps>(
           markdown={markdown}
           tag={tag}
           {...props}
-          data-testid={testId}
+          data-testid={testId ?? "one-ellipsis"}
           noTooltip={noTooltip}
         >
           {children}

--- a/packages/react/src/components/OneEllipsis/OneEllipsis.tsx
+++ b/packages/react/src/components/OneEllipsis/OneEllipsis.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, useEffect, useMemo, useRef, useState } from "react"
 
+import type { TestableProps } from "@/global.types"
 import { parseMarkdown, stripMarkdown } from "@/lib/markdown"
 import { cn } from "@/lib/utils"
 import {
@@ -135,7 +136,7 @@ const EllipsisWrapper = forwardRef<HTMLElement, EllipsisWrapperProps>(
 )
 EllipsisWrapper.displayName = "EllipsisWrapper"
 
-type OneEllipsisProps = {
+type OneEllipsisProps = TestableProps & {
   /**
    * The className to apply to the text.
    */
@@ -177,6 +178,7 @@ const OneEllipsis = forwardRef<HTMLElement, OneEllipsisProps>(
       disabled = false,
       markdown = false,
       tag = "span",
+      testId,
       ...props
     },
     forwardedRef
@@ -197,7 +199,7 @@ const OneEllipsis = forwardRef<HTMLElement, OneEllipsisProps>(
           markdown={markdown}
           tag={tag}
           {...props}
-          data-testid="one-ellipsis"
+          data-testid={testId}
           noTooltip={noTooltip}
         >
           {children}

--- a/packages/react/src/components/avatars/F0Avatar/F0Avatar.tsx
+++ b/packages/react/src/components/avatars/F0Avatar/F0Avatar.tsx
@@ -1,5 +1,7 @@
 import { ComponentProps, ReactNode } from "react"
 
+import type { TestableProps } from "@/global.types"
+
 import { F0AvatarCompany, F0AvatarCompanyProps } from "../F0AvatarCompany"
 import { F0AvatarEmoji, F0AvatarEmojiProps } from "../F0AvatarEmoji"
 import { F0AvatarFile, F0AvatarFileProps } from "../F0AvatarFile"
@@ -9,7 +11,7 @@ import { F0AvatarPerson, F0AvatarPersonProps } from "../F0AvatarPerson"
 import { F0AvatarTeam, F0AvatarTeamProps } from "../F0AvatarTeam"
 import { AvatarSize } from "../internal/BaseAvatar"
 
-export type AvatarProps = {
+export type AvatarProps = TestableProps & {
   avatar: AvatarVariant
   size?: AvatarSize
 }
@@ -23,7 +25,11 @@ export type AvatarVariant =
   | ({ type: "emoji" } & Omit<F0AvatarEmojiProps, "size">)
   | ({ type: "icon" } & Omit<F0AvatarIconProps, "size">)
 
-export const F0Avatar = ({ avatar, size = "xs" }: AvatarProps): ReactNode => {
+export const F0Avatar = ({
+  avatar,
+  size = "xs",
+  testId,
+}: AvatarProps): ReactNode => {
   switch (avatar.type) {
     case "person":
       return (
@@ -36,6 +42,7 @@ export const F0Avatar = ({ avatar, size = "xs" }: AvatarProps): ReactNode => {
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}
           deactivated={avatar.deactivated}
+          testId={testId}
         />
       )
     case "team":
@@ -47,6 +54,7 @@ export const F0Avatar = ({ avatar, size = "xs" }: AvatarProps): ReactNode => {
           size={size}
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}
+          testId={testId}
         />
       )
     case "company":
@@ -58,6 +66,7 @@ export const F0Avatar = ({ avatar, size = "xs" }: AvatarProps): ReactNode => {
           size={size}
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}
+          testId={testId}
         />
       )
     case "file":
@@ -68,6 +77,7 @@ export const F0Avatar = ({ avatar, size = "xs" }: AvatarProps): ReactNode => {
           badge={avatar.badge}
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}
+          testId={testId}
         />
       )
     case "flag":
@@ -78,6 +88,7 @@ export const F0Avatar = ({ avatar, size = "xs" }: AvatarProps): ReactNode => {
           badge={avatar.badge}
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}
+          testId={testId}
         />
       )
     case "emoji":
@@ -87,6 +98,7 @@ export const F0Avatar = ({ avatar, size = "xs" }: AvatarProps): ReactNode => {
           size={size as ComponentProps<typeof F0AvatarEmoji>["size"]}
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}
+          testId={testId}
         />
       )
     case "icon":
@@ -96,6 +108,7 @@ export const F0Avatar = ({ avatar, size = "xs" }: AvatarProps): ReactNode => {
           size={size as ComponentProps<typeof F0AvatarIcon>["size"]}
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}
+          testId={testId}
         />
       )
   }

--- a/packages/react/src/components/avatars/F0AvatarAlert/F0AvatarAlert.tsx
+++ b/packages/react/src/components/avatars/F0AvatarAlert/F0AvatarAlert.tsx
@@ -39,13 +39,14 @@ export const alertAvatarSizes = ["sm", "md", "lg"] as const
 export type AlertAvatarProps = VariantProps<typeof alertAvatarVariants> & {
   type: (typeof alertAvatarTypes)[number]
   size?: (typeof alertAvatarSizes)[number]
-} & Partial<Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">>
+} & Partial<Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">>
 
 export const F0AvatarAlert = ({
   type,
   size,
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
+  testId,
 }: AlertAvatarProps) => {
   const iconMap: Record<AlertAvatarProps["type"], IconType> = {
     critical: AlertCircle,
@@ -60,6 +61,7 @@ export const F0AvatarAlert = ({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
       role="alert"
+      data-testid={testId}
     >
       <F0Icon icon={iconMap[type]} size={size} />
     </div>

--- a/packages/react/src/components/avatars/F0AvatarCompany/F0AvatarCompany.tsx
+++ b/packages/react/src/components/avatars/F0AvatarCompany/F0AvatarCompany.tsx
@@ -8,6 +8,7 @@ export const F0AvatarCompany = ({
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
   badge,
+  testId,
 }: F0AvatarCompanyProps) => {
   return (
     <BaseAvatar
@@ -19,6 +20,7 @@ export const F0AvatarCompany = ({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
       badge={badge}
+      testId={testId}
     />
   )
 }

--- a/packages/react/src/components/avatars/F0AvatarCompany/types.ts
+++ b/packages/react/src/components/avatars/F0AvatarCompany/types.ts
@@ -6,4 +6,4 @@ export type F0AvatarCompanyProps = {
   src?: string
   size?: BaseAvatarProps["size"]
   badge?: AvatarBadge
-} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">
+} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">

--- a/packages/react/src/components/avatars/F0AvatarDate/F0AvatarDate.tsx
+++ b/packages/react/src/components/avatars/F0AvatarDate/F0AvatarDate.tsx
@@ -4,12 +4,13 @@ import { BaseAvatarProps } from "../internal/BaseAvatar"
 
 export type F0AvatarDateProps = {
   date: Date
-} & Partial<Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">>
+} & Partial<Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">>
 
 export const F0AvatarDate = ({
   date,
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
+  testId,
 }: F0AvatarDateProps) => {
   const dateDay = getDayOfMonth(date)
   const month = getAbbreviateMonth(date)
@@ -19,6 +20,7 @@ export const F0AvatarDate = ({
       className="flex h-10 w-10 flex-col items-center justify-center rounded border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary"
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
+      data-testid={testId}
     >
       <div className="pt-0.5 text-xs font-semibold uppercase leading-3 text-f1-special-highlight dark:text-f1-foreground-inverse-secondary">
         {month}

--- a/packages/react/src/components/avatars/F0AvatarEmoji/F0AvatarEmoji.tsx
+++ b/packages/react/src/components/avatars/F0AvatarEmoji/F0AvatarEmoji.tsx
@@ -7,7 +7,7 @@ export const avatarEmojiSizes = ["sm", "md", "lg", "xl"] as const
 export type F0AvatarEmojiProps = {
   emoji: string
   size?: (typeof avatarEmojiSizes)[number]
-} & Partial<Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">>
+} & Partial<Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">>
 
 const sizes = {
   sm: "w-6 h-6 rounded-sm",
@@ -31,6 +31,7 @@ export const F0AvatarEmoji = ({
   size = "md",
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
+  testId,
 }: F0AvatarEmojiProps) => {
   // Check legacy size
   if (!avatarEmojiSizes.includes(size)) {
@@ -58,6 +59,7 @@ export const F0AvatarEmoji = ({
       )}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
+      data-testid={testId}
     >
       <EmojiImage emoji={emoji} size={imageSizes[size]} />
     </div>

--- a/packages/react/src/components/avatars/F0AvatarFile/F0AvatarFile.tsx
+++ b/packages/react/src/components/avatars/F0AvatarFile/F0AvatarFile.tsx
@@ -18,10 +18,10 @@ export type F0AvatarFileProps = Omit<
   file: FileDef
   size?: AvatarFileSize
   badge?: AvatarBadge
-} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">
+} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">
 
 const F0AvatarFile = forwardRef<ElementRef<typeof Avatar>, F0AvatarFileProps>(
-  ({ file, badge, ...props }, ref) => {
+  ({ file, badge, testId, ...props }, ref) => {
     const { type: fileType, color: fileColor } = getFileTypeInfo(file)
 
     const reversedSizesMapping = useMemo(
@@ -70,6 +70,7 @@ const F0AvatarFile = forwardRef<ElementRef<typeof Avatar>, F0AvatarFileProps>(
         className={cn("bg-f1-background", "overflow-visible")}
         {...props}
         size={mappedSize}
+        data-testid={testId}
       >
         <AvatarFallback
           className={cn("select-none font-semibold", textSize, fileColor)}

--- a/packages/react/src/components/avatars/F0AvatarFlag/F0AvatarFlag.tsx
+++ b/packages/react/src/components/avatars/F0AvatarFlag/F0AvatarFlag.tsx
@@ -11,6 +11,7 @@ export const F0AvatarFlag = ({
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
   badge,
+  testId,
 }: F0AvatarFlagProps) => {
   const FlagComponent = getFlag(flag) as React.ComponentType | undefined
 
@@ -28,6 +29,7 @@ export const F0AvatarFlag = ({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
       badge={badge}
+      testId={testId}
     />
   )
 }

--- a/packages/react/src/components/avatars/F0AvatarFlag/types.ts
+++ b/packages/react/src/components/avatars/F0AvatarFlag/types.ts
@@ -7,4 +7,4 @@ export type F0AvatarFlagProps = {
   flag: CountryCode | (string & {})
   size?: BaseAvatarProps["size"]
   badge?: AvatarBadge
-} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">
+} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">

--- a/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
@@ -8,7 +8,7 @@ export const avatarIconSizes = ["sm", "md", "lg"] as const
 export type F0AvatarIconProps = {
   icon: IconType
   size?: (typeof avatarIconSizes)[number]
-} & Partial<Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">>
+} & Partial<Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">>
 
 const sizes = {
   sm: "size-6 rounded-sm",
@@ -21,6 +21,7 @@ export const F0AvatarIcon = ({
   size = "md",
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
+  testId,
 }: F0AvatarIconProps) => {
   return (
     <div
@@ -30,6 +31,7 @@ export const F0AvatarIcon = ({
       )}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
+      data-testid={testId}
     >
       <F0Icon
         icon={icon}

--- a/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
@@ -28,6 +28,7 @@ export const F0AvatarList = ({
   noTooltip = false,
   remainingCount: initialRemainingCount,
   max,
+  testId,
 }: F0AvatarListProps) => {
   // Check legacy size
   if (size && !avatarListSizes.includes(size)) {
@@ -65,6 +66,7 @@ export const F0AvatarList = ({
       gap={gap}
       itemsWidth={itemWidth}
       className="flex items-center"
+      data-testid={testId}
       renderListItem={(avatar, index) => {
         const displayName = getAvatarDisplayName(type, avatar)
 

--- a/packages/react/src/components/avatars/F0AvatarList/types.ts
+++ b/packages/react/src/components/avatars/F0AvatarList/types.ts
@@ -1,3 +1,5 @@
+import type { TestableProps } from "@/global.types"
+
 import {
   CompanyAvatarVariant,
   FileAvatarVariant,
@@ -34,7 +36,7 @@ export type F0AvatarListPropsAvatars =
     }
 
 // Discriminated union that enforces type consistency
-export type F0AvatarListProps = {
+export type F0AvatarListProps = TestableProps & {
   /**
    * The size of the avatars in the list.
    * @default "md"

--- a/packages/react/src/components/avatars/F0AvatarModule/F0AvatarModule.tsx
+++ b/packages/react/src/components/avatars/F0AvatarModule/F0AvatarModule.tsx
@@ -37,7 +37,7 @@ const iconSizeVariants = cva({
 
 export type F0AvatarModuleProps = VariantProps<typeof moduleAvatarVariants> & {
   module: ModuleId
-} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">
+} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">
 
 const squirclePath =
   "M50,0 C43,0 36,0 30,1 23,2 17,5 12,9 5,16 1,25 0,36 0,43 0,57 0,64 1,75 5,84 12,91 17,95 23,98 30,99 36,100 43,100 50,100 57,100 64,100 70,99 77,98 83,95 88,91 95,84 99,75 100,64 100,57 100,43 100,36 99,25 95,16 88,9 83,5 77,2 70,1 64,0 57,0 50,0"
@@ -51,6 +51,7 @@ const squirclePath =
 export function F0AvatarModule({
   size = "md",
   module,
+  testId,
   ...props
 }: F0AvatarModuleProps) {
   const IconComponent = modules[module as ModuleId]
@@ -69,6 +70,7 @@ export function F0AvatarModule({
       aria-hidden="true"
       aria-label={props["aria-label"]}
       aria-labelledby={props["aria-labelledby"]}
+      data-testid={testId}
     >
       <svg
         viewBox="0 0 100 100"

--- a/packages/react/src/components/avatars/F0AvatarPerson/F0AvatarPerson.tsx
+++ b/packages/react/src/components/avatars/F0AvatarPerson/F0AvatarPerson.tsx
@@ -12,6 +12,7 @@ export const F0AvatarPerson = ({
   "aria-labelledby": ariaLabelledby,
   badge,
   deactivated,
+  testId,
 }: F0AvatarPersonProps) => {
   return (
     <BaseAvatar
@@ -26,6 +27,7 @@ export const F0AvatarPerson = ({
       icon={
         deactivated ? { icon: PersonNegative, color: "secondary" } : undefined
       }
+      testId={testId}
     />
   )
 }

--- a/packages/react/src/components/avatars/F0AvatarPerson/types.ts
+++ b/packages/react/src/components/avatars/F0AvatarPerson/types.ts
@@ -26,4 +26,4 @@ export type F0AvatarPersonProps = {
    * Whether the person is deactivated. If true, the avatar will display an icon instead of the person's name or picture.
    */
   deactivated?: boolean
-} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">
+} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">

--- a/packages/react/src/components/avatars/F0AvatarPulse/F0AvatarPulse.tsx
+++ b/packages/react/src/components/avatars/F0AvatarPulse/F0AvatarPulse.tsx
@@ -65,7 +65,7 @@ export type F0AvatarPulseProps = {
    * The callback to be called when the pulse is clicked.
    */
   onPulseClick: () => void
-} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">
+} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">
 
 export const F0AvatarPulse = ({
   firstName,
@@ -75,12 +75,13 @@ export const F0AvatarPulse = ({
   "aria-labelledby": ariaLabelledby,
   pulse,
   onPulseClick,
+  testId,
 }: F0AvatarPulseProps) => {
   const translations = useI18n()
   const [showWave, setShowWave] = useState(!pulse)
 
   return (
-    <div className="relative h-10 w-10">
+    <div className="relative h-10 w-10" data-testid={testId}>
       <AnimatePresence mode="popLayout" initial={showWave ? true : false}>
         {showWave ? (
           <motion.div

--- a/packages/react/src/components/avatars/F0AvatarTeam/F0AvatarTeam.tsx
+++ b/packages/react/src/components/avatars/F0AvatarTeam/F0AvatarTeam.tsx
@@ -18,7 +18,7 @@ export type F0AvatarTeamProps = {
    * The badge to display on the avatar. Can be a module badge or a custom badge.
    */
   badge?: AvatarBadge
-} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">
+} & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby" | "testId">
 
 export const F0AvatarTeam = ({
   name,
@@ -27,6 +27,7 @@ export const F0AvatarTeam = ({
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
   badge,
+  testId,
 }: F0AvatarTeamProps) => {
   return (
     <BaseAvatar
@@ -38,6 +39,7 @@ export const F0AvatarTeam = ({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
       badge={badge}
+      testId={testId}
     />
   )
 }

--- a/packages/react/src/components/avatars/internal/BaseAvatar/BaseAvatar.tsx
+++ b/packages/react/src/components/avatars/internal/BaseAvatar/BaseAvatar.tsx
@@ -44,6 +44,7 @@ export const BaseAvatar = forwardRef<HTMLDivElement, BaseAvatarProps>(
       badge,
       flag,
       icon,
+      testId,
     },
     ref
   ) => {
@@ -98,7 +99,7 @@ export const BaseAvatar = forwardRef<HTMLDivElement, BaseAvatarProps>(
 
     return (
       <>
-        <div className="relative inline-flex h-fit w-fit">
+        <div className="relative inline-flex h-fit w-fit" data-testid={testId}>
           <div
             className="relative h-fit w-fit"
             style={

--- a/packages/react/src/components/avatars/internal/BaseAvatar/types.ts
+++ b/packages/react/src/components/avatars/internal/BaseAvatar/types.ts
@@ -2,6 +2,7 @@ import { ReactElement } from "react"
 
 import { AvatarBadge } from "@/components/avatars/F0Avatar/types"
 import { F0IconProps, IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 import { InternalAvatarProps } from "@/ui/Avatar"
 
 export const avatarSizes = ["xs", "sm", "md", "lg", "xl", "2xl"] as const
@@ -20,7 +21,7 @@ export const sizesMapping: Record<
   xsmall: "xs",
 } as const
 
-export type BaseAvatarProps = {
+export type BaseAvatarProps = TestableProps & {
   /**
    * The type of the avatar.
    */

--- a/packages/react/src/components/tags/F0TagAlert/F0TagAlert.tsx
+++ b/packages/react/src/components/tags/F0TagAlert/F0TagAlert.tsx
@@ -17,7 +17,7 @@ const iconMap: Record<Level, IconType> = {
 }
 
 export const F0TagAlert = forwardRef<HTMLDivElement, Props>(
-  ({ text, level }, ref) => {
+  ({ text, level, testId }, ref) => {
     useTextFormatEnforcer(
       text,
       { disallowEmpty: true, disallowEmojis: true },
@@ -54,6 +54,7 @@ export const F0TagAlert = forwardRef<HTMLDivElement, Props>(
           />
         }
         text={text}
+        testId={testId}
       />
     )
   }

--- a/packages/react/src/components/tags/F0TagAlert/types.ts
+++ b/packages/react/src/components/tags/F0TagAlert/types.ts
@@ -1,8 +1,10 @@
+import type { TestableProps } from "@/global.types"
+
 export const levels = ["info", "warning", "critical", "positive"] as const
 
 export type Level = (typeof levels)[number]
 
-export type Props<Text extends string = string> = {
+export type Props<Text extends string = string> = TestableProps & {
   text: Text extends "" ? never : Text
   level: Level
 }

--- a/packages/react/src/components/tags/F0TagBalance/F0TagBalance.tsx
+++ b/packages/react/src/components/tags/F0TagBalance/F0TagBalance.tsx
@@ -27,7 +27,7 @@ const statusMap: Record<"-1" | "0" | "1", BalanceStatus> = {
 }
 
 export const F0TagBalance = forwardRef<HTMLDivElement, F0TagBalanceProps>(
-  ({ percentage, amount, invertStatus, info, hint, nullText }, ref) => {
+  ({ percentage, amount, invertStatus, info, hint, nullText, testId }, ref) => {
     const normalizeNumericWithFormatter =
       useNormalizeNumericValueWithFormatter()
 
@@ -117,6 +117,7 @@ export const F0TagBalance = forwardRef<HTMLDivElement, F0TagBalanceProps>(
         left={icon}
         additionalAccessibleText={additionalAccessibleText}
         text={text}
+        testId={testId}
       />
     )
   }

--- a/packages/react/src/components/tags/F0TagBalance/types.ts
+++ b/packages/react/src/components/tags/F0TagBalance/types.ts
@@ -36,15 +36,15 @@ export type F0TagBalanceProps = TestableProps & {
    */
   amount: RelaxedNumericWithFormatter | Numeric
 } & (
-  | {
-      percentage:
-        | (Omit<RelaxedNumericWithFormatter, "value"> & {
-            value: Omit<Numeric, "units" | "unitsPosition">
-          })
-        | Omit<Numeric, "units" | "unitsPosition">
-    }
-  | {
-      percentage?: null
-      formatterOptions?: undefined
-    }
-)
+    | {
+        percentage:
+          | (Omit<RelaxedNumericWithFormatter, "value"> & {
+              value: Omit<Numeric, "units" | "unitsPosition">
+            })
+          | Omit<Numeric, "units" | "unitsPosition">
+      }
+    | {
+        percentage?: null
+        formatterOptions?: undefined
+      }
+  )

--- a/packages/react/src/components/tags/F0TagBalance/types.ts
+++ b/packages/react/src/components/tags/F0TagBalance/types.ts
@@ -1,3 +1,4 @@
+import type { TestableProps } from "@/global.types"
 import { Numeric, RelaxedNumericWithFormatter } from "@/lib/numeric"
 
 export const statuses = ["positive", "neutral", "negative"] as const
@@ -11,7 +12,7 @@ export interface NumericValue {
   locale?: string
 }
 
-export type F0TagBalanceProps = {
+export type F0TagBalanceProps = TestableProps & {
   /**
    * Inverts the balance status color. Is useful when a negative percent mean something positive.
    */

--- a/packages/react/src/components/tags/F0TagCompany/F0TagCompany.tsx
+++ b/packages/react/src/components/tags/F0TagCompany/F0TagCompany.tsx
@@ -5,7 +5,7 @@ import type { F0TagCompanyProps } from "./types"
 import { F0TagAvatar } from "../internal/TagAvatar"
 
 export const F0TagCompany = forwardRef<HTMLDivElement, F0TagCompanyProps>(
-  ({ name, src }, ref) => {
+  ({ name, src, testId }, ref) => {
     return (
       <F0TagAvatar
         ref={ref}
@@ -15,6 +15,7 @@ export const F0TagCompany = forwardRef<HTMLDivElement, F0TagCompanyProps>(
           src: src,
         }}
         text={name}
+        testId={testId}
       />
     )
   }

--- a/packages/react/src/components/tags/F0TagCompany/types.ts
+++ b/packages/react/src/components/tags/F0TagCompany/types.ts
@@ -1,4 +1,6 @@
-export interface F0TagCompanyProps {
+import type { TestableProps } from "@/global.types"
+
+export interface F0TagCompanyProps extends TestableProps {
   name: string
   src?: string
 }

--- a/packages/react/src/components/tags/F0TagDot/F0TagDot.tsx
+++ b/packages/react/src/components/tags/F0TagDot/F0TagDot.tsx
@@ -7,7 +7,7 @@ import { useTextFormatEnforcer } from "@/lib/text"
 import type { Props } from "./types"
 
 export const F0TagDot = forwardRef<HTMLDivElement, Props>(
-  ({ text, ...props }, ref) => {
+  ({ text, testId, ...props }, ref) => {
     useTextFormatEnforcer(
       text,
       { disallowEmpty: true },
@@ -35,6 +35,7 @@ export const F0TagDot = forwardRef<HTMLDivElement, Props>(
           />
         }
         text={text}
+        testId={testId}
       />
     )
   }

--- a/packages/react/src/components/tags/F0TagDot/types.ts
+++ b/packages/react/src/components/tags/F0TagDot/types.ts
@@ -1,5 +1,7 @@
 import { baseColors } from "@factorialco/f0-core"
 
+import type { TestableProps } from "@/global.types"
+
 type BaseColor = keyof typeof baseColors
 
 export const tagDotColors = [
@@ -18,6 +20,6 @@ export const tagDotColors = [
 
 export type NewColor = Extract<BaseColor, (typeof tagDotColors)[number]>
 
-export type Props = {
+export type Props = TestableProps & {
   text: string
 } & ({ color: NewColor } | { customColor: string })

--- a/packages/react/src/components/tags/F0TagList/F0TagList.tsx
+++ b/packages/react/src/components/tags/F0TagList/F0TagList.tsx
@@ -10,6 +10,7 @@ export const F0TagList = <T extends TagType>({
   tags,
   max = 4,
   remainingCount: initialRemainingCount,
+  testId,
 }: F0TagListProps<T>) => {
   // Convert tags to TagVariant
   const tagVariants = tags.map(
@@ -20,6 +21,7 @@ export const F0TagList = <T extends TagType>({
     <OverflowList
       items={tagVariants}
       max={max}
+      data-testid={testId}
       renderListItem={(tag) => <Tag tag={tag} />}
       renderDropdownItem={() => null}
       forceShowingOverflowIndicator={initialRemainingCount !== undefined}

--- a/packages/react/src/components/tags/F0TagList/types.ts
+++ b/packages/react/src/components/tags/F0TagList/types.ts
@@ -1,3 +1,5 @@
+import type { TestableProps } from "@/global.types"
+
 import { TagVariant } from "../F0Tag/F0Tag"
 
 // Generic type helper to create tag data types
@@ -31,7 +33,7 @@ type TagTypeMapping = {
   raw: TagDataType<"raw">
 }
 
-export type F0TagListProps<T extends TagType> = {
+export type F0TagListProps<T extends TagType> = TestableProps & {
   /**
    * The type of tags to display. Only one type can be used at a time.
    */

--- a/packages/react/src/components/tags/F0TagPerson/F0TagPerson.tsx
+++ b/packages/react/src/components/tags/F0TagPerson/F0TagPerson.tsx
@@ -5,7 +5,7 @@ import type { F0TagPersonProps } from "./types"
 import { F0TagAvatar } from "../internal/TagAvatar"
 
 export const F0TagPerson = forwardRef<HTMLDivElement, F0TagPersonProps>(
-  ({ src, name }, ref) => {
+  ({ src, name, testId }, ref) => {
     return (
       <F0TagAvatar
         ref={ref}
@@ -16,6 +16,7 @@ export const F0TagPerson = forwardRef<HTMLDivElement, F0TagPersonProps>(
           src: src,
         }}
         text={name}
+        testId={testId}
       />
     )
   }

--- a/packages/react/src/components/tags/F0TagPerson/types.ts
+++ b/packages/react/src/components/tags/F0TagPerson/types.ts
@@ -1,4 +1,6 @@
-export type F0TagPersonProps = {
+import type { TestableProps } from "@/global.types"
+
+export type F0TagPersonProps = TestableProps & {
   src?: string
   name: string
 }

--- a/packages/react/src/components/tags/F0TagRaw/F0TagRaw.tsx
+++ b/packages/react/src/components/tags/F0TagRaw/F0TagRaw.tsx
@@ -8,7 +8,7 @@ import type { F0TagRawProps } from "./types"
 import { BaseTag } from "../internal/BaseTag"
 
 export const F0TagRaw = forwardRef<HTMLDivElement, F0TagRawProps>(
-  ({ text, additionalAccessibleText, icon, onlyIcon }, ref) => {
+  ({ text, additionalAccessibleText, icon, onlyIcon, testId }, ref) => {
     useTextFormatEnforcer(
       text,
       { disallowEmpty: true },
@@ -32,6 +32,7 @@ export const F0TagRaw = forwardRef<HTMLDivElement, F0TagRawProps>(
         hideLabel={onlyIcon}
         text={text}
         additionalAccessibleText={additionalAccessibleText}
+        testId={testId}
       />
     )
   }

--- a/packages/react/src/components/tags/F0TagRaw/types.ts
+++ b/packages/react/src/components/tags/F0TagRaw/types.ts
@@ -11,12 +11,12 @@ export type F0TagRawProps = TestableProps & {
    */
   additionalAccessibleText?: string
 } & (
-  | {
-      icon: IconType
-      onlyIcon: true
-    }
-  | {
-      icon?: IconType
-      onlyIcon?: boolean
-    }
-)
+    | {
+        icon: IconType
+        onlyIcon: true
+      }
+    | {
+        icon?: IconType
+        onlyIcon?: boolean
+      }
+  )

--- a/packages/react/src/components/tags/F0TagRaw/types.ts
+++ b/packages/react/src/components/tags/F0TagRaw/types.ts
@@ -1,6 +1,7 @@
 import { IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 
-export type F0TagRawProps = {
+export type F0TagRawProps = TestableProps & {
   /**
    * The label to display in the tag or used for accessible text
    */

--- a/packages/react/src/components/tags/F0TagStatus/F0TagStatus.tsx
+++ b/packages/react/src/components/tags/F0TagStatus/F0TagStatus.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils"
 import type { F0TagStatusProps } from "./types"
 
 export const F0TagStatus = forwardRef<HTMLDivElement, F0TagStatusProps>(
-  ({ text, additionalAccessibleText, variant }, ref) => {
+  ({ text, additionalAccessibleText, variant, testId }, ref) => {
     useTextFormatEnforcer(
       text,
       { disallowEmpty: true },
@@ -43,6 +43,7 @@ export const F0TagStatus = forwardRef<HTMLDivElement, F0TagStatusProps>(
         }
         additionalAccessibleText={additionalAccessibleText}
         text={text}
+        testId={testId}
       />
     )
   }

--- a/packages/react/src/components/tags/F0TagStatus/types.ts
+++ b/packages/react/src/components/tags/F0TagStatus/types.ts
@@ -1,3 +1,5 @@
+import type { TestableProps } from "@/global.types"
+
 export const statuses = [
   "neutral",
   "info",
@@ -10,7 +12,7 @@ export type Variant = (typeof statuses)[number]
 
 export type StatusVariant = Variant
 
-export interface F0TagStatusProps {
+export interface F0TagStatusProps extends TestableProps {
   text: string
   variant: Variant
   /**

--- a/packages/react/src/components/tags/F0TagTeam/F0TagTeam.tsx
+++ b/packages/react/src/components/tags/F0TagTeam/F0TagTeam.tsx
@@ -5,7 +5,7 @@ import type { F0TagTeamProps } from "./types"
 import { F0TagAvatar } from "../internal/TagAvatar"
 
 export const F0TagTeam = forwardRef<HTMLDivElement, F0TagTeamProps>(
-  ({ name, src }, ref) => {
+  ({ name, src, testId }, ref) => {
     return (
       <F0TagAvatar
         ref={ref}
@@ -15,6 +15,7 @@ export const F0TagTeam = forwardRef<HTMLDivElement, F0TagTeamProps>(
           src: src,
         }}
         text={name}
+        testId={testId}
       />
     )
   }

--- a/packages/react/src/components/tags/F0TagTeam/types.ts
+++ b/packages/react/src/components/tags/F0TagTeam/types.ts
@@ -1,4 +1,6 @@
-export interface F0TagTeamProps {
+import type { TestableProps } from "@/global.types"
+
+export interface F0TagTeamProps extends TestableProps {
   name: string
   src?: string
 }

--- a/packages/react/src/components/tags/internal/BaseTag/index.tsx
+++ b/packages/react/src/components/tags/internal/BaseTag/index.tsx
@@ -3,10 +3,11 @@ import { forwardRef, ReactNode } from "react"
 import { F0Icon } from "@/components/F0Icon"
 import { OneEllipsis } from "@/components/OneEllipsis"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import type { TestableProps } from "@/global.types"
 import { InfoCircleLine } from "@/icons/app"
 import { cn } from "@/lib/utils"
 
-type BaseTagProps = {
+type BaseTagProps = TestableProps & {
   /**
    * Sometimes you need to clarify the status for screen reader users
    * E.g., when showing a tooltip for sighted user, provide the tooltip text to this prop because tooltips aren't accessible
@@ -48,13 +49,17 @@ export const BaseTag = forwardRef<HTMLDivElement, BaseTagProps>(
       info,
       shape = "rounded",
       hideLabel,
+      testId,
     },
     ref
   ) => {
     additionalAccessibleText =
       additionalAccessibleText || (hideLabel ? text : undefined)
     return (
-      <div className="flex w-fit max-w-full flex-row items-center justify-start gap-1">
+      <div
+        className="flex w-fit max-w-full flex-row items-center justify-start gap-1"
+        data-testid={testId}
+      >
         <div
           ref={ref}
           className={cn(

--- a/packages/react/src/components/tags/internal/BaseTag/index.tsx
+++ b/packages/react/src/components/tags/internal/BaseTag/index.tsx
@@ -25,17 +25,17 @@ type BaseTagProps = TestableProps & {
    */
   hideLabel?: boolean
 } & (
-  | {
-      left: ReactNode
-      text?: string
-      right?: ReactNode
-    }
-  | {
-      left?: ReactNode
-      text: string
-      right?: ReactNode
-    }
-)
+    | {
+        left: ReactNode
+        text?: string
+        right?: ReactNode
+      }
+    | {
+        left?: ReactNode
+        text: string
+        right?: ReactNode
+      }
+  )
 
 export const BaseTag = forwardRef<HTMLDivElement, BaseTagProps>(
   (

--- a/packages/react/src/components/tags/internal/TagAvatar/index.tsx
+++ b/packages/react/src/components/tags/internal/TagAvatar/index.tsx
@@ -1,18 +1,19 @@
 import { forwardRef } from "react"
 
 import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
+import type { TestableProps } from "@/global.types"
 import { useTextFormatEnforcer } from "@/lib/text"
 
 import { BaseTag } from "../BaseTag"
 
-type Props = {
+type Props = TestableProps & {
   text: string
   avatar: AvatarVariant
   onClick?: () => void
 }
 
 export const F0TagAvatar = forwardRef<HTMLDivElement, Props>(
-  ({ avatar, text }, ref) => {
+  ({ avatar, text, testId }, ref) => {
     useTextFormatEnforcer(
       text,
       { disallowEmpty: true },
@@ -26,6 +27,7 @@ export const F0TagAvatar = forwardRef<HTMLDivElement, Props>(
         left={<F0Avatar avatar={avatar} size="xs" />}
         text={text}
         shape={avatar.type === "person" ? "rounded" : "square"}
+        testId={testId}
       />
     )
   }

--- a/packages/react/src/experimental/Banners/F0Callout/CalloutInternal.tsx
+++ b/packages/react/src/experimental/Banners/F0Callout/CalloutInternal.tsx
@@ -40,7 +40,7 @@ const variantTitleColors: Record<string, string> = {
 
 export const CalloutInternal = forwardRef<HTMLDivElement, CalloutInternalProps>(
   function CalloutInternal(
-    { title, onClose, children, actions = [], variant },
+    { title, onClose, children, actions = [], variant, testId },
     ref
   ) {
     // Validate actions limit
@@ -55,7 +55,7 @@ export const CalloutInternal = forwardRef<HTMLDivElement, CalloutInternalProps>(
       <div
         ref={ref}
         className={calloutVariants({ variant })}
-        data-testid="sdm-callout"
+        data-testid={testId}
       >
         <div className="flex flex-row items-center justify-between px-4 py-2">
           <div

--- a/packages/react/src/experimental/Banners/F0Callout/CalloutInternal.tsx
+++ b/packages/react/src/experimental/Banners/F0Callout/CalloutInternal.tsx
@@ -55,7 +55,7 @@ export const CalloutInternal = forwardRef<HTMLDivElement, CalloutInternalProps>(
       <div
         ref={ref}
         className={calloutVariants({ variant })}
-        data-testid={testId}
+        data-testid={testId ?? "sdm-callout"}
       >
         <div className="flex flex-row items-center justify-between px-4 py-2">
           <div

--- a/packages/react/src/experimental/Banners/F0Callout/types.ts
+++ b/packages/react/src/experimental/Banners/F0Callout/types.ts
@@ -1,4 +1,5 @@
 import { IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 
 export type CalloutAction = {
   label: string
@@ -15,7 +16,7 @@ export const variants = [
 ] as const
 export type CalloutVariant = (typeof variants)[number]
 
-export interface CalloutInternalProps {
+export interface CalloutInternalProps extends TestableProps {
   title: string
   onClose?: () => void
   children: React.ReactNode

--- a/packages/react/src/experimental/F0ActionBar/index.tsx
+++ b/packages/react/src/experimental/F0ActionBar/index.tsx
@@ -7,6 +7,7 @@ import {
   F0ButtonDropdown,
 } from "@/components/F0ButtonDropdown"
 import { IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 import { Dropdown, MobileDropdown } from "@/experimental/Navigation/Dropdown"
 
 type ActionType = {
@@ -55,7 +56,7 @@ const normalizeItems = (
   }
 }
 
-interface F0ActionBarProps {
+interface F0ActionBarProps extends TestableProps {
   /**
    * Whether the action bar is open
    */
@@ -81,6 +82,7 @@ export const F0ActionBar = ({
   isOpen,
   secondaryActions = [],
   label,
+  testId,
   ...props
 }: F0ActionBarProps) => {
   const visibleSecondaryActions = secondaryActions.slice(0, 2)
@@ -141,6 +143,7 @@ export const F0ActionBar = ({
           exit={{ opacity: 0, y: 32, filter: "blur(6px)" }}
           transition={{ ease: [0.175, 0.885, 0.32, 1.275], duration: 0.3 }}
           className="fixed bottom-2 left-2 right-2 z-50 flex h-fit w-[calc(100%-16px)] flex-col items-center gap-2 rounded-xl bg-f1-background-inverse p-2 pl-4 text-f1-foreground shadow-lg backdrop-blur-sm dark:bg-f1-background-inverse-secondary sm:bottom-5 sm:mx-auto sm:h-12 sm:w-max sm:flex-row sm:gap-8"
+          data-testid={testId}
         >
           {!!label && (
             <span className="font-medium text-f1-foreground-inverse">

--- a/packages/react/src/experimental/Lists/DataList/index.tsx
+++ b/packages/react/src/experimental/Lists/DataList/index.tsx
@@ -4,13 +4,14 @@ import { F0AvatarCompany } from "@/components/avatars/F0AvatarCompany"
 import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
 import { F0AvatarTeam } from "@/components/avatars/F0AvatarTeam"
 import { IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 import { F0TagDot, TagDotProps } from "@/components/tags/F0TagDot"
 import { experimentalComponent } from "@/lib/experimental"
 import { cn } from "@/lib/utils"
 
 import { InternalActionType, ItemContainer } from "./ItemContainer"
 
-export type DataListProps = {
+export type DataListProps = TestableProps & {
   children: ReactElement<Items>[] | ReactElement<Items>
   label?: string
   isHorizontal?: boolean
@@ -23,7 +24,7 @@ type Items =
   | typeof TeamItem
 
 const _DataList = forwardRef<HTMLUListElement, DataListProps>(
-  ({ children, label, isHorizontal = false }, ref) => {
+  ({ children, label, isHorizontal = false, testId }, ref) => {
     return (
       <div
         className={cn(
@@ -31,6 +32,7 @@ const _DataList = forwardRef<HTMLUListElement, DataListProps>(
             ? "flex min-h-12 flex-1 flex-col py-1.5 pl-3 pr-1.5 xs:flex-row"
             : "min-w-32 md:max-w-80"
         )}
+        data-testid={testId}
       >
         {label && (
           <p

--- a/packages/react/src/experimental/Lists/DetailsItem/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps, FC, forwardRef } from "react"
 
+import type { TestableProps } from "@/global.types"
 import { Weekdays } from "@/experimental/Widgets/Content/Weekdays"
 import { experimentalComponent } from "@/lib/experimental"
 import { cn } from "@/lib/utils"
@@ -26,7 +27,7 @@ type Content =
       type: "dot-tag"
     })
 
-export interface DetailsItemType {
+export interface DetailsItemType extends TestableProps {
   title: string
   content: Content | Content[]
   isHorizontal?: boolean
@@ -50,7 +51,7 @@ const ItemContent: FC<{ content: Content }> = ({ content }) => (
 
 const _DetailsItem = forwardRef<HTMLDivElement, DetailsItemType>(
   function DetailsItem(
-    { title, content, isHorizontal = false, spacingAtTheBottom },
+    { title, content, isHorizontal = false, spacingAtTheBottom, testId },
     ref
   ) {
     const contentArray = Array.isArray(content) ? content : [content]
@@ -63,6 +64,7 @@ const _DetailsItem = forwardRef<HTMLDivElement, DetailsItemType>(
           spacingAtTheBottom && !isHorizontal && "pb-3",
           isHorizontal && "xs:[&_ul>li]:p-0 [&_ul]:flex-1"
         )}
+        data-testid={testId}
       >
         <DataList label={title} isHorizontal={isHorizontal}>
           {contentArray.map((c, i) => (

--- a/packages/react/src/experimental/Navigation/Page/index.tsx
+++ b/packages/react/src/experimental/Navigation/Page/index.tsx
@@ -1,17 +1,19 @@
-interface PageProps {
+import type { TestableProps } from "@/global.types"
+import { experimentalComponent } from "@/lib/experimental"
+
+interface PageProps extends TestableProps {
   children?: React.ReactNode
   header?: React.ReactNode
   embedded?: boolean
 }
 
-import { experimentalComponent } from "@/lib/experimental"
-
-function _Page({ children, header, embedded = false }: PageProps) {
+function _Page({ children, header, embedded = false, testId }: PageProps) {
   return (
     <div
       className={`flex min-h-full w-full flex-col overflow-hidden ${
         embedded ? "" : "xs:rounded-xl"
       } bg-f1-special-page ring-1 ring-inset ring-f1-border-secondary`}
+      data-testid={testId}
     >
       {header && <div className="flex flex-col">{header}</div>}
       <div className="isolate flex w-full flex-1 flex-col overflow-auto [&>*]:flex-1">

--- a/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
+import type { TestableProps } from "@/global.types"
 import { ChevronLeft, ChevronRight } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { useL10n } from "@/lib/providers/l10n"
@@ -26,7 +27,7 @@ import { isActiveDate, toDateRange } from "./utils"
 
 const privateProps = ["compact"] as const
 
-interface OneCalendarInternalProps {
+interface OneCalendarInternalProps extends TestableProps {
   mode: CalendarMode
   view: CalendarView
   onSelect?: (date: Date | DateRange | null) => void
@@ -82,6 +83,7 @@ const OneCalendarInternal = ({
   maxDate,
   compact = false,
   weekStartsOn,
+  testId,
 }: OneCalendarInternalProps) => {
   const i18n = useI18n()
   const l10n = useL10n()
@@ -245,7 +247,7 @@ const OneCalendarInternal = ({
   }
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col" data-testid={testId}>
       {showInput && (
         <div className="mb-2 flex gap-2">
           <Input

--- a/packages/react/src/experimental/OneChip/index.tsx
+++ b/packages/react/src/experimental/OneChip/index.tsx
@@ -2,6 +2,7 @@ import { cva, type VariantProps } from "cva"
 
 import { F0Avatar, type AvatarVariant } from "@/components/avatars/F0Avatar"
 import { F0Icon, type IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 import { CrossedCircle } from "@/icons/app"
 import { experimentalComponent } from "@/lib/experimental"
 import { cn, focusRing } from "@/lib/utils"
@@ -60,7 +61,8 @@ type ChipVariants =
     }
 
 export type ChipProps = BaseChipProps &
-  ChipVariants & {
+  ChipVariants &
+  TestableProps & {
     variant?: "default" | "selected"
   }
 
@@ -72,6 +74,7 @@ const _Chip = ({
   onClose,
   avatar,
   icon,
+  testId,
 }: ChipProps) => {
   return (
     <div
@@ -91,6 +94,7 @@ const _Chip = ({
         }
       }}
       tabIndex={onClick ? 0 : undefined}
+      data-testid={testId}
     >
       {avatar && <F0Avatar avatar={avatar} size="xs" />}
       <div className="flex items-center gap-0.5">

--- a/packages/react/src/experimental/OneDateNavigator/OneDateNavigator.tsx
+++ b/packages/react/src/experimental/OneDateNavigator/OneDateNavigator.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 
+import type { TestableProps } from "@/global.types"
 import { useL10n } from "@/lib/providers/l10n"
 import {
   DatePickerPopup,
@@ -16,10 +17,9 @@ import {
 import { DatePickerTrigger } from "./components/DateNavigatorTrigger"
 import { DatePickerValue } from "./types"
 
-export interface OneDatePickerProps extends Omit<
-  DatePickerPopupProps,
-  "children"
-> {
+export interface OneDatePickerProps
+  extends Omit<DatePickerPopupProps, "children">,
+    TestableProps {
   hideNavigation?: boolean
   hideGoToCurrent?: boolean
 }
@@ -35,6 +35,7 @@ export function OneDateNavigator({
   defaultCompareTo,
   onCompareToChange,
   value,
+  testId,
   ...props
 }: OneDatePickerProps) {
   const [localValue, setLocalValue] = useState<DatePickerValue | undefined>(
@@ -99,6 +100,7 @@ export function OneDateNavigator({
       onCompareToChange={handleCompareToChange}
       weekStartsOn={effectiveWeekStartsOn}
       asChild
+      testId={testId}
     >
       <DatePickerTrigger
         value={localValue}

--- a/packages/react/src/experimental/OneDateNavigator/OneDateNavigator.tsx
+++ b/packages/react/src/experimental/OneDateNavigator/OneDateNavigator.tsx
@@ -18,8 +18,7 @@ import { DatePickerTrigger } from "./components/DateNavigatorTrigger"
 import { DatePickerValue } from "./types"
 
 export interface OneDatePickerProps
-  extends Omit<DatePickerPopupProps, "children">,
-    TestableProps {
+  extends Omit<DatePickerPopupProps, "children">, TestableProps {
   hideNavigation?: boolean
   hideGoToCurrent?: boolean
 }
@@ -85,36 +84,37 @@ export function OneDateNavigator({
   }
 
   return (
-    <DatePickerPopup
-      onSelect={handleSelect}
-      value={localValue}
-      defaultValue={defaultValue}
-      presets={presets}
-      granularities={granularities}
-      minDate={props.minDate}
-      maxDate={props.maxDate}
-      open={isOpen}
-      onOpenChange={setIsOpen}
-      compareTo={compareTo}
-      defaultCompareTo={defaultCompareTo}
-      onCompareToChange={handleCompareToChange}
-      weekStartsOn={effectiveWeekStartsOn}
-      asChild
-      testId={testId}
-    >
-      <DatePickerTrigger
+    <div data-testid={testId}>
+      <DatePickerPopup
+        onSelect={handleSelect}
         value={localValue}
-        compareToValue={compareToValue}
-        highlighted={isOpen}
-        navigation={!hideNavigation}
-        onDateChange={handleNavigationChange}
-        granularity={granularityDefinition}
+        defaultValue={defaultValue}
+        presets={presets}
+        granularities={granularities}
         minDate={props.minDate}
         maxDate={props.maxDate}
-        disabled={props.disabled}
-        hideGoToCurrent={hideGoToCurrent}
-        onClick={() => setIsOpen(true)}
-      />
-    </DatePickerPopup>
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        compareTo={compareTo}
+        defaultCompareTo={defaultCompareTo}
+        onCompareToChange={handleCompareToChange}
+        weekStartsOn={effectiveWeekStartsOn}
+        asChild
+      >
+        <DatePickerTrigger
+          value={localValue}
+          compareToValue={compareToValue}
+          highlighted={isOpen}
+          navigation={!hideNavigation}
+          onDateChange={handleNavigationChange}
+          granularity={granularityDefinition}
+          minDate={props.minDate}
+          maxDate={props.maxDate}
+          disabled={props.disabled}
+          hideGoToCurrent={hideGoToCurrent}
+          onClick={() => setIsOpen(true)}
+        />
+      </DatePickerPopup>
+    </div>
   )
 }

--- a/packages/react/src/experimental/OneEmptyState/OneEmptyState.tsx
+++ b/packages/react/src/experimental/OneEmptyState/OneEmptyState.tsx
@@ -11,9 +11,13 @@ export function OneEmptyState({
   variant = "default",
   emoji,
   actions,
+  testId,
 }: Types.OneEmptyStateProps) {
   return (
-    <div className="flex flex-col items-center justify-center gap-5 p-8">
+    <div
+      className="flex flex-col items-center justify-center gap-5 p-8"
+      data-testid={testId}
+    >
       {variant === "default" && <F0AvatarEmoji emoji={emoji!} size="lg" />}
       {variant !== "default" && <F0AvatarAlert type={variant} size="lg" />}
       <div className="flex flex-col items-center justify-center gap-0.5">

--- a/packages/react/src/experimental/OneEmptyState/types.ts
+++ b/packages/react/src/experimental/OneEmptyState/types.ts
@@ -89,25 +89,25 @@ export type OneEmptyStateProps = TestableProps & {
    */
   actions?: ActionProps[]
 } & (
-  | {
-      /**
-       * The variant of the empty state
-       * @optional
-       */
-      variant?: "default"
+    | {
+        /**
+         * The variant of the empty state
+         * @optional
+         */
+        variant?: "default"
 
-      /**
-       * An icon will be displayed in the empty state.
-       * emoji string
-       */
-      emoji?: string
-    }
-  | {
-      /**
-       * The variant of the empty state
-       * @optional
-       */
-      variant: Exclude<AlertAvatarProps["type"], "positive">
-      emoji?: never
-    }
-)
+        /**
+         * An icon will be displayed in the empty state.
+         * emoji string
+         */
+        emoji?: string
+      }
+    | {
+        /**
+         * The variant of the empty state
+         * @optional
+         */
+        variant: Exclude<AlertAvatarProps["type"], "positive">
+        emoji?: never
+      }
+  )

--- a/packages/react/src/experimental/OneEmptyState/types.ts
+++ b/packages/react/src/experimental/OneEmptyState/types.ts
@@ -1,5 +1,6 @@
 import { AlertAvatarProps } from "@/components/avatars/F0AvatarAlert"
 import { IconType } from "@/components/F0Icon"
+import type { TestableProps } from "@/global.types"
 import { LoadingStateProps } from "@/components/UpsellingKit/UpsellingButton"
 import {
   ErrorMessageProps,
@@ -68,7 +69,7 @@ export type ActionProps = {
     }
 )
 
-export type OneEmptyStateProps = {
+export type OneEmptyStateProps = TestableProps & {
   /**
    * The title of the empty state
    */

--- a/packages/react/src/experimental/OnePagination/index.tsx
+++ b/packages/react/src/experimental/OnePagination/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react"
 
+import type { TestableProps } from "@/global.types"
 import { experimentalComponent } from "@/lib/experimental"
 import {
   PaginationContent,
@@ -13,7 +14,7 @@ import {
 
 import { cn } from "../../lib/utils"
 
-interface OnePaginationProps {
+interface OnePaginationProps extends TestableProps {
   /**
    * The total number of pages. Pass 0 if the total is unknown.
    */
@@ -70,6 +71,7 @@ function _OnePagination({
   visibleRange = 3,
   hasNextPage = true,
   disabled = false,
+  testId,
 }: OnePaginationProps) {
   const isIndeterminate = totalPages === 0
 
@@ -143,7 +145,7 @@ function _OnePagination({
   }, [currentPage, totalPages, visibleRange, isIndeterminate])
 
   return (
-    <PaginationRoot>
+    <PaginationRoot data-testid={testId}>
       <PaginationContent role="navigation" aria-label={ariaLabel}>
         {showControls && (
           <PaginationItem>

--- a/packages/react/src/experimental/OnePreset/index.tsx
+++ b/packages/react/src/experimental/OnePreset/index.tsx
@@ -1,20 +1,22 @@
 import { Await } from "@/components/Utilities/Await"
+import type { TestableProps } from "@/global.types"
 import { experimentalComponent } from "@/lib/experimental"
 import { Skeleton } from "@/ui/skeleton"
 
 import { cn } from "../../lib/utils"
 import { Counter } from "../Information/Counter"
 
-interface PresetProps {
+interface PresetProps extends TestableProps {
   label: string
   number?: number | Promise<number | undefined>
   onClick?: () => void
   selected?: boolean
 }
 
-const _Preset = ({ label, number, onClick, selected }: PresetProps) => {
+const _Preset = ({ label, number, onClick, selected, testId }: PresetProps) => {
   return (
     <label
+      data-testid={testId}
       className={cn(
         "flex cursor-default appearance-none items-center gap-2 rounded px-2.5 py-1.5 font-medium text-f1-foreground outline outline-1 outline-f1-border transition-all",
         onClick &&

--- a/packages/react/src/experimental/Overlays/Dialog/index.tsx
+++ b/packages/react/src/experimental/Overlays/Dialog/index.tsx
@@ -5,6 +5,7 @@ import {
   type AlertAvatarProps,
 } from "@/components/avatars/F0AvatarAlert"
 import { F0Button, F0ButtonProps } from "@/components/F0Button"
+import type { TestableProps } from "@/global.types"
 import { experimentalComponent } from "@/lib/experimental"
 import {
   Dialog,
@@ -23,7 +24,7 @@ type PrimaryAction = BaseAction & {
 }
 type SecondaryAction = BaseAction
 
-type DialogProps = {
+type DialogProps = TestableProps & {
   header: {
     type: AlertAvatarProps["type"]
     title: string
@@ -38,7 +39,7 @@ type DialogProps = {
 }
 
 const OneDialog = forwardRef<HTMLDivElement, DialogProps>(
-  ({ header, actions, open, onClose }, ref) => {
+  ({ header, actions, open, onClose, testId }, ref) => {
     // We do this in order to give the illusion of a controlled state via `open`, but in reality
     // we're taking control and closing the dialog after a few milliseconds to give the closing
     // animation time to play out.
@@ -60,7 +61,11 @@ const OneDialog = forwardRef<HTMLDivElement, DialogProps>(
         open={open && !closing}
         onOpenChange={(open) => !open && handleClose?.()}
       >
-        <DialogContent ref={ref} className="bottom-3 top-auto max-w-[400px]">
+        <DialogContent
+          ref={ref}
+          className="bottom-3 top-auto max-w-[400px]"
+          data-testid={testId}
+        >
           <DialogHeader className="flex flex-col gap-4 px-4 py-5">
             <F0AvatarAlert type={header.type} size="lg" />
             <div className="flex flex-col gap-0.5">

--- a/packages/react/src/global.types.ts
+++ b/packages/react/src/global.types.ts
@@ -3,3 +3,45 @@ export type UrlString = `http://${string}` | `https://${string}`
 export type DataAttributes = {
   [key: `data-${string}`]: string | undefined
 }
+
+/**
+ * Props for components that support test identifiers.
+ *
+ * @description
+ * The `testId` prop renders as a `data-testid` attribute on the component's
+ * root element. This enables reliable element selection in automated tests
+ * using testing libraries like React Testing Library, Playwright, or Cypress.
+ *
+ * @example
+ * ```tsx
+ * // Using testId in a component
+ * <F0Button label="Submit" testId="submit-button" />
+ *
+ * // Selecting in tests (React Testing Library)
+ * const button = screen.getByTestId('submit-button')
+ *
+ * // Selecting in tests (Playwright)
+ * await page.getByTestId('submit-button').click()
+ * ```
+ *
+ * @remarks
+ * - Use descriptive, kebab-case identifiers (e.g., `user-profile-card`)
+ * - Prefix with context for uniqueness (e.g., `sidebar-nav-button`)
+ * - Avoid using testId for styling or application logic
+ * - testId is optional and should only be added when needed for testing
+ */
+export type TestableProps = {
+  /**
+   * Test identifier for the component's root element.
+   *
+   * When provided, renders as `data-testid` attribute on the component's
+   * root DOM element for testing purposes.
+   *
+   * @example
+   * ```tsx
+   * <F0Card testId="employee-card" title="John Doe" />
+   * // Renders: <div data-testid="employee-card">...</div>
+   * ```
+   */
+  testId?: string
+}

--- a/packages/react/src/ui/chart.tsx
+++ b/packages/react/src/ui/chart.tsx
@@ -454,3 +454,5 @@ export {
   ChartTooltip,
   ChartTooltipContent,
 }
+
+export type { ChartContainerComponentProps }


### PR DESCRIPTION
## Summary

- Add optional `testId` prop to all components that renders as `data-testid` attribute on the component's root element
- Enables reliable element selection in automated tests using testing libraries like React Testing Library, Playwright, or Cypress
- Includes comprehensive JSDoc documentation with usage examples

## Changes

### Type Definition
- Add `TestableProps` type in `global.types.ts` with detailed documentation

### Core Components Updated
- F0Button, F0Alert, F0Text, F0Heading, F0Icon, F0Link
- F0Checkbox, F0BigNumber, F0Card, F0ChipList, F0Dialog
- F0Select, F0DatePicker, F0Widget, F0ButtonDropdown
- F0ButtonToggle, F0ButtonToggleGroup, OneEllipsis

### Avatar Components Updated
- BaseAvatar, F0Avatar, F0AvatarPerson, F0AvatarCompany
- F0AvatarTeam, F0AvatarAlert, F0AvatarIcon, F0AvatarEmoji
- F0AvatarDate, F0AvatarFile, F0AvatarFlag, F0AvatarModule
- F0AvatarList, F0AvatarPulse

### Tag Components Updated
- BaseTag, TagAvatar, F0TagPerson, F0TagStatus, F0TagDot
- F0TagTeam, F0TagCompany, F0TagAlert, F0TagBalance
- F0TagRaw, F0TagList

### Chart Components Updated
- BarChart, LineChart, AreaChart, VerticalBarChart, ComboChart
- RadarChart, PieChart, ProgressChart, CategoryBarChart, RadialProgressChart

### Experimental Components Updated
- OneChip, OneEmptyState, OnePagination, F0Callout, OnePreset
- Page, F0ActionBar, DetailsItem, DataList, OneDateNavigator
- OneCalendar, Dialog (experimental overlay)

### Stories
- Added `WithTestId` story examples for F0Button, F0Alert, and F0Card

## Usage Example

```tsx
// Using testId in a component
<F0Button label="Submit" testId="submit-button" />

// Selecting in tests (React Testing Library)
const button = screen.getByTestId('submit-button')

// Selecting in tests (Playwright)
await page.getByTestId('submit-button').click()
```

## Test plan

- [ ] Verify `testId` prop renders as `data-testid` attribute on component root elements
- [ ] Run existing tests to ensure no regressions
- [ ] Verify Storybook stories render correctly
- [ ] Check that `WithTestId` story examples work as expected


Made with [Cursor](https://cursor.com)