### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.388.3",
+  "packages/react": "1.388.4",
   "packages/react-native": "0.27.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.388.4](https://github.com/factorialco/f0/compare/f0-react-v1.388.3...f0-react-v1.388.4) (2026-03-03)
+
+
+### Bug Fixes
+
+* revert fix many ts errors showing in the editor for test files ([#3579](https://github.com/factorialco/f0/issues/3579)) ([286526a](https://github.com/factorialco/f0/commit/286526a5686b970bf4320018d37a308749ec21a2))
+
 ## [1.388.3](https://github.com/factorialco/f0/compare/f0-react-v1.388.2...f0-react-v1.388.3) (2026-03-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.388.3",
+  "version": "1.388.4",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.388.4</summary>

## [1.388.4](https://github.com/factorialco/f0/compare/f0-react-v1.388.3...f0-react-v1.388.4) (2026-03-03)


### Bug Fixes

* revert fix many ts errors showing in the editor for test files ([#3579](https://github.com/factorialco/f0/issues/3579)) ([286526a](https://github.com/factorialco/f0/commit/286526a5686b970bf4320018d37a308749ec21a2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only change (version/manifest/changelog) with no functional code modifications in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.388.3` to `1.388.4` and updates the release manifest accordingly.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.388.4` entry documenting a bugfix that reverts a prior change related to TypeScript errors in editor for test files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aafad78b5ce63fbd772c46e559c0dd81a8d00e60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->