### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.346.0",
+  "packages/react": "1.347.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.347.0](https://github.com/factorialco/f0/compare/f0-react-v1.346.0...f0-react-v1.347.0) (2026-02-04)
+
+
+### Features
+
+* export I18nProvider and related types from ai.ts  ([#3355](https://github.com/factorialco/f0/issues/3355)) ([3751faa](https://github.com/factorialco/f0/commit/3751faa4071a032f237beebe0b20baca8bbab58e))
+
 ## [1.346.0](https://github.com/factorialco/f0/compare/f0-react-v1.345.0...f0-react-v1.346.0) (2026-02-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.346.0",
+  "version": "1.347.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.347.0</summary>

## [1.347.0](https://github.com/factorialco/f0/compare/f0-react-v1.346.0...f0-react-v1.347.0) (2026-02-04)


### Features

* export I18nProvider and related types from ai.ts  ([#3355](https://github.com/factorialco/f0/issues/3355)) ([3751faa](https://github.com/factorialco/f0/commit/3751faa4071a032f237beebe0b20baca8bbab58e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata-only change: bumps `@factorialco/f0-react` version and updates the changelog/manifest, with no functional code changes in this diff.
> 
> **Overview**
> Publishes `@factorialco/f0-react` **v1.347.0** by bumping version numbers in `packages/react/package.json` and `.release-please-manifest.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the new release entry noting the feature to export `I18nProvider` and related types from `ai.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d3348bc1e4e959bb39e14edeb96a819302a7bf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->