### PR TITLE
fix: sm avatar list not showing up properly on DetailsItemList component

### DIFF
--- a/packages/react/src/experimental/Lists/DetailsItem/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.tsx
@@ -1,6 +1,5 @@
 import { ComponentProps, FC, forwardRef } from "react"
 
-import { withDataTestId } from "@/lib/data-testid"
 import { F0AvatarList } from "@/components/avatars/F0AvatarList"
 import { F0AvatarListProps } from "@/components/avatars/F0AvatarList/types"
 import { TagAlertProps } from "@/components/tags/F0TagAlert"
@@ -9,6 +8,7 @@ import { TagListProps, TagType } from "@/components/tags/F0TagList"
 import { TagRawProps } from "@/components/tags/F0TagRaw"
 import { TagStatusProps } from "@/components/tags/F0TagStatus"
 import { Weekdays } from "@/experimental/Widgets/Content/Weekdays"
+import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 import { cn } from "@/lib/utils"
 
@@ -83,7 +83,7 @@ const ItemContent: FC<{ content: Content }> = ({ content }) => (
       <DataList.TagListItem {...content.tagList} />
     )}
     {content.type === "avatar-list" && (
-      <li className="w-fit list-none px-1.5 py-1">
+      <li className="list-none px-1.5 py-1">
         <F0AvatarList {...content.avatarList} />
       </li>
     )}

--- a/packages/react/src/ui/OverflowList/index.tsx
+++ b/packages/react/src/ui/OverflowList/index.tsx
@@ -136,7 +136,7 @@ const OverflowList = function OverflowList<T>({
 
   // Common classes in the measurement and visible containers
   const itemsWrapperClasses =
-    "flex min-w-0 flex-1 items-center justify-start whitespace-nowrap"
+    "flex min-w-0 items-center justify-start whitespace-nowrap"
 
   return (
     <div


### PR DESCRIPTION
## Description

When trying to show an avatar list in DetailsItemList component with size "sm" we weren't properly showing the avatars there.
