### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.407.0",
+  "packages/react": "1.408.0",
   "packages/react-native": "0.42.0",
   "packages/core": "1.46.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.408.0](https://github.com/factorialco/f0/compare/f0-react-v1.407.0...f0-react-v1.408.0) (2026-03-19)
+
+
+### Features
+
+* **editable-table:** add cell-level error tooltip state ([#3690](https://github.com/factorialco/f0/issues/3690)) ([36ce446](https://github.com/factorialco/f0/commit/36ce446801a18a5d78aa1cf460848509ce3e1cf7))
+
 ## [1.407.0](https://github.com/factorialco/f0/compare/f0-react-v1.406.1...f0-react-v1.407.0) (2026-03-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.407.0",
+  "version": "1.408.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.408.0</summary>

## [1.408.0](https://github.com/factorialco/f0/compare/f0-react-v1.407.0...f0-react-v1.408.0) (2026-03-19)


### Features

* **editable-table:** add cell-level error tooltip state ([#3690](https://github.com/factorialco/f0/issues/3690)) ([36ce446](https://github.com/factorialco/f0/commit/36ce446801a18a5d78aa1cf460848509ce3e1cf7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).