### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.404.2",
+  "packages/react": "1.405.0",
   "packages/react-native": "0.39.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.405.0](https://github.com/factorialco/f0/compare/f0-react-v1.404.2...f0-react-v1.405.0) (2026-03-16)
+
+
+### Features
+
+* data collection grouped headers ([#3616](https://github.com/factorialco/f0/issues/3616)) ([209db3d](https://github.com/factorialco/f0/commit/209db3d47996f669652755035e330a6400c49349))
+
 ## [1.404.2](https://github.com/factorialco/f0/compare/f0-react-v1.404.1...f0-react-v1.404.2) (2026-03-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.404.2",
+  "version": "1.405.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.405.0</summary>

## [1.405.0](https://github.com/factorialco/f0/compare/f0-react-v1.404.2...f0-react-v1.405.0) (2026-03-16)


### Features

* data collection grouped headers ([#3616](https://github.com/factorialco/f0/issues/3616)) ([209db3d](https://github.com/factorialco/f0/commit/209db3d47996f669652755035e330a6400c49349))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release housekeeping: only version/manifest bumps and a changelog entry; no runtime code changes in this PR.
> 
> **Overview**
> Publishes a new `@factorialco/f0-react` release by bumping the version to `1.405.0` (including updating `.release-please-manifest.json`).
> 
> Updates `packages/react/CHANGELOG.md` to add the `1.405.0` entry noting the *data collection grouped headers* feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9db13bb7f5e863f200e70f73259bf0e8a213dd9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->