### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.355.2",
+  "packages/react": "1.356.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.356.0](https://github.com/factorialco/f0/compare/f0-react-v1.355.2...f0-react-v1.356.0) (2026-02-11)
+
+
+### Features
+
+* Ai One upsell kit ([#3352](https://github.com/factorialco/f0/issues/3352)) ([b5ff629](https://github.com/factorialco/f0/commit/b5ff629a25133c4492dfb2410ccfd6c8db591b57))
+
 ## [1.355.2](https://github.com/factorialco/f0/compare/f0-react-v1.355.1...f0-react-v1.355.2) (2026-02-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.355.2",
+  "version": "1.356.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.356.0</summary>

## [1.356.0](https://github.com/factorialco/f0/compare/f0-react-v1.355.2...f0-react-v1.356.0) (2026-02-11)


### Features

* Ai One upsell kit ([#3352](https://github.com/factorialco/f0/issues/3352)) ([b5ff629](https://github.com/factorialco/f0/commit/b5ff629a25133c4492dfb2410ccfd6c8db591b57))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and changelog updates only; no functional code changes included in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.355.2` to `1.356.0` and updates the release-please manifest accordingly.
> 
> Adds the `1.356.0` changelog entry, documenting the new *Ai One upsell kit* feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abbe7821d161e3d60652aac57485d66446a7278d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->