### PR TITLE
feat(react-native): add pages module ID for policies inbox tasks

### DIFF
--- a/packages/react-native/src/components/Avatars/ModuleAvatar/modules.ts
+++ b/packages/react-native/src/components/Avatars/ModuleAvatar/modules.ts
@@ -16,6 +16,7 @@ export const modules = {
   compensations: ModuleIcons.Payroll,
   discover: ModuleIcons.Discover,
   documents: ModuleIcons.Documents,
+  pages: ModuleIcons.Documents,
   employee_attendance: ModuleIcons.ClockIn,
   employees: ModuleIcons.Organization,
   engagement: ModuleIcons.Engagement,


### PR DESCRIPTION
Adds `pages` module ID to the ModuleAvatar modules mapping, using the Documents icon.

This is needed for the mobile inbox to display policy acknowledgement tasks without crashing. The `policies` task category in mobile maps to `pages` module ID, which wasn't previously defined in f0-react-native.