### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.357.0",
+  "packages/react": "1.358.0",
   "packages/react-native": "0.24.1",
-  "packages/core": "1.43.0"
+  "packages/core": "1.44.0"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.44.0](https://github.com/factorialco/f0/compare/f0-core-v1.43.0...f0-core-v1.44.0) (2026-02-11)
+
+
+### Features
+
+* **icons:** new ai icons ([#3375](https://github.com/factorialco/f0/issues/3375)) ([e60a5c0](https://github.com/factorialco/f0/commit/e60a5c0525414a0ef2dfad79a031faa7b95f5c61))
+
 ## [1.43.0](https://github.com/factorialco/f0/compare/f0-core-v1.42.1...f0-core-v1.43.0) (2026-01-28)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-core",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "description": "Core tokens and utilities for F0 Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.358.0](https://github.com/factorialco/f0/compare/f0-react-v1.357.0...f0-react-v1.358.0) (2026-02-11)
+
+
+### Features
+
+* **icons:** new ai icons ([#3375](https://github.com/factorialco/f0/issues/3375)) ([e60a5c0](https://github.com/factorialco/f0/commit/e60a5c0525414a0ef2dfad79a031faa7b95f5c61))
+
 ## [1.357.0](https://github.com/factorialco/f0/compare/f0-react-v1.356.2...f0-react-v1.357.0) (2026-02-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.357.0",
+  "version": "1.358.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.358.0</summary>

## [1.358.0](https://github.com/factorialco/f0/compare/f0-react-v1.357.0...f0-react-v1.358.0) (2026-02-11)


### Features

* **icons:** new ai icons ([#3375](https://github.com/factorialco/f0/issues/3375)) ([e60a5c0](https://github.com/factorialco/f0/commit/e60a5c0525414a0ef2dfad79a031faa7b95f5c61))
</details>

<details><summary>f0-core: 1.44.0</summary>

## [1.44.0](https://github.com/factorialco/f0/compare/f0-core-v1.43.0...f0-core-v1.44.0) (2026-02-11)


### Features

* **icons:** new ai icons ([#3375](https://github.com/factorialco/f0/issues/3375)) ([e60a5c0](https://github.com/factorialco/f0/commit/e60a5c0525414a0ef2dfad79a031faa7b95f5c61))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Automated release/version and changelog updates only; no runtime logic changes shown in the diff.
> 
> **Overview**
> Updates release metadata to publish new versions of `@factorialco/f0-core` (`1.43.0` → `1.44.0`) and `@factorialco/f0-react` (`1.357.0` → `1.358.0`).
> 
> Adds corresponding changelog entries noting a new feature: **new AI icons**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a886412e610923b00aca162a66d0cbde5591f757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->