### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.376.0",
+  "packages/react": "1.376.1",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.376.1](https://github.com/factorialco/f0/compare/f0-react-v1.376.0...f0-react-v1.376.1) (2026-02-24)
+
+
+### Bug Fixes
+
+* properly consider available space for responsive in data collection with card visualization ([#3512](https://github.com/factorialco/f0/issues/3512)) ([d5bfeaa](https://github.com/factorialco/f0/commit/d5bfeaa6eff1b752de4bedf6d26b903d11687ee9))
+
 ## [1.376.0](https://github.com/factorialco/f0/compare/f0-react-v1.375.1...f0-react-v1.376.0) (2026-02-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.376.0",
+  "version": "1.376.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.376.1</summary>

## [1.376.1](https://github.com/factorialco/f0/compare/f0-react-v1.376.0...f0-react-v1.376.1) (2026-02-24)


### Bug Fixes

* properly consider available space for responsive in data collection with card visualization ([#3512](https://github.com/factorialco/f0/issues/3512)) ([d5bfeaa](https://github.com/factorialco/f0/commit/d5bfeaa6eff1b752de4bedf6d26b903d11687ee9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata-only change (version/changelog updates) with no functional code modifications in this PR.
> 
> **Overview**
> Cuts a new `@factorialco/f0-react` release (`1.376.1`) by updating `.release-please-manifest.json` and the package version in `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` to document the `1.376.1` bug fix release (responsive available-space handling in data collection card visualization).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c41dca6ae2b709bd50f24f3258372281d8414e97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->