### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.345.0",
+  "packages/react": "1.346.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.346.0](https://github.com/factorialco/f0/compare/f0-react-v1.345.0...f0-react-v1.346.0) (2026-02-04)
+
+
+### Features
+
+* add deactivated view to tags ([#3293](https://github.com/factorialco/f0/issues/3293)) ([c0e2354](https://github.com/factorialco/f0/commit/c0e2354b137298d1abcb6cd2ae64ac4d07af4313))
+
 ## [1.345.0](https://github.com/factorialco/f0/compare/f0-react-v1.344.0...f0-react-v1.345.0) (2026-02-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.345.0",
+  "version": "1.346.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.346.0</summary>

## [1.346.0](https://github.com/factorialco/f0/compare/f0-react-v1.345.0...f0-react-v1.346.0) (2026-02-04)


### Features

* add deactivated view to tags ([#3293](https://github.com/factorialco/f0/issues/3293)) ([c0e2354](https://github.com/factorialco/f0/commit/c0e2354b137298d1abcb6cd2ae64ac4d07af4313))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: release metadata-only changes (version/changelog/manifest) with no functional code modifications.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.345.0` to `1.346.0` and updates `.release-please-manifest.json` accordingly.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.346.0` release notes (feature: deactivated view for tags).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ca761c010422b74d28b445220480420ec56f2f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->