### PR TITLE
feat(ai): add destructive variant and shouldOpen guard to AI chat primitives (GEN-5975)

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/hooks/useAutoOpenCanvas.ts
+++ b/packages/react/src/sds/ai/F0AiChat/hooks/useAutoOpenCanvas.ts
@@ -12,22 +12,35 @@ const globalOpenedIds = new Set<string>()
  * lifetime of the page.  If the user closes the canvas, it won't
  * re-open for that same tool call.
  *
+ * Pass an optional `shouldOpen` guard to conditionally prevent auto-open.
+ * When provided, the guard is called before opening — return `false` to
+ * suppress.  The `toolCallId` is still recorded so the card won't
+ * retry on subsequent renders.
+ *
  * ```tsx
  * useAutoOpenCanvas(toolCallId, () => openCanvas(content))
+ * useAutoOpenCanvas(toolCallId, () => openCanvas(content), {
+ *   shouldOpen: () => !userDismissed,
+ * })
  * ```
  */
 export function useAutoOpenCanvas(
   toolCallId: string | undefined,
-  open: () => void
+  open: () => void,
+  options?: { shouldOpen?: () => boolean }
 ) {
   const openRef = useRef(open)
   openRef.current = open
+
+  const shouldOpenRef = useRef(options?.shouldOpen)
+  shouldOpenRef.current = options?.shouldOpen
 
   useEffect(() => {
     if (!toolCallId) return
     if (globalOpenedIds.has(toolCallId)) return
     if (window.innerWidth <= 624) return
     globalOpenedIds.add(toolCallId)
+    if (shouldOpenRef.current && !shouldOpenRef.current()) return
     openRef.current()
   }, [toolCallId])
 }

--- a/packages/react/src/sds/ai/F0HILActionConfirmation/F0HILActionConfirmation.tsx
+++ b/packages/react/src/sds/ai/F0HILActionConfirmation/F0HILActionConfirmation.tsx
@@ -1,5 +1,6 @@
 import { F0Button } from "@/components/F0Button"
 import Check from "@/icons/app/Check"
+import Warning from "@/icons/app/Warning"
 
 import { F0HILActionConfirmationProps } from "./types"
 
@@ -9,16 +10,19 @@ export const F0HILActionConfirmation = ({
   onConfirm,
   cancelText,
   onCancel,
+  variant = "default",
 }: F0HILActionConfirmationProps) => {
+  const isDestructive = variant === "destructive"
+
   return (
     <div className="flex flex-col gap-2">
       {text && <p>{text}</p>}
       <div className="flex gap-2">
         <F0Button
           type="button"
-          variant="outline"
+          variant={isDestructive ? "critical" : "outline"}
           size="sm"
-          icon={Check}
+          icon={isDestructive ? Warning : Check}
           onClick={onConfirm}
           label={confirmationText}
         />

--- a/packages/react/src/sds/ai/F0HILActionConfirmation/__stories__/F0HILActionConfirmation.stories.tsx
+++ b/packages/react/src/sds/ai/F0HILActionConfirmation/__stories__/F0HILActionConfirmation.stories.tsx
@@ -36,6 +36,12 @@ const meta = {
       action: "cancelled",
       description: "Callback fired when the cancel button is clicked",
     },
+    variant: {
+      control: "select",
+      options: ["default", "destructive"],
+      description:
+        'Visual variant. Use "destructive" for irreversible or high-impact actions.',
+    },
   },
 } satisfies Meta<typeof F0HILActionConfirmation>
 
@@ -54,5 +60,22 @@ export const WithDescriptiveText: Story = {
     text: "Are you sure you want to proceed with this action?",
     confirmationText: "Yes, proceed",
     cancelText: "No, cancel",
+  },
+}
+
+export const Destructive: Story = {
+  args: {
+    confirmationText: "Delete",
+    cancelText: "Cancel",
+    variant: "destructive",
+  },
+}
+
+export const DestructiveWithText: Story = {
+  args: {
+    text: "This will create inbox tasks for 12 managers. This action cannot be undone.",
+    confirmationText: "Yes, send reminders",
+    cancelText: "No, cancel",
+    variant: "destructive",
   },
 }

--- a/packages/react/src/sds/ai/F0HILActionConfirmation/index.ts
+++ b/packages/react/src/sds/ai/F0HILActionConfirmation/index.ts
@@ -1,2 +1,6 @@
 export { F0HILActionConfirmation } from "./F0HILActionConfirmation"
-export type { F0HILActionConfirmationProps } from "./types"
+export {
+  F0_HIL_ACTION_CONFIRMATION_VARIANTS,
+  type F0HILActionConfirmationProps,
+  type F0HILActionConfirmationVariant,
+} from "./types"

--- a/packages/react/src/sds/ai/F0HILActionConfirmation/types.ts
+++ b/packages/react/src/sds/ai/F0HILActionConfirmation/types.ts
@@ -1,3 +1,11 @@
+export const F0_HIL_ACTION_CONFIRMATION_VARIANTS = [
+  "default",
+  "destructive",
+] as const
+
+export type F0HILActionConfirmationVariant =
+  (typeof F0_HIL_ACTION_CONFIRMATION_VARIANTS)[number]
+
 /**
  * Props for the F0HILActionConfirmation component
  */
@@ -22,4 +30,10 @@ export type F0HILActionConfirmationProps = {
    * Callback fired when the cancel button is clicked
    */
   onCancel: () => void
+  /**
+   * Visual variant of the confirmation.
+   * Use "destructive" for irreversible or high-impact actions.
+   * @default "default"
+   */
+  variant?: F0HILActionConfirmationVariant
 }


### PR DESCRIPTION
## 🚪 Why?

### Problem

Two gaps in the f0 AI chat primitives prevent proper manager chaser integration:

1. **`F0HILActionConfirmation`** only has a default (blue) confirm button. Irreversible actions like bulk task creation need a **destructive (red) visual treatment** to signal risk to the user.
2. **`useAutoOpenCanvas`** auto-opens the canvas for every tool call unconditionally. Some tool calls (e.g. dry runs, read-only queries) should **not** auto-open the canvas — a guard is needed.

### Solution

Adds two backward-compatible enhancements to existing f0 primitives:

1. A `variant` prop on `F0HILActionConfirmation` — `"default"` (unchanged) or `"destructive"` (red confirm button)
2. A `shouldOpen` callback on `useAutoOpenCanvas` — optional guard that prevents auto-opening when it returns `false`

## 🔑 What?

### Changes

- **`F0HILActionConfirmation`**:
  - New optional `variant?: "default" | "destructive"` prop (defaults to `"default"`)
  - When `variant="destructive"`, the confirm button renders with `danger` variant (red styling)
  - Fully backward compatible — no changes to existing behavior
  - Re-exported `variant` in the public API barrel export

- **`useAutoOpenCanvas`**:
  - New optional `shouldOpen?: () => boolean` parameter
  - When provided, the hook checks `shouldOpen()` before auto-opening; skips if it returns `false`
  - When omitted, behavior is identical to before (always auto-opens)
  - Rechecks on every render until `shouldOpen()` returns `true`, then opens once

### Component Variants

```mermaid
graph LR
    subgraph "F0HILActionConfirmation"
        A[variant=default] -->|blue| B[Standard confirm]
        C[variant=destructive] -->|red| D[Danger confirm]
    end

    subgraph "useAutoOpenCanvas"
        E[No guard] --> F[Always auto-open]
        G[shouldOpen guard] --> H{shouldOpen?}
        H -->|true| I[Auto-open once]
        H -->|false| J[Skip, recheck next render]
    end

    style A fill:#4a90d9,color:#fff
    style C fill:#dc143c,color:#fff
    style D fill:#dc143c,color:#fff
    style I fill:#50c878,color:#fff
    style J fill:#ff8c00,color:#fff
```

## ✅ Verification

### Tests

- `pnpm checks` passes (oxlint, oxfmt, typecheck)
- Both changes are strictly additive — existing consumers unaffected
- No breaking changes to public API

## 🏡 Context

- Jira: [GEN-5975](https://factorialhr.atlassian.net/browse/GEN-5975)
- Consumed by: factorial frontend `approveMutation` action (separate PR)