### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.396.0",
-  "packages/react-native": "0.33.0",
+  "packages/react-native": "0.34.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.34.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.33.0...f0-react-native-v0.34.0) (2026-03-11)
+
+
+### Features
+
+* **F0Badge:** introduce F0Badge component with variants and sizes ([#3631](https://github.com/factorialco/f0/issues/3631)) ([72febd3](https://github.com/factorialco/f0/commit/72febd3dbe6f7dc3bc1973f865f001069e98078e))
+
 ## [0.33.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.32.0...f0-react-native-v0.33.0) (2026-03-10)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.34.0</summary>

## [0.34.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.33.0...f0-react-native-v0.34.0) (2026-03-11)


### Features

* **F0Badge:** introduce F0Badge component with variants and sizes ([#3631](https://github.com/factorialco/f0/issues/3631)) ([72febd3](https://github.com/factorialco/f0/commit/72febd3dbe6f7dc3bc1973f865f001069e98078e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog/manifest) with no functional code modifications in this PR.
> 
> **Overview**
> Cuts a new `@factorialco/f0-react-native` release by bumping the version from `0.33.0` to `0.34.0` and updating the release manifest.
> 
> Updates `CHANGELOG.md` with the `0.34.0` entry noting the new `F0Badge` component feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 677eee0adeccae5cdbefcb2f3d7b4bdb90a69857. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->