### PR TITLE
fix: add hysteresis to OverflowList to prevent visible count oscillation

### DIFF
--- a/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
+++ b/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
@@ -154,7 +154,8 @@ export function useOverflowCalculation<T>(
     if (
       overflowItems.length === 1 &&
       !!visibleItems.length &&
-      overflowButtonWidth === (itemWidths[itemWidths.length - 1] ?? 0) - gap
+      itemWidths.length > 0 &&
+      overflowButtonWidth === itemWidths[itemWidths.length - 1] - gap
     ) {
       visibleItems = items
       overflowItems = []


### PR DESCRIPTION
### Why

On pages with `overflow: auto` scroll containers (e.g. the Jobs page), a vertical scrollbar appearing/disappearing steals ~17px of horizontal space. This causes the OverflowList to toggle the last visible item in and out on every ResizeObserver frame — creating a visible flickering loop. The 20px hysteresis buffer absorbs that oscillation while still allowing items to reappear on deliberate user resize.


### What

- Adds hysteresis to `useOverflowCalculation` in `OverflowList`. Once items overflow (visible count drops), they now require 20px of extra available space before being shown again. Also resets the hysteresis state when the items array length changes to prevent stale thresholds.
- Fix a bug where `itemWidths?.[-1]` (negative bracket index) always evaluated to undefined in JavaScript, making the "skip overflow button when only one item overflows" optimisation dead code. Replaced with `itemWidths.at(-1)`.

**Before:**

https://github.com/user-attachments/assets/8a1c7794-563c-4dfe-b8ca-0e9d7412456a

**After:**

https://github.com/user-attachments/assets/07cd54a2-f613-4170-a7e0-9a7573d522b5

