### PR TITLE
feat: implement bulk drag-and-drop functionality in Kanban

### DIFF
--- a/packages/react/src/lib/dnd/atlaskitDriver.ts
+++ b/packages/react/src/lib/dnd/atlaskitDriver.ts
@@ -39,7 +39,10 @@ export function createAtlaskitDriver(instanceId: symbol): DndDriver {
   )
 
   return {
-    registerDraggable(el, { payload, disabled, handle }) {
+    registerDraggable(
+      el,
+      { payload, disabled, handle, onGenerateDragPreview }
+    ) {
       if (disabled) return () => {}
       return draggable({
         element: el,
@@ -47,6 +50,11 @@ export function createAtlaskitDriver(instanceId: symbol): DndDriver {
           return { ...payload, instanceId }
         },
         dragHandle: handle ?? undefined,
+        onGenerateDragPreview: onGenerateDragPreview
+          ? ({ nativeSetDragImage }) => {
+              onGenerateDragPreview({ nativeSetDragImage })
+            }
+          : undefined,
       })
     },
     registerDroppable(el, { id }) {

--- a/packages/react/src/lib/dnd/hooks.ts
+++ b/packages/react/src/lib/dnd/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useMemo } from "react"
 
 import type { DragPayload, OnGenerateDragPreviewArgs } from "./types"
 
@@ -22,16 +22,18 @@ export function useDraggable<T = unknown>(args: {
     onGenerateDragPreview,
   } = args
 
-  // Enrich payload with selectedIds when present
-  const enrichedPayload: DragPayload<T> = selectedIds?.length
-    ? { ...payload, selectedIds }
-    : payload
-
   // Create a key that includes both id and currentParentId to detect moves
   // This ensures we re-register when an item moves to a different parent
   const payloadData = payload.data as { currentParentId?: string | null }
   const payloadKey = payload.id + "|" + (payloadData?.currentParentId ?? "null")
   const selectedIdsKey = selectedIds?.join(",") ?? ""
+
+  // Memoize enriched payload to avoid creating a new object every render,
+  // which would cause unnecessary useEffect re-registrations
+  const enrichedPayload = useMemo<DragPayload<T>>(
+    () => (selectedIds?.length ? { ...payload, selectedIds } : payload),
+    [payloadKey, selectedIdsKey]
+  )
 
   useEffect(() => {
     if (!ref.current) return

--- a/packages/react/src/lib/dnd/hooks.ts
+++ b/packages/react/src/lib/dnd/hooks.ts
@@ -29,10 +29,11 @@ export function useDraggable<T = unknown>(args: {
   const selectedIdsKey = selectedIds?.join(",") ?? ""
 
   // Memoize enriched payload to avoid creating a new object every render,
-  // which would cause unnecessary useEffect re-registrations
+  // which would cause unnecessary useEffect re-registrations.
+  // Include payload.kind so changes to the drag type also refresh registration.
   const enrichedPayload = useMemo<DragPayload<T>>(
     () => (selectedIds?.length ? { ...payload, selectedIds } : payload),
-    [payloadKey, selectedIdsKey]
+    [payloadKey, payload.kind, selectedIdsKey]
   )
 
   useEffect(() => {

--- a/packages/react/src/lib/dnd/hooks.ts
+++ b/packages/react/src/lib/dnd/hooks.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 
-import type { DragPayload } from "./types"
+import type { DragPayload, OnGenerateDragPreviewArgs } from "./types"
 
 import { useDndContextOptional } from "./context"
 
@@ -9,25 +9,50 @@ export function useDraggable<T = unknown>(args: {
   payload: DragPayload<T>
   disabled?: boolean
   handleRef?: React.RefObject<HTMLElement | null>
+  selectedIds?: string[]
+  onGenerateDragPreview?: (args: OnGenerateDragPreviewArgs) => void
 }) {
   const ctx = useDndContextOptional()
-  const { ref, payload, disabled, handleRef } = args
+  const {
+    ref,
+    payload,
+    disabled,
+    handleRef,
+    selectedIds,
+    onGenerateDragPreview,
+  } = args
+
+  // Enrich payload with selectedIds when present
+  const enrichedPayload: DragPayload<T> = selectedIds?.length
+    ? { ...payload, selectedIds }
+    : payload
 
   // Create a key that includes both id and currentParentId to detect moves
   // This ensures we re-register when an item moves to a different parent
   const payloadData = payload.data as { currentParentId?: string | null }
   const payloadKey = payload.id + "|" + (payloadData?.currentParentId ?? "null")
+  const selectedIdsKey = selectedIds?.join(",") ?? ""
 
   useEffect(() => {
     if (!ref.current) return
     if (!ctx || disabled) return
 
     return ctx.driver.registerDraggable(ref.current, {
-      payload,
+      payload: enrichedPayload,
       disabled,
       handle: handleRef?.current ?? null,
+      onGenerateDragPreview,
     })
-  }, [ctx, ref, payloadKey, disabled, handleRef, payload])
+  }, [
+    ctx,
+    ref,
+    payloadKey,
+    disabled,
+    handleRef,
+    enrichedPayload,
+    selectedIdsKey,
+    onGenerateDragPreview,
+  ])
 }
 
 export function useDroppableList(args?: {

--- a/packages/react/src/lib/dnd/types.ts
+++ b/packages/react/src/lib/dnd/types.ts
@@ -2,6 +2,12 @@ export type DragPayload<T = unknown> = {
   kind: string
   id: string
   data?: T
+  /** IDs of all selected items being moved together (including the primary dragged item) */
+  selectedIds?: string[]
+}
+
+export type OnGenerateDragPreviewArgs = {
+  nativeSetDragImage: DataTransfer["setDragImage"] | null
 }
 
 export type DropIntent =
@@ -23,6 +29,7 @@ export interface DndDriver<T = unknown> {
       payload: DragPayload<T>
       disabled?: boolean
       handle?: HTMLElement | null
+      onGenerateDragPreview?: (args: OnGenerateDragPreviewArgs) => void
     }
   ) => () => void
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -46,6 +46,7 @@ export const KanbanCollection = <
   avatar,
   metadata: optionsMetadata,
   onMove,
+  onBulkMove,
   onCreate,
   source,
   onSelectItems,
@@ -174,6 +175,7 @@ export const KanbanCollection = <
           total={total}
           laneId={laneId}
           showIndicator={allowReorder}
+          selectedIds={allSelectedIds.length > 1 ? allSelectedIds : undefined}
           title={title ? title(item) : String(index)}
           description={description ? description(item) : undefined}
           avatar={avatar ? avatar(item) : undefined}
@@ -248,15 +250,6 @@ export const KanbanCollection = <
     return maps
   }, [laneItems, idProvider])
 
-  kanbanProps.dnd = {
-    instanceId: instanceId,
-    getIndexById: (laneId: string, id: string) => {
-      const idx = laneIndexMaps.get(laneId)?.get(id) ?? -1
-      return allowReorder ? idx : -1
-    },
-    onMove: onMove,
-  }
-
   /**
    * Selection
    */
@@ -283,6 +276,29 @@ export const KanbanCollection = <
   >(lanesDef, source, (selectItemsStatus, clearCallback) => {
     onSelectItems?.(selectItemsStatus, clearCallback)
   })
+
+  // Collect all selected IDs across all lanes for bulk drag-and-drop
+  const allSelectedIds = useMemo(() => {
+    if (!lanesUseSelectable) return []
+    const ids: string[] = []
+    lanesUseSelectable.forEach((hook) => {
+      hook.selectedItems.forEach((_, key) => {
+        ids.push(String(key))
+      })
+    })
+    return ids
+  }, [lanesUseSelectable])
+
+  kanbanProps.dnd = {
+    instanceId: instanceId,
+    getIndexById: (laneId: string, id: string) => {
+      const idx = laneIndexMaps.get(laneId)?.get(id) ?? -1
+      return allowReorder ? idx : -1
+    },
+    onMove: onMove,
+    onBulkMove: onBulkMove,
+    selectedIds: allSelectedIds.length > 1 ? allSelectedIds : undefined,
+  }
 
   return (
     <>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/types.ts
@@ -8,7 +8,11 @@ import {
   RecordType,
   SortingsDefinition,
 } from "@/hooks/datasource"
-import { KanbanOnCreate, KanbanOnMove } from "@/ui/Kanban/types"
+import {
+  KanbanOnCreate,
+  KanbanOnMove,
+  KanbanOnBulkMove,
+} from "@/ui/Kanban/types"
 
 import { ItemActionsDefinition } from "../../../item-actions"
 import { NavigationFiltersDefinition } from "../../../navigationFilters/types"
@@ -33,6 +37,7 @@ export type KanbanVisualizationOptions<
     record: Record
   ) => ReadonlyArray<{ icon: IconType; property: CardMetadataProperty }>
   onMove?: KanbanOnMove<Record>
+  onBulkMove?: KanbanOnBulkMove<Record>
   onCreate?: KanbanOnCreate
 }
 

--- a/packages/react/src/ui/Kanban/Kanban.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.tsx
@@ -296,6 +296,9 @@ export function Kanban<TRecord extends RecordType>(
     const { selectedIds, toLaneId, indexOfTarget, position } = params
     if (!dnd?.onBulkMove || selectedIds.length === 0) return []
 
+    // Convert to Set for O(1) lookups inside nested loops
+    const selectedIdSet = new Set(selectedIds)
+
     // Snapshot
     const prev = localLanes
     const toLaneIdx = prev.findIndex((l) => l.id === toLaneId)
@@ -314,7 +317,7 @@ export function Kanban<TRecord extends RecordType>(
       for (let itemIdx = 0; itemIdx < lane.items.length; itemIdx++) {
         const item = lane.items[itemIdx]
         const key = String(getKey(item as TRecord, itemIdx, laneId))
-        if (selectedIds.includes(key)) {
+        if (selectedIdSet.has(key)) {
           moves.push({ fromLaneId: laneId, sourceRecord: item as TRecord })
           if (!removalsByLane.has(laneIdx)) {
             removalsByLane.set(laneIdx, [])

--- a/packages/react/src/ui/Kanban/Kanban.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils"
 
 import type {
   KanbanLaneAttributes,
+  KanbanOnBulkMoveParam,
   KanbanOnMoveParam,
   KanbanProps,
 } from "./types.ts"
@@ -291,6 +292,167 @@ export function Kanban<TRecord extends RecordType>(
     }
   }
 
+  const onBulkMove = async (params: KanbanOnBulkMoveParam) => {
+    const { selectedIds, toLaneId, indexOfTarget, position } = params
+    if (!dnd?.onBulkMove || selectedIds.length === 0) return []
+
+    // Snapshot
+    const prev = localLanes
+    const toLaneIdx = prev.findIndex((l) => l.id === toLaneId)
+    if (toLaneIdx === -1) return []
+
+    // Collect all selected records across lanes, preserving their relative order per lane
+    const moves: Array<{ fromLaneId: string; sourceRecord: TRecord }> = []
+    const removalsByLane = new Map<
+      number,
+      Array<{ index: number; record: TRecord }>
+    >()
+
+    for (let laneIdx = 0; laneIdx < prev.length; laneIdx++) {
+      const lane = prev[laneIdx]
+      const laneId = lane.id as string
+      for (let itemIdx = 0; itemIdx < lane.items.length; itemIdx++) {
+        const item = lane.items[itemIdx]
+        const key = String(getKey(item as TRecord, itemIdx, laneId))
+        if (selectedIds.includes(key)) {
+          moves.push({ fromLaneId: laneId, sourceRecord: item as TRecord })
+          if (!removalsByLane.has(laneIdx)) {
+            removalsByLane.set(laneIdx, [])
+          }
+          removalsByLane
+            .get(laneIdx)!
+            .push({ index: itemIdx, record: item as TRecord })
+        }
+      }
+    }
+
+    if (moves.length === 0) return []
+
+    // Compute insertion index
+    let insertIndex = 0
+    if (indexOfTarget != null && position != null) {
+      insertIndex = indexOfTarget + (position === "below" ? 1 : 0)
+    }
+
+    // Build next lanes state:
+    // 1. Remove all selected items from their source lanes
+    // 2. Insert them at the target position preserving relative order
+    const recordsToInsert = moves.map((m) => m.sourceRecord)
+
+    const next = prev.map((lane, laneIdx) => {
+      const items = [...lane.items]
+      const isTgtLane = laneIdx === toLaneIdx
+
+      // Remove items from this lane (reverse order to maintain indices)
+      const removals = removalsByLane.get(laneIdx)
+      let removedCount = 0
+      if (removals) {
+        for (let i = removals.length - 1; i >= 0; i--) {
+          items.splice(removals[i].index, 1)
+          removedCount++
+        }
+      }
+
+      // Insert into target lane
+      if (isTgtLane) {
+        // Adjust insert index for items removed from THIS lane that were before the insert point
+        let adjustedInsert = insertIndex
+        if (removals) {
+          const removedBefore = removals.filter(
+            (r) => r.index < insertIndex
+          ).length
+          adjustedInsert = Math.max(0, insertIndex - removedBefore)
+        }
+        const boundedIndex = Math.max(0, Math.min(adjustedInsert, items.length))
+        items.splice(boundedIndex, 0, ...recordsToInsert)
+      }
+
+      // Adjust totals
+      const isSourceOnly = removedCount > 0 && !isTgtLane
+      const isTargetOnly = isTgtLane && removedCount === 0
+      let nextTotal = lane.total
+      if (typeof lane.total === "number") {
+        if (isSourceOnly) {
+          nextTotal = Math.max(0, lane.total - removedCount)
+        } else if (isTargetOnly) {
+          nextTotal = lane.total + recordsToInsert.length
+        } else if (isTgtLane && removedCount > 0) {
+          // Same lane: total stays the same (items moved within it + new ones added)
+          nextTotal = lane.total - removedCount + recordsToInsert.length
+        }
+      }
+
+      return { ...lane, items, total: nextTotal }
+    })
+
+    // Optimistic apply
+    setLocalLanes(next)
+
+    const optimisticSignature = next
+      .map(
+        (l) =>
+          `${l.id}:[${l.items.map((item, idx) => getKey(item, idx, l.id)).join(",")}]`
+      )
+      .join("|")
+
+    optimisticSignatureRef.current = optimisticSignature
+    lastLanesRef.current = optimisticSignature
+
+    try {
+      // Build destiny record for the external callback
+      const destinyRecord =
+        indexOfTarget == null
+          ? null
+          : (prev[toLaneIdx].items[indexOfTarget] as TRecord | undefined)
+
+      const results = await dnd.onBulkMove(
+        moves,
+        toLaneId,
+        destinyRecord
+          ? {
+              record: destinyRecord,
+              position: (position as "above" | "below") ?? "above",
+            }
+          : null
+      )
+
+      if (results && results.length > 0) {
+        // Replace records in target lane with backend versions
+        setLocalLanes((curr) => {
+          const updated = curr.map((lane) => {
+            if (lane.id !== toLaneId) return lane
+            const items = [...lane.items]
+            for (const result of results) {
+              const resultKey = String(getKey(result as TRecord, 0, toLaneId))
+              const idx = items.findIndex((item, index) => {
+                const key = String(getKey(item as TRecord, index, toLaneId))
+                return key === resultKey
+              })
+              if (idx !== -1) items.splice(idx, 1, result)
+            }
+            return { ...lane, items }
+          })
+
+          const serverSignature = updated
+            .map(
+              (l) =>
+                `${l.id}:[${l.items.map((item, idx) => getKey(item, idx, l.id)).join(",")}]`
+            )
+            .join("|")
+          lastLanesRef.current = serverSignature
+
+          return updated
+        })
+      }
+      return results
+    } catch (e) {
+      // Rollback and exit optimistic mode
+      setLocalLanes(prev)
+      optimisticSignatureRef.current = null
+      throw e
+    }
+  }
+
   return (
     <div className={cn("relative h-full w-full px-4", className)}>
       <ScrollArea
@@ -315,6 +477,7 @@ export function Kanban<TRecord extends RecordType>(
                         : undefined
                     }
                     onMove={onMove}
+                    onBulkMove={dnd?.onBulkMove ? onBulkMove : undefined}
                     title={lane.title}
                     items={lane.items}
                     getKey={(item, index) => getKey(item, index, lane.id)}

--- a/packages/react/src/ui/Kanban/__stories__/Kanban.stories.tsx
+++ b/packages/react/src/ui/Kanban/__stories__/Kanban.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { expect, fn, waitFor, within } from "storybook/test"
 
 import { createAtlaskitDriver } from "@/lib/dnd/atlaskitDriver"
 import { DndProvider } from "@/lib/dnd/context"
 
-import type { KanbanProps } from "../types"
+import type { KanbanOnBulkMove, KanbanProps } from "../types"
 
 import { KanbanCard } from "../components/KanbanCard"
 import { Kanban } from "../Kanban"
@@ -537,5 +537,317 @@ export const SimpleOnMoveTest: Story = {
       expect(secondCall).toHaveTextContent(/"title":"Design spec"/)
       expect(secondCall).toHaveTextContent(/"position":"above"/)
     })
+  },
+}
+
+const initialBulkMoveLanes: KanbanProps<Task>["lanes"] = [
+  {
+    id: "backlog",
+    title: "Backlog",
+    items: [
+      { id: "t1", title: "Design spec", assignee: "Alice" },
+      { id: "t2", title: "Implement UI", assignee: "Bob" },
+      { id: "t3", title: "Write docs", assignee: "Carol" },
+    ],
+    total: 3,
+    variant: "neutral",
+  },
+  {
+    id: "in-progress",
+    title: "In Progress",
+    items: [
+      { id: "t4", title: "Write tests", assignee: "Dave" },
+      { id: "t5", title: "Wire data", assignee: "Eve" },
+    ],
+    total: 2,
+    variant: "info",
+  },
+  {
+    id: "review",
+    title: "In Review",
+    items: [{ id: "t6", title: "Code review", assignee: "Frank" }],
+    total: 1,
+    variant: "warning",
+  },
+  {
+    id: "done",
+    title: "Done",
+    items: [],
+    total: 0,
+    variant: "positive",
+  },
+]
+
+/**
+ * Demonstrates bulk drag-and-drop: select multiple cards via their built-in
+ * checkboxes (hover over a card to reveal it), then drag any selected card
+ * to move **all** selected cards to the target lane. A badge on the drag
+ * preview shows the count.
+ *
+ * **How to use:**
+ * 1. Hover over cards to reveal checkboxes, click to select 2+ cards
+ * 2. Drag any selected card to another lane — all selected cards move together
+ * 3. Or use the simulation buttons below for programmatic bulk moves
+ * 4. Hit "Reset board" to start over
+ */
+export const BulkMove: Story = {
+  args: {
+    lanes: [],
+    renderCard: () => null,
+    getKey: () => "",
+  },
+  render: function Render() {
+    const [instanceId] = useState(() => Symbol("kanban-bulk-instance"))
+    const [selected, setSelected] = useState<Set<string>>(() => new Set())
+    const [bulkMoveLog, setBulkMoveLog] = useState<
+      Array<{
+        movedIds: string[]
+        toLaneId: string
+        position: string
+      }>
+    >([])
+
+    const [lanes, setLanes] =
+      useState<KanbanProps<Task>["lanes"]>(initialBulkMoveLanes)
+
+    const selectedIds = useMemo(() => Array.from(selected), [selected])
+
+    const toggleSelection = useCallback((id: string) => {
+      setSelected((prev) => {
+        const next = new Set(prev)
+        if (next.has(id)) {
+          next.delete(id)
+        } else {
+          next.add(id)
+        }
+        return next
+      })
+    }, [])
+
+    const handleBulkMove: KanbanOnBulkMove<Task> = useCallback(
+      async (moves, toLaneId, destinyRecord) => {
+        setBulkMoveLog((prev) => [
+          ...prev,
+          {
+            movedIds: moves.map((m) => m.sourceRecord.id),
+            toLaneId,
+            position: destinyRecord
+              ? `${destinyRecord.position} ${destinyRecord.record.title}`
+              : "end of lane",
+          },
+        ])
+
+        // Simulate server delay
+        await new Promise((r) => setTimeout(r, 100))
+
+        // Update lanes state
+        const movedRecords = moves.map((m) => m.sourceRecord)
+        const movedIds = new Set(movedRecords.map((r) => r.id))
+
+        setLanes((prevLanes) => {
+          return prevLanes.map((lane) => {
+            const filtered = lane.items.filter((item) => !movedIds.has(item.id))
+
+            if (lane.id === toLaneId) {
+              if (destinyRecord) {
+                const targetIdx = filtered.findIndex(
+                  (item) => item.id === destinyRecord.record.id
+                )
+                const insertIdx =
+                  destinyRecord.position === "above" ? targetIdx : targetIdx + 1
+                filtered.splice(insertIdx, 0, ...movedRecords)
+              } else {
+                filtered.push(...movedRecords)
+              }
+            }
+
+            return {
+              ...lane,
+              items: filtered,
+              total: filtered.length,
+            }
+          })
+        })
+
+        // Clear selection after bulk move
+        setSelected(new Set())
+
+        return movedRecords
+      },
+      []
+    )
+
+    const handleReset = () => {
+      setLanes(initialBulkMoveLanes)
+      setSelected(new Set())
+      setBulkMoveLog([])
+    }
+
+    const simulateBulkMoveToDone = () => {
+      if (selectedIds.length < 2) return
+      window.dispatchEvent(
+        new CustomEvent("kanban-test-bulk-move", {
+          detail: {
+            selectedIds,
+            toLaneId: "done",
+            indexOfTarget: null,
+            position: null,
+          },
+        })
+      )
+    }
+
+    const simulateBulkMoveToBacklog = () => {
+      if (selectedIds.length < 2) return
+      window.dispatchEvent(
+        new CustomEvent("kanban-test-bulk-move", {
+          detail: {
+            selectedIds,
+            toLaneId: "backlog",
+            indexOfTarget: null,
+            position: null,
+          },
+        })
+      )
+    }
+
+    return (
+      <div className="space-y-4">
+        {/* Action bar: selection info + actions */}
+        <div className="flex items-center gap-3 rounded-lg border border-f1-border bg-f1-background-secondary px-4 py-2.5">
+          <span className="text-sm font-medium">
+            {selectedIds.length === 0
+              ? "Hover over cards to reveal checkboxes, then select 2+ cards"
+              : `${selectedIds.length} card${selectedIds.length === 1 ? "" : "s"} selected`}
+          </span>
+          <div className="flex-1" />
+          <button
+            onClick={simulateBulkMoveToDone}
+            disabled={selectedIds.length < 2}
+            className="rounded bg-f1-background-positive px-3 py-1.5 text-xs font-medium text-f1-foreground-positive disabled:opacity-40"
+            data-testid="bulk-move-done"
+          >
+            Move to Done
+          </button>
+          <button
+            onClick={simulateBulkMoveToBacklog}
+            disabled={selectedIds.length < 2}
+            className="rounded bg-f1-background-info px-3 py-1.5 text-xs font-medium text-f1-foreground-info disabled:opacity-40"
+            data-testid="bulk-move-backlog"
+          >
+            Move to Backlog
+          </button>
+          {selectedIds.length > 0 && (
+            <button
+              onClick={() => setSelected(new Set())}
+              className="text-xs text-f1-foreground-secondary underline"
+            >
+              Clear selection
+            </button>
+          )}
+          <button
+            onClick={handleReset}
+            className="rounded border border-f1-border px-3 py-1.5 text-xs font-medium text-f1-foreground-secondary"
+            data-testid="reset-board"
+          >
+            Reset board
+          </button>
+        </div>
+
+        {/* Kanban board */}
+        <DndProvider driver={createAtlaskitDriver(instanceId)}>
+          <Kanban<Task>
+            lanes={lanes}
+            getKey={(item) => item.id}
+            dnd={{
+              instanceId,
+              getIndexById: (laneId, id) => {
+                const lane = lanes.find((l) => l.id === laneId)
+                return lane?.items.findIndex((item) => item.id === id) ?? -1
+              },
+              onMove: async (fromLaneId, toLaneId, sourceRecord, destiny) => {
+                await new Promise((r) => setTimeout(r, 50))
+                setLanes((prev) =>
+                  prev.map((lane) => {
+                    if (lane.id === fromLaneId) {
+                      return {
+                        ...lane,
+                        items: lane.items.filter(
+                          (item) => item.id !== sourceRecord.id
+                        ),
+                        total: (lane.total ?? lane.items.length) - 1,
+                      }
+                    }
+                    if (lane.id === toLaneId) {
+                      const items = [...lane.items]
+                      if (destiny) {
+                        const idx = items.findIndex(
+                          (i) => i.id === destiny.record.id
+                        )
+                        const insertIdx =
+                          destiny.position === "above" ? idx : idx + 1
+                        items.splice(insertIdx, 0, sourceRecord)
+                      } else {
+                        items.push(sourceRecord)
+                      }
+                      return {
+                        ...lane,
+                        items,
+                        total: (lane.total ?? lane.items.length) + 1,
+                      }
+                    }
+                    return lane
+                  })
+                )
+                return sourceRecord
+              },
+              onBulkMove: handleBulkMove,
+              selectedIds: selectedIds.length > 1 ? selectedIds : undefined,
+            }}
+            renderCard={(item, index, total, laneId) => (
+              <KanbanCard<Task>
+                drag={{
+                  id: item.id,
+                  type: "list-card",
+                  data: { ...item },
+                }}
+                id={item.id}
+                index={index}
+                total={total}
+                laneId={laneId}
+                draggable
+                title={item.title}
+                description={item.assignee}
+                selectable
+                selected={selected.has(item.id)}
+                onSelect={() => toggleSelection(item.id)}
+                selectedIds={selectedIds.length > 1 ? selectedIds : undefined}
+              />
+            )}
+          />
+        </DndProvider>
+
+        {/* Bulk move log (collapsible) */}
+        {bulkMoveLog.length > 0 && (
+          <details className="rounded-lg border border-f1-border p-3">
+            <summary className="cursor-pointer text-xs font-medium text-f1-foreground-secondary">
+              Bulk Move Log ({bulkMoveLog.length})
+            </summary>
+            <div className="mt-2 space-y-1">
+              {bulkMoveLog.map((log, i) => (
+                <div
+                  key={i}
+                  className="rounded bg-f1-background-secondary p-2 text-xs"
+                  data-testid={`bulk-log-${i}`}
+                >
+                  Moved [{log.movedIds.join(", ")}] to {log.toLaneId} (
+                  {log.position})
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
+      </div>
+    )
   },
 }

--- a/packages/react/src/ui/Kanban/__stories__/Kanban.stories.tsx
+++ b/packages/react/src/ui/Kanban/__stories__/Kanban.stories.tsx
@@ -633,7 +633,7 @@ export const BulkMove: Story = {
             toLaneId,
             position: destinyRecord
               ? `${destinyRecord.position} ${destinyRecord.record.title}`
-              : "end of lane",
+              : "top of lane",
           },
         ])
 
@@ -657,7 +657,7 @@ export const BulkMove: Story = {
                   destinyRecord.position === "above" ? targetIdx : targetIdx + 1
                 filtered.splice(insertIdx, 0, ...movedRecords)
               } else {
-                filtered.push(...movedRecords)
+                filtered.unshift(...movedRecords)
               }
             }
 

--- a/packages/react/src/ui/Kanban/__tests__/Kanban.test.tsx
+++ b/packages/react/src/ui/Kanban/__tests__/Kanban.test.tsx
@@ -1,0 +1,387 @@
+import { act, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { createAtlaskitDriver } from "@/lib/dnd/atlaskitDriver"
+import { DndProvider } from "@/lib/dnd/context"
+import { zeroRender } from "@/testing/test-utils"
+
+import type { KanbanProps } from "../types"
+
+import { KanbanCard } from "../components/KanbanCard"
+import { Kanban } from "../Kanban"
+
+type Task = {
+  id: string
+  title: string
+}
+
+const tasks = {
+  t1: { id: "t1", title: "Design spec" },
+  t2: { id: "t2", title: "Implement UI" },
+  t3: { id: "t3", title: "Write tests" },
+  t4: { id: "t4", title: "Wire data" },
+  t5: { id: "t5", title: "Deploy" },
+}
+
+function renderKanban(
+  lanes: KanbanProps<Task>["lanes"],
+  options: {
+    onMove?: KanbanProps<Task>["dnd"] extends infer D
+      ? D extends { onMove?: infer M }
+        ? M
+        : never
+      : never
+    onBulkMove?: KanbanProps<Task>["dnd"] extends infer D
+      ? D extends { onBulkMove?: infer M }
+        ? M
+        : never
+      : never
+    selectedIds?: string[]
+  } = {}
+) {
+  const instanceId = Symbol("test-kanban")
+  const { onMove, onBulkMove, selectedIds } = options
+
+  return zeroRender(
+    <DndProvider driver={createAtlaskitDriver(instanceId)}>
+      <Kanban<Task>
+        lanes={lanes}
+        getKey={(item) => item.id}
+        dnd={{
+          instanceId,
+          getIndexById: (laneId, id) => {
+            const lane = lanes.find((l) => l.id === laneId)
+            return lane?.items.findIndex((item) => item.id === id) ?? -1
+          },
+          onMove,
+          onBulkMove,
+          selectedIds,
+        }}
+        renderCard={(item, index, total, laneId) => (
+          <KanbanCard<Task>
+            drag={{ id: item.id, type: "list-card", data: { ...item, laneId } }}
+            id={item.id}
+            index={index}
+            total={total}
+            laneId={laneId}
+            draggable
+            title={item.title}
+            selectedIds={selectedIds}
+          />
+        )}
+      />
+    </DndProvider>
+  )
+}
+
+/** Dispatch a synthetic bulk-move event via the test hook in KanbanLane */
+function dispatchBulkMove(detail: {
+  selectedIds: string[]
+  toLaneId: string
+  indexOfTarget: number | null
+  position: "above" | "below" | null
+}) {
+  window.dispatchEvent(new CustomEvent("kanban-test-bulk-move", { detail }))
+}
+
+/** Dispatch a synthetic single-move event via the test hook in KanbanLane */
+function dispatchMove(
+  detail:
+    | {
+        fromLaneId: string
+        toLaneId: string
+        sourceId: string
+        indexOfTarget: number
+        position: "above" | "below"
+      }
+    | {
+        fromLaneId: string
+        toLaneId: string
+        sourceId: string
+        indexOfTarget: null
+        position: null
+      }
+) {
+  window.dispatchEvent(new CustomEvent("kanban-test-move", { detail }))
+}
+
+describe("Kanban", () => {
+  describe("single move (onMove)", () => {
+    it("renders lanes and cards", () => {
+      renderKanban([
+        { id: "backlog", title: "Backlog", items: [tasks.t1, tasks.t2] },
+        { id: "done", title: "Done", items: [tasks.t3] },
+      ])
+
+      expect(screen.getByText("Design spec")).toBeInTheDocument()
+      expect(screen.getByText("Implement UI")).toBeInTheDocument()
+      expect(screen.getByText("Write tests")).toBeInTheDocument()
+    })
+
+    it("calls onMove and optimistically moves item across lanes", async () => {
+      const onMove = vi.fn().mockResolvedValue(tasks.t1)
+
+      renderKanban(
+        [
+          {
+            id: "backlog",
+            title: "Backlog",
+            items: [tasks.t1, tasks.t2],
+            total: 2,
+          },
+          { id: "done", title: "Done", items: [], total: 0 },
+        ],
+        { onMove }
+      )
+
+      // Verify initial state
+      const backlogLane = screen.getByTestId("lane-backlog")
+      expect(backlogLane).toBeInTheDocument()
+      expect(screen.getByText("Design spec")).toBeInTheDocument()
+
+      act(() => {
+        dispatchMove({
+          fromLaneId: "backlog",
+          toLaneId: "done",
+          sourceId: "t1",
+          indexOfTarget: null,
+          position: null,
+        })
+      })
+
+      await waitFor(() => {
+        expect(onMove).toHaveBeenCalledTimes(1)
+      })
+
+      // Verify onMove was called with correct params
+      expect(onMove).toHaveBeenCalledWith("backlog", "done", tasks.t1, null)
+    })
+  })
+
+  describe("bulk move (onBulkMove)", () => {
+    it("calls onBulkMove with selected items from multiple lanes", async () => {
+      const onBulkMove = vi.fn().mockResolvedValue([tasks.t1, tasks.t3])
+      const onMove = vi.fn().mockResolvedValue(tasks.t1)
+
+      renderKanban(
+        [
+          {
+            id: "backlog",
+            title: "Backlog",
+            items: [tasks.t1, tasks.t2],
+            total: 2,
+          },
+          {
+            id: "in-progress",
+            title: "In Progress",
+            items: [tasks.t3],
+            total: 1,
+          },
+          { id: "done", title: "Done", items: [], total: 0 },
+        ],
+        {
+          onMove,
+          onBulkMove,
+          selectedIds: ["t1", "t3"],
+        }
+      )
+
+      act(() => {
+        dispatchBulkMove({
+          selectedIds: ["t1", "t3"],
+          toLaneId: "done",
+          indexOfTarget: null,
+          position: null,
+        })
+      })
+
+      await waitFor(() => {
+        expect(onBulkMove).toHaveBeenCalledTimes(1)
+      })
+
+      // Verify the moves array includes both items from different source lanes
+      const [movesArg, toLaneIdArg, destinyArg] = onBulkMove.mock.calls[0]
+
+      expect(toLaneIdArg).toBe("done")
+      expect(destinyArg).toBeNull()
+      expect(movesArg).toHaveLength(2)
+      expect(movesArg).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            fromLaneId: "backlog",
+            sourceRecord: tasks.t1,
+          }),
+          expect.objectContaining({
+            fromLaneId: "in-progress",
+            sourceRecord: tasks.t3,
+          }),
+        ])
+      )
+
+      // onMove should NOT have been called (bulk path was used)
+      expect(onMove).not.toHaveBeenCalled()
+    })
+
+    it("calls onBulkMove with correct position when dropping on a card", async () => {
+      const onBulkMove = vi.fn().mockResolvedValue([tasks.t1, tasks.t2])
+
+      renderKanban(
+        [
+          {
+            id: "backlog",
+            title: "Backlog",
+            items: [tasks.t1, tasks.t2],
+            total: 2,
+          },
+          {
+            id: "done",
+            title: "Done",
+            items: [tasks.t4, tasks.t5],
+            total: 2,
+          },
+        ],
+        {
+          onBulkMove,
+          selectedIds: ["t1", "t2"],
+        }
+      )
+
+      act(() => {
+        dispatchBulkMove({
+          selectedIds: ["t1", "t2"],
+          toLaneId: "done",
+          indexOfTarget: 0,
+          position: "below",
+        })
+      })
+
+      await waitFor(() => {
+        expect(onBulkMove).toHaveBeenCalledTimes(1)
+      })
+
+      const [movesArg, toLaneIdArg, destinyArg] = onBulkMove.mock.calls[0]
+
+      expect(toLaneIdArg).toBe("done")
+      // destinyRecord should be the item at indexOfTarget (t4)
+      expect(destinyArg).toEqual({
+        record: tasks.t4,
+        position: "below",
+      })
+      expect(movesArg).toHaveLength(2)
+    })
+
+    it("does not call onBulkMove when selectedIds is empty", async () => {
+      const onBulkMove = vi.fn()
+
+      renderKanban(
+        [
+          {
+            id: "backlog",
+            title: "Backlog",
+            items: [tasks.t1],
+            total: 1,
+          },
+          { id: "done", title: "Done", items: [], total: 0 },
+        ],
+        { onBulkMove, selectedIds: [] }
+      )
+
+      act(() => {
+        dispatchBulkMove({
+          selectedIds: [],
+          toLaneId: "done",
+          indexOfTarget: null,
+          position: null,
+        })
+      })
+
+      // Small wait to ensure nothing fired
+      await new Promise((r) => setTimeout(r, 50))
+      expect(onBulkMove).not.toHaveBeenCalled()
+    })
+
+    it("rolls back optimistic state on error", async () => {
+      const onBulkMove = vi.fn().mockRejectedValue(new Error("Server error"))
+
+      renderKanban(
+        [
+          {
+            id: "backlog",
+            title: "Backlog",
+            items: [tasks.t1, tasks.t2],
+            total: 2,
+          },
+          { id: "done", title: "Done", items: [], total: 0 },
+        ],
+        {
+          onBulkMove,
+          selectedIds: ["t1", "t2"],
+        }
+      )
+
+      // Both items should be in backlog initially
+      expect(screen.getByText("Design spec")).toBeInTheDocument()
+      expect(screen.getByText("Implement UI")).toBeInTheDocument()
+
+      act(() => {
+        dispatchBulkMove({
+          selectedIds: ["t1", "t2"],
+          toLaneId: "done",
+          indexOfTarget: null,
+          position: null,
+        })
+      })
+
+      await waitFor(() => {
+        expect(onBulkMove).toHaveBeenCalledTimes(1)
+      })
+
+      // After error, items should still be rendered (rollback)
+      await waitFor(() => {
+        expect(screen.getByText("Design spec")).toBeInTheDocument()
+        expect(screen.getByText("Implement UI")).toBeInTheDocument()
+      })
+    })
+
+    it("replaces records with backend versions after successful bulk move", async () => {
+      const enrichedT1 = { ...tasks.t1, title: "Design spec (moved)" }
+      const enrichedT2 = { ...tasks.t2, title: "Implement UI (moved)" }
+      const onBulkMove = vi.fn().mockResolvedValue([enrichedT1, enrichedT2])
+
+      renderKanban(
+        [
+          {
+            id: "backlog",
+            title: "Backlog",
+            items: [tasks.t1, tasks.t2],
+            total: 2,
+          },
+          { id: "done", title: "Done", items: [], total: 0 },
+        ],
+        {
+          onBulkMove,
+          selectedIds: ["t1", "t2"],
+        }
+      )
+
+      act(() => {
+        dispatchBulkMove({
+          selectedIds: ["t1", "t2"],
+          toLaneId: "done",
+          indexOfTarget: null,
+          position: null,
+        })
+      })
+
+      await waitFor(() => {
+        expect(onBulkMove).toHaveBeenCalledTimes(1)
+      })
+
+      // After server response, the enriched titles should appear
+      await waitFor(() => {
+        expect(screen.getByText("Design spec (moved)")).toBeInTheDocument()
+        expect(screen.getByText("Implement UI (moved)")).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/packages/react/src/ui/Kanban/components/KanbanCard.tsx
+++ b/packages/react/src/ui/Kanban/components/KanbanCard.tsx
@@ -46,7 +46,7 @@ export function KanbanCard<T = unknown>({
   showIndicator?: boolean
   disabledEdges?: Array<"top" | "bottom">
   forcedEdge?: "top" | "bottom" | null
-  /** IDs of all selected items for bulk drag (includes this card's id when selected) */
+  /** Keys (from getKey) of all selected items for bulk drag (includes this card's key when selected) */
   selectedIds?: string[]
 } & React.ComponentProps<typeof CardInternal>) {
   const ref = useRef<HTMLDivElement | null>(null)

--- a/packages/react/src/ui/Kanban/components/KanbanCard.tsx
+++ b/packages/react/src/ui/Kanban/components/KanbanCard.tsx
@@ -4,7 +4,10 @@ import {
 } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge"
 import { DropIndicator } from "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box"
 import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter"
-import { useEffect, useRef, useState } from "react"
+import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import type { OnGenerateDragPreviewArgs } from "@/lib/dnd/types"
 
 import { CardInternal } from "@/components/F0Card/CardInternal"
 import { F0Link } from "@/components/F0Link"
@@ -31,6 +34,7 @@ export function KanbanCard<T = unknown>({
   showIndicator = true,
   disabledEdges = [],
   forcedEdge = null,
+  selectedIds,
   ...props
 }: {
   drag: DragConfig<T>
@@ -42,14 +46,105 @@ export function KanbanCard<T = unknown>({
   showIndicator?: boolean
   disabledEdges?: Array<"top" | "bottom">
   forcedEdge?: "top" | "bottom" | null
+  /** IDs of all selected items for bulk drag (includes this card's id when selected) */
+  selectedIds?: string[]
 } & React.ComponentProps<typeof CardInternal>) {
   const ref = useRef<HTMLDivElement | null>(null)
   const linkRef = useRef<HTMLAnchorElement | null>(null)
   const [overEdge, setOverEdge] = useState<"top" | "bottom" | null>(null)
 
+  const isBulkDrag =
+    selectedIds && selectedIds.length > 1 && selectedIds.includes(drag.id)
+  const bulkCount = isBulkDrag ? selectedIds.length : 0
+
+  const handleGenerateDragPreview = useCallback(
+    ({ nativeSetDragImage }: OnGenerateDragPreviewArgs) => {
+      if (!nativeSetDragImage || !ref.current) return
+      setCustomNativeDragPreview({
+        nativeSetDragImage,
+        render: ({ container }) => {
+          const cardWidth = ref.current!.offsetWidth
+          const cardHeight = ref.current!.offsetHeight
+          const shadowCount = bulkCount >= 3 ? 2 : 1
+          const offset = 8
+          const totalOffset = shadowCount * offset
+
+          // Size the container to fit the card + shadow offset + badge overhang
+          Object.assign(container.style, {
+            position: "relative",
+            width: `${cardWidth + totalOffset + 12}px`,
+            height: `${cardHeight + totalOffset + 12}px`,
+          })
+
+          // Resolve the page background so clones look opaque
+          // (cards use semi-transparent fills that rely on the page behind them)
+          const pageBg =
+            window.getComputedStyle(document.body).backgroundColor || "#0d1626"
+
+          // Render shadow layers as empty card shells (deepest first)
+          for (let i = shadowCount; i >= 1; i--) {
+            const shadowClone = ref.current!.cloneNode(true) as HTMLElement
+            // Hide inner content so only the card shape is visible
+            for (const child of shadowClone.children) {
+              ;(child as HTMLElement).style.visibility = "hidden"
+            }
+            Object.assign(shadowClone.style, {
+              position: "absolute",
+              top: `${i * offset}px`,
+              left: `${(shadowCount - i) * offset}px`,
+              width: `${cardWidth}px`,
+              height: `${cardHeight}px`,
+              backgroundColor: pageBg,
+              borderRadius: "12px",
+              overflow: "hidden",
+            })
+            container.appendChild(shadowClone)
+          }
+
+          // Clone the card element as the top layer
+          const clone = ref.current!.cloneNode(true) as HTMLElement
+          Object.assign(clone.style, {
+            position: "absolute",
+            top: "0px",
+            left: `${totalOffset}px`,
+            width: `${cardWidth}px`,
+            backgroundColor: pageBg,
+            borderRadius: "12px",
+          })
+          container.appendChild(clone)
+
+          // Count badge
+          const badge = document.createElement("div")
+          badge.textContent = String(bulkCount)
+          Object.assign(badge.style, {
+            position: "absolute",
+            top: "-4px",
+            right: "0px",
+            width: "24px",
+            height: "24px",
+            borderRadius: "50%",
+            backgroundColor: "#0066FF",
+            color: "#FFFFFF",
+            fontSize: "12px",
+            fontWeight: "700",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            boxShadow: "0 2px 4px rgba(0,0,0,0.2)",
+            zIndex: "1",
+          })
+          container.appendChild(badge)
+        },
+      })
+    },
+    [bulkCount]
+  )
+
   useDraggable<T>({
     ref: ref as React.RefObject<HTMLElement>,
     payload: { kind: drag.type ?? "list-card", id: drag.id, data: drag.data },
+    selectedIds: isBulkDrag ? selectedIds : undefined,
+    onGenerateDragPreview: isBulkDrag ? handleGenerateDragPreview : undefined,
   })
 
   useEffect(() => {

--- a/packages/react/src/ui/Kanban/components/KanbanLane.tsx
+++ b/packages/react/src/ui/Kanban/components/KanbanLane.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils"
 import type { LaneProps } from "../../Lane/types"
 
 import { Lane } from "../../Lane"
-import { KanbanOnMoveParam } from "../types"
+import { KanbanOnBulkMoveParam, KanbanOnMoveParam } from "../types"
 import {
   findTypeOfDropForLane,
   optimisticDifferentLaneInsertOverCard,
@@ -30,11 +30,13 @@ export function KanbanLane<TRecord extends RecordType>({
   id,
   getLaneResourceIndexById,
   onMove,
+  onBulkMove,
   ...laneProps
 }: {
   id?: string
   getLaneResourceIndexById?: (id: string) => number
   onMove?: (param: KanbanOnMoveParam) => Promise<TRecord>
+  onBulkMove?: (param: KanbanOnBulkMoveParam) => Promise<TRecord[]>
   allowReorder?: boolean
 } & LaneProps<TRecord>) {
   const laneRef = useRef<HTMLDivElement | null>(null)
@@ -387,6 +389,45 @@ export function KanbanLane<TRecord extends RecordType>({
           return
         }
 
+        // --- Bulk move detection ---
+        // If the dragged card carries selectedIds (bulk drag), delegate to onBulkMove
+        const selectedIds = (source.data as { selectedIds?: string[] })
+          .selectedIds
+        if (selectedIds && selectedIds.length > 1 && onBulkMove) {
+          // Determine drop position from card target or forced indicator
+          const bulkCardTarget = location.current.dropTargets.find((t) => {
+            const data = t.data as { type?: string }
+            return data.type === "list-card-target"
+          })
+
+          let bulkIndexOfTarget: number | null = null
+          let bulkPosition: "above" | "below" | null = null
+
+          if (bulkCardTarget && bulkCardTarget.data) {
+            const targetIndex = (bulkCardTarget.data as { index?: number })
+              .index
+            const edge = (bulkCardTarget.data as { closestEdge?: string })
+              .closestEdge as "top" | "bottom" | undefined
+            if (targetIndex !== undefined && edge) {
+              bulkIndexOfTarget = targetIndex
+              bulkPosition = edge === "bottom" ? "below" : "above"
+            }
+          } else if (forcedIndex !== null && forcedEdge) {
+            bulkIndexOfTarget = forcedIndex
+            bulkPosition = forcedEdge === "bottom" ? "below" : "above"
+          }
+
+          await onBulkMove({
+            selectedIds,
+            toLaneId: id as string,
+            indexOfTarget: bulkIndexOfTarget,
+            position: bulkPosition,
+          })
+          setForcedIndex(null)
+          setForcedEdge(null)
+          return
+        }
+
         let onMoveParams: KanbanOnMoveParam | null = null
         const { type: typeOfDrop, cardTarget } = findTypeOfDrop(
           location.current.dropTargets
@@ -487,6 +528,7 @@ export function KanbanLane<TRecord extends RecordType>({
     id,
     getLaneResourceIndexById,
     onMove,
+    onBulkMove,
     isDragging,
     laneProps.items,
     laneProps.getKey,
@@ -529,7 +571,7 @@ export function KanbanLane<TRecord extends RecordType>({
     }
   })
 
-  // Test hook: allow stories to trigger onMove without real DnD
+  // Test hook: allow stories/tests to trigger onMove without real DnD
   useEffect(() => {
     const handler = (e: Event) => {
       if (!id) return
@@ -559,6 +601,31 @@ export function KanbanLane<TRecord extends RecordType>({
     return () =>
       window.removeEventListener("kanban-test-move", handler as EventListener)
   }, [id, onMove])
+
+  // Test hook: allow stories/tests to trigger onBulkMove without real DnD
+  useEffect(() => {
+    if (!onBulkMove) return
+    const handler = (e: Event) => {
+      if (!id) return
+      const detail = (
+        e as CustomEvent<{
+          selectedIds: string[]
+          toLaneId: string
+          indexOfTarget: number | null
+          position: "above" | "below" | null
+        }>
+      ).detail
+      if (!detail) return
+      if (detail.toLaneId !== id) return
+      void onBulkMove(detail).catch(() => {})
+    }
+    window.addEventListener("kanban-test-bulk-move", handler as EventListener)
+    return () =>
+      window.removeEventListener(
+        "kanban-test-bulk-move",
+        handler as EventListener
+      )
+  }, [id, onBulkMove])
 
   // Calculate dynamic height based on content and container
   useLayoutEffect(() => {

--- a/packages/react/src/ui/Kanban/types.ts
+++ b/packages/react/src/ui/Kanban/types.ts
@@ -55,6 +55,9 @@ export interface KanbanProps<TRecord extends RecordType> {
     instanceId: symbol
     getIndexById: (laneId: string, id: string) => number
     onMove?: KanbanOnMove<TRecord>
+    onBulkMove?: KanbanOnBulkMove<TRecord>
+    /** IDs of all currently selected items (for bulk drag-and-drop) */
+    selectedIds?: string[]
   }
 }
 
@@ -66,6 +69,12 @@ export type KanbanOnMove<TRecord extends RecordType> = (
   sourceRecord: TRecord,
   destinyRecord: { record: TRecord; position: "above" | "below" } | null
 ) => Promise<TRecord>
+
+export type KanbanOnBulkMove<TRecord extends RecordType> = (
+  moves: Array<{ fromLaneId: string; sourceRecord: TRecord }>,
+  toLaneId: string,
+  destinyRecord: { record: TRecord; position: "above" | "below" } | null
+) => Promise<TRecord[]>
 
 export type KanbanOnMoveParam =
   | {
@@ -82,6 +91,16 @@ export type KanbanOnMoveParam =
       indexOfTarget: number
       position: "above" | "below"
     }
+
+export type KanbanOnBulkMoveParam = {
+  /** IDs of all selected items to move */
+  selectedIds: string[]
+  /** Target lane ID */
+  toLaneId: string
+  /** Target card position (null = drop into empty lane or end of lane) */
+  indexOfTarget: number | null
+  position: "above" | "below" | null
+}
 
 // (Removed) Leave/Insert split: we simplified to a single onMove orchestrated by Kanban
 

--- a/packages/react/src/ui/Kanban/types.ts
+++ b/packages/react/src/ui/Kanban/types.ts
@@ -56,7 +56,7 @@ export interface KanbanProps<TRecord extends RecordType> {
     getIndexById: (laneId: string, id: string) => number
     onMove?: KanbanOnMove<TRecord>
     onBulkMove?: KanbanOnBulkMove<TRecord>
-    /** IDs of all currently selected items (for bulk drag-and-drop) */
+    /** Keys (from getKey) of all currently selected items (for bulk drag-and-drop) */
     selectedIds?: string[]
   }
 }
@@ -93,11 +93,11 @@ export type KanbanOnMoveParam =
     }
 
 export type KanbanOnBulkMoveParam = {
-  /** IDs of all selected items to move */
+  /** Keys (from getKey) of all selected items to move */
   selectedIds: string[]
   /** Target lane ID */
   toLaneId: string
-  /** Target card position (null = drop into empty lane or end of lane) */
+  /** Target card position (null = top of lane, i.e. index 0) */
   indexOfTarget: number | null
   position: "above" | "below" | null
 }


### PR DESCRIPTION
## Description
Add bulk move (drag-one-moves-all) functionality to the Kanban board. When a user selects multiple cards via checkboxes and drags one of them, all selected cards move together to the target lane. A count badge on the drag preview shows how many items are being moved, with stacked card shadows behind the dragged card to visually represent the group.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/39018b25-b5c0-4abd-8812-57d8ef1a484a



## Implementation details

- Extended the DnD abstraction layer (src/lib/dnd/) with selectedIds in the drag payload and onGenerateDragPreview support, forwarded through to Atlaskit
- Added KanbanOnBulkMove type and onBulkMove/selectedIds to the Kanban dnd config
- KanbanCard renders a custom native drag preview with stacked opaque card shells + count badge, resolving the page background at drag time for light/dark mode support
- KanbanLane detects bulk drags in the drop handler and routes to onBulkMove when 2+ items are selected
- Kanban orchestrator handles full optimistic bulk moves: snapshot, remove from sources, insert at target preserving order, adjust totals, replace with backend versions on success, rollback on error
- ODC integration computes selected IDs from the per-lane selection state and wires them into the Kanban DnD config
- Edge cases: non-selected card drag, single selection, cross-lane selections, missing onBulkMove callback all fall through to normal single-card move
- 7 unit tests + interactive BulkMove story with card checkbox selection, simulation buttons, and reset
