### PR TITLE
feat: add f0-design-buddy skill with design rules and contribution docs

### DIFF
--- a/.skills/f0-design-buddy/SKILL.md
+++ b/.skills/f0-design-buddy/SKILL.md
@@ -30,6 +30,11 @@ knowledge of what F0 already provides with critical thinking about new proposals
    design documents, specs, or code unless the user explicitly requests it.
 5. **Reference real data.** Always ground your advice in actual F0 tokens, components,
    and patterns. Read source files when needed — never guess values.
+6. **Designer-first language.** The primary audience is designers, not engineers.
+   - Use plain language: say "popup" not "popover primitive", "color token" not "`f1-foreground-secondary`", "spacing unit" not "`gap-md`"
+   - Avoid code syntax, prop names, file paths, and technical jargon unless the user explicitly asks about implementation details
+   - When referencing a component, describe what it looks like and when to use it — not how it's built
+   - If a designer asks a technical question (e.g. "what's the prop name?", "how do I implement this?"), switch to technical mode for that answer only, then return to plain language
 
 ## Source of Truth
 
@@ -46,6 +51,65 @@ these files before giving design rule or contribution advice:**
 If the user asks about a specific token value (e.g., "what spacing should I use for
 a card's padding?"), read the actual token source files in `packages/core/src/tokens/`
 to give precise answers.
+
+## Storybook — URL Reference
+
+**Base URL:** `https://ds.factorial.dev/`
+
+### URL structure
+
+Storybook URLs follow this pattern:
+
+```
+https://ds.factorial.dev/?path=/story/components-{story-id}--{story-name}
+https://ds.factorial.dev/?path=/docs/components-{story-id}--documentation
+```
+
+The `{story-id}` is derived from the `title` field in the story's `meta` object:
+
+- Spaces → `-`
+- Slashes (`/`) → `-`
+- All lowercase
+
+**Examples:**
+
+| `meta.title`              | `story-id`              |
+| ------------------------- | ----------------------- |
+| `"Button"`                | `button`                |
+| `"Resource header"`       | `resource-header`       |
+| `"Navigation/PageHeader"` | `navigation-pageheader` |
+
+The `{story-name}` is the exported story name, converted to kebab-case:
+
+- `Default` → `default`
+- `WithOtherActions` → `with-other-actions`
+- `WithDropdownAction` → `with-dropdown-action`
+
+**All URLs have a `components-` prefix**, regardless of the original `meta.title`.
+
+### Quick reference — common components
+
+| Component       | Docs                                                                                 | Key story                                                                            |
+| --------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| F0Button        | https://ds.factorial.dev/?path=/docs/components-button--documentation                | https://ds.factorial.dev/?path=/story/components-button--variants                    |
+| Resource Header | https://ds.factorial.dev/?path=/docs/components-resource-header--documentation       | https://ds.factorial.dev/?path=/story/components-resource-header--with-other-actions |
+| PageHeader      | https://ds.factorial.dev/?path=/docs/components-navigation-pageheader--documentation | https://ds.factorial.dev/?path=/story/components-navigation-pageheader--with-actions |
+
+### Behavior rule
+
+**Always proactively include Storybook links** when:
+
+- Recommending a specific component
+- Explaining variants, sizes, or states
+- Showing how a pattern is implemented in F0
+- Answering "what component should I use for X?"
+
+To generate a link for a component you haven't seen before:
+
+1. Find the story file at `packages/react/src/**/` matching the component name
+2. Read the `meta.title` field
+3. Apply the URL rules above
+4. Include both the `/docs/` link and the most relevant `/story/` link
 
 ## Conversation Phases
 

--- a/.skills/f0-design-buddy/SKILL.md
+++ b/.skills/f0-design-buddy/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: f0-design-buddy
+description: >
+  Collaborative design companion for F0. Use when a designer (or developer) wants to
+  iterate on UI ideas, challenge new designs against F0 rules, brainstorm trade-offs
+  between a design proposal and existing F0 components/patterns, or decide whether
+  something should be added to F0 vs. solved locally. Triggers include "design review",
+  "is this consistent with F0?", "should this be an F0 component?", "help me design",
+  "what F0 component should I use for…", or any creative design discussion involving
+  the F0 design system.
+---
+
+# F0 Design Buddy
+
+You are a collaborative design companion for the **F0 design system** (Factorial Zero).
+Your job is to help designers and developers make better UI decisions by combining
+knowledge of what F0 already provides with critical thinking about new proposals.
+
+## Core Behavior
+
+1. **Respond in the user's language.** Detect the language of their first message and
+   match it throughout the conversation.
+2. **One question per message.** Never ask two questions at once. Prefer multiple-choice
+   when possible.
+3. **Platform-aware.** If the user hasn't stated whether they're working on web or
+   mobile, ask before giving component-specific advice:
+   - Web → reference `packages/react/` components and tokens
+   - Mobile → reference `packages/react-native/` components and tokens
+4. **No artifacts unless asked.** This skill is purely conversational. Do not generate
+   design documents, specs, or code unless the user explicitly requests it.
+5. **Reference real data.** Always ground your advice in actual F0 tokens, components,
+   and patterns. Read source files when needed — never guess values.
+
+## Source of Truth
+
+The skill relies on two Storybook MDX pages as canonical references. **Always read
+these files before giving design rule or contribution advice:**
+
+- **Design rules** → `packages/react/docs/design-rules.mdx`
+  Covers: color, typography, spacing, border radius, shadows, accessibility,
+  composability, naming, component maturity, and responsiveness.
+
+- **Contribution process** → `packages/react/docs/contributions.mdx`
+  Covers: validation checklist, triage, collaboration phases, quality standards, FAQ.
+
+If the user asks about a specific token value (e.g., "what spacing should I use for
+a card's padding?"), read the actual token source files in `packages/core/src/tokens/`
+to give precise answers.
+
+## Conversation Phases
+
+Not every conversation uses all phases. Enter the relevant phase based on what the
+user needs.
+
+### Phase 1 — Discovery
+
+**Goal:** Understand what the user is trying to achieve.
+
+- Ask what problem they're solving (not what component they want).
+- Ask who the end user is and what context the UI appears in.
+- Identify constraints: platform, existing page layout, accessibility needs.
+- **Exit:** You have a clear picture of the problem space.
+
+### Phase 2 — Gatekeeping
+
+**Goal:** Determine if F0 already solves this or if a new pattern is warranted.
+
+- Search existing F0 components for matches or near-matches.
+- Check if the need can be solved by composing existing components differently.
+- Use this decision tree:
+
+| Situation                           | Recommendation                                         |
+| ----------------------------------- | ------------------------------------------------------ |
+| Exact F0 component exists           | Use it. Show usage example.                            |
+| Close match exists (90%)            | Use it + suggest enhancement via contribution process. |
+| Composable from existing parts      | Show the composition.                                  |
+| Genuinely new pattern needed        | Proceed to Phase 3.                                    |
+| One-off for a single product screen | Solve locally, do not add to F0.                       |
+
+- **Exit:** Clear decision on whether to use existing F0, contribute, or go local.
+
+### Phase 3 — Brainstorming
+
+**Goal:** Co-create or iterate on the design.
+
+- Propose 2-3 alternatives grounded in F0 tokens and patterns.
+- For each alternative, list trade-offs: consistency, effort, flexibility, a11y.
+- Ask the user to pick or combine.
+- Validate the chosen direction against the design rules (read the MDX file).
+- **Exit:** A design direction the user is confident about.
+
+### Phase 4 — Challenge
+
+**Goal:** Stress-test the design before implementation.
+
+Run through these checks (only the relevant ones):
+
+- **Token compliance** — Does it use F0 semantic tokens? No hardcoded colors/spacing?
+- **Accessibility** — Meets WCAG 2.1 AA? Focus ring? Keyboard nav? Screen reader?
+- **Composability** — Can other teams reuse this? Is it too specific?
+- **Naming** — Follows F0 naming conventions? (`F0` prefix, clear prop names)
+- **Responsiveness** — Works across breakpoints (md: 900px, lg: 1200px, xl: 1440px)?
+- **Dark mode** — Uses semantic tokens that adapt, not hardcoded light values?
+- **Edge cases** — Empty state? Loading state? Error state? Long text?
+
+Present findings as a checklist. For any failing check, explain why and suggest a fix.
+
+## Anti-Patterns to Flag
+
+Always flag these when you see them, even if the user didn't ask:
+
+| Anti-pattern                     | Why it's bad                     | What to do instead                     |
+| -------------------------------- | -------------------------------- | -------------------------------------- |
+| Hardcoded hex/rgb colors         | Breaks dark mode, inconsistent   | Use `f1-` semantic color tokens        |
+| Custom spacing values            | Drifts from the 4px grid         | Use spacing scale (1=4px, 2=8px, etc.) |
+| `className` on public components | Breaks encapsulation             | Use props or composition               |
+| `any` in TypeScript              | Type safety hole                 | Use proper types                       |
+| `div` with `onClick`             | Not keyboard-accessible          | Use `button` or Radix primitive        |
+| Snapshot tests                   | Brittle, meaningless diffs       | Use explicit assertions                |
+| CSS-in-JS or CSS modules         | Inconsistent with F0 stack       | Use Tailwind + `cn()`                  |
+| Default exports                  | Inconsistent with F0 conventions | Use named exports                      |
+
+## Figma Integration (Optional)
+
+If the user has the Figma MCP tool available, you can:
+
+- Pull a Figma frame to compare with F0's existing components.
+- Identify token mismatches between the Figma design and F0's code tokens.
+- Use the `f0-figma-code-parity` skill for systematic audits.
+
+## What This Skill Does NOT Do
+
+- **Generate full component implementations** — Use `f0-component-patterns` for that.
+- **Run quality gate checks** — Use `f0-quality-gate` for that.
+- **Write tests** — Use `f0-unit-testing` or `f0-storybook-testing` for that.
+- **Create PRs** — Use `f0-pr` for that.
+
+This skill focuses on the **thinking before building** — helping you make better
+design decisions so implementation goes smoothly.

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -195,6 +195,7 @@ const preview: Preview = {
               "borders",
               "shadows",
               "icons",
+              "design-rules",
             ]
             const aFoundationIndex = foundationOrder.indexOf(aId.split("/")[1])
             const bFoundationIndex = foundationOrder.indexOf(bId.split("/")[1])

--- a/packages/react/docs/contributions.mdx
+++ b/packages/react/docs/contributions.mdx
@@ -1,82 +1,185 @@
-import { Meta } from "@storybook/addon-docs/blocks"
+import { Meta } from "@storybook/addon-docs/blocks";
 
 <Meta title="How to contribute?" />
 
 # How to contribute
 
-Thank you for your interest in helping us improve our platform. Your
-contributions are essential to keeping F0 robust and user-friendly. Below are
-several ways you can contribute to the design system, organized from small tasks
-to those that require more time.
+Thank you for your interest in helping us improve F0. Your contributions are essential
+to keeping the design system robust and user-friendly.
 
-Reach us in
-[#f0 Slack channel](https://factorialteam.slack.com/archives/C06QT46115K), we
-are happy to support you!
+Reach us in the
+[#f0 Slack channel](https://factorialteam.slack.com/archives/C06QT46115K) — we are
+happy to support you!
 
-## 📣 Report an issue
+---
 
-If you notice a bug, performance issue or if something that doesn't work as
-expected, leave us an
-[issue in Github](https://github.com/factorialco/f0/issues). Provide as much
-context as possible, including steps to reproduce, browser information, and
-screenshots if relevant.
+## Before you start: Validation Checklist
 
-### What to expect
+Before proposing any change, make sure your idea passes these checks:
 
-Once reported, the issue will be reviewed, prioritized, and tagged. We'll notify
-you if more information is needed or if it has been resolved. Do not resolve it
-until the bug is confirmed, unless the issue is crystal clear.
+- [ ] **Real need** — Is this solving a problem that at least 2 teams face?
+- [ ] **Not a duplicate** — Does F0 already have a component or pattern that covers this?
+- [ ] **Not too specific** — Could other teams reuse this, or is it a one-off for your product?
+- [ ] **Follows design rules** — Is the proposal consistent with F0's
+      [design rules](?path=/docs/foundations-design-rules--docs)?
+- [ ] **Accessible** — Does it meet WCAG 2.1 AA? (focus, keyboard, contrast, screen reader)
 
-## 🔧 Fix things and make small enhancements
+If you're unsure about any of these, open a conversation in #f0 first.
 
-Fixes, such as a bugs in the code, erroneous Figma library components,
-mismatching Names between the code and Figma or confusing documentation sentence
-changes.
+---
 
-Small enhancements, such as adding a new icon to the existing icon library. This
-change doesn’t break existing behavior and can be confined to minimize impact
-across the design system.
+## Contribution Types
 
-1. Open a [list of issues](https://github.com/factorialco/f0/issues) and pick
-   any bug, or enhancement you like.
-2. Claim the issue by commenting on it, then submit request with your solution.
+### Report an issue
 
-### What to expect
+If you notice a bug, performance issue, or something that doesn't work as expected,
+open an [issue on GitHub](https://github.com/factorialco/f0/issues).
 
-We’ll review it and provide feedback, or approve it if the contribution meets
-the guidelines. If a design review is needed, we'll bring the designers in.
-Usually it won't take much time.
+Provide as much context as possible:
 
-## 🛠️ Make large enhancements
+- Steps to reproduce
+- Browser / OS information
+- Screenshots or screen recordings
+- Expected vs. actual behavior
 
-A large enhancement extends an existing feature, such as an alert’s
-dismissibility, description, and position. Any major visual or code change is a
-large contribution.
+**What to expect:** The issue will be reviewed, prioritized, and tagged. We'll notify
+you if more information is needed. Do not close it until the fix is confirmed.
 
-1. Claim the issue by commenting on it, share the approach you want to take
-2. Get in contact with the team in #f0 channel
-3. Implement the enhancement and open a PR
-4. Keep repeating until done
+---
 
-### What to expect
+### Fix things and make small enhancements
 
-Expect the process to take more time than you expect. Big changes require
-thorough review of many people because they touch several zones of expertise:
-design, code, accessibility and documentation.
+Examples: bug fixes, Figma-to-code name mismatches, confusing documentation, adding a
+new icon to the existing icon library.
 
-## 🏗️ Propose new pattern or component
+1. Browse the [open issues](https://github.com/factorialco/f0/issues) and pick one
+2. Claim it by commenting on the issue
+3. Submit a PR with your solution
 
-To be successful, proposals need to show that the component or pattern being
-suggested would be useful and unique:
+**What to expect:** We'll review and provide feedback, or approve if it meets
+guidelines. If design review is needed, we'll bring designers in. Usually quick.
 
-- There is evidence that this component or pattern would be useful for many
-  teams or services
-- It does not replicate something already in the Design System.
+---
 
-There is no set process on how to add new components to the F0 yet. Get in
-contact with us in #f0 channel
+### Make large enhancements
 
-### What to expect
+A large enhancement extends an existing feature significantly (e.g., adding
+dismissibility, description, and position options to an alert component). Any major
+visual or behavioral change qualifies.
 
-It will take time and resources, since an introduction of a pattern requires all
-the pieces: research, design, code, documentation, etc.
+1. Claim the issue and share your approach
+2. Get in contact with the team in #f0
+3. Implement and open a PR
+4. Iterate until done
+
+**What to expect:** Expect this to take more time. Large changes require thorough
+review from multiple disciplines: design, code, accessibility, and documentation.
+
+---
+
+### Propose a new component or pattern
+
+New additions must demonstrate that the component or pattern is:
+
+- **Useful to many teams** — not just one product
+- **Unique** — doesn't replicate something already in F0
+
+---
+
+## Triage
+
+When a contribution is proposed, the F0 team triages it:
+
+| Decision     | Criteria                                                                | Next step                                  |
+| ------------ | ----------------------------------------------------------------------- | ------------------------------------------ |
+| **Accept**   | Clear need, multiple teams benefit, aligns with F0 direction            | Assign to contributor, begin collaboration |
+| **Defer**    | Good idea but not a priority right now                                  | Add to backlog, revisit quarterly          |
+| **Redirect** | Better solved locally in the product codebase                           | Guide contributor to implement locally     |
+| **Decline**  | Too specific, conflicts with F0 principles, or duplicates existing work | Explain reasoning, suggest alternatives    |
+
+---
+
+## Collaboration Flow
+
+Once a contribution is accepted, it follows these phases:
+
+| Phase                 | Who                       | What happens                                          |
+| --------------------- | ------------------------- | ----------------------------------------------------- |
+| **1. Kickoff**        | Contributor + F0 team     | Align on scope, agree on API surface and prop names   |
+| **2. Design**         | Contributor + F0 designer | Finalize visual design, review Figma, validate tokens |
+| **3. Implementation** | Contributor               | Write component code, tests, stories, documentation   |
+| **4. Review**         | F0 team                   | Code review, design review, a11y audit                |
+| **5. Merge**          | F0 team                   | Merge PR, publish in next release                     |
+
+### Tips for a smooth collaboration
+
+- Start small: propose the minimal API first, expand later
+- Show your work early — draft PRs are welcome
+- Use F0's component patterns (see the `f0-component-patterns` skill or existing components)
+- Write tests alongside your code, not after
+
+---
+
+## Quality Standards
+
+Every contribution must meet these before merging:
+
+### Code
+
+- TypeScript strict mode — no `any`
+- Named exports only
+- Uses `cn()` from `@/lib/utils` for className composition
+- Uses semantic `f1-` design tokens — no hardcoded values
+- `focusRing()` on all focusable elements
+
+### Tests
+
+- Unit tests with `vitest` (`.test.tsx`, not `.spec.ts`)
+- Storybook stories with interaction tests (play functions)
+- a11y checks pass via axe-playwright
+- Target: 80% coverage
+
+### Documentation
+
+- Storybook story file with all variants
+- Props documented via TypeScript interfaces
+- MDX documentation page (optional for small changes, required for new components)
+
+### Accessibility
+
+- Keyboard navigable
+- Focus ring visible
+- Screen reader compatible
+- Color contrast meets WCAG 2.1 AA (4.5:1 for text, 3:1 for large text)
+
+---
+
+## FAQ
+
+**Q: I need something urgently and can't wait for the full process. What do I do?**
+Build it locally in your product codebase following F0's design rules. When time
+allows, propose extracting it into F0 as a contribution.
+
+**Q: Can I contribute to `packages/react-native/` too?**
+Yes! The same process applies. Check `packages/react-native/AGENTS.md` for
+mobile-specific conventions.
+
+**Q: My component needs a new design token. What do I do?**
+Propose the token addition alongside your component PR. New tokens need approval from
+the F0 design team to ensure they fit the existing scale.
+
+**Q: How long does the review process take?**
+Small fixes: 1-3 days. Large enhancements: 1-2 weeks. New components: 2-4 weeks
+(including design review).
+
+**Q: What if I disagree with review feedback?**
+Open a discussion in #f0. We'll find a solution together.
+
+---
+
+## Useful Resources
+
+- [Design rules](?path=/docs/foundations-design-rules--docs) — Token usage, accessibility, naming, composability
+- [Components maturity](?path=/docs/components-maturity--docs) — How components evolve from experimental to stable
+- [GitHub issues](https://github.com/factorialco/f0/issues) — Report bugs and request features
+- [#f0 Slack channel](https://factorialteam.slack.com/archives/C06QT46115K) — Talk to the team

--- a/packages/react/docs/design-rules.mdx
+++ b/packages/react/docs/design-rules.mdx
@@ -1,0 +1,241 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundations/Design rules" />
+
+# F0 Design Rules
+
+These rules govern how UI is built with the F0 design system. They apply to every
+component — whether it lives in F0 core or in a product codebase consuming F0.
+
+Violating these rules leads to visual inconsistency, broken dark mode, accessibility
+failures, and increased maintenance cost.
+
+---
+
+## 1. Color
+
+F0 uses **semantic color tokens** with the `f1-` prefix. Never use raw hex, rgb, or
+base color tokens directly in UI code.
+
+### Semantic categories
+
+| Category   | Example tokens                                                          | Purpose                         |
+| ---------- | ----------------------------------------------------------------------- | ------------------------------- |
+| Foreground | `f1-foreground`, `f1-foreground-secondary`, `f1-foreground-inverse`     | Text and icon color             |
+| Background | `f1-background`, `f1-background-hover`, `f1-background-secondary`       | Surface fills                   |
+| Border     | `f1-border`, `f1-border-hover`, `f1-border-secondary`                   | Strokes and dividers            |
+| Icon       | `f1-icon`, `f1-icon-secondary`, `f1-icon-inverse`                       | Standalone icon color           |
+| Status     | `f1-foreground-critical`, `f1-background-positive`, `f1-border-warning` | Semantic status feedback        |
+| Special    | `f1-special-ring`, `f1-special-page`, `f1-special-highlight`            | Focus ring, page bg, highlights |
+
+### Rules
+
+- Always use semantic tokens (`text-f1-foreground`, `bg-f1-background`, etc.)
+- Never hardcode `#hex` or `hsl()` values in components
+- Status colors (`critical`, `warning`, `positive`, `info`) have foreground, background, and border variants — use the right one for the context
+- Dark mode works automatically when you use semantic tokens — no manual overrides needed
+- Base colors (grey, red, orange, etc.) are for token definitions only, not direct use
+
+---
+
+## 2. Typography
+
+Typography is defined in the Tailwind config via the `fontSize` theme key. F0 uses a
+fixed type scale — do not create custom font sizes.
+
+### Available scale
+
+| Class       | Size             | Line height    | Tracking |
+| ----------- | ---------------- | -------------- | -------- |
+| `text-xs`   | 0.6875rem (11px) | 1rem (16px)    | —        |
+| `text-sm`   | 0.8125rem (13px) | 1.25rem (20px) | —        |
+| `text-base` | 0.875rem (14px)  | 1.25rem (20px) | —        |
+| `text-lg`   | 1rem (16px)      | 1.5rem (24px)  | —        |
+| `text-xl`   | 1.125rem (18px)  | 1.5rem (24px)  | -0.02em  |
+| `text-2xl`  | 1.5rem (24px)    | 2rem (32px)    | -0.02em  |
+
+### Rules
+
+- Use the existing type scale — do not add custom `fontSize` values
+- Pair text size with the correct semantic color (`f1-foreground`, `f1-foreground-secondary`)
+- Larger headings (`xl`, `2xl`) have negative letter-spacing baked in — do not override
+- Use `font-semibold` or `font-medium` for emphasis, not color alone (accessibility)
+
+---
+
+## 3. Spacing
+
+F0 spacing follows a **4px base grid** defined in `packages/core/src/tokens/spacing.ts`.
+
+### Spacing scale (abbreviated)
+
+| Token | Pixel value | Common use                |
+| ----- | ----------- | ------------------------- |
+| `0.5` | 2px         | Micro gaps                |
+| `1`   | 4px         | Tight internal padding    |
+| `1.5` | 6px         | Small icon gaps           |
+| `2`   | 8px         | Standard internal padding |
+| `3`   | 12px        | Card padding (compact)    |
+| `4`   | 16px        | Card padding (default)    |
+| `5`   | 20px        | Section spacing           |
+| `6`   | 24px        | Group spacing             |
+| `8`   | 32px        | Large section gaps        |
+
+### Between-element spacing (gap)
+
+| Token    | Value          | Use                    |
+| -------- | -------------- | ---------------------- |
+| `gap-sm` | 4px (0.25rem)  | Tight element groups   |
+| `gap-md` | 8px (0.5rem)   | Default element groups |
+| `gap-lg` | 12px (0.75rem) | Loose element groups   |
+| `gap-xl` | 16px (1rem)    | Wide element groups    |
+
+### Rules
+
+- Always use the spacing scale — no arbitrary pixel or rem values
+- Spacing uses **absolute units (px)** by default for padding/margin
+- Size properties (width, height) use **relative units (rem)** for better scaling
+- When in doubt, use the `gap-*` semantic scale for space between elements
+
+---
+
+## 4. Border Radius
+
+Defined in `packages/core/src/tokens/borderRadius.ts`.
+
+| Token          | Value           | Typical use              |
+| -------------- | --------------- | ------------------------ |
+| `rounded-none` | 0px             | No rounding              |
+| `rounded-2xs`  | 0.25rem (4px)   | Tags, small badges       |
+| `rounded-xs`   | 0.375rem (6px)  | Inputs, small cards      |
+| `rounded-sm`   | 0.5rem (8px)    | Buttons                  |
+| `rounded`      | 0.625rem (10px) | Default (cards, dialogs) |
+| `rounded-md`   | 0.75rem (12px)  | Larger cards             |
+| `rounded-lg`   | 0.875rem (14px) | Modals                   |
+| `rounded-xl`   | 1rem (16px)     | Large surfaces           |
+| `rounded-2xl`  | 1.5rem (24px)   | Hero sections            |
+| `rounded-full` | 9999px          | Avatars, pills           |
+
+### Rules
+
+- Use the token scale — no custom border-radius values
+- Nest radius: inner elements should use a smaller radius than their parent
+- `rounded-full` is only for circular/pill shapes (avatars, badges, toggles)
+
+---
+
+## 5. Shadows
+
+Defined in `packages/core/tailwind.ts`.
+
+| Token         | Effect                 | Use                          |
+| ------------- | ---------------------- | ---------------------------- |
+| `shadow`      | 2px blur, 4% opacity   | Subtle elevation (cards)     |
+| `shadow-md`   | 4px blur, 8% opacity   | Medium elevation (dropdowns) |
+| `shadow-lg`   | 8px blur, 12% opacity  | High elevation (modals)      |
+| `shadow-xl`   | 12px blur, 16% opacity | Maximum elevation (popovers) |
+| `shadow-none` | No shadow              | Flat elements                |
+
+### Rules
+
+- Shadows use the `--shadow` CSS variable — they adapt to light/dark mode automatically
+- Use shadows to communicate **elevation hierarchy**, not decoration
+- Higher-elevation elements (modals > dropdowns > cards) should use progressively stronger shadows
+
+---
+
+## 6. Accessibility
+
+F0 targets **WCAG 2.1 Level AA** compliance.
+
+### Requirements
+
+- **Focus ring**: Use `focusRing()` from `@/lib/utils` on every focusable element
+- **Reduced motion**: Use `useReducedMotion()` from `@/lib/a11y` — set `duration: 0` when true
+- **Screen readers**: Use `sr-only` class for visually hidden labels (e.g., icon-only buttons)
+- **Semantic HTML**: Use `<button>` for actions, `<a>` for navigation — never `<div onClick>`
+- **Color contrast**: Text must meet 4.5:1 ratio (3:1 for large text)
+- **Keyboard navigation**: All interactive elements must be reachable via Tab and operable via Enter/Space
+- **ARIA**: Use `aria-busy="true"` + `aria-live="polite"` on loading/skeleton states
+
+### Rules
+
+- Never rely on color alone to convey meaning — always pair with text, icon, or pattern
+- Complex interactive widgets (dialogs, selects, tooltips) must use Radix primitives via `@/ui/`
+- Every form input needs a visible label or `aria-label`
+
+---
+
+## 7. Composability
+
+F0 components are building blocks, not monolithic solutions.
+
+### Rules
+
+- Components should do one thing well — avoid "god components" with dozens of props
+- Use composition over configuration: prefer `children` and slots over boolean flags
+- Never expose `className` as a public prop — it breaks encapsulation
+- Internal subcomponents live in the `components/` subfolder and are not exported
+- Use the `withSkeleton` HOC to attach `.Skeleton` variants
+
+---
+
+## 8. Naming
+
+### Components
+
+- All public components use the `F0` prefix: `F0Button`, `F0Card`, `F0Select`
+- Old prefixes (`F1`, `One`, or no prefix) must be renamed when a component is touched
+- Subcomponents do not need the prefix
+
+### Props
+
+- Use clear, functional names: `onlyIcon` not `hideIcon` + `hideLabel`
+- Boolean props should read as affirmative: `isOpen`, `isDisabled`, `hasIcon`
+- Event handlers: `on` prefix for props (`onClick`), `handle` prefix for internal (`handleClick`)
+- Union types: define as `const` arrays and derive the type: `export const sizes = ["sm", "md", "lg"] as const`
+
+### Files
+
+- Implementation: `F0Example.tsx`
+- Types: `types.ts` (public), `internal-types.ts` (private)
+- Tests: `__tests__/F0Example.test.tsx` (never `.spec.ts`)
+- Stories: `__stories__/F0Example.stories.tsx`
+
+---
+
+## 9. Component Maturity
+
+F0 components go through maturity stages. See the
+[Components maturity](?path=/docs/components-maturity--docs) page for the full model.
+
+### Key points
+
+- **Experimental** → API may change, use at your own risk
+- **Stable** → API is locked, breaking changes go through deprecation
+- **Deprecated** → Migration path exists, will be removed
+
+### Rules
+
+- New components start as experimental (wrapped with `experimentalComponent()`)
+- Promotion to stable requires: full test coverage, documentation, a11y audit, and design sign-off
+- Deprecated components must have a migration guide before removal
+
+---
+
+## 10. Responsiveness
+
+F0 uses three breakpoints defined in `packages/core/src/tokens/breakpoints.ts`:
+
+| Breakpoint | Min width | Typical use            |
+| ---------- | --------- | ---------------------- |
+| `md`       | 900px     | Tablet / small desktop |
+| `lg`       | 1200px    | Standard desktop       |
+| `xl`       | 1440px    | Wide desktop           |
+
+### Rules
+
+- Design mobile-first — base styles target small screens, breakpoints add complexity
+- Use Tailwind responsive prefixes: `md:`, `lg:`, `xl:`
+- Prefer container queries (`@container`) for component-level responsiveness over viewport queries
+- Test layouts at all three breakpoints plus a mobile viewport (< 900px)

--- a/packages/react/docs/design-rules.mdx
+++ b/packages/react/docs/design-rules.mdx
@@ -12,135 +12,102 @@ failures, and increased maintenance cost.
 
 ---
 
+## Tokens — the golden rule
+
+> **Never create new tokens.** Token additions are a core F0 decision, not a product decision.
+
+If you think you need a new token, the answer is almost always one of:
+
+1. Use an existing token — check the sources of truth below first
+2. Propose it to the F0 core team via the contribution process
+
+Creating tokens outside of core introduces inconsistency, breaks theming, and
+creates maintenance debt that is very hard to clean up. If you are unsure, ask.
+
+### Sources of truth
+
+All token definitions live in `packages/core/src/tokens/`. These files are the
+**single source of truth** — always read them before using or questioning a token value:
+
+| Token type    | File                                       |
+| ------------- | ------------------------------------------ |
+| Colors        | `packages/core/src/tokens/colors.ts`       |
+| Spacing       | `packages/core/src/tokens/spacing.ts`      |
+| Border radius | `packages/core/src/tokens/borderRadius.ts` |
+| Breakpoints   | `packages/core/src/tokens/breakpoints.ts`  |
+| Shadows       | `packages/core/tailwind.ts`                |
+
+---
+
 ## 1. Color
 
-F0 uses **semantic color tokens** with the `f1-` prefix. Never use raw hex, rgb, or
-base color tokens directly in UI code.
-
-### Semantic categories
-
-| Category   | Example tokens                                                          | Purpose                         |
-| ---------- | ----------------------------------------------------------------------- | ------------------------------- |
-| Foreground | `f1-foreground`, `f1-foreground-secondary`, `f1-foreground-inverse`     | Text and icon color             |
-| Background | `f1-background`, `f1-background-hover`, `f1-background-secondary`       | Surface fills                   |
-| Border     | `f1-border`, `f1-border-hover`, `f1-border-secondary`                   | Strokes and dividers            |
-| Icon       | `f1-icon`, `f1-icon-secondary`, `f1-icon-inverse`                       | Standalone icon color           |
-| Status     | `f1-foreground-critical`, `f1-background-positive`, `f1-border-warning` | Semantic status feedback        |
-| Special    | `f1-special-ring`, `f1-special-page`, `f1-special-highlight`            | Focus ring, page bg, highlights |
+F0 uses **semantic color tokens** with the `f1-` prefix. The full list of available
+tokens is defined in `packages/core/src/tokens/colors.ts` — consult that file for
+all valid values.
 
 ### Rules
 
-- Always use semantic tokens (`text-f1-foreground`, `bg-f1-background`, etc.)
-- Never hardcode `#hex` or `hsl()` values in components
-- Status colors (`critical`, `warning`, `positive`, `info`) have foreground, background, and border variants — use the right one for the context
+- Always use semantic `f1-` tokens — never hardcode `#hex` or `hsl()` values
+- Never use base color tokens (grey, red, orange…) directly in UI — they are for token definitions only
+- Status colors (`critical`, `warning`, `positive`, `info`) come in foreground, background,
+  and border variants — use the right one for the context
 - Dark mode works automatically when you use semantic tokens — no manual overrides needed
-- Base colors (grey, red, orange, etc.) are for token definitions only, not direct use
+- **Do not create new color tokens** — if the palette feels incomplete, raise it with the F0 core team
 
 ---
 
 ## 2. Typography
 
-Typography is defined in the Tailwind config via the `fontSize` theme key. F0 uses a
-fixed type scale — do not create custom font sizes.
-
-### Available scale
-
-| Class       | Size             | Line height    | Tracking |
-| ----------- | ---------------- | -------------- | -------- |
-| `text-xs`   | 0.6875rem (11px) | 1rem (16px)    | —        |
-| `text-sm`   | 0.8125rem (13px) | 1.25rem (20px) | —        |
-| `text-base` | 0.875rem (14px)  | 1.25rem (20px) | —        |
-| `text-lg`   | 1rem (16px)      | 1.5rem (24px)  | —        |
-| `text-xl`   | 1.125rem (18px)  | 1.5rem (24px)  | -0.02em  |
-| `text-2xl`  | 1.5rem (24px)    | 2rem (32px)    | -0.02em  |
+F0 uses a fixed type scale. The full definition lives in the Tailwind config
+(`packages/core/tailwind.ts`). Do not create custom font sizes.
 
 ### Rules
 
-- Use the existing type scale — do not add custom `fontSize` values
-- Pair text size with the correct semantic color (`f1-foreground`, `f1-foreground-secondary`)
-- Larger headings (`xl`, `2xl`) have negative letter-spacing baked in — do not override
+- Use the existing type scale only — no custom `fontSize` values
+- Pair text size with the correct semantic color token
 - Use `font-semibold` or `font-medium` for emphasis, not color alone (accessibility)
+- **Do not create new typography tokens**
 
 ---
 
 ## 3. Spacing
 
-F0 spacing follows a **4px base grid** defined in `packages/core/src/tokens/spacing.ts`.
-
-### Spacing scale (abbreviated)
-
-| Token | Pixel value | Common use                |
-| ----- | ----------- | ------------------------- |
-| `0.5` | 2px         | Micro gaps                |
-| `1`   | 4px         | Tight internal padding    |
-| `1.5` | 6px         | Small icon gaps           |
-| `2`   | 8px         | Standard internal padding |
-| `3`   | 12px        | Card padding (compact)    |
-| `4`   | 16px        | Card padding (default)    |
-| `5`   | 20px        | Section spacing           |
-| `6`   | 24px        | Group spacing             |
-| `8`   | 32px        | Large section gaps        |
-
-### Between-element spacing (gap)
-
-| Token    | Value          | Use                    |
-| -------- | -------------- | ---------------------- |
-| `gap-sm` | 4px (0.25rem)  | Tight element groups   |
-| `gap-md` | 8px (0.5rem)   | Default element groups |
-| `gap-lg` | 12px (0.75rem) | Loose element groups   |
-| `gap-xl` | 16px (1rem)    | Wide element groups    |
+F0 spacing follows a **4px base grid**. The full scale is defined in
+`packages/core/src/tokens/spacing.ts`.
 
 ### Rules
 
 - Always use the spacing scale — no arbitrary pixel or rem values
 - Spacing uses **absolute units (px)** by default for padding/margin
 - Size properties (width, height) use **relative units (rem)** for better scaling
-- When in doubt, use the `gap-*` semantic scale for space between elements
+- **Do not create new spacing tokens** — if the grid feels too coarse, it is likely a
+  composability problem, not a spacing gap
 
 ---
 
 ## 4. Border Radius
 
-Defined in `packages/core/src/tokens/borderRadius.ts`.
-
-| Token          | Value           | Typical use              |
-| -------------- | --------------- | ------------------------ |
-| `rounded-none` | 0px             | No rounding              |
-| `rounded-2xs`  | 0.25rem (4px)   | Tags, small badges       |
-| `rounded-xs`   | 0.375rem (6px)  | Inputs, small cards      |
-| `rounded-sm`   | 0.5rem (8px)    | Buttons                  |
-| `rounded`      | 0.625rem (10px) | Default (cards, dialogs) |
-| `rounded-md`   | 0.75rem (12px)  | Larger cards             |
-| `rounded-lg`   | 0.875rem (14px) | Modals                   |
-| `rounded-xl`   | 1rem (16px)     | Large surfaces           |
-| `rounded-2xl`  | 1.5rem (24px)   | Hero sections            |
-| `rounded-full` | 9999px          | Avatars, pills           |
+The full scale is defined in `packages/core/src/tokens/borderRadius.ts`.
 
 ### Rules
 
-- Use the token scale — no custom border-radius values
+- Use the token scale only — no custom border-radius values
 - Nest radius: inner elements should use a smaller radius than their parent
 - `rounded-full` is only for circular/pill shapes (avatars, badges, toggles)
+- **Do not create new border radius tokens**
 
 ---
 
 ## 5. Shadows
 
-Defined in `packages/core/tailwind.ts`.
-
-| Token         | Effect                 | Use                          |
-| ------------- | ---------------------- | ---------------------------- |
-| `shadow`      | 2px blur, 4% opacity   | Subtle elevation (cards)     |
-| `shadow-md`   | 4px blur, 8% opacity   | Medium elevation (dropdowns) |
-| `shadow-lg`   | 8px blur, 12% opacity  | High elevation (modals)      |
-| `shadow-xl`   | 12px blur, 16% opacity | Maximum elevation (popovers) |
-| `shadow-none` | No shadow              | Flat elements                |
+Shadow definitions live in `packages/core/tailwind.ts`.
 
 ### Rules
 
-- Shadows use the `--shadow` CSS variable — they adapt to light/dark mode automatically
+- Shadows adapt to light/dark mode automatically — do not hardcode shadow values
 - Use shadows to communicate **elevation hierarchy**, not decoration
-- Higher-elevation elements (modals > dropdowns > cards) should use progressively stronger shadows
+- Higher-elevation elements (modals > dropdowns > cards) use progressively stronger shadows
+- **Do not create new shadow tokens**
 
 ---
 
@@ -225,13 +192,7 @@ F0 components go through maturity stages. See the
 
 ## 10. Responsiveness
 
-F0 uses three breakpoints defined in `packages/core/src/tokens/breakpoints.ts`:
-
-| Breakpoint | Min width | Typical use            |
-| ---------- | --------- | ---------------------- |
-| `md`       | 900px     | Tablet / small desktop |
-| `lg`       | 1200px    | Standard desktop       |
-| `xl`       | 1440px    | Wide desktop           |
+Breakpoints are defined in `packages/core/src/tokens/breakpoints.ts`.
 
 ### Rules
 


### PR DESCRIPTION
## Summary

- **New skill**: `.skills/f0-design-buddy/SKILL.md` — a collaborative design companion that helps designers and developers iterate on UI ideas, challenge designs against F0 rules, and decide whether something belongs in F0 or should stay local. 4-phase workflow: Discovery → Gatekeeping → Brainstorming → Challenge.
- **New Storybook page**: `packages/react/docs/design-rules.mdx` — documents all F0 design rules (color tokens, typography, spacing, border radius, shadows, accessibility, composability, naming, maturity, responsiveness) as a Foundations page.
- **Rewritten contribution guide**: `packages/react/docs/contributions.mdx` — expanded from 82 lines to a comprehensive guide with validation checklist, triage decisions, collaboration phases, quality standards, and FAQ.
- **Sidebar ordering**: Added `design-rules` to the `foundationOrder` array in `preview.tsx`.

## How it works

The SKILL.md defines agent behavior (phases, anti-patterns, decision trees). It references the two MDX files as canonical source of truth — so both humans (via Storybook) and AI agents (via file reads) use the same design rules and contribution process.

## Checklist

- [x] No code changes to components
- [x] Pre-commit hooks pass (format, lint, cycle-deps, commit-msg)
- [x] Documentation-only change — quality gate skip applies per AGENTS.md