### PR TITLE
feat: add custom actions to the community card

### DIFF
--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import PushPin from "@/icons/app/PushPin"
+
 import { CommunityPost } from "./index"
 
 const meta: Meta<typeof CommunityPost> = {
@@ -97,6 +99,13 @@ export const Default: Story = {
         critical: true,
       },
     ],
+    actions: [
+      {
+        label: "Pin",
+        icon: PushPin,
+        onClick: () => {},
+      },
+    ],
   },
 }
 
@@ -148,6 +157,38 @@ export const WithEventAndVideo: Story = {
       date: eventDate,
     },
     noVideoPreload: true,
+  },
+}
+
+export const WithSingleCustomButton: Story = {
+  decorators: Default.decorators,
+  args: {
+    ...Default.args,
+    actions: [
+      {
+        label: "Pin",
+        icon: PushPin,
+        onClick: () => {},
+      },
+    ],
+  },
+}
+
+export const WithMultipleCustomButtons: Story = {
+  decorators: Default.decorators,
+  args: {
+    ...Default.args,
+    actions: [
+      {
+        label: "Pin",
+        icon: PushPin,
+        onClick: () => {},
+      },
+      {
+        label: "Another Action",
+        onClick: () => {},
+      },
+    ],
   },
 }
 

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -1,5 +1,7 @@
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
+import { F0Button } from "@/components/F0Button"
+import { IconType } from "@/components/F0Icon"
 import { F0Link } from "@/components/F0Link"
 import { Reactions, ReactionsProps } from "@/experimental/Information/Reactions"
 import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
@@ -16,6 +18,12 @@ import { Skeleton } from "@/ui/skeleton"
 import { PostDescription, PostDescriptionProps } from "../PostDescription"
 import { PostEvent, PostEventProps } from "../PostEvent"
 import { isVideo } from "./video"
+
+export type CommunityPostAction = {
+  label: string
+  icon?: IconType
+  onClick: () => void
+}
 
 export type CommunityPostProps = {
   id: string
@@ -50,6 +58,8 @@ export type CommunityPostProps = {
     onClick: () => void
   }
 
+  actions?: CommunityPostAction[]
+
   noVideoPreload?: boolean
 
   onClick: (id: string) => void
@@ -73,6 +83,7 @@ export const BaseCommunityPost = ({
   reactions,
   inLabel,
   comment,
+  actions,
   dropdownItems,
   noReactionsButton = false,
 }: CommunityPostProps) => {
@@ -176,6 +187,16 @@ export const BaseCommunityPost = ({
 
             <div className="flex flex-row gap-2">
               <div className="hidden flex-row gap-2 md:flex">
+                {actions?.map((act) => (
+                  <F0Button
+                    key={act.label}
+                    {...(act.icon && { icon: act.icon })}
+                    variant="outline"
+                    size="md"
+                    onClick={act.onClick}
+                    label={act.label}
+                  />
+                ))}
                 {dropdownItems?.length && (
                   <Dropdown
                     items={dropdownItems}


### PR DESCRIPTION
## Description

Add a new list of actions in the header of a community card

## Screenshots (if applicable)

One action:

<img width="920" height="774" alt="Screenshot 2026-02-12 at 12 17 23" src="https://github.com/user-attachments/assets/31aa3030-a6f6-4cdd-880c-a24d6f1e1fce" />


Many actions:
<img width="961" height="736" alt="Screenshot 2026-02-12 at 12 18 00" src="https://github.com/user-attachments/assets/cee709fa-34c5-47e5-bced-51ded2920418" />


[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
