### PR TITLE
feat(F0Select): add group-header item 

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -626,8 +626,10 @@ const F0SelectComponent = forwardRef(function Select<
             item: <SelectSeparator key={`separator-${index}`} />,
           })
         } else if (mappedOption.type === "group-header") {
-          // Auto-insert separator before non-first group headers
-          if (hasSeenGroupHeader) {
+          // Auto-insert separator before non-first group headers,
+          // but skip if the previous item is already a separator
+          const lastItem = result[result.length - 1]
+          if (hasSeenGroupHeader && lastItem?.height !== 1) {
             result.push({
               height: 1,
               item: <SelectSeparator key={`group-header-separator-${index}`} />,

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -664,6 +664,33 @@ const F0SelectComponent = forwardRef(function Select<
         }
       }
 
+      // Remove orphaned group headers (headers with no selectable items after them)
+      // This handles cases where search filtering removes all items under a header
+      for (let i = result.length - 1; i >= 0; i--) {
+        const item = result[i]
+        // Group headers have height 36 and no value
+        if (item.height === 36 && !("value" in item)) {
+          // Check if there are any selectable items between this header
+          // and the next header/separator/end
+          let hasSelectableItem = false
+          for (let j = i + 1; j < result.length; j++) {
+            if (result[j].height === 36 && !("value" in result[j])) break
+            if ("value" in result[j]) {
+              hasSelectableItem = true
+              break
+            }
+          }
+          if (!hasSelectableItem) {
+            // Remove the header and any auto-separator before it
+            if (i > 0 && result[i - 1].height === 1) {
+              result.splice(i - 1, 2)
+            } else {
+              result.splice(i, 1)
+            }
+          }
+        }
+      }
+
       return result
     },
     [optionMapper]

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -639,6 +639,7 @@ const F0SelectComponent = forwardRef(function Select<
             item: (
               <div
                 key={`group-header-${index}`}
+                role="presentation"
                 className="px-3 pt-3 pb-2 text-sm font-medium text-f1-foreground-secondary"
               >
                 {mappedOption.label}

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -668,6 +668,7 @@ const F0SelectComponent = forwardRef(function Select<
       // This handles cases where search filtering removes all items under a header
       for (let i = result.length - 1; i >= 0; i--) {
         const item = result[i]
+        if (!item) continue
         // Group headers have height 36 and no value
         if (item.height === 36 && !("value" in item)) {
           // Check if there are any selectable items between this header

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -615,38 +615,47 @@ const F0SelectComponent = forwardRef(function Select<
     (
       records: WithGroupId<ActualRecordType>[] | ActualRecordType[]
     ): VirtualItem[] => {
-      let hasSeenGroupHeader = false
       const result: VirtualItem[] = []
+      let pendingHeader: { index: number; label: string } | null = null
 
       for (const [index, option] of records.entries()) {
         const mappedOption = optionMapper(option)
+
         if (mappedOption.type === "separator") {
           result.push({
             height: 1,
             item: <SelectSeparator key={`separator-${index}`} />,
           })
         } else if (mappedOption.type === "group-header") {
-          const lastItem = result[result.length - 1]
-          if (hasSeenGroupHeader && lastItem?.height !== 1) {
-            result.push({
-              height: 1,
-              item: <SelectSeparator key={`group-header-separator-${index}`} />,
-            })
-          }
-          hasSeenGroupHeader = true
-          result.push({
-            height: 36,
-            item: (
-              <div
-                key={`group-header-${index}`}
-                role="presentation"
-                className="px-3 pt-3 pb-2 text-sm font-medium text-f1-foreground-secondary"
-              >
-                {mappedOption.label}
-              </div>
-            ),
-          })
+          pendingHeader = { index, label: mappedOption.label }
         } else {
+          if (pendingHeader) {
+            const lastItem = result[result.length - 1]
+            if (result.length > 0 && lastItem?.height !== 1) {
+              result.push({
+                height: 1,
+                item: (
+                  <SelectSeparator
+                    key={`group-header-separator-${pendingHeader.index}`}
+                  />
+                ),
+              })
+            }
+            result.push({
+              height: 36,
+              item: (
+                <div
+                  key={`group-header-${pendingHeader.index}`}
+                  role="presentation"
+                  className="px-3 pt-3 pb-2 text-sm font-medium text-f1-foreground-secondary"
+                >
+                  {pendingHeader.label}
+                </div>
+              ),
+            })
+            pendingHeader = null
+          }
+
           result.push({
             height: mappedOption.description ? 64 : 32,
             item: (
@@ -655,33 +664,8 @@ const F0SelectComponent = forwardRef(function Select<
                 item={mappedOption}
               />
             ),
-            // Convert to string to ensure consistent comparison with selectedItemsValues
-            // which also converts to strings
             value: String(mappedOption.value),
           })
-        }
-      }
-
-      for (let i = result.length - 1; i >= 0; i--) {
-        const item = result[i]
-        if (!item) continue
-        // Group headers have height 36 and no value
-        if (item.height === 36 && !("value" in item)) {
-          let hasSelectableItem = false
-          for (let j = i + 1; j < result.length; j++) {
-            if (result[j].height === 36 && !("value" in result[j])) break
-            if ("value" in result[j]) {
-              hasSelectableItem = true
-              break
-            }
-          }
-          if (!hasSelectableItem) {
-            if (i > 0 && result[i - 1].height === 1) {
-              result.splice(i - 1, 2)
-            } else {
-              result.splice(i, 1)
-            }
-          }
         }
       }
 

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -66,6 +66,7 @@ const defaultSearchFn = (
 ) => {
   return (
     option.type === "separator" ||
+    option.type === "group-header" ||
     !search ||
     option.label.toLowerCase().includes(search.toLowerCase())
   )
@@ -238,7 +239,8 @@ const F0SelectComponent = forwardRef(function Select<
           return undefined
         }
         const mappedOption = optionMapper(item)
-        return mappedOption.type !== "separator"
+        return mappedOption.type !== "separator" &&
+          mappedOption.type !== "group-header"
           ? String(mappedOption.value)
           : undefined
       },
@@ -303,7 +305,10 @@ const F0SelectComponent = forwardRef(function Select<
     // Only add items from paginated data (NOT fetchedItems)
     for (const record of data.records) {
       const mappedOption = optionMapper(record)
-      if (mappedOption.type !== "separator") {
+      if (
+        mappedOption.type !== "separator" &&
+        mappedOption.type !== "group-header"
+      ) {
         // Always use string keys for consistent lookups
         entries.push([
           String(mappedOption.value),
@@ -528,7 +533,7 @@ const F0SelectComponent = forwardRef(function Select<
       const values = checkedItems.map((item) => {
         if (item.item) {
           const option = optionMapper(item.item as ActualRecordType)
-          return option.type !== "separator"
+          return option.type !== "separator" && option.type !== "group-header"
             ? (option.value as T)
             : (String(item.id) as T)
         }
@@ -610,26 +615,53 @@ const F0SelectComponent = forwardRef(function Select<
     (
       records: WithGroupId<ActualRecordType>[] | ActualRecordType[]
     ): VirtualItem[] => {
-      return records.map((option, index) => {
+      let hasSeenGroupHeader = false
+      const result: VirtualItem[] = []
+
+      for (const [index, option] of records.entries()) {
         const mappedOption = optionMapper(option)
-        return mappedOption.type === "separator"
-          ? {
+        if (mappedOption.type === "separator") {
+          result.push({
+            height: 1,
+            item: <SelectSeparator key={`separator-${index}`} />,
+          })
+        } else if (mappedOption.type === "group-header") {
+          // Auto-insert separator before non-first group headers
+          if (hasSeenGroupHeader) {
+            result.push({
               height: 1,
-              item: <SelectSeparator key={`separator-${index}`} />,
-            }
-          : {
-              height: mappedOption.description ? 64 : 32,
-              item: (
-                <SelectItem
-                  key={String(mappedOption.value)}
-                  item={mappedOption}
-                />
-              ),
-              // Convert to string to ensure consistent comparison with selectedItemsValues
-              // which also converts to strings (line 623)
-              value: String(mappedOption.value),
-            }
-      })
+              item: <SelectSeparator key={`group-header-separator-${index}`} />,
+            })
+          }
+          hasSeenGroupHeader = true
+          result.push({
+            height: 36,
+            item: (
+              <div
+                key={`group-header-${index}`}
+                className="px-3 pt-3 pb-2 text-sm font-medium text-f1-foreground-secondary"
+              >
+                {mappedOption.label}
+              </div>
+            ),
+          })
+        } else {
+          result.push({
+            height: mappedOption.description ? 64 : 32,
+            item: (
+              <SelectItem
+                key={String(mappedOption.value)}
+                item={mappedOption}
+              />
+            ),
+            // Convert to string to ensure consistent comparison with selectedItemsValues
+            // which also converts to strings
+            value: String(mappedOption.value),
+          })
+        }
+      }
+
+      return result
     },
     [optionMapper]
   )

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -626,8 +626,6 @@ const F0SelectComponent = forwardRef(function Select<
             item: <SelectSeparator key={`separator-${index}`} />,
           })
         } else if (mappedOption.type === "group-header") {
-          // Auto-insert separator before non-first group headers,
-          // but skip if the previous item is already a separator
           const lastItem = result[result.length - 1]
           if (hasSeenGroupHeader && lastItem?.height !== 1) {
             result.push({
@@ -664,15 +662,11 @@ const F0SelectComponent = forwardRef(function Select<
         }
       }
 
-      // Remove orphaned group headers (headers with no selectable items after them)
-      // This handles cases where search filtering removes all items under a header
       for (let i = result.length - 1; i >= 0; i--) {
         const item = result[i]
         if (!item) continue
         // Group headers have height 36 and no value
         if (item.height === 36 && !("value" in item)) {
-          // Check if there are any selectable items between this header
-          // and the next header/separator/end
           let hasSelectableItem = false
           for (let j = i + 1; j < result.length; j++) {
             if (result[j].height === 36 && !("value" in result[j])) break
@@ -682,7 +676,6 @@ const F0SelectComponent = forwardRef(function Select<
             }
           }
           if (!hasSelectableItem) {
-            // Remove the header and any auto-separator before it
             if (i > 0 && result[i - 1].height === 1) {
               result.splice(i - 1, 2)
             } else {

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -544,6 +544,7 @@ export const WithSearchBox: Story = {
             console.log("searchFn", option, searchValue)
             return (
               option.type === "separator" ||
+              option.type === "group-header" ||
               !searchValue ||
               option.label.toLowerCase().includes(searchValue.toLowerCase()) ||
               option.description
@@ -584,6 +585,30 @@ export const LargeList: Story = {
       ...(meta.args?.options || []),
       { type: "separator" },
       ...mockItems,
+    ],
+  },
+}
+
+/**
+ * Static options with group headers to visually separate sections.
+ * Group headers are non-selectable labels rendered using `{ type: "group-header", label: "..." }`.
+ * A separator is automatically inserted before each group header (except the first).
+ */
+export const WithGroupHeaders: Story = {
+  args: {
+    label: "Select a vacancy",
+    placeholder: "Select a vacancy",
+    showSearchBox: true,
+    value: undefined,
+    options: [
+      { type: "group-header", label: "Assigned to me" },
+      { value: "vacancy-1", label: "Senior Frontend Engineer" },
+      { value: "vacancy-2", label: "Product Designer" },
+      { type: "group-header", label: "All vacancies" },
+      { value: "vacancy-3", label: "Backend Engineer" },
+      { value: "vacancy-4", label: "Data Analyst" },
+      { value: "vacancy-5", label: "DevOps Engineer" },
+      { value: "vacancy-6", label: "QA Engineer" },
     ],
   },
 }

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -424,3 +424,177 @@ describe("Select", () => {
     })
   })
 })
+
+describe("Group Headers", () => {
+  global.ResizeObserver = class MockResizeObserver {
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+  } as typeof ResizeObserver
+
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      value: 800,
+    })
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      value: 800,
+    })
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      () => ({
+        width: 120,
+        height: 120,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      })
+    )
+  })
+
+  const groupedOptions: F0SelectItemProps<string>[] = [
+    { type: "group-header", label: "Group A" },
+    { value: "a1", label: "Alpha 1" },
+    { value: "a2", label: "Alpha 2" },
+    { type: "group-header", label: "Group B" },
+    { value: "b1", label: "Beta 1" },
+  ]
+
+  const defaultGroupProps = {
+    label: "Pick an option",
+    placeholder: "Select...",
+    onChange: vi.fn(),
+  }
+
+  const openSelect = async (user: ReturnType<typeof userEvent.setup>) => {
+    user.click(screen.getByRole("combobox"))
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    const teaser = screen.getByRole("listbox")
+    fireEvent.animationStart(teaser)
+  }
+
+  it("renders group header labels", async () => {
+    const user = userEvent.setup()
+    render(<F0Select {...defaultGroupProps} options={groupedOptions} />)
+
+    await openSelect(user)
+
+    expect(screen.getByText("Group A")).toBeInTheDocument()
+    expect(screen.getByText("Group B")).toBeInTheDocument()
+  })
+
+  it("renders group headers with role=presentation for accessibility", async () => {
+    const user = userEvent.setup()
+    render(<F0Select {...defaultGroupProps} options={groupedOptions} />)
+
+    await openSelect(user)
+
+    const presentations = screen.getAllByRole("presentation")
+    const groupHeaders = presentations.filter(
+      (el) => el.textContent === "Group A" || el.textContent === "Group B"
+    )
+    expect(groupHeaders).toHaveLength(2)
+  })
+
+  it("does not trigger onChange when a group header is clicked", async () => {
+    const handleChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultGroupProps}
+        options={groupedOptions}
+        onChange={handleChange}
+      />
+    )
+
+    await openSelect(user)
+    await user.click(screen.getByText("Group A"))
+
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it("renders selectable items alongside group headers", async () => {
+    const handleChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultGroupProps}
+        options={groupedOptions}
+        onChange={handleChange}
+      />
+    )
+
+    await openSelect(user)
+    await user.click(screen.getByText("Alpha 1"))
+
+    expect(handleChange).toHaveBeenCalledWith(
+      "a1",
+      undefined,
+      expect.objectContaining({ label: "Alpha 1", value: "a1" })
+    )
+  })
+
+  it("hides orphaned group headers when search filters out all items in a group", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select {...defaultGroupProps} options={groupedOptions} showSearchBox />
+    )
+
+    await openSelect(user)
+
+    // Search for "Beta" — only Group B items match
+    await user.type(screen.getByRole("searchbox"), "Beta")
+
+    await waitFor(() => {
+      expect(screen.getByText("Beta 1")).toBeInTheDocument()
+      expect(screen.getByText("Group B")).toBeInTheDocument()
+      // Group A header should be hidden since all its items are filtered out
+      expect(screen.queryByText("Group A")).not.toBeInTheDocument()
+    })
+  })
+
+  it("restores all group headers when search is cleared", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select {...defaultGroupProps} options={groupedOptions} showSearchBox />
+    )
+
+    await openSelect(user)
+
+    // Type to filter
+    await user.type(screen.getByRole("searchbox"), "Beta")
+    await waitFor(() => {
+      expect(screen.queryByText("Group A")).not.toBeInTheDocument()
+    })
+
+    // Clear search
+    await user.clear(screen.getByRole("searchbox"))
+    await waitFor(() => {
+      expect(screen.getByText("Group A")).toBeInTheDocument()
+      expect(screen.getByText("Group B")).toBeInTheDocument()
+    })
+  })
+
+  it("hides all group headers when search matches no items", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultGroupProps}
+        options={groupedOptions}
+        showSearchBox
+        searchEmptyMessage="No results"
+      />
+    )
+
+    await openSelect(user)
+    await user.type(screen.getByRole("searchbox"), "zzz-no-match")
+
+    await waitFor(() => {
+      expect(screen.queryByText("Group A")).not.toBeInTheDocument()
+      expect(screen.queryByText("Group B")).not.toBeInTheDocument()
+      expect(screen.getByText("No results")).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -485,7 +485,7 @@ describe("Group Headers", () => {
     expect(screen.getByText("Group B")).toBeInTheDocument()
   })
 
-  it("renders group headers with role=presentation for accessibility", async () => {
+  it("group header elements have role=presentation", async () => {
     const user = userEvent.setup()
     render(<F0Select {...defaultGroupProps} options={groupedOptions} />)
 

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -188,5 +188,6 @@ export type F0SelectItemObject<T, R = unknown> = {
 export type F0SelectItemProps<T, R = unknown> =
   | F0SelectItemObject<T, R>
   | { type: "separator" }
+  | { type: "group-header"; label: string }
 
 export const selectSizes = INPUTFIELD_SIZES


### PR DESCRIPTION
## Description

Add `group-header` as a new item type for the `F0Select` component when using static `options`. This allows consumers to visually separate options into labeled sections (e.g. "Assigned to me" / "All vacancies") without resorting to disabled items or manual separators.

A `SelectSeparator` is automatically rendered before each group header (except the first), so consumers only need to insert `{ type: "group-header", label: "..." }` entries in their options array.

Fully backward compatible — existing `item` and `separator` types continue to work unchanged.

## Screenshots

<img width="1135" height="538" alt="image" src="https://github.com/user-attachments/assets/3082227a-960c-4d4c-835b-b82dadbb4060" />

The dropdown shows two group headers ("Assigned to me" and "All vacancies") separating selectable options, with an automatic separator line between groups.

## Implementation details

- **`types.ts`**: Extended `F0SelectItemProps` union with a new `{ type: "group-header"; label: string }` variant alongside the existing `item` and `separator` types.
- **`F0Select.tsx`** (5 touch points):
  - `defaultSearchFn` — skips `group-header` items from search filtering (same as `separator`)
  - `selectable` callback — excludes `group-header` from selectable items
  - `itemsByValue` mapping — excludes `group-header` from the value map
  - `onChange` handler — excludes `group-header` from value extraction
  - `getItems` callback — renders a styled `div` matching the Figma "Dropdown header" spec (secondary text, `font-medium`, `text-sm`, padding 12/8/12px) with auto `SelectSeparator` before non-first group headers
- **`F0Select.stories.tsx`**: Added a `WithGroupHeaders` story demonstrating group headers with static options. Updated the `WithSearchBox` story's custom `searchFn` to handle the new type.

## Verification

### Tests
- Existing F0Select tests pass (12 passed, 1 skipped — pre-existing)
- TypeScript compilation verified — no new type errors introduced
- Lint passes with 0 warnings

### Manual Verification
- Verified in Storybook via the new `WithGroupHeaders` story
- Group headers render with correct Figma styling (secondary color, font-weight 500, text-sm)
- Headers are non-selectable and excluded from search/selection logic
- Auto separator renders between groups but not before the first group