### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.362.1",
+  "packages/react": "1.362.2",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.362.2](https://github.com/factorialco/f0/compare/f0-react-v1.362.1...f0-react-v1.362.2) (2026-02-16)
+
+
+### Bug Fixes
+
+* keep preset counters consistent in overflow filter picker ([#3409](https://github.com/factorialco/f0/issues/3409)) ([309f8ca](https://github.com/factorialco/f0/commit/309f8ca8da4ff641deb805a242b432b7848edbd4))
+
 ## [1.362.1](https://github.com/factorialco/f0/compare/f0-react-v1.362.0...f0-react-v1.362.1) (2026-02-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.362.1",
+  "version": "1.362.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.362.2</summary>

## [1.362.2](https://github.com/factorialco/f0/compare/f0-react-v1.362.1...f0-react-v1.362.2) (2026-02-16)


### Bug Fixes

* keep preset counters consistent in overflow filter picker ([#3409](https://github.com/factorialco/f0/issues/3409)) ([309f8ca](https://github.com/factorialco/f0/commit/309f8ca8da4ff641deb805a242b432b7848edbd4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only change (version/changelog) with no functional code modifications in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.362.1` to `1.362.2` in both `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.362.2` release notes, documenting a bug fix to keep preset counters consistent in the overflow filter picker.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 775256851017f785eda2ce548e09b2de996ac1b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->