### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.369.2",
+  "packages/react": "1.369.3",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.369.3](https://github.com/factorialco/f0/compare/f0-react-v1.369.2...f0-react-v1.369.3) (2026-02-18)
+
+
+### Bug Fixes
+
+* **F0DatePicker:** reset range selection when clicking after complete range ([#3447](https://github.com/factorialco/f0/issues/3447)) ([aa1bd6f](https://github.com/factorialco/f0/commit/aa1bd6ff5d9fbb0e74056ea0a708668ed88b8264))
+
 ## [1.369.2](https://github.com/factorialco/f0/compare/f0-react-v1.369.1...f0-react-v1.369.2) (2026-02-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.369.2",
+  "version": "1.369.3",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.369.3</summary>

## [1.369.3](https://github.com/factorialco/f0/compare/f0-react-v1.369.2...f0-react-v1.369.3) (2026-02-18)


### Bug Fixes

* **F0DatePicker:** reset range selection when clicking after complete range ([#3447](https://github.com/factorialco/f0/issues/3447)) ([aa1bd6f](https://github.com/factorialco/f0/commit/aa1bd6ff5d9fbb0e74056ea0a708668ed88b8264))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only change (version/changelog/manifest) with no functional code modifications in this PR.
> 
> **Overview**
> Bumps the `@factorialco/f0-react` package version from `1.369.2` to `1.369.3` (including the release manifest).
> 
> Updates `packages/react/CHANGELOG.md` to document the included bug fix: resetting `F0DatePicker` range selection when clicking after completing a range.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4619a718cda61766167f96c4cd27e2d00c8d92e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->