### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.399.0",
-  "packages/react-native": "0.36.0",
+  "packages/react-native": "0.37.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.37.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.36.0...f0-react-native-v0.37.0) (2026-03-12)
+
+
+### Features
+
+* introduce F0Tag component with multiple variants ([#3642](https://github.com/factorialco/f0/issues/3642)) ([12f1927](https://github.com/factorialco/f0/commit/12f19272b3fe4df2a1ca7e1b7e2aa1ce9e302924))
+
 ## [0.36.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.35.0...f0-react-native-v0.36.0) (2026-03-11)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.37.0</summary>

## [0.37.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.36.0...f0-react-native-v0.37.0) (2026-03-12)


### Features

* introduce F0Tag component with multiple variants ([#3642](https://github.com/factorialco/f0/issues/3642)) ([12f1927](https://github.com/factorialco/f0/commit/12f19272b3fe4df2a1ca7e1b7e2aa1ce9e302924))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates release metadata (version and changelog) and does not change runtime code paths.
> 
> **Overview**
> Publishes `@factorialco/f0-react-native` **v0.37.0** by bumping the version in `package.json` and updating `.release-please-manifest.json`.
> 
> Updates `packages/react-native/CHANGELOG.md` with the `0.37.0` release notes (adds `F0Tag` with multiple variants).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbc8ba7e911da5d6ea1697fbf4a66664ad67a5d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->