### PR TITLE
fix(F0AiChat): surface file upload errors to the user

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -361,6 +361,7 @@ export const defaultTranslations = {
     },
     attachFile: "Attach file",
     removeFile: "Remove",
+    fileUploadError: "Upload failed",
     dropFilesHere: "Drop your files here",
     clarifyingQuestion: {
       submit: "Submit",

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/AttachedFilesList.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/AttachedFilesList.tsx
@@ -3,6 +3,7 @@ import { F0Icon } from "@/components/F0Icon"
 import { AlertCircle, CrossedCircle } from "@/icons/app"
 import { Skeleton } from "@/ui/skeleton"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { focusRing } from "@/lib/utils"
 
 import { type AttachedFile } from "./types"
 
@@ -31,23 +32,12 @@ export const AttachedFilesList = ({
         att.status === "uploading" ? (
           <Skeleton key={att.id} className="h-9 w-36 rounded-lg" />
         ) : att.status === "error" ? (
-          <Tooltip key={att.id} label={att.errorMessage ?? ""}>
-            <div
-              role="alert"
-              className="flex items-center gap-1.5 rounded-lg border border-f1-border-critical bg-f1-background-critical/10 px-2.5 py-1.5"
-            >
-              <F0Icon icon={AlertCircle} size="md" color="critical" />
-              <span className="max-w-40 truncate text-sm font-medium text-f1-foreground-critical">
-                {att.file.name}
-              </span>
-              <F0Icon
-                icon={CrossedCircle}
-                size="md"
-                className="cursor-pointer text-f1-foreground-critical hover:text-f1-foreground-critical/80"
-                onClick={() => onRemove(att.id)}
-              />
-            </div>
-          </Tooltip>
+          <ErrorFilePill
+            key={att.id}
+            att={att}
+            onRemove={onRemove}
+            removeLabel={removeLabel}
+          />
         ) : (
           <FileItem
             key={att.id}
@@ -65,4 +55,39 @@ export const AttachedFilesList = ({
       )}
     </div>
   )
+}
+
+function ErrorFilePill({
+  att,
+  onRemove,
+  removeLabel,
+}: {
+  att: AttachedFile
+  onRemove: (id: string) => void
+  removeLabel: string
+}) {
+  const content = (
+    <div className="flex items-center gap-1.5 rounded-lg border border-f1-border-critical bg-f1-background-critical/10 px-2.5 py-1.5">
+      <F0Icon icon={AlertCircle} size="md" color="critical" />
+      <span className="max-w-40 truncate text-sm font-medium text-f1-foreground-critical">
+        {att.file.name}
+      </span>
+      <button
+        type="button"
+        aria-label={removeLabel}
+        className={focusRing(
+          "rounded-full text-f1-foreground-critical hover:text-f1-foreground-critical/80"
+        )}
+        onClick={() => onRemove(att.id)}
+      >
+        <F0Icon icon={CrossedCircle} size="md" aria-hidden="true" />
+      </button>
+    </div>
+  )
+
+  if (att.errorMessage) {
+    return <Tooltip label={att.errorMessage}>{content}</Tooltip>
+  }
+
+  return content
 }

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/AttachedFilesList.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/AttachedFilesList.tsx
@@ -1,6 +1,8 @@
 import { FileItem } from "@/components/RichText/FileItem"
-import { CrossedCircle } from "@/icons/app"
+import { F0Icon } from "@/components/F0Icon"
+import { AlertCircle, CrossedCircle } from "@/icons/app"
 import { Skeleton } from "@/ui/skeleton"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
 
 import { type AttachedFile } from "./types"
 
@@ -28,6 +30,24 @@ export const AttachedFilesList = ({
       {attachedFiles.map((att) =>
         att.status === "uploading" ? (
           <Skeleton key={att.id} className="h-9 w-36 rounded-lg" />
+        ) : att.status === "error" ? (
+          <Tooltip key={att.id} label={att.errorMessage ?? ""}>
+            <div
+              role="alert"
+              className="flex items-center gap-1.5 rounded-lg border border-f1-border-critical bg-f1-background-critical/10 px-2.5 py-1.5"
+            >
+              <F0Icon icon={AlertCircle} size="md" color="critical" />
+              <span className="max-w-40 truncate text-sm font-medium text-f1-foreground-critical">
+                {att.file.name}
+              </span>
+              <F0Icon
+                icon={CrossedCircle}
+                size="md"
+                className="cursor-pointer text-f1-foreground-critical hover:text-f1-foreground-critical/80"
+                onClick={() => onRemove(att.id)}
+              />
+            </div>
+          </Tooltip>
         ) : (
           <FileItem
             key={att.id}

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/types.ts
@@ -16,6 +16,7 @@ export type AttachedFile = {
     filename: string
     mimetype: string
   }
+  errorMessage?: string
 }
 
 export type UserTextPart = { type: "text"; text: string }

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/useFileAttachments.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/useFileAttachments.ts
@@ -1,14 +1,19 @@
 import { useCallback, useMemo, useRef, useState } from "react"
 
+import { useI18n } from "@/lib/providers/i18n"
+
 import { type AiChatFileAttachmentConfig } from "../../../types"
 import { type AttachedFile } from "./types"
 import { filterByMimeType } from "./file-utils"
+
+const AUTO_REMOVE_ERROR_DELAY = 5000
 
 export function useFileAttachments(
   fileAttachments: AiChatFileAttachmentConfig | undefined
 ) {
   const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([])
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const translation = useI18n()
 
   const onUploadFiles = fileAttachments?.onUploadFiles
   const allowedMimeTypes = fileAttachments?.allowedMimeTypes
@@ -60,14 +65,23 @@ export function useFileAttachments(
             return { ...att, status: "error" as const }
           })
         )
-      } catch {
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : translation.ai.fileUploadError
+        const errorIds = newAttached.map((n) => n.id)
         setAttachedFiles((prev) =>
           prev.map((att) =>
-            newAttached.some((n) => n.id === att.id)
-              ? { ...att, status: "error" as const }
+            errorIds.includes(att.id)
+              ? { ...att, status: "error" as const, errorMessage }
               : att
           )
         )
+        // Auto-remove error files after a delay
+        setTimeout(() => {
+          setAttachedFiles((prev) =>
+            prev.filter((att) => !errorIds.includes(att.id))
+          )
+        }, AUTO_REMOVE_ERROR_DELAY)
       }
     },
     [onUploadFiles, maxFiles, attachedFiles.length, allowedMimeTypes]

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/useFileAttachments.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/useFileAttachments.ts
@@ -60,12 +60,18 @@ export function useFileAttachments(
                 uploadedFile: uploaded[idx],
               }
             }
-            return { ...att, status: "error" as const }
+            return {
+              ...att,
+              status: "error" as const,
+              errorMessage: translation.ai.fileUploadError,
+            }
           })
         )
       } catch (err) {
         const errorMessage =
-          err instanceof Error ? err.message : translation.ai.fileUploadError
+          err instanceof Error && err.message
+            ? err.message
+            : translation.ai.fileUploadError
         const errorIds = newAttached.map((n) => n.id)
         setAttachedFiles((prev) =>
           prev.map((att) =>

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/useFileAttachments.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/useFileAttachments.ts
@@ -6,8 +6,6 @@ import { type AiChatFileAttachmentConfig } from "../../../types"
 import { type AttachedFile } from "./types"
 import { filterByMimeType } from "./file-utils"
 
-const AUTO_REMOVE_ERROR_DELAY = 5000
-
 export function useFileAttachments(
   fileAttachments: AiChatFileAttachmentConfig | undefined
 ) {
@@ -76,12 +74,6 @@ export function useFileAttachments(
               : att
           )
         )
-        // Auto-remove error files after a delay
-        setTimeout(() => {
-          setAttachedFiles((prev) =>
-            prev.filter((att) => !errorIds.includes(att.id))
-          )
-        }, AUTO_REMOVE_ERROR_DELAY)
       }
     },
     [onUploadFiles, maxFiles, attachedFiles.length, allowedMimeTypes]


### PR DESCRIPTION
## Summary
The `catch` block in `useFileAttachments` silently swallowed upload errors — files were marked as `"error"` internally but rendered identically to successful uploads, then quietly excluded from the message payload on send. Users had no indication anything went wrong.

## Changes
- **`useFileAttachments.ts`**: Capture error message from thrown `Error` in catch block; also set `errorMessage` on the non-throw failure path (when `uploaded[idx]` is missing); guard against empty `err.message` by falling back to i18n generic message
- **`AttachedFilesList.tsx`**: Render error files with critical styling (red border, `AlertCircle` icon, filename in red); tooltip shows error message only when present; dismiss button is a semantic `<button>` with `aria-label` and `focusRing()` for keyboard accessibility; relies on the container's `aria-live="polite"` instead of per-item `role="alert"`
- **`types.ts`**: Add optional `errorMessage` field to `AttachedFile`
- **`i18n-provider-defaults.ts`**: Add `fileUploadError` translation key as generic fallback

## How it works
1. When `onUploadFiles` throws (e.g. "Each file must be 10MB or smaller"), the error message is captured and stored on the file
2. When `onUploadFiles` resolves but a specific file has no matching upload result, a generic fallback message is used
3. Failed files render with red critical styling and can be dismissed by the user via a keyboard-accessible button
4. Error details appear in a tooltip when `errorMessage` is present

<img width="1258" height="814" alt="image" src="https://github.com/user-attachments/assets/bc3419a5-222b-463a-a275-2591f36195fb" />
