### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.449.0",
+  "packages/react": "1.449.1",
   "packages/react-native": "0.50.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.449.1](https://github.com/factorialco/f0/compare/f0-react-v1.449.0...f0-react-v1.449.1) (2026-04-15)
+
+
+### Bug Fixes
+
+* richTextEditor issue with +3 mentions ([#3917](https://github.com/factorialco/f0/issues/3917)) ([54406a5](https://github.com/factorialco/f0/commit/54406a559db446b6e389598b9289cef899f2da12))
+
 ## [1.449.0](https://github.com/factorialco/f0/compare/f0-react-v1.448.0...f0-react-v1.449.0) (2026-04-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.449.0",
+  "version": "1.449.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.449.1</summary>

## [1.449.1](https://github.com/factorialco/f0/compare/f0-react-v1.449.0...f0-react-v1.449.1) (2026-04-15)


### Bug Fixes

* richTextEditor issue with +3 mentions ([#3917](https://github.com/factorialco/f0/issues/3917)) ([54406a5](https://github.com/factorialco/f0/commit/54406a559db446b6e389598b9289cef899f2da12))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).