### PR TITLE
feat(CoCreationForm): add entity-select question type

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -320,6 +320,11 @@ export const defaultTranslations = {
       numeric: "Numeric",
       link: "Link",
       date: "Date",
+      entitySelect: "Person selector",
+      entitySelectMulti: "Person selector (multi)",
+    },
+    entitySelectQuestion: {
+      placeholder: "Respondents will see a person selector here",
     },
     selectQuestion: {
       addOption: "Add option",

--- a/packages/react/src/sds/CoCreationForm/EntitySelectQuestion/index.stories.tsx
+++ b/packages/react/src/sds/CoCreationForm/EntitySelectQuestion/index.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useState } from "react"
+
+import { withSkipA11y } from "@/lib/storybook-utils/parameters"
+
+import { EntitySelectQuestion } from "."
+import { CoCreationFormProvider } from "../Context"
+import { CoCreationFormElement } from "../types"
+
+const mockEmployees = [
+  { id: 1, name: "Alice Johnson", avatar: undefined },
+  { id: 2, name: "Bob Smith", avatar: undefined },
+  { id: 3, name: "Carol Williams", avatar: undefined },
+  { id: 4, name: "David Brown", avatar: undefined },
+  { id: 5, name: "Eve Davis", avatar: undefined },
+  { id: 6, name: "Frank Miller", avatar: undefined },
+]
+
+const meta: Meta<typeof EntitySelectQuestion> = {
+  title: "CoCreationForm/EntitySelectQuestion",
+  component: EntitySelectQuestion,
+  tags: ["autodocs", "experimental"],
+  render: (args) => {
+    const [elements, setElements] = useState<CoCreationFormElement[]>([
+      { type: "question" as const, question: args },
+    ])
+
+    const question =
+      elements[0] && "question" in elements[0] ? elements[0].question : {}
+
+    return (
+      <div className="max-w-[750px]">
+        <CoCreationFormProvider
+          elements={elements}
+          onChange={setElements}
+          isEditMode
+        >
+          <EntitySelectQuestion {...args} {...question} />
+        </CoCreationFormProvider>
+      </div>
+    )
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof EntitySelectQuestion>
+
+export const EditMode: Story = {
+  parameters: withSkipA11y({}),
+  args: {
+    id: "question-1",
+    title: "Who is the project manager?",
+    description: "Select the person responsible for this project",
+    type: "entity-select",
+    value: null,
+    entities: mockEmployees,
+  },
+}
+
+export const AnswerModeSingle: Story = {
+  parameters: withSkipA11y({}),
+  render: (args) => {
+    const [elements, setElements] = useState<CoCreationFormElement[]>([
+      { type: "question" as const, question: args },
+    ])
+
+    const question =
+      elements[0] && "question" in elements[0] ? elements[0].question : {}
+
+    return (
+      <div className="h-[400px] max-w-[750px]">
+        <CoCreationFormProvider
+          elements={elements}
+          onChange={setElements}
+          isEditMode={false}
+        >
+          <EntitySelectQuestion {...args} {...question} />
+        </CoCreationFormProvider>
+      </div>
+    )
+  },
+  args: {
+    id: "question-2",
+    title: "Who is the project manager?",
+    description: "Select the person responsible for this project",
+    type: "entity-select",
+    value: null,
+    entities: mockEmployees,
+  },
+}
+
+export const AnswerModeMulti: Story = {
+  parameters: withSkipA11y({}),
+  render: (args) => {
+    const [elements, setElements] = useState<CoCreationFormElement[]>([
+      { type: "question" as const, question: args },
+    ])
+
+    const question =
+      elements[0] && "question" in elements[0] ? elements[0].question : {}
+
+    return (
+      <div className="h-[400px] max-w-[750px]">
+        <CoCreationFormProvider
+          elements={elements}
+          onChange={setElements}
+          isEditMode={false}
+        >
+          <EntitySelectQuestion {...args} {...question} />
+        </CoCreationFormProvider>
+      </div>
+    )
+  },
+  args: {
+    id: "question-3",
+    title: "Who are the team members?",
+    description: "Select all people involved in this project",
+    type: "entity-select-multi",
+    value: [],
+    entities: mockEmployees,
+  },
+}

--- a/packages/react/src/sds/CoCreationForm/EntitySelectQuestion/index.tsx
+++ b/packages/react/src/sds/CoCreationForm/EntitySelectQuestion/index.tsx
@@ -1,0 +1,157 @@
+import { useState } from "react"
+
+import { EntitySelect } from "@/experimental/Forms/EntitySelect"
+import {
+  EntityId,
+  EntitySelectEntity,
+} from "@/experimental/Forms/EntitySelect/types"
+import { Search } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+
+import { BaseQuestion } from "../BaseQuestion"
+import { useCoCreationFormContext } from "../Context"
+import { EntitySelectQuestionProps } from "./types"
+
+export type { EntitySelectQuestionProps } from "./types"
+
+const DEFAULT_GROUP = {
+  label: "All",
+  value: "all",
+  groupType: "avatar" as const,
+}
+
+export const EntitySelectQuestion = ({
+  value,
+  entities = [],
+  groups,
+  onLoadEntities,
+  entityLabel,
+  searchPlaceholder,
+  ...baseQuestionComponentProps
+}: EntitySelectQuestionProps) => {
+  const { onQuestionChange, isEditMode } = useCoCreationFormContext()
+  const { t } = useI18n()
+
+  const [selectedGroup, setSelectedGroup] = useState<string>("all")
+  const [expandedElements, setExpandedElements] = useState<EntityId[]>([])
+
+  const isSingle = baseQuestionComponentProps.type === "entity-select"
+
+  const handleItemExpandedChange = (id: EntityId, expanded: boolean) => {
+    if (expanded) {
+      setExpandedElements([id, ...expandedElements])
+    } else {
+      setExpandedElements(expandedElements.filter((el) => el !== id))
+    }
+  }
+
+  const handleOpenChange = (open: boolean) => {
+    if (open && onLoadEntities) {
+      onLoadEntities()
+    }
+  }
+
+  const handleSingleSelect = (entity: EntitySelectEntity | null) => {
+    onQuestionChange?.({
+      ...baseQuestionComponentProps,
+      type: "entity-select",
+      value: entity?.id ?? null,
+    })
+  }
+
+  const handleMultiSelect = (selected: EntitySelectEntity[]) => {
+    onQuestionChange?.({
+      ...baseQuestionComponentProps,
+      type: "entity-select-multi",
+      value: selected.map((e) => e.id),
+    })
+  }
+
+  const selectedEntities = entities.filter((entity) => {
+    if (isSingle) {
+      return entity.id === value
+    }
+    return Array.isArray(value) && value.includes(entity.id)
+  })
+
+  const entitiesWithExpanded = entities.map((entity) => ({
+    ...entity,
+    expanded: expandedElements.includes(entity.id),
+  }))
+
+  // In edit mode, show a placeholder preview
+  if (isEditMode) {
+    return (
+      <BaseQuestion {...baseQuestionComponentProps}>
+        <div className="flex items-center gap-2 rounded-md border border-dashed border-f1-border-secondary px-3 py-2.5 text-f1-foreground-secondary">
+          <span className="text-sm">
+            {entityLabel ??
+              t("coCreationForm.entitySelectQuestion.placeholder")}
+          </span>
+        </div>
+      </BaseQuestion>
+    )
+  }
+
+  // Answer mode: render EntitySelect
+  const entitySelectGroups = groups ?? [DEFAULT_GROUP]
+
+  return (
+    <BaseQuestion {...baseQuestionComponentProps}>
+      <div className="px-0.5">
+        {isSingle ? (
+          <EntitySelect
+            entities={entitiesWithExpanded}
+            groups={entitySelectGroups}
+            selectedGroup={selectedGroup}
+            onGroupChange={(val) => setSelectedGroup(val ?? "all")}
+            onItemExpandedChange={handleItemExpandedChange}
+            onOpenChange={handleOpenChange}
+            singleSelector
+            onSelect={handleSingleSelect}
+            selectedEntities={selectedEntities}
+            label={t("coCreationForm.answer.label")}
+            hideLabel
+            placeholder={
+              entityLabel ??
+              t("coCreationForm.entitySelectQuestion.placeholder")
+            }
+            icon={Search}
+            searchPlaceholder={searchPlaceholder ?? t("actions.search")}
+            selectedItemsCopy={t("status.selected.plural")}
+            notFoundTitle={t("select.noResults")}
+            notFoundSubtitle=""
+            size="md"
+          />
+        ) : (
+          <EntitySelect
+            entities={entitiesWithExpanded}
+            groups={entitySelectGroups}
+            selectedGroup={selectedGroup}
+            onGroupChange={(val) => setSelectedGroup(val ?? "all")}
+            onItemExpandedChange={handleItemExpandedChange}
+            onOpenChange={handleOpenChange}
+            singleSelector={undefined}
+            onSelect={handleMultiSelect}
+            selectedEntities={selectedEntities}
+            label={t("coCreationForm.answer.label")}
+            hideLabel
+            placeholder={
+              entityLabel ??
+              t("coCreationForm.entitySelectQuestion.placeholder")
+            }
+            icon={Search}
+            searchPlaceholder={searchPlaceholder ?? t("actions.search")}
+            selectedItemsCopy={t("status.selected.plural")}
+            selectAllLabel={t("actions.selectAll")}
+            clearLabel={t("actions.clear")}
+            selectedLabel={t("status.selected.singular")}
+            notFoundTitle={t("select.noResults")}
+            notFoundSubtitle=""
+            size="md"
+          />
+        )}
+      </div>
+    </BaseQuestion>
+  )
+}

--- a/packages/react/src/sds/CoCreationForm/EntitySelectQuestion/types.ts
+++ b/packages/react/src/sds/CoCreationForm/EntitySelectQuestion/types.ts
@@ -1,0 +1,38 @@
+import {
+  EntityId,
+  EntitySelectEntity,
+  EntitySelectNamedGroup,
+} from "@/experimental/Forms/EntitySelect/types"
+
+import { BaseQuestionPropsForOtherQuestionComponents } from "../BaseQuestion"
+import { BaseQuestionOnChangeParams } from "../types"
+
+export type EntitySelectQuestionOnChangeParams = BaseQuestionOnChangeParams &
+  (
+    | {
+        type: "entity-select"
+        value?: EntityId | null
+      }
+    | {
+        type: "entity-select-multi"
+        value?: EntityId[] | null
+      }
+  )
+
+export type EntitySelectQuestionProps =
+  BaseQuestionPropsForOtherQuestionComponents & {
+    entities?: EntitySelectEntity[]
+    groups?: EntitySelectNamedGroup[]
+    onLoadEntities?: () => void
+    entityLabel?: string
+    searchPlaceholder?: string
+  } & (
+      | {
+          type: "entity-select"
+          value?: EntityId | null
+        }
+      | {
+          type: "entity-select-multi"
+          value?: EntityId[] | null
+        }
+    )

--- a/packages/react/src/sds/CoCreationForm/Question/index.tsx
+++ b/packages/react/src/sds/CoCreationForm/Question/index.tsx
@@ -1,5 +1,7 @@
 import { BaseQuestionPropsForOtherQuestionComponents } from "../BaseQuestion"
 import { DateQuestion, DateQuestionProps } from "../DateQuestion"
+import { EntitySelectQuestion } from "../EntitySelectQuestion"
+import { EntitySelectQuestionProps } from "../EntitySelectQuestion/types"
 import { LinkQuestion, LinkQuestionProps } from "../LinkQuestion"
 import { NumericQuestion, NumericQuestionProps } from "../NumericQuestion"
 import { RatingQuestion, RatingQuestionProps } from "../RatingQuestion"
@@ -15,6 +17,7 @@ export type QuestionProps = BaseQuestionPropsForOtherQuestionComponents &
     | (NumericQuestionProps & { type: "numeric" })
     | (LinkQuestionProps & { type: "link" })
     | (DateQuestionProps & { type: "date" })
+    | EntitySelectQuestionProps
   )
 
 export const Question = ({ ...props }: QuestionProps) => {
@@ -33,6 +36,9 @@ export const Question = ({ ...props }: QuestionProps) => {
       return <LinkQuestion {...props} />
     case "date":
       return <DateQuestion {...props} />
+    case "entity-select":
+    case "entity-select-multi":
+      return <EntitySelectQuestion {...props} />
     default:
       throw new Error("Invalid question type provided")
   }

--- a/packages/react/src/sds/CoCreationForm/constants.ts
+++ b/packages/react/src/sds/CoCreationForm/constants.ts
@@ -1,5 +1,13 @@
 import { IconType } from "@/components/F0Icon/F0Icon"
-import { Check, CheckDouble, List, Numbers, Star, TextSize } from "@/icons/app"
+import {
+  Check,
+  CheckDouble,
+  List,
+  Numbers,
+  Person,
+  Star,
+  TextSize,
+} from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 
 import { useCoCreationFormContext } from "./Context"
@@ -44,6 +52,16 @@ export const useQuestionTypes = () => {
       label: t("coCreationForm.questionTypes.numeric"),
       icon: Numbers,
       questionType: "numeric",
+    },
+    {
+      label: t("coCreationForm.questionTypes.entitySelect"),
+      icon: Person,
+      questionType: "entity-select",
+    },
+    {
+      label: t("coCreationForm.questionTypes.entitySelectMulti"),
+      icon: Person,
+      questionType: "entity-select-multi",
     },
   ]
 

--- a/packages/react/src/sds/CoCreationForm/lib.ts
+++ b/packages/react/src/sds/CoCreationForm/lib.ts
@@ -87,6 +87,11 @@ export const getDefaultParamsForQuestionType = (questionType: QuestionType) => {
       return {
         value: new Date(),
       }
+    case "entity-select":
+    case "entity-select-multi":
+      return {
+        value: null,
+      }
     default:
       throw new Error(`Unsupported question type: ${questionType}`)
   }
@@ -103,6 +108,8 @@ const DEFAULT_QUESTION_TYPES: QuestionType[] = [
   "numeric",
   "link",
   "date",
+  "entity-select",
+  "entity-select-multi",
 ]
 
 export const getDefaultQuestionTypeToAdd = (

--- a/packages/react/src/sds/CoCreationForm/types.ts
+++ b/packages/react/src/sds/CoCreationForm/types.ts
@@ -1,4 +1,7 @@
+import { EntityId } from "@/experimental/Forms/EntitySelect/types"
+
 import { DateQuestionProps } from "./DateQuestion"
+import { EntitySelectQuestionProps } from "./EntitySelectQuestion/types"
 import { LinkQuestionProps } from "./LinkQuestion"
 import { NumericQuestionProps } from "./NumericQuestion"
 import { RatingQuestionProps } from "./RatingQuestion"
@@ -15,6 +18,8 @@ export type QuestionType =
   | "numeric"
   | "link"
   | "date"
+  | "entity-select"
+  | "entity-select-multi"
 
 export type ElementType = QuestionType | "section"
 
@@ -39,6 +44,7 @@ export type QuestionElement =
   | Omit<NumericQuestionProps & { type: "numeric" }, QuestionPropsToOmit>
   | Omit<LinkQuestionProps & { type: "link" }, QuestionPropsToOmit>
   | Omit<DateQuestionProps & { type: "date" }, QuestionPropsToOmit>
+  | Omit<EntitySelectQuestionProps, QuestionPropsToOmit>
 
 export type CoCreationFormElement =
   | { type: "section"; section: SectionElement }
@@ -98,6 +104,14 @@ type OnChangeQuestionParams = BaseQuestionOnChangeParams &
     | {
         type: "date"
         value?: Date | null
+      }
+    | {
+        type: "entity-select"
+        value?: EntityId | null
+      }
+    | {
+        type: "entity-select-multi"
+        value?: EntityId[] | null
       }
   )
 


### PR DESCRIPTION
## Summary

- Adds new `entity-select` (single) and `entity-select-multi` question types to CoCreationForm
- **Edit mode**: shows a dashed-border placeholder ("Respondents will see a person selector here")
- **Answer mode**: renders a full `EntitySelect` component with search, avatars, and selection
- Entities are provided by the consuming application via props (not stored in the form schema)
- Includes Storybook stories for edit mode, answer mode single, and answer mode multi

## Design decisions

The entity selector is fundamentally different from other question types because:
1. The "options" (employees) come from an external API, not from the form schema
2. The AI co-creation agent doesn't need to know the employee list — it just declares "put an employee selector here"
3. The consuming app (Factorial) is responsible for passing `entities` and optionally `onLoadEntities` when rendering

This means in the schema/JSON the AI manipulates, an entity-select question is simply:
```json
{ "type": "entity-select", "label": "Project manager", "id": "q1" }
```
No options array needed. The frontend wires in the employee data at render time.

## Changes

### New files
- `EntitySelectQuestion/index.tsx` — component with edit placeholder + EntitySelect in answer mode
- `EntitySelectQuestion/types.ts` — props including `entities`, `groups`, `onLoadEntities`
- `EntitySelectQuestion/index.stories.tsx` — 3 stories with mock employees

### Modified files
- `types.ts` — added `entity-select` and `entity-select-multi` to types
- `Question/index.tsx` — added switch cases
- `constants.ts` — added to "Add question" menu with `Person` icon
- `lib.ts` — added defaults
- `i18n-provider-defaults.ts` — added translations

## Test plan

- [ ] Check Storybook stories under `CoCreationForm/EntitySelectQuestion`
- [ ] Verify edit mode shows placeholder
- [ ] Verify answer mode renders EntitySelect with mock employees
- [ ] Verify entity-select types appear in the "Add question" menu
- [ ] TypeScript compiles cleanly (`pnpm tsc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)