### PR TITLE
feat: persistence per-viz filters data collection

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/filters/per-visualization-filters.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/filters/per-visualization-filters.stories.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react"
 import { Meta, StoryObj } from "@storybook/react-vite"
 
 import { Briefcase, Building, Envelope } from "@/icons/app"
@@ -356,6 +357,334 @@ const source = useDataCollectionSource({
       // No per-view overrides, uses global filters & presets
       options: { ... },
     },
+  ]}
+/>
+        `,
+      },
+    },
+  },
+}
+
+/* ------------------------------------------------------------------ */
+/* PersistenceAcrossRemounts                                           */
+/* Interactive harness to manually reproduce the multi-viz storage     */
+/* race fixed in useDataCollectionStorage. The wrapper exposes         */
+/* mount/unmount, seed/clear/read controls and a live snapshot of the  */
+/* localStorage value so you can verify visualizationFilters keys      */
+/* survive a remount cycle.                                            */
+/* ------------------------------------------------------------------ */
+
+const PERSISTENCE_STORAGE_ID = "per-viz-filters-persistence/v1"
+const PERSISTENCE_LS_KEY = `datacollection-${PERSISTENCE_STORAGE_ID}`
+const PERSISTENCE_SEED = {
+  visualization: 1,
+  visualizationFilters: {
+    "0": { department: ["Engineering"] },
+    "1": { salary: { mode: "single", value: 100000 } },
+  },
+}
+
+const PersistenceCollection = () => {
+  const dataSource = useDataCollectionSource({
+    filters,
+    presets: filterPresets,
+    sortings,
+    dataAdapter: {
+      fetchData: createPromiseDataFetch(),
+    },
+  })
+
+  return (
+    <OneDataCollection
+      source={dataSource}
+      id={PERSISTENCE_STORAGE_ID}
+      storage={{ features: ["visualization", "visualizationFilters"] }}
+      visualizations={[
+        {
+          type: "table",
+          filters: {
+            department: filters.department,
+          },
+          presets: [
+            {
+              label: "Engineering",
+              filter: { department: ["Engineering"] },
+            },
+          ],
+          options: {
+            columns: [
+              {
+                label: "Name",
+                render: (item: MockUser) => ({
+                  type: "person",
+                  value: {
+                    firstName: item.name.split(" ")[0],
+                    lastName: item.name.split(" ")[1],
+                  },
+                }),
+                sorting: "name",
+              },
+              {
+                label: "Email",
+                render: (item: MockUser) => item.email,
+                sorting: "email",
+              },
+              {
+                label: "Department",
+                render: (item: MockUser) => item.department,
+                sorting: "department",
+              },
+            ],
+          },
+        },
+        {
+          type: "card",
+          filters: {
+            salary: filters.salary,
+            search: filters.search,
+          },
+          presets: [
+            {
+              label: "High salary",
+              filter: { salary: { mode: "single", value: 100000 } },
+            },
+          ],
+          options: {
+            title: (item: MockUser) => item.name,
+            description: (item: MockUser) => item.role,
+            avatar: (item: MockUser) => ({
+              type: "person",
+              firstName: item.name.split(" ")[0],
+              lastName: item.name.split(" ")[1],
+            }),
+            cardProperties: [
+              {
+                label: "Email",
+                icon: Envelope,
+                render: (item: MockUser) => item.email,
+              },
+              {
+                label: "Department",
+                icon: Building,
+                render: (item: MockUser) => item.department,
+              },
+              {
+                label: "Role",
+                icon: Briefcase,
+                render: (item: MockUser) => item.role,
+              },
+            ],
+          },
+        },
+      ]}
+    />
+  )
+}
+
+const PersistenceHarness = () => {
+  const [mounted, setMounted] = useState(false)
+  const [snapshot, setSnapshot] = useState<string>(
+    () => localStorage.getItem(PERSISTENCE_LS_KEY) ?? ""
+  )
+
+  // Refresh snapshot on a 200 ms cadence while mounted so users can watch
+  // the debounced storage writes land in real time.
+  useEffect(() => {
+    if (!mounted) return
+    const id = window.setInterval(() => {
+      setSnapshot(localStorage.getItem(PERSISTENCE_LS_KEY) ?? "")
+    }, 200)
+    return () => window.clearInterval(id)
+  }, [mounted])
+
+  const refresh = () =>
+    setSnapshot(localStorage.getItem(PERSISTENCE_LS_KEY) ?? "")
+
+  const seed = () => {
+    localStorage.setItem(
+      PERSISTENCE_LS_KEY,
+      JSON.stringify(PERSISTENCE_SEED, null, 2)
+    )
+    refresh()
+  }
+
+  const reset = () => {
+    localStorage.removeItem(PERSISTENCE_LS_KEY)
+    refresh()
+  }
+
+  // Derive a status from the live snapshot so users see at a glance whether
+  // the persisted multi-visualization map survived (≥ 2 keys), shrank to one
+  // key (the bug signature), or is empty.
+  const parsed = (() => {
+    if (!snapshot) return null
+    try {
+      return JSON.parse(snapshot) as {
+        visualizationFilters?: Record<string, unknown>
+      }
+    } catch {
+      return null
+    }
+  })()
+  const vizFilterKeys = parsed?.visualizationFilters
+    ? Object.keys(parsed.visualizationFilters)
+    : []
+  const status: "ok" | "bug" | "empty" =
+    vizFilterKeys.length >= 2
+      ? "ok"
+      : vizFilterKeys.length === 1
+        ? "bug"
+        : "empty"
+
+  const statusBadge = {
+    ok: { icon: "✅", label: "Multi-visualization map preserved" },
+    bug: {
+      icon: "⚠️",
+      label: "Only one key present — multi-viz map was overwritten",
+    },
+    empty: { icon: "—", label: "No persisted state yet" },
+  }[status]
+
+  const buttonClass =
+    "rounded-md border border-f1-border bg-f1-background px-3 py-1 text-f1-foreground hover:bg-f1-background-hover"
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Description card */}
+      <div className="rounded-md border border-f1-border bg-f1-background-secondary p-4 text-sm leading-relaxed text-f1-foreground">
+        <div className="mb-2 font-semibold">
+          Per-visualization filter persistence
+        </div>
+        <p className="mb-2">
+          This data collection saves the filters of each visualization to{" "}
+          <code>localStorage</code>, so they survive a page reload. Switch
+          between <strong>Table</strong> and <strong>Card</strong>, apply some
+          filters in each, and watch the storage snapshot update live.
+        </p>
+        <p className="mb-1 font-medium">Bug repro:</p>
+        <ol className="ml-5 list-decimal space-y-1">
+          <li>
+            Click <strong>Pre-fill storage</strong> — this writes filters for{" "}
+            <em>both</em> visualizations into <code>localStorage</code>.
+          </li>
+          <li>
+            Click <strong>Mount</strong>. The collection hydrates from the
+            persisted state.
+          </li>
+          <li>
+            Wait ~500 ms. With the fix, the snapshot below still shows{" "}
+            <strong>two keys</strong> (✅). Without the fix, one key disappears
+            (⚠️) because a pre-hydration write overwrites the stored map.
+          </li>
+        </ol>
+      </div>
+
+      {/* Controls */}
+      <div className="flex flex-col gap-2">
+        <div className="text-xs font-semibold uppercase tracking-wide text-f1-foreground-secondary">
+          Controls
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className={buttonClass}
+            onClick={seed}
+            data-testid="persistence-seed"
+          >
+            Pre-fill storage
+          </button>
+          <button
+            type="button"
+            className={buttonClass}
+            onClick={reset}
+            data-testid="persistence-clear"
+          >
+            Reset storage
+          </button>
+          <button
+            type="button"
+            className={buttonClass}
+            onClick={() => setMounted((m) => !m)}
+            data-testid="persistence-toggle-mount"
+          >
+            {mounted ? "Unmount" : "Mount"}
+          </button>
+        </div>
+      </div>
+
+      {/* Storage status panel */}
+      <div className="flex flex-col gap-2 rounded-md border border-f1-border bg-f1-background p-4">
+        <div className="text-xs font-semibold uppercase tracking-wide text-f1-foreground-secondary">
+          localStorage state
+        </div>
+        <div className="font-mono text-xs text-f1-foreground-secondary">
+          {PERSISTENCE_LS_KEY}
+        </div>
+        <div
+          className="flex items-center gap-2 text-sm"
+          data-testid="persistence-status"
+          data-status={status}
+        >
+          <span aria-hidden>{statusBadge.icon}</span>
+          <span>
+            <strong>Visualization filter keys:</strong>{" "}
+            {vizFilterKeys.length > 0
+              ? `[${vizFilterKeys.map((k) => `"${k}"`).join(", ")}]`
+              : "(none)"}{" "}
+            — {statusBadge.label}
+          </span>
+        </div>
+        <details>
+          <summary className="cursor-pointer text-xs text-f1-foreground-secondary">
+            Full JSON
+          </summary>
+          <pre
+            className="mt-2 max-h-48 overflow-auto rounded-md border border-f1-border bg-f1-background-secondary p-3 text-xs"
+            data-testid="persistence-storage-snapshot"
+          >
+            {snapshot || "(empty)"}
+          </pre>
+        </details>
+      </div>
+
+      {mounted && <PersistenceCollection />}
+    </div>
+  )
+}
+
+export const PersistenceAcrossRemounts: Story = {
+  render: () => <PersistenceHarness />,
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Manual reproduction harness for the per-visualization-filters storage race.
+
+**Steps**
+1. Click **Mount OneDataCollection**, switch between Table and Card and apply
+   filters/presets in each view. The snapshot panel shows
+   \`visualizationFilters\` populated with both \`"0"\` and \`"1"\` keys.
+2. Click **Unmount**, then **Mount** again to simulate navigating away and
+   back. Wait ~500ms; both keys should still be present.
+3. Alternatively click **Seed storage** (writes a multi-viz map directly),
+   then **Mount**, then watch the snapshot. The map should not lose any key.
+
+**Bug behaviour (without the fix)**: the snapshot collapses to a single-key
+\`visualizationFilters\` map shortly after mount because a pre-hydration write
+overwrites the persisted multi-viz state.
+        `,
+      },
+      source: {
+        code: `
+const STORAGE_ID = "per-viz-filters-persistence/v1"
+
+<OneDataCollection
+  source={source}
+  id={STORAGE_ID}
+  storage={{ features: ["visualization", "visualizationFilters"] }}
+  visualizations={[
+    { type: "table", filters: { department: filters.department }, presets: [...], options: { columns: [...] } },
+    { type: "card",  filters: { salary: filters.salary, search: filters.search }, presets: [...], options: { ... } },
   ]}
 />
         `,

--- a/packages/react/src/patterns/OneDataCollection/__stories__/filters/per-visualization-filters.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/filters/per-visualization-filters.stories.tsx
@@ -660,18 +660,12 @@ export const PersistenceAcrossRemounts: Story = {
         story: `
 Manual reproduction harness for the per-visualization-filters storage race.
 
-**Steps**
-1. Click **Mount OneDataCollection**, switch between Table and Card and apply
-   filters/presets in each view. The snapshot panel shows
-   \`visualizationFilters\` populated with both \`"0"\` and \`"1"\` keys.
-2. Click **Unmount**, then **Mount** again to simulate navigating away and
-   back. Wait ~500ms; both keys should still be present.
-3. Alternatively click **Seed storage** (writes a multi-viz map directly),
-   then **Mount**, then watch the snapshot. The map should not lose any key.
-
-**Bug behaviour (without the fix)**: the snapshot collapses to a single-key
-\`visualizationFilters\` map shortly after mount because a pre-hydration write
-overwrites the persisted multi-viz state.
+Use the controls inside the story (Pre-fill storage / Reset storage / Mount)
+to verify that the persisted multi-visualization map survives a remount cycle.
+With the fix, the snapshot panel keeps both \`"0"\` and \`"1"\` keys; without it,
+one key disappears shortly after mount because a pre-hydration write overwrites
+the persisted multi-viz state. See the in-story description card for the full
+step-by-step.
         `,
       },
       source: {

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/__tests__/useDataCollectionStorage.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/__tests__/useDataCollectionStorage.test.ts
@@ -1,0 +1,365 @@
+import { act, renderHook } from "@testing-library/react"
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest"
+
+import { DataCollectionStorageProvider } from "@/lib/providers/datacollection/DataCollectionStorageProvider"
+import {
+  DataCollectionStorage,
+  DataCollectionStorageHandler,
+} from "@/lib/providers/datacollection/types"
+
+import { useDataCollectionStorage } from "../useDataCollectionStorage"
+import {
+  DataCollectionStorageFeaturesDefinition,
+  FeatureProviders,
+} from "../types"
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+type AnyFeatureProviders = FeatureProviders<
+  Record<string, unknown>,
+  never,
+  never,
+  Record<string, never>,
+  Record<string, never>
+>
+
+type DeferredHandler = {
+  handler: DataCollectionStorageHandler
+  resolveGet: (value: DataCollectionStorage) => void
+  setSpy: MockInstance<
+    Parameters<DataCollectionStorageHandler["set"]>,
+    ReturnType<DataCollectionStorageHandler["set"]>
+  >
+  getSpy: MockInstance<
+    Parameters<DataCollectionStorageHandler["get"]>,
+    ReturnType<DataCollectionStorageHandler["get"]>
+  >
+  /** In-memory state mimicking `localStorage[key]`. */
+  state: { value: DataCollectionStorage }
+}
+
+/**
+ * Creates a storage handler whose `get` resolves only when the test calls
+ * `resolveGet(...)` and whose `set` writes into an in-memory record so we can
+ * assert the final persisted value. `setSpy` records every call.
+ */
+const createDeferredHandler = (
+  initial: DataCollectionStorage = {}
+): DeferredHandler => {
+  const state = { value: { ...initial } as DataCollectionStorage }
+  let resolveGet: (value: DataCollectionStorage) => void = () => {}
+
+  const handler: DataCollectionStorageHandler = {
+    get: vi.fn(
+      () =>
+        new Promise<DataCollectionStorage>((resolve) => {
+          resolveGet = resolve
+        })
+    ),
+    set: vi.fn(async (_key, settings) => {
+      // Mirror `dataCollectionLocalStorageHandler` semantics: replace the whole key.
+      state.value = settings
+    }),
+  }
+
+  return {
+    handler,
+    resolveGet: (value) => resolveGet(value),
+    setSpy: handler.set as unknown as DeferredHandler["setSpy"],
+    getSpy: handler.get as unknown as DeferredHandler["getSpy"],
+    state,
+  }
+}
+
+/**
+ * Build a feature-providers object whose `setValue` for `visualizationFilters`
+ * mutates a shared map so we can simulate React's restoration setting state.
+ */
+const buildFeatureProviders = (
+  initial: {
+    visualization: number
+    visualizationFilters: Record<string, Record<string, unknown>>
+  } = { visualization: 0, visualizationFilters: {} }
+) => {
+  const ref = {
+    visualization: initial.visualization,
+    visualizationFilters: initial.visualizationFilters,
+  }
+
+  const visualizationSetValue = vi.fn((value: number) => {
+    ref.visualization = value
+  })
+  const visualizationFiltersSetValue = vi.fn(
+    (value: Record<string, Record<string, unknown>>) => {
+      ref.visualizationFilters = value
+    }
+  )
+
+  const buildProviders = (): AnyFeatureProviders =>
+    ({
+      visualization: {
+        value: ref.visualization,
+        setValue: visualizationSetValue,
+      },
+      visualizationFilters: {
+        value: ref.visualizationFilters,
+        setValue: visualizationFiltersSetValue,
+      },
+    }) as unknown as AnyFeatureProviders
+
+  return {
+    ref,
+    buildProviders,
+    visualizationSetValue,
+    visualizationFiltersSetValue,
+  }
+}
+
+const wrapperWith =
+  (handler: DataCollectionStorageHandler) =>
+  ({ children }: { children: React.ReactNode }) =>
+    DataCollectionStorageProvider({ children, handler })
+
+const flushMicrotasks = async () => {
+  // Allow queued Promise callbacks (storage.get().then(...)) to run.
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("useDataCollectionStorage — pre-hydration write race", () => {
+  const features: DataCollectionStorageFeaturesDefinition = [
+    "visualization",
+    "visualizationFilters",
+  ]
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("never calls storage.set with a partial pre-hydration snapshot", async () => {
+    const persisted: DataCollectionStorage = {
+      visualization: 1,
+      visualizationFilters: { "0": { x: [1] }, "1": { y: [2] } },
+    } as DataCollectionStorage
+
+    const { handler, resolveGet, setSpy } = createDeferredHandler(persisted)
+
+    // Before hydration the provider sees an empty visualizationFilters map and
+    // a default visualization of 0. This is the corrupting payload reported in
+    // the bug.
+    const { buildProviders } = buildFeatureProviders({
+      visualization: 0,
+      visualizationFilters: {},
+    })
+
+    const { rerender } = renderHook(
+      ({ providers }) =>
+        useDataCollectionStorage(
+          "test/v1",
+          features,
+          providers as AnyFeatureProviders
+        ),
+      {
+        wrapper: wrapperWith(handler),
+        initialProps: { providers: buildProviders() },
+      }
+    )
+
+    // Advance past the 200ms debounce window without resolving hydration.
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(setSpy).not.toHaveBeenCalled()
+
+    // Now resolve hydration. In production, `featureProvider.setValue(...)` is
+    // called inside the resolved `.then(...)` and updates consumer state — we
+    // simulate that by rerendering with providers reflecting the restored map.
+    await act(async () => {
+      resolveGet(persisted)
+    })
+    await flushMicrotasks()
+
+    const restored = buildFeatureProviders({
+      visualization: 1,
+      visualizationFilters: persisted.visualizationFilters as Record<
+        string,
+        Record<string, unknown>
+      >,
+    })
+    rerender({ providers: restored.buildProviders() })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    // Any set call observed must contain both "0" and "1" keys.
+    for (const call of setSpy.mock.calls) {
+      const settings = call[1] as DataCollectionStorage
+      const map = settings.visualizationFilters ?? {}
+      expect(Object.keys(map).sort()).toEqual(["0", "1"])
+    }
+  })
+
+  it("cancels pending writes on unmount before hydration resolves", async () => {
+    const { handler, setSpy } = createDeferredHandler()
+    const { buildProviders } = buildFeatureProviders({
+      visualization: 0,
+      visualizationFilters: { "0": { seeded: true } },
+    })
+
+    const { unmount } = renderHook(
+      ({ providers }) =>
+        useDataCollectionStorage(
+          "test/v1",
+          features,
+          providers as AnyFeatureProviders
+        ),
+      {
+        wrapper: wrapperWith(handler),
+        initialProps: { providers: buildProviders() },
+      }
+    )
+
+    // Schedule (but never resolve hydration), then unmount.
+    await act(async () => {
+      vi.advanceTimersByTime(50)
+    })
+    unmount()
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it("writes the merged multi-viz map after hydration completes", async () => {
+    const persisted: DataCollectionStorage = {
+      visualization: 1,
+      visualizationFilters: { "0": { x: [1] }, "1": { y: [2] } },
+    } as DataCollectionStorage
+
+    const { handler, resolveGet, setSpy, state } =
+      createDeferredHandler(persisted)
+
+    const restored = buildFeatureProviders({
+      visualization: 1,
+      visualizationFilters: persisted.visualizationFilters as Record<
+        string,
+        Record<string, unknown>
+      >,
+    })
+
+    const { rerender } = renderHook(
+      ({ providers }) =>
+        useDataCollectionStorage(
+          "test/v1",
+          features,
+          providers as AnyFeatureProviders
+        ),
+      {
+        wrapper: wrapperWith(handler),
+        initialProps: {
+          providers: buildFeatureProviders({
+            visualization: 0,
+            visualizationFilters: {},
+          }).buildProviders(),
+        },
+      }
+    )
+
+    // Pre-hydration tick.
+    await act(async () => {
+      vi.advanceTimersByTime(300)
+    })
+    expect(setSpy).not.toHaveBeenCalled()
+
+    // Resolve hydration. Simulate consumer re-rendering with the restored
+    // providers (which mirrors how setValue updates feed back as new props).
+    await act(async () => {
+      resolveGet(persisted)
+    })
+    await flushMicrotasks()
+    rerender({ providers: restored.buildProviders() })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(setSpy).toHaveBeenCalled()
+    expect(state.value.visualizationFilters).toEqual({
+      "0": { x: [1] },
+      "1": { y: [2] },
+    })
+  })
+
+  it("does not write when the storage key is undefined (storage disabled)", async () => {
+    const { handler, setSpy } = createDeferredHandler()
+    const { buildProviders } = buildFeatureProviders()
+
+    renderHook(
+      () =>
+        useDataCollectionStorage(
+          undefined,
+          features,
+          buildProviders() as AnyFeatureProviders
+        ),
+      {
+        wrapper: wrapperWith(handler),
+      }
+    )
+
+    await flushMicrotasks()
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it("does not write when explicitly disabled", async () => {
+    const { handler, setSpy } = createDeferredHandler()
+    const { buildProviders } = buildFeatureProviders()
+
+    renderHook(
+      () =>
+        useDataCollectionStorage(
+          "test/v1",
+          features,
+          buildProviders() as AnyFeatureProviders,
+          true
+        ),
+      {
+        wrapper: wrapperWith(handler),
+      }
+    )
+
+    await flushMicrotasks()
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/__tests__/useDataCollectionStorage.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/__tests__/useDataCollectionStorage.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react"
+import { act } from "@testing-library/react"
 import {
   afterEach,
   beforeEach,
@@ -14,7 +14,7 @@ import {
   DataCollectionStorage,
   DataCollectionStorageHandler,
 } from "@/lib/providers/datacollection/types"
-import { TestProviders } from "@/testing/test-utils"
+import { TestProviders, zeroRenderHook } from "@/testing/test-utils"
 
 import { useDataCollectionStorage } from "../useDataCollectionStorage"
 import {
@@ -181,7 +181,7 @@ describe("useDataCollectionStorage — pre-hydration write race", () => {
       visualizationFilters: {},
     })
 
-    const { rerender } = renderHook(
+    const { rerender } = zeroRenderHook(
       ({ providers }) =>
         useDataCollectionStorage(
           "test/v1",
@@ -237,7 +237,7 @@ describe("useDataCollectionStorage — pre-hydration write race", () => {
       visualizationFilters: { "0": { seeded: true } },
     })
 
-    const { unmount } = renderHook(
+    const { unmount } = zeroRenderHook(
       ({ providers }) =>
         useDataCollectionStorage(
           "test/v1",
@@ -279,7 +279,7 @@ describe("useDataCollectionStorage — pre-hydration write race", () => {
       >,
     })
 
-    const { rerender } = renderHook(
+    const { rerender } = zeroRenderHook(
       ({ providers }) =>
         useDataCollectionStorage(
           "test/v1",
@@ -326,7 +326,7 @@ describe("useDataCollectionStorage — pre-hydration write race", () => {
     const { handler, setSpy } = createDeferredHandler()
     const { buildProviders } = buildFeatureProviders()
 
-    renderHook(
+    zeroRenderHook(
       () =>
         useDataCollectionStorage(
           undefined,
@@ -350,7 +350,7 @@ describe("useDataCollectionStorage — pre-hydration write race", () => {
     const { handler, setSpy } = createDeferredHandler()
     const { buildProviders } = buildFeatureProviders()
 
-    renderHook(
+    zeroRenderHook(
       () =>
         useDataCollectionStorage(
           "test/v1",
@@ -369,5 +369,101 @@ describe("useDataCollectionStorage — pre-hydration write race", () => {
     })
 
     expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it("blocks writes during the second hydration when key changes", async () => {
+    // First key already hydrated with cached state.
+    const persistedA: DataCollectionStorage = {
+      visualization: 0,
+      visualizationFilters: { "0": { fromA: true } },
+    } as DataCollectionStorage
+
+    const { handler, resolveGet, setSpy } = createDeferredHandler(persistedA)
+
+    const restoredA = buildFeatureProviders({
+      visualization: 0,
+      visualizationFilters: persistedA.visualizationFilters as Record<
+        string,
+        Record<string, unknown>
+      >,
+    })
+
+    const { rerender } = zeroRenderHook(
+      ({ providers, storageKey }) =>
+        useDataCollectionStorage(
+          storageKey,
+          features,
+          providers as AnyFeatureProviders
+        ),
+      {
+        wrapper: wrapperWith(handler),
+        initialProps: {
+          providers: restoredA.buildProviders(),
+          storageKey: "key-a/v1",
+        },
+      }
+    )
+
+    // Resolve hydration for key A so storageReady becomes true.
+    await act(async () => {
+      resolveGet(persistedA)
+    })
+    await flushMicrotasks()
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+    setSpy.mockClear()
+
+    // Switch to key B with a seed (pre-hydration) provider state. Without the
+    // storageReady reset, the write effect would see storageReady=true and
+    // schedule a debounced write under key B with the seeded snapshot,
+    // potentially landing before key B's get resolves.
+    const seededB = buildFeatureProviders({
+      visualization: 0,
+      visualizationFilters: {},
+    })
+    rerender({
+      providers: seededB.buildProviders(),
+      storageKey: "key-b/v1",
+    })
+
+    // Advance well past the debounce window without resolving get(B).
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    // No write should have happened under key B before its hydration.
+    expect(setSpy).not.toHaveBeenCalled()
+
+    // Now resolve hydration for key B and simulate the consumer applying the
+    // restored providers; subsequent writes must target key-b/v1, not key-a/v1.
+    const persistedB: DataCollectionStorage = {
+      visualization: 1,
+      visualizationFilters: { "0": { fromB: true }, "1": { fromB: true } },
+    } as DataCollectionStorage
+    await act(async () => {
+      resolveGet(persistedB)
+    })
+    await flushMicrotasks()
+
+    const restoredB = buildFeatureProviders({
+      visualization: 1,
+      visualizationFilters: persistedB.visualizationFilters as Record<
+        string,
+        Record<string, unknown>
+      >,
+    })
+    rerender({
+      providers: restoredB.buildProviders(),
+      storageKey: "key-b/v1",
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    for (const call of setSpy.mock.calls) {
+      expect(call[0]).toBe("key-b/v1")
+    }
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/__tests__/useDataCollectionStorage.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/__tests__/useDataCollectionStorage.test.tsx
@@ -14,6 +14,7 @@ import {
   DataCollectionStorage,
   DataCollectionStorageHandler,
 } from "@/lib/providers/datacollection/types"
+import { TestProviders } from "@/testing/test-utils"
 
 import { useDataCollectionStorage } from "../useDataCollectionStorage"
 import {
@@ -125,10 +126,17 @@ const buildFeatureProviders = (
   }
 }
 
-const wrapperWith =
-  (handler: DataCollectionStorageHandler) =>
-  ({ children }: { children: React.ReactNode }) =>
-    DataCollectionStorageProvider({ children, handler })
+const wrapperWith = (handler: DataCollectionStorageHandler) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TestProviders>
+      <DataCollectionStorageProvider handler={handler}>
+        {children}
+      </DataCollectionStorageProvider>
+    </TestProviders>
+  )
+  Wrapper.displayName = "DeferredStorageWrapper"
+  return Wrapper
+}
 
 const flushMicrotasks = async () => {
   // Allow queued Promise callbacks (storage.get().then(...)) to run.

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/useDataCollectionStorage.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/useDataCollectionStorage.ts
@@ -82,6 +82,11 @@ export const useDataCollectionStorage = <
       return
     }
 
+    // Reset readiness while a new hydration is in flight so the write effect
+    // cannot schedule a debounced write under the new key using stale provider
+    // values left over from the previous key/inactive state.
+    setStorageReady(false)
+
     storageProvider.get(key!).then((status) => {
       Object.entries(featureProviders).forEach(
         ([featureName, featureProvider]) => {

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/useDataCollectionStorage.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/useDataCollectionStorage.ts
@@ -157,13 +157,27 @@ export const useDataCollectionStorage = <
 
   /** Saves the settings in storage when the settings change */
   useEffect(() => {
+    // Do not schedule any write before hydration completes or when storage is
+    // disabled. Without this gate, a pre-hydration snapshot (e.g. a partial
+    // visualizationFilters map containing only the default visualization)
+    // can be debounced and later flushed, overwriting the previously persisted
+    // multi-key map because the default storage handler replaces the whole key.
+    if (!active || !storageReady) return
+
     debouncedSetFeatures(featureProviders)
+
+    // Cancel any pending write when deps change or on unmount so a stale
+    // snapshot scheduled by a previous render cannot land after a newer one.
+    return () => {
+      debouncedSetFeatures.cancel()
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- This is intentional
   }, [
     key,
     storageFeatures,
     storageProvider,
     storageReady,
+    active,
     serializedFeatureValues,
   ])
 


### PR DESCRIPTION
## Description
Fixe a race condition in `useDataCollectionStorage` where a debounced localStorage write could overwrite the cached value with a stale snapshot. This was only visible when using more than 1 viz per dataCollection with different filters per viz.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/308826fb-9cba-4621-a022-0e2e7eb298ad



## Implementation details
- Fix (useDataCollectionStorage.ts): gate the write effect on active && storageReady so no debounced write is scheduled before hydration completes, and cancel any pending write in the effect cleanup so a stale snapshot from a prior render cannot land after a newer one. Added active to the dep array.
- Tests (__tests__/useDataCollectionStorage.test.ts): 5 new hook-level regression tests using renderHook + fake timers, including one that explicitly asserts no pre-hydration partial snapshot ever reaches storage.set. Verified to fail without the fix.
- Story (per-visualization-filters.stories.tsx → Persistence Across Remounts): an interactive harness with Pre-fill / Reset / Mount-Unmount controls and a live localStorage status panel, so the bug repro and the fix can be demoed manually in Storybook.
