### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.374.2",
+  "packages/react": "1.375.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.375.0](https://github.com/factorialco/f0/compare/f0-react-v1.374.2...f0-react-v1.375.0) (2026-02-23)
+
+
+### Features
+
+* submit and validation per section in F0Form ([#3487](https://github.com/factorialco/f0/issues/3487)) ([b217695](https://github.com/factorialco/f0/commit/b217695a1666fd1d41d3bb316fc012c66f28cefe))
+
 ## [1.374.2](https://github.com/factorialco/f0/compare/f0-react-v1.374.1...f0-react-v1.374.2) (2026-02-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.374.2",
+  "version": "1.375.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.375.0</summary>

## [1.375.0](https://github.com/factorialco/f0/compare/f0-react-v1.374.2...f0-react-v1.375.0) (2026-02-23)


### Features

* submit and validation per section in F0Form ([#3487](https://github.com/factorialco/f0/issues/3487)) ([b217695](https://github.com/factorialco/f0/commit/b217695a1666fd1d41d3bb316fc012c66f28cefe))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only update (manifest, package version, changelog) with no functional code changes in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.374.2` to `1.375.0` by updating `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.375.0` release notes (feature: per-section submit/validation in `F0Form`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d1d39515722f40f2fe47fa42f113176149e1f9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->