### PR TITLE
fix(core): align color tokens with Figma design system

### DIFF
--- a/packages/core/base.css
+++ b/packages/core/base.css
@@ -115,7 +115,7 @@
     --white-30: theme("colors.white.30");
     --white-40: theme("colors.white.40");
     --white-50: theme("colors.white.50");
-    --white-60: theme("colors.white.5");
+    --white-60: theme("colors.white.60");
     --white-70: theme("colors.white.70");
     --white-80: theme("colors.white.80");
     --white-90: theme("colors.white.90");

--- a/packages/core/src/tokens/colors.ts
+++ b/packages/core/src/tokens/colors.ts
@@ -152,6 +152,7 @@ export const f1Colors = {
     promote: {
       DEFAULT: "hsl(var(--promote-50) / 0.3)",
       hover: "hsl(var(--promote-50) / 0.4)",
+      bold: "hsl(var(--promote-50))",
     },
     critical: {
       DEFAULT: "hsl(var(--critical-50) / 0.1)",


### PR DESCRIPTION
## Summary

- Add missing `background.promote.bold` token (`Promote/Solid/50` = `yellow.50`) — present in Figma but absent in code. All other semantic categories (`info`, `warning`, `positive`, `critical`) already had their `bold` variant implemented.
- Fix `--white-60` dark mode typo in `base.css`: was incorrectly set to `white.5` instead of `white.60`, causing `background.inverse.secondary` to render near-transparent in dark mode.

## Changes

| File | Change |
|---|---|
| `packages/core/src/tokens/colors.ts` | Added `bold: "hsl(var(--promote-50))"` to `background.promote` |
| `packages/core/base.css` | Fixed `--white-60: theme("colors.white.5")` → `theme("colors.white.60")` in `.dark:root` |

## New Tailwind class

- `bg-f1-background-promote-bold`