### PR TITLE
fix: rich text field not getting updated when co-editing form

### DIFF
--- a/packages/react/src/patterns/F0Form/fields/richtext/RichTextFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/richtext/RichTextFieldRenderer.tsx
@@ -1,9 +1,13 @@
+import { useEffect, useRef } from "react"
 import { ControllerRenderProps, FieldValues } from "react-hook-form"
 
-import { RichTextEditor } from "@/components/RichText/RichTextEditor"
+import {
+  RichTextEditor,
+  type RichTextEditorHandle,
+} from "@/components/RichText/RichTextEditor"
 
-import type { F0RichTextField, RichTextValue } from "./types"
 import type { ResolvedField } from "../types"
+import type { F0RichTextField, RichTextValue } from "./types"
 
 interface RichTextFieldRendererProps {
   field: ResolvedField<F0RichTextField>
@@ -21,11 +25,29 @@ export function RichTextFieldRenderer({
   error,
   loading,
 }: RichTextFieldRendererProps) {
-  const currentValue = formField.value as RichTextValue | undefined
+  const { ref: _formRef, ...formFieldRest } = formField
+  const editorRef = useRef<RichTextEditorHandle>(null)
+  const lastInternalValueRef = useRef<string | null | undefined>(undefined)
+
+  // fillForm sets a plain string while the editor's onChange produces a
+  // RichTextValue object. Normalise both shapes into a content string.
+  const rawValue = formField.value as RichTextValue | string | undefined
+  const currentContent =
+    typeof rawValue === "string" ? rawValue : (rawValue?.value ?? "")
+
+  // Sync external value changes (e.g. from fillForm) into the TipTap editor.
+  // The editor only reads initialEditorState on mount, so programmatic updates
+  // via react-hook-form's setValue need to be pushed explicitly.
+  useEffect(() => {
+    if (currentContent !== lastInternalValueRef.current) {
+      editorRef.current?.setContent(currentContent)
+    }
+  }, [currentContent])
 
   return (
     <RichTextEditor
-      {...formField}
+      ref={editorRef}
+      {...formFieldRest}
       title={field.label}
       placeholder={field.placeholder ?? ""}
       maxCharacters={field.maxCharacters}
@@ -36,9 +58,10 @@ export function RichTextFieldRenderer({
       error={error}
       loading={loading}
       initialEditorState={{
-        content: currentValue?.value ?? "",
+        content: currentContent,
       }}
       onChange={(result) => {
+        lastInternalValueRef.current = result.value
         formField.onChange({
           value: result.value,
           mentionIds: result.mentionIds,

--- a/packages/react/src/patterns/F0Form/fields/richtext/RichTextFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/richtext/RichTextFieldRenderer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef } from "react"
 import { ControllerRenderProps, FieldValues } from "react-hook-form"
 
 import {
@@ -25,9 +25,23 @@ export function RichTextFieldRenderer({
   error,
   loading,
 }: RichTextFieldRendererProps) {
-  const { ref: _formRef, ...formFieldRest } = formField
+  const { ref: formRef, ...formFieldRest } = formField
   const editorRef = useRef<RichTextEditorHandle>(null)
-  const lastInternalValueRef = useRef<string | null | undefined>(undefined)
+  const lastInternalContentRef = useRef<string>("")
+
+  // Compose react-hook-form's ref (used for shouldFocusError) with our own
+  const composedRef = useCallback(
+    (handle: RichTextEditorHandle | null) => {
+      ;(
+        editorRef as React.MutableRefObject<RichTextEditorHandle | null>
+      ).current = handle
+      // react-hook-form expects a callback ref for focus management
+      if (typeof formRef === "function") {
+        formRef(handle)
+      }
+    },
+    [formRef]
+  )
 
   // fillForm sets a plain string while the editor's onChange produces a
   // RichTextValue object. Normalise both shapes into a content string.
@@ -39,14 +53,14 @@ export function RichTextFieldRenderer({
   // The editor only reads initialEditorState on mount, so programmatic updates
   // via react-hook-form's setValue need to be pushed explicitly.
   useEffect(() => {
-    if (currentContent !== lastInternalValueRef.current) {
+    if (currentContent !== lastInternalContentRef.current) {
       editorRef.current?.setContent(currentContent)
     }
   }, [currentContent])
 
   return (
     <RichTextEditor
-      ref={editorRef}
+      ref={composedRef}
       {...formFieldRest}
       title={field.label}
       placeholder={field.placeholder ?? ""}
@@ -61,7 +75,7 @@ export function RichTextFieldRenderer({
         content: currentContent,
       }}
       onChange={(result) => {
-        lastInternalValueRef.current = result.value
+        lastInternalContentRef.current = result.value ?? ""
         formField.onChange({
           value: result.value,
           mentionIds: result.mentionIds,

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx
@@ -575,6 +575,21 @@ const presentableFormSchema = z.object({
     rows: 3,
     helpText: "Internal notes visible only to HR",
   }),
+  welcomeMessage: f0FormField(
+    z.object({
+      value: z.string().optional(),
+      mentionIds: z.array(z.number()).optional(),
+    }),
+    {
+      label: "Welcome Message",
+      section: "additional",
+      fieldType: "richtext",
+      placeholder: "Write a welcome message for the new employee...",
+      height: "sm",
+      plainHtmlMode: true,
+      helpText: "Rich text welcome message sent on the first day",
+    }
+  ),
   termsAccepted: f0FormField(z.boolean(), {
     label: "Accepts Terms & Conditions",
     section: "additional",
@@ -761,6 +776,7 @@ const presentableFormDefinitions: F0AiAvailableFormDefinition[] = [
       emergencyContactName: undefined,
       emergencyContactPhone: undefined,
       notes: undefined,
+      welcomeMessage: { value: "" },
       termsAccepted: false,
     },
     sections: {


### PR DESCRIPTION
## Fix: Rich text field not updating when filled by AI

### Problem

When the AI assistant used `fillForm` to set a rich text field value, the `RichTextEditor` (TipTap) only reflected the content on the first fill. Subsequent fills appeared to do nothing — the editor stayed stuck with stale content until it was unmounted and remounted.

**Two root causes:**

1. **TipTap ignores prop changes after mount** — `RichTextEditor` only reads `initialEditorState.content` once during initialization. External value changes via react-hook-form's `setValue` were never pushed into the editor.
2. **Value shape mismatch** — `fillForm` sets the field to a plain `string`, but the renderer assumed the value was always a `RichTextValue` object (accessing `.value`). This meant `"Hello".value → undefined`, so the `useEffect` dependency stayed stuck at `undefined` and never re-triggered after the first call.

### Changes

**`RichTextFieldRenderer.tsx`**

- Added an imperative `ref` to `RichTextEditor` and a `useEffect` that calls `setContent()` when the form value changes externally
- Normalized both value shapes (`string` from fillForm vs `RichTextValue` from user edits) into a single `currentContent` string
- Tracked the last internally-produced value via `lastInternalValueRef` to avoid a feedback loop between `onChange` and the sync effect
- Destructured react-hook-form's `ref` out of `formField` to avoid the duplicate `ref` prop warning