### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.449.2",
+  "packages/react": "1.450.0",
   "packages/react-native": "0.50.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.450.0](https://github.com/factorialco/f0/compare/f0-react-v1.449.2...f0-react-v1.450.0) (2026-04-16)
+
+
+### Features
+
+* changes in one form actions ([#3906](https://github.com/factorialco/f0/issues/3906)) ([74d891e](https://github.com/factorialco/f0/commit/74d891ec5b566f6508d08d0c49b19e9b16a0aa7e))
+
 ## [1.449.2](https://github.com/factorialco/f0/compare/f0-react-v1.449.1...f0-react-v1.449.2) (2026-04-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.449.2",
+  "version": "1.450.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.450.0</summary>

## [1.450.0](https://github.com/factorialco/f0/compare/f0-react-v1.449.2...f0-react-v1.450.0) (2026-04-16)


### Features

* changes in one form actions ([#3906](https://github.com/factorialco/f0/issues/3906)) ([74d891e](https://github.com/factorialco/f0/commit/74d891ec5b566f6508d08d0c49b19e9b16a0aa7e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).