### PR TITLE
feat: manage opening status from provider to avoid closing on re-renders

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -39,6 +39,7 @@ import { CollectionProps } from "../../../types"
 import { statusToChecked } from "../utils"
 import { Row } from "./components/Row"
 import { useColumns } from "./hooks/useColums"
+import { NestedDataProvider } from "./providers/NestedProvider"
 import { TableVisualizationOptions } from "./types"
 import { useSticky } from "./useSticky"
 export * from "./settings/SettingsRenderer"
@@ -261,274 +262,280 @@ export const TableCollection = <
     })
   }
 
+  const TableWrapper = tableWithChildren ? NestedDataProvider : Fragment
+
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
-      <OneTable loading={isLoading}>
-        <TableHeader sticky={true}>
-          <TableRow>
-            {source.selectable && (
-              <TableHead
-                width={checkColumnWidth}
-                sticky={{ left: 0 }}
-                align="right"
-              >
-                <div className="flex w-full items-center justify-end">
-                  <F0Checkbox
-                    checked={
-                      allSelectedStatus.selectedCount > 0 ||
-                      allSelectedStatus.checked
-                    }
-                    indeterminate={
-                      allSelectedStatus.indeterminate ||
-                      (allSelectedStatus.selectedCount > 0 &&
-                        !allSelectedStatus.checked)
-                    }
-                    onCheckedChange={handleSelectAll}
-                    title={t.actions.selectAll}
-                    hideLabel
-                    disabled={data?.records.length === 0}
-                  />
-                </div>
-              </TableHead>
-            )}
-            {columns.map(({ sorting, label, ...column }, index) => (
-              <TableHead
-                key={`table-head-${index}`}
-                sortState={getColumnSortState(
-                  sorting,
-                  source.sortings,
-                  currentSortings
-                )}
-                width={column.width}
-                align={column.align}
-                sticky={getStickyPosition(index)}
-                {...column}
-                // Needs to force hidden column includes hidden prop, that is the definition not the final state
-                hidden={false}
-                onSortClick={
-                  sorting
-                    ? () => {
-                        if (!sorting) return
-                        handleSortClick(sorting)
-                      }
-                    : undefined
-                }
-              >
-                {label}
-              </TableHead>
-            ))}
-
-            {source.itemActions && (
-              <>
-                <th></th>
-                <TableHead
-                  key="actions"
-                  width={68}
-                  hidden
-                  sticky={{
-                    right: 0,
-                  }}
-                  className="table-cell md:hidden"
-                >
-                  {t.collections.actions.actions}
-                </TableHead>
-              </>
-            )}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {data?.type === "grouped" &&
-            data.groups.map((group, groupIndex) => {
-              const itemCount = group.itemCount
-              return (
-                <Fragment key={`group-${group.key}`}>
-                  <TableRow key={`group-header-${group.key}`} sticky>
-                    <TableCell
-                      sticky={{ left: 0 }}
-                      colSpan={
-                        (frozenColumnsLeft || 1) + (source.selectable ? 1 : 0)
-                      }
-                    >
-                      <GroupHeader
-                        className="px-3"
-                        selectable={!!source.selectable}
-                        select={statusToChecked(
-                          groupAllSelectedStatus[group.key]
-                        )}
-                        onSelectChange={(checked) =>
-                          handleSelectGroupChange(group, checked)
-                        }
-                        showOpenChange={collapsible}
-                        label={group.label}
-                        itemCount={itemCount}
-                        open={openGroups[group.key]}
-                        onOpenChange={(open) => setGroupOpen(group.key, open)}
-                      />
-                    </TableCell>
-                    <TableCell
-                      colSpan={
-                        columns.length -
-                        (frozenColumnsLeft || 1) +
-                        (source.selectable ? 1 : 0)
-                      }
-                    >
-                      &nbsp;
-                    </TableCell>
-                  </TableRow>
-
-                  <AnimatePresence key={`group-animate-${groupIndex}`}>
-                    {MotionRow &&
-                      (!collapsible || openGroups[group.key]) &&
-                      group.records.map((item, index) => {
-                        return (
-                          <MotionRow
-                            variants={getAnimationVariants()}
-                            initial={collapsible ? "hidden" : "visible"}
-                            animate="visible"
-                            exit="hidden"
-                            custom={index}
-                            key={`row-${groupIndex}-${getRowKey(item, index)}`}
-                            layout
-                            source={source}
-                            item={item}
-                            index={index}
-                            groupIndex={groupIndex}
-                            onCheckedChange={(checked) =>
-                              handleSelectItemChange(item, checked)
-                            }
-                            selectedItems={selectedItems}
-                            columns={columns}
-                            frozenColumnsLeft={frozenColumnsLeft}
-                            checkColumnWidth={checkColumnWidth}
-                          />
-                        )
-                      })}
-                  </AnimatePresence>
-                </Fragment>
-              )
-            })}
-          {data?.type === "flat" &&
-            data.records.map((item, index) => {
-              return (
-                <Row
-                  key={`row-${getRowKey(item, index)}`}
-                  groupIndex={0}
-                  source={source}
-                  item={item}
-                  index={index}
-                  onCheckedChange={(checked) =>
-                    handleSelectItemChange(item, checked)
-                  }
-                  selectedItems={selectedItems}
-                  columns={columns}
-                  frozenColumnsLeft={frozenColumnsLeft}
-                  checkColumnWidth={checkColumnWidth}
-                  tableWithChildren={tableWithChildren}
-                />
-              )
-            })}
-          {paginationInfo?.type === "infinite-scroll" &&
-            isLoadingMore &&
-            Array.from({ length: 5 }).map((_, rowIndex) => (
-              <TableRow key={`skeleton-row-${rowIndex}`}>
-                {Array.from({ length: skeletonColumns }).map((_, colIndex) => (
-                  <TableCell key={`skeleton-cell-${rowIndex}-${colIndex}`}>
-                    <Skeleton className="h-4 w-full" />
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          {isInfiniteScrollPagination(paginationInfo) &&
-            paginationInfo.hasMore && (
-              <tr>
-                <td
-                  colSpan={columns.length + (source.selectable ? 1 : 0) + 1}
-                  ref={loadingIndicatorRef}
-                  className="h-10"
-                  aria-hidden="true"
-                ></td>
-              </tr>
-            )}
-        </TableBody>
-        {/* TODO: maybe as new component? */}
-        {summaryData && (
-          <TableFooter>
-            <TableRow
-              className={cn(
-                summaryData.sticky &&
-                  "sticky bottom-0 z-10 bg-f1-background shadow-[0_-1px_0_0_var(--f1-border-secondary)] hover:bg-f1-background",
-                "font-medium"
-              )}
-            >
+      <TableWrapper>
+        <OneTable loading={isLoading}>
+          <TableHeader sticky={true}>
+            <TableRow>
               {source.selectable && (
-                <TableCell width={checkColumnWidth} sticky={{ left: 0 }}>
-                  {summaryData.label && (
-                    <div className="font-medium text-f1-foreground-secondary">
-                      {summaryData.label}
-                    </div>
-                  )}
-                </TableCell>
-              )}
-              {columns.map((column, cellIndex) => (
-                <TableCell
-                  key={`summary-${String(column.label)}`}
-                  firstCell={cellIndex === 0}
-                  width={column.width}
-                  sticky={getStickyPosition(cellIndex)}
+                <TableHead
+                  width={checkColumnWidth}
+                  sticky={{ left: 0 }}
+                  align="right"
                 >
-                  {cellIndex === 0 &&
-                  !source.selectable &&
-                  summaryData.label ? (
-                    <div className="font-medium text-f1-foreground-secondary">
-                      {summaryData.label}
-                    </div>
-                  ) : (
-                    <div
-                      className={cn(
-                        column.align === "right" ? "justify-end" : "",
-                        "flex"
-                      )}
-                    >
-                      {column.summary &&
-                      source.summaries &&
-                      source.summaries[column.summary]?.type === "sum" ? (
-                        <div className="flex gap-1">
-                          <span className="text-f1-foreground-secondary">
-                            {t.collections.summaries.types.sum}
-                          </span>
-                          {`${summaryData.data[column.summary]}`}
-                        </div>
-                      ) : (
-                        "-"
-                      )}
-                    </div>
+                  <div className="flex w-full items-center justify-end">
+                    <F0Checkbox
+                      checked={
+                        allSelectedStatus.selectedCount > 0 ||
+                        allSelectedStatus.checked
+                      }
+                      indeterminate={
+                        allSelectedStatus.indeterminate ||
+                        (allSelectedStatus.selectedCount > 0 &&
+                          !allSelectedStatus.checked)
+                      }
+                      onCheckedChange={handleSelectAll}
+                      title={t.actions.selectAll}
+                      hideLabel
+                      disabled={data?.records.length === 0}
+                    />
+                  </div>
+                </TableHead>
+              )}
+              {columns.map(({ sorting, label, ...column }, index) => (
+                <TableHead
+                  key={`table-head-${index}`}
+                  sortState={getColumnSortState(
+                    sorting,
+                    source.sortings,
+                    currentSortings
                   )}
-                </TableCell>
+                  width={column.width}
+                  align={column.align}
+                  sticky={getStickyPosition(index)}
+                  {...column}
+                  // Needs to force hidden column includes hidden prop, that is the definition not the final state
+                  hidden={false}
+                  onSortClick={
+                    sorting
+                      ? () => {
+                          if (!sorting) return
+                          handleSortClick(sorting)
+                        }
+                      : undefined
+                  }
+                >
+                  {label}
+                </TableHead>
               ))}
+
               {source.itemActions && (
                 <>
-                  <th className="hidden md:table-cell"></th>
-                  <TableCell
-                    key="summary-actions"
+                  <th></th>
+                  <TableHead
+                    key="actions"
                     width={68}
+                    hidden
                     sticky={{
                       right: 0,
                     }}
                     className="table-cell md:hidden"
                   >
-                    {""}
-                  </TableCell>
+                    {t.collections.actions.actions}
+                  </TableHead>
                 </>
               )}
             </TableRow>
-          </TableFooter>
-        )}
-      </OneTable>
-      <PagesPagination
-        paginationInfo={paginationInfo}
-        setPage={setPage}
-        className="pb-4"
-      />
+          </TableHeader>
+          <TableBody>
+            {data?.type === "grouped" &&
+              data.groups.map((group, groupIndex) => {
+                const itemCount = group.itemCount
+                return (
+                  <Fragment key={`group-${group.key}`}>
+                    <TableRow key={`group-header-${group.key}`} sticky>
+                      <TableCell
+                        sticky={{ left: 0 }}
+                        colSpan={
+                          (frozenColumnsLeft || 1) + (source.selectable ? 1 : 0)
+                        }
+                      >
+                        <GroupHeader
+                          className="px-3"
+                          selectable={!!source.selectable}
+                          select={statusToChecked(
+                            groupAllSelectedStatus[group.key]
+                          )}
+                          onSelectChange={(checked) =>
+                            handleSelectGroupChange(group, checked)
+                          }
+                          showOpenChange={collapsible}
+                          label={group.label}
+                          itemCount={itemCount}
+                          open={openGroups[group.key]}
+                          onOpenChange={(open) => setGroupOpen(group.key, open)}
+                        />
+                      </TableCell>
+                      <TableCell
+                        colSpan={
+                          columns.length -
+                          (frozenColumnsLeft || 1) +
+                          (source.selectable ? 1 : 0)
+                        }
+                      >
+                        &nbsp;
+                      </TableCell>
+                    </TableRow>
+
+                    <AnimatePresence key={`group-animate-${groupIndex}`}>
+                      {MotionRow &&
+                        (!collapsible || openGroups[group.key]) &&
+                        group.records.map((item, index) => {
+                          return (
+                            <MotionRow
+                              variants={getAnimationVariants()}
+                              initial={collapsible ? "hidden" : "visible"}
+                              animate="visible"
+                              exit="hidden"
+                              custom={index}
+                              key={`row-${groupIndex}-${getRowKey(item, index)}`}
+                              layout
+                              source={source}
+                              item={item}
+                              index={index}
+                              groupIndex={groupIndex}
+                              onCheckedChange={(checked) =>
+                                handleSelectItemChange(item, checked)
+                              }
+                              selectedItems={selectedItems}
+                              columns={columns}
+                              frozenColumnsLeft={frozenColumnsLeft}
+                              checkColumnWidth={checkColumnWidth}
+                            />
+                          )
+                        })}
+                    </AnimatePresence>
+                  </Fragment>
+                )
+              })}
+            {data?.type === "flat" &&
+              data.records.map((item, index) => {
+                return (
+                  <Row
+                    key={`row-${getRowKey(item, index)}`}
+                    groupIndex={0}
+                    source={source}
+                    item={item}
+                    index={index}
+                    onCheckedChange={(checked) =>
+                      handleSelectItemChange(item, checked)
+                    }
+                    selectedItems={selectedItems}
+                    columns={columns}
+                    frozenColumnsLeft={frozenColumnsLeft}
+                    checkColumnWidth={checkColumnWidth}
+                    tableWithChildren={tableWithChildren}
+                  />
+                )
+              })}
+            {paginationInfo?.type === "infinite-scroll" &&
+              isLoadingMore &&
+              Array.from({ length: 5 }).map((_, rowIndex) => (
+                <TableRow key={`skeleton-row-${rowIndex}`}>
+                  {Array.from({ length: skeletonColumns }).map(
+                    (_, colIndex) => (
+                      <TableCell key={`skeleton-cell-${rowIndex}-${colIndex}`}>
+                        <Skeleton className="h-4 w-full" />
+                      </TableCell>
+                    )
+                  )}
+                </TableRow>
+              ))}
+            {isInfiniteScrollPagination(paginationInfo) &&
+              paginationInfo.hasMore && (
+                <tr>
+                  <td
+                    colSpan={columns.length + (source.selectable ? 1 : 0) + 1}
+                    ref={loadingIndicatorRef}
+                    className="h-10"
+                    aria-hidden="true"
+                  ></td>
+                </tr>
+              )}
+          </TableBody>
+          {/* TODO: maybe as new component? */}
+          {summaryData && (
+            <TableFooter>
+              <TableRow
+                className={cn(
+                  summaryData.sticky &&
+                    "sticky bottom-0 z-10 bg-f1-background shadow-[0_-1px_0_0_var(--f1-border-secondary)] hover:bg-f1-background",
+                  "font-medium"
+                )}
+              >
+                {source.selectable && (
+                  <TableCell width={checkColumnWidth} sticky={{ left: 0 }}>
+                    {summaryData.label && (
+                      <div className="font-medium text-f1-foreground-secondary">
+                        {summaryData.label}
+                      </div>
+                    )}
+                  </TableCell>
+                )}
+                {columns.map((column, cellIndex) => (
+                  <TableCell
+                    key={`summary-${String(column.label)}`}
+                    firstCell={cellIndex === 0}
+                    width={column.width}
+                    sticky={getStickyPosition(cellIndex)}
+                  >
+                    {cellIndex === 0 &&
+                    !source.selectable &&
+                    summaryData.label ? (
+                      <div className="font-medium text-f1-foreground-secondary">
+                        {summaryData.label}
+                      </div>
+                    ) : (
+                      <div
+                        className={cn(
+                          column.align === "right" ? "justify-end" : "",
+                          "flex"
+                        )}
+                      >
+                        {column.summary &&
+                        source.summaries &&
+                        source.summaries[column.summary]?.type === "sum" ? (
+                          <div className="flex gap-1">
+                            <span className="text-f1-foreground-secondary">
+                              {t.collections.summaries.types.sum}
+                            </span>
+                            {`${summaryData.data[column.summary]}`}
+                          </div>
+                        ) : (
+                          "-"
+                        )}
+                      </div>
+                    )}
+                  </TableCell>
+                ))}
+                {source.itemActions && (
+                  <>
+                    <th className="hidden md:table-cell"></th>
+                    <TableCell
+                      key="summary-actions"
+                      width={68}
+                      sticky={{
+                        right: 0,
+                      }}
+                      className="table-cell md:hidden"
+                    >
+                      {""}
+                    </TableCell>
+                  </>
+                )}
+              </TableRow>
+            </TableFooter>
+          )}
+        </OneTable>
+        <PagesPagination
+          paginationInfo={paginationInfo}
+          setPage={setPage}
+          className="pb-4"
+        />
+      </TableWrapper>
     </div>
   )
 }

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -16,7 +16,7 @@
  *
  */
 
-import { forwardRef, useCallback, useRef, useState } from "react"
+import { forwardRef, useCallback, useRef } from "react"
 
 import { FiltersDefinition } from "@/components/OneFilterPicker/types"
 import { DataCollectionSource } from "@/experimental/OneDataCollection/hooks/useDataCollectionSource/types"
@@ -31,7 +31,7 @@ import {
 
 import { useCalculateConectorHeight } from "../hooks/useCalculateConectorHeight"
 import { useLoadChildren } from "../hooks/useLoadChildren"
-import { NestedDataProvider } from "../providers/NestedProvider"
+import { useNestedDataContext } from "../providers/NestedProvider"
 import { TableColumnDefinition } from "../types"
 import { LoadMoreRow } from "./LoadMore"
 import { NestedRowProps, Row } from "./Row"
@@ -90,11 +90,12 @@ const NestedRowContent = <
     | React.RefObject<HTMLTableRowElement>
     | null
 ) => {
-  const [open, setOpen] = useState(false)
-
   const internalRowRef = useRef<HTMLTableRowElement | null>(null)
 
-  const rowId = `${props.nestedRowProps?.depth ?? 0}-${"id" in props.item ? props.item.id : props.index}`
+  const rowId = `${props.nestedRowProps?.depth ?? 0}-${"id" in props.item ? props.item.id + "-" + props.index : props.index}`
+
+  const { expandedRowIds, setRowExpanded } = useNestedDataContext()
+  const open = expandedRowIds[rowId] ?? false
 
   /**
    * useLoadChildren hook manages:
@@ -108,7 +109,7 @@ const NestedRowContent = <
       rowId: rowId,
       item: props.item,
       source: props.source,
-      onClearFetchedData: () => setOpen(false),
+      onClearFetchedData: () => setRowExpanded(rowId, false),
     })
 
   const shouldShowLoading = open && isLoading
@@ -145,7 +146,7 @@ const NestedRowContent = <
 
   const handleExpand = () => {
     const isExpanding = !open
-    setOpen(isExpanding)
+    setRowExpanded(rowId, isExpanding)
 
     if (isExpanding && !children.length) {
       loadChildren()
@@ -335,17 +336,9 @@ const NestedRowComponentInner = <
     | React.RefObject<HTMLTableRowElement>
     | null
 ) => {
-  // Only wrap with Provider at the root level (depth === 0 or undefined)
-  // This ensures we have a single shared context for the entire tree
-  if ((props.nestedRowProps?.depth ?? 0) === 0) {
-    return (
-      <NestedDataProvider>
-        <NestedRowContentWithRef {...props} ref={ref} />
-      </NestedDataProvider>
-    )
-  }
-
-  // Nested children render without additional provider wrapping
+  // Provider is mounted at Table level when tableWithChildren is true, so we
+  // never wrap here. This keeps expansion state and fetched data in a single
+  // context that survives parent re-renders (e.g. GraphQL refetch).
   return <NestedRowContentWithRef {...props} ref={ref} />
 }
 

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
@@ -13,6 +13,9 @@ interface NestedDataContextValue<R extends RecordType> {
   fetchedData: Record<string, ChildrenResponse<R>>
   updateFetchedData: (rowId: string, data: ChildrenResponse<R>) => void
   clearFetchedData: () => void
+  /** Persisted expansion state so rows stay open across parent re-renders (e.g. GraphQL refetch) */
+  expandedRowIds: Record<string, boolean>
+  setRowExpanded: (rowId: string, expanded: boolean) => void
 }
 
 const NestedDataContext = createContext<
@@ -42,6 +45,19 @@ export const NestedDataProvider = <R extends RecordType>({
     setFetchedData({})
   }, [])
 
+  const [expandedRowIds, setExpandedRowIdsState] = useState<
+    Record<string, boolean>
+  >({})
+
+  const setRowExpanded = useCallback((rowId: string, expanded: boolean) => {
+    setExpandedRowIdsState((prev) => {
+      if (expanded) return { ...prev, [rowId]: true }
+      const next = { ...prev }
+      delete next[rowId]
+      return next
+    })
+  }, [])
+
   return (
     <NestedDataContext.Provider
       value={
@@ -49,6 +65,8 @@ export const NestedDataProvider = <R extends RecordType>({
           fetchedData,
           updateFetchedData,
           clearFetchedData,
+          expandedRowIds,
+          setRowExpanded,
         } as NestedDataContextValue<RecordType>
       }
     >


### PR DESCRIPTION
Using nested tables, we discovered that, when we updated the parent resource (from apollo cache), the row re-rendered and closed automatically the results.

With this change, we want to manage the opening status from outside, and avoid to lose what we interacted with the table on re-renders