### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.405.1",
-  "packages/react-native": "0.40.0",
+  "packages/react-native": "0.41.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.41.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.40.0...f0-react-native-v0.41.0) (2026-03-17)
+
+
+### Features
+
+* added `f0link` component ([#3677](https://github.com/factorialco/f0/issues/3677)) ([59657c9](https://github.com/factorialco/f0/commit/59657c958dd6076e4afdbdf957d9f0737083c071))
+
 ## [0.40.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.39.0...f0-react-native-v0.40.0) (2026-03-17)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.41.0</summary>

## [0.41.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.40.0...f0-react-native-v0.41.0) (2026-03-17)


### Features

* added `f0link` component ([#3677](https://github.com/factorialco/f0/issues/3677)) ([59657c9](https://github.com/factorialco/f0/commit/59657c958dd6076e4afdbdf957d9f0737083c071))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog/manifest updates, with no functional code changes in this PR.
> 
> **Overview**
> Bumps `@factorialco/f0-react-native` from `0.40.0` to `0.41.0` and updates the release manifest accordingly.
> 
> Updates the React Native package changelog to include the `0.41.0` release notes (noting the addition of the `f0link` component).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9889f3a6c2b5a056e8b1fb421caa3542d66cac17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->