### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.343.0",
+  "packages/react": "1.343.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.343.1](https://github.com/factorialco/f0/compare/f0-react-v1.343.0...f0-react-v1.343.1) (2026-02-03)
+
+
+### Bug Fixes
+
+* add missing apply selection button in F0Select ([#3345](https://github.com/factorialco/f0/issues/3345)) ([f3fa4c5](https://github.com/factorialco/f0/commit/f3fa4c5359446ab793159fc496ac290ac139dce0))
+
 ## [1.343.0](https://github.com/factorialco/f0/compare/f0-react-v1.342.0...f0-react-v1.343.0) (2026-02-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.343.0",
+  "version": "1.343.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.343.1</summary>

## [1.343.1](https://github.com/factorialco/f0/compare/f0-react-v1.343.0...f0-react-v1.343.1) (2026-02-03)


### Bug Fixes

* add missing apply selection button in F0Select ([#3345](https://github.com/factorialco/f0/issues/3345)) ([f3fa4c5](https://github.com/factorialco/f0/commit/f3fa4c5359446ab793159fc496ac290ac139dce0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata update: only version bumps and changelog entries; no runtime code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.343.0` to `1.343.1` and updates `.release-please-manifest.json` accordingly.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.343.1` release notes (bug fix: missing apply selection button in `F0Select`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efb62a5b8ce9e569a72cfc1d23e7d62896b0a38f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->