### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.393.0",
-  "packages/react-native": "0.29.0",
+  "packages/react-native": "0.30.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.30.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.29.0...f0-react-native-v0.30.0) (2026-03-10)
+
+
+### Features
+
+* add new primitive `F0Icon` ([#3594](https://github.com/factorialco/f0/issues/3594)) ([bea9161](https://github.com/factorialco/f0/commit/bea9161a0027d32c1669d0220c467bea5119d39b))
+
 ## [0.29.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.28.1...f0-react-native-v0.29.0) (2026-03-09)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.30.0</summary>

## [0.30.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.29.0...f0-react-native-v0.30.0) (2026-03-10)


### Features

* add new primitive `F0Icon` ([#3594](https://github.com/factorialco/f0/issues/3594)) ([bea9161](https://github.com/factorialco/f0/commit/bea9161a0027d32c1669d0220c467bea5119d39b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version/manifest bumps and a changelog entry, with no functional code changes in this diff.
> 
> **Overview**
> Publishes `@factorialco/f0-react-native` `0.30.0` by updating the release manifest and the package version.
> 
> Updates `packages/react-native/CHANGELOG.md` with the `0.30.0` entry noting the new `F0Icon` primitive.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4748c56028834a33dd1af66012617806cac1aeec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->