### PR TITLE
fix: do not show pagination footer in data collection when it's only one page

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/components/PagesPagination/PagesPagination.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/PagesPagination/PagesPagination.tsx
@@ -1,7 +1,7 @@
-import { OnePagination } from "@/ui/OnePagination"
 import { isPageBasedPagination, PaginationInfo } from "@/hooks/datasource"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
+import { OnePagination } from "@/ui/OnePagination"
 
 export const PagesPagination = ({
   paginationInfo,
@@ -13,30 +13,28 @@ export const PagesPagination = ({
   className?: string
 }) => {
   const t = useI18n()
+
+  if (!isPageBasedPagination(paginationInfo) || paginationInfo.pagesCount <= 1)
+    return null
+
   return (
-    isPageBasedPagination(paginationInfo) && (
-      <div
-        className={cn(
-          "flex w-full items-center justify-between px-4",
-          className
-        )}
-      >
-        <span className="shrink-0 text-f1-foreground-secondary">
-          {paginationInfo.total > 0 &&
-            `${(paginationInfo.currentPage - 1) * paginationInfo.perPage + 1}-${Math.min(
-              paginationInfo.currentPage * paginationInfo.perPage,
-              paginationInfo.total
-            )} ${t.collections.visualizations.pagination.of} ${paginationInfo.total}`}
-        </span>
-        <div className="flex items-center">
-          <OnePagination
-            totalPages={paginationInfo.pagesCount}
-            currentPage={paginationInfo.currentPage}
-            onPageChange={setPage}
-            disabled={paginationInfo.pagesCount <= 1}
-          />
-        </div>
+    <div
+      className={cn("flex w-full items-center justify-between px-4", className)}
+    >
+      <span className="shrink-0 text-f1-foreground-secondary">
+        {paginationInfo.total > 0 &&
+          `${(paginationInfo.currentPage - 1) * paginationInfo.perPage + 1}-${Math.min(
+            paginationInfo.currentPage * paginationInfo.perPage,
+            paginationInfo.total
+          )} ${t.collections.visualizations.pagination.of} ${paginationInfo.total}`}
+      </span>
+      <div className="flex items-center">
+        <OnePagination
+          totalPages={paginationInfo.pagesCount}
+          currentPage={paginationInfo.currentPage}
+          onPageChange={setPage}
+        />
       </div>
-    )
+    </div>
   )
 }

--- a/packages/react/src/experimental/OneDataCollection/components/PagesPagination/__tests__/PagesPagination.test.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/PagesPagination/__tests__/PagesPagination.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { PaginationInfo } from "@/hooks/datasource"
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { PagesPagination } from "../PagesPagination"
+
+vi.mock("@/ui/OnePagination", () => ({
+  OnePagination: ({
+    totalPages,
+    currentPage,
+  }: {
+    totalPages: number
+    currentPage: number
+  }) => (
+    <nav data-testid="pagination" data-total-pages={totalPages}>
+      Page {currentPage} of {totalPages}
+    </nav>
+  ),
+}))
+
+const makePagesPaginationInfo = (
+  overrides: Partial<Omit<PaginationInfo, "type">> = {}
+): PaginationInfo => ({
+  type: "pages" as const,
+  total: 50,
+  perPage: 10,
+  currentPage: 1,
+  pagesCount: 5,
+  ...overrides,
+})
+
+describe("PagesPagination", () => {
+  const setPage = vi.fn()
+
+  it("renders pagination when there are multiple pages", () => {
+    render(
+      <PagesPagination
+        paginationInfo={makePagesPaginationInfo()}
+        setPage={setPage}
+      />
+    )
+
+    expect(screen.getByTestId("pagination")).toBeInTheDocument()
+    expect(screen.getByText(/1-10/)).toBeInTheDocument()
+    expect(screen.getByText(/50/)).toBeInTheDocument()
+  })
+
+  it("does not render when pagesCount is 1", () => {
+    const { container } = render(
+      <PagesPagination
+        paginationInfo={makePagesPaginationInfo({
+          total: 5,
+          perPage: 10,
+          pagesCount: 1,
+        })}
+        setPage={setPage}
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("does not render when paginationInfo is null", () => {
+    const { container } = render(
+      <PagesPagination paginationInfo={null} setPage={setPage} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("does not render when pagination type is infinite-scroll", () => {
+    const infiniteScrollInfo: PaginationInfo = {
+      type: "infinite-scroll",
+      total: 50,
+      perPage: 10,
+      cursor: null,
+      hasMore: true,
+    }
+
+    const { container } = render(
+      <PagesPagination paginationInfo={infiniteScrollInfo} setPage={setPage} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("shows correct range text for middle pages", () => {
+    render(
+      <PagesPagination
+        paginationInfo={makePagesPaginationInfo({ currentPage: 3 })}
+        setPage={setPage}
+      />
+    )
+
+    expect(screen.getByText(/21-30/)).toBeInTheDocument()
+  })
+
+  it("clamps the range end to total on the last page", () => {
+    render(
+      <PagesPagination
+        paginationInfo={makePagesPaginationInfo({
+          currentPage: 5,
+          total: 47,
+          pagesCount: 5,
+        })}
+        setPage={setPage}
+      />
+    )
+
+    expect(screen.getByText(/41-47/)).toBeInTheDocument()
+  })
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <PagesPagination
+        paginationInfo={makePagesPaginationInfo()}
+        setPage={setPage}
+        className="pb-4"
+      />
+    )
+
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).toContain("pb-4")
+  })
+})


### PR DESCRIPTION
## Description

When we only have a single page of items it's pointless to show the data collection footer. Besides that, I never see the pagination in the Figmas in those scenarios (e.g. https://www.figma.com/design/PbfFcQ5TK7zvPFWOoObQF0/Surveys---Q4?node-id=23413-99840&t=v17KlQalr23150oh-0)