### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.352.0",
+  "packages/react": "1.353.0",
   "packages/react-native": "0.23.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.353.0](https://github.com/factorialco/f0/compare/f0-react-v1.352.0...f0-react-v1.353.0) (2026-02-09)
+
+
+### Features
+
+* create F0Form component ([#3384](https://github.com/factorialco/f0/issues/3384)) ([a26afe0](https://github.com/factorialco/f0/commit/a26afe03f1fc222b2a0cc769a928c875a2198390))
+
 ## [1.352.0](https://github.com/factorialco/f0/compare/f0-react-v1.351.0...f0-react-v1.352.0) (2026-02-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.352.0",
+  "version": "1.353.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.353.0</summary>

## [1.353.0](https://github.com/factorialco/f0/compare/f0-react-v1.352.0...f0-react-v1.353.0) (2026-02-09)


### Features

* create F0Form component ([#3384](https://github.com/factorialco/f0/issues/3384)) ([a26afe0](https://github.com/factorialco/f0/commit/a26afe03f1fc222b2a0cc769a928c875a2198390))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Automated release metadata/version updates only; no functional code changes included in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.352.0` to `1.353.0` and updates the Release Please manifest accordingly.
> 
> Updates the React package changelog to include the `1.353.0` release notes (feature: `F0Form` component).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95f641a20a85e67157ec5c2c55445f67ab15be40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->