### PR TITLE
feat: add delta display cell

### DIFF
--- a/packages/react/src/ui/value-display/__stories__/shared.tsx
+++ b/packages/react/src/ui/value-display/__stories__/shared.tsx
@@ -29,6 +29,14 @@ export const mockItem = {
       src: "/avatars/person02.jpg",
     },
   ],
+  positiveDelta: {
+    label: "10%",
+    deltaStatus: "positive" as const,
+  },
+  negativeDelta: {
+    label: "10%",
+    deltaStatus: "negative" as const,
+  },
   companyName: "Factorial",
   companyLogo: "/avatars/factorial.png",
   teamName: "Engineering",

--- a/packages/react/src/ui/value-display/renderers.tsx
+++ b/packages/react/src/ui/value-display/renderers.tsx
@@ -23,6 +23,7 @@ import { TagCell } from "./types/tag"
 import { TagListCell } from "./types/tagList"
 import { TeamCell } from "./types/team"
 import { TextCell } from "./types/text"
+import { DeltaCell } from "./types/delta"
 
 // Re-export for backward compatibility
 export type { ValueDisplayRendererContext }
@@ -60,6 +61,7 @@ export const valueDisplayRenderers = {
   file: FileCell,
   folder: FolderCell,
   country: CountryCell,
+  delta: DeltaCell,
 } as const satisfies Record<string, ValueDisplayRenderer>
 
 /**

--- a/packages/react/src/ui/value-display/types/delta/__stories__/delta.mdx
+++ b/packages/react/src/ui/value-display/types/delta/__stories__/delta.mdx
@@ -1,0 +1,34 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks"
+import * as DeltaStories from "./delta.stories"
+
+<Meta of={DeltaStories} />
+
+### delta
+
+Renders a single delta value with an icon indicating the direction of change.
+
+#### Value type
+
+```
+
+type value = {
+  label: string
+  deltaStatus: 'positive' | 'negative'
+}
+
+```
+
+<Canvas
+  of={DeltaStories.DeltaType}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'delta'
+    value: {
+        label: '10%'
+        deltaStatus: 'positive'
+    }
+})
+`,
+  }}
+/>

--- a/packages/react/src/ui/value-display/types/delta/__stories__/delta.stories.tsx
+++ b/packages/react/src/ui/value-display/types/delta/__stories__/delta.stories.tsx
@@ -1,0 +1,49 @@
+import { Meta, StoryObj } from "@storybook/react-vite"
+
+import { Cell, mockItem } from "../../../__stories__/shared"
+
+const meta = {
+  title: "Value Display/Delta",
+  component: Cell,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Renders a single delta value with an icon indicating the direction of change. Used for displaying changes or differences in data collections.",
+      },
+      source: {
+        code: null,
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const DeltaType: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Delta",
+      render: (item) => ({
+        type: "delta",
+        value: item.positiveDelta,
+      }),
+    },
+  },
+}
+
+export const NegativeDeltaType: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Delta",
+      render: (item) => ({
+        type: "delta",
+        value: item.negativeDelta,
+      }),
+    },
+  },
+}

--- a/packages/react/src/ui/value-display/types/delta/delta.tsx
+++ b/packages/react/src/ui/value-display/types/delta/delta.tsx
@@ -1,0 +1,37 @@
+/**
+ * Delta cell type for displaying single delta values.
+ * Used for displaying changes or differences in data collections.
+ */
+import { cn } from "@/lib/utils"
+import { ArrowDown, ArrowUp } from "@/icons/app"
+import { F0Icon, type IconType } from "@/components/F0Icon"
+
+type DeltaStatus = "positive" | "negative"
+
+interface DeltaValue {
+  label: string
+  deltaStatus: DeltaStatus
+}
+export type DeltaCellValue = DeltaValue
+
+const iconMap: Record<DeltaStatus, IconType> = {
+  positive: ArrowUp,
+  negative: ArrowDown,
+}
+
+const colorMap: Record<DeltaStatus, string> = {
+  positive: "text-f1-foreground-positive",
+  negative: "text-f1-foreground-critical",
+}
+
+export const DeltaCell = (args: DeltaCellValue) => {
+  const icon = iconMap[args.deltaStatus]
+  const colorClass = colorMap[args.deltaStatus]
+
+  return (
+    <div className={cn("flex items-center gap-1", colorClass)}>
+      {icon ? <F0Icon icon={icon} /> : null}
+      <span>{args.label}</span>
+    </div>
+  )
+}

--- a/packages/react/src/ui/value-display/types/delta/index.tsx
+++ b/packages/react/src/ui/value-display/types/delta/index.tsx
@@ -1,0 +1,1 @@
+export * from "./delta"


### PR DESCRIPTION
## Description
Adds a new delta value-display renderer to the React value-display system, enabling rendering of positive/negative deltas with directional icons for use in data-collection/table contexts.

## Screenshots (if applicable)
<img width="832" height="576" alt="Screenshot 2026-03-03 at 12 51 32" src="https://github.com/user-attachments/assets/765a6d05-6bc4-482c-9e1c-ce195d4bac05" />

[Link to Figma Design](https://www.figma.com/file/iGqeNj7ahbQ1qlGEiz3gHM?type=design&node-id=8077%3A10271&mode=dev)

## Implementation details
- Introduces DeltaCell renderer and registers it under the delta renderer type.
- Adds Storybook stories and MDX docs for the new delta value type.
- Extends shared Storybook mock data with positive/negative delta examples.
