### PR TITLE
feat: add id to the community post wrapper div

### DIFF
--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
@@ -26,6 +26,7 @@ export const Default: Story = {
     ),
   ],
   args: {
+    id: "123",
     author: {
       firstName: "Saúl",
       lastName: "Domínguez",

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -109,6 +109,7 @@ export const BaseCommunityPost = ({
     <div
       className="flex w-full cursor-pointer flex-row gap-3 rounded-xl border border-solid border-transparent p-3 pt-2 hover:bg-f1-background-hover focus:border-f1-border-secondary focus:outline focus:outline-1 focus:outline-offset-1 focus:outline-f1-border-selected-bold md:pb-4 md:pt-3"
       onClick={handleClick}
+      id={`community-post-${id}`}
     >
       <div className="hidden md:block">
         {author ? (


### PR DESCRIPTION
## Description

We need a mechanism to add an anchor link to the community post in a community page. This will be useful for the pinned post feature

## Screenshots (if applicable)

Before:
<img width="910" height="132" alt="Screenshot 2026-02-17 at 11 10 27" src="https://github.com/user-attachments/assets/0651846b-6064-4f12-9a7a-4b9e6d717ec3" />

After:
<img width="911" height="98" alt="Screenshot 2026-02-17 at 11 10 08" src="https://github.com/user-attachments/assets/f8544607-346a-49cb-bc7a-e83731be24c2" />



[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
