### PR TITLE
refactor(ai): canvas entity registry for multi-entity support

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/canvas/CANVAS_ENTITIES.md
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/CANVAS_ENTITIES.md
@@ -1,0 +1,193 @@
+# Canvas Entities
+
+The canvas system renders content alongside the AI chat sidebar. Each **entity type** (dashboard, survey, goal, job-posting…) is a self-contained module inside `canvas/entities/`. The shared canvas infrastructure knows nothing about specific entities.
+
+## Architecture
+
+```
+canvas/
+├── types.ts                    # CanvasEntityDefinition contract
+├── registry.ts                 # register/get entity definitions
+├── index.ts                    # Barrel + triggers entity registrations
+├── CANVAS_ENTITIES.md          # This file
+├── components/
+│   └── CanvasCard.tsx          # Shared inline card (module avatar + title + description + Open)
+└── entities/
+    └── dashboard/              # Example entity
+        ├── index.tsx           # Entity definition + registration (side-effect)
+        ├── DashboardCard.tsx   # Uses CanvasCard + dashboard-specific store logic
+        ├── DashboardContent.tsx# Canvas body renderer
+        ├── DashboardActions.tsx# Canvas header actions (Edit/Save/Discard)
+        ├── DashboardContext.tsx# Shared state between actions & content
+        ├── configStore.ts      # External store for saved configs
+        └── types.ts            # DashboardCanvasContent type
+```
+
+The `CanvasPanel.tsx` lives in `F0AiChat/components/` and is the generic shell (animation, title, close button). It delegates to the entity definition looked up from the registry.
+
+## Shared components
+
+### `CanvasCard`
+
+All entity cards share the same visual structure: a module avatar, a title, a description, and an "Open" button. Use the `CanvasCard` component from `canvas/components/CanvasCard.tsx`:
+
+```tsx
+import { CanvasCard } from "../../components/CanvasCard"
+
+export function SurveyCard({ title, onOpen }: SurveyCardProps) {
+  return (
+    <CanvasCard
+      module="surveys" // ModuleId — determines the avatar
+      title={title}
+      description="Survey"
+      onOpen={onOpen}
+    />
+  )
+}
+```
+
+Props: `module` (ModuleId), `title` (string), `description` (string), `onOpen` (() => void).
+
+If an entity needs extra logic (e.g. dashboard subscribes to a config store for live edits), wrap `CanvasCard` in an entity-specific card component. See `DashboardCard.tsx` for an example.
+
+## How to add a new entity
+
+### 1. Define the content type
+
+In `F0AiChat/types.ts`, add your content type to the discriminated union:
+
+```ts
+// types.ts
+export type SurveyCanvasContent = CanvasContentBase & {
+  type: "survey"
+  questions: SurveyQuestion[]
+  // ... entity-specific fields
+}
+
+// Add to the union
+export type CanvasContent = DashboardCanvasContent | SurveyCanvasContent
+```
+
+### 2. Create the entity folder
+
+```
+canvas/entities/survey/
+├── index.tsx            # Entity definition + registration
+├── SurveyCard.tsx       # Inline chat card (uses CanvasCard)
+├── SurveyContent.tsx    # Canvas body
+├── SurveyActions.tsx    # Canvas header actions (optional — return null if none)
+├── SurveyContext.tsx    # (optional) Shared state via context
+└── types.ts             # Re-export from main types
+```
+
+### 3. Implement the card
+
+The card renders **inline in the chat** when the copilot action completes. Use `CanvasCard` for the standard layout:
+
+```tsx
+// SurveyCard.tsx
+import { CanvasCard } from "../../components/CanvasCard"
+
+export function SurveyCard({
+  title,
+  onOpen,
+}: {
+  title: string
+  onOpen: () => void
+}) {
+  return (
+    <CanvasCard
+      module="surveys"
+      title={title}
+      description="Survey"
+      onOpen={onOpen}
+    />
+  )
+}
+```
+
+### 4. Implement the canvas content
+
+Renders inside the canvas body area.
+
+```tsx
+// SurveyContent.tsx
+export function SurveyContent({
+  content,
+  refreshKey,
+}: {
+  content: SurveyCanvasContent
+  refreshKey: number
+}) {
+  return <SurveyBuilder questions={content.questions} />
+}
+```
+
+### 5. Implement header actions
+
+Renders in the header bar, **before** the close button (which is always present). Return `null` if no actions are needed.
+
+```tsx
+// SurveyActions.tsx
+export function SurveyActions() {
+  return <F0Button label="Publish" onClick={handlePublish} />
+}
+```
+
+### 6. (Optional) Shared context
+
+If your header actions and content need to communicate (e.g. edit mode state), create a context provider and register it as the entity's `wrapper`.
+
+### 7. Register the entity
+
+```tsx
+// index.tsx
+import { registerCanvasEntity } from "../../registry"
+import type { CanvasEntityDefinition } from "../../types"
+import { SurveyContent } from "./SurveyContent"
+import { SurveyActions } from "./SurveyActions"
+import type { SurveyCanvasContent } from "./types"
+
+export const surveyCanvasEntity: CanvasEntityDefinition<SurveyCanvasContent> = {
+  type: "survey",
+  renderContent: ({ content, refreshKey }) => (
+    <SurveyContent content={content} refreshKey={refreshKey} />
+  ),
+  renderHeaderActions: () => <SurveyActions />,
+  // wrapper: ({ content, children }) => <SurveyProvider ...>{children}</SurveyProvider>,
+}
+
+registerCanvasEntity(surveyCanvasEntity)
+
+export { SurveyCard } from "./SurveyCard"
+export type { SurveyCanvasContent } from "./types"
+```
+
+### 8. Trigger registration
+
+Add the import in `canvas/index.ts`:
+
+```ts
+import "./entities/survey"
+```
+
+### 9. Create the copilot action
+
+In `copilotActions/`, create `useDisplaySurveyAction.tsx` that:
+
+- Registers the copilot action via `useCopilotAction`
+- Renders `SurveyCard` + `AutoOpenCanvas` in the `render` callback
+- Imports the entity module to ensure registration
+
+### 10. Add to default actions
+
+Import your action in `useDefaultCopilotActions.ts`.
+
+## Key principles
+
+1. **Card + Canvas = one module.** The inline card and the canvas content always go together. Both live in the same entity folder.
+2. **Use `CanvasCard` for cards.** All entity cards share the same visual structure. Only wrap it if you need extra logic (e.g. store subscriptions).
+3. **Entity modules are self-contained.** Each handles its own rendering, state, and persistence. The shared canvas is a thin shell.
+4. **Registration via side-effect.** Importing the entity module registers it. No switch statements, no config objects.
+5. **New entity = new folder.** Zero changes to `CanvasPanel.tsx` or the shared canvas infrastructure.
+6. **Auto-open on receive.** Use the `AutoOpenCanvas` component in your copilot action's render to open the canvas immediately when the agent produces content.

--- a/packages/react/src/sds/ai/F0AiChat/canvas/components/CanvasCard.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/components/CanvasCard.tsx
@@ -1,0 +1,55 @@
+import {
+  F0AvatarModule,
+  type ModuleId,
+} from "@/components/avatars/F0AvatarModule"
+import { F0Button } from "@/components/F0Button"
+import { OneEllipsis } from "@/components/OneEllipsis"
+import { useI18n } from "@/lib/providers/i18n"
+
+export type CanvasCardProps = {
+  /** Module avatar to display (e.g. "analytics", "surveys", "goals") */
+  module: ModuleId
+  /** Primary title */
+  title: string
+  /** Secondary description line */
+  description: string
+  /** Called when the user clicks the "Open" button */
+  onOpen: () => void
+}
+
+/**
+ * Shared inline card rendered in the AI chat for any canvas entity.
+ * Shows a module avatar, title, description, and an "Open" button.
+ */
+export function CanvasCard({
+  module,
+  title,
+  description,
+  onOpen,
+}: CanvasCardProps) {
+  const translations = useI18n()
+
+  return (
+    <div className="flex flex-row items-center justify-between gap-3 rounded-lg border border-solid border-f1-border-secondary p-4">
+      <div className="flex min-w-0 flex-row items-center gap-3">
+        <F0AvatarModule module={module} size="lg" />
+        <div className="flex min-w-0 flex-col">
+          <OneEllipsis className="text-lg font-semibold text-f1-foreground">
+            {title}
+          </OneEllipsis>
+          <OneEllipsis className="text-base text-f1-foreground-secondary">
+            {description}
+          </OneEllipsis>
+        </div>
+      </div>
+      <F0Button
+        variant="neutral"
+        size="md"
+        label={translations.ai.reportCard.openButton}
+        onClick={onOpen}
+      />
+    </div>
+  )
+}
+
+CanvasCard.displayName = "CanvasCard"

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardActions.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardActions.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { Pencil } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+
+import { useDashboardCanvas } from "./DashboardContext"
+
+export function DashboardActions(): ReactNode {
+  const { editMode, setEditMode, handleSave, handleDiscard } =
+    useDashboardCanvas()
+  const translations = useI18n()
+
+  if (editMode) {
+    return (
+      <>
+        <F0Button
+          variant="outline"
+          label={translations.ai.discardChanges}
+          onClick={handleDiscard}
+          size="md"
+        />
+        <F0Button
+          label={translations.ai.saveChanges}
+          onClick={handleSave}
+          size="md"
+        />
+      </>
+    )
+  }
+
+  return (
+    <F0Button
+      variant="outline"
+      icon={Pencil}
+      size="md"
+      onClick={() => setEditMode(true)}
+      label="Edit"
+    />
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardCard.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardCard.tsx
@@ -1,0 +1,50 @@
+import { useSyncExternalStore } from "react"
+
+import { useI18n } from "@/lib/providers/i18n"
+
+import type { ChatDashboardConfig } from "../../../../F0ChatDashboard/types"
+
+import { CanvasCard } from "../../components/CanvasCard"
+import { savedDashboardConfigStore } from "./configStore"
+
+export type DashboardCardProps = {
+  /** The original dashboard config from the agent */
+  config: ChatDashboardConfig
+  /** Callback when the user clicks the card to view the report */
+  onView: (config: ChatDashboardConfig) => void
+  /** Tool call ID used to look up saved (edited) dashboard configs */
+  toolCallId?: string
+}
+
+/**
+ * Dashboard-specific card that wraps CanvasCard with config-store
+ * subscription logic. Re-renders when the user edits and saves
+ * the dashboard layout.
+ */
+export function DashboardCard({
+  config: originalConfig,
+  onView,
+  toolCallId,
+}: DashboardCardProps) {
+  useSyncExternalStore(
+    savedDashboardConfigStore.subscribe,
+    savedDashboardConfigStore.getSnapshot
+  )
+
+  const translations = useI18n()
+
+  const config =
+    (toolCallId ? savedDashboardConfigStore.get(toolCallId) : undefined) ??
+    originalConfig
+
+  return (
+    <CanvasCard
+      module="analytics"
+      title={config.title}
+      description={translations.ai.reportCard.reportLabel}
+      onOpen={() => onView(config)}
+    />
+  )
+}
+
+DashboardCard.displayName = "DashboardCard"

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react"
+
+import { F0ChatDashboard } from "../../../../F0ChatDashboard"
+
+import { useDashboardCanvas } from "./DashboardContext"
+import type { DashboardCanvasContent } from "./types"
+
+export function DashboardContent({
+  content,
+  refreshKey,
+}: {
+  content: DashboardCanvasContent
+  refreshKey: number
+}): ReactNode {
+  const { editMode, onLayoutChange } = useDashboardCanvas()
+
+  return (
+    <F0ChatDashboard
+      config={content.config}
+      apiConfig={content.apiConfig}
+      refreshKey={refreshKey}
+      editMode={editMode}
+      onLayoutChange={onLayoutChange}
+    />
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContext.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContext.tsx
@@ -1,0 +1,127 @@
+import { useCopilotContext } from "@copilotkit/react-core"
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from "react"
+
+import type { DashboardItemLayout } from "@/components/F0AnalyticsDashboard/types"
+
+import type { ChatDashboardConfig } from "../../../../F0ChatDashboard/types"
+import { useSaveDashboardConfig } from "../../../../F0ChatDashboard/useSaveDashboardConfig"
+import { useAiChat } from "../../../providers/AiChatStateProvider"
+
+import { savedDashboardConfigStore } from "./configStore"
+import type { DashboardCanvasContent } from "./types"
+
+type DashboardCanvasContextValue = {
+  editMode: boolean
+  setEditMode: (editMode: boolean) => void
+  onLayoutChange: (layout: DashboardItemLayout[]) => void
+  handleSave: () => Promise<void>
+  handleDiscard: () => void
+}
+
+const DashboardCanvasContext =
+  createContext<DashboardCanvasContextValue | null>(null)
+
+export function useDashboardCanvas(): DashboardCanvasContextValue {
+  const ctx = useContext(DashboardCanvasContext)
+  if (!ctx) {
+    throw new Error(
+      "useDashboardCanvas must be used within DashboardCanvasProvider"
+    )
+  }
+  return ctx
+}
+
+export function DashboardCanvasProvider({
+  content,
+  children,
+}: {
+  content: DashboardCanvasContent
+  children: ReactNode
+}): ReactNode {
+  const [editMode, setEditMode] = useState(false)
+  const pendingLayoutRef = useRef<DashboardItemLayout[] | null>(null)
+  const { openCanvas } = useAiChat()
+  const { threadId } = useCopilotContext()
+
+  const saveConfigFn = useSaveDashboardConfig(content.apiConfig)
+
+  const applyLayout = useCallback(
+    (layout: DashboardItemLayout[]): ChatDashboardConfig | null => {
+      const itemsById = new Map(
+        content.config.items.map((item) => [item.id, item])
+      )
+      const newItems = layout
+        .map((entry) => {
+          const original = itemsById.get(entry.id)
+          if (!original) return null
+          return {
+            ...original,
+            colSpan: entry.colSpan,
+            rowSpan: entry.rowSpan,
+            x: entry.x,
+            y: entry.y,
+          }
+        })
+        .filter((item) => item !== null)
+
+      return { ...content.config, items: newItems }
+    },
+    [content]
+  )
+
+  const onLayoutChange = useCallback((layout: DashboardItemLayout[]) => {
+    pendingLayoutRef.current = layout
+  }, [])
+
+  const handleSave = async () => {
+    if (pendingLayoutRef.current) {
+      const updatedConfig = applyLayout(pendingLayoutRef.current)
+      if (!updatedConfig || !threadId) return
+
+      try {
+        await saveConfigFn(threadId, content.toolCallId, updatedConfig)
+
+        if (content.toolCallId) {
+          savedDashboardConfigStore.set(content.toolCallId, updatedConfig)
+        }
+
+        openCanvas({
+          ...content,
+          config: updatedConfig,
+        })
+
+        pendingLayoutRef.current = null
+      } catch {
+        return
+      }
+    }
+
+    setEditMode(false)
+  }
+
+  const handleDiscard = () => {
+    pendingLayoutRef.current = null
+    setEditMode(false)
+  }
+
+  return (
+    <DashboardCanvasContext.Provider
+      value={{
+        editMode,
+        setEditMode,
+        onLayoutChange,
+        handleSave,
+        handleDiscard,
+      }}
+    >
+      {children}
+    </DashboardCanvasContext.Provider>
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/configStore.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/configStore.ts
@@ -1,4 +1,4 @@
-import type { ChatDashboardConfig } from "../../F0ChatDashboard/types"
+import type { ChatDashboardConfig } from "../../../../F0ChatDashboard/types"
 
 /**
  * External store for saved (user-edited) dashboard configs.

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/index.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/index.tsx
@@ -1,0 +1,28 @@
+import type { CanvasEntityDefinition } from "../../types"
+import { registerCanvasEntity } from "../../registry"
+
+import { DashboardActions } from "./DashboardActions"
+import { DashboardContent } from "./DashboardContent"
+import { DashboardCanvasProvider } from "./DashboardContext"
+import type { DashboardCanvasContent } from "./types"
+
+export const dashboardCanvasEntity: CanvasEntityDefinition<DashboardCanvasContent> =
+  {
+    type: "dashboard",
+    renderContent: ({ content, refreshKey }) => (
+      <DashboardContent content={content} refreshKey={refreshKey} />
+    ),
+    renderHeaderActions: () => <DashboardActions />,
+    wrapper: ({ content, children }) => (
+      <DashboardCanvasProvider content={content}>
+        {children}
+      </DashboardCanvasProvider>
+    ),
+  }
+
+registerCanvasEntity(dashboardCanvasEntity)
+
+export type { DashboardCanvasContent } from "./types"
+export { savedDashboardConfigStore } from "./configStore"
+export { DashboardCard } from "./DashboardCard"
+export type { DashboardCardProps } from "./DashboardCard"

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/types.ts
@@ -1,0 +1,1 @@
+export type { DashboardCanvasContent } from "../../../types"

--- a/packages/react/src/sds/ai/F0AiChat/canvas/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/index.ts
@@ -1,0 +1,16 @@
+// Registry
+export { registerCanvasEntity, getCanvasEntity } from "./registry"
+
+// Types
+export type { CanvasEntityDefinition } from "./types"
+
+// Shared components
+export { CanvasCard } from "./components/CanvasCard"
+export type { CanvasCardProps } from "./components/CanvasCard"
+
+// Entity registrations — import to trigger side-effect registration.
+// When adding a new entity, add its import here.
+import "./entities/dashboard"
+
+export type { DashboardCanvasContent } from "./entities/dashboard"
+export { savedDashboardConfigStore } from "./entities/dashboard"

--- a/packages/react/src/sds/ai/F0AiChat/canvas/registry.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/registry.ts
@@ -1,0 +1,27 @@
+import type { CanvasContentBase } from "../types"
+
+import type { CanvasEntityDefinition } from "./types"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const entities = new Map<string, CanvasEntityDefinition<any>>()
+
+/**
+ * Register a canvas entity definition.
+ * Called as a side-effect when each entity module is imported.
+ */
+export function registerCanvasEntity<T extends CanvasContentBase>(
+  definition: CanvasEntityDefinition<T>
+): void {
+  entities.set(definition.type, definition)
+}
+
+/**
+ * Look up a registered entity definition by content type.
+ * Returns `undefined` if the type hasn't been registered.
+ */
+export function getCanvasEntity(
+  type: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): CanvasEntityDefinition<any> | undefined {
+  return entities.get(type)
+}

--- a/packages/react/src/sds/ai/F0AiChat/canvas/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/types.ts
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react"
+
+import type { CanvasContentBase } from "../types"
+
+/**
+ * Contract for a canvas entity type.
+ *
+ * Each entity (dashboard, survey, goal, job-posting…) implements this
+ * interface and registers itself via `registerCanvasEntity()`.
+ *
+ * To add a new entity type:
+ * 1. Create a folder in `canvas/entities/<your-entity>/`
+ * 2. Define a type extending `CanvasContentBase` in `types.ts`
+ * 3. Implement `CanvasEntityDefinition` in `index.ts`
+ * 4. Import the entity module in `canvas/index.ts`
+ */
+export type CanvasEntityDefinition<
+  T extends CanvasContentBase = CanvasContentBase,
+> = {
+  /** Must match the `type` discriminant on the content object */
+  type: T["type"]
+  /** Renders the main body of the canvas panel */
+  renderContent: (props: { content: T; refreshKey: number }) => ReactNode
+  /** Renders header actions (placed before the close button) */
+  renderHeaderActions: (props: { content: T }) => ReactNode
+  /**
+   * Optional wrapper providing entity-scoped context around
+   * both header actions and body (e.g. shared edit-mode state).
+   */
+  wrapper?: (props: { content: T; children: ReactNode }) => ReactNode
+}

--- a/packages/react/src/sds/ai/F0AiChat/components/CanvasPanel.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/CanvasPanel.tsx
@@ -1,41 +1,30 @@
-import { useCopilotContext } from "@copilotkit/react-core"
 import { AnimatePresence, motion } from "motion/react"
-import { useCallback, useEffect, useRef, useState } from "react"
-
-import type { DashboardItemLayout } from "@/components/F0AnalyticsDashboard/types"
+import { type ReactNode, useEffect, useRef, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { OneEllipsis } from "@/components/OneEllipsis"
-import { Cross, Pencil } from "@/icons/app"
+import { Cross } from "@/icons/app"
 import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
-import type { ChatDashboardConfig } from "../../F0ChatDashboard/types"
-
-import { F0ChatDashboard } from "../../F0ChatDashboard"
-import { useSaveDashboardConfig } from "../../F0ChatDashboard/useSaveDashboardConfig"
+import { getCanvasEntity } from "../canvas"
 import { useAiChat } from "../providers/AiChatStateProvider"
 
 /**
- * Canvas panel that renders content alongside the chat sidebar.
+ * Entity-agnostic canvas panel that renders content alongside the chat sidebar.
  *
- * Appears to the left of the chat sidebar when a copilot action opens
- * the canvas (e.g. `displayDashboard`). Overlays the main content
- * area (nav sidebar stays visible). Closes via the X button which
- * clears `canvasContent` and restores the previous visualization mode.
+ * Looks up the entity definition from the registry based on `canvasContent.type`
+ * and delegates rendering of body and header actions to the entity module.
+ * The canvas shell handles: animation, title, close button, and refreshKey.
  */
-export function CanvasPanel() {
-  const { canvasContent, closeCanvas, openCanvas, updateDashboardConfig } =
-    useAiChat()
-  const { threadId } = useCopilotContext()
+export function CanvasPanel(): ReactNode {
+  const { canvasContent, closeCanvas } = useAiChat()
   const translations = useI18n()
   const shouldReduceMotion = useReducedMotion()
   const [refreshKey, setRefreshKey] = useState(0)
-  const [editMode, setEditMode] = useState(false)
 
-  // When a new dashboard is displayed (LLM regeneration), auto-increment
-  // refreshKey to bust the compute cache in useDashboardCompute.
+  // Auto-increment refreshKey when content changes (e.g. LLM regeneration)
   const prevCanvasContentRef = useRef(canvasContent)
   useEffect(() => {
     if (
@@ -48,78 +37,48 @@ export function CanvasPanel() {
     prevCanvasContentRef.current = canvasContent
   }, [canvasContent])
 
-  // Pending layout changes that haven't been saved yet
-  const pendingLayoutRef = useRef<DashboardItemLayout[] | null>(null)
+  const entity = canvasContent ? getCanvasEntity(canvasContent.type) : undefined
 
-  const saveConfigFn = useSaveDashboardConfig(
-    canvasContent?.apiConfig ?? { baseUrl: "", headers: {} }
-  )
+  const renderInner = (): ReactNode => {
+    if (!canvasContent || !entity) return null
 
-  /**
-   * Reconcile a layout descriptor against the original config items.
-   * Reorders, resizes (colSpan), and removes items as described.
-   */
-  const applyLayout = useCallback(
-    (layout: DashboardItemLayout[]): ChatDashboardConfig | null => {
-      if (!canvasContent) return null
-      const itemsById = new Map(
-        canvasContent.config.items.map((item) => [item.id, item])
-      )
-      const newItems = layout
-        .map((entry) => {
-          const original = itemsById.get(entry.id)
-          if (!original) return null
-          return {
-            ...original,
-            colSpan: entry.colSpan,
-            rowSpan: entry.rowSpan,
-            x: entry.x,
-            y: entry.y,
-          }
-        })
-        .filter((item) => item !== null)
+    const headerActions = entity.renderHeaderActions({ content: canvasContent })
+    const content = entity.renderContent({
+      content: canvasContent,
+      refreshKey,
+    })
 
-      return { ...canvasContent.config, items: newItems }
-    },
-    [canvasContent]
-  )
+    const inner = (
+      <>
+        {/* Header */}
+        <div className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-f1-border-secondary px-7 py-5">
+          <OneEllipsis
+            tag="h2"
+            className="min-w-0 flex-1 text-2xl font-semibold text-f1-foreground"
+          >
+            {canvasContent.title}
+          </OneEllipsis>
+          {headerActions}
+          <F0Button
+            variant="ghost"
+            icon={Cross}
+            size="md"
+            hideLabel
+            onClick={() => closeCanvas()}
+            label={translations.ai.closeDashboard}
+          />
+        </div>
 
-  const handleLayoutChange = useCallback((layout: DashboardItemLayout[]) => {
-    pendingLayoutRef.current = layout
-  }, [])
+        {/* Content */}
+        <div className="relative flex-1 overflow-auto p-5">{content}</div>
+      </>
+    )
 
-  const handleSave = async () => {
-    if (!canvasContent) return
-
-    if (pendingLayoutRef.current) {
-      const updatedConfig = applyLayout(pendingLayoutRef.current)
-      if (!updatedConfig || !threadId) return
-
-      try {
-        await saveConfigFn(threadId, canvasContent.toolCallId, updatedConfig)
-
-        if (canvasContent.toolCallId) {
-          updateDashboardConfig(canvasContent.toolCallId, updatedConfig)
-        }
-
-        openCanvas({
-          ...canvasContent,
-          config: updatedConfig,
-        })
-
-        pendingLayoutRef.current = null
-      } catch {
-        // Keep edit mode open so user can retry
-        return
-      }
+    if (entity.wrapper) {
+      return entity.wrapper({ content: canvasContent, children: inner })
     }
 
-    setEditMode(false)
-  }
-
-  const handleDiscard = () => {
-    pendingLayoutRef.current = null
-    setEditMode(false)
+    return inner
   }
 
   return (
@@ -151,61 +110,7 @@ export function CanvasPanel() {
               duration: shouldReduceMotion ? 0 : 0.2,
             }}
           >
-            {/* Header */}
-            <div className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-f1-border-secondary px-7 py-5">
-              <OneEllipsis
-                tag="h2"
-                className="min-w-0 flex-1 text-2xl font-semibold text-f1-foreground"
-              >
-                {canvasContent.title}
-              </OneEllipsis>
-              {editMode ? (
-                <>
-                  <F0Button
-                    variant="outline"
-                    label={translations.ai.discardChanges}
-                    onClick={handleDiscard}
-                    size="md"
-                  />
-                  <F0Button
-                    label={translations.ai.saveChanges}
-                    onClick={handleSave}
-                    size="md"
-                  />
-                </>
-              ) : (
-                <>
-                  <F0Button
-                    variant="outline"
-                    icon={Pencil}
-                    size="md"
-                    onClick={() => setEditMode(true)}
-                    label="Edit"
-                  />
-                  <F0Button
-                    variant="ghost"
-                    icon={Cross}
-                    size="md"
-                    hideLabel
-                    onClick={() => closeCanvas()}
-                    label={translations.ai.closeDashboard}
-                  />
-                </>
-              )}
-            </div>
-
-            {/* Content */}
-            <div className="relative flex-1 overflow-auto p-5">
-              {canvasContent.type === "dashboard" && (
-                <F0ChatDashboard
-                  config={canvasContent.config}
-                  apiConfig={canvasContent.apiConfig}
-                  refreshKey={refreshKey}
-                  editMode={editMode}
-                  onLayoutChange={handleLayoutChange}
-                />
-              )}
-            </div>
+            {renderInner()}
           </motion.div>
         </motion.div>
       )}

--- a/packages/react/src/sds/ai/F0AiChat/copilotActions/useDisplayDashboardAction.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/copilotActions/useDisplayDashboardAction.tsx
@@ -1,9 +1,31 @@
 import { useCopilotAction, useCopilotContext } from "@copilotkit/react-core"
-import { useMemo } from "react"
+import { useEffect, useMemo, useRef } from "react"
 
-import { F0ChatReportCard } from "../../F0ChatReportCard"
 import type { ChatDashboardConfig } from "../../F0ChatDashboard/types"
+import type { CanvasContent } from "../types"
 import { useAiChat } from "../providers/AiChatStateProvider"
+import { DashboardCard } from "../canvas/entities/dashboard/DashboardCard"
+
+// Ensure dashboard entity is registered
+import "../canvas/entities/dashboard"
+
+/**
+ * Renders alongside the report card to auto-open the canvas
+ * the first time a dashboard is received from the agent.
+ */
+function AutoOpenCanvas({ content }: { content: CanvasContent }) {
+  const { openCanvas } = useAiChat()
+  const opened = useRef(false)
+
+  useEffect(() => {
+    if (!opened.current) {
+      opened.current = true
+      openCanvas(content)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps -- open once on mount
+
+  return null
+}
 
 /**
  * Hook to register the displayDashboard copilot action.
@@ -16,8 +38,8 @@ import { useAiChat } from "../providers/AiChatStateProvider"
  * definitions, fetchSpecs) and computes everything server-side via
  * POST /api/dashboard/compute.
  *
- * An inline report card is rendered in the chat. The user clicks
- * "Open" on the card to view the dashboard in the canvas panel.
+ * An inline report card is rendered in the chat. New dashboards
+ * auto-open in the canvas panel. The card stays for re-opening later.
  *
  * Uses `available: "frontend"` so the backend agent can invoke it
  * via `emitFrontendTool` from the `displayDashboard` proxy tool.
@@ -130,20 +152,31 @@ export const useDisplayDashboardAction = () => {
 
       const config = args as ChatDashboardConfig
 
+      const canvasContent: CanvasContent = {
+        type: "dashboard",
+        title: config.title,
+        config,
+        apiConfig,
+        toolCallId,
+      }
+
       return (
-        <F0ChatReportCard
-          config={config}
-          toolCallId={toolCallId}
-          onView={(c) =>
-            openCanvas({
-              type: "dashboard",
-              title: c.title,
-              config: c,
-              apiConfig,
-              toolCallId,
-            })
-          }
-        />
+        <>
+          <AutoOpenCanvas content={canvasContent} />
+          <DashboardCard
+            config={config}
+            toolCallId={toolCallId}
+            onView={(c) =>
+              openCanvas({
+                type: "dashboard",
+                title: c.title,
+                config: c,
+                apiConfig,
+                toolCallId,
+              })
+            }
+          />
+        </>
       )
     },
   })

--- a/packages/react/src/sds/ai/F0AiChat/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/index.ts
@@ -8,6 +8,8 @@ export type {
   AiChatProviderProps,
   AiChatToolHint,
   CanvasContent,
+  CanvasContentBase,
+  DashboardCanvasContent,
   EntityResolvers,
   PersonProfile,
   VisualizationMode,
@@ -15,6 +17,10 @@ export type {
   AiChatTranslations,
   AiChatTranslationsProviderProps,
 } from "./types"
+
+// Canvas entity registry
+export { registerCanvasEntity, getCanvasEntity } from "./canvas"
+export type { CanvasEntityDefinition } from "./canvas"
 
 export { aiTranslations } from "./types"
 

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -1,7 +1,5 @@
 import { type AIMessage, type Message } from "@copilotkit/shared"
 
-import type { ChatDashboardConfig } from "../F0ChatDashboard/types"
-
 import {
   type AiChatDisclaimer,
   type AiChatMode,
@@ -174,8 +172,6 @@ export type AiChatProviderReturnValue = {
 > & {
     /** The current canvas content, or null when canvas is closed */
     canvasContent: CanvasContent | null
-    /** The dashboard config from the current canvas content, or null */
-    canvasDashboard: ChatDashboardConfig | null
     /** Open the canvas panel with the given content */
     openCanvas: (content: CanvasContent) => void
     /** Close the canvas panel and restore the previous visualization mode */
@@ -186,15 +182,6 @@ export type AiChatProviderReturnValue = {
     setActiveToolHint: React.Dispatch<
       React.SetStateAction<AiChatToolHint | null>
     >
-    /** Get a saved dashboard config by toolCallId (returns updated config after user edits) */
-    getSavedDashboardConfig: (
-      toolCallId: string
-    ) => ChatDashboardConfig | undefined
-    /** Save an updated dashboard config keyed by toolCallId */
-    updateDashboardConfig: (
-      toolCallId: string,
-      config: ChatDashboardConfig
-    ) => void
   }
 
 /**

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -16,8 +16,6 @@ import {
 
 import { useI18n } from "@/lib/providers/i18n"
 
-import type { ChatDashboardConfig } from "../../F0ChatDashboard/types"
-
 import { DEFAULT_CHAT_WIDTH } from "../constants"
 import { AiChatProviderReturnValue, AiChatState } from "../internal-types"
 import {
@@ -31,8 +29,6 @@ import {
   readFromLocalStorage,
   writeToLocalStorage,
 } from "../utils/local-storage"
-import { savedDashboardConfigStore } from "./savedDashboardConfigStore"
-
 const AiChatStateContext = createContext<AiChatProviderReturnValue | null>(null)
 
 const CHAT_WIDTH_STORAGE_KEY = "ONE-ai-chat-width"
@@ -100,21 +96,6 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   }, [open])
 
   const [canvasContent, setCanvasContent] = useState<CanvasContent | null>(null)
-
-  // Saved dashboard configs live in an external store so that
-  // F0ChatReportCard (rendered inside CopilotKit) can subscribe
-  // via useSyncExternalStore independently of React context.
-  const getSavedDashboardConfig = useCallback(
-    (toolCallId: string) => savedDashboardConfigStore.get(toolCallId),
-    []
-  )
-
-  const updateDashboardConfig = useCallback(
-    (toolCallId: string, config: ChatDashboardConfig) => {
-      savedDashboardConfigStore.set(toolCallId, config)
-    },
-    []
-  )
 
   // Track the mode before canvas was opened so we can restore it on close
   const previousVisualizationModeRef = useRef<VisualizationMode>("sidepanel")
@@ -310,14 +291,10 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         entityResolvers,
         toolHints,
         canvasContent,
-        canvasDashboard:
-          canvasContent?.type === "dashboard" ? canvasContent.config : null,
         openCanvas,
         closeCanvas,
         activeToolHint,
         setActiveToolHint,
-        getSavedDashboardConfig,
-        updateDashboardConfig,
       }}
     >
       {children}
@@ -375,13 +352,10 @@ export function useAiChat(): AiChatProviderReturnValue {
       entityResolvers: undefined,
       toolHints: undefined,
       canvasContent: null,
-      canvasDashboard: null,
       openCanvas: noopFn,
       closeCanvas: noopFn,
       activeToolHint: null,
       setActiveToolHint: noopFn,
-      getSavedDashboardConfig: () => undefined,
-      updateDashboardConfig: noopFn,
     }
   }
 

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -6,16 +6,29 @@ import { IconType } from "@/components/F0Icon"
 import type { ChatDashboardConfig } from "../F0ChatDashboard/types"
 
 /**
- * Discriminated union for canvas panel content.
- * Expand this union to support new content types in the canvas.
+ * Base shape shared by all canvas content types.
+ * Every entity adds its own fields on top of this.
  */
-export type CanvasContent = {
-  type: "dashboard"
+export type CanvasContentBase = {
+  type: string
   title: string
-  config: ChatDashboardConfig
-  apiConfig: { baseUrl: string; headers: Record<string, string> }
   toolCallId?: string
 }
+
+/**
+ * Dashboard canvas content — renders an analytics dashboard.
+ */
+export type DashboardCanvasContent = CanvasContentBase & {
+  type: "dashboard"
+  config: ChatDashboardConfig
+  apiConfig: { baseUrl: string; headers: Record<string, string> }
+}
+
+/**
+ * Discriminated union for canvas panel content.
+ * Add new entity types to this union as they are implemented.
+ */
+export type CanvasContent = DashboardCanvasContent
 
 /**
  * Profile data for a person entity (employee), resolved asynchronously

--- a/packages/react/src/sds/ai/F0ChatReportCard/F0ChatReportCard.tsx
+++ b/packages/react/src/sds/ai/F0ChatReportCard/F0ChatReportCard.tsx
@@ -1,64 +1,14 @@
-import { useSyncExternalStore } from "react"
+import {
+  DashboardCard,
+  type DashboardCardProps,
+} from "../F0AiChat/canvas/entities/dashboard/DashboardCard"
 
-import { F0AvatarModule } from "@/components/avatars/F0AvatarModule/F0AvatarModule"
-import { F0Button } from "@/components/F0Button"
-import { OneEllipsis } from "@/components/OneEllipsis"
-import { useI18n } from "@/lib/providers/i18n"
-
-import type { F0ChatReportCardProps } from "./types"
-
-import { savedDashboardConfigStore } from "../F0AiChat/providers/savedDashboardConfigStore"
+export type F0ChatReportCardProps = DashboardCardProps
 
 /**
- * Compact card shown inline in the AI chat to represent a generated
- * dashboard report. Uses F0Card with an icon avatar, the dashboard
- * title/description, and an item summary in metadata. Clicking the
- * card triggers `onView` to open the canvas panel.
- *
- * Subscribes to the external `savedDashboardConfigStore` via
- * `useSyncExternalStore` so it re-renders when the user edits the
- * dashboard layout and saves — independently of React context.
+ * @deprecated Use `DashboardCard` from `canvas/entities/dashboard` directly.
+ * This re-export exists for backwards compatibility.
  */
-export function F0ChatReportCard({
-  config: originalConfig,
-  onView,
-  toolCallId,
-}: F0ChatReportCardProps) {
-  // Subscribe to the external store — triggers re-render on every
-  // savedDashboardConfigStore.set(), regardless of the React tree.
-  useSyncExternalStore(
-    savedDashboardConfigStore.subscribe,
-    savedDashboardConfigStore.getSnapshot
-  )
-
-  const translations = useI18n()
-
-  const config =
-    (toolCallId ? savedDashboardConfigStore.get(toolCallId) : undefined) ??
-    originalConfig
-
-  const { title } = config
-  return (
-    <div className="flex flex-row items-center justify-between gap-3 rounded-lg border border-solid border-f1-border-secondary p-4">
-      <div className="flex min-w-0 flex-row items-center gap-3">
-        <F0AvatarModule module="analytics" size="lg" />
-        <div className="flex min-w-0 flex-col">
-          <OneEllipsis className="text-lg font-semibold text-f1-foreground">
-            {title}
-          </OneEllipsis>
-          <OneEllipsis className="text-base text-f1-foreground-secondary">
-            {translations.ai.reportCard.reportLabel}
-          </OneEllipsis>
-        </div>
-      </div>
-      <F0Button
-        variant="neutral"
-        size="md"
-        label={translations.ai.reportCard.openButton}
-        onClick={() => onView(config)}
-      />
-    </div>
-  )
-}
+export const F0ChatReportCard = DashboardCard
 
 F0ChatReportCard.displayName = "F0ChatReportCard"

--- a/packages/react/src/sds/ai/F0ChatReportCard/types.ts
+++ b/packages/react/src/sds/ai/F0ChatReportCard/types.ts
@@ -1,10 +1,1 @@
-import type { ChatDashboardConfig } from "../F0ChatDashboard/types"
-
-export interface F0ChatReportCardProps {
-  /** The original dashboard config from the agent */
-  config: ChatDashboardConfig
-  /** Callback when the user clicks the card to view the report */
-  onView: (config: ChatDashboardConfig) => void
-  /** Tool call ID used to look up saved (edited) dashboard configs */
-  toolCallId?: string
-}
+export type { DashboardCardProps as F0ChatReportCardProps } from "../F0AiChat/canvas/entities/dashboard/DashboardCard"


### PR DESCRIPTION
## Summary

- Extract canvas entity registry pattern so new entity types (surveys, goals, job postings) can be added by creating a folder in `canvas/entities/` with zero changes to shared infrastructure
- Rewrite `CanvasPanel.tsx` from ~215 lines of dashboard-specific code to ~100 lines of entity-agnostic shell
- Move all dashboard logic (card, content, actions, context, config store) into `canvas/entities/dashboard/`
- Add shared `CanvasCard` component (module avatar + title + description + Open button) reusable across all entity types
- Remove `canvasDashboard`, `getSavedDashboardConfig`, `updateDashboardConfig` from `AiChatStateProvider` — dashboard state now lives in the entity module
- Add auto-open behavior: new canvas content opens immediately when received from the agent
- Add `CANVAS_ENTITIES.md` documenting how to add new entity types

## Adding a new entity

1. Define content type in `types.ts` (extends `CanvasContentBase`)
2. Create `canvas/entities/<name>/` with Card, Content, Actions, index.tsx
3. Add `import "./entities/<name>"` in `canvas/index.ts`
4. Create copilot action in `copilotActions/`

## Test plan

- [x] `pnpm build` passes (no new TS errors)
- [x] `pnpm vitest run` — 144 test files, 2073 tests passed
- [x] Pre-commit hooks (cycle-dependencies, format, lint) all pass
- [ ] Dashboard canvas opens and closes correctly
- [ ] Edit/Save/Discard layout works as before
- [ ] F0ChatReportCard reflects saved configs
- [ ] New dashboards auto-open on receive
- [ ] Re-clicking report card re-opens canvas