### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.369.3",
+  "packages/react": "1.369.4",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.369.4](https://github.com/factorialco/f0/compare/f0-react-v1.369.3...f0-react-v1.369.4) (2026-02-18)
+
+
+### Bug Fixes
+
+* get rid of max width in DetailsItemsList component ([#3462](https://github.com/factorialco/f0/issues/3462)) ([9807a8c](https://github.com/factorialco/f0/commit/9807a8c86f1ddbb09e99479c8be18a61547122d1))
+
 ## [1.369.3](https://github.com/factorialco/f0/compare/f0-react-v1.369.2...f0-react-v1.369.3) (2026-02-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.369.3",
+  "version": "1.369.4",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.369.4</summary>

## [1.369.4](https://github.com/factorialco/f0/compare/f0-react-v1.369.3...f0-react-v1.369.4) (2026-02-18)


### Bug Fixes

* get rid of max width in DetailsItemsList component ([#3462](https://github.com/factorialco/f0/issues/3462)) ([9807a8c](https://github.com/factorialco/f0/commit/9807a8c86f1ddbb09e99479c8be18a61547122d1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/changelog updates only; no functional code changes are included in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.369.3` to `1.369.4` in both the release manifest and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.369.4` release notes, documenting a bug fix that removes the max-width constraint from `DetailsItemsList`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0471be6233d0fc0f18d07a24a4eebb8dec85de05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->