### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.375.1",
+  "packages/react": "1.376.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.376.0](https://github.com/factorialco/f0/compare/f0-react-v1.375.1...f0-react-v1.376.0) (2026-02-24)
+
+
+### Features
+
+* improve post description rendering for updated editor ([#3478](https://github.com/factorialco/f0/issues/3478)) ([4dd04fe](https://github.com/factorialco/f0/commit/4dd04fed1ee456934b94acfad9a863f823fd6f8b))
+
 ## [1.375.1](https://github.com/factorialco/f0/compare/f0-react-v1.375.0...f0-react-v1.375.1) (2026-02-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.375.1",
+  "version": "1.376.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.376.0</summary>

## [1.376.0](https://github.com/factorialco/f0/compare/f0-react-v1.375.1...f0-react-v1.376.0) (2026-02-24)


### Features

* improve post description rendering for updated editor ([#3478](https://github.com/factorialco/f0/issues/3478)) ([4dd04fe](https://github.com/factorialco/f0/commit/4dd04fed1ee456934b94acfad9a863f823fd6f8b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no functional code modifications in this diff.
> 
> **Overview**
> Cuts a new `@factorialco/f0-react` release (**1.376.0**) by updating the release manifest and `packages/react/package.json` version.
> 
> Updates `packages/react/CHANGELOG.md` to document the release, noting a feature to improve post description rendering for the updated editor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dc026f2a70281304f54985d9360ee53acdb6a8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->