### PR TITLE
fix: export CandidateProfile and JobPostingProfile types

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/index.ts
@@ -19,6 +19,7 @@ export type {
   EntityResolvers,
   EntityUrlBuilders,
   EntityRefs,
+  JobPostingProfile,
   RequisitionProfile,
   PersonProfile,
   UploadedFile,


### PR DESCRIPTION
Adds `CandidateProfile` and `JobPostingProfile` to the type exports from `@factorialco/f0-react`.