### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.349.1",
+  "packages/react": "1.350.0",
   "packages/react-native": "0.23.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.350.0](https://github.com/factorialco/f0/compare/f0-react-v1.349.1...f0-react-v1.350.0) (2026-02-06)
+
+
+### Features
+
+* add onFullscreenChange callback to RichTextEditor ([#3325](https://github.com/factorialco/f0/issues/3325)) ([d86d5fb](https://github.com/factorialco/f0/commit/d86d5fb4f3c7f7b3baf019f11d040abd48dfae87))
+
 ## [1.349.1](https://github.com/factorialco/f0/compare/f0-react-v1.349.0...f0-react-v1.349.1) (2026-02-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.349.1",
+  "version": "1.350.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.350.0</summary>

## [1.350.0](https://github.com/factorialco/f0/compare/f0-react-v1.349.1...f0-react-v1.350.0) (2026-02-06)


### Features

* add onFullscreenChange callback to RichTextEditor ([#3325](https://github.com/factorialco/f0/issues/3325)) ([d86d5fb](https://github.com/factorialco/f0/commit/d86d5fb4f3c7f7b3baf019f11d040abd48dfae87))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/changelog and package version bumps only; no runtime code changes are included in this diff.
> 
> **Overview**
> Publishes a new `@factorialco/f0-react` release by bumping the version from `1.349.1` to `1.350.0` and updating the release manifest.
> 
> Updates the React package changelog to include the new `1.350.0` entry, noting the addition of an `onFullscreenChange` callback for `RichTextEditor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 048e1fe92d1a498d6af4d9cfb8c3f00d3a963a35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->