### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.382.0",
-  "packages/react-native": "0.24.1",
+  "packages/react-native": "0.25.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.25.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.24.1...f0-react-native-v0.25.0) (2026-02-26)
+
+
+### Features
+
+* **react-native:** add QuestionCircle icon ([7aa0cb8](https://github.com/factorialco/f0/commit/7aa0cb8f6ae3921c7abbd3d21c133770557880bc))
+
 ## [0.24.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.24.0...f0-react-native-v0.24.1) (2026-02-10)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.25.0</summary>

## [0.25.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.24.1...f0-react-native-v0.25.0) (2026-02-26)


### Features

* **react-native:** add QuestionCircle icon ([7aa0cb8](https://github.com/factorialco/f0/commit/7aa0cb8f6ae3921c7abbd3d21c133770557880bc))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a release bookkeeping change (version/manifest/changelog) with no functional code changes shown in the diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react-native` from `0.24.1` to `0.25.0` and updates the release manifest accordingly.
> 
> Updates the React Native package changelog to include the `0.25.0` release notes (adds the `QuestionCircle` icon).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9170537c3628afb60980d947a6f9f6b1b6d57915. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->