### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.388.1",
-  "packages/react-native": "0.26.0",
+  "packages/react-native": "0.27.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.27.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.26.0...f0-react-native-v0.27.0) (2026-03-03)
+
+
+### Features
+
+* **F0Text:** introduce F0Text primitive component  ([#3563](https://github.com/factorialco/f0/issues/3563)) ([a55dbcb](https://github.com/factorialco/f0/commit/a55dbcbd60e442b22e8b3f1f3a5f11f31d1ede7a))
+
 ## [0.26.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.25.0...f0-react-native-v0.26.0) (2026-02-27)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.27.0</summary>

## [0.27.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.26.0...f0-react-native-v0.27.0) (2026-03-03)


### Features

* **F0Text:** introduce F0Text primitive component  ([#3563](https://github.com/factorialco/f0/issues/3563)) ([a55dbcb](https://github.com/factorialco/f0/commit/a55dbcbd60e442b22e8b3f1f3a5f11f31d1ede7a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: only version/manifest bumps and changelog updates, with no functional code changes in this PR.
> 
> **Overview**
> Publishes `@factorialco/f0-react-native` **v0.27.0** by bumping the version in `.release-please-manifest.json` and `packages/react-native/package.json`.
> 
> Updates `packages/react-native/CHANGELOG.md` with the `0.27.0` release notes (highlighting the new `F0Text` primitive component).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12bbbb3c98eebad8c108f9a02a8ece199f483c87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->