### PR TITLE
feat(CoCreationForm): add dropdown question type with F0Select

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -315,6 +315,8 @@ export const defaultTranslations = {
       rating: "Rating",
       multipleChoice: "Multiple choice",
       singleChoice: "Single choice",
+      dropdown: "Dropdown",
+      dropdownMulti: "Dropdown (multi)",
       text: "Text",
       longText: "Long text",
       numeric: "Numeric",

--- a/packages/react/src/sds/CoCreationForm/DropdownQuestion/index.stories.tsx
+++ b/packages/react/src/sds/CoCreationForm/DropdownQuestion/index.stories.tsx
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useState } from "react"
+
+import { withSkipA11y } from "@/lib/storybook-utils/parameters"
+
+import { DropdownQuestion } from "."
+import { CoCreationFormProvider } from "../Context"
+import { CoCreationFormElement } from "../types"
+
+const meta: Meta<typeof DropdownQuestion> = {
+  title: "CoCreationForm/DropdownQuestion",
+  component: DropdownQuestion,
+  tags: ["autodocs", "experimental"],
+  render: (args) => {
+    const [elements, setElements] = useState<CoCreationFormElement[]>([
+      { type: "question" as const, question: args },
+    ])
+
+    const question =
+      elements[0] && "question" in elements[0] ? elements[0].question : {}
+
+    return (
+      <div className="max-w-[750px]">
+        <CoCreationFormProvider
+          elements={elements}
+          onChange={setElements}
+          isEditMode
+        >
+          <DropdownQuestion {...args} {...question} />
+        </CoCreationFormProvider>
+      </div>
+    )
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof DropdownQuestion>
+
+export const SingleDropdown: Story = {
+  parameters: withSkipA11y({}),
+  args: {
+    id: "question-1",
+    title: "What department are you in?",
+    description: "Select your department from the dropdown",
+    type: "dropdown",
+    value: null,
+    options: [
+      { value: "engineering", label: "Engineering" },
+      { value: "design", label: "Design" },
+      { value: "product", label: "Product" },
+      { value: "marketing", label: "Marketing" },
+      { value: "sales", label: "Sales" },
+      { value: "hr", label: "Human Resources" },
+      { value: "finance", label: "Finance" },
+      { value: "legal", label: "Legal" },
+    ],
+  },
+}
+
+export const MultiDropdown: Story = {
+  parameters: withSkipA11y({}),
+  args: {
+    id: "question-2",
+    title: "Which tools do you use daily?",
+    description: "Select all tools that apply",
+    type: "dropdown-multi",
+    value: [],
+    options: [
+      { value: "slack", label: "Slack" },
+      { value: "jira", label: "Jira" },
+      { value: "figma", label: "Figma" },
+      { value: "github", label: "GitHub" },
+      { value: "notion", label: "Notion" },
+      { value: "google-docs", label: "Google Docs" },
+      { value: "vscode", label: "VS Code" },
+      { value: "linear", label: "Linear" },
+    ],
+  },
+}
+
+export const AnswerMode: Story = {
+  parameters: withSkipA11y({}),
+  render: (args) => {
+    const [elements, setElements] = useState<CoCreationFormElement[]>([
+      { type: "question" as const, question: args },
+    ])
+
+    const question =
+      elements[0] && "question" in elements[0] ? elements[0].question : {}
+
+    return (
+      <div className="max-w-[750px]">
+        <CoCreationFormProvider
+          elements={elements}
+          onChange={setElements}
+          isEditMode={false}
+        >
+          <DropdownQuestion {...args} {...question} />
+        </CoCreationFormProvider>
+      </div>
+    )
+  },
+  args: {
+    id: "question-3",
+    title: "What department are you in?",
+    description: "Select your department from the dropdown",
+    type: "dropdown",
+    value: null,
+    options: [
+      { value: "engineering", label: "Engineering" },
+      { value: "design", label: "Design" },
+      { value: "product", label: "Product" },
+      { value: "marketing", label: "Marketing" },
+      { value: "sales", label: "Sales" },
+      { value: "hr", label: "Human Resources" },
+    ],
+  },
+}
+
+export const AnswerModeMulti: Story = {
+  parameters: withSkipA11y({}),
+  render: (args) => {
+    const [elements, setElements] = useState<CoCreationFormElement[]>([
+      { type: "question" as const, question: args },
+    ])
+
+    const question =
+      elements[0] && "question" in elements[0] ? elements[0].question : {}
+
+    return (
+      <div className="max-w-[750px]">
+        <CoCreationFormProvider
+          elements={elements}
+          onChange={setElements}
+          isEditMode={false}
+        >
+          <DropdownQuestion {...args} {...question} />
+        </CoCreationFormProvider>
+      </div>
+    )
+  },
+  args: {
+    id: "question-4",
+    title: "Which tools do you use daily?",
+    description: "Select all that apply",
+    type: "dropdown-multi",
+    value: [],
+    options: [
+      { value: "slack", label: "Slack" },
+      { value: "jira", label: "Jira" },
+      { value: "figma", label: "Figma" },
+      { value: "github", label: "GitHub" },
+      { value: "notion", label: "Notion" },
+    ],
+  },
+}

--- a/packages/react/src/sds/CoCreationForm/DropdownQuestion/index.tsx
+++ b/packages/react/src/sds/CoCreationForm/DropdownQuestion/index.tsx
@@ -1,0 +1,260 @@
+import { Reorder } from "motion/react"
+import { nanoid } from "nanoid"
+import { useEffect, useMemo } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { F0Select } from "@/components/F0Select"
+import { F0SelectItemProps } from "@/components/F0Select/types"
+import { Add } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+
+import { BaseQuestion } from "../BaseQuestion"
+import { useCoCreationFormContext } from "../Context"
+import { DragProvider } from "../DragContext"
+import { SelectQuestionOption } from "../types"
+import { SelectOption } from "../SelectQuestion/SelectOption"
+import {
+  OnChangeLabelParams,
+  OnClickOptionActionParams,
+} from "../SelectQuestion/SelectOption/types"
+import { DropdownQuestionOnChangeParams, DropdownQuestionProps } from "./types"
+
+export type { DropdownQuestionProps } from "./types"
+
+export const DropdownQuestion = ({
+  options,
+  ...props
+}: DropdownQuestionProps) => {
+  const { onQuestionChange, isEditMode, getSectionContainingQuestion } =
+    useCoCreationFormContext()
+
+  const someOptionsWithSameValue =
+    new Set(options.map((option) => option.value)).size !== options.length
+
+  const containingSection = getSectionContainingQuestion(props.id)
+
+  const questionLocked = props.locked || containingSection?.locked
+
+  const { t } = useI18n()
+
+  const baseOnChangeParams: DropdownQuestionOnChangeParams = useMemo(
+    () => ({
+      id: props.id,
+      type: props.type,
+      options,
+    }),
+    [props.id, props.type, options]
+  )
+
+  // preventing options with same value to cause unexpected behavior
+  useEffect(() => {
+    if (!someOptionsWithSameValue) return
+
+    let newOptions = options.map((option) => ({
+      ...option,
+      value: option.label.toLowerCase().replace(/\s+/g, "-"),
+    }))
+
+    const commonChangeParams = {
+      id: props.id,
+      type: props.type,
+    }
+
+    const newOptionsWithSameValue =
+      new Set(newOptions.map((option) => option.value)).size !==
+      newOptions.length
+
+    if (!newOptionsWithSameValue) {
+      onQuestionChange?.({ ...commonChangeParams, options: newOptions })
+      return
+    }
+
+    newOptions = newOptions.map((option) => ({
+      ...option,
+      value: nanoid(),
+    }))
+
+    onQuestionChange?.({ ...commonChangeParams, options: newOptions })
+  }, [
+    someOptionsWithSameValue,
+    onQuestionChange,
+    options,
+    props.id,
+    props.type,
+  ])
+
+  const handleClickOptionAction = (params: OnClickOptionActionParams) => {
+    let newOptions = options
+
+    if (params.action === "remove") {
+      newOptions = options.filter((option) => option.value !== params.value)
+    }
+
+    if (params.action === "mark-as-correct") {
+      newOptions = options.map((option) => ({
+        ...option,
+        correct:
+          option.value === params.value ? !option.correct : option.correct,
+      }))
+    }
+
+    onQuestionChange?.({
+      ...baseOnChangeParams,
+      options: newOptions,
+    })
+  }
+
+  const handleChangeLabel = (params: OnChangeLabelParams) => {
+    const newOptions = options.map((option, index) => ({
+      ...option,
+      ...(index === params.index
+        ? {
+            value: params.value,
+            label: params.newLabel,
+          }
+        : {}),
+    }))
+    onQuestionChange?.({
+      ...baseOnChangeParams,
+      options: newOptions,
+    })
+  }
+
+  const handleAddOption = () => {
+    const optionsLength = options.length
+    const newOption = {
+      value: `new-option-${optionsLength + 1}`,
+      label: t("coCreationForm.selectQuestion.newOption", {
+        number: optionsLength + 1,
+      }),
+    }
+    onQuestionChange?.({
+      ...baseOnChangeParams,
+      options: [...options, newOption],
+    })
+  }
+
+  const handleReorderOptions = (newOptions: SelectQuestionOption[]) => {
+    onQuestionChange?.({
+      ...baseOnChangeParams,
+      options: newOptions,
+    })
+  }
+
+  const handleDropdownChange = (value: string) => {
+    onQuestionChange?.({
+      ...baseOnChangeParams,
+      type: "dropdown",
+      value,
+    })
+  }
+
+  const handleDropdownMultiChange = (values: string[]) => {
+    onQuestionChange?.({
+      ...baseOnChangeParams,
+      type: "dropdown-multi",
+      value: values,
+    })
+  }
+
+  if (someOptionsWithSameValue) {
+    return null
+  }
+
+  const selectOptions: F0SelectItemProps<string>[] = options.map((option) => ({
+    value: option.value,
+    label: option.label,
+  }))
+
+  // In edit mode, show editable options list (like SelectQuestion)
+  // In answer mode, show a real F0Select dropdown
+  if (isEditMode) {
+    return (
+      <BaseQuestion {...props}>
+        <div className="-mx-0.5 flex flex-col items-start [&>div]:w-full">
+          <DragProvider>
+            <Reorder.Group
+              axis="y"
+              values={options}
+              onReorder={handleReorderOptions}
+              as="div"
+            >
+              {options.map((option, index) => (
+                <div className="w-full [&>div]:w-full" key={option.value}>
+                  <SelectOption
+                    index={index}
+                    option={option}
+                    correct={option.correct}
+                    selected={false}
+                    onClick={() => {}}
+                    onClickAction={handleClickOptionAction}
+                    onChangeLabel={handleChangeLabel}
+                    isEditMode={isEditMode}
+                    locked={questionLocked}
+                  />
+                </div>
+              ))}
+            </Reorder.Group>
+          </DragProvider>
+          {!questionLocked && (
+            <div className="opacity-50">
+              <F0Button
+                label={t("coCreationForm.selectQuestion.addOption")}
+                variant="ghost"
+                icon={Add}
+                onClick={handleAddOption}
+              />
+            </div>
+          )}
+        </div>
+      </BaseQuestion>
+    )
+  }
+
+  // Answer mode: render F0Select dropdown
+  return (
+    <BaseQuestion {...props}>
+      <div className="px-0.5">
+        {props.type === "dropdown" &&
+          (props.required ? (
+            <F0Select
+              options={selectOptions}
+              value={props.value ?? undefined}
+              onChange={handleDropdownChange}
+              label={t("coCreationForm.answer.label")}
+              hideLabel
+              placeholder={t("coCreationForm.answer.placeholder")}
+              showSearchBox={options.length > 5}
+              required
+              size="md"
+            />
+          ) : (
+            <F0Select
+              options={selectOptions}
+              value={props.value ?? undefined}
+              onChange={handleDropdownChange}
+              clearable
+              label={t("coCreationForm.answer.label")}
+              hideLabel
+              placeholder={t("coCreationForm.answer.placeholder")}
+              showSearchBox={options.length > 5}
+              size="md"
+            />
+          ))}
+        {props.type === "dropdown-multi" && (
+          <F0Select
+            options={selectOptions}
+            value={props.value ?? undefined}
+            onChange={handleDropdownMultiChange}
+            multiple
+            label={t("coCreationForm.answer.label")}
+            hideLabel
+            placeholder={t("coCreationForm.answer.placeholder")}
+            showSearchBox={options.length > 5}
+            size="md"
+          />
+        )}
+      </div>
+    </BaseQuestion>
+  )
+}

--- a/packages/react/src/sds/CoCreationForm/DropdownQuestion/types.ts
+++ b/packages/react/src/sds/CoCreationForm/DropdownQuestion/types.ts
@@ -1,0 +1,29 @@
+import { BaseQuestionPropsForOtherQuestionComponents } from "../BaseQuestion"
+import { BaseQuestionOnChangeParams, SelectQuestionOption } from "../types"
+
+export type DropdownQuestionOnChangeParams = BaseQuestionOnChangeParams & {
+  options: SelectQuestionOption[]
+} & (
+    | {
+        type: "dropdown"
+        value?: string | null
+      }
+    | {
+        type: "dropdown-multi"
+        value?: string[] | null
+      }
+  )
+
+export type DropdownQuestionProps =
+  BaseQuestionPropsForOtherQuestionComponents & {
+    options: SelectQuestionOption[]
+  } & (
+      | {
+          type: "dropdown"
+          value?: string | null
+        }
+      | {
+          type: "dropdown-multi"
+          value?: string[] | null
+        }
+    )

--- a/packages/react/src/sds/CoCreationForm/Question/index.tsx
+++ b/packages/react/src/sds/CoCreationForm/Question/index.tsx
@@ -1,5 +1,7 @@
 import { BaseQuestionPropsForOtherQuestionComponents } from "../BaseQuestion"
 import { DateQuestion, DateQuestionProps } from "../DateQuestion"
+import { DropdownQuestion } from "../DropdownQuestion"
+import { DropdownQuestionProps } from "../DropdownQuestion/types"
 import { LinkQuestion, LinkQuestionProps } from "../LinkQuestion"
 import { NumericQuestion, NumericQuestionProps } from "../NumericQuestion"
 import { RatingQuestion, RatingQuestionProps } from "../RatingQuestion"
@@ -15,6 +17,7 @@ export type QuestionProps = BaseQuestionPropsForOtherQuestionComponents &
     | (NumericQuestionProps & { type: "numeric" })
     | (LinkQuestionProps & { type: "link" })
     | (DateQuestionProps & { type: "date" })
+    | DropdownQuestionProps
   )
 
 export const Question = ({ ...props }: QuestionProps) => {
@@ -33,6 +36,9 @@ export const Question = ({ ...props }: QuestionProps) => {
       return <LinkQuestion {...props} />
     case "date":
       return <DateQuestion {...props} />
+    case "dropdown":
+    case "dropdown-multi":
+      return <DropdownQuestion {...props} />
     default:
       throw new Error("Invalid question type provided")
   }

--- a/packages/react/src/sds/CoCreationForm/constants.ts
+++ b/packages/react/src/sds/CoCreationForm/constants.ts
@@ -1,5 +1,13 @@
 import { IconType } from "@/components/F0Icon/F0Icon"
-import { Check, CheckDouble, List, Numbers, Star, TextSize } from "@/icons/app"
+import {
+  Check,
+  CheckDouble,
+  DropdownDefault,
+  List,
+  Numbers,
+  Star,
+  TextSize,
+} from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 
 import { useCoCreationFormContext } from "./Context"
@@ -29,6 +37,16 @@ export const useQuestionTypes = () => {
       label: t("coCreationForm.questionTypes.singleChoice"),
       icon: Check,
       questionType: "select",
+    },
+    {
+      label: t("coCreationForm.questionTypes.dropdown"),
+      icon: DropdownDefault,
+      questionType: "dropdown",
+    },
+    {
+      label: t("coCreationForm.questionTypes.dropdownMulti"),
+      icon: DropdownDefault,
+      questionType: "dropdown-multi",
     },
     {
       label: t("coCreationForm.questionTypes.text"),

--- a/packages/react/src/sds/CoCreationForm/lib.ts
+++ b/packages/react/src/sds/CoCreationForm/lib.ts
@@ -87,6 +87,16 @@ export const getDefaultParamsForQuestionType = (questionType: QuestionType) => {
       return {
         value: new Date(),
       }
+    case "dropdown":
+    case "dropdown-multi":
+      return {
+        options: [
+          {
+            value: "option-1",
+            label: "New option 1",
+          },
+        ],
+      }
     default:
       throw new Error(`Unsupported question type: ${questionType}`)
   }
@@ -103,6 +113,8 @@ const DEFAULT_QUESTION_TYPES: QuestionType[] = [
   "numeric",
   "link",
   "date",
+  "dropdown",
+  "dropdown-multi",
 ]
 
 export const getDefaultQuestionTypeToAdd = (

--- a/packages/react/src/sds/CoCreationForm/types.ts
+++ b/packages/react/src/sds/CoCreationForm/types.ts
@@ -1,4 +1,5 @@
 import { DateQuestionProps } from "./DateQuestion"
+import { DropdownQuestionProps } from "./DropdownQuestion/types"
 import { LinkQuestionProps } from "./LinkQuestion"
 import { NumericQuestionProps } from "./NumericQuestion"
 import { RatingQuestionProps } from "./RatingQuestion"
@@ -15,6 +16,8 @@ export type QuestionType =
   | "numeric"
   | "link"
   | "date"
+  | "dropdown"
+  | "dropdown-multi"
 
 export type ElementType = QuestionType | "section"
 
@@ -39,6 +42,7 @@ export type QuestionElement =
   | Omit<NumericQuestionProps & { type: "numeric" }, QuestionPropsToOmit>
   | Omit<LinkQuestionProps & { type: "link" }, QuestionPropsToOmit>
   | Omit<DateQuestionProps & { type: "date" }, QuestionPropsToOmit>
+  | Omit<DropdownQuestionProps, QuestionPropsToOmit>
 
 export type CoCreationFormElement =
   | { type: "section"; section: SectionElement }
@@ -98,6 +102,16 @@ type OnChangeQuestionParams = BaseQuestionOnChangeParams &
     | {
         type: "date"
         value?: Date | null
+      }
+    | {
+        type: "dropdown"
+        value?: string | null
+        options: SelectQuestionOption[]
+      }
+    | {
+        type: "dropdown-multi"
+        value?: string[] | null
+        options: SelectQuestionOption[]
       }
   )
 


### PR DESCRIPTION
## Summary

- Adds two new question types to CoCreationForm: `dropdown` (single) and `dropdown-multi`
- **Edit mode**: editable options list with drag-and-drop reordering (reuses existing `SelectOption` component)
- **Answer mode**: renders a real `F0Select` component with search support (auto-enabled when >5 options)
- Includes Storybook stories for both edit and answer modes

## Changes

### New files
- `DropdownQuestion/index.tsx` — main component with dual edit/answer mode rendering
- `DropdownQuestion/types.ts` — TypeScript types for props and onChange params
- `DropdownQuestion/index.stories.tsx` — 4 stories (single, multi, answer mode single, answer mode multi)

### Modified files
- `types.ts` — added `dropdown` and `dropdown-multi` to `QuestionType`, `QuestionElement`, `OnChangeQuestionParams`
- `Question/index.tsx` — added switch cases for the new types
- `constants.ts` — added to the "Add question" menu with `DropdownDefault` icon
- `lib.ts` — added default params and registered in `DEFAULT_QUESTION_TYPES`
- `i18n-provider-defaults.ts` — added translation keys

## Motivation

The existing `select`/`multi-select` question types render as inline radio buttons/checkboxes, which works for surveys with few options. For use cases like procurement workflows that need many options with search, a proper dropdown (F0Select) is needed.

## TODO

- [ ] Add search/filter functionality in the edit mode option list (currently only available in answer mode via F0Select)

## Test plan

- [ ] Check Storybook stories under `CoCreationForm/DropdownQuestion`
- [ ] Verify edit mode: add/remove/reorder options, drag-and-drop
- [ ] Verify answer mode: dropdown opens, search works, selection works
- [ ] Verify dropdown types appear in the "Add question" menu
- [ ] TypeScript compiles cleanly (`pnpm tsc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)