### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.451.0",
+  "packages/react": "1.452.0",
   "packages/react-native": "0.51.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.452.0](https://github.com/factorialco/f0/compare/f0-react-v1.451.0...f0-react-v1.452.0) (2026-04-17)
+
+
+### Features
+
+* add VacancyEntityRef and RequisitionEntityRef ([#3954](https://github.com/factorialco/f0/issues/3954)) ([8df32c4](https://github.com/factorialco/f0/commit/8df32c490d47706afef4b2cf72824a0074d5e91c))
+
 ## [1.451.0](https://github.com/factorialco/f0/compare/f0-react-v1.450.1...f0-react-v1.451.0) (2026-04-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.451.0",
+  "version": "1.452.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.452.0</summary>

## [1.452.0](https://github.com/factorialco/f0/compare/f0-react-v1.451.0...f0-react-v1.452.0) (2026-04-17)


### Features

* add VacancyEntityRef and RequisitionEntityRef ([#3954](https://github.com/factorialco/f0/issues/3954)) ([8df32c4](https://github.com/factorialco/f0/commit/8df32c490d47706afef4b2cf72824a0074d5e91c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).