### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.377.0",
+  "packages/react": "1.378.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.378.0](https://github.com/factorialco/f0/compare/f0-react-v1.377.0...f0-react-v1.378.0) (2026-02-24)
+
+
+### Features
+
+* dataTestId ([#3339](https://github.com/factorialco/f0/issues/3339)) ([3813ba9](https://github.com/factorialco/f0/commit/3813ba9fd43435043e76dc13fa1d1ee3fc7ab462))
+
 ## [1.377.0](https://github.com/factorialco/f0/compare/f0-react-v1.376.1...f0-react-v1.377.0) (2026-02-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.377.0",
+  "version": "1.378.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.378.0</summary>

## [1.378.0](https://github.com/factorialco/f0/compare/f0-react-v1.377.0...f0-react-v1.378.0) (2026-02-24)


### Features

* dataTestId ([#3339](https://github.com/factorialco/f0/issues/3339)) ([3813ba9](https://github.com/factorialco/f0/commit/3813ba9fd43435043e76dc13fa1d1ee3fc7ab462))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version/changelog/manifest-only release metadata changes; no runtime code modifications in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from **1.377.0** to **1.378.0** (Release Please), updating the release manifest and package version.
> 
> Updates the React package changelog to include the `1.378.0` release entry noting the `dataTestId` feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48a603ce8b83615c77ab57b8cd1489717a7fc136. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->