### PR TITLE
feat(ai-chat): improve fullscreen UX and close animation

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -110,6 +110,20 @@ const config: StorybookConfig = {
     // Ensure base is set to '/' to prevent absolute path issues in CI
     // This ensures paths are relative and work correctly when served
     config.base = config.base || "/"
+
+    // Pre-bundle dependencies that Vite would otherwise discover lazily
+    // when navigating to certain stories. Late discovery triggers a
+    // re-optimisation that invalidates already-loaded modules and breaks
+    // the page with "Failed to fetch dynamically imported module" errors.
+    config.optimizeDeps = config.optimizeDeps || {}
+    config.optimizeDeps.include = [
+      ...(config.optimizeDeps.include || []),
+      "@storybook/addon-links/react",
+      "@copilotkit/react-core",
+      "@copilotkit/react-ui",
+      "@copilotkit/shared",
+    ]
+
     return config
   },
 }

--- a/packages/react/src/sds/ai/F0AiChat/components/MessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/MessagesContainer.tsx
@@ -163,15 +163,13 @@ const Messages = ({
                 "w-full max-w-[712px]"
               )}
             >
-              <AnimatePresence mode="popLayout">
-                {showWelcomeBlock && (
-                  <WelcomeScreen
-                    greeting={greeting}
-                    initialMessages={initialMessages}
-                    suggestions={welcomeScreenSuggestions}
-                  />
-                )}
-              </AnimatePresence>
+              {showWelcomeBlock && (
+                <WelcomeScreen
+                  greeting={greeting}
+                  initialMessages={initialMessages}
+                  suggestions={welcomeScreenSuggestions}
+                />
+              )}
               {turns.map((turnMessages, turnIndex) => (
                 <div
                   ref={turnIndex === turns.length - 1 ? lastTurnRef : undefined}

--- a/packages/react/src/sds/ai/F0AiChat/components/WelcomeScreen.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/WelcomeScreen.tsx
@@ -1,6 +1,6 @@
 import { useCopilotChatInternal } from "@copilotkit/react-core"
 import { Message, randomId } from "@copilotkit/shared"
-import { motion } from "motion/react"
+import { AnimatePresence, motion } from "motion/react"
 import { useMemo } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
@@ -38,89 +38,85 @@ export const WelcomeScreen = ({
   )
 
   return (
-    <motion.div
-      key="welcome"
-      className="flex w-full flex-1 flex-col justify-end gap-6 sm:gap-4"
-      initial={{ opacity: 1 }}
-      exit={{
-        opacity: 0,
-        scale: 0.98,
-        filter: "blur(4px)",
-        transition: { duration: 0.2, ease: "easeIn" },
-      }}
-    >
-      <div className="pl-3">
-        <motion.div
-          className="flex w-fit justify-center"
-          initial={{ opacity: 0, scale: 0.8, filter: "blur(6px)" }}
-          animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
-          transition={{
-            duration: 0.3,
-            ease: "easeOut",
-            delay: 0.4,
-          }}
-        >
-          <F0OneIcon spin size="lg" className="my-4" />
-        </motion.div>
-        {greeting && (
-          <motion.p
-            className="text-lg font-semibold leading-[24px] text-f1-foreground-secondary"
-            initial={{ opacity: 0, filter: "blur(2px)", y: -8 }}
-            animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
-            transition={{
-              duration: 0.2,
-              ease: "easeOut",
-              delay: 0.5,
-            }}
-          >
-            {greeting}
-          </motion.p>
-        )}
-        {initialMessages.map((message) => (
-          <motion.p
-            className="text-xl font-semibold leading-[24px] text-f1-foreground"
-            key={message.id}
-            initial={{ opacity: 0, filter: "blur(2px)", y: -8 }}
-            animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
-            transition={{
-              duration: 0.2,
-              ease: "easeOut",
-              delay: 0.7,
-            }}
-          >
-            {message.content}
-          </motion.p>
-        ))}
-      </div>
-      <div className="flex flex-col items-start gap-[6px]">
-        {pickedSuggestions.map((suggestion, index) => (
+    <AnimatePresence mode="popLayout">
+      <motion.div
+        key="welcome"
+        className="flex w-full flex-1 flex-col justify-end gap-6 sm:gap-4"
+        initial={{ opacity: 1 }}
+      >
+        <div className="pl-3">
           <motion.div
-            className="w-full"
-            key={index}
-            initial={{ opacity: 0, filter: "blur(2px)", y: -8 }}
-            animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
+            className="flex w-fit justify-center"
+            initial={{ opacity: 0, scale: 0.8, filter: "blur(6px)" }}
+            animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
             transition={{
-              duration: 0.1,
+              duration: 0.3,
               ease: "easeOut",
-              delay: 0.9 + index * 0.1,
+              delay: 0.4,
             }}
           >
-            <ButtonInternal
-              variant="ghost"
-              className="border border-solid border-f1-border-secondary shadow sm:border-none sm:shadow-none"
-              label={suggestion.message}
-              icon={suggestion.icon}
-              onClick={() =>
-                sendMessage({
-                  id: randomId(),
-                  role: "user",
-                  content: suggestion.prompt || suggestion.message,
-                })
-              }
-            />
+            <F0OneIcon spin size="lg" className="my-4" />
           </motion.div>
-        ))}
-      </div>
-    </motion.div>
+          {greeting && (
+            <motion.p
+              className="text-lg font-semibold leading-[24px] text-f1-foreground-secondary"
+              initial={{ opacity: 0, filter: "blur(2px)", y: -8 }}
+              animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
+              transition={{
+                duration: 0.2,
+                ease: "easeOut",
+                delay: 0.5,
+              }}
+            >
+              {greeting}
+            </motion.p>
+          )}
+          {initialMessages.map((message) => (
+            <motion.p
+              className="text-xl font-semibold leading-[24px] text-f1-foreground"
+              key={message.id}
+              initial={{ opacity: 0, filter: "blur(2px)", y: -8 }}
+              animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
+              transition={{
+                duration: 0.2,
+                ease: "easeOut",
+                delay: 0.7,
+              }}
+            >
+              {message.content}
+            </motion.p>
+          ))}
+        </div>
+        <div className="flex flex-col items-start gap-[6px]">
+          {pickedSuggestions.map((suggestion, index) => (
+            <motion.div
+              className="w-full"
+              key={index}
+              initial={{ opacity: 0, filter: "blur(2px)", y: -8 }}
+              animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
+              transition={{
+                duration: 0.1,
+                ease: "easeOut",
+                delay: 0.9 + index * 0.1,
+              }}
+            >
+              <ButtonInternal
+                variant="ghost"
+                className="border border-solid border-f1-border-secondary shadow sm:border-none sm:shadow-none"
+                label={suggestion.message}
+                icon={suggestion.icon}
+                onClick={() =>
+                  sendMessage({
+                    id: randomId(),
+                    role: "user",
+                    content: suggestion.prompt || suggestion.message,
+                  })
+                }
+              />
+            </motion.div>
+          ))}
+        </div>
+      </motion.div>
+    </AnimatePresence>
   )
 }


### PR DESCRIPTION
## Summary

- **Close button always visible in fullscreen**: The close (X) button is now rendered in fullscreen mode so users can always dismiss the chat, regardless of visualization mode. When closing from fullscreen, the chat transitions to sidepanel first with a short delay before closing for a fluid animation.
- **Block new conversation when visualization is locked**: The "Start new conversation" button is now hidden when `lockVisualizationMode` is `true`, consistent with how the expand/collapse toggle already behaves.
- **Smooth textarea repositioning**: The textarea and disclaimer use `motion layout="position"` so they glide smoothly into place when switching between the welcome screen (centered in fullscreen) and the messages view (pinned to bottom).
- **Remove WelcomeScreen exit animation**: The WelcomeScreen now disappears instantly when starting a chat, avoiding unnecessary visual effects. Smooth transitions are preserved only for mode switches (fullscreen ↔ sidepanel).
- **Storybook configuration**: Optimized Storybook setup.

https://github.com/user-attachments/assets/8e6e651b-627f-4f95-9e69-e1eb386659e7

## Test plan

- [ ] Open AI chat in sidepanel mode → verify close button works normally
- [ ] Switch to fullscreen mode → verify the close button is visible and closes the chat with a smooth animation
- [ ] Enable `lockVisualizationMode` → verify the expand/collapse toggle AND "Start new conversation" button are both hidden
- [ ] In fullscreen welcome screen, send a message → verify the welcome screen disappears instantly and the textarea repositions smoothly
- [ ] Switch between fullscreen and sidepanel → verify the textarea glides smoothly between positions