### PR TITLE
feat: add SelectCell for EditableTable with F0Select integration

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -460,7 +460,14 @@ export const getMockVisualizations = (options?: {
           {
             id: "department",
             label: "Department",
-            editType: () => "text" as const,
+            editType: () => "select" as const,
+            selectConfig: {
+              options: DEPARTMENTS_MOCK.map((dept) => ({
+                value: dept,
+                label: dept,
+              })),
+              placeholder: "Select department",
+            },
             render: (item) => item.department,
             sorting: options?.table?.noSorting ? undefined : "department",
             order: options?.table?.allowColumnReordering ? 4 : undefined,

--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -3,6 +3,9 @@ import { format } from "date-fns"
 import { useMemo, useRef, useState } from "react"
 import { action } from "storybook/actions"
 
+import { createDataSourceDefinition, RecordType } from "@/hooks/datasource"
+import { ROLES_MOCK } from "@/mocks"
+
 import { OneDataCollection } from "../../.."
 import { useDataCollectionSource } from "../../../hooks/useDataCollectionSource"
 import {
@@ -750,45 +753,84 @@ export const EditableTableWithSummaryRowAndAddRow: Story = {
   },
 }
 
-export const TableAndEditableTable: Story = {
+type RoleRecord = { value: string; label: string }
+
+const roleNonPaginatedSource = createDataSourceDefinition<RoleRecord>({
+  dataAdapter: {
+    fetchData: async ({ search }) => {
+      await new Promise((resolve) => setTimeout(resolve, 150))
+
+      let results = ROLES_MOCK.map((role) => ({ value: role, label: role }))
+
+      if (search) {
+        const q = search.toLowerCase()
+        results = results.filter((r) => r.label.toLowerCase().includes(q))
+      }
+
+      return { records: results }
+    },
+  },
+})
+
+export const EditableTableWithDataSourceSelect: Story = {
   parameters: {
     docs: {
       description: {
         story:
-          "Both Table and Editable Table in the same collection. Switch via the settings selector; each view keeps its own column order and visibility.",
+          "Editable table where the Role column uses a source-based select with `defaultItem`. Some rows have a role pre-selected while others are empty, showing the placeholder.",
       },
     },
   },
   render: () => {
-    const mockVisualizations = getMockVisualizations({
-      table: {
-        allowColumnHiding: true,
-        allowColumnReordering: true,
-      },
-    })
-    const { dataAdapter, onCellChange } = useEditableTableData()
+    const mockVisualizations = getMockVisualizations()
+    const initialItems = generateMockUsers(10).map((user, i) =>
+      i % 2 === 0 ? { ...user, role: "" } : user
+    )
+    const { dataAdapter, onCellChange } = useEditableTableData(initialItems)
+
+    const baseOptions = (
+      mockVisualizations.editableTable as Extract<
+        typeof mockVisualizations.editableTable,
+        { type: "editableTable" }
+      >
+    ).options
 
     return (
       <ExampleComponent
-        tableAllowColumnReordering
-        tableAllowColumnHiding
         visualizations={[
-          mockVisualizations.table,
           {
             type: "editableTable" as const,
             options: {
-              ...(
-                mockVisualizations.editableTable as Extract<
-                  typeof mockVisualizations.editableTable,
-                  { type: "editableTable" }
-                >
-              ).options,
+              ...baseOptions,
+              columns: baseOptions.columns.map((col) => {
+                if (col.id === "role") {
+                  return {
+                    ...col,
+                    editType: () => "select" as const,
+                    render: (item: MockUser) => item.role || undefined,
+                    selectConfig: {
+                      source: roleNonPaginatedSource,
+                      mapOptions: (record: RecordType) => ({
+                        value: String(record.value),
+                        label: String(record.label),
+                      }),
+                      placeholder: "Select role",
+                      showSearchBox: true,
+                      defaultItem: (item: MockUser) => {
+                        if (!item.role) return undefined
+                        return { value: item.role, label: item.role }
+                      },
+                    },
+                  }
+                }
+                return col
+              }),
               onCellChange,
             },
           },
         ]}
         dataAdapter={dataAdapter}
-        id="table-and-editable/v1"
+        id="editable-table-datasource-select-partial/v1"
       />
     )
   },
@@ -853,6 +895,50 @@ export const EditableTableWithDateCell: Story = {
         ]}
         dataAdapter={dataAdapter}
         id="editable-table-date/v1"
+      />
+    )
+  },
+}
+
+export const TableAndEditableTable: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Both Table and Editable Table in the same collection. Switch via the settings selector; each view keeps its own column order and visibility.",
+      },
+    },
+  },
+  render: () => {
+    const mockVisualizations = getMockVisualizations({
+      table: {
+        allowColumnHiding: true,
+        allowColumnReordering: true,
+      },
+    })
+    const { dataAdapter, onCellChange } = useEditableTableData()
+
+    return (
+      <ExampleComponent
+        tableAllowColumnReordering
+        tableAllowColumnHiding
+        visualizations={[
+          mockVisualizations.table,
+          {
+            type: "editableTable" as const,
+            options: {
+              ...(
+                mockVisualizations.editableTable as Extract<
+                  typeof mockVisualizations.editableTable,
+                  { type: "editableTable" }
+                >
+              ).options,
+              onCellChange,
+            },
+          },
+        ]}
+        dataAdapter={dataAdapter}
+        id="table-and-editable/v1"
       />
     )
   },

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/EditableTable/__tests__/SelectCell.test.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/EditableTable/__tests__/SelectCell.test.tsx
@@ -1,0 +1,157 @@
+import "@testing-library/jest-dom/vitest"
+import { fireEvent, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render } from "../../../../../../testing/test-utils"
+import { EditableCellProps } from "../components/cells"
+import { SelectCell } from "../components/cells/SelectCell"
+
+type TestRecord = { id: string; role: string }
+
+const staticOptions = [
+  { value: "dev", label: "Developer" },
+  { value: "des", label: "Designer" },
+]
+
+function makeSelectColumn(
+  overrides: Partial<EditableCellProps<TestRecord>["editableColumn"]> = {}
+) {
+  return {
+    id: "role",
+    label: "Role",
+    render: (item: TestRecord) => item.role,
+    editType: () => "select" as const,
+    selectConfig: { options: staticOptions },
+    ...overrides,
+  } as EditableCellProps<TestRecord>["editableColumn"]
+}
+
+const testItem: TestRecord = { id: "1", role: "dev" }
+
+describe("SelectCell", () => {
+  globalThis.ResizeObserver = class MockResizeObserver {
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+  } as typeof ResizeObserver
+
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      value: 800,
+    })
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      value: 800,
+    })
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      () => ({
+        width: 120,
+        height: 120,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      })
+    )
+  })
+
+  const openSelect = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByRole("combobox"))
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    fireEvent.animationStart(screen.getByRole("listbox"))
+  }
+
+  const defaultProps: EditableCellProps<TestRecord> = {
+    editableColumn: makeSelectColumn(),
+    value: "dev",
+    onChange: vi.fn(),
+    item: testItem,
+  }
+
+  it("renders F0Select with static options", async () => {
+    const user = userEvent.setup()
+    render(<SelectCell {...defaultProps} />)
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+
+    await openSelect(user)
+
+    const listbox = screen.getByRole("listbox")
+    expect(within(listbox).getByText("Developer")).toBeInTheDocument()
+    expect(within(listbox).getByText("Designer")).toBeInTheDocument()
+  })
+
+  it("renders F0Select with source config", () => {
+    const sourceConfig = {
+      source: {
+        dataAdapter: {
+          fetchData: vi.fn().mockResolvedValue({ records: [], totalCount: 0 }),
+          paginationType: "no-pagination" as const,
+        },
+        filters: {},
+        currentFilters: {},
+      },
+      mapOptions: (record: { id: string; name: string }) => ({
+        value: String(record.id),
+        label: record.name,
+      }),
+    }
+
+    render(
+      <SelectCell
+        {...defaultProps}
+        editableColumn={makeSelectColumn({ selectConfig: sourceConfig })}
+      />
+    )
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+  })
+
+  it("calls onChange exactly once when selecting a new value", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(<SelectCell {...defaultProps} value="" onChange={onChange} />)
+
+    await openSelect(user)
+    await user.click(screen.getByText("Developer"))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith("dev")
+  })
+
+  it("does not call onChange when selecting the same value", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(<SelectCell {...defaultProps} value="dev" onChange={onChange} />)
+
+    await openSelect(user)
+    const listbox = screen.getByRole("listbox")
+    await user.click(within(listbox).getByText("Developer"))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("renders non-editable fallback when selectConfig is missing", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    render(
+      <SelectCell
+        {...defaultProps}
+        editableColumn={makeSelectColumn({ selectConfig: undefined })}
+      />
+    )
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('has editType "select" but no selectConfig')
+    )
+
+    warnSpy.mockRestore()
+  })
+})

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
@@ -1,0 +1,102 @@
+import { F0Select } from "@/components/F0Select"
+import { renderProperty } from "@/experimental/OneDataCollection/property-render"
+import { RecordType } from "@/hooks/datasource/types/records.typings"
+import { useI18n } from "@/lib/providers/i18n/i18n-provider"
+import { cn } from "@/lib/utils"
+
+import { EditableCellProps } from "."
+import { BaseCell } from "./BaseCell"
+
+const warnedColumns = new Set<string>()
+
+export function SelectCell<R extends RecordType>({
+  editableColumn,
+  value,
+  error,
+  loading,
+  onChange,
+  item,
+}: EditableCellProps<R>) {
+  const i18n = useI18n()
+  const config = editableColumn.selectConfig
+  if (!config) {
+    if (!warnedColumns.has(editableColumn.label)) {
+      warnedColumns.add(editableColumn.label)
+      console.warn(
+        `SelectCell: column "${editableColumn.label}" has editType "select" but no selectConfig`
+      )
+    }
+    return (
+      <BaseCell>
+        {renderProperty(item, editableColumn, "editableTable", i18n)}
+      </BaseCell>
+    )
+  }
+
+  const sharedProps = {
+    label: editableColumn.label,
+    hideLabel: true as const,
+    value: value || undefined,
+    onChange: (val: string | undefined) => {
+      const newVal = val ?? ""
+      if (newVal !== value) {
+        onChange(newVal)
+      }
+    },
+    error,
+    loading,
+    size: "sm" as const,
+    placeholder: config.placeholder,
+    showSearchBox: config.showSearchBox,
+    defaultItem: config.defaultItem?.(item),
+    multiple: false as const,
+  }
+
+  const clearableProps = config.clearable
+    ? ({ clearable: true } as const)
+    : ({} as const)
+
+  return (
+    <BaseCell>
+      <div
+        className={cn(
+          "flex w-full min-w-0 h-full",
+          "items-center",
+          "[&_[data-testid=input-field-wrapper]]:border-0",
+          "[&_[data-testid=input-field-wrapper]]:bg-transparent",
+          "[&_[data-testid=input-field-wrapper]]:shadow-none",
+          "[&_[data-testid=input-field-wrapper]]:ring-0",
+          "[&_[data-testid=input-field-wrapper]]:focus-within:ring-0",
+          "[&_[data-testid=input-field-wrapper]]:focus-within:ring-offset-0",
+          "[&_[data-testid=input-field-wrapper]]:h-full",
+          "[&_[data-testid=input-field-wrapper]_.absolute]:top-1/2",
+          "[&_[data-testid=input-field-wrapper]_.absolute]:-translate-y-1/2",
+          "[&_[data-testid=input-field-wrapper]_.absolute]:bottom-auto",
+          "[&>div]:h-full",
+          "[&>div]:w-full",
+          "[&>div>button]:h-full",
+          editableColumn.align === "right" && "justify-end"
+        )}
+      >
+        {"source" in config && config.source ? (
+          <F0Select
+            {...sharedProps}
+            {...clearableProps}
+            source={config.source}
+            mapOptions={config.mapOptions}
+          />
+        ) : (
+          <F0Select
+            {...sharedProps}
+            {...clearableProps}
+            options={
+              typeof config.options === "function"
+                ? config.options(item)
+                : config.options
+            }
+          />
+        )}
+      </div>
+    </BaseCell>
+  )
+}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/EditableTable/consts.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/EditableTable/consts.ts
@@ -1,5 +1,6 @@
 import { EditableTableCellEditType } from "./components/cells"
 import { DateCell } from "./components/cells/DateCell"
+import { SelectCell } from "./components/cells/SelectCell"
 import { DisabledCell } from "./components/cells/status/DisabledCell"
 import { NonEditableCell } from "./components/cells/status/NonEditableCell"
 import { TextCell } from "./components/cells/TextCell"
@@ -7,6 +8,7 @@ import { TextCell } from "./components/cells/TextCell"
 type EditableCellComponent =
   | typeof TextCell
   | typeof DateCell
+  | typeof SelectCell
   | typeof NonEditableCell
   | typeof DisabledCell
 
@@ -23,7 +25,7 @@ export const editableCellMap: Record<
 > = {
   text: TextCell,
   date: DateCell,
-  select: TextCell,
+  select: SelectCell,
   multiselect: TextCell,
   "display-only": NonEditableCell,
   disabled: DisabledCell,

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -1,4 +1,9 @@
+import type {
+  F0SelectItemObject,
+  F0SelectItemProps,
+} from "@/components/F0Select"
 import {
+  DataSourceDefinition,
   FiltersDefinition,
   GroupingDefinition,
   RecordType,
@@ -18,6 +23,45 @@ import { CollectionProps } from "../../../types"
 import { EditableTableCellEditType } from "./components/cells"
 
 export type EditableTableVisualizationSettings = TableVisualizationSettings
+
+/**
+ * Configuration for select-type cells. Mirrors F0Select's two data modes:
+ * - Static `options` (array or per-row function)
+ * - Async `source` (DataSourceDefinition) with `mapOptions`
+ */
+export type SelectCellConfig<R extends RecordType> = {
+  placeholder?: string
+  clearable?: boolean
+  showSearchBox?: boolean
+  defaultItem?: (item: R) => F0SelectItemObject<string, RecordType> | undefined
+} & (
+  | {
+      options:
+        | F0SelectItemProps<string>[]
+        | ((item: R) => F0SelectItemProps<string>[])
+      source?: never
+      mapOptions?: never
+    }
+  | {
+      source: Omit<
+        DataSourceDefinition<
+          RecordType,
+          FiltersDefinition,
+          SortingsDefinition,
+          GroupingDefinition<RecordType>
+        >,
+        | "selectable"
+        | "grouping"
+        | "defaultGrouping"
+        | "currentGrouping"
+        | "fetchChildren"
+        | "itemsWithChildren"
+        | "childrenCount"
+      >
+      mapOptions: (record: RecordType) => F0SelectItemProps<string, RecordType>
+      options?: never
+    }
+)
 
 /**
  * Column definition for Editable Table.
@@ -42,6 +86,16 @@ export type EditableTableColumnDefinition<
    * When omitted, the cell is always rendered read-only.
    */
   editType?: (item: R) => EditableTableCellEditType | undefined
+  /**
+   * Configuration for `"select"` cells. Required when `editType` returns `"select"`.
+   * Accepts either static `options` or a `source` + `mapOptions` for async data.
+   *
+   * If `editType` returns `"select"` but `selectConfig` is missing, the cell
+   * falls back to a non-editable display with a `console.warn` at runtime.
+   * Type-level enforcement is not possible because `editType` is a per-row
+   * function whose return value isn't statically known.
+   */
+  selectConfig?: SelectCellConfig<R>
 }
 
 export type EditableTableVisualizationOptions<


### PR DESCRIPTION
## 🚪 Why?

The EditableTable component only supported text inputs for editable cells. We need a select cell type so columns can offer dropdown selection — either from static options or from an async data source — enabling richer inline editing workflows.

## 🔑 What?

- **New `SelectCell` component** wrapping `F0Select`, supporting both static `options` and async `source` + `mapOptions` data modes. Styled to match `TextCell` (transparent, borderless, full-height within the cell).
- **New `SelectCellConfig` type** added to `EditableTable/types.ts` as a discriminated union mirroring F0Select's two data modes: static options (array or per-row function) and async `DataSourceDefinition`.
- **Extended `EditableTableColumnDefinition`** with an optional `selectConfig` field, required when `editType` returns `"select"`.
- **Registered `SelectCell`** in the `editableCellMap` (in `consts.ts`) so the `"select"` edit type renders the new component instead of falling back to `TextCell`.
- **Fixed event propagation** in `EditableCellRenderer` — changed `onClickCapture`/`onMouseDownCapture` to `onClick`/`onMouseDown` so interactive components like `F0Select` can handle their own click events (the dropdown wouldn't open otherwise).
- **Duplicate onChange guard** — prevents `onCellChange` from firing twice per selection by comparing the incoming value against the current one before propagating.
- **Updated mock data** — the "Department" column now uses a static-options select in the default editable table stories.
- **Added `EditableTableWithDataSourceSelect` story** demonstrating the `source` + `mapOptions` pattern with a non-paginated data source on the "Role" column.

## 📸 Demo

https://github.com/user-attachments/assets/ca24efc8-566c-4864-b40c-0b880000396f

<img width="2240" height="839" alt="Screenshot 2026-03-13 at 10 19 42" src="https://github.com/user-attachments/assets/58a6dabf-0e27-456c-85cc-a911445ac168" />
