### PR TITLE
feat: add prop size and variant heading to F0Text component

### DIFF
--- a/packages/react/src/components/F0Text/F0Text.tsx
+++ b/packages/react/src/components/F0Text/F0Text.tsx
@@ -3,6 +3,7 @@ import { forwardRef } from "react"
 import { Text, TextProps, type TextTags } from "@/ui/Text"
 
 const _allowedVariants = [
+  "heading",
   "body",
   "description",
   "small",
@@ -11,14 +12,33 @@ const _allowedVariants = [
   "label",
 ] as const
 
+const _allowedSizes = ["sm", "md", "lg", "xl"] as const
+
+const sizeClassMap: Record<(typeof _allowedSizes)[number], string> = {
+  sm: "text-sm",
+  md: "text-base",
+  lg: "text-lg",
+  xl: "text-xl",
+}
+
 export type F0TextProps = Omit<TextProps, "className" | "variant" | "as"> & {
   variant?: (typeof _allowedVariants)[number]
+  size?: (typeof _allowedSizes)[number]
   as?: TextTags
   markdown?: boolean
 }
 
-export const F0Text = forwardRef<HTMLElement, F0TextProps>((props, ref) => {
-  return <Text ref={ref} markdown={props.markdown ?? true} {...props} />
-})
+export const F0Text = forwardRef<HTMLElement, F0TextProps>(
+  ({ size, ...props }, ref) => {
+    return (
+      <Text
+        ref={ref}
+        markdown={props.markdown ?? true}
+        className={size ? sizeClassMap[size] : undefined}
+        {...props}
+      />
+    )
+  }
+)
 
 F0Text.displayName = "F0Text"

--- a/packages/react/src/components/F0Text/__stories__/Text.stories.tsx
+++ b/packages/react/src/components/F0Text/__stories__/Text.stories.tsx
@@ -10,12 +10,29 @@ const meta = {
   tags: ["autodocs", "experimental"],
   argTypes: {
     variant: {
-      options: ["body", "description", "small", "inverse", "code", "label"],
+      options: [
+        "heading",
+        "body",
+        "description",
+        "small",
+        "inverse",
+        "code",
+        "label",
+      ],
       control: "select",
       description: "The variant of the text",
       table: {
         type: { summary: "string" },
         defaultValue: { summary: "body" },
+      },
+    },
+    size: {
+      options: ["sm", "md", "lg", "xl"],
+      control: "select",
+      description: "The size of the text",
+      table: {
+        type: { summary: "string" },
+        defaultValue: { summary: "md" },
       },
     },
     as: {
@@ -82,6 +99,20 @@ export const Variants: Story = {
   ),
 }
 
+export const Sizes: Story = {
+  args: {
+    content: "",
+  },
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <F0Text size="sm" content="Small size text (sm)" />
+      <F0Text size="md" content="Medium size text (md) - default" />
+      <F0Text size="lg" content="Large size text (lg)" />
+      <F0Text size="xl" content="Extra large size text (xl)" />
+    </div>
+  ),
+}
+
 export const TextAlignment: Story = {
   parameters: {
     chromatic: { disableSnapshot: true },
@@ -144,12 +175,23 @@ export const Snapshot: Story = {
       <section>
         <h4 className="text-lg font-semibold">All Variants</h4>
         <div className="flex flex-col gap-2">
+          <F0Text variant="heading" content="Heading variant text" />
           <F0Text variant="description" content="Description variant text" />
           <F0Text variant="body" content="Body variant text (default)" />
           <F0Text variant="small" content="Small variant text" />
           <F0Text variant="code" content="const code = 'Code variant text';" />
           <F0Text variant="label" content="Label variant text" />
           <F0Text variant="inverse" content="Inverse variant text" />
+        </div>
+      </section>
+
+      <section>
+        <h4 className="text-lg font-semibold">All Sizes</h4>
+        <div className="flex flex-col gap-2">
+          <F0Text size="sm" content="Small size text (sm)" />
+          <F0Text size="md" content="Medium size text (md)" />
+          <F0Text size="lg" content="Large size text (lg)" />
+          <F0Text size="xl" content="Extra large size text (xl)" />
         </div>
       </section>
 

--- a/packages/react/src/components/F0Text/__tests__/Text.test.tsx
+++ b/packages/react/src/components/F0Text/__tests__/Text.test.tsx
@@ -6,6 +6,11 @@ import { F0Text } from "../F0Text"
 
 describe("F0Text Component", () => {
   describe("Allowed Variants", () => {
+    it("renders heading variant", () => {
+      render(<F0Text variant="heading" content="Heading" />)
+      expect(screen.getByText("Heading")).toBeInTheDocument()
+    })
+
     it("renders body variant", () => {
       render(<F0Text variant="body" content="Body" />)
       expect(screen.getByText("Body")).toBeInTheDocument()
@@ -34,6 +39,28 @@ describe("F0Text Component", () => {
     it("renders label variant", () => {
       render(<F0Text variant="label" content="Label" />)
       expect(screen.getByText("Label")).toBeInTheDocument()
+    })
+  })
+
+  describe("Sizes", () => {
+    it("renders sm size", () => {
+      render(<F0Text size="sm" content="Small" />)
+      expect(screen.getByText("Small")).toBeInTheDocument()
+    })
+
+    it("renders md size (default)", () => {
+      render(<F0Text size="md" content="Medium" />)
+      expect(screen.getByText("Medium")).toBeInTheDocument()
+    })
+
+    it("renders lg size", () => {
+      render(<F0Text size="lg" content="Large" />)
+      expect(screen.getByText("Large")).toBeInTheDocument()
+    })
+
+    it("renders xl size", () => {
+      render(<F0Text size="xl" content="Extra Large" />)
+      expect(screen.getByText("Extra Large")).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Description

Add prop size and variant heading to F0Text component

<img width="890" height="594" alt="image" src="https://github.com/user-attachments/assets/518ac66c-d596-400f-82f2-6081b03442e3" />
<!-- Attach any relevant screenshots, especially for visual or responsive checks -->