### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.383.1",
+  "packages/react": "1.383.2",
   "packages/react-native": "0.25.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.383.2](https://github.com/factorialco/f0/compare/f0-react-v1.383.1...f0-react-v1.383.2) (2026-02-27)
+
+
+### Bug Fixes
+
+* update single-select questions in CoCreationForm radio appearance ([#3546](https://github.com/factorialco/f0/issues/3546)) ([79762f0](https://github.com/factorialco/f0/commit/79762f0970b3beaafc16cb395ec94c640d09c9b0))
+
 ## [1.383.1](https://github.com/factorialco/f0/compare/f0-react-v1.383.0...f0-react-v1.383.1) (2026-02-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.383.1",
+  "version": "1.383.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.383.2</summary>

## [1.383.2](https://github.com/factorialco/f0/compare/f0-react-v1.383.1...f0-react-v1.383.2) (2026-02-27)


### Bug Fixes

* update single-select questions in CoCreationForm radio appearance ([#3546](https://github.com/factorialco/f0/issues/3546)) ([79762f0](https://github.com/factorialco/f0/commit/79762f0970b3beaafc16cb395ec94c640d09c9b0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata update: only version/changelog/manifest bumps with no runtime code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.383.1` to `1.383.2` (updates `.release-please-manifest.json` and `packages/react/package.json`).
> 
> Updates `packages/react/CHANGELOG.md` to include the `1.383.2` release notes for a bug fix affecting single-select questions in `CoCreationForm` radio appearance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e7b400920331394e9cde8bb05198b6c79b383e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->