### PR TITLE
feat(metadata): add progress-bar variant to ResourceHeader metadata

### DIFF
--- a/packages/react/src/experimental/Information/Headers/Metadata/MetadataValue.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/MetadataValue.tsx
@@ -1,12 +1,14 @@
 import { F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0AvatarList } from "@/components/avatars/F0AvatarList"
 import { F0AvatarListProps } from "@/components/avatars/F0AvatarList/types"
+import { getColor } from "@/components/Charts/utils/colors"
 import { F0Icon } from "@/components/F0Icon"
 import { F0TagDot } from "@/components/tags/F0TagDot"
 import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
 import { AlertCircle, Warning } from "@/icons/app"
 import { cn } from "@/lib/utils"
+import { Progress } from "@/ui/progress"
 
 import { MetadataItem } from "./index"
 
@@ -112,6 +114,32 @@ export function MetadataValue({
         <div className="flex items-center justify-center gap-0.5 font-medium">
           <F0Icon icon={icon} color={iconColor} />
           <span className={textColor}>{value.formattedDate}</span>
+        </div>
+      )
+    }
+    case "progress-bar": {
+      const barColor = value.color
+        ? getColor(value.color)
+        : getColor("categorical-1")
+      const safeMax = value.max && value.max > 0 ? value.max : 100
+      const clampedValue = Math.min(Math.max(0, value.value), safeMax)
+
+      return (
+        <div className="flex items-center gap-2">
+          <div className="min-w-16">
+            <Progress
+              color={barColor}
+              value={clampedValue}
+              max={safeMax}
+              aria-label={item.label}
+              aria-valuetext={value.label}
+            />
+          </div>
+          {value.label && (
+            <span className="whitespace-nowrap text-sm font-medium">
+              {value.label}
+            </span>
+          )}
         </div>
       )
     }

--- a/packages/react/src/experimental/Information/Headers/Metadata/index.stories.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/index.stories.tsx
@@ -115,6 +115,15 @@ export const Default: Story = {
           icon: "warning",
         },
       },
+      {
+        label: "Progress",
+        value: {
+          type: "progress-bar",
+          value: 75,
+          max: 100,
+          label: "75%",
+        },
+      },
     ],
   },
 }

--- a/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
@@ -51,6 +51,13 @@ type MetadataItemValue =
   | { type: "tag-list"; tags: string[] }
   | { type: "dot-tag"; label: string; color: NewColor }
   | { type: "date"; formattedDate: string; icon?: "warning" | "critical" }
+  | {
+      type: "progress-bar"
+      value: number
+      max?: number
+      label?: string
+      color?: string
+    }
 
 type MetadataAction = {
   icon: IconType
@@ -139,6 +146,11 @@ function MetadataItem({ item }: { item: MetadataItem }) {
         return value.data.join(", ")
       case "list":
         return ""
+      case "progress-bar": {
+        const normalizedMax =
+          typeof value.max === "number" && value.max > 0 ? value.max : 100
+        return value.label ?? `${value.value}/${normalizedMax}`
+      }
       default:
         _exhaustiveCheck = value // Nice hack to ensure we covered all cases
         return _exhaustiveCheck

--- a/packages/react/src/experimental/Information/Headers/index.mdx
+++ b/packages/react/src/experimental/Information/Headers/index.mdx
@@ -169,6 +169,8 @@ characteristics:
 8. **Date**: Display temporal information in a standardized format. Can show
    dates like creation dates, due dates, or any other relevant timestamps for
    the resource.
+9. **Progress Bar**: Display progress or completion status as a visual bar
+   with an optional label.
 
 ### Guidelines
 


### PR DESCRIPTION
## 🚪 Why?

### Problem

The ResourceHeader metadata system supports 8 variant types (text, avatar, status, list, data-list, tag-list, dot-tag, date) but lacks a way to display progress or completion status visually. Teams needing to show metrics like onboarding completion, project progress, or goal attainment had no built-in metadata variant for this.

## 🔑 What?

### Changes

- **`Metadata/index.tsx`**: Added `progress-bar` variant to the `MetadataItemValue` discriminated union with props (`value`, `max?`, `label?`, `color?`) and handled it in the exhaustive `getValueToCopy` switch
- **`Metadata/MetadataValue.tsx`**: Added rendering case using the existing `Progress` UI primitive (`@/ui/progress`) and `getColor()` from Charts utils for color resolution, consistent with `ProgressBarCell`
- **`Metadata/index.stories.tsx`**: Added a progress-bar example (75%) to the Default story so it displays alongside all other metadata variants
- **`Headers/index.mdx`**: Added "Progress Bar" as variant #9 in the Resource metadata documentation

## ✅ Verification

### Tests
- TypeScript typecheck passes (`pnpm tsc`) — no new errors introduced
- No existing unit tests for the Metadata component to break
- Lint and format hooks pass (lefthook pre-commit)

### Manual Verification
- Verified in Storybook that the progress bar renders correctly in the "Resource header" metadata section alongside all other variant types

<img width="1626" height="978" alt="image" src="https://github.com/user-attachments/assets/b4a97a6b-2fa0-43b6-9ff5-67aeb870586c" />
<img width="1030" height="165" alt="image" src="https://github.com/user-attachments/assets/06362b8c-2d06-4b1c-bb47-9890cf29bf14" />

