### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.397.0",
+  "packages/react": "1.398.0",
   "packages/react-native": "0.35.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.398.0](https://github.com/factorialco/f0/compare/f0-react-v1.397.0...f0-react-v1.398.0) (2026-03-11)
+
+
+### Features
+
+* survey answering component ([#3610](https://github.com/factorialco/f0/issues/3610)) ([5b72edf](https://github.com/factorialco/f0/commit/5b72edf218f23796acbdf70fe8a458c112970d48))
+
 ## [1.397.0](https://github.com/factorialco/f0/compare/f0-react-v1.396.0...f0-react-v1.397.0) (2026-03-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.397.0",
+  "version": "1.398.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.398.0</summary>

## [1.398.0](https://github.com/factorialco/f0/compare/f0-react-v1.397.0...f0-react-v1.398.0) (2026-03-11)


### Features

* survey answering component ([#3610](https://github.com/factorialco/f0/issues/3610)) ([5b72edf](https://github.com/factorialco/f0/commit/5b72edf218f23796acbdf70fe8a458c112970d48))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version/changelog-only release metadata updates; no runtime code changes in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.397.0` to `1.398.0` and updates the Release Please manifest accordingly.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.398.0` release notes (adds the “survey answering component” feature entry).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a23135fab0c77c9054d49d4eb5ff674d104b62d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->