### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.362.2",
+  "packages/react": "1.362.3",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.362.3](https://github.com/factorialco/f0/compare/f0-react-v1.362.2...f0-react-v1.362.3) (2026-02-16)
+
+
+### Bug Fixes
+
+* accept F0Form schema refine for more advanced validation ([#3439](https://github.com/factorialco/f0/issues/3439)) ([0314598](https://github.com/factorialco/f0/commit/0314598fa93e076fadd44281a676dbb19dca01b5))
+
 ## [1.362.2](https://github.com/factorialco/f0/compare/f0-react-v1.362.1...f0-react-v1.362.2) (2026-02-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.362.2",
+  "version": "1.362.3",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.362.3</summary>

## [1.362.3](https://github.com/factorialco/f0/compare/f0-react-v1.362.2...f0-react-v1.362.3) (2026-02-16)


### Bug Fixes

* accept F0Form schema refine for more advanced validation ([#3439](https://github.com/factorialco/f0/issues/3439)) ([0314598](https://github.com/factorialco/f0/commit/0314598fa93e076fadd44281a676dbb19dca01b5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only changes (version/manifest/changelog) with no functional code modifications; low risk aside from publishing an updated package version.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.362.2` to `1.362.3` and updates the release manifest accordingly.
> 
> Updates the React package changelog to include the `1.362.3` entry noting a bug fix to accept `F0Form` schema `refine` for more advanced validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d42a553553a0539450fc4ede4bf0aa79fb256e6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->