### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.350.0",
+  "packages/react": "1.351.0",
   "packages/react-native": "0.23.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.351.0](https://github.com/factorialco/f0/compare/f0-react-v1.350.0...f0-react-v1.351.0) (2026-02-09)
+
+
+### Features
+
+* create F0Form component ([#3317](https://github.com/factorialco/f0/issues/3317)) ([5733b36](https://github.com/factorialco/f0/commit/5733b36710c1026b3f9d2de39def0a81008aafae))
+
 ## [1.350.0](https://github.com/factorialco/f0/compare/f0-react-v1.349.1...f0-react-v1.350.0) (2026-02-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.350.0",
+  "version": "1.351.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.351.0</summary>

## [1.351.0](https://github.com/factorialco/f0/compare/f0-react-v1.350.0...f0-react-v1.351.0) (2026-02-09)


### Features

* create F0Form component ([#3317](https://github.com/factorialco/f0/issues/3317)) ([5733b36](https://github.com/factorialco/f0/commit/5733b36710c1026b3f9d2de39def0a81008aafae))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no runtime code modifications in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.350.0` to `1.351.0` and updates `.release-please-manifest.json` accordingly.
> 
> Updates the React package changelog to include the `1.351.0` release notes (feature: `F0Form` component).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9341bb98ecd0fd1f9bd1ed2f46d1938dcdbd83f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->