### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.402.3",
+  "packages/react": "1.403.0",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.403.0](https://github.com/factorialco/f0/compare/f0-react-v1.402.3...f0-react-v1.403.0) (2026-03-16)
+
+
+### Features
+
+* restore add-row and summary stories for editable table ([#3643](https://github.com/factorialco/f0/issues/3643)) ([7574eff](https://github.com/factorialco/f0/commit/7574eff1db077bbe8f0e502190e6d2c071f09e72))
+
 ## [1.402.3](https://github.com/factorialco/f0/compare/f0-react-v1.402.2...f0-react-v1.402.3) (2026-03-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.402.3",
+  "version": "1.403.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.403.0</summary>

## [1.403.0](https://github.com/factorialco/f0/compare/f0-react-v1.402.3...f0-react-v1.403.0) (2026-03-16)


### Features

* restore add-row and summary stories for editable table ([#3643](https://github.com/factorialco/f0/issues/3643)) ([7574eff](https://github.com/factorialco/f0/commit/7574eff1db077bbe8f0e502190e6d2c071f09e72))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates release metadata (versions and changelog) for `@factorialco/f0-react`, with no functional code changes.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.402.3` to `1.403.0` in `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` to add the `1.403.0` release entry ("restore add-row and summary stories for editable table").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 226d382434f9e65fc4bfd2095d695063cb31b342. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->