### PR TITLE
feat: counter inside filter component

### DIFF
--- a/packages/react/src/components/F0Button/internal-types.ts
+++ b/packages/react/src/components/F0Button/internal-types.ts
@@ -30,6 +30,10 @@ export type ButtonInternalProps = Pick<
      */
     variant?: ActionButtonVariant
     /**
+     * The filters'counter value to display.
+     */
+    counterValue?: number
+    /**
      * Callback fired when the button is clicked. Supports async functions for loading state.
      */
     onClick?: (

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -10,6 +10,7 @@ import { Action } from "@/ui/Action"
 import { OneEllipsis } from "../OneEllipsis"
 import { ButtonInternalProps } from "./internal-types"
 import { fontSizeVariants } from "./variants"
+import { Counter } from "@/experimental/Information/Counter"
 
 const IconMotion = motion.create(F0Icon)
 
@@ -38,6 +39,7 @@ const ButtonInternal = forwardRef<
     noAutoTooltip,
     noTitle,
     iconRotate = false,
+    counterValue,
     ...props
   },
   ref
@@ -173,7 +175,10 @@ const ButtonInternal = forwardRef<
           ) : (
             <span className="sr-only">{buttonLabel}</span>
           )}
-          {append}
+          {append}{" "}
+          {counterValue && (
+            <Counter value={counterValue} size="sm" type="selected" />
+          )}
         </div>
       </Action>
     </>

--- a/packages/react/src/components/OneFilterPicker/OneFilterPicker.tsx
+++ b/packages/react/src/components/OneFilterPicker/OneFilterPicker.tsx
@@ -33,6 +33,8 @@ export type OneFilterPickerRootProps<Definition extends FiltersDefinition> = {
   mode?: FiltersMode
   /** Callback fired when filters open state is changed */
   onOpenChange?: (isOpen: boolean) => void
+  /** Display counter for the applied filters */
+  displayCounter?: boolean
 }
 
 /**
@@ -172,6 +174,7 @@ const FiltersControls = () => {
     presets,
     emitFilterChange,
     mode,
+    displayCounter,
   } = useContext(FiltersContext)
 
   const shownFilters = filters
@@ -197,6 +200,7 @@ const FiltersControls = () => {
         isOpen={isFiltersOpen}
         hideLabel={!!presets || mode === "simple"}
         mode={mode}
+        displayCounter={displayCounter}
       />
       {!!presets?.length && (
         <div className="flex items-center">

--- a/packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersControls.tsx
@@ -27,6 +27,7 @@ interface FiltersControlsProps<Filters extends FiltersDefinition> {
   onOpenChange?: (open: boolean) => void
   hideLabel?: boolean
   mode?: FiltersMode
+  displayCounter?: boolean
 }
 
 const DEFAULT_FORM_HEIGHT = 388
@@ -39,6 +40,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
   onOpenChange: controlledOnOpenChange,
   hideLabel,
   mode = "default",
+  displayCounter = false,
 }: FiltersControlsProps<Filters>) {
   const [selectedFilterKey, setSelectedFilterKey] = useState<
     keyof Filters | null
@@ -162,6 +164,12 @@ export function FiltersControls<Filters extends FiltersDefinition>({
     () => getActiveFilterKeys(filters, localFiltersValue, i18n),
     [filters, localFiltersValue, i18n]
   )
+
+  const appliedFiltersCount = useMemo(() => {
+    const count = getActiveFilterKeys(filters, value, i18n).length
+    if (count === 0) return undefined
+    return count
+  }, [filters, value, i18n])
 
   const activeFiltersTooltip = useMemo(() => {
     return activeFilters.length > 0
@@ -303,6 +311,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
             pressed={isOpen}
             hideLabel={hideLabel}
             aria-controls={isOpen ? id : undefined}
+            counterValue={displayCounter ? appliedFiltersCount : undefined}
           />
         </PopoverTrigger>
         <PopoverContent

--- a/packages/react/src/components/OneFilterPicker/context.ts
+++ b/packages/react/src/components/OneFilterPicker/context.ts
@@ -19,6 +19,7 @@ export type FiltersContextType<Definition extends FiltersDefinition> = {
   emitFilterChange: (filters: FiltersState<Definition>) => void
   emitPresetClick: (filters: FiltersState<Definition>) => void
   mode?: FiltersMode
+  displayCounter?: boolean
 }
 
 export const FiltersContext = createContext<
@@ -35,4 +36,5 @@ export const FiltersContext = createContext<
   emitFilterChange: () => {},
   emitPresetClick: () => {},
   mode: "default",
+  displayCounter: false,
 })


### PR DESCRIPTION
## Description

- Add optional displayCounter prop to OneFilterPicker that shows the count of applied filters on the filter button
- The counter displays only after filters are applied (uses committed value prop, not pending local state)
- Reuses the existing experimental Counter component from the design system

## Screenshots (if applicable)


https://github.com/user-attachments/assets/26b4952f-72c7-403d-a670-332a77f9bc4c


<img width="347" height="69" alt="image" src="https://github.com/user-attachments/assets/2b69465f-c9cb-4004-85ed-5b8d3fcda3da" />

## Implementation details

OneFilterPicker

- Added `displayCounter?: boolean` prop to `OneFilterPickerRootProps`
- Prop flows through context to FiltersControls

FiltersControls

- Added `appliedFiltersCount` computed from the value prop (applied filters) rather than localFiltersValue (pending selections) so we show only the counter once the filters are applied.
- Counter only appears when `displayCounter` is enabled, filters are applied and its length is > 0.

ButtonInternal (F0Button)
- We want to render this counter inside the button, so in this case we need to render it inside the `ButtonInternal`
- Added `counterValue?: number` prop to display a counter badge
- Uses the experimental Counter component with `size="sm"` and `type="selected"`

