### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.442.0",
+  "packages/react": "1.442.1",
   "packages/react-native": "0.49.1",
   "packages/core": "1.48.2"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.442.1](https://github.com/factorialco/f0/compare/f0-react-v1.442.0...f0-react-v1.442.1) (2026-04-13)
+
+
+### Bug Fixes
+
+* passing props credit warning to applicationframe ([#3922](https://github.com/factorialco/f0/issues/3922)) ([84f3cdb](https://github.com/factorialco/f0/commit/84f3cdb22564ea1f0040140020ed03bf530daf49))
+
 ## [1.442.0](https://github.com/factorialco/f0/compare/f0-react-v1.441.1...f0-react-v1.442.0) (2026-04-13)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.442.0",
+  "version": "1.442.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.442.1</summary>

## [1.442.1](https://github.com/factorialco/f0/compare/f0-react-v1.442.0...f0-react-v1.442.1) (2026-04-13)


### Bug Fixes

* passing props credit warning to applicationframe ([#3922](https://github.com/factorialco/f0/issues/3922)) ([84f3cdb](https://github.com/factorialco/f0/commit/84f3cdb22564ea1f0040140020ed03bf530daf49))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).