### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.359.0",
+  "packages/react": "1.360.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.360.0](https://github.com/factorialco/f0/compare/f0-react-v1.359.0...f0-react-v1.360.0) (2026-02-12)
+
+
+### Features
+
+* add custom actions to the community card ([#3427](https://github.com/factorialco/f0/issues/3427)) ([675aa78](https://github.com/factorialco/f0/commit/675aa7889179808d16a799339a5b8f4481f1f7e1))
+
 ## [1.359.0](https://github.com/factorialco/f0/compare/f0-react-v1.358.1...f0-react-v1.359.0) (2026-02-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.359.0",
+  "version": "1.360.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.360.0</summary>

## [1.360.0](https://github.com/factorialco/f0/compare/f0-react-v1.359.0...f0-react-v1.360.0) (2026-02-12)


### Features

* add custom actions to the community card ([#3427](https://github.com/factorialco/f0/issues/3427)) ([675aa78](https://github.com/factorialco/f0/commit/675aa7889179808d16a799339a5b8f4481f1f7e1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version/changelog/manifest) with no functional code changes in this diff.
> 
> **Overview**
> Bumps the `@factorialco/f0-react` package version from `1.359.0` to `1.360.0` and updates the release manifest accordingly.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.360.0` release entry (noting the new community card custom actions feature).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ee909b7325d8ed0d8cb7e71e02197360873d3a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->