### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.383.2",
+  "packages/react": "1.384.0",
   "packages/react-native": "0.25.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.384.0](https://github.com/factorialco/f0/compare/f0-react-v1.383.2...f0-react-v1.384.0) (2026-02-27)
+
+
+### Features
+
+* add min width of 320px (w-80) to select content ([#3542](https://github.com/factorialco/f0/issues/3542)) ([8bc550f](https://github.com/factorialco/f0/commit/8bc550f1b9ad7ba237ed2aeeb24fa98adc1c084e))
+
 ## [1.383.2](https://github.com/factorialco/f0/compare/f0-react-v1.383.1...f0-react-v1.383.2) (2026-02-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.383.2",
+  "version": "1.384.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.384.0</summary>

## [1.384.0](https://github.com/factorialco/f0/compare/f0-react-v1.383.2...f0-react-v1.384.0) (2026-02-27)


### Features

* add min width of 320px (w-80) to select content ([#3542](https://github.com/factorialco/f0/issues/3542)) ([8bc550f](https://github.com/factorialco/f0/commit/8bc550f1b9ad7ba237ed2aeeb24fa98adc1c084e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a release-metadata bump (manifest/package version + changelog) with no functional code changes in this diff.
> 
> **Overview**
> Updates the `@factorialco/f0-react` release to `1.384.0` by bumping versions in `.release-please-manifest.json` and `packages/react/package.json`, and adding the `1.384.0` entry to `packages/react/CHANGELOG.md` (noting the select content min-width feature).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8b0176ac9ccc55be699cb6866d0ff2a5bed0f6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->