### PR TITLE
fix: shrink useI18n blast radius in F0Alert and DetailsItemsList

### DIFF
--- a/packages/react/src/components/F0Alert/F0Alert.tsx
+++ b/packages/react/src/components/F0Alert/F0Alert.tsx
@@ -1,4 +1,5 @@
 import { cva } from "cva"
+import { useRef } from "react"
 
 import { F0AvatarAlert } from "@/components/avatars/F0AvatarAlert"
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
@@ -10,7 +11,6 @@ import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import { cn } from "@/lib/utils"
 
 import type { F0AlertProps } from "./types"
-import { useRef } from "react"
 
 const alertVariants = cva({
   base: "w-full rounded-md p-2 pr-3 text-f1-foreground",
@@ -44,6 +44,27 @@ const titleVariants = cva({
   },
 })
 
+/**
+ * Leaf component wrapping the close button so `useI18n()` is only read when
+ * an `onClose` handler is actually provided. Keeps F0Alert renderable
+ * without an `I18nProvider` for consumers (and tests) that don't use the
+ * close affordance.
+ */
+const CloseButton = ({ onClose }: { onClose: () => void }) => {
+  const { actions } = useI18n()
+  return (
+    <F0Button
+      icon={Cross}
+      label={actions.close}
+      hideLabel
+      variant="outline"
+      size="sm"
+      onClick={onClose}
+      type="button"
+    />
+  )
+}
+
 const _F0Alert = ({
   title,
   description,
@@ -54,7 +75,6 @@ const _F0Alert = ({
   onClose,
 }: F0AlertProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
-  const { actions } = useI18n()
 
   const alertRole =
     variant === "critical" || variant === "warning" ? "alert" : "status"
@@ -92,7 +112,6 @@ const _F0Alert = ({
                     size="sm"
                   >
                     {link.label}
-                    <span className="sr-only"> (opens in new tab)</span>
                   </F0Link>
                 )}
                 {action && (
@@ -110,15 +129,7 @@ const _F0Alert = ({
           </div>
           {onClose && (
             <div className="flex-shrink-0 self-start @xs:self-center">
-              <F0Button
-                icon={Cross}
-                label={actions.close}
-                hideLabel
-                variant="outline"
-                size="sm"
-                onClick={onClose}
-                type="button"
-              />
+              <CloseButton onClose={onClose} />
             </div>
           )}
         </div>

--- a/packages/react/src/components/F0Link/__tests__/index.test.tsx
+++ b/packages/react/src/components/F0Link/__tests__/index.test.tsx
@@ -27,7 +27,7 @@ describe("F0Link", () => {
         External Link
       </F0Link>
     )
-    expect(screen.getByText("opens in new tab")).toBeInTheDocument()
+    expect(screen.getByText(/opens in new tab/)).toBeInTheDocument()
   })
 
   it("applies custom className", () => {

--- a/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
@@ -16,6 +16,22 @@ interface DetailsItemsListProps extends WithDataTestIdProps {
   onClickSeeMore?: () => void
 }
 
+/**
+ * Leaf component wrapping the "see more" button so `useI18n()` is only read
+ * when `showSeeMore` is true. Keeps DetailsItemsList renderable without an
+ * `I18nProvider` for consumers (and tests) that don't opt into the button.
+ */
+const SeeMoreButton = ({ onClick }: { onClick?: () => void }) => {
+  const i18n = useI18n()
+  return (
+    <F0Button
+      label={i18n.actions.seeMore}
+      onClick={onClick}
+      variant="neutral"
+    />
+  )
+}
+
 const _DetailsItemsList = forwardRef<HTMLDivElement, DetailsItemsListProps>(
   function DetailsItemList(
     {
@@ -28,8 +44,6 @@ const _DetailsItemsList = forwardRef<HTMLDivElement, DetailsItemsListProps>(
     },
     ref
   ) {
-    const i18n = useI18n()
-
     return (
       <DataTestIdWrapper dataTestId={dataTestId}>
         <div ref={ref} className="flex flex-col gap-4">
@@ -62,13 +76,7 @@ const _DetailsItemsList = forwardRef<HTMLDivElement, DetailsItemsListProps>(
               </React.Fragment>
             ))}
           </div>
-          {showSeeMore && (
-            <F0Button
-              label={i18n.actions.seeMore}
-              onClick={onClickSeeMore}
-              variant="neutral"
-            />
-          )}
+          {showSeeMore && <SeeMoreButton onClick={onClickSeeMore} />}
         </div>
       </DataTestIdWrapper>
     )


### PR DESCRIPTION
## Summary

Follow-up to #3975. Two more primitive components still call \`useI18n()\` unconditionally, so any consumer that mounts them without an \`I18nProvider\` crashes with \`useI18n must be used within an I18nProvider\`:

- **\`F0Alert\`** reads \`actions.close\` but only renders the close button when \`onClose\` is provided.
- **\`experimental/Lists/DetailsItemsList\`** reads \`actions.seeMore\` but only renders the button when \`showSeeMore\` is true.

Same quirúrgical pattern as #3975: hoist the sub-UI into a leaf component so \`useI18n()\` is only invoked when the string is actually about to be rendered. No change to the public API, no change to the translated strings, no contract change on the hook.

## Why?

After bumping \`@factorialco/f0-react\` past 1.445, integrators see hundreds of unit tests fail with:

\`\`\`
useI18n must be used within an I18nProvider
\`\`\`

These tests render components with plain \`@testing-library/react\` \`render()\` — they never wrapped the tree in an \`I18nProvider\` because they didn't need to before. Now they transitively touch an \`F0Alert\` or a \`DetailsItemsList\` (often buried inside other primitives or patterns) and the hook throws even though the sub-UI that actually needs the translation is not rendered.

## What?

### \`F0Alert\`

\`\`\`diff
-const _F0Alert = ({ ..., onClose }) => {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const { actions } = useI18n()
-  ...
+const CloseButton = ({ onClose }: { onClose: () => void }) => {
+  const { actions } = useI18n()
+  return <F0Button icon={Cross} label={actions.close} hideLabel ... />
+}
+
+const _F0Alert = ({ ..., onClose }) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  ...
   {onClose && (
     <div className=\"flex-shrink-0 self-start @xs:self-center\">
-      <F0Button icon={Cross} label={actions.close} hideLabel ... />
+      <CloseButton onClose={onClose} />
     </div>
   )}
\`\`\`

Also removes a duplicated screen-reader hint. After #3975 hardcoded \`(opens in new tab)\` inside \`F0Link\`, \`F0Alert\` was still adding its own \`<span className=\"sr-only\"> (opens in new tab)</span>\` as a child of the \`F0Link\` — the DOM ended up with two identical sr-only spans, and the existing \`getByText(\"(opens in new tab)\")\` test crashed with \"multiple elements\". Drop the alert-level duplicate.

### \`DetailsItemsList\`

\`\`\`diff
+const SeeMoreButton = ({ onClick }: { onClick?: () => void }) => {
+  const i18n = useI18n()
+  return <F0Button label={i18n.actions.seeMore} onClick={onClick} variant=\"neutral\" />
+}
+
 const _DetailsItemsList = forwardRef<...>(function DetailsItemList({ ..., showSeeMore, onClickSeeMore }, ref) {
-  const i18n = useI18n()
-
   return (
     ...
-    {showSeeMore && (
-      <F0Button label={i18n.actions.seeMore} onClick={onClickSeeMore} variant=\"neutral\" />
-    )}
+    {showSeeMore && <SeeMoreButton onClick={onClickSeeMore} />}
\`\`\`

### Test adjustment

\`F0Link/__tests__/index.test.tsx\` switches \`getByText(\"opens in new tab\")\` to a regex because the on-screen text is \`\" (opens in new tab)\"\` (with surrounding whitespace/parens).

## Test plan

- [x] \`pnpm --filter @factorialco/f0-react exec tsc --noEmit\` clean
- [x] F0Alert, F0Link, DetailsItemsList test files pass (23 tests)
- [x] Remaining vitest suite green except for a pre-existing \`RichTextEditor/mentions\` flake that also fails on \`main\` (unrelated)
- [ ] Visual review: F0Alert with \`onClose\` still shows the close button; F0Alert with an external link still announces the new-tab hint (exactly once now).