### PR TITLE
POC: add Ask AI tutor flow in bubble menu

### DIFF
--- a/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorButton.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorButton.tsx
@@ -1,0 +1,57 @@
+import { cn, focusRing } from "@/lib/utils"
+import { Editor } from "@tiptap/react"
+import { useCallback, useState } from "react"
+import OneIcon from "@/experimental/AiPromotionChat/OneIcon"
+import { AiTutorLabels, AiTutorChatConfig } from "./AskAITutorDialog"
+
+export interface AiTutorMessage {
+  role: "user" | "assistant"
+  content: string
+}
+
+export interface AiTutorConfig {
+  labels: AiTutorLabels
+  chatConfig?: AiTutorChatConfig
+  onAskAI?: (selectedText: string) => void
+  onGoDeeper?: (messages: AiTutorMessage[]) => void
+}
+
+interface AskAITutorButtonProps {
+  editor: Editor
+  config: AiTutorConfig
+  onOpen: (selectedText: string) => void
+}
+
+export const AskAITutorButton = ({
+  editor,
+  config,
+  onOpen,
+}: AskAITutorButtonProps) => {
+  const [isHover, setIsHover] = useState(false)
+
+  const handleClick = useCallback(() => {
+    const { from, to } = editor.state.selection
+    const text = editor.state.doc.textBetween(from, to, " ")
+    if (!text.trim()) return
+
+    onOpen(text)
+    config.onAskAI?.(text)
+  }, [editor, config, onOpen])
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      onMouseEnter={() => setIsHover(true)}
+      onMouseLeave={() => setIsHover(false)}
+      aria-label={config.labels.buttonLabel}
+      title={config.labels.buttonTooltip}
+      className={cn(
+        "flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-lg transition-transform hover:scale-110 active:scale-95",
+        focusRing()
+      )}
+    >
+      <OneIcon size="md" hover={isHover} />
+    </button>
+  )
+}

--- a/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorButton.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorButton.tsx
@@ -14,6 +14,7 @@ export interface AiTutorConfig {
   chatConfig?: AiTutorChatConfig
   onAskAI?: (selectedText: string) => void
   onGoDeeper?: (messages: AiTutorMessage[]) => void
+  onQuizMe?: (messages: AiTutorMessage[]) => void
 }
 
 interface AskAITutorButtonProps {

--- a/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorDialog.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorDialog.tsx
@@ -6,7 +6,6 @@ import {
 import { randomId } from "@copilotkit/shared"
 
 import { F0AiChat, F0AiChatProvider, useAiChat } from "@/sds/ai/F0AiChat"
-import { F0HILActionConfirmation } from "@/sds/ai/F0HILActionConfirmation"
 import OneIcon from "@/experimental/AiPromotionChat/OneIcon"
 import { cn } from "@/lib/utils"
 
@@ -32,16 +31,20 @@ const AiTutorChatInner = ({
   selectedText,
   onClose,
   onGoDeeper,
+  onQuizMe,
 }: {
   selectedText: string
   onClose: () => void
   onGoDeeper?: (messages: AiTutorMessage[]) => void
+  onQuizMe?: (messages: AiTutorMessage[]) => void
 }) => {
   const { setOpen, open, sendMessage, inProgress } = useAiChat()
   const { messages } = useCopilotChatInternal()
   const hasSentRef = useRef(false)
   const onGoDeeperRef = useRef(onGoDeeper)
   onGoDeeperRef.current = onGoDeeper
+  const onQuizMeRef = useRef(onQuizMe)
+  onQuizMeRef.current = onQuizMe
   const onCloseRef = useRef(onClose)
   onCloseRef.current = onClose
   const messagesRef = useRef(messages)
@@ -57,38 +60,46 @@ const AiTutorChatInner = ({
       .filter((m) => m.content)
   }, [])
 
-  // Register "go_deeper" CopilotKit action — Mastra emits this via
-  // emitFrontendTool and CopilotKit renders the F0HILActionConfirmation
-  // inline in the chat messages.
+  // Register "tutor_next_step" CopilotKit action — Mastra emits this via
+  // emitFrontendTool and CopilotKit renders action buttons inline in the chat.
   useCopilotAction({
-    name: "go_deeper",
+    name: "tutor_next_step",
     description:
-      "Offer the user the option to explore the topic in more detail in a sidepanel.",
+      "Offer the user options to continue learning: go deeper or take a quiz.",
     parameters: [
       {
         name: "prompt",
         type: "string",
-        description: "Short text asking if the user wants to go deeper",
+        description: "Short text asking what the user wants to do next",
         required: false,
       },
     ],
-    available: onGoDeeper ? "frontend" : "disabled",
+    available: onGoDeeper || onQuizMe ? "frontend" : "disabled",
     render: (props) => {
       if (props.status === "inProgress") return <></>
       return (
-        <F0HILActionConfirmation
+        <AiTutorNextStepActions
           text={
-            (props.args.prompt as string) ??
-            "Would you like me to explain this in more detail?"
+            (props.args.prompt as string) ?? "What would you like to do next?"
           }
-          confirmationText="Go deeper"
-          cancelText="No, thanks"
-          onConfirm={() => {
-            const serialized = serializeMessages()
-            onGoDeeperRef.current?.(serialized)
-            onCloseRef.current()
-          }}
-          onCancel={() => {}}
+          onGoDeeper={
+            onGoDeeperRef.current
+              ? () => {
+                  const serialized = serializeMessages()
+                  onGoDeeperRef.current?.(serialized)
+                  onCloseRef.current()
+                }
+              : undefined
+          }
+          onQuizMe={
+            onQuizMeRef.current
+              ? () => {
+                  const serialized = serializeMessages()
+                  onQuizMeRef.current?.(serialized)
+                  onCloseRef.current()
+                }
+              : undefined
+          }
         />
       )
     },
@@ -126,6 +137,74 @@ const AiTutorChatInner = ({
 }
 
 // ---------------------------------------------------------------------------
+// Next step action buttons — rendered inline in the chat
+// ---------------------------------------------------------------------------
+
+const AiTutorNextStepActions = ({
+  text,
+  onGoDeeper,
+  onQuizMe,
+}: {
+  text: string
+  onGoDeeper?: () => void
+  onQuizMe?: () => void
+}) => (
+  <div className="flex flex-col gap-2 rounded-xl border border-solid border-f1-border-secondary bg-f1-background p-3">
+    <p className="text-sm text-f1-foreground-secondary">{text}</p>
+    <div className="flex gap-2">
+      {onGoDeeper && (
+        <button
+          type="button"
+          onClick={onGoDeeper}
+          className="flex items-center gap-1.5 rounded-lg border border-solid border-f1-border bg-f1-background px-3 py-2 text-sm font-medium text-f1-foreground transition-colors hover:bg-f1-background-secondary"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6 3H3v10h10v-3M10 2h4v4M9 7l5-5"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          Go deeper
+        </button>
+      )}
+      {onQuizMe && (
+        <button
+          type="button"
+          onClick={onQuizMe}
+          className="flex items-center gap-1.5 rounded-lg border border-solid border-f1-border bg-f1-background px-3 py-2 text-sm font-medium text-f1-foreground transition-colors hover:bg-f1-background-secondary"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12ZM6.5 6a1.5 1.5 0 1 1 2.112 1.372.833.833 0 0 0-.529.628L8 8.5M8 11h.01"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          Quiz me
+        </button>
+      )}
+    </div>
+  </div>
+)
+
+// ---------------------------------------------------------------------------
 // Mock mode: standalone chat UI with simulated responses
 // ---------------------------------------------------------------------------
 
@@ -152,10 +231,12 @@ const MockAiTutorChat = ({
   selectedText,
   greeting,
   onGoDeeper,
+  onQuizMe,
 }: {
   selectedText: string
   greeting?: string
   onGoDeeper?: (messages: AiTutorMessage[]) => void
+  onQuizMe?: (messages: AiTutorMessage[]) => void
 }) => {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState("")
@@ -204,10 +285,15 @@ const MockAiTutorChat = ({
     onGoDeeper?.(messages)
   }, [messages, onGoDeeper])
 
-  // Show "Go deeper" after first assistant response
+  const handleQuizMe = useCallback(() => {
+    onQuizMe?.(messages)
+  }, [messages, onQuizMe])
+
+  // Show actions after first assistant response
   const hasAssistantResponse =
     messages.filter((m) => m.role === "assistant").length > 0
-  const showGoDeeper = onGoDeeper && hasAssistantResponse && !isLoading
+  const showActions =
+    (onGoDeeper || onQuizMe) && hasAssistantResponse && !isLoading
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -270,17 +356,13 @@ const MockAiTutorChat = ({
           </div>
         )}
 
-        {/* Go deeper action — inline in the messages area */}
-        {showGoDeeper && (
+        {/* Next step actions — inline in the messages area */}
+        {showActions && (
           <div className="mb-4">
-            <F0HILActionConfirmation
-              text="Would you like me to explain this in more detail?"
-              confirmationText="Go deeper"
-              cancelText="No, thanks"
-              onConfirm={handleGoDeeper}
-              onCancel={() => {
-                // Do nothing — user stays in floating chat
-              }}
+            <AiTutorNextStepActions
+              text="What would you like to do next?"
+              onGoDeeper={onGoDeeper ? handleGoDeeper : undefined}
+              onQuizMe={onQuizMe ? handleQuizMe : undefined}
             />
           </div>
         )}
@@ -337,6 +419,7 @@ interface AskAITutorChatProps {
   chatConfig?: AiTutorChatConfig
   onClose?: () => void
   onGoDeeper?: (messages: AiTutorMessage[]) => void
+  onQuizMe?: (messages: AiTutorMessage[]) => void
   position?: { top: number; left: number } | null
 }
 
@@ -346,6 +429,7 @@ export const AskAITutorChat = ({
   chatConfig,
   onClose,
   onGoDeeper,
+  onQuizMe,
   position,
 }: AskAITutorChatProps) => {
   if (!isOpen) return null
@@ -379,6 +463,7 @@ export const AskAITutorChat = ({
             selectedText={selectedText}
             onClose={handleClose}
             onGoDeeper={onGoDeeper}
+            onQuizMe={onQuizMe}
           />
         </F0AiChatProvider>
       </div>
@@ -395,6 +480,7 @@ export const AskAITutorChat = ({
         selectedText={selectedText}
         greeting={chatConfig?.greeting}
         onGoDeeper={onGoDeeper}
+        onQuizMe={onQuizMe}
       />
     </div>
   )

--- a/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorDialog.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorDialog.tsx
@@ -1,0 +1,432 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  useCopilotAction,
+  useCopilotChatInternal,
+} from "@copilotkit/react-core"
+import { randomId } from "@copilotkit/shared"
+
+import { F0AiChat, F0AiChatProvider, useAiChat } from "@/sds/ai/F0AiChat"
+import { F0HILActionConfirmation } from "@/sds/ai/F0HILActionConfirmation"
+import OneIcon from "@/experimental/AiPromotionChat/OneIcon"
+import { cn } from "@/lib/utils"
+
+import type { AiTutorMessage } from "./AskAITutorButton"
+
+export interface AiTutorLabels {
+  buttonLabel: string
+  buttonTooltip: string
+}
+
+export interface AiTutorChatConfig {
+  runtimeUrl?: string
+  agent?: string
+  credentials?: RequestCredentials
+  greeting?: string
+}
+
+// ---------------------------------------------------------------------------
+// Real mode: F0AiChatProvider + F0AiChat in floating mode
+// ---------------------------------------------------------------------------
+
+const AiTutorChatInner = ({
+  selectedText,
+  onClose,
+  onGoDeeper,
+}: {
+  selectedText: string
+  onClose: () => void
+  onGoDeeper?: (messages: AiTutorMessage[]) => void
+}) => {
+  const { setOpen, open, sendMessage, inProgress } = useAiChat()
+  const { messages } = useCopilotChatInternal()
+  const hasSentRef = useRef(false)
+  const onGoDeeperRef = useRef(onGoDeeper)
+  onGoDeeperRef.current = onGoDeeper
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+  const messagesRef = useRef(messages)
+  messagesRef.current = messages
+
+  const serializeMessages = useCallback((): AiTutorMessage[] => {
+    return messagesRef.current
+      .filter((m) => m.role === "user" || m.role === "assistant")
+      .map((m) => ({
+        role: m.role as "user" | "assistant",
+        content: "content" in m ? String(m.content) : "",
+      }))
+      .filter((m) => m.content)
+  }, [])
+
+  // Register "go_deeper" CopilotKit action — Mastra emits this via
+  // emitFrontendTool and CopilotKit renders the F0HILActionConfirmation
+  // inline in the chat messages.
+  useCopilotAction({
+    name: "go_deeper",
+    description:
+      "Offer the user the option to explore the topic in more detail in a sidepanel.",
+    parameters: [
+      {
+        name: "prompt",
+        type: "string",
+        description: "Short text asking if the user wants to go deeper",
+        required: false,
+      },
+    ],
+    available: onGoDeeper ? "frontend" : "disabled",
+    render: (props) => {
+      if (props.status === "inProgress") return null
+      return (
+        <F0HILActionConfirmation
+          text={
+            (props.args.prompt as string) ??
+            "Would you like me to explain this in more detail?"
+          }
+          confirmationText="Go deeper"
+          cancelText="No, thanks"
+          onConfirm={() => {
+            const serialized = serializeMessages()
+            onGoDeeperRef.current?.(serialized)
+            onCloseRef.current()
+          }}
+          onCancel={() => {}}
+        />
+      )
+    },
+  })
+
+  useEffect(() => {
+    setOpen(true)
+  }, [setOpen])
+
+  // When the user closes the One chat (X button), close the floating container too
+  useEffect(() => {
+    if (!open && hasSentRef.current) {
+      onClose()
+    }
+  }, [open, onClose])
+
+  // Send the selected text as a user message once CopilotKit is ready
+  useEffect(() => {
+    if (!selectedText || hasSentRef.current || inProgress) return
+
+    const timer = setTimeout(() => {
+      const prompt = `Please explain the following text in simpler terms, as if you were a tutor helping me understand it:\n\n"${selectedText}"`
+      sendMessage(prompt)
+      hasSentRef.current = true
+    }, 500)
+
+    return () => clearTimeout(timer)
+  }, [selectedText, sendMessage, inProgress])
+
+  return (
+    <div className="flex h-full w-full flex-col [&>div]:h-full [&>div]:w-full [&>div>div]:h-full [&>div>div]:w-full">
+      <F0AiChat />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Mock mode: standalone chat UI with simulated responses
+// ---------------------------------------------------------------------------
+
+interface ChatMessage {
+  role: "user" | "assistant"
+  content: string
+}
+
+function getMockResponse(messages: ChatMessage[]): string {
+  const count = messages.filter((m) => m.role === "user").length
+  const last = messages.filter((m) => m.role === "user").pop()?.content ?? ""
+  const snippet = last.slice(0, 60) + (last.length > 60 ? "..." : "")
+
+  if (count === 1) {
+    return `Great question! Let me explain "${snippet}" in simpler terms.\n\nThis refers to a concept that is fundamental to understanding this topic. Think of it as the building blocks that help you grasp the bigger picture.\n\nWould you like me to go deeper into any specific part?`
+  }
+  if (count === 2) {
+    return `Let me dive deeper.\n\nThis concept originates from established methodologies in organizational development. At its core, it defines a structured process where multiple stakeholders participate in evaluation cycles, reducing individual bias by aggregating diverse perspectives.\n\nFeel free to ask more!`
+  }
+  return `Here's another perspective.\n\nResearch shows that understanding this concept requires connecting it to real-world applications. The most effective approach is to practice applying these concepts incrementally.\n\nAnything else you'd like to explore?`
+}
+
+const MockAiTutorChat = ({
+  selectedText,
+  greeting,
+  onGoDeeper,
+}: {
+  selectedText: string
+  greeting?: string
+  onGoDeeper?: (messages: AiTutorMessage[]) => void
+}) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  const scrollToBottom = () =>
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+
+  useEffect(scrollToBottom, [messages])
+
+  useEffect(() => {
+    if (selectedText) {
+      const userMsg: ChatMessage = { role: "user", content: selectedText }
+      setMessages([userMsg])
+      setIsLoading(true)
+      const t = setTimeout(() => {
+        setMessages((prev) => [
+          ...prev,
+          { role: "assistant", content: getMockResponse([userMsg]) },
+        ])
+        setIsLoading(false)
+      }, 800)
+      return () => clearTimeout(t)
+    }
+  }, [selectedText])
+
+  const handleSend = useCallback(() => {
+    const text = input.trim()
+    if (!text || isLoading) return
+    const userMsg: ChatMessage = { role: "user", content: text }
+    const next = [...messages, userMsg]
+    setMessages(next)
+    setInput("")
+    setIsLoading(true)
+    setTimeout(() => {
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: getMockResponse(next) },
+      ])
+      setIsLoading(false)
+    }, 800)
+  }, [input, isLoading, messages])
+
+  const handleGoDeeper = useCallback(() => {
+    onGoDeeper?.(messages)
+  }, [messages, onGoDeeper])
+
+  // Show "Go deeper" after first assistant response
+  const hasAssistantResponse =
+    messages.filter((m) => m.role === "assistant").length > 0
+  const showGoDeeper = onGoDeeper && hasAssistantResponse && !isLoading
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  const greetingText =
+    greeting ??
+    "Hello! I'm your AI tutor. I'll help you understand the text you selected."
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-xl border border-solid border-f1-border-secondary bg-f1-special-page shadow-xl">
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        <div className="mb-4 flex items-start gap-3">
+          <div className="flex-shrink-0 pt-0.5">
+            <OneIcon size="sm" />
+          </div>
+          <div className="max-w-[85%] whitespace-pre-wrap text-sm leading-relaxed text-f1-foreground">
+            {greetingText}
+          </div>
+        </div>
+
+        {messages.map((msg, i) => (
+          <div
+            key={i}
+            className={cn(
+              "mb-4 flex",
+              msg.role === "user" ? "justify-end" : "items-start gap-3"
+            )}
+          >
+            {msg.role === "assistant" && (
+              <div className="flex-shrink-0 pt-0.5">
+                <OneIcon size="sm" />
+              </div>
+            )}
+            <div
+              className={cn(
+                "max-w-[85%] whitespace-pre-wrap rounded-2xl px-4 py-3 text-sm leading-relaxed",
+                msg.role === "user"
+                  ? "bg-f1-background-tertiary text-f1-foreground"
+                  : "text-f1-foreground"
+              )}
+            >
+              {msg.content}
+            </div>
+          </div>
+        ))}
+
+        {isLoading && (
+          <div className="mb-4 flex items-start gap-3">
+            <div className="flex-shrink-0 pt-0.5">
+              <OneIcon size="sm" spin />
+            </div>
+            <div className="py-3 text-sm text-f1-foreground-secondary">
+              Thinking...
+            </div>
+          </div>
+        )}
+
+        {/* Go deeper action — inline in the messages area */}
+        {showGoDeeper && (
+          <div className="mb-4">
+            <F0HILActionConfirmation
+              text="Would you like me to explain this in more detail?"
+              confirmationText="Go deeper"
+              cancelText="No, thanks"
+              onConfirm={handleGoDeeper}
+              onCancel={() => {
+                // Do nothing — user stays in floating chat
+              }}
+            />
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-solid border-f1-border px-4 py-3">
+        <div className="flex items-end gap-2">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask a follow-up question..."
+            rows={1}
+            className="flex-1 resize-none rounded-xl border border-solid border-f1-border bg-f1-background px-4 py-2.5 text-sm text-f1-foreground placeholder-f1-foreground-tertiary outline-none transition-colors focus:border-f1-border-bold"
+          />
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={!input.trim() || isLoading}
+            className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-f1-background-accent-bold text-white transition-opacity disabled:opacity-40"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M14.5 1.5L7 9M14.5 1.5L10 14.5L7 9M14.5 1.5L1.5 6L7 9"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Public component: picks real or mock, positioned as floating widget
+// ---------------------------------------------------------------------------
+
+interface AskAITutorChatProps {
+  isOpen: boolean
+  selectedText: string
+  chatConfig?: AiTutorChatConfig
+  onClose?: () => void
+  onGoDeeper?: (messages: AiTutorMessage[]) => void
+  position?: { top: number; left: number } | null
+}
+
+export const AskAITutorChat = ({
+  isOpen,
+  selectedText,
+  chatConfig,
+  onClose,
+  onGoDeeper,
+  position,
+}: AskAITutorChatProps) => {
+  if (!isOpen) return null
+
+  const handleClose = onClose ?? (() => {})
+
+  const positionStyle: React.CSSProperties = position
+    ? { top: position.top, left: position.left }
+    : { bottom: 16, right: 16 }
+
+  // Real mode: use F0AiChat with native floating visualization mode
+  if (chatConfig?.runtimeUrl) {
+    return (
+      <div
+        className="absolute z-[9999] h-[460px] w-[360px]"
+        style={positionStyle}
+      >
+        <F0AiChatProvider
+          enabled
+          runtimeUrl={chatConfig.runtimeUrl}
+          agent={chatConfig.agent}
+          credentials={chatConfig.credentials}
+          greeting={
+            chatConfig.greeting ??
+            "Hello! I'm your AI tutor. I'll help you understand the text you selected."
+          }
+          defaultVisualizationMode="floating"
+          lockVisualizationMode
+        >
+          <AiTutorChatInner
+            selectedText={selectedText}
+            onClose={handleClose}
+            onGoDeeper={onGoDeeper}
+          />
+        </F0AiChatProvider>
+      </div>
+    )
+  }
+
+  // Mock mode: standalone chat UI
+  return (
+    <div
+      className="absolute z-[9999] h-[460px] w-[360px]"
+      style={positionStyle}
+    >
+      <MockAiTutorChat
+        selectedText={selectedText}
+        greeting={chatConfig?.greeting}
+        onGoDeeper={onGoDeeper}
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// MessageInjector: seeds a F0AiChatProvider with previous messages on mount
+// Used by consumers (e.g. trainings) to restore conversation in sidepanel
+// ---------------------------------------------------------------------------
+
+export const AiTutorMessageInjector = ({
+  messages,
+}: {
+  messages: AiTutorMessage[]
+}) => {
+  const { setMessages } = useCopilotChatInternal()
+  const { setOpen } = useAiChat()
+  const injectedRef = useRef(false)
+
+  useEffect(() => {
+    if (!injectedRef.current && messages.length > 0) {
+      setMessages(
+        messages.map((m) => ({
+          id: randomId(),
+          role: m.role,
+          content: m.content,
+        }))
+      )
+      setOpen(true)
+      injectedRef.current = true
+    }
+  }, [messages, setMessages, setOpen])
+
+  return null
+}

--- a/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorDialog.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorDialog.tsx
@@ -110,7 +110,7 @@ const AiTutorChatInner = ({
     if (!selectedText || hasSentRef.current || inProgress) return
 
     const timer = setTimeout(() => {
-      const prompt = `Please explain the following text in simpler terms, as if you were a tutor helping me understand it:\n\n"${selectedText}"`
+      const prompt = `<tool-context tool="ai-tutor">Please give a brief, concise explanation (3-4 sentences max) of the following text in simpler terms:</tool-context>${selectedText}`
       sendMessage(prompt)
       hasSentRef.current = true
     }, 500)
@@ -410,7 +410,7 @@ export const AiTutorMessageInjector = ({
 }: {
   messages: AiTutorMessage[]
 }) => {
-  const { setMessages } = useCopilotChatInternal()
+  const { setMessages, sendMessage } = useCopilotChatInternal()
   const { setOpen } = useAiChat()
   const injectedRef = useRef(false)
 
@@ -425,8 +425,18 @@ export const AiTutorMessageInjector = ({
       )
       setOpen(true)
       injectedRef.current = true
+
+      // After injecting history, send a follow-up message to trigger a deeper explanation
+      setTimeout(() => {
+        sendMessage({
+          id: randomId(),
+          role: "user",
+          content:
+            "Please go deeper into this topic. Provide a detailed explanation with examples, and include helpful resources like articles, videos, or documentation links.",
+        })
+      }, 500)
     }
-  }, [messages, setMessages, setOpen])
+  }, [messages, setMessages, setOpen, sendMessage])
 
   return null
 }

--- a/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorDialog.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorDialog.tsx
@@ -74,7 +74,7 @@ const AiTutorChatInner = ({
     ],
     available: onGoDeeper ? "frontend" : "disabled",
     render: (props) => {
-      if (props.status === "inProgress") return null
+      if (props.status === "inProgress") return <></>
       return (
         <F0HILActionConfirmation
           text={

--- a/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/index.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/index.tsx
@@ -1,9 +1,13 @@
 import { BubbleMenu, Editor, isTextSelection } from "@tiptap/react"
 import { NodeSelection } from "prosemirror-state"
+import { useCallback, useState } from "react"
 
 import { EnhanceActivator } from "../../RichTextEditor/Enhance"
 import { enhanceConfig, lastIntentType } from "../../RichTextEditor/utils/types"
-import { Toolbar, ToolbarDivider } from "../Toolbar"
+import { ToolbarDivider } from "../Toolbar/ToolbarDivider"
+import { Toolbar } from "../Toolbar"
+import { AiTutorConfig, AskAITutorButton } from "./AskAITutorButton"
+import { AskAITutorChat } from "./AskAITutorDialog"
 
 interface EditorBubbleMenuProps {
   editor: Editor
@@ -12,6 +16,8 @@ interface EditorBubbleMenuProps {
   isFullscreen: boolean
   editorId: string
   plainHtmlMode?: boolean
+  aiTutorConfig?: AiTutorConfig
+  readonlyAiMode?: boolean
   // Optional enhance props
   enhanceConfig?: enhanceConfig
   onEnhanceWithAI?: (
@@ -38,6 +44,8 @@ export const EditorBubbleMenu = ({
   setLastIntent,
   isAcceptChangesOpen = false,
   hasError = false,
+  aiTutorConfig,
+  readonlyAiMode = false,
 }: EditorBubbleMenuProps) => {
   const showEnhance = enhanceConfig && onEnhanceWithAI && setLastIntent
 
@@ -45,74 +53,145 @@ export const EditorBubbleMenu = ({
   const shouldHideForEnhance =
     isLoadingEnhance || isAcceptChangesOpen || hasError
 
+  const [isAiDialogOpen, setIsAiDialogOpen] = useState(false)
+  const [selectedText, setSelectedText] = useState("")
+  const [chatPosition, setChatPosition] = useState<{
+    top: number
+    left: number
+  } | null>(null)
+
+  const handleAiOpen = useCallback(
+    (text: string) => {
+      // Capture selection coordinates before collapsing
+      const { from, to } = editor.state.selection
+      const start = editor.view.coordsAtPos(from)
+      const end = editor.view.coordsAtPos(to)
+      const editorEl = document.getElementById(editorId)
+      if (editorEl) {
+        const editorRect = editorEl.getBoundingClientRect()
+        setChatPosition({
+          top: end.bottom - editorRect.top + 8,
+          left: Math.min(
+            start.left - editorRect.left,
+            editorRect.width - 370 // ensure chat doesn't overflow right
+          ),
+        })
+      }
+
+      setSelectedText(text)
+      setIsAiDialogOpen(true)
+      editor.chain().setTextSelection(from).blur().run()
+    },
+    [editor, editorId]
+  )
+
   return (
-    <BubbleMenu
-      tippyOptions={{
-        duration: 100,
-        placement: "top",
-        hideOnClick: false,
-        appendTo: () =>
-          isFullscreen
-            ? document.body
-            : document.getElementById(editorId) || document.body,
-        zIndex: 9999,
-      }}
-      editor={editor}
-      shouldShow={({ view, state, from, to }) => {
-        const { doc, selection } = state
-        const { empty } = selection
+    <>
+      <BubbleMenu
+        tippyOptions={{
+          duration: 100,
+          placement: "top",
+          hideOnClick: false,
+          appendTo: () =>
+            isFullscreen
+              ? document.body
+              : document.getElementById(editorId) || document.body,
+          zIndex: 9999,
+        }}
+        editor={editor}
+        shouldShow={({ view, state, from, to }) => {
+          const { doc, selection } = state
+          const { empty } = selection
 
-        if (selection instanceof NodeSelection) {
-          return false
-        }
-        const isEmptyTextBlock =
-          !doc.textBetween(from, to).length && isTextSelection(state.selection)
+          if (selection instanceof NodeSelection) {
+            return false
+          }
+          const isEmptyTextBlock =
+            !doc.textBetween(from, to).length &&
+            isTextSelection(state.selection)
 
-        const isChildOfMenu = document
-          .getElementById(editorId)
-          ?.contains(document.activeElement)
+          const isChildOfMenu = document
+            .getElementById(editorId)
+            ?.contains(document.activeElement)
 
-        const hasEditorFocus = view.hasFocus() || isChildOfMenu
+          const hasEditorFocus = view.hasFocus() || isChildOfMenu
 
-        if (
-          !hasEditorFocus ||
-          empty ||
-          isEmptyTextBlock ||
-          !editor.isEditable
-        ) {
-          return false
-        }
+          if (readonlyAiMode) {
+            // In readonly mode, only show if text is selected and focused
+            return !!(hasEditorFocus && !empty && !isEmptyTextBlock)
+          }
 
-        return true
-      }}
-    >
-      {!isToolbarOpen && !shouldHideForEnhance && (
-        <div className="dark z-50 flex w-max flex-row items-center gap-1 rounded-lg border border-solid border-f1-border bg-f1-background p-1 drop-shadow-sm">
-          {showEnhance && (
-            <>
-              <EnhanceActivator
+          if (
+            !hasEditorFocus ||
+            empty ||
+            isEmptyTextBlock ||
+            !editor.isEditable
+          ) {
+            return false
+          }
+
+          return true
+        }}
+      >
+        {readonlyAiMode && aiTutorConfig ? (
+          <div className="z-50">
+            <AskAITutorButton
+              editor={editor}
+              config={aiTutorConfig}
+              onOpen={handleAiOpen}
+            />
+          </div>
+        ) : (
+          !isToolbarOpen &&
+          !shouldHideForEnhance && (
+            <div className="dark z-50 flex w-max flex-row items-center gap-1 rounded-lg border border-solid border-f1-border bg-f1-background p-1 drop-shadow-sm">
+              {showEnhance && (
+                <>
+                  <EnhanceActivator
+                    editor={editor}
+                    onEnhanceWithAI={onEnhanceWithAI}
+                    isLoadingEnhance={isLoadingEnhance}
+                    enhanceConfig={enhanceConfig}
+                    disableButtons={disableButtons}
+                    hideLabel
+                    position="top"
+                    setLastIntent={setLastIntent}
+                  />
+
+                  <ToolbarDivider />
+                </>
+              )}
+              <Toolbar
                 editor={editor}
-                onEnhanceWithAI={onEnhanceWithAI}
-                isLoadingEnhance={isLoadingEnhance}
-                enhanceConfig={enhanceConfig}
                 disableButtons={disableButtons}
-                hideLabel
-                position="top"
-                setLastIntent={setLastIntent}
+                darkMode
+                showEmojiPicker={false}
+                plainHtmlMode={plainHtmlMode}
               />
-
-              <ToolbarDivider />
-            </>
-          )}
-          <Toolbar
-            editor={editor}
-            disableButtons={disableButtons}
-            darkMode
-            showEmojiPicker={false}
-            plainHtmlMode={plainHtmlMode}
-          />
-        </div>
+              {aiTutorConfig && (
+                <>
+                  <ToolbarDivider />
+                  <AskAITutorButton
+                    editor={editor}
+                    config={aiTutorConfig}
+                    onOpen={handleAiOpen}
+                  />
+                </>
+              )}
+            </div>
+          )
+        )}
+      </BubbleMenu>
+      {aiTutorConfig && (
+        <AskAITutorChat
+          isOpen={isAiDialogOpen}
+          selectedText={selectedText}
+          chatConfig={aiTutorConfig.chatConfig}
+          onClose={() => setIsAiDialogOpen(false)}
+          onGoDeeper={aiTutorConfig.onGoDeeper}
+          position={chatPosition}
+        />
       )}
-    </BubbleMenu>
+    </>
   )
 }

--- a/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/index.tsx
+++ b/packages/react/src/experimental/RichText/CoreEditor/BubbleMenu/index.tsx
@@ -189,6 +189,7 @@ export const EditorBubbleMenu = ({
           chatConfig={aiTutorConfig.chatConfig}
           onClose={() => setIsAiDialogOpen(false)}
           onGoDeeper={aiTutorConfig.onGoDeeper}
+          onQuizMe={aiTutorConfig.onQuizMe}
           position={chatPosition}
         />
       )}

--- a/packages/react/src/experimental/RichText/NotesTextEditor/index.stories.tsx
+++ b/packages/react/src/experimental/RichText/NotesTextEditor/index.stories.tsx
@@ -248,6 +248,9 @@ export const WithAITutor: Story = {
       onGoDeeper: (messages) => {
         console.log("Go deeper triggered with messages:", messages)
       },
+      onQuizMe: (messages) => {
+        console.log("Quiz me triggered with messages:", messages)
+      },
     },
   },
 }

--- a/packages/react/src/experimental/RichText/NotesTextEditor/index.stories.tsx
+++ b/packages/react/src/experimental/RichText/NotesTextEditor/index.stories.tsx
@@ -215,6 +215,43 @@ export const Blank: Story = {
   },
 }
 
+const defaultAiTutorLabels = {
+  buttonLabel: "Ask tutor",
+  buttonTooltip: "Ask your AI tutor",
+}
+
+const trainingContent = `<h2 data-id="t1">Introduction to Performance Reviews</h2><p data-id="t2">Performance reviews are a systematic evaluation of an employee's job performance and overall contribution to the organization. They provide an opportunity for managers and employees to discuss achievements, identify areas for improvement, and set goals for future development.</p><p data-id="t3"></p><h3 data-id="t4">Key Concepts</h3><p data-id="t5"><strong>360-degree feedback</strong> is a method where employees receive confidential, anonymous feedback from the people who work around them. This typically includes the employee's manager, peers, and direct reports. The feedback covers a range of workplace competencies and behaviors.</p><p data-id="t6"></p><p data-id="t7"><strong>OKRs (Objectives and Key Results)</strong> is a goal-setting framework used by teams and individuals to define measurable goals and track their outcomes. The development of OKRs is generally attributed to Andy Grove who introduced the approach at Intel.</p><p data-id="t8"></p><h3 data-id="t9">Best Practices</h3><ul class="f1-bullet-list" data-id="t10"><li data-id="t11"><p data-id="t12">Provide specific, actionable feedback rather than vague generalizations</p></li><li data-id="t13"><p data-id="t14">Focus on behaviors and outcomes, not personality traits</p></li><li data-id="t15"><p data-id="t16">Use the SBI model (Situation, Behavior, Impact) for structured feedback</p></li></ul>`
+
+export const WithAITutor: Story = {
+  args: {
+    placeholder: "Start reading the training material...",
+    readonly: true,
+    titlePlaceholder: "Training module title",
+    onChange: (value) => {
+      console.log("Content changed:", value)
+    },
+    initialEditorState: {
+      content: trainingContent,
+      title: "Performance Review Training",
+    },
+    aiTutorConfig: {
+      labels: defaultAiTutorLabels,
+      chatConfig: {
+        runtimeUrl: "http://localhost:4111/copilotkit",
+        agent: "one-workflow",
+        greeting:
+          "Hello! I'm your AI tutor. Highlight any text in the training material and I'll help you understand it better.",
+      },
+      onAskAI: (selectedText) => {
+        console.log("AI Tutor asked about:", selectedText)
+      },
+      onGoDeeper: (messages) => {
+        console.log("Go deeper triggered with messages:", messages)
+      },
+    },
+  },
+}
+
 type SkeletonStory = StoryObj<typeof NotesTextEditorSkeleton>
 
 export const Skeleton: SkeletonStory = {

--- a/packages/react/src/experimental/RichText/NotesTextEditor/index.tsx
+++ b/packages/react/src/experimental/RichText/NotesTextEditor/index.tsx
@@ -18,6 +18,7 @@ import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Icon } from "@/components/F0Icon"
 import { EditorBubbleMenu } from "@/experimental/RichText/CoreEditor"
 import { Toolbar } from "@/experimental/RichText/CoreEditor"
+import { AiTutorConfig } from "@/experimental/RichText/CoreEditor/BubbleMenu/AskAITutorButton"
 import { Handle, Plus } from "@/icons/app"
 import { DataTestIdWrapper, WithDataTestIdProps } from "@/lib/data-testid"
 import { useI18n } from "@/lib/providers/i18n"
@@ -51,6 +52,7 @@ interface NotesTextEditorProps extends WithDataTestIdProps {
   readonly?: boolean
   aiBlockConfig?: AIBlockConfig
   imageUploadConfig?: ImageUploadConfig
+  aiTutorConfig?: AiTutorConfig
   onTitleChange?: (title: string) => void
   titlePlaceholder?: string
   primaryAction?: PrimaryActionButton | PrimaryDropdownAction<string>
@@ -72,6 +74,7 @@ const NotesTextEditorComponent = forwardRef<
     readonly = false,
     aiBlockConfig,
     imageUploadConfig,
+    aiTutorConfig,
     onTitleChange,
     primaryAction,
     secondaryActions,
@@ -354,6 +357,19 @@ const NotesTextEditorComponent = forwardRef<
             isToolbarOpen={!showBubbleMenu}
             isFullscreen={false}
             plainHtmlMode={false}
+            aiTutorConfig={aiTutorConfig}
+          />
+        )}
+        {readonly && aiTutorConfig && (
+          <EditorBubbleMenu
+            editorId={editorId}
+            editor={editor}
+            disableButtons={true}
+            isToolbarOpen={false}
+            isFullscreen={false}
+            plainHtmlMode={false}
+            aiTutorConfig={aiTutorConfig}
+            readonlyAiMode
           />
         )}
       </div>
@@ -438,6 +454,12 @@ export const NotesTextEditorSkeleton = ({
   )
 }
 
+export type { AiTutorLabels } from "../CoreEditor/BubbleMenu/AskAITutorDialog"
+export { AiTutorMessageInjector } from "../CoreEditor/BubbleMenu/AskAITutorDialog"
+export type {
+  AiTutorConfig,
+  AiTutorMessage,
+} from "../CoreEditor/BubbleMenu/AskAITutorButton"
 export type { Message, User } from "../CoreEditor/Extensions/Transcript"
 export type { ImageUploadConfig } from "./types"
 export const NotesTextEditor = NotesTextEditorComponent

--- a/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
@@ -6,7 +6,7 @@ import { experimentalComponent } from "@/lib/experimental"
 import { useRegisteredActions } from "./actions"
 import { ChatInput } from "./components/input/ChatInput"
 import { ChatHeader } from "./components/layout/ChatHeader"
-import { SidebarWindow } from "./components/layout/ChatWindow"
+import { FloatingWindow, SidebarWindow } from "./components/layout/ChatWindow"
 import { AssistantMessage } from "./components/messages/AssistantMessage"
 import { MessagesContainer } from "./components/messages/MessagesContainer"
 import { UserMessage } from "./components/messages/UserMessage"
@@ -79,7 +79,8 @@ const AiChatKitWrapper = ({
 }
 
 const F0AiChatComponent = () => {
-  const { enabled, open, setOpen, mode, VoiceMode } = useAiChat()
+  const { enabled, open, setOpen, mode, VoiceMode, visualizationMode } =
+    useAiChat()
 
   useRegisteredActions()
 
@@ -97,6 +98,9 @@ const F0AiChatComponent = () => {
     )
   }
 
+  const WindowComponent =
+    visualizationMode === "floating" ? FloatingWindow : SidebarWindow
+
   return (
     <CopilotSidebar
       className="h-full w-full"
@@ -104,7 +108,7 @@ const F0AiChatComponent = () => {
       onSetOpen={(isOpen) => {
         setOpen(isOpen)
       }}
-      Window={SidebarWindow}
+      Window={WindowComponent}
       Header={ChatHeader}
       Messages={MessagesContainer}
       Button={() => {

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -8,6 +8,31 @@ import { MAX_CHAT_WIDTH, MIN_CHAT_WIDTH } from "../../utils/constants"
 import { useAiChat } from "../../providers/AiChatStateProvider"
 import { ResizeHandle } from "./ResizeHandle"
 
+/**
+ * Compact floating chat window — renders as a small card (360x460px).
+ * Used when visualizationMode is "floating".
+ */
+export const FloatingWindow = ({ children }: WindowProps) => {
+  const { open } = useAiChat()
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          key="floating-chat"
+          className="pointer-events-auto flex h-full w-full flex-col overflow-hidden rounded-xl border border-solid border-f1-border-secondary bg-f1-special-page shadow-xl"
+          initial={{ opacity: 0, scale: 0.95, y: 10 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.95, y: 10 }}
+          transition={{ duration: 0.2, ease: "easeOut" }}
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}
+
 export const SidebarWindow = ({ children }: WindowProps) => {
   const {
     open,

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -91,7 +91,11 @@ export type AiChatMode = "chat" | "voice"
 /**
  * Visualization mode for the AI chat
  */
-export type VisualizationMode = "sidepanel" | "fullscreen" | "canvas"
+export type VisualizationMode =
+  | "sidepanel"
+  | "fullscreen"
+  | "canvas"
+  | "floating"
 
 /**
  * Tracking options for the AI chat


### PR DESCRIPTION
## Summary
- add a new Ask AI Tutor button and dialog in the RichText bubble menu
- wire NotesTextEditor and chat components to open guided tutoring from selected content
- update stories and chat types/layout to support the new tutor entrypoint

## Test plan
- [x] pre-commit hooks pass (format, lint, cycle dependencies)
- [ ] validate Ask AI Tutor flow in Notes editor manually
- [ ] verify storybook stories render and interaction works as expected

Made with [Cursor](https://cursor.com)