### PR TITLE
fix(OneDataCollection): fix z-index hierarchy for group header rows

### DIFF
--- a/packages/react/src/experimental/OneTable/TableFooter/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableFooter/index.tsx
@@ -10,7 +10,7 @@ export function TableFooter({ children }: TableFooterProps) {
   return (
     <TableFooterRoot
       className={cn(
-        "bg-f1-background-default sticky bottom-0 z-10 shadow-[0_-1px_0_0_var(--f1-border-secondary)]"
+        "bg-f1-background-default sticky bottom-0 z-30 shadow-[0_-1px_0_0_var(--f1-border-secondary)]"
       )}
     >
       {children}

--- a/packages/react/src/experimental/OneTable/TableHeader/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHeader/index.tsx
@@ -8,7 +8,7 @@ interface TableHeaderProps {
 
 export function TableHeader({ children, sticky = false }: TableHeaderProps) {
   return (
-    <TableHeaderRoot className={cn(sticky && "sticky top-0 z-20")}>
+    <TableHeaderRoot className={cn(sticky && "sticky top-0 z-30")}>
       {children}
     </TableHeaderRoot>
   )

--- a/packages/react/src/experimental/OneTable/TableRow/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableRow/index.tsx
@@ -25,7 +25,7 @@ const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
           "relative before:pointer-events-none before:absolute before:inset-0 before:z-10 before:content-['']",
           "[&:has(.table-cell-action-button:focus)]:before:rounded-sm [&:has(.table-cell-action-button:focus)]:before:ring-1 [&:has(.table-cell-action-button:focus)]:before:ring-inset [&:has(.table-cell-action-button:focus)]:before:ring-f1-special-ring",
           "[&:has(a:focus)]:before:rounded-sm [&:has(a:focus)]:before:ring-1 [&:has(a:focus)]:before:ring-inset [&:has(a:focus)]:before:ring-f1-special-ring",
-          sticky && "hover:bg-f1-background-hover! sticky z-50 bg-f1-background"
+          sticky && "hover:bg-f1-background-hover! sticky z-20 bg-f1-background"
         )}
         style={sticky ? { top: TABLE_ROW_STICKY_TOP_OFFSET } : undefined}
       >

--- a/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
@@ -4,10 +4,10 @@ import {
   Controls,
   Unstyled,
   Story,
-} from "@storybook/addon-docs/blocks";
-import { DoDonts } from "@/lib/storybook-utils/do-donts";
+} from "@storybook/addon-docs/blocks"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
-import * as GroupingStories from "./grouping.stories";
+import * as GroupingStories from "./grouping.stories"
 
 <Meta title="Data collection/Grouping" />
 
@@ -75,23 +75,23 @@ The grouping is configured in the `grouping` property of the `useDataCollection`
 
 ```ts
 export type GroupingDefinition<R extends RecordType> = {
-  mandatory?: boolean;
-  collapsible?: boolean;
-  defaultOpenGroups?: boolean | string[];
+  mandatory?: boolean
+  collapsible?: boolean
+  defaultOpenGroups?: boolean | string[]
   groupBy: {
     [K in keyof R]?: {
-      name: string;
+      name: string
       label: (
         groupId: R[K],
-        filters: FiltersState<FiltersDefinition>,
-      ) => string | Promise<string>;
+        filters: FiltersState<FiltersDefinition>
+      ) => string | Promise<string>
       itemCount?: (
         groupId: R[K],
-        filters: FiltersState<FiltersDefinition>,
-      ) => number | undefined | Promise<number | undefined>;
-    };
-  };
-};
+        filters: FiltersState<FiltersDefinition>
+      ) => number | undefined | Promise<number | undefined>
+    }
+  }
+}
 ```
 
 ### Mandatory
@@ -128,7 +128,7 @@ field of the record and the value is an object with the following properties:
 >   manager: {
 >     name: "John Doe",
 >   },
-> };
+> }
 > ```
 >
 > "manager.name" will group by the `name` property of the `manager` object.

--- a/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
@@ -4,10 +4,10 @@ import {
   Controls,
   Unstyled,
   Story,
-} from "@storybook/addon-docs/blocks"
-import { DoDonts } from "@/lib/storybook-utils/do-donts"
+} from "@storybook/addon-docs/blocks";
+import { DoDonts } from "@/lib/storybook-utils/do-donts";
 
-import * as GroupingStories from "./grouping.stories"
+import * as GroupingStories from "./grouping.stories";
 
 <Meta title="Data collection/Grouping" />
 
@@ -75,23 +75,23 @@ The grouping is configured in the `grouping` property of the `useDataCollection`
 
 ```ts
 export type GroupingDefinition<R extends RecordType> = {
-  mandatory?: boolean
-  collapsible?: boolean
-  defaultOpenGroups?: boolean | string[]
+  mandatory?: boolean;
+  collapsible?: boolean;
+  defaultOpenGroups?: boolean | string[];
   groupBy: {
     [K in keyof R]?: {
-      name: string
+      name: string;
       label: (
         groupId: R[K],
-        filters: FiltersState<FiltersDefinition>
-      ) => string | Promise<string>
+        filters: FiltersState<FiltersDefinition>,
+      ) => string | Promise<string>;
       itemCount?: (
         groupId: R[K],
-        filters: FiltersState<FiltersDefinition>
-      ) => number | undefined | Promise<number | undefined>
-    }
-  }
-}
+        filters: FiltersState<FiltersDefinition>,
+      ) => number | undefined | Promise<number | undefined>;
+    };
+  };
+};
 ```
 
 ### Mandatory
@@ -128,7 +128,7 @@ field of the record and the value is an object with the following properties:
 >   manager: {
 >     name: "John Doe",
 >   },
-> }
+> };
 > ```
 >
 > "manager.name" will group by the `name` property of the `manager` object.
@@ -176,4 +176,9 @@ field of the record and the value is an object with the following properties:
 ### Selectable grouping
 
 <Canvas of={GroupingStories.SelectableGrouping} />
-```
+
+### With grouping and summary
+
+Group headers remain below the sticky summary footer when scrolling vertically.
+
+<Canvas of={GroupingStories.WithGroupingAndSummary} />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/grouping.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/grouping.stories.tsx
@@ -544,6 +544,81 @@ export const SelectableGrouping: Story = {
   ),
 }
 
+export const WithGroupingAndSummary: Story = {
+  parameters: { a11y: { skipCi: true } },
+  render: () => {
+    const paginatedMockUsers = generateMockUsers(50)
+
+    const grouping: GroupingDefinition<MockUser> = {
+      mandatory: true,
+      collapsible: true,
+      defaultOpenGroups: ["Engineering"],
+      groupBy: {
+        department: {
+          name: "Department",
+          label: (groupId) => groupId,
+          itemCount: async (groupId) => {
+            await new Promise((resolve) => setTimeout(resolve, 1000))
+            return paginatedMockUsers.filter(
+              (user) => user.department === groupId
+            ).length
+          },
+        },
+        role: {
+          name: "Role",
+          label: (groupId) => groupId,
+          itemCount: (groupId) =>
+            paginatedMockUsers.filter((user) => user.role === groupId).length,
+        },
+      },
+    }
+
+    const source = useDataCollectionSource({
+      sortings,
+      grouping,
+      currentGrouping: { field: "department", order: "asc" },
+      summaries: {
+        salary: { type: "sum", label: "Total" },
+      },
+      dataAdapter: createDataAdapter({
+        data: paginatedMockUsers,
+        delay: 500,
+        paginationType: "infinite-scroll",
+        perPage: 10,
+        useObservable: true,
+      }),
+    })
+
+    return (
+      <div style={{ height: 500 }}>
+        <OneDataCollection
+          fullHeight
+          source={source}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                columns: [
+                  { label: "Name", render: (item) => item.name },
+                  { label: "Email", render: (item) => item.email },
+                  { label: "Role", render: (item) => item.role },
+                  { label: "Department", render: (item) => item.department },
+                  {
+                    label: "Salary",
+                    summary: "salary",
+                    align: "right",
+                    render: (item) => item.salary,
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      </div>
+    )
+  },
+}
+
 export const SelectableGroupingAndActions: Story = {
   render: () => (
     <ExampleComponent

--- a/packages/react/src/patterns/OneDataCollection/__stories__/grouping.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/grouping.stories.tsx
@@ -590,7 +590,7 @@ export const WithGroupingAndSummary: Story = {
     })
 
     return (
-      <div style={{ height: 500 }}>
+      <div className="h-[500px]">
         <OneDataCollection
           fullHeight
           source={source}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -792,7 +792,7 @@ export const TableCollection = <
                   <TableRow
                     className={cn(
                       summaryData.sticky &&
-                        "sticky bottom-0 z-10 bg-f1-background shadow-[0_-1px_0_0_var(--f1-border-secondary)] hover:bg-f1-background",
+                        "sticky bottom-0 z-30 bg-f1-background shadow-[0_-1px_0_0_var(--f1-border-secondary)] hover:bg-f1-background",
                       "font-medium"
                     )}
                   >


### PR DESCRIPTION
## 🚪 Why?

### Problem

Sticky group header rows in `OneDataCollection`'s table view paint over the sticky summary footer and the table header when scrolling. The footer disappears behind group headers, and the header loses its sticky stacking order against group headers.

### Root Cause

The `sticky` prop on `TableRow` applied `z-50`, which f0's Tailwind config remaps to `z-index: 1250` — the same tier as Radix portals (dialogs, popovers, tooltips). The intent was "beat other table elements" but it overshot by ~60x. Concretely:

- Group header `<tr>` at z-50 (CSS 1250) > Table header `<thead>` at z-20 (CSS 20) → header scrolled behind group headers
- Group header `<tr>` at z-50 (CSS 1250) > Summary footer `<tr>` at z-10 (CSS 10) → footer covered by group headers

## 🔑 What?

### Changes

- `OneTable/TableRow/index.tsx`: `z-50` → `z-20` on the sticky group header `<tr>` — removes it from the overlay tier, keeps it above frozen cells (z-10)
- `OneTable/TableHeader/index.tsx`: `z-20` → `z-30` on sticky `<thead>` — now correctly wins over group header rows
- `OneTable/TableFooter/index.tsx`: `z-10` → `z-30` on sticky `<tfoot>` — now correctly wins over group header rows
- `OneDataCollection/.../Table.tsx`: `z-10` → `z-30` on the sticky summary `<tr>` inside `<tfoot>` — consistent with footer elevation

**Resulting hierarchy:**

| CSS z-index | Tailwind | Element |
|-------------|----------|---------|
| 1250 | z-50 | Radix portals, ActionBar (unchanged) |
| 30 | z-30 | Table `<thead>`, summary `<tfoot>` + `<tr>` |
| 20 | z-20 | Group header `<tr>` (sticky) |
| 10 | z-10 | Frozen column cells, item action cells (unchanged) |
| — | — | Normal rows (unchanged) |

## ✅ Verification

### Tests

- Existing tests pass: 138 test files / 1935 tests, 0 failures (`pnpm vitest:ci`)
- No new type errors introduced (`pnpm tsc --noEmit`, pre-existing errors only)

### Manual Verification

- Grouped table with summaries → footer stays above group headers when scrolling vertically
- Grouped table with frozen columns → frozen cells scroll below group headers correctly
- Non-grouped table → no change in behaviour
- Radix dropdowns on row actions → still render above everything at z-50 (1250) via portal

### Before

Pay attention to summary footer and group headers:

https://github.com/user-attachments/assets/ce9cf6c2-7ac4-4459-bb2f-cf4c900afca6

### After

https://github.com/user-attachments/assets/ab12df73-0791-4e05-8c9e-560a42b1c30f


