### PR TITLE
fix: add support for required custom field in F0Form

### DIFF
--- a/packages/react/src/components/F0Form/fields/FieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/FieldRenderer.tsx
@@ -5,6 +5,7 @@ import {
   useFormContext,
 } from "react-hook-form"
 
+import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import {
   FormControl,
   FormDescription,
@@ -46,6 +47,7 @@ interface RenderFieldInputOptions {
   formField: ControllerRenderProps<FieldValues>
   fieldState: FieldState
   isSubmitting: boolean
+  isRequired?: boolean
 }
 
 /**
@@ -56,6 +58,7 @@ function renderFieldInput({
   formField,
   fieldState,
   isSubmitting,
+  isRequired,
 }: RenderFieldInputOptions): React.ReactNode {
   const hasError = !!fieldState.error
   const { isValidating } = fieldState
@@ -143,8 +146,8 @@ function renderFieldInput({
         <CustomFieldRenderer
           field={{ ...field, disabled: isDisabled }}
           formField={formField}
-          error={fieldState.error?.message}
           isValidating={isValidating}
+          required={isRequired}
         />
       )
     default:
@@ -168,6 +171,7 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
   const values = form.watch()
   const { isSubmitting } = form.formState
   const { formName } = useF0FormContext()
+  const { forms } = useI18n()
 
   // Check if field should be visible based on renderIf condition
   const isVisible = !field.renderIf || evaluateRenderIf(field.renderIf, values)
@@ -211,12 +215,24 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
             </label>
           )}
           <FormControl>
-            {renderFieldInput({ field, formField, fieldState, isSubmitting })}
+            {renderFieldInput({
+              field,
+              formField,
+              fieldState,
+              isSubmitting,
+              isRequired,
+            })}
           </FormControl>
           {field.helpText && (
             <FormDescription>{field.helpText}</FormDescription>
           )}
-          <FormMessage />
+          <FormMessage
+            fallback={
+              isRequired
+                ? forms.validation.required
+                : forms.validation.invalidType
+            }
+          />
         </FormItem>
       )}
     />

--- a/packages/react/src/components/F0Form/fields/custom/CustomFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/custom/CustomFieldRenderer.tsx
@@ -7,6 +7,7 @@ interface CustomFieldRendererProps {
   formField: ControllerRenderProps<FieldValues>
   error?: string
   isValidating: boolean
+  required?: boolean
 }
 
 /**
@@ -18,6 +19,7 @@ export function CustomFieldRenderer({
   formField,
   error,
   isValidating,
+  required,
 }: CustomFieldRendererProps) {
   const renderProps: CustomFieldRenderPropsBase & { config: unknown } = {
     id: field.id,
@@ -29,6 +31,7 @@ export function CustomFieldRenderer({
     error,
     isValidating,
     disabled: field.disabled,
+    required,
     config: field.fieldConfig,
   }
 

--- a/packages/react/src/components/F0Form/fields/custom/types.ts
+++ b/packages/react/src/components/F0Form/fields/custom/types.ts
@@ -38,6 +38,8 @@ export interface CustomFieldRenderPropsBase {
   isValidating: boolean
   /** Whether the field is disabled */
   disabled?: boolean
+  /** Whether the field is required (derived from Zod schema) */
+  required?: boolean
 }
 
 /**
@@ -65,6 +67,8 @@ export interface CustomFieldRenderProps<TValue = unknown, TConfig = undefined> {
   isValidating: boolean
   /** Whether the field is disabled */
   disabled?: boolean
+  /** Whether the field is required (derived from Zod schema) */
+  required?: boolean
   /** Custom configuration passed via fieldConfig */
   config: TConfig
 }

--- a/packages/react/src/ui/form.tsx
+++ b/packages/react/src/ui/form.tsx
@@ -12,6 +12,7 @@ import {
 
 import { F0Icon } from "../components/F0Icon"
 import { AlertCircle } from "../icons/app"
+import { useI18n } from "../lib/providers/i18n/i18n-provider"
 import { cn } from "../lib/utils"
 import { Label } from "./label"
 
@@ -144,31 +145,39 @@ const FormDescription = React.forwardRef<
 })
 FormDescription.displayName = "FormDescription"
 
-const FormMessage = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, children, ...props }, ref) => {
-  const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message) : children
+interface FormMessageProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Fallback message when error exists but has no message */
+  fallback?: string
+}
 
-  if (!body) {
-    return null
+const FormMessage = React.forwardRef<HTMLDivElement, FormMessageProps>(
+  ({ className, children, fallback, ...props }, ref) => {
+    const { error, formMessageId } = useFormField()
+    const { forms } = useI18n()
+    // Use fallback message when error exists but message is undefined
+    const body = error
+      ? (error.message ?? fallback ?? forms.validation.invalidType)
+      : children
+
+    if (!body) {
+      return null
+    }
+
+    return (
+      <div
+        ref={ref}
+        id={formMessageId}
+        className={cn("flex gap-1", className)}
+        {...props}
+      >
+        <F0Icon icon={AlertCircle} color="critical" />
+        <span className="text-base font-medium text-f1-foreground-critical">
+          {body}
+        </span>
+      </div>
+    )
   }
-
-  return (
-    <div
-      ref={ref}
-      id={formMessageId}
-      className={cn("flex gap-1", className)}
-      {...props}
-    >
-      <F0Icon icon={AlertCircle} color="critical" />
-      <span className="text-base font-medium text-f1-foreground-critical">
-        {body}
-      </span>
-    </div>
-  )
-})
+)
 FormMessage.displayName = "FormMessage"
 
 export {


### PR DESCRIPTION
## Description

We wanted to trigger a validation error when no option is selected in a F0Select rendered via custom field. This is a product need that we have in our frontend because we are rendering our Employee Selector this way.
