### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.342.0",
+  "packages/react": "1.343.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.343.0](https://github.com/factorialco/f0/compare/f0-react-v1.342.0...f0-react-v1.343.0) (2026-02-03)
+
+
+### Features
+
+* set long label for consistency ([#3318](https://github.com/factorialco/f0/issues/3318)) ([6e98745](https://github.com/factorialco/f0/commit/6e9874599f91aeb520f6c5e5eef2f5467fa6b621))
+
 ## [1.342.0](https://github.com/factorialco/f0/compare/f0-react-v1.341.1...f0-react-v1.342.0) (2026-02-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.342.0",
+  "version": "1.343.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.343.0</summary>

## [1.343.0](https://github.com/factorialco/f0/compare/f0-react-v1.342.0...f0-react-v1.343.0) (2026-02-03)


### Features

* set long label for consistency ([#3318](https://github.com/factorialco/f0/issues/3318)) ([6e98745](https://github.com/factorialco/f0/commit/6e9874599f91aeb520f6c5e5eef2f5467fa6b621))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata update: only version bumps and changelog entries, with no functional code changes included in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.342.0` to `1.343.0` and updates the release manifest accordingly.
> 
> Adds the `1.343.0` changelog entry noting the feature “set long label for consistency” (per #3318).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 844f26a4f5511690c2c1fe508a7ebd9a6a91a076. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->