### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.361.0",
+  "packages/react": "1.362.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.362.0](https://github.com/factorialco/f0/compare/f0-react-v1.361.0...f0-react-v1.362.0) (2026-02-13)
+
+
+### Features
+
+* add useF0Form hook for better integration with dialogs ([#3430](https://github.com/factorialco/f0/issues/3430)) ([eb46fdf](https://github.com/factorialco/f0/commit/eb46fdf12c823e4ea53621501d5cdb608872e353))
+
 ## [1.361.0](https://github.com/factorialco/f0/compare/f0-react-v1.360.0...f0-react-v1.361.0) (2026-02-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.361.0",
+  "version": "1.362.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.362.0</summary>

## [1.362.0](https://github.com/factorialco/f0/compare/f0-react-v1.361.0...f0-react-v1.362.0) (2026-02-13)


### Features

* add useF0Form hook for better integration with dialogs ([#3430](https://github.com/factorialco/f0/issues/3430)) ([eb46fdf](https://github.com/factorialco/f0/commit/eb46fdf12c823e4ea53621501d5cdb608872e353))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no functional code modifications in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.361.0` to `1.362.0` and updates the Release Please manifest accordingly.
> 
> Updates the React package changelog to include the `1.362.0` release entry (noting the new `useF0Form` hook for better dialog integration).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e43a0f8b1ed5e01a5a0774eec18aac6d4df3f80e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->