### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.419.0",
-  "packages/react-native": "0.43.0",
+  "packages/react-native": "0.44.0",
   "packages/core": "1.47.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.44.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.43.0...f0-react-native-v0.44.0) (2026-03-25)
+
+
+### Features
+
+* **chip:** introduce F0Chip component with showcase and styles ([#3755](https://github.com/factorialco/f0/issues/3755)) ([ad1738e](https://github.com/factorialco/f0/commit/ad1738e883df76f67d67bf4e24794a1f972e3c71))
+
 ## [0.43.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.42.0...f0-react-native-v0.43.0) (2026-03-25)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.44.0</summary>

## [0.44.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.43.0...f0-react-native-v0.44.0) (2026-03-25)


### Features

* **chip:** introduce F0Chip component with showcase and styles ([#3755](https://github.com/factorialco/f0/issues/3755)) ([ad1738e](https://github.com/factorialco/f0/commit/ad1738e883df76f67d67bf4e24794a1f972e3c71))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).