### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.387.0",
+  "packages/react": "1.388.0",
   "packages/react-native": "0.26.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.388.0](https://github.com/factorialco/f0/compare/f0-react-v1.387.0...f0-react-v1.388.0) (2026-03-02)
+
+
+### Features
+
+* add get started module icon ([#3557](https://github.com/factorialco/f0/issues/3557)) ([b392902](https://github.com/factorialco/f0/commit/b3929025e02d2b14264e95c382c2bb7251b2fbc4))
+
 ## [1.387.0](https://github.com/factorialco/f0/compare/f0-react-v1.386.0...f0-react-v1.387.0) (2026-03-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.387.0",
+  "version": "1.388.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.388.0</summary>

## [1.388.0](https://github.com/factorialco/f0/compare/f0-react-v1.387.0...f0-react-v1.388.0) (2026-03-02)


### Features

* add get started module icon ([#3557](https://github.com/factorialco/f0/issues/3557)) ([b392902](https://github.com/factorialco/f0/commit/b3929025e02d2b14264e95c382c2bb7251b2fbc4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates version metadata and changelog without modifying runtime code paths.
> 
> **Overview**
> Publishes `@factorialco/f0-react` `1.388.0` by updating `.release-please-manifest.json` and the package `version`.
> 
> Adds a `1.388.0` entry to `packages/react/CHANGELOG.md` noting the new feature (*get started module icon*).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7526255c3267389bd613c93172c80efa110f9f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->