### PR TITLE
fix(react): handle query params in isActive link matching

### DIFF
--- a/packages/react/src/lib/linkHandler.spec.tsx
+++ b/packages/react/src/lib/linkHandler.spec.tsx
@@ -81,4 +81,76 @@ describe("useLink", () => {
       "false"
     )
   })
+
+  test("isActive ignores query params in currentPath when href has no query params", async () => {
+    render(
+      <LinkProvider currentPath="/foo?startDate=2026-01-01">
+        <Component href="/foo" />
+      </LinkProvider>
+    )
+
+    expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
+      "true"
+    )
+  })
+
+  test("isActive matches when both currentPath and href have the same query params", async () => {
+    render(
+      <LinkProvider currentPath="/foo?tab=form">
+        <Component href="/foo?tab=form" />
+      </LinkProvider>
+    )
+
+    expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
+      "true"
+    )
+  })
+
+  test("isActive returns false when href has different query params than currentPath", async () => {
+    render(
+      <LinkProvider currentPath="/foo?tab=form">
+        <Component href="/foo?tab=workflows" />
+      </LinkProvider>
+    )
+
+    expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
+      "false"
+    )
+  })
+
+  test("isActive matches when query params are in different order", async () => {
+    render(
+      <LinkProvider currentPath="/foo?b=2&a=1">
+        <Component href="/foo?a=1&b=2" />
+      </LinkProvider>
+    )
+
+    expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
+      "true"
+    )
+  })
+
+  test("isActive matches when href has query params and currentPath has extra params", async () => {
+    render(
+      <LinkProvider currentPath="/foo?tab=form&startDate=2026-01-01">
+        <Component href="/foo?tab=form" />
+      </LinkProvider>
+    )
+
+    expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
+      "true"
+    )
+  })
+
+  test("isActive matches parent path when currentPath has query params", async () => {
+    render(
+      <LinkProvider currentPath="/foo/bar?startDate=2026-01-01">
+        <Component href="/foo" />
+      </LinkProvider>
+    )
+
+    expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
+      "true"
+    )
+  })
 })

--- a/packages/react/src/lib/linkHandler.tsx
+++ b/packages/react/src/lib/linkHandler.tsx
@@ -49,6 +49,29 @@ function stripTrailingSlash(path: string) {
   return path.endsWith("/") ? path.slice(0, -1) : path
 }
 
+function splitPathAndSearch(fullPath: string): [string, URLSearchParams] {
+  const queryIndex = fullPath.indexOf("?")
+  if (queryIndex === -1) return [fullPath, new URLSearchParams()]
+  return [
+    fullPath.slice(0, queryIndex),
+    new URLSearchParams(fullPath.slice(queryIndex)),
+  ]
+}
+
+function searchParamsMatch(
+  current: URLSearchParams,
+  target: URLSearchParams
+): boolean {
+  for (const [key, value] of target) {
+    if (current.get(key) !== value) return false
+  }
+  return true
+}
+
+function searchParamsEqual(a: URLSearchParams, b: URLSearchParams): boolean {
+  return searchParamsMatch(a, b) && searchParamsMatch(b, a)
+}
+
 export const useNavigation = () => {
   const { currentPath } = useLinkContext()
 
@@ -59,12 +82,29 @@ export const useNavigation = () => {
     ) => {
       if (currentPath === undefined || path === undefined) return false
 
-      if (exact)
-        return stripTrailingSlash(currentPath) === stripTrailingSlash(path)
+      const [currentPathname, currentSearch] = splitPathAndSearch(currentPath)
+      const [targetPathname, targetSearch] = splitPathAndSearch(path)
 
-      return `${stripTrailingSlash(currentPath)}/`.startsWith(
-        `${stripTrailingSlash(path)}/`
-      )
+      if (exact)
+        return (
+          stripTrailingSlash(currentPathname) ===
+            stripTrailingSlash(targetPathname) &&
+          searchParamsEqual(currentSearch, targetSearch)
+        )
+
+      const pathnameMatch =
+        `${stripTrailingSlash(currentPathname)}/`.startsWith(
+          `${stripTrailingSlash(targetPathname)}/`
+        )
+
+      if (!pathnameMatch) return false
+
+      // When the href has query params, verify they are all present in the current URL
+      if (targetSearch.size > 0) {
+        return searchParamsMatch(currentSearch, targetSearch)
+      }
+
+      return true
     },
     [currentPath]
   )


### PR DESCRIPTION
## Summary

- Fix `isActive` in `useNavigation` to properly handle query parameters when determining active link/tab state
- Split path comparison into pathname and search components, performing `startsWith` only on pathnames
- When the `href` contains query params, additionally verify they match in the current URL

## Why

The Factorial app passes `currentPath: location.pathname + location.search` to the F0 provider ([context](https://github.com/nickel-lang/nickel/commit/616ff2c8cf7)). This was intentionally added to support tabs that differentiate via query params (e.g., procurement's `?tab=form` vs `?tab=workflows`).

However, this broke active state detection for tabs whose `href` is a plain pathname when the page URL contains query params. For example:

- `currentPath = "/expenses/list/expenses?startDate=2026-01-01&endDate=2026-03-16"`
- `href = "/expenses/list/expenses"`
- The old check: `"/expenses/list/expenses?startDate=.../".startsWith("/expenses/list/expenses/")` → **false** (because `?` ≠ `/`)

This caused navigation tabs (Expenses, Groups, Report) to never show as active when the page had date filter query params, while tabs like Budgets and Policies (whose hrefs are parent paths with child routes) worked fine.

## How it works now

1. Both `currentPath` and `href` are split into `[pathname, search]`
2. The `startsWith` check runs on **pathnames only**
3. If the `href` has no query params → pathname match is sufficient (fixes the expenses case)
4. If the `href` has query params → pathname must match AND query params must match (preserves the procurement case)