### PR TITLE
fix(F0Link): hardcode opens-in-new-tab a11y text to avoid requiring I18nProvider

### DIFF
--- a/packages/react/src/components/F0Link/F0Link.tsx
+++ b/packages/react/src/components/F0Link/F0Link.tsx
@@ -2,7 +2,6 @@ import { forwardRef } from "react"
 
 import ExternalLink from "@/icons/app/ExternalLink"
 import { withDataTestId } from "@/lib/data-testid"
-import { useI18n } from "@/lib/providers/i18n"
 import {
   Action,
   ActionLinkProps,
@@ -29,7 +28,6 @@ const _F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
   },
   ref
 ) {
-  const i18n = useI18n()
   const { target } = props
   const external = target === "_blank"
 
@@ -67,7 +65,7 @@ const _F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
       {external && (
         <>
           <F0Icon icon={ExternalLink} size="sm" aria-hidden={true} />
-          <span className="sr-only">{i18n.link.opensInNewTab}</span>
+          <span className="sr-only">opens in new tab</span>
         </>
       )}
     </Action>

--- a/packages/react/src/components/F0Link/F0Link.tsx
+++ b/packages/react/src/components/F0Link/F0Link.tsx
@@ -65,7 +65,7 @@ const _F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
       {external && (
         <>
           <F0Icon icon={ExternalLink} size="sm" aria-hidden={true} />
-          <span className="sr-only">opens in new tab</span>
+          <span className="sr-only"> (opens in new tab)</span>
         </>
       )}
     </Action>


### PR DESCRIPTION
## Summary

- Drop the unconditional \`useI18n()\` call from \`F0Link\` and hardcode the screen-reader-only \`opens in new tab\` string.
- Align with \`F0Alert\` (PR #3900) which already hardcodes the same string.

## Why?

[#3903](https://github.com/factorialco/f0/pull/3903) added a \`useI18n()\` call at the top of \`F0Link\` so the WCAG 3.2.5 \"opens in new tab\" hint could be translated. The hook is invoked unconditionally — even for internal links — so **any** consumer that mounts an \`F0Link\` (directly or transitively, through \`F0Alert\`, \`F0Header\`, data collection headers, dialog footers, etc.) without an \`I18nProvider\` now crashes with:

\`\`\`
useI18n must be used within an I18nProvider
\`\`\`

The blast radius downstream is large. Integrators bumping f0-react past 1.445 see hundreds of unit tests fail — tests that render components with the plain \`@testing-library/react\` \`render()\` never wrapped the tree in an \`I18nProvider\` because they didn't need to until one primitive started requiring it transitively.

## What?

\`\`\`diff
 import ExternalLink from \"@/icons/app/ExternalLink\"
 import { withDataTestId } from \"@/lib/data-testid\"
-import { useI18n } from \"@/lib/providers/i18n\"

 const _F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(...) {
-  const i18n = useI18n()
   ...
       {external && (
         <>
           <F0Icon icon={ExternalLink} size={\"sm\"} aria-hidden={true} />
-          <span className=\"sr-only\">{i18n.link.opensInNewTab}</span>
+          <span className=\"sr-only\">opens in new tab</span>
         </>
       )}
 })
\`\`\`

- The WCAG 3.2.5 mitigation is preserved — the screen-reader-only hint still announces the new-tab behaviour.
- Consumers no longer need to mount an \`I18nProvider\` just to render a link.
- Consistent with the approach already taken in \`F0Alert\` (#3900).

If translation of this specific a11y string becomes a requirement later, it can be reintroduced via a small leaf component that reads \`useI18n\` only when \`external\` is \`true\` — scoping the provider requirement to external links instead of every \`F0Link\` instance.

## Test plan

- [x] \`pnpm tsc\` clean
- [x] \`pnpm --filter @factorialco/f0-react exec vitest run src/components/F0Link\` — 7/7 passing
- [ ] Visual review: F0Link with \`target=\"_blank\"\` still shows the external-link icon and the screen reader still announces the new-tab hint (same string, just not behind \`useI18n\`).