### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.405.0",
-  "packages/react-native": "0.39.0",
+  "packages/react-native": "0.40.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.40.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.39.0...f0-react-native-v0.40.0) (2026-03-17)
+
+
+### Features
+
+* f0 react native F0Avatar component ([#3670](https://github.com/factorialco/f0/issues/3670)) ([a91f808](https://github.com/factorialco/f0/commit/a91f808ef9182249cbcddddbba6ed76123f69b25))
+
 ## [0.39.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.38.0...f0-react-native-v0.39.0) (2026-03-12)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.40.0</summary>

## [0.40.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.39.0...f0-react-native-v0.40.0) (2026-03-17)


### Features

* f0 react native F0Avatar component ([#3670](https://github.com/factorialco/f0/issues/3670)) ([a91f808](https://github.com/factorialco/f0/commit/a91f808ef9182249cbcddddbba6ed76123f69b25))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version and changelog) with no runtime logic modifications shown in this diff.
> 
> **Overview**
> Bumps `@factorialco/f0-react-native` from `0.39.0` to `0.40.0` and updates the release manifest accordingly.
> 
> Updates `packages/react-native/CHANGELOG.md` with the `0.40.0` release notes, highlighting the addition of the `F0Avatar` component.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 424b5dd39f08dcc2b07e56a4e6cfbd3e18e84db8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->