### PR TITLE
refactor(F0Widget): promote from experimental to stable

### DIFF
--- a/packages/react/src/components/F0Widget/__stories__/F0Widget.stories.tsx
+++ b/packages/react/src/components/F0Widget/__stories__/F0Widget.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof F0Widget> = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "stable"],
   decorators: [
     (Story) => (
       <div className="h-60 w-80">


### PR DESCRIPTION
## Summary

Promotes `F0Widget` from experimental to stable status.

## Changes

- `F0Widget.stories.tsx`: changed `tags: ["autodocs", "experimental"]` → `tags: ["autodocs", "stable"]`

## Notes

- `index.tsx` was already a clean `export * from "./F0Widget"` — no `experimentalComponent` wrapper present
- `F0Widget.tsx` had no `experimentalComponent` usage — no changes needed there