### PR TITLE
fix(EditableTable): improve nested row add button alignment and number cell clamping

### DIFF
--- a/packages/react/src/experimental/OneTable/TableCell/utils/nested.ts
+++ b/packages/react/src/experimental/OneTable/TableCell/utils/nested.ts
@@ -32,7 +32,7 @@ export const getNestedMarginLeftForLoadMore = ({
 }) => {
   return getNestedMarginLeft({
     depth,
-    padding: isDetailedVariant ? -BUTTON_HEIGHT / 2 : -BUTTON_PADDING,
+    padding: isDetailedVariant ? -BUTTON_PADDING : -BUTTON_PADDING,
   })
 }
 

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -420,12 +420,18 @@ export function useSelectable<
     (
       itemId: SelectionId | readonly SelectionId[],
       checked: boolean,
-      onlyIfNotPreviousState: boolean = false
+      onlyIfNotPreviousState: boolean = false,
+      fallbackItem?: R | readonly R[]
     ) => {
       const itemIds = (Array.isArray(itemId) ? itemId : [itemId]).slice(
         0,
         isMultiSelection ? undefined : 1
       )
+      const fallbackItems = Array.isArray(fallbackItem)
+        ? fallbackItem
+        : fallbackItem !== undefined
+          ? [fallbackItem]
+          : []
 
       setLocalSelectedState((current) => {
         // Single selection: replace previous selection entirely
@@ -441,8 +447,13 @@ export function useSelectable<
 
           updated++
           const existingItem = current.items?.get(id)?.item
+          const matchingFallbackItem = fallbackItems.find((item) => {
+            const fallbackId = getSelectable?.(item)
+            return fallbackId !== undefined && fallbackId === id
+          })
           const item =
             existingItem ??
+            matchingFallbackItem ??
             data.records.find((record) => {
               const recordId = getSelectable?.(record)
               return recordId !== undefined && recordId === id
@@ -513,7 +524,7 @@ export function useSelectable<
       if (isRecordItem(itemOrId, getSelectable !== undefined)) {
         const id = getSelectable?.(itemOrId)
         if (id !== undefined) {
-          handleSelectItemChangeInternal(id, checked)
+          handleSelectItemChangeInternal(id, checked, false, itemOrId)
         }
         return
       }

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -2,7 +2,11 @@ import { useDeepCompareEffect } from "@reactuses/core"
 import { motion } from "motion/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
-import { Spinner } from "@/ui/Spinner"
+import type {
+  FiltersDefinition,
+  FiltersState,
+} from "@/patterns/OneFilterPicker/types"
+
 import { OneEmptyState } from "@/components/OneEmptyState"
 import {
   GroupingDefinition,
@@ -15,11 +19,9 @@ import { useLayout } from "@/layouts/LayoutProvider"
 import { useI18n } from "@/lib/providers/i18n"
 import { useDebounceBoolean } from "@/lib/useDebounceBoolean"
 import { cn } from "@/lib/utils"
+import { OneFilterPicker } from "@/patterns/OneFilterPicker"
+import { Spinner } from "@/ui/Spinner"
 
-import type {
-  FiltersDefinition,
-  FiltersState,
-} from "@/patterns/OneFilterPicker/types"
 import type {
   BulkActionDefinition,
   GroupingState,
@@ -29,7 +31,6 @@ import type {
 } from "./types"
 import type { Visualization } from "./visualizations/collection"
 
-import { OneFilterPicker } from "@/patterns/OneFilterPicker"
 import {
   filterActions,
   getPrimaryActions,
@@ -47,9 +48,9 @@ import {
 } from "./hooks/useDataColectionStorage/types"
 import { useDataCollectionStorage } from "./hooks/useDataColectionStorage/useDataCollectionStorage"
 import { DataCollectionSource } from "./hooks/useDataCollectionSource"
-import { usePerVisualizationFilters } from "./hooks/usePerVisualizationFilters"
 import { CustomEmptyStates, useEmptyState } from "./hooks/useEmptyState"
 import { useExportAction } from "./hooks/useExportAction"
+import { usePerVisualizationFilters } from "./hooks/usePerVisualizationFilters"
 import { ItemActionsDefinition } from "./item-actions"
 import { NavigationFiltersDefinition } from "./navigationFilters/types"
 import { Settings } from "./Settings"

--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -623,6 +623,14 @@ export const getMockVisualizations = (options?: {
             // No-op handler when cache is not available
           }
         })(),
+        addRowActions: () => ({
+          label: "Add row",
+          onClick: () => console.log("Add row clicked"),
+        }),
+        addNestedRowActions: (parent) => ({
+          label: "Add child",
+          onClick: () => console.log("Add child clicked", parent),
+        }),
       },
     } as Visualization<
       MockUser,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableTableAddRow.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableTableAddRow.test.tsx
@@ -4,11 +4,11 @@ import { describe, expect, it, vi } from "vitest"
 
 import type { GroupingDefinition, SortingsDefinition } from "@/hooks/datasource"
 
-import { TextCell } from "@/ui/value-display/types/text"
+import { BaseFetchOptions, FiltersDefinition } from "@/hooks/datasource"
 import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
 import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
-import { BaseFetchOptions, FiltersDefinition } from "@/hooks/datasource"
 import { zeroRender as render } from "@/testing/test-utils"
+import { TextCell } from "@/ui/value-display/types/text"
 
 import { ItemActionsDefinition } from "../../../../item-actions"
 import { SummariesDefinition } from "../../../../summary"
@@ -430,6 +430,61 @@ describe("EditableTable addRowActions (footer)", () => {
 })
 
 describe("EditableTable addNestedRowActions", () => {
+  it("reports the selected child item instead of the parent when selecting nested rows", async () => {
+    const user = userEvent.setup()
+    const onSelectItems = vi.fn()
+
+    render(
+      <TableCollection<
+        Person,
+        TestFilters,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        TestNavigationFilters,
+        GroupingDefinition<Person>
+      >
+        columns={testColumns}
+        source={createNestedTestSource({
+          allPagesSelection: true,
+          selectable: (item) => item.id,
+        })}
+        onSelectItems={onSelectItems}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("Parent User")).toBeInTheDocument()
+    })
+
+    const parentRow = screen.getByText("Parent User").closest("tr")!
+    const chevron = parentRow.querySelector("[class*='cursor-pointer']")!
+    await user.click(chevron)
+
+    await waitFor(() => {
+      expect(screen.getByText("Child A")).toBeInTheDocument()
+    })
+
+    const childRow = screen.getByText("Child A").closest("tr")!
+    const childCheckbox = within(childRow).getByRole("checkbox")
+    await user.click(childCheckbox)
+
+    await waitFor(() => {
+      expect(
+        onSelectItems.mock.calls.some(([selection]) =>
+          selection.itemsStatus.some(
+            ({ checked, item }: { checked: boolean; item: Person }) =>
+              checked &&
+              item.id === childItems[0]?.id &&
+              item.name === childItems[0]?.name
+          )
+        )
+      ).toBe(true)
+    })
+  })
+
   it("does not render add-row button when addNestedRowActions is not provided", async () => {
     const user = userEvent.setup()
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
@@ -94,7 +94,7 @@ describe("NumberCell", () => {
     )
 
     const input = screen.getByRole("textbox")
-    const alignWrapper = input.closest('[class*="[&_input]"]')
+    const alignWrapper = input.closest(".justify-end")
     expect(alignWrapper).toBeInTheDocument()
   })
 
@@ -122,8 +122,7 @@ describe("NumberCell", () => {
       />
     )
 
-    const wrapper = screen.getByRole("textbox").closest("[data-units]")
-    expect(wrapper).toHaveAttribute("data-units", "EUR")
+    expect(screen.getByText("EUR")).toBeInTheDocument()
   })
 
   it("renders value '0' when stored value is '0' (no units)", () => {
@@ -144,7 +143,6 @@ describe("NumberCell", () => {
     )
 
     expect(screen.getByRole("textbox")).toHaveValue("0")
-    const wrapper = screen.getByRole("textbox").closest("[data-units]")
-    expect(wrapper).toHaveAttribute("data-units", "€")
+    expect(screen.getByText("€")).toBeInTheDocument()
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -1,13 +1,13 @@
-import { useMemo } from "react"
+import { useCallback, useState } from "react"
 
 import { NumberInput } from "@/experimental/Forms/Fields/NumberInput"
 import { RecordType } from "@/hooks/datasource/types/records.typings"
-import { useL10n } from "@/lib/providers/l10n"
 import { cn } from "@/lib/utils"
 
 import type { EditableCellProps } from "."
 
 import { BaseCell } from "./BaseCell"
+import { useNumberCellLayout } from "./hooks/useNumberCellLayout"
 
 export function NumberCell<R extends RecordType>({
   editableColumn,
@@ -16,55 +16,86 @@ export function NumberCell<R extends RecordType>({
   loading,
   onChange,
 }: EditableCellProps<R>) {
-  const { locale: contextLocale } = useL10n()
   const config = editableColumn.numberConfig
-  const locale = config?.locale ?? contextLocale
-
-  const unitsBefore = useMemo(
-    () => (config?.units ? config.unitsPosition : false),
-    [locale, config?.units]
-  )
+  // When clamping produces the same value the parent already holds,
+  // NumberInput's internal state won't re-sync (the prop didn't change).
+  // Bumping a key forces a re-mount so the displayed text resets.
+  const [resetKey, setResetKey] = useState(0)
 
   const trimmed = typeof value === "string" ? value.trim() : value
   const parsed = trimmed !== "" && trimmed != null ? Number(trimmed) : NaN
   const numericValue: number | null = isFinite(parsed) ? parsed : 0
 
+  const { ref, width, locale, units, unitsBefore } = useNumberCellLayout(
+    config,
+    numericValue
+  )
+
   const handleChange = (newValue: number | null) => {
-    const stringValue = String(newValue ?? 0)
+    let clamped = newValue ?? 0
+    if (config?.min != null && clamped < config.min) clamped = config.min
+    if (config?.max != null && clamped > config.max) clamped = config.max
+
+    const stringValue = String(clamped)
     if (stringValue !== value) {
       onChange(stringValue)
+    } else {
+      setResetKey((k) => k + 1)
     }
   }
+
+  const unitsSpan = units && (
+    <span className="flex shrink-0 select-none items-center self-center pt-[1px] text-sm text-f1-foreground">
+      {units}
+    </span>
+  )
+
+  // The input is shrink-wrapped to its content, so clicking on the
+  // empty area of the cell won't naturally focus it. We delegate
+  // focus manually to preserve the expected table editing UX.
+  const handleCellClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const input = e.currentTarget.querySelector("input")
+    if (input && e.target !== input) {
+      input.focus()
+    }
+  }, [])
 
   return (
     <BaseCell error={error}>
       <div
+        ref={ref}
+        onClick={handleCellClick}
         className={cn(
-          "flex h-full w-full min-w-0 cursor-text items-center",
-          editableColumn.align === "right" && "[&_input]:text-right",
-          config?.units &&
-            unitsBefore &&
-            "[&_input]:pl-0 before:shrink-0 before:select-none before:pl-3 before:text-sm before:text-f1-foreground before:content-[attr(data-units)]",
-          config?.units &&
-            !unitsBefore &&
-            "[&_input]:pr-1 after:shrink-0 after:select-none after:pr-3 after:text-sm after:text-f1-foreground after:content-[attr(data-units)]"
+          "flex h-full w-full cursor-text items-center",
+          editableColumn.align === "right" && "justify-end"
         )}
-        data-units={config?.units}
       >
-        <NumberInput
-          label={editableColumn.label}
-          hideLabel
-          value={numericValue}
-          onChange={handleChange}
-          loading={loading}
-          transparent
-          hint=""
-          locale={locale}
-          min={config?.min}
-          max={config?.max}
-          step={config?.step}
-          maxDecimals={config?.maxDecimals}
-        />
+        <div
+          className={cn(
+            "flex h-full max-w-full items-center gap-1",
+            unitsBefore && "pl-3 [&_input]:pl-1",
+            !unitsBefore && units && "pr-3 [&_input]:pr-1"
+          )}
+          style={{ width }}
+        >
+          {unitsBefore && unitsSpan}
+          <NumberInput
+            key={resetKey}
+            label={editableColumn.label}
+            hideLabel
+            value={numericValue}
+            onChange={handleChange}
+            loading={loading}
+            transparent
+            hint=""
+            locale={locale}
+            min={config?.min}
+            max={config?.max}
+            step={config?.step}
+            maxDecimals={config?.maxDecimals}
+          />
+          {!unitsBefore && unitsSpan}
+        </div>
       </div>
     </BaseCell>
   )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/hooks/useInputTextWidth.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/hooks/useInputTextWidth.ts
@@ -1,0 +1,40 @@
+import { useCallback, useState } from "react"
+
+let measureCanvas: HTMLCanvasElement | null = null
+function getTextWidth(text: string, font: string): number {
+  if (!measureCanvas) measureCanvas = document.createElement("canvas")
+  const ctx = measureCanvas.getContext("2d")
+  if (!ctx) return 0
+  ctx.font = font
+  return Math.ceil(ctx.measureText(text).width)
+}
+
+/**
+ * Returns the pixel width of the given text, measured using the actual
+ * computed font of the first <input> found inside the referenced container.
+ *
+ * The NumberInput component forces w-full at every wrapper level, making it
+ * impossible to shrink-wrap with CSS alone. This hook lets us set an explicit
+ * container width so the input + currency label hug the content tightly.
+ */
+export function useInputTextWidth(text: string, extraPx = 26, minPx = 48) {
+  const [font, setFont] = useState<string | null>(null)
+
+  // Captures the real computed font from the first <input> inside the node.
+  // Without this, the fallback measurement would be inaccurate because the
+  // actual rendered font-family and font-size may differ.
+  const ref = useCallback((node: HTMLDivElement | null) => {
+    if (node) {
+      const input = node.querySelector("input")
+      if (input) {
+        setFont(getComputedStyle(input).font)
+      }
+    }
+  }, [])
+
+  const width = font
+    ? Math.max(getTextWidth(text || "\u00A0", font) + extraPx, minPx)
+    : undefined
+
+  return { ref, width }
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/hooks/useNumberCellLayout.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/hooks/useNumberCellLayout.ts
@@ -1,0 +1,41 @@
+import { useMemo } from "react"
+
+import { useL10n } from "@/lib/providers/l10n"
+
+import { NumberCellConfig } from "../../../types"
+import { useInputTextWidth } from "./useInputTextWidth"
+
+/**
+ * Encapsulates formatting, units placement, and width measurement
+ * for number/money cells so the component only deals with rendering.
+ */
+export function useNumberCellLayout(
+  config: NumberCellConfig | undefined,
+  numericValue: number | null
+) {
+  const { locale: contextLocale } = useL10n()
+  const locale = config?.locale ?? contextLocale
+
+  const units = config?.units
+  const unitsBefore = units ? config.unitsPosition === "before" : false
+  const formatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        maximumFractionDigits: config?.maxDecimals,
+        useGrouping: false,
+      }),
+    [locale, config?.maxDecimals]
+  )
+
+  const formatted = numericValue != null ? formatter.format(numericValue) : ""
+
+  const fullText = units
+    ? unitsBefore
+      ? `${units} ${formatted}`
+      : `${formatted} ${units}`
+    : formatted
+
+  const { ref, width } = useInputTextWidth(fullText)
+
+  return { ref, width, locale, units, unitsBefore }
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -634,6 +634,7 @@ export const TableCollection = <
                               item={item}
                               index={index}
                               groupIndex={groupIndex}
+                              onItemCheckedChange={handleSelectItemChange}
                               onCheckedChange={(checked) =>
                                 handleSelectItemChange(item, checked)
                               }
@@ -675,6 +676,7 @@ export const TableCollection = <
                     source={effectiveSource}
                     item={item}
                     index={index}
+                    onItemCheckedChange={handleSelectItemChange}
                     onCheckedChange={(checked) =>
                       handleSelectItemChange(item, checked)
                     }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -83,6 +83,7 @@ export type RowProps<
   index: number
   groupIndex: number
   onCheckedChange: (checked: boolean) => void
+  onItemCheckedChange?: (item: R, checked: boolean) => void
   selectedItems: Map<string | number, R>
   columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>
   frozenColumnsLeft: number
@@ -150,9 +151,10 @@ const NestedRowContent = <
   const shouldShowChildren = open
   const shouldShowLoadMore = open && paginationInfo?.hasMore
 
-  const addRowActions = open
-    ? normalizeAddRowActions(addRow?.addNestedRowActions?.(props.item))
-    : []
+  const addRowActions =
+    open && !isLoading
+      ? normalizeAddRowActions(addRow?.addNestedRowActions?.(props.item))
+      : []
   const hasAddRowActions = addRowActions.length > 0
 
   const firstRow = (props.nestedRowProps?.depth ?? 0) === 0
@@ -304,6 +306,9 @@ const NestedRowContent = <
                 key={`nested-row-${props.groupIndex}-${child.id}-${props.index}-${childIndex}`}
                 index={childIndex}
                 item={childItem}
+                onCheckedChange={(checked) => {
+                  props.onItemCheckedChange?.(childItem, checked)
+                }}
                 tableWithChildren={props.tableWithChildren}
                 ref={getChildRef()}
                 nestedRowProps={{
@@ -341,6 +346,9 @@ const NestedRowContent = <
                 key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
                 index={childIndex}
                 item={childItem}
+                onCheckedChange={(checked) => {
+                  props.onItemCheckedChange?.(childItem, checked)
+                }}
                 noBorder={leafShouldHideBorder}
                 ref={getChildRef()}
                 nestedRowProps={{

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -57,6 +57,7 @@ export type RowProps<
   index: number
   groupIndex: number
   onCheckedChange: (checked: boolean) => void
+  onItemCheckedChange?: (item: R, checked: boolean) => void
   selectedItems: Map<string | number, R>
   columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>
   frozenColumnsLeft: number
@@ -125,6 +126,7 @@ const RowComponentInner = <
     source,
     item,
     onCheckedChange,
+    onItemCheckedChange,
     selectedItems,
     columns,
     frozenColumnsLeft,
@@ -195,6 +197,7 @@ const RowComponentInner = <
         source={source}
         item={item}
         onCheckedChange={onCheckedChange}
+        onItemCheckedChange={onItemCheckedChange}
         selectedItems={selectedItems}
         columns={columns}
         frozenColumnsLeft={frozenColumnsLeft}


### PR DESCRIPTION
- Fix add row button padding in detailed nested rows to align with
  sibling cells at the same depth level
- Hide add row button while children are still loading on first expand
- Clamp NumberCell values to min/max and force re-sync when the clamped
  value matches the current state (resetKey)
- Add MoneyCell component and tests
- Fix tree connector height calculation and sticky parent row scroll
  handling
- Fix count and summary value-display renderers