### PR TITLE
fix(ai-chat): fix preamble dedup and thinking group ordering

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/__tests__/MessagesContainer.test.ts
+++ b/packages/react/src/sds/ai/F0AiChat/__tests__/MessagesContainer.test.ts
@@ -80,14 +80,15 @@ describe("convertMessagesToTurn", () => {
       },
     ]
     const turns = convertMessagesToTurns(messages)
-    // user message + assistant message + group of thoughts
+    // user message + group of thoughts + assistant message
     expect(turns[0]).toHaveLength(3)
     expect(turns[1]).toHaveLength(1)
 
+    // Thinking group is hoisted above text messages
     expect(
       turns[0].map((m) => (Array.isArray(m) ? "array" : m.role))
-    ).toStrictEqual(["user", "assistant", "array"])
-    expect(turns[0][2]).toHaveLength(3)
+    ).toStrictEqual(["user", "array", "assistant"])
+    expect(turns[0][1]).toHaveLength(3)
 
     expect(
       turns[1].map((m) => (Array.isArray(m) ? "array" : m.role))
@@ -117,14 +118,15 @@ describe("convertMessagesToTurn", () => {
     ]
     const turns = convertMessagesToTurns(messages)
 
-    // All thinking messages merged into one group
+    // All thinking messages merged into one group, hoisted above text
     expect(turns[0]).toHaveLength(4)
     expect(turns[1]).toHaveLength(1)
 
+    // Thinking group hoisted to position 1 (right after user message)
     expect(
       turns[0].map((m) => (Array.isArray(m) ? "array" : m.role))
-    ).toStrictEqual(["user", "assistant", "array", "assistant"])
-    expect(turns[0][2]).toHaveLength(2)
+    ).toStrictEqual(["user", "array", "assistant", "assistant"])
+    expect(turns[0][1]).toHaveLength(2)
 
     expect(
       turns[1].map((m) => (Array.isArray(m) ? "array" : m.role))
@@ -191,6 +193,71 @@ describe("convertMessagesToTurn", () => {
     expect(thinkingGroup).toHaveLength(2)
     expect(thinkingGroup[0].content).toBe("same thought")
     expect(thinkingGroup[1].content).toBe("different thought")
+  })
+
+  it("groups thinking messages with empty content but different arguments (real CopilotKit shape)", () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        role: "user",
+        content: "Hello!",
+      },
+      createActionThinkingMessage("Pulling leave types…"),
+      createActionThinkingMessage("Fetching approved absences…"),
+      createActionThinkingMessage("Calculating absenteeism rate…"),
+    ]
+    const turns = convertMessagesToTurns(messages)
+    expect(turns[0]).toHaveLength(2)
+
+    const thinkingGroup = turns[0][1] as Message[]
+    expect(thinkingGroup).toHaveLength(3)
+  })
+
+  it("deduplicates action thinking messages with identical arguments", () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        role: "user",
+        content: "Hello!",
+      },
+      createActionThinkingMessage("same step"),
+      createActionThinkingMessage("same step"),
+      createActionThinkingMessage("different step"),
+    ]
+    const turns = convertMessagesToTurns(messages)
+
+    const thinkingGroup = turns[0][1] as Message[]
+    expect(thinkingGroup).toHaveLength(2)
+  })
+
+  it("hoists thinking group above text when thinking arrives after text in multi-run turns", () => {
+    // Simulates: Run1 produces text, Run2 produces thinking + text (same turn, no new user message)
+    const messages: Message[] = [
+      {
+        id: "1",
+        role: "user",
+        content: "Take a day off tomorrow",
+      },
+      {
+        id: "2",
+        role: "assistant",
+        content: "I've prepared a time-off request.",
+      },
+      createActionThinkingMessage("Processing cancellation…"),
+      {
+        id: "3",
+        role: "assistant",
+        content: "Your request was cancelled.",
+      },
+    ]
+    const turns = convertMessagesToTurns(messages)
+    expect(turns).toHaveLength(1)
+    expect(turns[0]).toHaveLength(4)
+
+    // Thinking group hoisted above text messages
+    expect(
+      turns[0].map((m) => (Array.isArray(m) ? "array" : m.role))
+    ).toStrictEqual(["user", "array", "assistant", "assistant"])
   })
 
   it("hoists agentState message above thinking tool calls if agentState comes between thinking calls", () => {
@@ -265,6 +332,26 @@ const createThinkingMessage = (content: string = randomUUID()): Message => ({
       function: {
         name: "orchestratorThinking",
         arguments: "",
+      },
+    },
+  ],
+})
+
+/**
+ * Realistic CopilotKit action-execution message shape:
+ * content is undefined, preamble text lives in toolCalls arguments.
+ */
+const createActionThinkingMessage = (preamble: string): Message => ({
+  id: randomUUID(),
+  role: "assistant",
+  content: undefined as unknown as string,
+  toolCalls: [
+    {
+      id: randomUUID(),
+      type: "function",
+      function: {
+        name: "orchestratorThinking",
+        arguments: JSON.stringify({ message: preamble }),
       },
     },
   ],

--- a/packages/react/src/sds/ai/F0AiChat/components/MessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/MessagesContainer.tsx
@@ -369,12 +369,18 @@ export function convertMessagesToTurns(messages: Message[]): Turn[] {
     if (isThinkingMessage(message)) {
       if (thinkingGroup) {
         const prev = thinkingGroup[thinkingGroup.length - 1]
-        if (prev.content !== message.content) {
+        if (getThinkingKey(prev) !== getThinkingKey(message)) {
           thinkingGroup.push(message)
         }
       } else {
         thinkingGroup = [message]
-        currentTurn.push(thinkingGroup)
+        // Always insert thinking group right after the user message (index 1)
+        // so it appears above any text messages from earlier runs in the same turn
+        if (currentTurn.length > 1) {
+          currentTurn.splice(1, 0, thinkingGroup)
+        } else {
+          currentTurn.push(thinkingGroup)
+        }
       }
       continue
     }
@@ -392,4 +398,21 @@ function isThinkingMessage(message: Message): boolean {
       (call) => call.function.name === "orchestratorThinking"
     ) === true
   )
+}
+
+/**
+ * Dedup key for thinking messages.
+ *
+ * CopilotKit action-execution messages have empty/undefined `content` — the
+ * actual preamble text lives in `toolCalls[0].function.arguments`.
+ * Fall back to `content` for backwards compatibility with any call-site that
+ * sets it directly, then to `id` as a last resort.
+ */
+function getThinkingKey(message: Message): string {
+  const tc = (
+    message as {
+      toolCalls?: { function: { name: string; arguments: string } }[]
+    }
+  ).toolCalls?.find((c) => c.function.name === "orchestratorThinking")
+  return tc?.function.arguments || message.content || message.id
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in `convertMessagesToTurns` that caused incorrect rendering of orchestrator thinking (Reasoning accordion) in the AI chat.

## Bug 1: Only the first preamble was shown

**Root cause**: Deduplication compared `content`, but CopilotKit action-execution messages have empty/undefined `content`. The actual preamble text lives in `toolCalls[0].function.arguments`. Since all messages had the same empty `content`, every preamble after the first was treated as a duplicate and dropped.

**Fix**: New `getThinkingKey()` function that extracts the dedup key from `toolCalls[0].function.arguments`, falling back to `content` then `id`.

## Bug 2: Reasoning accordion appeared after text in multi-run turns

**Root cause**: `thinkingGroup` was appended at its arrival position via `push()`. In multi-run turns (e.g. user requests day off → assistant prepares it → user cancels → assistant confirms), the thinking from the second run appeared *between* the two text responses instead of at the top of the turn.

**Fix**: Insert `thinkingGroup` at position 1 (right after the user message) via `splice(1, 0, n)` so it always appears above text messages.

## Before / After

**Before**: Reasoning accordion sandwiched between two text responses, only one preamble visible
**After**: Reasoning accordion at the top of the turn with all preambles grouped

## Tests

- 2 existing tests updated to match new ordering (`["user", "array", "assistant"]` instead of `["user", "assistant", "array"]`)
- 1 new test: "hoists thinking group above text when thinking arrives after text in multi-run turns"
- All 10 tests passing

## Related

- Backend PR: https://github.com/factorialco/factorial-agent/pull/642