### PR TITLE
fix(EntitySelect): render popover inside dialogs and fix scroll/height issues

### DIFF
--- a/packages/react/src/deprecated/EntitySelect/Content/index.tsx
+++ b/packages/react/src/deprecated/EntitySelect/Content/index.tsx
@@ -70,7 +70,7 @@ export const Content = ({
 
   return (
     <div
-      className="relative overflow-hidden"
+      className="flex overflow-hidden"
       style={{
         height:
           singleSelector && (!actions || actions.length === 0)
@@ -80,23 +80,7 @@ export const Content = ({
       }}
     >
       <div
-        className="absolute right-0 top-0"
-        style={{
-          width: asideWidth + "px",
-        }}
-      >
-        <SecondaryContent
-          groupView={groupView}
-          onRemove={onRemove}
-          onSubItemRemove={onSubItemRemove}
-          selectedEntities={selectedEntities ?? []}
-          selectedLabel={selectedLabel}
-          disabled={props.disabled}
-          hiddenAvatar={hiddenAvatar}
-        />
-      </div>
-      <div
-        className="absolute left-0"
+        className="min-h-0 flex-1"
         style={{ width: finalWidthMain + 1 + "px" }}
       >
         <MainContent
@@ -114,6 +98,24 @@ export const Content = ({
           onCreateLabel={onCreateLabel}
         />
       </div>
+      {isExpanded && (
+        <div
+          className="min-h-0"
+          style={{
+            width: asideWidth + "px",
+          }}
+        >
+          <SecondaryContent
+            groupView={groupView}
+            onRemove={onRemove}
+            onSubItemRemove={onSubItemRemove}
+            selectedEntities={selectedEntities ?? []}
+            selectedLabel={selectedLabel}
+            disabled={props.disabled}
+            hiddenAvatar={hiddenAvatar}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/react/src/deprecated/EntitySelect/index.stories.tsx
+++ b/packages/react/src/deprecated/EntitySelect/index.stories.tsx
@@ -172,17 +172,8 @@ export const Default = {
     // Get the popover content and use within to scope our queries
     const popoverContent = within(popover as HTMLElement)
 
-    // Find the main content section (left side) where the list is
-    const mainContent = popoverContent
-      .getByRole("dialog")
-      .querySelector(".absolute.left-0")
-    expect(mainContent).toBeInTheDocument()
-
-    // Use within to scope our search to just the main content
-    const mainContentQueries = within(mainContent as HTMLElement)
-
     // Find and click the item in the main list
-    const listItem = mainContentQueries.getByRole("checkbox", {
+    const listItem = popoverContent.getByRole("checkbox", {
       name: /Albert Einstein/i,
     })
     expect(listItem).toBeInTheDocument()

--- a/packages/react/src/deprecated/EntitySelect/index.tsx
+++ b/packages/react/src/deprecated/EntitySelect/index.tsx
@@ -1,9 +1,17 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
+import {
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { useDebounceValue } from "usehooks-ts"
 
+import { cn } from "@/lib/utils"
+import { F0DialogContext } from "@/patterns/F0Dialog"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
-import { cn } from "@/lib/utils"
 import { Content } from "./Content"
 import { Trigger } from "./Trigger"
 import {
@@ -47,6 +55,16 @@ export const EntitySelect = <T,>(
       ),
     [props.entities]
   )
+
+  const dialogContext = useContext(F0DialogContext)
+  const shouldUseDialogContainer =
+    dialogContext.portalContainer &&
+    (dialogContext.position === "center" ||
+      dialogContext.position === "fullscreen")
+
+  const effectivePopoverContainer = shouldUseDialogContainer
+    ? dialogContext.portalContainer
+    : undefined
 
   function onPrivateSelect(entity: EntitySelectEntity) {
     if (props.singleSelector) {
@@ -414,7 +432,7 @@ export const EntitySelect = <T,>(
       <div
         ref={containerRef}
         className={cn(
-          "scrollbar-macos relative overflow-auto rounded-xl border-[1px] border-solid border-f1-border-secondary bg-transparent p-0",
+          "scrollbar-macos relative overflow-hidden rounded-xl border-[1px] border-solid border-f1-border-secondary bg-transparent p-0",
           !props.width ? "w-full" : "w-fit"
         )}
       >
@@ -487,8 +505,9 @@ export const EntitySelect = <T,>(
         )}
       </PopoverTrigger>
       <PopoverContent
+        container={effectivePopoverContainer}
         className={cn(
-          "scrollbar-macos relative w-full overflow-auto rounded-xl border-[1px] border-solid border-f1-border-secondary bg-transparent p-0"
+          "scrollbar-macos relative w-full overflow-hidden overscroll-contain rounded-xl border-[1px] border-solid border-f1-border-secondary bg-transparent p-0"
         )}
       >
         <Content


### PR DESCRIPTION
Portal EntitySelect dropdown into the dialog container when rendered inside F0Dialog (center/fullscreen), matching the pattern used by F0Select. Switch from absolute positioning to flex layout in the Content component, conditionally render SecondaryContent only when expanded, add overscroll-contain to prevent scroll chaining, and change overflow-auto to overflow-hidden to eliminate double scrollbars.