### PR TITLE
fix: remove redundant install step that broke Storybook build with npm-published f0-core

### DIFF
--- a/.github/workflows/build-and-deploy-storybook.yaml
+++ b/.github/workflows/build-and-deploy-storybook.yaml
@@ -36,11 +36,6 @@ jobs:
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
 
-      - name: Install dependencies
-        run: |
-          sed -i 's/"workspace:\*"/"latest"/g' packages/react/package.json
-          pnpm install --no-frozen-lockfile
-
       - name: Build Core
         run: pnpm --filter @factorialco/f0-core build
 


### PR DESCRIPTION
## Problem

The `build-and-deploy-storybook` workflow was failing because `docs/components/ShadowTable.tsx` imports `boxShadow` from `@factorialco/f0-core`, but the published npm version (`1.48.2`) doesn't export it yet (it was added in #3828 after the last release).

Root cause: the workflow had a step that ran `sed -i 's/"workspace:\*"/"latest"/g'` on `packages/react/package.json` followed by `pnpm install --no-frozen-lockfile`. This replaced the workspace link to `f0-core` with the `latest` npm version, which was installed **before** the local `Build Core` step ran — making the Storybook build use the stale npm-published dist instead of the local source.

```
# Old order (broken):
1. Setup Node and PNPM  → installs deps via workspace links ✓
2. Install dependencies → sed replaces workspace:* with latest, re-installs f0-core FROM NPM ✗
3. Build Core           → builds local source, but node_modules already has npm version ✗
4. Build Storybook      → uses npm f0-core@1.48.2 → missing boxShadow → FAIL
```

## Fix

Remove the redundant "Install dependencies" step entirely. The `setup-node-pnpm` composite action already installs all dependencies using pnpm workspace links (resolving `f0-core` to the local source). There's no need to reinstall with `latest` from npm.

```
# New order (fixed):
1. Setup Node and PNPM  → installs deps via workspace links ✓
2. Build Core           → builds local source ✓
3. Build Storybook      → uses workspace-linked f0-core with boxShadow → OK ✓
```