### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.436.0",
+  "packages/react": "1.436.1",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.436.1](https://github.com/factorialco/f0/compare/f0-react-v1.436.0...f0-react-v1.436.1) (2026-04-03)
+
+
+### Bug Fixes
+
+* pass useUpload hook at F0Form level instead of field-level ([#3752](https://github.com/factorialco/f0/issues/3752)) ([9e7775b](https://github.com/factorialco/f0/commit/9e7775b6a73e2c27e74637bc406e11ca69691f6f))
+
 ## [1.436.0](https://github.com/factorialco/f0/compare/f0-react-v1.435.0...f0-react-v1.436.0) (2026-04-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.436.0",
+  "version": "1.436.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.436.1</summary>

## [1.436.1](https://github.com/factorialco/f0/compare/f0-react-v1.436.0...f0-react-v1.436.1) (2026-04-03)


### Bug Fixes

* pass useUpload hook at F0Form level instead of field-level ([#3752](https://github.com/factorialco/f0/issues/3752)) ([9e7775b](https://github.com/factorialco/f0/commit/9e7775b6a73e2c27e74637bc406e11ca69691f6f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).