### PR TITLE
fix(Hub): remove unsupported filter attribute from SVG

### DIFF
--- a/packages/react-native/src/icons/modules/Hub.tsx
+++ b/packages/react-native/src/icons/modules/Hub.tsx
@@ -1,6 +1,5 @@
 import { Ref, forwardRef } from "react"
 import Svg, { G, Path, Defs } from "react-native-svg"
-/* SVGR has dropped some elements not supported by react-native-svg: filter */
 import type { SvgProps } from "react-native-svg"
 const SvgHub = (props: SvgProps, ref: Ref<Svg>) => (
   <Svg


### PR DESCRIPTION
## Description
This Hub icon was copypasted from web but the filter attribute is not supported by `react-native-svg` and is also unused by any test suite. It's also causing an annoying infinite warning error on console for DX.

[💬 Slack thread](https://factorialteam.slack.com/archives/C06RR7WBYG5/p1770734846130149)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated SVG markup change limited to one icon; main risk is a minor visual difference if the filter previously had any effect.
> 
> **Overview**
> Removes the unsupported `filter` attribute from the `Hub` icon’s `<G>` element in `packages/react-native/src/icons/modules/Hub.tsx` (and the related autogenerated comment), avoiding `react-native-svg` console warnings while keeping the icon rendering otherwise unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe8b469890d45dc79a4f553596c937943913e188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->