### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.405.1",
-  "packages/react-native": "0.41.0",
+  "packages/react-native": "0.42.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.42.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.41.0...f0-react-native-v0.42.0) (2026-03-18)
+
+
+### Features
+
+* new item to datalist ([#3532](https://github.com/factorialco/f0/issues/3532)) ([0eebb0a](https://github.com/factorialco/f0/commit/0eebb0a13aa3222e1d684c98f136c9ddffa138bb))
+
 ## [0.41.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.40.0...f0-react-native-v0.41.0) (2026-03-17)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.42.0</summary>

## [0.42.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.41.0...f0-react-native-v0.42.0) (2026-03-18)


### Features

* new item to datalist ([#3532](https://github.com/factorialco/f0/issues/3532)) ([0eebb0a](https://github.com/factorialco/f0/commit/0eebb0a13aa3222e1d684c98f136c9ddffa138bb))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).