### PR TITLE
fix(AiChat): Fix autofocus for Activities

### DIFF
--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -156,6 +156,19 @@ export const F0AiChatTextArea = ({
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const translation = useI18n()
 
+  // Skip autofocus when URL has a hash (e.g. #section) so we don't steal focus
+  // from the element the hash points to when the URL updates. We use an effect
+  // so we only read window on the client and avoid hydration mismatch.
+  useEffect(() => {
+    if (
+      autoFocus &&
+      typeof window !== "undefined" &&
+      window.location.hash.length === 0
+    ) {
+      textareaRef.current?.focus()
+    }
+  }, [autoFocus])
+
   const resolvedDefaultPlaceholder =
     defaultPlaceholder ?? translation.ai.inputPlaceholder
 
@@ -256,7 +269,7 @@ export const F0AiChatTextArea = ({
           </p>
         )}
         <textarea
-          autoFocus={autoFocus}
+          autoFocus={false}
           name="one-ai-input"
           rows={1}
           ref={textareaRef}


### PR DESCRIPTION
## Description

The chat textarea was always auto-focusing on load, including when the URL had a hash (e.g. #section), so it took focus away from the target of the hash

## Implementation details

Run autofocus only when window.location.hash is empty. The hash check is done inside a useEffect so window is only read on the client and there’s no hydration mismatch

Broken here: #3287
