### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.393.0",
-  "packages/react-native": "0.30.0",
+  "packages/react": "1.394.0",
+  "packages/react-native": "0.31.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.31.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.30.0...f0-react-native-v0.31.0) (2026-03-10)
+
+
+### Features
+
+* pressableFeedback primitive ([#3620](https://github.com/factorialco/f0/issues/3620)) ([7603842](https://github.com/factorialco/f0/commit/760384269d416d0eff7899e31466827a8edf7255))
+
 ## [0.30.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.29.0...f0-react-native-v0.30.0) (2026-03-10)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.394.0](https://github.com/factorialco/f0/compare/f0-react-v1.393.0...f0-react-v1.394.0) (2026-03-10)
+
+
+### Features
+
+* **F0DataChart:** add unified chart component with multiple chart types ([#3613](https://github.com/factorialco/f0/issues/3613)) ([aa4e5e0](https://github.com/factorialco/f0/commit/aa4e5e07ee02f6bf4c17763e2247b46711e5d9a0))
+
 ## [1.393.0](https://github.com/factorialco/f0/compare/f0-react-v1.392.1...f0-react-v1.393.0) (2026-03-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.393.0",
+  "version": "1.394.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.394.0</summary>

## [1.394.0](https://github.com/factorialco/f0/compare/f0-react-v1.393.0...f0-react-v1.394.0) (2026-03-10)


### Features

* **F0DataChart:** add unified chart component with multiple chart types ([#3613](https://github.com/factorialco/f0/issues/3613)) ([aa4e5e0](https://github.com/factorialco/f0/commit/aa4e5e07ee02f6bf4c17763e2247b46711e5d9a0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog updates) with no functional code modifications in this diff.
> 
> **Overview**
> Publishes new package versions for `@factorialco/f0-react` and `@factorialco/f0-react-native` via Release Please.
> 
> This bumps versions in `.release-please-manifest.json` and both packages’ `package.json`, and updates changelogs to include `f0-react` `1.394.0` (adds `F0DataChart`) and `f0-react-native` `0.31.0` (adds `pressableFeedback`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2731fb7f6a35d9edec7ebab7b4b1dd26801e2ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->