### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.400.0",
-  "packages/react-native": "0.37.0",
+  "packages/react-native": "0.37.1",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.37.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.37.0...f0-react-native-v0.37.1) (2026-03-12)
+
+
+### Bug Fixes
+
+* **F0Button:** update button sizes in styles and snapshots for consis… ([#3650](https://github.com/factorialco/f0/issues/3650)) ([da3103c](https://github.com/factorialco/f0/commit/da3103c17ec8814c1068afb75ac785c0faf77381))
+
 ## [0.37.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.36.0...f0-react-native-v0.37.0) (2026-03-12)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.37.1</summary>

## [0.37.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.37.0...f0-react-native-v0.37.1) (2026-03-12)


### Bug Fixes

* **F0Button:** update button sizes in styles and snapshots for consis… ([#3650](https://github.com/factorialco/f0/issues/3650)) ([da3103c](https://github.com/factorialco/f0/commit/da3103c17ec8814c1068afb75ac785c0faf77381))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata-only change: version bumps and changelog updates with no runtime code modifications in this PR.
> 
> **Overview**
> Publishes `@factorialco/f0-react-native` `0.37.1` by bumping the version in `.release-please-manifest.json` and `packages/react-native/package.json`.
> 
> Updates `packages/react-native/CHANGELOG.md` with the `0.37.1` release notes, documenting a `F0Button` sizing/snapshot consistency bug fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c0b3f3d79ad31332be148784aad4b8bd09b6504. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->