### PR TITLE
fix: improve feedback when submitting forms

### DIFF
--- a/packages/react/src/components/F0Form/F0Form.tsx
+++ b/packages/react/src/components/F0Form/F0Form.tsx
@@ -1,24 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { flushSync } from "react-dom"
 import { DefaultValues, Path, useForm } from "react-hook-form"
 import { z } from "zod"
 
 import { F0Button } from "@/components/F0Button"
-import { F0Icon } from "@/components/F0Icon"
-import { F0ActionBar } from "@/experimental/F0ActionBar"
+import { ActionBarStatus } from "@/experimental/F0ActionBar"
 import { F0TableOfContent } from "@/experimental/Navigation/F0TableOfContent"
 import { TOCItem } from "@/experimental/Navigation/F0TableOfContent/types"
-import { AlertCircle, ChevronDown, ChevronUp, Delete, Save } from "@/icons/app"
+import { Delete, Save } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import { cn } from "@/lib/utils"
 import { Form as FormProvider } from "@/ui/form"
 
-import { RowRenderer } from "./components/RowRenderer"
-import { SectionRenderer } from "./components/SectionRenderer"
-import { SwitchGroupRenderer } from "./components/SwitchGroupRenderer"
-import { createConditionalResolver } from "./conditionalResolver"
-import { FORM_MAX_WIDTH, SECTION_MARGIN } from "./constants"
-import { F0FormContext, generateAnchorId } from "./context"
-import { FieldRenderer } from "./fields/FieldRenderer"
 import type { F0SwitchField } from "./fields/switch/types"
 import type {
   F0FormProps,
@@ -30,6 +23,15 @@ import type {
   SectionDefinition,
 } from "./types"
 import type { F0FormStateCallback } from "./useF0Form"
+
+import { FormActionBar } from "./components/ActionBar"
+import { RowRenderer } from "./components/RowRenderer"
+import { SectionRenderer } from "./components/SectionRenderer"
+import { SwitchGroupRenderer } from "./components/SwitchGroupRenderer"
+import { createConditionalResolver } from "./conditionalResolver"
+import { FORM_MAX_WIDTH, SECTION_MARGIN } from "./constants"
+import { F0FormContext, generateAnchorId } from "./context"
+import { FieldRenderer } from "./fields/FieldRenderer"
 import { useErrorNavigation } from "./useErrorNavigation"
 import { useSchemaDefinition } from "./useSchemaDefinition"
 import { createZodErrorMap } from "./zodErrorMap"
@@ -181,9 +183,12 @@ export function F0Form<TSchema extends F0FormSchema>(
   const discardIcon =
     discardConfig?.icon === null ? undefined : (discardConfig?.icon ?? Delete)
 
-  const actionBarLabel = isActionBar
+  const actionBarIdleLabel = isActionBar
     ? (submitConfig?.actionBarLabel ?? forms.actionBar.unsavedChanges)
     : forms.actionBar.unsavedChanges
+
+  const actionBarSavingLabel =
+    submitConfig?.savingMessage ?? forms.actionBar.saving
 
   const centerActionBarInFrameContent =
     isActionBar && !!submitConfig?.centerActionBarInFrameContent
@@ -252,6 +257,11 @@ export function F0Form<TSchema extends F0FormSchema>(
   const rootError = form.formState.errors.root
   const { isDirty, isSubmitting, errors } = form.formState
 
+  const [actionBarStatus, setActionBarStatus] =
+    useState<ActionBarStatus>("idle")
+  const [successMessage, setSuccessMessage] = useState<string | undefined>()
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   // Error navigation and auto-focus
   const {
     hasErrors,
@@ -264,11 +274,25 @@ export function F0Form<TSchema extends F0FormSchema>(
     errors,
   })
 
-  // Handle form submission
+  const resolvedActionBarLabel = (() => {
+    if (hasErrors) return undefined
+    if (actionBarStatus === "loading") return actionBarSavingLabel
+    if (actionBarStatus === "success")
+      return successMessage ?? forms.actionBar.saved
+    return actionBarIdleLabel
+  })()
+
+  // Handle form submission with status flow: idle -> loading -> success -> idle
   const handleSubmit = async (data: TValues) => {
-    // Convert null values back to undefined before passing to onSubmit.
-    // Clearable date fields store null internally to prevent react-hook-form
-    // from falling back to defaultValues, but consumers expect undefined.
+    if (successTimerRef.current) {
+      clearTimeout(successTimerRef.current)
+      successTimerRef.current = null
+    }
+
+    flushSync(() => {
+      setActionBarStatus("loading")
+    })
+
     const cleanedData = { ...data }
     for (const key of Object.keys(cleanedData)) {
       if ((cleanedData as Record<string, unknown>)[key] === null) {
@@ -280,25 +304,59 @@ export function F0Form<TSchema extends F0FormSchema>(
     if (result.success) {
       form.reset(data)
       resetErrorNavigation()
+      setSuccessMessage(result.message)
+      setActionBarStatus("success")
+
+      successTimerRef.current = setTimeout(() => {
+        setActionBarStatus("idle")
+        setSuccessMessage(undefined)
+        successTimerRef.current = null
+      }, 3000)
     } else {
-      // Set field-specific errors
+      setActionBarStatus("idle")
+
       if (result.errors) {
         Object.entries(result.errors).forEach(([field, message]) => {
           form.setError(field as Path<TValues>, { message })
         })
       }
 
-      // Set root error if provided
       if (result.rootMessage) {
         form.setError("root", { message: result.rootMessage })
       }
     }
   }
 
+  useEffect(() => {
+    return () => {
+      if (successTimerRef.current) {
+        clearTimeout(successTimerRef.current)
+      }
+    }
+  }, [])
+
+  // Reset action bar status when the form becomes dirty again after a successful save
+  useEffect(() => {
+    if (isDirty && actionBarStatus === "success") {
+      if (successTimerRef.current) {
+        clearTimeout(successTimerRef.current)
+        successTimerRef.current = null
+      }
+      setActionBarStatus("idle")
+      setSuccessMessage(undefined)
+    }
+  }, [isDirty, actionBarStatus])
+
   // Handle discard action
   const handleDiscard = () => {
     form.reset()
     resetErrorNavigation()
+    setActionBarStatus("idle")
+    setSuccessMessage(undefined)
+    if (successTimerRef.current) {
+      clearTimeout(successTimerRef.current)
+      successTimerRef.current = null
+    }
   }
 
   // Store state callback from useF0Form hook
@@ -430,7 +488,7 @@ export function F0Form<TSchema extends F0FormSchema>(
         {showSectionsSidepanel && tocItems.length > 0 ? (
           <div className="flex w-full gap-4">
             {/* Sections sidebar */}
-            <div className="shrink-0 sticky top-4 h-fit self-start pt-3">
+            <div className="sticky top-4 h-fit shrink-0 self-start pt-3">
               <F0TableOfContent
                 items={tocItems}
                 activeItem={activeSection}
@@ -448,72 +506,26 @@ export function F0Form<TSchema extends F0FormSchema>(
           formContent
         )}
 
-        {/* Action bar submit - rendered outside form to prevent accidental form submission */}
-        {isActionBar && (
-          <F0ActionBar
-            isOpen={isDirty}
-            variant="light"
-            centerInFrameContent={centerActionBarInFrameContent}
-            label={!hasErrors ? actionBarLabel : undefined}
-            leftContent={
-              hasErrors ? (
-                <div className="flex items-center gap-3">
-                  <div className="flex items-center gap-0.5">
-                    <F0Icon icon={AlertCircle} size="md" color="critical" />
-                    <span className="font-medium text-f1-foreground-critical">
-                      {errorCount === 1
-                        ? forms.actionBar.issues.one.replace(
-                            "{{count}}",
-                            String(errorCount)
-                          )
-                        : forms.actionBar.issues.other.replace(
-                            "{{count}}",
-                            String(errorCount)
-                          )}
-                    </span>
-                  </div>
-                  {errorCount > 1 && (
-                    <div className="flex items-center gap-2">
-                      <F0Button
-                        icon={ChevronUp}
-                        onClick={goToPreviousError}
-                        variant="outline"
-                        label="Go to previous error"
-                        hideLabel
-                      />
-                      <F0Button
-                        icon={ChevronDown}
-                        onClick={goToNextError}
-                        variant="outline"
-                        label="Go to next error"
-                        hideLabel
-                      />
-                    </div>
-                  )}
-                </div>
-              ) : undefined
-            }
-            primaryActions={[
-              {
-                label: submitLabel,
-                icon: submitIcon,
-                onClick: form.handleSubmit(handleSubmit),
-                disabled: hasErrors,
-              },
-            ]}
-            secondaryActions={
-              discardableChanges
-                ? [
-                    {
-                      label: discardLabel,
-                      icon: discardIcon,
-                      onClick: handleDiscard,
-                    },
-                  ]
-                : []
-            }
-          />
-        )}
+        <FormActionBar
+          isActionBar={isActionBar}
+          isDirty={isDirty}
+          actionBarStatus={actionBarStatus}
+          hasErrors={hasErrors}
+          errorCount={errorCount}
+          resolvedActionBarLabel={resolvedActionBarLabel}
+          centerActionBarInFrameContent={centerActionBarInFrameContent}
+          submitLabel={submitLabel}
+          submitIcon={submitIcon}
+          discardableChanges={discardableChanges}
+          discardLabel={discardLabel}
+          discardIcon={discardIcon}
+          issuesOneLabel={forms.actionBar.issues.one}
+          issuesOtherLabel={forms.actionBar.issues.other}
+          onSubmit={form.handleSubmit(handleSubmit)}
+          onDiscard={handleDiscard}
+          goToPreviousError={goToPreviousError}
+          goToNextError={goToNextError}
+        />
       </FormProvider>
     </F0FormContext.Provider>
   )

--- a/packages/react/src/components/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/components/F0Form/__stories__/F0Form.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+
 import { useState } from "react"
 import { z } from "zod"
 
@@ -59,8 +60,8 @@ export const Default: Story = {
         defaultValues={{ username: "", email: "", bio: "" }}
         onSubmit={async (data) => {
           await sleep(1000)
-          alert(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+          return { success: true, message: "Account created successfully" }
         }}
         submitConfig={{ label: "Create Account" }}
       />
@@ -117,7 +118,7 @@ export const WithRows: Story = {
         }}
         onSubmit={async (data) => {
           await sleep(1000)
-          alert(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
           return { success: true }
         }}
       />
@@ -193,8 +194,8 @@ export const WithSections: Story = {
         }}
         onSubmit={async (data) => {
           await sleep(1000)
-          alert(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+          return { success: true, message: "Profile saved" }
         }}
       />
     )
@@ -302,7 +303,9 @@ export const WithSectionsSidepanel: Story = {
         action: {
           label: "Privacy settings",
           icon: Settings,
-          onClick: () => alert("Opening privacy settings..."),
+          onClick: () => {
+            console.info("Opening privacy settings...")
+          },
         },
       },
       editors: {
@@ -332,7 +335,7 @@ export const WithSectionsSidepanel: Story = {
         }}
         onSubmit={async (data) => {
           await sleep(1000)
-          alert(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
           return { success: true }
         }}
         submitConfig={{ label: "Save Survey" }}
@@ -395,7 +398,7 @@ export const ConditionalRendering: Story = {
         }}
         onSubmit={async (data) => {
           await sleep(1000)
-          alert(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
           return { success: true }
         }}
       />
@@ -494,7 +497,7 @@ export const DynamicDisabled: Story = {
         }}
         onSubmit={async (data) => {
           await sleep(1000)
-          alert(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
           return { success: true }
         }}
       />
@@ -641,7 +644,7 @@ export const AllFieldTypes: Story = {
         }}
         onSubmit={async (data) => {
           await sleep(1000)
-          alert(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
           return { success: true }
         }}
       />
@@ -815,7 +818,7 @@ export const AllFieldTypesDisabled: Story = {
         }}
         onSubmit={async (data) => {
           await sleep(1000)
-          alert(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
           return { success: true }
         }}
       />
@@ -945,7 +948,7 @@ export const CustomField: Story = {
         }}
         onSubmit={async (data) => {
           await sleep(1000)
-          alert(`Task created: ${JSON.stringify(data, null, 2)}`)
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
           return { success: true }
         }}
         submitConfig={{ label: "Create Task", icon: null }}
@@ -996,7 +999,7 @@ export const ServerValidation: Story = {
             }
           }
 
-          alert(`Account created successfully!`)
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
           return { success: true }
         }}
       />
@@ -1113,7 +1116,7 @@ export const VisualDesignExample: Story = {
           }}
           onSubmit={async (data) => {
             await sleep(1000)
-            alert(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+            console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
             return { success: true }
           }}
           submitConfig={{ label: "Create Survey", icon: null }}
@@ -1166,8 +1169,8 @@ export const WithActionBar: Story = {
           }}
           onSubmit={async (data) => {
             await sleep(1000)
-            alert(`Settings saved: ${JSON.stringify(data, null, 2)}`)
-            return { success: true }
+            console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+            return { success: true, message: "Settings saved successfully" }
           }}
         />
         <p className="mt-4 text-sm text-f1-foreground-secondary">
@@ -1228,8 +1231,8 @@ export const WithActionBarAndDiscard: Story = {
           }}
           onSubmit={async (data) => {
             await sleep(1000)
-            alert(`Company updated: ${JSON.stringify(data, null, 2)}`)
-            return { success: true }
+            console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+            return { success: true, message: "Company details updated" }
           }}
         />
         <p className="mt-4 text-sm text-f1-foreground-secondary">
@@ -1478,7 +1481,7 @@ export const SelectWithDataSource: Story = {
           defaultValues={defaultValues}
           onSubmit={async (data) => {
             await sleep(1000)
-            alert(`Selected: ${JSON.stringify(data, null, 2)}`)
+            console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
             return { success: true }
           }}
         />
@@ -1565,7 +1568,7 @@ export const FormInDialog: Story = {
             submitConfig={{ type: "default", hideSubmitButton: true }}
             onSubmit={async (data) => {
               await sleep(1000)
-              alert(`Team member added: ${JSON.stringify(data, null, 2)}`)
+              console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
               setOpen(false)
               return { success: true }
             }}
@@ -1651,7 +1654,7 @@ export const DynamicDateConstraints: Story = {
         }}
         onSubmit={async (data) => {
           await sleep(1000)
-          alert(`Project created: ${JSON.stringify(data, null, 2)}`)
+          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
           return { success: true }
         }}
       />

--- a/packages/react/src/components/F0Form/__tests__/F0FormActionBarStatus.test.tsx
+++ b/packages/react/src/components/F0Form/__tests__/F0FormActionBarStatus.test.tsx
@@ -1,0 +1,489 @@
+import {
+  zeroRender as render,
+  screen,
+  waitFor,
+  act,
+} from "@/testing/test-utils"
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { z } from "zod"
+import userEvent from "@testing-library/user-event"
+
+import { F0Form } from "../F0Form"
+import { f0FormField } from "../f0Schema"
+
+const formSchema = z.object({
+  name: f0FormField(z.string().min(1), { label: "Name" }),
+})
+
+const actionBarConfig = {
+  type: "action-bar" as const,
+  discardable: true,
+}
+
+async function makeFormDirtyAndSubmit(
+  user: ReturnType<typeof userEvent.setup>
+) {
+  const input = screen.getByLabelText("Name")
+  await user.clear(input)
+  await user.type(input, "updated")
+
+  await waitFor(() => {
+    expect(
+      screen.getByText("You have changes pending to be saved")
+    ).toBeInTheDocument()
+  })
+
+  const submitButtons = screen.getAllByText("Submit")
+  await user.click(submitButtons[0])
+}
+
+describe("F0Form action bar status flow", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("shows idle label before submitting", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="status-idle-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={actionBarConfig}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("You have changes pending to be saved")
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("shows loading status while submitting", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    let resolveSubmit: (value: { success: true }) => void
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<{ success: true }>((resolve) => {
+          resolveSubmit = resolve
+        })
+    )
+
+    render(
+      <F0Form
+        name="status-loading-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={actionBarConfig}
+      />
+    )
+
+    await makeFormDirtyAndSubmit(user)
+
+    await waitFor(() => {
+      expect(screen.getByText("Saving...")).toBeInTheDocument()
+    })
+
+    const submitButtons = screen.getAllByRole("button", { name: /submit/i })
+    submitButtons.forEach((btn) => expect(btn).toBeDisabled())
+
+    await act(async () => {
+      resolveSubmit!({ success: true })
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("shows custom saving message from submitConfig", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    let resolveSubmit: (value: { success: true }) => void
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<{ success: true }>((resolve) => {
+          resolveSubmit = resolve
+        })
+    )
+
+    render(
+      <F0Form
+        name="status-custom-saving-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={{
+          ...actionBarConfig,
+          savingMessage: "Updating employee...",
+        }}
+      />
+    )
+
+    await makeFormDirtyAndSubmit(user)
+
+    await waitFor(() => {
+      expect(screen.getByText("Updating employee...")).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      resolveSubmit!({ success: true })
+    })
+  })
+
+  it("shows default success message after successful submit", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="status-success-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={actionBarConfig}
+      />
+    )
+
+    await makeFormDirtyAndSubmit(user)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("shows custom success message from onSubmit result", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi
+      .fn()
+      .mockResolvedValue({ success: true, message: "Employee updated!" })
+
+    render(
+      <F0Form
+        name="status-custom-message-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={actionBarConfig}
+      />
+    )
+
+    await makeFormDirtyAndSubmit(user)
+
+    await waitFor(() => {
+      expect(screen.getByText("Employee updated!")).toBeInTheDocument()
+    })
+  })
+
+  it("auto-hides success message after 3 seconds", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="status-auto-hide-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={actionBarConfig}
+      />
+    )
+
+    await makeFormDirtyAndSubmit(user)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Your changes have been saved")
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("keeps action bar open during success state even though form is not dirty", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="status-open-during-success-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={actionBarConfig}
+      />
+    )
+
+    await makeFormDirtyAndSubmit(user)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+
+    // The action bar should still be visible with the success message
+    // even though form.reset(data) was called and isDirty is false
+    const submitButtons = screen.getAllByRole("button", { name: /submit/i })
+    submitButtons.forEach((btn) => expect(btn).toBeDisabled())
+  })
+
+  it("returns to idle status on failed submission", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({
+      success: false,
+      errors: { name: "Name already taken" },
+    })
+
+    render(
+      <F0Form
+        name="status-failure-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={actionBarConfig}
+      />
+    )
+
+    await makeFormDirtyAndSubmit(user)
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("1 issue")).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByText("Your changes have been saved")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Saving...")).not.toBeInTheDocument()
+  })
+
+  it("does not show success message on failed submission", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({
+      success: false,
+      rootMessage: "Server error",
+    })
+
+    render(
+      <F0Form
+        name="status-no-success-on-failure-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={actionBarConfig}
+      />
+    )
+
+    await makeFormDirtyAndSubmit(user)
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled()
+    })
+
+    expect(
+      screen.queryByText("Your changes have been saved")
+    ).not.toBeInTheDocument()
+  })
+})
+
+describe("F0Form default submit type shows success action bar", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("shows loading action bar while submitting", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    let resolveSubmit: (value: { success: true }) => void
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<{ success: true }>((resolve) => {
+          resolveSubmit = resolve
+        })
+    )
+
+    render(
+      <F0Form
+        name="default-loading-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    const submitButton = screen.getByRole("button", { name: /submit/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText("Saving...")).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      resolveSubmit!({ success: true })
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("shows success action bar after successful submit", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="default-success-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    const submitButton = screen.getByRole("button", { name: /submit/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("shows custom success message for default submit type", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi
+      .fn()
+      .mockResolvedValue({ success: true, message: "Record created!" })
+
+    render(
+      <F0Form
+        name="default-custom-message-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    const submitButton = screen.getByRole("button", { name: /submit/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText("Record created!")).toBeInTheDocument()
+    })
+  })
+
+  it("auto-hides success action bar after 3 seconds", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="default-auto-hide-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    const submitButton = screen.getByRole("button", { name: /submit/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Your changes have been saved")
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("does not show success action bar on failed submission", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({
+      success: false,
+      rootMessage: "Server error",
+    })
+
+    render(
+      <F0Form
+        name="default-failure-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    const submitButton = screen.getByRole("button", { name: /submit/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled()
+    })
+
+    expect(
+      screen.queryByText("Your changes have been saved")
+    ).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/F0Form/components/ActionBar.test.tsx
+++ b/packages/react/src/components/F0Form/components/ActionBar.test.tsx
@@ -1,0 +1,284 @@
+import { zeroRender as render, screen } from "@/testing/test-utils"
+import { describe, expect, it, vi } from "vitest"
+
+import { FormActionBar } from "./ActionBar"
+
+const defaultProps = {
+  isActionBar: true,
+  isDirty: true,
+  actionBarStatus: "idle" as const,
+  hasErrors: false,
+  errorCount: 0,
+  resolvedActionBarLabel: "You have changes pending to be saved",
+  centerActionBarInFrameContent: false,
+  submitLabel: "Save",
+  submitIcon: undefined,
+  discardableChanges: false,
+  discardLabel: "Discard",
+  discardIcon: undefined,
+  issuesOneLabel: "{{count}} issue",
+  issuesOtherLabel: "{{count}} issues",
+  onSubmit: vi.fn(),
+  onDiscard: vi.fn(),
+  goToPreviousError: vi.fn(),
+  goToNextError: vi.fn(),
+}
+
+describe("FormActionBar", () => {
+  describe("action-bar mode", () => {
+    it("is open when form is dirty", () => {
+      render(<FormActionBar {...defaultProps} />)
+
+      expect(
+        screen.getByText("You have changes pending to be saved")
+      ).toBeInTheDocument()
+    })
+
+    it("is open during loading status even when not dirty", () => {
+      render(
+        <FormActionBar
+          {...defaultProps}
+          isDirty={false}
+          actionBarStatus="loading"
+          resolvedActionBarLabel="Saving..."
+        />
+      )
+
+      expect(screen.getByText("Saving...")).toBeInTheDocument()
+    })
+
+    it("is open during success status even when not dirty", () => {
+      render(
+        <FormActionBar
+          {...defaultProps}
+          isDirty={false}
+          actionBarStatus="success"
+          resolvedActionBarLabel="Your changes have been saved"
+        />
+      )
+
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+
+    it("is closed when idle and not dirty", () => {
+      render(
+        <FormActionBar
+          {...defaultProps}
+          isDirty={false}
+          actionBarStatus="idle"
+        />
+      )
+
+      expect(
+        screen.queryByText("You have changes pending to be saved")
+      ).not.toBeInTheDocument()
+    })
+
+    it("suppresses status when there are errors", () => {
+      const { container } = render(
+        <FormActionBar
+          {...defaultProps}
+          hasErrors={true}
+          errorCount={1}
+          actionBarStatus="loading"
+        />
+      )
+
+      expect(screen.getByText("1 issue")).toBeInTheDocument()
+      expect(
+        container.querySelector('[aria-busy="true"][aria-live="polite"]')
+      ).not.toBeInTheDocument()
+    })
+
+    it("shows singular issue label for 1 error", () => {
+      render(
+        <FormActionBar {...defaultProps} hasErrors={true} errorCount={1} />
+      )
+
+      expect(screen.getByText("1 issue")).toBeInTheDocument()
+    })
+
+    it("shows plural issues label for multiple errors", () => {
+      render(
+        <FormActionBar {...defaultProps} hasErrors={true} errorCount={3} />
+      )
+
+      expect(screen.getByText("3 issues")).toBeInTheDocument()
+    })
+
+    it("shows error navigation buttons for multiple errors", () => {
+      render(
+        <FormActionBar {...defaultProps} hasErrors={true} errorCount={3} />
+      )
+
+      expect(
+        screen.getByRole("button", { name: "Go to previous error" })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", { name: "Go to next error" })
+      ).toBeInTheDocument()
+    })
+
+    it("does not show error navigation for a single error", () => {
+      render(
+        <FormActionBar {...defaultProps} hasErrors={true} errorCount={1} />
+      )
+
+      expect(
+        screen.queryByRole("button", { name: "Go to previous error" })
+      ).not.toBeInTheDocument()
+    })
+
+    it("calls goToPreviousError when clicking navigation", async () => {
+      const goToPreviousError = vi.fn()
+      render(
+        <FormActionBar
+          {...defaultProps}
+          hasErrors={true}
+          errorCount={3}
+          goToPreviousError={goToPreviousError}
+        />
+      )
+
+      screen.getByRole("button", { name: "Go to previous error" }).click()
+      expect(goToPreviousError).toHaveBeenCalledOnce()
+    })
+
+    it("calls goToNextError when clicking navigation", async () => {
+      const goToNextError = vi.fn()
+      render(
+        <FormActionBar
+          {...defaultProps}
+          hasErrors={true}
+          errorCount={3}
+          goToNextError={goToNextError}
+        />
+      )
+
+      screen.getByRole("button", { name: "Go to next error" }).click()
+      expect(goToNextError).toHaveBeenCalledOnce()
+    })
+
+    it("disables submit button when there are errors", () => {
+      render(
+        <FormActionBar {...defaultProps} hasErrors={true} errorCount={1} />
+      )
+
+      const saveButtons = screen.getAllByRole("button", { name: /save/i })
+      saveButtons.forEach((btn) => expect(btn).toBeDisabled())
+    })
+
+    it("shows discard button when discardable", () => {
+      render(<FormActionBar {...defaultProps} discardableChanges={true} />)
+
+      expect(
+        screen.getAllByRole("button", { name: /discard/i }).length
+      ).toBeGreaterThan(0)
+    })
+
+    it("does not show discard button when not discardable", () => {
+      render(<FormActionBar {...defaultProps} discardableChanges={false} />)
+
+      expect(
+        screen.queryByRole("button", { name: /discard/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it("calls onDiscard when clicking discard", () => {
+      const onDiscard = vi.fn()
+      render(
+        <FormActionBar
+          {...defaultProps}
+          discardableChanges={true}
+          onDiscard={onDiscard}
+        />
+      )
+
+      const discardButtons = screen.getAllByRole("button", {
+        name: /discard/i,
+      })
+      discardButtons[0].click()
+      expect(onDiscard).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe("default submit mode", () => {
+    const defaultModeProps = {
+      ...defaultProps,
+      isActionBar: false,
+    }
+
+    it("is closed when idle", () => {
+      render(
+        <FormActionBar
+          {...defaultModeProps}
+          actionBarStatus="idle"
+          resolvedActionBarLabel="You have changes pending to be saved"
+        />
+      )
+
+      expect(
+        screen.queryByText("You have changes pending to be saved")
+      ).not.toBeInTheDocument()
+    })
+
+    it("is open during loading status", () => {
+      render(
+        <FormActionBar
+          {...defaultModeProps}
+          actionBarStatus="loading"
+          resolvedActionBarLabel="Saving..."
+        />
+      )
+
+      expect(screen.getByText("Saving...")).toBeInTheDocument()
+    })
+
+    it("is open during success status", () => {
+      render(
+        <FormActionBar
+          {...defaultModeProps}
+          actionBarStatus="success"
+          resolvedActionBarLabel="Your changes have been saved"
+        />
+      )
+
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+
+    it("does not render submit or discard buttons", () => {
+      render(
+        <FormActionBar
+          {...defaultModeProps}
+          actionBarStatus="loading"
+          resolvedActionBarLabel="Saving..."
+        />
+      )
+
+      expect(
+        screen.queryByRole("button", { name: /save/i })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: /discard/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it("does not render error content", () => {
+      render(
+        <FormActionBar
+          {...defaultModeProps}
+          hasErrors={true}
+          errorCount={2}
+          actionBarStatus="loading"
+          resolvedActionBarLabel="Saving..."
+        />
+      )
+
+      expect(screen.queryByText("2 issues")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react/src/components/F0Form/components/ActionBar.tsx
+++ b/packages/react/src/components/F0Form/components/ActionBar.tsx
@@ -1,0 +1,122 @@
+import { F0Button } from "@/components/F0Button"
+import { F0Icon, IconType } from "@/components/F0Icon"
+import { F0ActionBar, ActionBarStatus } from "@/experimental/F0ActionBar"
+import { AlertCircle, ChevronDown, ChevronUp } from "@/icons/app"
+
+interface FormActionBarProps {
+  isActionBar: boolean
+  isDirty: boolean
+  actionBarStatus: ActionBarStatus
+  hasErrors: boolean
+  errorCount: number
+  resolvedActionBarLabel: string | undefined
+  centerActionBarInFrameContent: boolean
+  submitLabel: string
+  submitIcon: IconType | undefined
+  discardableChanges: boolean | "" | undefined
+  discardLabel: string
+  discardIcon: IconType | undefined
+  issuesOneLabel: string
+  issuesOtherLabel: string
+  onSubmit: () => void
+  onDiscard: () => void
+  goToPreviousError: () => void
+  goToNextError: () => void
+}
+
+export function FormActionBar({
+  isActionBar,
+  isDirty,
+  actionBarStatus,
+  hasErrors,
+  errorCount,
+  resolvedActionBarLabel,
+  centerActionBarInFrameContent,
+  submitLabel,
+  submitIcon,
+  discardableChanges,
+  discardLabel,
+  discardIcon,
+  issuesOneLabel,
+  issuesOtherLabel,
+  onSubmit,
+  onDiscard,
+  goToPreviousError,
+  goToNextError,
+}: FormActionBarProps) {
+  if (isActionBar) {
+    return (
+      <F0ActionBar
+        isOpen={
+          isDirty ||
+          actionBarStatus === "loading" ||
+          actionBarStatus === "success"
+        }
+        variant="light"
+        status={hasErrors ? undefined : actionBarStatus}
+        centerInFrameContent={centerActionBarInFrameContent}
+        label={resolvedActionBarLabel}
+        leftContent={
+          hasErrors ? (
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-0.5">
+                <F0Icon icon={AlertCircle} size="md" color="critical" />
+                <span className="font-medium text-f1-foreground-critical">
+                  {errorCount === 1
+                    ? issuesOneLabel.replace("{{count}}", String(errorCount))
+                    : issuesOtherLabel.replace("{{count}}", String(errorCount))}
+                </span>
+              </div>
+              {errorCount > 1 && (
+                <div className="flex items-center gap-2">
+                  <F0Button
+                    icon={ChevronUp}
+                    onClick={goToPreviousError}
+                    variant="outline"
+                    label="Go to previous error"
+                    hideLabel
+                  />
+                  <F0Button
+                    icon={ChevronDown}
+                    onClick={goToNextError}
+                    variant="outline"
+                    label="Go to next error"
+                    hideLabel
+                  />
+                </div>
+              )}
+            </div>
+          ) : undefined
+        }
+        primaryActions={[
+          {
+            label: submitLabel,
+            icon: submitIcon,
+            onClick: onSubmit,
+            disabled: hasErrors,
+          },
+        ]}
+        secondaryActions={
+          discardableChanges
+            ? [
+                {
+                  label: discardLabel,
+                  icon: discardIcon,
+                  onClick: onDiscard,
+                },
+              ]
+            : []
+        }
+      />
+    )
+  }
+
+  return (
+    <F0ActionBar
+      isOpen={actionBarStatus === "loading" || actionBarStatus === "success"}
+      variant="light"
+      status={actionBarStatus}
+      label={resolvedActionBarLabel}
+    />
+  )
+}

--- a/packages/react/src/components/F0Form/types.ts
+++ b/packages/react/src/components/F0Form/types.ts
@@ -130,6 +130,8 @@ interface F0FormSubmitConfigBase {
    * - IconType: custom icon
    */
   icon?: IconType | null
+  /** Label shown in the action bar while submitting (defaults to i18n "forms.actionBar.saving") */
+  savingMessage?: string
 }
 
 /**
@@ -292,7 +294,11 @@ export interface F0FormProps<TSchema extends F0FormSchema> {
  * Result of form submission
  */
 export type F0FormSubmitResult =
-  | { success: true }
+  | {
+      success: true
+      /** Optional message shown in the action bar after successful submission */
+      message?: string
+    }
   | {
       success: false
       /** Root error message displayed at the top of the form */

--- a/packages/react/src/experimental/F0ActionBar/index.stories.tsx
+++ b/packages/react/src/experimental/F0ActionBar/index.stories.tsx
@@ -1,10 +1,12 @@
+import { useEffect, useState } from "react"
+
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { fn } from "storybook/test"
 
 import { Reset, Save } from "@/icons/app"
 
-import { F0ActionBar } from "."
+import { F0ActionBar, ActionBarStatus } from "."
 
 const meta: Meta<typeof F0ActionBar> = {
   title: "Experimental/F0ActionBar",
@@ -15,8 +17,6 @@ const meta: Meta<typeof F0ActionBar> = {
       story: { inline: false, height: "400px" },
     },
     a11y: {
-      // This rule is disabled as dark-themed buttons are not compliant, we have to fix this in Figma first
-      // Meanwhile, disabling this rule
       skipCi: true,
     },
   },
@@ -37,6 +37,11 @@ const meta: Meta<typeof F0ActionBar> = {
     label: {
       control: "text",
       description: "The label of the action bar",
+    },
+    status: {
+      control: "select",
+      options: ["idle", "loading", "success"],
+      description: "The current status of the action bar",
     },
   },
 }
@@ -63,4 +68,121 @@ export const Default: Story = {
     ],
     label: "Unsaved changes",
   },
+}
+
+export const Idle: Story = {
+  args: {
+    isOpen: true,
+    variant: "light",
+    status: "idle",
+    primaryActions: [
+      {
+        label: "Save",
+        onClick: fn(),
+        icon: Save,
+      },
+    ],
+    secondaryActions: [
+      {
+        label: "Discard",
+        onClick: fn(),
+      },
+    ],
+    label: "You have changes pending to be saved",
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    isOpen: true,
+    variant: "light",
+    status: "loading",
+    primaryActions: [
+      {
+        label: "Save",
+        icon: Save,
+      },
+    ],
+    secondaryActions: [
+      {
+        label: "Discard",
+      },
+    ],
+    label: "Saving...",
+  },
+}
+
+export const Success: Story = {
+  args: {
+    isOpen: true,
+    variant: "light",
+    status: "success",
+    primaryActions: [
+      {
+        label: "Save",
+        icon: Save,
+      },
+    ],
+    secondaryActions: [
+      {
+        label: "Discard",
+      },
+    ],
+    label: "Your changes have been saved",
+  },
+}
+
+const StatusFlowDemo = () => {
+  const [status, setStatus] = useState<ActionBarStatus>("idle")
+  const [label, setLabel] = useState("You have changes pending to be saved")
+
+  const handleSave = () => {
+    setStatus("loading")
+    setLabel("Saving...")
+    setTimeout(() => {
+      setStatus("success")
+      setLabel("Your changes have been saved")
+    }, 2000)
+  }
+
+  const handleDiscard = () => {
+    setStatus("idle")
+    setLabel("You have changes pending to be saved")
+  }
+
+  useEffect(() => {
+    if (status === "success") {
+      const timer = setTimeout(() => {
+        setStatus("idle")
+        setLabel("You have changes pending to be saved")
+      }, 3000)
+      return () => clearTimeout(timer)
+    }
+  }, [status])
+
+  return (
+    <F0ActionBar
+      isOpen
+      variant="light"
+      status={status}
+      label={label}
+      primaryActions={[
+        {
+          label: "Save",
+          icon: Save,
+          onClick: handleSave,
+        },
+      ]}
+      secondaryActions={[
+        {
+          label: "Discard",
+          onClick: handleDiscard,
+        },
+      ]}
+    />
+  )
+}
+
+export const StatusFlow: Story = {
+  render: () => <StatusFlowDemo />,
 }

--- a/packages/react/src/experimental/F0ActionBar/index.test.tsx
+++ b/packages/react/src/experimental/F0ActionBar/index.test.tsx
@@ -1,0 +1,124 @@
+import { zeroRender as render, screen } from "@/testing/test-utils"
+import { describe, expect, it, vi } from "vitest"
+
+import { F0ActionBar } from "."
+
+describe("F0ActionBar status prop", () => {
+  const defaultProps = {
+    isOpen: true,
+    variant: "light" as const,
+    primaryActions: [{ label: "Save", onClick: vi.fn() }],
+    secondaryActions: [{ label: "Discard", onClick: vi.fn() }],
+    label: "Unsaved changes",
+  }
+
+  describe("idle status", () => {
+    it("renders the label text", () => {
+      render(<F0ActionBar {...defaultProps} status="idle" />)
+
+      expect(screen.getByText("Unsaved changes")).toBeInTheDocument()
+    })
+
+    it("does not render a status icon", () => {
+      const { container } = render(
+        <F0ActionBar {...defaultProps} status="idle" />
+      )
+
+      expect(
+        container.querySelector('[aria-busy="true"][aria-live="polite"]')
+      ).not.toBeInTheDocument()
+    })
+
+    it("keeps buttons enabled", () => {
+      render(<F0ActionBar {...defaultProps} status="idle" />)
+
+      const saveButtons = screen.getAllByRole("button", { name: /save/i })
+      saveButtons.forEach((btn) => expect(btn).not.toBeDisabled())
+    })
+  })
+
+  describe("loading status", () => {
+    it("renders the label text", () => {
+      render(
+        <F0ActionBar {...defaultProps} status="loading" label="Saving..." />
+      )
+
+      expect(screen.getByText("Saving...")).toBeInTheDocument()
+    })
+
+    it("disables all primary action buttons", () => {
+      render(<F0ActionBar {...defaultProps} status="loading" />)
+
+      const saveButtons = screen.getAllByRole("button", { name: /save/i })
+      saveButtons.forEach((btn) => expect(btn).toBeDisabled())
+    })
+
+    it("disables secondary action buttons", () => {
+      render(<F0ActionBar {...defaultProps} status="loading" />)
+
+      const discardButtons = screen.getAllByRole("button", {
+        name: /discard/i,
+      })
+      discardButtons.forEach((btn) => expect(btn).toBeDisabled())
+    })
+
+    it("shows a spinner", () => {
+      const { container } = render(
+        <F0ActionBar {...defaultProps} status="loading" />
+      )
+
+      expect(
+        container.querySelector('[aria-busy="true"][aria-live="polite"]')
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe("success status", () => {
+    it("renders the label text", () => {
+      render(
+        <F0ActionBar
+          {...defaultProps}
+          status="success"
+          label="Your changes have been saved"
+        />
+      )
+
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+
+    it("disables all primary action buttons", () => {
+      render(<F0ActionBar {...defaultProps} status="success" />)
+
+      const saveButtons = screen.getAllByRole("button", { name: /save/i })
+      saveButtons.forEach((btn) => expect(btn).toBeDisabled())
+    })
+
+    it("disables secondary action buttons", () => {
+      render(<F0ActionBar {...defaultProps} status="success" />)
+
+      const discardButtons = screen.getAllByRole("button", {
+        name: /discard/i,
+      })
+      discardButtons.forEach((btn) => expect(btn).toBeDisabled())
+    })
+  })
+
+  describe("without status prop", () => {
+    it("defaults to idle and keeps buttons enabled", () => {
+      render(<F0ActionBar {...defaultProps} />)
+
+      const saveButtons = screen.getAllByRole("button", { name: /save/i })
+      saveButtons.forEach((btn) => expect(btn).not.toBeDisabled())
+    })
+  })
+
+  describe("when isOpen is false", () => {
+    it("does not render the action bar content", () => {
+      render(<F0ActionBar {...defaultProps} isOpen={false} />)
+
+      expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react/src/experimental/F0ActionBar/index.tsx
+++ b/packages/react/src/experimental/F0ActionBar/index.tsx
@@ -6,9 +6,12 @@ import {
   ButtonDropdownGroup,
   F0ButtonDropdown,
 } from "@/components/F0ButtonDropdown"
-import { IconType } from "@/components/F0Icon"
+import { F0Icon, IconType } from "@/components/F0Icon"
 import { Dropdown, MobileDropdown } from "@/experimental/Navigation/Dropdown"
+import CheckCircleAnimated from "@/icons/animated/CheckCircle"
+import { AlertCircleLine } from "@/icons/app"
 import { cn } from "@/lib/utils"
+import { Spinner } from "@/ui/Spinner"
 
 type ActionType = {
   label: string
@@ -56,6 +59,8 @@ const normalizeItems = (
   }
 }
 
+export type ActionBarStatus = "idle" | "loading" | "success"
+
 interface F0ActionBarProps {
   /**
    * Whether the action bar is open
@@ -96,6 +101,49 @@ interface F0ActionBarProps {
    * @default false
    */
   centerInFrameContent?: boolean
+
+  /**
+   * The current status of the action bar.
+   * - "idle": Default state, shows an alert icon (pending changes)
+   * - "loading": Shows a spinner and disables all actions
+   * - "success": Shows a checkmark icon and disables all actions
+   * @default "idle"
+   */
+  status?: ActionBarStatus
+}
+
+const StatusIcon = ({
+  status,
+  isLight,
+}: {
+  status: ActionBarStatus
+  isLight: boolean
+}) => {
+  if (status === "loading") {
+    return (
+      <Spinner
+        size="small"
+        className={cn(!isLight && "text-f1-foreground-inverse")}
+      />
+    )
+  }
+
+  if (status === "success") {
+    return (
+      <CheckCircleAnimated
+        animate="animate"
+        className="h-5 w-5 text-f1-icon-positive"
+      />
+    )
+  }
+
+  return (
+    <F0Icon
+      icon={AlertCircleLine}
+      size="md"
+      color={isLight ? "currentColor" : "inverse"}
+    />
+  )
 }
 
 export const F0ActionBar = ({
@@ -105,6 +153,7 @@ export const F0ActionBar = ({
   variant = "dark",
   leftContent,
   centerInFrameContent = false,
+  status = "idle",
   ...props
 }: F0ActionBarProps) => {
   const visibleSecondaryActions = secondaryActions.slice(0, 2)
@@ -114,6 +163,7 @@ export const F0ActionBar = ({
   }))
 
   const isLight = variant === "light"
+  const isInteractionDisabled = status === "loading" || status === "success"
 
   /**
    * Normalize the primary actions to be a list of groups
@@ -170,7 +220,7 @@ export const F0ActionBar = ({
           exit={{ opacity: 0, y: 32, filter: "blur(6px)" }}
           transition={{ ease: [0.175, 0.885, 0.32, 1.275], duration: 0.3 }}
           className={cn(
-            "fixed bottom-2 left-2 right-2 z-50 flex h-fit flex-col items-center gap-2 rounded-xl p-2 shadow-lg backdrop-blur-sm sm:bottom-5 sm:h-12 sm:w-max sm:flex-row sm:gap-4",
+            "fixed bottom-2 left-2 right-2 z-50 flex h-fit flex-col items-center gap-2 rounded-xl p-2 shadow-lg backdrop-blur-sm sm:bottom-5 sm:h-12 sm:w-max sm:flex-row sm:gap-4 sm:min-w-[475px] sm:justify-between",
             centerInFrameContent
               ? "sm:left-[240px] sm:right-2 sm:mx-auto"
               : "sm:left-2 sm:right-2 sm:mx-auto",
@@ -180,15 +230,24 @@ export const F0ActionBar = ({
           )}
         >
           {leftContent}
-          {!!label && (
-            <span
-              className={cn(
-                "font-medium ml-2",
-                isLight ? "text-f1-foreground" : "text-f1-foreground-inverse"
+          {(!!label || (status && status !== "idle")) && (
+            <div className="ml-2 flex items-center gap-2">
+              {status && status !== "idle" && (
+                <StatusIcon status={status} isLight={isLight} />
               )}
-            >
-              {label}
-            </span>
+              {!!label && (
+                <span
+                  className={cn(
+                    "font-medium",
+                    isLight
+                      ? "text-f1-foreground"
+                      : "text-f1-foreground-inverse"
+                  )}
+                >
+                  {label}
+                </span>
+              )}
+            </div>
           )}
           <div>
             <div
@@ -207,13 +266,17 @@ export const F0ActionBar = ({
                       ;(action as ActionType)?.onClick?.()
                     }}
                     size="lg"
+                    disabled={isInteractionDisabled}
                   />
                 ) : (
                   <F0Button
                     label={singlePrimaryAction.label}
                     icon={singlePrimaryAction.icon}
                     onClick={singlePrimaryAction.onClick}
-                    disabled={singlePrimaryAction.disabled}
+                    disabled={
+                      isInteractionDisabled || singlePrimaryAction.disabled
+                    }
+                    loading={status === "loading"}
                     size="lg"
                   />
                 )}
@@ -239,7 +302,7 @@ export const F0ActionBar = ({
                       label={action.label}
                       icon={action.icon}
                       onClick={action.onClick}
-                      disabled={action.disabled}
+                      disabled={isInteractionDisabled || action.disabled}
                     />
                   ))}
                 {!singlePrimaryAction ? (
@@ -250,6 +313,7 @@ export const F0ActionBar = ({
                         const action = getActionByValue(value)
                         ;(action as ActionType)?.onClick?.()
                       }}
+                      disabled={isInteractionDisabled}
                     />
                   </>
                 ) : (
@@ -257,7 +321,10 @@ export const F0ActionBar = ({
                     label={singlePrimaryAction.label}
                     icon={singlePrimaryAction.icon}
                     onClick={singlePrimaryAction.onClick}
-                    disabled={singlePrimaryAction.disabled}
+                    disabled={
+                      isInteractionDisabled || singlePrimaryAction.disabled
+                    }
+                    loading={status === "loading"}
                   />
                 )}
               </Fragment>

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -418,6 +418,8 @@ export const defaultTranslations = {
   forms: {
     actionBar: {
       unsavedChanges: "You have changes pending to be saved",
+      saving: "Saving...",
+      saved: "Your changes have been saved",
       discard: "Discard",
       issues: {
         one: "{{count}} issue",


### PR DESCRIPTION
## Description

Previously, we weren't showing any feedback to the user apart from the loading indicator in the submit button. We were handling a toast showing up in the frontend/monorepo code. Now, by default, we'll display an action bar with the message set by the dev returned on the onSubmit callback.


https://github.com/user-attachments/assets/a33d46fa-db92-4e01-9ea7-aca346ff76c1

<img width="705" height="345" alt="Screenshot 2026-02-23 at 09 58 56" src="https://github.com/user-attachments/assets/ab53d108-95fb-4402-a058-cce4ddceb200" />

[Figma link](https://www.figma.com/design/PbfFcQ5TK7zvPFWOoObQF0/Surveys---Q4?node-id=21050-17883&t=v17KlQalr23150oh-4)