### PR TITLE
feat(F0DataChart): add ECharts-based chart component

### DIFF
--- a/packages/react/src/components/F0DataChart/F0DataChart.tsx
+++ b/packages/react/src/components/F0DataChart/F0DataChart.tsx
@@ -1,0 +1,16 @@
+import type { F0DataChartProps } from "./types"
+
+import { BarChart } from "./components/BarChart/BarChart"
+import { FunnelChart } from "./components/FunnelChart/FunnelChart"
+import { LineChart } from "./components/LineChart/LineChart"
+
+export const F0DataChart = (props: F0DataChartProps) => {
+  switch (props.type) {
+    case "bar":
+      return <BarChart {...props} />
+    case "line":
+      return <LineChart {...props} />
+    case "funnel":
+      return <FunnelChart {...props} />
+  }
+}

--- a/packages/react/src/components/F0DataChart/__stories__/decorators.tsx
+++ b/packages/react/src/components/F0DataChart/__stories__/decorators.tsx
@@ -1,0 +1,7 @@
+import type { StoryFn } from "@storybook/react-vite"
+
+export const ChartDecorator = (Story: StoryFn) => (
+  <div className="h-[360px] w-[600px]">
+    <Story />
+  </div>
+)

--- a/packages/react/src/components/F0DataChart/__stories__/index.stories.tsx
+++ b/packages/react/src/components/F0DataChart/__stories__/index.stories.tsx
@@ -1,0 +1,685 @@
+import type { Meta, StoryFn, StoryObj } from "@storybook/react-vite"
+
+import { F0DataChart } from "../index"
+import {
+  BarChartSkeleton,
+  FunnelChartSkeleton,
+  LineChartSkeleton,
+} from "../skeletons"
+import { ChartDecorator } from "./decorators"
+
+const meta = {
+  component: F0DataChart,
+  title: "F0DataChart",
+  tags: ["autodocs", "experimental"],
+  decorators: [ChartDecorator],
+} satisfies Meta<typeof F0DataChart>
+
+export default meta
+type Story = StoryObj<typeof F0DataChart>
+
+// ---------------------------------------------------------------------------
+// Bar stories
+// ---------------------------------------------------------------------------
+
+export const BarDefault: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Feb", "Mar", "Apr", "May", "Jun", "Jul"],
+    series: [
+      {
+        name: "Revenue",
+        data: [
+          9_200_000, 10_800_000, 8_100_000, 5_400_000, 3_200_000, 2_400_000,
+        ],
+      },
+    ],
+    showLegend: true,
+    valueFormatter: (v) => `${v / 1_000_000}M`,
+  },
+}
+
+export const BarMultipleSeries: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["New York", "London", "Barcelona", "Berlin", "Remote"],
+    series: [
+      {
+        name: "Headcount",
+        data: [145, 89, 67, 90, 96],
+      },
+      {
+        name: "Open positions",
+        data: [12, 8, 40, 30, 22],
+      },
+      {
+        name: "Turnovers",
+        data: [8, 19, 4, 3, 2],
+      },
+    ],
+  },
+}
+
+export const BarWithTargets: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Feb", "Mar", "Apr", "May", "Jun", "Jul"],
+    series: [
+      {
+        name: "Revenue",
+        data: [
+          { value: 9_200_000, target: 12_000_000 },
+          { value: 10_800_000, target: 12_000_000 },
+          { value: 8_100_000, target: 12_000_000 },
+          { value: 5_400_000, target: 12_000_000 },
+          { value: 3_200_000, target: 12_000_000 },
+          { value: 2_400_000, target: 12_000_000 },
+        ],
+      },
+    ],
+    showLegend: false,
+    valueFormatter: (v) => `${v / 1_000_000}M`,
+  },
+}
+
+export const BarMultipleSeriesWithTargets: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Q1", "Q2", "Q3", "Q4"],
+    series: [
+      {
+        name: "Sales",
+        data: [
+          { value: 4000, target: 6000 },
+          { value: 5200, target: 6000 },
+          { value: 3800, target: 6000 },
+          { value: 5800, target: 6000 },
+        ],
+      },
+      {
+        name: "Marketing",
+        data: [
+          { value: 2000, target: 3500 },
+          { value: 3100, target: 3500 },
+          { value: 2800, target: 3500 },
+          { value: 3400, target: 3500 },
+        ],
+      },
+    ],
+    valueFormatter: (v) => `${v} €`,
+  },
+}
+
+export const BarHorizontal: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    orientation: "horizontal",
+    categories: [
+      "Sarah Johnson",
+      "Michael Chen",
+      "Emma Thompson",
+      "James Wilson",
+      "Olivia Martinez",
+      "David Brown",
+    ],
+    series: [
+      {
+        name: "Successful hires",
+        data: [28, 25, 23, 21, 19, 18],
+      },
+    ],
+    showLegend: false,
+    showLabels: true,
+    valueFormatter: (v) => `${v} hires`,
+  },
+}
+
+export const BarHorizontalWithTargets: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    orientation: "horizontal",
+    categories: [
+      "Sarah Johnson",
+      "Michael Chen",
+      "Emma Thompson",
+      "James Wilson",
+      "Olivia Martinez",
+    ],
+    series: [
+      {
+        name: "Completed",
+        data: [
+          { value: 28, target: 35 },
+          { value: 25, target: 35 },
+          { value: 23, target: 35 },
+          { value: 21, target: 35 },
+          { value: 19, target: 35 },
+        ],
+      },
+    ],
+    showLegend: false,
+    valueFormatter: (v) => `${v} tasks`,
+  },
+}
+
+export const BarCustomFormatters: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["January", "February", "March", "April", "May", "June"],
+    series: [
+      {
+        name: "Profit",
+        data: [4000, 3200, 5000, 7000, 4500, 6200],
+      },
+      {
+        name: "Expenses",
+        data: [2800, 3100, 2500, 3800, 2900, 3500],
+      },
+    ],
+    valueFormatter: (v) => `${v / 1000}k €`,
+    categoryFormatter: (v) => v.slice(0, 3),
+  },
+}
+
+export const BarNoGrid: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Mon", "Tue", "Wed", "Thu", "Fri"],
+    series: [
+      {
+        name: "Tasks completed",
+        data: [12, 19, 8, 15, 22],
+      },
+    ],
+    showGrid: false,
+    showLabels: true,
+    showLegend: false,
+  },
+}
+
+export const BarPerBarColors: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Engineering", "Design", "Product", "Sales", "Support"],
+    series: [
+      {
+        name: "Headcount",
+        data: [
+          { value: 45, color: "malibu" },
+          { value: 28, color: "purple" },
+          { value: 18, color: "grass" },
+          { value: 32, color: "orange" },
+          { value: 22, color: "red" },
+        ],
+      },
+    ],
+    showLegend: false,
+  },
+}
+
+export const BarPerBarColorsWithTargets: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Engineering", "Design", "Product", "Sales"],
+    series: [
+      {
+        name: "Headcount",
+        data: [
+          { value: 45, target: 60, color: "malibu" },
+          { value: 28, target: 35, color: "purple" },
+          { value: 18, target: 25, color: "grass" },
+          { value: 32, target: 40, color: "orange" },
+        ],
+      },
+    ],
+    showLegend: false,
+  },
+}
+
+export const BarStacked: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Q1", "Q2", "Q3", "Q4"],
+    stacked: true,
+    series: [
+      {
+        name: "Fixed salary",
+        data: [120_000, 125_000, 130_000, 128_000],
+      },
+      {
+        name: "Variable pay",
+        data: [18_000, 22_000, 15_000, 30_000],
+      },
+      {
+        name: "Benefits",
+        data: [8_000, 8_500, 9_000, 9_200],
+      },
+    ],
+    valueFormatter: (v) => `${v / 1000}k €`,
+  },
+}
+
+export const BarStackedHorizontal: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Engineering", "Design", "Product", "Sales"],
+    orientation: "horizontal",
+    stacked: true,
+    series: [
+      {
+        name: "Juniors",
+        data: [30, 12, 8, 20],
+      },
+      {
+        name: "Mid-level",
+        data: [45, 18, 15, 35],
+      },
+      {
+        name: "Seniors",
+        data: [25, 10, 12, 15],
+      },
+    ],
+  },
+}
+
+export const BarAllColors: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: [
+      "Lilac",
+      "Barbie",
+      "Smoke",
+      "Army",
+      "Flubber",
+      "Indigo",
+      "Camel",
+      "Radical",
+      "Viridian",
+      "Orange",
+      "Red",
+      "Grass",
+      "Malibu",
+      "Yellow",
+      "Purple",
+    ],
+    series: [
+      {
+        name: "Color palette",
+        data: [
+          { value: 90, color: "lilac" },
+          { value: 85, color: "barbie" },
+          { value: 80, color: "smoke" },
+          { value: 75, color: "army" },
+          { value: 70, color: "flubber" },
+          { value: 65, color: "indigo" },
+          { value: 60, color: "camel" },
+          { value: 55, color: "radical" },
+          { value: 50, color: "viridian" },
+          { value: 45, color: "orange" },
+          { value: 40, color: "red" },
+          { value: 35, color: "grass" },
+          { value: 30, color: "malibu" },
+          { value: 25, color: "yellow" },
+          { value: 20, color: "purple" },
+        ],
+      },
+    ],
+    showLegend: false,
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Line stories
+// ---------------------------------------------------------------------------
+
+export const LineLinear: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "line",
+    categories: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    series: [
+      {
+        name: "Revenue",
+        data: [4200, 5800, 5100, 7400, 6800, 8900],
+      },
+    ],
+    lineType: "linear",
+    showArea: true,
+    valueFormatter: (v) => `${(v / 1000).toFixed(1)}k`,
+  },
+}
+
+export const LineSmooth: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "line",
+    categories: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    series: [
+      {
+        name: "Sessions",
+        data: [3200, 4100, 3800, 5600, 5200, 6700],
+      },
+    ],
+    lineType: "smooth",
+    showArea: true,
+  },
+}
+
+export const LineStep: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "line",
+    categories: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    series: [
+      {
+        name: "Headcount",
+        data: [120, 120, 125, 125, 130, 138],
+      },
+    ],
+    lineType: "step",
+    showArea: true,
+  },
+}
+
+export const LineNoFill: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "line",
+    categories: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    series: [
+      {
+        name: "Active users",
+        data: [1800, 2400, 2100, 3200, 2900, 3600],
+      },
+    ],
+    showArea: false,
+  },
+}
+
+export const LineMultipleSeries: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "line",
+    categories: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    series: [
+      {
+        name: "Coffee",
+        data: [120, 132, 101, 134, 90, 230],
+      },
+      {
+        name: "Tea",
+        data: [220, 182, 191, 234, 290, 330],
+      },
+      {
+        name: "Cola",
+        data: [150, 232, 201, 154, 190, 330],
+      },
+    ],
+    showArea: false,
+  },
+}
+
+export const LineMultipleSeriesWithDashed: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "line",
+    categories: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    series: [
+      {
+        name: "Actual",
+        data: [4200, 5800, 5100, 7400, 6800, 8900],
+      },
+      {
+        name: "Target",
+        data: [5000, 5500, 6000, 6500, 7000, 7500],
+        dashed: true,
+      },
+    ],
+    showArea: false,
+    valueFormatter: (v) => `${(v / 1000).toFixed(1)}k`,
+  },
+}
+
+export const LineCustomFormatters: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "line",
+    categories: ["January", "February", "March", "April", "May", "June"],
+    series: [
+      {
+        name: "Profit",
+        data: [
+          4_000_000, 3_200_000, 5_000_000, 7_000_000, 4_500_000, 6_200_000,
+        ],
+      },
+      {
+        name: "Expenses",
+        data: [
+          2_800_000, 3_100_000, 2_500_000, 3_800_000, 2_900_000, 3_500_000,
+        ],
+      },
+    ],
+    showArea: false,
+    valueFormatter: (v) => `${v / 1_000_000}M €`,
+    categoryFormatter: (v) => v.slice(0, 3),
+  },
+}
+
+export const LineWithDots: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "line",
+    categories: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    series: [
+      {
+        name: "Revenue",
+        data: [4200, 5800, 5100, 7400, 6800, 8900],
+      },
+    ],
+    showDots: true,
+    showArea: true,
+    valueFormatter: (v) => `${(v / 1000).toFixed(1)}k`,
+  },
+}
+
+export const LineNoGrid: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "line",
+    categories: ["Mon", "Tue", "Wed", "Thu", "Fri"],
+    series: [
+      {
+        name: "Tasks completed",
+        data: [12, 19, 8, 15, 22],
+      },
+    ],
+    showGrid: false,
+    showLegend: false,
+    showArea: true,
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Funnel stories
+// ---------------------------------------------------------------------------
+
+const FunnelDecorator = (Story: StoryFn) => (
+  <div className="h-[360px] w-[900px]">
+    <Story />
+  </div>
+)
+
+export const FunnelDefault: Story = {
+  decorators: [FunnelDecorator],
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "funnel",
+    series: {
+      name: "Hiring Pipeline",
+      data: [
+        { value: 1200, name: "Applied" },
+        { value: 800, name: "Phone Screen" },
+        { value: 400, name: "Technical" },
+        { value: 180, name: "Onsite" },
+        { value: 80, name: "Offer" },
+        { value: 50, name: "Hired" },
+      ],
+    },
+  },
+}
+
+export const FunnelWithConversion: Story = {
+  decorators: [FunnelDecorator],
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "funnel",
+    showConversion: true,
+    series: {
+      name: "Hiring Pipeline",
+      data: [
+        { value: 1200, name: "Applied" },
+        { value: 800, name: "Phone Screen" },
+        { value: 400, name: "Technical" },
+        { value: 180, name: "Onsite" },
+        { value: 80, name: "Offer" },
+        { value: 50, name: "Hired" },
+      ],
+    },
+  },
+}
+
+export const FunnelCustomColors: Story = {
+  decorators: [FunnelDecorator],
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "funnel",
+    series: {
+      name: "Conversion",
+      data: [
+        { value: 10_000, name: "Visitors", color: "malibu" },
+        { value: 6_500, name: "Signups", color: "purple" },
+        { value: 3_200, name: "Activated", color: "grass" },
+        { value: 1_800, name: "Subscribed", color: "orange" },
+        { value: 900, name: "Retained", color: "viridian" },
+      ],
+    },
+    valueFormatter: (v) =>
+      v >= 1000 ? `${(v / 1000).toFixed(1)}k` : String(v),
+  },
+}
+
+export const FunnelAscending: Story = {
+  decorators: [FunnelDecorator],
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "funnel",
+    sort: "ascending",
+    series: {
+      name: "Growth",
+      data: [
+        { value: 20, name: "Week 1" },
+        { value: 45, name: "Week 2" },
+        { value: 80, name: "Week 3" },
+        { value: 130, name: "Week 4" },
+        { value: 200, name: "Week 5" },
+      ],
+    },
+  },
+}
+
+export const FunnelNoConversion: Story = {
+  decorators: [FunnelDecorator],
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "funnel",
+    showConversion: false,
+    series: {
+      name: "Support Tickets",
+      data: [
+        { value: 450, name: "Received" },
+        { value: 380, name: "Triaged" },
+        { value: 290, name: "In Progress" },
+        { value: 250, name: "Resolved" },
+        { value: 230, name: "Closed" },
+      ],
+    },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton stories
+// ---------------------------------------------------------------------------
+
+const SkeletonDecorator = (Story: StoryFn) => (
+  <div className="h-[320px] w-[420px] rounded-lg border border-f1-border-secondary bg-f1-background p-4">
+    <Story />
+  </div>
+)
+
+export const SkeletonBar: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <BarChartSkeleton />,
+}
+
+export const SkeletonBarHorizontal: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <BarChartSkeleton orientation="horizontal" />,
+}
+
+export const SkeletonBarStacked: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <BarChartSkeleton stacked />,
+}
+
+export const SkeletonBarHorizontalStacked: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <BarChartSkeleton orientation="horizontal" stacked />,
+}
+
+export const SkeletonLine: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <LineChartSkeleton />,
+}
+
+export const SkeletonLineLinear: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <LineChartSkeleton lineType="linear" />,
+}
+
+export const SkeletonLineStep: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <LineChartSkeleton lineType="step" />,
+}
+
+export const SkeletonLineNoArea: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <LineChartSkeleton showArea={false} />,
+}
+
+export const SkeletonLineWithDots: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <LineChartSkeleton showDots />,
+}
+
+export const SkeletonFunnel: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <FunnelChartSkeleton />,
+}
+
+export const SkeletonFunnelAscending: StoryObj = {
+  decorators: [SkeletonDecorator],
+  render: () => <FunnelChartSkeleton sort="ascending" />,
+}

--- a/packages/react/src/components/F0DataChart/components/BarChart/BarChart.tsx
+++ b/packages/react/src/components/F0DataChart/components/BarChart/BarChart.tsx
@@ -1,0 +1,14 @@
+import { useRef } from "react"
+
+import type { F0DataChartBarProps } from "../../types"
+
+import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { useBarChartOptions } from "./useBarChartOptions"
+
+export const BarChart = (props: F0DataChartBarProps) => {
+  const ref = useRef<HTMLDivElement>(null)
+  const options = useBarChartOptions(ref, props)
+  useEChartsInstance(ref, options)
+
+  return <div ref={ref} className="h-full w-full" />
+}

--- a/packages/react/src/components/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/components/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -1,0 +1,270 @@
+import * as echarts from "echarts"
+import { type RefObject, useMemo } from "react"
+
+import type {
+  F0DataChartBarDataPoint,
+  F0DataChartBarProps,
+  F0DataChartBarSeries,
+} from "../../types"
+
+import { paletteColor, resolveChartColorToken } from "../../utils/colors"
+import { buildBaseChartOptions, formatNumericValue } from "../../utils/options"
+import { useChartTheme } from "../../utils/useChartTheme"
+import { useContainerWidth } from "../../utils/useContainerWidth"
+
+/** Extract the numeric value from a data point */
+function getValue(point: F0DataChartBarDataPoint): number {
+  return typeof point === "number" ? point : point.value
+}
+
+/** Extract the target from a data point (if any) */
+function getTarget(point: F0DataChartBarDataPoint): number | undefined {
+  return typeof point === "number" ? undefined : point.target
+}
+
+/** Extract the per-bar color override from a data point, resolved to hex */
+function getPointColor(point: F0DataChartBarDataPoint): string | undefined {
+  if (typeof point === "number" || point.color === undefined) {
+    return undefined
+  }
+  return resolveChartColorToken(point.color)
+}
+
+/** Resolve the color for a series to hex, falling back to the shared palette */
+function resolveColor(series: F0DataChartBarSeries, index: number): string {
+  return series.color
+    ? resolveChartColorToken(series.color)
+    : paletteColor(index)
+}
+
+/** Check whether a series contains any target values */
+function hasTargets(series: F0DataChartBarSeries): boolean {
+  return series.data.some(
+    (d) => typeof d !== "number" && d.target !== undefined
+  )
+}
+
+/**
+ * Build ECharts series entries for a single F0DataChartBarSeries.
+ *
+ * When the series contains target data points, two ECharts series are produced:
+ *  1. The main (solid) bar showing `value`
+ *  2. A stacked "target" bar showing `target - value` with a linear gradient fill
+ */
+function buildSeriesEntries(
+  series: F0DataChartBarSeries,
+  index: number,
+  isVertical: boolean,
+  showLabels: boolean,
+  stacked: boolean,
+  isLastSeries: boolean,
+  labelColor: string
+): echarts.BarSeriesOption[] {
+  const color = resolveColor(series, index)
+  const hasTargetData = hasTargets(series)
+  // When stacked, all series share "stacked"; when using targets, each series
+  // gets its own stack so the ghost bar stacks on its own solid bar only
+  const stackId = stacked
+    ? hasTargetData
+      ? `stacked-${index}`
+      : "stacked"
+    : hasTargetData
+      ? `stack-${index}`
+      : undefined
+
+  // Build per-item data: use plain numbers when no per-bar color overrides
+  // exist, otherwise produce ECharts data items with per-item itemStyle
+  const hasPerBarColors = series.data.some(
+    (d) => getPointColor(d) !== undefined
+  )
+
+  const mainData = hasPerBarColors
+    ? series.data.map((point) => {
+        const pointColor = getPointColor(point)
+        if (pointColor === undefined) {
+          return getValue(point)
+        }
+        return {
+          value: getValue(point),
+          itemStyle: { color: pointColor },
+        }
+      })
+    : series.data.map(getValue)
+
+  // Round only the far end (away from the axis):
+  // - Vertical: top corners rounded, bottom flat against x-axis
+  // - Horizontal: right corners rounded, left flat against y-axis
+  const borderRadius = isVertical ? [4, 4, 0, 0] : [0, 4, 4, 0]
+  // Stacked series that aren't the last one get no rounding (sandwiched)
+  const effectiveBorderRadius = stacked && !isLastSeries ? 0 : borderRadius
+
+  const mainSeries: echarts.BarSeriesOption = {
+    name: series.name,
+    type: "bar",
+    data: mainData,
+    stack: stackId,
+    itemStyle: {
+      color,
+      borderRadius: effectiveBorderRadius,
+    },
+    label: {
+      show: showLabels,
+      position: isVertical ? "top" : "right",
+      color: labelColor,
+      fontWeight: "bold",
+      formatter: (params: { value?: number | { value: number } }) => {
+        const val =
+          typeof params.value === "object"
+            ? params.value.value
+            : Number(params.value ?? 0)
+        return formatNumericValue(val)
+      },
+    },
+    emphasis: {
+      itemStyle: {
+        shadowBlur: 0,
+        shadowOffsetX: 0,
+        shadowColor: "transparent",
+      },
+    },
+  }
+
+  if (!hasTargetData) {
+    return [mainSeries]
+  }
+
+  const targetData = series.data.map((point) => {
+    const value = getValue(point)
+    const target = getTarget(point)
+    if (target === undefined || target <= value) {
+      return 0
+    }
+    const pointColor = getPointColor(point)
+    if (pointColor !== undefined) {
+      return {
+        value: target - value,
+        itemStyle: {
+          color: new echarts.graphic.LinearGradient(
+            ...(isVertical
+              ? ([0, 0, 0, 1] as [number, number, number, number])
+              : ([1, 0, 0, 0] as [number, number, number, number])),
+            [
+              { offset: 0, color: `${pointColor}33` },
+              { offset: 1, color: "rgba(0, 0, 0, 0)" },
+            ]
+          ),
+          borderRadius,
+        },
+      }
+    }
+    return target - value
+  })
+
+  const targetSeries: echarts.BarSeriesOption = {
+    name: `${series.name} (target)`,
+    type: "bar",
+    data: targetData,
+    stack: stackId,
+    // Hide from legend and tooltip
+    legendHoverLink: false,
+    tooltip: {
+      show: false,
+    },
+    itemStyle: {
+      color: new echarts.graphic.LinearGradient(
+        // Gradient direction: offset 0 is the far end from the solid bar
+        // Vertical: top-to-bottom (0,0 → 0,1) — dark at top
+        // Horizontal: right-to-left (1,0 → 0,0) — dark at right
+        ...(isVertical
+          ? ([0, 0, 0, 1] as [number, number, number, number])
+          : ([1, 0, 0, 0] as [number, number, number, number])),
+        [
+          // offset 0 = far end from the solid bar → more opaque (darker)
+          { offset: 0, color: `${color}33` },
+          // offset 1 = near the solid bar → transparent
+          { offset: 1, color: "rgba(0, 0, 0, 0)" },
+        ]
+      ),
+      // Only round the far end (away from the solid bar)
+      borderRadius,
+    },
+    label: {
+      show: false,
+    },
+    emphasis: {
+      disabled: true,
+    },
+  }
+
+  return [mainSeries, targetSeries]
+}
+
+/**
+ * Converts typed bar chart props into a full ECharts option object.
+ */
+export function useBarChartOptions(
+  containerRef: RefObject<HTMLDivElement | null>,
+  {
+    categories,
+    series,
+    orientation = "vertical",
+    stacked = false,
+    showLegend = true,
+    showGrid = true,
+    showLabels = false,
+    valueFormatter,
+    categoryFormatter,
+    echartsOptions,
+  }: F0DataChartBarProps
+): echarts.EChartsOption {
+  const theme = useChartTheme(containerRef)
+  const containerWidth = useContainerWidth(containerRef)
+
+  return useMemo(() => {
+    const isVertical = orientation === "vertical"
+
+    // Build all ECharts series (including target ghost bars)
+    const echartsSeries = series.flatMap((s, i) =>
+      buildSeriesEntries(
+        s,
+        i,
+        isVertical,
+        showLabels,
+        stacked,
+        i === series.length - 1,
+        theme.colors.foregroundSecondary
+      )
+    )
+
+    // Legend should only show the main series (not the target ghost bars)
+    const legendData = series.map((s) => s.name)
+
+    return buildBaseChartOptions({
+      categories,
+      theme,
+      series: echartsSeries,
+      legendData,
+      isVertical,
+      showGrid,
+      showLegend,
+      valueFormatter,
+      categoryFormatter,
+      tooltipFilterSeries: (name) => name.endsWith(" (target)"),
+      echartsOptions,
+      containerWidth,
+    })
+  }, [
+    categories,
+    series,
+    orientation,
+    stacked,
+    showLegend,
+    showGrid,
+    showLabels,
+    valueFormatter,
+    categoryFormatter,
+    echartsOptions,
+    theme,
+    containerWidth,
+  ])
+}

--- a/packages/react/src/components/F0DataChart/components/FunnelChart/FunnelChart.tsx
+++ b/packages/react/src/components/F0DataChart/components/FunnelChart/FunnelChart.tsx
@@ -1,0 +1,120 @@
+import { OneEllipsis } from "@/components/OneEllipsis"
+import { Tag } from "@/components/tags/F0Tag/F0Tag"
+
+import type { F0DataChartFunnelProps } from "../../types"
+
+import { resolveChartColorToken } from "../../utils/colors"
+import { formatNumericValue } from "../../utils/options"
+import { formatPercent, resolveStageColor } from "./utils"
+
+// ---------------------------------------------------------------------------
+// FunnelChart — pure HTML horizontal funnel with inline labels.
+// Uses a shared flex structure for labels, separators, and bars to guarantee
+// perfect column alignment without any percentage math.
+// ---------------------------------------------------------------------------
+
+export const FunnelChart = ({
+  series,
+  sort = "descending",
+  showConversion = false,
+  valueFormatter,
+}: F0DataChartFunnelProps) => {
+  const dataPoints = series.data ?? []
+  const resolvedSeriesColor = series.color
+    ? resolveChartColorToken(series.color)
+    : undefined
+
+  const sorted =
+    sort === "none"
+      ? dataPoints
+      : sort === "ascending"
+        ? [...dataPoints].sort((a, b) => a.value - b.value)
+        : [...dataPoints].sort((a, b) => b.value - a.value)
+
+  const maxValue = Math.max(...sorted.map((d) => d.value), 1)
+  // Conversion % is always relative to the first stage in display order
+  const firstValue = sorted[0]?.value ?? 0
+
+  return (
+    <div className="relative h-full w-full">
+      {/* Label area — flex-1 columns */}
+      <div className="absolute left-0 right-0 top-0 z-10 flex h-24">
+        {sorted.map((point, i) => {
+          const formattedValue = valueFormatter
+            ? valueFormatter(point.value)
+            : formatNumericValue(point.value)
+          const pct =
+            showConversion && firstValue > 0
+              ? formatPercent(point.value, firstValue)
+              : null
+
+          return (
+            <div key={i} className="min-w-0 flex-1 overflow-hidden pt-2">
+              <div className="flex h-full flex-col gap-3 overflow-hidden border-0 border-l border-dashed border-f1-border px-2.5">
+                <OneEllipsis
+                  className="text-base text-f1-foreground-secondary"
+                  lines={2}
+                >
+                  {point.name}
+                </OneEllipsis>
+                <div className="flex items-baseline gap-1.5">
+                  <OneEllipsis
+                    className="text-2xl font-semibold leading-none text-f1-foreground"
+                    lines={2}
+                  >
+                    {formattedValue}
+                  </OneEllipsis>
+                  {pct && <Tag tag={{ type: "raw", text: pct }} />}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Funnel body — smooth curved stages */}
+      <div className="absolute bottom-0 left-0 right-0 top-24 flex">
+        {sorted.map((point, i) => {
+          const color = resolveStageColor(point, resolvedSeriesColor, i)
+          const leftH = (point.value / maxValue) * 100
+          const nextValue = sorted[i + 1]?.value ?? point.value
+          const rightH = (nextValue / maxValue) * 100
+
+          // Centered vertically around 50
+          const topL = 50 - leftH / 2
+          const botL = 50 + leftH / 2
+          const topR = 50 - rightH / 2
+          const botR = 50 + rightH / 2
+
+          // SVG path: flat left half, then cubic bezier curve to next height
+          // Top edge: flat from 0→50, then curve from 50→100
+          // Bottom edge: curve from 100→50, then flat from 50→0
+          const d = [
+            `M 0,${topL}`,
+            `L 50,${topL}`,
+            `C 65,${topL} 90,${topR} 100,${topR}`,
+            `L 100,${botR}`,
+            `C 90,${botR} 65,${botL} 50,${botL}`,
+            `L 0,${botL}`,
+            "Z",
+          ].join(" ")
+
+          return (
+            <div
+              key={i}
+              className="relative flex-1 border-0 border-l border-dashed border-f1-border"
+            >
+              <svg
+                viewBox="0 0 100 100"
+                preserveAspectRatio="none"
+                className="absolute inset-0 h-full w-full"
+              >
+                <path d={d} fill={color} />
+              </svg>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/components/F0DataChart/components/FunnelChart/utils.ts
+++ b/packages/react/src/components/F0DataChart/components/FunnelChart/utils.ts
@@ -1,0 +1,21 @@
+import type { F0DataChartFunnelDataPoint } from "../../types"
+import { paletteColor, resolveChartColorToken } from "../../utils/colors"
+
+/** Format a conversion percentage (one decimal place) */
+export function formatPercent(value: number, total: number): string {
+  if (total === 0) return "0%"
+  const pct = (value / total) * 100
+  if (pct === 100) return "100%"
+  return `${pct.toFixed(1)}%`
+}
+
+/** Resolve the color for a single funnel data point */
+export function resolveStageColor(
+  point: F0DataChartFunnelDataPoint,
+  seriesColor: string | undefined,
+  index: number
+): string {
+  if (point.color) return resolveChartColorToken(point.color)
+  if (seriesColor) return seriesColor
+  return paletteColor(index)
+}

--- a/packages/react/src/components/F0DataChart/components/LineChart/LineChart.tsx
+++ b/packages/react/src/components/F0DataChart/components/LineChart/LineChart.tsx
@@ -1,0 +1,14 @@
+import { useRef } from "react"
+
+import type { F0DataChartLineProps } from "../../types"
+
+import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { useLineChartOptions } from "./useLineChartOptions"
+
+export const LineChart = (props: F0DataChartLineProps) => {
+  const ref = useRef<HTMLDivElement>(null)
+  const options = useLineChartOptions(ref, props)
+  useEChartsInstance(ref, options)
+
+  return <div ref={ref} className="h-full w-full" />
+}

--- a/packages/react/src/components/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/components/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -1,0 +1,182 @@
+import * as echarts from "echarts"
+import { type RefObject, useMemo } from "react"
+
+import type {
+  F0DataChartLineDataPoint,
+  F0DataChartLineProps,
+  F0DataChartLineSeries,
+  F0DataChartLineType,
+} from "../../types"
+
+import { paletteColor, resolveChartColorToken } from "../../utils/colors"
+import { buildBaseChartOptions, formatNumericValue } from "../../utils/options"
+import { useChartTheme } from "../../utils/useChartTheme"
+import { useContainerWidth } from "../../utils/useContainerWidth"
+
+/** Extract the numeric value from a data point */
+function getValue(point: F0DataChartLineDataPoint): number {
+  return typeof point === "number" ? point : point.value
+}
+
+/** Resolve the color for a series to hex, falling back to the shared palette */
+function resolveColor(series: F0DataChartLineSeries, index: number): string {
+  return series.color
+    ? resolveChartColorToken(series.color)
+    : paletteColor(index)
+}
+
+/**
+ * Map the `lineType` prop to ECharts `smooth` and `step` properties.
+ *
+ * ECharts uses:
+ * - `smooth: false` for straight segments
+ * - `smooth: true` for bezier curves
+ * - `step: "end"` for staircase patterns (overrides smooth)
+ */
+function resolveLineStyle(lineType: F0DataChartLineType): {
+  smooth: boolean
+  step: "end" | "start" | "middle" | false
+} {
+  switch (lineType) {
+    case "smooth":
+      return { smooth: true, step: false }
+    case "step":
+      return { smooth: false, step: "end" }
+    case "linear":
+    default:
+      return { smooth: false, step: false }
+  }
+}
+
+/**
+ * Build the area gradient fill for a line series.
+ * Fades from seriesColor at ~35% opacity to transparent, top to bottom.
+ */
+function buildAreaStyle(color: string): echarts.LineSeriesOption["areaStyle"] {
+  return {
+    color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+      { offset: 0, color: `${color}59` },
+      { offset: 1, color: "rgba(0, 0, 0, 0)" },
+    ]),
+  }
+}
+
+/**
+ * Build a single ECharts line series entry from an F0DataChartLineSeries.
+ */
+function buildSeriesEntry(
+  series: F0DataChartLineSeries,
+  index: number,
+  globalLineType: F0DataChartLineType,
+  globalShowArea: boolean,
+  showDots: boolean,
+  showLabels: boolean,
+  labelColor: string
+): echarts.LineSeriesOption {
+  const color = resolveColor(series, index)
+  const lineType = series.lineType ?? globalLineType
+  const showArea = series.showArea ?? globalShowArea
+  const { smooth, step } = resolveLineStyle(lineType)
+
+  return {
+    name: series.name,
+    type: "line",
+    data: series.data.map(getValue),
+    smooth,
+    step,
+    itemStyle: {
+      color,
+    },
+    lineStyle: {
+      width: 2,
+      type: series.dashed ? "dashed" : "solid",
+    },
+    areaStyle: showArea ? buildAreaStyle(color) : undefined,
+    showSymbol: showDots,
+    symbol: "circle",
+    symbolSize: 6,
+    label: {
+      show: showLabels,
+      position: "top",
+      color: labelColor,
+      fontWeight: "bold",
+      formatter: (params: { value?: number }) =>
+        formatNumericValue(Number(params.value ?? 0)),
+    },
+    emphasis: {
+      itemStyle: {
+        shadowBlur: 0,
+        shadowOffsetX: 0,
+        shadowColor: "transparent",
+      },
+    },
+  }
+}
+
+/**
+ * Converts typed line chart props into a full ECharts option object.
+ */
+export function useLineChartOptions(
+  containerRef: RefObject<HTMLDivElement | null>,
+  {
+    categories,
+    series,
+    lineType = "linear",
+    showArea = true,
+    showDots = false,
+    showLegend = true,
+    showGrid = true,
+    showLabels = false,
+    valueFormatter,
+    categoryFormatter,
+    echartsOptions,
+  }: F0DataChartLineProps
+): echarts.EChartsOption {
+  const theme = useChartTheme(containerRef)
+  const containerWidth = useContainerWidth(containerRef)
+
+  return useMemo(() => {
+    const echartsSeries = series.map((s, i) =>
+      buildSeriesEntry(
+        s,
+        i,
+        lineType,
+        showArea,
+        showDots,
+        showLabels,
+        theme.colors.foregroundSecondary
+      )
+    )
+
+    const legendData = series.map((s) => s.name)
+
+    return buildBaseChartOptions({
+      categories,
+      theme,
+      series: echartsSeries,
+      legendData,
+      isVertical: true,
+      showGrid,
+      showLegend,
+      valueFormatter,
+      categoryFormatter,
+      echartsOptions,
+      containerWidth,
+      boundaryGap: false,
+    })
+  }, [
+    categories,
+    series,
+    lineType,
+    showArea,
+    showDots,
+    showLegend,
+    showGrid,
+    showLabels,
+    valueFormatter,
+    categoryFormatter,
+    echartsOptions,
+    theme,
+    containerWidth,
+  ])
+}

--- a/packages/react/src/components/F0DataChart/index.ts
+++ b/packages/react/src/components/F0DataChart/index.ts
@@ -1,0 +1,33 @@
+import { experimentalComponent } from "@/lib/experimental"
+
+import { F0DataChart as _F0DataChart } from "./F0DataChart"
+
+export type {
+  F0DataChartBarDataPoint,
+  F0DataChartBarProps,
+  F0DataChartBarSeries,
+  F0DataChartFunnelDataPoint,
+  F0DataChartFunnelProps,
+  F0DataChartFunnelSeries,
+  F0DataChartLineDataPoint,
+  F0DataChartLineProps,
+  F0DataChartLineSeries,
+  F0DataChartLineType,
+  F0DataChartProps,
+} from "./types"
+
+export { type ChartColorToken, chartColorTokens } from "./utils/colors"
+export type { ChartTheme } from "./utils/theme"
+export {
+  BarChartSkeleton,
+  FunnelChartSkeleton,
+  LineChartSkeleton,
+} from "./skeletons"
+
+/**
+ * @experimental This is an experimental component use it at your own risk
+ */
+export const F0DataChart = experimentalComponent<typeof _F0DataChart>(
+  "F0DataChart",
+  _F0DataChart
+)

--- a/packages/react/src/components/F0DataChart/skeletons.tsx
+++ b/packages/react/src/components/F0DataChart/skeletons.tsx
@@ -1,0 +1,425 @@
+import { Skeleton } from "@/ui/skeleton"
+
+// ---------------------------------------------------------------------------
+// AxisSkeleton — shared axis frame for bar and line chart skeletons
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared axis skeleton — mimics a chart with category labels along one axis,
+ * value labels along the other, and an optional legend row at the bottom.
+ * Children render in the plot area.
+ *
+ * When `horizontal` is true the axes swap: category labels on the left (wider)
+ * and value labels on the bottom — matching a horizontal bar chart layout.
+ *
+ * Wrapped in px-4 py-3 to match the padding of the real chart content area
+ * inside ChartItem.
+ */
+function AxisSkeleton({
+  children,
+  showLegend = true,
+  horizontal = false,
+}: {
+  children: React.ReactNode
+  showLegend?: boolean
+  horizontal?: boolean
+}) {
+  if (horizontal) {
+    return (
+      <div className="flex h-full animate-pulse flex-col px-4 py-3">
+        {/* Chart area: category labels (left) + plot area (right) */}
+        <div className="flex min-h-0 flex-1 gap-2">
+          {/* Category axis labels (left side for horizontal charts) */}
+          <div className="flex flex-col justify-between py-1">
+            <Skeleton className="h-2.5 w-12 rounded-sm" />
+            <Skeleton className="h-2.5 w-10 rounded-sm" />
+            <Skeleton className="h-2.5 w-14 rounded-sm" />
+            <Skeleton className="h-2.5 w-11 rounded-sm" />
+          </div>
+
+          {/* Plot area */}
+          <div className="relative min-h-0 flex-1">
+            <div className="relative h-full w-full">{children}</div>
+          </div>
+        </div>
+
+        {/* Value axis labels (bottom for horizontal charts) */}
+        <div className="ml-16 flex justify-between pt-1">
+          <Skeleton className="h-2.5 w-5 rounded-sm" />
+          <Skeleton className="h-2.5 w-6 rounded-sm" />
+          <Skeleton className="h-2.5 w-5 rounded-sm" />
+          <Skeleton className="h-2.5 w-7 rounded-sm" />
+        </div>
+
+        {/* Legend */}
+        {showLegend && (
+          <div className="flex items-center justify-center gap-4 pt-3">
+            <div className="flex items-center gap-1.5">
+              <Skeleton className="size-2.5 rounded-full" />
+              <Skeleton className="h-2.5 w-10 rounded-sm" />
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Skeleton className="size-2.5 rounded-full" />
+              <Skeleton className="h-2.5 w-12 rounded-sm" />
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full animate-pulse flex-col px-4 py-3">
+      {/* Chart area: value labels (left) + plot area (right) */}
+      <div className="flex min-h-0 flex-1 gap-2">
+        {/* Value axis labels */}
+        <div className="flex flex-col justify-between py-1">
+          <Skeleton className="h-2.5 w-6 rounded-sm" />
+          <Skeleton className="h-2.5 w-5 rounded-sm" />
+          <Skeleton className="h-2.5 w-7 rounded-sm" />
+          <Skeleton className="h-2.5 w-5 rounded-sm" />
+        </div>
+
+        {/* Plot area — content only, no grid lines */}
+        <div className="relative min-h-0 flex-1">
+          <div className="relative h-full w-full">{children}</div>
+        </div>
+      </div>
+
+      {/* Category axis labels */}
+      <div className="ml-9 flex justify-between pt-1">
+        <Skeleton className="h-2.5 w-6 rounded-sm" />
+        <Skeleton className="h-2.5 w-8 rounded-sm" />
+        <Skeleton className="h-2.5 w-5 rounded-sm" />
+        <Skeleton className="h-2.5 w-7 rounded-sm" />
+        <Skeleton className="h-2.5 w-6 rounded-sm" />
+        <Skeleton className="h-2.5 w-5 rounded-sm" />
+      </div>
+
+      {/* Legend */}
+      {showLegend && (
+        <div className="flex items-center justify-center gap-4 pt-3">
+          <div className="flex items-center gap-1.5">
+            <Skeleton className="size-2.5 rounded-full" />
+            <Skeleton className="h-2.5 w-10 rounded-sm" />
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Skeleton className="size-2.5 rounded-full" />
+            <Skeleton className="h-2.5 w-12 rounded-sm" />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// BarChartSkeleton
+// ---------------------------------------------------------------------------
+
+interface BarChartSkeletonProps {
+  /** Bar orientation. @default "vertical" */
+  orientation?: "vertical" | "horizontal"
+  /** Show stacked bar segments. @default false */
+  stacked?: boolean
+  /** Show legend below chart. @default true */
+  showLegend?: boolean
+}
+
+/**
+ * Skeleton for bar chart content area.
+ *
+ * - `orientation: "vertical"` (default): vertical bars with varying heights.
+ * - `orientation: "horizontal"`: horizontal bars extending left-to-right.
+ * - `stacked: true`: each bar has 2–3 stacked segments.
+ */
+export function BarChartSkeleton({
+  orientation = "vertical",
+  stacked = false,
+  showLegend = true,
+}: BarChartSkeletonProps = {}) {
+  const isHorizontal = orientation === "horizontal"
+
+  if (isHorizontal) {
+    return (
+      <AxisSkeleton showLegend={showLegend} horizontal>
+        <div className="flex h-full flex-col gap-2">
+          {stacked ? (
+            <>
+              <div className="flex flex-1 gap-0.5">
+                <Skeleton className="h-full w-1/2 rounded" />
+                <Skeleton className="h-full w-1/4 rounded" />
+                <Skeleton className="h-full w-[15%] rounded" />
+              </div>
+              <div className="flex flex-1 gap-0.5">
+                <Skeleton className="h-full w-1/3 rounded" />
+                <Skeleton className="h-full w-1/5 rounded" />
+                <Skeleton className="h-full w-[12%] rounded" />
+              </div>
+              <div className="flex flex-1 gap-0.5">
+                <Skeleton className="h-full w-3/5 rounded" />
+                <Skeleton className="h-full w-1/6 rounded" />
+                <Skeleton className="h-full w-[10%] rounded" />
+              </div>
+              <div className="flex flex-1 gap-0.5">
+                <Skeleton className="h-full w-2/5 rounded" />
+                <Skeleton className="h-full w-1/4 rounded" />
+                <Skeleton className="h-full w-[8%] rounded" />
+              </div>
+            </>
+          ) : (
+            <>
+              <Skeleton className="w-3/4 flex-1 rounded" />
+              <Skeleton className="w-1/2 flex-1 rounded" />
+              <Skeleton className="w-full flex-1 rounded" />
+              <Skeleton className="w-1/3 flex-1 rounded" />
+            </>
+          )}
+        </div>
+      </AxisSkeleton>
+    )
+  }
+
+  // Vertical bars (default)
+  if (stacked) {
+    return (
+      <AxisSkeleton showLegend={showLegend}>
+        <div className="flex h-full items-end gap-2">
+          <div className="flex flex-1 flex-col gap-0.5">
+            <Skeleton className="h-[15%] w-full rounded" />
+            <Skeleton className="h-1/4 w-full rounded" />
+            <Skeleton className="h-1/3 w-full rounded" />
+          </div>
+          <div className="flex flex-1 flex-col gap-0.5">
+            <Skeleton className="h-[10%] w-full rounded" />
+            <Skeleton className="h-1/5 w-full rounded" />
+            <Skeleton className="h-1/4 w-full rounded" />
+          </div>
+          <div className="flex flex-1 flex-col gap-0.5">
+            <Skeleton className="h-[12%] w-full rounded" />
+            <Skeleton className="h-1/4 w-full rounded" />
+            <Skeleton className="h-2/5 w-full rounded" />
+          </div>
+          <div className="flex flex-1 flex-col gap-0.5">
+            <Skeleton className="h-[8%] w-full rounded" />
+            <Skeleton className="h-1/5 w-full rounded" />
+            <Skeleton className="h-1/6 w-full rounded" />
+          </div>
+          <div className="flex flex-1 flex-col gap-0.5">
+            <Skeleton className="h-[10%] w-full rounded" />
+            <Skeleton className="h-1/6 w-full rounded" />
+            <Skeleton className="h-1/4 w-full rounded" />
+          </div>
+          <div className="flex flex-1 flex-col gap-0.5">
+            <Skeleton className="h-[12%] w-full rounded" />
+            <Skeleton className="h-1/5 w-full rounded" />
+            <Skeleton className="h-1/3 w-full rounded" />
+          </div>
+        </div>
+      </AxisSkeleton>
+    )
+  }
+
+  // Simple vertical bars
+  return (
+    <AxisSkeleton showLegend={showLegend}>
+      <div className="flex h-full items-end gap-2">
+        <Skeleton className="h-3/4 flex-1 rounded" />
+        <Skeleton className="h-1/2 flex-1 rounded" />
+        <Skeleton className="h-full flex-1 rounded" />
+        <Skeleton className="h-1/3 flex-1 rounded" />
+        <Skeleton className="h-2/3 flex-1 rounded" />
+        <Skeleton className="h-3/4 flex-1 rounded" />
+      </div>
+    </AxisSkeleton>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// LineChartSkeleton
+// ---------------------------------------------------------------------------
+
+interface LineChartSkeletonProps {
+  /** Line interpolation type. @default "linear" */
+  lineType?: "linear" | "smooth" | "step"
+  /** Show gradient area fill below line. @default true */
+  showArea?: boolean
+  /** Show data point dots on the line. @default false */
+  showDots?: boolean
+  /** Show legend below chart. @default true */
+  showLegend?: boolean
+}
+
+/** SVG path data for each line type */
+const LINE_PATHS = {
+  smooth: "M0 60 Q25 45 50 50 T100 35 T150 42 T200 20",
+  linear: "M0 60 L40 45 L80 50 L120 35 L160 42 L200 20",
+  step: "M0 60 H40 V45 H80 V52 H120 V32 H160 V40 H200 V20",
+} as const
+
+/** Data point x/y coordinates for dots (shared across all line types) */
+const DOT_POINTS = [
+  [0, 60],
+  [40, 45],
+  [80, 50],
+  [120, 35],
+  [160, 42],
+  [200, 20],
+] as const
+
+/**
+ * Skeleton for line chart content area.
+ *
+ * - `lineType`: controls the SVG path shape (smooth curves, straight lines, or steps).
+ * - `showArea: true` (default): gradient fill below the line.
+ * - `showArea: false`: line only, no fill.
+ * - `showDots: true`: SVG circles at each data point.
+ */
+export function LineChartSkeleton({
+  lineType = "linear",
+  showArea = true,
+  showDots = false,
+  showLegend = true,
+}: LineChartSkeletonProps = {}) {
+  const pathD = LINE_PATHS[lineType]
+  const fillD = `${pathD} V80 H0 Z`
+  // Unique gradient ID per lineType to avoid SVG ID collisions
+  const gradientId = `line-sk-grad-${lineType}`
+
+  return (
+    <AxisSkeleton showLegend={showLegend}>
+      <div className="relative h-full w-full">
+        <svg
+          viewBox="0 0 200 80"
+          preserveAspectRatio="none"
+          className="h-full w-full"
+        >
+          {showArea && (
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop
+                  offset="0%"
+                  stopColor="currentColor"
+                  stopOpacity="0.10"
+                  className="text-f1-foreground-secondary"
+                />
+                <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+              </linearGradient>
+            </defs>
+          )}
+          {showArea && <path d={fillD} fill={`url(#${gradientId})`} />}
+          <path
+            d={pathD}
+            fill="none"
+            strokeWidth="2"
+            vectorEffect="non-scaling-stroke"
+            stroke="currentColor"
+            strokeOpacity="0.15"
+            className="text-f1-foreground-secondary"
+          />
+        </svg>
+        {showDots &&
+          DOT_POINTS.map(([x, y]) => (
+            <Skeleton
+              key={`${x}-${y}`}
+              className="absolute size-2 rounded-full"
+              style={{
+                left: `${(x / 200) * 100}%`,
+                top: `${(y / 80) * 100}%`,
+                transform: "translate(-50%, -50%)",
+              }}
+            />
+          ))}
+      </div>
+    </AxisSkeleton>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// FunnelChartSkeleton
+// ---------------------------------------------------------------------------
+
+interface FunnelChartSkeletonProps {
+  /** Sort direction. @default "descending" */
+  sort?: "descending" | "ascending" | "none"
+}
+
+/** Default stage sizes (descending — largest first) */
+const FUNNEL_STAGES_DESC = [
+  { sizePct: 100, label: "w-8" },
+  { sizePct: 80, label: "w-6" },
+  { sizePct: 58, label: "w-7" },
+  { sizePct: 38, label: "w-5" },
+  { sizePct: 22, label: "w-6" },
+]
+
+/**
+ * Skeleton for funnel chart content area.
+ * Renders a horizontal funnel with label placeholders above each stage.
+ */
+export function FunnelChartSkeleton({
+  sort = "descending",
+}: FunnelChartSkeletonProps = {}) {
+  const stages =
+    sort === "ascending"
+      ? [...FUNNEL_STAGES_DESC].reverse()
+      : FUNNEL_STAGES_DESC
+
+  const n = stages.length
+
+  return (
+    <div className="flex h-full animate-pulse flex-col px-4 py-3">
+      {/* Label placeholders above each stage */}
+      <div className="flex gap-1.5 pb-2">
+        {stages.map((stage, i) => (
+          <div key={i} className="flex flex-1 flex-col gap-1">
+            <Skeleton
+              className={`h-2.5 flex-shrink-0 rounded-sm ${stage.label}`}
+            />
+            <Skeleton className="h-4 w-8 rounded-sm" />
+          </div>
+        ))}
+      </div>
+
+      {/* Funnel body — smooth curved stages matching the real chart shape */}
+      <div className="min-h-0 flex-1">
+        <svg
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          className="h-full w-full"
+        >
+          {stages.map((stage, i) => {
+            const stageWidth = 100 / n
+            const x = i * stageWidth
+            const midX = x + stageWidth / 2
+            const nextX = x + stageWidth
+            const leftH = stage.sizePct
+            const nextH = stages[i + 1]?.sizePct ?? stage.sizePct
+
+            const topL = 50 - leftH / 2
+            const botL = 50 + leftH / 2
+            const topR = 50 - nextH / 2
+            const botR = 50 + nextH / 2
+
+            // Flat left half, then cubic bezier curve to next height
+            const cp1X = midX + stageWidth * 0.15
+            const cp2X = midX + stageWidth * 0.4
+            const d = [
+              `M ${x},${topL}`,
+              `L ${midX},${topL}`,
+              `C ${cp1X},${topL} ${cp2X},${topR} ${nextX},${topR}`,
+              `L ${nextX},${botR}`,
+              `C ${cp2X},${botR} ${cp1X},${botL} ${midX},${botL}`,
+              `L ${x},${botL}`,
+              "Z",
+            ].join(" ")
+
+            return (
+              <path key={i} d={d} className="fill-f1-background-secondary" />
+            )
+          })}
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/components/F0DataChart/types.ts
+++ b/packages/react/src/components/F0DataChart/types.ts
@@ -1,0 +1,201 @@
+import type * as echarts from "echarts"
+
+import type { ChartColorToken } from "./utils/colors"
+
+// ---------------------------------------------------------------------------
+// Bar data types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single data point in a bar chart series.
+ * Can be a simple number or an object with value and optional target.
+ */
+export type F0DataChartBarDataPoint =
+  | number
+  | {
+      value: number
+      /** When set, renders a gradient fade from the bar top up to the target value */
+      target?: number
+      /** Override color for this individual bar. Must be an F0 design token name. */
+      color?: ChartColorToken
+    }
+
+/**
+ * A series of bars to render in the chart.
+ */
+export interface F0DataChartBarSeries {
+  /** Display name used in legend and tooltip */
+  name: string
+  /** Data points — one per category */
+  data: F0DataChartBarDataPoint[]
+  /** Override color for this series. Must be an F0 design token name. Falls back to the theme palette. */
+  color?: ChartColorToken
+}
+
+// ---------------------------------------------------------------------------
+// Line data types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single data point in a line chart series.
+ * Can be a simple number or an object with a value.
+ */
+export type F0DataChartLineDataPoint =
+  | number
+  | {
+      value: number
+    }
+
+/** Line interpolation type */
+export type F0DataChartLineType = "linear" | "smooth" | "step"
+
+/**
+ * A series of data points to render as a line.
+ */
+export interface F0DataChartLineSeries {
+  /** Display name used in legend and tooltip */
+  name: string
+  /** Data points — one per category */
+  data: F0DataChartLineDataPoint[]
+  /** Override color for this series. Must be an F0 design token name. Falls back to the theme palette. */
+  color?: ChartColorToken
+  /** Render this line with a dashed pattern (useful for projections/targets) */
+  dashed?: boolean
+  /** Override line interpolation for this series */
+  lineType?: F0DataChartLineType
+  /** Override area fill for this series */
+  showArea?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Shared base props
+// ---------------------------------------------------------------------------
+
+interface F0DataChartBaseProps {
+  /** Labels for the category axis (one per data point) */
+  categories: string[]
+
+  /** Show the legend below the chart. @default true */
+  showLegend?: boolean
+  /** Show the background grid lines. @default true */
+  showGrid?: boolean
+  /** Show value labels on each data point. @default false */
+  showLabels?: boolean
+
+  /** Format the value axis tick labels (e.g. `(v) => \`${v}M\`` ) */
+  valueFormatter?: (value: number) => string
+  /** Format category axis tick labels */
+  categoryFormatter?: (value: string) => string
+
+  /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
+  echartsOptions?: Partial<echarts.EChartsOption>
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union: bar variant
+// ---------------------------------------------------------------------------
+
+/**
+ * Bar chart variant props.
+ */
+export interface F0DataChartBarProps extends F0DataChartBaseProps {
+  /** Chart type */
+  type: "bar"
+  /** One or more data series to render as bars */
+  series: F0DataChartBarSeries[]
+  /** Bar orientation. @default "vertical" */
+  orientation?: "vertical" | "horizontal"
+  /** Stack all series into a single bar per category. @default false */
+  stacked?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union: line variant
+// ---------------------------------------------------------------------------
+
+/**
+ * Line chart variant props.
+ */
+export interface F0DataChartLineProps extends F0DataChartBaseProps {
+  /** Chart type */
+  type: "line"
+  /** One or more data series to render as lines */
+  series: F0DataChartLineSeries[]
+  /** Line interpolation type. @default "linear" */
+  lineType?: F0DataChartLineType
+  /** Show gradient area fill below lines. @default true */
+  showArea?: boolean
+  /** Show data point dots on the lines. @default false */
+  showDots?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Funnel data types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single data point in a funnel chart series.
+ * Each point has a value and a stage name.
+ */
+export interface F0DataChartFunnelDataPoint {
+  /** Numeric value for this funnel stage */
+  value: number
+  /** Stage label (e.g. "Applied", "Phone Screen", "Hired") */
+  name: string
+  /** Override color for this individual stage. Must be an F0 design token name. */
+  color?: ChartColorToken
+}
+
+/**
+ * A single funnel series with named data points.
+ */
+export interface F0DataChartFunnelSeries {
+  /** Display name used in legend and tooltip */
+  name: string
+  /** Data points — one per funnel stage */
+  data: F0DataChartFunnelDataPoint[]
+  /** Override color for the entire series. Must be an F0 design token name. */
+  color?: ChartColorToken
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union: funnel variant
+// ---------------------------------------------------------------------------
+
+/**
+ * Funnel chart variant props.
+ *
+ * Funnels do NOT use category/value axes — stage names come from the data
+ * points themselves. This interface is separate from `F0DataChartBaseProps`.
+ */
+export interface F0DataChartFunnelProps {
+  /** Chart type */
+  type: "funnel"
+  /** The funnel series to render */
+  series: F0DataChartFunnelSeries
+  /** Sort direction of funnel stages. @default "descending" */
+  sort?: "descending" | "ascending" | "none"
+  /**
+   * Show conversion percentages in labels.
+   * Each stage displays its value as a percentage of the first stage.
+   * @default false
+   */
+  showConversion?: boolean
+  /** Format the value displayed in labels */
+  valueFormatter?: (value: number) => string
+}
+
+// ---------------------------------------------------------------------------
+// Union
+// ---------------------------------------------------------------------------
+
+/**
+ * Props for the F0DataChart component.
+ *
+ * A unified chart component that supports bar, line, and funnel chart types
+ * via a discriminated `type` prop.
+ */
+export type F0DataChartProps =
+  | F0DataChartBarProps
+  | F0DataChartLineProps
+  | F0DataChartFunnelProps

--- a/packages/react/src/components/F0DataChart/utils/colors.ts
+++ b/packages/react/src/components/F0DataChart/utils/colors.ts
@@ -1,0 +1,121 @@
+import { colord } from "colord"
+
+import { baseColors } from "../../../../../core/src/tokens/colors"
+
+// ---------------------------------------------------------------------------
+// Chart color tokens — constrained to the chromatic baseColors palette
+// ---------------------------------------------------------------------------
+
+/**
+ * The 15 chromatic color names from the F0 design token palette.
+ * These are the only colors allowed for custom series / data-point colors.
+ */
+export const chartColorTokens = [
+  "lilac",
+  "barbie",
+  "smoke",
+  "army",
+  "flubber",
+  "indigo",
+  "camel",
+  "radical",
+  "viridian",
+  "orange",
+  "red",
+  "grass",
+  "malibu",
+  "yellow",
+  "purple",
+] as const
+
+/** A valid chart color token — one of the 15 chromatic F0 base-color names. */
+export type ChartColorToken = (typeof chartColorTokens)[number]
+
+/**
+ * Map from token name → HSL string (shade 50, the base variant).
+ * Used internally to resolve a `ChartColorToken` to a hex color for Canvas.
+ */
+const chartColorHslMap: Record<ChartColorToken, string> = {
+  lilac: baseColors.lilac[50],
+  barbie: baseColors.barbie[50],
+  smoke: baseColors.smoke[50],
+  army: baseColors.army[50],
+  flubber: baseColors.flubber[50],
+  indigo: baseColors.indigo[50],
+  camel: baseColors.camel[50],
+  radical: baseColors.radical[50],
+  viridian: baseColors.viridian[50],
+  orange: baseColors.orange[50],
+  red: baseColors.red[50],
+  grass: baseColors.grass[50],
+  malibu: baseColors.malibu[50],
+  yellow: baseColors.yellow[50],
+  purple: baseColors.purple[50],
+}
+
+/**
+ * Resolve a `ChartColorToken` to a hex color string for Canvas rendering.
+ *
+ * @example
+ * ```ts
+ * resolveChartColorToken("viridian") // → "#0aa69b"
+ * ```
+ */
+export function resolveChartColorToken(token: ChartColorToken): string {
+  return chartColor(chartColorHslMap[token])
+}
+
+/**
+ * Convert an HSL token value (e.g. "174 52% 38%") to a hex color string
+ * that ECharts (Canvas) can render directly.
+ */
+export function chartColor(hslValue: string): string {
+  return colord(`hsl(${hslValue})`).toHex()
+}
+
+/**
+ * Resolve a CSS custom property to a hex color for Canvas rendering.
+ *
+ * When `element` is provided, `getComputedStyle(element)` is used so that
+ * the resolved value respects any `.dark` ancestor in the DOM tree (the
+ * `:root .dark` selector in `base.css` flips all semantic tokens).
+ * Falls back to `document.documentElement` when no element is given, and
+ * to the provided HSL token during SSR.
+ */
+export function resolveCssColor(
+  varName: string,
+  fallbackHsl: string,
+  element?: Element | null
+): string {
+  if (typeof document === "undefined") {
+    return chartColor(fallbackHsl)
+  }
+  const target = element ?? document.documentElement
+  const raw = getComputedStyle(target).getPropertyValue(varName).trim()
+  if (!raw) {
+    return chartColor(fallbackHsl)
+  }
+  return colord(`hsl(${raw})`).toHex()
+}
+
+/**
+ * 10-color palette for ECharts-based chart components,
+ * derived from F0 design token baseColors.
+ */
+export const echartsColorPalette = [
+  chartColor(baseColors.viridian[50]),
+  chartColor(baseColors.purple[50]),
+  chartColor(baseColors.barbie[50]),
+  chartColor(baseColors.yellow[50]),
+  chartColor(baseColors.indigo[50]),
+  chartColor(baseColors.lilac[70]),
+  chartColor(baseColors.smoke[60]),
+  chartColor(baseColors.malibu[70]),
+  chartColor(baseColors.grass[50]),
+  chartColor(baseColors.red[60]),
+]
+
+/** Look up a palette color by index (wraps around) */
+export function paletteColor(index: number): string {
+  return echartsColorPalette[index % echartsColorPalette.length] ?? "#999"
+}

--- a/packages/react/src/components/F0DataChart/utils/options.ts
+++ b/packages/react/src/components/F0DataChart/utils/options.ts
@@ -1,0 +1,450 @@
+import type * as echarts from "echarts"
+
+import type { ChartTheme } from "./theme"
+
+/**
+ * Format a numeric value to at most 2 decimal places.
+ * Integers remain unchanged (no trailing ".00").
+ */
+export function formatNumericValue(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(3)
+}
+
+// ---------------------------------------------------------------------------
+// Category axis
+// ---------------------------------------------------------------------------
+
+interface CategoryAxisOptions {
+  data: string[]
+  theme: ChartTheme
+  formatter?: (value: string) => string
+  /** Container width in pixels — used to auto-compute label interval */
+  containerWidth?: number
+  /**
+   * Whether to leave space at the edges of the category axis.
+   * - `true` (default for ECharts) — centres categories with padding at edges.
+   *   Appropriate for bar charts where bars need centering space.
+   * - `false` — first/last data points sit flush against the axis edges.
+   *   Appropriate for line charts.
+   */
+  boundaryGap?: boolean
+}
+
+/**
+ * Minimum pixels of space each category label needs before we start
+ * skipping labels. Labels narrower than this overlap and become unreadable.
+ */
+const MIN_LABEL_WIDTH = 60
+
+/**
+ * Compute how many labels to skip so that they don't overlap.
+ * Returns 0 (show every label) when there's enough room, or N to
+ * show every (N+1)th label.
+ */
+function computeLabelInterval(
+  categoryCount: number,
+  containerWidth: number | undefined
+): number | undefined {
+  if (!containerWidth || categoryCount <= 1) return undefined
+  const spacePerLabel = containerWidth / categoryCount
+  if (spacePerLabel >= MIN_LABEL_WIDTH) return undefined
+  // How many labels fit comfortably
+  const fitCount = Math.max(1, Math.floor(containerWidth / MIN_LABEL_WIDTH))
+  // interval = skip every N labels so that only fitCount labels are shown
+  return Math.max(0, Math.ceil(categoryCount / fitCount) - 1)
+}
+
+/** Build a styled category axis matching F0 chart conventions */
+export function buildCategoryAxis({
+  data,
+  theme,
+  formatter,
+  containerWidth,
+  boundaryGap,
+}: CategoryAxisOptions) {
+  const interval = computeLabelInterval(data.length, containerWidth)
+
+  return {
+    type: "category" as const,
+    data,
+    ...(boundaryGap !== undefined ? { boundaryGap } : {}),
+    axisLine: {
+      lineStyle: {
+        color: theme.colors.borderSecondary,
+      },
+    },
+    axisTick: {
+      show: false,
+    },
+    axisLabel: {
+      fontSize: theme.textStyle.fontSize,
+      fontWeight: theme.textStyle.fontWeight,
+      color: theme.colors.foregroundTertiary,
+      ...(interval !== undefined ? { interval } : {}),
+      ...(formatter
+        ? {
+            formatter: (_value: string | number) => formatter(String(_value)),
+          }
+        : {}),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Value axis
+// ---------------------------------------------------------------------------
+
+interface ValueAxisOptions {
+  theme: ChartTheme
+  showGrid: boolean
+  formatter?: (value: number) => string
+}
+
+/** Build a styled value axis with optional solid grid lines */
+export function buildValueAxis({
+  theme,
+  showGrid,
+  formatter,
+}: ValueAxisOptions) {
+  return {
+    type: "value" as const,
+    axisLine: {
+      show: false,
+    },
+    axisTick: {
+      show: false,
+    },
+    axisLabel: {
+      fontSize: theme.textStyle.fontSize,
+      fontWeight: theme.textStyle.fontWeight,
+      color: theme.colors.foregroundTertiary,
+      formatter: (_value: string | number) =>
+        formatter
+          ? formatter(Number(_value))
+          : formatNumericValue(Number(_value)),
+    },
+    splitLine: {
+      show: showGrid,
+      lineStyle: {
+        type: "solid" as const,
+        color: theme.colors.borderSecondary,
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Legend
+// ---------------------------------------------------------------------------
+
+interface LegendOptions {
+  show: boolean
+  data: string[]
+  theme: ChartTheme
+}
+
+/**
+ * Build the standard F0 chart legend: circle icons, centered at bottom,
+ * with a 16px gap between chart area and legend.
+ */
+export function buildLegend({
+  show,
+  data,
+  theme,
+}: LegendOptions): echarts.EChartsOption["legend"] {
+  if (!show) return undefined
+
+  return {
+    show: true,
+    data,
+    bottom: 0,
+    left: "center",
+    icon: "circle",
+    itemWidth: 10,
+    itemHeight: 10,
+    selectedMode: false,
+    textStyle: {
+      fontWeight: theme.textStyle.fontWeight,
+      color: theme.colors.foregroundSecondary,
+    },
+  } as echarts.EChartsOption["legend"]
+}
+
+// ---------------------------------------------------------------------------
+// Grid
+// ---------------------------------------------------------------------------
+
+interface GridOptions {
+  showLegend: boolean
+}
+
+/** Standard chart grid — minimal padding, containLabel keeps axis labels visible */
+export function buildGrid({ showLegend }: GridOptions) {
+  return {
+    left: 4,
+    right: 4,
+    top: 8,
+    // Legend height (~20px) + 8px gap between chart and legend
+    bottom: showLegend ? 28 : 4,
+    containLabel: true,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Emphasis
+// ---------------------------------------------------------------------------
+
+/** Default emphasis config: disables label and removes shadow */
+export const DEFAULT_EMPHASIS = {
+  label: {
+    show: false,
+  },
+  itemStyle: {
+    shadowBlur: 0,
+    shadowOffsetX: 0,
+    shadowColor: "transparent",
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip
+// ---------------------------------------------------------------------------
+
+interface TooltipOptions {
+  theme: ChartTheme
+  /** Filter out series whose name matches this predicate */
+  filterSeries?: (seriesName: string) => boolean
+  valueFormatter?: (value: number) => string
+}
+
+/**
+ * Build a fully styled axis-triggered tooltip that optionally filters out
+ * ghost series (e.g. target gradient bars).
+ *
+ * Replicates the visual style from the old f0.light theme:
+ * - padding, borderWidth, borderRadius
+ * - frosted glass background (light and dark variants)
+ * - smart position function (flips left/right at chart midpoint)
+ * - dashed axis pointer line
+ * - transition duration
+ */
+export function buildTooltip({
+  theme,
+  filterSeries,
+  valueFormatter,
+}: TooltipOptions): echarts.EChartsOption["tooltip"] {
+  const { tooltip, axisPointer, colors } = theme
+
+  return {
+    trigger: "axis",
+    confine: true,
+    padding: tooltip.padding,
+    borderWidth: tooltip.borderWidth,
+    transitionDuration: tooltip.transitionDuration,
+    textStyle: {
+      color: colors.foreground,
+      fontSize: 14,
+    },
+    // Smart position: flip tooltip to the other side of the cursor at the
+    // chart midpoint so it never clips outside the container
+    position(
+      point: [number, number],
+      _params: unknown,
+      _dom: unknown,
+      _rect: unknown,
+      size: { viewSize: [number, number]; contentSize: [number, number] }
+    ) {
+      const tooltipWidth = size.contentSize[0]
+      const isLeftHalf = point[0] < size.viewSize[0] / 2
+      const x = isLeftHalf ? point[0] + 10 : point[0] - tooltipWidth - 10
+
+      return [x, "20%"]
+    },
+    axisPointer: {
+      type: "line",
+      lineStyle: {
+        color: axisPointer.color,
+        type: axisPointer.type,
+      },
+    },
+    extraCssText: [
+      `box-shadow: ${tooltip.boxShadow}`,
+      `border-radius: ${tooltip.borderRadius}px`,
+      `border: 1px solid ${colors.borderSecondary}`,
+      "backdrop-filter: blur(30px)",
+      `-webkit-backdrop-filter: blur(30px)`,
+      `background: ${tooltip.background}`,
+    ].join("; "),
+    formatter: (params: unknown) => {
+      if (!Array.isArray(params)) return ""
+
+      const filtered = filterSeries
+        ? params.filter(
+            (p: { seriesName?: string }) =>
+              !filterSeries(String(p.seriesName ?? ""))
+          )
+        : params
+
+      if (filtered.length === 0) return ""
+
+      const header = `<div style="margin-bottom: 4px; font-weight: 500">${String(filtered[0].axisValueLabel ?? filtered[0].name ?? "")}</div>`
+      const items = filtered
+        .map((p: { marker?: string; seriesName?: string; value?: number }) => {
+          const formattedValue = valueFormatter
+            ? valueFormatter(Number(p.value))
+            : formatNumericValue(Number(p.value ?? 0))
+          return `<div>${String(p.marker ?? "")} ${String(p.seriesName ?? "")} <strong>${formattedValue}</strong></div>`
+        })
+        .join("")
+
+      return `${header}${items}`
+    },
+  } as echarts.EChartsOption["tooltip"]
+}
+
+// ---------------------------------------------------------------------------
+// Axes builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble the axes for a chart that supports both vertical and horizontal
+ * orientations. Returns `{ xAxis, yAxis }` with proper ECharts casts.
+ */
+export function buildAxes({
+  isVertical,
+  categories,
+  theme,
+  showGrid,
+  valueFormatter,
+  categoryFormatter,
+  containerWidth,
+  boundaryGap,
+}: {
+  isVertical: boolean
+  categories: string[]
+  theme: ChartTheme
+  showGrid: boolean
+  valueFormatter?: (value: number) => string
+  categoryFormatter?: (value: string) => string
+  containerWidth?: number
+  boundaryGap?: boolean
+}) {
+  const categoryAxis = buildCategoryAxis({
+    data: categories,
+    theme,
+    formatter: categoryFormatter,
+    containerWidth,
+    boundaryGap,
+  })
+
+  const valueAxis = buildValueAxis({
+    theme,
+    showGrid,
+    formatter: valueFormatter,
+  })
+
+  return {
+    xAxis: (isVertical
+      ? { ...categoryAxis }
+      : { ...valueAxis }) as echarts.EChartsOption["xAxis"],
+    yAxis: (isVertical
+      ? { ...valueAxis }
+      : { ...categoryAxis }) as echarts.EChartsOption["yAxis"],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Base chart options builder
+// ---------------------------------------------------------------------------
+
+interface BaseChartOptionsParams {
+  /** Category axis labels */
+  categories: string[]
+  /** Resolved chart theme */
+  theme: ChartTheme
+  /** ECharts series array (bar or line) — already built by the caller */
+  series: echarts.EChartsOption["series"]
+  /** Legend entry names (main series only, excluding ghost/target series) */
+  legendData: string[]
+  /** Whether the category axis is horizontal (true) or vertical (false) */
+  isVertical: boolean
+  /** Show grid lines on the value axis */
+  showGrid: boolean
+  /** Show the legend below the chart */
+  showLegend: boolean
+  /** Format value axis labels */
+  valueFormatter?: (value: number) => string
+  /** Format category axis labels */
+  categoryFormatter?: (value: string) => string
+  /** Predicate to filter series out of the tooltip (e.g. target ghost bars) */
+  tooltipFilterSeries?: (seriesName: string) => boolean
+  /** User-provided ECharts overrides (shallow-merged on top) */
+  echartsOptions?: Partial<echarts.EChartsOption>
+  /** Container width in pixels — used to auto-compute category label interval */
+  containerWidth?: number
+  /** Whether to leave space at the edges of the category axis */
+  boundaryGap?: boolean
+}
+
+/**
+ * Assemble a complete ECharts option from pre-built series.
+ *
+ * Both bar and line hooks delegate here so that axes, legend, grid, tooltip,
+ * and emphasis are built in exactly one place. Future chart types (pie,
+ * scatter, etc.) should also delegate here for consistent styling.
+ */
+export function buildBaseChartOptions({
+  categories,
+  theme,
+  series,
+  legendData,
+  isVertical,
+  showGrid,
+  showLegend,
+  valueFormatter,
+  categoryFormatter,
+  tooltipFilterSeries,
+  echartsOptions,
+  containerWidth,
+  boundaryGap,
+}: BaseChartOptionsParams): echarts.EChartsOption {
+  const { xAxis, yAxis } = buildAxes({
+    isVertical,
+    categories,
+    theme,
+    showGrid,
+    valueFormatter,
+    categoryFormatter,
+    containerWidth,
+    boundaryGap,
+  })
+
+  const baseOptions: echarts.EChartsOption = {
+    animation: false,
+    color: theme.palette,
+    textStyle: {
+      fontFamily: theme.textStyle.fontFamily,
+    },
+    xAxis,
+    yAxis,
+    series,
+    legend: buildLegend({
+      show: showLegend,
+      data: legendData,
+      theme,
+    }),
+    grid: buildGrid({ showLegend }),
+    tooltip: buildTooltip({
+      theme,
+      filterSeries: tooltipFilterSeries,
+      valueFormatter,
+    }),
+    emphasis: DEFAULT_EMPHASIS,
+  }
+
+  if (echartsOptions) {
+    return Object.assign({}, baseOptions, echartsOptions)
+  }
+
+  return baseOptions
+}

--- a/packages/react/src/components/F0DataChart/utils/theme.ts
+++ b/packages/react/src/components/F0DataChart/utils/theme.ts
@@ -1,0 +1,195 @@
+import { baseColors } from "../../../../../core/src/tokens/colors"
+import { chartColor, echartsColorPalette, resolveCssColor } from "./colors"
+
+// ---------------------------------------------------------------------------
+// Chart theme — the single source of truth for all chart styling
+// ---------------------------------------------------------------------------
+
+/** Semantic colors used by every chart type */
+export interface ChartThemeColors {
+  /** Primary text — tooltip body, strong labels. Resolves from --neutral-80 */
+  foreground: string
+  /** Secondary text — legend labels. Resolves from --neutral-50 */
+  foregroundSecondary: string
+  /** Tertiary text — axis tick labels. Resolves from --neutral-40 */
+  foregroundTertiary: string
+  /** Grid / split lines, category axis line. Resolves from --neutral-10 */
+  borderSecondary: string
+  /** Axis pointer line, subtle dividers. Resolves from --neutral-30 */
+  border: string
+  /** Tooltip background color (CSS rgba string) */
+  tooltipBackground: string
+  /** Chart container background — used when chart needs to know its own bg */
+  background: string
+}
+
+/** Tooltip visual configuration */
+export interface ChartThemeTooltip {
+  padding: number[]
+  borderWidth: number
+  borderRadius: number
+  transitionDuration: number
+  /** CSS box-shadow applied via extraCssText */
+  boxShadow: string
+  /** Full CSS background string (may include rgba + filters) */
+  background: string
+}
+
+/** Axis pointer visual configuration */
+export interface ChartThemeAxisPointer {
+  color: string
+  type: "dashed" | "solid"
+}
+
+/** Typography configuration */
+export interface ChartThemeTextStyle {
+  fontFamily: string
+  fontSize: number
+  fontWeight: number
+}
+
+/**
+ * Complete chart theme — everything a chart type needs to render correctly.
+ *
+ * Resolved at runtime from CSS custom properties so that it automatically
+ * adapts to light / dark mode. Every chart type hook receives this object
+ * and passes it through to the shared option builders.
+ */
+export interface ChartTheme {
+  /** Current mode — useful for conditional logic in chart-type hooks */
+  mode: "light" | "dark"
+  /** Semantic colors */
+  colors: ChartThemeColors
+  /** Default series color palette (hex strings) */
+  palette: string[]
+  /** Tooltip visual config */
+  tooltip: ChartThemeTooltip
+  /** Axis pointer visual config */
+  axisPointer: ChartThemeAxisPointer
+  /** Base text style applied to the entire ECharts instance */
+  textStyle: ChartThemeTextStyle
+}
+
+// ---------------------------------------------------------------------------
+// Light theme constants
+// ---------------------------------------------------------------------------
+
+const LIGHT_TOOLTIP: ChartThemeTooltip = {
+  // text size 14px, padding 8px eje x 6 en eje y
+  padding: [6, 8],
+  borderWidth: 1,
+  borderRadius: 10,
+  transitionDuration: 0.2,
+  boxShadow: "0px 12px 24px -14px rgba(13, 22, 37, 0.2)",
+  background: "rgba(255, 255, 255, 0.85)",
+}
+
+// ---------------------------------------------------------------------------
+// Dark theme constants
+// ---------------------------------------------------------------------------
+
+const DARK_TOOLTIP: ChartThemeTooltip = {
+  padding: [8, 6],
+  borderWidth: 1,
+  borderRadius: 10,
+  transitionDuration: 0.2,
+  boxShadow: "0px 12px 24px -14px rgba(0, 0, 0, 0.4)",
+  background: "rgba(15, 18, 25, 0.85)",
+}
+
+// ---------------------------------------------------------------------------
+// Shared constants
+// ---------------------------------------------------------------------------
+
+const TEXT_STYLE: ChartThemeTextStyle = {
+  fontFamily: "Inter, sans-serif",
+  fontSize: 12,
+  fontWeight: 500,
+}
+
+// ---------------------------------------------------------------------------
+// Detection helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether the given element (or the document root) is inside a dark
+ * mode context. Walks up the DOM via `closest(".dark")` so it detects:
+ *  - `.dark` on `<html>` (production app)
+ *  - `.dark` on `<body>` (Storybook)
+ *  - `.dark` on any wrapper `<div>` (dark-island components)
+ */
+function isDarkMode(element?: Element | null): boolean {
+  if (typeof document === "undefined") return false
+  const target = element ?? document.documentElement
+  return target.closest(".dark") !== null
+}
+
+// ---------------------------------------------------------------------------
+// Theme resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the complete chart theme from CSS custom properties.
+ *
+ * When `element` is provided, dark mode detection uses `element.closest(".dark")`
+ * and CSS variable resolution uses `getComputedStyle(element)` — this ensures
+ * the theme is correct even when the chart lives inside a localized dark island
+ * (a parent `<div class="dark">`).
+ *
+ * Call this inside a React hook — the companion `useChartTheme()` hook
+ * handles reactivity via a MutationObserver.
+ *
+ * The color palette is shared between light and dark modes because the
+ * chromatic F0 tokens have enough saturation for both backgrounds. If
+ * individual tokens need per-mode adjustment in the future, the palette
+ * can be split here without touching any consumer code.
+ */
+export function resolveChartTheme(element?: Element | null): ChartTheme {
+  const dark = isDarkMode(element)
+
+  const colors: ChartThemeColors = {
+    foreground: resolveCssColor(
+      "--neutral-80",
+      dark ? baseColors.white[80] : baseColors.grey[80],
+      element
+    ),
+    foregroundSecondary: resolveCssColor(
+      "--neutral-50",
+      dark ? baseColors.white[50] : baseColors.grey[50],
+      element
+    ),
+    foregroundTertiary: resolveCssColor(
+      "--neutral-40",
+      dark ? baseColors.white[40] : baseColors.grey[40],
+      element
+    ),
+    borderSecondary: resolveCssColor(
+      "--neutral-10",
+      dark ? baseColors.white[10] : baseColors.grey[10],
+      element
+    ),
+    border: resolveCssColor(
+      "--neutral-30",
+      dark ? baseColors.white[30] : baseColors.grey[30],
+      element
+    ),
+    tooltipBackground: dark
+      ? DARK_TOOLTIP.background
+      : LIGHT_TOOLTIP.background,
+    background: dark
+      ? chartColor(baseColors.grey[100])
+      : chartColor(baseColors.white[100]),
+  }
+
+  return {
+    mode: dark ? "dark" : "light",
+    colors,
+    palette: echartsColorPalette,
+    tooltip: dark ? DARK_TOOLTIP : LIGHT_TOOLTIP,
+    axisPointer: {
+      color: colors.border,
+      type: "dashed",
+    },
+    textStyle: TEXT_STYLE,
+  }
+}

--- a/packages/react/src/components/F0DataChart/utils/useChartTheme.ts
+++ b/packages/react/src/components/F0DataChart/utils/useChartTheme.ts
@@ -1,0 +1,70 @@
+import { type RefObject, useCallback, useEffect, useState } from "react"
+
+import { type ChartTheme, resolveChartTheme } from "./theme"
+
+/**
+ * Collect every ancestor element from `element` up to (and including)
+ * `document.documentElement`. These are the elements that could have the
+ * `.dark` class toggled on them, so we need to observe all of them.
+ */
+function getAncestors(element: Element): Element[] {
+  const ancestors: Element[] = []
+  let current: Element | null = element
+  while (current) {
+    ancestors.push(current)
+    current = current.parentElement
+  }
+  return ancestors
+}
+
+/**
+ * Resolves the complete chart theme from CSS custom properties and
+ * re-resolves it when the dark mode context changes.
+ *
+ * Accepts a ref to the chart's container element so it can:
+ * 1. Detect `.dark` on **any ancestor** via `element.closest(".dark")`
+ * 2. Resolve CSS custom properties via `getComputedStyle(element)` so
+ *    that localized dark islands (a parent `<div class="dark">`) are
+ *    respected.
+ * 3. Observe class attribute changes on every ancestor element so the
+ *    theme re-resolves when `.dark` is added or removed at any level.
+ *
+ * Every chart-type hook (bar, line, pie, …) should call this once and
+ * pass the returned `ChartTheme` through to `buildBaseChartOptions()`.
+ */
+export function useChartTheme(
+  containerRef: RefObject<HTMLDivElement | null>
+): ChartTheme {
+  const [theme, setTheme] = useState<ChartTheme>(() =>
+    resolveChartTheme(containerRef.current)
+  )
+
+  const refresh = useCallback(() => {
+    setTheme(resolveChartTheme(containerRef.current))
+  }, [containerRef])
+
+  // Re-resolve on mount (when the ref becomes available) and whenever
+  // any ancestor's class attribute changes (covers .dark toggles at
+  // any level: <html>, <body>, or a wrapper <div>).
+  useEffect(() => {
+    const element = containerRef.current
+    if (!element) return
+
+    // Initial resolution now that the element is mounted
+    setTheme(resolveChartTheme(element))
+
+    const observer = new MutationObserver(refresh)
+
+    // Observe every ancestor for class changes
+    for (const ancestor of getAncestors(element)) {
+      observer.observe(ancestor, {
+        attributes: true,
+        attributeFilter: ["class"],
+      })
+    }
+
+    return () => observer.disconnect()
+  }, [containerRef, refresh])
+
+  return theme
+}

--- a/packages/react/src/components/F0DataChart/utils/useContainerWidth.ts
+++ b/packages/react/src/components/F0DataChart/utils/useContainerWidth.ts
@@ -1,0 +1,30 @@
+import { type RefObject, useEffect, useState } from "react"
+
+/**
+ * Tracks the `clientWidth` of a container element via `ResizeObserver`.
+ *
+ * Returns 0 until the element mounts. Updates whenever the element is
+ * resized, so downstream computations (like axis label intervals) react
+ * to layout changes automatically.
+ */
+export function useContainerWidth(ref: RefObject<HTMLElement | null>): number {
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    setWidth(el.clientWidth)
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setWidth(entry.contentRect.width)
+      }
+    })
+    observer.observe(el)
+
+    return () => observer.disconnect()
+  }, [ref])
+
+  return width
+}

--- a/packages/react/src/components/F0DataChart/utils/useEChartsInstance.ts
+++ b/packages/react/src/components/F0DataChart/utils/useEChartsInstance.ts
@@ -1,0 +1,43 @@
+import * as echarts from "echarts"
+import { AriaComponent } from "echarts/components"
+import { type RefObject, useEffect, useRef } from "react"
+
+// @ts-expect-error - Duplicate echarts types in dependency tree
+echarts.use(AriaComponent)
+
+/**
+ * Manages the ECharts instance lifecycle: init, resize, option updates,
+ * and cleanup. Shared across all ECharts-based F0 chart components.
+ *
+ * Accepts a ref to the container `<div>` so it can be shared with other
+ * hooks that need access to the same DOM element (e.g. `useChartTheme`
+ * for dark mode detection via `element.closest(".dark")`).
+ */
+export function useEChartsInstance(
+  ref: RefObject<HTMLDivElement | null>,
+  options: echarts.EChartsOption
+) {
+  const chart = useRef<echarts.ECharts | null>(null)
+
+  useEffect(() => {
+    if (ref.current) {
+      chart.current = echarts.init(ref.current)
+
+      const container = ref.current
+      const resizeObserver = new ResizeObserver(() => {
+        chart.current?.resize()
+      })
+
+      resizeObserver.observe(container)
+
+      return () => {
+        resizeObserver.disconnect()
+        chart.current?.dispose()
+      }
+    }
+  }, [ref])
+
+  useEffect(() => {
+    chart.current?.setOption(options, true)
+  }, [options])
+}

--- a/packages/react/src/components/exports.ts
+++ b/packages/react/src/components/exports.ts
@@ -25,6 +25,7 @@ export * from "./tags/exports"
 export * from "./Utilities/Await"
 export * from "./Utilities/F0GridStack"
 export * from "./F0TableOfContentPopover"
+export * from "./F0DataChart"
 /**
  * @deprecated UpsellingKit has moved to @/sds/UpsellingKit. Import from there instead.
  */


### PR DESCRIPTION
## Summary

New unified `F0DataChart` component supporting bar, line, and funnel chart types via a discriminated `type` prop.

- **Bar chart**: vertical/horizontal, stacked, per-bar colors, targets with gradient fade, custom formatters
- **Line chart**: linear/smooth/step interpolation, area fill, dashed lines, data point dots
- **Funnel chart**: pure HTML renderer with smooth SVG bezier curves — no ECharts overhead
- **Skeletons**: matching skeletons for all chart types (bar, line, funnel)
- **Shared utilities**: chart theme (dark/light mode via MutationObserver), color palette with F0 design tokens, ECharts instance management

### Funnel chart specifics

The funnel chart was simplified to a pure HTML/SVG renderer (ECharts mode was removed):

- Smooth curved transitions between stages using cubic bezier paths
- `showConversion` prop displays percentage relative to the first stage
- Extracted shared `formatPercent` and `resolveStageColor` into `utils.ts`
- Removed ECharts-only props (`gap`, `showLabels`, `showLegend`, `echartsOptions`) — fewer knobs = simpler API for LLM-generated dashboards
- Skeleton uses the same curved geometry as the real chart

### Files (19 new, 1 modified)

| Path | Description |
|------|-------------|
| `F0DataChart.tsx` | Root component — routes to Bar/Line/Funnel by `type` |
| `types.ts` | Discriminated union types for all chart variants |
| `index.ts` | Public exports |
| `components/BarChart/*` | Bar chart + options hook |
| `components/LineChart/*` | Line chart + options hook |
| `components/FunnelChart/FunnelChart.tsx` | Pure HTML/SVG funnel |
| `components/FunnelChart/utils.ts` | Shared funnel utilities |
| `skeletons.tsx` | Skeleton components for all chart types |
| `utils/*` | Chart theme, color tokens, ECharts instance, shared options |
| `__stories__/*` | Storybook stories + decorator |
| `exports.ts` | Added `F0DataChart` export |

## Test plan

- [ ] Storybook: verify all bar, line, and funnel stories render correctly
- [ ] Storybook: `FunnelWithConversion` shows percentage tags
- [ ] Storybook: funnel skeleton matches curved shape
- [ ] Dark mode: verify charts adapt to theme changes
- [ ] `pnpm tsc` passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)