### PR TITLE
Fix: nested rows selectable

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -1044,25 +1044,44 @@ const createdMixedNestedRecords = (filteredData: MockUser[]) => {
         ? [
             {
               ...user,
+              id: `${user.id}-child-0`,
               children: [
-                { ...user },
+                { ...user, id: `${user.id}-child-0-0` },
                 {
                   ...user,
+                  id: `${user.id}-child-0-1`,
                   detailed: index === 0,
                   children: [
-                    { ...user, detailed: index === 0 },
-                    { ...user, detailed: index === 0 },
+                    {
+                      ...user,
+                      id: `${user.id}-child-0-1-0`,
+                      detailed: index === 0,
+                    },
+                    {
+                      ...user,
+                      id: `${user.id}-child-0-1-1`,
+                      detailed: index === 0,
+                    },
                   ],
                 },
-                { ...user },
+                { ...user, id: `${user.id}-child-0-2` },
               ],
             },
             {
               ...user,
+              id: `${user.id}-child-1`,
               detailed: index === 0,
               children: [
-                { ...user, detailed: index === 0 },
-                { ...user, detailed: index === 0 },
+                {
+                  ...user,
+                  id: `${user.id}-child-1-0`,
+                  detailed: index === 0,
+                },
+                {
+                  ...user,
+                  id: `${user.id}-child-1-1`,
+                  detailed: index === 0,
+                },
               ],
             },
           ]
@@ -1074,8 +1093,8 @@ const createdBasicNestedRecords = (filteredData: MockUser[]) => {
   return filteredData.map((user) => ({
     ...user,
     children: [
-      { ...user, name: "Child_of " + user.name },
-      { ...user, name: "Child_of " + user.name },
+      { ...user, id: `${user.id}-child-0`, name: "Child_of " + user.name },
+      { ...user, id: `${user.id}-child-1`, name: "Child_of " + user.name },
     ],
   }))
 }
@@ -1085,8 +1104,18 @@ const createdDetailedNestedRecords = (filteredData: MockUser[]) => {
     ...user,
     detailed: true,
     children: [
-      { ...user, name: "Child_of " + user.name, detailed: true },
-      { ...user, name: "Child_of " + user.name, detailed: true },
+      {
+        ...user,
+        id: `${user.id}-child-0`,
+        name: "Child_of " + user.name,
+        detailed: true,
+      },
+      {
+        ...user,
+        id: `${user.id}-child-1`,
+        name: "Child_of " + user.name,
+        detailed: true,
+      },
     ],
   }))
 }

--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -467,9 +467,7 @@ export const EditableTableWithSelectableNestedRecordsDetailed: Story = {
       <ExampleComponent
         noSorting
         storage={false}
-        selectable={() => {
-          return ""
-        }}
+        selectable={(item) => item.id}
         visualizations={[
           {
             type: "editableTable" as const,

--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -193,9 +193,7 @@ export const TableWithSelectableNestedRecords: Story = {
         id="employees/v1"
         nestedRecords
         nestedRecordsType="mixed"
-        selectable={() => {
-          return ""
-        }}
+        selectable={(item) => item.id}
       />
     )
   },

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -528,9 +528,7 @@ export const TableCollection = <
                               item={item}
                               index={index}
                               groupIndex={groupIndex}
-                              onCheckedChange={(checked) =>
-                                handleSelectItemChange(item, checked)
-                              }
+                              onSelectItem={handleSelectItemChange}
                               selectedItems={selectedItems}
                               columns={columns}
                               frozenColumnsLeft={frozenColumnsLeft}
@@ -568,9 +566,7 @@ export const TableCollection = <
                     source={effectiveSource}
                     item={item}
                     index={index}
-                    onCheckedChange={(checked) =>
-                      handleSelectItemChange(item, checked)
-                    }
+                    onSelectItem={handleSelectItemChange}
                     selectedItems={selectedItems}
                     columns={columns}
                     frozenColumnsLeft={frozenColumnsLeft}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/LoadMore/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/LoadMore/index.tsx
@@ -68,6 +68,7 @@ const LoadMoreRowInner = <
   return (
     <Row
       {...props}
+      source={{ ...props.source, selectable: () => undefined }}
       columns={formattedColumns}
       ref={combinedRef}
       noBorder={depth > 0}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -71,7 +71,7 @@ export type RowProps<
   item: R
   index: number
   groupIndex: number
-  onCheckedChange: (checked: boolean) => void
+  onSelectItem: (item: R, checked: boolean) => void
   selectedItems: Map<string | number, R>
   columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>
   frozenColumnsLeft: number

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -16,7 +16,7 @@
  *
  */
 
-import { forwardRef, useCallback, useRef } from "react"
+import { forwardRef, useCallback, useEffect, useMemo, useRef } from "react"
 
 import type { TableVisualizationType } from "@/experimental/OneDataCollection/types"
 
@@ -85,6 +85,8 @@ export type RowProps<
   /** Row wrapper for child rows (provides per-row context, e.g. editing state) */
   rowWrapper?: React.ComponentType<RowWrapperProps<R>>
   fromVisualization?: TableVisualizationType
+  indeterminate?: boolean
+  allChildrenSelected?: boolean
 }
 
 const NestedRowContent = <
@@ -175,6 +177,56 @@ const NestedRowContent = <
     }
   }
 
+  const handleSelectItemWithChildren = useCallback(
+    (selectedItem: R, checked: boolean) => {
+      props.onSelectItem(selectedItem, checked)
+
+      const selectedId = props.source.selectable?.(selectedItem)
+      const parentId = props.source.selectable?.(props.item)
+      if (
+        selectedId !== undefined &&
+        selectedId === parentId &&
+        children.length > 0
+      ) {
+        for (const child of children) {
+          props.onSelectItem(child as R, checked)
+        }
+      }
+    },
+    [props.onSelectItem, props.source, props.item, children]
+  )
+
+  const { parentIndeterminate, allChildrenSelected } = useMemo(() => {
+    if (children.length === 0)
+      return { parentIndeterminate: false, allChildrenSelected: false }
+    const childIds = children
+      .map((child) => props.source.selectable?.(child as R))
+      .filter((id): id is string | number => id !== undefined)
+    if (childIds.length === 0)
+      return { parentIndeterminate: false, allChildrenSelected: false }
+    const selectedCount = childIds.filter((id) =>
+      props.selectedItems.has(id)
+    ).length
+    return {
+      parentIndeterminate: selectedCount > 0 && selectedCount < childIds.length,
+      allChildrenSelected: selectedCount === childIds.length,
+    }
+  }, [children, props.source, props.selectedItems])
+
+  useEffect(() => {
+    if (!allChildrenSelected || children.length === 0) return
+    const parentId = props.source.selectable?.(props.item)
+    if (parentId === undefined || props.selectedItems.has(parentId)) return
+    props.onSelectItem(props.item, true)
+  }, [
+    allChildrenSelected,
+    children.length,
+    props.source,
+    props.item,
+    props.onSelectItem,
+    props.selectedItems,
+  ])
+
   const sharedNestedRowProps = {
     depth: props.nestedRowProps?.depth ?? 0,
     expanded: open,
@@ -200,6 +252,9 @@ const NestedRowContent = <
     <>
       <Row
         {...props}
+        onSelectItem={handleSelectItemWithChildren}
+        indeterminate={parentIndeterminate}
+        allChildrenSelected={allChildrenSelected}
         disableHover={!props.source.itemOnClick}
         noBorder={shouldHideBorder}
         ref={combinedRowRef}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -227,6 +227,32 @@ const NestedRowContent = <
     props.selectedItems,
   ])
 
+  const prevParentSelectedRef = useRef(false)
+
+  useEffect(() => {
+    const parentId = props.source.selectable?.(props.item)
+    if (parentId === undefined || children.length === 0) return
+
+    const parentIsSelected = props.selectedItems.has(parentId)
+    const wasSelected = prevParentSelectedRef.current
+    prevParentSelectedRef.current = parentIsSelected
+
+    if (parentIsSelected && !wasSelected) {
+      for (const child of children) {
+        const childId = props.source.selectable?.(child as R)
+        if (childId !== undefined && !props.selectedItems.has(childId)) {
+          props.onSelectItem(child as R, true)
+        }
+      }
+    }
+  }, [
+    props.selectedItems,
+    props.source,
+    props.item,
+    children,
+    props.onSelectItem,
+  ])
+
   const sharedNestedRowProps = {
     depth: props.nestedRowProps?.depth ?? 0,
     expanded: open,

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -73,6 +73,8 @@ export type RowProps<
   /** Row wrapper passed through to NestedRow for wrapping child rows */
   rowWrapper?: React.ComponentType<RowWrapperProps<R>>
   fromVisualization?: TableVisualizationType
+  indeterminate?: boolean
+  allChildrenSelected?: boolean
 }
 
 export type NestedRowProps = {
@@ -121,6 +123,8 @@ const RowComponentInner = <
     cellRenderer: CellRenderer,
     rowWrapper,
     fromVisualization,
+    indeterminate = false,
+    allChildrenSelected = false,
   }: RowProps<
     R,
     Filters,
@@ -190,7 +194,9 @@ const RowComponentInner = <
     )
   }
 
-  const isSelected = id !== undefined && selectedItems.has(id)
+  const isSelected =
+    id !== undefined &&
+    (selectedItems.has(id) || indeterminate || allChildrenSelected)
   const referenceRowType = referenceRowTypeFn?.(item) ?? "none"
 
   const cellRenderedClass = CellRenderer
@@ -227,7 +233,10 @@ const RowComponentInner = <
           {id !== undefined && (
             <div className="pointer-events-auto ml-1.5 flex h-full items-center justify-start">
               <Checkbox
-                checked={selectedItems.has(id)}
+                checked={
+                  selectedItems.has(id) || indeterminate || allChildrenSelected
+                }
+                indeterminate={indeterminate}
                 onCheckedChange={(checked) => onSelectItem(item, !!checked)}
                 title={`Select ${source.selectable(item)}`}
                 hideLabel

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -54,7 +54,7 @@ export type RowProps<
   item: R
   index: number
   groupIndex: number
-  onCheckedChange: (checked: boolean) => void
+  onSelectItem: (item: R, checked: boolean) => void
   selectedItems: Map<string | number, R>
   columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>
   frozenColumnsLeft: number
@@ -105,7 +105,7 @@ const RowComponentInner = <
   {
     source,
     item,
-    onCheckedChange,
+    onSelectItem,
     selectedItems,
     columns,
     frozenColumnsLeft,
@@ -172,7 +172,7 @@ const RowComponentInner = <
       <NestedRow
         source={source}
         item={item}
-        onCheckedChange={onCheckedChange}
+        onSelectItem={onSelectItem}
         selectedItems={selectedItems}
         columns={columns}
         frozenColumnsLeft={frozenColumnsLeft}
@@ -228,7 +228,7 @@ const RowComponentInner = <
             <div className="pointer-events-auto ml-1.5 flex h-full items-center justify-start">
               <Checkbox
                 checked={selectedItems.has(id)}
-                onCheckedChange={onCheckedChange}
+                onCheckedChange={(checked) => onSelectItem(item, !!checked)}
                 title={`Select ${source.selectable(item)}`}
                 hideLabel
               />

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
@@ -36,7 +36,7 @@ const SingleLoadingRowInner = <
     frozenColumnsLeft,
     nestedRowProps,
     groupIndex,
-    onCheckedChange,
+    onSelectItem,
     selectedItems,
     checkColumnWidth,
     tableWithChildren,
@@ -94,7 +94,7 @@ const SingleLoadingRowInner = <
       columns={columns}
       noBorder={shouldHideBorder ?? false}
       groupIndex={groupIndex}
-      onCheckedChange={onCheckedChange}
+      onSelectItem={onSelectItem}
       selectedItems={selectedItems}
       checkColumnWidth={checkColumnWidth}
       loading

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -541,7 +541,7 @@ export function useSelectable<
     (checked: boolean) => {
       if (!isMultiSelection) return
 
-      if (!checked && allSelectedCheck) {
+      if (!checked) {
         setAllSelectedCheck(false)
         wasExplicitSelectAll.current = false
         setSelectAllTotal(null)
@@ -557,9 +557,7 @@ export function useSelectable<
 
       const currentPageCount = data.records?.length || 0
 
-      if (checked) {
-        setSelectAllTotal((prev) => (prev !== null ? prev : currentPageCount))
-      }
+      setSelectAllTotal((prev) => (prev !== null ? prev : currentPageCount))
 
       if (isGrouped && data.type === "grouped") {
         const allGroupIds = data.groups.map((group) => group.key)
@@ -574,12 +572,6 @@ export function useSelectable<
         if (allItemIds.length > 0) {
           handleSelectItemChangeInternal(allItemIds, checked)
         }
-      }
-
-      if (!checked) {
-        setAllSelectedCheck(false)
-        wasExplicitSelectAll.current = false
-        setSelectAllTotal(null)
       }
     },
     [

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -233,9 +233,13 @@ export function useSelectable<
     const itemsStatus = Array.from(items.values())
       .filter((itemState) => {
         if (itemState.item === undefined) return false
-        // Filter to only current page items in page-only selection mode
+        // In page-only mode, include items from the current page OR items
+        // with a resolved item reference (e.g. children loaded via nested rows
+        // that aren't in data.records but are visible on the current page).
         if (isPageOnlySelection && currentPageItemIds) {
-          return currentPageItemIds.has(itemState.id)
+          return (
+            currentPageItemIds.has(itemState.id) || itemState.item !== undefined
+          )
         }
         return true
       })
@@ -244,9 +248,8 @@ export function useSelectable<
     const selectedIds = Array.from(items.entries())
       .filter(([id, itemState]) => {
         if (!itemState.checked) return false
-        // Filter to only current page items in page-only selection mode
         if (isPageOnlySelection && currentPageItemIds) {
-          return currentPageItemIds.has(id)
+          return currentPageItemIds.has(id) || itemState.item !== undefined
         }
         return true
       })
@@ -420,7 +423,8 @@ export function useSelectable<
     (
       itemId: SelectionId | readonly SelectionId[],
       checked: boolean,
-      onlyIfNotPreviousState: boolean = false
+      onlyIfNotPreviousState: boolean = false,
+      itemRef?: WithGroupId<R>
     ) => {
       const itemIds = (Array.isArray(itemId) ? itemId : [itemId]).slice(
         0,
@@ -443,6 +447,7 @@ export function useSelectable<
           const existingItem = current.items?.get(id)?.item
           const item =
             existingItem ??
+            itemRef ??
             data.records.find((record) => {
               const recordId = getSelectable?.(record)
               return recordId !== undefined && recordId === id
@@ -513,7 +518,12 @@ export function useSelectable<
       if (isRecordItem(itemOrId, getSelectable !== undefined)) {
         const id = getSelectable?.(itemOrId)
         if (id !== undefined) {
-          handleSelectItemChangeInternal(id, checked)
+          handleSelectItemChangeInternal(
+            id,
+            checked,
+            false,
+            itemOrId as WithGroupId<R>
+          )
         }
         return
       }


### PR DESCRIPTION
## 🚪 Why?

Selecting children rows in a DataCollection with nested records was broken in multiple ways: clicking a child checkbox selected the parent instead, children were excluded from bulk actions, "select all" only selected top-level parents (ignoring nested children), and Storybook stories had duplicate IDs causing all items to be checked at once.

## 🔑 What?

**Fix children row selection:**

- Replace `onCheckedChange` with `onSelectItem` prop in `Row`/`NestedRow` so each row calls `handleSelectItemChange` with its own item instead of inheriting the parent's closure
- Update `useSelectable` to accept and store the item reference directly in `handleSelectItemChangeInternal`, preventing failed lookups for children not present in `data.records`
- Relax the `currentPageItemIds` filter in `itemsStatus`/`selectedIds` to include items with a resolved reference (children are visible on the current page but not in top-level records)

**Cascade "select all" to nested children:**

- Add a `useEffect` in `NestedRow` that detects when a parent transitions from unselected → selected (e.g., via "select all") and cascades selection to all loaded children
- Track previous parent selection state with a ref to avoid infinite loops and double-triggers with the existing `handleSelectItemWithChildren` click handler

**Parent indeterminate/checked state from children:**

- Compute `parentIndeterminate` and `allChildrenSelected` in `NestedRow` based on loaded children's selection state
- When all children are individually selected, auto-select the parent via a `useEffect`
- Pass indeterminate/allChildrenSelected props to `Row` for correct checkbox rendering

**Hide checkbox on "load more" rows:**

- Override `selectable` to `() => undefined` on `LoadMore` rows so the column remains rendered (preserving table alignment) but no checkbox is displayed

**Fix Storybook mock data:**

- Generate unique IDs for child items in `mockData.tsx` (`${user.id}-child-0`, etc.)
- Fix `selectable` prop in nested records stories to use `item.id` instead of a hardcoded empty string

### Edge cases handled

| Scenario | Behavior |
|---|---|
| **Select all** (page or all-pages) | Parents are selected by `useSelectable`, then the `useEffect` in `NestedRow` cascades to all loaded children |
| **Deselect all** | `handleSelectAll(false)` resets the entire items Map to empty, clearing both parents and children in one operation |
| **Click parent checkbox directly** | `handleSelectItemWithChildren` cascades immediately on click; the `useEffect` does not double-trigger because the ref already tracks the parent as selected |
| **Expand a row after select-all** | When children load, the `children` dependency changes, the `useEffect` re-runs, sees the parent is selected, and cascades to newly loaded children |
| **Manually deselect a child** | Parent becomes indeterminate. The cascade `useEffect` does not re-select the child because the ref already has `wasSelected = true` (no transition detected) |
| **Deselect all children individually** | Parent auto-deselects via the existing `allChildrenSelected` effect (which detects 0 selected children and does nothing), and the indeterminate logic resets |

### Known limitation: selection scope is tied to expanded rows

"Select all" can only cascade to children that have been loaded — i.e., the parent row was previously expanded. Children of collapsed/never-expanded rows are not selected because they don't exist in memory yet (they are lazily loaded via `NestedDataProvider`).

This means **both selection and count only reflect what has been expanded**:

- If you click "select all" with 5 parents and 2 of them have been expanded (showing 3 children each), the selection will include 5 parents + 6 children = 11 items. The 3 unexpanded parents' children are not selected.
- If you then expand one of those 3 remaining parents, the cascade `useEffect` fires (parent is already selected → new children loaded → auto-selected), and the count increases.

**Counter accuracy per mode:**

- **Page-only mode**: the counter uses `checkedCount` (actual checked items in state). It accurately reflects what is selected — parents + expanded children. As you expand more rows, children get cascaded and the count goes up incrementally.
- **All-pages mode**: the counter uses `selectAllTotal - uncheckedCount`, where `selectAllTotal` comes from `paginationInfo.total` (top-level items only). This formula does not account for children at all, so even after children are loaded and selected, the displayed count can be lower than the actual number of selected items. This is a pre-existing architectural limitation of how `useSelectable` tracks counts separately from `NestedDataProvider`.