### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.445.3",
+  "packages/react": "1.446.0",
   "packages/react-native": "0.49.1",
   "packages/core": "1.49.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.446.0](https://github.com/factorialco/f0/compare/f0-react-v1.445.3...f0-react-v1.446.0) (2026-04-14)
+
+
+### Features
+
+* add tooltip support to DataCollection secondary actions ([#3930](https://github.com/factorialco/f0/issues/3930)) ([21ce8a2](https://github.com/factorialco/f0/commit/21ce8a2c2a3ca9263d3bec7da26b3c3d9144cc2a))
+
 ## [1.445.3](https://github.com/factorialco/f0/compare/f0-react-v1.445.2...f0-react-v1.445.3) (2026-04-14)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.445.3",
+  "version": "1.446.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.446.0</summary>

## [1.446.0](https://github.com/factorialco/f0/compare/f0-react-v1.445.3...f0-react-v1.446.0) (2026-04-14)


### Features

* add tooltip support to DataCollection secondary actions ([#3930](https://github.com/factorialco/f0/issues/3930)) ([21ce8a2](https://github.com/factorialco/f0/commit/21ce8a2c2a3ca9263d3bec7da26b3c3d9144cc2a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).