### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.399.0",
-  "packages/react-native": "0.35.0",
+  "packages/react-native": "0.36.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.36.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.35.0...f0-react-native-v0.36.0) (2026-03-11)
+
+
+### Features
+
+* f0 react native f0image primitive ([#3639](https://github.com/factorialco/f0/issues/3639)) ([ebfae3f](https://github.com/factorialco/f0/commit/ebfae3fdd50bead2f4191555313700e1f509493a))
+
 ## [0.35.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.34.0...f0-react-native-v0.35.0) (2026-03-11)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.36.0</summary>

## [0.36.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.35.0...f0-react-native-v0.36.0) (2026-03-11)


### Features

* f0 react native f0image primitive ([#3639](https://github.com/factorialco/f0/issues/3639)) ([ebfae3f](https://github.com/factorialco/f0/commit/ebfae3fdd50bead2f4191555313700e1f509493a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version/changelog updates) with no functional code modifications in this diff.
> 
> **Overview**
> This PR is a Release Please version bump for `@factorialco/f0-react-native`, updating the version from `0.35.0` to `0.36.0` in both `.release-please-manifest.json` and `packages/react-native/package.json`.
> 
> It also appends the `0.36.0` entry to `packages/react-native/CHANGELOG.md`, noting the new `F0Image` primitive feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e09de7a8fea83f8f9ade334b97926b7407599f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->