### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.374.1",
+  "packages/react": "1.374.2",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.374.2](https://github.com/factorialco/f0/compare/f0-react-v1.374.1...f0-react-v1.374.2) (2026-02-23)
+
+
+### Bug Fixes
+
+* do not show pagination footer in data collection when it's only one page ([#3505](https://github.com/factorialco/f0/issues/3505)) ([df07496](https://github.com/factorialco/f0/commit/df07496367e8dff0a370c05091b365f7e535314c))
+
 ## [1.374.1](https://github.com/factorialco/f0/compare/f0-react-v1.374.0...f0-react-v1.374.1) (2026-02-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.374.1",
+  "version": "1.374.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.374.2</summary>

## [1.374.2](https://github.com/factorialco/f0/compare/f0-react-v1.374.1...f0-react-v1.374.2) (2026-02-23)


### Bug Fixes

* do not show pagination footer in data collection when it's only one page ([#3505](https://github.com/factorialco/f0/issues/3505)) ([df07496](https://github.com/factorialco/f0/commit/df07496367e8dff0a370c05091b365f7e535314c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no functional code modifications.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.374.1` to `1.374.2` and updates the release manifest accordingly.
> 
> Adds the `1.374.2` changelog entry noting a bug fix to hide the data collection pagination footer when there is only a single page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0142d3fa05bd24047d1917b660023dabed1131c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->