### PR TITLE
feat: add tooltip support to DataCollection secondary actions

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/actions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/actions.tsx
@@ -48,6 +48,7 @@ export type SecondaryActionItem = Pick<
   loading?: boolean
   disabled?: boolean
   onClick?: () => void | Promise<void>
+  tooltip?: string
 }
 
 export type SecondaryActionGroup = {

--- a/packages/react/src/patterns/OneDataCollection/actions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/actions.tsx
@@ -48,7 +48,10 @@ export type SecondaryActionItem = Pick<
   loading?: boolean
   disabled?: boolean
   onClick?: () => void | Promise<void>
-  tooltip?: string
+  tooltip?: (params: {
+    disabled: boolean
+    loading: boolean
+  }) => string | undefined
 }
 
 export type SecondaryActionGroup = {

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
@@ -4,6 +4,7 @@ import { F0Button } from "@/components/F0Button"
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
 import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { Ellipsis } from "@/icons/app"
 
 import {
@@ -102,19 +103,29 @@ export const CollectionActions = ({
         )
       )}
 
-      {secondaryActionsButtons?.map((action) => (
-        <F0Button
-          size="md"
-          key={action.label}
-          onClick={action.onClick}
-          icon={action.icon}
-          variant="outline"
-          hideLabel={action.hideLabelWhenExpanded}
-          label={action.label}
-          disabled={action.disabled}
-          loading={action.loading}
-        />
-      ))}
+      {secondaryActionsButtons?.map((action) => {
+        const button = (
+          <F0Button
+            size="md"
+            key={action.label}
+            onClick={action.onClick}
+            icon={action.icon}
+            variant="outline"
+            hideLabel={action.hideLabelWhenExpanded}
+            label={action.label}
+            disabled={action.disabled}
+            loading={action.loading}
+          />
+        )
+
+        return action.tooltip ? (
+          <Tooltip key={action.label} description={action.tooltip}>
+            {button}
+          </Tooltip>
+        ) : (
+          button
+        )
+      })}
 
       {dropdownItems.length > 0 && (
         <Dropdown

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import React, { useMemo, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { ButtonInternal } from "@/components/F0Button/internal"
@@ -107,7 +107,6 @@ export const CollectionActions = ({
         const button = (
           <F0Button
             size="md"
-            key={action.label}
             onClick={action.onClick}
             icon={action.icon}
             variant="outline"
@@ -123,7 +122,7 @@ export const CollectionActions = ({
             {button}
           </Tooltip>
         ) : (
-          button
+          <React.Fragment key={action.label}>{button}</React.Fragment>
         )
       })}
 

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
@@ -104,6 +104,11 @@ export const CollectionActions = ({
       )}
 
       {secondaryActionsButtons?.map((action) => {
+        const tooltipText = action.tooltip?.({
+          disabled: !!action.disabled,
+          loading: !!action.loading,
+        })
+
         const button = (
           <F0Button
             size="md"
@@ -117,8 +122,8 @@ export const CollectionActions = ({
           />
         )
 
-        return action.tooltip ? (
-          <Tooltip key={action.label} description={action.tooltip}>
+        return tooltipText ? (
+          <Tooltip key={action.label} description={tooltipText}>
             {button}
           </Tooltip>
         ) : (

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/__tests__/CollectionActions.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/__tests__/CollectionActions.test.tsx
@@ -271,7 +271,7 @@ describe("CollectionActions", () => {
   })
 
   describe("secondary actions tooltip", () => {
-    it("wraps secondary action with Tooltip when tooltip is provided", () => {
+    it("wraps secondary action with Tooltip when tooltip returns a string", () => {
       render(
         <CollectionActions
           secondaryActions={[
@@ -280,7 +280,8 @@ describe("CollectionActions", () => {
               icon: mockIcon,
               onClick: vi.fn(),
               disabled: true,
-              tooltip: "Nothing to export",
+              tooltip: ({ disabled }) =>
+                disabled ? "Nothing to export" : undefined,
             },
           ]}
         />
@@ -289,6 +290,26 @@ describe("CollectionActions", () => {
       const tooltip = screen.getByTestId("tooltip")
       expect(tooltip).toBeInTheDocument()
       expect(tooltip).toHaveAttribute("data-description", "Nothing to export")
+      expect(screen.getByText("Export")).toBeInTheDocument()
+    })
+
+    it("renders secondary action without Tooltip when tooltip returns undefined", () => {
+      render(
+        <CollectionActions
+          secondaryActions={[
+            {
+              label: "Export",
+              icon: mockIcon,
+              onClick: vi.fn(),
+              disabled: false,
+              tooltip: ({ disabled }) =>
+                disabled ? "Nothing to export" : undefined,
+            },
+          ]}
+        />
+      )
+
+      expect(screen.queryByTestId("tooltip")).not.toBeInTheDocument()
       expect(screen.getByText("Export")).toBeInTheDocument()
     })
 

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/__tests__/CollectionActions.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/__tests__/CollectionActions.test.tsx
@@ -88,6 +88,20 @@ vi.mock("@/experimental/Navigation/Dropdown", () => ({
   ),
 }))
 
+vi.mock("@/experimental/Overlays/Tooltip", () => ({
+  Tooltip: ({
+    children,
+    description,
+  }: {
+    children: React.ReactNode
+    description: string
+  }) => (
+    <div data-testid="tooltip" data-description={description}>
+      {children}
+    </div>
+  ),
+}))
+
 vi.mock("@/icons/app", () => ({
   Ellipsis: () => <div data-testid="ellipsis-icon">...</div>,
 }))
@@ -253,6 +267,46 @@ describe("CollectionActions", () => {
         />
       )
       expect(container).toBeEmptyDOMElement()
+    })
+  })
+
+  describe("secondary actions tooltip", () => {
+    it("wraps secondary action with Tooltip when tooltip is provided", () => {
+      render(
+        <CollectionActions
+          secondaryActions={[
+            {
+              label: "Export",
+              icon: mockIcon,
+              onClick: vi.fn(),
+              disabled: true,
+              tooltip: "Nothing to export",
+            },
+          ]}
+        />
+      )
+
+      const tooltip = screen.getByTestId("tooltip")
+      expect(tooltip).toBeInTheDocument()
+      expect(tooltip).toHaveAttribute("data-description", "Nothing to export")
+      expect(screen.getByText("Export")).toBeInTheDocument()
+    })
+
+    it("renders secondary action without Tooltip when tooltip is not provided", () => {
+      render(
+        <CollectionActions
+          secondaryActions={[
+            {
+              label: "Export",
+              icon: mockIcon,
+              onClick: vi.fn(),
+            },
+          ]}
+        />
+      )
+
+      expect(screen.queryByTestId("tooltip")).not.toBeInTheDocument()
+      expect(screen.getByText("Export")).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## What

Add optional `tooltip` prop to `SecondaryActionItem` and render it using the `<Tooltip>` component in the DataCollection toolbar.

## Why

Currently there is no way to show a tooltip on secondary action buttons in `OneDataCollection`. This is needed for cases like disabled sync/export buttons where we want to explain why the action is unavailable (e.g. "You have nothing to export at the moment").

## How

- **`actions.tsx`**: Added `tooltip?: string` to `SecondaryActionItem` type.
- **`CollectionActions.tsx`**: When `action.tooltip` is provided, wraps the `<F0Button>` with the existing `<Tooltip>` component. Otherwise renders the button as before.
- **`CollectionActions.test.tsx`**: Added tests for tooltip rendering on secondary actions.

## Usage

```tsx
const dataSource = useDataCollectionSource({
  secondaryActions: {
    expanded: 1,
    actions: () => [
      {
        label: "Export",
        icon: Upload,
        onClick: handleExport,
        disabled: true,
        tooltip: "You have nothing to export at the moment",
      },
    ],
  },
})
```

Discussed with @saul-factorial — he suggested adding it to useDataCollectionSource secondary actions.