### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.426.0",
+  "packages/react": "1.427.0",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.427.0](https://github.com/factorialco/f0/compare/f0-react-v1.426.0...f0-react-v1.427.0) (2026-03-31)
+
+
+### Features
+
+* add wiggle and error highlight to F0ActionBar ([#3795](https://github.com/factorialco/f0/issues/3795)) ([7086b14](https://github.com/factorialco/f0/commit/7086b14592c2454aacfc9a1e7fe8d25cefea54bb))
+
 ## [1.426.0](https://github.com/factorialco/f0/compare/f0-react-v1.425.4...f0-react-v1.426.0) (2026-03-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.426.0",
+  "version": "1.427.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.427.0</summary>

## [1.427.0](https://github.com/factorialco/f0/compare/f0-react-v1.426.0...f0-react-v1.427.0) (2026-03-31)


### Features

* add wiggle and error highlight to F0ActionBar ([#3795](https://github.com/factorialco/f0/issues/3795)) ([7086b14](https://github.com/factorialco/f0/commit/7086b14592c2454aacfc9a1e7fe8d25cefea54bb))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).