### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.429.0",
+  "packages/react": "1.430.0",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.430.0](https://github.com/factorialco/f0/compare/f0-react-v1.429.0...f0-react-v1.430.0) (2026-04-01)
+
+
+### Features
+
+* wip add sentinel-based sticky parent rows for nested table hierarchies ([#3685](https://github.com/factorialco/f0/issues/3685)) ([4375423](https://github.com/factorialco/f0/commit/437542350c6f5a4e27cb6a74e16f26b771301e9f))
+
 ## [1.429.0](https://github.com/factorialco/f0/compare/f0-react-v1.428.2...f0-react-v1.429.0) (2026-04-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.429.0",
+  "version": "1.430.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.430.0</summary>

## [1.430.0](https://github.com/factorialco/f0/compare/f0-react-v1.429.0...f0-react-v1.430.0) (2026-04-01)


### Features

* wip add sentinel-based sticky parent rows for nested table hierarchies ([#3685](https://github.com/factorialco/f0/issues/3685)) ([4375423](https://github.com/factorialco/f0/commit/437542350c6f5a4e27cb6a74e16f26b771301e9f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).