### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.425.0",
+  "packages/react": "1.425.1",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.425.1](https://github.com/factorialco/f0/compare/f0-react-v1.425.0...f0-react-v1.425.1) (2026-03-30)
+
+
+### Bug Fixes
+
+* **OneDateNavigator:** use locale from l10n context in granularity label ([#3767](https://github.com/factorialco/f0/issues/3767)) ([d3bcc52](https://github.com/factorialco/f0/commit/d3bcc521c79402ef9865a5743bc1fa05be20c33c))
+
 ## [1.425.0](https://github.com/factorialco/f0/compare/f0-react-v1.424.0...f0-react-v1.425.0) (2026-03-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.425.0",
+  "version": "1.425.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.425.1</summary>

## [1.425.1](https://github.com/factorialco/f0/compare/f0-react-v1.425.0...f0-react-v1.425.1) (2026-03-30)


### Bug Fixes

* **OneDateNavigator:** use locale from l10n context in granularity label ([#3767](https://github.com/factorialco/f0/issues/3767)) ([d3bcc52](https://github.com/factorialco/f0/commit/d3bcc521c79402ef9865a5743bc1fa05be20c33c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).