### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.401.1",
+  "packages/react": "1.402.0",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.402.0](https://github.com/factorialco/f0/compare/f0-react-v1.401.1...f0-react-v1.402.0) (2026-03-12)
+
+
+### Features
+
+* add F0DurationInput compound input component ([#3641](https://github.com/factorialco/f0/issues/3641)) ([7dc3112](https://github.com/factorialco/f0/commit/7dc311200f8f12d5b61f6104ec069a00daaeceb9))
+
 ## [1.401.1](https://github.com/factorialco/f0/compare/f0-react-v1.401.0...f0-react-v1.401.1) (2026-03-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.401.1",
+  "version": "1.402.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.402.0</summary>

## [1.402.0](https://github.com/factorialco/f0/compare/f0-react-v1.401.1...f0-react-v1.402.0) (2026-03-12)


### Features

* add F0DurationInput compound input component ([#3641](https://github.com/factorialco/f0/issues/3641)) ([7dc3112](https://github.com/factorialco/f0/commit/7dc311200f8f12d5b61f6104ec069a00daaeceb9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only change that bumps versions and updates the changelog; no functional code changes in this PR, so risk is low aside from potential downstream dependency/versioning impact.
> 
> **Overview**
> Publishes a new `@factorialco/f0-react` release by bumping the version to `1.402.0` (including the Release Please manifest) and updating the React package changelog to document the new feature (`F0DurationInput`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a5dee744217fc10953b5822df3c321e35d5e26c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->