### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.378.0",
+  "packages/react": "1.379.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.379.0](https://github.com/factorialco/f0/compare/f0-react-v1.378.0...f0-react-v1.379.0) (2026-02-24)
+
+
+### Features
+
+* add barSeries and hourDistribution value-display types ([#3327](https://github.com/factorialco/f0/issues/3327)) ([49be7a1](https://github.com/factorialco/f0/commit/49be7a1fba0318ccd01f6d3ed38069927429743a))
+
 ## [1.378.0](https://github.com/factorialco/f0/compare/f0-react-v1.377.0...f0-react-v1.378.0) (2026-02-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.378.0",
+  "version": "1.379.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.379.0</summary>

## [1.379.0](https://github.com/factorialco/f0/compare/f0-react-v1.378.0...f0-react-v1.379.0) (2026-02-24)


### Features

* add barSeries and hourDistribution value-display types ([#3327](https://github.com/factorialco/f0/issues/3327)) ([49be7a1](https://github.com/factorialco/f0/commit/49be7a1fba0318ccd01f6d3ed38069927429743a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no functional code modifications in this PR.
> 
> **Overview**
> Bumps the `@factorialco/f0-react` package release from `1.378.0` to `1.379.0` and updates the release manifest.
> 
> Updates `packages/react/CHANGELOG.md` to include the `1.379.0` entry noting the new `barSeries` and `hourDistribution` value-display types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11fef5842fa495c1c932b24a6b267a69bf4bcf89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->