### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.403.0",
+  "packages/react": "1.403.1",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.403.1](https://github.com/factorialco/f0/compare/f0-react-v1.403.0...f0-react-v1.403.1) (2026-03-16)
+
+
+### Bug Fixes
+
+* handle text overflow for unspaced content in CommunityPost ([#3527](https://github.com/factorialco/f0/issues/3527)) ([00306e0](https://github.com/factorialco/f0/commit/00306e0ebfcdf874cd43fb34ce9d9b641b8e03ea))
+
 ## [1.403.0](https://github.com/factorialco/f0/compare/f0-react-v1.402.3...f0-react-v1.403.0) (2026-03-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.403.0",
+  "version": "1.403.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.403.1</summary>

## [1.403.1](https://github.com/factorialco/f0/compare/f0-react-v1.403.0...f0-react-v1.403.1) (2026-03-16)


### Bug Fixes

* handle text overflow for unspaced content in CommunityPost ([#3527](https://github.com/factorialco/f0/issues/3527)) ([00306e0](https://github.com/factorialco/f0/commit/00306e0ebfcdf874cd43fb34ce9d9b641b8e03ea))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata change only: bumps the `packages/react` version and updates the changelog/manifest with no functional code modifications in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.403.0` to `1.403.1` and updates `.release-please-manifest.json` accordingly.
> 
> Updates `packages/react/CHANGELOG.md` to include the `1.403.1` release notes (bug fix: text overflow handling for unspaced content in `CommunityPost`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4650aee28aeed8cffcc544cac350d94f25f812a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->