### PR TITLE
fix: render CardLink as native button when no href is provided

### DIFF
--- a/packages/react/src/experimental/Widgets/Widget/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.stories.tsx
@@ -152,3 +152,13 @@ export const FullHeight: Story = {
     fullHeight: true,
   },
 }
+
+export const WithOnClickOnlyLink: Story = {
+  args: {
+    ...meta.args,
+    header: {
+      title: "Balance",
+      link: { title: "Balance", onClick: fn() },
+    },
+  },
+}

--- a/packages/react/src/ui/Card/Card.tsx
+++ b/packages/react/src/ui/Card/Card.tsx
@@ -136,26 +136,52 @@ CardInfo.displayName = "CardInfo"
 
 /**
  * Card Link
+ *
+ * When an `href` is provided, renders as a `Link` for navigation.
+ * When only `onClick` is provided (no `href`), renders as a native `<button>`
+ * for correct accessibility semantics and keyboard support.
  */
 const CardLink = React.forwardRef<
-  HTMLAnchorElement,
+  HTMLElement,
   React.ComponentPropsWithoutRef<"a"> & { icon?: IconType }
->(({ className, title, icon = ChevronRight, ...props }, ref) => {
+>(({ className, title, icon = ChevronRight, href, ...rest }, ref) => {
+  const sharedClassName = cn(
+    "group inline-flex aspect-square h-6 items-center justify-center gap-1", //layout
+    "rounded-sm border border-solid border-f1-border bg-f1-background-inverse-secondary", //appearance
+    "whitespace-nowrap px-0 text-base font-medium text-f1-foreground", //typography
+    "cursor-pointer transition-colors hover:border-f1-border-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-special-ring focus-visible:ring-offset-1", //interaction
+    className
+  )
+  const iconElement = (
+    <F0Icon size="sm" icon={icon} className="text-f1-icon-bold" />
+  )
+
+  if (!href) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { target, rel, download, type: _type, ...buttonProps } = rest
+    return (
+      <button
+        ref={ref as React.Ref<HTMLButtonElement>}
+        className={sharedClassName}
+        aria-label={title}
+        type="button"
+        {...(buttonProps as React.ComponentPropsWithoutRef<"button">)}
+      >
+        {iconElement}
+      </button>
+    )
+  }
+
   return (
     <Link
-      ref={ref}
-      className={cn(
-        "group inline-flex aspect-square h-6 items-center justify-center gap-1", //layout
-        "rounded-sm border border-solid border-f1-border bg-f1-background-inverse-secondary", //appearance
-        "whitespace-nowrap px-0 text-base font-medium text-f1-foreground", //typography
-        "cursor-pointer transition-colors hover:border-f1-border-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-special-ring focus-visible:ring-offset-1", //interaction
-        className
-      )}
+      ref={ref as React.Ref<HTMLAnchorElement>}
+      className={sharedClassName}
       role="button"
       aria-label={title}
-      {...props}
+      href={href}
+      {...rest}
     >
-      <F0Icon size="sm" icon={icon} className="text-f1-icon-bold" />
+      {iconElement}
     </Link>
   )
 })

--- a/packages/react/src/ui/Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/ui/Card/__stories__/Card.stories.tsx
@@ -138,3 +138,49 @@ export const Complete: Story = {
     </Card>
   ),
 }
+
+export const WithHrefLink: Story = {
+  render: () => (
+    <Card>
+      <CardHeader>
+        <CardTitle>Card with Navigation Link</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p>
+          The CardLink below uses an href, rendering as an anchor tag via the
+          Link component.
+        </p>
+      </CardContent>
+      <CardFooter>
+        <CardLink
+          title="Navigate to page"
+          icon={ChevronRight}
+          href="/example"
+        />
+      </CardFooter>
+    </Card>
+  ),
+}
+
+export const WithClickableLink: Story = {
+  render: () => (
+    <Card>
+      <CardHeader>
+        <CardTitle>Card with Clickable Link</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p>
+          The CardLink below uses onClick only (no href), rendering as a native
+          button for correct accessibility.
+        </p>
+      </CardContent>
+      <CardFooter>
+        <CardLink
+          title="Open panel"
+          icon={ChevronRight}
+          onClick={() => alert("Panel opened!")}
+        />
+      </CardFooter>
+    </Card>
+  ),
+}

--- a/packages/react/src/ui/Card/__tests__/Card.test.tsx
+++ b/packages/react/src/ui/Card/__tests__/Card.test.tsx
@@ -134,6 +134,34 @@ describe("Card Components", () => {
       const link = screen.getByLabelText("Test Link")
       expect(link).toBeInTheDocument()
     })
+
+    it("renders a <button> when no href is provided", () => {
+      renderWithWrapper(
+        <CardLink title="Action" icon={ChevronRight} onClick={() => {}} />
+      )
+      const el = screen.getByLabelText("Action")
+      expect(el.tagName).toBe("BUTTON")
+      expect(el).toHaveAttribute("type", "button")
+      expect(el).not.toHaveAttribute("aria-disabled")
+      expect(el).not.toHaveAttribute("disabled")
+    })
+
+    it("fires onClick when rendered as a button", () => {
+      const handleClick = vi.fn()
+      renderWithWrapper(
+        <CardLink title="Click me" icon={ChevronRight} onClick={handleClick} />
+      )
+      fireEvent.click(screen.getByLabelText("Click me"))
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it("renders via Link when href is provided", () => {
+      renderWithWrapper(
+        <CardLink title="Navigate" icon={ChevronRight} href="/test" />
+      )
+      const el = screen.getByLabelText("Navigate")
+      expect(el.tagName).not.toBe("BUTTON")
+    })
   })
 
   describe("CardComment", () => {


### PR DESCRIPTION
## Summary

- **CardLink** now renders a native `<button>` when no `href` is provided (onClick-only usage), instead of going through the `Link` component which marks it as `aria-disabled="true"` 
- Fixes an accessibility issue where screen readers announce the element as disabled and keyboard users cannot activate it, despite the button being fully functional
- Adds tests and stories for the new button fallback behavior

## Problem

When `CardLink` is used without an `href` (e.g. in Factorial's `BalanceCounter` widget which passes `onClick` but no `url`), the underlying `Link` component in `linkHandler.tsx` evaluates `!props.href` as truthy and sets `isDisabled = true`. This renders a `<span aria-disabled="true" disabled="">` with `role="button"` — semantically misleading and inaccessible:

- Screen readers announce it as disabled/unavailable
- No native keyboard support (Enter/Space don't activate `<span>`)
- `role="button"` + `aria-disabled="true"` contradicts the element's actual behavior

## Solution

`CardLink` now branches on `href`:
- **No `href`** → renders a native `<button type="button">` with proper a11y semantics
- **Has `href`** → unchanged behavior via `Link`

Anchor-specific props (`target`, `rel`, `download`) are stripped when rendering as `<button>`.

## Alternatives Considered

**Fix in `Link`/`linkHandler.tsx`**: Change the `isDisabled = !props.href || disabled` logic so `Link` doesn't mark itself disabled when `href` is absent but `onClick` is present. This would fix it globally for all `Link` consumers.

We opted against this because:
- Changing `Link`'s core disabled logic could have unintended side effects across the design system
- A `<button>` is the semantically correct element for a click-only action — it's not a link without a destination, it's an action trigger
- Localizing the fix to `CardLink` has zero risk to other `Link` consumers

## Testing

- 3 new unit tests for `Card.test.tsx` (button rendering, click handler, link fallback)
- New stories: `WithClickableLink`, `WithHrefLink` in Card stories
- New story `WithOnClickOnlyLink` in Widget stories
- All 18 tests passing