### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.362.0",
+  "packages/react": "1.362.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.362.1](https://github.com/factorialco/f0/compare/f0-react-v1.362.0...f0-react-v1.362.1) (2026-02-13)
+
+
+### Bug Fixes
+
+* **AiChat:** Fix autofocus for Activities ([#3432](https://github.com/factorialco/f0/issues/3432)) ([d0cc2d6](https://github.com/factorialco/f0/commit/d0cc2d6d1debc6348d9c99cce05476baf01f2354))
+
 ## [1.362.0](https://github.com/factorialco/f0/compare/f0-react-v1.361.0...f0-react-v1.362.0) (2026-02-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.362.0",
+  "version": "1.362.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.362.1</summary>

## [1.362.1](https://github.com/factorialco/f0/compare/f0-react-v1.362.0...f0-react-v1.362.1) (2026-02-13)


### Bug Fixes

* **AiChat:** Fix autofocus for Activities ([#3432](https://github.com/factorialco/f0/issues/3432)) ([d0cc2d6](https://github.com/factorialco/f0/commit/d0cc2d6d1debc6348d9c99cce05476baf01f2354))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/version bump only; no functional code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.362.0` to `1.362.1` and updates the Release Please manifest accordingly.
> 
> Updates `packages/react/CHANGELOG.md` to include the `1.362.1` release notes, documenting a bug fix for AiChat activity autofocus.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dd967a969c27cd057f0f758fc27f670f96dbef6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->