### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.445.1",
+  "packages/react": "1.445.2",
   "packages/react-native": "0.49.1",
   "packages/core": "1.49.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.445.2](https://github.com/factorialco/f0/compare/f0-react-v1.445.1...f0-react-v1.445.2) (2026-04-14)
+
+
+### Bug Fixes
+
+* **F0Alert:** stability audit BLOCKING fixes ([#3900](https://github.com/factorialco/f0/issues/3900)) ([8ef3c7f](https://github.com/factorialco/f0/commit/8ef3c7f966206dcd23f4640380b2adf5ec8fb01f))
+
 ## [1.445.1](https://github.com/factorialco/f0/compare/f0-react-v1.445.0...f0-react-v1.445.1) (2026-04-14)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.445.1",
+  "version": "1.445.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.445.2</summary>

## [1.445.2](https://github.com/factorialco/f0/compare/f0-react-v1.445.1...f0-react-v1.445.2) (2026-04-14)


### Bug Fixes

* **F0Alert:** stability audit BLOCKING fixes ([#3900](https://github.com/factorialco/f0/issues/3900)) ([8ef3c7f](https://github.com/factorialco/f0/commit/8ef3c7f966206dcd23f4640380b2adf5ec8fb01f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).