### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.402.0",
+  "packages/react": "1.402.1",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.402.1](https://github.com/factorialco/f0/compare/f0-react-v1.402.0...f0-react-v1.402.1) (2026-03-13)
+
+
+### Bug Fixes
+
+* add support for survey answering form to be on side position ([#3666](https://github.com/factorialco/f0/issues/3666)) ([f6aad7f](https://github.com/factorialco/f0/commit/f6aad7f3a6a6a8b4574c5a03bf6a21d351f73f44))
+
 ## [1.402.0](https://github.com/factorialco/f0/compare/f0-react-v1.401.1...f0-react-v1.402.0) (2026-03-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.402.0",
+  "version": "1.402.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.402.1</summary>

## [1.402.1](https://github.com/factorialco/f0/compare/f0-react-v1.402.0...f0-react-v1.402.1) (2026-03-13)


### Bug Fixes

* add support for survey answering form to be on side position ([#3666](https://github.com/factorialco/f0/issues/3666)) ([f6aad7f](https://github.com/factorialco/f0/commit/f6aad7f3a6a6a8b4574c5a03bf6a21d351f73f44))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates release metadata (versions/changelog) and does not modify runtime code.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.402.0` to `1.402.1` and updates `.release-please-manifest.json` accordingly.
> 
> Updates `packages/react/CHANGELOG.md` to include the `1.402.1` release notes (bug fix: survey answering form can be positioned on the side).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13b95ab3553951344870f58a5d0dbe7281099f38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->