### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.360.0",
+  "packages/react": "1.361.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.361.0](https://github.com/factorialco/f0/compare/f0-react-v1.360.0...f0-react-v1.361.0) (2026-02-12)
+
+
+### Features
+
+* improved renderIf and disable fields logic ([#3429](https://github.com/factorialco/f0/issues/3429)) ([d3df4e4](https://github.com/factorialco/f0/commit/d3df4e40c2c4c0fee0c89fb52b75ab0c5d69adf1))
+
 ## [1.360.0](https://github.com/factorialco/f0/compare/f0-react-v1.359.0...f0-react-v1.360.0) (2026-02-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.360.0",
+  "version": "1.361.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.361.0</summary>

## [1.361.0](https://github.com/factorialco/f0/compare/f0-react-v1.360.0...f0-react-v1.361.0) (2026-02-12)


### Features

* improved renderIf and disable fields logic ([#3429](https://github.com/factorialco/f0/issues/3429)) ([d3df4e4](https://github.com/factorialco/f0/commit/d3df4e40c2c4c0fee0c89fb52b75ab0c5d69adf1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/changelog-only updates with no runtime code changes.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.360.0` to `1.361.0` (manifest + package version) and adds the `1.361.0` changelog entry.
> 
> No functional code changes are included in this PR; it’s release bookkeeping for the previously landed “improved `renderIf` and disabled fields logic” work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1110e25f6dff2dfe21bb81b389adb23b30d65e5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->