### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.354.0",
-  "packages/react-native": "0.23.1",
+  "packages/react-native": "0.24.0",
   "packages/core": "1.43.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.24.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.23.1...f0-react-native-v0.24.0) (2026-02-10)
+
+
+### Features
+
+* add oxlint anf oxfmt to react-native ([#3391](https://github.com/factorialco/f0/issues/3391)) ([dcf3854](https://github.com/factorialco/f0/commit/dcf3854a3d5675728948a8e933273ab98234bd8f))
+
 ## [0.23.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.23.0...f0-react-native-v0.23.1) (2026-02-06)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.24.0</summary>

## [0.24.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.23.1...f0-react-native-v0.24.0) (2026-02-10)


### Features

* add oxlint anf oxfmt to react-native ([#3391](https://github.com/factorialco/f0/issues/3391)) ([dcf3854](https://github.com/factorialco/f0/commit/dcf3854a3d5675728948a8e933273ab98234bd8f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version/changelog updates) with no runtime code changes shown in the diff.
> 
> **Overview**
> Publishes `@factorialco/f0-react-native` **v0.24.0** by bumping the version in `.release-please-manifest.json` and `packages/react-native/package.json`.
> 
> Updates `packages/react-native/CHANGELOG.md` with the new 0.24.0 release notes (adds `oxlint`/`oxfmt` tooling entry).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b2d5f5bf76a0fd76b25eb3777cf483e1febe034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->