### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.355.0",
+  "packages/react": "1.355.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.355.1](https://github.com/factorialco/f0/compare/f0-react-v1.355.0...f0-react-v1.355.1) (2026-02-11)
+
+
+### Bug Fixes
+
+* take care of large filter names in OneFilterPicker component ([#3402](https://github.com/factorialco/f0/issues/3402)) ([5e23940](https://github.com/factorialco/f0/commit/5e2394087949158f6bd3a22a92f5d17d530d173e))
+
 ## [1.355.0](https://github.com/factorialco/f0/compare/f0-react-v1.354.0...f0-react-v1.355.0) (2026-02-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.355.0",
+  "version": "1.355.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.355.1</summary>

## [1.355.1](https://github.com/factorialco/f0/compare/f0-react-v1.355.0...f0-react-v1.355.1) (2026-02-11)


### Bug Fixes

* take care of large filter names in OneFilterPicker component ([#3402](https://github.com/factorialco/f0/issues/3402)) ([5e23940](https://github.com/factorialco/f0/commit/5e2394087949158f6bd3a22a92f5d17d530d173e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only change (version/changelog/manifest) with no functional code modifications in this PR.
> 
> **Overview**
> Bumps the `@factorialco/f0-react` package version from `1.355.0` to `1.355.1` and updates `.release-please-manifest.json` accordingly.
> 
> Adds the `1.355.1` changelog entry noting a bug fix for handling large filter names in `OneFilterPicker`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75fa8fdd329808ded99bf902bb29f4e0cdcea8fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->