### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.344.0",
+  "packages/react": "1.345.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.345.0](https://github.com/factorialco/f0/compare/f0-react-v1.344.0...f0-react-v1.345.0) (2026-02-04)
+
+
+### Features
+
+* counter inside filter component ([#3346](https://github.com/factorialco/f0/issues/3346)) ([d455d69](https://github.com/factorialco/f0/commit/d455d698953efaf4722e7478f758151035d08896))
+
 ## [1.344.0](https://github.com/factorialco/f0/compare/f0-react-v1.343.2...f0-react-v1.344.0) (2026-02-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.344.0",
+  "version": "1.345.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.345.0</summary>

## [1.345.0](https://github.com/factorialco/f0/compare/f0-react-v1.344.0...f0-react-v1.345.0) (2026-02-04)


### Features

* counter inside filter component ([#3346](https://github.com/factorialco/f0/issues/3346)) ([d455d69](https://github.com/factorialco/f0/commit/d455d698953efaf4722e7478f758151035d08896))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates release metadata (versions and changelog) and does not change runtime code.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.344.0` to `1.345.0` in both `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.345.0` release entry noting the new *counter inside filter component* feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9b2ebd94fe705e1a43dcab4b362e7b19b62ed0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->