### PR TITLE
feat: add RotateCcwSquare icon from lucide

### DIFF
--- a/packages/core/assets/icons/app/rotate-ccw-square.svg
+++ b/packages/core/assets/icons/app/rotate-ccw-square.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 9V7a2 2 0 0 0-2-2h-6"/><path d="m15 2-3 3 3 3"/><path d="M20 13v5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h2"/></svg>

--- a/packages/react/src/icons/app/RotateCcwSquare.tsx
+++ b/packages/react/src/icons/app/RotateCcwSquare.tsx
@@ -1,0 +1,26 @@
+import type { SVGProps } from "react"
+import { Ref, forwardRef } from "react"
+const SvgRotateCcwSquare = (
+  props: SVGProps<SVGSVGElement>,
+  ref: Ref<SVGSVGElement>
+) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    viewBox="0 0 24 24"
+    ref={ref}
+    {...props}
+  >
+    <path d="M20 9V7a2 2 0 0 0-2-2h-6" vectorEffect="non-scaling-stroke" />
+    <path d="m15 2-3 3 3 3" vectorEffect="non-scaling-stroke" />
+    <path
+      d="M20 13v5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h2"
+      vectorEffect="non-scaling-stroke"
+    />
+  </svg>
+)
+const ForwardRef = forwardRef(SvgRotateCcwSquare)
+export default ForwardRef


### PR DESCRIPTION
## Description

Adds this new icon to the icons assets.

## Screenshots (if applicable)

<img width="43" height="41" alt="Screenshot 2026-02-18 at 16 53 44" src="https://github.com/user-attachments/assets/d1a93fb0-2c34-4677-96f2-c051b164a8ed" />


## Implementation details

We've implemented a rotate feature but the icons that were in f0 were not enough. So Amadeu our designed proposed to change the icon to this one from Lucide.