### PR TITLE
feat(core): add xs container query breakpoint

### DIFF
--- a/packages/core/tailwind.ts
+++ b/packages/core/tailwind.ts
@@ -133,6 +133,7 @@ export const baseConfig: Omit<Config, "content"> = {
         autofill: "autofill 0s both",
       },
       containers: {
+        xs: "24rem",
         sm: "40rem",
         "8xl": "96rem",
         "9xl": "120rem",

--- a/packages/react/src/components/F0Alert/F0Alert.tsx
+++ b/packages/react/src/components/F0Alert/F0Alert.tsx
@@ -57,7 +57,7 @@ export const F0Alert = ({
       <div className={alertVariants({ variant })}>
         <div
           className={cn(
-            "flex flex-col items-start gap-3 @sm:flex-row @sm:items-center @sm:justify-between"
+            "flex flex-col items-start gap-3 @xs:flex-row @xs:items-center @xs:justify-between"
           )}
         >
           <div className="flex flex-row gap-2">
@@ -78,7 +78,7 @@ export const F0Alert = ({
           {(action || link) && (
             <div
               className={cn(
-                "flex flex-shrink-0 flex-row items-center gap-3 pl-8 @sm:pl-0"
+                "flex flex-shrink-0 flex-row items-center gap-3 pl-8 @xs:pl-0"
               )}
             >
               {link && (

--- a/packages/react/src/components/F0Alert/__stories__/F0Alert.stories.tsx
+++ b/packages/react/src/components/F0Alert/__stories__/F0Alert.stories.tsx
@@ -105,3 +105,22 @@ export const DeactivatedAction: Story = {
     </div>
   ),
 }
+
+export const InDialog: Story = {
+  args: {
+    title: "Create a new job",
+    description:
+      "Craft a job description that aligns with this vacancy's requirements.",
+    action: {
+      label: "New job",
+      onClick: fn(),
+    },
+    variant: "info",
+    link: undefined,
+  },
+  render: (args) => (
+    <div className="w-[450px]">
+      <F0Alert {...args} />
+    </div>
+  ),
+}


### PR DESCRIPTION
## Why - Problem

The current `@sm` container query breakpoint (640px) is too large for medium-sized containers like dialogs and sidebars. Components like alerts inside dialogs (~400-500px) display in column layout when they could use a more compact row layout.

**Example:** An alert with a single action button inside a 450px dialog shows stacked (column) when there's enough space for the button to be inline.

## What - Changes

- Add `xs: "24rem"` (384px) as a new container query breakpoint in `packages/core/tailwind.ts`
- Update `F0Alert` to use `@xs` instead of `@sm` for responsive layout switching
- Add `InDialog` story in Storybook demonstrating the use case

## Breakpoint comparison

| Breakpoint | Size | Use case |
|------------|------|----------|
| `@xs` (new) | 384px | Dialogs, sidebars, cards |
| `@sm` (existing) | 640px | Full-width containers |

## Test plan

- [ ] View the `InDialog` story in Storybook to verify the alert displays correctly in a 450px container
- [ ] Compare with `Narrow` story (320px) which should still show column layout
- [ ] Verify no regressions in the `Default` story (640px)

<img width="1045" height="298" alt="image" src="https://github.com/user-attachments/assets/3fe28f77-d952-4ab1-811f-86efef8310f6" />

