### PR TITLE
fix: show actual loaded selected items count in ActionBar

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/experimental/OneDataCollection/OneDatacollection.tsx
@@ -360,9 +360,10 @@ const OneDataCollectionComp = <
     )
 
     /**
-     * Selected items count
+     * Selected items count — use the actual loaded selected IDs length
+     * instead of selectedCount, which may include unloaded paginated items.
      */
-    setSelectedItemsCount(selectedItems.selectedCount)
+    setSelectedItemsCount(selectedItems.selectedIds.length)
 
     /**
      * Clear selected items function


### PR DESCRIPTION
https://factorialmakers.atlassian.net/browse/FCT-48041

Use `selectedIds.length` instead of `selectedCount` so the [ActionBar](url) displays a count that matches the items actually available to the onBulkAction callback, avoiding a mismatch with unloaded paginated items.

Here in this example only 10 are selected, not 2160

<img width="1172" height="993" alt="Screenshot 2026-02-11 at 11 29 57" src="https://github.com/user-attachments/assets/84f4eb3c-1866-4d29-977f-02574ee9f295" />



