### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.413.1",
+  "packages/react": "1.414.0",
   "packages/react-native": "0.42.0",
   "packages/core": "1.46.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.414.0](https://github.com/factorialco/f0/compare/f0-react-v1.413.1...f0-react-v1.414.0) (2026-03-23)
+
+
+### Features
+
+* **F0AiChat:** Pong easter egg in welcome screen ([#3711](https://github.com/factorialco/f0/issues/3711)) ([cc4c2e7](https://github.com/factorialco/f0/commit/cc4c2e7d7fa8e6a1bc7897b695a62c94d96f9658))
+
 ## [1.413.1](https://github.com/factorialco/f0/compare/f0-react-v1.413.0...f0-react-v1.413.1) (2026-03-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.413.1",
+  "version": "1.414.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.414.0</summary>

## [1.414.0](https://github.com/factorialco/f0/compare/f0-react-v1.413.1...f0-react-v1.414.0) (2026-03-23)


### Features

* **F0AiChat:** Pong easter egg in welcome screen ([#3711](https://github.com/factorialco/f0/issues/3711)) ([cc4c2e7](https://github.com/factorialco/f0/commit/cc4c2e7d7fa8e6a1bc7897b695a62c94d96f9658))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).