### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.349.1",
-  "packages/react-native": "0.22.0",
+  "packages/react-native": "0.23.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.23.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.22.0...f0-react-native-v0.23.0) (2026-02-06)
+
+
+### Features
+
+* React Native Design System migration to Uniwind and Tailwind 4 ([#3333](https://github.com/factorialco/f0/issues/3333)) ([ce05b98](https://github.com/factorialco/f0/commit/ce05b987d2b26298cc12e4bd7a4876405a0fb628))
+
 ## [0.22.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.21.0...f0-react-native-v0.22.0) (2025-12-17)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.23.0</summary>

## [0.23.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.22.0...f0-react-native-v0.23.0) (2026-02-06)


### Features

* React Native Design System migration to Uniwind and Tailwind 4 ([#3333](https://github.com/factorialco/f0/issues/3333)) ([ce05b98](https://github.com/factorialco/f0/commit/ce05b987d2b26298cc12e4bd7a4876405a0fb628))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only release/version metadata and changelog updates; no functional code changes in this diff.
> 
> **Overview**
> Publishes `@factorialco/f0-react-native` **v0.23.0** by bumping versions in `.release-please-manifest.json` and `packages/react-native/package.json`.
> 
> Updates `packages/react-native/CHANGELOG.md` with the v0.23.0 release entry noting the React Native design system migration to `uniwind` and Tailwind 4.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5fc06da53c5840e0453c5c9ccb540e2544b298e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->