### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.385.0",
+  "packages/react": "1.386.0",
   "packages/react-native": "0.26.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.386.0](https://github.com/factorialco/f0/compare/f0-react-v1.385.0...f0-react-v1.386.0) (2026-02-28)
+
+
+### Features
+
+* **ai-chat:** entity refs, [@mentions](https://github.com/mentions), tool hints, data download with Excel/CSV export ([#3553](https://github.com/factorialco/f0/issues/3553)) ([e3a2576](https://github.com/factorialco/f0/commit/e3a257601fa6ea579529a1d773c86641ad831720))
+
 ## [1.385.0](https://github.com/factorialco/f0/compare/f0-react-v1.384.0...f0-react-v1.385.0) (2026-02-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.385.0",
+  "version": "1.386.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.386.0</summary>

## [1.386.0](https://github.com/factorialco/f0/compare/f0-react-v1.385.0...f0-react-v1.386.0) (2026-02-28)


### Features

* **ai-chat:** entity refs, [@mentions](https://github.com/mentions), tool hints, data download with Excel/CSV export ([#3553](https://github.com/factorialco/f0/issues/3553)) ([e3a2576](https://github.com/factorialco/f0/commit/e3a257601fa6ea579529a1d773c86641ad831720))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a release bookkeeping change updating version metadata and the changelog, with no runtime code changes in the diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.385.0` to `1.386.0` by updating `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` to include the `1.386.0` release entry (ai-chat enhancements: entity refs, @mentions, tool hints, and Excel/CSV export).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32fda4b0b752e4fa607ad3437abdddb74fc2f3bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->