### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.354.0",
+  "packages/react": "1.355.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.355.0](https://github.com/factorialco/f0/compare/f0-react-v1.354.0...f0-react-v1.355.0) (2026-02-10)
+
+
+### Features
+
+* add device catalog module icon ([#3351](https://github.com/factorialco/f0/issues/3351)) ([0f373fd](https://github.com/factorialco/f0/commit/0f373fd5c98012ace929e5a7936dc5ba669c5269))
+
 ## [1.354.0](https://github.com/factorialco/f0/compare/f0-react-v1.353.0...f0-react-v1.354.0) (2026-02-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.354.0",
+  "version": "1.355.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.355.0</summary>

## [1.355.0](https://github.com/factorialco/f0/compare/f0-react-v1.354.0...f0-react-v1.355.0) (2026-02-10)


### Features

* add device catalog module icon ([#3351](https://github.com/factorialco/f0/issues/3351)) ([0f373fd](https://github.com/factorialco/f0/commit/0f373fd5c98012ace929e5a7936dc5ba669c5269))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog) with no runtime logic modifications in this diff.
> 
> **Overview**
> Bumps the `@factorialco/f0-react` package version from `1.354.0` to `1.355.0` (including `.release-please-manifest.json` and `packages/react/package.json`).
> 
> Updates `packages/react/CHANGELOG.md` with the `1.355.0` release entry, documenting the new device catalog module icon feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45b0cb4497a2217ccf80dfa6493a01f4c754d012. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->