### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.340.1",
+  "packages/react": "1.340.2",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.340.2](https://github.com/factorialco/f0/compare/f0-react-v1.340.1...f0-react-v1.340.2) (2026-01-30)
+
+
+### Bug Fixes
+
+* **useSelectable:** maintain selection ([#3328](https://github.com/factorialco/f0/issues/3328)) ([2993f59](https://github.com/factorialco/f0/commit/2993f59eeb0ef733f8353f76548bf89497ba4a75))
+
 ## [1.340.1](https://github.com/factorialco/f0/compare/f0-react-v1.340.0...f0-react-v1.340.1) (2026-01-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.340.1",
+  "version": "1.340.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.340.2</summary>

## [1.340.2](https://github.com/factorialco/f0/compare/f0-react-v1.340.1...f0-react-v1.340.2) (2026-01-30)


### Bug Fixes

* **useSelectable:** maintain selection ([#3328](https://github.com/factorialco/f0/issues/3328)) ([2993f59](https://github.com/factorialco/f0/commit/2993f59eeb0ef733f8353f76548bf89497ba4a75))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata-only change: bumps the `@factorialco/f0-react` version and updates the changelog/manifest without modifying runtime code.
> 
> **Overview**
> Publishes `@factorialco/f0-react` `1.340.2` by bumping versions in `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` to include the `1.340.2` entry noting a `useSelectable` selection-retention bug fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a7421baaf38a6eb0e815c434e416092a1f3fc0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->