### PR TITLE
feat: restore add-row and summary stories for editable table

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -622,9 +622,18 @@ export const EditableTableWithSummaryRowAndAddRow: Story = {
     const counter = useRef(0)
 
     const onCellChange = async (updatedItem: MockUser) => {
-      action("onCellChange")(updatedItem)
+      const normalized: MockUser = {
+        ...updatedItem,
+        salary:
+          updatedItem.salary === undefined ||
+          updatedItem.salary === null ||
+          (typeof updatedItem.salary === "string" && updatedItem.salary === "")
+            ? undefined
+            : Number(updatedItem.salary),
+      }
+      action("onCellChange")(normalized)
       setItems((prev) =>
-        prev.map((i) => (i.id === updatedItem.id ? updatedItem : i))
+        prev.map((i) => (i.id === normalized.id ? normalized : i))
       )
     }
 
@@ -645,14 +654,17 @@ export const EditableTableWithSummaryRowAndAddRow: Story = {
       return adapter
     }, [items])
 
-    const dataSource = useDataCollectionSource({
-      summaries: {
-        salary: {
-          type: "sum",
+    const dataSource = useDataCollectionSource(
+      {
+        summaries: {
+          salary: {
+            type: "sum",
+          },
         },
+        dataAdapter,
       },
-      dataAdapter,
-    })
+      [dataAdapter]
+    )
 
     const onAddRow = async () => {
       counter.current += 1
@@ -732,7 +744,6 @@ export const EditableTableWithSummaryRowAndAddRow: Story = {
             },
           },
         ]}
-        nestedRecordsType="detailed"
       />
     )
   },


### PR DESCRIPTION
## Summary

- Restores three editable table stories that were removed in #3588:
  - `EditableTableWithNestedRecordsAndAddRow` — nested records with add row buttons (parent + child)
  - `EditableTableWithAddRow` — flat table with dynamic row addition
  - `EditableTableWithSummaryRowAndAddRow` — summary row (salary sum) combined with add row


Made with [Cursor](https://cursor.com)