### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.438.0",
+  "packages/react": "1.438.1",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.438.1](https://github.com/factorialco/f0/compare/f0-react-v1.438.0...f0-react-v1.438.1) (2026-04-03)
+
+
+### Bug Fixes
+
+* improve numeric fields in f0form ([#3854](https://github.com/factorialco/f0/issues/3854)) ([567b703](https://github.com/factorialco/f0/commit/567b703e881596d8019c925b893723da5136b9f6))
+
 ## [1.438.0](https://github.com/factorialco/f0/compare/f0-react-v1.437.0...f0-react-v1.438.0) (2026-04-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.438.0",
+  "version": "1.438.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.438.1</summary>

## [1.438.1](https://github.com/factorialco/f0/compare/f0-react-v1.438.0...f0-react-v1.438.1) (2026-04-03)


### Bug Fixes

* improve numeric fields in f0form ([#3854](https://github.com/factorialco/f0/issues/3854)) ([567b703](https://github.com/factorialco/f0/commit/567b703e881596d8019c925b893723da5136b9f6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).