### PR TITLE
fix: properly consider available space for responsive in data collection with card visualization

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -67,13 +67,15 @@ const CardGrid = ({
   tmpFullWidth?: boolean
 }) => {
   return (
-    <div
-      className={cn(
-        "grid grid-cols-1 gap-4 px-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
-        tmpFullWidth && "px-0"
-      )}
-    >
-      {children}
+    <div className={cn("@container", tmpFullWidth ? "px-0" : "px-4")}>
+      <div
+        className={cn(
+          "grid grid-cols-1 gap-4",
+          "@sm:grid-cols-2 @5xl:grid-cols-3 @7xl:grid-cols-4"
+        )}
+      >
+        {children}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Description

It was happening to us while using the data collection with card visualization mode that the buttons were clearly overflowing easily, that was caused by the media queries not being used properly with container queries to only account for available space in the component rather than based on the viewport width.

<img width="948" height="400" alt="Screenshot 2026-02-24 at 12 09 21" src="https://github.com/user-attachments/assets/7cb322e1-1bf2-4ce0-8b71-8f0a1965b63c" />
