### PR TITLE
feat(PageHeader): support onClick handler on PageAction

### DIFF
--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -77,6 +77,22 @@ export const Default: Story = {
   },
 }
 
+export const WithOnClickAction: Story = {
+  args: {
+    module: defaultModule,
+    actions: [
+      {
+        label: "Run",
+        icon: Settings,
+        onClick: () => {
+          // eslint-disable-next-line no-alert
+          alert("Run clicked")
+        },
+      },
+    ],
+  },
+}
+
 export const WithActions: Story = {
   args: {
     module: defaultModule,

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -30,6 +30,9 @@ export type PageAction = {
       href: string
     }
   | {
+      onClick: () => void
+    }
+  | {
       actions: Array<{ label: string; href: string }>
     }
 )
@@ -309,6 +312,19 @@ function PageAction({ action }: { action: PageAction }): ReactElement {
           pressed={isOpen}
         />
       </Dropdown>
+    )
+  }
+
+  if ("onClick" in action) {
+    return (
+      <F0Button
+        size="md"
+        variant="outline"
+        label={action.label}
+        icon={action.icon}
+        hideLabel
+        onClick={action.onClick}
+      />
     )
   }
 


### PR DESCRIPTION
## Summary

Add a third variant \`{ onClick: () => void }\` to \`PageAction\` and render a plain F0Button for it, so host apps can run arbitrary logic on click without routing through a URL hash.

## Why?

Today \`PageAction\` accepts two shapes:

- \`{ href: string }\` — anchor + button, click forwarded via ref.
- \`{ actions: Array<{ label, href }> }\` — dropdown.

Some host flows need to execute arbitrary logic on click — e.g. open the One AI chat panel and inject a seed message — without polluting the URL. Right now there's no clean way:

- **Using \`href=\"#something\"\`** forces the host to listen for a hash change in a layout-level effect and then \`navigate(pathname, { replace: true })\` to clean the URL. That couples the layout to the feature and adds an implicit, URL-driven control flow.
- **Casting to \`PageAction\` and passing \`onClick\`** silently does nothing in runtime: \`PageHeader\` wraps the button in \`<Link href={action.href}>\` and the button's internal \`onClick\` calls \`preventDefault()\` then \`ref.current?.click()\`. The host-provided \`onClick\` is never invoked.

Concretely this blocks the saved-dashboards header button in factorialco/factorial#95683.

## What?

\`\`\`diff
 export type PageAction = {
   label: string
   icon: IconType
 } & (
   | { href: string }
+  | { onClick: () => void }
   | { actions: Array<{ label: string; href: string }> }
 )
\`\`\`

And in the runtime \`PageAction\` component:

\`\`\`diff
   if (\"actions\" in action) {
     return <Dropdown ... />
   }

+  if (\"onClick\" in action) {
+    return (
+      <F0Button
+        size=\"md\"
+        variant=\"outline\"
+        label={action.label}
+        icon={action.icon}
+        hideLabel
+        onClick={action.onClick}
+      />
+    )
+  }
+
   // href variant — unchanged
   return <Link href={action.href} ...><F0Button ... /></Link>
\`\`\`

The existing \`href\` and \`actions\` variants render identically to today. Nothing is removed.

## Test plan

- [x] \`pnpm --filter @factorialco/f0-react exec tsc --noEmit\` clean.
- [x] \`oxfmt\` applied.
- [ ] New story \`Navigation/PageHeader — WithOnClickAction\` renders a button that alerts on click. Validate via Chromatic.
- [ ] Existing \`WithActions\` / \`Default\` stories visually unchanged.

## Downstream

Factorial PR factorialco/factorial#95683 already has the consumer wired — it casts \`onClick\` today with an \`as unknown as PageAction\` escape hatch that does nothing at runtime. After this PR merges and a new f0-react is published, the cast can go away and the button will actually fire.