### PR TITLE
chore: add AGENTS.md with factorial-skills instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+## Factorial Skills
+
+Before starting any task, check if `factorial-skills` is available (look for skills with `factorial-` prefix via the Skill tool or check `~/.config/opencode/skills/`). If factorial-skills are installed, always search for and load the most relevant skill before proceeding — they contain institutional knowledge, workflows, and MCP integration guides specific to Factorial. If they are not installed, ask the user: "Would you like me to install factorial-skills? (`npx skills add factorialco/factorial-skills -g -y`)"


### PR DESCRIPTION
## Summary

- Creates `AGENTS.md` with a **Factorial Skills** section
- Instructs AI agents (Codex, Copilot, Cursor, Claude, etc.) to check for `factorial-skills` before starting any task
- If installed, agents will load the most relevant skill for institutional knowledge, workflows, and MCP integration guides
- If not installed, agents will prompt the user to install via `npx skills add factorialco/factorial-skills -g -y`

Part of a cross-repo rollout to 6 Factorial repositories.