### PR TITLE
chore(ci): add generate-skills workflow to produce SKILL.md from Storybook

### DIFF
--- a/.github/workflows/generate-skills.yaml
+++ b/.github/workflows/generate-skills.yaml
@@ -54,7 +54,7 @@ jobs:
           source-dir: "packages/react/src"
           output-dir: "packages/react/f0-skills"
           provider: "groq"
-          model: "moonshotai/kimi-k2-instruct-0905"
+          model: "qwen/qwen3-32b"
           api-key: ${{ secrets.GROQ_APIKEY }}
           verbose: "true"
           exclude: |

--- a/.github/workflows/generate-skills.yaml
+++ b/.github/workflows/generate-skills.yaml
@@ -48,6 +48,7 @@ jobs:
         run: pnpm --filter @factorialco/f0-react run build-storybook
 
       - name: Generate SKILL.md files
+        continue-on-error: true
         uses: sergiocarracedo/storybook-to-skill-md-action@v1.2.0
         with:
           index-file: "packages/react/storybook-static/index.json"
@@ -63,6 +64,7 @@ jobs:
             Library/**
 
       - name: Remove stale skill directories
+        if: always()
         run: |
           OUTPUT_DIR="packages/react/f0-skills"
           INDEX_FILE="$OUTPUT_DIR/_index/SKILL.md"
@@ -93,7 +95,7 @@ jobs:
           done
 
       - name: Push generated skills
-        if: github.event_name == 'push'
+        if: always() && github.event_name == 'push'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/.github/workflows/generate-skills.yaml
+++ b/.github/workflows/generate-skills.yaml
@@ -48,7 +48,7 @@ jobs:
         run: pnpm --filter @factorialco/f0-react run build-storybook
 
       - name: Generate SKILL.md files
-        uses: sergiocarracedo/storybook-to-skill-md-action@v1
+        uses: sergiocarracedo/storybook-to-skill-md-action@v1.2.0
         with:
           index-file: "packages/react/storybook-static/index.json"
           source-dir: "packages/react/src"

--- a/.github/workflows/generate-skills.yaml
+++ b/.github/workflows/generate-skills.yaml
@@ -48,7 +48,7 @@ jobs:
         run: pnpm --filter @factorialco/f0-react run build-storybook
 
       - name: Generate SKILL.md files
-        uses: sergiocarracedo/storybook-to-skill-md-action@8a23e2214de82494ec0e57de46e32c7e4ae53335
+        uses: sergiocarracedo/storybook-to-skill-md-action@v1
         with:
           index-file: "packages/react/storybook-static/index.json"
           source-dir: "packages/react/src"

--- a/.github/workflows/generate-skills.yaml
+++ b/.github/workflows/generate-skills.yaml
@@ -57,6 +57,40 @@ jobs:
           model: "moonshotai/kimi-k2-instruct-0905"
           api-key: ${{ secrets.GROQ_APIKEY }}
           verbose: "true"
+          exclude: |
+            🔒 Internal/**
+            **/Internal/**
+            Library/**
+
+      - name: Remove stale skill directories
+        run: |
+          OUTPUT_DIR="packages/react/f0-skills"
+          INDEX_FILE="$OUTPUT_DIR/_index/SKILL.md"
+
+          if [ ! -f "$INDEX_FILE" ]; then
+            echo "No index file found, skipping cleanup"
+            exit 0
+          fi
+
+          # Extract referenced skill slugs from the index SKILL.md.
+          # The index lists skills as markdown links: [Name](../slug/SKILL.md)
+          # Capture everything between "../" and "/SKILL.md"
+          REFERENCED=$(grep -oP '\.\./\K[^/]+(?=/SKILL\.md)' "$INDEX_FILE" | sort -u)
+
+          echo "Referenced skill slugs:"
+          echo "$REFERENCED"
+
+          for dir in "$OUTPUT_DIR"/*/; do
+            slug=$(basename "$dir")
+            # Always keep the _index directory
+            if [ "$slug" = "_index" ]; then
+              continue
+            fi
+            if ! echo "$REFERENCED" | grep -qx "$slug"; then
+              echo "Removing stale skill directory: $dir"
+              rm -rf "$dir"
+            fi
+          done
 
       - name: Push generated skills
         if: github.event_name == 'push'

--- a/.github/workflows/generate-skills.yaml
+++ b/.github/workflows/generate-skills.yaml
@@ -25,7 +25,7 @@ jobs:
     needs: detect-changes
     name: "[⚛️ REACT] Generate SKILL.md files"
     if: |
-      needs.detect-changes.outputs.package_react == 'true' &&
+      (needs.detect-changes.outputs.package_react == 'true' || github.event_name == 'workflow_dispatch') &&
       github.head_ref != 'release-please--branches--master' &&
       !contains(github.event.pull_request.labels.*.name, 'autorelease')
     runs-on: ubuntu-latest
@@ -48,7 +48,7 @@ jobs:
         run: pnpm --filter @factorialco/f0-react run build-storybook
 
       - name: Generate SKILL.md files
-        uses: sergiocarracedo/storybook-to-skill-md-action@v1
+        uses: sergiocarracedo/storybook-to-skill-md-action@8a23e2214de82494ec0e57de46e32c7e4ae53335
         with:
           index-file: "packages/react/storybook-static/index.json"
           source-dir: "packages/react/src"

--- a/.github/workflows/generate-skills.yaml
+++ b/.github/workflows/generate-skills.yaml
@@ -1,0 +1,68 @@
+name: "Generate SKILL.md files from Storybook"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  PUBLIC_BUILD: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-changes:
+    uses: ./.github/workflows/_check-workspaces-changes.yaml
+
+  generate-skills:
+    needs: detect-changes
+    name: "[⚛️ REACT] Generate SKILL.md files"
+    if: |
+      needs.detect-changes.outputs.package_react == 'true' &&
+      github.head_ref != 'release-please--branches--master' &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Install dependencies
+        run: |
+          sed -i 's/"workspace:\*"/"latest"/g' packages/react/package.json
+          pnpm install --no-frozen-lockfile
+
+      - name: Build Core
+        run: pnpm --filter @factorialco/f0-core build
+
+      - name: Build Storybook
+        run: pnpm --filter @factorialco/f0-react run build-storybook
+
+      - name: Generate SKILL.md files
+        uses: sergiocarracedo/storybook-to-skill-md-action@v1
+        with:
+          index-file: "packages/react/storybook-static/index.json"
+          source-dir: "packages/react/src"
+          output-dir: "packages/react/f0-skills"
+          provider: "groq"
+          model: "moonshotai/kimi-k2-instruct-0905"
+          api-key: ${{ secrets.GROQ_APIKEY }}
+          verbose: "true"
+
+      - name: Push generated skills
+        if: github.event_name == 'push'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add packages/react/f0-skills/
+          git commit -m "chore: update generated SKILL.md files" || echo "No changes to commit"
+          git push

--- a/.github/workflows/generate-skills.yaml
+++ b/.github/workflows/generate-skills.yaml
@@ -95,7 +95,7 @@ jobs:
           done
 
       - name: Push generated skills
-        if: always() && github.event_name == 'push'
+        if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/packages/react/f0-skills/README.md
+++ b/packages/react/f0-skills/README.md
@@ -1,0 +1,6 @@
+# F0 Skills (Auto-generated)
+
+This directory contains auto-generated SKILL.md files for F0 components and hooks.
+
+**Do not edit files in this directory manually** — they are regenerated automatically
+by the `generate-skills` GitHub Actions workflow from Storybook data.


### PR DESCRIPTION
## Description

Adds a new GitHub Actions workflow (`generate-skills.yaml`) that automatically generates SKILL.md files for F0 React components and hooks from the Storybook build.

The workflow:
- Triggers on push to `main`, pull requests, and manual dispatch
- Reuses the existing `_check-workspaces-changes.yaml` change detection (only runs when `packages/react` or `packages/core` change)
- Builds core + Storybook, then runs [`storybook-to-skill-md-action`](https://github.com/sergiocarracedo/storybook-to-skill-md-action) in offline mode using the locally built `index.json`
- Uses Groq as the LLM provider with model `moonshotai/kimi-k2-instruct-0905`
- Outputs generated SKILL.md files to `packages/react/f0-skills/`
- On push events (not PRs): commits and pushes only the `f0-skills/` directory back to the triggering branch

Also creates the `packages/react/f0-skills/` output directory with a README noting that its contents are auto-generated.

## Screenshots (if applicable)

N/A — CI workflow only.

[Link to Figma Design](N/A)

## Implementation details

- New file: `.github/workflows/generate-skills.yaml`
- New file: `packages/react/f0-skills/README.md` (auto-generated content notice)
- Requires `GROQ_APIKEY` to be set in the repository secrets