### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.386.0",
+  "packages/react": "1.387.0",
   "packages/react-native": "0.26.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.387.0](https://github.com/factorialco/f0/compare/f0-react-v1.386.0...f0-react-v1.387.0) (2026-03-02)
+
+
+### Features
+
+* **Select:** support TagPerson in select options ([#3536](https://github.com/factorialco/f0/issues/3536)) ([20b8917](https://github.com/factorialco/f0/commit/20b8917b5e4ee70c8855cad2f1af97ab15968fb8))
+
 ## [1.386.0](https://github.com/factorialco/f0/compare/f0-react-v1.385.0...f0-react-v1.386.0) (2026-02-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.386.0",
+  "version": "1.387.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.387.0</summary>

## [1.387.0](https://github.com/factorialco/f0/compare/f0-react-v1.386.0...f0-react-v1.387.0) (2026-03-02)


### Features

* **Select:** support TagPerson in select options ([#3536](https://github.com/factorialco/f0/issues/3536)) ([20b8917](https://github.com/factorialco/f0/commit/20b8917b5e4ee70c8855cad2f1af97ab15968fb8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a Release Please version bump and changelog update with no functional code changes in the diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.386.0` to `1.387.0` in `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.387.0` release entry noting **Select** support for `TagPerson` in select options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e113b5e0ef2f57931aa299bcec5007f39e43e9b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->