### PR TITLE
refactor(F0DatePicker): promote from experimental to stable

### DIFF
--- a/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.stories.tsx
+++ b/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.stories.tsx
@@ -96,7 +96,7 @@ const meta = {
     ...getInputFieldArgs(inputFieldInheritedProps),
     ...dataTestIdArgs,
   },
-  tags: ["autodocs", "experimental"],
+  tags: ["autodocs", "stable"],
   decorators: [
     (Story, { args, parameters }) => {
       const width = parameters?.width || "300px"

--- a/packages/react/src/components/F0DatePicker/index.ts
+++ b/packages/react/src/components/F0DatePicker/index.ts
@@ -1,13 +1,7 @@
 import { withDataTestId } from "@/lib/data-testid"
-import { experimentalComponent } from "@/lib/experimental"
 
 import { F0DatePicker as _F0DatePicker } from "./F0DatePicker"
 export * from "./presets"
 export * from "./types"
 
-/**
- * @experimental This is an experimental component use it at your own risk
- */
-export const F0DatePicker = withDataTestId(
-  experimentalComponent<typeof _F0DatePicker>("F0DatePicker", _F0DatePicker)
-)
+export const F0DatePicker = withDataTestId(_F0DatePicker)


### PR DESCRIPTION
## Summary

- Removes `experimentalComponent()` wrapper from `F0DatePicker` export
- Removes `@experimental` JSDoc comment and unused `experimentalComponent` import
- Updates Storybook stories tag from `"experimental"` to `"stable"`

## Changes

- `packages/react/src/components/F0DatePicker/index.ts` — simplified export using `withDataTestId` directly
- `packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.stories.tsx` — updated tags to `["autodocs", "stable"]`