### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.436.1",
+  "packages/react": "1.437.0",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.437.0](https://github.com/factorialco/f0/compare/f0-react-v1.436.1...f0-react-v1.437.0) (2026-04-03)
+
+
+### Features
+
+* add support for nested fields rendered inside card selectable groups ([#3833](https://github.com/factorialco/f0/issues/3833)) ([5d7e2f8](https://github.com/factorialco/f0/commit/5d7e2f8f61db54710638b5190a982ca9b649b11b))
+
 ## [1.436.1](https://github.com/factorialco/f0/compare/f0-react-v1.436.0...f0-react-v1.436.1) (2026-04-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.436.1",
+  "version": "1.437.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.437.0</summary>

## [1.437.0](https://github.com/factorialco/f0/compare/f0-react-v1.436.1...f0-react-v1.437.0) (2026-04-03)


### Features

* add support for nested fields rendered inside card selectable groups ([#3833](https://github.com/factorialco/f0/issues/3833)) ([5d7e2f8](https://github.com/factorialco/f0/commit/5d7e2f8f61db54710638b5190a982ca9b649b11b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).