### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.340.2",
+  "packages/react": "1.341.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.341.0](https://github.com/factorialco/f0/compare/f0-react-v1.340.2...f0-react-v1.341.0) (2026-01-30)
+
+
+### Features
+
+* enhance item actions handling in table rows ([#3321](https://github.com/factorialco/f0/issues/3321)) ([62566b6](https://github.com/factorialco/f0/commit/62566b6b8fbc9f96de89818f8b2e3840d4bb65a9))
+
 ## [1.340.2](https://github.com/factorialco/f0/compare/f0-react-v1.340.1...f0-react-v1.340.2) (2026-01-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.340.2",
+  "version": "1.341.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.341.0</summary>

## [1.341.0](https://github.com/factorialco/f0/compare/f0-react-v1.340.2...f0-react-v1.341.0) (2026-01-30)


### Features

* enhance item actions handling in table rows ([#3321](https://github.com/factorialco/f0/issues/3321)) ([62566b6](https://github.com/factorialco/f0/commit/62566b6b8fbc9f96de89818f8b2e3840d4bb65a9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version manifest/package.json and changelog). Low risk because no runtime/source code is modified in this PR.
> 
> **Overview**
> Updates the `@factorialco/f0-react` release from `1.340.2` to `1.341.0` by bumping versions in `.release-please-manifest.json` and `packages/react/package.json` and adding the corresponding `CHANGELOG.md` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8accf2949af8417082a42d8744e3d00359f63d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->