### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.380.0",
+  "packages/react": "1.381.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.381.0](https://github.com/factorialco/f0/compare/f0-react-v1.380.0...f0-react-v1.381.0) (2026-02-25)
+
+
+### Features
+
+* **dataCollection:** selectable header ([#3518](https://github.com/factorialco/f0/issues/3518)) ([db9fd03](https://github.com/factorialco/f0/commit/db9fd034f6a528af634e08078f8deb37d4e55104))
+
 ## [1.380.0](https://github.com/factorialco/f0/compare/f0-react-v1.379.0...f0-react-v1.380.0) (2026-02-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.380.0",
+  "version": "1.381.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.381.0</summary>

## [1.381.0](https://github.com/factorialco/f0/compare/f0-react-v1.380.0...f0-react-v1.381.0) (2026-02-25)


### Features

* **dataCollection:** selectable header ([#3518](https://github.com/factorialco/f0/issues/3518)) ([db9fd03](https://github.com/factorialco/f0/commit/db9fd034f6a528af634e08078f8deb37d4e55104))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no runtime logic modifications.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.380.0` to `1.381.0` via Release Please, updating the release manifest and package version.
> 
> Adds the `1.381.0` changelog entry, which notes the `dataCollection` feature for a selectable header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ebca9c48182ffb6cef99e54f08e0901bee1ece3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->