### PR TITLE
Increase NotesTextEditor image default limit to 50MB

### DIFF
--- a/packages/react/src/experimental/RichText/CoreEditor/Extensions/Image/index.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/Extensions/Image/index.tsx
@@ -27,7 +27,7 @@ export interface ImageUploadConfig {
   onError?: (errorType: ImageUploadErrorType) => void
 }
 
-const DEFAULT_MAX_SIZE = 15 * 1024 * 1024 // 15MB
+const DEFAULT_MAX_SIZE = 50 * 1024 * 1024 // 50MB
 export const DEFAULT_ACCEPTED_TYPES = [
   "image/jpeg",
   "image/png",


### PR DESCRIPTION
## Summary
- increase NotesTextEditor image upload default max size from 15MB to 50MB
- keep behavior unchanged when consumers pass an explicit maxFileSize value

## Validation
- pnpm -C packages/react lint src/experimental/RichText/CoreEditor/Extensions/Image/index.tsx
- pnpm -C packages/react tsc