### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.388.4",
-  "packages/react-native": "0.27.0",
+  "packages/react-native": "0.28.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.28.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.27.0...f0-react-native-v0.28.0) (2026-03-04)
+
+
+### Features
+
+* f0-react-native-headingxl-and-animatedf0text ([#3581](https://github.com/factorialco/f0/issues/3581)) ([41e31f6](https://github.com/factorialco/f0/commit/41e31f6d85a801df4a84ec163b735deba441c847))
+
 ## [0.27.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.26.0...f0-react-native-v0.27.0) (2026-03-03)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.28.0</summary>

## [0.28.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.27.0...f0-react-native-v0.28.0) (2026-03-04)


### Features

* f0-react-native-headingxl-and-animatedf0text ([#3581](https://github.com/factorialco/f0/issues/3581)) ([41e31f6](https://github.com/factorialco/f0/commit/41e31f6d85a801df4a84ec163b735deba441c847))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog) with no functional code modifications shown in the diff.
> 
> **Overview**
> This PR is a Release Please version bump for `@factorialco/f0-react-native`, updating the release manifest and the package version from `0.27.0` to `0.28.0`.
> 
> It also appends the `0.28.0` changelog entry, noting the included feature work (`f0-react-native-headingxl-and-animatedf0text`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc65ad69f9893be7e6daf9725cb7347854082b9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->