### PR TITLE
fix(F0AiChat): sanitize streaming entity-ref tags

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/utils/__tests__/sanitizeEntityRefs.test.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/utils/__tests__/sanitizeEntityRefs.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+
+import { sanitizeEntityRefs } from "../sanitizeEntityRefs"
+
+const OPEN = '<entity-ref type="person" id="123">'
+const OPEN2 = '<entity-ref type="person" id="456">'
+const CLOSE = "</entity-ref>"
+
+describe("sanitizeEntityRefs", () => {
+  it("returns input unchanged when no entity-ref tags are present", () => {
+    expect(sanitizeEntityRefs("hello world")).toBe("hello world")
+  })
+
+  it("leaves fully balanced tags untouched", () => {
+    const input = `Hi ${OPEN}Alice${CLOSE}!`
+    expect(sanitizeEntityRefs(input)).toBe(input)
+  })
+
+  it("strips a single orphan closing tag", () => {
+    const input = `Goodbye ${CLOSE}friend`
+    expect(sanitizeEntityRefs(input)).toBe("Goodbye friend")
+  })
+
+  it("strips multiple orphan closing tags", () => {
+    const input = `${CLOSE}a${CLOSE}b${CLOSE}`
+    expect(sanitizeEntityRefs(input)).toBe("ab")
+  })
+
+  it("collapses an unterminated trailing open tag to its label", () => {
+    const input = `Hello ${OPEN}Bob`
+    expect(sanitizeEntityRefs(input)).toBe("Hello Bob")
+  })
+
+  it("sanitizes a mid-stream chunk that ends inside an entity-ref", () => {
+    // First chunk: opened but not yet closed
+    const chunkA = `Meeting with ${OPEN}Alice`
+    expect(sanitizeEntityRefs(chunkA)).toBe("Meeting with Alice")
+  })
+
+  it("handles the orphan-close pattern produced by streaming the last ref", () => {
+    // Second chunk arrives carrying only the dangling closer
+    const chunk = `@Alice${CLOSE} and team`
+    expect(sanitizeEntityRefs(chunk)).toBe("@Alice and team")
+  })
+
+  it("preserves earlier balanced refs while stripping a later orphan close", () => {
+    const input = `${OPEN}Alice${CLOSE} and ${OPEN2}Bob${CLOSE}${CLOSE}`
+    expect(sanitizeEntityRefs(input)).toBe(
+      `${OPEN}Alice${CLOSE} and ${OPEN2}Bob${CLOSE}`
+    )
+  })
+
+  it("preserves balanced refs while collapsing an unterminated trailing open", () => {
+    const input = `${OPEN}Alice${CLOSE} and ${OPEN2}Bob`
+    expect(sanitizeEntityRefs(input)).toBe(`${OPEN}Alice${CLOSE} and Bob`)
+  })
+
+  it("works inside markdown formatting", () => {
+    const input = `**Hi ${OPEN}Alice${CLOSE}**, see \`${CLOSE}\``
+    // The orphan close inside backticks is still stripped (we do not
+    // parse markdown, but rehype-raw would not render the pill either).
+    expect(sanitizeEntityRefs(input)).toBe("**Hi " + OPEN + "Alice" + CLOSE + "**, see ``")
+  })
+
+  it("is idempotent on already-sanitized input", () => {
+    const raw = `${OPEN}Alice${CLOSE}${CLOSE}`
+    const once = sanitizeEntityRefs(raw)
+    const twice = sanitizeEntityRefs(once)
+    expect(twice).toBe(once)
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/utils/sanitizeEntityRefs.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/utils/sanitizeEntityRefs.ts
@@ -1,0 +1,91 @@
+/**
+ * Sanitize a streaming assistant message containing `<entity-ref>` tags.
+ *
+ * Streaming can deliver partial XML-ish fragments chunk-by-chunk.  Two
+ * failure modes are observed and fixed here:
+ *
+ * 1. Orphan closing tag.  A `</entity-ref>` arrives without a preceding
+ *    opening tag in the current buffer (because the opener was already
+ *    rendered in a previous flush).  If we leave it in place,
+ *    `rehype-raw` renders it as stray text like `@Name</entity-ref>`.
+ *    We strip any `</entity-ref>` that does not balance an earlier
+ *    open.
+ *
+ * 2. Unterminated opening tag.  `<entity-ref type="…" id="…">Label`
+ *    arrives with no closing tag yet.  Rendering it early produces a
+ *    hover-card pill that will be re-rendered once the close arrives,
+ *    causing visible flicker.  We collapse the trailing unterminated
+ *    fragment to its visible label text only — the next chunk brings
+ *    the real tag pair and renders correctly.
+ *
+ * The function is pure and idempotent; fully-balanced input is returned
+ * unchanged.
+ *
+ * Regex literals are declared inside the function body so no `RegExp`
+ * object is shared across calls — this avoids the `g`-flag `lastIndex`
+ * footgun when the function is invoked from multiple call sites or
+ * interleaved code paths.
+ */
+export function sanitizeEntityRefs(input: string): string {
+  if (!input.includes("entity-ref")) return input
+
+  const openTag = /<entity-ref\s+type="[^"]+"\s+id="[^"]+">/g
+  const closeTag = /<\/entity-ref>/g
+
+  // Pass 1: strip orphan closers.  `matchAll` yields iterators without
+  // mutating shared state; merge by index to walk opens and closes in
+  // document order and drop any close that has no matching open.
+  const opens = Array.from(input.matchAll(openTag), (m) => ({
+    kind: "open" as const,
+    start: m.index,
+    end: m.index + m[0].length,
+  }))
+  const closes = Array.from(input.matchAll(closeTag), (m) => ({
+    kind: "close" as const,
+    start: m.index,
+    end: m.index + m[0].length,
+  }))
+  const tokens = [...opens, ...closes].sort((a, b) => a.start - b.start)
+
+  const orphanCloseRanges: Array<[number, number]> = []
+  let depth = 0
+  for (const t of tokens) {
+    if (t.kind === "open") {
+      depth += 1
+    } else if (depth > 0) {
+      depth -= 1
+    } else {
+      orphanCloseRanges.push([t.start, t.end])
+    }
+  }
+
+  let out = input
+  if (orphanCloseRanges.length > 0) {
+    let result = ""
+    let cursor = 0
+    for (const [start, end] of orphanCloseRanges) {
+      result += input.slice(cursor, start)
+      cursor = end
+    }
+    result += input.slice(cursor)
+    out = result
+  }
+
+  // Pass 2: collapse an unterminated trailing open tag.  Find the last
+  // opener in the (possibly-stripped) string and check whether any
+  // close follows it.  If not, hide the tag markup and keep only the
+  // label text after it.
+  const remainingOpens = Array.from(
+    out.matchAll(/<entity-ref\s+type="[^"]+"\s+id="[^"]+">/g)
+  )
+  const lastOpen = remainingOpens.at(-1)
+  if (lastOpen) {
+    const afterOpen = lastOpen.index + lastOpen[0].length
+    const hasClose = out.indexOf("</entity-ref>", afterOpen) !== -1
+    if (!hasClose) {
+      out = out.slice(0, lastOpen.index) + out.slice(afterOpen)
+    }
+  }
+
+  return out
+}

--- a/packages/react/src/sds/ai/F0AiChat/components/messages/AssistantMessage.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/messages/AssistantMessage.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useEffect } from "react"
 
 import { useAiChat } from "../../providers/AiChatStateProvider"
 import { markdownRenderers } from "../markdownRenderers"
+import { sanitizeEntityRefs } from "../markdownRenderers/entityRef/utils/sanitizeEntityRefs"
 
 /**
  * Context that provides the current tool call ID to action render
@@ -63,7 +64,7 @@ export const AssistantMessage = ({
         {message && content && (
           <div className="w-fit max-w-full [&>div]:flex [&>div]:flex-col [&>div]:gap-1">
             <Markdown
-              content={content}
+              content={sanitizeEntityRefs(content)}
               components={{ ...markdownRenderers, ...markdownTagRenderers }}
             />
           </div>


### PR DESCRIPTION
## Problem
Streaming assistant messages that contain `<entity-ref>` tags can render malformed output when the opening and closing tags land in different chunks. Two failure modes:

1. **Orphan closing tag.** The opener renders a hover-card pill in one chunk; the matching `</entity-ref>` arrives in the next chunk with no opener in that buffer, and `rehype-raw` renders it as stray text: @Krystal Raynor</entity-ref>
2. **Unterminated trailing open.** A chunk ends mid-tag (`<entity-ref type="person" id="123">Label`). Rendering it early
produces a pill that re-renders a moment later when the close arrives, causing visible flicker. The bug only ever affects the **last** entity-ref in a message, because earlier ones are corrected when subsequent text triggers a re-parse.

## Fix
New pure utility `F0AiChat/components/markdownRenderers/entityRef/utils/sanitizeEntityRefs.ts`:
- Walks the input once, tracking open/close depth.
- Drops every `</entity-ref>` with no matching open in the current buffer.
- Finds the last opener; if no close follows it in the same buffer, collapses the tag to its label text.
- Idempotent and stateless: regex literals live inside the function body, so no `RegExp.lastIndex` is shared across calls.
`AssistantMessage` now pipes `message.content` through the sanitizer immediately before handing it to `<Markdown>`. All other code paths are untouched.

## Why sanitize in the renderer
This is defense-in-depth for any producer feeding `F0AiChat`, not just Factorial's agent. A follow-up PR in the agent repo will also tighten its flush-boundary emissions and prompt guidance — but the renderer should not assume balanced input.