### PR TITLE
feat: improved renderIf and disable fields logic

### DIFF
--- a/packages/react/src/components/F0Form/__tests__/F0Form.test.tsx
+++ b/packages/react/src/components/F0Form/__tests__/F0Form.test.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { zeroRender as render, screen } from "@/testing/test-utils"
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
+import userEvent from "@testing-library/user-event"
 
 import { F0Form } from "../F0Form"
 import {
@@ -13,6 +14,7 @@ import {
 import type { F0SectionConfig } from "../types"
 import { getSchemaDefinition } from "../useSchemaDefinition"
 import { isFieldRequired, isOptionalOrNullable } from "../fields/schema"
+import { evaluateDisabled, evaluateRenderIf } from "../fields/utils"
 
 describe("F0Form", () => {
   it("renders a basic form using schema prop", () => {
@@ -517,5 +519,605 @@ describe("getSchemaDefinition - field types", () => {
     }
 
     expect(fieldItem.field.clearable).toBe(false)
+  })
+})
+
+describe("evaluateDisabled", () => {
+  it("returns false when disabled is undefined", () => {
+    expect(evaluateDisabled(undefined, {})).toBe(false)
+  })
+
+  it("returns the boolean value when disabled is a boolean", () => {
+    expect(evaluateDisabled(true, {})).toBe(true)
+    expect(evaluateDisabled(false, {})).toBe(false)
+  })
+
+  it("evaluates the function when disabled is a function", () => {
+    const disabledFn = ({ values }: { values: Record<string, unknown> }) =>
+      values.status === "archived"
+
+    expect(evaluateDisabled(disabledFn, { status: "archived" })).toBe(true)
+    expect(evaluateDisabled(disabledFn, { status: "active" })).toBe(false)
+  })
+
+  it("passes values object to the function", () => {
+    const disabledFn = ({ values }: { values: Record<string, unknown> }) =>
+      (values.count as number) > 10
+
+    expect(evaluateDisabled(disabledFn, { count: 15 })).toBe(true)
+    expect(evaluateDisabled(disabledFn, { count: 5 })).toBe(false)
+  })
+
+  it("handles complex conditions in function", () => {
+    const disabledFn = ({ values }: { values: Record<string, unknown> }) =>
+      values.role === "viewer" || values.locked === true
+
+    expect(
+      evaluateDisabled(disabledFn, { role: "viewer", locked: false })
+    ).toBe(true)
+    expect(evaluateDisabled(disabledFn, { role: "admin", locked: true })).toBe(
+      true
+    )
+    expect(evaluateDisabled(disabledFn, { role: "admin", locked: false })).toBe(
+      false
+    )
+  })
+})
+
+describe("evaluateRenderIf", () => {
+  describe("with condition objects", () => {
+    it("evaluates equalsTo condition", () => {
+      const condition = { fieldId: "status", equalsTo: "active" }
+      expect(evaluateRenderIf(condition, { status: "active" })).toBe(true)
+      expect(evaluateRenderIf(condition, { status: "inactive" })).toBe(false)
+    })
+
+    it("evaluates notEqualsTo condition", () => {
+      const condition = { fieldId: "status", notEqualsTo: "archived" }
+      expect(evaluateRenderIf(condition, { status: "active" })).toBe(true)
+      expect(evaluateRenderIf(condition, { status: "archived" })).toBe(false)
+    })
+
+    it("evaluates isEmpty condition", () => {
+      const condition = { fieldId: "name", isEmpty: true }
+      expect(evaluateRenderIf(condition, { name: "" })).toBe(true)
+      expect(evaluateRenderIf(condition, { name: null })).toBe(true)
+      expect(evaluateRenderIf(condition, { name: undefined })).toBe(true)
+      expect(evaluateRenderIf(condition, { name: "John" })).toBe(false)
+    })
+
+    it("evaluates greaterThan condition", () => {
+      const condition = { fieldId: "count", greaterThan: 10 }
+      expect(evaluateRenderIf(condition, { count: 15 })).toBe(true)
+      expect(evaluateRenderIf(condition, { count: 10 })).toBe(false)
+      expect(evaluateRenderIf(condition, { count: 5 })).toBe(false)
+    })
+
+    it("evaluates greaterThanOrEqual condition", () => {
+      const condition = { fieldId: "count", greaterThanOrEqual: 10 }
+      expect(evaluateRenderIf(condition, { count: 15 })).toBe(true)
+      expect(evaluateRenderIf(condition, { count: 10 })).toBe(true)
+      expect(evaluateRenderIf(condition, { count: 5 })).toBe(false)
+    })
+
+    it("evaluates lowerThan condition", () => {
+      const condition = { fieldId: "count", lowerThan: 10 }
+      expect(evaluateRenderIf(condition, { count: 5 })).toBe(true)
+      expect(evaluateRenderIf(condition, { count: 10 })).toBe(false)
+      expect(evaluateRenderIf(condition, { count: 15 })).toBe(false)
+    })
+
+    it("evaluates lowerThanOrEqual condition", () => {
+      const condition = { fieldId: "count", lowerThanOrEqual: 10 }
+      expect(evaluateRenderIf(condition, { count: 5 })).toBe(true)
+      expect(evaluateRenderIf(condition, { count: 10 })).toBe(true)
+      expect(evaluateRenderIf(condition, { count: 15 })).toBe(false)
+    })
+
+    it("evaluates includes condition for arrays", () => {
+      const condition = { fieldId: "roles", includes: "admin" }
+      expect(evaluateRenderIf(condition, { roles: ["admin", "user"] })).toBe(
+        true
+      )
+      expect(evaluateRenderIf(condition, { roles: ["user"] })).toBe(false)
+    })
+
+    it("evaluates notIncludes condition for arrays", () => {
+      const condition = { fieldId: "roles", notIncludes: "admin" }
+      expect(evaluateRenderIf(condition, { roles: ["user"] })).toBe(true)
+      expect(evaluateRenderIf(condition, { roles: ["admin", "user"] })).toBe(
+        false
+      )
+    })
+
+    it("evaluates matches condition for regex", () => {
+      const condition = { fieldId: "email", matches: /@example\.com$/ }
+      expect(evaluateRenderIf(condition, { email: "test@example.com" })).toBe(
+        true
+      )
+      expect(evaluateRenderIf(condition, { email: "test@other.com" })).toBe(
+        false
+      )
+    })
+  })
+
+  describe("with function", () => {
+    it("evaluates function that returns boolean", () => {
+      const renderIfFn = ({ values }: { values: Record<string, unknown> }) =>
+        values.status === "active"
+
+      expect(evaluateRenderIf(renderIfFn, { status: "active" })).toBe(true)
+      expect(evaluateRenderIf(renderIfFn, { status: "inactive" })).toBe(false)
+    })
+
+    it("passes values object to the function", () => {
+      const renderIfFn = ({ values }: { values: Record<string, unknown> }) =>
+        (values.count as number) >= 50
+
+      expect(evaluateRenderIf(renderIfFn, { count: 50 })).toBe(true)
+      expect(evaluateRenderIf(renderIfFn, { count: 49 })).toBe(false)
+    })
+
+    it("handles complex conditions in function", () => {
+      const renderIfFn = ({ values }: { values: Record<string, unknown> }) =>
+        values.role === "admin" && (values.employeeCount as number) > 10
+
+      expect(
+        evaluateRenderIf(renderIfFn, { role: "admin", employeeCount: 15 })
+      ).toBe(true)
+      expect(
+        evaluateRenderIf(renderIfFn, { role: "admin", employeeCount: 5 })
+      ).toBe(false)
+      expect(
+        evaluateRenderIf(renderIfFn, { role: "user", employeeCount: 15 })
+      ).toBe(false)
+    })
+
+    it("can access multiple field values", () => {
+      const renderIfFn = ({ values }: { values: Record<string, unknown> }) =>
+        values.hasAccount === true && (values.accountId as string)?.length > 0
+
+      expect(
+        evaluateRenderIf(renderIfFn, { hasAccount: true, accountId: "ABC123" })
+      ).toBe(true)
+      expect(
+        evaluateRenderIf(renderIfFn, { hasAccount: true, accountId: "" })
+      ).toBe(false)
+      expect(
+        evaluateRenderIf(renderIfFn, { hasAccount: false, accountId: "ABC123" })
+      ).toBe(false)
+    })
+  })
+})
+
+describe("f0FormField with dynamic disabled", () => {
+  it("supports disabled as boolean", () => {
+    const schema = f0FormField(z.string(), {
+      label: "Test",
+      disabled: true,
+    })
+
+    const config = getF0Config(schema)
+    expect(config?.disabled).toBe(true)
+  })
+
+  it("supports disabled as function", () => {
+    const disabledFn = ({ values }: { values: Record<string, unknown> }) =>
+      values.status === "readonly"
+
+    const schema = f0FormField(z.string(), {
+      label: "Test",
+      disabled: disabledFn,
+    })
+
+    const config = getF0Config(schema)
+    expect(typeof config?.disabled).toBe("function")
+  })
+})
+
+describe("f0FormField with dynamic renderIf", () => {
+  it("supports renderIf as condition object", () => {
+    const schema = f0FormField(z.string(), {
+      label: "Test",
+      renderIf: { fieldId: "status", equalsTo: "active" },
+    })
+
+    const config = getF0Config(schema)
+    expect(config?.renderIf).toEqual({ fieldId: "status", equalsTo: "active" })
+  })
+
+  it("supports renderIf as function", () => {
+    const renderIfFn = ({ values }: { values: Record<string, unknown> }) =>
+      values.showField === true
+
+    const schema = f0FormField(z.string(), {
+      label: "Test",
+      renderIf: renderIfFn,
+    })
+
+    const config = getF0Config(schema)
+    expect(typeof config?.renderIf).toBe("function")
+  })
+})
+
+describe("F0Form with dynamic disabled", () => {
+  it("renders disabled field when disabled function returns true", async () => {
+    const formSchema = z.object({
+      status: f0FormField(z.string(), {
+        label: "Status",
+        options: [
+          { value: "active", label: "Active" },
+          { value: "archived", label: "Archived" },
+        ],
+      }),
+      title: f0FormField(z.string(), {
+        label: "Title",
+        disabled: ({ values }) => values.status === "archived",
+      }),
+    })
+
+    render(
+      <F0Form
+        name="dynamic-disabled-test"
+        schema={formSchema}
+        defaultValues={{ status: "archived", title: "" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    const titleInput = screen.getByLabelText("Title")
+    expect(titleInput).toBeDisabled()
+  })
+
+  it("renders enabled field when disabled function returns false", async () => {
+    const formSchema = z.object({
+      status: f0FormField(z.string(), {
+        label: "Status",
+        options: [
+          { value: "active", label: "Active" },
+          { value: "archived", label: "Archived" },
+        ],
+      }),
+      title: f0FormField(z.string(), {
+        label: "Title",
+        disabled: ({ values }) => values.status === "archived",
+      }),
+    })
+
+    render(
+      <F0Form
+        name="dynamic-disabled-test"
+        schema={formSchema}
+        defaultValues={{ status: "active", title: "" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    const titleInput = screen.getByLabelText("Title")
+    expect(titleInput).not.toBeDisabled()
+  })
+})
+
+describe("F0Form with dynamic renderIf", () => {
+  it("shows field when renderIf function returns true", async () => {
+    const formSchema = z.object({
+      showDetails: f0FormField(z.boolean(), {
+        label: "Show Details",
+        fieldType: "checkbox",
+      }),
+      details: f0FormField(z.string().optional(), {
+        label: "Details",
+        renderIf: ({ values }) => values.showDetails === true,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="dynamic-renderif-test"
+        schema={formSchema}
+        defaultValues={{ showDetails: true, details: "" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    expect(screen.getByLabelText("Details")).toBeInTheDocument()
+  })
+
+  it("hides field when renderIf function returns false", async () => {
+    const formSchema = z.object({
+      showDetails: f0FormField(z.boolean(), {
+        label: "Show Details",
+        fieldType: "checkbox",
+      }),
+      details: f0FormField(z.string().optional(), {
+        label: "Details",
+        renderIf: ({ values }) => values.showDetails === true,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="dynamic-renderif-test"
+        schema={formSchema}
+        defaultValues={{ showDetails: false, details: "" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    expect(screen.queryByLabelText("Details")).not.toBeInTheDocument()
+  })
+
+  it("toggles field visibility when dependent value changes", async () => {
+    const user = userEvent.setup()
+
+    const formSchema = z.object({
+      showDetails: f0FormField(z.boolean(), {
+        label: "Show Details",
+        fieldType: "checkbox",
+      }),
+      details: f0FormField(z.string().optional(), {
+        label: "Details",
+        renderIf: ({ values }) => values.showDetails === true,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="dynamic-renderif-toggle-test"
+        schema={formSchema}
+        defaultValues={{ showDetails: false, details: "" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // Initially hidden
+    expect(screen.queryByLabelText("Details")).not.toBeInTheDocument()
+
+    // Click checkbox to show
+    const checkbox = screen.getByLabelText("Show Details")
+    await user.click(checkbox)
+
+    // Now visible
+    expect(screen.getByLabelText("Details")).toBeInTheDocument()
+  })
+})
+
+describe("F0Form with resetOnDisable", () => {
+  it("resets field to default value when it becomes disabled", async () => {
+    const user = userEvent.setup()
+
+    const formSchema = z.object({
+      enableField: f0FormField(z.boolean(), {
+        label: "Enable Field",
+        fieldType: "checkbox",
+      }),
+      dependentField: f0FormField(z.string().optional(), {
+        label: "Dependent Field",
+        disabled: ({ values }) => !values.enableField,
+        resetOnDisable: true,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="reset-on-disable-test"
+        schema={formSchema}
+        defaultValues={{ enableField: true, dependentField: "" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // Type some value in the dependent field
+    const dependentInput = screen.getByLabelText("Dependent Field")
+    await user.type(dependentInput, "some value")
+    expect(dependentInput).toHaveValue("some value")
+
+    // Disable the field by unchecking the checkbox
+    const checkbox = screen.getByLabelText("Enable Field")
+    await user.click(checkbox)
+
+    // Field should be reset to default value (empty string)
+    await waitFor(() => {
+      expect(dependentInput).toHaveValue("")
+    })
+    expect(dependentInput).toBeDisabled()
+  })
+
+  it("does not reset field when resetOnDisable is false", async () => {
+    const user = userEvent.setup()
+
+    const formSchema = z.object({
+      enableField: f0FormField(z.boolean(), {
+        label: "Enable Field",
+        fieldType: "checkbox",
+      }),
+      dependentField: f0FormField(z.string().optional(), {
+        label: "Dependent Field",
+        disabled: ({ values }) => !values.enableField,
+        // resetOnDisable is not set (defaults to false)
+      }),
+    })
+
+    render(
+      <F0Form
+        name="no-reset-on-disable-test"
+        schema={formSchema}
+        defaultValues={{ enableField: true, dependentField: "" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // Type some value in the dependent field
+    const dependentInput = screen.getByLabelText("Dependent Field")
+    await user.type(dependentInput, "some value")
+    expect(dependentInput).toHaveValue("some value")
+
+    // Disable the field by unchecking the checkbox
+    const checkbox = screen.getByLabelText("Enable Field")
+    await user.click(checkbox)
+
+    // Field should keep its value (not reset)
+    expect(dependentInput).toHaveValue("some value")
+    expect(dependentInput).toBeDisabled()
+  })
+
+  it("resets to non-empty default value", async () => {
+    const user = userEvent.setup()
+
+    const formSchema = z.object({
+      enableField: f0FormField(z.boolean(), {
+        label: "Enable Field",
+        fieldType: "checkbox",
+      }),
+      dependentField: f0FormField(z.string().optional(), {
+        label: "Dependent Field",
+        disabled: ({ values }) => !values.enableField,
+        resetOnDisable: true,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="reset-to-default-test"
+        schema={formSchema}
+        defaultValues={{ enableField: true, dependentField: "default value" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // Clear and type new value
+    const dependentInput = screen.getByLabelText("Dependent Field")
+    await user.clear(dependentInput)
+    await user.type(dependentInput, "new value")
+    expect(dependentInput).toHaveValue("new value")
+
+    // Disable the field
+    const checkbox = screen.getByLabelText("Enable Field")
+    await user.click(checkbox)
+
+    // Field should be reset to default value
+    await waitFor(() => {
+      expect(dependentInput).toHaveValue("default value")
+    })
+  })
+
+  it("does not reset when field is already disabled", async () => {
+    const formSchema = z.object({
+      enableField: f0FormField(z.boolean(), {
+        label: "Enable Field",
+        fieldType: "checkbox",
+      }),
+      dependentField: f0FormField(z.string().optional(), {
+        label: "Dependent Field",
+        disabled: ({ values }) => !values.enableField,
+        resetOnDisable: true,
+      }),
+    })
+
+    // Start with field disabled and with a value
+    render(
+      <F0Form
+        name="already-disabled-test"
+        schema={formSchema}
+        defaultValues={{ enableField: false, dependentField: "initial value" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // Field should have initial value and be disabled
+    const dependentInput = screen.getByLabelText("Dependent Field")
+    expect(dependentInput).toHaveValue("initial value")
+    expect(dependentInput).toBeDisabled()
+  })
+})
+
+describe("f0FormField with resetOnDisable", () => {
+  it("supports resetOnDisable option", () => {
+    const schema = f0FormField(z.string(), {
+      label: "Test",
+      resetOnDisable: true,
+    })
+
+    const config = getF0Config(schema)
+    expect(config?.resetOnDisable).toBe(true)
+  })
+
+  it("defaults resetOnDisable to undefined", () => {
+    const schema = f0FormField(z.string(), {
+      label: "Test",
+    })
+
+    const config = getF0Config(schema)
+    expect(config?.resetOnDisable).toBeUndefined()
+  })
+})
+
+describe("F0Form switch groups with resetOnDisable", () => {
+  it("resets switch fields in group when they become disabled", async () => {
+    const user = userEvent.setup()
+
+    const formSchema = z.object({
+      enableNotifications: f0FormField(z.boolean(), {
+        label: "Enable Notifications",
+        fieldType: "switch",
+      }),
+      notifyOnComments: f0FormField(z.boolean(), {
+        label: "Notify on Comments",
+        fieldType: "switch",
+        disabled: ({ values }) => !values.enableNotifications,
+        resetOnDisable: true,
+      }),
+      notifyOnEdits: f0FormField(z.boolean(), {
+        label: "Notify on Edits",
+        fieldType: "switch",
+        disabled: ({ values }) => !values.enableNotifications,
+        resetOnDisable: true,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="switch-group-reset-test"
+        schema={formSchema}
+        defaultValues={{
+          enableNotifications: true,
+          notifyOnComments: false,
+          notifyOnEdits: false,
+        }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // Helper to find switch by label text
+    const findSwitch = (label: string) =>
+      screen.getByText(label).closest("[role='switch']")!
+
+    // Verify initial state - notifyOnEdits is not selected
+    expect(findSwitch("Notify on Edits")).toHaveAttribute(
+      "aria-checked",
+      "false"
+    )
+
+    // Turn on notifyOnEdits
+    await user.click(findSwitch("Notify on Edits"))
+
+    // Verify it's now selected
+    await waitFor(() => {
+      expect(findSwitch("Notify on Edits")).toHaveAttribute(
+        "aria-checked",
+        "true"
+      )
+    })
+
+    // Now turn off enableNotifications - this should disable and reset notifyOnEdits
+    await user.click(findSwitch("Enable Notifications"))
+
+    // Wait for the reset to happen - notifyOnEdits should be reset to false (default)
+    await waitFor(() => {
+      expect(findSwitch("Notify on Edits")).toHaveAttribute(
+        "aria-checked",
+        "false"
+      )
+    })
   })
 })

--- a/packages/react/src/components/F0Form/components/SectionRenderer.tsx
+++ b/packages/react/src/components/F0Form/components/SectionRenderer.tsx
@@ -9,31 +9,12 @@ import { generateAnchorId, useF0FormContext } from "../context"
 import { FieldRenderer } from "../fields/FieldRenderer"
 import type { F0SwitchField } from "../fields/switch/types"
 import { evaluateRenderIf } from "../fields/utils"
-import type {
-  FieldItem,
-  RowDefinition,
-  SectionDefinition,
-  SectionRenderIf,
-} from "../types"
+import type { FieldItem, RowDefinition, SectionDefinition } from "../types"
 import { RowRenderer } from "./RowRenderer"
 import { SwitchGroupRenderer } from "./SwitchGroupRenderer"
 
 interface SectionRendererProps {
   section: SectionDefinition
-}
-
-/**
- * Evaluate a section's renderIf condition which can be either
- * a RenderIfCondition object or a function
- */
-function evaluateSectionRenderIf(
-  renderIf: SectionRenderIf,
-  values: Record<string, unknown>
-): boolean {
-  if (typeof renderIf === "function") {
-    return renderIf(values)
-  }
-  return evaluateRenderIf(renderIf, values)
 }
 
 type RenderedItem =
@@ -89,7 +70,7 @@ export function SectionRenderer({ section }: SectionRendererProps) {
   const sectionId = section.id
 
   // Check if section should be rendered based on renderIf condition
-  if (renderIf && !evaluateSectionRenderIf(renderIf, values)) {
+  if (renderIf && !evaluateRenderIf(renderIf, values)) {
     return null
   }
 

--- a/packages/react/src/components/F0Form/f0Schema.ts
+++ b/packages/react/src/components/F0Form/f0Schema.ts
@@ -1,6 +1,9 @@
 import { z, ZodTypeAny } from "zod"
 
-import type { RenderIfCondition } from "./fields/types"
+import type {
+  F0BaseFieldDisabledProp,
+  F0BaseFieldRenderIfProp,
+} from "./fields/types"
 import type { F0TextConfig } from "./fields/text/types"
 import type { F0NumberConfig } from "./fields/number/types"
 import type { F0TextareaConfig } from "./fields/textarea/types"
@@ -71,12 +74,36 @@ export interface F0BaseConfig {
   placeholder?: string
   /** Helper text displayed below the field */
   helpText?: string
-  /** Whether the field is disabled */
-  disabled?: boolean
+  /**
+   * Whether the field is disabled.
+   * Can be a boolean or a function that receives form values.
+   * @example
+   * // Static disabled
+   * disabled: true
+   *
+   * // Dynamic disabled based on other field values
+   * disabled: ({ values }) => values.status === 'readonly'
+   */
+  disabled?: F0BaseFieldDisabledProp
+  /**
+   * When true, resets the field to its default value when it becomes disabled.
+   * Useful for clearing dependent fields when their controlling field changes.
+   * @default false
+   */
+  resetOnDisable?: boolean
   /** Row ID for horizontal grouping with other fields */
   row?: string
-  /** Conditional rendering based on another field's value */
-  renderIf?: RenderIfCondition
+  /**
+   * Conditional rendering based on another field's value.
+   * Can be a condition object or a function that receives form values.
+   * @example
+   * // Condition object
+   * renderIf: { fieldId: 'status', equalsTo: 'active' }
+   *
+   * // Dynamic renderIf based on form values
+   * renderIf: ({ values }) => values.status === 'active'
+   */
+  renderIf?: F0BaseFieldRenderIfProp
 }
 
 // Re-export field-specific config types

--- a/packages/react/src/components/F0Form/fields/checkbox/CheckboxFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/checkbox/CheckboxFieldRenderer.tsx
@@ -5,9 +5,10 @@ import { F0Checkbox } from "@/components/F0Checkbox"
 
 import { isZodType, unwrapZodSchema } from "../../f0Schema"
 import type { F0CheckboxField } from "./types"
+import type { ResolvedField } from "../types"
 
 interface CheckboxFieldRendererProps {
-  field: F0CheckboxField
+  field: ResolvedField<F0CheckboxField>
   formField: ControllerRenderProps<FieldValues>
 }
 

--- a/packages/react/src/components/F0Form/fields/checkbox/types.ts
+++ b/packages/react/src/components/F0Form/fields/checkbox/types.ts
@@ -1,4 +1,8 @@
-import type { F0BaseField, CommonRenderIfCondition } from "../types"
+import type {
+  F0BaseField,
+  F0BaseFieldRenderIfFunction,
+  CommonRenderIfCondition,
+} from "../types"
 
 // ============================================================================
 // Boolean Field RenderIf Conditions (shared by checkbox and switch)
@@ -23,6 +27,7 @@ export type BooleanRenderIfCondition = BooleanRenderIfBase &
 export type CheckboxFieldRenderIf =
   | BooleanRenderIfCondition
   | CommonRenderIfCondition
+  | F0BaseFieldRenderIfFunction
 
 // ============================================================================
 // Checkbox Field Config and Type

--- a/packages/react/src/components/F0Form/fields/custom/CustomFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/custom/CustomFieldRenderer.tsx
@@ -1,9 +1,10 @@
 import { ControllerRenderProps, FieldValues } from "react-hook-form"
 
 import type { F0CustomField, CustomFieldRenderPropsBase } from "./types"
+import type { ResolvedField } from "../types"
 
 interface CustomFieldRendererProps {
-  field: F0CustomField
+  field: ResolvedField<F0CustomField>
   formField: ControllerRenderProps<FieldValues>
   error?: string
   isValidating: boolean

--- a/packages/react/src/components/F0Form/fields/custom/types.ts
+++ b/packages/react/src/components/F0Form/fields/custom/types.ts
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react"
 
-import type { F0BaseField, CommonRenderIfCondition } from "../types"
+import type {
+  F0BaseField,
+  F0BaseFieldRenderIfFunction,
+  CommonRenderIfCondition,
+} from "../types"
 
 // ============================================================================
 // Custom Field RenderIf Conditions
@@ -10,7 +14,9 @@ import type { F0BaseField, CommonRenderIfCondition } from "../types"
 /**
  * All valid renderIf conditions for custom fields
  */
-export type CustomFieldRenderIf = CommonRenderIfCondition
+export type CustomFieldRenderIf =
+  | CommonRenderIfCondition
+  | F0BaseFieldRenderIfFunction
 
 // ============================================================================
 // Custom Field Render Props

--- a/packages/react/src/components/F0Form/fields/date/DateFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/date/DateFieldRenderer.tsx
@@ -4,10 +4,11 @@ import { ControllerRenderProps, FieldValues } from "react-hook-form"
 import { F0DatePicker, DatePickerValue } from "@/components/F0DatePicker"
 
 import type { F0DateField } from "./types"
+import type { ResolvedField } from "../types"
 import { FORM_SIZE } from "../../constants"
 
 interface DateFieldRendererProps {
-  field: F0DateField
+  field: ResolvedField<F0DateField>
   formField: ControllerRenderProps<FieldValues>
   error?: boolean
   loading?: boolean

--- a/packages/react/src/components/F0Form/fields/date/DateTimeFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/date/DateTimeFieldRenderer.tsx
@@ -2,12 +2,13 @@ import { useCallback, useMemo } from "react"
 import { ControllerRenderProps, FieldValues } from "react-hook-form"
 
 import type { F0DateTimeField, F0DateField, F0TimeField } from "./types"
+import type { ResolvedField } from "../types"
 import { DateFieldRenderer } from "./DateFieldRenderer"
 import { TimeFieldRenderer } from "./TimeFieldRenderer"
 import { dateToTimeString, combineDateAndTime } from "./utils"
 
 interface DateTimeFieldRendererProps {
-  field: F0DateTimeField
+  field: ResolvedField<F0DateTimeField>
   formField: ControllerRenderProps<FieldValues>
   error?: boolean
   loading?: boolean
@@ -69,7 +70,7 @@ export function DateTimeFieldRenderer({
   )
 
   // Create synthetic field and formField props for DateFieldRenderer
-  const dateField: F0DateField = useMemo(
+  const dateField: ResolvedField<F0DateField> = useMemo(
     () => ({
       id: `${field.id}-date`,
       type: "date",
@@ -95,7 +96,7 @@ export function DateTimeFieldRenderer({
   )
 
   // Create synthetic field and formField props for TimeFieldRenderer
-  const timeField: F0TimeField = useMemo(
+  const timeField: ResolvedField<F0TimeField> = useMemo(
     () => ({
       id: `${field.id}-time`,
       type: "time",

--- a/packages/react/src/components/F0Form/fields/date/TimeFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/date/TimeFieldRenderer.tsx
@@ -5,11 +5,12 @@ import { Input } from "@/experimental/Forms/Fields/Input"
 import { Clock } from "@/icons/app"
 
 import type { F0TimeField } from "./types"
+import type { ResolvedField } from "../types"
 import { dateToTimeString, timeStringToDate } from "./utils"
 import { FORM_SIZE } from "../../constants"
 
 export interface TimeFieldRendererProps {
-  field: F0TimeField
+  field: ResolvedField<F0TimeField>
   formField: ControllerRenderProps<FieldValues>
   error?: boolean
   loading?: boolean

--- a/packages/react/src/components/F0Form/fields/date/types.ts
+++ b/packages/react/src/components/F0Form/fields/date/types.ts
@@ -1,6 +1,10 @@
 import type { DatePreset } from "@/components/F0DatePicker"
 
-import type { F0BaseField, CommonRenderIfCondition } from "../types"
+import type {
+  F0BaseField,
+  F0BaseFieldRenderIfFunction,
+  CommonRenderIfCondition,
+} from "../types"
 
 /**
  * Valid granularity keys for date pickers
@@ -42,7 +46,10 @@ export type DateRenderIfCondition = DateRenderIfBase &
 /**
  * All valid renderIf conditions for date fields
  */
-export type DateFieldRenderIf = DateRenderIfCondition | CommonRenderIfCondition
+export type DateFieldRenderIf =
+  | DateRenderIfCondition
+  | CommonRenderIfCondition
+  | F0BaseFieldRenderIfFunction
 
 // ============================================================================
 // Date Field Config and Type

--- a/packages/react/src/components/F0Form/fields/daterange/DateRangeFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/daterange/DateRangeFieldRenderer.tsx
@@ -4,10 +4,11 @@ import { ControllerRenderProps, FieldValues } from "react-hook-form"
 import { F0DatePicker, DatePickerValue } from "@/components/F0DatePicker"
 
 import type { F0DateRangeField, DateRangeValue } from "./types"
+import type { ResolvedField } from "../types"
 import { FORM_SIZE } from "../../constants"
 
 interface DateRangeFieldRendererProps {
-  field: F0DateRangeField
+  field: ResolvedField<F0DateRangeField>
   formField: ControllerRenderProps<FieldValues>
   error?: boolean
   loading?: boolean

--- a/packages/react/src/components/F0Form/fields/daterange/types.ts
+++ b/packages/react/src/components/F0Form/fields/daterange/types.ts
@@ -1,6 +1,10 @@
 import type { DatePreset } from "@/components/F0DatePicker"
 
-import type { F0BaseField, CommonRenderIfCondition } from "../types"
+import type {
+  F0BaseField,
+  F0BaseFieldRenderIfFunction,
+  CommonRenderIfCondition,
+} from "../types"
 import type { DateGranularity } from "../date/types"
 
 // ============================================================================
@@ -27,6 +31,7 @@ export type DateRangeRenderIfCondition = DateRangeRenderIfBase & {
 export type DateRangeFieldRenderIf =
   | DateRangeRenderIfCondition
   | CommonRenderIfCondition
+  | F0BaseFieldRenderIfFunction
 
 // ============================================================================
 // Date Range Field Config and Type

--- a/packages/react/src/components/F0Form/fields/number/NumberFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/number/NumberFieldRenderer.tsx
@@ -2,10 +2,11 @@ import { ControllerRenderProps, FieldValues } from "react-hook-form"
 
 import { NumberInput } from "@/experimental/Forms/Fields/NumberInput"
 import type { F0NumberField } from "./types"
+import type { ResolvedField } from "../types"
 import { FORM_SIZE } from "../../constants"
 
 interface NumberFieldRendererProps {
-  field: F0NumberField
+  field: ResolvedField<F0NumberField>
   formField: ControllerRenderProps<FieldValues>
   error?: boolean
   loading?: boolean

--- a/packages/react/src/components/F0Form/fields/number/types.ts
+++ b/packages/react/src/components/F0Form/fields/number/types.ts
@@ -1,4 +1,8 @@
-import type { F0BaseField, CommonRenderIfCondition } from "../types"
+import type {
+  F0BaseField,
+  F0BaseFieldRenderIfFunction,
+  CommonRenderIfCondition,
+} from "../types"
 
 // ============================================================================
 // Number Field RenderIf Conditions
@@ -31,6 +35,7 @@ export type NumberRenderIfCondition = NumberRenderIfBase &
 export type NumberFieldRenderIf =
   | NumberRenderIfCondition
   | CommonRenderIfCondition
+  | F0BaseFieldRenderIfFunction
 
 // ============================================================================
 // Number Field Config and Type

--- a/packages/react/src/components/F0Form/fields/richtext/RichTextFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/richtext/RichTextFieldRenderer.tsx
@@ -3,9 +3,10 @@ import { ControllerRenderProps, FieldValues } from "react-hook-form"
 import { RichTextEditor } from "@/experimental/RichText/RichTextEditor"
 
 import type { F0RichTextField, RichTextValue } from "./types"
+import type { ResolvedField } from "../types"
 
 interface RichTextFieldRendererProps {
-  field: F0RichTextField
+  field: ResolvedField<F0RichTextField>
   formField: ControllerRenderProps<FieldValues>
 }
 

--- a/packages/react/src/components/F0Form/fields/richtext/types.ts
+++ b/packages/react/src/components/F0Form/fields/richtext/types.ts
@@ -1,7 +1,11 @@
 import type { MentionsConfig } from "@/experimental/RichText/CoreEditor"
 import type { heightType } from "@/experimental/RichText/RichTextEditor"
 
-import type { F0BaseField, CommonRenderIfCondition } from "../types"
+import type {
+  F0BaseField,
+  F0BaseFieldRenderIfFunction,
+  CommonRenderIfCondition,
+} from "../types"
 
 // ============================================================================
 // RichText Field RenderIf Conditions
@@ -11,7 +15,9 @@ import type { F0BaseField, CommonRenderIfCondition } from "../types"
 /**
  * All valid renderIf conditions for richtext fields
  */
-export type RichTextFieldRenderIf = CommonRenderIfCondition
+export type RichTextFieldRenderIf =
+  | CommonRenderIfCondition
+  | F0BaseFieldRenderIfFunction
 
 // ============================================================================
 // RichText Value Type

--- a/packages/react/src/components/F0Form/fields/select/SelectFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/select/SelectFieldRenderer.tsx
@@ -3,10 +3,11 @@ import { ControllerRenderProps, FieldValues } from "react-hook-form"
 import { F0Select } from "@/components/F0Select"
 
 import type { F0SelectField } from "./types"
+import type { ResolvedField } from "../types"
 import { FORM_SIZE } from "../../constants"
 
 interface SelectFieldRendererProps {
-  field: F0SelectField
+  field: ResolvedField<F0SelectField>
   formField: ControllerRenderProps<FieldValues>
   error?: boolean
   loading?: boolean
@@ -21,7 +22,9 @@ function SelectWithOptions({
   error,
   loading,
 }: SelectFieldRendererProps & {
-  field: F0SelectField & { options: NonNullable<F0SelectField["options"]> }
+  field: ResolvedField<F0SelectField> & {
+    options: NonNullable<F0SelectField["options"]>
+  }
 }) {
   const baseProps = {
     label: field.label,
@@ -79,7 +82,7 @@ function SelectWithSource({
   error,
   loading,
 }: SelectFieldRendererProps & {
-  field: F0SelectField & {
+  field: ResolvedField<F0SelectField> & {
     source: NonNullable<F0SelectField["source"]>
     mapOptions: NonNullable<F0SelectField["mapOptions"]>
   }

--- a/packages/react/src/components/F0Form/fields/select/types.ts
+++ b/packages/react/src/components/F0Form/fields/select/types.ts
@@ -7,7 +7,11 @@ import type {
   RecordType,
 } from "@/hooks/datasource"
 
-import type { F0BaseField, CommonRenderIfCondition } from "../types"
+import type {
+  F0BaseField,
+  F0BaseFieldRenderIfFunction,
+  CommonRenderIfCondition,
+} from "../types"
 
 // ============================================================================
 // Select Field RenderIf Conditions
@@ -38,6 +42,7 @@ export type SelectRenderIfCondition = SelectRenderIfBase &
 export type SelectFieldRenderIf =
   | SelectRenderIfCondition
   | CommonRenderIfCondition
+  | F0BaseFieldRenderIfFunction
 
 // ============================================================================
 // Select Field Config and Type

--- a/packages/react/src/components/F0Form/fields/switch/SwitchFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/switch/SwitchFieldRenderer.tsx
@@ -5,9 +5,10 @@ import { Switch } from "@/experimental/Forms/Fields/Switch"
 
 import { isZodType, unwrapZodSchema } from "../../f0Schema"
 import type { F0SwitchField } from "./types"
+import type { ResolvedField } from "../types"
 
 interface SwitchFieldRendererProps {
-  field: F0SwitchField
+  field: ResolvedField<F0SwitchField>
   formField: ControllerRenderProps<FieldValues>
 }
 

--- a/packages/react/src/components/F0Form/fields/switch/types.ts
+++ b/packages/react/src/components/F0Form/fields/switch/types.ts
@@ -1,4 +1,8 @@
-import type { F0BaseField, CommonRenderIfCondition } from "../types"
+import type {
+  F0BaseField,
+  F0BaseFieldRenderIfFunction,
+  CommonRenderIfCondition,
+} from "../types"
 import type { BooleanRenderIfCondition } from "../checkbox/types"
 
 // ============================================================================
@@ -12,6 +16,7 @@ import type { BooleanRenderIfCondition } from "../checkbox/types"
 export type SwitchFieldRenderIf =
   | BooleanRenderIfCondition
   | CommonRenderIfCondition
+  | F0BaseFieldRenderIfFunction
 
 // ============================================================================
 // Switch Field Config and Type

--- a/packages/react/src/components/F0Form/fields/text/TextFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/text/TextFieldRenderer.tsx
@@ -4,10 +4,11 @@ import { Input } from "@/experimental/Forms/Fields/Input"
 import { Link, Envelope } from "@/icons/app"
 import { IconType } from "@/components/F0Icon"
 import type { F0TextConfig, F0TextField } from "./types"
+import type { ResolvedField } from "../types"
 import { FORM_SIZE } from "../../constants"
 
 interface TextFieldRendererProps {
-  field: F0TextField
+  field: ResolvedField<F0TextField>
   formField: ControllerRenderProps<FieldValues>
   error?: boolean
   loading?: boolean

--- a/packages/react/src/components/F0Form/fields/text/types.ts
+++ b/packages/react/src/components/F0Form/fields/text/types.ts
@@ -1,4 +1,8 @@
-import type { F0BaseField, CommonRenderIfCondition } from "../types"
+import type {
+  F0BaseField,
+  F0BaseFieldRenderIfFunction,
+  CommonRenderIfCondition,
+} from "../types"
 
 // ============================================================================
 // Text Field RenderIf Conditions
@@ -25,7 +29,10 @@ export type TextRenderIfCondition = TextRenderIfBase &
 /**
  * All valid renderIf conditions for text fields
  */
-export type TextFieldRenderIf = TextRenderIfCondition | CommonRenderIfCondition
+export type TextFieldRenderIf =
+  | TextRenderIfCondition
+  | CommonRenderIfCondition
+  | F0BaseFieldRenderIfFunction
 
 // ============================================================================
 // Text Field Config and Type

--- a/packages/react/src/components/F0Form/fields/textarea/TextareaFieldRenderer.tsx
+++ b/packages/react/src/components/F0Form/fields/textarea/TextareaFieldRenderer.tsx
@@ -2,10 +2,11 @@ import { ControllerRenderProps, FieldValues } from "react-hook-form"
 
 import { Textarea } from "@/experimental/Forms/Fields/TextArea"
 import type { F0TextareaField } from "./types"
+import type { ResolvedField } from "../types"
 import { FORM_SIZE } from "../../constants"
 
 interface TextareaFieldRendererProps {
-  field: F0TextareaField
+  field: ResolvedField<F0TextareaField>
   formField: ControllerRenderProps<FieldValues>
   error?: boolean
   loading?: boolean

--- a/packages/react/src/components/F0Form/fields/textarea/types.ts
+++ b/packages/react/src/components/F0Form/fields/textarea/types.ts
@@ -1,4 +1,8 @@
-import type { F0BaseField, CommonRenderIfCondition } from "../types"
+import type {
+  F0BaseField,
+  F0BaseFieldRenderIfFunction,
+  CommonRenderIfCondition,
+} from "../types"
 import type { TextRenderIfCondition } from "../text/types"
 
 // ============================================================================
@@ -12,6 +16,7 @@ import type { TextRenderIfCondition } from "../text/types"
 export type TextareaFieldRenderIf =
   | TextRenderIfCondition
   | CommonRenderIfCondition
+  | F0BaseFieldRenderIfFunction
 
 // ============================================================================
 // Textarea Field Config and Type

--- a/packages/react/src/components/F0Form/fields/types.ts
+++ b/packages/react/src/components/F0Form/fields/types.ts
@@ -32,6 +32,20 @@ export type RenderIfCondition =
   | DateRenderIfCondition
   | DateRangeRenderIfCondition
 
+/**
+ * Function type for dynamic renderIf evaluation based on form values
+ */
+export type F0BaseFieldRenderIfFunction = (context: {
+  values: Record<string, unknown>
+}) => boolean
+
+/**
+ * RenderIf property can be a condition object or a function that receives form values
+ */
+export type F0BaseFieldRenderIfProp =
+  | RenderIfCondition
+  | F0BaseFieldRenderIfFunction
+
 // ============================================================================
 // Field-Specific RenderIf Condition Types (imported from each field)
 // ============================================================================
@@ -58,6 +72,18 @@ export type {
 // ============================================================================
 
 /**
+ * Function type for dynamic disabled evaluation based on form values
+ */
+export type F0BaseFieldDisabledFunction = (context: {
+  values: Record<string, unknown>
+}) => boolean
+
+/**
+ * Disabled property can be a boolean or a function that receives form values
+ */
+export type F0BaseFieldDisabledProp = boolean | F0BaseFieldDisabledFunction
+
+/**
  * Base properties shared across all F0 field types
  */
 export interface F0BaseField {
@@ -71,7 +97,30 @@ export interface F0BaseField {
   helpText?: string
   /** Placeholder text for the input */
   placeholder?: string
-  /** Whether the field is disabled */
+  /**
+   * Whether the field is disabled.
+   * Can be a boolean or a function that receives form values.
+   * @example
+   * // Static disabled
+   * disabled: true
+   *
+   * // Dynamic disabled based on other field values
+   * disabled: ({ values }) => values.status === 'readonly'
+   */
+  disabled?: F0BaseFieldDisabledProp
+  /**
+   * When true, resets the field to its default value when it becomes disabled.
+   * Useful for clearing dependent fields when their controlling field changes.
+   * @default false
+   */
+  resetOnDisable?: boolean
+}
+
+/**
+ * Utility type that converts F0BaseFieldDisabledProp to boolean in a field type.
+ * Used internally by field renderers after the disabled prop has been evaluated.
+ */
+export type ResolvedField<T extends F0BaseField> = Omit<T, "disabled"> & {
   disabled?: boolean
 }
 

--- a/packages/react/src/components/F0Form/fields/utils.ts
+++ b/packages/react/src/components/F0Form/fields/utils.ts
@@ -1,9 +1,13 @@
-import type { RenderIfCondition } from "./types"
+import type {
+  F0BaseFieldDisabledProp,
+  F0BaseFieldRenderIfProp,
+  RenderIfCondition,
+} from "./types"
 
 /**
- * Evaluate a renderIf condition against the current form values
+ * Evaluate a renderIf condition object against the current form values
  */
-export function evaluateRenderIf(
+function evaluateRenderIfCondition(
   condition: RenderIfCondition,
   values: Record<string, unknown>
 ): boolean {
@@ -102,4 +106,33 @@ export function evaluateRenderIf(
   }
 
   return true
+}
+
+/**
+ * Evaluate a renderIf property which can be a condition object or a function
+ */
+export function evaluateRenderIf(
+  renderIf: F0BaseFieldRenderIfProp,
+  values: Record<string, unknown>
+): boolean {
+  if (typeof renderIf === "function") {
+    return renderIf({ values })
+  }
+  return evaluateRenderIfCondition(renderIf, values)
+}
+
+/**
+ * Evaluate a disabled property which can be a boolean or a function
+ */
+export function evaluateDisabled(
+  disabled: F0BaseFieldDisabledProp | undefined,
+  values: Record<string, unknown>
+): boolean {
+  if (disabled === undefined) {
+    return false
+  }
+  if (typeof disabled === "function") {
+    return disabled({ values })
+  }
+  return disabled
 }

--- a/packages/react/src/components/F0Form/types.ts
+++ b/packages/react/src/components/F0Form/types.ts
@@ -2,7 +2,11 @@ import type { z, ZodRawShape } from "zod"
 
 import type { IconType } from "@/components/F0Icon"
 
-import type { F0Field, RenderIfCondition } from "./fields/types"
+import type {
+  F0Field,
+  F0BaseFieldRenderIfFunction,
+  RenderIfCondition,
+} from "./fields/types"
 
 // Re-export F0 schema types
 export type { F0FieldConfig, F0FieldType, F0ZodType } from "./f0Schema"
@@ -16,9 +20,7 @@ export {
 /**
  * Conditional rendering for sections - can be a condition object or a function
  */
-export type SectionRenderIf =
-  | RenderIfCondition
-  | ((values: Record<string, unknown>) => boolean)
+export type SectionRenderIf = RenderIfCondition | F0BaseFieldRenderIfFunction
 
 /**
  * Action button configuration for a section.

--- a/packages/react/src/components/F0Form/useSchemaDefinition.ts
+++ b/packages/react/src/components/F0Form/useSchemaDefinition.ts
@@ -56,6 +56,7 @@ function configToF0Field(
     placeholder: config.placeholder,
     helpText: config.helpText,
     disabled: config.disabled,
+    resetOnDisable: config.resetOnDisable,
     validation: schema,
   }
 


### PR DESCRIPTION
## Description

- **Dynamic `disabled` property** - Form fields can now use a function `({ values }) => boolean` for the `disabled` prop, allowing fields to be conditionally disabled based on other field values.

- **Dynamic `renderIf` property** - Extended `renderIf` to also accept a function `({ values }) => boolean`, in addition to the existing condition object syntax.

- **`resetOnDisable` property** - Added a new optional `resetOnDisable: boolean` attribute to fields. When `true`, the field automatically resets to its default value when it becomes disabled. Useful for clearing dependent fields when their controlling field changes.

- **Tests and documentation** - Added comprehensive unit tests for all new functionality and updated the `DynamicDisabled` Storybook story to demonstrate these features.

https://github.com/user-attachments/assets/038585a0-34e0-4f8a-9e86-3a6812554f24
