### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.425.2",
+  "packages/react": "1.425.3",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.425.3](https://github.com/factorialco/f0/compare/f0-react-v1.425.2...f0-react-v1.425.3) (2026-03-30)
+
+
+### Bug Fixes
+
+* do not show import banner on doc pages with no components ([#3792](https://github.com/factorialco/f0/issues/3792)) ([ec3ccf5](https://github.com/factorialco/f0/commit/ec3ccf542a0ee8a05229429d055eb6c42df44830))
+
 ## [1.425.2](https://github.com/factorialco/f0/compare/f0-react-v1.425.1...f0-react-v1.425.2) (2026-03-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.425.2",
+  "version": "1.425.3",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.425.3</summary>

## [1.425.3](https://github.com/factorialco/f0/compare/f0-react-v1.425.2...f0-react-v1.425.3) (2026-03-30)


### Bug Fixes

* do not show import banner on doc pages with no components ([#3792](https://github.com/factorialco/f0/issues/3792)) ([ec3ccf5](https://github.com/factorialco/f0/commit/ec3ccf542a0ee8a05229429d055eb6c42df44830))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).