### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.427.1",
+  "packages/react": "1.427.2",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.427.2](https://github.com/factorialco/f0/compare/f0-react-v1.427.1...f0-react-v1.427.2) (2026-03-31)
+
+
+### Bug Fixes
+
+* add error status to f0 action bar ([#3806](https://github.com/factorialco/f0/issues/3806)) ([507053f](https://github.com/factorialco/f0/commit/507053f3f0cfab0b8307e7cf5f309773f5fd4d27))
+
 ## [1.427.1](https://github.com/factorialco/f0/compare/f0-react-v1.427.0...f0-react-v1.427.1) (2026-03-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.427.1",
+  "version": "1.427.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.427.2</summary>

## [1.427.2](https://github.com/factorialco/f0/compare/f0-react-v1.427.1...f0-react-v1.427.2) (2026-03-31)


### Bug Fixes

* add error status to f0 action bar ([#3806](https://github.com/factorialco/f0/issues/3806)) ([507053f](https://github.com/factorialco/f0/commit/507053f3f0cfab0b8307e7cf5f309773f5fd4d27))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).