### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.413.0",
+  "packages/react": "1.413.1",
   "packages/react-native": "0.42.0",
   "packages/core": "1.46.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.413.1](https://github.com/factorialco/f0/compare/f0-react-v1.413.0...f0-react-v1.413.1) (2026-03-22)
+
+
+### Bug Fixes
+
+* remove .glsl file format from F0AiMask ([#3720](https://github.com/factorialco/f0/issues/3720)) ([a7c795b](https://github.com/factorialco/f0/commit/a7c795bdd820eaa18e3537930c200fc6ae9b4268))
+
 ## [1.413.0](https://github.com/factorialco/f0/compare/f0-react-v1.412.0...f0-react-v1.413.0) (2026-03-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.413.0",
+  "version": "1.413.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.413.1</summary>

## [1.413.1](https://github.com/factorialco/f0/compare/f0-react-v1.413.0...f0-react-v1.413.1) (2026-03-22)


### Bug Fixes

* remove .glsl file format from F0AiMask ([#3720](https://github.com/factorialco/f0/issues/3720)) ([a7c795b](https://github.com/factorialco/f0/commit/a7c795bdd820eaa18e3537930c200fc6ae9b4268))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).