### PR TITLE
feat: include avatar list as a variant in DetailsItemsList component

### DIFF
--- a/packages/react/src/experimental/Lists/DetailsItem/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.tsx
@@ -1,5 +1,7 @@
 import { ComponentProps, FC, forwardRef } from "react"
 
+import { F0AvatarList } from "@/components/avatars/F0AvatarList"
+import { F0AvatarListProps } from "@/components/avatars/F0AvatarList/types"
 import { Weekdays } from "@/experimental/Widgets/Content/Weekdays"
 import { experimentalComponent } from "@/lib/experimental"
 import { cn } from "@/lib/utils"
@@ -25,6 +27,10 @@ type Content =
   | (ComponentProps<typeof DataList.DotTagItem> & {
       type: "dot-tag"
     })
+  | {
+      type: "avatar-list"
+      avatarList: F0AvatarListProps
+    }
 
 export interface DetailsItemType {
   title: string
@@ -45,6 +51,11 @@ const ItemContent: FC<{ content: Content }> = ({ content }) => (
     {content.type === "team" && <DataList.TeamItem {...content} />}
     {content.type === "company" && <DataList.CompanyItem {...content} />}
     {content.type === "dot-tag" && <DataList.DotTagItem {...content} />}
+    {content.type === "avatar-list" && (
+      <li className="w-fit list-none px-1.5 py-1">
+        <F0AvatarList {...content.avatarList} />
+      </li>
+    )}
   </>
 )
 

--- a/packages/react/src/experimental/Lists/DetailsItemsList/index.stories.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItemsList/index.stories.tsx
@@ -84,3 +84,205 @@ export const TableView: Story = {
     tableView: true,
   },
 }
+
+export const TableViewWithPersonList: Story = {
+  args: {
+    title: "Team Members",
+    tableView: true,
+    details: [
+      {
+        title: "Manager",
+        content: {
+          type: "person",
+          firstName: "Saul",
+          lastName: "Dominguez",
+          avatarUrl: "/avatars/person01.jpg",
+        },
+      },
+      {
+        title: "Tech Lead",
+        content: {
+          type: "person",
+          firstName: "Dani",
+          lastName: "Moreno",
+          avatarUrl: "/avatars/person05.jpg",
+        },
+      },
+      {
+        title: "Designer",
+        content: {
+          type: "person",
+          firstName: "Josep Jaume",
+          lastName: "Rey Peroy",
+          avatarUrl: "/avatars/person07.jpg",
+        },
+      },
+      {
+        title: "Engineers",
+        content: [
+          {
+            type: "person",
+            firstName: "Alex",
+            lastName: "Garcia",
+            avatarUrl: "/avatars/person06.jpg",
+          },
+          {
+            type: "person",
+            firstName: "Maria",
+            lastName: "Lopez",
+            avatarUrl: "/avatars/person02.jpg",
+          },
+        ],
+      },
+    ],
+  },
+}
+
+export const WithAvatarList: Story = {
+  args: {
+    title: "Details",
+    details: [
+      {
+        title: "Participants",
+        content: {
+          type: "avatar-list",
+          avatarList: {
+            type: "person",
+            size: "sm",
+            remainingCount: 9,
+            avatars: [
+              {
+                firstName: "Saul",
+                lastName: "Dominguez",
+                src: "/avatars/person01.jpg",
+              },
+              {
+                firstName: "Dani",
+                lastName: "Moreno",
+                src: "/avatars/person05.jpg",
+              },
+              {
+                firstName: "Josep Jaume",
+                lastName: "Rey Peroy",
+                src: "/avatars/person07.jpg",
+              },
+            ],
+          },
+        },
+      },
+      {
+        title: "Publish on",
+        content: {
+          type: "item",
+          text: "Now",
+        },
+      },
+      {
+        title: "Anonymous answers",
+        content: {
+          type: "item",
+          text: "No",
+        },
+      },
+    ],
+  },
+}
+
+export const TableViewWithAvatarList: Story = {
+  args: {
+    tableView: true,
+    details: [
+      {
+        title: "Participants",
+        content: {
+          type: "avatar-list",
+          avatarList: {
+            type: "person",
+            size: "sm",
+            remainingCount: 9,
+            avatars: [
+              {
+                firstName: "Saul",
+                lastName: "Dominguez",
+                src: "/avatars/person01.jpg",
+              },
+              {
+                firstName: "Dani",
+                lastName: "Moreno",
+                src: "/avatars/person05.jpg",
+              },
+              {
+                firstName: "Josep Jaume",
+                lastName: "Rey Peroy",
+                src: "/avatars/person07.jpg",
+              },
+            ],
+          },
+        },
+      },
+      {
+        title: "Publish on",
+        content: {
+          type: "item",
+          text: "Now",
+        },
+      },
+      {
+        title: "Anonymous answers",
+        content: {
+          type: "item",
+          text: "No",
+        },
+      },
+    ],
+  },
+}
+
+export const WithTeamAvatarList: Story = {
+  args: {
+    title: "Project Info",
+    tableView: true,
+    details: [
+      {
+        title: "Teams",
+        content: {
+          type: "avatar-list",
+          avatarList: {
+            type: "team",
+            size: "sm",
+            remainingCount: 9,
+            avatars: [
+              { name: "Engineering" },
+              { name: "Design" },
+              { name: "Management" },
+              { name: "Marketing" },
+            ],
+          },
+        },
+      },
+      {
+        title: "Companies",
+        content: {
+          type: "avatar-list",
+          avatarList: {
+            type: "company",
+            size: "sm",
+            remainingCount: 9,
+            avatars: [
+              { name: "Factorial", src: "/avatars/company01.jpg" },
+              { name: "Acme Corp", src: "/avatars/company02.jpg" },
+            ],
+          },
+        },
+      },
+      {
+        title: "Status",
+        content: {
+          type: "dot-tag",
+          text: "Active",
+          customColor: "#07A2AD",
+        },
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Description

We need to support showing a list of people, teams or companies horizontally in this `DetailsItemsList` component.

## Screenshots

<img width="733" height="664" alt="Screenshot 2026-02-18 at 16 49 05" src="https://github.com/user-attachments/assets/a793bc6d-8f0c-4f60-b1c7-39c33810a753" />
