### PR TITLE
fix: prevent answer selection in edit mode for SelectOption

### DIFF
--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/SelectOption/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/SelectOption/index.tsx
@@ -59,7 +59,7 @@ export const SelectOption = ({
   const isDraggingThisItem = isDragging && draggedItemId === value
 
   const handleClick = () => {
-    if (disabled && !answering) return
+    if (!disabled && !answering) return // edit mode — do not select answer
     onClick(value)
   }
 
@@ -67,11 +67,13 @@ export const SelectOption = ({
     onClickAction({ value, index, action })
   }
 
-  const handleClickMarkAsCorrect = () => {
+  const handleClickMarkAsCorrect = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation()
     handleClickAction("mark-as-correct")
   }
 
-  const handleClickRemove = () => {
+  const handleClickRemove = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation()
     handleClickAction("remove")
   }
 


### PR DESCRIPTION
## Summary

- Fixes inverted click guard in `SelectOption` that prevented quiz builders from marking options as correct or removing them
- The `handleClick` condition `disabled && !answering` was inverted during the CoCreationForm → SurveyFormBuilder refactor — it should be `!disabled && !answering` to match the original `if (isEditMode) return` behavior
- Adds `stopPropagation` to mark-as-correct and remove button handlers as defense-in-depth

## Context

After the SurveyFormBuilder refactor (commit `5b72edf21`, PR #3610), the `SelectOption` component's click guard logic was inverted. In edit mode (`disabled=undefined, answering=undefined`), clicking an option's action buttons (mark-as-correct, remove) would also trigger the parent div's `onClick` → `handleClick` → `onClick(value)`, which selected the option as an answer. This caused a conflicting state update that made the buttons appear non-functional.

The old `CoCreationForm` code had:
```tsx
if (isEditMode) return // edit mode = clicking the option does nothing
```

The new code had:
```tsx
if (disabled && !answering) return // WRONG: never matches edit mode
```

This fix restores the correct behavior:
```tsx
if (!disabled && !answering) return // edit mode = do not select answer
```

## How to test

1. Go to Training LMS admin → create/edit a course
2. Add a section, add a quiz inside the section
3. Add a select/multi-select question with options
4. Hover an option → checkmark and trash buttons should appear
5. Click the checkmark → should toggle the "Correct" label
6. Click the trash → should remove the option

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI event-handling change limited to select option interactions; low likelihood of side effects beyond builder click behavior.
> 
> **Overview**
> Prevents `SelectOption` from selecting an answer when used in SurveyFormBuilder edit mode by correcting the click guard (`handleClick`) so only answering/disabled contexts trigger selection.
> 
> Adds `stopPropagation()` to the “mark as correct” and “remove” button handlers to avoid bubbling into the option container click and causing conflicting state updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3823737fcf763933ad1a9e0a4761f58accd6cb0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->