### PR TITLE
docs(storybook): replace welcome banner with Introduction and System Principles content

### DIFF
--- a/packages/react/docs/Introduction.mdx
+++ b/packages/react/docs/Introduction.mdx
@@ -1,6 +1,53 @@
-import { Meta, Unstyled } from "@storybook/addon-docs/blocks"
-import { WelcomeMessage } from "./components/Welcome"
+import { Meta } from "@storybook/addon-docs/blocks";
 
-# Welcome to f0 Storybook
+<Meta title="Introduction" />
 
-<WelcomeMessage />
+# Introduction
+
+## What is f0?
+
+f0 is Factorial's official design system, created to unify the user experience across all our products. It provides a robust set of reusable components, design patterns, and guidelines that promote consistency, accessibility, and efficiency between design and development.
+
+f0 is more than just a UI component library — it's a living ecosystem that evolves with our products and user needs. It includes:
+
+- **Reusable, responsive UI component library**
+- **Design tokens** for color, typography, spacing, and more
+- **Interaction patterns** and UX best practices
+- **Accessibility standards and guidelines**
+- **Tools and resources** for designers and developers
+- **Complete documentation** for frictionless implementation
+
+## Why f0?
+
+f0 was created to support the development of scalable, cohesive products at Factorial. It helps teams:
+
+- Speed up product development
+- Ensure consistency across products
+- Improve accessibility and usability
+- Focus on solving product-specific challenges instead of reinventing basic UI elements
+
+---
+
+# System Principles
+
+f0's principles guide how we build and use our design system to create coherent user experiences across all Factorial products.
+
+## 1. Product first
+
+We prioritize the overall product experience over individual features. Every design decision considers its impact across the Factorial platform, ensuring scalable and consistent solutions. Before adding new components, we carefully evaluate how they integrate with existing workflows.
+
+## 2. Pragmatism and systematization
+
+We develop flexible and efficient solutions tailored to our users' real-world challenges. Our patterns adapt to a variety of use cases, helping users work more efficiently and giving our teams adjustable components.
+
+## 3. Purposeful consistency
+
+We maintain meaningful consistency in visual design and interaction patterns. This helps users build intuition when using the platform, reducing cognitive load and increasing efficiency. We reuse established patterns and ensure that new components follow existing models.
+
+## 4. Accessibility by default
+
+Accessibility is built into our design from the start — not an afterthought. All our components follow WCAG guidelines and are usable across devices. This improves overall usability and extends our reach, ensuring compatibility with screen readers, keyboard navigation, and proper contrast.
+
+## 5. Efficient composition
+
+We design components to work well together, allowing complex interfaces to be built from simple, dynamic blocks. Our components have consistent APIs and predictable behavior, making integration easier and accelerating development.


### PR DESCRIPTION
## 🚪 Why?

### Problem
The Storybook welcome page displayed a banner redirecting users to the external documentation site (f0.factorial.dev). This created friction for developers who expected to see useful information directly in Storybook.

## 🔑 What?

### Changes
- Replaced the `WelcomeMessage` redirect banner with actual documentation content
- Added "Introduction" section (What is f0?, Why f0?)
- Added "System Principles" section (5 core principles)
- Content matches the official f0 documentation site

## ✅ Verification

### Manual Verification
- Storybook welcome page now displays the Introduction and System Principles content directly
- No more redirect banner to external site

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change affecting the Storybook intro page content; no runtime logic or API behavior changes.
> 
> **Overview**
> Replaces the Storybook welcome/redirect banner on `Introduction.mdx` (and removes the `WelcomeMessage` usage) with in-Storybook documentation content.
> 
> Adds an **Introduction** section (what/why f0) and a **System Principles** section outlining five core principles, and sets the page meta title via `@storybook/addon-docs/blocks` `Meta`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e082d274fad251d9b2f3bf93c6f23e15b1b8908. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->