### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.367.0",
+  "packages/react": "1.368.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.368.0](https://github.com/factorialco/f0/compare/f0-react-v1.367.0...f0-react-v1.368.0) (2026-02-18)
+
+
+### Features
+
+* **Select:** support DotTag in select options ([#3422](https://github.com/factorialco/f0/issues/3422)) ([eef8882](https://github.com/factorialco/f0/commit/eef88829de45fceee7f37bcc4259648add4e9a70))
+
 ## [1.367.0](https://github.com/factorialco/f0/compare/f0-react-v1.366.0...f0-react-v1.367.0) (2026-02-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.367.0",
+  "version": "1.368.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.368.0</summary>

## [1.368.0](https://github.com/factorialco/f0/compare/f0-react-v1.367.0...f0-react-v1.368.0) (2026-02-18)


### Features

* **Select:** support DotTag in select options ([#3422](https://github.com/factorialco/f0/issues/3422)) ([eef8882](https://github.com/factorialco/f0/commit/eef88829de45fceee7f37bcc4259648add4e9a70))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/manifest/changelog) with no functional code modifications in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.367.0` to `1.368.0` and updates the Release Please manifest.
> 
> Adds the `1.368.0` changelog entry, documenting the new `Select` feature to support `DotTag` in select options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cad7fc60a6d9e59b285ca4049feda304de2b18b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->