### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.431.0",
+  "packages/react": "1.432.0",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.432.0](https://github.com/factorialco/f0/compare/f0-react-v1.431.0...f0-react-v1.432.0) (2026-04-01)
+
+
+### Features
+
+* add support for datasets in dropdown single and multi questions ([#3823](https://github.com/factorialco/f0/issues/3823)) ([0fdc445](https://github.com/factorialco/f0/commit/0fdc445e441b1f1c618df4906a967880bc44225f))
+
 ## [1.431.0](https://github.com/factorialco/f0/compare/f0-react-v1.430.0...f0-react-v1.431.0) (2026-04-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.431.0",
+  "version": "1.432.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.432.0</summary>

## [1.432.0](https://github.com/factorialco/f0/compare/f0-react-v1.431.0...f0-react-v1.432.0) (2026-04-01)


### Features

* add support for datasets in dropdown single and multi questions ([#3823](https://github.com/factorialco/f0/issues/3823)) ([0fdc445](https://github.com/factorialco/f0/commit/0fdc445e441b1f1c618df4906a967880bc44225f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).