### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.438.2",
+  "packages/react": "1.438.3",
   "packages/react-native": "0.49.0",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.438.3](https://github.com/factorialco/f0/compare/f0-react-v1.438.2...f0-react-v1.438.3) (2026-04-07)
+
+
+### Bug Fixes
+
+* F0TagList overflow visibility, HoverCard interaction, and popover styling ([#3859](https://github.com/factorialco/f0/issues/3859)) ([e3077f7](https://github.com/factorialco/f0/commit/e3077f70d43819d9c3c0619a166238bd745d9d2e))
+
 ## [1.438.2](https://github.com/factorialco/f0/compare/f0-react-v1.438.1...f0-react-v1.438.2) (2026-04-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.438.2",
+  "version": "1.438.3",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.438.3</summary>

## [1.438.3](https://github.com/factorialco/f0/compare/f0-react-v1.438.2...f0-react-v1.438.3) (2026-04-07)


### Bug Fixes

* F0TagList overflow visibility, HoverCard interaction, and popover styling ([#3859](https://github.com/factorialco/f0/issues/3859)) ([e3077f7](https://github.com/factorialco/f0/commit/e3077f70d43819d9c3c0619a166238bd745d9d2e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).