### PR TITLE
fix(OneFilterPicker): increase FilterList width to fit translations

### DIFF
--- a/packages/react/src/components/OneFilterPicker/components/FilterList.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FilterList.tsx
@@ -64,7 +64,7 @@ export function FilterList<Definition extends FiltersDefinition>({
     <div
       className={cn(
         "z-30 flex h-full w-full flex-col",
-        isCompactMode ? "min-w-[224px]" : "w-[224px]",
+        isCompactMode ? "min-w-[256px]" : "w-[256px]",
         !isCompactMode &&
           "border border-solid border-transparent border-r-f1-border-secondary"
       )}


### PR DESCRIPTION
## Summary
- Increase FilterList width from 224px to 256px to accommodate most translated labels

## Context
Reported via Slack: https://factorialteam.slack.com/archives/C295M8USW/p1770287648019709

Some translations didn't fit within the previous 224px width. The new 256px width accommodates most translations.

## Test plan
- [ ] Verify FilterList displays correctly with long translations
- [ ] Check compact mode still works as expected

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI layout adjustment (width change only) with minimal blast radius and no logic/data changes.
> 
> **Overview**
> Increases the `OneFilterPicker` `FilterList` sidebar width from `224px` to `256px` in both normal and compact modes to better accommodate longer translated filter labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fb20d83395a3439012430ec944f9f9518346ef9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->