### PR TITLE
fix(TableHead): adjust z-index for sticky header styling

### DIFF
--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -180,8 +180,8 @@ export function TableHead({
         "bg-f1-background",
         isSticky &&
           (isScrolled || isScrolledRight) &&
-          "relative bg-f1-background before:absolute before:inset-x-0 before:bottom-0 before:h-px before:w-full before:bg-f1-border-secondary before:content-['']",
-        isSticky && "sticky z-10",
+          "relative bg-f1-background z-10 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:w-full before:bg-f1-border-secondary before:content-['']",
+        isSticky && "sticky",
         hidden && "after:hidden",
         className
       )}


### PR DESCRIPTION
## Summary

Fixes sticky header border not appearing correctly when there's no scroll.

## Problem

The previous implementation applied `z-index: 10` unconditionally to all sticky headers, while the bottom border was only rendered when scrolled. This caused the header being above the cell below. Now, this z-index will be applied on scrolling, as the regular cells.

## Solution

Moved `z-10` to the same conditional as the border pseudo-element, ensuring both are applied together only when scroll is detected.

BEFORE:
<img width="1334" height="598" alt="Captura de pantalla 2026-01-30 a las 16 34 42" src="https://github.com/user-attachments/assets/f399dfd9-3d8a-4375-bef8-810a79f4dbb5" />


AFTER:
<img width="1401" height="597" alt="Captura de pantalla 2026-01-30 a las 16 41 05" src="https://github.com/user-attachments/assets/4a6bcaa0-3ec7-4412-80fb-90baf7dd69df" />

