### PR TITLE
fix: no dot allow sorting-through tabeofcontent when SurveyFormBuilder is disabled

### DIFF
--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/TableOfContent/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/TableOfContent/index.tsx
@@ -5,6 +5,7 @@ import { F0TableOfContentPopover } from "@/components/F0TableOfContentPopover/F0
 import { IdStructure } from "@/experimental/Navigation/F0TableOfContent/types"
 import { useI18n } from "@/lib/providers/i18n"
 
+import { useSurveyFormBuilderContext } from "../../Context"
 import {
   SurveyFormBuilderElement,
   QuestionElement,
@@ -88,6 +89,7 @@ export const TableOfContent = ({
   answering?: boolean
 }) => {
   const { t } = useI18n()
+  const { disabled } = useSurveyFormBuilderContext()
   const { portalContainer } = useContext(F0DialogContext)
 
   const tocItems = useTableOfContentItems(elements, {
@@ -117,7 +119,7 @@ export const TableOfContent = ({
         size="md"
         collapsible
         showChildrenCounter
-        sortable={!answering}
+        sortable={!answering && !disabled}
         onReorder={handleReorder}
         portalContainer={portalContainer}
       />

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
@@ -1,5 +1,7 @@
+import { userEvent } from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
-import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
 
 import { SurveyFormBuilderElement } from "../../types"
 import { SurveyFormBuilder } from "../index"
@@ -194,5 +196,29 @@ describe("SurveyFormBuilder", () => {
     // Should have the add button since last element is a section
     const buttons = screen.getAllByRole("button")
     expect(buttons.length).toBeGreaterThan(0)
+  })
+
+  it("does not make the table of content sortable when disabled", async () => {
+    const elements: SurveyFormBuilderElement[] = [
+      makeQuestion("q1", "Question 1"),
+      makeQuestion("q2", "Question 2"),
+    ]
+
+    render(
+      <SurveyFormBuilder elements={elements} onChange={vi.fn()} disabled />
+    )
+
+    // Open the table of content popover by clicking the trigger
+    const tocTrigger = screen.getByLabelText("Menu")
+    await userEvent.click(tocTrigger)
+
+    // Verify the popover opened and ToC items are visible
+    await waitFor(() => {
+      expect(screen.getAllByText("Question 1").length).toBeGreaterThan(1)
+    })
+
+    // When disabled, items should not be draggable
+    const draggableItems = document.querySelectorAll("[draggable='true']")
+    expect(draggableItems).toHaveLength(0)
   })
 })

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -10,7 +10,7 @@ import { SurveyFormBuilderElement } from "../types"
 const meta: Meta<typeof SurveyFormBuilder> = {
   title: "Surveys/SurveyFormBuilder",
   component: SurveyFormBuilder,
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs"],
   render: (args) => {
     const [elements, setElements] = useState<SurveyFormBuilderElement[]>(
       args.elements


### PR DESCRIPTION
## Description

When SurveyFormBuilder is disabled, we shouldn't allow users to reorder items in F0TableOfContent.