### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.402.2",
+  "packages/react": "1.402.3",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.402.3](https://github.com/factorialco/f0/compare/f0-react-v1.402.2...f0-react-v1.402.3) (2026-03-16)
+
+
+### Bug Fixes
+
+* javascript heap out of memory ([#3672](https://github.com/factorialco/f0/issues/3672)) ([de8aad4](https://github.com/factorialco/f0/commit/de8aad42676e2be95a2dc20f6b68011c07280729))
+
 ## [1.402.2](https://github.com/factorialco/f0/compare/f0-react-v1.402.1...f0-react-v1.402.2) (2026-03-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.402.2",
+  "version": "1.402.3",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.402.3</summary>

## [1.402.3](https://github.com/factorialco/f0/compare/f0-react-v1.402.2...f0-react-v1.402.3) (2026-03-16)


### Bug Fixes

* javascript heap out of memory ([#3672](https://github.com/factorialco/f0/issues/3672)) ([de8aad4](https://github.com/factorialco/f0/commit/de8aad42676e2be95a2dc20f6b68011c07280729))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only change that bumps `@factorialco/f0-react` version/manifest and updates the changelog; no functional code changes included in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.402.2` to `1.402.3` and updates `.release-please-manifest.json` accordingly.
> 
> Updates the React package changelog to include the `1.402.3` entry (bug fix: “javascript heap out of memory”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08efab7f002b3d349290b64e5d8fff44eb2fa24c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->