### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.388.1",
+  "packages/react": "1.388.2",
   "packages/react-native": "0.27.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.388.2](https://github.com/factorialco/f0/compare/f0-react-v1.388.1...f0-react-v1.388.2) (2026-03-03)
+
+
+### Bug Fixes
+
+* add more detail item types to DetailItemsList component ([#3572](https://github.com/factorialco/f0/issues/3572)) ([255502b](https://github.com/factorialco/f0/commit/255502b5eb64c4edec9c328e612b244c6333d420))
+
 ## [1.388.1](https://github.com/factorialco/f0/compare/f0-react-v1.388.0...f0-react-v1.388.1) (2026-03-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.388.1",
+  "version": "1.388.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,
@@ -43,7 +43,7 @@
     "test-storybook": "test-storybook --testTimeout=60000",
     "format": "sh -c 'oxfmt \"${@:-src/}\"' --",
     "format:check": "sh -c 'oxfmt --check \"${@:-src/}\"' --",
-    "tsc": "tsc --noEmit --project ./tsconfig-build.json",
+    "tsc": "tsc --noEmit",
     "vitest": "vitest --project=unit",
     "vitest:ui": "vitest --project=unit --ui",
     "vitest:watch": "vitest --project=unit dev",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.388.2</summary>

## [1.388.2](https://github.com/factorialco/f0/compare/f0-react-v1.388.1...f0-react-v1.388.2) (2026-03-03)


### Bug Fixes

* add more detail item types to DetailItemsList component ([#3572](https://github.com/factorialco/f0/issues/3572)) ([255502b](https://github.com/factorialco/f0/commit/255502b5eb64c4edec9c328e612b244c6333d420))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a version/changelog release bump; the only behavior change is the `tsc` script invocation, which may affect CI/typecheck configuration but not runtime.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.388.1` to `1.388.2`, updating `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.388.2` release entry (bug fix: additional detail item types in `DetailItemsList`) and tweaks the `tsc` script to run `tsc --noEmit` without the `tsconfig-build.json` project flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28bdc332367183976c1dd5bfc41c604964b3834e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->