### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.422.2",
+  "packages/react": "1.422.3",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.422.3](https://github.com/factorialco/f0/compare/f0-react-v1.422.2...f0-react-v1.422.3) (2026-03-27)
+
+
+### Bug Fixes
+
+* **editable-table:** add active, hover states to the cells of the editable table ([#3733](https://github.com/factorialco/f0/issues/3733)) ([a39652f](https://github.com/factorialco/f0/commit/a39652f92a86a4a86a238d1c7e152b3f3ac1d672))
+
 ## [1.422.2](https://github.com/factorialco/f0/compare/f0-react-v1.422.1...f0-react-v1.422.2) (2026-03-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.422.2",
+  "version": "1.422.3",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.422.3</summary>

## [1.422.3](https://github.com/factorialco/f0/compare/f0-react-v1.422.2...f0-react-v1.422.3) (2026-03-27)


### Bug Fixes

* **editable-table:** add active, hover states to the cells of the editable table ([#3733](https://github.com/factorialco/f0/issues/3733)) ([a39652f](https://github.com/factorialco/f0/commit/a39652f92a86a4a86a238d1c7e152b3f3ac1d672))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).