### PR TITLE
fix: clear visibleItems state when items becomes empty

### DIFF
--- a/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
+++ b/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
@@ -110,6 +110,7 @@ export function useOverflowCalculation<T>(
         }
         return { visibleItems: [], overflowItems: [] }
       })
+      return
     }
 
     if (!containerRef.current) return


### PR DESCRIPTION
## Description

Fix stale items rendering in `OverflowList` when the `items` prop transitions from a non-empty array to `[]`.

### Before


https://github.com/user-attachments/assets/cf415223-3b62-4917-bef4-3b25d642f3f2


## Implementation details

In `useOverflowCalculation`, in the `calculateVisibleItems` function, when items is empty, explicitly clear the state so the UI reflects the change.

### After


https://github.com/user-attachments/assets/e0d51546-462a-4c12-bf45-0f054ea06bc0




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small state-handling change confined to `useOverflowCalculation` to correctly reflect an empty `items` prop in the UI.
> 
> **Overview**
> Prevents stale items from remaining rendered in `OverflowList` when the `items` prop transitions to an empty array.
> 
> `useOverflowCalculation` now explicitly resets `visibleItems` and `overflowItems` to `[]` when `items.length === 0`, while avoiding redundant state updates if they’re already empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c15f5675f11bcbd2195aca45b9e0e26307bfe04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->