### PR TITLE
feat: add GhostListItem component

### DIFF
--- a/packages/react/src/components/F0GhostListItem/index.stories.tsx
+++ b/packages/react/src/components/F0GhostListItem/index.stories.tsx
@@ -61,6 +61,16 @@ export const Selected: Story = {
   },
 }
 
+export const Disabled: Story = {
+  args: {
+    icon: FileFilled,
+    title: "Pixar Animation",
+    filled: false,
+    date: "04/12/2026",
+    disabled: true,
+  },
+}
+
 export const SkeletonStory: Story = {
   name: "Skeleton",
   render: () => <F0GhostListItem.Skeleton />,
@@ -96,6 +106,13 @@ export const List: Story = {
         filled: false,
         date: "04/15/2026",
       },
+      {
+        id: "6",
+        title: "Umbrella Corp",
+        filled: false,
+        date: "04/20/2026",
+        disabled: true,
+      },
     ]
 
     return (
@@ -107,6 +124,7 @@ export const List: Story = {
             title={card.title}
             filled={card.filled}
             date={card.date}
+            disabled={"disabled" in card && card.disabled}
             selected={selectedId === card.id}
             onClick={() =>
               setSelectedId(selectedId === card.id ? null : card.id)
@@ -152,6 +170,14 @@ export const Snapshot: Story = {
         filled
         date="04/12/2026"
         selected
+        onClick={() => {}}
+      />
+      <F0GhostListItem
+        icon={FileFilled}
+        title="Disabled item"
+        filled={false}
+        date="04/12/2026"
+        disabled
         onClick={() => {}}
       />
       <F0GhostListItem.Skeleton />

--- a/packages/react/src/components/F0GhostListItem/index.tsx
+++ b/packages/react/src/components/F0GhostListItem/index.tsx
@@ -22,6 +22,8 @@ export interface F0GhostListItemProps {
   date: string
   /** Whether the item is selected */
   selected?: boolean
+  /** Whether the item is disabled */
+  disabled?: boolean
   /** Click handler */
   onClick: () => void
 }
@@ -29,49 +31,67 @@ export interface F0GhostListItemProps {
 const BaseF0GhostListItem = React.forwardRef<
   HTMLDivElement,
   F0GhostListItemProps
->(({ icon, title, filled, date, selected = false, onClick }, ref) => {
-  const { t } = useI18n()
+>(
+  (
+    { icon, title, filled, date, selected = false, disabled = false, onClick },
+    ref
+  ) => {
+    const { t } = useI18n()
 
-  return (
-    <div
-      ref={ref}
-      role="button"
-      tabIndex={0}
-      aria-pressed={selected}
-      className={cn(
-        "flex cursor-pointer items-start gap-3 rounded-xl border border-solid border-transparent bg-f1-background p-3 transition-all hover:bg-f1-background-hover",
-        selected && "border-f1-border bg-f1-background",
-        focusRing()
-      )}
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.target !== e.currentTarget) return
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault()
-          onClick()
+    return (
+      <div
+        ref={ref}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-pressed={selected}
+        aria-disabled={disabled}
+        className={cn(
+          "flex items-start gap-3 rounded-xl border border-solid border-transparent bg-f1-background p-3 transition-all",
+          disabled
+            ? "cursor-not-allowed opacity-50"
+            : "cursor-pointer hover:bg-f1-background-hover",
+          selected && !disabled && "border-f1-border bg-f1-background",
+          !disabled && focusRing()
+        )}
+        onClick={disabled ? undefined : onClick}
+        onKeyDown={
+          disabled
+            ? undefined
+            : (e) => {
+                if (e.target !== e.currentTarget) return
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault()
+                  onClick()
+                }
+              }
         }
-      }}
-    >
-      <F0AvatarIcon icon={icon} size="md" />
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <span className="truncate text-base font-semibold text-f1-foreground">
-          {title}
-        </span>
-        <div className="flex items-center gap-2">
-          {filled ? (
-            <F0TagRaw icon={Check} text={t("lists.ghostListItem.filled")} />
-          ) : (
-            <F0TagStatus
-              variant="warning"
-              text={t("lists.ghostListItem.pending")}
-            />
-          )}
-          <span className="text-sm text-f1-foreground-secondary">{date}</span>
+      >
+        <F0AvatarIcon icon={icon} size="md" />
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="truncate text-base font-semibold text-f1-foreground">
+            {title}
+          </span>
+          <div className="flex items-center gap-2">
+            {disabled ? (
+              <F0TagStatus
+                variant="neutral"
+                text={t("lists.ghostListItem.disabled")}
+              />
+            ) : filled ? (
+              <F0TagRaw icon={Check} text={t("lists.ghostListItem.filled")} />
+            ) : (
+              <F0TagStatus
+                variant="warning"
+                text={t("lists.ghostListItem.pending")}
+              />
+            )}
+            <span className="text-sm text-f1-foreground-secondary">{date}</span>
+          </div>
         </div>
       </div>
-    </div>
-  )
-})
+    )
+  }
+)
 
 const F0GhostListItemSkeleton = () => {
   return (

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -600,6 +600,7 @@ export const defaultTranslations = {
     ghostListItem: {
       filled: "Filled",
       pending: "Pending",
+      disabled: "Disabled",
     },
   },
 } as const


### PR DESCRIPTION
## Summary

### GhostListItem (new component)
- New experimental component in `experimental/Lists/GhostListItem` — ghost-style list item with no border by default, border on hover/active, and subtle grey background on hover
- Uses `filled` boolean to render either `F0TagRaw` with check icon (Filled) or `F0TagStatus` warning (Pending)
- Includes Skeleton support, `experimentalComponent` and `withDataTestId` wrappers
- i18n labels via `lists.ghostListItem.filled` / `lists.ghostListItem.pending`

<img width="485" height="425" alt="Screenshot 2026-04-08 at 00 07 18" src="https://github.com/user-attachments/assets/799098a4-f85e-41be-b785-7e5e9009ee88" />

https://www.figma.com/design/doiL1fqBMbZSw4vqyY1baS/Workflows-Abstraction?node-id=20551-22628&t=dmWlblLGnzscd7Kd-0

## Test plan
- [x] Check Storybook stories at `List/GhostListItem`
- [x] Verify GhostListItem hover/active/selected states match Figma

🤖 Generated with [Claude Code](https://claude.com/claude-code)