### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.402.1",
+  "packages/react": "1.402.2",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.402.2](https://github.com/factorialco/f0/compare/f0-react-v1.402.1...f0-react-v1.402.2) (2026-03-13)
+
+
+### Bug Fixes
+
+* **react:** align F0DurationInput disabled and error highlight ([#3665](https://github.com/factorialco/f0/issues/3665)) ([a026b34](https://github.com/factorialco/f0/commit/a026b3444800929cd79282b131f1f4d17a361fe9))
+
 ## [1.402.1](https://github.com/factorialco/f0/compare/f0-react-v1.402.0...f0-react-v1.402.1) (2026-03-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.402.1",
+  "version": "1.402.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.402.2</summary>

## [1.402.2](https://github.com/factorialco/f0/compare/f0-react-v1.402.1...f0-react-v1.402.2) (2026-03-13)


### Bug Fixes

* **react:** align F0DurationInput disabled and error highlight ([#3665](https://github.com/factorialco/f0/issues/3665)) ([a026b34](https://github.com/factorialco/f0/commit/a026b3444800929cd79282b131f1f4d17a361fe9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates release metadata (manifest, package version, changelog) and does not change runtime code.
> 
> **Overview**
> Publishes `@factorialco/f0-react` **v1.402.2** by bumping the version in `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the v1.402.2 entry noting a bug fix to align `F0DurationInput` disabled and error highlight styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9a943486e56435dd33796500c3c6be45ed3721a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->