### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.356.2",
+  "packages/react": "1.357.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.43.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.357.0](https://github.com/factorialco/f0/compare/f0-react-v1.356.2...f0-react-v1.357.0) (2026-02-11)
+
+
+### Features
+
+* useSelectable add pageOnlySelection feature  ([#3174](https://github.com/factorialco/f0/issues/3174)) ([a58c2f3](https://github.com/factorialco/f0/commit/a58c2f3a7375bcc2636a3a661a32d2bc4ec957e2))
+
 ## [1.356.2](https://github.com/factorialco/f0/compare/f0-react-v1.356.1...f0-react-v1.356.2) (2026-02-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.356.2",
+  "version": "1.357.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.357.0</summary>

## [1.357.0](https://github.com/factorialco/f0/compare/f0-react-v1.356.2...f0-react-v1.357.0) (2026-02-11)


### Features

* useSelectable add pageOnlySelection feature  ([#3174](https://github.com/factorialco/f0/issues/3174)) ([a58c2f3](https://github.com/factorialco/f0/commit/a58c2f3a7375bcc2636a3a661a32d2bc4ec957e2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and changelog/manifest updates with no functional code changes in this diff.
> 
> **Overview**
> Bumps the `@factorialco/f0-react` package version from `1.356.2` to `1.357.0` and updates the release manifest.
> 
> Adds the `1.357.0` changelog entry noting the new `useSelectable` *page-only selection* feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45ce8a197060d2d2b704a7f66b7aaf113ac7eddf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->