### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.369.4",
+  "packages/react": "1.370.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.370.0](https://github.com/factorialco/f0/compare/f0-react-v1.369.4...f0-react-v1.370.0) (2026-02-18)
+
+
+### Features
+
+* add YouTube and Vimeo video embed extension ([#3425](https://github.com/factorialco/f0/issues/3425)) ([971ff5b](https://github.com/factorialco/f0/commit/971ff5b740c455a39f4ce9ae9dbc02ebf7bb7224))
+* include avatar list as a variant in DetailsItemsList component ([#3470](https://github.com/factorialco/f0/issues/3470)) ([011793a](https://github.com/factorialco/f0/commit/011793a320ccce2bcb0f0d7cbdb15f5891715bce))
+
 ## [1.369.4](https://github.com/factorialco/f0/compare/f0-react-v1.369.3...f0-react-v1.369.4) (2026-02-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.369.4",
+  "version": "1.370.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.370.0</summary>

## [1.370.0](https://github.com/factorialco/f0/compare/f0-react-v1.369.4...f0-react-v1.370.0) (2026-02-18)


### Features

* add YouTube and Vimeo video embed extension ([#3425](https://github.com/factorialco/f0/issues/3425)) ([971ff5b](https://github.com/factorialco/f0/commit/971ff5b740c455a39f4ce9ae9dbc02ebf7bb7224))
* include avatar list as a variant in DetailsItemsList component ([#3470](https://github.com/factorialco/f0/issues/3470)) ([011793a](https://github.com/factorialco/f0/commit/011793a320ccce2bcb0f0d7cbdb15f5891715bce))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/manifest/changelog) with no functional code modifications in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.369.4` to `1.370.0` and updates the Release Please manifest accordingly.
> 
> Updates the React package changelog to publish the `1.370.0` release notes, highlighting the new YouTube/Vimeo embed extension and an `DetailsItemsList` avatar-list variant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09ee96899c2de4331275b4343e1307b277793d73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->