### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.438.4",
-  "packages/react-native": "0.49.0",
+  "packages/react-native": "0.49.1",
   "packages/core": "1.48.2"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.49.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.49.0...f0-react-native-v0.49.1) (2026-04-07)
+
+
+### Bug Fixes
+
+* no thumbnail variant ([#3860](https://github.com/factorialco/f0/issues/3860)) ([0eb01d8](https://github.com/factorialco/f0/commit/0eb01d828f60884d7535e5f69f675d4428195c7f))
+
 ## [0.49.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.48.0...f0-react-native-v0.49.0) (2026-03-26)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.49.1</summary>

## [0.49.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.49.0...f0-react-native-v0.49.1) (2026-04-07)


### Bug Fixes

* no thumbnail variant ([#3860](https://github.com/factorialco/f0/issues/3860)) ([0eb01d8](https://github.com/factorialco/f0/commit/0eb01d828f60884d7535e5f69f675d4428195c7f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).