### PR TITLE
chore: make community post action label optional

### DIFF
--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
@@ -192,6 +192,19 @@ export const WithMultipleCustomButtons: Story = {
   },
 }
 
+export const WithCustomButtonWithoutLabel: Story = {
+  decorators: Default.decorators,
+  args: {
+    ...Default.args,
+    actions: [
+      {
+        icon: PushPin,
+        onClick: () => {},
+      },
+    ],
+  },
+}
+
 type SkeletonStory = StoryObj<typeof CommunityPost.Skeleton>
 
 export const Skeleton: SkeletonStory = {

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -20,7 +20,7 @@ import { PostEvent, PostEventProps } from "../PostEvent"
 import { isVideo } from "./video"
 
 export type CommunityPostAction = {
-  label: string
+  label?: string
   icon?: IconType
   onClick: () => void
 }
@@ -185,13 +185,14 @@ export const BaseCommunityPost = ({
               <div className="hidden flex-row gap-2 md:flex">
                 {actions?.map((act) => (
                   <F0Button
+                    hideLabel={!act.label}
                     key={act.label}
                     {...(act.icon && { icon: act.icon })}
                     variant="outline"
                     size="md"
                     onClick={act.onClick}
-                    label={act.label}
-                    title={act.label}
+                    label={act.label ?? ""}
+                    title={act.label ?? ""}
                   />
                 ))}
                 {dropdownItems?.length && (


### PR DESCRIPTION
## Description

Add the option to not pass labels for community post actions.

If we don't make it optional, we may end up with a strange UI
<img width="655" height="235" alt="Screenshot 2026-02-16 at 11 58 24" src="https://github.com/user-attachments/assets/e38a8d33-30f1-4559-879a-79aaf8692cc2" />


## Screenshots (if applicable)

<img width="930" height="775" alt="Screenshot 2026-02-16 at 11 57 18" src="https://github.com/user-attachments/assets/32dcac9d-1918-4579-9b72-ad617d9de926" />


[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
