### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.422.2",
-  "packages/react-native": "0.48.0",
+  "packages/react-native": "0.49.0",
   "packages/core": "1.48.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.49.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.48.0...f0-react-native-v0.49.0) (2026-03-26)
+
+
+### Features
+
+* add `F0BlurView` primitive ([#3778](https://github.com/factorialco/f0/issues/3778)) ([20d8067](https://github.com/factorialco/f0/commit/20d8067a16602797e48ee57f7350a494bc7ccf97))
+
 ## [0.48.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.47.0...f0-react-native-v0.48.0) (2026-03-26)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.49.0</summary>

## [0.49.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.48.0...f0-react-native-v0.49.0) (2026-03-26)


### Features

* add `F0BlurView` primitive ([#3778](https://github.com/factorialco/f0/issues/3778)) ([20d8067](https://github.com/factorialco/f0/commit/20d8067a16602797e48ee57f7350a494bc7ccf97))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).