### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.343.1",
+  "packages/react": "1.343.2",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.343.2](https://github.com/factorialco/f0/compare/f0-react-v1.343.1...f0-react-v1.343.2) (2026-02-03)
+
+
+### Bug Fixes
+
+* add intuitive default placeholders for date inputs ([#3348](https://github.com/factorialco/f0/issues/3348)) ([dddfe59](https://github.com/factorialco/f0/commit/dddfe59183c486519bb356de34cf141e88802d51))
+
 ## [1.343.1](https://github.com/factorialco/f0/compare/f0-react-v1.343.0...f0-react-v1.343.1) (2026-02-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.343.1",
+  "version": "1.343.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.343.2</summary>

## [1.343.2](https://github.com/factorialco/f0/compare/f0-react-v1.343.1...f0-react-v1.343.2) (2026-02-03)


### Bug Fixes

* add intuitive default placeholders for date inputs ([#3348](https://github.com/factorialco/f0/issues/3348)) ([dddfe59](https://github.com/factorialco/f0/commit/dddfe59183c486519bb356de34cf141e88802d51))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog updates with no functional code changes in this PR.
> 
> **Overview**
> Publishes `@factorialco/f0-react` `1.343.2` by bumping the version in `packages/react/package.json` and updating `.release-please-manifest.json`.
> 
> Updates `packages/react/CHANGELOG.md` to include the `1.343.2` entry noting the date input placeholder bug fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7033c83dbe9d4ea2dd31dcc8dc14f9efcfe2a9e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->