### PR TITLE
fix(editable-table): fix disabled cell background color, add new color

### DIFF
--- a/packages/core/base.css
+++ b/packages/core/base.css
@@ -12,6 +12,7 @@
 
     --neutral-0: theme("colors.white.100");
     --neutral-2: theme("colors.grey.0");
+    --neutral-3: theme("colors.grey.2");
     --neutral-5: theme("colors.grey.5");
     --neutral-10: theme("colors.grey.10");
     --neutral-20: theme("colors.grey.20");
@@ -94,6 +95,7 @@
   :root .dark {
     --neutral-0: theme("colors.grey.100");
     --neutral-2: theme("colors.grey.0");
+    --neutral-3: theme("colors.grey.2");
     --neutral-5: theme("colors.white.5");
     --neutral-10: theme("colors.white.10");
     --neutral-20: theme("colors.white.20");

--- a/packages/core/src/tokens/colors.ts
+++ b/packages/core/src/tokens/colors.ts
@@ -17,6 +17,7 @@ export const baseColors = {
   transparent: "transparent",
   grey: {
     0: "210 91% 22% / 0.02",
+    2: "219 88% 17% / 0.02",
     5: "220 88% 17% / 0.04",
     10: "216 89% 18% / 0.06",
     20: "214 70% 20% / 0.1",
@@ -132,6 +133,7 @@ export const f1Colors = {
   background: {
     DEFAULT: "hsl(var(--neutral-0))",
     hover: "hsl(var(--neutral-5))",
+    disabled: "hsl(var(--neutral-3))",
     secondary: {
       DEFAULT: "hsl(var(--neutral-10))",
       hover: "hsl(var(--neutral-20))",

--- a/packages/react/docs/colors.mdx
+++ b/packages/react/docs/colors.mdx
@@ -85,6 +85,10 @@ Use these tokens for backgrounds.
       description="Primary background color for content"
     />
     <ColorToken
+      name="f1-background-disabled"
+      description="Background color for disabled elements"
+    />
+    <ColorToken
       name="f1-background-secondary"
       description="Secondary background color for content"
     />
@@ -221,6 +225,7 @@ Bare colors available:
 <div className="mb-12 space-y-2">
   <BareColor name="neutral-0" />
   <BareColor name="neutral-2" />
+  <BareColor name="neutral-3" />
   <BareColor name="neutral-5" />
   <BareColor name="neutral-10" />
   <BareColor name="neutral-20" />

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
@@ -18,7 +18,7 @@ export function DisabledCell<R extends RecordType>({
         className={cn(
           editableColumn.align === "right" ? "justify-end" : "",
           "flex p-4 min-h-12 items-center border-0 h-full",
-          "bg-f1-background-hover h-full",
+          "bg-f1-background-disabled h-full",
           "cursor-pointer w-full"
         )}
       >


### PR DESCRIPTION
- Added `grey[2]: "219 88% 17% / 0.02" `to baseColors in `colors.ts` — the exact HSL equivalent of #051F51 at 2% opacity (distinct from the existing grey[0] which has a different hue)
- Added `--neutral-3: theme("colors.grey.2")` CSS variable to both light (:root) and dark (`.dark:root / :root .dark`) sections in `base.css`
- Added `background.disabled: "hsl(var(--neutral-3))"` semantic token to f1Colors in colors.ts, making the Tailwind class `bg-f1-background-disabled` available
- Updated `DisabledCell.tsx` to use b`g-f1-background-disabled` instead of `bg-f1-background-hover`
Documented the new f1-background-disabled semantic token and neutral-3 bare color in docs/colors.mdx


