### PR TITLE
fix(F0DatePicker): reset range selection when clicking after complete range

### DIFF
--- a/packages/react/src/experimental/OneCalendar/granularities/day/DayView.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/day/DayView.tsx
@@ -1,4 +1,5 @@
 import { AnimatePresence, motion } from "motion/react"
+import { useCallback } from "react"
 import {
   SelectRangeEventHandler,
   SelectSingleEventHandler,
@@ -28,6 +29,17 @@ interface DayViewProps {
   weekStartsOn?: WeekStartsOn
 }
 
+/**
+ * Checks if a DateRange spans multiple days (not just a single day).
+ * A range with from and to on the same day is considered incomplete
+ * because the user is still selecting the end date.
+ */
+const isMultiDayRange = (range: DateRange | null | undefined): boolean => {
+  if (!range?.from || !range?.to) return false
+  // Check if from and to are on different days
+  return range.from.toDateString() !== range.to.toDateString()
+}
+
 export function DayView({
   mode,
   selected,
@@ -46,6 +58,43 @@ export function DayView({
     weekStartsOn ?? date?.weekStartsOn ?? WeekStartDay.Monday
 
   const disabled = toCalendarPickerMatcher({ minDate, maxDate })
+
+  /**
+   * Custom range selection handler that resets when a complete range exists.
+   * When the user already has a complete range (from + to) and clicks a new date,
+   * we start a fresh selection instead of modifying the existing range.
+   */
+  const handleRangeSelect: SelectRangeEventHandler = useCallback(
+    (range) => {
+      if (!onSelect) return
+
+      const previousRange = selected as DateRange | undefined
+      const hadMultiDayRange = isMultiDayRange(previousRange)
+
+      // If we had a multi-day range, start fresh with just the clicked date
+      if (hadMultiDayRange && range?.from) {
+        // Determine which date the user clicked by comparing with the previous range
+        // If 'from' changed, the user clicked on what became the new 'from'
+        // If 'to' changed, the user clicked on what became the new 'to'
+        const fromChanged =
+          range.from.getTime() !== previousRange?.from?.getTime()
+        const toChanged = range.to?.getTime() !== previousRange?.to?.getTime()
+
+        // The clicked date is whichever one changed (default to from if both changed)
+        const clickedDate =
+          fromChanged || !toChanged ? range.from : (range.to ?? range.from)
+
+        // Start a new range with only the clicked date
+        onSelect({ from: clickedDate, to: undefined })
+      } else if (range?.from) {
+        // Normal behavior: building a range
+        onSelect({ from: range.from, to: range.to })
+      } else {
+        onSelect(null)
+      }
+    },
+    [onSelect, selected]
+  )
 
   const motionVariants = {
     hidden: (direction: number) => ({
@@ -106,7 +155,7 @@ export function DayView({
           mode="range"
           disabled={disabled}
           selected={selected as DateRange}
-          onSelect={onSelect as SelectRangeEventHandler}
+          onSelect={handleRangeSelect}
           month={month}
           onMonthChange={onMonthChange}
           locale={getLocale(locale)}


### PR DESCRIPTION
## Summary

- Fixes bug where clicking a new date after selecting a complete range would modify the existing range instead of starting fresh
- When a multi-day range is selected, clicking any date now resets the selection and uses that date as the new start
- Allows users to completely change date ranges without needing to clear the selection first

## Changes

- Added `isMultiDayRange` helper function to detect when a range spans multiple days
- Added `handleRangeSelect` callback that intercepts range selection and resets when needed
- Determines which date was clicked by comparing the previous and new range values

Before:

https://github.com/user-attachments/assets/ae92d503-2521-4955-b495-699d462714dd


After

https://github.com/user-attachments/assets/db1c04ac-2a93-4575-a76a-b62cd615fb19



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI behavior change in `DayView` range selection; main risk is subtle regressions in edge cases for date-range picking.
> 
> **Overview**
> Fixes day-level range selection so that once a *multi-day* range is complete, clicking any new date resets the selection and uses that date as the new `from` (instead of adjusting the existing range).
> 
> Adds an `isMultiDayRange` helper and a memoized `handleRangeSelect` that compares the previous and next `DateRange` to infer the clicked date, then wires this handler into the range-mode `Calendar` `onSelect` callback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c1fda547a75cafbeb8797322ddfca5b58c2e737. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->