### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.394.0",
-  "packages/react-native": "0.31.0",
+  "packages/react-native": "0.32.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.32.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.31.0...f0-react-native-v0.32.0) (2026-03-10)
+
+
+### Features
+
+* add f0bignumber component ([#3144](https://github.com/factorialco/f0/issues/3144)) ([cc289d7](https://github.com/factorialco/f0/commit/cc289d7b187e04af2b8a962cb0385a4ce068fde8))
+* add new primitive `F0Icon` ([#3594](https://github.com/factorialco/f0/issues/3594)) ([bea9161](https://github.com/factorialco/f0/commit/bea9161a0027d32c1669d0220c467bea5119d39b))
+* add oxlint anf oxfmt to react-native ([#3391](https://github.com/factorialco/f0/issues/3391)) ([dcf3854](https://github.com/factorialco/f0/commit/dcf3854a3d5675728948a8e933273ab98234bd8f))
+* allow className for layout on F0Text ([#3606](https://github.com/factorialco/f0/issues/3606)) ([2ec6f3b](https://github.com/factorialco/f0/commit/2ec6f3b27f0f6b5a79ba568746d1fbfc15e0aa23))
+* f0-react-native-headingxl-and-animatedf0text ([#3581](https://github.com/factorialco/f0/issues/3581)) ([41e31f6](https://github.com/factorialco/f0/commit/41e31f6d85a801df4a84ec163b735deba441c847))
+* **F0Text:** introduce F0Text primitive component  ([#3563](https://github.com/factorialco/f0/issues/3563)) ([a55dbcb](https://github.com/factorialco/f0/commit/a55dbcbd60e442b22e8b3f1f3a5f11f31d1ede7a))
+* pressableFeedback primitive ([#3620](https://github.com/factorialco/f0/issues/3620)) ([7603842](https://github.com/factorialco/f0/commit/760384269d416d0eff7899e31466827a8edf7255))
+* React Native Design System migration to Uniwind and Tailwind 4 ([#3333](https://github.com/factorialco/f0/issues/3333)) ([ce05b98](https://github.com/factorialco/f0/commit/ce05b987d2b26298cc12e4bd7a4876405a0fb628))
+* react native tokens renaming from f1-* to f0-* ([#3554](https://github.com/factorialco/f0/issues/3554)) ([c6568d7](https://github.com/factorialco/f0/commit/c6568d739882a4d5e40291ef928c1a06a5af71a8))
+* **react-native:** add QuestionCircle icon ([7aa0cb8](https://github.com/factorialco/f0/commit/7aa0cb8f6ae3921c7abbd3d21c133770557880bc))
+* **react-native:** upgrade to Expo SDK 54, React 19, and React Nativ… ([#3132](https://github.com/factorialco/f0/issues/3132)) ([1877d24](https://github.com/factorialco/f0/commit/1877d2457b1ef76eb9b6e855f1e9a7289a7aec32))
+
+
+### Bug Fixes
+
+* font differences between Android and iOS ([#3596](https://github.com/factorialco/f0/issues/3596)) ([4ec216a](https://github.com/factorialco/f0/commit/4ec216a04cfae36f43b173d2805587ee52a0684b))
+* **Hub:** remove unsupported filter attribute from SVG ([ae6ae4f](https://github.com/factorialco/f0/commit/ae6ae4f49fb44be1ebfad190ef1a0ad430ff514e))
+* theme typography tokens ([#3371](https://github.com/factorialco/f0/issues/3371)) ([8b39216](https://github.com/factorialco/f0/commit/8b39216584c31874aef95e0206a58bddc30ba6ec))
+
 ## [0.31.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.30.0...f0-react-native-v0.31.0) (2026-03-10)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.32.0</summary>

## [0.32.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.31.0...f0-react-native-v0.32.0) (2026-03-10)


### Features

* add f0bignumber component ([#3144](https://github.com/factorialco/f0/issues/3144)) ([cc289d7](https://github.com/factorialco/f0/commit/cc289d7b187e04af2b8a962cb0385a4ce068fde8))
* add new primitive `F0Icon` ([#3594](https://github.com/factorialco/f0/issues/3594)) ([bea9161](https://github.com/factorialco/f0/commit/bea9161a0027d32c1669d0220c467bea5119d39b))
* add oxlint anf oxfmt to react-native ([#3391](https://github.com/factorialco/f0/issues/3391)) ([dcf3854](https://github.com/factorialco/f0/commit/dcf3854a3d5675728948a8e933273ab98234bd8f))
* allow className for layout on F0Text ([#3606](https://github.com/factorialco/f0/issues/3606)) ([2ec6f3b](https://github.com/factorialco/f0/commit/2ec6f3b27f0f6b5a79ba568746d1fbfc15e0aa23))
* f0-react-native-headingxl-and-animatedf0text ([#3581](https://github.com/factorialco/f0/issues/3581)) ([41e31f6](https://github.com/factorialco/f0/commit/41e31f6d85a801df4a84ec163b735deba441c847))
* **F0Text:** introduce F0Text primitive component  ([#3563](https://github.com/factorialco/f0/issues/3563)) ([a55dbcb](https://github.com/factorialco/f0/commit/a55dbcbd60e442b22e8b3f1f3a5f11f31d1ede7a))
* pressableFeedback primitive ([#3620](https://github.com/factorialco/f0/issues/3620)) ([7603842](https://github.com/factorialco/f0/commit/760384269d416d0eff7899e31466827a8edf7255))
* React Native Design System migration to Uniwind and Tailwind 4 ([#3333](https://github.com/factorialco/f0/issues/3333)) ([ce05b98](https://github.com/factorialco/f0/commit/ce05b987d2b26298cc12e4bd7a4876405a0fb628))
* react native tokens renaming from f1-* to f0-* ([#3554](https://github.com/factorialco/f0/issues/3554)) ([c6568d7](https://github.com/factorialco/f0/commit/c6568d739882a4d5e40291ef928c1a06a5af71a8))
* **react-native:** add QuestionCircle icon ([7aa0cb8](https://github.com/factorialco/f0/commit/7aa0cb8f6ae3921c7abbd3d21c133770557880bc))
* **react-native:** upgrade to Expo SDK 54, React 19, and React Nativ… ([#3132](https://github.com/factorialco/f0/issues/3132)) ([1877d24](https://github.com/factorialco/f0/commit/1877d2457b1ef76eb9b6e855f1e9a7289a7aec32))


### Bug Fixes

* font differences between Android and iOS ([#3596](https://github.com/factorialco/f0/issues/3596)) ([4ec216a](https://github.com/factorialco/f0/commit/4ec216a04cfae36f43b173d2805587ee52a0684b))
* **Hub:** remove unsupported filter attribute from SVG ([ae6ae4f](https://github.com/factorialco/f0/commit/ae6ae4f49fb44be1ebfad190ef1a0ad430ff514e))
* theme typography tokens ([#3371](https://github.com/factorialco/f0/issues/3371)) ([8b39216](https://github.com/factorialco/f0/commit/8b39216584c31874aef95e0206a58bddc30ba6ec))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version bumps and changelog updates) with no functional code modifications in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react-native` from `0.31.0` to `0.32.0` (updates `.release-please-manifest.json` and `packages/react-native/package.json`).
> 
> Updates `packages/react-native/CHANGELOG.md` with the `0.32.0` release notes (new primitives/components and a few bug fixes) generated by Release Please.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99df33cc71a15e8c1dd631500e0b6c4886245937. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->