### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.388.0",
+  "packages/react": "1.388.1",
   "packages/react-native": "0.26.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.388.1](https://github.com/factorialco/f0/compare/f0-react-v1.388.0...f0-react-v1.388.1) (2026-03-02)
+
+
+### Bug Fixes
+
+* question not being able to be changed to rating type in CoCreationForm ([#3562](https://github.com/factorialco/f0/issues/3562)) ([20a29d2](https://github.com/factorialco/f0/commit/20a29d2095b1c6129e02177699bcd34f8adab7f4))
+
 ## [1.388.0](https://github.com/factorialco/f0/compare/f0-react-v1.387.0...f0-react-v1.388.0) (2026-03-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.388.0",
+  "version": "1.388.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.388.1</summary>

## [1.388.1](https://github.com/factorialco/f0/compare/f0-react-v1.388.0...f0-react-v1.388.1) (2026-03-02)


### Bug Fixes

* question not being able to be changed to rating type in CoCreationForm ([#3562](https://github.com/factorialco/f0/issues/3562)) ([20a29d2](https://github.com/factorialco/f0/commit/20a29d2095b1c6129e02177699bcd34f8adab7f4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog/manifest updates with no runtime code changes.
> 
> **Overview**
> Publishes `@factorialco/f0-react` **v1.388.1** by bumping the package version and updating the Release Please manifest.
> 
> Adds the `1.388.1` changelog entry documenting a bug fix for CoCreationForm questions not being changeable to the *rating* type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76726241a9fdbd49736daea89f9a6635757fb389. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->