### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.450.1",
-  "packages/react-native": "0.50.0",
+  "packages/react-native": "0.51.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.51.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.50.0...f0-react-native-v0.51.0) (2026-04-16)
+
+
+### Features
+
+* **F0Tabs:** improvements and changes ([#3948](https://github.com/factorialco/f0/issues/3948)) ([488dfff](https://github.com/factorialco/f0/commit/488dfff3db73b2aa2888fec0dfcc5eeea7a1fd1f))
+
 ## [0.50.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.49.1...f0-react-native-v0.50.0) (2026-04-15)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.51.0</summary>

## [0.51.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.50.0...f0-react-native-v0.51.0) (2026-04-16)


### Features

* **F0Tabs:** improvements and changes ([#3948](https://github.com/factorialco/f0/issues/3948)) ([488dfff](https://github.com/factorialco/f0/commit/488dfff3db73b2aa2888fec0dfcc5eeea7a1fd1f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).