### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.348.0",
+  "packages/react": "1.348.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.348.1](https://github.com/factorialco/f0/compare/f0-react-v1.348.0...f0-react-v1.348.1) (2026-02-05)
+
+
+### Bug Fixes
+
+* show more selected items in select input when possible ([#3362](https://github.com/factorialco/f0/issues/3362)) ([6b7afa5](https://github.com/factorialco/f0/commit/6b7afa5458f23b8305b7fe00ff035535776b6107))
+
 ## [1.348.0](https://github.com/factorialco/f0/compare/f0-react-v1.347.0...f0-react-v1.348.0) (2026-02-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.348.0",
+  "version": "1.348.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.348.1</summary>

## [1.348.1](https://github.com/factorialco/f0/compare/f0-react-v1.348.0...f0-react-v1.348.1) (2026-02-05)


### Bug Fixes

* show more selected items in select input when possible ([#3362](https://github.com/factorialco/f0/issues/3362)) ([6b7afa5](https://github.com/factorialco/f0/commit/6b7afa5458f23b8305b7fe00ff035535776b6107))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no runtime code modifications in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.348.0` to `1.348.1` and updates the release manifest.
> 
> Updates the React package changelog to include the `1.348.1` entry, documenting a bug fix to show more selected items in the select input when possible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09abff4fe51e2bb5ffb69f6e14d862e6544f9916. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->