### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.400.0",
-  "packages/react-native": "0.37.1",
+  "packages/react-native": "0.38.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.38.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.37.1...f0-react-native-v0.38.0) (2026-03-12)
+
+
+### Features
+
+* add F0Counter component with size and type variants ([#3649](https://github.com/factorialco/f0/issues/3649)) ([d8bbae4](https://github.com/factorialco/f0/commit/d8bbae450dad7453b08eab68027970b7df1c71d8))
+
 ## [0.37.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.37.0...f0-react-native-v0.37.1) (2026-03-12)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.38.0</summary>

## [0.38.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.37.1...f0-react-native-v0.38.0) (2026-03-12)


### Features

* add F0Counter component with size and type variants ([#3649](https://github.com/factorialco/f0/issues/3649)) ([d8bbae4](https://github.com/factorialco/f0/commit/d8bbae450dad7453b08eab68027970b7df1c71d8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version/manifest bumps and changelog updates, with no functional code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react-native` from `0.37.1` to `0.38.0` (including updating `.release-please-manifest.json`).
> 
> Updates `packages/react-native/CHANGELOG.md` to include the `0.38.0` release notes (notably the `F0Counter` feature entry).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe9f5305ba7438f1f5f034c658bbe0885e3d5d23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->