### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.457.0",
+  "packages/react": "1.457.1",
   "packages/react-native": "0.51.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.457.1](https://github.com/factorialco/f0/compare/f0-react-v1.457.0...f0-react-v1.457.1) (2026-04-21)
+
+
+### Bug Fixes
+
+* update mentionIds to use string format in tests ([#3982](https://github.com/factorialco/f0/issues/3982)) ([9ef715e](https://github.com/factorialco/f0/commit/9ef715e27687c86259c6cfd4270ef35d315703db))
+
 ## [1.457.0](https://github.com/factorialco/f0/compare/f0-react-v1.456.3...f0-react-v1.457.0) (2026-04-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.457.0",
+  "version": "1.457.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.457.1</summary>

## [1.457.1](https://github.com/factorialco/f0/compare/f0-react-v1.457.0...f0-react-v1.457.1) (2026-04-21)


### Bug Fixes

* update mentionIds to use string format in tests ([#3982](https://github.com/factorialco/f0/issues/3982)) ([9ef715e](https://github.com/factorialco/f0/commit/9ef715e27687c86259c6cfd4270ef35d315703db))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).