### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.356.0",
+  "packages/react": "1.356.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.356.1](https://github.com/factorialco/f0/compare/f0-react-v1.356.0...f0-react-v1.356.1) (2026-02-11)
+
+
+### Bug Fixes
+
+* make multi-selection in F0Select work with numerical ids ([#3410](https://github.com/factorialco/f0/issues/3410)) ([aaa8a81](https://github.com/factorialco/f0/commit/aaa8a812fe7a76eee8c7fe0b682c81b176fc095f))
+
 ## [1.356.0](https://github.com/factorialco/f0/compare/f0-react-v1.355.2...f0-react-v1.356.0) (2026-02-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.356.0",
+  "version": "1.356.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.356.1</summary>

## [1.356.1](https://github.com/factorialco/f0/compare/f0-react-v1.356.0...f0-react-v1.356.1) (2026-02-11)


### Bug Fixes

* make multi-selection in F0Select work with numerical ids ([#3410](https://github.com/factorialco/f0/issues/3410)) ([aaa8a81](https://github.com/factorialco/f0/commit/aaa8a812fe7a76eee8c7fe0b682c81b176fc095f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version/changelog/manifest) with no runtime code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.356.0` to `1.356.1` and updates `.release-please-manifest.json` accordingly.
> 
> Updates the React package changelog to document the included bug fix: multi-selection in `F0Select` now works with numerical IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6efbd40964f5deb5395ef0818fda8c6bbe040bcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->