### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.362.3",
+  "packages/react": "1.363.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.363.0](https://github.com/factorialco/f0/compare/f0-react-v1.362.3...f0-react-v1.363.0) (2026-02-16)
+
+
+### Features
+
+* Add card interactiveChildren prop to make children components clickable ([#3419](https://github.com/factorialco/f0/issues/3419)) ([13e0b71](https://github.com/factorialco/f0/commit/13e0b718ea50c5f14f6e0e89386636958afd5257))
+
 ## [1.362.3](https://github.com/factorialco/f0/compare/f0-react-v1.362.2...f0-react-v1.362.3) (2026-02-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.362.3",
+  "version": "1.363.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.363.0</summary>

## [1.363.0](https://github.com/factorialco/f0/compare/f0-react-v1.362.3...f0-react-v1.363.0) (2026-02-16)


### Features

* Add card interactiveChildren prop to make children components clickable ([#3419](https://github.com/factorialco/f0/issues/3419)) ([13e0b71](https://github.com/factorialco/f0/commit/13e0b718ea50c5f14f6e0e89386636958afd5257))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version/manifest/changelog-only release metadata updates with no functional code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.362.3` to `1.363.0` (manifest + package version) and adds the corresponding `CHANGELOG` entry.
> 
> The release notes call out a new `Card` `interactiveChildren` prop that allows children components to be clickable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1a644373268de056df515ea84ba1a0e305421d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->