### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.379.0",
+  "packages/react": "1.380.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.380.0](https://github.com/factorialco/f0/compare/f0-react-v1.379.0...f0-react-v1.380.0) (2026-02-25)
+
+
+### Features
+
+* filters per visualization ([#3455](https://github.com/factorialco/f0/issues/3455)) ([95405f9](https://github.com/factorialco/f0/commit/95405f955b76b0a24b64f05231821f065cfd23c7))
+
 ## [1.379.0](https://github.com/factorialco/f0/compare/f0-react-v1.378.0...f0-react-v1.379.0) (2026-02-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.379.0",
+  "version": "1.380.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.380.0</summary>

## [1.380.0](https://github.com/factorialco/f0/compare/f0-react-v1.379.0...f0-react-v1.380.0) (2026-02-25)


### Features

* filters per visualization ([#3455](https://github.com/factorialco/f0/issues/3455)) ([95405f9](https://github.com/factorialco/f0/commit/95405f955b76b0a24b64f05231821f065cfd23c7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/manifest/changelog) with no functional code modifications in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.379.0` to `1.380.0` and updates the Release Please manifest accordingly.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.380.0` release notes (feature: *filters per visualization*).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 379ff1f56c21a2e2fd927185e9b45ce3cc89c852. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->