### PR TITLE
fix: update mentionIds to use string format in tests

### DIFF
--- a/packages/react/src/components/RichText/RichTextEditor/mentions.test.tsx
+++ b/packages/react/src/components/RichText/RichTextEditor/mentions.test.tsx
@@ -76,7 +76,7 @@ describe("RichTextEditor mentions", () => {
       .reverse()
       .find((value) => Array.isArray(value?.mentionIds))
 
-    expect(lastCallWithMentions?.mentionIds).toEqual([1, 2, 3, 4])
+    expect(lastCallWithMentions?.mentionIds).toEqual(["1", "2", "3", "4"])
   })
 
   it("supports mentions across paragraphs and consecutive mentions", async () => {


### PR DESCRIPTION
## Description
There was a PR merged after the fix to multiple mentions was introduced that wasn't rebased with the new unit test and thus it didn't do the change. This made both PRs have a green CI but conflict once they got into main.

## Implementation details
Properly typing the mentionIds asserstion on the unit test
