### PR TITLE
feat(ai): expose onSaveDashboard callback, save report button, and refresh button in dashboard header

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -280,6 +280,7 @@ export const defaultTranslations = {
     thinking: "Thinking...",
     closeDashboard: "Close dashboard",
     saveReport: "Save report",
+    refreshDashboard: "Refresh",
     unsavedChanges: "Unsaved changes",
     saveChanges: "Save changes",
     discardChanges: "Discard",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -279,6 +279,7 @@ export const defaultTranslations = {
     resourcesGroupTitle: "Resources",
     thinking: "Thinking...",
     closeDashboard: "Close dashboard",
+    saveReport: "Save report",
     unsavedChanges: "Unsaved changes",
     saveChanges: "Save changes",
     discardChanges: "Discard",

--- a/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
@@ -36,6 +36,7 @@ const F0AiChatProviderComponent = ({
   fileAttachments,
   onThumbsUp,
   onThumbsDown,
+  onSaveDashboard,
   children,
   agent,
   tracking,
@@ -63,6 +64,7 @@ const F0AiChatProviderComponent = ({
       credits={credits}
       creditWarning={creditWarning}
       fileAttachments={fileAttachments}
+      onSaveDashboard={onSaveDashboard}
     >
       <AiChatKitWrapper {...copilotKitProps}>{children}</AiChatKitWrapper>
     </AiChatStateProvider>

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
@@ -458,14 +458,16 @@ export function DashboardContent({
     }
   }, [content.config, itemTransforms])
 
-  // Derive a refresh key tied only to the data identity (fetchSpecs reference).
-  // The canvas-level refreshKey from CanvasPanel bumps on every content
-  // reference change, which includes save (layout/transform persistence). On
-  // save, fetchSpecs is preserved by reference (handleSave only spreads the
-  // config / items), so this key stays stable and we avoid a redundant
-  // dashboard remount + recompute. LLM regeneration produces a new fetchSpecs
-  // reference, which correctly bumps this key and triggers a real refetch.
-  const dataRefreshKey = useMemo(() => Date.now(), [content.config.fetchSpecs])
+  // Derive a refresh key tied to data identity (fetchSpecs reference) AND
+  // the parent refresh key from CanvasPanel. The parent key bumps on manual
+  // refresh (button click) and on content reference changes. We include it
+  // so that manual refreshes trigger a dashboard remount + recompute.
+  // On save, fetchSpecs is preserved by reference and _parentRefreshKey
+  // doesn't change, so we avoid a redundant recompute.
+  const dataRefreshKey = useMemo(
+    () => Date.now(),
+    [content.config.fetchSpecs, _parentRefreshKey]
+  )
 
   return (
     <>

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContext.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContext.tsx
@@ -1,92 +1,99 @@
-import { useCopilotContext } from "@copilotkit/react-core"
+import { useCopilotContext } from "@copilotkit/react-core";
 import {
   createContext,
   type ReactNode,
   useCallback,
   useContext,
   useState,
-} from "react"
+} from "react";
 
-import type { DashboardItemLayout } from "@/patterns/F0AnalyticsDashboard/types"
+import type { DashboardItemLayout } from "@/patterns/F0AnalyticsDashboard/types";
 
-import type { ChatDashboardConfig, ChatDashboardItem } from "./types"
-import { useSaveDashboardConfig } from "./useSaveDashboardConfig"
-import { useAiChat } from "../../../providers/AiChatStateProvider"
+import type { ChatDashboardConfig, ChatDashboardItem } from "./types";
+import { useSaveDashboardConfig } from "./useSaveDashboardConfig";
+import { useAiChat } from "../../../providers/AiChatStateProvider";
+import type {
+  DashboardCanvasContent,
+  SaveDashboardPayload,
+} from "../../../types";
 
-import { savedDashboardConfigStore } from "./configStore"
-import type { DashboardCanvasContent } from "../../../types"
+import { savedDashboardConfigStore } from "./configStore";
 
 type DashboardCanvasContextValue = {
   /** Whether there are unsaved layout changes */
-  isDirty: boolean
+  isDirty: boolean;
   /** Incrementing counter — changes when discard is called to reset the grid */
-  discardKey: number
+  discardKey: number;
   /** Pending item transforms keyed by item id (chart type changes, etc.) */
-  itemTransforms: Map<string, Partial<ChatDashboardItem>>
+  itemTransforms: Map<string, Partial<ChatDashboardItem>>;
   /** Called by the grid when layout changes (drag/resize/delete) */
-  onLayoutChange: (layout: DashboardItemLayout[]) => void
+  onLayoutChange: (layout: DashboardItemLayout[]) => void;
   /** Persist current layout and update canvas */
-  handleSave: () => Promise<void>
+  handleSave: () => Promise<void>;
   /** Discard pending layout changes */
-  handleDiscard: () => void
+  handleDiscard: () => void;
   /** Transform an item's config (e.g. change chart type). Marks dirty without refetch. */
-  transformItem: (itemId: string, patch: Partial<ChatDashboardItem>) => void
+  transformItem: (itemId: string, patch: Partial<ChatDashboardItem>) => void;
   /** Export the dashboard as Excel */
-  exportAsExcel?: () => Promise<void>
+  exportAsExcel?: () => Promise<void>;
   /** Register the export function from the dashboard component */
-  registerExport: (fn: (() => Promise<void>) | undefined) => void
-}
+  registerExport: (fn: (() => Promise<void>) | undefined) => void;
+  /** The current dashboard config (reflects any saved layout edits) */
+  config: ChatDashboardConfig;
+  /** Callback to persist the dashboard to the backend. Undefined when not provided by the host app. */
+  onSaveDashboard?: (payload: SaveDashboardPayload) => Promise<void>;
+};
 
 const DashboardCanvasContext =
-  createContext<DashboardCanvasContextValue | null>(null)
+  createContext<DashboardCanvasContextValue | null>(null);
 
 export function useDashboardCanvas(): DashboardCanvasContextValue {
-  const ctx = useContext(DashboardCanvasContext)
+  const ctx = useContext(DashboardCanvasContext);
   if (!ctx) {
     throw new Error(
-      "useDashboardCanvas must be used within DashboardCanvasProvider"
-    )
+      "useDashboardCanvas must be used within DashboardCanvasProvider",
+    );
   }
-  return ctx
+  return ctx;
 }
 
 export function DashboardCanvasProvider({
   content,
   children,
 }: {
-  content: DashboardCanvasContent
-  children: ReactNode
+  content: DashboardCanvasContent;
+  children: ReactNode;
 }): ReactNode {
   const [pendingLayout, setPendingLayout] = useState<
     DashboardItemLayout[] | null
-  >(null)
+  >(null);
   const [itemTransforms, setItemTransforms] = useState<
     Map<string, Partial<ChatDashboardItem>>
-  >(new Map())
-  const [discardKey, setDiscardKey] = useState(0)
+  >(new Map());
+  const [discardKey, setDiscardKey] = useState(0);
   const [exportAsExcel, setExportAsExcel] = useState<
     (() => Promise<void>) | undefined
-  >()
+  >();
   const registerExport = useCallback(
     (fn: (() => Promise<void>) | undefined) => {
-      setExportAsExcel(() => fn)
+      setExportAsExcel(() => fn);
     },
-    []
-  )
-  const { openCanvas } = useAiChat()
-  const { threadId } = useCopilotContext()
+    [],
+  );
+  const { openCanvas, onSaveDashboard } = useAiChat();
+  const { threadId } = useCopilotContext();
 
-  const saveConfigFn = useSaveDashboardConfig(content.apiConfig)
+  const saveConfigFn = useSaveDashboardConfig(content.apiConfig);
 
   const applyLayout = useCallback(
     (layout: DashboardItemLayout[]): ChatDashboardConfig | null => {
       const itemsById = new Map(
-        content.config.items.map((item) => [item.id, item])
-      )
+        content.config.items.map((item) => [item.id, item]),
+      );
       const newItems = layout
         .map((entry) => {
-          const original = itemsById.get(entry.id)
-          if (!original) return null
+          const original = itemsById.get(entry.id);
+          if (!original) return null;
           return {
             ...original,
             colSpan: entry.colSpan,
@@ -97,62 +104,62 @@ export function DashboardCanvasProvider({
             itemHeight: entry.itemHeight,
             x: entry.x,
             y: entry.y,
-          }
+          };
         })
-        .filter((item) => item !== null)
+        .filter((item) => item !== null);
 
-      return { ...content.config, items: newItems }
+      return { ...content.config, items: newItems };
     },
-    [content]
-  )
+    [content],
+  );
 
   const onLayoutChange = useCallback((layout: DashboardItemLayout[]) => {
-    setPendingLayout(layout)
-  }, [])
+    setPendingLayout(layout);
+  }, []);
 
   const transformItem = useCallback(
     (itemId: string, patch: Partial<ChatDashboardItem>) => {
       setItemTransforms((prev) => {
-        const next = new Map(prev)
-        next.set(itemId, patch)
-        return next
-      })
+        const next = new Map(prev);
+        next.set(itemId, patch);
+        return next;
+      });
     },
-    []
-  )
+    [],
+  );
 
   /** Apply item transforms to a config, producing a new config with patched items. */
   const applyTransforms = useCallback(
     (config: ChatDashboardConfig): ChatDashboardConfig => {
-      if (itemTransforms.size === 0) return config
+      if (itemTransforms.size === 0) return config;
       return {
         ...config,
         items: config.items.map((item) => {
-          const patch = itemTransforms.get(item.id)
-          return patch ? ({ ...item, ...patch } as typeof item) : item
+          const patch = itemTransforms.get(item.id);
+          return patch ? ({ ...item, ...patch } as typeof item) : item;
         }),
-      }
+      };
     },
-    [itemTransforms]
-  )
+    [itemTransforms],
+  );
 
   const handleSave = async () => {
-    const hasPendingChanges = pendingLayout || itemTransforms.size > 0
-    if (!hasPendingChanges) return
+    const hasPendingChanges = pendingLayout || itemTransforms.size > 0;
+    if (!hasPendingChanges) return;
 
     // Start from current config, apply layout then transforms
     let updatedConfig = pendingLayout
       ? applyLayout(pendingLayout)
-      : { ...content.config }
-    if (!updatedConfig || !threadId) return
+      : { ...content.config };
+    if (!updatedConfig || !threadId) return;
 
-    updatedConfig = applyTransforms(updatedConfig)
+    updatedConfig = applyTransforms(updatedConfig);
 
     try {
-      await saveConfigFn(threadId, content.toolCallId, updatedConfig)
+      await saveConfigFn(threadId, content.toolCallId, updatedConfig);
 
       if (content.toolCallId) {
-        savedDashboardConfigStore.set(content.toolCallId, updatedConfig)
+        savedDashboardConfigStore.set(content.toolCallId, updatedConfig);
       }
 
       // Update canvas content. handleSave only ever spreads the config / items
@@ -162,20 +169,20 @@ export function DashboardCanvasProvider({
       openCanvas({
         ...content,
         config: updatedConfig,
-      })
+      });
 
-      setPendingLayout(null)
-      setItemTransforms(new Map())
+      setPendingLayout(null);
+      setItemTransforms(new Map());
     } catch {
       // Keep pending state on failure so user can retry
     }
-  }
+  };
 
   const handleDiscard = () => {
-    setPendingLayout(null)
-    setItemTransforms(new Map())
-    setDiscardKey((k) => k + 1)
-  }
+    setPendingLayout(null);
+    setItemTransforms(new Map());
+    setDiscardKey((k) => k + 1);
+  };
 
   return (
     <DashboardCanvasContext.Provider
@@ -189,9 +196,11 @@ export function DashboardCanvasProvider({
         transformItem,
         exportAsExcel,
         registerExport,
+        config: content.config,
+        onSaveDashboard,
       }}
     >
       {children}
     </DashboardCanvasContext.Provider>
-  )
+  );
 }

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContext.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContext.tsx
@@ -1,99 +1,99 @@
-import { useCopilotContext } from "@copilotkit/react-core";
+import { useCopilotContext } from "@copilotkit/react-core"
 import {
   createContext,
   type ReactNode,
   useCallback,
   useContext,
   useState,
-} from "react";
+} from "react"
 
-import type { DashboardItemLayout } from "@/patterns/F0AnalyticsDashboard/types";
+import type { DashboardItemLayout } from "@/patterns/F0AnalyticsDashboard/types"
 
-import type { ChatDashboardConfig, ChatDashboardItem } from "./types";
-import { useSaveDashboardConfig } from "./useSaveDashboardConfig";
-import { useAiChat } from "../../../providers/AiChatStateProvider";
 import type {
   DashboardCanvasContent,
   SaveDashboardPayload,
-} from "../../../types";
+} from "../../../types"
+import type { ChatDashboardConfig, ChatDashboardItem } from "./types"
 
-import { savedDashboardConfigStore } from "./configStore";
+import { useAiChat } from "../../../providers/AiChatStateProvider"
+import { savedDashboardConfigStore } from "./configStore"
+import { useSaveDashboardConfig } from "./useSaveDashboardConfig"
 
 type DashboardCanvasContextValue = {
   /** Whether there are unsaved layout changes */
-  isDirty: boolean;
+  isDirty: boolean
   /** Incrementing counter — changes when discard is called to reset the grid */
-  discardKey: number;
+  discardKey: number
   /** Pending item transforms keyed by item id (chart type changes, etc.) */
-  itemTransforms: Map<string, Partial<ChatDashboardItem>>;
+  itemTransforms: Map<string, Partial<ChatDashboardItem>>
   /** Called by the grid when layout changes (drag/resize/delete) */
-  onLayoutChange: (layout: DashboardItemLayout[]) => void;
+  onLayoutChange: (layout: DashboardItemLayout[]) => void
   /** Persist current layout and update canvas */
-  handleSave: () => Promise<void>;
+  handleSave: () => Promise<void>
   /** Discard pending layout changes */
-  handleDiscard: () => void;
+  handleDiscard: () => void
   /** Transform an item's config (e.g. change chart type). Marks dirty without refetch. */
-  transformItem: (itemId: string, patch: Partial<ChatDashboardItem>) => void;
+  transformItem: (itemId: string, patch: Partial<ChatDashboardItem>) => void
   /** Export the dashboard as Excel */
-  exportAsExcel?: () => Promise<void>;
+  exportAsExcel?: () => Promise<void>
   /** Register the export function from the dashboard component */
-  registerExport: (fn: (() => Promise<void>) | undefined) => void;
+  registerExport: (fn: (() => Promise<void>) | undefined) => void
   /** The current dashboard config (reflects any saved layout edits) */
-  config: ChatDashboardConfig;
+  config: ChatDashboardConfig
   /** Callback to persist the dashboard to the backend. Undefined when not provided by the host app. */
-  onSaveDashboard?: (payload: SaveDashboardPayload) => Promise<void>;
-};
+  onSaveDashboard?: (payload: SaveDashboardPayload) => Promise<void>
+}
 
 const DashboardCanvasContext =
-  createContext<DashboardCanvasContextValue | null>(null);
+  createContext<DashboardCanvasContextValue | null>(null)
 
 export function useDashboardCanvas(): DashboardCanvasContextValue {
-  const ctx = useContext(DashboardCanvasContext);
+  const ctx = useContext(DashboardCanvasContext)
   if (!ctx) {
     throw new Error(
-      "useDashboardCanvas must be used within DashboardCanvasProvider",
-    );
+      "useDashboardCanvas must be used within DashboardCanvasProvider"
+    )
   }
-  return ctx;
+  return ctx
 }
 
 export function DashboardCanvasProvider({
   content,
   children,
 }: {
-  content: DashboardCanvasContent;
-  children: ReactNode;
+  content: DashboardCanvasContent
+  children: ReactNode
 }): ReactNode {
   const [pendingLayout, setPendingLayout] = useState<
     DashboardItemLayout[] | null
-  >(null);
+  >(null)
   const [itemTransforms, setItemTransforms] = useState<
     Map<string, Partial<ChatDashboardItem>>
-  >(new Map());
-  const [discardKey, setDiscardKey] = useState(0);
+  >(new Map())
+  const [discardKey, setDiscardKey] = useState(0)
   const [exportAsExcel, setExportAsExcel] = useState<
     (() => Promise<void>) | undefined
-  >();
+  >()
   const registerExport = useCallback(
     (fn: (() => Promise<void>) | undefined) => {
-      setExportAsExcel(() => fn);
+      setExportAsExcel(() => fn)
     },
-    [],
-  );
-  const { openCanvas, onSaveDashboard } = useAiChat();
-  const { threadId } = useCopilotContext();
+    []
+  )
+  const { openCanvas, onSaveDashboard } = useAiChat()
+  const { threadId } = useCopilotContext()
 
-  const saveConfigFn = useSaveDashboardConfig(content.apiConfig);
+  const saveConfigFn = useSaveDashboardConfig(content.apiConfig)
 
   const applyLayout = useCallback(
     (layout: DashboardItemLayout[]): ChatDashboardConfig | null => {
       const itemsById = new Map(
-        content.config.items.map((item) => [item.id, item]),
-      );
+        content.config.items.map((item) => [item.id, item])
+      )
       const newItems = layout
         .map((entry) => {
-          const original = itemsById.get(entry.id);
-          if (!original) return null;
+          const original = itemsById.get(entry.id)
+          if (!original) return null
           return {
             ...original,
             colSpan: entry.colSpan,
@@ -104,62 +104,62 @@ export function DashboardCanvasProvider({
             itemHeight: entry.itemHeight,
             x: entry.x,
             y: entry.y,
-          };
+          }
         })
-        .filter((item) => item !== null);
+        .filter((item) => item !== null)
 
-      return { ...content.config, items: newItems };
+      return { ...content.config, items: newItems }
     },
-    [content],
-  );
+    [content]
+  )
 
   const onLayoutChange = useCallback((layout: DashboardItemLayout[]) => {
-    setPendingLayout(layout);
-  }, []);
+    setPendingLayout(layout)
+  }, [])
 
   const transformItem = useCallback(
     (itemId: string, patch: Partial<ChatDashboardItem>) => {
       setItemTransforms((prev) => {
-        const next = new Map(prev);
-        next.set(itemId, patch);
-        return next;
-      });
+        const next = new Map(prev)
+        next.set(itemId, patch)
+        return next
+      })
     },
-    [],
-  );
+    []
+  )
 
   /** Apply item transforms to a config, producing a new config with patched items. */
   const applyTransforms = useCallback(
     (config: ChatDashboardConfig): ChatDashboardConfig => {
-      if (itemTransforms.size === 0) return config;
+      if (itemTransforms.size === 0) return config
       return {
         ...config,
         items: config.items.map((item) => {
-          const patch = itemTransforms.get(item.id);
-          return patch ? ({ ...item, ...patch } as typeof item) : item;
+          const patch = itemTransforms.get(item.id)
+          return patch ? ({ ...item, ...patch } as typeof item) : item
         }),
-      };
+      }
     },
-    [itemTransforms],
-  );
+    [itemTransforms]
+  )
 
   const handleSave = async () => {
-    const hasPendingChanges = pendingLayout || itemTransforms.size > 0;
-    if (!hasPendingChanges) return;
+    const hasPendingChanges = pendingLayout || itemTransforms.size > 0
+    if (!hasPendingChanges) return
 
     // Start from current config, apply layout then transforms
     let updatedConfig = pendingLayout
       ? applyLayout(pendingLayout)
-      : { ...content.config };
-    if (!updatedConfig || !threadId) return;
+      : { ...content.config }
+    if (!updatedConfig || !threadId) return
 
-    updatedConfig = applyTransforms(updatedConfig);
+    updatedConfig = applyTransforms(updatedConfig)
 
     try {
-      await saveConfigFn(threadId, content.toolCallId, updatedConfig);
+      await saveConfigFn(threadId, content.toolCallId, updatedConfig)
 
       if (content.toolCallId) {
-        savedDashboardConfigStore.set(content.toolCallId, updatedConfig);
+        savedDashboardConfigStore.set(content.toolCallId, updatedConfig)
       }
 
       // Update canvas content. handleSave only ever spreads the config / items
@@ -169,20 +169,20 @@ export function DashboardCanvasProvider({
       openCanvas({
         ...content,
         config: updatedConfig,
-      });
+      })
 
-      setPendingLayout(null);
-      setItemTransforms(new Map());
+      setPendingLayout(null)
+      setItemTransforms(new Map())
     } catch {
       // Keep pending state on failure so user can retry
     }
-  };
+  }
 
   const handleDiscard = () => {
-    setPendingLayout(null);
-    setItemTransforms(new Map());
-    setDiscardKey((k) => k + 1);
-  };
+    setPendingLayout(null)
+    setItemTransforms(new Map())
+    setDiscardKey((k) => k + 1)
+  }
 
   return (
     <DashboardCanvasContext.Provider
@@ -202,5 +202,5 @@ export function DashboardCanvasProvider({
     >
       {children}
     </DashboardCanvasContext.Provider>
-  );
+  )
 }

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardHeader.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardHeader.tsx
@@ -1,35 +1,23 @@
-import { useCallback, useRef, useState } from "react"
+import type { ReactNode } from "react";
 
-import { ButtonInternal } from "@/components/F0Button/internal"
-import { OneEllipsis } from "@/lib/OneEllipsis"
-import { Download } from "@/icons/app"
-import { useI18n } from "@/lib/providers/i18n"
+import { useCallback, useRef, useState } from "react";
 
-import { CloseCanvasButton } from "../../components/CloseCanvasButton"
-import { useDashboardCanvas } from "./DashboardContext"
+import { F0Button } from "@/components/F0Button";
+import { Save } from "@/icons/app";
+import { OneEllipsis } from "@/lib/OneEllipsis";
+import { useI18n } from "@/lib/providers/i18n";
+import { ExportDropdown } from "@/patterns/F0AnalyticsDashboard/components/ExportDropdown/ExportDropdown";
+
+import { CloseCanvasButton } from "../../components/CloseCanvasButton";
+import { useDashboardCanvas } from "./DashboardContext";
 
 export function DashboardHeader({
   title,
   onClose,
 }: {
-  title: string
-  onClose: () => void
+  title: string;
+  onClose: () => void;
 }) {
-  const { t } = useI18n()
-  const { exportAsExcel } = useDashboardCanvas()
-  const [isExporting, setIsExporting] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-
-  const handleExport = useCallback(async () => {
-    if (!exportAsExcel) return
-    setIsExporting(true)
-    try {
-      await exportAsExcel()
-    } finally {
-      setIsExporting(false)
-    }
-  }, [exportAsExcel])
-
   return (
     <div className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-f1-border-secondary p-5">
       <OneEllipsis
@@ -38,22 +26,81 @@ export function DashboardHeader({
       >
         {title}
       </OneEllipsis>
-      <div ref={ref} className="flex items-center gap-2">
-        {exportAsExcel && (
-          <ButtonInternal
-            variant="outline"
-            icon={Download}
-            onClick={handleExport}
-            label={
-              isExporting
-                ? t("ai.dataDownload.exporting")
-                : t("ai.dataDownload.exportDashboard", { format: "Excel" })
-            }
-          />
-        )}
-      </div>
+      <DashboardActions />
       <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
       <CloseCanvasButton onClick={onClose} />
     </div>
-  )
+  );
+}
+
+function DashboardActions(): ReactNode {
+  const {
+    isDirty,
+    handleSave,
+    handleDiscard,
+    exportAsExcel,
+    config,
+    onSaveDashboard,
+  } = useDashboardCanvas();
+  const translations = useI18n();
+  const ref = useRef<HTMLDivElement>(null);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = useCallback(async () => {
+    if (!exportAsExcel) return;
+    setIsExporting(true);
+    try {
+      await exportAsExcel();
+    } finally {
+      setIsExporting(false);
+    }
+  }, [exportAsExcel]);
+
+  const handleSaveReport = useCallback(async () => {
+    if (!onSaveDashboard) return;
+    await onSaveDashboard({
+      title: config.title,
+      items: config.items,
+      fetchSpecs: config.fetchSpecs,
+      filters: config.filters,
+    });
+  }, [onSaveDashboard, config]);
+
+  if (isDirty) {
+    return (
+      <div ref={ref} className="flex gap-2">
+        <F0Button
+          variant="outline"
+          label={translations.ai.discardChanges}
+          onClick={handleDiscard}
+          size="md"
+        />
+        <F0Button
+          label={translations.ai.saveChanges}
+          onClick={handleSave}
+          size="md"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div ref={ref} className="flex items-center gap-2">
+      {onSaveDashboard && (
+        <F0Button
+          variant="outline"
+          icon={Save}
+          size="md"
+          onClick={handleSaveReport}
+          label={translations.ai.saveReport}
+        />
+      )}
+      {exportAsExcel && (
+        <ExportDropdown
+          onExportExcel={handleExport}
+          isExporting={isExporting}
+        />
+      )}
+    </div>
+  );
 }

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardHeader.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardHeader.tsx
@@ -1,22 +1,24 @@
-import type { ReactNode } from "react";
+import type { ReactNode } from "react"
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react"
 
-import { F0Button } from "@/components/F0Button";
-import { Save } from "@/icons/app";
-import { OneEllipsis } from "@/lib/OneEllipsis";
-import { useI18n } from "@/lib/providers/i18n";
-import { ExportDropdown } from "@/patterns/F0AnalyticsDashboard/components/ExportDropdown/ExportDropdown";
+import { F0Button } from "@/components/F0Button"
+import { ArrowCycle, Save } from "@/icons/app"
+import { OneEllipsis } from "@/lib/OneEllipsis"
+import { useI18n } from "@/lib/providers/i18n"
+import { ExportDropdown } from "@/patterns/F0AnalyticsDashboard/components/ExportDropdown/ExportDropdown"
 
-import { CloseCanvasButton } from "../../components/CloseCanvasButton";
-import { useDashboardCanvas } from "./DashboardContext";
+import { CloseCanvasButton } from "../../components/CloseCanvasButton"
+import { useDashboardCanvas } from "./DashboardContext"
 
 export function DashboardHeader({
   title,
   onClose,
+  onRefresh,
 }: {
-  title: string;
-  onClose: () => void;
+  title: string
+  onClose: () => void
+  onRefresh: () => void
 }) {
   return (
     <div className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-f1-border-secondary p-5">
@@ -26,14 +28,14 @@ export function DashboardHeader({
       >
         {title}
       </OneEllipsis>
-      <DashboardActions />
+      <DashboardActions onRefresh={onRefresh} />
       <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
       <CloseCanvasButton onClick={onClose} />
     </div>
-  );
+  )
 }
 
-function DashboardActions(): ReactNode {
+function DashboardActions({ onRefresh }: { onRefresh: () => void }): ReactNode {
   const {
     isDirty,
     handleSave,
@@ -41,30 +43,30 @@ function DashboardActions(): ReactNode {
     exportAsExcel,
     config,
     onSaveDashboard,
-  } = useDashboardCanvas();
-  const translations = useI18n();
-  const ref = useRef<HTMLDivElement>(null);
-  const [isExporting, setIsExporting] = useState(false);
+  } = useDashboardCanvas()
+  const translations = useI18n()
+  const ref = useRef<HTMLDivElement>(null)
+  const [isExporting, setIsExporting] = useState(false)
 
   const handleExport = useCallback(async () => {
-    if (!exportAsExcel) return;
-    setIsExporting(true);
+    if (!exportAsExcel) return
+    setIsExporting(true)
     try {
-      await exportAsExcel();
+      await exportAsExcel()
     } finally {
-      setIsExporting(false);
+      setIsExporting(false)
     }
-  }, [exportAsExcel]);
+  }, [exportAsExcel])
 
   const handleSaveReport = useCallback(async () => {
-    if (!onSaveDashboard) return;
+    if (!onSaveDashboard) return
     await onSaveDashboard({
       title: config.title,
       items: config.items,
       fetchSpecs: config.fetchSpecs,
       filters: config.filters,
-    });
-  }, [onSaveDashboard, config]);
+    })
+  }, [onSaveDashboard, config])
 
   if (isDirty) {
     return (
@@ -81,7 +83,7 @@ function DashboardActions(): ReactNode {
           size="md"
         />
       </div>
-    );
+    )
   }
 
   return (
@@ -95,6 +97,14 @@ function DashboardActions(): ReactNode {
           label={translations.ai.saveReport}
         />
       )}
+      <F0Button
+        variant="outline"
+        icon={ArrowCycle}
+        size="md"
+        onClick={onRefresh}
+        label={translations.ai.refreshDashboard}
+        hideLabel
+      />
       {exportAsExcel && (
         <ExportDropdown
           onExportExcel={handleExport}
@@ -102,5 +112,5 @@ function DashboardActions(): ReactNode {
         />
       )}
     </div>
-  );
+  )
 }

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/index.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/index.tsx
@@ -1,9 +1,9 @@
+import type { DashboardCanvasContent } from "../../../types"
 import type { CanvasEntityDefinition } from "../../types"
 
 import { DashboardContent } from "./DashboardContent"
 import { DashboardCanvasProvider } from "./DashboardContext"
 import { DashboardHeader } from "./DashboardHeader"
-import type { DashboardCanvasContent } from "../../../types"
 
 export const dashboardCanvasEntity: CanvasEntityDefinition<DashboardCanvasContent> =
   {
@@ -11,8 +11,12 @@ export const dashboardCanvasEntity: CanvasEntityDefinition<DashboardCanvasConten
     renderContent: ({ content, refreshKey }) => (
       <DashboardContent content={content} refreshKey={refreshKey} />
     ),
-    renderHeader: ({ content, onClose }) => (
-      <DashboardHeader title={content.title} onClose={onClose} />
+    renderHeader: ({ content, onClose, onRefresh }) => (
+      <DashboardHeader
+        title={content.title}
+        onClose={onClose}
+        onRefresh={onRefresh}
+      />
     ),
     wrapper: ({ content, children }) => (
       <DashboardCanvasProvider content={content}>

--- a/packages/react/src/sds/ai/F0AiChat/canvas/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/types.ts
@@ -22,7 +22,11 @@ export type CanvasEntityDefinition<
   /** Renders the main body of the canvas panel */
   renderContent: (props: { content: T; refreshKey: number }) => ReactNode
   /** Renders the full header (title, actions, close button) */
-  renderHeader: (props: { content: T; onClose: () => void }) => ReactNode
+  renderHeader: (props: {
+    content: T
+    onClose: () => void
+    onRefresh: () => void
+  }) => ReactNode
   /**
    * Optional wrapper providing entity-scoped context around
    * both header and body (e.g. shared edit-mode state).

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/CanvasPanel.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/CanvasPanel.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "motion/react"
-import { type ReactNode, useEffect, useRef, useState } from "react"
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react"
 
 import { useReducedMotion } from "@/lib/a11y"
 import { cn } from "@/lib/utils"
@@ -34,12 +34,17 @@ export function CanvasPanel(): ReactNode {
 
   const entity = canvasContent ? getCanvasEntity(canvasContent.type) : undefined
 
+  const handleRefresh = useCallback(() => {
+    setRefreshKey((k) => k + 1)
+  }, [])
+
   const renderInner = (): ReactNode => {
     if (!canvasContent || !entity) return null
 
     const header = entity.renderHeader({
       content: canvasContent,
       onClose: closeCanvas,
+      onRefresh: handleRefresh,
     })
     const content = entity.renderContent({
       content: canvasContent,

--- a/packages/react/src/sds/ai/F0AiChat/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/index.ts
@@ -19,6 +19,7 @@ export type {
   EntityUrlBuilders,
   EntityRefs,
   PersonProfile,
+  SaveDashboardPayload,
   UploadedFile,
   VisualizationMode,
   WelcomeScreenSuggestion,

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -12,6 +12,7 @@ import {
   type AiChatCredits,
   type AiChatCreditWarning,
   type EntityRefs,
+  type SaveDashboardPayload,
   type VisualizationMode,
   WelcomeScreenSuggestion,
 } from "./types"
@@ -48,6 +49,7 @@ export interface AiChatState {
     { threadId, feedback }: { threadId: string; feedback: string }
   ) => void
   tracking?: AiChatTrackingOptions
+  onSaveDashboard?: (payload: SaveDashboardPayload) => Promise<void>
 }
 
 /**
@@ -210,6 +212,7 @@ export type AiChatProviderReturnValue = {
   | "credits"
   | "creditWarning"
   | "fileAttachments"
+  | "onSaveDashboard"
 > & {
     /** The current canvas content, or null when canvas is closed */
     canvasContent: CanvasContent | null

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -16,9 +16,9 @@ import {
 
 import { useI18n } from "@/lib/providers/i18n"
 
-import { DEFAULT_CHAT_WIDTH } from "../utils/constants"
-import { AiChatProviderReturnValue, AiChatState } from "../internal-types"
 import type { ClarifyingQuestionState } from "../actions/core/clarifyingQuestion/types"
+
+import { AiChatProviderReturnValue, AiChatState } from "../internal-types"
 import {
   type AiChatMode,
   type AppendMessage,
@@ -27,6 +27,7 @@ import {
   type AiChatToolHint,
   WelcomeScreenSuggestion,
 } from "../types"
+import { DEFAULT_CHAT_WIDTH } from "../utils/constants"
 import {
   readFromLocalStorage,
   writeToLocalStorage,
@@ -66,6 +67,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   fileAttachments,
   onThumbsDown,
   onThumbsUp,
+  onSaveDashboard,
   tracking,
   ...rest
 }) => {
@@ -346,6 +348,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         toolHints,
         credits,
         fileAttachments,
+        onSaveDashboard,
         inProgress,
         setInProgress,
         canvasContent,
@@ -420,6 +423,7 @@ export function useAiChat(): AiChatProviderReturnValue {
       credits: undefined,
       creditWarning: undefined,
       fileAttachments: undefined,
+      onSaveDashboard: undefined,
       inProgress: false,
       setInProgress: noopFn,
       canvasContent: null,

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -4,8 +4,8 @@ import { type AIMessage, type Message } from "@copilotkit/shared"
 import { IconType } from "@/components/F0Icon"
 import { defaultTranslations } from "@/lib/providers/i18n/i18n-provider-defaults"
 
-import type { ChatDashboardConfig } from "./canvas/entities/dashboard/types"
 import type { DataDownloadDataset } from "./actions/core/dataDownload/types"
+import type { ChatDashboardConfig } from "./canvas/entities/dashboard/types"
 export type { PersonProfile } from "./components/markdownRenderers/entityRef/entities/person/types"
 export type { CandidateProfile } from "./components/markdownRenderers/entityRef/entities/candidate/types"
 export type { JobPostingProfile } from "./components/markdownRenderers/entityRef/entities/jobPosting/types"
@@ -36,6 +36,22 @@ export type AppendMessage = {
   role: "user" | "assistant"
   content: string
   toolCalls?: AppendToolCall[]
+}
+
+/**
+ * Payload passed to onSaveDashboard when the user saves a dashboard.
+ * Contains the full compute payload so it can be persisted and replayed
+ * without going through the AI agent.
+ */
+export type SaveDashboardPayload = {
+  /** Dashboard title */
+  title: string
+  /** Dashboard items (charts, metrics, collections) */
+  items: ChatDashboardConfig["items"]
+  /** Fetch specs for server-side data retrieval */
+  fetchSpecs: ChatDashboardConfig["fetchSpecs"]
+  /** Optional filter definitions */
+  filters?: ChatDashboardConfig["filters"]
 }
 
 /**
@@ -248,6 +264,12 @@ export type AiChatProviderProps = {
     message: AIMessage,
     { threadId, feedback }: { threadId: string; feedback: string }
   ) => void
+  /**
+   * Callback fired when the user clicks "Save report" in the dashboard header.
+   * The host app provides this to persist the dashboard config to the backend.
+   * When not provided, the save button is hidden.
+   */
+  onSaveDashboard?: (payload: SaveDashboardPayload) => Promise<void>
   tracking?: AiChatTrackingOptions
 } & Pick<
   CopilotKitProps,


### PR DESCRIPTION
## Description

Add support for persisting AI-generated dashboards and refreshing them from the F0 design system side. This PR exposes the necessary callbacks and UI elements that the host app (Factorial) uses to implement save and refresh functionality.

## Changes

### Save report button
- Add `SaveDashboardPayload` type and `onSaveDashboard` optional callback to `AiChatProviderProps`
- Wire `onSaveDashboard` through the provider chain (`AiChatStateProvider` → `DashboardContext`)
- Show a "Save report" button in `DashboardHeader` when `onSaveDashboard` is provided
- Export `SaveDashboardPayload` from the public API (`index.ts`)

### Refresh button
- Add `onRefresh` callback to `renderHeader` props in `CanvasEntityDefinition`
- `CanvasPanel` manages a `refreshKey` state and passes `handleRefresh` (increment key) to `renderHeader`
- Dashboard entity forwards `onRefresh` to `DashboardHeader`
- Add icon-only refresh button (ArrowCycle icon) with `hideLabel` in the dashboard header

### i18n
- Add `saveReport` and `refreshDashboard` default translation strings

## Implementation details

F0 is a design system library — it doesn't call the Factorial backend directly. Instead, it exposes the `onSaveDashboard` callback that the host app provides the implementation for. The refresh mechanism works by incrementing a `refreshKey` that causes `ChatDashboard` to remount `<F0AnalyticsDashboard>`, triggering fresh `POST /dashboard/compute` calls.

## Skills

- `factorial-pr`