### PR TITLE
feat: new item to datalist

### DIFF
--- a/packages/react-native/playground/components/DataListShowcase/index.tsx
+++ b/packages/react-native/playground/components/DataListShowcase/index.tsx
@@ -205,7 +205,7 @@ export function DataListShowcase() {
                 value: "50",
               },
               {
-                type: "dateAlert",
+                type: "alertTag",
                 value: "Due on Feb 13",
                 level: "warning",
               },
@@ -251,7 +251,7 @@ export function DataListShowcase() {
                 value: "1 hour",
               },
               {
-                type: "dateAlert",
+                type: "alertTag",
                 value: "Overdue",
                 level: "critical",
               },

--- a/packages/react-native/playground/components/DetailsItemsListShowcase/index.tsx
+++ b/packages/react-native/playground/components/DetailsItemsListShowcase/index.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { ScrollView, Text, View } from "react-native"
-import { Clock } from "src/icons/app"
 import { useCSSVariable } from "uniwind"
 
 import { DetailsItemsList } from "../../../src/components/experimental/Lists/DetailsItemsList"

--- a/packages/react-native/src/components/experimental/Lists/DataList/index.tsx
+++ b/packages/react-native/src/components/experimental/Lists/DataList/index.tsx
@@ -1,14 +1,16 @@
 import React, { ReactElement } from "react"
-import { View, Text, Image } from "react-native"
+import { View, Text } from "react-native"
 import Svg, { Circle } from "react-native-svg"
+import { useCSSVariable } from "uniwind"
 
 import { cn } from "../../../../lib/utils"
 import { CompanyAvatar } from "../../../Avatars/CompanyAvatar"
 import { PersonAvatar } from "../../../Avatars/PersonAvatar"
 import { TeamAvatar } from "../../../Avatars/TeamAvatar"
-import { AlertTag, F0Text, Icon, PressableFeedback } from "../../../exports"
+import { AlertTag, F0Image, F0Text, PressableFeedback } from "../../../exports"
 import { F0Icon, type IconType } from "../../../primitives/F0Icon"
 import { DotTag, DotTagProps, NewColor } from "../../../Tags/DotTag"
+
 import { ItemContainer } from "./ItemContainer"
 
 export type DataListProps = {
@@ -170,9 +172,9 @@ const DotTagItem = ({ ...props }: DotTagItemProps) => {
 
 type CardMetadataProperty = {
   icon?: IconType
-  type: "text" | "progress" | "statusTag" | "alertTag" | "dateAlert"
+  type: "text" | "progress" | "statusTag" | "alertTag"
   value: string
-  status?: "completed" | "neutral"
+  status?: "warning" | "critical" | "completed" | "neutral"
   level?: "info" | "warning" | "critical"
 }
 
@@ -184,7 +186,15 @@ type CardItemProps = {
 }
 
 const CardItem = ({ action, name, thumbnailUrl, metadata }: CardItemProps) => {
-  const statusColor: Record<typeof status, NewColor> = {
+  const [trackColor, activeColor] = useCSSVariable([
+    "--color-f0-border",
+    "--color-f0-background-info-bold",
+  ])
+
+  const statusColor: Record<
+    "warning" | "critical" | "completed" | "neutral",
+    NewColor
+  > = {
     warning: "yellow",
     critical: "army",
     completed: "viridian",
@@ -195,7 +205,7 @@ const CardItem = ({ action, name, thumbnailUrl, metadata }: CardItemProps) => {
       case "text":
         return <F0Text variant="body-sm-default">{property.value}</F0Text>
       case "progress": {
-        //TODO: USe the F0ProgressCircle component once it's implemented instead of manually calculating the progress circle
+        //TODO: Use the F0ProgressCircle component once it's implemented instead of manually calculating the progress circle
         const size = 16
         const strokeWidth = 2.5
         const radius = (size - strokeWidth) / 2
@@ -210,7 +220,7 @@ const CardItem = ({ action, name, thumbnailUrl, metadata }: CardItemProps) => {
                 cx={size / 2}
                 cy={size / 2}
                 r={radius}
-                stroke="#e5e7eb"
+                stroke={String(trackColor)}
                 strokeWidth={strokeWidth}
                 fill="none"
               />
@@ -218,7 +228,7 @@ const CardItem = ({ action, name, thumbnailUrl, metadata }: CardItemProps) => {
                 cx={size / 2}
                 cy={size / 2}
                 r={radius}
-                stroke="#3b82f6"
+                stroke={String(activeColor)}
                 strokeWidth={strokeWidth}
                 fill="none"
                 strokeDasharray={`${circumference}`}
@@ -240,7 +250,6 @@ const CardItem = ({ action, name, thumbnailUrl, metadata }: CardItemProps) => {
           />
         )
       case "alertTag":
-      case "dateAlert":
         return (
           <AlertTag text={property.value} level={property.level ?? "info"} />
         )
@@ -254,16 +263,10 @@ const CardItem = ({ action, name, thumbnailUrl, metadata }: CardItemProps) => {
     <>
       {thumbnailUrl ? (
         <View className="h-32 w-full overflow-hidden rounded-lg">
-          <Image
-            style={{ width: "100%", height: "100%" }}
-            source={{
-              uri: thumbnailUrl,
-            }}
-            aria-label={name}
-          />
+          <F0Image source={thumbnailUrl} accessibilityLabel={name} />
         </View>
       ) : (
-        <View className="bg-f1-background-secondary aspect-square h-32 w-32 rounded-sm" />
+        <View className="aspect-square h-32 w-32 rounded-sm bg-f0-background-secondary" />
       )}
       <View className="flex w-full flex-1 flex-col gap-2">
         <F0Text variant="heading-sm">{name}</F0Text>
@@ -284,7 +287,7 @@ const CardItem = ({ action, name, thumbnailUrl, metadata }: CardItemProps) => {
   )
 
   return (
-    <View className="border-f0-border-secondary flex w-full items-start gap-3 rounded-lg border p-3">
+    <View className="flex w-full items-start gap-3 rounded-lg border border-f0-border-secondary p-3">
       {handlePress ? (
         <PressableFeedback onPress={handlePress} className="flex w-full gap-3">
           {cardContent}

--- a/packages/react-native/src/components/experimental/Lists/DetailsItem/index.tsx
+++ b/packages/react-native/src/components/experimental/Lists/DetailsItem/index.tsx
@@ -30,6 +30,7 @@ export interface DetailsItemType {
   spacingAtTheBottom?: boolean
   isHorizontalItem?: boolean
   tableView?: boolean
+  fullWidth?: boolean
 }
 
 const ItemContent: FC<{ content: Content }> = ({ content }) => (
@@ -48,10 +49,10 @@ export const DetailsItem = ({
   content,
   isHorizontalItem = false,
   tableView = false,
+  fullWidth = false,
   spacingAtTheBottom,
 }: DetailsItemType) => {
   const contentArray = Array.isArray(content) ? content : [content]
-  const hasCard = contentArray.some((c) => c.type === "card")
 
   return (
     <View
@@ -64,7 +65,7 @@ export const DetailsItem = ({
         label={title}
         isHorizontalItem={isHorizontalItem}
         tableView={tableView}
-        fullWidth={hasCard}
+        fullWidth={fullWidth}
       >
         {contentArray.map((c, i) => (
           <ItemContent key={i} content={c} />

--- a/packages/react-native/src/components/experimental/Lists/DetailsItemsList/index.tsx
+++ b/packages/react-native/src/components/experimental/Lists/DetailsItemsList/index.tsx
@@ -41,6 +41,7 @@ export const DetailsItemsList = function DetailsItemList({
               spacingAtTheBottom={item.spacingAtTheBottom}
               tableView={tableView}
               isHorizontalItem={isHorizontalItem}
+              fullWidth={item.fullWidth}
             />
             {tableView && index !== details.length - 1 && (
               <View className="h-[1px] w-full bg-f0-border-secondary" />


### PR DESCRIPTION
## Description

- Add a new `CardItem` variant to `DataList` for rendering rich card-style entries with thumbnail, metadata, and press actions
- Add `card` content type to `DetailsItem` for integration with `DetailsItemsList`
- Add `fullWidth` prop to `DataList` for cards that need full container width
- Add playground showcase for all `CardItem` variations

## Screenshots (if applicable)


https://github.com/user-attachments/assets/72270aca-d530-4d3f-b78f-e419717cbbe7


[Link to Figma Design](Figma URL here)

## Implementation details

### New `DataList.CardItem` component

A new `CardItem` variant has been added to the `DataList` component namespace. It renders a card with:

- **Thumbnail**: optional image with rounded corners, or a placeholder square when no URL is provided
- **Name**: title text displayed below the thumbnail
- **Metadata**: an array of metadata properties rendered as a flexible row of tags, icons, and inline widgets

Supported metadata types:

| Type        | Renders                                               |
| ----------- | ----------------------------------------------------- |
| `text`      | Plain text with optional icon                         |
| `progress`  | Circular SVG progress indicator with percentage label |
| `statusTag` | `DotTag` with semantic color mapping                  |
| `alertTag`  | `AlertTag` with level (info/warning/critical)         |

### Press action support

`CardItem` accepts an optional `action` prop of type `ActionType`. When a `generic` action is provided, the card content is wrapped in `PressableFeedback` to handle press interactions. Without an action (or with `noop`), content renders inside a plain `View`.

### `fullWidth` prop on DataList

A new `fullWidth` boolean prop was added to `DataList` to allow the container to expand to full width (`w-full`), which is needed for card layouts that should not be constrained to the default `max-w-72` sizing.

### DetailsItem integration

The `Content` type in `DetailsItem` was extended with a `"card"` type, enabling `CardItem` to be used within `DetailsItemsList`. When a card content type is detected, `fullWidth` is automatically set on the parent `DataList`.

