### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.351.0",
+  "packages/react": "1.352.0",
   "packages/react-native": "0.23.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.352.0](https://github.com/factorialco/f0/compare/f0-react-v1.351.0...f0-react-v1.352.0) (2026-02-09)
+
+
+### Features
+
+* done state taskslist component ([#3385](https://github.com/factorialco/f0/issues/3385)) ([9a861d2](https://github.com/factorialco/f0/commit/9a861d225a5b64eaa741df3a470cf9066c889316))
+
 ## [1.351.0](https://github.com/factorialco/f0/compare/f0-react-v1.350.0...f0-react-v1.351.0) (2026-02-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.351.0",
+  "version": "1.352.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.352.0</summary>

## [1.352.0](https://github.com/factorialco/f0/compare/f0-react-v1.351.0...f0-react-v1.352.0) (2026-02-09)


### Features

* done state taskslist component ([#3385](https://github.com/factorialco/f0/issues/3385)) ([9a861d2](https://github.com/factorialco/f0/commit/9a861d225a5b64eaa741df3a470cf9066c889316))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version + changelog/manifest) with no functional code modifications in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.351.0` to `1.352.0` and updates the release manifest.
> 
> Updates the React package changelog to include the `1.352.0` release entry (noting the new “done state” for the taskslist component).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2cea07a37dacb145c59fd0feda2cfca3cf43d6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->