### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.372.0",
+  "packages/react": "1.372.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.372.1](https://github.com/factorialco/f0/compare/f0-react-v1.372.0...f0-react-v1.372.1) (2026-02-23)
+
+
+### Bug Fixes
+
+* improve feedback when submitting forms ([#3495](https://github.com/factorialco/f0/issues/3495)) ([1278002](https://github.com/factorialco/f0/commit/127800256a90d278249e79a8b935bfb9669a7ab5))
+
 ## [1.372.0](https://github.com/factorialco/f0/compare/f0-react-v1.371.1...f0-react-v1.372.0) (2026-02-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.372.0",
+  "version": "1.372.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.372.1</summary>

## [1.372.1](https://github.com/factorialco/f0/compare/f0-react-v1.372.0...f0-react-v1.372.1) (2026-02-23)


### Bug Fixes

* improve feedback when submitting forms ([#3495](https://github.com/factorialco/f0/issues/3495)) ([1278002](https://github.com/factorialco/f0/commit/127800256a90d278249e79a8b935bfb9669a7ab5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only change (version/changelog/manifest) with no functional code modifications, so regression risk is minimal.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.372.0` to `1.372.1` and updates the release manifest.
> 
> Adds the `1.372.1` changelog entry documenting a bug fix to improve feedback when submitting forms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e2f2a06cdbbf03fe47d2bc2791425257d96236d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->