### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.355.1",
+  "packages/react": "1.355.2",
   "packages/react-native": "0.24.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.355.2](https://github.com/factorialco/f0/compare/f0-react-v1.355.1...f0-react-v1.355.2) (2026-02-11)
+
+
+### Bug Fixes
+
+* do not trigger validation for hidden fields in F0Form ([#3406](https://github.com/factorialco/f0/issues/3406)) ([3bf0e59](https://github.com/factorialco/f0/commit/3bf0e5966d589873fa48d723405dcb54ec33caaf))
+
 ## [1.355.1](https://github.com/factorialco/f0/compare/f0-react-v1.355.0...f0-react-v1.355.1) (2026-02-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.355.1",
+  "version": "1.355.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.355.2</summary>

## [1.355.2](https://github.com/factorialco/f0/compare/f0-react-v1.355.1...f0-react-v1.355.2) (2026-02-11)


### Bug Fixes

* do not trigger validation for hidden fields in F0Form ([#3406](https://github.com/factorialco/f0/issues/3406)) ([3bf0e59](https://github.com/factorialco/f0/commit/3bf0e5966d589873fa48d723405dcb54ec33caaf))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and changelog/version bumps only; no code changes included in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.355.1` to `1.355.2` in both `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.355.2` release notes, documenting a bug fix to avoid triggering validation for hidden fields in `F0Form`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35724f887f78dda245f59312b6761ccf7b41f861. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->