### PR TITLE
fix: ensure we don't keep the pending changes bar opened after form submission

### DIFF
--- a/packages/react/src/components/F0Form/F0Form.tsx
+++ b/packages/react/src/components/F0Form/F0Form.tsx
@@ -277,7 +277,10 @@ export function F0Form<TSchema extends F0FormSchema>(
     }
     const result = await onSubmit(cleanedData)
 
-    if (!result.success) {
+    if (result.success) {
+      form.reset(data)
+      resetErrorNavigation()
+    } else {
       // Set field-specific errors
       if (result.errors) {
         Object.entries(result.errors).forEach(([field, message]) => {


### PR DESCRIPTION
## Description

Some weird behavior I have seen before is that we sometimes kept the pending changes bar open after the form was submitted successfully by the user. We need to get rid of that as it's super confusing for the user.
