### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.400.0",
-  "packages/react-native": "0.38.0",
+  "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.39.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.38.0...f0-react-native-v0.39.0) (2026-03-12)
+
+
+### Features
+
+* add F0Preset component with showcase and documentation ([#3654](https://github.com/factorialco/f0/issues/3654)) ([5faacc6](https://github.com/factorialco/f0/commit/5faacc6714855241b734977ed015a72ae67cd66c))
+
 ## [0.38.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.37.1...f0-react-native-v0.38.0) (2026-03-12)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.39.0</summary>

## [0.39.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.38.0...f0-react-native-v0.39.0) (2026-03-12)


### Features

* add F0Preset component with showcase and documentation ([#3654](https://github.com/factorialco/f0/issues/3654)) ([5faacc6](https://github.com/factorialco/f0/commit/5faacc6714855241b734977ed015a72ae67cd66c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog/manifest updates with no runtime code changes in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react-native` from `0.38.0` to `0.39.0` and updates `.release-please-manifest.json` accordingly.
> 
> Updates `packages/react-native/CHANGELOG.md` to include the `0.39.0` release notes (notably the addition of `F0Preset` documentation/showcase).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2204fb6e60b6265e05948144b831c4063958fd5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->