### PR TITLE
refactor(F0Select): promote from experimental to stable

### DIFF
--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -320,7 +320,7 @@ const meta: Meta = {
       </div>
     ),
   ],
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "stable"],
 } satisfies Meta<typeof F0Select>
 
 export default meta

--- a/packages/react/src/components/F0Select/index.tsx
+++ b/packages/react/src/components/F0Select/index.tsx
@@ -1,10 +1,2 @@
-import { experimentalComponent } from "@/lib/experimental"
-
-import { F0Select as F0SelectComponent } from "./F0Select"
-
 export * from "./types"
-
-/**
- * @experimental This is an experimental component use it at your own risk
- */
-export const F0Select = experimentalComponent("F0Select", F0SelectComponent)
+export { F0Select } from "./F0Select"


### PR DESCRIPTION
## Summary

- Removes `experimentalComponent()` wrapper from `F0Select` export
- Removes `@experimental` JSDoc comment from `index.tsx`
- Removes unused `import { experimentalComponent } from "@/lib/experimental"`
- Updates story tags from `"experimental"` to `"stable"` in `F0Select.stories.tsx`

## Changes

- `packages/react/src/components/F0Select/index.tsx` — simplified to direct re-export
- `packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx` — tag updated to `stable`