### PR TITLE
feat: data collection grouped headers

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -305,3 +305,79 @@ export const TableColumnOrderingAndHiddenWithColumnsChanges: Story = {
     )
   },
 }
+
+export const TableWithGroupedHeaders: Story = {
+  render: () => {
+    const mockVisualizations = getMockVisualizations({
+      table: { noSorting: true },
+    })
+    const baseOptions = (mockVisualizations.table as any)["options"]
+
+    return (
+      <ExampleComponent
+        noSorting
+        frozenColumns={2}
+        visualizations={[
+          {
+            ...mockVisualizations.table,
+            type: "table",
+            options: {
+              ...baseOptions,
+              headerGroupLabels: {
+                personal: "Personal Information",
+                employment: "Employment Details",
+              },
+              columns: [
+                {
+                  label: "Employee",
+                  render: (item: any) => ({
+                    type: "person",
+                    value: {
+                      firstName: item.name.split(" ")[0],
+                      lastName: item.name.split(" ")[1],
+                    },
+                  }),
+                  id: "name",
+                },
+                {
+                  label: "Email",
+                  align: "right",
+                  render: (item: any) => item.email,
+                  id: "email",
+                  headerGroupId: "personal",
+                },
+                {
+                  label: "Role",
+                  align: "right",
+                  render: (item: any) => item.role,
+                  id: "role",
+                  headerGroupId: "employment",
+                },
+                {
+                  label: "Department",
+                  align: "right",
+                  render: (item: any) => item.department,
+                  id: "department",
+                  headerGroupId: "employment",
+                },
+                {
+                  label: "Manager",
+                  align: "right",
+                  render: (item: any) => item.manager,
+                  id: "manager",
+                  headerGroupId: "employment",
+                },
+                {
+                  label: "Status",
+                  align: "right",
+                  render: (item: any) => item.status,
+                  id: "status",
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+  },
+}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -47,6 +47,7 @@ import { useAddRow } from "../EditableTable/context/AddRowContext"
 import { statusToChecked } from "../utils"
 import { Row } from "./components/Row"
 import { useColumns } from "./hooks/useColums"
+import { groupBorderClass, useHeaderGroups } from "./hooks/useHeaderGroups"
 import { NestedDataProvider } from "./providers/NestedProvider"
 import { useSticky } from "./useSticky"
 export * from "./settings/SettingsRenderer"
@@ -90,6 +91,7 @@ export const TableCollection = <
   allowColumnHiding,
   allowColumnReordering,
   referenceRowType,
+  headerGroupLabels,
   rowWrapper: RowWrapper,
   cellRenderer,
   showItemActions: showItemActionsProp,
@@ -291,6 +293,8 @@ export const TableCollection = <
     !!source.selectable
   )
 
+  const headerGroups = useHeaderGroups(columns, headerGroupLabels)
+
   const tableWithChildren = data?.records.some((item) =>
     source.itemsWithChildren?.(item)
   )
@@ -402,72 +406,153 @@ export const TableCollection = <
                 </th>
               </TableRow>
             ) : (
-              <TableRow>
-                {source.selectable && (
-                  <TableHead
-                    width={checkColumnWidth}
-                    sticky={{ left: 0 }}
-                    align="left"
-                  >
-                    <div className="ml-1.5 flex w-full items-center justify-start">
-                      <F0Checkbox
-                        checked={false}
-                        onCheckedChange={handleSelectAll}
-                        title={i18n.actions.selectAll}
-                        hideLabel
-                        disabled={data?.records.length === 0}
-                      />
-                    </div>
-                  </TableHead>
-                )}
-                {columns.map(({ sorting, label, ...column }, index) => (
-                  <TableHead
-                    key={`table-head-${index}`}
-                    sortState={getColumnSortState(
-                      sorting,
-                      source.sortings,
-                      currentSortings
+              <>
+                {headerGroups ? (
+                  <TableRow>
+                    {source.selectable && (
+                      <TableHead
+                        align="left"
+                        sticky={{ left: 0 }}
+                        width={checkColumnWidth}
+                        className={cn(
+                          groupBorderClass,
+                          "hover:after:bg-transparent"
+                        )}
+                      >
+                        <div className="ml-1.5 flex w-full items-center justify-start" />
+                      </TableHead>
                     )}
-                    width={column.width}
-                    align={column.align}
-                    sticky={getStickyPosition(index)}
-                    className={
-                      fromVisualization === "editableTable" &&
-                      index !== columns.length - 1
-                        ? "border-0 border-r-[1px] border-solid border-f1-border-secondary"
-                        : undefined
-                    }
-                    {...column}
-                    hidden={false}
-                    onSortClick={
-                      sorting
-                        ? () => {
-                            if (!sorting) return
-                            handleSortClick(sorting)
-                          }
-                        : undefined
-                    }
-                  >
-                    {label}
-                  </TableHead>
-                ))}
-                {showItemActions && (
-                  <>
-                    <th className="hidden md:table-cell"></th>
+                    {headerGroups.map((entry, entryIndex) => {
+                      const borderClass = cn(
+                        groupBorderClass,
+                        "hover:after:bg-transparent"
+                      )
+                      return entry.type === "group" ? (
+                        <TableHead
+                          align="right"
+                          colSpan={entry.colSpan}
+                          className={borderClass}
+                          key={`header-group-${entry.id}-${entryIndex}`}
+                        >
+                          {entry.label}
+                        </TableHead>
+                      ) : (
+                        <TableHead
+                          align="right"
+                          className={borderClass}
+                          width={columns[entry.columnIndices[0]].width}
+                          key={`header-ungrouped-${entry.columnIndices[0]}`}
+                          sticky={getStickyPosition(entry.columnIndices[0])}
+                        >
+                          <span />
+                        </TableHead>
+                      )
+                    })}
+                    {showItemActions && (
+                      <>
+                        <th className="hidden md:table-cell" />
+                        <TableHead
+                          hidden
+                          width={68}
+                          key="actions"
+                          sticky={{ right: 0 }}
+                          className="table-cell md:hidden"
+                        >
+                          <span />
+                        </TableHead>
+                      </>
+                    )}
+                  </TableRow>
+                ) : null}
+                <TableRow>
+                  {source.selectable && (
                     <TableHead
-                      key="actions"
-                      width={68}
-                      hidden
-                      sticky={{
-                        right: 0,
-                      }}
-                      className="table-cell md:hidden"
+                      width={checkColumnWidth}
+                      sticky={{ left: 0 }}
+                      align="left"
+                      className={
+                        headerGroups
+                          ? cn("[&>div:first-child]:hidden", groupBorderClass)
+                          : undefined
+                      }
                     >
-                      {i18n.collections.actions.actions}
+                      <div className="ml-1.5 flex w-full items-center justify-start">
+                        <F0Checkbox
+                          checked={false}
+                          onCheckedChange={handleSelectAll}
+                          title={i18n.actions.selectAll}
+                          hideLabel
+                          disabled={data?.records.length === 0}
+                        />
+                      </div>
                     </TableHead>
-                  </>
-                )}
-              </TableRow>
+                  )}
+                  {columns.map(({ sorting, label, ...column }, index) => {
+                    const headerGroup = headerGroups?.find(
+                      (group) =>
+                        group.type === "group" &&
+                        group.columnIndices.includes(index)
+                    )
+                    const isLastInGroup =
+                      !!headerGroups &&
+                      (!headerGroup ||
+                        headerGroup.columnIndices[
+                          headerGroup.columnIndices.length - 1
+                        ] === index)
+
+                    return (
+                      <TableHead
+                        key={`table-head-${index}`}
+                        sortState={getColumnSortState(
+                          sorting,
+                          source.sortings,
+                          currentSortings
+                        )}
+                        width={column.width}
+                        align={column.align}
+                        sticky={getStickyPosition(index)}
+                        {...column}
+                        hidden={false}
+                        className={
+                          cn(
+                            headerGroups && "[&>div:first-child]:hidden",
+                            isLastInGroup && groupBorderClass,
+                            fromVisualization === "editableTable" &&
+                              index !== columns.length - 1 &&
+                              "border-0 border-r-[1px] border-solid border-f1-border-secondary"
+                          ) || undefined
+                        }
+                        onSortClick={
+                          sorting
+                            ? () => {
+                                if (!sorting) return
+                                handleSortClick(sorting)
+                              }
+                            : undefined
+                        }
+                      >
+                        {label}
+                      </TableHead>
+                    )
+                  })}
+                  {showItemActions && (
+                    <>
+                      <th className="hidden md:table-cell"></th>
+                      <TableHead
+                        key="actions"
+                        width={68}
+                        hidden
+                        sticky={{
+                          right: 0,
+                        }}
+                        className="table-cell md:hidden"
+                      >
+                        {i18n.collections.actions.actions}
+                      </TableHead>
+                    </>
+                  )}
+                </TableRow>
+              </>
             )}
           </TableHeader>
           <TableBody>
@@ -538,6 +623,7 @@ export const TableCollection = <
                               referenceRowType={referenceRowType}
                               rowWrapper={RowWrapper}
                               cellRenderer={cellRenderer}
+                              headerGroups={headerGroups}
                             />
                           )
                           if (RowWrapper) {
@@ -580,6 +666,7 @@ export const TableCollection = <
                     rowWrapper={RowWrapper}
                     cellRenderer={cellRenderer}
                     fromVisualization={fromVisualization}
+                    headerGroups={headerGroups}
                   />
                 )
                 if (RowWrapper) {

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -49,6 +49,7 @@ import { useNestedDataContext } from "../providers/NestedProvider"
 import { LoadMoreRow } from "./LoadMore"
 import { NestedRowProps, Row } from "./Row"
 import { RowLoading } from "./RowLoading"
+import { HeaderGroupEntry } from "../hooks/useHeaderGroups"
 
 export type RowProps<
   R extends RecordType,
@@ -85,6 +86,7 @@ export type RowProps<
   /** Row wrapper for child rows (provides per-row context, e.g. editing state) */
   rowWrapper?: React.ComponentType<RowWrapperProps<R>>
   fromVisualization?: TableVisualizationType
+  headerGroups: HeaderGroupEntry[] | null
 }
 
 const NestedRowContent = <

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -32,6 +32,7 @@ import type {
 import { ItemActionsRow } from "../../../../components/itemActions/ItemActionsRow/ItemActionsRow"
 import { useSticky } from "../useSticky"
 import { NestedRow } from "./NestedRow"
+import { groupBorderClass, HeaderGroupEntry } from "../hooks/useHeaderGroups"
 
 export type RowProps<
   R extends RecordType,
@@ -73,6 +74,7 @@ export type RowProps<
   /** Row wrapper passed through to NestedRow for wrapping child rows */
   rowWrapper?: React.ComponentType<RowWrapperProps<R>>
   fromVisualization?: TableVisualizationType
+  headerGroups: HeaderGroupEntry[] | null
 }
 
 export type NestedRowProps = {
@@ -121,6 +123,7 @@ const RowComponentInner = <
     cellRenderer: CellRenderer,
     rowWrapper,
     fromVisualization,
+    headerGroups,
   }: RowProps<
     R,
     Filters,
@@ -184,6 +187,7 @@ const RowComponentInner = <
         referenceRowType={referenceRowTypeFn}
         cellRenderer={CellRenderer}
         rowWrapper={rowWrapper}
+        headerGroups={headerGroups}
         key={key}
         fromVisualization={fromVisualization}
       />
@@ -220,6 +224,8 @@ const RowComponentInner = <
           loading={loading}
           className={cn(
             loading && tableWithChildren ? "first:pl-4" : "",
+            headerGroups && "[&>div:first-child]:hidden",
+            headerGroups && groupBorderClass,
             cellRenderedClass
           )}
           referenceRowType={referenceRowType}
@@ -238,6 +244,18 @@ const RowComponentInner = <
       )}
 
       {columns.map((column, cellIndex) => {
+        const headerGroup = headerGroups?.find((group) => {
+          return (
+            group.type === "group" && group.columnIndices.includes(cellIndex)
+          )
+        })
+
+        const isLastInGroup =
+          !!headerGroups &&
+          (!headerGroup ||
+            headerGroup.columnIndices[headerGroup.columnIndices.length - 1] ===
+              cellIndex)
+
         const defaultContent = (
           <div
             className={cn(
@@ -264,9 +282,9 @@ const RowComponentInner = <
               tableWithChildren,
               selectableRow: !!source.selectable,
             }}
-            className={cellRenderedClass}
             fromVisualization={fromVisualization}
             referenceRowType={referenceRowType}
+            className={cn(cellRenderedClass, isLastInGroup && groupBorderClass)}
           >
             {CellRenderer ? (
               <CellRenderer

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
@@ -42,6 +42,7 @@ const SingleLoadingRowInner = <
     tableWithChildren,
     shouldHideBorder,
     fromVisualization,
+    headerGroups,
   }: RowProps<
     R,
     Filters,
@@ -98,6 +99,7 @@ const SingleLoadingRowInner = <
       selectedItems={selectedItems}
       checkColumnWidth={checkColumnWidth}
       loading
+      headerGroups={headerGroups}
       ref={combinedRef}
       nestedRowProps={{
         ...nestedRowProps,

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/hooks/useHeaderGroups.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/hooks/useHeaderGroups.ts
@@ -1,0 +1,87 @@
+import { useMemo } from "react"
+
+import { RecordType, SortingsDefinition } from "@/hooks/datasource"
+
+import { SummariesDefinition } from "../../../../summary"
+import { TableColumnDefinition } from "../types"
+
+export type HeaderGroupSpan = {
+  type: "group"
+  id: string
+  label: string
+  colSpan: number
+  columnIndices: number[]
+}
+
+export type HeaderUngroupedSpan = {
+  type: "ungrouped"
+  columnIndices: number[]
+}
+
+export type HeaderGroupEntry = HeaderGroupSpan | HeaderUngroupedSpan
+
+export const groupBorderClass =
+  "border-0 border-r border-solid border-f1-border-secondary"
+
+/**
+ * Computes header group entries from columns and a label map.
+ * Adjacent columns sharing the same `headerGroupId` are merged into a single
+ * spanning entry. Columns without a `headerGroupId` produce an ungrouped entry
+ * that renders an empty cell in the group row and the real header in the column row.
+ */
+export const computeHeaderGroups = (
+  columns: ReadonlyArray<{ headerGroupId?: string }>,
+  headerGroupLabels: Record<string, string>
+): HeaderGroupEntry[] => {
+  const entries: HeaderGroupEntry[] = []
+
+  columns.forEach((column, index) => {
+    const groupId = column.headerGroupId
+    if (!groupId) {
+      entries.push({
+        type: "ungrouped",
+        columnIndices: [index],
+      })
+      return
+    }
+
+    const last = entries[entries.length - 1]
+    if (last && last.type === "group" && last.id === groupId) {
+      last.colSpan++
+      last.columnIndices.push(index)
+    } else {
+      entries.push({
+        colSpan: 1,
+        id: groupId,
+        type: "group",
+        columnIndices: [index],
+        label: headerGroupLabels[groupId] ?? groupId,
+      })
+    }
+  })
+
+  return entries
+}
+
+/**
+ * Returns header group entries for a two-row header, memoized by column identity
+ * and label map. Returns `null` when no columns use `headerGroupId`, signaling
+ * the single-row header should be rendered instead.
+ */
+export const useHeaderGroups = <
+  R extends RecordType,
+  Sortings extends SortingsDefinition,
+  Summaries extends SummariesDefinition,
+>(
+  columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>,
+  headerGroupLabels?: Record<string, string>
+): HeaderGroupEntry[] | null => {
+  return useMemo(() => {
+    if (!headerGroupLabels) return null
+
+    const hasGroups = columns.some((col) => col.headerGroupId)
+    if (!hasGroups) return null
+
+    return computeHeaderGroups(columns, headerGroupLabels)
+  }, [columns, headerGroupLabels])
+}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/types.ts
@@ -72,6 +72,14 @@ export type TableColumnDefinition<
      * Avoid hiding the column by the user
      */
     noHiding?: boolean
+
+    /**
+     * Assigns this column to a header group. Columns with the same
+     * headerGroupId are visually grouped under a shared spanning header.
+     * The label for each group is provided via `headerGroupLabels` in
+     * the visualization options.
+     */
+    headerGroupId?: string
   }
 
 export type ReferenceType = "none" | "striped"
@@ -104,6 +112,11 @@ export type TableVisualizationOptions<
    * Reference rows are rendered with a slanted background pattern across the full row.
    */
   referenceRowType?: (item: R) => ReferenceType
+  /**
+   * Labels for header groups. Keys are headerGroupId values used in column
+   * definitions, values are the display labels rendered in the spanning header row.
+   */
+  headerGroupLabels?: Record<string, string>
 }
 
 export type TableCollectionProps<

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -66,6 +66,11 @@ interface TableHeadProps {
    * The class name of the header cell
    */
   className?: string
+
+  /**
+   * The number of columns this header cell should span
+   */
+  colSpan?: number
 }
 
 export function TableHead({
@@ -79,6 +84,7 @@ export function TableHead({
   hidden = false,
   align = "left",
   className,
+  colSpan,
 }: TableHeadProps) {
   const { isScrolled, isScrolledRight } = useTable()
 
@@ -186,6 +192,7 @@ export function TableHead({
         className
       )}
       tabIndex={sticky ? 0 : undefined}
+      colSpan={colSpan}
       // Min and max width is needed to prevent the cell from shrinking or expanding when the table is scrolled
       style={{
         width: colWidth,


### PR DESCRIPTION
## Description
Add support for grouped headers in the Table visualization. Columns can now be visually grouped under a shared spanning header row, allowing related columns to be presented together (e.g. "Personal Information", "Employment Details")

<!-- Provide a brief summary of the changes (e.g., "Add new Button component to experimental" or "Promote Card component to stable"). Describe what this PR does and why it's needed -->

## Screenshots (if applicable)
<img width="1440" height="900" alt="Screenshot 2026-03-10 at 10 40 58" src="https://github.com/user-attachments/assets/467dfab5-dae1-454f-8387-2e01d7a2836f" />

[Link to Figma Design](https://www.figma.com/design/pMG3lnD48iLQoSG9nSHGrt/DC-Grouped-headers--04-11-2025-?node-id=1-2831&p=f&t=IEHu9nn9LlYSkuMR-0)

## Implementation details

### New Types
- Added `headerGroupId?: string` to `TableColumnDefinition` to assign columns to a group.
- Added `headerGroupLabels?: Record<string, string>` to `TableVisualizationOptions` to define the display labels for each group.

### New Hook: `useHeaderGroups`
Contains the core grouping logic.

- **`computeHeaderGroups`**  
  A pure function that merges adjacent columns sharing the same `headerGroupId` into spanning entries. It tracks `columnIndices` for reliable boundary detection. Ungrouped columns produce separate entries.

- **`useHeaderGroups`**  
  A memoized wrapper that returns `null` when no groups are configured, signaling that the table should render the standard single-row header.

- **`groupBorderClass`**  
  A shared constant defining the vertical border style between groups, reducing style duplication.

### `TableHead` (`OneTable`)
- Added `colSpan` prop support.
- The prop is passed through to the underlying `<th>` element.

### `Table.tsx`
- Renders a **two-row header** when groups are present:
  - **Row 1:** Group headers with `colSpan` and right borders between groups.
  - **Row 2:** Individual column headers.

- Column headers hide their top borders using:

```css
[&>div:first-child]:hidden
```

- Columns at group boundaries receive a right border in both header rows.
- When no groups are configured, the table falls back to the standard single-row header.

### `Row.tsx`
- Applies the same vertical group border on data cells at group boundaries.
- Uses `columnIndices` for accurate **last-in-group detection**, preventing issues with:
  - non-adjacent groups sharing the same ID
  - duplicate group labels

### `NestedRow.tsx` / `RowLoading`
- Threaded the new `headerGroups` prop through to child components.

### Storybook
- Added a `TableWithGroupedHeaders` story demonstrating the feature with two groups:
  - Personal Information
  - Employment Details