### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.370.0",
+  "packages/react": "1.370.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.44.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.370.1](https://github.com/factorialco/f0/compare/f0-react-v1.370.0...f0-react-v1.370.1) (2026-02-18)
+
+
+### Bug Fixes
+
+* ensure we don't keep the pending changes bar opened after form submission ([#3473](https://github.com/factorialco/f0/issues/3473)) ([44ba9ab](https://github.com/factorialco/f0/commit/44ba9abb2a399f1d498388d922dc63b464687a63))
+
 ## [1.370.0](https://github.com/factorialco/f0/compare/f0-react-v1.369.4...f0-react-v1.370.0) (2026-02-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.370.0",
+  "version": "1.370.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.370.1</summary>

## [1.370.1](https://github.com/factorialco/f0/compare/f0-react-v1.370.0...f0-react-v1.370.1) (2026-02-18)


### Bug Fixes

* ensure we don't keep the pending changes bar opened after form submission ([#3473](https://github.com/factorialco/f0/issues/3473)) ([44ba9ab](https://github.com/factorialco/f0/commit/44ba9abb2a399f1d498388d922dc63b464687a63))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version/changelog/manifest); no functional code changes are included in this diff.
> 
> **Overview**
> Cuts a `@factorialco/f0-react` patch release (`1.370.0` → `1.370.1`).
> 
> Updates the release manifest and `packages/react` metadata/changelog to publish the bug fix for keeping the pending changes bar open after form submission.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 917a3243987f9725f81bcaccac2922dbb4388eff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->