### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.341.0",
+  "packages/react": "1.341.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.341.1](https://github.com/factorialco/f0/compare/f0-react-v1.341.0...f0-react-v1.341.1) (2026-02-02)
+
+
+### Bug Fixes
+
+* **TableHead:** adjust z-index for sticky header styling ([#3332](https://github.com/factorialco/f0/issues/3332)) ([02ea776](https://github.com/factorialco/f0/commit/02ea7766a5c6a647912740f2ca0a54b3a3902f8e))
+
 ## [1.341.0](https://github.com/factorialco/f0/compare/f0-react-v1.340.2...f0-react-v1.341.0) (2026-01-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.341.0",
+  "version": "1.341.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.341.1</summary>

## [1.341.1](https://github.com/factorialco/f0/compare/f0-react-v1.341.0...f0-react-v1.341.1) (2026-02-02)


### Bug Fixes

* **TableHead:** adjust z-index for sticky header styling ([#3332](https://github.com/factorialco/f0/issues/3332)) ([02ea776](https://github.com/factorialco/f0/commit/02ea7766a5c6a647912740f2ca0a54b3a3902f8e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-only change: updates version metadata and changelog with no functional code modifications in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.341.0` to `1.341.1` by updating the release manifest and `packages/react/package.json`.
> 
> Adds the `1.341.1` changelog entry documenting a `TableHead` sticky header z-index bug fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cc9040292025d7ccf953191afe637e92ef1c537. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->