### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.410.0",
+  "packages/react": "1.411.0",
   "packages/react-native": "0.42.0",
   "packages/core": "1.46.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.411.0](https://github.com/factorialco/f0/compare/f0-react-v1.410.0...f0-react-v1.411.0) (2026-03-19)
+
+
+### Features
+
+* **Dialog:** enable width variants for side panel positions ([#3492](https://github.com/factorialco/f0/issues/3492)) ([789d327](https://github.com/factorialco/f0/commit/789d327b170d1c95b17a48c8e39c6ae32ab44f53))
+
 ## [1.410.0](https://github.com/factorialco/f0/compare/f0-react-v1.409.0...f0-react-v1.410.0) (2026-03-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.410.0",
+  "version": "1.411.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.411.0</summary>

## [1.411.0](https://github.com/factorialco/f0/compare/f0-react-v1.410.0...f0-react-v1.411.0) (2026-03-19)


### Features

* **Dialog:** enable width variants for side panel positions ([#3492](https://github.com/factorialco/f0/issues/3492)) ([789d327](https://github.com/factorialco/f0/commit/789d327b170d1c95b17a48c8e39c6ae32ab44f53))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).