### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.358.1",
+  "packages/react": "1.359.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.359.0](https://github.com/factorialco/f0/compare/f0-react-v1.358.1...f0-react-v1.359.0) (2026-02-12)
+
+
+### Features
+
+* add date-time field inputs on F0Form ([#3424](https://github.com/factorialco/f0/issues/3424)) ([efc4951](https://github.com/factorialco/f0/commit/efc4951695719e3d56cfecfe63a149cf1becf28b))
+
 ## [1.358.1](https://github.com/factorialco/f0/compare/f0-react-v1.358.0...f0-react-v1.358.1) (2026-02-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.358.1",
+  "version": "1.359.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.359.0</summary>

## [1.359.0](https://github.com/factorialco/f0/compare/f0-react-v1.358.1...f0-react-v1.359.0) (2026-02-12)


### Features

* add date-time field inputs on F0Form ([#3424](https://github.com/factorialco/f0/issues/3424)) ([efc4951](https://github.com/factorialco/f0/commit/efc4951695719e3d56cfecfe63a149cf1becf28b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/changelog and version bumps only; no runtime code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.358.1` to `1.359.0` (manifest + package version) and adds the corresponding changelog entry.
> 
> The release notes call out one feature: adding date-time field inputs on `F0Form`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b84554eb4f947223c57ea98dbdd82eeb16300f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->