### PR TITLE
refactor(F0ChipList): promote from experimental to stable

### DIFF
--- a/packages/react/src/components/F0ChipList/index.stories.tsx
+++ b/packages/react/src/components/F0ChipList/index.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "stable"],
   argTypes: {
     ...dataTestIdArgs,
   },

--- a/packages/react/src/components/F0ChipList/index.tsx
+++ b/packages/react/src/components/F0ChipList/index.tsx
@@ -1,5 +1,4 @@
 import { withDataTestId } from "@/lib/data-testid"
-import { experimentalComponent } from "@/lib/experimental"
 import { OverflowList } from "@/ui/OverflowList"
 
 import { Chip, type ChipProps } from "@/components/OneChip"
@@ -83,9 +82,4 @@ const _F0ChipList = ({
 
 _F0ChipList.displayName = "F0ChipList"
 
-/**
- * @experimental This is an experimental component use it at your own risk
- */
-export const F0ChipList = withDataTestId(
-  experimentalComponent<typeof _F0ChipList>("F0ChipList", _F0ChipList)
-)
+export const F0ChipList = withDataTestId(_F0ChipList)


### PR DESCRIPTION
## Summary

Promotes `F0ChipList` from experimental to stable.

## Changes

- Removed `experimentalComponent()` wrapper from the component export
- Removed `@experimental` JSDoc comment
- Removed unused `import { experimentalComponent } from "@/lib/experimental"`
- Updated story tags from `experimental` to `stable`

## Checklist

- [x] `tags: ["autodocs", "stable"]` in stories
- [x] `experimentalComponent()` wrapper removed
- [x] `@experimental` JSDoc removed
- [x] Unused `experimentalComponent` import removed