### PR TITLE
fix(NumberInput): reject non-numeric characters on input

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/NumberInput/internal.tsx
+++ b/packages/react/src/experimental/Forms/Fields/NumberInput/internal.tsx
@@ -59,35 +59,29 @@ export const NumberInputInternal = forwardRef<
   const handleChange = (value: string) => {
     const extractedData = extractNumber(value, { maxDecimals })
     if (!extractedData) {
-      setFieldValue("")
       return
     }
 
-    const { value: parsedValue } = extractedData
+    const { value: parsedValue, formattedValue } = extractedData
 
-    /**
-     * Apply min and max constraints
-     */
     if (parsedValue === null) {
-      setFieldValue("")
+      setFieldValue(formattedValue)
       onChange?.(null)
       return
     }
 
-    /**
-     * Reformat the number to the correct format
-     */
-    const finalValue = Math.max(
+    const clampedValue = Math.max(
       min ?? -Infinity,
       Math.min(max ?? Infinity, parsedValue)
     )
 
-    const finalExtractedData = extractNumber(finalValue.toString(), {
-      maxDecimals,
-    })
-    setFieldValue(finalExtractedData?.formattedValue ?? "")
+    if (clampedValue !== parsedValue) {
+      setFieldValue(formatValue(clampedValue, locale, maxDecimals))
+    } else {
+      setFieldValue(formattedValue)
+    }
 
-    onChange?.(finalExtractedData?.value ?? null)
+    onChange?.(clampedValue)
   }
 
   const handleStep = (type: "increase" | "decrease") => () => {
@@ -114,6 +108,20 @@ export const NumberInputInternal = forwardRef<
     setFieldValue(value ? formatValue(value, locale, maxDecimals) : "")
   }, [fieldValue, maxDecimals, value, locale])
 
+  const handleBeforeInput = (e: React.FormEvent<HTMLInputElement>) => {
+    const { data } = e.nativeEvent as InputEvent
+    if (!data) return
+
+    const input = e.currentTarget
+    const start = input.selectionStart ?? 0
+    const end = input.selectionEnd ?? 0
+    const newValue = input.value.slice(0, start) + data + input.value.slice(end)
+
+    if (!extractNumber(newValue, { maxDecimals })) {
+      e.preventDefault()
+    }
+  }
+
   return (
     <div className="group relative">
       <Input
@@ -123,6 +131,7 @@ export const NumberInputInternal = forwardRef<
         inputMode="decimal"
         onChange={handleChange}
         {...props}
+        onBeforeInput={handleBeforeInput}
         hint={localHint}
         appendTag={units}
         append={


### PR DESCRIPTION
### Why

`NumberInput` uses `type="text"` (instead of `type="number")` to support locale-specific decimal separators (both `,` and `.`) and full control over formatting. However, there was no mechanism to prevent non-numeric characters at the input level.

The existing `handleChange` → `extractNumber` pipeline only validated after the character entered the DOM. Due to `InputField` maintaining its own internal `localValue` state independently from `NumberInput`'s fieldValue, rejecting input in `handleChange` didn't reset the displayed value — `InputField`'s `useEffect` that syncs from the value prop wouldn't fire because the prop value hadn't changed. This caused letters and symbols to visually persist in the input even though `onChange` never emitted invalid values.

`onBeforeInput` intercepts characters before the DOM mutation, preventing `InputField` from ever seeing invalid input — which is the standard approach for `type="text"` inputs that need character filtering (used by `react-number-format`, `react-imask`, etc.).

### What

Add `onBeforeInput` handler to `NumberInputInternal` that prevents non-numeric characters from entering the input field. The handler simulates the resulting value before the DOM mutation and calls `e.preventDefault()` if the result wouldn't match the number format regex.

Also simplifies the `handleChange` logic by using the already-extracted `formattedValue` directly and renaming `finalValue` → `clampedValue` for clarity.

**Before**

https://github.com/user-attachments/assets/8434b0c8-2c77-493f-8e92-3807cd9ab41c

**After**

https://github.com/user-attachments/assets/ff40764a-54b8-46c0-8d97-6e414723b9c1


