### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.348.1",
+  "packages/react": "1.349.0",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.349.0](https://github.com/factorialco/f0/compare/f0-react-v1.348.1...f0-react-v1.349.0) (2026-02-05)
+
+
+### Features
+
+* **AIChat:** Resize functionality, disclaimer and fixed tooltip bug ([#3361](https://github.com/factorialco/f0/issues/3361)) ([e343aaf](https://github.com/factorialco/f0/commit/e343aaf54765de3fa1da1813bf688d613ca740fd))
+
 ## [1.348.1](https://github.com/factorialco/f0/compare/f0-react-v1.348.0...f0-react-v1.348.1) (2026-02-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.348.1",
+  "version": "1.349.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.349.0</summary>

## [1.349.0](https://github.com/factorialco/f0/compare/f0-react-v1.348.1...f0-react-v1.349.0) (2026-02-05)


### Features

* **AIChat:** Resize functionality, disclaimer and fixed tooltip bug ([#3361](https://github.com/factorialco/f0/issues/3361)) ([e343aaf](https://github.com/factorialco/f0/commit/e343aaf54765de3fa1da1813bf688d613ca740fd))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no functional code modifications in this PR.
> 
> **Overview**
> Bumps the `@factorialco/f0-react` package version from `1.348.1` to `1.349.0` and updates the release manifest accordingly.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.349.0` release entry, noting AIChat improvements (resize support, added disclaimer, and a tooltip bug fix).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 876b0eeb4fe41caeb8510d0a9aeacd7f41191f8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->