### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.381.0",
+  "packages/react": "1.382.0",
   "packages/react-native": "0.24.1",
   "packages/core": "1.45.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.382.0](https://github.com/factorialco/f0/compare/f0-react-v1.381.0...f0-react-v1.382.0) (2026-02-25)
+
+
+### Features
+
+* add support for file field type in F0Form ([#3520](https://github.com/factorialco/f0/issues/3520)) ([082bb29](https://github.com/factorialco/f0/commit/082bb29491c25577f6f661543e37730b0bca177b))
+
 ## [1.381.0](https://github.com/factorialco/f0/compare/f0-react-v1.380.0...f0-react-v1.381.0) (2026-02-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.381.0",
+  "version": "1.382.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.382.0</summary>

## [1.382.0](https://github.com/factorialco/f0/compare/f0-react-v1.381.0...f0-react-v1.382.0) (2026-02-25)


### Features

* add support for file field type in F0Form ([#3520](https://github.com/factorialco/f0/issues/3520)) ([082bb29](https://github.com/factorialco/f0/commit/082bb29491c25577f6f661543e37730b0bca177b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version/changelog/manifest updates with no functional code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.381.0` to `1.382.0` and updates release metadata via Release Please.
> 
> Updates the React package changelog to include the `1.382.0` entry, noting the new feature: *support for a file field type in `F0Form`*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83910b545df43dceb2577192ff1b12d236a72280. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->