### PR TITLE
feat(F0Icon): add tintColor prop for runtime color customization and …

### DIFF
--- a/packages/react-native/playground/components/F0IconShowcase/index.tsx
+++ b/packages/react-native/playground/components/F0IconShowcase/index.tsx
@@ -411,6 +411,59 @@ export function F0IconShowcase() {
           color="mood-super-positive"
         />
       </View>
+
+      {/* tintColor — Runtime Color Escape Hatch */}
+      <Text
+        className="mt-6 mb-4 text-lg font-bold"
+        style={{ color: asString(f0Foreground) }}
+      >
+        tintColor — Runtime Colors
+      </Text>
+      <View
+        className="mb-4 flex-row flex-wrap justify-around rounded-lg p-4"
+        style={{ backgroundColor: asString(f0BackgroundSecondary) }}
+      >
+        <View className="items-center justify-center">
+          <F0Icon icon={AppIcons.Heart} size="lg" tintColor="#FF355E" />
+          <Text
+            className="mt-2 text-center text-xs"
+            style={{ color: asString(f0Foreground) }}
+          >
+            #FF355E
+          </Text>
+        </View>
+        <View className="items-center justify-center">
+          <F0Icon icon={AppIcons.Star} size="lg" tintColor="rgb(0, 200, 83)" />
+          <Text
+            className="mt-2 text-center text-xs"
+            style={{ color: asString(f0Foreground) }}
+          >
+            rgb(0, 200, 83)
+          </Text>
+        </View>
+        <View className="items-center justify-center">
+          <F0Icon
+            icon={AppIcons.Archive}
+            size="lg"
+            tintColor="hsl(270, 100%, 60%)"
+          />
+          <Text
+            className="mt-2 text-center text-xs"
+            style={{ color: asString(f0Foreground) }}
+          >
+            hsl(270, 100%, 60%)
+          </Text>
+        </View>
+        <View className="items-center justify-center">
+          <F0Icon icon={ModuleIcons.Home} size="lg" tintColor="orange" />
+          <Text
+            className="mt-2 text-center text-xs"
+            style={{ color: asString(f0Foreground) }}
+          >
+            orange
+          </Text>
+        </View>
+      </View>
     </ScrollView>
   )
 }

--- a/packages/react-native/src/components/primitives/F0Icon/F0Icon.md
+++ b/packages/react-native/src/components/primitives/F0Icon/F0Icon.md
@@ -100,7 +100,7 @@ import { Archive } from "@factorialco/f0-react-native/icons/app"
 
 - **Type:** `ColorValue` (from `react-native`)
 - **Default:** none
-- **Description:** Arbitrary runtime color for the icon, bypassing semantic tokens. Accepts any React Native `ColorValue` (hex, rgb, hsl, named color). When set, overrides both the semantic `color` prop and any `text-*` class from `className`.
+- **Description:** Arbitrary runtime color for the icon, bypassing semantic tokens. Accepts any React Native `ColorValue` (hex, rgb, hsl, named color). When set, it disables the semantic `color` variant and strips `text-*` utilities from `className`, so `tintColor` is the deterministic color source.
 
 Use sparingly — prefer the semantic `color` prop for design-system colors. This escape hatch exists for cases where the icon color is determined at runtime (e.g. backend-driven widget colors, user-customizable themes).
 

--- a/packages/react-native/src/components/primitives/F0Icon/F0Icon.md
+++ b/packages/react-native/src/components/primitives/F0Icon/F0Icon.md
@@ -27,6 +27,8 @@ import { Home } from "@factorialco/f0-react-native/icons/modules"
 <F0Icon icon={Archive} color="critical" />
 
 <F0Icon icon={Archive} size="sm" color="positive" testID="archive-icon" />
+
+<F0Icon icon={Archive} tintColor="#FF355E" />
 ```
 
 ## Props
@@ -94,9 +96,25 @@ import { Archive } from "@factorialco/f0-react-native/icons/app"
 <F0Icon icon={Star} className="text-yellow-500" />
 ```
 
+### `tintColor`
+
+- **Type:** `ColorValue` (from `react-native`)
+- **Default:** none
+- **Description:** Arbitrary runtime color for the icon, bypassing semantic tokens. Accepts any React Native `ColorValue` (hex, rgb, hsl, named color). When set, overrides both the semantic `color` prop and any `text-*` class from `className`.
+
+Use sparingly — prefer the semantic `color` prop for design-system colors. This escape hatch exists for cases where the icon color is determined at runtime (e.g. backend-driven widget colors, user-customizable themes).
+
+When `tintColor` is set, it is passed as the native SVG `color` prop, which `react-native-svg` uses as the resolved value for `currentColor` in `fill`/`stroke` attributes.
+
+<!-- prettier-ignore -->
+```tsx
+<F0Icon icon={Star} tintColor="#FF355E" />
+<F0Icon icon={Star} tintColor={dynamicColor} size="lg" />
+```
+
 ### Other Props
 
-F0Icon accepts all SVG props from `react-native-svg` except `style` (use `color` or `className` instead).
+F0Icon accepts all SVG props from `react-native-svg` except `style` and `color` (use `color` for semantic tokens, `tintColor` for arbitrary colors, or `className` for Tailwind overrides).
 
 ## Size Variants
 
@@ -147,11 +165,12 @@ F0Icon automatically applies UniWind interop to icon components using `withUniwi
 
 ### TypeScript
 
-Style prop is blocked at compile-time to enforce `color`/`className` usage:
+`style` and the native SVG `color` props are blocked at compile-time to enforce `color`/`tintColor`/`className` usage:
 
 <!-- prettier-ignore -->
 ```tsx
 <F0Icon icon={Archive} color="critical" />
+<F0Icon icon={Archive} tintColor="#FF355E" />
 
 // TypeScript error - style not allowed
 <F0Icon icon={Archive} style={{ color: 'red' }} />

--- a/packages/react-native/src/components/primitives/F0Icon/F0Icon.tsx
+++ b/packages/react-native/src/components/primitives/F0Icon/F0Icon.tsx
@@ -30,17 +30,29 @@ export function applyIconInterop(icon: IconType): IconType {
  * Renders SVG icons with consistent sizing and semantic colors.
  * Icons are automatically wrapped with UniWind for className support.
  *
+ * Prefer the semantic `color` prop for design-system colors.
+ * Use `tintColor` only when the color is determined at runtime
+ * (e.g. backend-driven widget colors).
+ *
  * @example
  * import { Archive } from '@/icons/app';
  *
  * <F0Icon icon={Archive} size="lg" />
  * <F0Icon icon={Archive} color="critical" />
- * <F0Icon icon={Archive} size="sm" color="positive" />
+ * <F0Icon icon={Archive} tintColor="#FF355E" />
  */
 const F0Icon = React.memo(
   React.forwardRef<Svg, F0IconProps>(
     (
-      { size = "md", color, icon, testID, className: customClassName, ...rest },
+      {
+        size = "md",
+        color,
+        tintColor,
+        icon,
+        testID,
+        className: customClassName,
+        ...rest
+      },
       ref
     ) => {
       const IconComponent = useMemo(
@@ -48,9 +60,15 @@ const F0Icon = React.memo(
         [icon]
       )
 
+      // When tintColor is set, skip the semantic color variant so it doesn't
+      // compete with the native SVG color prop.
       const className = useMemo(
-        () => cn(iconVariants({ size, color }), customClassName),
-        [size, color, customClassName]
+        () =>
+          cn(
+            iconVariants({ size, color: tintColor ? undefined : color }),
+            customClassName
+          ),
+        [size, color, tintColor, customClassName]
       )
 
       // Early return if no icon provided (after all hooks)
@@ -61,6 +79,9 @@ const F0Icon = React.memo(
           ref={ref}
           className={className}
           testID={testID}
+          // tintColor sets the native SVG `color` prop, which react-native-svg
+          // uses as the resolved value for `currentColor` in fill/stroke attrs.
+          {...(tintColor != null ? { color: tintColor } : {})}
           {...rest}
         />
       )

--- a/packages/react-native/src/components/primitives/F0Icon/F0Icon.tsx
+++ b/packages/react-native/src/components/primitives/F0Icon/F0Icon.tsx
@@ -2,13 +2,29 @@ import React, { useMemo } from "react"
 import type { Svg } from "react-native-svg"
 import { withUniwind } from "uniwind"
 
-import { cn } from "../../../lib/utils"
+import { cn, omitProps } from "../../../lib/utils"
 
 import { iconVariants } from "./F0Icon.styles"
-import type { F0IconProps, IconType } from "./F0Icon.types"
+import {
+  F0_ICON_BLOCKED_FORWARD_PROPS,
+  type F0IconProps,
+  type IconType,
+} from "./F0Icon.types"
 
 // Cache original icon -> wrapped icon so withUniwind is only applied once per icon type
 const interopCache = new WeakMap<IconType, IconType>()
+
+function stripTextClasses(className?: string): string | undefined {
+  if (!className) return className
+
+  const filteredClassName = className
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((classToken) => !classToken.startsWith("text-"))
+    .join(" ")
+
+  return filteredClassName || undefined
+}
 
 /**
  * Applies UniWind interop to an icon component
@@ -65,11 +81,18 @@ const F0Icon = React.memo(
       const className = useMemo(
         () =>
           cn(
-            iconVariants({ size, color: tintColor ? undefined : color }),
-            customClassName
+            iconVariants({
+              size,
+              color: tintColor != null ? undefined : color,
+            }),
+            tintColor != null
+              ? stripTextClasses(customClassName)
+              : customClassName
           ),
         [size, color, tintColor, customClassName]
       )
+
+      const forwardedProps = omitProps(rest, F0_ICON_BLOCKED_FORWARD_PROPS)
 
       // Early return if no icon provided (after all hooks)
       if (!icon || !IconComponent) return null
@@ -77,12 +100,12 @@ const F0Icon = React.memo(
       return (
         <IconComponent
           ref={ref}
+          {...forwardedProps}
           className={className}
           testID={testID}
           // tintColor sets the native SVG `color` prop, which react-native-svg
           // uses as the resolved value for `currentColor` in fill/stroke attrs.
           {...(tintColor != null ? { color: tintColor } : {})}
-          {...rest}
         />
       )
     }

--- a/packages/react-native/src/components/primitives/F0Icon/F0Icon.types.ts
+++ b/packages/react-native/src/components/primitives/F0Icon/F0Icon.types.ts
@@ -44,6 +44,15 @@ export const ICON_COLORS = [
 export type IconColor = (typeof ICON_COLORS)[number]
 
 /**
+ * Runtime-blocked props that must not be forwarded to the underlying SVG.
+ *
+ * - `style` is banned from the public API for semantic consistency.
+ * - Native `color` is controlled by `color`/`tintColor` and must not be
+ *   forwardable via unsafe casts.
+ */
+export const F0_ICON_BLOCKED_FORWARD_PROPS = ["style", "color"] as const
+
+/**
  * Public F0Icon props
  * Supports semantic color via `color` prop, with `className` as escape hatch.
  */

--- a/packages/react-native/src/components/primitives/F0Icon/F0Icon.types.ts
+++ b/packages/react-native/src/components/primitives/F0Icon/F0Icon.types.ts
@@ -1,4 +1,5 @@
 import type { ForwardRefExoticComponent, RefAttributes } from "react"
+import type { ColorValue } from "react-native"
 import type { SvgProps } from "react-native-svg"
 import type { Svg } from "react-native-svg"
 import type { VariantProps } from "tailwind-variants"
@@ -46,7 +47,7 @@ export type IconColor = (typeof ICON_COLORS)[number]
  * Public F0Icon props
  * Supports semantic color via `color` prop, with `className` as escape hatch.
  */
-export interface F0IconProps extends Omit<SvgProps, "style"> {
+export interface F0IconProps extends Omit<SvgProps, "style" | "color"> {
   /**
    * Tailwind className for custom styling or color overrides.
    * Prefer the `color` prop for semantic icon colors.
@@ -54,8 +55,9 @@ export interface F0IconProps extends Omit<SvgProps, "style"> {
   className?: string
 
   /**
-   * Semantic icon color from the F0 design system
-   * Maps to f0-icon-* tokens (e.g. color="critical" -> text-f0-icon-critical)
+   * Semantic icon color from the F0 design system.
+   * Maps to f0-icon-* tokens (e.g. color="critical" -> text-f0-icon-critical).
+   * Ignored when `tintColor` is set.
    */
   color?: IconColor
 
@@ -74,4 +76,21 @@ export interface F0IconProps extends Omit<SvgProps, "style"> {
    * Test ID for testing
    */
   testID?: string
+
+  /**
+   * Arbitrary runtime color for the icon, bypassing semantic tokens.
+   * Accepts any React Native ColorValue (hex, rgb, hsl, named color, etc.).
+   * When set, overrides both `color` and any text-* class from `className`.
+   *
+   * Use sparingly — prefer the semantic `color` prop for design-system colors.
+   * This escape hatch exists for cases where icon color is determined at runtime
+   * (e.g. backend-driven widget colors, user-customizable themes).
+   *
+   * @example
+   * ```tsx
+   * <F0Icon icon={Star} tintColor="#FF355E" />
+   * <F0Icon icon={Star} tintColor={dynamicColor} size="lg" />
+   * ```
+   */
+  tintColor?: ColorValue
 }

--- a/packages/react-native/src/components/primitives/F0Icon/__tests__/F0Icon.spec.tsx
+++ b/packages/react-native/src/components/primitives/F0Icon/__tests__/F0Icon.spec.tsx
@@ -128,4 +128,68 @@ describe("F0Icon", () => {
       expect(element.props.className).toContain("opacity-50")
     })
   })
+
+  describe("tintColor — runtime color escape hatch", () => {
+    it("renders with tintColor", () => {
+      const { getByTestId } = render(
+        <F0Icon icon={Archive} tintColor="#FF355E" testID="icon" />
+      )
+      expect(getByTestId("icon")).toBeTruthy()
+    })
+
+    it("passes tintColor as native SVG color prop", () => {
+      const { getByTestId } = render(
+        <F0Icon icon={Archive} tintColor="#FF355E" testID="icon" />
+      )
+      const element = getByTestId("icon")
+      expect(element.props.color).toBe("#FF355E")
+    })
+
+    it("skips semantic color variant when tintColor is set", () => {
+      const { getByTestId } = render(
+        <F0Icon
+          icon={Archive}
+          color="critical"
+          tintColor="#FF355E"
+          testID="icon"
+        />
+      )
+      const element = getByTestId("icon")
+      expect(element.props.className).not.toContain("text-f0-icon-critical")
+      expect(element.props.color).toBe("#FF355E")
+    })
+
+    it("preserves size variant when tintColor is set", () => {
+      const { getByTestId } = render(
+        <F0Icon icon={Archive} size="lg" tintColor="#00FF00" testID="icon" />
+      )
+      const element = getByTestId("icon")
+      expect(element.props.className).toContain("w-6")
+      expect(element.props.className).toContain("h-6")
+      expect(element.props.color).toBe("#00FF00")
+    })
+
+    it("does not set native color prop when tintColor is undefined", () => {
+      const { getByTestId } = render(
+        <F0Icon icon={Archive} color="info" testID="icon" />
+      )
+      const element = getByTestId("icon")
+      expect(element.props.color).toBeUndefined()
+      expect(element.props.className).toContain("text-f0-icon-info")
+    })
+
+    it("combines tintColor with custom className layout", () => {
+      const { getByTestId } = render(
+        <F0Icon
+          icon={Archive}
+          tintColor="rgb(255, 0, 0)"
+          className="-ml-0.5"
+          testID="icon"
+        />
+      )
+      const element = getByTestId("icon")
+      expect(element.props.className).toContain("-ml-0.5")
+      expect(element.props.color).toBe("rgb(255, 0, 0)")
+    })
+  })
 })

--- a/packages/react-native/src/components/primitives/F0Icon/__tests__/F0Icon.spec.tsx
+++ b/packages/react-native/src/components/primitives/F0Icon/__tests__/F0Icon.spec.tsx
@@ -178,6 +178,20 @@ describe("F0Icon", () => {
       expect(element.props.className).toContain("text-f0-icon-info")
     })
 
+    it("ignores unsafe cast native color prop when tintColor is undefined", () => {
+      const unsafeColorProps = {
+        icon: Archive,
+        color: "#00FF00",
+        testID: "icon",
+      } as unknown as React.ComponentProps<typeof F0Icon>
+
+      const { getByTestId } = render(<F0Icon {...unsafeColorProps} />)
+      const element = getByTestId("icon")
+      expect(element.props.color).toBeUndefined()
+      expect(element.props.className).toContain("w-5")
+      expect(element.props.className).toContain("h-5")
+    })
+
     it("combines tintColor with custom className layout", () => {
       const { getByTestId } = render(
         <F0Icon
@@ -190,6 +204,40 @@ describe("F0Icon", () => {
       const element = getByTestId("icon")
       expect(element.props.className).toContain("-ml-0.5")
       expect(element.props.color).toBe("rgb(255, 0, 0)")
+    })
+
+    it("strips custom text-* classes when tintColor is set", () => {
+      const { getByTestId } = render(
+        <F0Icon
+          icon={Archive}
+          tintColor="#FF355E"
+          className="text-red-500 opacity-50"
+          testID="icon"
+        />
+      )
+      const element = getByTestId("icon")
+      expect(element.props.className).not.toContain("text-red-500")
+      expect(element.props.className).toContain("opacity-50")
+      expect(element.props.color).toBe("#FF355E")
+    })
+
+    it("ignores unsafe cast style prop at runtime", () => {
+      const unsafeStyleProps = {
+        icon: Archive,
+        tintColor: "#FF355E",
+        style: { opacity: 0.5 },
+        testID: "icon",
+      } as unknown as React.ComponentProps<typeof F0Icon>
+
+      const { getByTestId } = render(<F0Icon {...unsafeStyleProps} />)
+      const element = getByTestId("icon")
+      const flattenedStyle = Array.isArray(element.props.style)
+        ? element.props.style.flat(Infinity)
+        : [element.props.style]
+      expect(flattenedStyle).not.toContainEqual(
+        expect.objectContaining({ opacity: 0.5 })
+      )
+      expect(element.props.color).toBe("#FF355E")
     })
   })
 })


### PR DESCRIPTION
## Description

- add tintColor prop for runtime color customization and update documentation

## Screenshots (if applicable)
 
<img width="515" height="986" alt="image" src="https://github.com/user-attachments/assets/ce163373-363f-496f-802f-3bc841411388" />

