### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.404.0",
+  "packages/react": "1.404.1",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.404.1](https://github.com/factorialco/f0/compare/f0-react-v1.404.0...f0-react-v1.404.1) (2026-03-16)
+
+
+### Bug Fixes
+
+* **one-data-collection:** add summary placeholders (FCT-48392) ([#3538](https://github.com/factorialco/f0/issues/3538)) ([59e7051](https://github.com/factorialco/f0/commit/59e7051fecd83d3b3be386c95ca6f391ea3257bd))
+
 ## [1.404.0](https://github.com/factorialco/f0/compare/f0-react-v1.403.1...f0-react-v1.404.0) (2026-03-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.404.0",
+  "version": "1.404.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.404.1</summary>

## [1.404.1](https://github.com/factorialco/f0/compare/f0-react-v1.404.0...f0-react-v1.404.1) (2026-03-16)


### Bug Fixes

* **one-data-collection:** add summary placeholders (FCT-48392) ([#3538](https://github.com/factorialco/f0/issues/3538)) ([59e7051](https://github.com/factorialco/f0/commit/59e7051fecd83d3b3be386c95ca6f391ea3257bd))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata update: only version/manifest bumps and changelog entry additions, with no functional code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react` from `1.404.0` to `1.404.1` in `.release-please-manifest.json` and `packages/react/package.json`.
> 
> Updates `packages/react/CHANGELOG.md` with the `1.404.1` release notes (bug fix: *one-data-collection* summary placeholders).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6795bd6f8adc76604fd7fcd06be91f81b41642c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->