### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.349.0",
+  "packages/react": "1.349.1",
   "packages/react-native": "0.22.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.349.1](https://github.com/factorialco/f0/compare/f0-react-v1.349.0...f0-react-v1.349.1) (2026-02-05)
+
+
+### Bug Fixes
+
+* **select:** prevent layout jump when toggling filters ([#3365](https://github.com/factorialco/f0/issues/3365)) ([04043dd](https://github.com/factorialco/f0/commit/04043ddc9bb2e856e06a723110ef84a946b8eb44))
+
 ## [1.349.0](https://github.com/factorialco/f0/compare/f0-react-v1.348.1...f0-react-v1.349.0) (2026-02-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.349.0",
+  "version": "1.349.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.349.1</summary>

## [1.349.1](https://github.com/factorialco/f0/compare/f0-react-v1.349.0...f0-react-v1.349.1) (2026-02-05)


### Bug Fixes

* **select:** prevent layout jump when toggling filters ([#3365](https://github.com/factorialco/f0/issues/3365)) ([04043dd](https://github.com/factorialco/f0/commit/04043ddc9bb2e856e06a723110ef84a946b8eb44))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version/changelog/manifest-only release automation changes with no runtime code modifications in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.349.0` to `1.349.1` and updates the Release Please manifest.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.349.1` entry noting a `select` bug fix to prevent layout jumps when toggling filters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceb0eceaa284021148c2395794db636f02ede674. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->