### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.383.0",
+  "packages/react": "1.383.1",
   "packages/react-native": "0.25.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.383.1](https://github.com/factorialco/f0/compare/f0-react-v1.383.0...f0-react-v1.383.1) (2026-02-27)
+
+
+### Bug Fixes
+
+* **data-testid:** preserve discriminated union props in WithDataTestIdPropsOf ([#3525](https://github.com/factorialco/f0/issues/3525)) ([5656938](https://github.com/factorialco/f0/commit/5656938da02d1867065b423f875f217f24ad7a28))
+
 ## [1.383.0](https://github.com/factorialco/f0/compare/f0-react-v1.382.0...f0-react-v1.383.0) (2026-02-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.383.0",
+  "version": "1.383.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.383.1</summary>

## [1.383.1](https://github.com/factorialco/f0/compare/f0-react-v1.383.0...f0-react-v1.383.1) (2026-02-27)


### Bug Fixes

* **data-testid:** preserve discriminated union props in WithDataTestIdPropsOf ([#3525](https://github.com/factorialco/f0/issues/3525)) ([5656938](https://github.com/factorialco/f0/commit/5656938da02d1867065b423f875f217f24ad7a28))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog updates with no functional code changes in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.383.0` to `1.383.1` in `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.383.1` release notes, documenting a bug fix to preserve discriminated union props in `WithDataTestIdPropsOf`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 302cf0636ccc9b397703a7b44bafdccd9ed986a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->