### PR TITLE
feat: editable table with actions column

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/actions/actions.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/actions/actions.mdx
@@ -167,6 +167,10 @@ The items provide a streamlined interaction approach:
   resource, side panel or modal.
 - Do not support individual cell-level actions
 
+> **Editable table:** Item actions are rendered in a dedicated, always-visible
+> column instead of the hover overlay used by the regular table. Up to two
+> primary actions appear as buttons, with remaining actions in a dropdown menu.
+
 The actions are defined in the `itemActions` prop of the
 `useDataCollectionSource` hook via a function that get the item and returns an
 array of actions, that allows you to define diffrent actions for each item, or

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.mdx
@@ -271,16 +271,50 @@ To add a new cell type (e.g. `"date"`, `"select"`):
 
 ## Table vs Editable Table
 
-| Aspect                    | Table                   | Editable Table                                |
-| ------------------------- | ----------------------- | --------------------------------------------- |
-| Storage key               | `table`                 | `editableTable`                               |
-| Column order/hidden state | Shared for "Table view" | Independent from Table                        |
-| Cell editing              | Read-only               | Supports inline editing via `editType`        |
-| Item actions              | Supported               | Disabled (cells are interactive)              |
-| `onCellChange` callback   | N/A                     | Fires on every cell edit with the updated row |
-| Use case                  | Default read-only table | Inline editing or a different default layout  |
+| Aspect                    | Table                     | Editable Table                                |
+| ------------------------- | ------------------------- | --------------------------------------------- |
+| Storage key               | `table`                   | `editableTable`                               |
+| Column order/hidden state | Shared for "Table view"   | Independent from Table                        |
+| Cell editing              | Read-only                 | Supports inline editing via `editType`        |
+| Item actions              | Supported (hover overlay) | Supported (dedicated column)                  |
+| `onCellChange` callback   | N/A                       | Fires on every cell edit with the updated row |
+| Use case                  | Default read-only table   | Inline editing or a different default layout  |
 
 You can offer both in the same collection; users switch via the visualization
 selector and each view keeps its own column order and visibility.
 
 <Canvas of={EditableTableStories.TableAndEditableTable} />
+
+## Item Actions
+
+The editable table supports item actions rendered in a **dedicated, always-visible
+column** at the end of each row. This differs from the regular table, where
+actions appear as a floating overlay on hover.
+
+- Up to two **primary** actions are shown as icon buttons.
+- Remaining actions are grouped in an ellipsis dropdown menu.
+- The column is always visible — no hover required.
+
+Define `itemActions` in `useDataCollectionSource` the same way as for any other
+visualization:
+
+```tsx
+const dataSource = useDataCollectionSource({
+  itemActions: (item) => [
+    {
+      label: "Edit",
+      icon: Pencil,
+      onClick: () => console.log(`Editing ${item.name}`),
+      type: "primary",
+    },
+    {
+      label: "Delete",
+      icon: Delete,
+      onClick: () => console.log(`Deleting ${item.name}`),
+      critical: true,
+    },
+  ],
+})
+```
+
+<Canvas of={EditableTableStories.EditableTableWithItemActions} />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -4,6 +4,7 @@ import { useMemo, useRef, useState } from "react"
 import { action } from "storybook/actions"
 
 import { createDataSourceDefinition, RecordType } from "@/hooks/datasource"
+import { Delete, Pencil } from "@/icons/app"
 import { ROLES_MOCK } from "@/mocks"
 
 import { OneDataCollection } from "../../.."
@@ -1075,6 +1076,122 @@ export const TableAndEditableTable: Story = {
         ]}
         dataAdapter={dataAdapter}
         id="table-and-editable/v1"
+      />
+    )
+  },
+}
+
+export const EditableTableWithItemActions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Editable table with item actions rendered in a dedicated, always-visible column. Up to two primary actions appear as buttons, with remaining actions in a dropdown menu. This differs from the regular table where actions appear on hover.",
+      },
+    },
+  },
+  render: () => {
+    const mockVisualizations = getMockVisualizations()
+    const { dataAdapter, onCellChange } = useEditableTableData()
+
+    const baseOptions = (
+      mockVisualizations.editableTable as Extract<
+        typeof mockVisualizations.editableTable,
+        { type: "editableTable" }
+      >
+    ).options
+
+    const source = useDataCollectionSource({
+      dataAdapter,
+      itemActions: (item) => [
+        {
+          label: "Edit",
+          icon: Pencil,
+          onClick: () => action("edit")(`Editing ${item.name}`),
+          type: "primary" as const,
+        },
+        {
+          label: "Delete",
+          icon: Delete,
+          onClick: () => action("delete")(`Deleting ${item.name}`),
+          type: "primary" as const,
+          critical: true,
+        },
+      ],
+    })
+
+    return (
+      <OneDataCollection
+        source={source}
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              ...baseOptions,
+              onCellChange,
+            },
+          },
+        ]}
+        id="editable-table-item-actions/v1"
+      />
+    )
+  },
+}
+
+export const EditableTableWithIconOnlyActions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Editable table with icon-only action buttons using `hideLabel`. The label is still used for the tooltip and accessibility, but only the icon is rendered in the button.",
+      },
+    },
+  },
+  render: () => {
+    const mockVisualizations = getMockVisualizations()
+    const { dataAdapter, onCellChange } = useEditableTableData()
+
+    const baseOptions = (
+      mockVisualizations.editableTable as Extract<
+        typeof mockVisualizations.editableTable,
+        { type: "editableTable" }
+      >
+    ).options
+
+    const source = useDataCollectionSource({
+      dataAdapter,
+      itemActions: (item) => [
+        {
+          label: "Edit",
+          icon: Pencil,
+          onClick: () => action("edit")(`Editing ${item.name}`),
+          type: "primary" as const,
+          hideLabel: true,
+        },
+        {
+          label: "Delete",
+          icon: Delete,
+          onClick: () => action("delete")(`Deleting ${item.name}`),
+          type: "primary" as const,
+          critical: true,
+          hideLabel: true,
+        },
+      ],
+    })
+
+    return (
+      <OneDataCollection
+        source={source}
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              ...baseOptions,
+              onCellChange,
+            },
+          },
+        ]}
+        id="editable-table-icon-only-actions/v1"
       />
     )
   },

--- a/packages/react/src/patterns/OneDataCollection/components/itemActions/ItemActionsRow/ItemActionsRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/itemActions/ItemActionsRow/ItemActionsRow.tsx
@@ -3,9 +3,9 @@ import {
   DropdownItem,
   DropdownItemSeparator,
 } from "@/experimental/Navigation/Dropdown/internal"
+import { cn } from "@/lib/utils"
 import { ItemActionsDropdown } from "@/patterns/OneDataCollection/components/itemActions/ItemActionsDropdown"
 import { ActionDefinition } from "@/patterns/OneDataCollection/item-actions"
-import { cn } from "@/lib/utils"
 
 type ItemActionsRowProps = {
   className?: string
@@ -21,11 +21,17 @@ export const ItemActionsRow = ({
   handleDropDownOpenChange,
 }: ItemActionsRowProps) => {
   return (
-    <aside className={cn("items-center justify-end gap-2 md:flex", className)}>
+    <aside
+      className={cn(
+        "pointer-events-auto items-center justify-end gap-2 md:flex",
+        className
+      )}
+    >
       {primaryItemActions.map((action) => (
         <F0Button
           key={action.label}
           label={action.label}
+          hideLabel={action.hideLabel}
           variant="outline"
           onClick={action.onClick}
           icon={action.icon}

--- a/packages/react/src/patterns/OneDataCollection/item-actions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/item-actions.tsx
@@ -1,9 +1,8 @@
-import { RecordType } from "@/hooks/datasource"
-
 import {
   DropdownItemObject,
   DropdownItemSeparator,
 } from "@/experimental/Navigation/Dropdown/internal"
+import { RecordType } from "@/hooks/datasource"
 
 export type ActionDefinition =
   | DropdownItemSeparator
@@ -11,6 +10,7 @@ export type ActionDefinition =
       onClick: () => void
       enabled?: boolean
       type?: "primary" | "secondary" | "other"
+      hideLabel?: boolean
     })
 
 export type ItemActionsDefinition<T extends RecordType> = (

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/EditableTable.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/EditableTable.tsx
@@ -82,7 +82,6 @@ export const EditableTableCollection = <
         {...props}
         rowWrapper={RowWrapper}
         cellRenderer={EditableCellRenderer}
-        showItemActions={false}
         visualizationSettings={settings.visualization?.editableTable}
         fromVisualization="editableTable"
       />

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/README.md
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/README.md
@@ -259,15 +259,15 @@ Provider that wraps each row. Normally not used directly; `EditableTableCollecti
 
 ## Differences from TableCollection
 
-| Feature                 | TableCollection | EditableTableCollection |
-| ----------------------- | --------------- | ----------------------- |
-| Editable cells          | ❌              | ✅                      |
-| `editType` on columns   | ❌              | ✅                      |
-| `editable` on columns   | ❌              | ✅ (required)           |
-| `onCellChange` callback | ❌              | ✅ (required)           |
-| Item actions            | ✅              | ❌ (disabled)           |
-| Row wrapper             | Optional        | `EditableRowProvider`   |
-| Cell renderer           | Optional        | `EditableCellRenderer`  |
+| Feature                 | TableCollection    | EditableTableCollection |
+| ----------------------- | ------------------ | ----------------------- |
+| Editable cells          | ❌                 | ✅                      |
+| `editType` on columns   | ❌                 | ✅                      |
+| `editable` on columns   | ❌                 | ✅ (required)           |
+| `onCellChange` callback | ❌                 | ✅ (required)           |
+| Item actions            | ✅ (hover overlay) | ✅ (dedicated column)   |
+| Row wrapper             | Optional           | `EditableRowProvider`   |
+| Cell renderer           | Optional           | `EditableCellRenderer`  |
 
 ---
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableTableItemActions.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableTableItemActions.test.tsx
@@ -1,0 +1,208 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import type { GroupingDefinition, SortingsDefinition } from "@/hooks/datasource"
+
+import { BaseFetchOptions, FiltersDefinition } from "@/hooks/datasource"
+import { zeroRender as render } from "@/testing/test-utils"
+import { TextCell } from "@/ui/value-display/types/text"
+
+import { DataCollectionSource } from "../../../../hooks/useDataCollectionSource/types"
+import { ItemActionsDefinition } from "../../../../item-actions"
+import { NavigationFiltersDefinition } from "../../../../navigationFilters/types"
+import { SummariesDefinition } from "../../../../summary"
+import { EditableTableCollection } from "../EditableTable"
+
+vi.mock("../../../property", () => ({
+  propertyRenderers: {
+    text: TextCell,
+  },
+}))
+
+type TestFilters = FiltersDefinition
+type TestNavigationFilters = NavigationFiltersDefinition
+type Person = {
+  id: number
+  name: string
+  email: string
+}
+
+const testData: Person[] = [
+  { id: 1, name: "John Doe", email: "john@example.com" },
+  { id: 2, name: "Jane Smith", email: "jane@example.com" },
+]
+
+const testColumns = [
+  { label: "name", render: (item: Person) => item.name },
+  { label: "email", render: (item: Person) => item.email },
+]
+
+const createTestSource = (
+  data: Person[] = testData,
+  itemActions?: ItemActionsDefinition<Person>
+): DataCollectionSource<
+  Person,
+  TestFilters,
+  SortingsDefinition,
+  SummariesDefinition,
+  ItemActionsDefinition<Person>,
+  TestNavigationFilters,
+  GroupingDefinition<Person>
+> => ({
+  currentFilters: {},
+  setCurrentFilters: vi.fn(),
+  currentSortings: null,
+  setCurrentSortings: vi.fn(),
+  currentNavigationFilters: {},
+  setCurrentNavigationFilters: vi.fn(),
+  navigationFilters: undefined,
+  currentSearch: undefined,
+  debouncedCurrentSearch: undefined,
+  setCurrentSearch: vi.fn(),
+  isLoading: false,
+  setIsLoading: vi.fn(),
+  dataAdapter: {
+    fetchData: async ({ filters: _filters }: BaseFetchOptions<TestFilters>) => {
+      return { records: data }
+    },
+  },
+  currentGrouping: undefined,
+  setCurrentGrouping: vi.fn(),
+  itemActions,
+})
+
+class MockIntersectionObserver implements IntersectionObserver {
+  root: Document | Element | null = null
+  rootMargin: string = ``
+  thresholds: readonly number[] = []
+
+  disconnect = vi.fn()
+  observe = vi.fn()
+  takeRecords = vi.fn()
+  unobserve = vi.fn()
+}
+window.IntersectionObserver = MockIntersectionObserver
+
+const renderEditableTable = (itemActions?: ItemActionsDefinition<Person>) => {
+  return render(
+    <EditableTableCollection<
+      Person,
+      TestFilters,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Person>,
+      TestNavigationFilters,
+      GroupingDefinition<Person>
+    >
+      columns={testColumns}
+      source={createTestSource(testData, itemActions)}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+    />
+  )
+}
+
+describe("EditableTable Item Actions", () => {
+  it("renders primary action buttons in the action column", async () => {
+    const itemActions: ItemActionsDefinition<Person> = () => [
+      {
+        label: "Edit",
+        type: "primary",
+        onClick: vi.fn(),
+      },
+    ]
+
+    renderEditableTable(itemActions)
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument()
+    })
+
+    // Editable table renders action buttons always visible (no hover needed)
+    // Each row should have an "Edit" button
+    const editButtons = screen.getAllByRole("button", { name: /edit/i })
+    expect(editButtons.length).toBeGreaterThanOrEqual(2) // one per row
+  })
+
+  it("calls onClick handler when an action button is clicked", async () => {
+    const user = userEvent.setup()
+    const onClickMock = vi.fn()
+
+    const itemActions: ItemActionsDefinition<Person> = () => [
+      {
+        label: "Edit",
+        type: "primary",
+        onClick: onClickMock,
+      },
+    ]
+
+    renderEditableTable(itemActions)
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument()
+    })
+
+    const editButtons = screen.getAllByRole("button", { name: /edit/i })
+    await user.click(editButtons[0])
+
+    expect(onClickMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders icon-only buttons when hideLabel is true", async () => {
+    const itemActions: ItemActionsDefinition<Person> = () => [
+      {
+        label: "Edit",
+        type: "primary",
+        onClick: vi.fn(),
+        hideLabel: true,
+      },
+    ]
+
+    renderEditableTable(itemActions)
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument()
+    })
+
+    // With hideLabel, the button label should not be visible as text
+    // but should still be accessible via the button's accessible name
+    const editButtons = screen.getAllByRole("button", { name: /edit/i })
+    expect(editButtons.length).toBeGreaterThanOrEqual(2)
+
+    // The label text should be visually hidden (sr-only), not rendered as visible text
+    // F0Button with hideLabel renders the label in a tooltip / sr-only span
+    const firstButton = editButtons[0]
+
+    // The label should be visually hidden via sr-only
+    const hiddenLabel = firstButton.querySelector(".sr-only")
+    expect(hiddenLabel).toBeInTheDocument()
+    expect(hiddenLabel).toHaveTextContent("Edit")
+  })
+
+  it("renders dropdown menu for secondary actions", async () => {
+    const itemActions: ItemActionsDefinition<Person> = () => [
+      {
+        label: "Edit",
+        type: "primary",
+        onClick: vi.fn(),
+      },
+      {
+        label: "Delete",
+        type: "secondary",
+        onClick: vi.fn(),
+      },
+    ]
+
+    renderEditableTable(itemActions)
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument()
+    })
+
+    // Secondary actions go into the dropdown menu trigger
+    const dropdownButtons = screen.getAllByRole("button", { name: /actions/i })
+    expect(dropdownButtons.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -4,8 +4,6 @@ import { Fragment, useEffect, useMemo, useState } from "react"
 import { F0Button } from "@/components/F0Button"
 import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
 import { F0Checkbox } from "@/components/F0Checkbox"
-import { PagesPagination } from "@/patterns/OneDataCollection/components/PagesPagination"
-import { useDataCollectionSettings } from "@/patterns/OneDataCollection/Settings/SettingsProvider"
 import {
   OneTable,
   TableBody,
@@ -30,6 +28,8 @@ import {
 import { Add } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
+import { PagesPagination } from "@/patterns/OneDataCollection/components/PagesPagination"
+import { useDataCollectionSettings } from "@/patterns/OneDataCollection/Settings/SettingsProvider"
 import { GroupHeader } from "@/ui/GroupHeader/index"
 import { Skeleton } from "@/ui/skeleton.tsx"
 
@@ -175,6 +175,11 @@ export const TableCollection = <
   const { currentSortings, setCurrentSortings, isLoading } = source
 
   const showItemActions = showItemActionsProp !== false && !!source.itemActions
+
+  // Editable tables render actions as a single dedicated column,
+  // while the regular table uses two columns (desktop overlay + mobile dropdown).
+  const isEditableTable = fromVisualization === "editableTable"
+  const actionColCount = isEditableTable ? 1 : 2
 
   const effectiveSource = useMemo(
     () =>
@@ -352,7 +357,8 @@ export const TableCollection = <
     paginationInfo?.total !== undefined &&
     paginationInfo.total > allSelectedStatus.selectedCount
 
-  const selectionHeaderColSpan = columns.length + (showItemActions ? 2 : 0)
+  const selectionHeaderColSpan =
+    columns.length + (showItemActions ? actionColCount : 0)
 
   const selectedText =
     allSelectedStatus.selectedCount === 1
@@ -469,20 +475,31 @@ export const TableCollection = <
                         </TableHead>
                       )
                     })}
-                    {showItemActions && (
-                      <>
-                        <th className="hidden md:table-cell" />
+                    {showItemActions &&
+                      (isEditableTable ? (
                         <TableHead
-                          hidden
-                          width={68}
                           key="actions"
                           sticky={{ right: 0 }}
-                          className="table-cell md:hidden"
+                          className="border-0 border-l-[1px] border-solid border-f1-border-secondary"
                         >
-                          <span />
+                          <span className="sr-only">
+                            {i18n.collections.actions.actions}
+                          </span>
                         </TableHead>
-                      </>
-                    )}
+                      ) : (
+                        <>
+                          <th className="hidden md:table-cell" />
+                          <TableHead
+                            hidden
+                            width={68}
+                            key="actions"
+                            sticky={{ right: 0 }}
+                            className="table-cell md:hidden"
+                          >
+                            <span />
+                          </TableHead>
+                        </>
+                      ))}
                   </TableRow>
                 ) : null}
                 <TableRow>
@@ -556,22 +573,31 @@ export const TableCollection = <
                       </TableHead>
                     )
                   })}
-                  {showItemActions && (
-                    <>
-                      <th className="hidden md:table-cell"></th>
+                  {showItemActions &&
+                    (isEditableTable ? (
                       <TableHead
                         key="actions"
-                        width={68}
-                        hidden
-                        sticky={{
-                          right: 0,
-                        }}
-                        className="table-cell md:hidden"
+                        sticky={{ right: 0 }}
+                        className="border-0 border-l-[1px] border-solid border-f1-border-secondary"
                       >
-                        {i18n.collections.actions.actions}
+                        <span />
                       </TableHead>
-                    </>
-                  )}
+                    ) : (
+                      <>
+                        <th className="hidden md:table-cell"></th>
+                        <TableHead
+                          key="actions"
+                          width={68}
+                          hidden
+                          sticky={{
+                            right: 0,
+                          }}
+                          className="table-cell md:hidden"
+                        >
+                          {i18n.collections.actions.actions}
+                        </TableHead>
+                      </>
+                    ))}
                 </TableRow>
               </>
             )}
@@ -645,6 +671,7 @@ export const TableCollection = <
                               rowWrapper={RowWrapper}
                               cellRenderer={cellRenderer}
                               headerGroups={headerGroups}
+                              fromVisualization={fromVisualization}
                             />
                           )
                           if (RowWrapper) {
@@ -816,21 +843,30 @@ export const TableCollection = <
                         )}
                       </TableCell>
                     ))}
-                    {showItemActions && (
-                      <>
-                        <th className="hidden md:table-cell"></th>
+                    {showItemActions &&
+                      (isEditableTable ? (
                         <TableCell
                           key="summary-actions"
-                          width={68}
-                          sticky={{
-                            right: 0,
-                          }}
-                          className="table-cell md:hidden"
+                          sticky={{ right: 0 }}
+                          className="border-0 border-l-[1px] border-solid border-f1-border-secondary"
                         >
                           {""}
                         </TableCell>
-                      </>
-                    )}
+                      ) : (
+                        <>
+                          <th className="hidden md:table-cell"></th>
+                          <TableCell
+                            key="summary-actions"
+                            width={68}
+                            sticky={{
+                              right: 0,
+                            }}
+                            className="table-cell md:hidden"
+                          >
+                            {""}
+                          </TableCell>
+                        </>
+                      ))}
                   </TableRow>
                 )}
                 {actions.length > 0 && (
@@ -839,7 +875,7 @@ export const TableCollection = <
                       colSpan={
                         columns.length +
                         (source.selectable ? 1 : 0) +
-                        (showItemActions ? 2 : 0)
+                        (showItemActions ? actionColCount : 0)
                       }
                       className="h-[48px] align-middle"
                     >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -327,7 +327,22 @@ const RowComponentInner = <
       {hasItemActions &&
         !loading &&
         !nestedRowProps?.onLoadMoreChildren &&
-        !nestedRowProps?.onAddRow && (
+        !nestedRowProps?.onAddRow &&
+        (fromVisualization === "editableTable" ? (
+          <TableCell
+            key={`table-cell-${groupIndex}-${index}-actions`}
+            sticky={{ right: 0 }}
+            referenceRowType={referenceRowType}
+            className="border-0 border-b-[1px] border-l-[1px] border-solid border-f1-border-secondary bg-f1-background !px-3 align-middle"
+          >
+            <ItemActionsRow
+              className="flex flex-nowrap justify-center"
+              primaryItemActions={primaryItemActions}
+              dropdownItemActions={dropdownItemActions}
+              handleDropDownOpenChange={handleDropDownOpenChange}
+            />
+          </TableCell>
+        ) : (
           <>
             {/** Desktop item actions adds a sticky column to the table to not overflow when the table is scrolled horizontally*/}
             <td className="sticky right-0 top-0 z-10 hidden md:table-cell">
@@ -356,7 +371,7 @@ const RowComponentInner = <
               />
             </TableCell>
           </>
-        )}
+        ))}
     </TableRow>
   )
 }


### PR DESCRIPTION
## Description

Enable item actions support for the editable table visualization in OneDataCollection. Instead of the floating hover-reveal overlay used by the regular table, the editable table renders actions in a dedicated, always-visible sticky column with primary action buttons and a dropdown menu. The column includes the same shadow indicator used by frozen columns to signal scrollable content behind it.
Also adds a hideLabel option to ActionDefinition, allowing consumers to render action buttons as icon-only while preserving the label for tooltip and accessibility.

Changes:
- Removed showItemActions={false} from EditableTable.tsx to enable item actions
- Added conditional rendering in Row.tsx: editable table gets a single sticky TableCell column with ItemActionsRow; regular table keeps existing desktop overlay + mobile dropdown behavior
- Updated Table.tsx with actionColCount to correctly handle colspan differences between editable (1 column) and regular (2 columns)
- Added pointer-events-auto to ItemActionsRow's <aside> to fix button clicks inside TableCell's pointer-events-none wrapper
- Added hideLabel?: boolean to ActionDefinition type and forwarded it to F0Button in ItemActionsRow
- Updated documentation: editable-table.mdx, actions.mdx, and README.md
Added two new stories: EditableTableWithItemActions showing the dedicated action column, and EditableTableWithIconOnlyActions demonstrating hideLabel for icon-only action buttons

## Screenshots

editable table actions story

<img width="1859" height="715" alt="editable table actions story" src="https://github.com/user-attachments/assets/1e7a9142-89e5-42f8-bf2d-57327c42da5b" />

story without showing labels

<img width="1851" height="716" alt="editable table without labels story" src="https://github.com/user-attachments/assets/27892706-9e3e-4c86-b438-7e7179015215" />

example with scroll (sticky to the right)

<img width="791" height="491" alt="example sticky right" src="https://github.com/user-attachments/assets/83ca6e1f-bd51-42a2-af64-2b86c8f7ad47" />

example of use case in factorial

<img width="1651" height="804" alt="example use case" src="https://github.com/user-attachments/assets/1a6ece10-8781-4fa7-8510-1826fd03969e" />
