### PR TITLE
feat(ai): enhance message filtering to exclude non-renderable messages

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/__tests__/internal-types.test.ts
+++ b/packages/react/src/sds/ai/F0AiChat/__tests__/internal-types.test.ts
@@ -1,0 +1,171 @@
+import { type Message } from "@copilotkit/shared"
+import { describe, expect, it } from "vitest"
+
+import {
+  filterCoagentPlaceholders,
+  filterNonRenderableMessages,
+  isAgentStateMessage,
+  isCoagentPlaceholder,
+} from "../internal-types"
+
+/* ---------- helpers to build minimal Message objects ---------- */
+
+function userMsg(id: string, content: string): Message {
+  return { id, role: "user", content } as Message
+}
+
+function assistantMsg(id: string, content: string): Message {
+  return { id, role: "assistant", content } as Message
+}
+
+function toolResultMsg(id: string): Message {
+  return { id, role: "tool", content: '{"ok":true}' } as Message
+}
+
+function coagentPlaceholder(id: string): Message {
+  return {
+    id,
+    role: "assistant",
+    content: "",
+    name: "coagent-state-render",
+  } as unknown as Message
+}
+
+function agentStateMsg(id: string, agentName: string): Message {
+  return {
+    id,
+    role: "assistant",
+    content: "",
+    agentName,
+  } as Message
+}
+
+/* ---------- isAgentStateMessage ---------- */
+
+describe("isAgentStateMessage", () => {
+  it("returns true for assistant message with agentName", () => {
+    expect(isAgentStateMessage(agentStateMsg("1", "my-agent"))).toBe(true)
+  })
+
+  it("returns false for regular assistant message", () => {
+    expect(isAgentStateMessage(assistantMsg("2", "Hello"))).toBe(false)
+  })
+
+  it("returns false for user message", () => {
+    expect(isAgentStateMessage(userMsg("3", "Hi"))).toBe(false)
+  })
+})
+
+/* ---------- isCoagentPlaceholder ---------- */
+
+describe("isCoagentPlaceholder", () => {
+  it("returns true for coagent-state-render message", () => {
+    expect(isCoagentPlaceholder(coagentPlaceholder("1"))).toBe(true)
+  })
+
+  it("returns false for regular assistant message", () => {
+    expect(isCoagentPlaceholder(assistantMsg("2", "response"))).toBe(false)
+  })
+
+  it("returns false for tool result message", () => {
+    expect(isCoagentPlaceholder(toolResultMsg("3"))).toBe(false)
+  })
+})
+
+/* ---------- filterCoagentPlaceholders ---------- */
+
+describe("filterCoagentPlaceholders", () => {
+  it("removes coagent placeholders and keeps other messages", () => {
+    const messages = [
+      userMsg("1", "Hi"),
+      coagentPlaceholder("2"),
+      assistantMsg("3", "Hello"),
+      coagentPlaceholder("4"),
+    ]
+
+    const result = filterCoagentPlaceholders(messages)
+
+    expect(result).toHaveLength(2)
+    expect(result.map((m) => m.id)).toEqual(["1", "3"])
+  })
+
+  it("returns all messages when no placeholders present", () => {
+    const messages = [userMsg("1", "Hi"), assistantMsg("2", "Hello")]
+    expect(filterCoagentPlaceholders(messages)).toHaveLength(2)
+  })
+})
+
+/* ---------- filterNonRenderableMessages ---------- */
+
+describe("filterNonRenderableMessages", () => {
+  it("removes tool result messages (role: 'tool')", () => {
+    const messages = [
+      userMsg("1", "Do something"),
+      toolResultMsg("2"),
+      assistantMsg("3", "Done"),
+    ]
+
+    const result = filterNonRenderableMessages(messages)
+
+    expect(result).toHaveLength(2)
+    expect(result.map((m) => m.id)).toEqual(["1", "3"])
+  })
+
+  it("removes coagent-state-render placeholders", () => {
+    const messages = [
+      userMsg("1", "Hi"),
+      coagentPlaceholder("2"),
+      assistantMsg("3", "Hello"),
+    ]
+
+    const result = filterNonRenderableMessages(messages)
+
+    expect(result).toHaveLength(2)
+    expect(result.map((m) => m.id)).toEqual(["1", "3"])
+  })
+
+  it("removes both tool results and coagent placeholders in same array", () => {
+    const messages = [
+      userMsg("1", "Start"),
+      toolResultMsg("2"),
+      coagentPlaceholder("3"),
+      assistantMsg("4", "Working"),
+      toolResultMsg("5"),
+      coagentPlaceholder("6"),
+      assistantMsg("7", "Done"),
+    ]
+
+    const result = filterNonRenderableMessages(messages)
+
+    expect(result).toHaveLength(3)
+    expect(result.map((m) => m.id)).toEqual(["1", "4", "7"])
+  })
+
+  it("preserves regular user and assistant messages", () => {
+    const messages = [
+      userMsg("1", "Question"),
+      assistantMsg("2", "Answer"),
+      userMsg("3", "Follow-up"),
+      assistantMsg("4", "More info"),
+    ]
+
+    const result = filterNonRenderableMessages(messages)
+
+    expect(result).toHaveLength(4)
+    expect(result).toEqual(messages)
+  })
+
+  it("returns empty array when all messages are non-renderable", () => {
+    const messages = [
+      toolResultMsg("1"),
+      coagentPlaceholder("2"),
+      toolResultMsg("3"),
+    ]
+
+    expect(filterNonRenderableMessages(messages)).toEqual([])
+  })
+
+  it("returns empty array for empty input", () => {
+    expect(filterNonRenderableMessages([])).toEqual([])
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatInput.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatInput.tsx
@@ -7,7 +7,7 @@ import { OneEllipsis } from "@/lib/OneEllipsis"
 import { Link } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
 
-import { filterCoagentPlaceholders } from "../../internal-types"
+import { filterNonRenderableMessages } from "../../internal-types"
 import { useAiChat } from "../../providers/AiChatStateProvider"
 import { ChatTextarea } from "./ChatTextarea"
 
@@ -22,7 +22,7 @@ export const ChatInput = (props: InputProps) => {
   const { messages } = useCopilotChatInternal()
   const containerRef = useRef<HTMLDivElement>(null)
   const filteredMessages = useMemo(
-    () => filterCoagentPlaceholders(messages),
+    () => filterNonRenderableMessages(messages),
     [messages]
   )
   const isWelcomeScreen = filteredMessages.length === 0 && !isLoadingThread

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/ChatHeader.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/ChatHeader.tsx
@@ -17,7 +17,7 @@ import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { Action } from "@/ui/Action"
 
-import { filterCoagentPlaceholders } from "../../internal-types"
+import { filterNonRenderableMessages } from "../../internal-types"
 import { useAiChat } from "../../providers/AiChatStateProvider"
 import { ChatHistoryDialog } from "../history/ChatHistoryDialog"
 import { CreditsPopover } from "./CreditsPopover"
@@ -150,7 +150,7 @@ const ChatHeaderLegacy = (props: HeaderProps) => {
   const translations = useI18n()
   const hasDefaultTitle = labels.title === "CopilotKit"
   const filteredMessages = useMemo(
-    () => filterCoagentPlaceholders(messages),
+    () => filterNonRenderableMessages(messages),
     [messages]
   )
   const hasMessages = filteredMessages.length > 0

--- a/packages/react/src/sds/ai/F0AiChat/components/messages/MessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/messages/MessagesContainer.tsx
@@ -12,7 +12,7 @@ import { Skeleton } from "@/ui/skeleton"
 
 import { F0ActionItem } from "../../../F0ActionItem"
 import { useMessageScroll } from "../../hooks/useMessageScroll"
-import { filterCoagentPlaceholders } from "../../internal-types"
+import { filterNonRenderableMessages } from "../../internal-types"
 import { useAiChat } from "../../providers/AiChatStateProvider"
 import {
   type Turn,
@@ -83,7 +83,12 @@ const Messages = ({
     [initialMessage, translations.ai.defaultInitialMessage]
   )
 
-  // Filter coagent placeholders and expand multi-tool-call messages.
+  // Filter non-renderable messages and expand multi-tool-call messages.
+  //
+  // Non-renderable messages include coagent-state-render placeholders and
+  // tool-result messages (role: "tool") — internal CopilotKit bookkeeping
+  // that carries the stringified return value of frontend tool handlers
+  // (e.g. the JSON response from approveMutation's respond() callback).
   //
   // CopilotKit v1.51+ AG-UI packs multiple tool calls into a single
   // assistant message (e.g. 2× orchestratorThinking + 1× downloadData +
@@ -95,7 +100,7 @@ const Messages = ({
   // by AssistantMessage which looks up actions from CopilotKit context.
   const filteredMessages = useMemo(
     () =>
-      filterCoagentPlaceholders(messages).flatMap((msg) => {
+      filterNonRenderableMessages(messages).flatMap((msg) => {
         if (msg.role !== "assistant") return [msg]
 
         const toolCalls = msg.toolCalls as

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -229,3 +229,26 @@ export function isCoagentPlaceholder(message: Message): boolean {
 export function filterCoagentPlaceholders(messages: Message[]): Message[] {
   return messages.filter((m) => !isCoagentPlaceholder(m))
 }
+
+/**
+ * Check whether a message is a tool-result message (role: "tool").
+ *
+ * These are internal CopilotKit bookkeeping messages that carry the
+ * stringified return value of frontend tool handlers (e.g. the JSON
+ * response from `approveMutation`'s `respond()` callback).  They must
+ * never be rendered in the chat UI.
+ */
+function isToolResultMessage(message: Message): boolean {
+  return message.role === "tool"
+}
+
+/**
+ * Filter out all messages that should never be rendered in the chat UI:
+ * - coagent-state-render placeholders (CopilotKit internal)
+ * - tool-result messages (role: "tool") carrying frontend tool handler output
+ */
+export function filterNonRenderableMessages(messages: Message[]): Message[] {
+  return messages.filter(
+    (m) => !isCoagentPlaceholder(m) && !isToolResultMessage(m)
+  )
+}


### PR DESCRIPTION

## Description

- Added  function to identify tool-result messages.
- Introduced  to filter out both coagent placeholders and tool-result messages from the chat UI.
- Updated components to use the new filtering function.


## Screenshots (if applicable)

## Before 

<img width="1044" height="1432" alt="image (23)" src="https://github.com/user-attachments/assets/40d17a59-a5ff-47da-98c4-f9ee5d1a9886" />


## After 
<img width="1094" height="2350" alt="image (24)" src="https://github.com/user-attachments/assets/9152ae98-f983-43df-a409-25ed601faecc" />

