### PR TITLE
feat(FileUpload): improve document upload experience

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
@@ -13,7 +13,7 @@ export type F0AvatarIconProps = {
 
 const sizes = {
   sm: "size-6 rounded-sm",
-  md: "size-9 rounded-md",
+  md: "size-8 rounded-md",
   lg: "size-10 rounded-lg",
 }
 

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -559,7 +559,7 @@ export const defaultTranslations = {
       uploadFailed: "Upload failed",
       fileTooLarge: "File exceeds {{maxSize}} MB limit",
       invalidFileType: "File type not accepted. Accepted formats: {{types}}",
-      fileWeight: "File size: {{size}}",
+      fileWeight: "File weight: {{size}}",
       maxFilesReached: "Maximum {{maxFiles}} files",
     },
     moreInformation: "More information",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -559,7 +559,6 @@ export const defaultTranslations = {
       uploadFailed: "Upload failed",
       fileTooLarge: "File exceeds {{maxSize}} MB limit",
       invalidFileType: "File type not accepted. Accepted formats: {{types}}",
-      fileWeight: "File weight: {{size}}",
       maxFilesReached: "Maximum {{maxFiles}} files",
     },
     moreInformation: "More information",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -559,7 +559,7 @@ export const defaultTranslations = {
       uploadFailed: "Upload failed",
       fileTooLarge: "File exceeds {{maxSize}} MB limit",
       invalidFileType: "File type not accepted. Accepted formats: {{types}}",
-      fileWeight: "File weight: {{size}}",
+      fileWeight: "File size: {{size}}",
       maxFilesReached: "Maximum {{maxFiles}} files",
     },
     moreInformation: "More information",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -559,6 +559,8 @@ export const defaultTranslations = {
       uploadFailed: "Upload failed",
       fileTooLarge: "File exceeds {{maxSize}} MB limit",
       invalidFileType: "File type not accepted. Accepted formats: {{types}}",
+      fileWeight: "File weight: {{size}}",
+      maxFilesReached: "Maximum {{maxFiles}} files",
     },
     moreInformation: "More information",
     validation: {

--- a/packages/react/src/patterns/F0Form/fields/file/FileAttachment.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileAttachment.tsx
@@ -5,7 +5,7 @@ import { F0Button } from "@/components/F0Button"
 import { Cross } from "@/icons/app"
 import { cn } from "@/lib/utils"
 
-import type { FileUploadItemProps } from "./types"
+import type { FileAttachmentProps } from "./types"
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -13,20 +13,37 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
+const positionRadius: Record<
+  NonNullable<FileAttachmentProps["position"]>,
+  string
+> = {
+  single: "rounded-xl",
+  top: "rounded-t-xl rounded-b-none",
+  middle: "rounded-none",
+  bottom: "rounded-b-xl rounded-t-none",
+}
+
 /**
- * Renders a single file row. Handles two modes:
+ * Renders a single file attachment row.
+ * Handles two modes:
  * - New upload (entry.file): triggers useUpload, shows progress
  * - Pre-existing (entry.initialFile): displays immediately, no upload
+ *
+ * The `position` prop controls border-radius for grouped lists:
+ * - "single": full radius (standalone)
+ * - "top" / "middle" / "bottom": partial radius for grouped lists
  */
-export function FileUploadItem({
+export function FileAttachment({
   entry,
   useUpload,
   onUploadComplete,
   onRemove,
   onError,
   disabled,
+  position = "single",
+  className,
   translations,
-}: FileUploadItemProps) {
+}: FileAttachmentProps) {
   const isNewUpload = !!entry.file
   const uploadHook = useUpload?.()
   const upload = uploadHook?.upload
@@ -88,35 +105,41 @@ export function FileUploadItem({
   const fileName = entry.file?.name ?? entry.initialFile?.name ?? ""
   const fileSize = entry.file?.size ?? entry.initialFile?.size
 
+  const subtitleText = error
+    ? error
+    : isUploading
+      ? status === "processing"
+        ? translations.processing
+        : `${translations.uploading} ${progressPercent}%`
+      : fileSize != null
+        ? translations.fileWeight.replace("{{size}}", formatFileSize(fileSize))
+        : null
+
   return (
     <div
       className={cn(
-        "flex items-center gap-3 rounded-lg border border-solid border-f1-border-secondary px-2.5 py-2",
-        error && "border-f1-border-critical"
+        "flex items-center gap-[10px] border border-solid bg-f1-background p-3",
+        positionRadius[position],
+        error ? "border-f1-border-critical" : "border-f1-border-secondary",
+        className
       )}
     >
-      <F0AvatarFile file={fileDef} size="md" />
+      <F0AvatarFile file={fileDef} size="lg" />
 
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate text-base font-medium text-f1-foreground">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm font-medium text-f1-foreground">
           {fileName}
         </span>
-        <span className="text-sm text-f1-foreground-secondary">
-          {error
-            ? error
-            : isUploading
-              ? status === "processing"
-                ? translations.processing
-                : `${translations.uploading} ${progressPercent}%`
-              : fileSize != null
-                ? formatFileSize(fileSize)
-                : null}
-        </span>
+        {subtitleText && (
+          <span className="text-sm text-f1-foreground-secondary">
+            {subtitleText}
+          </span>
+        )}
       </div>
 
       {!disabled && (
         <F0Button
-          variant="ghost"
+          variant="outline"
           size="sm"
           label={translations.remove}
           onClick={handleRemove}

--- a/packages/react/src/patterns/F0Form/fields/file/FileAttachment.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileAttachment.tsx
@@ -112,7 +112,7 @@ export function FileAttachment({
         ? translations.processing
         : `${translations.uploading} ${progressPercent}%`
       : fileSize != null
-        ? translations.fileWeight.replace("{{size}}", formatFileSize(fileSize))
+        ? formatFileSize(fileSize)
         : null
 
   return (

--- a/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
@@ -523,7 +523,6 @@ export function FileFieldRenderer({
                   uploading: translations.uploading,
                   processing: translations.processing,
                   uploadFailed: translations.uploadFailed,
-                  fileWeight: translations.fileWeight,
                 }}
               />
             )

--- a/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
@@ -236,29 +236,73 @@ export function FileFieldRenderer({
     (files: File[]) => {
       setValidationError(null)
 
-      const filesToProcess = isMultiple ? files : [files[0]]
-
-      for (const file of filesToProcess) {
+      if (!isMultiple) {
+        const file = files[0]
         const validationMsg = validateFile(file)
         if (validationMsg) {
           setValidationError(validationMsg)
-          continue
+          return
         }
-
         if (!resolvedUseUpload) {
           console.warn(
             "[F0Form] No useUpload hook provided. Pass useUpload to <F0Form> or to the file field config."
           )
         }
-
         const key = `${file.name}-${file.size}-${Date.now()}-${Math.random()}`
-        setEntries((prev) => {
-          if (!isMultiple) return [{ key, file }]
-          return [...prev, { key, file }]
-        })
+        setEntries([{ key, file }])
+        return
+      }
+
+      // Multiple mode: use functional updater to always read latest entries count.
+      // Validation error is captured via a local variable and scheduled after.
+      let errorMsg: string | null = null
+
+      setEntries((prev) => {
+        const remaining =
+          field.maxFiles != null ? field.maxFiles - prev.length : Infinity
+
+        if (remaining <= 0) {
+          errorMsg = translations.maxFilesReached.replace(
+            "{{maxFiles}}",
+            String(field.maxFiles)
+          )
+          return prev
+        }
+
+        const filesToProcess = files.slice(0, remaining)
+        if (files.length > remaining) {
+          errorMsg = translations.maxFilesReached.replace(
+            "{{maxFiles}}",
+            String(field.maxFiles)
+          )
+        }
+
+        const newEntries: FileEntry[] = []
+        for (const file of filesToProcess) {
+          const validationMsg = validateFile(file)
+          if (validationMsg) {
+            errorMsg = validationMsg
+            continue
+          }
+          if (!resolvedUseUpload) {
+            console.warn(
+              "[F0Form] No useUpload hook provided. Pass useUpload to <F0Form> or to the file field config."
+            )
+          }
+          newEntries.push({
+            key: `${file.name}-${file.size}-${Date.now()}-${Math.random()}`,
+            file,
+          })
+        }
+        return [...prev, ...newEntries]
+      })
+
+      // Apply captured error after the state update batch
+      if (errorMsg !== null) {
+        setValidationError(errorMsg)
       }
     },
-    [isMultiple, validateFile, resolvedUseUpload]
+    [isMultiple, field.maxFiles, validateFile, resolvedUseUpload, translations]
   )
 
   const handleDragOver = useCallback(

--- a/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
@@ -3,8 +3,9 @@ import { ControllerRenderProps, FieldValues } from "react-hook-form"
 
 import type { InputFieldStatusType } from "@/ui/InputField/types"
 
+import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0Icon } from "@/components/F0Icon"
-import { Upload } from "@/icons/app"
+import { AlertCircle, Upload } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import { cn, focusRing } from "@/lib/utils"
 
@@ -12,7 +13,7 @@ import type { ResolvedField } from "../types"
 import type { F0FileField, FileEntry, InitialFile } from "./types"
 
 import { useOptionalF0FormContext } from "../../context"
-import { FileUploadItem } from "./FileUploadItem"
+import { FileAttachment } from "./FileAttachment"
 
 const BARE_CATEGORIES = new Set([
   "image",
@@ -103,11 +104,11 @@ function getDropzoneStatusClasses({
   statusType?: InputFieldStatusType
 }): string {
   if (isDragOver) {
-    return "border-f1-border-accent bg-f1-background-accent-bold/5"
+    return "border-f1-border-selected-bold bg-f1-background-selected"
   }
 
   if (hasCriticalStatus) {
-    return "border-f1-border-critical-bold bg-f1-background-critical bg-opacity-10"
+    return "border-f1-border-critical-bold bg-f1-background-critical/10"
   }
 
   if (statusType === "warning") {
@@ -186,8 +187,11 @@ export function FileFieldRenderer({
 
   const hasFiles = entries.length > 0
 
-  // In single mode, hide dropzone once a file entry exists
-  const showDropzone = isMultiple || !hasFiles
+  // In single mode, hide dropzone once a file entry exists.
+  // In multiple mode, hide dropzone if maxFiles limit is reached.
+  const isAtLimit =
+    isMultiple && field.maxFiles != null && entries.length >= field.maxFiles
+  const showDropzone = !isAtLimit && (isMultiple || !hasFiles)
 
   const acceptString = field.accept
     ? field.accept.map(normalizeMime).join(",")
@@ -384,7 +388,7 @@ export function FileFieldRenderer({
   })
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-4">
       {showDropzone && (
         <div
           role="button"
@@ -396,25 +400,23 @@ export function FileFieldRenderer({
           onKeyDown={handleDropzoneKeyDown}
           aria-disabled={field.disabled}
           className={cn(
-            "flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed px-4 py-6 transition-colors",
+            "flex cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border-[1px] border-dashed px-4 py-10 transition-colors",
             dropzoneStatusClasses,
             !field.disabled &&
               !isDragOver &&
               !hasDecorativeStatus &&
               "hover:border-f1-border-hover hover:bg-f1-background-secondary",
             field.disabled && "cursor-not-allowed opacity-50",
-            focusRing("rounded-lg")
+            focusRing("rounded-xl")
           )}
         >
-          <div className="flex aspect-square items-center justify-center rounded-md border border-solid border-f1-border p-1 text-f1-icon">
-            <F0Icon icon={Upload} size="lg" />
-          </div>
+          <F0AvatarIcon icon={Upload} size="md" />
           <div className="flex flex-col items-center gap-0.5">
-            <span className="text-center text-base text-f1-foreground-secondary">
+            <span className="text-center text-base font-medium text-f1-foreground">
               {dropzoneText}
             </span>
-            {!isDragOver && acceptedTypesLabel && (
-              <span className="text-center text-sm text-f1-foreground-secondary/70">
+            {acceptedTypesLabel && (
+              <span className="text-center text-base text-f1-foreground-secondary">
                 {translations.acceptedTypes.replace(
                   "{{types}}",
                   acceptedTypesLabel
@@ -438,32 +440,50 @@ export function FileFieldRenderer({
       />
 
       {validationError && (
-        <p className="text-base text-f1-foreground-critical">
-          {validationError}
-        </p>
+        <div className="-mt-2 flex items-center gap-1">
+          <F0Icon icon={AlertCircle} color="critical" />
+          <p className="text-sm font-medium text-f1-foreground-critical">
+            {validationError}
+          </p>
+        </div>
       )}
 
       {entries.length > 0 && (
-        <div className="flex flex-col gap-2">
-          {entries.map((entry) => (
-            <FileUploadItem
-              key={entry.key}
-              entry={entry}
-              useUpload={entry.file ? resolvedUseUpload : undefined}
-              onUploadComplete={(value) =>
-                handleUploadComplete(entry.key, value)
-              }
-              onRemove={() => handleRemove(entry.key)}
-              onError={(msg) => handleUploadError(entry.key, msg)}
-              disabled={field.disabled}
-              translations={{
-                remove: translations.remove,
-                uploading: translations.uploading,
-                processing: translations.processing,
-                uploadFailed: translations.uploadFailed,
-              }}
-            />
-          ))}
+        <div className="flex flex-col">
+          {entries.map((entry, index) => {
+            const total = entries.length
+            const position =
+              total === 1
+                ? "single"
+                : index === 0
+                  ? "top"
+                  : index === total - 1
+                    ? "bottom"
+                    : "middle"
+
+            return (
+              <FileAttachment
+                key={entry.key}
+                className={index > 0 ? "-mt-px" : undefined}
+                entry={entry}
+                useUpload={entry.file ? resolvedUseUpload : undefined}
+                onUploadComplete={(value) =>
+                  handleUploadComplete(entry.key, value)
+                }
+                onRemove={() => handleRemove(entry.key)}
+                onError={(msg) => handleUploadError(entry.key, msg)}
+                disabled={field.disabled}
+                position={position}
+                translations={{
+                  remove: translations.remove,
+                  uploading: translations.uploading,
+                  processing: translations.processing,
+                  uploadFailed: translations.uploadFailed,
+                  fileWeight: translations.fileWeight,
+                }}
+              />
+            )
+          })}
         </div>
       )}
     </div>

--- a/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
@@ -1,80 +1,80 @@
-import userEvent from "@testing-library/user-event";
-import React from "react";
-import { describe, expect, it, vi } from "vitest";
-import { z } from "zod";
+import userEvent from "@testing-library/user-event"
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { z } from "zod"
 
 import {
   zeroRender as render,
   screen,
   waitFor,
   fireEvent,
-} from "@/testing/test-utils";
+} from "@/testing/test-utils"
 
 import type {
   FileUploadResult,
   FileUploadStatus,
   UseFileUpload,
-} from "../types";
+} from "../types"
 
-import { F0Form } from "../../../F0Form";
-import { f0FormField } from "../../../f0Schema";
+import { F0Form } from "../../../F0Form"
+import { f0FormField } from "../../../f0Schema"
 
 function createMockUploadHook(
   options: {
-    delay?: number;
-    shouldFail?: boolean;
-  } = {},
+    delay?: number
+    shouldFail?: boolean
+  } = {}
 ): UseFileUpload {
-  const { delay = 0, shouldFail = false } = options;
+  const { delay = 0, shouldFail = false } = options
 
   return () => {
-    const [progress, setProgress] = React.useState(0);
-    const [status, setStatus] = React.useState<FileUploadStatus>("idle");
+    const [progress, setProgress] = React.useState(0)
+    const [status, setStatus] = React.useState<FileUploadStatus>("idle")
 
     const upload = React.useCallback(
       async (file: File): Promise<FileUploadResult> => {
-        setStatus("processing");
-        setProgress(0);
+        setStatus("processing")
+        setProgress(0)
 
         if (delay > 0) {
-          await new Promise((r) => setTimeout(r, delay));
+          await new Promise((r) => setTimeout(r, delay))
         }
 
         if (shouldFail) {
-          setStatus("idle");
-          throw new Error("Upload failed");
+          setStatus("idle")
+          throw new Error("Upload failed")
         }
 
-        setStatus("uploading");
-        setProgress(0.5);
+        setStatus("uploading")
+        setProgress(0.5)
 
         if (delay > 0) {
-          await new Promise((r) => setTimeout(r, delay));
+          await new Promise((r) => setTimeout(r, delay))
         }
 
-        setProgress(1);
-        setStatus("success");
-        return { type: "success", value: `signed_${file.name}` };
+        setProgress(1)
+        setStatus("success")
+        return { type: "success", value: `signed_${file.name}` }
       },
-      [delay, shouldFail],
-    );
+      [delay, shouldFail]
+    )
 
     const cancelUpload = React.useCallback(() => {
-      setStatus("idle");
-      setProgress(0);
-    }, []);
+      setStatus("idle")
+      setProgress(0)
+    }, [])
 
-    return { upload, cancelUpload, progress, status };
-  };
+    return { upload, cancelUpload, progress, status }
+  }
 }
 
 function createFile(
   name: string,
   size: number = 1024,
-  type: string = "application/pdf",
+  type: string = "application/pdf"
 ): File {
-  const content = new Uint8Array(size);
-  return new File([content], name, { type });
+  const content = new Uint8Array(size)
+  return new File([content], name, { type })
 }
 
 describe("FileFieldRenderer", () => {
@@ -84,7 +84,7 @@ describe("FileFieldRenderer", () => {
         label: "Document",
         fieldType: "file",
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -92,14 +92,14 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
-    expect(screen.getByText("Document")).toBeInTheDocument();
+    expect(screen.getByText("Document")).toBeInTheDocument()
     expect(
-      screen.getByText("Drag and drop a file, or click to select"),
-    ).toBeInTheDocument();
-  });
+      screen.getByText("Drag and drop a file, or click to select")
+    ).toBeInTheDocument()
+  })
 
   it("applies neutral hover classes when no status is set", () => {
     const schema = z.object({
@@ -107,7 +107,7 @@ describe("FileFieldRenderer", () => {
         label: "Document",
         fieldType: "file",
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -115,16 +115,16 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
     const dropzone = screen.getByRole("button", {
       name: /drag and drop a file, or click to select/i,
-    });
+    })
 
-    expect(dropzone).toHaveClass("hover:border-f1-border-hover");
-    expect(dropzone).toHaveClass("hover:bg-f1-background-secondary");
-  });
+    expect(dropzone).toHaveClass("hover:border-f1-border-hover")
+    expect(dropzone).toHaveClass("hover:bg-f1-background-secondary")
+  })
 
   it("keeps warning dropzone styles by skipping neutral hover classes", () => {
     const schema = z.object({
@@ -133,7 +133,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         status: { type: "warning", message: "Potential issue" },
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -141,17 +141,17 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
     const dropzone = screen.getByRole("button", {
       name: /drag and drop a file, or click to select/i,
-    });
+    })
 
-    expect(dropzone).toHaveClass("border-f1-border-warning-bold");
-    expect(dropzone).not.toHaveClass("hover:border-f1-border-hover");
-    expect(dropzone).not.toHaveClass("hover:bg-f1-background-secondary");
-  });
+    expect(dropzone).toHaveClass("border-f1-border-warning-bold")
+    expect(dropzone).not.toHaveClass("hover:border-f1-border-hover")
+    expect(dropzone).not.toHaveClass("hover:bg-f1-background-secondary")
+  })
 
   it("renders custom description text", () => {
     const schema = z.object({
@@ -160,7 +160,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         description: "Upload a photo (max 5 MB)",
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -168,11 +168,11 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
-    expect(screen.getByText("Upload a photo (max 5 MB)")).toBeInTheDocument();
-  });
+    expect(screen.getByText("Upload a photo (max 5 MB)")).toBeInTheDocument()
+  })
 
   it("renders multiple file dropzone text", () => {
     const schema = z.object({
@@ -181,7 +181,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         multiple: true,
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -189,23 +189,23 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ files: [] }}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
     expect(
-      screen.getByText("Drag and drop files, or click to select"),
-    ).toBeInTheDocument();
-  });
+      screen.getByText("Drag and drop files, or click to select")
+    ).toBeInTheDocument()
+  })
 
   it("uploads a file and sets the form value", async () => {
-    const onSubmit = vi.fn(async () => ({ success: true }));
+    const onSubmit = vi.fn(async () => ({ success: true }))
 
     const schema = z.object({
       file: f0FormField(z.string().min(1), {
         label: "Document",
         fieldType: "file",
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -215,34 +215,34 @@ describe("FileFieldRenderer", () => {
         onSubmit={onSubmit}
         useUpload={createMockUploadHook()}
         submitConfig={{ label: "Save" }}
-      />,
-    );
+      />
+    )
 
     const input = document.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
-    expect(input).toBeTruthy();
+      'input[type="file"]'
+    ) as HTMLInputElement
+    expect(input).toBeTruthy()
 
-    const file = createFile("test.pdf");
-    await userEvent.upload(input, file);
+    const file = createFile("test.pdf")
+    await userEvent.upload(input, file)
 
     // Wait for the file name to appear (upload complete)
     await waitFor(() => {
-      expect(screen.getByText("test.pdf")).toBeInTheDocument();
-    });
+      expect(screen.getByText("test.pdf")).toBeInTheDocument()
+    })
 
     // Submit the form
-    const submitButton = screen.getByText("Save");
-    await userEvent.click(submitButton);
+    const submitButton = screen.getByText("Save")
+    await userEvent.click(submitButton)
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           file: "signed_test.pdf",
-        }),
-      );
-    });
-  });
+        })
+      )
+    })
+  })
 
   it("shows accepted file types in the dropzone", () => {
     const schema = z.object({
@@ -251,7 +251,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         accept: ["application/pdf", "image/jpeg", "image/png"],
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -259,13 +259,13 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
     expect(
-      screen.getByText("Accepted formats: PDF, JPEG, PNG"),
-    ).toBeInTheDocument();
-  });
+      screen.getByText("Accepted formats: PDF, JPEG, PNG")
+    ).toBeInTheDocument()
+  })
 
   it("shows accepted types in file type validation error on drag-and-drop", async () => {
     const schema = z.object({
@@ -274,7 +274,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         accept: ["image/jpeg", "image/png"],
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -282,30 +282,30 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
     // Drag-and-drop bypasses the <input accept> filter, so our
     // client-side validateFile runs and rejects the wrong type.
     const dropzone = screen.getByRole("button", {
       name: /drag and drop/i,
-    });
-    const pdfFile = createFile("doc.pdf", 1024, "application/pdf");
+    })
+    const pdfFile = createFile("doc.pdf", 1024, "application/pdf")
 
     const dataTransfer = {
       files: [pdfFile],
       types: ["Files"],
-    };
+    }
 
-    fireEvent.dragOver(dropzone, { dataTransfer });
-    fireEvent.drop(dropzone, { dataTransfer });
+    fireEvent.dragOver(dropzone, { dataTransfer })
+    fireEvent.drop(dropzone, { dataTransfer })
 
     await waitFor(() => {
       expect(
-        screen.getByText("File type not accepted. Accepted formats: JPEG, PNG"),
-      ).toBeInTheDocument();
-    });
-  });
+        screen.getByText("File type not accepted. Accepted formats: JPEG, PNG")
+      ).toBeInTheDocument()
+    })
+  })
 
   it("shows file size validation error", async () => {
     const schema = z.object({
@@ -314,7 +314,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         maxSizeMB: 0.001, // ~1 KB
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -322,22 +322,22 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
     const input = document.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
-    const largeFile = createFile("large.pdf", 10 * 1024); // 10 KB
+      'input[type="file"]'
+    ) as HTMLInputElement
+    const largeFile = createFile("large.pdf", 10 * 1024) // 10 KB
 
-    await userEvent.upload(input, largeFile);
+    await userEvent.upload(input, largeFile)
 
     await waitFor(() => {
       expect(
-        screen.getByText("File exceeds 0.001 MB limit"),
-      ).toBeInTheDocument();
-    });
-  });
+        screen.getByText("File exceeds 0.001 MB limit")
+      ).toBeInTheDocument()
+    })
+  })
 
   it("shows upload failure error", async () => {
     const schema = z.object({
@@ -345,7 +345,7 @@ describe("FileFieldRenderer", () => {
         label: "Failing Upload",
         fieldType: "file",
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -354,20 +354,20 @@ describe("FileFieldRenderer", () => {
         defaultValues={{ file: "" }}
         useUpload={createMockUploadHook({ shouldFail: true })}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
     const input = document.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
-    const file = createFile("fail.pdf");
+      'input[type="file"]'
+    ) as HTMLInputElement
+    const file = createFile("fail.pdf")
 
-    await userEvent.upload(input, file);
+    await userEvent.upload(input, file)
 
     await waitFor(() => {
-      expect(screen.getByText("Upload failed")).toBeInTheDocument();
-    });
-  });
+      expect(screen.getByText("Upload failed")).toBeInTheDocument()
+    })
+  })
 
   it("removes an uploaded file", async () => {
     const schema = z.object({
@@ -375,7 +375,7 @@ describe("FileFieldRenderer", () => {
         label: "Removable",
         fieldType: "file",
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -383,32 +383,32 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
     const input = document.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
-    const file = createFile("remove-me.pdf");
+      'input[type="file"]'
+    ) as HTMLInputElement
+    const file = createFile("remove-me.pdf")
 
-    await userEvent.upload(input, file);
-
-    await waitFor(() => {
-      expect(screen.getByText("remove-me.pdf")).toBeInTheDocument();
-    });
-
-    const removeButton = screen.getByLabelText("Remove");
-    await userEvent.click(removeButton);
+    await userEvent.upload(input, file)
 
     await waitFor(() => {
-      expect(screen.queryByText("remove-me.pdf")).not.toBeInTheDocument();
-    });
+      expect(screen.getByText("remove-me.pdf")).toBeInTheDocument()
+    })
+
+    const removeButton = screen.getByLabelText("Remove")
+    await userEvent.click(removeButton)
+
+    await waitFor(() => {
+      expect(screen.queryByText("remove-me.pdf")).not.toBeInTheDocument()
+    })
 
     // Dropzone should reappear
     expect(
-      screen.getByText("Drag and drop a file, or click to select"),
-    ).toBeInTheDocument();
-  });
+      screen.getByText("Drag and drop a file, or click to select")
+    ).toBeInTheDocument()
+  })
 
   it("renders disabled state", () => {
     const schema = z.object({
@@ -417,7 +417,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         disabled: true,
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -425,14 +425,14 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
     const dropzone = screen.getByRole("button", {
       name: /drag and drop/i,
-    });
-    expect(dropzone).toHaveAttribute("aria-disabled", "true");
-  });
+    })
+    expect(dropzone).toHaveAttribute("aria-disabled", "true")
+  })
 
   it("renders a single initial file without uploading", () => {
     const schema = z.object({
@@ -440,7 +440,7 @@ describe("FileFieldRenderer", () => {
         label: "Contract",
         fieldType: "file",
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -456,26 +456,26 @@ describe("FileFieldRenderer", () => {
           },
         ]}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
-    expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument();
-    expect(screen.getByText("File weight: 2.4 MB")).toBeInTheDocument();
+    expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument()
+    expect(screen.getByText("File weight: 2.4 MB")).toBeInTheDocument()
 
     expect(
-      screen.queryByText("Drag and drop a file, or click to select"),
-    ).not.toBeInTheDocument();
-  });
+      screen.queryByText("Drag and drop a file, or click to select")
+    ).not.toBeInTheDocument()
+  })
 
   it("removes a single initial file and restores the dropzone", async () => {
-    const onSubmit = vi.fn(async () => ({ success: true }));
+    const onSubmit = vi.fn(async () => ({ success: true }))
 
     const schema = z.object({
       file: f0FormField(z.string().optional(), {
         label: "Contract",
         fieldType: "file",
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -492,24 +492,24 @@ describe("FileFieldRenderer", () => {
         ]}
         onSubmit={onSubmit}
         submitConfig={{ label: "Save" }}
-      />,
-    );
+      />
+    )
 
-    expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument();
+    expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument()
 
-    const removeButton = screen.getByLabelText("Remove");
-    await userEvent.click(removeButton);
+    const removeButton = screen.getByLabelText("Remove")
+    await userEvent.click(removeButton)
 
     await waitFor(() => {
-      expect(screen.queryByText("contract_2024.pdf")).not.toBeInTheDocument();
-    });
+      expect(screen.queryByText("contract_2024.pdf")).not.toBeInTheDocument()
+    })
 
     await waitFor(() => {
       expect(
-        screen.getByText("Drag and drop a file, or click to select"),
-      ).toBeInTheDocument();
-    });
-  });
+        screen.getByText("Drag and drop a file, or click to select")
+      ).toBeInTheDocument()
+    })
+  })
 
   it("renders multiple initial files with dropzone still visible", () => {
     const schema = z.object({
@@ -518,7 +518,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         multiple: true,
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -540,19 +540,19 @@ describe("FileFieldRenderer", () => {
           },
         ]}
         onSubmit={async () => ({ success: true })}
-      />,
-    );
+      />
+    )
 
-    expect(screen.getByText("invoice.pdf")).toBeInTheDocument();
-    expect(screen.getByText("receipt.png")).toBeInTheDocument();
+    expect(screen.getByText("invoice.pdf")).toBeInTheDocument()
+    expect(screen.getByText("receipt.png")).toBeInTheDocument()
 
     expect(
-      screen.getByText("Drag and drop files, or click to select"),
-    ).toBeInTheDocument();
-  });
+      screen.getByText("Drag and drop files, or click to select")
+    ).toBeInTheDocument()
+  })
 
   it("removes one initial file from a multi-file field and submits the rest", async () => {
-    const onSubmit = vi.fn(async () => ({ success: true }));
+    const onSubmit = vi.fn(async () => ({ success: true }))
 
     const schema = z.object({
       files: f0FormField(z.array(z.string()), {
@@ -560,7 +560,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         multiple: true,
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -583,42 +583,42 @@ describe("FileFieldRenderer", () => {
         ]}
         onSubmit={onSubmit}
         submitConfig={{ label: "Save" }}
-      />,
-    );
+      />
+    )
 
-    expect(screen.getByText("invoice.pdf")).toBeInTheDocument();
-    expect(screen.getByText("receipt.png")).toBeInTheDocument();
+    expect(screen.getByText("invoice.pdf")).toBeInTheDocument()
+    expect(screen.getByText("receipt.png")).toBeInTheDocument()
 
-    const removeButtons = screen.getAllByLabelText("Remove");
-    await userEvent.click(removeButtons[0]);
+    const removeButtons = screen.getAllByLabelText("Remove")
+    await userEvent.click(removeButtons[0])
 
     await waitFor(() => {
-      expect(screen.queryByText("invoice.pdf")).not.toBeInTheDocument();
-    });
+      expect(screen.queryByText("invoice.pdf")).not.toBeInTheDocument()
+    })
 
-    expect(screen.getByText("receipt.png")).toBeInTheDocument();
+    expect(screen.getByText("receipt.png")).toBeInTheDocument()
 
-    const submitButton = screen.getByText("Save");
-    await userEvent.click(submitButton);
+    const submitButton = screen.getByText("Save")
+    await userEvent.click(submitButton)
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           files: ["receipt_id"],
-        }),
-      );
-    });
-  });
+        })
+      )
+    })
+  })
 
   it("submits initial file values without re-uploading", async () => {
-    const onSubmit = vi.fn(async () => ({ success: true }));
+    const onSubmit = vi.fn(async () => ({ success: true }))
 
     const schema = z.object({
       file: f0FormField(z.string().min(1), {
         label: "Document",
         fieldType: "file",
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -634,25 +634,25 @@ describe("FileFieldRenderer", () => {
         ]}
         onSubmit={onSubmit}
         submitConfig={{ label: "Save" }}
-      />,
-    );
+      />
+    )
 
-    expect(screen.getByText("contract.pdf")).toBeInTheDocument();
+    expect(screen.getByText("contract.pdf")).toBeInTheDocument()
 
-    const submitButton = screen.getByText("Save");
-    await userEvent.click(submitButton);
+    const submitButton = screen.getByText("Save")
+    await userEvent.click(submitButton)
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           file: "https://cdn.example.com/contract.pdf",
-        }),
-      );
-    });
-  });
+        })
+      )
+    })
+  })
 
   it("handles multiple file uploads", async () => {
-    const onSubmit = vi.fn(async () => ({ success: true }));
+    const onSubmit = vi.fn(async () => ({ success: true }))
 
     const schema = z.object({
       files: f0FormField(z.array(z.string()), {
@@ -660,7 +660,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         multiple: true,
       }),
-    });
+    })
 
     render(
       <F0Form
@@ -669,35 +669,35 @@ describe("FileFieldRenderer", () => {
         defaultValues={{ files: [] }}
         onSubmit={onSubmit}
         submitConfig={{ label: "Save" }}
-      />,
-    );
+      />
+    )
 
     const input = document.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
+      'input[type="file"]'
+    ) as HTMLInputElement
 
-    const file1 = createFile("doc1.pdf");
-    const file2 = createFile("doc2.pdf");
+    const file1 = createFile("doc1.pdf")
+    const file2 = createFile("doc2.pdf")
 
-    await userEvent.upload(input, file1);
-
-    await waitFor(() => {
-      expect(screen.getByText("doc1.pdf")).toBeInTheDocument();
-    });
-
-    await userEvent.upload(input, file2);
+    await userEvent.upload(input, file1)
 
     await waitFor(() => {
-      expect(screen.getByText("doc2.pdf")).toBeInTheDocument();
-    });
+      expect(screen.getByText("doc1.pdf")).toBeInTheDocument()
+    })
+
+    await userEvent.upload(input, file2)
+
+    await waitFor(() => {
+      expect(screen.getByText("doc2.pdf")).toBeInTheDocument()
+    })
 
     // Both files should be visible
-    expect(screen.getByText("doc1.pdf")).toBeInTheDocument();
-    expect(screen.getByText("doc2.pdf")).toBeInTheDocument();
+    expect(screen.getByText("doc1.pdf")).toBeInTheDocument()
+    expect(screen.getByText("doc2.pdf")).toBeInTheDocument()
 
     // Dropzone should still be visible in multiple mode
     expect(
-      screen.getByText("Drag and drop files, or click to select"),
-    ).toBeInTheDocument();
-  });
-});
+      screen.getByText("Drag and drop files, or click to select")
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
@@ -700,4 +700,95 @@ describe("FileFieldRenderer", () => {
       screen.getByText("Drag and drop files, or click to select")
     ).toBeInTheDocument()
   })
+
+  it("hides dropzone when maxFiles limit is reached", async () => {
+    const schema = z.object({
+      files: f0FormField(z.array(z.string()).optional(), {
+        label: "Files",
+        fieldType: "file",
+        multiple: true,
+        maxFiles: 2,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="test-maxfiles-dropzone"
+        schema={schema}
+        defaultValues={{ files: ["file1.pdf", "file2.pdf"] }}
+        initialFiles={[
+          {
+            value: "file1.pdf",
+            name: "file1.pdf",
+            type: "application/pdf",
+            size: 100,
+          },
+          {
+            value: "file2.pdf",
+            name: "file2.pdf",
+            type: "application/pdf",
+            size: 100,
+          },
+        ]}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // Both initial files rendered — limit reached, dropzone should be hidden
+    expect(screen.getByText("file1.pdf")).toBeInTheDocument()
+    expect(screen.getByText("file2.pdf")).toBeInTheDocument()
+    expect(
+      screen.queryByText("Drag and drop files, or click to select")
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows maxFilesReached error when adding more files than remaining slots", async () => {
+    const schema = z.object({
+      files: f0FormField(z.array(z.string()).optional(), {
+        label: "Files",
+        fieldType: "file",
+        multiple: true,
+        maxFiles: 2,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="test-maxfiles-error"
+        schema={schema}
+        defaultValues={{ files: ["file1.pdf"] }}
+        initialFiles={[
+          {
+            value: "file1.pdf",
+            name: "file1.pdf",
+            type: "application/pdf",
+            size: 100,
+          },
+        ]}
+        useUpload={createMockUploadHook()}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // 1 initial file, 1 slot remaining — try to upload 2 at once
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+
+    await userEvent.upload(input, [
+      createFile("file2.pdf"),
+      createFile("file3.pdf"),
+    ])
+
+    // file2 should be added (fits in remaining slot)
+    await waitFor(() =>
+      expect(screen.getByText("file2.pdf")).toBeInTheDocument()
+    )
+    // file3 should NOT appear (exceeded limit)
+    expect(screen.queryByText("file3.pdf")).not.toBeInTheDocument()
+    // Error message should be shown
+    await waitFor(() =>
+      expect(screen.getByText("Maximum 2 files")).toBeInTheDocument()
+    )
+  })
 })

--- a/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
@@ -460,7 +460,7 @@ describe("FileFieldRenderer", () => {
     )
 
     expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument()
-    expect(screen.getByText("File weight: 2.4 MB")).toBeInTheDocument()
+    expect(screen.getByText("2.4 MB")).toBeInTheDocument()
 
     expect(
       screen.queryByText("Drag and drop a file, or click to select")

--- a/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
@@ -1,80 +1,80 @@
-import userEvent from "@testing-library/user-event"
-import React from "react"
-import { describe, expect, it, vi } from "vitest"
-import { z } from "zod"
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 import {
   zeroRender as render,
   screen,
   waitFor,
   fireEvent,
-} from "@/testing/test-utils"
+} from "@/testing/test-utils";
 
 import type {
   FileUploadResult,
   FileUploadStatus,
   UseFileUpload,
-} from "../types"
+} from "../types";
 
-import { F0Form } from "../../../F0Form"
-import { f0FormField } from "../../../f0Schema"
+import { F0Form } from "../../../F0Form";
+import { f0FormField } from "../../../f0Schema";
 
 function createMockUploadHook(
   options: {
-    delay?: number
-    shouldFail?: boolean
-  } = {}
+    delay?: number;
+    shouldFail?: boolean;
+  } = {},
 ): UseFileUpload {
-  const { delay = 0, shouldFail = false } = options
+  const { delay = 0, shouldFail = false } = options;
 
   return () => {
-    const [progress, setProgress] = React.useState(0)
-    const [status, setStatus] = React.useState<FileUploadStatus>("idle")
+    const [progress, setProgress] = React.useState(0);
+    const [status, setStatus] = React.useState<FileUploadStatus>("idle");
 
     const upload = React.useCallback(
       async (file: File): Promise<FileUploadResult> => {
-        setStatus("processing")
-        setProgress(0)
+        setStatus("processing");
+        setProgress(0);
 
         if (delay > 0) {
-          await new Promise((r) => setTimeout(r, delay))
+          await new Promise((r) => setTimeout(r, delay));
         }
 
         if (shouldFail) {
-          setStatus("idle")
-          throw new Error("Upload failed")
+          setStatus("idle");
+          throw new Error("Upload failed");
         }
 
-        setStatus("uploading")
-        setProgress(0.5)
+        setStatus("uploading");
+        setProgress(0.5);
 
         if (delay > 0) {
-          await new Promise((r) => setTimeout(r, delay))
+          await new Promise((r) => setTimeout(r, delay));
         }
 
-        setProgress(1)
-        setStatus("success")
-        return { type: "success", value: `signed_${file.name}` }
+        setProgress(1);
+        setStatus("success");
+        return { type: "success", value: `signed_${file.name}` };
       },
-      [delay, shouldFail]
-    )
+      [delay, shouldFail],
+    );
 
     const cancelUpload = React.useCallback(() => {
-      setStatus("idle")
-      setProgress(0)
-    }, [])
+      setStatus("idle");
+      setProgress(0);
+    }, []);
 
-    return { upload, cancelUpload, progress, status }
-  }
+    return { upload, cancelUpload, progress, status };
+  };
 }
 
 function createFile(
   name: string,
   size: number = 1024,
-  type: string = "application/pdf"
+  type: string = "application/pdf",
 ): File {
-  const content = new Uint8Array(size)
-  return new File([content], name, { type })
+  const content = new Uint8Array(size);
+  return new File([content], name, { type });
 }
 
 describe("FileFieldRenderer", () => {
@@ -84,7 +84,7 @@ describe("FileFieldRenderer", () => {
         label: "Document",
         fieldType: "file",
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -92,14 +92,14 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText("Document")).toBeInTheDocument()
+    expect(screen.getByText("Document")).toBeInTheDocument();
     expect(
-      screen.getByText("Drag and drop a file, or click to select")
-    ).toBeInTheDocument()
-  })
+      screen.getByText("Drag and drop a file, or click to select"),
+    ).toBeInTheDocument();
+  });
 
   it("applies neutral hover classes when no status is set", () => {
     const schema = z.object({
@@ -107,7 +107,7 @@ describe("FileFieldRenderer", () => {
         label: "Document",
         fieldType: "file",
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -115,16 +115,16 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
     const dropzone = screen.getByRole("button", {
       name: /drag and drop a file, or click to select/i,
-    })
+    });
 
-    expect(dropzone).toHaveClass("hover:border-f1-border-hover")
-    expect(dropzone).toHaveClass("hover:bg-f1-background-secondary")
-  })
+    expect(dropzone).toHaveClass("hover:border-f1-border-hover");
+    expect(dropzone).toHaveClass("hover:bg-f1-background-secondary");
+  });
 
   it("keeps warning dropzone styles by skipping neutral hover classes", () => {
     const schema = z.object({
@@ -133,7 +133,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         status: { type: "warning", message: "Potential issue" },
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -141,17 +141,17 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
     const dropzone = screen.getByRole("button", {
       name: /drag and drop a file, or click to select/i,
-    })
+    });
 
-    expect(dropzone).toHaveClass("border-f1-border-warning-bold")
-    expect(dropzone).not.toHaveClass("hover:border-f1-border-hover")
-    expect(dropzone).not.toHaveClass("hover:bg-f1-background-secondary")
-  })
+    expect(dropzone).toHaveClass("border-f1-border-warning-bold");
+    expect(dropzone).not.toHaveClass("hover:border-f1-border-hover");
+    expect(dropzone).not.toHaveClass("hover:bg-f1-background-secondary");
+  });
 
   it("renders custom description text", () => {
     const schema = z.object({
@@ -160,7 +160,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         description: "Upload a photo (max 5 MB)",
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -168,11 +168,11 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText("Upload a photo (max 5 MB)")).toBeInTheDocument()
-  })
+    expect(screen.getByText("Upload a photo (max 5 MB)")).toBeInTheDocument();
+  });
 
   it("renders multiple file dropzone text", () => {
     const schema = z.object({
@@ -181,7 +181,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         multiple: true,
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -189,23 +189,23 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ files: [] }}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
     expect(
-      screen.getByText("Drag and drop files, or click to select")
-    ).toBeInTheDocument()
-  })
+      screen.getByText("Drag and drop files, or click to select"),
+    ).toBeInTheDocument();
+  });
 
   it("uploads a file and sets the form value", async () => {
-    const onSubmit = vi.fn(async () => ({ success: true }))
+    const onSubmit = vi.fn(async () => ({ success: true }));
 
     const schema = z.object({
       file: f0FormField(z.string().min(1), {
         label: "Document",
         fieldType: "file",
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -215,34 +215,34 @@ describe("FileFieldRenderer", () => {
         onSubmit={onSubmit}
         useUpload={createMockUploadHook()}
         submitConfig={{ label: "Save" }}
-      />
-    )
+      />,
+    );
 
     const input = document.querySelector(
-      'input[type="file"]'
-    ) as HTMLInputElement
-    expect(input).toBeTruthy()
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(input).toBeTruthy();
 
-    const file = createFile("test.pdf")
-    await userEvent.upload(input, file)
+    const file = createFile("test.pdf");
+    await userEvent.upload(input, file);
 
     // Wait for the file name to appear (upload complete)
     await waitFor(() => {
-      expect(screen.getByText("test.pdf")).toBeInTheDocument()
-    })
+      expect(screen.getByText("test.pdf")).toBeInTheDocument();
+    });
 
     // Submit the form
-    const submitButton = screen.getByText("Save")
-    await userEvent.click(submitButton)
+    const submitButton = screen.getByText("Save");
+    await userEvent.click(submitButton);
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           file: "signed_test.pdf",
-        })
-      )
-    })
-  })
+        }),
+      );
+    });
+  });
 
   it("shows accepted file types in the dropzone", () => {
     const schema = z.object({
@@ -251,7 +251,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         accept: ["application/pdf", "image/jpeg", "image/png"],
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -259,13 +259,13 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
     expect(
-      screen.getByText("Accepted formats: PDF, JPEG, PNG")
-    ).toBeInTheDocument()
-  })
+      screen.getByText("Accepted formats: PDF, JPEG, PNG"),
+    ).toBeInTheDocument();
+  });
 
   it("shows accepted types in file type validation error on drag-and-drop", async () => {
     const schema = z.object({
@@ -274,7 +274,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         accept: ["image/jpeg", "image/png"],
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -282,30 +282,30 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
     // Drag-and-drop bypasses the <input accept> filter, so our
     // client-side validateFile runs and rejects the wrong type.
     const dropzone = screen.getByRole("button", {
       name: /drag and drop/i,
-    })
-    const pdfFile = createFile("doc.pdf", 1024, "application/pdf")
+    });
+    const pdfFile = createFile("doc.pdf", 1024, "application/pdf");
 
     const dataTransfer = {
       files: [pdfFile],
       types: ["Files"],
-    }
+    };
 
-    fireEvent.dragOver(dropzone, { dataTransfer })
-    fireEvent.drop(dropzone, { dataTransfer })
+    fireEvent.dragOver(dropzone, { dataTransfer });
+    fireEvent.drop(dropzone, { dataTransfer });
 
     await waitFor(() => {
       expect(
-        screen.getByText("File type not accepted. Accepted formats: JPEG, PNG")
-      ).toBeInTheDocument()
-    })
-  })
+        screen.getByText("File type not accepted. Accepted formats: JPEG, PNG"),
+      ).toBeInTheDocument();
+    });
+  });
 
   it("shows file size validation error", async () => {
     const schema = z.object({
@@ -314,7 +314,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         maxSizeMB: 0.001, // ~1 KB
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -322,22 +322,22 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
     const input = document.querySelector(
-      'input[type="file"]'
-    ) as HTMLInputElement
-    const largeFile = createFile("large.pdf", 10 * 1024) // 10 KB
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const largeFile = createFile("large.pdf", 10 * 1024); // 10 KB
 
-    await userEvent.upload(input, largeFile)
+    await userEvent.upload(input, largeFile);
 
     await waitFor(() => {
       expect(
-        screen.getByText("File exceeds 0.001 MB limit")
-      ).toBeInTheDocument()
-    })
-  })
+        screen.getByText("File exceeds 0.001 MB limit"),
+      ).toBeInTheDocument();
+    });
+  });
 
   it("shows upload failure error", async () => {
     const schema = z.object({
@@ -345,7 +345,7 @@ describe("FileFieldRenderer", () => {
         label: "Failing Upload",
         fieldType: "file",
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -354,20 +354,20 @@ describe("FileFieldRenderer", () => {
         defaultValues={{ file: "" }}
         useUpload={createMockUploadHook({ shouldFail: true })}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
     const input = document.querySelector(
-      'input[type="file"]'
-    ) as HTMLInputElement
-    const file = createFile("fail.pdf")
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = createFile("fail.pdf");
 
-    await userEvent.upload(input, file)
+    await userEvent.upload(input, file);
 
     await waitFor(() => {
-      expect(screen.getByText("Upload failed")).toBeInTheDocument()
-    })
-  })
+      expect(screen.getByText("Upload failed")).toBeInTheDocument();
+    });
+  });
 
   it("removes an uploaded file", async () => {
     const schema = z.object({
@@ -375,7 +375,7 @@ describe("FileFieldRenderer", () => {
         label: "Removable",
         fieldType: "file",
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -383,32 +383,32 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
     const input = document.querySelector(
-      'input[type="file"]'
-    ) as HTMLInputElement
-    const file = createFile("remove-me.pdf")
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = createFile("remove-me.pdf");
 
-    await userEvent.upload(input, file)
-
-    await waitFor(() => {
-      expect(screen.getByText("remove-me.pdf")).toBeInTheDocument()
-    })
-
-    const removeButton = screen.getByLabelText("Remove")
-    await userEvent.click(removeButton)
+    await userEvent.upload(input, file);
 
     await waitFor(() => {
-      expect(screen.queryByText("remove-me.pdf")).not.toBeInTheDocument()
-    })
+      expect(screen.getByText("remove-me.pdf")).toBeInTheDocument();
+    });
+
+    const removeButton = screen.getByLabelText("Remove");
+    await userEvent.click(removeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText("remove-me.pdf")).not.toBeInTheDocument();
+    });
 
     // Dropzone should reappear
     expect(
-      screen.getByText("Drag and drop a file, or click to select")
-    ).toBeInTheDocument()
-  })
+      screen.getByText("Drag and drop a file, or click to select"),
+    ).toBeInTheDocument();
+  });
 
   it("renders disabled state", () => {
     const schema = z.object({
@@ -417,7 +417,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         disabled: true,
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -425,14 +425,14 @@ describe("FileFieldRenderer", () => {
         schema={schema}
         defaultValues={{ file: "" }}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
     const dropzone = screen.getByRole("button", {
       name: /drag and drop/i,
-    })
-    expect(dropzone).toHaveAttribute("aria-disabled", "true")
-  })
+    });
+    expect(dropzone).toHaveAttribute("aria-disabled", "true");
+  });
 
   it("renders a single initial file without uploading", () => {
     const schema = z.object({
@@ -440,7 +440,7 @@ describe("FileFieldRenderer", () => {
         label: "Contract",
         fieldType: "file",
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -456,26 +456,26 @@ describe("FileFieldRenderer", () => {
           },
         ]}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument()
-    expect(screen.getByText("2.4 MB")).toBeInTheDocument()
+    expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument();
+    expect(screen.getByText("File weight: 2.4 MB")).toBeInTheDocument();
 
     expect(
-      screen.queryByText("Drag and drop a file, or click to select")
-    ).not.toBeInTheDocument()
-  })
+      screen.queryByText("Drag and drop a file, or click to select"),
+    ).not.toBeInTheDocument();
+  });
 
   it("removes a single initial file and restores the dropzone", async () => {
-    const onSubmit = vi.fn(async () => ({ success: true }))
+    const onSubmit = vi.fn(async () => ({ success: true }));
 
     const schema = z.object({
       file: f0FormField(z.string().optional(), {
         label: "Contract",
         fieldType: "file",
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -492,24 +492,24 @@ describe("FileFieldRenderer", () => {
         ]}
         onSubmit={onSubmit}
         submitConfig={{ label: "Save" }}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument()
+    expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument();
 
-    const removeButton = screen.getByLabelText("Remove")
-    await userEvent.click(removeButton)
+    const removeButton = screen.getByLabelText("Remove");
+    await userEvent.click(removeButton);
 
     await waitFor(() => {
-      expect(screen.queryByText("contract_2024.pdf")).not.toBeInTheDocument()
-    })
+      expect(screen.queryByText("contract_2024.pdf")).not.toBeInTheDocument();
+    });
 
     await waitFor(() => {
       expect(
-        screen.getByText("Drag and drop a file, or click to select")
-      ).toBeInTheDocument()
-    })
-  })
+        screen.getByText("Drag and drop a file, or click to select"),
+      ).toBeInTheDocument();
+    });
+  });
 
   it("renders multiple initial files with dropzone still visible", () => {
     const schema = z.object({
@@ -518,7 +518,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         multiple: true,
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -540,19 +540,19 @@ describe("FileFieldRenderer", () => {
           },
         ]}
         onSubmit={async () => ({ success: true })}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText("invoice.pdf")).toBeInTheDocument()
-    expect(screen.getByText("receipt.png")).toBeInTheDocument()
+    expect(screen.getByText("invoice.pdf")).toBeInTheDocument();
+    expect(screen.getByText("receipt.png")).toBeInTheDocument();
 
     expect(
-      screen.getByText("Drag and drop files, or click to select")
-    ).toBeInTheDocument()
-  })
+      screen.getByText("Drag and drop files, or click to select"),
+    ).toBeInTheDocument();
+  });
 
   it("removes one initial file from a multi-file field and submits the rest", async () => {
-    const onSubmit = vi.fn(async () => ({ success: true }))
+    const onSubmit = vi.fn(async () => ({ success: true }));
 
     const schema = z.object({
       files: f0FormField(z.array(z.string()), {
@@ -560,7 +560,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         multiple: true,
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -583,42 +583,42 @@ describe("FileFieldRenderer", () => {
         ]}
         onSubmit={onSubmit}
         submitConfig={{ label: "Save" }}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText("invoice.pdf")).toBeInTheDocument()
-    expect(screen.getByText("receipt.png")).toBeInTheDocument()
+    expect(screen.getByText("invoice.pdf")).toBeInTheDocument();
+    expect(screen.getByText("receipt.png")).toBeInTheDocument();
 
-    const removeButtons = screen.getAllByLabelText("Remove")
-    await userEvent.click(removeButtons[0])
+    const removeButtons = screen.getAllByLabelText("Remove");
+    await userEvent.click(removeButtons[0]);
 
     await waitFor(() => {
-      expect(screen.queryByText("invoice.pdf")).not.toBeInTheDocument()
-    })
+      expect(screen.queryByText("invoice.pdf")).not.toBeInTheDocument();
+    });
 
-    expect(screen.getByText("receipt.png")).toBeInTheDocument()
+    expect(screen.getByText("receipt.png")).toBeInTheDocument();
 
-    const submitButton = screen.getByText("Save")
-    await userEvent.click(submitButton)
+    const submitButton = screen.getByText("Save");
+    await userEvent.click(submitButton);
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           files: ["receipt_id"],
-        })
-      )
-    })
-  })
+        }),
+      );
+    });
+  });
 
   it("submits initial file values without re-uploading", async () => {
-    const onSubmit = vi.fn(async () => ({ success: true }))
+    const onSubmit = vi.fn(async () => ({ success: true }));
 
     const schema = z.object({
       file: f0FormField(z.string().min(1), {
         label: "Document",
         fieldType: "file",
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -634,25 +634,25 @@ describe("FileFieldRenderer", () => {
         ]}
         onSubmit={onSubmit}
         submitConfig={{ label: "Save" }}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText("contract.pdf")).toBeInTheDocument()
+    expect(screen.getByText("contract.pdf")).toBeInTheDocument();
 
-    const submitButton = screen.getByText("Save")
-    await userEvent.click(submitButton)
+    const submitButton = screen.getByText("Save");
+    await userEvent.click(submitButton);
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           file: "https://cdn.example.com/contract.pdf",
-        })
-      )
-    })
-  })
+        }),
+      );
+    });
+  });
 
   it("handles multiple file uploads", async () => {
-    const onSubmit = vi.fn(async () => ({ success: true }))
+    const onSubmit = vi.fn(async () => ({ success: true }));
 
     const schema = z.object({
       files: f0FormField(z.array(z.string()), {
@@ -660,7 +660,7 @@ describe("FileFieldRenderer", () => {
         fieldType: "file",
         multiple: true,
       }),
-    })
+    });
 
     render(
       <F0Form
@@ -669,35 +669,35 @@ describe("FileFieldRenderer", () => {
         defaultValues={{ files: [] }}
         onSubmit={onSubmit}
         submitConfig={{ label: "Save" }}
-      />
-    )
+      />,
+    );
 
     const input = document.querySelector(
-      'input[type="file"]'
-    ) as HTMLInputElement
+      'input[type="file"]',
+    ) as HTMLInputElement;
 
-    const file1 = createFile("doc1.pdf")
-    const file2 = createFile("doc2.pdf")
+    const file1 = createFile("doc1.pdf");
+    const file2 = createFile("doc2.pdf");
 
-    await userEvent.upload(input, file1)
-
-    await waitFor(() => {
-      expect(screen.getByText("doc1.pdf")).toBeInTheDocument()
-    })
-
-    await userEvent.upload(input, file2)
+    await userEvent.upload(input, file1);
 
     await waitFor(() => {
-      expect(screen.getByText("doc2.pdf")).toBeInTheDocument()
-    })
+      expect(screen.getByText("doc1.pdf")).toBeInTheDocument();
+    });
+
+    await userEvent.upload(input, file2);
+
+    await waitFor(() => {
+      expect(screen.getByText("doc2.pdf")).toBeInTheDocument();
+    });
 
     // Both files should be visible
-    expect(screen.getByText("doc1.pdf")).toBeInTheDocument()
-    expect(screen.getByText("doc2.pdf")).toBeInTheDocument()
+    expect(screen.getByText("doc1.pdf")).toBeInTheDocument();
+    expect(screen.getByText("doc2.pdf")).toBeInTheDocument();
 
     // Dropzone should still be visible in multiple mode
     expect(
-      screen.getByText("Drag and drop files, or click to select")
-    ).toBeInTheDocument()
-  })
-})
+      screen.getByText("Drag and drop files, or click to select"),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/patterns/F0Form/fields/file/types.ts
+++ b/packages/react/src/patterns/F0Form/fields/file/types.ts
@@ -259,6 +259,5 @@ export interface FileAttachmentProps {
     uploading: string
     processing: string
     uploadFailed: string
-    fileWeight: string
   }
 }

--- a/packages/react/src/patterns/F0Form/fields/file/types.ts
+++ b/packages/react/src/patterns/F0Form/fields/file/types.ts
@@ -144,6 +144,26 @@ export interface InitialFile {
 }
 
 // ============================================================================
+// File Entry (in-flight or pre-existing)
+// ============================================================================
+
+/**
+ * Metadata for a file that has been selected, uploaded, or pre-existing
+ */
+export interface FileEntry {
+  /** Unique key for React list rendering */
+  key: string
+  /** The File object — present for new uploads, absent for pre-existing files */
+  file?: File
+  /** Pre-existing file metadata — present when seeded from `initialFiles` */
+  initialFile?: InitialFile
+  /** The form value returned after successful upload, or from initialFile */
+  value?: string
+  /** Error message if upload failed */
+  error?: string
+}
+
+// ============================================================================
 // File Field Config and Type
 // ============================================================================
 
@@ -164,6 +184,8 @@ export interface F0FileConfig {
   maxSizeMB?: number
   /** Allow multiple file uploads (form value becomes `string[]`) */
   multiple?: boolean
+  /** Maximum number of files allowed (only relevant when multiple is true) */
+  maxFiles?: number
   /** Helper text shown in the dropzone area */
   description?: string
   /**
@@ -188,6 +210,8 @@ export type F0FileField = F0BaseField & {
   maxSizeMB?: number
   /** Allow multiple files */
   multiple?: boolean
+  /** Maximum number of files allowed (only relevant when multiple is true) */
+  maxFiles?: number
   /** Dropzone description text */
   description?: string
   /**
@@ -199,26 +223,14 @@ export type F0FileField = F0BaseField & {
   renderIf?: FileFieldRenderIf
 }
 
-/**
- * Metadata for a file that has been selected, uploaded, or pre-existing
- */
-export interface FileEntry {
-  /** Unique key for React list rendering */
-  key: string
-  /** The File object — present for new uploads, absent for pre-existing files */
-  file?: File
-  /** Pre-existing file metadata — present when seeded from `initialFiles` */
-  initialFile?: InitialFile
-  /** The form value returned after successful upload, or from initialFile */
-  value?: string
-  /** Error message if upload failed */
-  error?: string
-}
+// ============================================================================
+// Component Props
+// ============================================================================
 
 /**
- * Props for the FileUploadItem component
+ * Props for the FileAttachment component
  */
-export interface FileUploadItemProps {
+export interface FileAttachmentProps {
   /** The file entry (new upload or pre-existing) */
   entry: FileEntry
   /** Consumer-provided upload hook — only needed for new uploads */
@@ -231,11 +243,22 @@ export interface FileUploadItemProps {
   onError: (error: string) => void
   /** Whether the field is disabled */
   disabled?: boolean
+  /** Additional class names — internal use only, for layout adjustments in grouped lists */
+  className?: string
+  /**
+   * Controls border-radius based on position in a grouped list.
+   * - "single": full radius (standalone, default)
+   * - "top": top corners rounded, bottom flat
+   * - "middle": all corners flat
+   * - "bottom": bottom corners rounded, top flat
+   */
+  position?: "single" | "top" | "middle" | "bottom"
   /** i18n strings */
   translations: {
     remove: string
     uploading: string
     processing: string
     uploadFailed: string
+    fileWeight: string
   }
 }

--- a/packages/react/src/patterns/F0Form/useSchemaDefinition.ts
+++ b/packages/react/src/patterns/F0Form/useSchemaDefinition.ts
@@ -264,6 +264,7 @@ function configToF0Field(
         accept: "accept" in config ? config.accept : undefined,
         maxSizeMB: "maxSizeMB" in config ? config.maxSizeMB : undefined,
         multiple: "multiple" in config ? config.multiple : undefined,
+        maxFiles: "maxFiles" in config ? config.maxFiles : undefined,
         description: "description" in config ? config.description : undefined,
         useUpload: "useUpload" in config ? config.useUpload : undefined,
         renderIf: config.renderIf,

--- a/packages/react/src/patterns/F0FormField/__stories__/F0FormField.stories.tsx
+++ b/packages/react/src/patterns/F0FormField/__stories__/F0FormField.stories.tsx
@@ -388,6 +388,36 @@ export const File: Story = {
 }
 
 /**
+ * Multiple file uploads with grouped border-radius per position.
+ */
+export const FileMultiple: Story = {
+  render() {
+    const [value, setValue] = useState<string[]>([])
+
+    const field: F0Field = {
+      id: "attachments",
+      type: "file",
+      label: "Attachments",
+      multiple: true,
+      maxFiles: 3,
+      accept: ["image", "application/pdf"],
+      maxSizeMB: 10,
+      useUpload: useMockUpload,
+    }
+
+    return (
+      <div className="max-w-sm">
+        <F0FormField
+          field={field}
+          value={value}
+          onChange={(v) => setValue(v as string[])}
+        />
+      </div>
+    )
+  },
+}
+
+/**
  * A checkbox field.
  */
 export const Checkbox: Story = {


### PR DESCRIPTION
## Summary

Rework of the file upload UI (`FileFieldRenderer` + `FileAttachment`) to be pixel-accurate to the Figma spec. `FileUploadItem` is removed and replaced by the new `FileAttachment` component.

## Changes

### `FileAttachment.tsx` (new)
Replaces `FileUploadItem`. Key additions:
- `position` prop (`single | top | middle | bottom`) drives per-card border-radius so cards in a list share a rounded group
- `-mt-px` on non-first cards to collapse double borders into a single 1px line
- Border color: `border-f1-border-secondary` (normal) / `border-f1-border-critical` (error)
- `F0AvatarFile size="lg"` (40px), filename `text-sm font-medium`, subtitle `text-sm text-f1-foreground-secondary`
- Remove button: `F0Button variant="outline" size="sm" hideLabel icon={Cross}`

### `FileFieldRenderer.tsx` (rewritten)
- `rounded-xl` (16px) dropzone
- Drag state: `border-f1-border-selected-bold bg-f1-background-selected`
- Error state: `border-f1-border-critical-bold bg-f1-background-critical/10`
- `border-[1px]` (not `border-2`)
- `py-10` (40px) vertical padding, `gap-3` between icon and text, `gap-4` between dropzone and card list
- Error hint: `AlertCircle` icon + `text-sm font-medium text-f1-foreground-critical` (matches `InputMessages` pattern)
- `maxFiles` support — hides dropzone when limit is reached
- Dropzone text: `text-base` (14px)

### `FileUploadItem.tsx` (deleted)
Superseded by `FileAttachment`.

### `F0AvatarIcon.tsx`
- `md` size corrected: `size-9` (36px) → `size-8` (32px) per Figma

### `i18n-provider-defaults.ts`
- Added `fileWeight: "File weight: {{size}}"`
- Added `maxFilesReached: "Maximum {{maxFiles}} files"`

### `F0FormField.stories.tsx`
- Added `FileMultiple` story

## Design reference

Figma: `https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Components`
- FileAttachment card: nodes `30003:118744` / `30003:118869`
- DropArea default: node `29978:13631`
- Error state: node `30003:119126`

## Token decisions

| Decision | Token used | Rationale |
|---|---|---|
| Card border (normal) | `border-f1-border-secondary` (6% opacity) | Closest available — Figma specifies 14%, no exact token exists |
| Dropzone border | `border-f1-border` (20% opacity) | Matches default dashed outline |
| Border radius | `rounded-xl` (16px) | Applied consistently to dropzone and all cards |

## Notes

- `F0AvatarIcon md` size change (32px) also affects `CommunityPost`, `ActivityItem`, `CardSelectable` — all consume `md` and will render correctly at the intended Figma size
- TypeScript: `pnpm tsc --noEmit` passes with zero errors