### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.384.0",
-  "packages/react-native": "0.25.0",
+  "packages/react": "1.385.0",
+  "packages/react-native": "0.26.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.26.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.25.0...f0-react-native-v0.26.0) (2026-02-27)
+
+
+### Features
+
+* react native tokens renaming from f1-* to f0-* ([#3554](https://github.com/factorialco/f0/issues/3554)) ([c6568d7](https://github.com/factorialco/f0/commit/c6568d739882a4d5e40291ef928c1a06a5af71a8))
+
 ## [0.25.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.24.1...f0-react-native-v0.25.0) (2026-02-26)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.385.0](https://github.com/factorialco/f0/compare/f0-react-v1.384.0...f0-react-v1.385.0) (2026-02-27)
+
+
+### Features
+
+* **F0AiChat:** New events in ai chat ([#3501](https://github.com/factorialco/f0/issues/3501)) ([a3e7e01](https://github.com/factorialco/f0/commit/a3e7e010c054d186551cb1ea98d442ef336eee8d))
+
 ## [1.384.0](https://github.com/factorialco/f0/compare/f0-react-v1.383.2...f0-react-v1.384.0) (2026-02-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.384.0",
+  "version": "1.385.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.385.0</summary>

## [1.385.0](https://github.com/factorialco/f0/compare/f0-react-v1.384.0...f0-react-v1.385.0) (2026-02-27)


### Features

* **F0AiChat:** New events in ai chat ([#3501](https://github.com/factorialco/f0/issues/3501)) ([a3e7e01](https://github.com/factorialco/f0/commit/a3e7e010c054d186551cb1ea98d442ef336eee8d))
</details>

<details><summary>f0-react-native: 0.26.0</summary>

## [0.26.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.25.0...f0-react-native-v0.26.0) (2026-02-27)


### Features

* react native tokens renaming from f1-* to f0-* ([#3554](https://github.com/factorialco/f0/issues/3554)) ([c6568d7](https://github.com/factorialco/f0/commit/c6568d739882a4d5e40291ef928c1a06a5af71a8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a Release Please version/changelog update with no runtime code changes. Main risk is consumer impact from the newly released changes referenced in the changelogs (e.g., token renames) rather than this PR’s diff itself.
> 
> **Overview**
> Publishes a new release by bumping package versions and updating release metadata.
> 
> `@factorialco/f0-react` is released as `1.385.0` (changelog notes new `F0AiChat` events) and `@factorialco/f0-react-native` as `0.26.0` (changelog notes token renaming from `f1-*` to `f0-*`), with corresponding updates to `.release-please-manifest.json` and each package’s `package.json`/`CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35dadf754fc7ab4e11eac71c8355ed1a11f92c44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->