### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.448.0",
-  "packages/react-native": "0.49.1",
+  "packages/react-native": "0.50.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.50.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.49.1...f0-react-native-v0.50.0) (2026-04-15)
+
+
+### Features
+
+* **F0Icon:** add tintColor prop for runtime color customization and … ([#3934](https://github.com/factorialco/f0/issues/3934)) ([403d9dd](https://github.com/factorialco/f0/commit/403d9dd18cefe77f386f4cd3c833085e7ce52e62))
+
 ## [0.49.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.49.0...f0-react-native-v0.49.1) (2026-04-07)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.50.0</summary>

## [0.50.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.49.1...f0-react-native-v0.50.0) (2026-04-15)


### Features

* **F0Icon:** add tintColor prop for runtime color customization and … ([#3934](https://github.com/factorialco/f0/issues/3934)) ([403d9dd](https://github.com/factorialco/f0/commit/403d9dd18cefe77f386f4cd3c833085e7ce52e62))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).