### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.354.0",
-  "packages/react-native": "0.24.0",
+  "packages/react-native": "0.24.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.24.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.24.0...f0-react-native-v0.24.1) (2026-02-10)
+
+
+### Bug Fixes
+
+* **Hub:** remove unsupported filter attribute from SVG ([ae6ae4f](https://github.com/factorialco/f0/commit/ae6ae4f49fb44be1ebfad190ef1a0ad430ff514e))
+
 ## [0.24.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.23.1...f0-react-native-v0.24.0) (2026-02-10)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.24.1</summary>

## [0.24.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.24.0...f0-react-native-v0.24.1) (2026-02-10)


### Bug Fixes

* **Hub:** remove unsupported filter attribute from SVG ([ae6ae4f](https://github.com/factorialco/f0/commit/ae6ae4f49fb44be1ebfad190ef1a0ad430ff514e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).