### PR TITLE
fix(SurveyFormBuilder): use nanoid for new option values and remove duplicate onChange call

### DIFF
--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
@@ -143,7 +143,7 @@ export const SelectQuestion = ({ options, ...props }: SelectQuestionProps) => {
 
   const handleAddOption = () => {
     const newOption: SelectQuestionOption = {
-      value: nanoid(),
+      value: `new-option-${nanoid()}`,
       label: t("surveyFormBuilder.selectQuestion.newOption", {
         number: options.length + 1,
       }),

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
@@ -71,10 +71,6 @@ export const SelectQuestion = ({ options, ...props }: SelectQuestionProps) => {
       value: nanoid(),
     }))
 
-    if (newOptionsWithSameValue) {
-      onQuestionChange?.({ ...commonChangeParams, options: newOptions })
-    }
-
     onQuestionChange?.({ ...commonChangeParams, options: newOptions })
   }, [
     someOptionsWithSameValue,
@@ -146,11 +142,10 @@ export const SelectQuestion = ({ options, ...props }: SelectQuestionProps) => {
   }
 
   const handleAddOption = () => {
-    const optionsLength = options.length
-    const newOption = {
-      value: `new-option-${optionsLength + 1}`,
+    const newOption: SelectQuestionOption = {
+      value: nanoid(),
       label: t("surveyFormBuilder.selectQuestion.newOption", {
-        number: optionsLength + 1,
+        number: options.length + 1,
       }),
     }
     onQuestionChange?.({


### PR DESCRIPTION
## Summary

Fixes silent deletion failure for newly added answer options in `SelectQuestion` (SurveyFormBuilder).

## Problem

When a user adds options, deletes one, then adds another, the counter-based value generation (`new-option-${options.length + 1}`) recycles values, causing collisions. This triggers the `someOptionsWithSameValue` dedup `useEffect`, which rewrites ALL option values to random `nanoid()` strings. The delete handler's closure still holds the pre-rewrite value, so the filter `options.filter(o => o.value !== params.value)` matches nothing — the option silently survives.

Additionally, the dedup `useEffect` fallback branch called `onQuestionChange` twice with identical data, causing redundant state updates.

## Changes

- **`handleAddOption`**: Use `nanoid()` instead of `new-option-${optionsLength + 1}` to generate unique option values that won't collide after add-delete-add cycles.
- **Dedup `useEffect`**: Remove the duplicate `onQuestionChange` call in the nanoid fallback branch (lines 74-76 were redundant since line 78 always executed).

The dedup `useEffect` is kept as a safety net for legacy data that may arrive with duplicate values, but with the `nanoid()` fix, newly created options will never trigger it.

## Related

- Previous f0 PR: https://github.com/factorialco/f0/pull/3811 (fixed inverted click guard in SelectOption)
- Factorial PR: https://github.com/factorialco/factorial/pull/94028 (content builder bug fixes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state fix limited to `SelectQuestion`, changing how new option IDs are generated and removing a redundant `onQuestionChange` call.
> 
> **Overview**
> Fixes `SelectQuestion` option value collisions by generating new option `value`s with `nanoid()` instead of counter-based strings, preventing add/delete/add cycles from reusing IDs.
> 
> Also removes a redundant `onQuestionChange` invocation in the duplicate-value dedup `useEffect`, avoiding unnecessary duplicate state updates when normalizing option values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fff09d746e8d80c9c6059cd36a16ddaf7212e86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->