### PR TITLE
fix: add intuitive default placeholders for date inputs

### DIFF
--- a/packages/react/src/components/F0DatePicker/components/DateInput.tsx
+++ b/packages/react/src/components/F0DatePicker/components/DateInput.tsx
@@ -92,7 +92,7 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     }
 
     // Use granularity placeholder as default if no placeholder provided
-    const placeholder = inputProps.placeholder ?? granularity.placeholder(i18n)
+    const placeholder = inputProps.placeholder ?? granularity.placeholder()
 
     return (
       <>

--- a/packages/react/src/experimental/OneCalendar/granularities/day/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/day/index.tsx
@@ -14,6 +14,7 @@ import {
   formatDate,
   formatDateRange,
   formatDateToString,
+  formatToPlaceholder,
   isAfterOrEqual,
   isBeforeOrEqual,
   toDateRangeString,
@@ -22,6 +23,8 @@ import {
 import { rangeSeparator } from "../consts"
 import { DateStringFormat, GranularityDefinition } from "../types"
 import { DayView } from "./DayView"
+
+export const DAY_FORMAT = "dd/MM/yyyy"
 
 export function toDayGranularityDateRange<
   T extends Date | DateRange | undefined | null,
@@ -91,16 +94,16 @@ export const dayGranularity: GranularityDefinition = {
     }
   },
   toRange: (date) => toDayGranularityDateRange(date),
-  toRangeString: (date) => formatDateRange(date, "dd/MM/yyyy"),
+  toRangeString: (date) => formatDateRange(date, DAY_FORMAT),
   toString: (date, _, format = "default") => {
     const formats: Record<DateStringFormat, string> = {
-      default: formatDateToString(date, "dd/MM/yyyy"),
+      default: formatDateToString(date, DAY_FORMAT),
       long: formatLong(date),
     }
     return formats[format] ?? formats.default
   },
   toStringMaxWidth: () => 160,
-  placeholder: (i18n) => i18n.date.granularities.day.placeholder,
+  placeholder: () => formatToPlaceholder(DAY_FORMAT),
   fromString: (dateStr) => {
     const dateRangeString = toDateRangeString(dateStr)
     if (!dateRangeString) {

--- a/packages/react/src/experimental/OneCalendar/granularities/halfyear/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/halfyear/index.tsx
@@ -22,6 +22,9 @@ import { rangeSeparator } from "../consts"
 import { DateStringFormat, GranularityDefinition } from "../types"
 import { HalfYearView } from "./HalfyearView"
 
+// Halfyear uses a custom format (not a date-fns pattern): "H1 yyyy" or "H2 yyyy"
+const HALFYEAR_PLACEHOLDER = "Hn yyyy"
+
 const formatHalfYearFull = (date: Date) => {
   return `${formatHalfYear(date)} ${date.getFullYear()}`
 }
@@ -144,7 +147,7 @@ export const halfyearGranularity: GranularityDefinition = {
     return formats[format] ?? formats.default
   },
   toStringMaxWidth: () => 155,
-  placeholder: (i18n) => i18n.date.granularities.halfyear.placeholder,
+  placeholder: () => HALFYEAR_PLACEHOLDER,
   fromString: (dateStr) => {
     const dateRangeString = toDateRangeString(dateStr)
     if (!dateRangeString) {

--- a/packages/react/src/experimental/OneCalendar/granularities/month/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/month/index.tsx
@@ -14,6 +14,7 @@ import { DateRange, DateRangeComplete } from "../../types"
 import {
   formatDateRange,
   formatDateToString,
+  formatToPlaceholder,
   isAfterOrEqual,
   isBeforeOrEqual,
   toDateRangeString,
@@ -22,6 +23,8 @@ import {
 import { rangeSeparator } from "../consts"
 import { DateStringFormat, GranularityDefinition } from "../types"
 import { MonthView } from "./MonthView"
+
+const MONTH_FORMAT = "MM/yyyy"
 
 export function toMonthGranularityDateRange<
   T extends Date | DateRange | undefined | null,
@@ -37,7 +40,7 @@ const add = (date: DateRangeComplete, delta: number): DateRangeComplete => {
 }
 
 const formatMonthShort = (date: Date | DateRange | undefined | null) => {
-  return formatDateToString(date, "MM/yyyy")
+  return formatDateToString(date, MONTH_FORMAT)
 }
 
 const formatMonthLong = (date: Date | DateRange | undefined | null) => {
@@ -94,7 +97,7 @@ export const monthGranularity: GranularityDefinition = {
     return formats[format] ?? formats.default
   },
   toStringMaxWidth: () => 140,
-  placeholder: (i18n) => i18n.date.granularities.month.placeholder,
+  placeholder: () => formatToPlaceholder(MONTH_FORMAT),
   fromString: (dateStr) => {
     const dateRangeString = toDateRangeString(dateStr)
     if (!dateRangeString) {

--- a/packages/react/src/experimental/OneCalendar/granularities/quarter/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/quarter/index.tsx
@@ -12,6 +12,7 @@ import { DateRange, DateRangeComplete } from "../../types"
 import {
   formatDateRange,
   formatDateToString,
+  formatToPlaceholder,
   isAfterOrEqual,
   isBeforeOrEqual,
   toDateRangeString,
@@ -20,6 +21,8 @@ import {
 import { rangeSeparator } from "../consts"
 import { DateStringFormat, GranularityDefinition } from "../types"
 import { QuarterView } from "./QuarterView"
+
+const QUARTER_FORMAT = "'Q'Q yyyy"
 
 export function toQuarterGranularityDateRange<
   T extends Date | DateRange | undefined | null,
@@ -35,7 +38,7 @@ const add = (date: DateRangeComplete, delta: number): DateRangeComplete => {
 }
 
 const formatQuarterShort = (date: Date | DateRange | undefined | null) => {
-  return formatDateToString(date, "'Q'Q yyyy")
+  return formatDateToString(date, QUARTER_FORMAT)
 }
 
 const formatQuarterLong = (date: Date | DateRange | undefined | null) => {
@@ -93,7 +96,7 @@ export const quarterGranularity: GranularityDefinition = {
     return formats[format] ?? formats.default
   },
   toStringMaxWidth: () => 110,
-  placeholder: (i18n) => i18n.date.granularities.quarter.placeholder,
+  placeholder: () => formatToPlaceholder(QUARTER_FORMAT),
   fromString: (dateStr) => {
     const dateRangeString = toDateRangeString(dateStr)
     if (!dateRangeString) {

--- a/packages/react/src/experimental/OneCalendar/granularities/range/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/range/index.tsx
@@ -1,8 +1,13 @@
 import { addDays, differenceInDays, endOfDay, startOfDay } from "date-fns"
 
 import { DateRangeComplete } from "../../types"
-import { isAfterOrEqual, isBeforeOrEqual } from "../../utils"
-import { dayGranularity, toDayGranularityDateRange } from "../day"
+import {
+  formatToPlaceholder,
+  isAfterOrEqual,
+  isBeforeOrEqual,
+} from "../../utils"
+import { rangeSeparator } from "../consts"
+import { DAY_FORMAT, dayGranularity, toDayGranularityDateRange } from "../day"
 import { GranularityDefinition } from "../types"
 /**
  * This is a special case of the day granularity.
@@ -17,10 +22,12 @@ const add = (date: DateRangeComplete, delta: number): DateRangeComplete => {
   }
 }
 
+const dayPlaceholder = formatToPlaceholder(DAY_FORMAT)
+
 export const rangeGranularity: GranularityDefinition = {
   ...dayGranularity,
   calendarMode: "range",
-  placeholder: (i18n) => i18n.date.granularities.range.placeholder,
+  placeholder: () => `${dayPlaceholder} ${rangeSeparator} ${dayPlaceholder}`,
   add,
   getPrevNext: (value, options) => {
     const dateRange = toDayGranularityDateRange(value)

--- a/packages/react/src/experimental/OneCalendar/granularities/types.ts
+++ b/packages/react/src/experimental/OneCalendar/granularities/types.ts
@@ -50,9 +50,8 @@ export interface GranularityDefinition {
   ) => string
   // Calculate the maximum width of the string representation of the date
   toStringMaxWidth: () => number
-  // Default placeholder text for the input field (e.g "dd/mm/yyyy" for day granularity)
-  // Uses i18n for locale-aware placeholders
-  placeholder: (i18n: TranslationsType) => string
+  // Default placeholder text for the input field, derived from the format pattern
+  placeholder: () => string
   // Parse the date range string to a date range
   fromString: (
     dateStr: string | DateRangeString,

--- a/packages/react/src/experimental/OneCalendar/granularities/week/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/week/index.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../types"
 import {
   formatDateRange,
+  formatToPlaceholder,
   isAfterOrEqual,
   isBeforeOrEqual,
   toDateRangeString,
@@ -30,6 +31,8 @@ import {
 import { rangeSeparator } from "../consts"
 import { DateStringFormat, GranularityDefinition } from "../types"
 import { WeekView } from "./WeekView"
+
+const WEEK_FORMAT = "'W'I yyyy"
 
 // Helper functions that use ISO week functions when weekStartsOn === WeekStartDay.Monday, otherwise use configurable versions
 export const getStartOfWeek = (date: Date, weekStartsOn: WeekStartsOn) => {
@@ -91,17 +94,17 @@ const toStringSort = (
     !dateRange.to ||
     getIsSameWeek(dateRange.from, dateRange.to, weekStartsOn)
   ) {
-    return formatDate(dateRange.from, "'W'I yyyy")
+    return formatDate(dateRange.from, WEEK_FORMAT)
   }
 
   // Range
   // Same year
   if (isSameYear(dateRange.from, dateRange.to)) {
-    return `${formatDate(dateRange.from, "'W'I")} ${rangeSeparator} ${formatDate(dateRange.to, "'W'I yyyy")}`
+    return `${formatDate(dateRange.from, "'W'I")} ${rangeSeparator} ${formatDate(dateRange.to, WEEK_FORMAT)}`
   }
 
   // Different month and year
-  return `${formatDate(dateRange.from, "'W'I yyyy")} ${rangeSeparator} ${formatDate(dateRange.to, "'W'I yyyy")}`
+  return `${formatDate(dateRange.from, WEEK_FORMAT)} ${rangeSeparator} ${formatDate(dateRange.to, WEEK_FORMAT)}`
 }
 
 const toStringLong = (
@@ -212,7 +215,7 @@ export const createWeekGranularity = (
     toStringMaxWidth: function () {
       return 240
     },
-    placeholder: (i18n) => i18n.date.granularities.week.placeholder,
+    placeholder: () => formatToPlaceholder(WEEK_FORMAT),
     fromString: function (dateStr) {
       const dateRangeString = toDateRangeString(dateStr)
       if (!dateRangeString) {

--- a/packages/react/src/experimental/OneCalendar/granularities/year/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/year/index.tsx
@@ -4,6 +4,7 @@ import { DateRange, DateRangeComplete } from "../../types"
 import {
   formatDateRange,
   formatDateToString,
+  formatToPlaceholder,
   isAfterOrEqual,
   isBeforeOrEqual,
   toDateRangeString,
@@ -12,6 +13,8 @@ import {
 import { rangeSeparator } from "../consts"
 import { DateStringFormat, GranularityDefinition } from "../types"
 import { YearView } from "./YearView"
+
+const YEAR_FORMAT = "yyyy"
 
 export function toYearGranularityDateRange<
   T extends Date | DateRange | undefined | null,
@@ -56,16 +59,16 @@ export const yearGranularity: GranularityDefinition = {
     }
   },
   toRange: (date) => toYearGranularityDateRange(date),
-  toRangeString: (date) => formatDateRange(date, "yyyy"),
+  toRangeString: (date) => formatDateRange(date, YEAR_FORMAT),
   toString: (date, _, format = "default") => {
     const formats: Record<DateStringFormat, string> = {
-      default: formatDateToString(date, "yyyy"),
-      long: formatDateToString(date, "yyyy"), // For years, long format is the same as default
+      default: formatDateToString(date, YEAR_FORMAT),
+      long: formatDateToString(date, YEAR_FORMAT), // For years, long format is the same as default
     }
     return formats[format] ?? formats.default
   },
   toStringMaxWidth: () => 70,
-  placeholder: (i18n) => i18n.date.granularities.year.placeholder,
+  placeholder: () => formatToPlaceholder(YEAR_FORMAT),
   fromString: (dateStr) => {
     const dateRangeString = toDateRangeString(dateStr)
     if (!dateRangeString) {

--- a/packages/react/src/experimental/OneCalendar/utils.ts
+++ b/packages/react/src/experimental/OneCalendar/utils.ts
@@ -5,6 +5,21 @@ import { Matcher } from "react-day-picker"
 import { GranularityDefinition } from "./granularities"
 import { rangeSeparator } from "./granularities/consts"
 import { DateRange, DateRangeComplete, DateRangeString } from "./types"
+
+/**
+ * Converts a date-fns format string to a human-readable placeholder pattern.
+ * e.g. "dd/MM/yyyy" → "dd/mm/yyyy", "'W'I yyyy" → "Wnn yyyy"
+ */
+export const formatToPlaceholder = (formatStr: string): string => {
+  return formatStr
+    .replace(/'([^']+)'/g, "$1") // Remove quotes around literals (e.g., 'W' → W, 'Q' → Q)
+    .replace(/MM/g, "mm") // Month number → mm
+    .replace(/dd/g, "dd") // Day → dd
+    .replace(/yyyy/g, "yyyy") // Year → yyyy
+    .replace(/I/g, "nn") // ISO week number → nn
+    .replace(/Q/g, "n") // Quarter number → n
+}
+
 // Get the locale object from date-fns/locale
 
 export const getLocale = (localeKey: string) => {

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -201,7 +201,6 @@ export const defaultTranslations = {
       day: {
         currentDate: "Today",
         label: "Day",
-        placeholder: "dd/mm/yyyy",
       },
       week: {
         currentDate: "This week",
@@ -209,32 +208,26 @@ export const defaultTranslations = {
         long: "Week of {{day}} {{month}} {{year}}",
         longSingular: "Week of {{date}}",
         longPlural: "Weeks of {{date}}",
-        placeholder: "Week of dd mm yyyy",
       },
       month: {
         currentDate: "This month",
         label: "Month",
-        placeholder: "mm/yyyy",
       },
       quarter: {
         currentDate: "This quarter",
         label: "Quarter",
-        placeholder: "Qn yyyy",
       },
       halfyear: {
         currentDate: "This half year",
         label: "Half year",
-        placeholder: "Half year of yyyy",
       },
       year: {
         currentDate: "This year",
         label: "Year",
-        placeholder: "yyyy",
       },
       range: {
         currentDate: "Today",
         label: "Range",
-        placeholder: "dd/mm/yyyy - dd/mm/yyyy",
       },
     },
     month: {


### PR DESCRIPTION
## Description

For date inputs shown in any form of our platform we should provide a clear hint for the user as placeholder depending on the granularity. We will always be able to override this placeholder for some specific cases though.

## Screenshots

<img width="343" height="99" alt="Screenshot 2026-02-03 at 13 10 43" src="https://github.com/user-attachments/assets/10d5b5ad-307c-4a8d-9b82-7b0849342ece" />
