### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.356.1",
+  "packages/react": "1.356.2",
   "packages/react-native": "0.24.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.356.2](https://github.com/factorialco/f0/compare/f0-react-v1.356.1...f0-react-v1.356.2) (2026-02-11)
+
+
+### Bug Fixes
+
+* add support for required custom field in F0Form ([#3413](https://github.com/factorialco/f0/issues/3413)) ([8827bff](https://github.com/factorialco/f0/commit/8827bff2aab7d72783b9d0155efc9ec997b3439f))
+
 ## [1.356.1](https://github.com/factorialco/f0/compare/f0-react-v1.356.0...f0-react-v1.356.1) (2026-02-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.356.1",
+  "version": "1.356.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.356.2</summary>

## [1.356.2](https://github.com/factorialco/f0/compare/f0-react-v1.356.1...f0-react-v1.356.2) (2026-02-11)


### Bug Fixes

* add support for required custom field in F0Form ([#3413](https://github.com/factorialco/f0/issues/3413)) ([8827bff](https://github.com/factorialco/f0/commit/8827bff2aab7d72783b9d0155efc9ec997b3439f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no functional code modifications in this diff.
> 
> **Overview**
> Bumps the `@factorialco/f0-react` package version from `1.356.1` to `1.356.2` and updates the release manifest accordingly.
> 
> Updates the React package changelog to include the `1.356.2` release notes (bug fix: required custom field support in `F0Form`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9717240d57f1164c36cbb4e510434cc61a7432f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->