### PR TITLE
refactor: use f0FormDefinition in stories

### DIFF
--- a/packages/react/src/components/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/components/F0Form/__stories__/F0Form.stories.tsx
@@ -35,9 +35,10 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 /**
- * Basic form with simple text fields using the schema-based API.
+ * Basic form with simple text fields.
+ * All form configuration is bundled into a `formDefinition` via `useF0FormDefinition`.
  * Field metadata (label, placeholder) is embedded directly in the Zod schema.
- * Position is derived from declaration order - no need to specify it.
+ * Position is derived from declaration order.
  */
 export const Default: Story = {
   render() {
@@ -59,19 +60,19 @@ export const Default: Story = {
       }),
     })
 
-    return (
-      <F0Form
-        name="basic"
-        schema={formSchema}
-        defaultValues={{ username: "", email: "", bio: "" }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true, message: "Account created successfully" }
-        }}
-        submitConfig={{ label: "Create Account" }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "basic",
+      schema: formSchema,
+      defaultValues: { username: "", email: "", bio: "" },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true, message: "Account created successfully" }
+      },
+      submitConfig: { label: "Create Account" },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
@@ -111,24 +112,24 @@ export const WithRows: Story = {
       }),
     })
 
-    return (
-      <F0Form
-        name="with-rows"
-        schema={formSchema}
-        defaultValues={{
-          fullName: "",
-          email: "",
-          phone: "",
-          city: "",
-          country: "",
-        }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
-        }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "with-rows",
+      schema: formSchema,
+      defaultValues: {
+        fullName: "",
+        email: "",
+        phone: "",
+        city: "",
+        country: "",
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
@@ -185,26 +186,26 @@ export const WithSections: Story = {
       },
     }
 
-    return (
-      <F0Form
-        name="with-sections"
-        schema={formSchema}
-        sections={sections}
-        defaultValues={{
-          firstName: "",
-          lastName: "",
-          age: undefined,
-          birthdate: undefined,
-          newsletter: false,
-          darkMode: false,
-        }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true, message: "Profile saved" }
-        }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "with-sections",
+      schema: formSchema,
+      sections,
+      defaultValues: {
+        firstName: "",
+        lastName: "",
+        age: undefined,
+        birthdate: undefined,
+        newsletter: false,
+        darkMode: false,
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true, message: "Profile saved" }
+      },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
@@ -319,32 +320,34 @@ export const WithSectionsSidepanel: Story = {
       },
     }
 
+    const formDefinition = useF0FormDefinition({
+      name: "survey-settings",
+      schema: formSchema,
+      sections,
+      defaultValues: {
+        title: "Workplace climate survey",
+        description:
+          "This short workplace climate survey contains just 12 simple questions. It is designed to help measure employees' perceptions, experiences, and overall satisfaction within the workplace.",
+        participants: "",
+        publishOn: undefined,
+        endsAt: undefined,
+        recurrence: "none",
+        managerVisibility: false,
+        anonymousAnswers: false,
+        editors: "none",
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+      submitConfig: { label: "Save Survey" },
+    })
+
     return (
       <F0Form
-        name="survey-settings"
-        schema={formSchema}
-        sections={sections}
-        styling={{
-          showSectionsSidepanel: true,
-        }}
-        defaultValues={{
-          title: "Workplace climate survey",
-          description:
-            "This short workplace climate survey contains just 12 simple questions. It is designed to help measure employees' perceptions, experiences, and overall satisfaction within the workplace.",
-          participants: "",
-          publishOn: undefined,
-          endsAt: undefined,
-          recurrence: "none",
-          managerVisibility: false,
-          anonymousAnswers: false,
-          editors: "none",
-        }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
-        }}
-        submitConfig={{ label: "Save Survey" }}
+        formDefinition={formDefinition}
+        styling={{ showSectionsSidepanel: true }}
       />
     )
   },
@@ -391,24 +394,24 @@ export const ConditionalRendering: Story = {
       }),
     })
 
-    return (
-      <F0Form
-        name="conditional-rendering"
-        schema={formSchema}
-        defaultValues={{
-          hasAccount: false,
-          accountId: "",
-          newUsername: "",
-          employeeCount: 1,
-          enterprisePlan: false,
-        }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
-        }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "conditional-rendering",
+      schema: formSchema,
+      defaultValues: {
+        hasAccount: false,
+        accountId: "",
+        newUsername: "",
+        employeeCount: 1,
+        enterprisePlan: false,
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
@@ -487,32 +490,32 @@ export const DynamicDisabled: Story = {
       }),
     })
 
-    return (
-      <F0Form
-        name="dynamic-disabled"
-        schema={formSchema}
-        defaultValues={{
-          status: "draft",
-          title: "",
-          content: "",
-          enableNotifications: true,
-          notifyOnComments: false,
-          notifyOnEdits: false,
-          employeeCount: 1,
-          bulkAction: undefined,
-        }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
-        }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "dynamic-disabled",
+      schema: formSchema,
+      defaultValues: {
+        status: "draft",
+        title: "",
+        content: "",
+        enableNotifications: true,
+        notifyOnComments: false,
+        notifyOnEdits: false,
+        employeeCount: 1,
+        bulkAction: undefined,
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
 /**
- * Form demonstrating all available field types
+ * Form demonstrating all available field types.
  */
 export const AllFieldTypes: Story = {
   render() {
@@ -628,33 +631,33 @@ export const AllFieldTypes: Story = {
       ),
     })
 
-    return (
-      <F0Form
-        name="all-field-types"
-        schema={formSchema}
-        defaultValues={{
-          textField: "",
-          emailField: "",
-          passwordField: "",
-          numberField: 0,
-          textareaField: "",
-          selectField: "option1",
-          multiSelectField: [],
-          checkboxField: false,
-          switchField: false,
-          dateField: undefined,
-          timeField: undefined,
-          datetimeField: undefined,
-          dateRangeField: undefined,
-          richTextField: { value: null },
-        }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
-        }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "all-field-types",
+      schema: formSchema,
+      defaultValues: {
+        textField: "",
+        emailField: "",
+        passwordField: "",
+        numberField: 0,
+        textareaField: "",
+        selectField: "option1",
+        multiSelectField: [],
+        checkboxField: false,
+        switchField: false,
+        dateField: undefined,
+        timeField: undefined,
+        datetimeField: undefined,
+        dateRangeField: undefined,
+        richTextField: { value: null },
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
@@ -793,42 +796,42 @@ export const AllFieldTypesDisabled: Story = {
       ),
     })
 
-    return (
-      <F0Form
-        name="all-field-types-disabled"
-        schema={formSchema}
-        defaultValues={{
-          textField: "Sample text value",
-          emailField: "user@example.com",
-          passwordField: "secretpassword",
-          numberField: 42,
-          textareaField:
-            "This is a longer piece of text that demonstrates the textarea field in its disabled state.",
-          selectField: "option2",
-          multiSelectField: ["a", "b"],
-          urlField: "https://example.com",
-          checkboxField: true,
-          requiredCheckboxField: true,
-          switchField: true,
-          requiredSwitchField: true,
-          dateField: new Date("2024-06-15"),
-          timeField: new Date("2024-06-15T14:30:00"),
-          datetimeField: new Date("2024-06-15T14:30:00"),
-          dateRangeField: {
-            from: new Date("2024-01-01"),
-            to: new Date("2024-12-31"),
-          },
-          richTextField: {
-            value: "<p>This is <strong>rich text</strong> content.</p>",
-          },
-        }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
-        }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "all-field-types-disabled",
+      schema: formSchema,
+      defaultValues: {
+        textField: "Sample text value",
+        emailField: "user@example.com",
+        passwordField: "secretpassword",
+        numberField: 42,
+        textareaField:
+          "This is a longer piece of text that demonstrates the textarea field in its disabled state.",
+        selectField: "option2",
+        multiSelectField: ["a", "b"],
+        urlField: "https://example.com",
+        checkboxField: true,
+        requiredCheckboxField: true,
+        switchField: true,
+        requiredSwitchField: true,
+        dateField: new Date("2024-06-15"),
+        timeField: new Date("2024-06-15T14:30:00"),
+        datetimeField: new Date("2024-06-15T14:30:00"),
+        dateRangeField: {
+          from: new Date("2024-01-01"),
+          to: new Date("2024-12-31"),
+        },
+        richTextField: {
+          value: "<p>This is <strong>rich text</strong> content.</p>",
+        },
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
@@ -901,24 +904,24 @@ export const FileFields: Story = {
       }),
     })
 
-    return (
-      <F0Form
-        name="file-fields"
-        schema={formSchema}
-        defaultValues={{
-          title: "",
-          singleFile: "",
-          attachments: [],
-          notes: "",
-        }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true, message: "Document saved" }
-        }}
-        submitConfig={{ label: "Save Document" }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "file-fields",
+      schema: formSchema,
+      defaultValues: {
+        title: "",
+        singleFile: "",
+        attachments: [],
+        notes: "",
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true, message: "Document saved" }
+      },
+      submitConfig: { label: "Save Document" },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
@@ -949,14 +952,24 @@ export const FileFieldsWithInitialFiles: Story = {
       ),
     })
 
+    const formDefinition = useF0FormDefinition({
+      name: "file-initial",
+      schema: formSchema,
+      defaultValues: {
+        document: "signed_contract_2024.pdf",
+        attachments: ["signed_invoice.pdf", "signed_receipt.png"],
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true, message: "Document updated" }
+      },
+      submitConfig: { label: "Update Document" },
+    })
+
     return (
       <F0Form
-        name="file-initial"
-        schema={formSchema}
-        defaultValues={{
-          document: "signed_contract_2024.pdf",
-          attachments: ["signed_invoice.pdf", "signed_receipt.png"],
-        }}
+        formDefinition={formDefinition}
         initialFiles={[
           {
             value: "signed_contract_2024.pdf",
@@ -977,12 +990,6 @@ export const FileFieldsWithInitialFiles: Story = {
             size: 850_000,
           },
         ]}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true, message: "Document updated" }
-        }}
-        submitConfig={{ label: "Update Document" }}
       />
     )
   },
@@ -1098,29 +1105,29 @@ export const CustomField: Story = {
       }),
     })
 
-    return (
-      <F0Form
-        name="custom-field-example"
-        schema={formSchema}
-        defaultValues={{
-          title: "",
-          assignee: "",
-          reviewer: "",
-          description: "",
-        }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
-        }}
-        submitConfig={{ label: "Create Task", icon: null }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "custom-field-example",
+      schema: formSchema,
+      defaultValues: {
+        title: "",
+        assignee: "",
+        reviewer: "",
+        description: "",
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+      submitConfig: { label: "Create Task", icon: null },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
 /**
- * Form with server-side validation errors
+ * Form with server-side validation errors.
  */
 export const ServerValidation: Story = {
   render() {
@@ -1135,37 +1142,37 @@ export const ServerValidation: Story = {
       }),
     })
 
-    return (
-      <F0Form
-        name="server-validation"
-        schema={formSchema}
-        defaultValues={{ username: "", email: "" }}
-        onSubmit={async (data) => {
-          await sleep(1000)
+    const formDefinition = useF0FormDefinition({
+      name: "server-validation",
+      schema: formSchema,
+      defaultValues: { username: "", email: "" },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
 
-          const errors: Record<string, string> = {}
+        const errors: Record<string, string> = {}
 
-          if (data.username === "admin") {
-            errors.username = "This username is reserved"
+        if (data.username === "admin") {
+          errors.username = "This username is reserved"
+        }
+
+        if (data.email === "taken@example.com") {
+          errors.email = "This email is already registered"
+        }
+
+        if (Object.keys(errors).length > 0) {
+          return {
+            success: false,
+            rootMessage: "Please fix the errors below",
+            errors,
           }
+        }
 
-          if (data.email === "taken@example.com") {
-            errors.email = "This email is already registered"
-          }
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+    })
 
-          if (Object.keys(errors).length > 0) {
-            return {
-              success: false,
-              rootMessage: "Please fix the errors below",
-              errors,
-            }
-          }
-
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
-        }}
-      />
-    )
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
@@ -1258,31 +1265,33 @@ export const VisualDesignExample: Story = {
       editors: { title: "Editors" },
     }
 
+    const formDefinition = useF0FormDefinition({
+      name: "visual-design-example",
+      schema: formSchema,
+      sections,
+      defaultValues: {
+        title: "Workplace climate survey",
+        description:
+          "This short workplace climate survey contains just 12 simple questions. It is designed to help measure employees' perceptions, experiences, and overall satisfaction within the workplace.",
+        participants: "",
+        publishOn: undefined,
+        endsAt: undefined,
+        recurrence: "none",
+        managerVisibility: false,
+        anonymousAnswers: false,
+        editors: "none",
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+      submitConfig: { label: "Create Survey", icon: null },
+    })
+
     return (
       <div className="max-w-lg">
-        <F0Form
-          name="visual-design-example"
-          schema={formSchema}
-          sections={sections}
-          defaultValues={{
-            title: "Workplace climate survey",
-            description:
-              "This short workplace climate survey contains just 12 simple questions. It is designed to help measure employees' perceptions, experiences, and overall satisfaction within the workplace.",
-            participants: "",
-            publishOn: undefined,
-            endsAt: undefined,
-            recurrence: "none",
-            managerVisibility: false,
-            anonymousAnswers: false,
-            editors: "none",
-          }}
-          onSubmit={async (data) => {
-            await sleep(1000)
-            console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-            return { success: true }
-          }}
-          submitConfig={{ label: "Create Survey", icon: null }}
-        />
+        <F0Form formDefinition={formDefinition} />
       </div>
     )
   },
@@ -1314,27 +1323,29 @@ export const WithActionBar: Story = {
       }),
     })
 
+    const formDefinition = useF0FormDefinition({
+      name: "action-bar-example",
+      schema: formSchema,
+      submitConfig: {
+        type: "action-bar",
+        label: "Save Changes",
+      },
+      defaultValues: {
+        firstName: "John",
+        lastName: "Doe",
+        email: "john@example.com",
+        notifications: true,
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true, message: "Settings saved successfully" }
+      },
+    })
+
     return (
       <div className="max-w-lg">
-        <F0Form
-          name="action-bar-example"
-          schema={formSchema}
-          submitConfig={{
-            type: "action-bar",
-            label: "Save Changes",
-          }}
-          defaultValues={{
-            firstName: "John",
-            lastName: "Doe",
-            email: "john@example.com",
-            notifications: true,
-          }}
-          onSubmit={async (data) => {
-            await sleep(1000)
-            console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-            return { success: true, message: "Settings saved successfully" }
-          }}
-        />
+        <F0Form formDefinition={formDefinition} />
         <p className="mt-4 text-sm text-f1-foreground-secondary">
           Modify any field to see the action bar appear
         </p>
@@ -1374,29 +1385,31 @@ export const WithActionBarAndDiscard: Story = {
       }),
     })
 
+    const formDefinition = useF0FormDefinition({
+      name: "action-bar-discard-example",
+      schema: formSchema,
+      submitConfig: {
+        type: "action-bar",
+        label: "Save",
+        discardable: true,
+        discardConfig: { label: "Discard Changes" },
+      },
+      defaultValues: {
+        companyName: "Acme Corp",
+        industry: "tech",
+        employeeCount: 500,
+        publicCompany: false,
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true, message: "Company details updated" }
+      },
+    })
+
     return (
       <div className="max-w-lg">
-        <F0Form
-          name="action-bar-discard-example"
-          schema={formSchema}
-          submitConfig={{
-            type: "action-bar",
-            label: "Save",
-            discardable: true,
-            discardConfig: { label: "Discard Changes" },
-          }}
-          defaultValues={{
-            companyName: "Acme Corp",
-            industry: "tech",
-            employeeCount: 500,
-            publicCompany: false,
-          }}
-          onSubmit={async (data) => {
-            await sleep(1000)
-            console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-            return { success: true, message: "Company details updated" }
-          }}
-        />
+        <F0Form formDefinition={formDefinition} />
         <p className="mt-4 text-sm text-f1-foreground-secondary">
           Modify any field to see the action bar with Save and Discard buttons
         </p>
@@ -1428,6 +1441,35 @@ export const ErrorTriggerModes: Story = {
 
     const defaultValues = { name: "", email: "" }
 
+    const onSubmit = async () => {
+      await sleep(500)
+      return { success: true as const }
+    }
+
+    const blurDefinition = useF0FormDefinition({
+      name: "error-mode-blur",
+      schema: formSchema,
+      defaultValues,
+      errorTriggerMode: "on-blur",
+      onSubmit,
+    })
+
+    const changeDefinition = useF0FormDefinition({
+      name: "error-mode-change",
+      schema: formSchema,
+      defaultValues,
+      errorTriggerMode: "on-change",
+      onSubmit,
+    })
+
+    const submitDefinition = useF0FormDefinition({
+      name: "error-mode-submit",
+      schema: formSchema,
+      defaultValues,
+      errorTriggerMode: "on-submit",
+      onSubmit,
+    })
+
     return (
       <div className="grid max-w-4xl grid-cols-3 gap-8">
         <div>
@@ -1435,16 +1477,7 @@ export const ErrorTriggerModes: Story = {
           <p className="mb-4 text-sm text-f1-foreground-secondary">
             Errors appear when you leave a field
           </p>
-          <F0Form
-            name="error-mode-blur"
-            schema={formSchema}
-            defaultValues={defaultValues}
-            errorTriggerMode="on-blur"
-            onSubmit={async () => {
-              await sleep(500)
-              return { success: true }
-            }}
-          />
+          <F0Form formDefinition={blurDefinition} />
         </div>
 
         <div>
@@ -1452,16 +1485,7 @@ export const ErrorTriggerModes: Story = {
           <p className="mb-4 text-sm text-f1-foreground-secondary">
             Errors appear as you type
           </p>
-          <F0Form
-            name="error-mode-change"
-            schema={formSchema}
-            defaultValues={defaultValues}
-            errorTriggerMode="on-change"
-            onSubmit={async () => {
-              await sleep(500)
-              return { success: true }
-            }}
-          />
+          <F0Form formDefinition={changeDefinition} />
         </div>
 
         <div>
@@ -1469,16 +1493,7 @@ export const ErrorTriggerModes: Story = {
           <p className="mb-4 text-sm text-f1-foreground-secondary">
             Errors only appear after clicking submit
           </p>
-          <F0Form
-            name="error-mode-submit"
-            schema={formSchema}
-            defaultValues={defaultValues}
-            errorTriggerMode="on-submit"
-            onSubmit={async () => {
-              await sleep(500)
-              return { success: true }
-            }}
-          />
+          <F0Form formDefinition={submitDefinition} />
         </div>
       </div>
     )
@@ -1585,7 +1600,7 @@ const countriesPaginatedSource = createDataSourceDefinition<Country>({
   },
 })
 
-const defaultValues = {
+const selectDefaultValues = {
   country: 1,
   countryPaginated: 1,
   countries: [],
@@ -1635,25 +1650,27 @@ export const SelectWithDataSource: Story = {
       }),
     })
 
+    const formDefinition = useF0FormDefinition({
+      name: "select-datasource-example",
+      schema: formSchema,
+      defaultValues: selectDefaultValues,
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+    })
+
     return (
       <div className="max-w-lg">
-        <F0Form
-          name="select-datasource-example"
-          schema={formSchema}
-          defaultValues={defaultValues}
-          onSubmit={async (data) => {
-            await sleep(1000)
-            console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-            return { success: true }
-          }}
-        />
+        <F0Form formDefinition={formDefinition} />
       </div>
     )
   },
 }
 
 /**
- * Form inside a Dialog using `useF0Form` hook.
+ * Form inside a Dialog using `useF0Form` hook for external control.
  *
  * The `useF0Form` hook provides:
  * - `formRef`: Pass to F0Form to enable external control
@@ -1694,6 +1711,23 @@ export const FormInDialog: Story = {
       }),
     })
 
+    const formDefinition = useF0FormDefinition({
+      name: "dialog-form",
+      schema: formSchema,
+      defaultValues: {
+        name: "",
+        email: "",
+        role: undefined,
+      },
+      submitConfig: { type: "default", hideSubmitButton: true },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        setOpen(false)
+        return { success: true }
+      },
+    })
+
     return (
       <>
         <F0Button
@@ -1718,23 +1752,7 @@ export const FormInDialog: Story = {
             onClick: () => setOpen(false),
           }}
         >
-          <F0Form
-            formRef={formRef}
-            name="dialog-form"
-            schema={formSchema}
-            defaultValues={{
-              name: "",
-              email: "",
-              role: undefined,
-            }}
-            submitConfig={{ type: "default", hideSubmitButton: true }}
-            onSubmit={async (data) => {
-              await sleep(1000)
-              console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-              setOpen(false)
-              return { success: true }
-            }}
-          />
+          <F0Form formDefinition={formDefinition} formRef={formRef} />
         </F0Dialog>
       </>
     )
@@ -1804,23 +1822,23 @@ export const DynamicDateConstraints: Story = {
         }
       })
 
-    return (
-      <F0Form
-        name="dynamic-date-constraints"
-        schema={formSchema}
-        defaultValues={{
-          projectName: "",
-          startDate: undefined,
-          endDate: undefined,
-          deadline: undefined,
-        }}
-        onSubmit={async (data) => {
-          await sleep(1000)
-          console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-          return { success: true }
-        }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "dynamic-date-constraints",
+      schema: formSchema,
+      defaultValues: {
+        projectName: "",
+        startDate: undefined,
+        endDate: undefined,
+        deadline: undefined,
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
@@ -1828,8 +1846,8 @@ export const DynamicDateConstraints: Story = {
  * Form with per-section schema: each section has its own independent schema,
  * validation, and submit button. Submitting one section does not affect others.
  *
- * The `schema` prop receives a record where keys are section IDs and values
- * are Zod schemas. The `onSubmit` callback receives the section ID and its data.
+ * Uses `useF0FormDefinition` with a record of schemas. The `onSubmit`
+ * callback receives `{ sectionId, data, fullData }`.
  */
 export const PerSectionSubmit: Story = {
   render() {
@@ -1874,40 +1892,40 @@ export const PerSectionSubmit: Story = {
       }),
     }
 
-    return (
-      <F0Form
-        name="per-section"
-        schema={schema}
-        sections={{
-          personal: {
-            title: "Personal Information",
-            description: "Your basic profile details",
-          },
-          contact: {
-            title: "Contact Details",
-            description: "How we can reach you",
-          },
-          preferences: {
-            title: "Preferences",
-            description: "Customize your experience",
-            submitConfig: { label: "Save Preferences" },
-          },
-        }}
-        defaultValues={{
-          personal: { firstName: "", lastName: "", bio: "" },
-          contact: { email: "", phone: "" },
-          preferences: { theme: "system", notifications: true },
-        }}
-        onSubmit={async (sectionId, data) => {
-          await sleep(1000)
-          alert(
-            `Section "${sectionId}" submitted: ${JSON.stringify(data, null, 2)}`
-          )
-          return { success: true }
-        }}
-        submitConfig={{ label: "Save" }}
-      />
-    )
+    const formDefinition = useF0FormDefinition({
+      name: "per-section",
+      schema,
+      sections: {
+        personal: {
+          title: "Personal Information",
+          description: "Your basic profile details",
+        },
+        contact: {
+          title: "Contact Details",
+          description: "How we can reach you",
+        },
+        preferences: {
+          title: "Preferences",
+          description: "Customize your experience",
+          submitConfig: { label: "Save Preferences" },
+        },
+      },
+      defaultValues: {
+        personal: { firstName: "", lastName: "", bio: "" },
+        contact: { email: "", phone: "" },
+        preferences: { theme: "system", notifications: true },
+      },
+      onSubmit: async ({ sectionId, data }) => {
+        await sleep(1000)
+        alert(
+          `Section "${sectionId}" submitted: ${JSON.stringify(data, null, 2)}`
+        )
+        return { success: true }
+      },
+      submitConfig: { label: "Save" },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
   },
 }
 
@@ -1949,35 +1967,37 @@ export const PerSectionWithSidebar: Story = {
       }),
     }
 
+    const formDefinition = useF0FormDefinition({
+      name: "per-section-sidebar",
+      schema,
+      sections: {
+        general: {
+          title: "General",
+          description: "Basic survey information",
+        },
+        settings: {
+          title: "Settings",
+          description: "Privacy and visibility",
+        },
+        schedule: { title: "Schedule", description: "When the survey runs" },
+      },
+      defaultValues: {
+        general: { title: "", description: "" },
+        settings: { anonymousAnswers: false, managerVisibility: false },
+        schedule: { publishOn: undefined, endsAt: undefined },
+      },
+      onSubmit: async ({ sectionId, data }) => {
+        await sleep(1000)
+        alert(`Section "${sectionId}" saved: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+      submitConfig: { label: "Save" },
+    })
+
     return (
       <F0Form
-        name="per-section-sidebar"
-        schema={schema}
-        sections={{
-          general: {
-            title: "General",
-            description: "Basic survey information",
-          },
-          settings: {
-            title: "Settings",
-            description: "Privacy and visibility",
-          },
-          schedule: { title: "Schedule", description: "When the survey runs" },
-        }}
-        defaultValues={{
-          general: { title: "", description: "" },
-          settings: { anonymousAnswers: false, managerVisibility: false },
-          schedule: { publishOn: undefined, endsAt: undefined },
-        }}
-        onSubmit={async (sectionId, data) => {
-          await sleep(1000)
-          alert(
-            `Section "${sectionId}" saved: ${JSON.stringify(data, null, 2)}`
-          )
-          return { success: true }
-        }}
+        formDefinition={formDefinition}
         styling={{ showSectionsSidepanel: true }}
-        submitConfig={{ label: "Save" }}
       />
     )
   },
@@ -2028,166 +2048,37 @@ export const PerSectionShowSubmitWhenDirty: Story = {
       }),
     }
 
-    return (
-      <F0Form
-        name="per-section-dirty"
-        schema={schema}
-        sections={{
-          profile: {
-            title: "Profile",
-            description: "Your public profile information",
-            submitConfig: { showSubmitWhenDirty: true },
-          },
-          notifications: {
-            title: "Notifications",
-            description: "Choose how you want to be notified",
-            submitConfig: { showSubmitWhenDirty: true },
-          },
-          security: {
-            title: "Security",
-            description: "Update your password",
-            submitConfig: { label: "Change Password" },
-          },
-        }}
-        defaultValues={{
-          profile: { displayName: "Jane Doe", bio: "" },
-          notifications: {
-            emailNotifications: true,
-            pushNotifications: false,
-          },
-          security: { currentPassword: "", newPassword: "" },
-        }}
-        onSubmit={async (sectionId, data) => {
-          await sleep(1000)
-          alert(
-            `Section "${sectionId}" saved: ${JSON.stringify(data, null, 2)}`
-          )
-          return { success: true }
-        }}
-        submitConfig={{ label: "Save" }}
-      />
-    )
-  },
-}
-
-/**
- * Single-schema form using `formDefinition` prop.
- * Instead of passing individual form props, all form-related configuration
- * is bundled into a single `formDefinition` object via `useF0FormDefinition`.
- * Rendering props (`className`, `styling`, `formRef`, `initialFiles`) remain
- * as direct props on `F0Form`.
- */
-export const WithFormDefinitionSingleSchema: Story = {
-  render() {
-    const formSchema = z.object({
-      firstName: f0FormField(z.string().min(1), {
-        label: "First Name",
-        section: "personal",
-      }),
-      lastName: f0FormField(z.string().min(1), {
-        label: "Last Name",
-        section: "personal",
-      }),
-      email: f0FormField(z.string().email(), {
-        label: "Email",
-        section: "contact",
-        placeholder: "you@example.com",
-      }),
-      phone: f0FormField(z.string().optional(), {
-        label: "Phone",
-        section: "contact",
-        placeholder: "+1 (555) 000-0000",
-      }),
-    })
-
     const formDefinition = useF0FormDefinition({
-      name: "form-definition-single",
-      schema: formSchema,
-      sections: {
-        personal: { title: "Personal Information" },
-        contact: { title: "Contact Details" },
-      },
-      defaultValues: {
-        firstName: "Alicia",
-        lastName: "Keys",
-        email: "alicia.keys@factorial.co",
-        phone: "",
-      },
-      onSubmit: async ({ data }) => {
-        await sleep(1000)
-        console.info(
-          `Form submitted via formDefinition: ${JSON.stringify(data, null, 2)}`
-        )
-        return { success: true, message: "Saved successfully" }
-      },
-      submitConfig: { label: "Save Profile" },
-    })
-
-    return <F0Form formDefinition={formDefinition} />
-  },
-}
-
-/**
- * Per-section form using `formDefinition` prop.
- * Each section is independently validated and submitted. The `onSubmit`
- * callback receives `{ sectionId, data, fullData }` — where `sectionId`
- * narrows `data` to the correct section type, and `fullData` always
- * contains all sections' latest values.
- */
-export const WithFormDefinitionPerSection: Story = {
-  render() {
-    const schema = {
-      profile: z.object({
-        displayName: f0FormField(z.string().min(1), {
-          label: "Display Name",
-          placeholder: "Enter your display name",
-        }),
-        bio: f0FormField(z.string().max(200).optional(), {
-          label: "Bio",
-          fieldType: "textarea",
-          rows: 3,
-        }),
-      }),
-      settings: z.object({
-        theme: f0FormField(z.enum(["light", "dark", "system"]), {
-          label: "Theme",
-          options: [
-            { value: "light", label: "Light" },
-            { value: "dark", label: "Dark" },
-            { value: "system", label: "System" },
-          ],
-        }),
-        notifications: f0FormField(z.boolean(), {
-          label: "Enable notifications",
-          fieldType: "switch",
-        }),
-      }),
-    }
-
-    const formDefinition = useF0FormDefinition({
-      name: "form-definition-per-section",
+      name: "per-section-dirty",
       schema,
       sections: {
         profile: {
           title: "Profile",
           description: "Your public profile information",
+          submitConfig: { showSubmitWhenDirty: true },
         },
-        settings: {
-          title: "Settings",
-          description: "Customize your experience",
+        notifications: {
+          title: "Notifications",
+          description: "Choose how you want to be notified",
+          submitConfig: { showSubmitWhenDirty: true },
+        },
+        security: {
+          title: "Security",
+          description: "Update your password",
+          submitConfig: { label: "Change Password" },
         },
       },
       defaultValues: {
         profile: { displayName: "Jane Doe", bio: "" },
-        settings: { theme: "system", notifications: true },
+        notifications: {
+          emailNotifications: true,
+          pushNotifications: false,
+        },
+        security: { currentPassword: "", newPassword: "" },
       },
-      onSubmit: async ({ sectionId, data, fullData }) => {
+      onSubmit: async ({ sectionId, data }) => {
         await sleep(1000)
-        console.info(
-          `Section "${sectionId}" submitted via formDefinition:`,
-          data
-        )
-        console.info("Full data:", fullData)
+        alert(`Section "${sectionId}" saved: ${JSON.stringify(data, null, 2)}`)
         return { success: true }
       },
       submitConfig: { label: "Save" },


### PR DESCRIPTION
## Description

Going forward, forms should be defined using `useF0FormDefinition` and passed via the `formDefinition` prop. The previous approach of passing individual props directly to <F0Form> is still supported for backwards compatibility while we migrate the remaining forms in our frontend, but it will be removed once that migration is complete. The formDefinition pattern documented here is the only recommended way to declare forms.
