### PR TITLE
fix: F0TagList overflow visibility, HoverCard interaction, and popover styling

### DIFF
--- a/packages/react/src/components/tags/F0TagList/F0TagList.tsx
+++ b/packages/react/src/components/tags/F0TagList/F0TagList.tsx
@@ -20,6 +20,7 @@ export const F0TagList = <T extends TagType>({
     <OverflowList
       items={tagVariants}
       max={max}
+      min={1}
       renderListItem={(tag) => <Tag tag={tag} />}
       renderDropdownItem={() => null}
       forceShowingOverflowIndicator={initialRemainingCount !== undefined}

--- a/packages/react/src/components/tags/F0TagList/components/TagCounter.tsx
+++ b/packages/react/src/components/tags/F0TagList/components/TagCounter.tsx
@@ -19,10 +19,15 @@ export const TagCounter = ({ count, list }: Props) => {
   return (
     <HoverCard>
       <HoverCardTrigger>
-        <span className="cursor-pointer">{counter}</span>
+        <span className="pointer-events-auto relative z-[1] cursor-pointer">
+          {counter}
+        </span>
       </HoverCardTrigger>
-      <HoverCardContent side="top">
-        <ScrollArea className="[*[data-state=visible]_div]:bg-f1-background dark flex max-h-[220px] flex-col">
+      <HoverCardContent
+        side="top"
+        className="bg-f1-background text-f1-foreground shadow-md ring-1 ring-f1-border-secondary"
+      >
+        <ScrollArea className="flex max-h-[220px] flex-col">
           {list.map((tag, index) => (
             <div
               key={index}
@@ -39,10 +44,7 @@ export const TagCounter = ({ count, list }: Props) => {
               )}
             </div>
           ))}
-          <ScrollBar
-            orientation="vertical"
-            className="[&_div]:bg-f1-background"
-          />
+          <ScrollBar orientation="vertical" />
         </ScrollArea>
       </HoverCardContent>
     </HoverCard>


### PR DESCRIPTION
## Summary

### Show at least one tag before the counter

**What:** Added `min={1}` to the `OverflowList` inside `F0TagList`.

**Why:** When rendered in narrow containers (e.g., DataCollection table cells), the overflow calculation can resolve to 0 visible items due to layout race conditions or insufficient initial width. This results in displaying only a "+3" counter with no tag chips visible at all, which provides no context about the actual content. Showing at least one tag is the expected behavior — existing tests for `OverflowList` never assert 0 visible items as a valid state.

### Fix HoverCard not triggering inside table cells

**What:** Added `pointer-events-auto relative z-[1]` to the `TagCounter` HoverCard trigger.

**Why:** DataCollection table cells wrap their content in a `pointer-events-none` div to allow an underlying full-cell navigation link to receive clicks. This blocks all hover events on the "+N" badge, making the HoverCard impossible to open. Other interactive elements inside table cells (checkboxes, editable fields) already use the same `pointer-events-auto` escape hatch — the TagCounter was missing it.

### Use light popover style for the TagCounter HoverCard

**What:** Replaced the hardcoded dark inverse tokens (`bg-f1-background-inverse`) with semantic theme tokens (`bg-f1-background`, `text-f1-foreground`) and removed the `dark` class workaround from the ScrollArea.

**Why:** The dark tooltip style was inherited from the base `HoverCardContent` defaults and doesn't match the popover context of a tag list. Using semantic tokens ensures the popover looks correct in the current theme and will adapt automatically to a future dark mode, unlike the previous inverse approach which would flip to a light popover in dark mode.

**Before:**

<img width="942" height="386" alt="Screenshot 2026-04-03 at 15 30 35" src="https://github.com/user-attachments/assets/0bef3bf3-406f-4666-8e11-dcdaa87f8406" />

**After:**

<img width="1087" height="393" alt="Screenshot 2026-04-03 at 15 31 06" src="https://github.com/user-attachments/assets/978c471f-4b8a-400d-89bd-81b5ec1da80b" />


- [Jira Ticket](https://factorialmakers.atlassian.net/browse/FCT-50904)
