### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.389.0",
+  "packages/react": "1.390.0",
   "packages/react-native": "0.28.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.390.0](https://github.com/factorialco/f0/compare/f0-react-v1.389.0...f0-react-v1.390.0) (2026-03-05)
+
+
+### Features
+
+* button dropdown mode for primary actions with descriptions ([#3590](https://github.com/factorialco/f0/issues/3590)) ([e26efa6](https://github.com/factorialco/f0/commit/e26efa6252096bc1cda2b4c395696467b59ab454))
+
 ## [1.389.0](https://github.com/factorialco/f0/compare/f0-react-v1.388.4...f0-react-v1.389.0) (2026-03-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.389.0",
+  "version": "1.390.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.390.0</summary>

## [1.390.0](https://github.com/factorialco/f0/compare/f0-react-v1.389.0...f0-react-v1.390.0) (2026-03-05)


### Features

* button dropdown mode for primary actions with descriptions ([#3590](https://github.com/factorialco/f0/issues/3590)) ([e26efa6](https://github.com/factorialco/f0/commit/e26efa6252096bc1cda2b4c395696467b59ab454))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/changelog updates only; no runtime code changes in this PR.
> 
> **Overview**
> Bumps the `@factorialco/f0-react` package version to `1.390.0` by updating the Release Please manifest and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.390.0` release entry, noting the new primary-action button dropdown mode feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3735ef7d0c980667b227923f07a266256949e126. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->