### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.358.0",
+  "packages/react": "1.358.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.358.1](https://github.com/factorialco/f0/compare/f0-react-v1.358.0...f0-react-v1.358.1) (2026-02-12)
+
+
+### Bug Fixes
+
+* visual upgrade for the F0Form ([#3418](https://github.com/factorialco/f0/issues/3418)) ([b17d41b](https://github.com/factorialco/f0/commit/b17d41b5a0fc625b10f0ce18310cdd34e24c8471))
+
 ## [1.358.0](https://github.com/factorialco/f0/compare/f0-react-v1.357.0...f0-react-v1.358.0) (2026-02-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.358.0",
+  "version": "1.358.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.358.1</summary>

## [1.358.1](https://github.com/factorialco/f0/compare/f0-react-v1.358.0...f0-react-v1.358.1) (2026-02-12)


### Bug Fixes

* visual upgrade for the F0Form ([#3418](https://github.com/factorialco/f0/issues/3418)) ([b17d41b](https://github.com/factorialco/f0/commit/b17d41b5a0fc625b10f0ce18310cdd34e24c8471))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version/changelog updates) with no runtime code changes.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.358.0` to `1.358.1` (manifest + package version) and adds the corresponding `CHANGELOG` entry.
> 
> No functional source changes are included beyond release/versioning metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8693b2058a3a09f5425ddfe8af5f36436622e00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->