### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.353.0",
+  "packages/react": "1.354.0",
   "packages/react-native": "0.23.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.354.0](https://github.com/factorialco/f0/compare/f0-react-v1.353.0...f0-react-v1.354.0) (2026-02-10)
+
+
+### Features
+
+* F0Box component ([#3374](https://github.com/factorialco/f0/issues/3374)) ([364b7a6](https://github.com/factorialco/f0/commit/364b7a657d1204daf3bb615d4d7b038317d2ce33))
+
 ## [1.353.0](https://github.com/factorialco/f0/compare/f0-react-v1.352.0...f0-react-v1.353.0) (2026-02-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.353.0",
+  "version": "1.354.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.354.0</summary>

## [1.354.0](https://github.com/factorialco/f0/compare/f0-react-v1.353.0...f0-react-v1.354.0) (2026-02-10)


### Features

* F0Box component ([#3374](https://github.com/factorialco/f0/issues/3374)) ([364b7a6](https://github.com/factorialco/f0/commit/364b7a657d1204daf3bb615d4d7b038317d2ce33))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no functional code modifications in this diff.
> 
> **Overview**
> Publishes `@factorialco/f0-react` **v1.354.0** by bumping the version in `packages/react/package.json` and updating `.release-please-manifest.json`.
> 
> Updates `packages/react/CHANGELOG.md` to include the `1.354.0` release notes, highlighting the new `F0Box` component feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8dc03cea1270c59bbbe6bb0c3161c78f4cafb18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->