### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.369.0",
+  "packages/react": "1.369.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.369.1](https://github.com/factorialco/f0/compare/f0-react-v1.369.0...f0-react-v1.369.1) (2026-02-18)
+
+
+### Bug Fixes
+
+* One tools ([#3457](https://github.com/factorialco/f0/issues/3457)) ([dc9ab24](https://github.com/factorialco/f0/commit/dc9ab24eaca1052799992b88ed6abbc4341db81e))
+
 ## [1.369.0](https://github.com/factorialco/f0/compare/f0-react-v1.368.0...f0-react-v1.369.0) (2026-02-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.369.0",
+  "version": "1.369.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.369.1</summary>

## [1.369.1](https://github.com/factorialco/f0/compare/f0-react-v1.369.0...f0-react-v1.369.1) (2026-02-18)


### Bug Fixes

* One tools ([#3457](https://github.com/factorialco/f0/issues/3457)) ([dc9ab24](https://github.com/factorialco/f0/commit/dc9ab24eaca1052799992b88ed6abbc4341db81e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no functional code modifications.
> 
> **Overview**
> Publishes `@factorialco/f0-react` patch release `1.369.1` by bumping the version in `packages/react/package.json` and updating `.release-please-manifest.json`.
> 
> Adds the `1.369.1` changelog entry in `packages/react/CHANGELOG.md`, documenting a single bug fix (“One tools”, #3457).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af83bbc53daa817d9b056953e5e5131c24d95665. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->