### PR TITLE
fix(react): fix subfilter bugs and add WithSubfilters story

### DIFF
--- a/packages/react/src/components/OneFilterPicker/OneFilterPicker.tsx
+++ b/packages/react/src/components/OneFilterPicker/OneFilterPicker.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils"
 
 import type { FiltersDefinition, FiltersMode, FiltersState } from "./types"
 
+import { collectNestedFilterKeys } from "./filterTypes/InFilter/components/option-utils"
 import { FiltersChipsList as FiltersChipsListComponent } from "./components/FiltersChipsList"
 import { FiltersControls as FiltersControlsComponent } from "./components/FiltersControls"
 import { FiltersPresets as FiltersPresetsComponent } from "./components/FiltersPresets"
@@ -130,6 +131,16 @@ const FiltersRoot = <Definition extends FiltersDefinition>({
   const removeFilterValue = (key: keyof Definition) => {
     const newFilters = { ...localFiltersValue }
     delete newFilters[key]
+
+    // Also clear nested child filter keys to avoid orphaned values
+    const filterDef = filters?.[key]
+    if (filterDef?.type === "in" && filterDef.options) {
+      const nestedKeys = collectNestedFilterKeys(filterDef.options)
+      nestedKeys.forEach((nestedKey) => {
+        delete newFilters[nestedKey as keyof Definition]
+      })
+    }
+
     setLocalFiltersValue(newFilters as FiltersState<Definition>)
     props.onChange(newFilters as FiltersState<Definition>)
   }

--- a/packages/react/src/components/OneFilterPicker/filterTypes/InFilter/InFilter.tsx
+++ b/packages/react/src/components/OneFilterPicker/filterTypes/InFilter/InFilter.tsx
@@ -18,8 +18,13 @@ import {
   collectNestedFilterKeys,
   optionMatchesSearch,
 } from "./components/option-utils"
-import { InFilterOptions } from "./types"
-import { cacheLabel, getCacheKey, useLoadOptions } from "./useLoadOptions"
+import { InFilterOptionItem, InFilterOptions } from "./types"
+import {
+  cacheLabel,
+  cacheNestedLabel,
+  getCacheKey,
+  useLoadOptions,
+} from "./useLoadOptions"
 
 /**
  * Props for the InFilter component.
@@ -102,6 +107,34 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
   })
 
   const cacheKey = getCacheKey(schema)
+
+  // Pre-populate nested label cache for existing selections (e.g., after localStorage restore)
+  useEffect(() => {
+    if (!allFiltersValue || !options.length) return
+
+    const populateNestedCache = (parentOptions: InFilterOptionItem<T>[]) => {
+      for (const option of parentOptions) {
+        if (option.children) {
+          const { filterKey, options: childOptions } = option.children
+          const childValues = (allFiltersValue[filterKey] as T[]) ?? []
+
+          for (const child of childOptions) {
+            if (childValues.includes(child.value as T)) {
+              const contextualLabel = `${option.label} > ${child.label}`
+              cacheNestedLabel(filterKey, child.value, contextualLabel)
+              cacheLabel(cacheKey, child.value, child.label)
+            }
+            // Recurse for deeper nesting
+            if (child.children) {
+              populateNestedCache([child as InFilterOptionItem<T>])
+            }
+          }
+        }
+      }
+    }
+
+    populateNestedCache(options as InFilterOptionItem<T>[])
+  }, [options, allFiltersValue, cacheKey])
 
   useEffect(() => {
     let timeout: NodeJS.Timeout

--- a/packages/react/src/experimental/OneDataCollection/__stories__/filters/filters.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/filters/filters.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
 
-import { ExampleComponent } from "../mockData"
+import { ExampleComponent, SubfiltersExampleComponent } from "../mockData"
 
 const meta = {
   title: "Data Collection/Filters",
@@ -58,6 +58,44 @@ export const WithSyncSearch: Story = {
                   enabled: true,
                   sync: true,
                   debounceTime: 300,
+              },
+              //...
+          })
+          `,
+      },
+    },
+  },
+}
+
+export const WithSubfilters: Story = {
+  render: () => <SubfiltersExampleComponent />,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+           const source = useDataCollectionSource({
+              //...
+              filters: {
+                  office: {
+                      type: "in",
+                      label: "Office",
+                      options: {
+                          options: [
+                              {
+                                  value: "101", label: "Barcelona HQ",
+                                  children: {
+                                      filterKey: "space",
+                                      options: [
+                                          { value: "1", label: "Floor 1", children: { filterKey: "desk", options: [...] } },
+                                          { value: "2", label: "Floor 2" },
+                                      ],
+                                  },
+                              },
+                          ],
+                      },
+                  },
+                  space: { type: "in", label: "Space", hideSelector: true, options: { options: [...] } },
+                  desk: { type: "in", label: "Desk", hideSelector: true, options: { options: [...] } },
               },
               //...
           })

--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -76,6 +76,100 @@ import {
 import { OnBulkActionCallback } from "../types"
 import { Visualization, VisualizationType } from "../visualizations/collection"
 
+// Mock data for nested subfilters (office → space → desk)
+const OFFICES = [
+  { id: 101, name: "Barcelona HQ" },
+  { id: 102, name: "Madrid Office" },
+  { id: 103, name: "London" },
+  { id: 104, name: "New York" },
+] as const
+
+const SPACES = [
+  { id: 1, name: "Floor 1", officeId: 101 },
+  { id: 2, name: "Floor 2", officeId: 101 },
+  { id: 3, name: "Rooftop Terrace", officeId: 101 },
+  { id: 4, name: "Floor 1", officeId: 102 },
+  { id: 5, name: "Floor 2", officeId: 102 },
+  { id: 6, name: "Ground Floor", officeId: 103 },
+  { id: 7, name: "Main Floor", officeId: 104 },
+] as const
+
+const DESKS = [
+  { id: 100, name: "Desk A1", spaceId: 1 },
+  { id: 101, name: "Desk A2", spaceId: 1 },
+  { id: 102, name: "Desk B1", spaceId: 2 },
+  { id: 103, name: "Desk B2", spaceId: 2 },
+  { id: 104, name: "Hot Desk 1", spaceId: 7 },
+] as const
+
+export const nestedFilters = {
+  office: {
+    type: "in" as const,
+    label: "Office",
+    options: {
+      options: OFFICES.map((office) => {
+        const officeSpaces = SPACES.filter((s) => s.officeId === office.id)
+        return {
+          value: String(office.id),
+          label: office.name,
+          ...(officeSpaces.length > 0 && {
+            children: {
+              filterKey: "space",
+              options: officeSpaces.map((space) => {
+                const spaceDesks = DESKS.filter((d) => d.spaceId === space.id)
+                return {
+                  value: String(space.id),
+                  label: space.name,
+                  ...(spaceDesks.length > 0 && {
+                    children: {
+                      filterKey: "desk",
+                      options: spaceDesks.map((desk) => ({
+                        value: String(desk.id),
+                        label: desk.name,
+                      })),
+                    },
+                  }),
+                }
+              }),
+            },
+          }),
+        }
+      }),
+    },
+  },
+  space: {
+    type: "in" as const,
+    label: "Space",
+    hideSelector: true,
+    options: {
+      options: SPACES.map((space) => ({
+        value: String(space.id),
+        label: space.name,
+      })),
+    },
+  },
+  desk: {
+    type: "in" as const,
+    label: "Desk",
+    hideSelector: true,
+    options: {
+      options: DESKS.map((desk) => ({
+        value: String(desk.id),
+        label: desk.name,
+      })),
+    },
+  },
+  department: {
+    type: "in" as const,
+    label: "Department",
+    options: {
+      options: DEPARTMENTS_MOCK.map((value) => ({ value, label: value })),
+    },
+  },
+} as const
+
+export type NestedFiltersType = typeof nestedFilters
+
 // Example filter definition
 export const filters = {
   search: {
@@ -1440,6 +1534,72 @@ export const ExampleComponent = ({
             mockVisualizations.editableTable,
           ]
         }
+      />
+    </div>
+  )
+}
+
+export const SubfiltersExampleComponent = () => {
+  const dataAdapterMemoized = useMemo(
+    () => ({
+      fetchData: (
+        options: DataCollectionBaseFetchOptions<
+          NestedFiltersType,
+          NavigationFiltersDefinition
+        >
+      ) => {
+        const { filters: f, sortings: s, search } = options
+        return new Promise<BaseResponse<MockUser>>((resolve) => {
+          setTimeout(() => {
+            const filtered = filterUsers(
+              mockUsers,
+              f as FiltersState<FiltersType>,
+              s,
+              undefined,
+              search
+            )
+            resolve({ records: filtered })
+          }, 100)
+        })
+      },
+    }),
+    []
+  )
+
+  const dataSource = useDataCollectionSource(
+    {
+      filters: nestedFilters,
+      sortings,
+      itemOnClick: (item) => () => console.log(`Clicking ${item.name}`),
+      itemUrl: (item) => `/users/${item.id}`,
+      dataAdapter: dataAdapterMemoized,
+    },
+    []
+  )
+
+  const mockVisualizations = getMockVisualizations({}) as unknown as Record<
+    string,
+    Visualization<
+      MockUser,
+      NestedFiltersType,
+      typeof sortings,
+      SummariesDefinition,
+      ItemActionsDefinition<MockUser>,
+      NavigationFiltersDefinition,
+      GroupingDefinition<MockUser>
+    >
+  >
+
+  return (
+    <div className="space-y-4">
+      <OneDataCollection
+        dataTestId="one-data-collection-subfilters"
+        source={dataSource}
+        visualizations={[
+          mockVisualizations.table,
+          mockVisualizations.card,
+          mockVisualizations.list,
+        ]}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

This PR fixes two bugs related to nested subfilters in `OneFilterPicker` and adds a new Storybook story demonstrating the feature.

### Bug fixes

- **Fix `removeFilterValue` not clearing nested children**: When removing a parent filter chip (e.g., "Office"), child filter values ("Space", "Desk") remained orphaned in state and localStorage. This caused crashes when reopening the filter component. The fix recursively collects all nested child filter keys from the filter definition and deletes them alongside the parent.

- **Fix chip labels losing parent context after reload**: The `nestedLabelCache` (module-level `Map`) was only populated when a user interactively clicked a child option. After page reload with localStorage restore, the cache was empty, so chips couldn't display "Barcelona HQ > Floor 1" format. The fix adds a `useEffect` in `InFilter` that pre-populates the nested label cache from current options and `allFiltersValue` on mount.

### New story

- **`WithSubfilters`** story in `Data Collection/Filters` demonstrating nested filter definitions (office → space → desk) with `hideSelector` child filters, matching the pattern already used in F0Select stories.

## Files changed

| File | Change |
|------|--------|
| `OneFilterPicker.tsx` | `removeFilterValue` now clears nested child keys |
| `InFilter/InFilter.tsx` | `useEffect` to pre-populate nested label cache on mount |
| `filters.stories.tsx` | New `WithSubfilters` story |
| `mockData.tsx` | Nested filter mock data (offices, spaces, desks) + `SubfiltersExampleComponent` |

## Test plan

- [x] `pnpm build` passes
- [x] All 2042 tests pass (140 test files)
- [ ] Open Storybook → "Data Collection/Filters/WithSubfilters":
  - Select a parent filter option (office) and expand to select a child (space)
  - Verify chips show "Space: Barcelona HQ > Floor 1" format
  - Click X on the parent chip → verify child chips also disappear
  - Click "Clear all" → verify all filter state is cleared
- [ ] Verify localStorage persistence: select subfilters → reload → chip labels restore with parent context