### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.371.0",
+  "packages/react": "1.371.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.371.1](https://github.com/factorialco/f0/compare/f0-react-v1.371.0...f0-react-v1.371.1) (2026-02-19)
+
+
+### Bug Fixes
+
+* add setFooter to AiChat ([#3481](https://github.com/factorialco/f0/issues/3481)) ([61895d0](https://github.com/factorialco/f0/commit/61895d0bff5d551658a658e96977e901a418d0d7))
+
 ## [1.371.0](https://github.com/factorialco/f0/compare/f0-react-v1.370.1...f0-react-v1.371.0) (2026-02-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.371.0",
+  "version": "1.371.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.371.1</summary>

## [1.371.1](https://github.com/factorialco/f0/compare/f0-react-v1.371.0...f0-react-v1.371.1) (2026-02-19)


### Bug Fixes

* add setFooter to AiChat ([#3481](https://github.com/factorialco/f0/issues/3481)) ([61895d0](https://github.com/factorialco/f0/commit/61895d0bff5d551658a658e96977e901a418d0d7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version/changelog updates with no functional code changes in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.371.0` to `1.371.1` (manifest + package version).
> 
> Updates the React package changelog to include the `1.371.1` release notes, highlighting the bug fix adding `setFooter` to `AiChat`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acf4db77fa6b4b96be1cef4cbf9d2ebef8141e7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->