### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.398.0",
+  "packages/react": "1.399.0",
   "packages/react-native": "0.35.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.399.0](https://github.com/factorialco/f0/compare/f0-react-v1.398.0...f0-react-v1.399.0) (2026-03-11)
+
+
+### Features
+
+* editable table - nested design fixes ([#3588](https://github.com/factorialco/f0/issues/3588)) ([ed9969f](https://github.com/factorialco/f0/commit/ed9969f0ba1fea53fa6b21a704a2ec6ce018f794))
+
 ## [1.398.0](https://github.com/factorialco/f0/compare/f0-react-v1.397.0...f0-react-v1.398.0) (2026-03-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.398.0",
+  "version": "1.399.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.399.0</summary>

## [1.399.0](https://github.com/factorialco/f0/compare/f0-react-v1.398.0...f0-react-v1.399.0) (2026-03-11)


### Features

* editable table - nested design fixes ([#3588](https://github.com/factorialco/f0/issues/3588)) ([ed9969f](https://github.com/factorialco/f0/commit/ed9969f0ba1fea53fa6b21a704a2ec6ce018f794))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata update only (version/changelog/manifest) with no runtime code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.398.0` to `1.399.0` and updates `.release-please-manifest.json` accordingly.
> 
> Adds the `1.399.0` changelog entry noting the *editable table nested design fixes* feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29bb997f81b59c1affd9bf6f0b7d91b822962fe6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->