### PR TITLE
chore(react-native): add repository data to `package.json`

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -3,6 +3,11 @@
   "version": "0.24.1",
   "type": "module",
   "description": "React Native components for F0 Design System",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/factorialco.git",
+    "directory": "packages/react-native"
+  }
   "main": "expo-router/entry",
   "module": "./lib/module/index.js",
   "types": "./lib/typescript/index.d.ts",


### PR DESCRIPTION
## Description

While adding the library to React Native Directory I have spotted that `package.json` does not include `repository` entry, ref:
* https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository

See: https://reactnative.directory/package/@factorialco/f0-react-native

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

Add missing `repository` field in `react-native` package `package.json`.
