### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.376.1",
+  "packages/react": "1.377.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.377.0](https://github.com/factorialco/f0/compare/f0-react-v1.376.1...f0-react-v1.377.0) (2026-02-24)
+
+
+### Features
+
+* adding custom tooltip to F0OneSwitch ([#3436](https://github.com/factorialco/f0/issues/3436)) ([acec605](https://github.com/factorialco/f0/commit/acec60548b9243d47d017a25028e63fc45657105))
+
 ## [1.376.1](https://github.com/factorialco/f0/compare/f0-react-v1.376.0...f0-react-v1.376.1) (2026-02-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.376.1",
+  "version": "1.377.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.377.0</summary>

## [1.377.0](https://github.com/factorialco/f0/compare/f0-react-v1.376.1...f0-react-v1.377.0) (2026-02-24)


### Features

* adding custom tooltip to F0OneSwitch ([#3436](https://github.com/factorialco/f0/issues/3436)) ([acec605](https://github.com/factorialco/f0/commit/acec60548b9243d47d017a25028e63fc45657105))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/changelog updates only; no functional code changes in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` to `1.377.0` by updating `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.377.0` release notes (custom tooltip support for `F0OneSwitch`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c7e42cf92715cca8be6c9566953f27df42cf39d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->