### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.340.0",
+  "packages/react": "1.340.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.340.1](https://github.com/factorialco/f0/compare/f0-react-v1.340.0...f0-react-v1.340.1) (2026-01-29)
+
+
+### Bug Fixes
+
+* **OneFilterPicker:** prevent double toggle when closing open popover ([#3319](https://github.com/factorialco/f0/issues/3319)) ([764a086](https://github.com/factorialco/f0/commit/764a08648a498a9168785be09f117c716e33f111))
+
 ## [1.340.0](https://github.com/factorialco/f0/compare/f0-react-v1.339.1...f0-react-v1.340.0) (2026-01-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.340.0",
+  "version": "1.340.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.340.1</summary>

## [1.340.1](https://github.com/factorialco/f0/compare/f0-react-v1.340.0...f0-react-v1.340.1) (2026-01-29)


### Bug Fixes

* **OneFilterPicker:** prevent double toggle when closing open popover ([#3319](https://github.com/factorialco/f0/issues/3319)) ([764a086](https://github.com/factorialco/f0/commit/764a08648a498a9168785be09f117c716e33f111))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only metadata changes (version bump and changelog update) with no functional code modifications in this diff, so runtime risk is low.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.340.0` to `1.340.1` in `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.340.1` release entry noting a `OneFilterPicker` bug fix (double toggle when closing an open popover).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f0cd50683ff3fb6c49024e096c1b3ca3316471e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->