### PR TITLE
feat(TimeLine): add F0TimelineRowNestedtask variant

### DIFF
--- a/packages/react/src/sds/TimeLine/F0TimelineRow.tsx
+++ b/packages/react/src/sds/TimeLine/F0TimelineRow.tsx
@@ -10,12 +10,13 @@ import { TaskRow } from "./components/TaskRow"
 
 const isNestedtask = (
   props: F0TimelineRowProps
-): props is F0TimelineRowNestedtaskProps => "items" in props && "icon" in props
+): props is F0TimelineRowNestedtaskProps =>
+  "items" in props && "icon" in props && props.icon !== undefined
 
 const isMultitask = (
   props: F0TimelineRowProps
 ): props is F0TimelineRowMultitaskProps =>
-  "items" in props && !("icon" in props)
+  "items" in props && !("icon" in props && props.icon !== undefined)
 
 export const F0TimelineRow = (props: F0TimelineRowProps) => {
   if (isNestedtask(props)) return <NestedtaskRow props={props} />

--- a/packages/react/src/sds/TimeLine/F0TimelineRow.tsx
+++ b/packages/react/src/sds/TimeLine/F0TimelineRow.tsx
@@ -1,15 +1,24 @@
-import type { F0TimelineRowMultitaskProps, F0TimelineRowProps } from "./types"
+import type {
+  F0TimelineRowMultitaskProps,
+  F0TimelineRowNestedtaskProps,
+  F0TimelineRowProps,
+} from "./types"
 
 import { MultitaskRow } from "./components/MultitaskRow"
+import { NestedtaskRow } from "./components/NestedtaskRow"
 import { TaskRow } from "./components/TaskRow"
+
+const isNestedtask = (
+  props: F0TimelineRowProps
+): props is F0TimelineRowNestedtaskProps => "items" in props && "icon" in props
 
 const isMultitask = (
   props: F0TimelineRowProps
-): props is F0TimelineRowMultitaskProps => "items" in props
+): props is F0TimelineRowMultitaskProps =>
+  "items" in props && !("icon" in props)
 
-export const F0TimelineRow = (props: F0TimelineRowProps) =>
-  isMultitask(props) ? (
-    <MultitaskRow props={props} />
-  ) : (
-    <TaskRow props={props} />
-  )
+export const F0TimelineRow = (props: F0TimelineRowProps) => {
+  if (isNestedtask(props)) return <NestedtaskRow props={props} />
+  if (isMultitask(props)) return <MultitaskRow props={props} />
+  return <TaskRow props={props} />
+}

--- a/packages/react/src/sds/TimeLine/__stories__/F0TimelineRow.stories.tsx
+++ b/packages/react/src/sds/TimeLine/__stories__/F0TimelineRow.stories.tsx
@@ -1118,6 +1118,10 @@ export const NestedtaskNotStarted: Story = {
     icon: FileSigned,
     title: "Sign document",
     description: "Estimated on 14/04/2026",
+    taskCount: 0,
+    expanded: false,
+    onExpandToggle: () => {},
+    items: [],
     metadata: [
       {
         label: "",
@@ -1237,7 +1241,7 @@ function MultitaskWithNestedtaskDemo() {
   const [nestedtaskExpanded, setNestedtaskExpanded] = useState(true)
 
   return (
-    <div className="f1-bg-surface-default p-4" style={{ maxWidth: 600 }}>
+    <div className="f1-bg-surface-default max-w-[600px] p-4">
       <F0TimelineRow
         status="in-progress"
         title="tasks"

--- a/packages/react/src/sds/TimeLine/__stories__/F0TimelineRow.stories.tsx
+++ b/packages/react/src/sds/TimeLine/__stories__/F0TimelineRow.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { useState } from "react"
 
+import { EyeVisible } from "@/icons/app"
 import Check from "@/icons/app/Check"
 import Clock from "@/icons/app/Clock"
 import Comment from "@/icons/app/Comment"
@@ -14,7 +15,6 @@ import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0TimelineRow } from "../"
 import { timelineRowStatuses } from "../types"
-import { EyeVisible } from "@/icons/app"
 
 const meta = {
   component: F0TimelineRow,

--- a/packages/react/src/sds/TimeLine/__stories__/F0TimelineRow.stories.tsx
+++ b/packages/react/src/sds/TimeLine/__stories__/F0TimelineRow.stories.tsx
@@ -3,9 +3,12 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { useState } from "react"
 
 import Check from "@/icons/app/Check"
+import Clock from "@/icons/app/Clock"
 import Comment from "@/icons/app/Comment"
 import Cross from "@/icons/app/Cross"
+import FileSigned from "@/icons/app/FileSigned"
 import Marker from "@/icons/app/Marker"
+import Pencil from "@/icons/app/Pencil"
 import ThumbsUp from "@/icons/app/ThumbsUp"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
@@ -851,4 +854,437 @@ export const Snapshot: Story = {
       />
     </div>
   ),
+}
+
+const NestedtaskInProgressDemo = () => {
+  const [expanded, setExpanded] = useState(true)
+
+  return (
+    <div className="w-full">
+      <F0TimelineRow
+        status="in-progress"
+        icon={FileSigned}
+        title="Sign document"
+        description="Estimated on 14/04/2026"
+        taskCount={2}
+        completedCount={0}
+        expanded={expanded}
+        onExpandToggle={() => setExpanded(!expanded)}
+        metadata={[
+          {
+            label: "",
+            hideLabel: true,
+            value: {
+              type: "list",
+              variant: "person",
+              avatars: [
+                {
+                  type: "person",
+                  firstName: "Hellen",
+                  lastName: "the HR",
+                },
+              ],
+            },
+          },
+          {
+            label: "",
+            actions: [
+              {
+                label: "View",
+                icon: EyeVisible,
+                onClick: () => {},
+              },
+            ],
+            value: {
+              type: "avatar",
+              variant: {
+                type: "file",
+                file: {
+                  name: "Demo notes.pdf",
+                  type: "application/pdf",
+                },
+              },
+              text: "Demo notes",
+            },
+          },
+        ]}
+        items={[
+          {
+            status: "in-progress",
+            icon: Clock,
+            title: "Hellen the HR (hellen@factorial.co)",
+            description: "Pending",
+          },
+          {
+            status: "in-progress",
+            icon: Clock,
+            title: "Danilo Pereira (danilo@gmail.com)",
+            description: "Pending",
+          },
+        ]}
+        isLast
+      />
+    </div>
+  )
+}
+
+export const NestedtaskInProgress: Story = {
+  args: {
+    status: "in-progress",
+  },
+
+  render: () => <NestedtaskInProgressDemo />,
+}
+
+const NestedtaskCompletedDemo = () => {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="w-full">
+      <F0TimelineRow
+        status="completed"
+        icon={FileSigned}
+        title="Sign document"
+        description="Completed on 14/04/2026 06:08"
+        taskCount={2}
+        completedCount={2}
+        expanded={expanded}
+        onExpandToggle={() => setExpanded(!expanded)}
+        metadata={[
+          {
+            label: "",
+            hideLabel: true,
+            value: {
+              type: "list",
+              variant: "person",
+              avatars: [
+                {
+                  type: "person",
+                  firstName: "Hellen",
+                  lastName: "the HR",
+                  badge: { type: "positive", icon: Check },
+                },
+              ],
+            },
+          },
+          {
+            label: "",
+            actions: [
+              {
+                label: "View",
+                icon: EyeVisible,
+                onClick: () => {},
+              },
+            ],
+            value: {
+              type: "avatar",
+              variant: {
+                type: "file",
+                file: {
+                  name: "Demo notes.pdf",
+                  type: "application/pdf",
+                },
+              },
+              text: "Demo notes",
+            },
+          },
+        ]}
+        items={[
+          {
+            status: "completed",
+            icon: Check,
+            title: "Hellen the HR (hellen@factorial.co)",
+            description: "Signed",
+          },
+          {
+            status: "completed",
+            icon: Check,
+            title: "Danilo Pereira (danilo@gmail.com)",
+            description: "Signed",
+          },
+        ]}
+        isLast
+      />
+    </div>
+  )
+}
+
+export const NestedtaskCompleted: Story = {
+  render: () => <NestedtaskCompletedDemo />,
+}
+
+const NestedtaskTimelineDemo = () => {
+  const [expanded, setExpanded] = useState(true)
+
+  return (
+    <div className="w-full">
+      <F0TimelineRow
+        status="in-progress"
+        icon={FileSigned}
+        title="Sign document"
+        description="Estimated on 14/04/2026"
+        taskCount={2}
+        completedCount={0}
+        expanded={expanded}
+        onExpandToggle={() => setExpanded(!expanded)}
+        metadata={[
+          {
+            label: "",
+            hideLabel: true,
+            value: {
+              type: "list",
+              variant: "person",
+              avatars: [
+                {
+                  type: "person",
+                  firstName: "Hellen",
+                  lastName: "the HR",
+                },
+              ],
+            },
+          },
+          {
+            label: "",
+            actions: [
+              {
+                label: "View",
+                icon: EyeVisible,
+                onClick: () => {},
+              },
+            ],
+            value: {
+              type: "avatar",
+              variant: {
+                type: "file",
+                file: {
+                  name: "Demo notes.pdf",
+                  type: "application/pdf",
+                },
+              },
+              text: "Demo notes",
+            },
+          },
+        ]}
+        items={[
+          {
+            status: "in-progress",
+            icon: Clock,
+            title: "Hellen the HR (hellen@factorial.co)",
+            description: "Pending",
+          },
+          {
+            status: "in-progress",
+            icon: Clock,
+            title: "Danilo Pereira (danilo@gmail.com)",
+            description: "Pending",
+          },
+        ]}
+      />
+      <F0TimelineRow
+        status="not-started"
+        icon={ThumbsUp}
+        title="Manual review"
+        description="Estimated on 19/04/2026"
+        metadata={[
+          {
+            label: "",
+            hideLabel: true,
+            value: {
+              type: "list",
+              variant: "person",
+              avatars: [
+                {
+                  type: "person",
+                  firstName: "Hellen",
+                  lastName: "the HR",
+                },
+              ],
+            },
+          },
+        ]}
+        isLast
+      />
+    </div>
+  )
+}
+
+export const NestedtaskTimeline: Story = {
+  render: () => <NestedtaskTimelineDemo />,
+}
+
+export const NestedtaskNotStarted: Story = {
+  args: {
+    status: "not-started",
+    icon: FileSigned,
+    title: "Sign document",
+    description: "Estimated on 14/04/2026",
+    metadata: [
+      {
+        label: "",
+        hideLabel: true,
+        value: {
+          type: "list",
+          variant: "person",
+          avatars: [
+            {
+              type: "person",
+              firstName: "Hellen",
+              lastName: "the HR",
+            },
+          ],
+        },
+      },
+    ],
+    primaryAction: {
+      label: "Request signature",
+      icon: FileSigned,
+      onClick: () => {},
+    },
+    isLast: true,
+  },
+}
+
+const NestedtaskInProgressWithActionsDemo = () => {
+  const [expanded, setExpanded] = useState(true)
+
+  return (
+    <div className="w-full">
+      <F0TimelineRow
+        status="in-progress"
+        icon={FileSigned}
+        title="Sign document"
+        description="Estimated on 14/04/2026"
+        taskCount={2}
+        completedCount={0}
+        expanded={expanded}
+        onExpandToggle={() => setExpanded(!expanded)}
+        metadata={[
+          {
+            label: "",
+            hideLabel: true,
+            value: {
+              type: "list",
+              variant: "person",
+              avatars: [
+                {
+                  type: "person",
+                  firstName: "Hellen",
+                  lastName: "the HR",
+                },
+              ],
+            },
+          },
+          {
+            label: "",
+            actions: [
+              {
+                label: "View",
+                icon: EyeVisible,
+                onClick: () => {},
+              },
+            ],
+            value: {
+              type: "avatar",
+              variant: {
+                type: "file",
+                file: {
+                  name: "Demo notes.pdf",
+                  type: "application/pdf",
+                },
+              },
+              text: "Demo notes",
+            },
+          },
+        ]}
+        items={[
+          {
+            status: "in-progress",
+            icon: Clock,
+            title: "Hellen the HR (hellen@factorial.co)",
+            description: "Pending",
+          },
+          {
+            status: "in-progress",
+            icon: Clock,
+            title: "Danilo Pereira (danilo@gmail.com)",
+            description: "Pending",
+          },
+        ]}
+        secondaryActions={[
+          {
+            label: "Edit signature",
+            icon: Pencil,
+            onClick: () => {},
+          },
+          {
+            label: "Cancel signature",
+            icon: Cross,
+            onClick: () => {},
+          },
+        ]}
+        isLast
+      />
+    </div>
+  )
+}
+
+export const NestedtaskInProgressWithActions: Story = {
+  render: () => <NestedtaskInProgressWithActionsDemo />,
+}
+
+function MultitaskWithNestedtaskDemo() {
+  const [multitaskExpanded, setMultitaskExpanded] = useState(true)
+  const [nestedtaskExpanded, setNestedtaskExpanded] = useState(true)
+
+  return (
+    <div className="f1-bg-surface-default p-4" style={{ maxWidth: 600 }}>
+      <F0TimelineRow
+        status="in-progress"
+        title="tasks"
+        taskCount={3}
+        completedCount={1}
+        expanded={multitaskExpanded}
+        onExpandToggle={() => setMultitaskExpanded((v) => !v)}
+        items={[
+          {
+            status: "completed",
+            title: "Manager approval",
+          },
+          {
+            status: "in-progress",
+            icon: FileSigned,
+            title: "Sign document",
+            description: "Laptop agreement",
+            taskCount: 2,
+            completedCount: 1,
+            expanded: nestedtaskExpanded,
+            onExpandToggle: () => setNestedtaskExpanded((v) => !v),
+            items: [
+              {
+                status: "in-progress",
+                icon: Clock,
+                title: "Hellen the HR (hellen@factorial.co)",
+                description: "Pending",
+              },
+              {
+                status: "completed",
+                icon: Check,
+                title: "Danilo Pereira (danilo@gmail.com)",
+                description: "Signed",
+              },
+            ],
+          },
+          {
+            status: "not-started",
+            title: "Final review",
+          },
+        ]}
+        isLast
+      />
+    </div>
+  )
+}
+
+export const MultitaskWithNestedtask: Story = {
+  render: () => <MultitaskWithNestedtaskDemo />,
 }

--- a/packages/react/src/sds/TimeLine/__tests__/F0TimelineRow.test.tsx
+++ b/packages/react/src/sds/TimeLine/__tests__/F0TimelineRow.test.tsx
@@ -408,4 +408,83 @@ describe("F0TimelineRow", () => {
       expect(title.className).not.toContain("line-through")
     })
   })
+
+  describe("multitask with nestedtask items", () => {
+    const nestedtaskItem = {
+      status: "in-progress" as const,
+      icon: FileSigned,
+      title: "Sign document",
+      description: "Laptop agreement",
+      taskCount: 2,
+      completedCount: 1,
+      expanded: true,
+      onExpandToggle: vi.fn(),
+      items: [
+        {
+          status: "in-progress" as const,
+          icon: Clock,
+          title: "Hellen (hellen@factorial.co)",
+          description: "Pending",
+        },
+        {
+          status: "completed" as const,
+          icon: Check,
+          title: "Danilo (danilo@gmail.com)",
+          description: "Signed",
+        },
+      ],
+    }
+
+    it("renders nestedtask header inside multitask", () => {
+      render(
+        <F0TimelineRow
+          status="in-progress"
+          title="Tasks"
+          taskCount={2}
+          completedCount={0}
+          expanded={true}
+          onExpandToggle={() => {}}
+          items={[nestedtaskItem]}
+        />
+      )
+      expect(screen.getByText("Sign document")).toBeInTheDocument()
+      expect(screen.getByText("1/2")).toBeInTheDocument()
+    })
+
+    it("renders nestedtask nested items when expanded inside multitask", () => {
+      render(
+        <F0TimelineRow
+          status="in-progress"
+          title="Tasks"
+          taskCount={2}
+          completedCount={0}
+          expanded={true}
+          onExpandToggle={() => {}}
+          items={[nestedtaskItem]}
+        />
+      )
+      expect(
+        screen.getByText("Hellen (hellen@factorial.co)")
+      ).toBeInTheDocument()
+      expect(screen.getByText("Danilo (danilo@gmail.com)")).toBeInTheDocument()
+    })
+
+    it("calls nestedtask onExpandToggle when clicking its header", async () => {
+      const user = userEvent.setup()
+      const onNestedToggle = vi.fn()
+      render(
+        <F0TimelineRow
+          status="in-progress"
+          title="Tasks"
+          taskCount={2}
+          completedCount={0}
+          expanded={true}
+          onExpandToggle={() => {}}
+          items={[{ ...nestedtaskItem, onExpandToggle: onNestedToggle }]}
+        />
+      )
+      await user.click(screen.getByText("Sign document"))
+      expect(onNestedToggle).toHaveBeenCalledOnce()
+    })
+  })
 })

--- a/packages/react/src/sds/TimeLine/__tests__/F0TimelineRow.test.tsx
+++ b/packages/react/src/sds/TimeLine/__tests__/F0TimelineRow.test.tsx
@@ -2,8 +2,10 @@ import { userEvent } from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
 import Check from "@/icons/app/Check"
+import Clock from "@/icons/app/Clock"
 import Comment from "@/icons/app/Comment"
 import Cross from "@/icons/app/Cross"
+import FileSigned from "@/icons/app/FileSigned"
 import Settings from "@/icons/app/Settings"
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
@@ -305,6 +307,105 @@ describe("F0TimelineRow", () => {
     it("does not render actions when not provided", () => {
       render(<F0TimelineRow {...defaultProps} />)
       expect(screen.queryByText("Approve")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("nestedtask", () => {
+    const nestedtaskProps = {
+      status: "in-progress" as const,
+      icon: FileSigned,
+      title: "Sign document",
+      description: "Estimated on 14/04/2026",
+      taskCount: 2,
+      completedCount: 0,
+      expanded: false,
+      onExpandToggle: vi.fn(),
+      items: [
+        {
+          status: "in-progress" as const,
+          icon: Clock,
+          title: "Hellen (hellen@factorial.co)",
+          description: "Pending",
+        },
+        {
+          status: "in-progress" as const,
+          icon: Clock,
+          title: "Danilo (danilo@gmail.com)",
+          description: "Pending",
+        },
+      ],
+    }
+
+    it("renders the title and description", () => {
+      render(<F0TimelineRow {...nestedtaskProps} />)
+      expect(screen.getByText("Sign document")).toBeInTheDocument()
+      expect(screen.getByText("Estimated on 14/04/2026")).toBeInTheDocument()
+    })
+
+    it("renders the progress pill", () => {
+      render(<F0TimelineRow {...nestedtaskProps} />)
+      expect(screen.getByText("0/2")).toBeInTheDocument()
+    })
+
+    it("renders completed progress pill with positive variant", () => {
+      render(
+        <F0TimelineRow
+          {...nestedtaskProps}
+          status="completed"
+          completedCount={2}
+        />
+      )
+      expect(screen.getByText("2/2")).toBeInTheDocument()
+    })
+
+    it("calls onExpandToggle when clicking the header", async () => {
+      const user = userEvent.setup()
+      const onToggle = vi.fn()
+      render(<F0TimelineRow {...nestedtaskProps} onExpandToggle={onToggle} />)
+      await user.click(screen.getByText("Sign document"))
+      expect(onToggle).toHaveBeenCalledOnce()
+    })
+
+    it("shows items when expanded", () => {
+      render(<F0TimelineRow {...nestedtaskProps} expanded />)
+      expect(
+        screen.getByText("Hellen (hellen@factorial.co)")
+      ).toBeInTheDocument()
+      expect(screen.getByText("Danilo (danilo@gmail.com)")).toBeInTheDocument()
+    })
+
+    it("hides items when collapsed", () => {
+      render(<F0TimelineRow {...nestedtaskProps} expanded={false} />)
+      expect(
+        screen.queryByText("Hellen (hellen@factorial.co)")
+      ).not.toBeInTheDocument()
+    })
+
+    it("renders metadata when provided", () => {
+      render(
+        <F0TimelineRow
+          {...nestedtaskProps}
+          metadata={[
+            {
+              label: "Team",
+              value: { type: "text", content: "Operations" },
+            },
+          ]}
+        />
+      )
+      expect(screen.getByText("Operations")).toBeInTheDocument()
+    })
+
+    it("renders strikethrough title when completed", () => {
+      render(<F0TimelineRow {...nestedtaskProps} status="completed" />)
+      const title = screen.getByText("Sign document")
+      expect(title.className).toContain("line-through")
+    })
+
+    it("does not render strikethrough title when in-progress", () => {
+      render(<F0TimelineRow {...nestedtaskProps} />)
+      const title = screen.getByText("Sign document")
+      expect(title.className).not.toContain("line-through")
     })
   })
 })

--- a/packages/react/src/sds/TimeLine/components/MultitaskRow.tsx
+++ b/packages/react/src/sds/TimeLine/components/MultitaskRow.tsx
@@ -1,11 +1,17 @@
 import type {
   F0TimelineRowMultitaskProps,
-  F0TimelineRowTaskProps,
+  F0TimelineRowMultitaskItemProps,
+  F0TimelineRowNestedtaskProps,
 } from "../types"
 
 import { MultitaskHeader } from "./MultitaskHeader"
+import { NestedtaskRow } from "./NestedtaskRow"
 import { TaskRow } from "./TaskRow"
 import { TimelineRowLayout } from "./TimelineRowLayout"
+
+const isNestedtaskItem = (
+  item: F0TimelineRowMultitaskItemProps
+): item is F0TimelineRowNestedtaskProps => "items" in item && "icon" in item
 
 export const MultitaskRow = ({
   props,
@@ -21,16 +27,27 @@ export const MultitaskRow = ({
       </div>
       {expanded && (
         <div className="flex flex-col pl-4">
-          {items.map((item: F0TimelineRowTaskProps, index: number) => (
-            <TaskRow
-              key={`${item.title}-${index}`}
-              props={{
-                ...item,
-                hideStatus: true,
-                isLast: index === items.length - 1,
-              }}
-            />
-          ))}
+          {items.map((item, index: number) =>
+            isNestedtaskItem(item) ? (
+              <NestedtaskRow
+                key={`${item.title}-${index}`}
+                props={{
+                  ...item,
+                  hideStatus: true,
+                  isLast: index === items.length - 1,
+                }}
+              />
+            ) : (
+              <TaskRow
+                key={`${item.title}-${index}`}
+                props={{
+                  ...item,
+                  hideStatus: true,
+                  isLast: index === items.length - 1,
+                }}
+              />
+            )
+          )}
         </div>
       )}
     </TimelineRowLayout>

--- a/packages/react/src/sds/TimeLine/components/MultitaskRow.tsx
+++ b/packages/react/src/sds/TimeLine/components/MultitaskRow.tsx
@@ -11,7 +11,8 @@ import { TimelineRowLayout } from "./TimelineRowLayout"
 
 const isNestedtaskItem = (
   item: F0TimelineRowMultitaskItemProps
-): item is F0TimelineRowNestedtaskProps => "items" in item && "icon" in item
+): item is F0TimelineRowNestedtaskProps =>
+  "items" in item && "icon" in item && item.icon !== undefined
 
 export const MultitaskRow = ({
   props,

--- a/packages/react/src/sds/TimeLine/components/NestedtaskHeader.tsx
+++ b/packages/react/src/sds/TimeLine/components/NestedtaskHeader.tsx
@@ -1,0 +1,62 @@
+import type { F0TimelineRowNestedtaskProps } from "../types"
+
+import { F0Icon } from "@/components/F0Icon"
+import { F0Text } from "@/components/F0Text"
+import { F0TagStatus } from "@/components/tags/F0TagStatus"
+import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon/F0AvatarIcon"
+import ChevronDown from "@/icons/app/ChevronDown"
+import ChevronUp from "@/icons/app/ChevronUp"
+import { cn } from "@/lib/utils"
+
+export const NestedtaskHeader = ({
+  props,
+}: {
+  props: F0TimelineRowNestedtaskProps
+}) => {
+  const {
+    status,
+    icon,
+    title,
+    description,
+    taskCount,
+    completedCount,
+    expanded,
+    onExpandToggle,
+  } = props
+
+  return (
+    <>
+      <F0AvatarIcon icon={icon} size="sm" />
+      <div className="flex flex-1 items-center justify-between">
+        <button
+          type="button"
+          onClick={() => onExpandToggle()}
+          className="pointer-events-auto flex items-center gap-2"
+        >
+          <h4
+            className={cn(
+              "text-base font-semibold text-f1-foreground whitespace-nowrap",
+              status === "completed" && "line-through"
+            )}
+          >
+            {title}
+          </h4>
+          {description && (
+            <F0Text content={description} variant="description" />
+          )}
+          <F0Icon
+            icon={expanded ? ChevronUp : ChevronDown}
+            size="xs"
+            color="secondary"
+          />
+        </button>
+        {completedCount !== undefined && (
+          <F0TagStatus
+            text={`${completedCount}/${taskCount}`}
+            variant={status === "completed" ? "positive" : "warning"}
+          />
+        )}
+      </div>
+    </>
+  )
+}

--- a/packages/react/src/sds/TimeLine/components/NestedtaskHeader.tsx
+++ b/packages/react/src/sds/TimeLine/components/NestedtaskHeader.tsx
@@ -1,12 +1,12 @@
-import type { F0TimelineRowNestedtaskProps } from "../types"
-
+import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon/F0AvatarIcon"
 import { F0Icon } from "@/components/F0Icon"
 import { F0Text } from "@/components/F0Text"
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
-import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon/F0AvatarIcon"
 import ChevronDown from "@/icons/app/ChevronDown"
 import ChevronUp from "@/icons/app/ChevronUp"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
+
+import type { F0TimelineRowNestedtaskProps } from "../types"
 
 export const NestedtaskHeader = ({
   props,
@@ -30,19 +30,23 @@ export const NestedtaskHeader = ({
       <div className="flex flex-1 items-center justify-between">
         <button
           type="button"
-          onClick={() => onExpandToggle()}
-          className="pointer-events-auto flex items-center gap-2"
+          aria-expanded={expanded}
+          onClick={onExpandToggle}
+          className={cn(
+            "pointer-events-auto flex items-center gap-3 rounded-sm",
+            focusRing()
+          )}
         >
-          <h4
+          <span
             className={cn(
               "text-base font-semibold text-f1-foreground whitespace-nowrap",
               status === "completed" && "line-through"
             )}
           >
             {title}
-          </h4>
+          </span>
           {description && (
-            <F0Text content={description} variant="description" />
+            <F0Text content={description} variant="description" as="span" />
           )}
           <F0Icon
             icon={expanded ? ChevronUp : ChevronDown}

--- a/packages/react/src/sds/TimeLine/components/NestedtaskHeader.tsx
+++ b/packages/react/src/sds/TimeLine/components/NestedtaskHeader.tsx
@@ -10,8 +10,10 @@ import type { F0TimelineRowNestedtaskProps } from "../types"
 
 export const NestedtaskHeader = ({
   props,
+  contentId,
 }: {
   props: F0TimelineRowNestedtaskProps
+  contentId?: string
 }) => {
   const {
     status,
@@ -35,6 +37,7 @@ export const NestedtaskHeader = ({
           <button
             type="button"
             aria-expanded={expanded}
+            aria-controls={contentId}
             onClick={onExpandToggle}
             className={cn(
               "pointer-events-auto flex items-center gap-3 rounded-sm",

--- a/packages/react/src/sds/TimeLine/components/NestedtaskHeader.tsx
+++ b/packages/react/src/sds/TimeLine/components/NestedtaskHeader.tsx
@@ -22,38 +22,57 @@ export const NestedtaskHeader = ({
     completedCount,
     expanded,
     onExpandToggle,
+    items,
   } = props
+
+  const hasItems = items.length > 0
 
   return (
     <>
       <F0AvatarIcon icon={icon} size="sm" />
       <div className="flex flex-1 items-center justify-between">
-        <button
-          type="button"
-          aria-expanded={expanded}
-          onClick={onExpandToggle}
-          className={cn(
-            "pointer-events-auto flex items-center gap-3 rounded-sm",
-            focusRing()
-          )}
-        >
-          <span
+        {hasItems ? (
+          <button
+            type="button"
+            aria-expanded={expanded}
+            onClick={onExpandToggle}
             className={cn(
-              "text-base font-semibold text-f1-foreground whitespace-nowrap",
-              status === "completed" && "line-through"
+              "pointer-events-auto flex items-center gap-3 rounded-sm",
+              focusRing()
             )}
           >
-            {title}
-          </span>
-          {description && (
-            <F0Text content={description} variant="description" as="span" />
-          )}
-          <F0Icon
-            icon={expanded ? ChevronUp : ChevronDown}
-            size="xs"
-            color="secondary"
-          />
-        </button>
+            <span
+              className={cn(
+                "text-base font-semibold text-f1-foreground whitespace-nowrap",
+                status === "completed" && "line-through"
+              )}
+            >
+              {title}
+            </span>
+            {description && (
+              <F0Text content={description} variant="description" as="span" />
+            )}
+            <F0Icon
+              icon={expanded ? ChevronUp : ChevronDown}
+              size="xs"
+              color="secondary"
+            />
+          </button>
+        ) : (
+          <div className="flex items-center gap-3">
+            <span
+              className={cn(
+                "text-base font-semibold text-f1-foreground whitespace-nowrap",
+                status === "completed" && "line-through"
+              )}
+            >
+              {title}
+            </span>
+            {description && (
+              <F0Text content={description} variant="description" as="span" />
+            )}
+          </div>
+        )}
         {completedCount !== undefined && (
           <F0TagStatus
             text={`${completedCount}/${taskCount}`}

--- a/packages/react/src/sds/TimeLine/components/NestedtaskRow.tsx
+++ b/packages/react/src/sds/TimeLine/components/NestedtaskRow.tsx
@@ -57,7 +57,7 @@ export const NestedtaskRow = ({
 
   return (
     <TimelineRowLayout status={status} isLast={isLast} hideStatus={hideStatus}>
-      <div className="flex min-h-8 items-center gap-2">
+      <div className="flex min-h-8 items-center gap-3">
         <NestedtaskHeader props={props} />
       </div>
       {metadata && hasMetadata && (

--- a/packages/react/src/sds/TimeLine/components/NestedtaskRow.tsx
+++ b/packages/react/src/sds/TimeLine/components/NestedtaskRow.tsx
@@ -1,0 +1,86 @@
+import type {
+  F0TimelineRowNestedtaskProps,
+  F0TimelineRowTaskProps,
+} from "../types"
+
+import { Metadata } from "@/experimental/Information/Headers/Metadata"
+import { F0Text } from "@/components/F0Text"
+import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon/F0AvatarIcon"
+import Marker from "@/icons/app/Marker"
+import { cn } from "@/lib/utils"
+
+import { Actions } from "./Actions"
+import { NestedtaskHeader } from "./NestedtaskHeader"
+import { TimelineRowLayout } from "./TimelineRowLayout"
+
+const NestedItem = ({ props }: { props: F0TimelineRowTaskProps }) => {
+  const { status, icon = Marker, title, description } = props
+
+  return (
+    <div className="flex items-center gap-3 min-h-8">
+      <F0AvatarIcon icon={icon} size="sm" />
+      <h4
+        className={cn(
+          "text-base font-semibold text-f1-foreground",
+          status === "completed" && "line-through"
+        )}
+      >
+        {title}
+      </h4>
+      {description && <F0Text content={description} variant="description" />}
+    </div>
+  )
+}
+
+export const NestedtaskRow = ({
+  props,
+}: {
+  props: F0TimelineRowNestedtaskProps
+}) => {
+  const {
+    status,
+    isLast = false,
+    hideStatus = false,
+    expanded,
+    items,
+    metadata,
+    primaryAction,
+    secondaryActions,
+    otherActions,
+  } = props
+
+  const hasMetadata = metadata?.some(Boolean)
+  const hasActions =
+    primaryAction ||
+    (secondaryActions && secondaryActions.length > 0) ||
+    (otherActions && otherActions.length > 0)
+
+  return (
+    <TimelineRowLayout status={status} isLast={isLast} hideStatus={hideStatus}>
+      <div className="flex min-h-8 items-center gap-2">
+        <NestedtaskHeader props={props} />
+      </div>
+      {metadata && hasMetadata && (
+        <div className="pl-9">
+          <Metadata items={metadata} />
+        </div>
+      )}
+      {expanded && (
+        <div className="flex flex-col gap-0 pl-4">
+          {items.map((item: F0TimelineRowTaskProps, index: number) => (
+            <NestedItem key={`${item.title}-${index}`} props={item} />
+          ))}
+        </div>
+      )}
+      {hasActions && (
+        <div className="pl-9">
+          <Actions
+            primaryAction={primaryAction}
+            secondaryActions={secondaryActions}
+            otherActions={otherActions}
+          />
+        </div>
+      )}
+    </TimelineRowLayout>
+  )
+}

--- a/packages/react/src/sds/TimeLine/components/NestedtaskRow.tsx
+++ b/packages/react/src/sds/TimeLine/components/NestedtaskRow.tsx
@@ -1,13 +1,15 @@
+import { useId } from "react"
+
+import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon/F0AvatarIcon"
+import { F0Text } from "@/components/F0Text"
+import { Metadata } from "@/experimental/Information/Headers/Metadata"
+import Marker from "@/icons/app/Marker"
+import { cn } from "@/lib/utils"
+
 import type {
   F0TimelineRowNestedtaskProps,
   F0TimelineRowTaskProps,
 } from "../types"
-
-import { Metadata } from "@/experimental/Information/Headers/Metadata"
-import { F0Text } from "@/components/F0Text"
-import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon/F0AvatarIcon"
-import Marker from "@/icons/app/Marker"
-import { cn } from "@/lib/utils"
 
 import { Actions } from "./Actions"
 import { NestedtaskHeader } from "./NestedtaskHeader"
@@ -17,7 +19,7 @@ const NestedItem = ({ props }: { props: F0TimelineRowTaskProps }) => {
   const { status, icon = Marker, title, description } = props
 
   return (
-    <div className="flex items-center gap-3 min-h-8">
+    <div className="flex min-h-8 items-center gap-3">
       <F0AvatarIcon icon={icon} size="sm" />
       <h4
         className={cn(
@@ -49,6 +51,7 @@ export const NestedtaskRow = ({
     otherActions,
   } = props
 
+  const contentId = useId()
   const hasMetadata = metadata?.some(Boolean)
   const hasActions =
     primaryAction ||
@@ -58,7 +61,7 @@ export const NestedtaskRow = ({
   return (
     <TimelineRowLayout status={status} isLast={isLast} hideStatus={hideStatus}>
       <div className="flex min-h-8 items-center gap-3">
-        <NestedtaskHeader props={props} />
+        <NestedtaskHeader props={props} contentId={contentId} />
       </div>
       {metadata && hasMetadata && (
         <div className="pl-9">
@@ -66,7 +69,7 @@ export const NestedtaskRow = ({
         </div>
       )}
       {expanded && (
-        <div className="flex flex-col gap-0 pl-4">
+        <div id={contentId} role="region" className="flex flex-col gap-0 pl-4">
           {items.map((item: F0TimelineRowTaskProps, index: number) => (
             <NestedItem key={`${item.title}-${index}`} props={item} />
           ))}

--- a/packages/react/src/sds/TimeLine/index.tsx
+++ b/packages/react/src/sds/TimeLine/index.tsx
@@ -5,7 +5,9 @@ import { F0TimelineRow as _F0TimelineRow } from "./F0TimelineRow"
 
 export type {
   F0TimelineRowAction,
+  F0TimelineRowMultitaskItemProps,
   F0TimelineRowMultitaskProps,
+  F0TimelineRowNestedtaskProps,
   F0TimelineRowOtherAction,
   F0TimelineRowProps,
   F0TimelineRowTaskProps,

--- a/packages/react/src/sds/TimeLine/types.ts
+++ b/packages/react/src/sds/TimeLine/types.ts
@@ -1,6 +1,6 @@
-import { type IconType } from "@/components/F0Icon"
-import { type DropdownItem } from "@/experimental/Navigation/Dropdown"
-import { type MetadataItem } from "@/experimental/Information/Headers/Metadata"
+import type { IconType } from "@/components/F0Icon"
+import type { DropdownItem } from "@/experimental/Navigation/Dropdown"
+import type { MetadataItem } from "@/experimental/Information/Headers/Metadata"
 
 export const timelineRowStatuses = [
   "completed",
@@ -52,6 +52,11 @@ export interface F0TimelineRowTaskProps extends F0TimelineRowBaseProps {
   otherActions?: F0TimelineRowOtherAction[]
 }
 
+/** Item types that can be rendered inside a multitask row */
+export type F0TimelineRowMultitaskItemProps =
+  | F0TimelineRowTaskProps
+  | F0TimelineRowNestedtaskProps
+
 /** Props for a multitask (collapsible group) timeline row */
 export interface F0TimelineRowMultitaskProps extends F0TimelineRowBaseProps {
   /** Number of grouped tasks */
@@ -62,10 +67,42 @@ export interface F0TimelineRowMultitaskProps extends F0TimelineRowBaseProps {
   expanded: boolean
   /** Callback when multitask row expand/collapse is toggled */
   onExpandToggle: () => void
-  /** The subtask items to render when expanded */
+  /** The subtask items to render when expanded. Can be single tasks or nestedtask groups */
+  items: F0TimelineRowMultitaskItemProps[]
+}
+
+/**
+ * Props for a nestedtask timeline row.
+ * Renders a task-style header (custom icon, title, description, chevron toggle)
+ * with collapsible nested items and optional group-level metadata (assignees, file chips, etc.).
+ * Unlike multitask, the header looks like a regular task row with expand/collapse capability.
+ */
+export interface F0TimelineRowNestedtaskProps extends F0TimelineRowBaseProps {
+  /** The icon representing the task type */
+  icon: IconType
+  /** Description text (e.g., "Estimated on 18/07/2025") */
+  description?: string
+  /** Number of nested items (displayed in the progress pill) */
+  taskCount: number
+  /** Number of completed items (displayed in the progress pill) */
+  completedCount?: number
+  /** Whether the row is expanded (controlled) */
+  expanded: boolean
+  /** Callback when expand/collapse is toggled */
+  onExpandToggle: () => void
+  /** Metadata items displayed below the header (e.g., assignees, file chips). Always visible regardless of expand/collapse */
+  metadata?: (MetadataItem | undefined | boolean)[]
+  /** The nested task items to render when expanded */
   items: F0TimelineRowTaskProps[]
+  /** Primary action button (displayed on the right after a divider) */
+  primaryAction?: F0TimelineRowAction
+  /** Secondary action buttons (displayed on the left) */
+  secondaryActions?: F0TimelineRowAction[]
+  /** Overflow menu items (displayed as a dropdown via ellipsis button) */
+  otherActions?: F0TimelineRowOtherAction[]
 }
 
 export type F0TimelineRowProps =
   | F0TimelineRowTaskProps
   | F0TimelineRowMultitaskProps
+  | F0TimelineRowNestedtaskProps


### PR DESCRIPTION
## Summary

Add a new **nestedtask** variant to `F0TimelineRow` that renders a task-style header (custom icon, title, description, chevron toggle) with collapsible nested items and optional group-level metadata.

## What's new

### New components
- **NestedtaskHeader** — custom icon, title (strikethrough when completed), description, chevron toggle, and progress pill
- **NestedtaskRow** — compact NestedItem rows, metadata section (always visible), and action buttons (primary, secondary, other)

### Updated components
- **F0TimelineRow** — updated discriminator: task (no items), multitask (items, no icon), nestedtask (items + icon)
- **MultitaskRow** — now accepts nestedtask items inside its items array via `F0TimelineRowMultitaskItemProps` union type

### New types
- `F0TimelineRowNestedtaskProps` — icon, description, metadata, items, actions (primary/secondary/other)
- `F0TimelineRowMultitaskItemProps` — union of `TaskProps | NestedtaskProps` for multitask items

### Storybook
6 new stories: NestedtaskInProgress, NestedtaskCompleted, NestedtaskTimeline, NestedtaskNotStarted, NestedtaskInProgressWithActions, MultitaskWithNestedtask

<img width="1218" height="815" alt="Screenshot 2026-04-14 at 10 36 10" src="https://github.com/user-attachments/assets/0b5280ee-396e-4e81-bf09-06ac16744899" />
<img width="1218" height="815" alt="Screenshot 2026-04-14 at 10 36 03" src="https://github.com/user-attachments/assets/72d7cdd9-a3de-4c07-9e77-50844fb24542" />
<img width="1218" height="815" alt="Screenshot 2026-04-14 at 10 35 55" src="https://github.com/user-attachments/assets/1e61edb2-6af8-4325-8222-80e4ab1f4d10" />
<img width="1218" height="815" alt="Screenshot 2026-04-14 at 10 35 48" src="https://github.com/user-attachments/assets/07af255a-41fb-4fb4-a528-8aa539644b57" />
