### PR TITLE
fix(ui/checkbox): stability BLOCKING a11y fixes

### DIFF
--- a/packages/react/src/components/F0Checkbox/__test__/F0Checkbox.test.tsx
+++ b/packages/react/src/components/F0Checkbox/__test__/F0Checkbox.test.tsx
@@ -134,10 +134,24 @@ describe("F0Checkbox", () => {
 
     const checkbox = screen.getByRole("checkbox")
 
-    expect(checkbox).toHaveAttribute("aria-label", "Accessible checkbox")
+    // Visible label is associated via htmlFor/id — no aria-label override
     expect(checkbox).toHaveAttribute("id", "accessible-id")
     expect(checkbox).toBeChecked()
     expect(checkbox).not.toBeDisabled()
+  })
+
+  it("sets aria-label when hideLabel is true", () => {
+    render(
+      <F0Checkbox
+        title="Hidden label checkbox"
+        hideLabel
+        checked={true}
+        disabled={false}
+      />
+    )
+
+    const checkbox = screen.getByRole("checkbox")
+    expect(checkbox).toHaveAttribute("aria-label", "Hidden label checkbox")
   })
 
   it("generates unique id when not provided", () => {

--- a/packages/react/src/ui/checkbox.tsx
+++ b/packages/react/src/ui/checkbox.tsx
@@ -30,7 +30,7 @@ const Checkbox = React.forwardRef<
           ref={ref}
           id={checkboxId}
           name={props.name || checkboxId}
-          aria-label={props.title}
+          aria-label={hideLabel ? props.title : undefined}
           className={cn(
             "relative h-6 w-6 shrink-0 rounded-sm text-f1-foreground-selected data-[state=checked]:text-f1-foreground-inverse",
             "after:absolute after:left-0.5 after:top-0.5 after:z-[1] after:h-5 after:w-5 after:rounded-xs after:border after:border-solid after:border-f1-border after:transition-[background-color,border-color] after:content-[''] hover:after:border-f1-border-hover data-[state=checked]:after:bg-f1-background-selected-bold hover:data-[state=checked]:after:border-transparent",
@@ -42,7 +42,7 @@ const Checkbox = React.forwardRef<
             focusRing("focus-visible:ring-offset-0"),
             className
           )}
-          checked={props.checked}
+          checked={indeterminate ? "indeterminate" : props.checked}
           onCheckedChange={props.onCheckedChange}
           disabled={disabled}
         >
@@ -67,7 +67,12 @@ const Checkbox = React.forwardRef<
           >
             {props.title}
             {required && (
-              <span className="ml-0.5 text-f1-foreground-critical">*</span>
+              <span
+                aria-hidden="true"
+                className="ml-0.5 text-f1-foreground-critical"
+              >
+                *
+              </span>
             )}
           </label>
         )}


### PR DESCRIPTION
## Summary

Fixes all BLOCKING a11y findings for `ui/checkbox.tsx` (shared primitive used by F0Checkbox, SelectItem, Table Row, deprecated EntitySelect).

## Changes

- **WCAG 1.3.1 / 4.1.2** — `aria-label` only set when `hideLabel=true`; when a visible `<label>` is present, the label association via `htmlFor`/`id` is sufficient and overriding with `aria-label` is harmful to AT users
- **WCAG 4.1.2** — Pass `checked="indeterminate"` to `CheckboxPrimitive.Root` when `indeterminate=true`; previously the indeterminate state was never communicated to AT
- **WCAG 1.3.1** — Add `aria-hidden="true"` to required asterisk `*` span; avoids stray character read by some AT

## Quality Gate

- `pnpm tsc --noEmit` — ✅ clean
- `pnpm lint` — ✅ 0 warnings, 0 errors
- `pnpm vitest:ci` — ✅ 2423 passed, 0 failed

## Related

Prerequisite shared-file fix for stability audit issue:
- #3872 (F0Checkbox)