### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.450.0",
+  "packages/react": "1.450.1",
   "packages/react-native": "0.50.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.450.1](https://github.com/factorialco/f0/compare/f0-react-v1.450.0...f0-react-v1.450.1) (2026-04-16)
+
+
+### Bug Fixes
+
+* **EditableTable:** improve nested row add button alignment and number cell clamping ([#3947](https://github.com/factorialco/f0/issues/3947)) ([3965a19](https://github.com/factorialco/f0/commit/3965a199993208fea4706f1279778801b63aded6))
+
 ## [1.450.0](https://github.com/factorialco/f0/compare/f0-react-v1.449.2...f0-react-v1.450.0) (2026-04-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.450.0",
+  "version": "1.450.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.450.1</summary>

## [1.450.1](https://github.com/factorialco/f0/compare/f0-react-v1.450.0...f0-react-v1.450.1) (2026-04-16)


### Bug Fixes

* **EditableTable:** improve nested row add button alignment and number cell clamping ([#3947](https://github.com/factorialco/f0/issues/3947)) ([3965a19](https://github.com/factorialco/f0/commit/3965a199993208fea4706f1279778801b63aded6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).