### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.400.0",
+  "packages/react": "1.401.0",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.401.0](https://github.com/factorialco/f0/compare/f0-react-v1.400.0...f0-react-v1.401.0) (2026-03-12)
+
+
+### Features
+
+* **F0Card:** add 16:9 image aspect ratio ([#3652](https://github.com/factorialco/f0/issues/3652)) ([fa71f7f](https://github.com/factorialco/f0/commit/fa71f7f00c9e58983878579fb4ec4ddab3deb5f6))
+
 ## [1.400.0](https://github.com/factorialco/f0/compare/f0-react-v1.399.0...f0-react-v1.400.0) (2026-03-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.400.0",
+  "version": "1.401.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.401.0</summary>

## [1.401.0](https://github.com/factorialco/f0/compare/f0-react-v1.400.0...f0-react-v1.401.0) (2026-03-12)


### Features

* **F0Card:** add 16:9 image aspect ratio ([#3652](https://github.com/factorialco/f0/issues/3652)) ([fa71f7f](https://github.com/factorialco/f0/commit/fa71f7f00c9e58983878579fb4ec4ddab3deb5f6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only change (version/manifest/changelog) with no runtime code modifications in this PR.
> 
> **Overview**
> Bumps the `@factorialco/f0-react` package version from `1.400.0` to `1.401.0` and updates the Release Please manifest accordingly.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.401.0` release entry, noting the new `F0Card` 16:9 image aspect ratio feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a7b03457a5dabd29e13c4be0215df4ecf9533f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->