### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.403.1",
+  "packages/react": "1.404.0",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.404.0](https://github.com/factorialco/f0/compare/f0-react-v1.403.1...f0-react-v1.404.0) (2026-03-16)
+
+
+### Features
+
+* add SelectCell for EditableTable with F0Select integration ([#3607](https://github.com/factorialco/f0/issues/3607)) ([49fe9a1](https://github.com/factorialco/f0/commit/49fe9a195bee19902cce73b85535ed80934a7605))
+
 ## [1.403.1](https://github.com/factorialco/f0/compare/f0-react-v1.403.0...f0-react-v1.403.1) (2026-03-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.403.1",
+  "version": "1.404.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.404.0</summary>

## [1.404.0](https://github.com/factorialco/f0/compare/f0-react-v1.403.1...f0-react-v1.404.0) (2026-03-16)


### Features

* add SelectCell for EditableTable with F0Select integration ([#3607](https://github.com/factorialco/f0/issues/3607)) ([49fe9a1](https://github.com/factorialco/f0/commit/49fe9a195bee19902cce73b85535ed80934a7605))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog updates with no functional code changes included in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.403.1` to `1.404.0` (updates `.release-please-manifest.json` and `packages/react/package.json`).
> 
> Updates `packages/react/CHANGELOG.md` to document the `1.404.0` release, noting the new EditableTable `SelectCell` feature with `F0Select` integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83435e5df9b98f1c15bcbcf796a8ae00ac1704ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->