### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.423.0",
+  "packages/react": "1.424.0",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.424.0](https://github.com/factorialco/f0/compare/f0-react-v1.423.0...f0-react-v1.424.0) (2026-03-27)
+
+
+### Features
+
+* **EditableTable:** add NumberCell for editable numeric columns ([#3724](https://github.com/factorialco/f0/issues/3724)) ([0441735](https://github.com/factorialco/f0/commit/0441735153f9416446acfab9b03afe2eada6951a))
+
 ## [1.423.0](https://github.com/factorialco/f0/compare/f0-react-v1.422.3...f0-react-v1.423.0) (2026-03-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.423.0",
+  "version": "1.424.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.424.0</summary>

## [1.424.0](https://github.com/factorialco/f0/compare/f0-react-v1.423.0...f0-react-v1.424.0) (2026-03-27)


### Features

* **EditableTable:** add NumberCell for editable numeric columns ([#3724](https://github.com/factorialco/f0/issues/3724)) ([0441735](https://github.com/factorialco/f0/commit/0441735153f9416446acfab9b03afe2eada6951a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).