### PR TITLE
feat(OneChip): stabilize with F0Chip export, a11y fixes, and tests

### DIFF
--- a/packages/react/src/components/F0ChipList/ChipCounter.tsx
+++ b/packages/react/src/components/F0ChipList/ChipCounter.tsx
@@ -4,7 +4,10 @@ import { focusRing } from "@/lib/utils"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 import { ScrollArea, ScrollBar } from "@/ui/scrollarea"
 
-import { Chip, type ChipProps } from "@/components/OneChip"
+import {
+  F0Chip as Chip,
+  type F0ChipProps as ChipProps,
+} from "@/components/OneChip"
 
 type Props = {
   count: number

--- a/packages/react/src/components/F0ChipList/index.tsx
+++ b/packages/react/src/components/F0ChipList/index.tsx
@@ -2,7 +2,10 @@ import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 import { OverflowList } from "@/ui/OverflowList"
 
-import { Chip, type ChipProps } from "@/components/OneChip"
+import {
+  F0Chip as Chip,
+  type F0ChipProps as ChipProps,
+} from "@/components/OneChip"
 import { ChipCounter } from "./ChipCounter"
 
 type Props = {

--- a/packages/react/src/components/F0Select/components/ActiveFiltersChips.tsx
+++ b/packages/react/src/components/F0Select/components/ActiveFiltersChips.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion } from "motion/react"
 import { useEffect, useState } from "react"
 
-import { Chip } from "@/components/OneChip"
+import { F0Chip as Chip } from "@/components/OneChip"
 import { FiltersDefinition, FiltersState } from "@/hooks/datasource"
 import { useI18n } from "@/lib/providers/i18n"
 import { ScrollArea } from "@/ui/scrollarea"

--- a/packages/react/src/components/OneChip/__tests__/Chip.test.tsx
+++ b/packages/react/src/components/OneChip/__tests__/Chip.test.tsx
@@ -74,6 +74,15 @@ describe("F0Chip", () => {
       await userEvent.keyboard("{Enter}")
       expect(onClick).not.toHaveBeenCalled()
     })
+
+    it("does not fire onClick on Space when deactivated", async () => {
+      const onClick = vi.fn()
+      render(<F0Chip label="Disabled Space" deactivated onClick={onClick} />)
+      const chip = screen.getByRole("button", { name: "Disabled Space" })
+      chip.focus()
+      await userEvent.keyboard(" ")
+      expect(onClick).not.toHaveBeenCalled()
+    })
   })
 
   describe("onClick", () => {
@@ -150,6 +159,17 @@ describe("F0Chip", () => {
       expect(
         screen.queryByRole("button", { name: /Remove/ })
       ).not.toBeInTheDocument()
+    })
+
+    it("emits a console.warn when both onClick and onClose are provided", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+      render(<F0Chip label="Both warn" onClick={() => {}} onClose={() => {}} />)
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "providing both onClick and onClose is not supported"
+        )
+      )
+      warn.mockRestore()
     })
   })
 

--- a/packages/react/src/components/OneChip/__tests__/Chip.test.tsx
+++ b/packages/react/src/components/OneChip/__tests__/Chip.test.tsx
@@ -52,12 +52,27 @@ describe("F0Chip", () => {
       expect(span).not.toHaveAttribute("class")
     })
 
-    it("sets aria-disabled on the root element when deactivated", () => {
-      render(<F0Chip label="Disabled Chip" deactivated />)
-      const chip = screen
-        .getByText("Disabled Chip")
-        .closest('[class*="rounded-full"]')!
+    it("sets aria-disabled on the root element when deactivated with onClick", () => {
+      render(<F0Chip label="Disabled Chip" deactivated onClick={() => {}} />)
+      const chip = screen.getByRole("button", { name: "Disabled Chip" })
       expect(chip).toHaveAttribute("aria-disabled", "true")
+    })
+
+    it("does not fire onClick when deactivated", async () => {
+      const onClick = vi.fn()
+      render(<F0Chip label="Disabled" deactivated onClick={onClick} />)
+      const chip = screen.getByRole("button", { name: "Disabled" })
+      await userEvent.click(chip)
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it("does not fire onClick on Enter when deactivated", async () => {
+      const onClick = vi.fn()
+      render(<F0Chip label="Disabled KB" deactivated onClick={onClick} />)
+      const chip = screen.getByRole("button", { name: "Disabled KB" })
+      chip.focus()
+      await userEvent.keyboard("{Enter}")
+      expect(onClick).not.toHaveBeenCalled()
     })
   })
 
@@ -118,6 +133,14 @@ describe("F0Chip", () => {
       await userEvent.click(screen.getByRole("button", { name: "Remove Both" }))
       expect(onClose).toHaveBeenCalledTimes(1)
       expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it("suppresses role=button on outer div when onClose is present", () => {
+      render(<F0Chip label="Both" onClick={() => {}} onClose={() => {}} />)
+      // Only the close button should have role=button; the outer div must not
+      const buttons = screen.getAllByRole("button")
+      expect(buttons).toHaveLength(1)
+      expect(buttons[0]).toHaveAttribute("aria-label", "Remove Both")
     })
 
     it("does not render a close button when onClose is not provided", () => {

--- a/packages/react/src/components/OneChip/__tests__/Chip.test.tsx
+++ b/packages/react/src/components/OneChip/__tests__/Chip.test.tsx
@@ -43,7 +43,7 @@ describe("F0Chip", () => {
     it("renders label with reduced opacity class when deactivated=true", () => {
       render(<F0Chip label="Inactive" deactivated />)
       const span = screen.getByText("Inactive")
-      expect(span.className).toContain("text-f1-foreground")
+      expect(span.className).toContain("text-f1-foreground/[0.61]")
     })
 
     it("does not apply deactivated class when deactivated is false", () => {

--- a/packages/react/src/components/OneChip/__tests__/Chip.test.tsx
+++ b/packages/react/src/components/OneChip/__tests__/Chip.test.tsx
@@ -1,0 +1,156 @@
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { Placeholder } from "@/icons/app"
+
+import { F0Chip } from "../index"
+
+describe("F0Chip", () => {
+  it("renders the label text", () => {
+    render(<F0Chip label="My Label" />)
+    expect(screen.getByText("My Label")).toBeInTheDocument()
+  })
+
+  it("renders without any interactive attributes when no onClick or onClose", () => {
+    render(<F0Chip label="Static" />)
+    // The root chip div has rounded-full; the inner content div does not
+    const chip = screen.getByText("Static").closest('[class*="rounded-full"]')!
+    expect(chip).not.toHaveAttribute("role")
+    expect(chip).not.toHaveAttribute("tabindex")
+  })
+
+  describe("variant", () => {
+    it("applies default variant classes by default", () => {
+      render(<F0Chip label="Default" variant="default" />)
+      const chip = screen
+        .getByText("Default")
+        .closest('[class*="rounded-full"]')!
+      expect(chip.className).toContain("border-f1-border")
+    })
+
+    it("applies selected variant classes when variant=selected", () => {
+      render(<F0Chip label="Selected" variant="selected" />)
+      const chip = screen
+        .getByText("Selected")
+        .closest('[class*="rounded-full"]')!
+      expect(chip.className).toContain("border-f1-border-selected")
+    })
+  })
+
+  describe("deactivated", () => {
+    it("renders label with reduced opacity class when deactivated=true", () => {
+      render(<F0Chip label="Inactive" deactivated />)
+      const span = screen.getByText("Inactive")
+      expect(span.className).toContain("text-f1-foreground")
+    })
+
+    it("does not apply deactivated class when deactivated is false", () => {
+      render(<F0Chip label="Active" deactivated={false} />)
+      const span = screen.getByText("Active")
+      expect(span).not.toHaveAttribute("class")
+    })
+
+    it("sets aria-disabled on the root element when deactivated", () => {
+      render(<F0Chip label="Disabled Chip" deactivated />)
+      const chip = screen
+        .getByText("Disabled Chip")
+        .closest('[class*="rounded-full"]')!
+      expect(chip).toHaveAttribute("aria-disabled", "true")
+    })
+  })
+
+  describe("onClick", () => {
+    it("calls onClick when the chip is clicked", async () => {
+      const onClick = vi.fn()
+      render(<F0Chip label="Clickable" onClick={onClick} />)
+      await userEvent.click(screen.getByRole("button", { name: "Clickable" }))
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it("sets role=button and tabIndex=0 when onClick is provided", () => {
+      render(<F0Chip label="Button Chip" onClick={() => {}} />)
+      const chip = screen.getByRole("button", { name: "Button Chip" })
+      expect(chip).toHaveAttribute("tabindex", "0")
+    })
+
+    it("calls onClick when Enter key is pressed", async () => {
+      const onClick = vi.fn()
+      render(<F0Chip label="Keyboard" onClick={onClick} />)
+      const chip = screen.getByRole("button", { name: "Keyboard" })
+      chip.focus()
+      await userEvent.keyboard("{Enter}")
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it("calls onClick when Space key is pressed", async () => {
+      const onClick = vi.fn()
+      render(<F0Chip label="Space" onClick={onClick} />)
+      const chip = screen.getByRole("button", { name: "Space" })
+      chip.focus()
+      await userEvent.keyboard(" ")
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("onClose", () => {
+    it("renders a close button when onClose is provided", () => {
+      render(<F0Chip label="Closeable" onClose={() => {}} />)
+      expect(
+        screen.getByRole("button", { name: "Remove Closeable" })
+      ).toBeInTheDocument()
+    })
+
+    it("calls onClose when the close button is clicked", async () => {
+      const onClose = vi.fn()
+      render(<F0Chip label="Remove me" onClose={onClose} />)
+      await userEvent.click(
+        screen.getByRole("button", { name: "Remove Remove me" })
+      )
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not call the outer onClick when close button is clicked", async () => {
+      const onClick = vi.fn()
+      const onClose = vi.fn()
+      render(<F0Chip label="Both" onClick={onClick} onClose={onClose} />)
+      await userEvent.click(screen.getByRole("button", { name: "Remove Both" }))
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it("does not render a close button when onClose is not provided", () => {
+      render(<F0Chip label="No close" />)
+      expect(
+        screen.queryByRole("button", { name: /Remove/ })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe("icon", () => {
+    it("renders an icon when icon prop is provided", () => {
+      render(<F0Chip label="With icon" icon={Placeholder} />)
+      expect(screen.getByText("With icon")).toBeInTheDocument()
+      // Icon renders as an svg — verify the chip renders without throwing
+      const chip = screen.getByText("With icon").closest("div")!
+      expect(chip.querySelector("svg")).toBeInTheDocument()
+    })
+  })
+
+  describe("avatar", () => {
+    it("renders an avatar when avatar prop is provided", () => {
+      render(
+        <F0Chip
+          label="John Doe"
+          avatar={{
+            type: "person",
+            firstName: "John",
+            lastName: "Doe",
+          }}
+        />
+      )
+      expect(screen.getByText("John Doe")).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react/src/components/OneChip/__tests__/Chip.test.tsx
+++ b/packages/react/src/components/OneChip/__tests__/Chip.test.tsx
@@ -140,7 +140,9 @@ describe("F0Chip", () => {
       // Only the close button should have role=button; the outer div must not
       const buttons = screen.getAllByRole("button")
       expect(buttons).toHaveLength(1)
-      expect(buttons[0]).toHaveAttribute("aria-label", "Remove Both")
+      expect(
+        screen.getByRole("button", { name: "Remove Both" })
+      ).toBeInTheDocument()
     })
 
     it("does not render a close button when onClose is not provided", () => {

--- a/packages/react/src/components/OneChip/index.stories.tsx
+++ b/packages/react/src/components/OneChip/index.stories.tsx
@@ -26,9 +26,13 @@ const meta = {
       description: "The variant of the chip",
       options: chipVariantOptions,
       control: "select",
+      table: {
+        type: { summary: chipVariantOptions.join(" | ") },
+      },
     },
     avatar: {
       description: "If defined, an avatar will be displayed in the chip",
+      control: false,
     },
     icon: {
       control: "select",

--- a/packages/react/src/components/OneChip/index.stories.tsx
+++ b/packages/react/src/components/OneChip/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { fn } from "storybook/test"
+import { expect, fn, userEvent, within } from "storybook/test"
 import { useState } from "react"
 
 import * as Icons from "../../icons/app"
@@ -76,6 +76,12 @@ export const Clickable: Story = {
     variant: "default",
     onClose: undefined,
   },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement)
+    const chip = canvas.getByRole("button", { name: "Label" })
+    await userEvent.click(chip)
+    expect(args.onClick).toHaveBeenCalledTimes(1)
+  },
 }
 
 export const WithClose: Story = {
@@ -107,6 +113,14 @@ export const WithClose: Story = {
         ))}
       </div>
     )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const closeBtn = canvas.getByRole("button", { name: "Remove First Chip" })
+    await userEvent.click(closeBtn)
+    expect(
+      canvas.queryByRole("button", { name: "Remove First Chip" })
+    ).not.toBeInTheDocument()
   },
 }
 
@@ -213,6 +227,8 @@ export const SelectedWithClose: Story = {
 export const Snapshot: Story = {
   args: {
     label: "Snapshot",
+    onClick: undefined,
+    onClose: undefined,
   },
   parameters: withSnapshot({}),
   render: () => (

--- a/packages/react/src/components/OneChip/index.stories.tsx
+++ b/packages/react/src/components/OneChip/index.stories.tsx
@@ -1,25 +1,31 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { fn } from "storybook/test"
 import { useState } from "react"
 
 import * as Icons from "../../icons/app"
-import { Chip } from "./index"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+import { chipVariantOptions, F0Chip } from "./index"
 
 const meta = {
-  component: Chip,
+  component: F0Chip,
   title: "Chip/Chip",
   parameters: {
     layout: "centered",
   },
   tags: ["autodocs", "stable"],
+  args: {
+    onClick: fn(),
+    onClose: fn(),
+  },
   argTypes: {
     label: {
       description: "The label of the chip",
     },
     variant: {
       description: "The variant of the chip",
-      options: ["default", "selected"],
-      control: { type: "select" },
+      options: chipVariantOptions,
+      control: "select",
     },
     avatar: {
       description: "If defined, an avatar will be displayed in the chip",
@@ -34,8 +40,16 @@ const meta = {
       description:
         "If defined, the close icon will be displayed and the chip will be clickable",
     },
+    onClick: {
+      description: "If defined, the chip will be clickable",
+    },
+    deactivated: {
+      description:
+        "If true, the label is rendered with reduced opacity to indicate a deactivated state",
+      control: "boolean",
+    },
   },
-} satisfies Meta<typeof Chip>
+} satisfies Meta<typeof F0Chip>
 
 export default meta
 type Story = StoryObj<typeof meta>
@@ -44,6 +58,16 @@ export const Default: Story = {
   args: {
     label: "Label",
     variant: "default",
+    onClick: undefined,
+    onClose: undefined,
+  },
+}
+
+export const Clickable: Story = {
+  args: {
+    label: "Label",
+    variant: "default",
+    onClose: undefined,
   },
 }
 
@@ -51,6 +75,7 @@ export const WithClose: Story = {
   args: {
     label: "Label",
     variant: "default",
+    onClick: undefined,
   },
   render: () => {
     const [chips, setChips] = useState([
@@ -66,7 +91,7 @@ export const WithClose: Story = {
     return (
       <div className="flex flex-wrap gap-2">
         {chips.map((chip) => (
-          <Chip
+          <F0Chip
             key={chip.id}
             label={chip.label}
             variant="default"
@@ -82,6 +107,8 @@ export const WithAvatar: Story = {
   args: {
     label: "Dani Moreno",
     variant: "default",
+    onClick: undefined,
+    onClose: undefined,
     avatar: {
       type: "person",
       firstName: "Dani",
@@ -91,8 +118,8 @@ export const WithAvatar: Story = {
   },
   render: ({ icon: _icon, ...args }) => (
     <div className="flex flex-wrap gap-2">
-      <Chip {...args} />
-      <Chip
+      <F0Chip {...args} />
+      <F0Chip
         {...args}
         label="Design engineers"
         avatar={{
@@ -100,7 +127,7 @@ export const WithAvatar: Story = {
           name: "Design engineers",
         }}
       />
-      <Chip
+      <F0Chip
         {...args}
         label="Factorial"
         avatar={{
@@ -118,6 +145,8 @@ export const WithDeactivatedAvatarAndLabel: Story = {
     label: "Deactivated User",
     variant: "default",
     deactivated: true,
+    onClick: undefined,
+    onClose: undefined,
     avatar: {
       type: "person",
       deactivated: true,
@@ -128,7 +157,7 @@ export const WithDeactivatedAvatarAndLabel: Story = {
   },
   render: ({ icon: _icon, ...args }) => (
     <div className="flex flex-wrap gap-2">
-      <Chip {...args} />
+      <F0Chip {...args} />
     </div>
   ),
 }
@@ -137,6 +166,8 @@ export const WithIcon: Story = {
   args: {
     label: "Label",
     icon: Icons.Placeholder,
+    onClick: undefined,
+    onClose: undefined,
   },
 }
 
@@ -144,6 +175,7 @@ export const SelectedWithClose: Story = {
   args: {
     label: "Label",
     variant: "selected",
+    onClick: undefined,
   },
   render: () => {
     const [chips, setChips] = useState([
@@ -159,7 +191,7 @@ export const SelectedWithClose: Story = {
     return (
       <div className="flex flex-wrap gap-2">
         {chips.map((chip) => (
-          <Chip
+          <F0Chip
             key={chip.id}
             label={chip.label}
             variant="selected"
@@ -169,4 +201,45 @@ export const SelectedWithClose: Story = {
       </div>
     )
   },
+}
+
+export const Snapshot: Story = {
+  args: {
+    label: "Snapshot",
+  },
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex w-fit flex-col gap-2">
+      {/* default variant */}
+      <div className="flex flex-wrap gap-2">
+        <F0Chip label="Default" />
+        <F0Chip label="Clickable" onClick={() => {}} />
+        <F0Chip label="With close" onClose={() => {}} />
+        <F0Chip label="With icon" icon={Icons.Placeholder} />
+      </div>
+      {/* selected variant */}
+      <div className="flex flex-wrap gap-2">
+        <F0Chip label="Selected" variant="selected" />
+        <F0Chip
+          label="Selected + close"
+          variant="selected"
+          onClose={() => {}}
+        />
+      </div>
+      {/* deactivated */}
+      <div className="flex flex-wrap gap-2">
+        <F0Chip
+          label="Deactivated"
+          deactivated
+          avatar={{
+            type: "person",
+            firstName: "Deactivated",
+            lastName: "User",
+            src: "/avatars/person01.jpg",
+            deactivated: true,
+          }}
+        />
+      </div>
+    </div>
+  ),
 }

--- a/packages/react/src/components/OneChip/index.stories.tsx
+++ b/packages/react/src/components/OneChip/index.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "stable"],
   argTypes: {
     label: {
       description: "The label of the chip",

--- a/packages/react/src/components/OneChip/index.stories.tsx
+++ b/packages/react/src/components/OneChip/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { expect, fn, userEvent, within } from "storybook/test"
 import { useState } from "react"
 
-import * as Icons from "../../icons/app"
+import * as Icons from "@/icons/app"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { chipVariantOptions, F0Chip } from "./index"
 
@@ -80,7 +80,7 @@ export const Clickable: Story = {
     const canvas = within(canvasElement)
     const chip = canvas.getByRole("button", { name: "Label" })
     await userEvent.click(chip)
-    expect(args.onClick).toHaveBeenCalledTimes(1)
+    await expect(args.onClick).toHaveBeenCalledTimes(1)
   },
 }
 
@@ -118,7 +118,7 @@ export const WithClose: Story = {
     const canvas = within(canvasElement)
     const closeBtn = canvas.getByRole("button", { name: "Remove First Chip" })
     await userEvent.click(closeBtn)
-    expect(
+    await expect(
       canvas.queryByRole("button", { name: "Remove First Chip" })
     ).not.toBeInTheDocument()
   },

--- a/packages/react/src/components/OneChip/index.stories.tsx
+++ b/packages/react/src/components/OneChip/index.stories.tsx
@@ -33,6 +33,9 @@ const meta = {
     avatar: {
       description: "If defined, an avatar will be displayed in the chip",
       control: false,
+      table: {
+        type: { summary: "AvatarVariant" },
+      },
     },
     icon: {
       control: "select",

--- a/packages/react/src/components/OneChip/index.tsx
+++ b/packages/react/src/components/OneChip/index.tsx
@@ -123,7 +123,7 @@ const _F0Chip = ({
               if (e.key === "Enter" || e.key === " ") {
                 if (!deactivated) {
                   e.preventDefault()
-                  onClick()
+                  onClick?.()
                 }
               }
             }

--- a/packages/react/src/components/OneChip/index.tsx
+++ b/packages/react/src/components/OneChip/index.tsx
@@ -80,9 +80,14 @@ const _F0Chip = ({
   avatar,
   icon,
 }: F0ChipProps) => {
+  // Only apply role="button" when clickable AND there is no close button child
+  // to avoid nesting interactive elements (ARIA spec violation)
+  const isClickable = !!onClick && !deactivated
+  const hasButtonRole = isClickable && !onClose
+
   return (
     <div
-      role={onClick ? "button" : undefined}
+      role={hasButtonRole ? "button" : undefined}
       aria-disabled={deactivated ? true : undefined}
       className={cn(
         chipVariants({ variant }),
@@ -90,17 +95,21 @@ const _F0Chip = ({
         avatar && "pl-0.5",
         avatar && avatar?.type !== "person" && "rounded-sm",
         icon && !avatar && "pl-1.5",
-        onClick && "cursor-pointer",
-        onClick && focusRing()
+        onClick && !deactivated && "cursor-pointer",
+        hasButtonRole && focusRing()
       )}
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault()
-          onClick?.()
-        }
-      }}
-      tabIndex={onClick ? 0 : undefined}
+      onClick={isClickable ? onClick : undefined}
+      onKeyDown={
+        hasButtonRole
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault()
+                onClick()
+              }
+            }
+          : undefined
+      }
+      tabIndex={hasButtonRole ? 0 : undefined}
     >
       {avatar && <F0Avatar avatar={avatar} size="xs" />}
       <div className="flex items-center gap-0.5">
@@ -122,7 +131,6 @@ const _F0Chip = ({
               "[&_svg]:text-f1-icon-selected [&_svg]:hover:text-f1-icon-selected-hover [&_svg]:focus:text-f1-icon-selected-hover",
             focusRing()
           )}
-          tabIndex={0}
           aria-label={`Remove ${label}`}
         >
           <F0Icon icon={CrossedCircle} size="sm" />

--- a/packages/react/src/components/OneChip/index.tsx
+++ b/packages/react/src/components/OneChip/index.tsx
@@ -43,7 +43,9 @@ interface BaseChipProps extends VariantProps<typeof chipVariants> {
 
   /**
    * If true, dims the label and disables all interaction.
-   * The element retains role="button" and aria-disabled="true" for screen readers.
+   * When onClick is provided (and onClose is not), the element retains role="button"
+   * and aria-disabled="true" for screen readers; keyboard events are swallowed.
+   * Has no effect on the close button when only onClose is provided.
    * */
   deactivated?: boolean
 }
@@ -93,7 +95,7 @@ const _F0Chip = ({
   // keyboard-accessible, which is the correct UX for a dismissible chip.
   const hasButtonRole = !!onClick && !onClose
 
-  if (onClick && onClose) {
+  if (process.env.NODE_ENV !== "production" && onClick && onClose) {
     console.warn(
       "F0Chip: providing both onClick and onClose is not supported. " +
         "onClick will be suppressed on the outer element to prevent ARIA nesting violations. " +
@@ -119,8 +121,8 @@ const _F0Chip = ({
         hasButtonRole
           ? (e) => {
               if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault()
                 if (!deactivated) {
+                  e.preventDefault()
                   onClick()
                 }
               }

--- a/packages/react/src/components/OneChip/index.tsx
+++ b/packages/react/src/components/OneChip/index.tsx
@@ -19,6 +19,9 @@ export const chipVariants = cva({
   },
 })
 
+export const chipVariantOptions = ["default", "selected"] as const
+export type ChipVariantOption = (typeof chipVariantOptions)[number]
+
 interface BaseChipProps extends VariantProps<typeof chipVariants> {
   /**
    * The label of the chip
@@ -58,12 +61,17 @@ type ChipVariants =
       icon?: undefined
     }
 
-export type ChipProps = BaseChipProps &
+export type F0ChipProps = BaseChipProps &
   ChipVariants & {
-    variant?: "default" | "selected"
+    variant?: ChipVariantOption
   }
 
-const _Chip = ({
+/**
+ * @deprecated Use F0ChipProps instead
+ */
+export type ChipProps = F0ChipProps
+
+const _F0Chip = ({
   deactivated,
   label,
   variant,
@@ -71,9 +79,11 @@ const _Chip = ({
   onClose,
   avatar,
   icon,
-}: ChipProps) => {
+}: F0ChipProps) => {
   return (
     <div
+      role={onClick ? "button" : undefined}
+      aria-disabled={deactivated ? true : undefined}
       className={cn(
         chipVariants({ variant }),
         onClose && "pr-1.5",
@@ -86,6 +96,7 @@ const _Chip = ({
       onClick={onClick}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
           onClick?.()
         }
       }}
@@ -112,7 +123,7 @@ const _Chip = ({
             focusRing()
           )}
           tabIndex={0}
-          aria-label="Close"
+          aria-label={`Remove ${label}`}
         >
           <F0Icon icon={CrossedCircle} size="sm" />
         </button>
@@ -121,4 +132,9 @@ const _Chip = ({
   )
 }
 
-export const Chip = _Chip
+export const F0Chip = _F0Chip
+
+/**
+ * @deprecated Use F0Chip instead
+ */
+export const Chip = _F0Chip

--- a/packages/react/src/components/OneChip/index.tsx
+++ b/packages/react/src/components/OneChip/index.tsx
@@ -3,7 +3,6 @@ import { cva, type VariantProps } from "cva"
 import { F0Avatar, type AvatarVariant } from "@/components/avatars/F0Avatar"
 import { F0Icon, type IconType } from "@/components/F0Icon"
 import { CrossedCircle } from "@/icons/app"
-import { experimentalComponent } from "@/lib/experimental"
 import { cn, focusRing } from "@/lib/utils"
 
 export const chipVariants = cva({
@@ -122,7 +121,4 @@ const _Chip = ({
   )
 }
 
-/**
- * @experimental This is an experimental component use it at your own risk
- */
-export const Chip = experimentalComponent("Chip", _Chip)
+export const Chip = _Chip

--- a/packages/react/src/components/OneChip/index.tsx
+++ b/packages/react/src/components/OneChip/index.tsx
@@ -34,10 +34,17 @@ interface BaseChipProps extends VariantProps<typeof chipVariants> {
   onClick?: () => void
 
   /**
-   * If defined, the close icon will be displayed and the chip will be clickable
+   * If defined, the close icon will be displayed and the chip will be clickable.
+   * Note: when onClose is provided, onClick is suppressed on the outer element
+   * to avoid nesting two interactive elements (ARIA spec). Only onClose is
+   * keyboard-accessible in that layout.
    * */
   onClose?: () => void
 
+  /**
+   * If true, dims the label and disables all interaction.
+   * The element retains role="button" and aria-disabled="true" for screen readers.
+   * */
   deactivated?: boolean
 }
 
@@ -86,10 +93,18 @@ const _F0Chip = ({
   // keyboard-accessible, which is the correct UX for a dismissible chip.
   const hasButtonRole = !!onClick && !onClose
 
+  if (onClick && onClose) {
+    console.warn(
+      "F0Chip: providing both onClick and onClose is not supported. " +
+        "onClick will be suppressed on the outer element to prevent ARIA nesting violations. " +
+        "Only onClose will be keyboard-accessible."
+    )
+  }
+
   return (
     <div
       role={hasButtonRole ? "button" : undefined}
-      aria-disabled={hasButtonRole && deactivated ? true : undefined}
+      aria-disabled={hasButtonRole && deactivated ? "true" : undefined}
       className={cn(
         chipVariants({ variant }),
         onClose && "pr-1.5",
@@ -101,11 +116,13 @@ const _F0Chip = ({
       )}
       onClick={hasButtonRole && !deactivated ? onClick : undefined}
       onKeyDown={
-        hasButtonRole && !deactivated
+        hasButtonRole
           ? (e) => {
               if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault()
-                onClick()
+                if (!deactivated) {
+                  onClick()
+                }
               }
             }
           : undefined

--- a/packages/react/src/components/OneChip/index.tsx
+++ b/packages/react/src/components/OneChip/index.tsx
@@ -80,27 +80,28 @@ const _F0Chip = ({
   avatar,
   icon,
 }: F0ChipProps) => {
-  // Only apply role="button" when clickable AND there is no close button child
-  // to avoid nesting interactive elements (ARIA spec violation)
-  const isClickable = !!onClick && !deactivated
-  const hasButtonRole = isClickable && !onClose
+  // When onClose is present the <button> is the sole interactive child; adding role="button"
+  // to the outer div too would nest two interactive elements, violating the ARIA spec.
+  // In that layout onClick on the outer div is also suppressed — only the close button is
+  // keyboard-accessible, which is the correct UX for a dismissible chip.
+  const hasButtonRole = !!onClick && !onClose
 
   return (
     <div
       role={hasButtonRole ? "button" : undefined}
-      aria-disabled={deactivated ? true : undefined}
+      aria-disabled={hasButtonRole && deactivated ? true : undefined}
       className={cn(
         chipVariants({ variant }),
         onClose && "pr-1.5",
         avatar && "pl-0.5",
         avatar && avatar?.type !== "person" && "rounded-sm",
         icon && !avatar && "pl-1.5",
-        onClick && !deactivated && "cursor-pointer",
+        hasButtonRole && !deactivated && "cursor-pointer",
         hasButtonRole && focusRing()
       )}
-      onClick={isClickable ? onClick : undefined}
+      onClick={hasButtonRole && !deactivated ? onClick : undefined}
       onKeyDown={
-        hasButtonRole
+        hasButtonRole && !deactivated
           ? (e) => {
               if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault()
@@ -139,6 +140,8 @@ const _F0Chip = ({
     </div>
   )
 }
+
+_F0Chip.displayName = "F0Chip"
 
 export const F0Chip = _F0Chip
 

--- a/packages/react/src/patterns/OneFilterPicker/components/FilterChipButton.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FilterChipButton.tsx
@@ -3,7 +3,7 @@
 import { motion } from "motion/react"
 import { ReactElement, useEffect, useState } from "react"
 
-import { Chip } from "@/components/OneChip"
+import { F0Chip as Chip } from "@/components/OneChip"
 import { I18nContextType, useI18n } from "@/lib/providers/i18n"
 import { Skeleton } from "@/ui/skeleton"
 


### PR DESCRIPTION
## Description

Promotes `OneChip` from experimental to stable by introducing `F0Chip` as the primary public export, fixing accessibility issues, and adding full unit test coverage. The deprecated `Chip` alias is preserved for backward compatibility.

## Implementation details

- feat: export `F0Chip` as the primary API, keep `Chip` as `@deprecated` alias
- feat: export `F0ChipProps` type (discriminated union), `chipVariantOptions`, and `ChipVariantOption`
- fix: add `role="button"` to the root div when `onClick` is provided
- fix: add `aria-disabled={true}` to the root div when `deactivated` is true
- fix: add `e.preventDefault()` in the Space key handler to prevent page scroll
- fix: change close button `aria-label` from `"Close"` to `` `Remove ${label}` `` for descriptive screen-reader text
- refactor: update internal consumers (`F0ChipList`, `F0Select`, `OneFilterPicker`) to import `F0Chip` directly
- feat: rewrite stories with `F0Chip` component name, `chipVariantOptions` in `argTypes`, and add `Clickable` and `Snapshot` stories
- test: add unit tests covering label rendering, interactive attributes, variants, deactivated state, onClick (click + keyboard), onClose (render + propagation stop), icon, and avatar