### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.394.1",
-  "packages/react-native": "0.32.0",
+  "packages/react-native": "0.33.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.33.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.32.0...f0-react-native-v0.33.0) (2026-03-10)
+
+
+### Features
+
+* add GitHub Actions workflow for automated Expo preview on PRs ([#3629](https://github.com/factorialco/f0/issues/3629)) ([d100867](https://github.com/factorialco/f0/commit/d100867292e605088257675b517db090568102a9))
+
 ## [0.32.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.31.0...f0-react-native-v0.32.0) (2026-03-10)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.33.0</summary>

## [0.33.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.32.0...f0-react-native-v0.33.0) (2026-03-10)


### Features

* add GitHub Actions workflow for automated Expo preview on PRs ([#3629](https://github.com/factorialco/f0/issues/3629)) ([d100867](https://github.com/factorialco/f0/commit/d100867292e605088257675b517db090568102a9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version bumps and changelog update) with no runtime code modifications.
> 
> **Overview**
> Bumps `@factorialco/f0-react-native` from `0.32.0` to `0.33.0` (updating `.release-please-manifest.json` and the package’s `package.json`).
> 
> Updates `packages/react-native/CHANGELOG.md` with the `0.33.0` release entry, noting the added GitHub Actions workflow for automated Expo previews on PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72fce6da79de6967138f7d0e8c3d5e966c3a2aec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->