### PR TITLE
fix: update single-select questions in CoCreationForm radio appearance

### DIFF
--- a/packages/react/src/sds/CoCreationForm/SelectQuestion/SelectOption/index.tsx
+++ b/packages/react/src/sds/CoCreationForm/SelectQuestion/SelectOption/index.tsx
@@ -10,6 +10,29 @@ import { cn } from "@/lib/utils"
 import { useDragContext } from "../../DragContext"
 import { OnClickOptionActionParams, SelectOptionProps } from "./types"
 
+function RadioIndicator({
+  checked,
+  disabled,
+}: {
+  checked: boolean
+  disabled?: boolean
+}) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "flex h-5 w-5 shrink-0 items-center justify-center rounded-full transition-colors",
+        checked
+          ? "bg-f1-background-selected-bold"
+          : "border border-solid border-f1-border bg-f1-background",
+        disabled && "opacity-50"
+      )}
+    >
+      {checked && <div className="h-2 w-2 rounded-full bg-f1-background" />}
+    </div>
+  )
+}
+
 const TEXT_AREA_STYLE: object = {
   fieldSizing: "content",
 }
@@ -24,6 +47,7 @@ export const SelectOption = ({
   isEditMode,
   correct,
   locked,
+  type,
 }: SelectOptionProps) => {
   const { value, label } = option
 
@@ -93,14 +117,21 @@ export const SelectOption = ({
             isDragging && "cursor-grabbing [&_button]:cursor-grabbing"
           )}
         >
-          <F0Checkbox
-            title={label}
-            checked={!!(selected && !isEditMode)}
-            onCheckedChange={handleClick}
-            disabled={isEditMode}
-            presentational={isEditMode}
-            hideLabel
-          />
+          {type === "multi-select" ? (
+            <F0Checkbox
+              title={label}
+              checked={!!(selected && !isEditMode)}
+              onCheckedChange={handleClick}
+              disabled={isEditMode}
+              presentational={isEditMode}
+              hideLabel
+            />
+          ) : (
+            <RadioIndicator
+              checked={!!(selected && !isEditMode)}
+              disabled={isEditMode}
+            />
+          )}
         </div>
         <div
           className={cn(

--- a/packages/react/src/sds/CoCreationForm/SelectQuestion/SelectOption/types.ts
+++ b/packages/react/src/sds/CoCreationForm/SelectQuestion/SelectOption/types.ts
@@ -22,4 +22,5 @@ export type SelectOptionProps = {
   isEditMode?: boolean
   correct?: boolean
   locked?: boolean
+  type: "select" | "multi-select"
 }

--- a/packages/react/src/sds/CoCreationForm/SelectQuestion/index.tsx
+++ b/packages/react/src/sds/CoCreationForm/SelectQuestion/index.tsx
@@ -188,6 +188,7 @@ export const SelectQuestion = ({ options, ...props }: SelectQuestionProps) => {
                   onChangeLabel={handleChangeLabel}
                   isEditMode={isEditMode}
                   locked={questionLocked}
+                  type={props.type}
                 />
               </div>
             ))}


### PR DESCRIPTION
## Description

To allow our users to differentiate easily which of their questions are single-selection vs multi-selection, we are changing the appearance of single-selection ones to use a radio button instead of a checkbox.

<img width="768" height="595" alt="Screenshot 2026-02-27 at 10 40 08" src="https://github.com/user-attachments/assets/01fbdd95-852f-4bb8-856c-0acb0b2654ab" />
