### PR TITLE
fix: do not trigger validation for hidden fields in F0Form

### DIFF
--- a/packages/react/src/components/F0Form/F0Form.tsx
+++ b/packages/react/src/components/F0Form/F0Form.tsx
@@ -1,4 +1,3 @@
-import { zodResolver } from "@hookform/resolvers/zod"
 import { useMemo } from "react"
 import { DefaultValues, Path, useForm } from "react-hook-form"
 import { z, ZodRawShape } from "zod"
@@ -14,6 +13,7 @@ import { Form as FormProvider } from "@/ui/form"
 import { RowRenderer } from "./components/RowRenderer"
 import { SectionRenderer } from "./components/SectionRenderer"
 import { SwitchGroupRenderer } from "./components/SwitchGroupRenderer"
+import { createConditionalResolver } from "./conditionalResolver"
 import { FIELD_GAP, SECTION_MARGIN } from "./constants"
 import { F0FormContext } from "./context"
 import { FieldRenderer } from "./fields/FieldRenderer"
@@ -188,9 +188,15 @@ export function F0Form<TSchema extends z.ZodObject<ZodRawShape>>(
   // Map our errorTriggerMode to react-hook-form's mode
   const formMode = ERROR_TRIGGER_MODE_MAP[errorTriggerMode]
 
+  // Create conditional resolver that skips validation for hidden fields
+  const conditionalResolver = useMemo(
+    () => createConditionalResolver(schema, { errorMap }),
+    [schema, errorMap]
+  )
+
   // Initialize form with react-hook-form
   const form = useForm<TValues>({
-    resolver: zodResolver(schema, { errorMap }),
+    resolver: conditionalResolver,
     mode: formMode,
     defaultValues: defaultValues as DefaultValues<TValues>,
   })

--- a/packages/react/src/components/F0Form/conditionalResolver.ts
+++ b/packages/react/src/components/F0Form/conditionalResolver.ts
@@ -1,0 +1,77 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import type { Resolver, FieldValues, ResolverOptions } from "react-hook-form"
+import { z, ZodTypeAny, ZodRawShape, ZodObject } from "zod"
+
+import { getF0Config } from "./f0Schema"
+import { evaluateRenderIf } from "./fields/utils"
+
+/**
+ * Creates a conditional Zod resolver that only validates visible fields.
+ *
+ * Fields with `renderIf` conditions that evaluate to `false` are automatically
+ * skipped during validation, preventing validation errors for hidden fields.
+ *
+ * @param schema - The original Zod object schema
+ * @param schemaOptions - Options passed to zodResolver (e.g., errorMap)
+ * @returns A resolver function compatible with react-hook-form
+ */
+export function createConditionalResolver<
+  TSchema extends ZodObject<ZodRawShape>,
+>(
+  schema: TSchema,
+  schemaOptions?: Parameters<typeof zodResolver>[1]
+): Resolver<z.infer<TSchema>> {
+  return async (
+    values: FieldValues,
+    context: unknown,
+    options: ResolverOptions<z.infer<TSchema>>
+  ) => {
+    // Build a dynamic schema that skips validation for hidden fields
+    const dynamicSchema = buildDynamicSchema(schema, values)
+
+    // Use the standard zodResolver with the dynamic schema
+    const resolver = zodResolver(dynamicSchema, schemaOptions)
+    return resolver(values, context, options)
+  }
+}
+
+/**
+ * Builds a dynamic schema where hidden fields (based on renderIf) skip validation.
+ *
+ * For each field in the schema:
+ * - If it has no renderIf, keep the original schema
+ * - If renderIf evaluates to true (field is visible), keep the original schema
+ * - If renderIf evaluates to false (field is hidden), use z.any() to skip all validation
+ */
+function buildDynamicSchema<TSchema extends ZodObject<ZodRawShape>>(
+  schema: TSchema,
+  values: Record<string, unknown>
+): ZodObject<ZodRawShape> {
+  const shape = schema.shape
+  const newShape: ZodRawShape = {}
+
+  for (const [fieldId, fieldSchema] of Object.entries(shape)) {
+    const config = getF0Config(fieldSchema as ZodTypeAny)
+
+    // If field has no config or no renderIf, keep original schema
+    if (!config || !config.renderIf) {
+      newShape[fieldId] = fieldSchema
+      continue
+    }
+
+    // Evaluate the renderIf condition
+    const isVisible = evaluateRenderIf(config.renderIf, values)
+
+    if (isVisible) {
+      // Field is visible, keep original validation
+      newShape[fieldId] = fieldSchema
+    } else {
+      // Field is hidden - use z.any() to completely skip validation
+      // This allows any value (including empty arrays, empty strings, etc.)
+      // without triggering validation errors
+      newShape[fieldId] = z.any()
+    }
+  }
+
+  return z.object(newShape)
+}


### PR DESCRIPTION
## Description

When using the `F0Form` component in the survey settings form we were seeing an unwanted behavior, select fields that weren't shown because of the `renderIf` logic were triggering its validation. We shouldn't expect hidden fields to have any value at all.

