### PR TITLE
fix(OneDataCollection): align group header checkboxes with header and row checkboxes

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -653,11 +653,13 @@ export const TableCollection = <
                           onOpenChange={(open) => setGroupOpen(group.key, open)}
                         />
                       </TableCell>
-                      <TableCell
-                        colSpan={columns.length - (frozenColumnsLeft || 1)}
-                      >
-                        &nbsp;
-                      </TableCell>
+                      {columns.length - (frozenColumnsLeft || 1) > 0 && (
+                        <TableCell
+                          colSpan={columns.length - (frozenColumnsLeft || 1)}
+                        >
+                          &nbsp;
+                        </TableCell>
+                      )}
                     </TableRow>
 
                     <AnimatePresence key={`group-animate-${groupIndex}`}>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -617,7 +617,7 @@ export const TableCollection = <
                           width={checkColumnWidth}
                           sticky={{ left: 0 }}
                         >
-                          <div className="ml-1.5 flex items-center justify-start">
+                          <div className="pointer-events-auto ml-1.5 flex items-center justify-start">
                             <F0Checkbox
                               checked={
                                 !!statusToChecked(

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -612,21 +612,41 @@ export const TableCollection = <
                 return (
                   <Fragment key={`group-${group.key}`}>
                     <TableRow key={`group-header-${group.key}`} sticky>
+                      {source.selectable && (
+                        <TableCell
+                          width={checkColumnWidth}
+                          sticky={{ left: 0 }}
+                        >
+                          <div className="ml-1.5 flex items-center justify-start">
+                            <F0Checkbox
+                              checked={
+                                !!statusToChecked(
+                                  groupAllSelectedStatus[group.key]
+                                )
+                              }
+                              indeterminate={
+                                statusToChecked(
+                                  groupAllSelectedStatus[group.key]
+                                ) === "indeterminate"
+                              }
+                              title="Select all"
+                              hideLabel
+                              onCheckedChange={(checked) =>
+                                handleSelectGroupChange(group, checked)
+                              }
+                            />
+                          </div>
+                        </TableCell>
+                      )}
                       <TableCell
-                        sticky={{ left: 0 }}
-                        colSpan={
-                          (frozenColumnsLeft || 1) + (source.selectable ? 1 : 0)
-                        }
+                        sticky={{
+                          left: source.selectable ? checkColumnWidth : 0,
+                        }}
+                        colSpan={frozenColumnsLeft || 1}
                       >
                         <GroupHeader
-                          className={source.selectable ? "pl-1.5 pr-3" : "px-3"}
-                          selectable={!!source.selectable}
-                          select={statusToChecked(
-                            groupAllSelectedStatus[group.key]
-                          )}
-                          onSelectChange={(checked) =>
-                            handleSelectGroupChange(group, checked)
-                          }
+                          className="px-3"
+                          selectable={false}
                           showOpenChange={collapsible}
                           label={group.label}
                           itemCount={itemCount}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -643,9 +643,9 @@ export const TableCollection = <
                           left: source.selectable ? checkColumnWidth : 0,
                         }}
                         colSpan={frozenColumnsLeft || 1}
+                        className="pl-3"
                       >
                         <GroupHeader
-                          className="px-3"
                           selectable={false}
                           showOpenChange={collapsible}
                           label={group.label}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -629,7 +629,7 @@ export const TableCollection = <
                                   groupAllSelectedStatus[group.key]
                                 ) === "indeterminate"
                               }
-                              title="Select all"
+                              title={i18n.actions.selectAll}
                               hideLabel
                               onCheckedChange={(checked) =>
                                 handleSelectGroupChange(group, checked)
@@ -643,7 +643,6 @@ export const TableCollection = <
                           left: source.selectable ? checkColumnWidth : 0,
                         }}
                         colSpan={frozenColumnsLeft || 1}
-                        className="pl-3"
                       >
                         <GroupHeader
                           selectable={false}
@@ -655,11 +654,7 @@ export const TableCollection = <
                         />
                       </TableCell>
                       <TableCell
-                        colSpan={
-                          columns.length -
-                          (frozenColumnsLeft || 1) +
-                          (source.selectable ? 1 : 0)
-                        }
+                        colSpan={columns.length - (frozenColumnsLeft || 1)}
                       >
                         &nbsp;
                       </TableCell>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -619,7 +619,7 @@ export const TableCollection = <
                         }
                       >
                         <GroupHeader
-                          className="px-3"
+                          className={source.selectable ? "pl-1.5 pr-3" : "px-3"}
                           selectable={!!source.selectable}
                           select={statusToChecked(
                             groupAllSelectedStatus[group.key]

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -2065,6 +2065,5 @@ describe("TableCollection", () => {
 
       expect(onSelectItems.mock.calls.length).toBe(callCountAfterRender)
     })
-
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -2,7 +2,11 @@ import { act, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
-import type { GroupingDefinition, SortingsDefinition } from "@/hooks/datasource"
+import type {
+  GroupingDefinition,
+  GroupingState,
+  SortingsDefinition,
+} from "@/hooks/datasource"
 
 import { TextCell } from "@/ui/value-display/types/text"
 import { useDataCollectionData } from "@/patterns/OneDataCollection/hooks/useDataCollectionData/useDataCollectionData"
@@ -1223,7 +1227,9 @@ describe("TableCollection", () => {
       // Secondary actions go to dropdown (just verify dropdown exists)
       // ItemActionsRenderer renders both desktop and mobile versions,
       // so we expect 2 buttons total (1 desktop + 1 mobile for 1 row)
-      const actionsButtons = screen.getAllByRole("button", { name: /actions/i })
+      const actionsButtons = screen.getAllByRole("button", {
+        name: /actions/i,
+      })
       expect(actionsButtons).toHaveLength(2) // Desktop + Mobile
       expect(actionsButtons[0]).toBeInTheDocument()
     })
@@ -1840,5 +1846,225 @@ describe("TableCollection", () => {
     expect(
       screen.queryByRole("button", { name: /add row/i })
     ).not.toBeInTheDocument()
+  })
+  describe("grouped and selectable", () => {
+    type GroupedPerson = Person & { department: string }
+
+    const groupedTestData: GroupedPerson[] = [
+      {
+        id: 1,
+        name: "Alice",
+        email: "alice@example.com",
+        displayName: "Dr. Alice",
+        department: "Engineering",
+      },
+      {
+        id: 2,
+        name: "Bob",
+        email: "bob@example.com",
+        displayName: "Dr. Bob",
+        department: "Engineering",
+      },
+      {
+        id: 3,
+        name: "Carol",
+        email: "carol@example.com",
+        displayName: "Dr. Carol",
+        department: "Marketing",
+      },
+    ]
+
+    const groupedTestColumns = [
+      { label: "name", render: (item: GroupedPerson) => item.name },
+      { label: "email", render: (item: GroupedPerson) => item.email },
+      {
+        label: "department",
+        render: (item: GroupedPerson) => item.department,
+      },
+    ]
+
+    const createGroupedSelectableSource = (
+      data: GroupedPerson[] = groupedTestData,
+      collapsible = true
+    ): DataCollectionSource<
+      GroupedPerson,
+      TestFilters,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<GroupedPerson>,
+      TestNavigationFilters,
+      GroupingDefinition<GroupedPerson>
+    > => ({
+      currentFilters: {},
+      setCurrentFilters: vi.fn(),
+      currentSortings: null,
+      setCurrentSortings: vi.fn(),
+      currentNavigationFilters: {},
+      setCurrentNavigationFilters: vi.fn(),
+      navigationFilters: undefined,
+      currentSearch: undefined,
+      debouncedCurrentSearch: undefined,
+      setCurrentSearch: vi.fn(),
+      isLoading: false,
+      setIsLoading: vi.fn(),
+      dataAdapter: {
+        fetchData: async (_options: BaseFetchOptions<TestFilters>) => {
+          return { records: data }
+        },
+      },
+      selectable: (item: GroupedPerson) => item.id,
+      grouping: {
+        mandatory: true,
+        ...(collapsible
+          ? { collapsible: true, defaultOpenGroups: true }
+          : { collapsible: false }),
+        groupBy: {
+          department: {
+            name: "Department",
+            label: (groupId: string) => groupId,
+            itemCount: (groupId: string) =>
+              data.filter((p) => p.department === groupId).length,
+          },
+        },
+      },
+      currentGrouping: {
+        field: "department",
+        order: "asc",
+      } as GroupingState<GroupedPerson, GroupingDefinition<GroupedPerson>>,
+      setCurrentGrouping: vi.fn(),
+    })
+
+    it("renders group headers with separate checkbox cells when grouped and selectable", async () => {
+      render(
+        <TableCollection<
+          GroupedPerson,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<GroupedPerson>,
+          TestNavigationFilters,
+          GroupingDefinition<GroupedPerson>
+        >
+          columns={groupedTestColumns}
+          source={createGroupedSelectableSource()}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+          frozenColumns={2}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Alice")).toBeInTheDocument()
+      })
+
+      // Both group headers are rendered (use getAllByText since "Engineering"
+      // also appears in department data cells)
+      expect(screen.getAllByText("Engineering").length).toBeGreaterThan(0)
+      expect(screen.getAllByText("Marketing").length).toBeGreaterThan(0)
+
+      // All data rows are rendered
+      expect(screen.getByText("Bob")).toBeInTheDocument()
+      expect(screen.getByText("Carol")).toBeInTheDocument()
+
+      // Each group header row contains a checkbox in its own cell.
+      // Target the <h6> group heading to find the group header row specifically.
+      const engineeringHeading = screen.getByRole("heading", {
+        name: "Engineering",
+      })
+      const engineeringRow = engineeringHeading.closest("tr")!
+      expect(within(engineeringRow).getByRole("checkbox")).toBeInTheDocument()
+
+      const marketingHeading = screen.getByRole("heading", {
+        name: "Marketing",
+      })
+      const marketingRow = marketingHeading.closest("tr")!
+      expect(within(marketingRow).getByRole("checkbox")).toBeInTheDocument()
+    })
+
+    it("group header checkbox toggles selection for that group's items", async () => {
+      const user = userEvent.setup()
+      const onSelectItems = vi.fn()
+
+      render(
+        <TableCollection<
+          GroupedPerson,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<GroupedPerson>,
+          TestNavigationFilters,
+          GroupingDefinition<GroupedPerson>
+        >
+          columns={groupedTestColumns}
+          source={createGroupedSelectableSource()}
+          onSelectItems={onSelectItems}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+          frozenColumns={2}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Alice")).toBeInTheDocument()
+      })
+
+      // Click the Engineering group header checkbox.
+      // Target the <h6> heading to find the group header row specifically.
+      const engineeringHeading = screen.getByRole("heading", {
+        name: "Engineering",
+      })
+      const engineeringRow = engineeringHeading.closest("tr")!
+      const groupCheckbox = within(engineeringRow).getByRole("checkbox")
+
+      await user.click(groupCheckbox)
+
+      // onSelectItems must have been called with Engineering group members selected
+      expect(onSelectItems).toHaveBeenCalled()
+      const lastCall =
+        onSelectItems.mock.calls[onSelectItems.mock.calls.length - 1]
+      const selectedItems = lastCall[0]
+      expect(selectedItems.selectedIds).toEqual(expect.arrayContaining([1, 2]))
+    })
+
+    it("group label text click does not toggle selection when table is not collapsible", async () => {
+      const user = userEvent.setup()
+      const onSelectItems = vi.fn()
+
+      render(
+        <TableCollection<
+          GroupedPerson,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<GroupedPerson>,
+          TestNavigationFilters,
+          GroupingDefinition<GroupedPerson>
+        >
+          columns={groupedTestColumns}
+          source={createGroupedSelectableSource(groupedTestData, false)}
+          onSelectItems={onSelectItems}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+          frozenColumns={2}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Alice")).toBeInTheDocument()
+      })
+
+      const callCountAfterRender = onSelectItems.mock.calls.length
+
+      // Click the group label heading text (not the checkbox) — it should not
+      // trigger group selection since the checkbox is the only selection affordance
+      const engineeringHeading = screen.getByRole("heading", {
+        name: "Engineering",
+      })
+      await user.click(engineeringHeading)
+
+      expect(onSelectItems.mock.calls.length).toBe(callCountAfterRender)
+    })
+
   })
 })

--- a/packages/react/src/ui/table.tsx
+++ b/packages/react/src/ui/table.tsx
@@ -97,7 +97,7 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "relative min-h-[48px] whitespace-nowrap p-2 align-top first:pl-6 last:pr-6",
+      "relative min-h-[48px] whitespace-nowrap px-3 py-2 align-top first:pl-6 last:pr-6",
       "[&:has([role=checkbox])]:px-2 [&:has([role=checkbox])]:py-2",
       className
     )}


### PR DESCRIPTION
## What

Fixes three visual alignment issues in `OneDataCollection`'s Table visualization when grouping is enabled:

1. **Group header checkbox alignment** — group header checkboxes were offset 6px to the right of header/row checkboxes (`px-3` padding vs `ml-1.5` margin).
2. **Group header label alignment** — group label text was misaligned with the first data column. Fixed by splitting the group header row into a dedicated checkbox cell (46px, matching `checkColumnWidth`) and a separate label cell, so each element lands at exactly the same horizontal position as its counterpart in the header and data rows.
3. **Data row alignment in selectable tables** — `TableCell` primitive used `p-2` (8px horizontal padding) while `TableHead` used `px-3` (12px), causing a 4px misalignment on all data cells in selectable tables. Fixed by changing `p-2` → `px-3 py-2` in `ui/table.tsx`.

## Changes

- `Table.tsx` — split group header row into separate checkbox cell + label cell; use `i18n.actions.selectAll` for checkbox title; fix filler cell `colSpan` (was double-counting the checkbox column after the split)
- `ui/table.tsx` — align `TableCell` horizontal padding with `TableHead` (`p-2` → `px-3 py-2`)

## Behaviour note

When `collapsible=false` and `selectable=true`, clicking the group label text previously toggled group selection (via `GroupHeader`'s `handleGroupClick`). With the structural split, the label cell renders `GroupHeader` with `selectable={false}`, so selection is only triggered by the checkbox. This is intentional — the checkbox is the unambiguous selection affordance. When `collapsible=true` (the common case), behaviour is unchanged since `showOpenChange` already takes priority over `selectable` in `handleGroupClick`.