### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.339.1",
+  "packages/react": "1.340.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.340.0](https://github.com/factorialco/f0/compare/f0-react-v1.339.1...f0-react-v1.340.0) (2026-01-29)
+
+
+### Features
+
+* allowed disabled action in one alert ([#3311](https://github.com/factorialco/f0/issues/3311)) ([f289de7](https://github.com/factorialco/f0/commit/f289de7e95b05a808748a616875b3482fc836c68))
+
 ## [1.339.1](https://github.com/factorialco/f0/compare/f0-react-v1.339.0...f0-react-v1.339.1) (2026-01-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.339.1",
+  "version": "1.340.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.340.0</summary>

## [1.340.0](https://github.com/factorialco/f0/compare/f0-react-v1.339.1...f0-react-v1.340.0) (2026-01-29)


### Features

* allowed disabled action in one alert ([#3311](https://github.com/factorialco/f0/issues/3311)) ([f289de7](https://github.com/factorialco/f0/commit/f289de7e95b05a808748a616875b3482fc836c68))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: only version/manifest updates and a changelog entry, with no functional code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.339.1` to `1.340.0` in both `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.340.0` release notes (feature: allow a disabled action in `one alert`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3c3737d4b9973cefacd72afd6ead6dc9a2ff68f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->