### PR TITLE
feat(ai-chat): redesign Person entity-ref hover card with Manager row

### DIFF
--- a/packages/react/src/experimental/Lists/DataList/ItemContainer.tsx
+++ b/packages/react/src/experimental/Lists/DataList/ItemContainer.tsx
@@ -28,6 +28,7 @@ export type InternalCopyActionType = {
 export type InternalNavigateActionType = {
   type: "navigate"
   href: string
+  showChevron?: boolean
 }
 
 export type InternalOpenLinkActionType = {

--- a/packages/react/src/experimental/Lists/DataList/actions/NavigateAction.tsx
+++ b/packages/react/src/experimental/Lists/DataList/actions/NavigateAction.tsx
@@ -9,10 +9,16 @@ import { InternalNavigateActionType } from "../ItemContainer"
 export type NavigateActionProps = {
   children: ReactNode
   className?: string
+  showChevron?: boolean
 } & InternalNavigateActionType
 
 export const NavigateAction = memo(
-  ({ children, className, ...props }: NavigateActionProps) => {
+  ({
+    children,
+    className,
+    showChevron = true,
+    ...props
+  }: NavigateActionProps) => {
     return (
       <Link
         {...props}
@@ -23,9 +29,11 @@ export const NavigateAction = memo(
         )}
       >
         {children}
-        <div className="grid">
-          <F0Icon aria-hidden={true} icon={ChevronRight} size="md" />
-        </div>
+        {showChevron && (
+          <div className="grid">
+            <F0Icon aria-hidden={true} icon={ChevronRight} size="md" />
+          </div>
+        )}
       </Link>
     )
   }

--- a/packages/react/src/experimental/Lists/DataList/types/actions.ts
+++ b/packages/react/src/experimental/Lists/DataList/types/actions.ts
@@ -11,6 +11,7 @@ export type CopyActionType = {
 export type NavigateActionType = {
   type: "navigate"
   href: string
+  showChevron?: boolean
 }
 
 export type OpenLinkActionType = {

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -317,6 +317,11 @@ export const defaultTranslations = {
     ask: "Ask One",
     view: "View",
     tools: "Tools",
+    entityRef: {
+      person: {
+        manager: "Manager",
+      },
+    },
     credits: {
       title: "Credits",
       creditsLeft: "{{total}} left",

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/person/PersonEntityRef.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/person/PersonEntityRef.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useMemo } from "react"
 
 import type { F0CardProps } from "@/components/F0Card"
+import { DetailsItem, type DetailsItemType } from "@/experimental/Lists/DetailsItem"
 
 import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils"
@@ -32,34 +33,74 @@ PersonTrigger.displayName = "PersonTrigger"
  *
  * Renders the trigger as a styled @mention. On hover, lazily fetches
  * the employee profile via `entityRefs.resolvers.person` and displays
- * avatar, name, and job title. Optionally links via `entityRefs.urls.person`.
+ * avatar, name, job title, and a row for the direct manager
+ *
+ * The manager becomes a clickable link when `entityRefs.urls.person` is
+ * provided. Trailing chevrons are suppressed via DataList's `showChevron`
+ * prop to keep the card dense.
  */
 export function PersonEntityRef({ id, label }: { id: string; label: string }) {
   const { entityRefs } = useAiChat()
   const resolver = entityRefs?.resolvers?.person
   const i18n = useI18n()
 
-  const personUrl = entityRefs?.urls?.person?.(id)
+  const personUrlBuilder = entityRefs?.urls?.person
+  const personUrl = personUrlBuilder?.(id)
 
   const mapToCard = useMemo(
     () =>
-      (profile: PersonProfile): F0CardProps => ({
-        avatar: {
-          type: "person",
-          firstName: profile.firstName,
-          lastName: profile.lastName,
-          src: profile.avatarUrl,
-        },
-        title: `${profile.firstName} ${profile.lastName}`,
-        description: profile.jobTitle,
-        ...(personUrl && {
-          secondaryActions: {
-            label: i18n.t("ai.view"),
-            href: personUrl,
+      (profile: PersonProfile): F0CardProps => {
+        const details: DetailsItemType[] = []
+
+        if (profile.managerFirstName && profile.managerLastName) {
+          const managerHref = profile.managerId
+            ? personUrlBuilder?.(profile.managerId)
+            : undefined
+          details.push({
+            title: i18n.t("ai.entityRef.person.manager"),
+            content: {
+              type: "person",
+              firstName: profile.managerFirstName,
+              lastName: profile.managerLastName,
+              avatarUrl: profile.managerAvatarUrl,
+              ...(managerHref && {
+                action: {
+                  type: "navigate",
+                  href: managerHref,
+                  showChevron: false,
+                },
+              }),
+            },
+          })
+        }
+
+        return {
+          avatar: {
+            type: "person",
+            firstName: profile.firstName,
+            lastName: profile.lastName,
+            src: profile.avatarUrl,
           },
-        }),
-      }),
-    [i18n, personUrl]
+          title: `${profile.firstName} ${profile.lastName}`,
+          description: profile.jobTitle,
+          ...(details.length > 0 && {
+            children: (
+              <div className="-mx-1.5 flex flex-col gap-2">
+                {details.map((d) => (
+                  <DetailsItem key={d.title} {...d} />
+                ))}
+              </div>
+            ),
+          }),
+          ...(personUrl && {
+            secondaryActions: {
+              label: i18n.t("ai.view"),
+              href: personUrl,
+            },
+          }),
+        }
+      },
+    [i18n, personUrl, personUrlBuilder]
   )
 
   const fallbackCard = useMemo(

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/person/__stories__/PersonEntityRef.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/person/__stories__/PersonEntityRef.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { I18nProvider, defaultTranslations } from "@/lib/providers/i18n"
+
+import type { EntityRefs } from "../../../../../../types"
+import { AiChatStateProvider } from "../../../../../../providers/AiChatStateProvider"
+import { PersonEntityRef } from "../PersonEntityRef"
+import type { PersonProfile } from "../types"
+
+const fullProfile: PersonProfile = {
+  id: "42",
+  firstName: "Ana",
+  lastName: "García",
+  avatarUrl:
+    "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=128&h=128&fit=crop",
+  jobTitle: "Staff Software Engineer",
+  managerId: "99",
+  managerFirstName: "Marta",
+  managerLastName: "Ruiz",
+}
+
+const minimalProfile: PersonProfile = {
+  id: "43",
+  firstName: "Leandro",
+  lastName: "Bechtelar",
+  jobTitle: "Product Designer",
+}
+
+const makeEntityRefs = (profile: PersonProfile, delayMs = 200): EntityRefs => ({
+  resolvers: {
+    person: (id: string) =>
+      new Promise((resolve) => {
+        setTimeout(() => resolve({ ...profile, id }), delayMs)
+      }),
+  },
+  urls: {
+    person: (id: string) => `https://app.factorialhr.com/employees/${id}`,
+  },
+})
+
+type StoryArgs = {
+  profile: PersonProfile
+  includeResolver: boolean
+  rejectResolver: boolean
+  neverResolves: boolean
+}
+
+const Wrapper = ({
+  profile,
+  includeResolver,
+  rejectResolver,
+  neverResolves,
+}: StoryArgs) => {
+  let entityRefs: EntityRefs | undefined
+
+  if (includeResolver) {
+    if (rejectResolver) {
+      entityRefs = {
+        resolvers: {
+          person: () => Promise.reject(new Error("Network error")),
+        },
+      }
+    } else if (neverResolves) {
+      entityRefs = {
+        resolvers: {
+          person: () => new Promise(() => {}),
+        },
+      }
+    } else {
+      entityRefs = makeEntityRefs(profile)
+    }
+  }
+
+  return (
+    <I18nProvider translations={defaultTranslations}>
+      <AiChatStateProvider enabled entityRefs={entityRefs}>
+        <div className="p-12">
+          <p className="text-f1-foreground">
+            Hover the mention:{" "}
+            <PersonEntityRef
+              id={String(profile.id)}
+              label={`${profile.firstName} ${profile.lastName}`}
+            />
+          </p>
+        </div>
+      </AiChatStateProvider>
+    </I18nProvider>
+  )
+}
+
+const meta: Meta<typeof Wrapper> = {
+  title: "AI/EntityRef/PersonEntityRef",
+  component: Wrapper,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    profile: fullProfile,
+    includeResolver: true,
+    rejectResolver: false,
+    neverResolves: false,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Wrapper>
+
+export const Default: Story = {}
+
+export const MinimalProfile: Story = {
+  args: {
+    profile: minimalProfile,
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    neverResolves: true,
+  },
+}
+
+export const Error: Story = {
+  args: {
+    rejectResolver: true,
+  },
+}
+
+export const NoResolver: Story = {
+  args: {
+    includeResolver: false,
+  },
+}

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/person/__tests__/PersonEntityRef.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/person/__tests__/PersonEntityRef.test.tsx
@@ -13,7 +13,9 @@ import type { PersonProfile } from "../types"
 const mockResolver = vi.fn<(id: string) => Promise<PersonProfile>>()
 let mockEntityRefs: {
   resolvers?: { person?: typeof mockResolver }
-  urls?: { person?: (id: string) => string }
+  urls?: {
+    person?: (id: string) => string
+  }
 } = {
   resolvers: { person: mockResolver },
 }
@@ -32,6 +34,9 @@ const profile: PersonProfile = {
   lastName: "García",
   avatarUrl: "https://example.com/avatar.jpg",
   jobTitle: "Engineer",
+  managerId: "99",
+  managerFirstName: "Marta",
+  managerLastName: "Ruiz",
 }
 
 describe("PersonEntityRef", () => {
@@ -110,5 +115,78 @@ describe("PersonEntityRef", () => {
     await waitFor(() => {
       expect(screen.getByText("Ana García")).toBeInTheDocument()
     })
+  })
+
+  it("renders manager details", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+
+    render(<PersonEntityRef id="42" label="Ana García" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Marta Ruiz")).toBeInTheDocument()
+    })
+  })
+
+  it("renders manager as a link when person URL builder is provided", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+    mockEntityRefs = {
+      resolvers: { person: mockResolver },
+      urls: {
+        person: (pid) => `https://app.example.com/people/${pid}`,
+      },
+    }
+
+    render(<PersonEntityRef id="42" label="Ana García" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Marta Ruiz")).toBeInTheDocument()
+    })
+
+    const managerLink = screen.getByText("Marta Ruiz").closest("a")
+    expect(managerLink).toHaveAttribute(
+      "href",
+      "https://app.example.com/people/99"
+    )
+  })
+
+  it("renders manager as plain text when URL builder is absent", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+
+    render(<PersonEntityRef id="42" label="Ana García" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Marta Ruiz")).toBeInTheDocument()
+    })
+
+    expect(screen.getByText("Marta Ruiz").closest("a")).toBeNull()
+  })
+
+  it("omits metadata rows when optional fields are absent", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue({
+      id: "42",
+      firstName: "Ana",
+      lastName: "García",
+      jobTitle: "Engineer",
+    })
+
+    render(<PersonEntityRef id="42" label="Ana García" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Engineer")).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText("Marta Ruiz")).not.toBeInTheDocument()
   })
 })

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/person/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/person/types.ts
@@ -8,4 +8,8 @@ export type PersonProfile = {
   lastName: string
   avatarUrl?: string
   jobTitle?: string
+  managerId?: string
+  managerFirstName?: string
+  managerLastName?: string
+  managerAvatarUrl?: string
 }


### PR DESCRIPTION
- Add showChevron prop to DataList NavigateAction
- Redesign PersonEntityRef hover card to show Manager row via DataList
- Remove teams from PersonEntityRef (no longer displayed)
- Add PersonEntityRef stories
- Update i18n defaults for entityRef.person