### PR TITLE
fix: GraphQL Int -> BigInt ID migration - allow strings as mentioned user IDs in the Rich Text editor

### DIFF
--- a/packages/react/src/components/RichText/CoreEditor/Extensions/Mention/types.tsx
+++ b/packages/react/src/components/RichText/CoreEditor/Extensions/Mention/types.tsx
@@ -16,7 +16,7 @@ export interface MentionItemComponentProps {
 }
 
 export type MentionedUser = {
-  id: number
+  id: string | number
   label: string
   image_url?: string
   href?: string

--- a/packages/react/src/components/RichText/RichTextEditor/index.stories.tsx
+++ b/packages/react/src/components/RichText/RichTextEditor/index.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
     onChange: {
       control: false,
       description:
-        "Callback function triggered when editor content changes. Receives an object with { value: string | null, mentionIds?: number[] }",
+        "Callback function triggered when editor content changes. Receives an object with { value: string | null, mentionIds?: string[] }",
       required: true,
     },
     initialEditorState: {
@@ -149,17 +149,17 @@ const enhancementOptions: EnhancementOption[] = [
 
 const users = [
   {
-    id: 1,
+    id: "1",
     label: "Raúl Sigüenza Sánchez",
     href: "/avatars/person01.jpg",
   },
   {
-    id: 2,
+    id: "2",
     label: "Jacob Bamio Cordero",
     href: "/avatars/person02.jpg",
   },
   {
-    id: 3,
+    id: "3",
     label: "Xavier Val Parejo",
     href: "/avatars/person03.jpg",
   },

--- a/packages/react/src/components/RichText/RichTextEditor/utils/helpers.tsx
+++ b/packages/react/src/components/RichText/RichTextEditor/utils/helpers.tsx
@@ -114,12 +114,12 @@ const handleEditorUpdate = ({
     json: null,
   })
 
-  const mentions: number[] = []
+  const mentions: string[] = []
   const doc = editor.state.doc
 
   doc.descendants((node) => {
     if (node.type.name === "mention") {
-      mentions.push(Number(node.attrs.id))
+      mentions.push(String(node.attrs.id))
     }
   })
 

--- a/packages/react/src/components/RichText/RichTextEditor/utils/helpers.tsx
+++ b/packages/react/src/components/RichText/RichTextEditor/utils/helpers.tsx
@@ -118,7 +118,7 @@ const handleEditorUpdate = ({
   const doc = editor.state.doc
 
   doc.descendants((node) => {
-    if (node.type.name === "mention") {
+    if (node.type.name === "mention" && node.attrs.id != null) {
       mentions.push(String(node.attrs.id))
     }
   })

--- a/packages/react/src/components/RichText/RichTextEditor/utils/types.tsx
+++ b/packages/react/src/components/RichText/RichTextEditor/utils/types.tsx
@@ -6,7 +6,7 @@ import { FileType } from "./constants"
 
 type resultType = {
   value: string | null
-  mentionIds?: number[]
+  mentionIds?: string[]
 }
 
 type enhanceTextParams = {

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -1021,7 +1021,7 @@ export const AllFieldTypes: Story = {
       richTextField: f0FormField(
         z.object({
           value: z.string().min(1),
-          mentionIds: z.array(z.number()).optional(),
+          mentionIds: z.array(z.string()).optional(),
         }),
         {
           label: "Rich Text Field",
@@ -1195,7 +1195,7 @@ export const AllFieldTypesDisabled: Story = {
       richTextField: f0FormField(
         z.object({
           value: z.string(),
-          mentionIds: z.array(z.number()).optional(),
+          mentionIds: z.array(z.string()).optional(),
         }),
         {
           label: "Rich Text Field",

--- a/packages/react/src/patterns/F0Form/__stories__/ValidationIssues.test.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/ValidationIssues.test.stories.tsx
@@ -50,7 +50,7 @@ export const RequiredFieldsTest: Story = {
         z
           .object({
             value: z.string().nullable(),
-            mentionIds: z.array(z.number()).optional(),
+            mentionIds: z.array(z.string()).optional(),
           })
           .refine(
             (data) => data.value !== null && data.value.trim().length > 0,

--- a/packages/react/src/patterns/F0Form/__tests__/F0Form.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0Form.test.tsx
@@ -696,7 +696,7 @@ describe("isFieldRequired", () => {
         isFieldRequired(
           z.object({
             value: z.string().nullable(),
-            mentionIds: z.array(z.number()).optional(),
+            mentionIds: z.array(z.string()).optional(),
           })
         )
       ).toBe(false)
@@ -707,7 +707,7 @@ describe("isFieldRequired", () => {
         isFieldRequired(
           z.object({
             value: z.string().min(1),
-            mentionIds: z.array(z.number()).optional(),
+            mentionIds: z.array(z.string()).optional(),
           })
         )
       ).toBe(true)

--- a/packages/react/src/patterns/F0Form/__tests__/F0FormValidation.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0FormValidation.test.tsx
@@ -374,7 +374,7 @@ describe("F0Form rich text field error and loading props", () => {
       content: f0FormField(
         z.object({
           value: z.string().min(1),
-          mentionIds: z.array(z.number()).optional(),
+          mentionIds: z.array(z.string()).optional(),
         }),
         {
           label: "Content",
@@ -412,7 +412,7 @@ describe("F0Form rich text field error and loading props", () => {
       content: f0FormField(
         z.object({
           value: z.string().nullable(),
-          mentionIds: z.array(z.number()).optional(),
+          mentionIds: z.array(z.string()).optional(),
         }),
         {
           label: "Content",

--- a/packages/react/src/patterns/F0Form/fields/richtext/types.ts
+++ b/packages/react/src/patterns/F0Form/fields/richtext/types.ts
@@ -30,7 +30,7 @@ export interface RichTextValue {
   /** HTML content of the editor */
   value: string | null
   /** IDs of mentioned users */
-  mentionIds?: number[]
+  mentionIds?: string[]
 }
 
 // ============================================================================

--- a/packages/react/src/patterns/F0FormField/__stories__/F0FormField.stories.tsx
+++ b/packages/react/src/patterns/F0FormField/__stories__/F0FormField.stories.tsx
@@ -292,7 +292,7 @@ export const RichText: Story = {
   render() {
     const [value, setValue] = useState<{
       value: string | null
-      mentionIds?: number[]
+      mentionIds?: string[]
     }>({ value: null })
 
     const field: F0Field = {
@@ -308,7 +308,7 @@ export const RichText: Story = {
           field={field}
           value={value}
           onChange={(v) =>
-            setValue(v as { value: string | null; mentionIds?: number[] })
+            setValue(v as { value: string | null; mentionIds?: string[] })
           }
         />
       </div>


### PR DESCRIPTION
## Description

- `MentionedUser.id` is typed as `number`, forcing to cast IDs with `Number()` to satisfy TS
  After [the BigInt migration](https://github.com/factorialco/factorial/pull/85001), IDs are strings, so it's wrong

## Screenshots (if applicable)

<img width="1770" height="232" alt="20260322052055" src="https://github.com/user-attachments/assets/1e7063cb-5109-4d5f-9215-7ab32e4324ee" />
<img width="1380" height="79" alt="20260322052829" src="https://github.com/user-attachments/assets/9e96d8a4-e0a0-45e4-a965-b460b1482f1f" />

## Implementation details

- Allow strings and numbers in `MentionedUser.id` (trying to match the f0's code)
  Normalize the hooks' output as strings
