### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.375.0",
+  "packages/react": "1.375.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.375.1](https://github.com/factorialco/f0/compare/f0-react-v1.375.0...f0-react-v1.375.1) (2026-02-24)
+
+
+### Bug Fixes
+
+* add cursor-pointer to dropdown ([#3421](https://github.com/factorialco/f0/issues/3421)) ([91c6695](https://github.com/factorialco/f0/commit/91c6695b965d7ec7204e294f7347e6d260880bbb))
+
 ## [1.375.0](https://github.com/factorialco/f0/compare/f0-react-v1.374.2...f0-react-v1.375.0) (2026-02-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.375.0",
+  "version": "1.375.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.375.1</summary>

## [1.375.1](https://github.com/factorialco/f0/compare/f0-react-v1.375.0...f0-react-v1.375.1) (2026-02-24)


### Bug Fixes

* add cursor-pointer to dropdown ([#3421](https://github.com/factorialco/f0/issues/3421)) ([91c6695](https://github.com/factorialco/f0/commit/91c6695b965d7ec7204e294f7347e6d260880bbb))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/changelog/version bumps only; no functional code changes are included in this diff.
> 
> **Overview**
> This PR is a Release Please–generated patch release for `@factorialco/f0-react`, bumping the version from `1.375.0` to `1.375.1`.
> 
> It updates `.release-please-manifest.json` and `packages/react/package.json`, and adds the `1.375.1` changelog entry noting a dropdown cursor-pointer bug fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f6415278323ab40f26b8211913cdfc48844cabf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->