### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.422.1",
-  "packages/react-native": "0.45.0",
+  "packages/react-native": "0.46.0",
   "packages/core": "1.48.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.46.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.45.0...f0-react-native-v0.46.0) (2026-03-26)
+
+
+### Features
+
+* **tabs:** add F0Tabs component with showcase, styles, and docs ([#3765](https://github.com/factorialco/f0/issues/3765)) ([97b0bd7](https://github.com/factorialco/f0/commit/97b0bd7b5c63099a88b65f2c603f559b559b0d06))
+
 ## [0.45.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.44.0...f0-react-native-v0.45.0) (2026-03-25)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.46.0</summary>

## [0.46.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.45.0...f0-react-native-v0.46.0) (2026-03-26)


### Features

* **tabs:** add F0Tabs component with showcase, styles, and docs ([#3765](https://github.com/factorialco/f0/issues/3765)) ([97b0bd7](https://github.com/factorialco/f0/commit/97b0bd7b5c63099a88b65f2c603f559b559b0d06))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).