### PR TITLE
feat: add device catalog module icon

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarModule/modules.ts
+++ b/packages/react/src/components/avatars/F0AvatarModule/modules.ts
@@ -17,6 +17,7 @@ export const modules = {
   company_trainings: ModuleIcons.Trainings,
   compensations: ModuleIcons.Payroll,
   complaints: ModuleIcons.Complaints,
+  device_catalog: ModuleIcons.Marketplace,
   discover: ModuleIcons.Discover,
   documents: ModuleIcons.Documents,
   employee_attendance: ModuleIcons.ClockIn,


### PR DESCRIPTION
## Description

Adds new module for Device Catalog with the Marketplace icon.

## Screenshots (if applicable)

<img width="903" height="353" alt="Screenshot 2026-02-03 at 16 44 05" src="https://github.com/user-attachments/assets/9d894d04-55c3-440f-ad12-9f26f77ca13b" />

[Link to Figma Design](https://www.figma.com/design/OapOAF2BXqpyWgwt0jxYCt/Device---Procurement?node-id=8008-40645&t=vPfQAPzimVHbRaRJ-4)

## Implementation details

Added a new module (device_catalog) with the existing Marketplace icon.
