### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.427.2",
+  "packages/react": "1.427.3",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.427.3](https://github.com/factorialco/f0/compare/f0-react-v1.427.2...f0-react-v1.427.3) (2026-03-31)
+
+
+### Bug Fixes
+
+* no dot allow sorting-through tabeofcontent when SurveyFormBuilder is disabled ([#3807](https://github.com/factorialco/f0/issues/3807)) ([ba57032](https://github.com/factorialco/f0/commit/ba57032ca06f10bb4d1d43a0d7aa2b70dcc23bd7))
+
 ## [1.427.2](https://github.com/factorialco/f0/compare/f0-react-v1.427.1...f0-react-v1.427.2) (2026-03-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.427.2",
+  "version": "1.427.3",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.427.3</summary>

## [1.427.3](https://github.com/factorialco/f0/compare/f0-react-v1.427.2...f0-react-v1.427.3) (2026-03-31)


### Bug Fixes

* no dot allow sorting-through tabeofcontent when SurveyFormBuilder is disabled ([#3807](https://github.com/factorialco/f0/issues/3807)) ([ba57032](https://github.com/factorialco/f0/commit/ba57032ca06f10bb4d1d43a0d7aa2b70dcc23bd7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).