### PR TITLE
feat(ResourceHeader): :sparkles: Add loading prop to primary/secondary actions

### DIFF
--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -152,6 +152,7 @@ export function BaseHeader({
                 size="lg"
                 disabled={primaryAction.disabled}
                 tooltip={primaryAction.tooltip}
+                loading={primaryAction.loading}
               />
             </div>
           )}
@@ -165,6 +166,7 @@ export function BaseHeader({
                 size="lg"
                 disabled={primaryAction.disabled}
                 tooltip={primaryAction.tooltip}
+                loading={primaryAction.loading}
               />
             </div>
           )}
@@ -181,6 +183,7 @@ export function BaseHeader({
                   hideLabel={action.hideLabel}
                   disabled={action.disabled}
                   tooltip={action.tooltip}
+                  loading={action.loading}
                 />
               </div>
             </Fragment>
@@ -210,6 +213,7 @@ export function BaseHeader({
                   hideLabel={action.hideLabel}
                   disabled={action.disabled}
                   tooltip={action.tooltip}
+                  loading={action.loading}
                 />
               </div>
             </Fragment>
@@ -227,6 +231,7 @@ export function BaseHeader({
                 icon={primaryAction.icon}
                 disabled={primaryAction.disabled}
                 tooltip={primaryAction.tooltip}
+                loading={primaryAction.loading}
               />
             </div>
           )}
@@ -240,6 +245,7 @@ export function BaseHeader({
                 size="md"
                 disabled={primaryAction.disabled}
                 tooltip={primaryAction.tooltip}
+                loading={primaryAction.loading}
               />
             </div>
           )}

--- a/packages/react/src/experimental/Information/Headers/ResourceHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Headers/ResourceHeader/index.stories.tsx
@@ -91,6 +91,11 @@ export const Default: Story = {
         hideLabel: true,
         onClick: fn(),
       },
+      {
+        label: "Syncing",
+        loading: true,
+        onClick: fn(),
+      },
     ],
 
     otherActions: [

--- a/packages/react/src/experimental/Information/Headers/index.mdx
+++ b/packages/react/src/experimental/Information/Headers/index.mdx
@@ -36,6 +36,7 @@ actions they can perform.
 - Primary actions vary by context (e.g., "Add members")
 - Most visually prominent in the header
 - Can include icons when they aid recognition or match design patterns
+- Handle loading status by passing an async callback or using the `loading` prop
 
 #### Edit
 

--- a/packages/react/src/experimental/Information/utils.tsx
+++ b/packages/react/src/experimental/Information/utils.tsx
@@ -5,6 +5,7 @@ export interface PrimaryAction {
   disabled?: boolean
   tooltip?: string
   isVisible?: boolean
+  loading?: boolean
 }
 export interface PrimaryActionButton extends PrimaryAction {
   label: string


### PR DESCRIPTION
## Description
Add loading prop to PrimaryAction and SecondaryAction to manually handle when the button shows the spinner

## Screenshots 
<img width="721" height="427" alt="image" src="https://github.com/user-attachments/assets/58360d22-1bf2-457c-b801-c2d80b6cb294" />
