### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.363.0",
+  "packages/react": "1.364.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.364.0](https://github.com/factorialco/f0/compare/f0-react-v1.363.0...f0-react-v1.364.0) (2026-02-17)
+
+
+### Features
+
+* add dropdown element as question type ([#3412](https://github.com/factorialco/f0/issues/3412)) ([481c0c6](https://github.com/factorialco/f0/commit/481c0c643371ec204319ce51c09cfba7975c0fa4))
+
 ## [1.363.0](https://github.com/factorialco/f0/compare/f0-react-v1.362.3...f0-react-v1.363.0) (2026-02-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.363.0",
+  "version": "1.364.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.364.0</summary>

## [1.364.0](https://github.com/factorialco/f0/compare/f0-react-v1.363.0...f0-react-v1.364.0) (2026-02-17)


### Features

* add dropdown element as question type ([#3412](https://github.com/factorialco/f0/issues/3412)) ([481c0c6](https://github.com/factorialco/f0/commit/481c0c643371ec204319ce51c09cfba7975c0fa4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only changes (version/changelog/manifest) with no runtime or logic modifications.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.363.0` to `1.364.0` and updates the Release Please manifest accordingly.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.364.0` release entry noting the new feature: dropdown element as a question type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cf007324657c2bd155e5ba7113aefb50882b742. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->