### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.422.1",
-  "packages/react-native": "0.46.0",
+  "packages/react-native": "0.47.0",
   "packages/core": "1.48.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.47.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.46.0...f0-react-native-v0.47.0) (2026-03-26)
+
+
+### Features
+
+* add F0Metadata component ([#3766](https://github.com/factorialco/f0/issues/3766)) ([7d98d34](https://github.com/factorialco/f0/commit/7d98d34d58e533bb7af7a0e81449ad0aeafa4756))
+
 ## [0.46.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.45.0...f0-react-native-v0.46.0) (2026-03-26)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.47.0</summary>

## [0.47.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.46.0...f0-react-native-v0.47.0) (2026-03-26)


### Features

* add F0Metadata component ([#3766](https://github.com/factorialco/f0/issues/3766)) ([7d98d34](https://github.com/factorialco/f0/commit/7d98d34d58e533bb7af7a0e81449ad0aeafa4756))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).