### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.404.1",
+  "packages/react": "1.404.2",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.404.2](https://github.com/factorialco/f0/compare/f0-react-v1.404.1...f0-react-v1.404.2) (2026-03-16)
+
+
+### Bug Fixes
+
+* **react:** handle query params in isActive link matching ([#3680](https://github.com/factorialco/f0/issues/3680)) ([67ba14d](https://github.com/factorialco/f0/commit/67ba14d5e722df5dfe0dcc4c69266a8f8c9422ea))
+
 ## [1.404.1](https://github.com/factorialco/f0/compare/f0-react-v1.404.0...f0-react-v1.404.1) (2026-03-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.404.1",
+  "version": "1.404.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.404.2</summary>

## [1.404.2](https://github.com/factorialco/f0/compare/f0-react-v1.404.1...f0-react-v1.404.2) (2026-03-16)


### Bug Fixes

* **react:** handle query params in isActive link matching ([#3680](https://github.com/factorialco/f0/issues/3680)) ([67ba14d](https://github.com/factorialco/f0/commit/67ba14d5e722df5dfe0dcc4c69266a8f8c9422ea))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-only change: bumps package/version metadata and updates the changelog, with no functional code changes included in this diff.
> 
> **Overview**
> Publishes `@factorialco/f0-react` `v1.404.2` by updating the Release Please manifest and the package version.
> 
> Updates `packages/react/CHANGELOG.md` to include the `1.404.2` entry noting a bug fix for `isActive` link matching with query params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63ba87665eedf0116115d2db5fbe574abf909a29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->