### PR TITLE
feat: enhance item actions handling in table rows

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/components/itemActions/useItemActions.ts
+++ b/packages/react/src/experimental/OneDataCollection/components/itemActions/useItemActions.ts
@@ -43,6 +43,7 @@ type UseItemActionProps<
 }
 
 export type UseItemActions = {
+  hasItemActions: boolean
   primaryItemActions: Exclude<ActionDefinition, DropdownItemSeparator>[]
   dropdownItemActions: DropdownItem[]
   mobileDropdownItemActions: DropdownItem[]
@@ -77,6 +78,7 @@ export const useItemActions = <
 
   if (!source.itemActions) {
     return {
+      hasItemActions: false,
       primaryItemActions: [],
       dropdownItemActions: [],
       mobileDropdownItemActions: [],
@@ -132,6 +134,7 @@ export const useItemActions = <
   }
 
   return {
+    hasItemActions: itemActions.length > 0,
     primaryItemActions,
     dropdownItemActions,
     mobileDropdownItemActions,

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -175,7 +175,7 @@ const NestedRowContent = <
     <>
       <Row
         {...props}
-        disableHover={true}
+        disableHover={!props.source.itemOnClick}
         noBorder={shouldHideBorder}
         ref={combinedRowRef}
         nestedRowProps={{

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -128,6 +128,7 @@ const RowComponentInner = <
   )
 
   const {
+    hasItemActions,
     primaryItemActions,
     dropdownItemActions,
     mobileDropdownItemActions,
@@ -214,38 +215,36 @@ const RowComponentInner = <
         </TableCell>
       ))}
 
-      {source.itemActions &&
-        !loading &&
-        !nestedRowProps?.onLoadMoreChildren && (
-          <>
-            {/** Desktop item actions adds a sticky column to the table to not overflow when the table is scrolled horizontally*/}
-            <td className="sticky right-0 top-0 z-10 hidden md:table-cell">
-              <ItemActionsRowContainer dropDownOpen={dropDownOpen}>
-                <ItemActionsRow
-                  primaryItemActions={primaryItemActions}
-                  dropdownItemActions={dropdownItemActions}
-                  handleDropDownOpenChange={handleDropDownOpenChange}
-                />
-              </ItemActionsRowContainer>
-            </td>
-            {/** Mobile item actions */}
-            <TableCell
-              key={`table-cell-${groupIndex}-${index}-actions`}
-              width={68}
-              sticky={{
-                right: 0,
-              }}
-              href={itemHref}
-              className="table-cell md:hidden"
-              loading={loading}
-            >
-              <ItemActionsMobile
-                items={mobileDropdownItemActions}
-                onOpenChange={handleDropDownOpenChange}
+      {hasItemActions && !loading && !nestedRowProps?.onLoadMoreChildren && (
+        <>
+          {/** Desktop item actions adds a sticky column to the table to not overflow when the table is scrolled horizontally*/}
+          <td className="sticky right-0 top-0 z-10 hidden md:table-cell">
+            <ItemActionsRowContainer dropDownOpen={dropDownOpen}>
+              <ItemActionsRow
+                primaryItemActions={primaryItemActions}
+                dropdownItemActions={dropdownItemActions}
+                handleDropDownOpenChange={handleDropDownOpenChange}
               />
-            </TableCell>
-          </>
-        )}
+            </ItemActionsRowContainer>
+          </td>
+          {/** Mobile item actions */}
+          <TableCell
+            key={`table-cell-${groupIndex}-${index}-actions`}
+            width={68}
+            sticky={{
+              right: 0,
+            }}
+            href={itemHref}
+            className="table-cell md:hidden"
+            loading={loading}
+          >
+            <ItemActionsMobile
+              items={mobileDropdownItemActions}
+              onOpenChange={handleDropDownOpenChange}
+            />
+          </TableCell>
+        </>
+      )}
     </TableRow>
   )
 }


### PR DESCRIPTION
## Summary

This PR enhances the item actions handling in table rows by introducing a more reliable way to determine when item actions should be rendered and improving hover behavior in nested rows.

### Changes

- **Added `hasItemActions` property to `useItemActions` hook**
  - Returns `true` when there are actual item actions available, `false` otherwise
  - Provides a cleaner way to check for item actions existence instead of checking the source config

- **Improved hover behavior in `NestedRow`**
  - Changed from always disabling hover (`disableHover={true}`) to conditionally disabling based on whether an `itemOnClick` handler exists
  - Rows with click handlers now properly show hover states

- **Refactored item actions rendering condition in `Row`**
  - Replaced `source.itemActions &&` check with the new `hasItemActions` flag
  - This ensures actions column is only rendered when there are actual actions to display, not just when the config exists

### Why

Previously, the item actions column could render even when no actions were available (e.g., when `itemActions` was defined but returned an empty array). This change ensures the actions column only appears when there are actual actions to show, preventing empty action cells in the table.
