### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.425.3",
+  "packages/react": "1.425.4",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.425.4](https://github.com/factorialco/f0/compare/f0-react-v1.425.3...f0-react-v1.425.4) (2026-03-30)
+
+
+### Bug Fixes
+
+* clear visibleItems state when items becomes empty ([#3794](https://github.com/factorialco/f0/issues/3794)) ([a5f9a94](https://github.com/factorialco/f0/commit/a5f9a94f2155bd65c86beccb6ed80f027be6d565))
+
 ## [1.425.3](https://github.com/factorialco/f0/compare/f0-react-v1.425.2...f0-react-v1.425.3) (2026-03-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.425.3",
+  "version": "1.425.4",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.425.4</summary>

## [1.425.4](https://github.com/factorialco/f0/compare/f0-react-v1.425.3...f0-react-v1.425.4) (2026-03-30)


### Bug Fixes

* clear visibleItems state when items becomes empty ([#3794](https://github.com/factorialco/f0/issues/3794)) ([a5f9a94](https://github.com/factorialco/f0/commit/a5f9a94f2155bd65c86beccb6ed80f027be6d565))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).