### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.397.0",
-  "packages/react-native": "0.34.0",
+  "packages/react-native": "0.35.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.35.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.34.0...f0-react-native-v0.35.0) (2026-03-11)
+
+
+### Features
+
+* introduce F0Button component ([#3626](https://github.com/factorialco/f0/issues/3626)) ([05bc2b2](https://github.com/factorialco/f0/commit/05bc2b2f29b7db8da6a487639fc7dc21184dfb54))
+
 ## [0.34.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.33.0...f0-react-native-v0.34.0) (2026-03-11)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.35.0</summary>

## [0.35.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.34.0...f0-react-native-v0.35.0) (2026-03-11)


### Features

* introduce F0Button component ([#3626](https://github.com/factorialco/f0/issues/3626)) ([05bc2b2](https://github.com/factorialco/f0/commit/05bc2b2f29b7db8da6a487639fc7dc21184dfb54))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version bumps and changelog updates) with no runtime code modifications.
> 
> **Overview**
> Publishes `@factorialco/f0-react-native` **v0.35.0** by updating the release manifest and the package version.
> 
> Updates `packages/react-native/CHANGELOG.md` with the 0.35.0 release notes, highlighting the new `F0Button` component.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4dc4686dd6d35c6e46844c3534ce4188cfda0d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->