### PR TITLE
fix(F0Select): resolve stability audit BLOCKING issues

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -580,7 +580,7 @@ const F0SelectComponent = forwardRef(function Select<
 
   const handleApply = useCallback(() => {
     handleChangeOpenLocal(false)
-  }, [])
+  }, [handleChangeOpenLocal])
 
   // Track when filters panel is open to hide bottom actions
   const [isFiltersOpen, setIsFiltersOpen] = useState(false)
@@ -817,12 +817,12 @@ const F0SelectComponent = forwardRef(function Select<
       <SelectPrimitive {...selectPrimitiveProps}>
         <SelectTrigger ref={ref} asChild>
           {children ? (
-            <div
+            <button
               className="flex w-full items-center justify-between"
               aria-label={label || placeholder}
             >
               {children}
-            </div>
+            </button>
           ) : (
             <InputField
               label={label}
@@ -878,7 +878,6 @@ const F0SelectComponent = forwardRef(function Select<
             >
               <button
                 className="flex w-full items-center justify-between"
-                aria-label={label || placeholder}
                 onClick={(e) => {
                   e.preventDefault()
                 }}

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -16,6 +16,7 @@ import { withSkipA11y, withSnapshot } from "@/lib/storybook-utils/parameters"
 import { inputFieldStatus } from "@/ui/InputField"
 
 import { F0Select, selectSizes } from "../index"
+import type { F0SelectProps } from "../types"
 import {
   Employee,
   employeeNestedPaginatedSource,
@@ -313,7 +314,7 @@ const meta: Meta = {
       <div
         className="w-[330px]"
         onClick={() => {
-          console.log("click was received in elements below the select")
+          // decorator captures click events propagated from the select
         }}
       >
         <Story />
@@ -541,7 +542,6 @@ export const WithSearchBox: Story = {
           label="Select a theme"
           onChange={fn()}
           searchFn={(option, searchValue) => {
-            console.log("searchFn", option, searchValue)
             return (
               option.type === "separator" ||
               !searchValue ||
@@ -770,7 +770,7 @@ export const MultiplePaginated: Story = {
       avatar: item.avatar,
     }),
     onSelectItems: fn((selectionStatus) => {
-      console.log("selectionStatus", selectionStatus)
+      void selectionStatus
     }),
   },
 }
@@ -811,7 +811,7 @@ export const MultiplePaginatedWithPreview: Story = {
       avatar: item.avatar,
     }),
     onSelectItems: fn((selectionStatus) => {
-      console.log("selectionStatus", selectionStatus)
+      void selectionStatus
     }),
   },
 }
@@ -855,14 +855,14 @@ export const MultiplePaginatedAsList: Story = {
       avatar: item.avatar,
     }),
     onSelectItems: fn((selectionStatus) => {
-      console.log("selectionStatus", selectionStatus)
+      void selectionStatus
     }),
     hideLabel: true,
   },
   render: (args) => {
     return (
       <div className="flex h-[400px] flex-row w-[600px]">
-        <F0Select {...(args as any)} />
+        <F0Select {...(args as F0SelectProps<string>)} />
       </div>
     )
   },
@@ -877,7 +877,7 @@ export const AsList: Story = {
   render: (args) => {
     return (
       <div className="flex h-max w-[300px]">
-        <F0Select {...(args as any)} />
+        <F0Select {...(args as F0SelectProps<string>)} />
       </div>
     )
   },

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -1,6 +1,5 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { fireEvent, screen, waitFor } from "@/testing/test-utils"
 import userEvent from "@testing-library/user-event"
-import "@testing-library/jest-dom/vitest"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { RecordType } from "@/hooks/datasource"
@@ -58,9 +57,7 @@ const defaultSelectProps = {
   placeholder: "",
   label: "Pick an option",
   hideLabel: false,
-  onChange: (value: string) => {
-    console.log(value)
-  },
+  onChange: vi.fn(),
 }
 
 describe("Select", () => {
@@ -94,12 +91,12 @@ describe("Select", () => {
   })
 
   const openSelect = async (user: ReturnType<typeof userEvent.setup>) => {
-    user.click(screen.getByRole("combobox"))
+    await user.click(screen.getByRole("combobox"))
 
-    // Wait for animation to finish
+    // Wait for the listbox to appear, then trigger animationStart so the
+    // virtualizer becomes enabled and renders items in JSDOM (no real CSS animations)
     await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
-    const teaser = screen.getByRole("listbox")
-    fireEvent.animationStart(teaser)
+    fireEvent.animationStart(screen.getByRole("listbox"))
   }
 
   it("renders with placeholder", async () => {
@@ -367,7 +364,7 @@ describe("Select", () => {
     const handleChangeSelectedOption = vi.fn()
     const user = userEvent.setup()
 
-    const { container } = render(
+    render(
       <F0Select
         {...defaultSelectProps}
         options={mockOptions}
@@ -405,15 +402,13 @@ describe("Select", () => {
       expect(screen.getByText("Option 1")).toBeInTheDocument()
     })
 
-    // Find the clear button using the same approach as InputField tests
+    // Find the clear button using accessible role query
     // The clear button should be visible when there's a value
-    const clearButton = container.querySelector(
-      "button[data-testid='clear-button']"
-    )
+    const clearButton = screen.getByRole("button", { name: /clear/i })
     expect(clearButton).toBeInTheDocument()
 
-    // Click the clear button using fireEvent directly
-    await fireEvent.click(clearButton)
+    // Click the clear button using userEvent
+    await user.click(clearButton)
 
     // Verify that onChange is called with empty string and onChangeSelectedOption with undefined
     await waitFor(() => {

--- a/packages/react/src/components/F0Select/components/SelectAll.tsx
+++ b/packages/react/src/components/F0Select/components/SelectAll.tsx
@@ -1,3 +1,5 @@
+import { useId } from "react"
+
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Checkbox } from "@/components/F0Checkbox"
 import { OneEllipsis } from "@/lib/OneEllipsis"
@@ -28,6 +30,7 @@ export const SelectAll = ({
   paddingTop = false,
 }: SelectAllProps) => {
   const i18n = useI18n()
+  const selectAllId = useId()
 
   const handleChange = (checked: boolean) => {
     if (indeterminate) {
@@ -68,7 +71,7 @@ export const SelectAll = ({
       {!hideCheckbox ? (
         <div className="shrink-0 pr-1">
           <F0Checkbox
-            id="select-all"
+            id={selectAllId}
             title={i18n.actions.selectAll}
             checked={indeterminate || value}
             indeterminate={indeterminate}

--- a/packages/react/src/components/F0Select/components/SelectItem.tsx
+++ b/packages/react/src/components/F0Select/components/SelectItem.tsx
@@ -24,7 +24,10 @@ export const SelectItem = <T extends string, R>({
           </div>
         )}
         {item.icon && (
-          <div className="flex shrink-0 items-center text-f1-icon">
+          <div
+            className="flex shrink-0 items-center text-f1-icon"
+            aria-hidden="true"
+          >
             <F0Icon icon={item.icon} />
           </div>
         )}

--- a/packages/react/src/components/F0Select/components/SelectionPreview.tsx
+++ b/packages/react/src/components/F0Select/components/SelectionPreview.tsx
@@ -26,9 +26,11 @@ const SCROLL_BOTTOM_MARGIN = 10
 function PreviewItem<T extends string>({
   item,
   onDeselect,
+  removeLabel,
 }: {
   item: F0SelectItemObject<T>
   onDeselect: (value: string) => void
+  removeLabel: string
 }) {
   return (
     <div className="flex w-fit max-w-full min-w-0 items-center justify-between gap-1.5 rounded-md border border-solid border-f1-border-secondary p-1">
@@ -48,7 +50,7 @@ function PreviewItem<T extends string>({
           "flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-full border-0 bg-transparent p-0",
           focusRing()
         )}
-        aria-label={`Remove ${item.label}`}
+        aria-label={removeLabel}
         type="button"
         tabIndex={0}
         onClick={(e) => {
@@ -128,6 +130,9 @@ export function SelectionPreview<T extends string>({
                   key={String(item.value)}
                   item={item}
                   onDeselect={onDeselect}
+                  removeLabel={i18n.t("actions.removeItem", {
+                    label: item.label,
+                  })}
                 />
               ))}
               {isLoadingMore && (

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -61,6 +61,7 @@ export const defaultTranslations = {
     toggleDropdownMenu: "Toggle dropdown menu",
     selectAll: "Select all",
     selectAllItems: "Select all {{total}} items",
+    removeItem: "Remove {{label}}",
   },
   status: {
     selected: {


### PR DESCRIPTION
## Summary

Resolves BLOCKING findings from stability audit issue #3874 for `F0Select`.

## Changes

### Accessibility
- **SelectionPreview**: Replace hardcoded `` `Remove ${item.label}` `` aria-label with i18n key `actions.removeItem` (new key added to `i18n-provider-defaults.ts`)
- **SelectItem**: Add `aria-hidden="true"` to decorative icon wrapper `<div>` so screen readers skip it
- **Custom trigger**: Change wrapper from `<div>` to `<button>` so Radix merges `combobox` role onto interactive host
- **InputField inner button**: Remove duplicate `aria-label={label || placeholder}` (already on outer trigger)
- **SelectAll**: Use `useId()` for stable id instead of hardcoded `id="select-all"`

### Bug fixes
- **handleApply stale closure**: Add `handleChangeOpenLocal` to `useCallback` deps array

### Test / story quality
- Replace `console.log` onChange with `vi.fn()` in test setup
- Fix `openSelect` helper: restore `fireEvent.animationStart` to enable virtualizer in JSDOM
- Replace `container.querySelector` with `screen.getByRole` for clear button
- Replace `console.log` callbacks with `void` in stories
- Replace `args as any` with typed `F0SelectProps<string>` cast in stories

## Testing

- `pnpm tsc --noEmit` ✅
- `pnpm lint` ✅  
- `pnpm vitest:ci src/components/F0Select` ✅ (12 passed, 1 skipped)

Closes #3874