### PR TITLE
fix: One tools

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/copilotActions/useMessageSourcesAction.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/copilotActions/useMessageSourcesAction.tsx
@@ -48,7 +48,7 @@ export const useMessageSourcesAction = () => {
       },
     ],
     // render only when backend wants to attach sources
-    available: "disabled",
+    available: "frontend",
     render: (props) => {
       const sources: MessageSourceItem[] = props.args.sources ?? []
       return <MessageSources sources={sources} />

--- a/packages/react/src/sds/ai/F0AiChat/copilotActions/useOrchestratorThinkingAction.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/copilotActions/useOrchestratorThinkingAction.tsx
@@ -19,7 +19,7 @@ export const useOrchestratorThinkingAction = () => {
       },
     ],
     // render only when backend wants to display the thinking
-    available: "disabled",
+    available: "frontend",
     render: (props) => {
       const title: string = props.args.message ?? "thinking"
       const result: OrchestratorThinkingResult | undefined = props.result


### PR DESCRIPTION
Tools marked as "disabled" in CopilotKit send a response back to Mastra, in this case an empty response. This causes issues since a new workflow is started with an empty message at the backend.

Changing them to "frontend" allows us to render the content in the chat without signaling back Mastra.