### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.350.0",
-  "packages/react-native": "0.23.0",
+  "packages/react-native": "0.23.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.23.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.23.0...f0-react-native-v0.23.1) (2026-02-06)
+
+
+### Bug Fixes
+
+* theme typography tokens ([#3371](https://github.com/factorialco/f0/issues/3371)) ([8b39216](https://github.com/factorialco/f0/commit/8b39216584c31874aef95e0206a58bddc30ba6ec))
+
 ## [0.23.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.22.0...f0-react-native-v0.23.0) (2026-02-06)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.23.1</summary>

## [0.23.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.23.0...f0-react-native-v0.23.1) (2026-02-06)


### Bug Fixes

* theme typography tokens ([#3371](https://github.com/factorialco/f0/issues/3371)) ([8b39216](https://github.com/factorialco/f0/commit/8b39216584c31874aef95e0206a58bddc30ba6ec))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version/changelog updates; no functional source code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react-native` from `0.23.0` to `0.23.1` (manifest + package version).
> 
> Updates `packages/react-native/CHANGELOG.md` with the `0.23.1` release notes, calling out a bug fix to *theme typography tokens* (per #3371).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81310be5fe657771b7a4b51be5a18125e8fa029e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->