### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.374.0",
+  "packages/react": "1.374.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.374.1](https://github.com/factorialco/f0/compare/f0-react-v1.374.0...f0-react-v1.374.1) (2026-02-23)
+
+
+### Bug Fixes
+
+* render CardLink as native button when no href is provided ([#3476](https://github.com/factorialco/f0/issues/3476)) ([69e634b](https://github.com/factorialco/f0/commit/69e634b735368eaede87fd441233727ea30c6708))
+
 ## [1.374.0](https://github.com/factorialco/f0/compare/f0-react-v1.373.2...f0-react-v1.374.0) (2026-02-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.374.0",
+  "version": "1.374.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.374.1</summary>

## [1.374.1](https://github.com/factorialco/f0/compare/f0-react-v1.374.0...f0-react-v1.374.1) (2026-02-23)


### Bug Fixes

* render CardLink as native button when no href is provided ([#3476](https://github.com/factorialco/f0/issues/3476)) ([69e634b](https://github.com/factorialco/f0/commit/69e634b735368eaede87fd441233727ea30c6708))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version/changelog updates with no functional code changes in this diff; low risk aside from publishing the new package version.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.374.0` to `1.374.1` and updates the release manifest.
> 
> Updates the React package changelog to include the `1.374.1` release notes (bug fix: render `CardLink` as a native button when no `href` is provided).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8e174d3e346fd98f40644ec803a2bcdfd668cdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->