### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.366.0",
+  "packages/react": "1.367.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.367.0](https://github.com/factorialco/f0/compare/f0-react-v1.366.0...f0-react-v1.367.0) (2026-02-17)
+
+
+### Features
+
+* add id to the community post wrapper div ([#3452](https://github.com/factorialco/f0/issues/3452)) ([17da663](https://github.com/factorialco/f0/commit/17da6634f6484375e1e962f819a4a98632279154))
+
 ## [1.366.0](https://github.com/factorialco/f0/compare/f0-react-v1.365.0...f0-react-v1.366.0) (2026-02-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.366.0",
+  "version": "1.367.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.367.0</summary>

## [1.367.0](https://github.com/factorialco/f0/compare/f0-react-v1.366.0...f0-react-v1.367.0) (2026-02-17)


### Features

* add id to the community post wrapper div ([#3452](https://github.com/factorialco/f0/issues/3452)) ([17da663](https://github.com/factorialco/f0/commit/17da6634f6484375e1e962f819a4a98632279154))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/changelog/version bumps only; no functional code changes in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.366.0` to `1.367.0` and updates the Release Please manifest accordingly.
> 
> Updates the `packages/react/CHANGELOG.md` with the `1.367.0` release notes (feature: adds an id to the community post wrapper div).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfa06d637bbbae614a08fde8a9b99b238f4a42bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->