### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.392.0",
-  "packages/react-native": "0.28.1",
+  "packages/react": "1.392.1",
+  "packages/react-native": "0.29.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.29.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.28.1...f0-react-native-v0.29.0) (2026-03-09)
+
+
+### Features
+
+* allow className for layout on F0Text ([#3606](https://github.com/factorialco/f0/issues/3606)) ([2ec6f3b](https://github.com/factorialco/f0/commit/2ec6f3b27f0f6b5a79ba568746d1fbfc15e0aa23))
+
 ## [0.28.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.28.0...f0-react-native-v0.28.1) (2026-03-06)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.392.1](https://github.com/factorialco/f0/compare/f0-react-v1.392.0...f0-react-v1.392.1) (2026-03-09)
+
+
+### Bug Fixes
+
+* Adding new follow up props to Frontend tools ([#3589](https://github.com/factorialco/f0/issues/3589)) ([0a96517](https://github.com/factorialco/f0/commit/0a96517d78c3289bb849f9fa6b8d20f5822852b8))
+
 ## [1.392.0](https://github.com/factorialco/f0/compare/f0-react-v1.391.0...f0-react-v1.392.0) (2026-03-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.392.0",
+  "version": "1.392.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.392.1</summary>

## [1.392.1](https://github.com/factorialco/f0/compare/f0-react-v1.392.0...f0-react-v1.392.1) (2026-03-09)


### Bug Fixes

* Adding new follow up props to Frontend tools ([#3589](https://github.com/factorialco/f0/issues/3589)) ([0a96517](https://github.com/factorialco/f0/commit/0a96517d78c3289bb849f9fa6b8d20f5822852b8))
</details>

<details><summary>f0-react-native: 0.29.0</summary>

## [0.29.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.28.1...f0-react-native-v0.29.0) (2026-03-09)


### Features

* allow className for layout on F0Text ([#3606](https://github.com/factorialco/f0/issues/3606)) ([2ec6f3b](https://github.com/factorialco/f0/commit/2ec6f3b27f0f6b5a79ba568746d1fbfc15e0aa23))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only changes (version bumps and changelog updates) with no functional code modifications in this diff.
> 
> **Overview**
> Updates release metadata to publish new package versions: bumps `@factorialco/f0-react` to `1.392.1` and `@factorialco/f0-react-native` to `0.29.0` (via `.release-please-manifest.json` and each package’s `package.json`).
> 
> Refreshes both packages’ `CHANGELOG.md` entries for the new releases, noting a React bugfix (new follow-up props for Frontend tools) and a React Native feature (allow `className` for layout on `F0Text`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27eed0d2f7ae8458bce6c4eac222011cfd56b660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->