### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.405.1",
+  "packages/react": "1.406.0",
   "packages/react-native": "0.42.0",
   "packages/core": "1.46.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.406.0](https://github.com/factorialco/f0/compare/f0-react-v1.405.1...f0-react-v1.406.0) (2026-03-18)
+
+
+### Features
+
+* add ai_ticketing module icon ([#3693](https://github.com/factorialco/f0/issues/3693)) ([78c41b6](https://github.com/factorialco/f0/commit/78c41b62caeff77bfb3f56c7f939c356cd9aa031))
+
 ## [1.405.1](https://github.com/factorialco/f0/compare/f0-react-v1.405.0...f0-react-v1.405.1) (2026-03-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.405.1",
+  "version": "1.406.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.406.0</summary>

## [1.406.0](https://github.com/factorialco/f0/compare/f0-react-v1.405.1...f0-react-v1.406.0) (2026-03-18)


### Features

* add ai_ticketing module icon ([#3693](https://github.com/factorialco/f0/issues/3693)) ([78c41b6](https://github.com/factorialco/f0/commit/78c41b62caeff77bfb3f56c7f939c356cd9aa031))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).