### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.373.1",
+  "packages/react": "1.373.2",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.373.2](https://github.com/factorialco/f0/compare/f0-react-v1.373.1...f0-react-v1.373.2) (2026-02-23)
+
+
+### Bug Fixes
+
+* **ai-chat:** fix preamble dedup and thinking group ordering ([#3494](https://github.com/factorialco/f0/issues/3494)) ([b81f80d](https://github.com/factorialco/f0/commit/b81f80da4bdcdc88b8b49705af7f99b1d7663a7f))
+
 ## [1.373.1](https://github.com/factorialco/f0/compare/f0-react-v1.373.0...f0-react-v1.373.1) (2026-02-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.373.1",
+  "version": "1.373.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.373.2</summary>

## [1.373.2](https://github.com/factorialco/f0/compare/f0-react-v1.373.1...f0-react-v1.373.2) (2026-02-23)


### Bug Fixes

* **ai-chat:** fix preamble dedup and thinking group ordering ([#3494](https://github.com/factorialco/f0/issues/3494)) ([b81f80d](https://github.com/factorialco/f0/commit/b81f80da4bdcdc88b8b49705af7f99b1d7663a7f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/version metadata only; no functional code changes beyond documenting an already-merged bug fix.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.373.1` to `1.373.2` and updates the release manifest/changelog accordingly.
> 
> Release notes indicate a single bug fix in **ai-chat**: fixes preamble deduplication and thinking-group ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07f81cb9259f24425d9a65e5cc2027f255493955. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->