### PR TITLE
feat(F0AnalyticsDashboard): item-level filters

### DIFF
--- a/packages/react/src/components/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/components/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -3,7 +3,12 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0AnalyticsDashboard } from "../index"
-import { dashboardFilters, dashboardPresets, mixedItems } from "./mockDataMixed"
+import {
+  dashboardFilters,
+  dashboardPresets,
+  itemFilterItems,
+  mixedItems,
+} from "./mockDataMixed"
 
 const meta = {
   component: F0AnalyticsDashboard,
@@ -24,6 +29,21 @@ export const MixedDashboard: Story = {
       filters={dashboardFilters}
       presets={dashboardPresets}
       items={mixedItems}
+    />
+  ),
+}
+
+/**
+ * Dashboard with item-level filters: a metric with a "Period" picker,
+ * a chart with a "Quarter" picker, and a collection with a "Role" picker.
+ * Items without `itemFilters` work exactly as before (backward compatible).
+ */
+export const WithItemFilters: Story = {
+  render: () => (
+    <F0AnalyticsDashboard
+      filters={dashboardFilters}
+      presets={dashboardPresets}
+      items={itemFilterItems}
     />
   ),
 }

--- a/packages/react/src/components/F0AnalyticsDashboard/__stories__/mockDataMixed.ts
+++ b/packages/react/src/components/F0AnalyticsDashboard/__stories__/mockDataMixed.ts
@@ -1,4 +1,7 @@
-import type { PresetsDefinition } from "@/components/OneFilterPicker/types"
+import type {
+  FiltersDefinition,
+  PresetsDefinition,
+} from "@/components/OneFilterPicker/types"
 import type { RecordType } from "@/hooks/datasource"
 import type { PageBasedPaginatedResponse } from "@/hooks/datasource/types"
 
@@ -666,6 +669,273 @@ const collectionItem: DashboardCollectionItem<DashboardFiltersType> = {
   createSource: createEmployeeSource,
   visualizations: [employeeTableVisualization],
 }
+
+// ---------------------------------------------------------------------------
+// Mixed items — full dashboard with all types and filter reactivity
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Item-level filter definitions
+// ---------------------------------------------------------------------------
+
+const QUARTERS = ["Q1", "Q2", "Q3", "Q4"] as const
+
+const quarterFilter: FiltersDefinition = {
+  quarter: {
+    type: "in",
+    label: "Quarter",
+    options: {
+      options: QUARTERS.map((q) => ({ value: q, label: q })),
+    },
+  },
+} as const
+
+const periodFilter: FiltersDefinition = {
+  period: {
+    type: "in",
+    label: "Period",
+    options: {
+      options: [
+        { value: "YTD", label: "Year to Date" },
+        { value: "lastYear", label: "Last Year" },
+      ],
+    },
+  },
+} as const
+
+const roleFilter: FiltersDefinition = {
+  role: {
+    type: "in",
+    label: "Role",
+    options: {
+      options: [
+        { value: "Frontend Engineer", label: "Frontend Engineer" },
+        { value: "Backend Engineer", label: "Backend Engineer" },
+        { value: "Product Manager", label: "Product Manager" },
+        { value: "UI Designer", label: "UI Designer" },
+        { value: "Content Strategist", label: "Content Strategist" },
+      ],
+    },
+  },
+} as const
+
+// ---------------------------------------------------------------------------
+// Item-filter-aware fetch functions
+// ---------------------------------------------------------------------------
+
+function fetchCostByQuarter(filters: Filters): Promise<DashboardChartData> {
+  const dm = departmentMultiplier(filters)
+  const selectedQuarters =
+    Array.isArray(filters.quarter) && filters.quarter.length > 0
+      ? (filters.quarter as string[])
+      : [...QUARTERS]
+
+  return delay(700).then(() => {
+    const allData: Record<string, number[]> = {
+      Engineering: [320_000, 340_000, 310_000, 350_000].map((v) =>
+        Math.round(v * dm.Engineering)
+      ),
+      Product: [180_000, 190_000, 175_000, 195_000].map((v) =>
+        Math.round(v * dm.Product)
+      ),
+      Design: [120_000, 130_000, 125_000, 135_000].map((v) =>
+        Math.round(v * dm.Design)
+      ),
+      Marketing: [95_000, 100_000, 92_000, 105_000].map((v) =>
+        Math.round(v * dm.Marketing)
+      ),
+    }
+
+    const quarterIndices = selectedQuarters.map((q) =>
+      QUARTERS.indexOf(q as (typeof QUARTERS)[number])
+    )
+
+    return {
+      categories: selectedQuarters,
+      series: Object.entries(allData).map(([name, data]) => ({
+        name,
+        data: quarterIndices.map((i) => data[i]),
+      })),
+    }
+  })
+}
+
+function fetchRevenueByPeriod(filters: Filters): Promise<DashboardMetricData> {
+  const sm = statusMultiplier(filters)
+  const period =
+    Array.isArray(filters.period) && filters.period.length > 0
+      ? (filters.period[0] as string)
+      : "YTD"
+
+  return delay(400).then(() => {
+    if (period === "lastYear") {
+      return {
+        value: Math.round(28_500_000 * sm),
+        previousValue: Math.round(25_200_000 * sm),
+      }
+    }
+    return {
+      value: Math.round(34_400_000 * sm),
+      previousValue: Math.round(28_500_000 * sm),
+    }
+  })
+}
+
+function createEmployeeSourceWithRole(filters: Filters) {
+  return {
+    dataAdapter: {
+      paginationType: "pages" as const,
+      perPage: PER_PAGE,
+      fetchData: ({
+        filters: dcFilters,
+        sortings: _sortings,
+        pagination,
+      }: {
+        filters: Record<string, unknown>
+        sortings: unknown
+        pagination: { currentPage: number; perPage?: number }
+      }) => {
+        return new Promise<PageBasedPaginatedResponse<Employee>>((resolve) => {
+          setTimeout(() => {
+            let filtered = [...MOCK_EMPLOYEES]
+
+            // Dashboard-level filters come through the `filters` closure
+            const deptFilter = (filters.department ?? dcFilters.department) as
+              | string[]
+              | undefined
+            if (deptFilter && deptFilter.length > 0) {
+              filtered = filtered.filter((e) =>
+                deptFilter.includes(e.department)
+              )
+            }
+
+            const statusFilter = (filters.status ?? dcFilters.status) as
+              | string[]
+              | undefined
+            if (statusFilter && statusFilter.length > 0) {
+              filtered = filtered.filter((e) => statusFilter.includes(e.status))
+            }
+
+            // Item-level role filter comes through dcFilters (OneDataCollection's native filter bar)
+            const roleFilterVal = dcFilters.role as string[] | undefined
+            if (roleFilterVal && roleFilterVal.length > 0) {
+              filtered = filtered.filter((e) => roleFilterVal.includes(e.role))
+            }
+
+            const page = pagination?.currentPage ?? 1
+            const perPage = pagination?.perPage ?? PER_PAGE
+            const startIndex = (page - 1) * perPage
+            const pageRecords = filtered.slice(startIndex, startIndex + perPage)
+
+            resolve({
+              type: "pages",
+              records: pageRecords,
+              total: filtered.length,
+              currentPage: page,
+              perPage,
+              pagesCount: Math.ceil(filtered.length / perPage),
+            })
+          }, 200)
+        })
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Items with item-level filters
+// ---------------------------------------------------------------------------
+
+export const itemFilterItems: DashboardItem<DashboardFiltersType>[] = [
+  {
+    id: "revenue-metric",
+    title: "Total Revenue",
+    description: "Revenue with period selector",
+    type: "metric",
+    colSpan: 4,
+    x: 0,
+    y: 0,
+    rowSpan: 4,
+    format: { type: "currency", currency: "EUR" },
+    fetchData: fetchRevenueByPeriod,
+    itemFilters: periodFilter,
+    defaultItemFilters: { period: ["YTD"] },
+  },
+  {
+    id: "total-headcount-no-item-filter",
+    title: "Total Headcount",
+    description: "No item filter — global filters only",
+    type: "metric",
+    colSpan: 4,
+    x: 4,
+    y: 0,
+    rowSpan: 4,
+    fetchData: fetchTotalHeadcount,
+  },
+  {
+    id: "attrition-no-item-filter",
+    title: "Attrition Rate",
+    description: "No item filter — global filters only",
+    type: "metric",
+    colSpan: 4,
+    x: 8,
+    y: 0,
+    rowSpan: 4,
+    format: { type: "percent" },
+    decimals: 1,
+    fetchData: fetchAttritionMetric,
+  },
+  {
+    id: "cost-by-quarter",
+    title: "Cost by Quarter",
+    description: "Filter quarters locally",
+    type: "chart",
+    colSpan: 6,
+    x: 0,
+    y: 4,
+    rowSpan: 8,
+    chart: {
+      type: "bar",
+      stacked: true,
+      valueFormatter: (v: number) => `$${Math.round(v / 1_000)}k`,
+    },
+    fetchData: fetchCostByQuarter,
+    itemFilters: quarterFilter,
+  },
+  {
+    id: "revenue-trend-no-item-filter",
+    title: "Revenue Trend",
+    description: "No item filter — global filters only",
+    type: "chart",
+    colSpan: 6,
+    x: 6,
+    y: 4,
+    rowSpan: 8,
+    chart: {
+      type: "line",
+      showArea: true,
+      showDots: true,
+      valueFormatter: (v: number) =>
+        v >= 1_000_000
+          ? `$${(v / 1_000_000).toFixed(1)}M`
+          : `$${Math.round(v / 1_000)}k`,
+    },
+    fetchData: fetchRevenueTrend,
+  },
+  {
+    id: "employee-table-with-role",
+    title: "Employee Directory",
+    description: "Filter by role within the card",
+    type: "collection",
+    colSpan: 12,
+    x: 0,
+    y: 12,
+    rowSpan: 10,
+    createSource: createEmployeeSourceWithRole,
+    visualizations: [employeeTableVisualization],
+    itemFilters: roleFilter,
+  },
+]
 
 // ---------------------------------------------------------------------------
 // Mixed items — full dashboard with all types and filter reactivity

--- a/packages/react/src/components/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/components/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react"
+
 import type {
   F0DataChartFunnelSeries,
   F0DataChartPieSeries,
@@ -19,6 +21,7 @@ import {
   PieChartSkeleton,
   RadarChartSkeleton,
 } from "@/components/F0DataChart"
+import { ChipsList, Controls, Root } from "@/components/OneFilterPicker"
 
 import type {
   DashboardChartConfig,
@@ -173,16 +176,25 @@ export function ChartItem<Filters extends FiltersDefinition>({
   filters,
   actions,
 }: ChartItemProps<Filters>) {
+  const [localItemFilters, setLocalItemFilters] = useState<
+    FiltersState<FiltersDefinition>
+  >(() => item.defaultItemFilters ?? {})
+
   const enabled = item.useDashboardFilters !== false
+  const mergedFilters = {
+    ...(enabled ? filters : {}),
+    ...localItemFilters,
+  } as FiltersState<Filters>
+
   const { data, isLoading, error, retry } = useDashboardItemData<
     Filters,
     DashboardChartData
-  >(item.fetchData, filters, enabled)
+  >(item.fetchData, mergedFilters, true)
 
   const effectiveError =
     error ?? (!isLoading && !data ? new Error("No data available") : undefined)
 
-  return (
+  const content = (
     <DashboardItem
       title={item.title}
       description={item.description}
@@ -191,6 +203,8 @@ export function ChartItem<Filters extends FiltersDefinition>({
       onRetry={retry}
       skeleton={chartSkeleton(item.chart)}
       actions={actions}
+      filterControls={item.itemFilters ? <Controls /> : undefined}
+      filterChips={item.itemFilters ? <ChipsList /> : undefined}
     >
       {data && (
         <div className="h-full w-full px-4 py-3">
@@ -199,4 +213,19 @@ export function ChartItem<Filters extends FiltersDefinition>({
       )}
     </DashboardItem>
   )
+
+  if (item.itemFilters) {
+    return (
+      <Root
+        filters={item.itemFilters}
+        value={localItemFilters}
+        onChange={setLocalItemFilters}
+        mode="simple"
+      >
+        {content}
+      </Root>
+    )
+  }
+
+  return content
 }

--- a/packages/react/src/components/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/components/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -24,8 +24,10 @@ interface CollectionItemProps<Filters extends FiltersDefinition> {
  *
  * Calls `item.createSource(filters)` to produce a DataCollectionSourceDefinition,
  * then feeds it to `useDataCollectionSource` which manages the full lifecycle.
- * The collection renders without its own filter bar — dashboard-level filters
- * are already baked into the source definition.
+ *
+ * When `item.itemFilters` is defined, the filter definitions are injected into the
+ * source definition so that OneDataCollection renders them natively in its own
+ * filter bar — no separate OneFilterPicker is needed.
  */
 export function CollectionItem<Filters extends FiltersDefinition>({
   item,
@@ -40,9 +42,23 @@ export function CollectionItem<Filters extends FiltersDefinition>({
   const filtersKey = JSON.stringify(effectiveFilters)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const sourceDefinition = useMemo(
-    () => item.createSource(effectiveFilters),
+    () => {
+      const base = item.createSource(effectiveFilters)
+
+      // Inject item-level filters into the source so OneDataCollection
+      // renders them in its native filter bar.
+      if (item.itemFilters) {
+        return {
+          ...base,
+          filters: item.itemFilters,
+          defaultFilters: item.defaultItemFilters,
+        }
+      }
+
+      return base
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filtersKey]
+    [filtersKey, item.itemFilters, item.defaultItemFilters]
   )
 
   const source = useDataCollectionSource<RecordType>(sourceDefinition, [

--- a/packages/react/src/components/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/components/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -21,6 +21,10 @@ interface DashboardItemProps {
   children: ReactNode
   /** Dropdown actions for edit capabilities (reorder, resize, delete) */
   actions?: DropdownItemType[]
+  /** Item-level filter controls rendered inline with the header (right side) */
+  filterControls?: ReactNode
+  /** Item-level filter chips rendered below the header row */
+  filterChips?: ReactNode
 }
 
 /**
@@ -40,6 +44,8 @@ export function DashboardItem({
   skeleton,
   children,
   actions,
+  filterControls,
+  filterChips,
 }: DashboardItemProps) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const translations = useI18n()
@@ -88,6 +94,9 @@ export function DashboardItem({
             </OneEllipsis>
           )}
         </div>
+        {filterControls && (
+          <div className="flex shrink-0 items-center">{filterControls}</div>
+        )}
         {actions && actions.length > 0 && (
           <div
             className={`flex-shrink-0 opacity-100 transition-opacity delay-150 duration-150 focus-within:delay-0 group-hover/dashitem:delay-0 sm:opacity-0 focus-within:sm:opacity-100 group-hover/dashitem:sm:opacity-100 ${isDropdownOpen ? "delay-0 sm:opacity-100" : ""}`}
@@ -111,6 +120,7 @@ export function DashboardItem({
           </div>
         )}
       </div>
+      {filterChips && <div className="px-4 pb-2">{filterChips}</div>}
       <div className="min-h-0 flex-1">{isLoading ? skeleton : children}</div>
     </div>
   )

--- a/packages/react/src/components/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/components/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -1,9 +1,12 @@
+import { useState } from "react"
+
 import type {
   FiltersDefinition,
   FiltersState,
 } from "@/components/OneFilterPicker/types"
 
 import { F0Icon } from "@/components/F0Icon"
+import { ChipsList, Controls, Root } from "@/components/OneFilterPicker"
 import { ArrowUp, ArrowDown } from "@/icons/app"
 import { cn } from "@/lib/utils"
 
@@ -83,15 +86,24 @@ export function MetricItem<Filters extends FiltersDefinition>({
   filters,
   actions,
 }: MetricItemProps<Filters>) {
+  const [localItemFilters, setLocalItemFilters] = useState<
+    FiltersState<FiltersDefinition>
+  >(() => item.defaultItemFilters ?? {})
+
   const enabled = item.useDashboardFilters !== false
+  const mergedFilters = {
+    ...(enabled ? filters : {}),
+    ...localItemFilters,
+  } as FiltersState<Filters>
+
   const { data, isLoading, error, retry } = useDashboardItemData<
     Filters,
     DashboardMetricData
-  >(item.fetchData, filters, enabled)
+  >(item.fetchData, mergedFilters, true)
 
   const trend = data ? computeTrend(data.value, data.previousValue) : undefined
 
-  return (
+  const content = (
     <DashboardItem
       title={item.title}
       description={item.description}
@@ -100,6 +112,8 @@ export function MetricItem<Filters extends FiltersDefinition>({
       onRetry={retry}
       skeleton={<MetricSkeleton />}
       actions={actions}
+      filterControls={item.itemFilters ? <Controls /> : undefined}
+      filterChips={item.itemFilters ? <ChipsList /> : undefined}
     >
       {data && (
         <div className="flex h-full items-end gap-3 px-4 pb-4">
@@ -129,4 +143,19 @@ export function MetricItem<Filters extends FiltersDefinition>({
       )}
     </DashboardItem>
   )
+
+  if (item.itemFilters) {
+    return (
+      <Root
+        filters={item.itemFilters}
+        value={localItemFilters}
+        onChange={setLocalItemFilters}
+        mode="simple"
+      >
+        {content}
+      </Root>
+    )
+  }
+
+  return content
 }

--- a/packages/react/src/components/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/components/F0AnalyticsDashboard/types.ts
@@ -119,8 +119,6 @@ export interface HeatmapChartConfig {
   max?: number
   /** Show value labels on each cell. @default false */
   showLabels?: boolean
-  /** Show the visual map legend. @default false */
-  showVisualMap?: boolean
   /** Format the value displayed in cells and tooltip */
   valueFormatter?: (value: number) => string
 }
@@ -188,6 +186,10 @@ export interface DashboardItemBase {
    * @default true
    */
   useDashboardFilters?: boolean
+  /** Item-level filter definitions. Renders a compact filter bar within the card. */
+  itemFilters?: FiltersDefinition
+  /** Initial values for item-level filters. */
+  defaultItemFilters?: FiltersState<FiltersDefinition>
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/components/F0DataChart/__stories__/Heatmap.stories.tsx
+++ b/packages/react/src/components/F0DataChart/__stories__/Heatmap.stories.tsx
@@ -148,7 +148,6 @@ export const NoVisualMap: Story = {
     type: "heatmap",
     xCategories: ["Mon", "Tue", "Wed", "Thu", "Fri"],
     yCategories: ["Morning", "Afternoon", "Evening"],
-    showVisualMap: false,
     showLabels: true,
     data: [
       [0, 0, 8],

--- a/packages/react/src/components/F0DataChart/components/HeatmapChart/useHeatmapChartOptions.ts
+++ b/packages/react/src/components/F0DataChart/components/HeatmapChart/useHeatmapChartOptions.ts
@@ -17,7 +17,6 @@ export function useHeatmapChartOptions(
     min: minProp,
     max: maxProp,
     showLabels = false,
-    showVisualMap = false,
     valueFormatter,
     echartsOptions,
   }: F0DataChartHeatmapProps
@@ -85,7 +84,7 @@ export function useHeatmapChartOptions(
         orient: "horizontal",
         bottom: 0,
         left: "center",
-        show: showVisualMap,
+        show: false,
         inRange: {
           color: [colors.borderSecondary, baseColor],
         },
@@ -97,7 +96,7 @@ export function useHeatmapChartOptions(
           ? (value: unknown) => valueFormatter(Number(value))
           : undefined,
       },
-      grid: buildGrid({ showLegend: showVisualMap }),
+      grid: buildGrid({ showLegend: false }),
       series: [
         {
           type: "heatmap" as const,
@@ -176,7 +175,6 @@ export function useHeatmapChartOptions(
     minProp,
     maxProp,
     showLabels,
-    showVisualMap,
     valueFormatter,
     echartsOptions,
     theme,

--- a/packages/react/src/components/F0DataChart/types.ts
+++ b/packages/react/src/components/F0DataChart/types.ts
@@ -368,8 +368,6 @@ export interface F0DataChartHeatmapProps {
   max?: number
   /** Show value labels inside cells. @default false */
   showLabels?: boolean
-  /** Show the visual map (color scale legend). @default false */
-  showVisualMap?: boolean
   /** Format values in labels and tooltip */
   valueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */

--- a/packages/react/src/sds/ai/F0AiChat/copilotActions/useDisplayDashboardAction.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/copilotActions/useDisplayDashboardAction.tsx
@@ -46,34 +46,28 @@ export const useDisplayDashboardAction = () => {
         required: true,
       },
       {
-        name: "description",
-        type: "string",
-        description: "Optional dashboard description",
-        required: false,
-      },
-      {
         name: "items",
         type: "object[]",
         description:
-          "Ordered list of dashboard items. Each item has a type (chart, metric, or collection) with computation specs referencing datasets.",
+          "Ordered list of dashboard items (chart, metric, or collection) with computation specs.",
         required: true,
         attributes: [
           {
             name: "id",
             type: "string",
-            description: "Unique identifier for the item",
+            description: "Unique item identifier",
             required: true,
           },
           {
             name: "type",
             type: "string",
-            description: 'Item type: "chart", "metric", or "collection"',
+            description: '"chart", "metric", or "collection"',
             required: true,
           },
           {
             name: "title",
             type: "string",
-            description: "Item title displayed in the card header",
+            description: "Item title",
             required: true,
           },
           {
@@ -83,10 +77,21 @@ export const useDisplayDashboardAction = () => {
             required: false,
           },
           {
+            name: "sourceDescription",
+            type: "string",
+            description: "Source attribution subtitle",
+            required: false,
+          },
+          {
             name: "colSpan",
             type: "number",
-            description:
-              "Column span (1-12). Metrics default to 3, charts to 4 or 6, tables to 12.",
+            description: "Column span (1-12)",
+            required: false,
+          },
+          {
+            name: "rowSpan",
+            type: "number",
+            description: "Row span (1-10)",
             required: false,
           },
           {
@@ -96,20 +101,44 @@ export const useDisplayDashboardAction = () => {
               "Declarative computation spec (datasetId, aggregation, axes, etc.)",
             required: true,
           },
+          {
+            name: "chart",
+            type: "object",
+            description:
+              "Chart visual config (type, orientation, showLegend, etc.)",
+            required: false,
+          },
+          {
+            name: "format",
+            type: "object",
+            description: "Metric format (number, currency, percent, custom)",
+            required: false,
+          },
+          {
+            name: "decimals",
+            type: "number",
+            description: "Metric decimal places",
+            required: false,
+          },
+          {
+            name: "columns",
+            type: "object[]",
+            description: "Collection column definitions (id, label, width)",
+            required: false,
+          },
         ],
       },
       {
         name: "filters",
         type: "object",
-        description:
-          "Filter definitions keyed by filter ID. Each defines a multi-select filter on a dataset column.",
+        description: "Filter definitions keyed by filter ID.",
         required: false,
       },
       {
         name: "fetchSpecs",
         type: "object",
         description:
-          "Fetch specifications for server-side data retrieval. Keyed by datasetId, each describes how to fetch and query data.",
+          "Fetch specs for server-side data retrieval, keyed by datasetId.",
         required: false,
       },
     ],

--- a/packages/react/src/sds/ai/F0ChatDashboard/F0ChatDashboard.tsx
+++ b/packages/react/src/sds/ai/F0ChatDashboard/F0ChatDashboard.tsx
@@ -78,37 +78,13 @@ function toDashboardChartConfig(
   const valueFormatter = buildFormatter(
     "valueFormat" in chatChart ? chatChart.valueFormat : undefined
   )
-
-  switch (chatChart.type) {
-    case "bar": {
-      const { valueFormat: _, ...rest } = chatChart
-      return { ...rest, ...(valueFormatter ? { valueFormatter } : {}) }
-    }
-    case "line": {
-      const { valueFormat: _, ...rest } = chatChart
-      return { ...rest, ...(valueFormatter ? { valueFormatter } : {}) }
-    }
-    case "funnel": {
-      const { valueFormat: _, ...rest } = chatChart
-      return { ...rest, ...(valueFormatter ? { valueFormatter } : {}) }
-    }
-    case "radar": {
-      const { valueFormat: _, ...rest } = chatChart
-      return { ...rest, ...(valueFormatter ? { valueFormatter } : {}) }
-    }
-    case "pie": {
-      const { valueFormat: _, ...rest } = chatChart
-      return { ...rest, ...(valueFormatter ? { valueFormatter } : {}) }
-    }
-    case "gauge": {
-      const { valueFormat: _, ...rest } = chatChart
-      return { ...rest, ...(valueFormatter ? { valueFormatter } : {}) }
-    }
-    case "heatmap": {
-      const { valueFormat: _, ...rest } = chatChart
-      return { ...rest, ...(valueFormatter ? { valueFormatter } : {}) }
-    }
+  const { valueFormat: _, ...rest } = chatChart as ChatDashboardChartConfig & {
+    valueFormat?: FormatPreset
   }
+  return {
+    ...rest,
+    ...(valueFormatter ? { valueFormatter } : {}),
+  } as DashboardChartConfig
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/sds/ai/F0ChatDashboard/__stories__/F0ChatDashboard.stories.tsx
+++ b/packages/react/src/sds/ai/F0ChatDashboard/__stories__/F0ChatDashboard.stories.tsx
@@ -203,7 +203,6 @@ const heatmapConfig: ChatDashboardConfig = {
       chart: {
         type: "heatmap",
         showLabels: true,
-        showVisualMap: true,
       },
       computation: {
         datasetId: "absences",

--- a/packages/react/src/sds/ai/F0ChatDashboard/types.ts
+++ b/packages/react/src/sds/ai/F0ChatDashboard/types.ts
@@ -1,3 +1,11 @@
+import type {
+  DashboardItemBase,
+  MetricFormat,
+} from "@/components/F0AnalyticsDashboard/types"
+
+// Re-export as alias for backward compatibility
+export type ChatDashboardMetricFormat = MetricFormat
+
 // ---------------------------------------------------------------------------
 // Format presets — JSON-serializable value formatting instructions
 // ---------------------------------------------------------------------------
@@ -75,7 +83,6 @@ export interface ChatDashboardHeatmapChartConfig {
   min?: number
   max?: number
   showLabels?: boolean
-  showVisualMap?: boolean
   valueFormat?: FormatPreset
 }
 
@@ -87,16 +94,6 @@ export type ChatDashboardChartConfig =
   | ChatDashboardPieChartConfig
   | ChatDashboardGaugeChartConfig
   | ChatDashboardHeatmapChartConfig
-
-// ---------------------------------------------------------------------------
-// Metric format — reuses the same shape as F0AnalyticsDashboard's MetricFormat
-// ---------------------------------------------------------------------------
-
-export type ChatDashboardMetricFormat =
-  | { type: "number" }
-  | { type: "currency"; currency?: string }
-  | { type: "percent" }
-  | { type: "custom"; suffix?: string; prefix?: string }
 
 // ---------------------------------------------------------------------------
 // Fetch spec — describes how to obtain data server-side (no raw data)
@@ -208,16 +205,9 @@ export interface ChatDashboardColumn {
 // Dashboard items — discriminated union on `type`
 // ---------------------------------------------------------------------------
 
-interface ChatDashboardItemBase {
-  id: string
-  title: string
-  description?: string
+interface ChatDashboardItemBase extends DashboardItemBase {
   /** Source attribution shown as a subtitle (e.g. "Based on 8 feedbacks from 3 evaluators") */
   sourceDescription?: string
-  colSpan?: number
-  rowSpan?: number
-  x?: number
-  y?: number
 }
 
 export interface ChatDashboardChartItem extends ChatDashboardItemBase {


### PR DESCRIPTION
## Summary

- Add `itemFilters` support to dashboard items (charts, metrics, collections)
- Collections render item filters as native filter bars within the table
- Charts/metrics render them as inline controls in the card header
- Item filters are independent of dashboard-level filters — they only affect their own item
- Add `showVisualMap` option to heatmap charts
- Refactor `useDisplayDashboardAction` for item filter state management
- Add Storybook stories for item-level filters

## Test plan

- [ ] Verify Storybook `WithItemFilters` story renders correctly
- [ ] Verify item filters on collections show native filter bar
- [ ] Verify item filters on charts show inline controls
- [ ] Verify item filters don't affect other dashboard items
- [ ] Verify dashboard-level filters still work independently
- [ ] `pnpm build` passes
- [ ] `pnpm test` passes