### PR TITLE
feat: allow to format fields properly in FormCard

### DIFF
--- a/packages/react/src/experimental/Lists/DetailsItem/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils"
 
 import { DataList } from "../DataList"
 
-type Content =
+export type DetailsItemContent =
   | (ComponentProps<typeof DataList.Item> & {
       type: "item"
     })
@@ -58,12 +58,18 @@ type Content =
 
 export interface DetailsItemType {
   title: string
-  content: Content | Content[]
+  content: DetailsItemContent | DetailsItemContent[]
   isHorizontal?: boolean
+  /**
+   * When true inside a tableView, keeps the table-row padding but stacks
+   * the label above the content instead of side-by-side. Useful for
+   * long-form text fields like rich-text or textarea.
+   */
+  verticalLayout?: boolean
   spacingAtTheBottom?: boolean
 }
 
-const ItemContent: FC<{ content: Content }> = ({ content }) => (
+const ItemContent: FC<{ content: DetailsItemContent }> = ({ content }) => (
   <>
     {content.type === "weekdays" && (
       <li className="list-none px-1.5 py-1">
@@ -92,7 +98,13 @@ const ItemContent: FC<{ content: Content }> = ({ content }) => (
 
 const _DetailsItem = forwardRef<HTMLDivElement, DetailsItemType>(
   function DetailsItem(
-    { title, content, isHorizontal = false, spacingAtTheBottom },
+    {
+      title,
+      content,
+      isHorizontal = false,
+      verticalLayout = false,
+      spacingAtTheBottom,
+    },
     ref
   ) {
     const contentArray = Array.isArray(content) ? content : [content]
@@ -103,7 +115,10 @@ const _DetailsItem = forwardRef<HTMLDivElement, DetailsItemType>(
         className={cn(
           "flex flex-col gap-0.5",
           spacingAtTheBottom && !isHorizontal && "pb-3",
-          isHorizontal && "xs:[&_ul>li]:p-0 [&_ul]:flex-1"
+          isHorizontal && !verticalLayout && "xs:[&_ul>li]:p-0 [&_ul]:flex-1",
+          isHorizontal &&
+            verticalLayout &&
+            "[&_ul>li>*]:px-0 [&_ul]:flex-1 xs:[&>div]:flex-col"
         )}
       >
         <DataList label={title} isHorizontal={isHorizontal}>

--- a/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
@@ -54,6 +54,7 @@ const _DetailsItemsList = forwardRef<HTMLDivElement, DetailsItemsListProps>(
                   content={item.content}
                   spacingAtTheBottom={item.spacingAtTheBottom}
                   isHorizontal={tableView}
+                  verticalLayout={item.verticalLayout}
                 />
                 {tableView && index !== details.length - 1 && (
                   <div className="h-[1px] w-full bg-f1-border-secondary" />

--- a/packages/react/src/lib/providers/f0/f0-provider.tsx
+++ b/packages/react/src/lib/providers/f0/f0-provider.tsx
@@ -8,6 +8,10 @@ import {
 } from "react"
 import { useIsomorphicLayoutEffect } from "usehooks-ts"
 
+import type { F0FormLikeComponent } from "@/patterns/F0Form/types"
+
+import { FormCardValueFormatterProvider } from "@/sds/ai/F0AiChat/providers/FormCardValueFormatterProvider"
+
 import { ImageContextValue, ImageProvider } from "../../imageHandler"
 import { LinkContextValue, LinkProvider } from "../../linkHandler"
 import { PrivacyModeProvider } from "../../privacyMode"
@@ -18,8 +22,6 @@ import { DataCollectionStorageHandler } from "../datacollection/types"
 import { I18nProvider, I18nProviderProps } from "../i18n"
 import { L10nProvider, L10nProviderProps } from "../l10n"
 import { UserPlatformProvider } from "../user-platafform"
-
-import type { F0FormLikeComponent } from "@/patterns/F0Form/types"
 
 interface LayoutProps {
   fullScreen?: boolean
@@ -134,7 +136,9 @@ export const F0Provider: React.FC<{
                         handler={dataCollectionStorageHandler}
                       >
                         <FormComponentContext.Provider value={formComponent}>
-                          {children}
+                          <FormCardValueFormatterProvider>
+                            {children}
+                          </FormCardValueFormatterProvider>
                         </FormComponentContext.Provider>
                       </DataCollectionStorageProvider>
                     </ImageProvider>

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -563,6 +563,8 @@ export const defaultTranslations = {
     },
   },
   forms: {
+    yes: "Yes",
+    no: "No",
     actionBar: {
       unsavedChanges: "You have changes pending to be saved",
       saving: "Saving...",

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCard.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCard.tsx
@@ -50,6 +50,11 @@ function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, "").trim()
 }
 
+function capitalizeFirst(text: string): string {
+  if (!text) return text
+  return text.charAt(0).toUpperCase() + text.slice(1)
+}
+
 function formatDuration(totalSeconds: number): string {
   const { days, hours, minutes, seconds } = secondsToFields(totalSeconds)
   const parts: string[] = []
@@ -132,7 +137,7 @@ function formatFieldContent(
     return { type: "item", text: JSON.stringify(value) }
   }
 
-  return { type: "item", text: String(value) }
+  return { type: "item", text: capitalizeFirst(String(value)) }
 }
 
 function extractText(content: DetailsItemContent): string {

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCard.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCard.tsx
@@ -47,7 +47,15 @@ export type FormCardProps = {
 }
 
 function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "").trim()
+  if (typeof DOMParser !== "undefined") {
+    const doc = new DOMParser().parseFromString(html, "text/html")
+    return doc.body.textContent?.replace(/\s+/g, " ").trim() ?? ""
+  }
+
+  return html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
 }
 
 function capitalizeFirst(text: string): string {
@@ -95,7 +103,8 @@ function formatFieldContent(
     "value" in value
   ) {
     const html = (value as { value: string | null }).value
-    return { type: "item", text: html ? stripHtml(html) : "—" }
+    const text = html ? stripHtml(html) : ""
+    return { type: "item", text: text || "—" }
   }
 
   if (
@@ -121,7 +130,7 @@ function formatFieldContent(
   if (Array.isArray(value)) {
     const texts = value
       .map((v) => {
-        const content = formatFieldContent(v)
+        const content = formatFieldContent(v, undefined, booleanLabels)
         if (Array.isArray(content)) return content.map(extractText).join(", ")
         return extractText(content)
       })

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCard.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCard.tsx
@@ -7,6 +7,7 @@ import { useI18n } from "@/lib/providers/i18n"
 
 import { useAutoOpenCanvas } from "../../../hooks/useAutoOpenCanvas"
 import { useAiChat } from "../../../providers/AiChatStateProvider"
+import { useFormCardValueFormatter } from "../../../providers/FormCardValueFormatterProvider"
 import { CanvasCard } from "../../components/CanvasCard"
 
 const MAX_VISIBLE_FIELDS = 7
@@ -157,6 +158,8 @@ export function FormCard({
 }: FormCardProps) {
   const { canvasContent, openCanvas, closeCanvas } = useAiChat()
   const i18n = useI18n()
+  const contextFormatter = useFormCardValueFormatter(formName)
+  const resolvedFormatter = valueFormatter ?? contextFormatter
 
   const title = cardTitle ?? formName
   const description = cardDescription ?? formDescription ?? ""
@@ -181,7 +184,7 @@ export function FormCard({
       ? Object.entries(fieldDescriptions)
           .map(([key, meta]) => {
             const raw = formValues[key]
-            const custom = valueFormatter?.(key, raw, {
+            const custom = resolvedFormatter?.(key, raw, {
               fieldType: meta.fieldType,
               customFieldName: meta.customFieldName,
             })

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCard.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCard.tsx
@@ -1,11 +1,27 @@
 import type { ModuleId } from "@/components/avatars/F0AvatarModule"
+import type { DetailsItemContent } from "@/experimental/Lists/DetailsItem"
+
+import { secondsToFields } from "@/components/F0DurationInput/utils"
+import { DetailsItemsList } from "@/experimental/Lists/DetailsItemsList"
+import { useI18n } from "@/lib/providers/i18n"
 
 import { useAutoOpenCanvas } from "../../../hooks/useAutoOpenCanvas"
 import { useAiChat } from "../../../providers/AiChatStateProvider"
 import { CanvasCard } from "../../components/CanvasCard"
-import { DetailsItemsList } from "@/experimental/Lists/DetailsItemsList"
 
 const MAX_VISIBLE_FIELDS = 7
+
+type FieldMeta = {
+  label: string
+  fieldType?: string
+  customFieldName?: string
+}
+
+export type FormCardValueFormatter = (
+  key: string,
+  value: unknown,
+  meta: { fieldType?: string; customFieldName?: string }
+) => DetailsItemContent | DetailsItemContent[] | undefined
 
 export type FormCardProps = {
   /** Unique name of the form in the registry */
@@ -19,23 +35,108 @@ export type FormCardProps = {
   /** Custom description override for the card (set by the AI via fillForm) */
   cardDescription: string
   /** Field label metadata from the form schema */
-  fieldDescriptions?: Record<
-    string,
-    {
-      label: string
-    }
-  >
+  fieldDescriptions?: Record<string, FieldMeta>
   /** Current form values */
   formValues?: Record<string, unknown>
+  /**
+   * Optional callback to format a field value into a DetailsItemContent.
+   * Return `undefined` to fall back to built-in formatting.
+   */
+  valueFormatter?: FormCardValueFormatter
 }
 
-function formatFieldValue(value: unknown): string {
-  if (value == null || value === "") return "—"
-  if (value instanceof Date) return value.toLocaleDateString()
-  if (Array.isArray(value)) return value.map(formatFieldValue).join(", ")
-  if (typeof value === "boolean") return value ? "Yes" : "No"
-  if (typeof value === "object") return JSON.stringify(value)
-  return String(value)
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, "").trim()
+}
+
+function formatDuration(totalSeconds: number): string {
+  const { days, hours, minutes, seconds } = secondsToFields(totalSeconds)
+  const parts: string[] = []
+  if (days > 0) parts.push(`${days}d`)
+  if (hours > 0) parts.push(`${hours}h`)
+  if (minutes > 0) parts.push(`${minutes}m`)
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`)
+  return parts.join(" ")
+}
+
+function isDateLike(value: unknown): value is Date | string {
+  if (value instanceof Date) return true
+  if (typeof value !== "string") return false
+  const d = new Date(value)
+  return !isNaN(d.getTime())
+}
+
+function toLocaleDateString(value: Date | string): string {
+  const d = value instanceof Date ? value : new Date(value)
+  return d.toLocaleDateString()
+}
+
+function formatFieldContent(
+  value: unknown,
+  fieldType?: string,
+  booleanLabels?: { yes: string; no: string }
+): DetailsItemContent | DetailsItemContent[] {
+  if (value == null || value === "") return { type: "item", text: "—" }
+
+  if (fieldType === "duration" && typeof value === "number") {
+    return { type: "item", text: formatDuration(value) }
+  }
+
+  if (
+    fieldType === "richtext" &&
+    typeof value === "object" &&
+    value !== null &&
+    "value" in value
+  ) {
+    const html = (value as { value: string | null }).value
+    return { type: "item", text: html ? stripHtml(html) : "—" }
+  }
+
+  if (
+    fieldType === "daterange" &&
+    typeof value === "object" &&
+    value !== null &&
+    "from" in value &&
+    "to" in value
+  ) {
+    const { from, to } = value as { from: unknown; to: unknown }
+    const fromStr = isDateLike(from) ? toLocaleDateString(from) : String(from)
+    const toStr = isDateLike(to) ? toLocaleDateString(to) : String(to)
+    return { type: "item", text: `${fromStr} – ${toStr}` }
+  }
+
+  if (value instanceof Date)
+    return { type: "item", text: value.toLocaleDateString() }
+  if (typeof value === "boolean")
+    return {
+      type: "item",
+      text: value ? (booleanLabels?.yes ?? "Yes") : (booleanLabels?.no ?? "No"),
+    }
+  if (Array.isArray(value)) {
+    const texts = value
+      .map((v) => {
+        const content = formatFieldContent(v)
+        if (Array.isArray(content)) return content.map(extractText).join(", ")
+        return extractText(content)
+      })
+      .filter(Boolean)
+    return { type: "item", text: texts.join(", ") || "—" }
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const obj = value as Record<string, unknown>
+    if (typeof obj.label === "string") return { type: "item", text: obj.label }
+    if (typeof obj.name === "string") return { type: "item", text: obj.name }
+    if (typeof obj.text === "string") return { type: "item", text: obj.text }
+    return { type: "item", text: JSON.stringify(value) }
+  }
+
+  return { type: "item", text: String(value) }
+}
+
+function extractText(content: DetailsItemContent): string {
+  if (content.type === "item") return content.text
+  return ""
 }
 
 /**
@@ -52,8 +153,10 @@ export function FormCard({
   cardDescription,
   fieldDescriptions,
   formValues,
+  valueFormatter,
 }: FormCardProps) {
   const { canvasContent, openCanvas, closeCanvas } = useAiChat()
+  const i18n = useI18n()
 
   const title = cardTitle ?? formName
   const description = cardDescription ?? formDescription ?? ""
@@ -76,13 +179,36 @@ export function FormCard({
   const fields =
     fieldDescriptions && formValues
       ? Object.entries(fieldDescriptions)
-          .map(([key, { label }]) => ({
-            label,
-            value: formatFieldValue(formValues[key]),
-          }))
-          .filter(
-            ({ value }) => value !== "" && value !== undefined && value !== null
-          )
+          .map(([key, meta]) => {
+            const raw = formValues[key]
+            const custom = valueFormatter?.(key, raw, {
+              fieldType: meta.fieldType,
+              customFieldName: meta.customFieldName,
+            })
+            // Skip custom fields with object values when no formatter handles them
+            if (
+              !custom &&
+              meta.fieldType === "custom" &&
+              typeof raw === "object" &&
+              raw !== null
+            ) {
+              return null
+            }
+            const content =
+              custom ??
+              formatFieldContent(raw, meta.fieldType, {
+                yes: i18n.forms.yes,
+                no: i18n.forms.no,
+              })
+            const verticalTypes = ["richtext", "textarea"]
+            const verticalLayout = verticalTypes.includes(meta.fieldType ?? "")
+            return { label: meta.label, content, verticalLayout }
+          })
+          .filter((f): f is NonNullable<typeof f> => {
+            if (!f) return false
+            const c = Array.isArray(f.content) ? f.content[0] : f.content
+            return !(c?.type === "item" && (c as { text: string }).text === "—")
+          })
       : []
 
   const visibleFields = fields.slice(0, MAX_VISIBLE_FIELDS)
@@ -99,14 +225,12 @@ export function FormCard({
       showOpenButton={isActive}
     >
       {visibleFields.length > 0 && !isActive && (
-        <div className="w-full flex flex-col -mx-3 overflow-hidden pb-1">
+        <div className="-mx-3 flex w-full flex-col overflow-hidden pb-1">
           <DetailsItemsList
             details={visibleFields.map((field) => ({
               title: field.label,
-              content: {
-                type: "item" as const,
-                text: field.value,
-              },
+              content: field.content,
+              ...(field.verticalLayout && { verticalLayout: true }),
             }))}
             showSeeMore={hasMore}
             onClickSeeMore={handleOpen}

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__stories__/FormCard.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__stories__/FormCard.stories.tsx
@@ -1,8 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { useEffect } from "react"
+
 import type { FormCardValueFormatter } from "../FormCard"
 
 import { AiChatStateProvider } from "../../../../providers/AiChatStateProvider"
+import {
+  FormCardValueFormatterProvider,
+  useSetFormCardValueFormatter,
+} from "../../../../providers/FormCardValueFormatterProvider"
 import { FormCard } from "../FormCard"
 
 const meta = {
@@ -246,5 +252,70 @@ export const MixedFieldTypes: Story = {
       createPerAssignee: false,
     },
     valueFormatter: customValueFormatter,
+  },
+}
+
+/**
+ * Demonstrates the provider-based approach: the formatter is registered
+ * via `useSetFormCardValueFormatter` scoped to a specific formName
+ * and customFieldName, instead of being passed as a prop.
+ */
+function RegisterFormatter() {
+  const setFormatter = useSetFormCardValueFormatter()
+
+  useEffect(() => {
+    setFormatter({
+      formName: "create-task",
+      customFieldName: "assignees_selector",
+      format: () => ({
+        type: "avatar-list",
+        avatarList: {
+          type: "person" as const,
+          size: "sm",
+          avatars: [
+            { firstName: "Alice", lastName: "Garcia", src: "" },
+            { firstName: "Bob", lastName: "Martinez", src: "" },
+          ],
+        },
+      }),
+    })
+  }, [setFormatter])
+
+  return null
+}
+
+export const WithProviderFormatter: Story = {
+  decorators: [
+    (Story) => (
+      <AiChatStateProvider enabled={false}>
+        <FormCardValueFormatterProvider>
+          <RegisterFormatter />
+          <div className="w-[420px]">
+            <Story />
+          </div>
+        </FormCardValueFormatterProvider>
+      </AiChatStateProvider>
+    ),
+  ],
+  args: {
+    formName: "create-task",
+    formDescription: "Create a new task",
+    module: "tasks",
+    cardTitle: "Create task",
+    cardDescription: "Task with provider-based formatter",
+    fieldDescriptions: {
+      taskName: { label: "Task name" },
+      assignees: {
+        label: "Assignees",
+        fieldType: "custom",
+        customFieldName: "assignees_selector",
+      },
+      dueDate: { label: "Due date" },
+    },
+    formValues: {
+      taskName: "Prepare Q3 report",
+      assignees: { type: "manual", ids: ["5", "12"] },
+      dueDate: "2026-08-01",
+    },
   },
 }

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__stories__/FormCard.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__stories__/FormCard.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import type { FormCardValueFormatter } from "../FormCard"
+
 import { AiChatStateProvider } from "../../../../providers/AiChatStateProvider"
 import { FormCard } from "../FormCard"
 
@@ -85,5 +87,164 @@ export const MoreThanSevenFields: Story = {
       department: "Engineering",
       manager: "Jane Doe",
     },
+  },
+}
+
+export const WithDurationField: Story = {
+  args: {
+    formName: "shift-config",
+    formDescription: "Configure a work shift",
+    module: "clock-in",
+    cardTitle: "Work shift",
+    cardDescription: "Morning shift configuration",
+    fieldDescriptions: {
+      shiftName: { label: "Shift name" },
+      duration: { label: "Duration", fieldType: "duration" },
+      breakDuration: { label: "Break duration", fieldType: "duration" },
+    },
+    formValues: {
+      shiftName: "Morning shift",
+      duration: 28800, // 8h
+      breakDuration: 1800, // 30m
+    },
+  },
+}
+
+export const WithRichTextField: Story = {
+  args: {
+    formName: "create-task",
+    formDescription: "Create a new task",
+    module: "tasks",
+    cardTitle: "Create task",
+    cardDescription: "New task with description",
+    fieldDescriptions: {
+      taskName: { label: "Task name" },
+      description: { label: "Description", fieldType: "richtext" },
+      priority: { label: "Priority" },
+    },
+    formValues: {
+      taskName: "Review onboarding process",
+      description: {
+        value:
+          "<p>This is a <strong>test task</strong> created with dummy data to validate the creation and assignment flow. The goal is to ensure that the name, description, and mandatory fields are properly handled.</p>",
+      },
+      priority: "High",
+    },
+  },
+}
+
+export const WithDateRangeField: Story = {
+  args: {
+    formName: "leave-request",
+    formDescription: "Request time off",
+    module: "timeoff",
+    cardTitle: "Leave request",
+    cardDescription: "Vacation request",
+    fieldDescriptions: {
+      leaveType: { label: "Leave type" },
+      period: { label: "Period", fieldType: "daterange" },
+      notes: { label: "Notes" },
+    },
+    formValues: {
+      leaveType: "Vacation",
+      period: {
+        from: new Date("2026-07-01"),
+        to: new Date("2026-07-15"),
+      },
+      notes: "Summer holidays",
+    },
+  },
+}
+
+const customValueFormatter: FormCardValueFormatter = (
+  _key,
+  _value,
+  { customFieldName }
+) => {
+  if (customFieldName === "assignees_selector") {
+    return {
+      type: "avatar-list",
+      avatarList: {
+        type: "person" as const,
+        size: "sm",
+        avatars: [
+          {
+            firstName: "Alice",
+            lastName: "Garcia",
+            src: "",
+          },
+          {
+            firstName: "Bob",
+            lastName: "Martinez",
+            src: "",
+          },
+        ],
+      },
+    }
+  }
+  return undefined
+}
+
+export const WithCustomAvatarList: Story = {
+  args: {
+    formName: "create-task",
+    formDescription: "Create a new task",
+    module: "tasks",
+    cardTitle: "Create task",
+    cardDescription: "Task with custom assignee rendering",
+    fieldDescriptions: {
+      taskName: { label: "Task name" },
+      assignees: {
+        label: "Assignees",
+        fieldType: "custom",
+        customFieldName: "assignees_selector",
+      },
+      dueDate: { label: "Due date" },
+    },
+    formValues: {
+      taskName: "Prepare Q3 report",
+      assignees: { type: "manual", ids: ["5", "12"] },
+      dueDate: "2026-08-01",
+    },
+    valueFormatter: customValueFormatter,
+  },
+}
+
+export const MixedFieldTypes: Story = {
+  args: {
+    formName: "full-task-form",
+    formDescription: "Complete task creation form",
+    module: "tasks",
+    cardTitle: "New task",
+    cardDescription: "Task with mixed field types",
+    fieldDescriptions: {
+      taskName: { label: "Task name" },
+      description: { label: "Description", fieldType: "richtext" },
+      duration: { label: "Estimated time", fieldType: "duration" },
+      period: { label: "Period", fieldType: "daterange" },
+      assignees: {
+        label: "Assignees",
+        fieldType: "custom",
+        customFieldName: "assignees_selector",
+      },
+      priority: { label: "Priority" },
+      createPerAssignee: { label: "Create one per assignee" },
+    },
+    formValues: {
+      taskName: "Review onboarding process",
+      description: {
+        value:
+          "<p>Verify that <strong>all steps</strong> of the onboarding checklist are up to date.</p>",
+      },
+      duration: 9000, // 2h 30m
+      period: {
+        from: new Date("2026-04-01"),
+        to: new Date("2026-04-30"),
+      },
+      assignees: { type: "manual", ids: ["5"] },
+      priority: "High",
+      createPerAssignee: false,
+    },
+    valueFormatter: customValueFormatter,
   },
 }

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCard.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCard.test.tsx
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi, beforeEach } from "vitest"
+import { useEffect } from "react"
 import "@testing-library/jest-dom/vitest"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
 import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
 
 import type { FormCardValueFormatter } from "../FormCard"
@@ -302,10 +304,12 @@ describe("FormCard", () => {
     it("uses formatter from FormCardValueFormatterProvider context", () => {
       function SetupFormatter() {
         const setFormatter = useSetFormCardValueFormatter()
-        setFormatter({
-          customFieldName: "team_selector",
-          format: () => ({ type: "item", text: "Engineering Team" }),
-        })
+        useEffect(() => {
+          setFormatter({
+            customFieldName: "team_selector",
+            format: () => ({ type: "item", text: "Engineering Team" }),
+          })
+        }, [setFormatter])
         return null
       }
 
@@ -332,11 +336,13 @@ describe("FormCard", () => {
     it("uses scoped formatter when registered for a specific formName", () => {
       function SetupFormatter() {
         const setFormatter = useSetFormCardValueFormatter()
-        setFormatter({
-          formName: "edit-employee",
-          customFieldName: "team_selector",
-          format: () => ({ type: "item", text: "Scoped Team" }),
-        })
+        useEffect(() => {
+          setFormatter({
+            formName: "edit-employee",
+            customFieldName: "team_selector",
+            format: () => ({ type: "item", text: "Scoped Team" }),
+          })
+        }, [setFormatter])
         return null
       }
 
@@ -363,10 +369,12 @@ describe("FormCard", () => {
     it("does not apply scoped formatter to a different formName", () => {
       function SetupFormatter() {
         const setFormatter = useSetFormCardValueFormatter()
-        setFormatter({
-          formName: "other-form",
-          format: () => ({ type: "item", text: "Should not appear" }),
-        })
+        useEffect(() => {
+          setFormatter({
+            formName: "other-form",
+            format: () => ({ type: "item", text: "Should not appear" }),
+          })
+        }, [setFormatter])
         return null
       }
 
@@ -390,13 +398,15 @@ describe("FormCard", () => {
     it("scoped formatter takes precedence over global formatter", () => {
       function SetupFormatters() {
         const setFormatter = useSetFormCardValueFormatter()
-        setFormatter({
-          format: () => ({ type: "item", text: "From global" }),
-        })
-        setFormatter({
-          formName: "edit-employee",
-          format: () => ({ type: "item", text: "From scoped" }),
-        })
+        useEffect(() => {
+          setFormatter({
+            format: () => ({ type: "item", text: "From global" }),
+          })
+          setFormatter({
+            formName: "edit-employee",
+            format: () => ({ type: "item", text: "From scoped" }),
+          })
+        }, [setFormatter])
         return null
       }
 
@@ -420,9 +430,11 @@ describe("FormCard", () => {
     it("prop valueFormatter takes precedence over context formatter", () => {
       function SetupFormatter() {
         const setFormatter = useSetFormCardValueFormatter()
-        setFormatter({
-          format: () => ({ type: "item", text: "From context" }),
-        })
+        useEffect(() => {
+          setFormatter({
+            format: () => ({ type: "item", text: "From context" }),
+          })
+        }, [setFormatter])
         return null
       }
 

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCard.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCard.test.tsx
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi, beforeEach } from "vitest"
 import "@testing-library/jest-dom/vitest"
-
 import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
 
 import type { FormCardValueFormatter } from "../FormCard"
+
+import {
+  FormCardValueFormatterProvider,
+  useSetFormCardValueFormatter,
+} from "../../../../providers/FormCardValueFormatterProvider"
 
 const mockOpenCanvas = vi.fn()
 const mockCloseCanvas = vi.fn()
@@ -293,6 +297,156 @@ describe("FormCard", () => {
       )
 
       expect(screen.getByText("Yes")).toBeInTheDocument()
+    })
+
+    it("uses formatter from FormCardValueFormatterProvider context", () => {
+      function SetupFormatter() {
+        const setFormatter = useSetFormCardValueFormatter()
+        setFormatter({
+          customFieldName: "team_selector",
+          format: () => ({ type: "item", text: "Engineering Team" }),
+        })
+        return null
+      }
+
+      render(
+        <FormCardValueFormatterProvider>
+          <SetupFormatter />
+          <FormCard
+            {...defaultProps}
+            fieldDescriptions={{
+              team: {
+                label: "Team",
+                fieldType: "custom",
+                customFieldName: "team_selector",
+              },
+            }}
+            formValues={{ team: { id: 1, name: "eng" } }}
+          />
+        </FormCardValueFormatterProvider>
+      )
+
+      expect(screen.getByText("Engineering Team")).toBeInTheDocument()
+    })
+
+    it("uses scoped formatter when registered for a specific formName", () => {
+      function SetupFormatter() {
+        const setFormatter = useSetFormCardValueFormatter()
+        setFormatter({
+          formName: "edit-employee",
+          customFieldName: "team_selector",
+          format: () => ({ type: "item", text: "Scoped Team" }),
+        })
+        return null
+      }
+
+      render(
+        <FormCardValueFormatterProvider>
+          <SetupFormatter />
+          <FormCard
+            {...defaultProps}
+            fieldDescriptions={{
+              team: {
+                label: "Team",
+                fieldType: "custom",
+                customFieldName: "team_selector",
+              },
+            }}
+            formValues={{ team: { id: 1, name: "eng" } }}
+          />
+        </FormCardValueFormatterProvider>
+      )
+
+      expect(screen.getByText("Scoped Team")).toBeInTheDocument()
+    })
+
+    it("does not apply scoped formatter to a different formName", () => {
+      function SetupFormatter() {
+        const setFormatter = useSetFormCardValueFormatter()
+        setFormatter({
+          formName: "other-form",
+          format: () => ({ type: "item", text: "Should not appear" }),
+        })
+        return null
+      }
+
+      render(
+        <FormCardValueFormatterProvider>
+          <SetupFormatter />
+          <FormCard
+            {...defaultProps}
+            fieldDescriptions={{
+              name: { label: "Name" },
+            }}
+            formValues={{ name: "Test value" }}
+          />
+        </FormCardValueFormatterProvider>
+      )
+
+      expect(screen.getByText("Test value")).toBeInTheDocument()
+      expect(screen.queryByText("Should not appear")).not.toBeInTheDocument()
+    })
+
+    it("scoped formatter takes precedence over global formatter", () => {
+      function SetupFormatters() {
+        const setFormatter = useSetFormCardValueFormatter()
+        setFormatter({
+          format: () => ({ type: "item", text: "From global" }),
+        })
+        setFormatter({
+          formName: "edit-employee",
+          format: () => ({ type: "item", text: "From scoped" }),
+        })
+        return null
+      }
+
+      render(
+        <FormCardValueFormatterProvider>
+          <SetupFormatters />
+          <FormCard
+            {...defaultProps}
+            fieldDescriptions={{
+              name: { label: "Name" },
+            }}
+            formValues={{ name: "test" }}
+          />
+        </FormCardValueFormatterProvider>
+      )
+
+      expect(screen.getByText("From scoped")).toBeInTheDocument()
+      expect(screen.queryByText("From global")).not.toBeInTheDocument()
+    })
+
+    it("prop valueFormatter takes precedence over context formatter", () => {
+      function SetupFormatter() {
+        const setFormatter = useSetFormCardValueFormatter()
+        setFormatter({
+          format: () => ({ type: "item", text: "From context" }),
+        })
+        return null
+      }
+
+      const propFormatter: FormCardValueFormatter = () => ({
+        type: "item",
+        text: "From prop",
+      })
+
+      render(
+        <FormCardValueFormatterProvider>
+          <SetupFormatter />
+          <FormCard
+            {...defaultProps}
+            fieldDescriptions={{
+              name: { label: "Name" },
+            }}
+            formValues={{ name: "test" }}
+            valueFormatter={propFormatter}
+          />
+        </FormCardValueFormatterProvider>
+      )
+
+      expect(screen.getByText("From prop")).toBeInTheDocument()
+      expect(screen.queryByText("From context")).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCard.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCard.test.tsx
@@ -3,6 +3,8 @@ import "@testing-library/jest-dom/vitest"
 
 import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
 
+import type { FormCardValueFormatter } from "../FormCard"
+
 const mockOpenCanvas = vi.fn()
 const mockCloseCanvas = vi.fn()
 let mockCanvasContent: Record<string, unknown> | null = null
@@ -112,6 +114,185 @@ describe("FormCard", () => {
       formName: "edit-employee",
       formDescription: "Edit an employee",
       formModule: "people",
+    })
+  })
+
+  describe("field value formatting", () => {
+    it("formats duration fields as compact time string", () => {
+      render(
+        <FormCard
+          {...defaultProps}
+          fieldDescriptions={{
+            shiftDuration: { label: "Duration", fieldType: "duration" },
+          }}
+          formValues={{ shiftDuration: 9000 }}
+        />
+      )
+
+      expect(screen.getByText("2h 30m")).toBeInTheDocument()
+    })
+
+    it("formats zero-second duration as 0s", () => {
+      render(
+        <FormCard
+          {...defaultProps}
+          fieldDescriptions={{
+            dur: { label: "Duration", fieldType: "duration" },
+          }}
+          formValues={{ dur: 0 }}
+        />
+      )
+
+      expect(screen.getByText("0s")).toBeInTheDocument()
+    })
+
+    it("strips HTML from rich text values", () => {
+      render(
+        <FormCard
+          {...defaultProps}
+          fieldDescriptions={{
+            desc: { label: "Description", fieldType: "richtext" },
+          }}
+          formValues={{
+            desc: {
+              value: "<p>Some <strong>bold</strong> text</p>",
+            },
+          }}
+        />
+      )
+
+      expect(screen.getByText("Some bold text")).toBeInTheDocument()
+    })
+
+    it("shows dash for richtext with null value", () => {
+      render(
+        <FormCard
+          {...defaultProps}
+          fieldDescriptions={{
+            desc: { label: "Description", fieldType: "richtext" },
+          }}
+          formValues={{
+            desc: { value: null },
+          }}
+        />
+      )
+
+      // Empty richtext → filtered out (shown as dash)
+      expect(screen.queryByText("Description")).not.toBeInTheDocument()
+    })
+
+    it("formats daterange as from – to", () => {
+      render(
+        <FormCard
+          {...defaultProps}
+          fieldDescriptions={{
+            period: { label: "Period", fieldType: "daterange" },
+          }}
+          formValues={{
+            period: {
+              from: new Date("2026-04-01"),
+              to: new Date("2026-04-30"),
+            },
+          }}
+        />
+      )
+
+      expect(screen.getByText("Period")).toBeInTheDocument()
+      // The text should contain a dash between two dates
+      const text = screen.getByText(/–/)
+      expect(text).toBeInTheDocument()
+    })
+
+    it("extracts label from objects with a label property", () => {
+      render(
+        <FormCard
+          {...defaultProps}
+          fieldDescriptions={{
+            status: { label: "Status" },
+          }}
+          formValues={{
+            status: { label: "In progress", id: 3 },
+          }}
+        />
+      )
+
+      expect(screen.getByText("In progress")).toBeInTheDocument()
+    })
+
+    it("uses valueFormatter when provided", () => {
+      const formatter: FormCardValueFormatter = (_key, _value, meta) => {
+        if (meta.customFieldName === "assignees_selector") {
+          return {
+            type: "item",
+            text: "Alice Garcia, Bob Martinez",
+          }
+        }
+        return undefined
+      }
+
+      render(
+        <FormCard
+          {...defaultProps}
+          fieldDescriptions={{
+            assignees: {
+              label: "Assignees",
+              fieldType: "custom",
+              customFieldName: "assignees_selector",
+            },
+          }}
+          formValues={{
+            assignees: { type: "manual", ids: ["5", "12"] },
+          }}
+          valueFormatter={formatter}
+        />
+      )
+
+      expect(screen.getByText("Alice Garcia, Bob Martinez")).toBeInTheDocument()
+    })
+
+    it("falls back to built-in formatting when valueFormatter returns undefined", () => {
+      const formatter: FormCardValueFormatter = () => undefined
+
+      render(
+        <FormCard
+          {...defaultProps}
+          fieldDescriptions={{
+            name: { label: "Name" },
+          }}
+          formValues={{ name: "Test value" }}
+          valueFormatter={formatter}
+        />
+      )
+
+      expect(screen.getByText("Test value")).toBeInTheDocument()
+    })
+
+    it("formats plain string values as item text", () => {
+      render(
+        <FormCard
+          {...defaultProps}
+          fieldDescriptions={{
+            concept: { label: "Concept" },
+          }}
+          formValues={{ concept: "Ticket restaurant" }}
+        />
+      )
+
+      expect(screen.getByText("Ticket restaurant")).toBeInTheDocument()
+    })
+
+    it("formats boolean values as Yes/No", () => {
+      render(
+        <FormCard
+          {...defaultProps}
+          fieldDescriptions={{
+            active: { label: "Active" },
+          }}
+          formValues={{ active: true }}
+        />
+      )
+
+      expect(screen.getByText("Yes")).toBeInTheDocument()
     })
   })
 })

--- a/packages/react/src/sds/ai/F0AiChat/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/index.ts
@@ -42,6 +42,12 @@ export {
   AiChatTranslationsProvider,
   useAiChatTranslations,
 } from "./providers/AiChatTranslationsProvider"
+export {
+  FormCardValueFormatterProvider,
+  useFormCardValueFormatter,
+  useSetFormCardValueFormatter,
+  type FormCardValueFormatterEntry,
+} from "./providers/FormCardValueFormatterProvider"
 
 // Copilot Actions
 export {

--- a/packages/react/src/sds/ai/F0AiChat/providers/FormCardValueFormatterProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/FormCardValueFormatterProvider.tsx
@@ -1,0 +1,162 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+
+import type { DetailsItemContent } from "@/experimental/Lists/DetailsItem"
+
+export interface FormCardValueFormatterEntry<T = unknown> {
+  /** Scope to a specific form. Omit to apply to all forms. */
+  formName?: string
+  /** Scope to a specific custom field name. Omit to apply to all fields. */
+  customFieldName?: string
+  /** Format function. Return `undefined` to fall back to built-in formatting. */
+  format: (
+    value: T,
+    meta: { key: string; fieldType?: string; customFieldName?: string }
+  ) => DetailsItemContent | DetailsItemContent[] | undefined
+}
+
+type SetFormCardValueFormatter = <T = unknown>(
+  entry: FormCardValueFormatterEntry<T>
+) => void
+
+interface FormCardValueFormatterContextValue {
+  formatters: FormCardValueFormatterEntry[]
+  setFormCardValueFormatter: SetFormCardValueFormatter
+}
+
+const FormCardValueFormatterContext =
+  createContext<FormCardValueFormatterContextValue | null>(null)
+
+export function FormCardValueFormatterProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const [version, setVersion] = useState(0)
+  const formattersRef = useRef<FormCardValueFormatterEntry[]>([])
+
+  const setFormCardValueFormatter = useCallback(
+    <T = unknown>(entry: FormCardValueFormatterEntry<T>) => {
+      const entries = formattersRef.current
+      const idx = entries.findIndex(
+        (e) =>
+          e.formName === entry.formName &&
+          e.customFieldName === entry.customFieldName
+      )
+      const typed = entry as FormCardValueFormatterEntry
+      if (idx >= 0) {
+        entries[idx] = typed
+      } else {
+        entries.push(typed)
+      }
+      setVersion((v) => v + 1)
+    },
+    []
+  )
+
+  const value = useMemo(
+    () => ({
+      formatters: formattersRef.current,
+      setFormCardValueFormatter,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [setFormCardValueFormatter, version]
+  )
+
+  return (
+    <FormCardValueFormatterContext.Provider value={value}>
+      {children}
+    </FormCardValueFormatterContext.Provider>
+  )
+}
+
+/**
+ * Returns a resolved formatter for the given `formName`.
+ * Matches registered formatters by specificity:
+ *   formName + customFieldName > formName only > customFieldName only > global
+ * Returns `null` when no provider is present or no formatters are registered.
+ */
+export function useFormCardValueFormatter(
+  formName: string
+):
+  | ((
+      key: string,
+      value: unknown,
+      meta: { fieldType?: string; customFieldName?: string }
+    ) => DetailsItemContent | DetailsItemContent[] | undefined)
+  | null {
+  const context = useContext(FormCardValueFormatterContext)
+  const formatters = context?.formatters
+
+  return useMemo(() => {
+    if (!formatters || formatters.length === 0) return null
+
+    return (
+      key: string,
+      value: unknown,
+      meta: { fieldType?: string; customFieldName?: string }
+    ) => {
+      let bestMatch: FormCardValueFormatterEntry | undefined
+      let bestScore = -1
+
+      for (const entry of formatters) {
+        const formMatch =
+          entry.formName === undefined || entry.formName === formName
+        const fieldMatch =
+          entry.customFieldName === undefined ||
+          entry.customFieldName === meta.customFieldName
+
+        if (!formMatch || !fieldMatch) continue
+
+        // Score: +2 for formName match, +1 for customFieldName match
+        let score = 0
+        if (entry.formName !== undefined) score += 2
+        if (entry.customFieldName !== undefined) score += 1
+
+        if (score > bestScore) {
+          bestScore = score
+          bestMatch = entry
+        }
+      }
+
+      if (!bestMatch) return undefined
+      return bestMatch.format(value, { key, ...meta })
+    }
+  }, [formatters, formName])
+}
+
+/**
+ * Returns a setter to register value formatters used by FormCard.
+ *
+ * ```ts
+ * const setFormatter = useSetFormCardValueFormatter()
+ *
+ * // Global formatter (all forms, all fields)
+ * setFormatter({ format: (value) => ({ type: "item", text: String(value) }) })
+ *
+ * // Scoped to a form
+ * setFormatter({ formName: "create-task", format: (value) => ... })
+ *
+ * // Scoped to a custom field name (across all forms)
+ * setFormatter({ customFieldName: "assignees_selector", format: (value) => ... })
+ *
+ * // Scoped to both
+ * setFormatter({ formName: "create-task", customFieldName: "assignees_selector", format: (value) => ... })
+ * ```
+ */
+export function useSetFormCardValueFormatter(): SetFormCardValueFormatter {
+  const context = useContext(FormCardValueFormatterContext)
+  if (!context) {
+    throw new Error(
+      "useSetFormCardValueFormatter must be used within a FormCardValueFormatterProvider"
+    )
+  }
+  return context.setFormCardValueFormatter
+}

--- a/packages/react/src/sds/ai/F0AiChat/providers/FormCardValueFormatterProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/FormCardValueFormatterProvider.tsx
@@ -63,7 +63,7 @@ export function FormCardValueFormatterProvider({
 
   const value = useMemo(
     () => ({
-      formatters: formattersRef.current,
+      formatters: [...formattersRef.current],
       setFormCardValueFormatter,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Fix formatting issues in FormCard shown in AI Chat

### What

Improved how `FormCard` (the AI chat canvas card that previews form values) formats and displays field values, and introduced a pluggable `FormCardValueFormatterProvider` for custom field formatting.

### Why

`FormCard` previously used a naive `formatFieldValue` that stringified everything with `JSON.stringify` or basic `String()` coercion. This produced unreadable output for complex field types (dates, durations, booleans, rich text, date ranges, arrays of objects) and had no way for consumers to customize formatting for custom fields.

### Changes

- **`FormCard`** — replaced the flat `formatFieldValue` with a type-aware `formatFieldContent` that handles `duration`, `richtext`, `daterange`, booleans (i18n-aware), arrays, objects with `label`/`name` keys, and capitalizes plain strings by default.
- **`FormCardValueFormatterProvider`** (new) — context-based registry that lets consumers register value formatters scoped by `formName` and/or `customFieldName`, resolved by specificity. Wired into `F0Provider` by default.
- **`DetailsItem`** — exported the `DetailsItemContent` type and added a `verticalLayout` prop for long-form fields (rich text, textarea) to stack label above content in table view.
- **`DetailsItemsList`** — passes through the new `verticalLayout` prop.
- **i18n** — added `forms.yes` / `forms.no` default translations for boolean formatting.
- **Exports** — re-exported `FormCardValueFormatterProvider`, `useFormCardValueFormatter`, `useSetFormCardValueFormatter`, and `FormCardValueFormatterEntry` from the `F0AiChat` barrel.
- **Tests & stories** — expanded `FormCard` tests and added stories covering all new field types and formatter scenarios.