### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.411.1",
+  "packages/react": "1.412.0",
   "packages/react-native": "0.42.0",
   "packages/core": "1.46.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.412.0](https://github.com/factorialco/f0/compare/f0-react-v1.411.1...f0-react-v1.412.0) (2026-03-20)
+
+
+### Features
+
+* **ResourceHeader:** :sparkles: Add loading prop to primary/secondary actions ([#3698](https://github.com/factorialco/f0/issues/3698)) ([7ce4b18](https://github.com/factorialco/f0/commit/7ce4b188d4ef1b9b7e5f0ce3f8157a0bdb75dae2))
+
 ## [1.411.1](https://github.com/factorialco/f0/compare/f0-react-v1.411.0...f0-react-v1.411.1) (2026-03-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.411.1",
+  "version": "1.412.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.412.0</summary>

## [1.412.0](https://github.com/factorialco/f0/compare/f0-react-v1.411.1...f0-react-v1.412.0) (2026-03-20)


### Features

* **ResourceHeader:** :sparkles: Add loading prop to primary/secondary actions ([#3698](https://github.com/factorialco/f0/issues/3698)) ([7ce4b18](https://github.com/factorialco/f0/commit/7ce4b188d4ef1b9b7e5f0ce3f8157a0bdb75dae2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).