### PR TITLE
refactor(F0Checkbox): promote from experimental to stable

### DIFF
--- a/packages/react/src/components/F0Checkbox/F0Checkbox.tsx
+++ b/packages/react/src/components/F0Checkbox/F0Checkbox.tsx
@@ -1,6 +1,5 @@
 import { DataAttributes } from "@/global.types"
 import { withDataTestId } from "@/lib/data-testid"
-import { experimentalComponent } from "@/lib/experimental"
 import { Checkbox as CheckboxRoot } from "@/ui/checkbox"
 
 interface CheckboxProps extends DataAttributes {
@@ -106,9 +105,4 @@ function _F0Checkbox({
   )
 }
 
-/**
- * @experimental This is an experimental component use it at your own risk
- */
-export const F0Checkbox = withDataTestId(
-  experimentalComponent<typeof _F0Checkbox>("F0Checkbox", _F0Checkbox)
-)
+export const F0Checkbox = withDataTestId(_F0Checkbox)

--- a/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.stories.tsx
+++ b/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.stories.tsx
@@ -9,7 +9,7 @@ import { F0Checkbox } from "../F0Checkbox"
 
 const meta = {
   component: F0Checkbox,
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "stable"],
   title: "Checkbox",
   parameters: {
     layout: "centered",


### PR DESCRIPTION
## Summary

- Promotes `F0Checkbox` from experimental to stable
- Removes `experimentalComponent()` wrapper and the `@experimental` JSDoc comment
- Removes the now-unused `import { experimentalComponent } from "@/lib/experimental"`
- Updates story tag from `"experimental"` to `"stable"`

## Changes

- `F0Checkbox.tsx`: Remove `experimentalComponent` import, `@experimental` JSDoc, and unwrap the export to `withDataTestId(_F0Checkbox)`
- `F0Checkbox.stories.tsx`: Change `tags: ["autodocs", "experimental"]` → `tags: ["autodocs", "stable"]`