### PR TITLE
fix: accept f0FormDefinition in availableFormDefinitions

### DIFF
--- a/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
+++ b/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
@@ -5,17 +5,24 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react"
+import { z } from "zod"
 import { zodToJsonSchema } from "zod-to-json-schema"
 
 import type { ModuleId } from "@/components/avatars/F0AvatarModule"
-import type { F0WizardFormStep } from "@/patterns/F0WizardForm/types"
+import type {
+  F0FormDefinitionSingleSchema,
+  F0FormDefinitionPerSection,
+  F0WizardFormStep,
+} from "@/patterns/F0WizardForm/types"
 
 import type {
   F0FormErrorTriggerMode,
   F0FormSchema,
+  F0PerSectionSchema,
   F0SectionConfig,
   F0FormSubmitConfig,
 } from "./types"
@@ -101,6 +108,98 @@ export interface F0AiAvailableFormDefinition<
 }
 
 /**
+ * An item that can be passed in the `availableFormDefinitions` array.
+ * Accepts either a plain {@link F0AiAvailableFormDefinition} or the result
+ * of calling {@link useF0FormDefinition} (i.e. {@link F0FormDefinitionSingleSchema}
+ * or {@link F0FormDefinitionPerSection}).
+ */
+export type AvailableFormDefinitionItem =
+  | F0AiAvailableFormDefinition
+  | F0FormDefinitionSingleSchema<F0FormSchema>
+  | F0FormDefinitionPerSection<F0PerSectionSchema>
+
+/**
+ * Type guard: returns true when the item is an F0FormDefinition (single or per-section)
+ * produced by useF0FormDefinition, as opposed to a plain F0AiAvailableFormDefinition.
+ */
+function isF0FormDefinition(
+  item: AvailableFormDefinitionItem
+): item is
+  | F0FormDefinitionSingleSchema<F0FormSchema>
+  | F0FormDefinitionPerSection<F0PerSectionSchema> {
+  return "_brand" in item
+}
+
+/**
+ * Normalises any {@link AvailableFormDefinitionItem} into an
+ * {@link F0AiAvailableFormDefinition} so the rest of the registry can
+ * consume it uniformly.
+ */
+function toAvailableFormDefinition(
+  item: AvailableFormDefinitionItem
+): F0AiAvailableFormDefinition {
+  if (!isF0FormDefinition(item)) return item
+
+  const schema: F0FormSchema =
+    item._brand === "single"
+      ? item.schema
+      : // Per-section: merge all section schemas into one object.
+        // The registry only understands a single F0FormSchema, so we
+        // merge the shapes into a flat z.object.
+        // (section boundaries are preserved in `sections`)
+        (() => {
+          const shapes: Record<string, ZodType> = {}
+          for (const sectionSchema of Object.values(
+            item.schema as Record<string, F0FormSchema>
+          )) {
+            const unwrapped = unwrapZodSchema(sectionSchema) as {
+              shape?: ZodRawShape
+            }
+            if (unwrapped.shape) Object.assign(shapes, unwrapped.shape)
+          }
+          return z.object(shapes) as F0FormSchema
+        })()
+
+  // Adapt the typed onSubmit to the untyped (values) => void signature
+  const originalOnSubmit = item.onSubmit
+  const onSubmit = originalOnSubmit
+    ? async (values: Record<string, unknown>) => {
+        if (item._brand === "single") {
+          await (
+            originalOnSubmit as F0FormDefinitionSingleSchema<F0FormSchema>["onSubmit"]
+          )({ data: values })
+        } else {
+          // For per-section, wrap values as a single-section submit arg
+          const firstSection = Object.keys(
+            item.schema as Record<string, F0FormSchema>
+          )[0]
+          await (
+            originalOnSubmit as F0FormDefinitionPerSection<F0PerSectionSchema>["onSubmit"]
+          )({
+            sectionId: firstSection,
+            data: values,
+            fullData: values,
+          } as never)
+        }
+      }
+    : undefined
+
+  return {
+    name: item.name,
+    schema,
+    defaultValues: item.defaultValues as Record<string, unknown> | undefined,
+    defaultValuesParamsSchema: item.defaultValuesParamsSchema,
+    sections: item.sections as Record<string, F0SectionConfig> | undefined,
+    onSubmit,
+    description: item.description,
+    module: item.module,
+    steps: item.steps,
+    submitConfig: item.submitConfig as F0FormSubmitConfig | undefined,
+    errorTriggerMode: item.errorTriggerMode,
+  }
+}
+
+/**
  * Helper to define an available form with proper params typing.
  * TypeScript infers `TParams` from `defaultValuesParamsSchema`, so the
  * `defaultValues` callback receives fully typed params.
@@ -122,8 +221,21 @@ export function defineAvailableForm<
   TParams extends Record<string, unknown> = Record<string, unknown>,
 >(
   definition: F0AiAvailableFormDefinition<TParams>
-): F0AiAvailableFormDefinition<TParams> {
-  return definition
+): F0AiAvailableFormDefinition<TParams>
+
+/**
+ * Overload that accepts an `F0FormDefinitionSingleSchema` (the return value
+ * of `useF0FormDefinition` with a single schema) and converts it into an
+ * `F0AiAvailableFormDefinition`.
+ */
+export function defineAvailableForm<TSchema extends F0FormSchema>(
+  definition: F0FormDefinitionSingleSchema<TSchema>
+): F0AiAvailableFormDefinition
+
+export function defineAvailableForm(
+  definition: AvailableFormDefinitionItem
+): F0AiAvailableFormDefinition {
+  return toAvailableFormDefinition(definition)
 }
 
 /**
@@ -397,12 +509,20 @@ const F0AiFormRegistryContext =
  */
 export function F0AiFormRegistryProvider({
   children,
-  availableFormDefinitions,
+  availableFormDefinitions: rawAvailableFormDefinitions,
 }: {
   children: React.ReactNode
-  /** Form definitions the AI can interact with even if the form is not rendered on the page */
-  availableFormDefinitions?: F0AiAvailableFormDefinition[]
+  /** Form definitions the AI can interact with even if the form is not rendered on the page.
+   *  Accepts plain definitions, or the return value of `useF0FormDefinition` hooks. */
+  availableFormDefinitions?: AvailableFormDefinitionItem[]
 }) {
+  // Normalise all items to F0AiAvailableFormDefinition.
+  // Memoise so the reference stays stable when the raw input hasn't changed,
+  // preventing the downstream useEffect from firing on every render.
+  const availableFormDefinitions = useMemo(
+    () => rawAvailableFormDefinitions?.map(toAvailableFormDefinition),
+    [rawAvailableFormDefinitions]
+  )
   const registryRef = useRef<Map<string, F0AiFormEntry>>(new Map())
   const lastDescriptionsJsonRef = useRef<string>("")
   const fillVersionsRef = useRef<Map<string, number>>(new Map())

--- a/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
+++ b/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
@@ -127,7 +127,39 @@ function isF0FormDefinition(
 ): item is
   | F0FormDefinitionSingleSchema<F0FormSchema>
   | F0FormDefinitionPerSection<F0PerSectionSchema> {
-  return "_brand" in item
+  return (
+    "_brand" in item &&
+    ((item as { _brand: unknown })._brand === "single" ||
+      (item as { _brand: unknown })._brand === "per-section")
+  )
+}
+
+/**
+ * Deeply unwraps a Zod schema, including ZodEffects (`.refine()`, `.transform()`, etc.),
+ * until it reaches a ZodObject with a `.shape`.
+ */
+function unwrapToZodObject(schema: ZodType): { shape?: ZodRawShape } {
+  let current: ZodType = schema
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (current) {
+    const def = (current as unknown as { _def: Record<string, unknown> })._def
+    // ZodObject → has shape
+    if ("shape" in def && typeof def.shape === "function") {
+      return { shape: (def.shape as () => ZodRawShape)() }
+    }
+    // ZodEffects → follow _def.schema
+    if ("schema" in def && def.schema instanceof z.ZodType) {
+      current = def.schema as ZodType
+      continue
+    }
+    // ZodOptional / ZodNullable / ZodDefault → follow innerType
+    if ("innerType" in def && def.innerType instanceof z.ZodType) {
+      current = def.innerType as ZodType
+      continue
+    }
+    break
+  }
+  return {}
 }
 
 /**
@@ -140,22 +172,41 @@ function toAvailableFormDefinition(
 ): F0AiAvailableFormDefinition {
   if (!isF0FormDefinition(item)) return item
 
+  // Build a mapping of sectionId → field keys for per-section definitions
+  const perSectionFieldKeys: Record<string, string[]> | undefined =
+    item._brand === "per-section"
+      ? Object.fromEntries(
+          Object.entries(item.schema as Record<string, F0FormSchema>).map(
+            ([sectionId, sectionSchema]) => [
+              sectionId,
+              Object.keys(unwrapToZodObject(sectionSchema).shape ?? {}),
+            ]
+          )
+        )
+      : undefined
+
   const schema: F0FormSchema =
     item._brand === "single"
       ? item.schema
-      : // Per-section: merge all section schemas into one object.
-        // The registry only understands a single F0FormSchema, so we
-        // merge the shapes into a flat z.object.
+      : // Per-section: merge all section schemas into one flat z.object.
+        // The registry only understands a single F0FormSchema.
         // (section boundaries are preserved in `sections`)
         (() => {
           const shapes: Record<string, ZodType> = {}
-          for (const sectionSchema of Object.values(
+          for (const [sectionId, sectionSchema] of Object.entries(
             item.schema as Record<string, F0FormSchema>
           )) {
-            const unwrapped = unwrapZodSchema(sectionSchema) as {
-              shape?: ZodRawShape
+            const unwrapped = unwrapToZodObject(sectionSchema)
+            if (!unwrapped.shape) continue
+            for (const [key, fieldSchema] of Object.entries(unwrapped.shape)) {
+              if (key in shapes) {
+                console.warn(
+                  `[toAvailableFormDefinition] Duplicate field "${key}" found in section "${sectionId}". ` +
+                    "The later section's field will overwrite the earlier one."
+                )
+              }
+              shapes[key] = fieldSchema
             }
-            if (unwrapped.shape) Object.assign(shapes, unwrapped.shape)
           }
           return z.object(shapes) as F0FormSchema
         })()
@@ -169,25 +220,52 @@ function toAvailableFormDefinition(
             originalOnSubmit as F0FormDefinitionSingleSchema<F0FormSchema>["onSubmit"]
           )({ data: values })
         } else {
-          // For per-section, wrap values as a single-section submit arg
-          const firstSection = Object.keys(
-            item.schema as Record<string, F0FormSchema>
-          )[0]
-          await (
-            originalOnSubmit as F0FormDefinitionPerSection<F0PerSectionSchema>["onSubmit"]
-          )({
-            sectionId: firstSection,
-            data: values,
-            fullData: values,
-          } as never)
+          // Reconstruct per-section fullData: { [sectionId]: { ...sectionFields } }
+          const sectionSchemas = item.schema as Record<string, F0FormSchema>
+          const fullData: Record<string, Record<string, unknown>> = {}
+          for (const [sectionId, fieldKeys] of Object.entries(
+            perSectionFieldKeys!
+          )) {
+            const sectionValues: Record<string, unknown> = {}
+            for (const key of fieldKeys) {
+              if (key in values) sectionValues[key] = values[key]
+            }
+            fullData[sectionId] = sectionValues
+          }
+          // Call onSubmit for each section (matching per-section contract)
+          const sectionIds = Object.keys(sectionSchemas)
+          for (const sectionId of sectionIds) {
+            await (
+              originalOnSubmit as F0FormDefinitionPerSection<F0PerSectionSchema>["onSubmit"]
+            )({
+              sectionId,
+              data: fullData[sectionId],
+              fullData,
+            } as never)
+          }
         }
       }
     : undefined
 
+  // Flatten per-section defaultValues from { sectionId: { field: val } } to { field: val }
+  let flatDefaultValues: Record<string, unknown> | undefined
+  if (item._brand === "per-section" && item.defaultValues) {
+    flatDefaultValues = {}
+    for (const sectionDefaults of Object.values(
+      item.defaultValues as Record<string, Record<string, unknown>>
+    )) {
+      Object.assign(flatDefaultValues, sectionDefaults)
+    }
+  } else {
+    flatDefaultValues = item.defaultValues as
+      | Record<string, unknown>
+      | undefined
+  }
+
   return {
     name: item.name,
     schema,
-    defaultValues: item.defaultValues as Record<string, unknown> | undefined,
+    defaultValues: flatDefaultValues,
     defaultValuesParamsSchema: item.defaultValuesParamsSchema,
     sections: item.sections as Record<string, F0SectionConfig> | undefined,
     onSubmit,

--- a/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
+++ b/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
@@ -115,8 +115,10 @@ export interface F0AiAvailableFormDefinition<
  */
 export type AvailableFormDefinitionItem =
   | F0AiAvailableFormDefinition
-  | F0FormDefinitionSingleSchema<F0FormSchema>
-  | F0FormDefinitionPerSection<F0PerSectionSchema>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | F0FormDefinitionSingleSchema<any>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | F0FormDefinitionPerSection<any>
 
 /**
  * Type guard: returns true when the item is an F0FormDefinition (single or per-section)
@@ -124,9 +126,7 @@ export type AvailableFormDefinitionItem =
  */
 function isF0FormDefinition(
   item: AvailableFormDefinitionItem
-): item is
-  | F0FormDefinitionSingleSchema<F0FormSchema>
-  | F0FormDefinitionPerSection<F0PerSectionSchema> {
+): item is F0FormDefinitionSingleSchema<any> | F0FormDefinitionPerSection<any> {
   return (
     "_brand" in item &&
     ((item as { _brand: unknown })._brand === "single" ||

--- a/packages/react/src/patterns/F0Form/__tests__/F0AiFormRegistryAvailableDefinitions.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0AiFormRegistryAvailableDefinitions.test.tsx
@@ -2,6 +2,11 @@ import React, { useState } from "react"
 import { describe, expect, it, vi } from "vitest"
 import { z } from "zod"
 
+import type {
+  F0FormDefinitionSingleSchema,
+  F0FormDefinitionPerSection,
+} from "@/patterns/F0WizardForm/types"
+
 import { zeroRender as render, waitFor, act } from "@/testing/test-utils"
 
 import type { F0AiAvailableFormDefinition } from "../F0AiFormRegistry"
@@ -9,6 +14,7 @@ import type { F0AiAvailableFormDefinition } from "../F0AiFormRegistry"
 import {
   F0AiFormRegistryProvider,
   useF0AiFormRegistry,
+  defineAvailableForm,
 } from "../F0AiFormRegistry"
 import { F0Form } from "../F0Form"
 import { f0FormField } from "../f0Schema"
@@ -958,5 +964,271 @@ describe("F0AiFormRegistryProvider availableFormDefinitions", () => {
       expect(entry!.ref.current!.getValues().name).toBe("Alice")
       expect(entry!.ref.current!.getValues().email).toBe("alice@test.com")
     })
+  })
+})
+
+// =============================================================================
+// Tests for F0FormDefinition normalization (single + per-section)
+// =============================================================================
+
+describe("F0AiFormRegistryProvider with F0FormDefinition items", () => {
+  const singleSchema = z.object({
+    firstName: z.string().min(1, "Required"),
+    lastName: z.string().min(1, "Required"),
+  })
+
+  const singleDefinition: F0FormDefinitionSingleSchema<typeof singleSchema> = {
+    _brand: "single",
+    name: "single-form",
+    schema: singleSchema,
+    description: "A single-schema form",
+    defaultValues: { firstName: "Jane", lastName: "Doe" },
+    onSubmit: vi.fn(async () => ({ success: true })),
+  }
+
+  it("registers a single-schema F0FormDefinition as virtual", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider availableFormDefinitions={[singleDefinition]}>
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry).not.toBeNull()
+      expect(capturedRegistry!.getFormNames()).toContain("single-form")
+    })
+
+    const entry = capturedRegistry!.get("single-form")
+    expect(entry).toBeDefined()
+    expect(entry!.virtual).toBe(true)
+    expect(entry!.ref.current!.getValues()).toEqual({
+      firstName: "Jane",
+      lastName: "Doe",
+    })
+  })
+
+  it("single-schema onSubmit adapter wraps values in { data }", async () => {
+    const onSubmit = vi.fn(async () => ({ success: true as const }))
+    const def: F0FormDefinitionSingleSchema<typeof singleSchema> = {
+      ...singleDefinition,
+      onSubmit,
+    }
+
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider availableFormDefinitions={[def]}>
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("single-form")).toBeDefined()
+    })
+
+    const ref = capturedRegistry!.get("single-form")!.ref.current!
+    ref.setValues({ firstName: "Alice", lastName: "Smith" })
+    await ref.submit()
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      data: { firstName: "Alice", lastName: "Smith" },
+    })
+  })
+
+  it("defineAvailableForm converts a single-schema F0FormDefinition", () => {
+    const result = defineAvailableForm(singleDefinition)
+    expect(result.name).toBe("single-form")
+    expect(result.description).toBe("A single-schema form")
+    // Should be a plain F0AiAvailableFormDefinition (no _brand)
+    expect("_brand" in result).toBe(false)
+  })
+
+  // -- Per-section tests --
+
+  const personalSchema = z.object({
+    firstName: z.string().min(1),
+    lastName: z.string().min(1),
+  })
+
+  const workSchema = z.object({
+    role: z.enum(["engineer", "designer"]),
+  })
+
+  const perSectionSchema = { personal: personalSchema, work: workSchema }
+
+  const perSectionDefinition: F0FormDefinitionPerSection<
+    typeof perSectionSchema
+  > = {
+    _brand: "per-section",
+    name: "per-section-form",
+    schema: perSectionSchema,
+    description: "A per-section form",
+    defaultValues: {
+      personal: { firstName: "Bob", lastName: "Jones" },
+      work: { role: "engineer" },
+    },
+    onSubmit: vi.fn(async () => ({ success: true })),
+  }
+
+  it("registers a per-section F0FormDefinition with flattened defaults", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider
+        availableFormDefinitions={[perSectionDefinition]}
+      >
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry).not.toBeNull()
+      expect(capturedRegistry!.getFormNames()).toContain("per-section-form")
+    })
+
+    const entry = capturedRegistry!.get("per-section-form")
+    expect(entry).toBeDefined()
+    expect(entry!.virtual).toBe(true)
+    // defaultValues should be flattened
+    expect(entry!.ref.current!.getValues()).toEqual({
+      firstName: "Bob",
+      lastName: "Jones",
+      role: "engineer",
+    })
+  })
+
+  it("per-section merged schema contains all fields", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider
+        availableFormDefinitions={[perSectionDefinition]}
+      >
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("per-section-form")).toBeDefined()
+    })
+
+    const ref = capturedRegistry!.get("per-section-form")!.ref.current!
+    const fieldNames = ref.getFieldNames()
+    expect(fieldNames).toContain("firstName")
+    expect(fieldNames).toContain("lastName")
+    expect(fieldNames).toContain("role")
+  })
+
+  it("per-section onSubmit reconstructs section data correctly", async () => {
+    const onSubmit = vi.fn(async () => ({ success: true as const }))
+    const def: F0FormDefinitionPerSection<typeof perSectionSchema> = {
+      ...perSectionDefinition,
+      onSubmit,
+    }
+
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider availableFormDefinitions={[def]}>
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("per-section-form")).toBeDefined()
+    })
+
+    const ref = capturedRegistry!.get("per-section-form")!.ref.current!
+    ref.setValues({
+      firstName: "Alice",
+      lastName: "Smith",
+      role: "designer",
+    })
+    await ref.submit()
+
+    // onSubmit is called once per section
+    expect(onSubmit).toHaveBeenCalledTimes(2)
+
+    // First call: personal section
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sectionId: "personal",
+        data: { firstName: "Alice", lastName: "Smith" },
+      })
+    )
+
+    // Second call: work section
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sectionId: "work",
+        data: { role: "designer" },
+      })
+    )
+  })
+
+  it("handles per-section with ZodEffects (refined schemas)", async () => {
+    const refinedPersonal = personalSchema.refine(
+      (v) => v.firstName !== v.lastName,
+      { message: "Names must differ" }
+    )
+
+    const refinedPerSection: F0FormDefinitionPerSection<{
+      personal: typeof refinedPersonal
+      work: typeof workSchema
+    }> = {
+      _brand: "per-section",
+      name: "refined-form",
+      schema: { personal: refinedPersonal, work: workSchema },
+      defaultValues: {
+        personal: { firstName: "A", lastName: "B" },
+        work: { role: "engineer" },
+      },
+      onSubmit: vi.fn(async () => ({ success: true })),
+    }
+
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider availableFormDefinitions={[refinedPerSection]}>
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("refined-form")).toBeDefined()
+    })
+
+    const ref = capturedRegistry!.get("refined-form")!.ref.current!
+    // Fields from the refined schema should still be extracted
+    const fieldNames = ref.getFieldNames()
+    expect(fieldNames).toContain("firstName")
+    expect(fieldNames).toContain("lastName")
+    expect(fieldNames).toContain("role")
   })
 })

--- a/packages/react/src/patterns/F0Form/index.tsx
+++ b/packages/react/src/patterns/F0Form/index.tsx
@@ -144,6 +144,7 @@ export {
 export type {
   F0AiFormEntry,
   F0AiAvailableFormDefinition,
+  AvailableFormDefinitionItem,
 } from "./F0AiFormRegistry"
 
 // Export AI schema description utility


### PR DESCRIPTION
## Accept `F0FormDefinition` in `availableFormDefinitions` and `defineAvailableForm`

### What

Extends the AI form registry to accept `F0FormDefinitionSingleSchema` and `F0FormDefinitionPerSection` (the return types of `useF0FormDefinition`) in addition to plain `F0AiAvailableFormDefinition` objects.

### Changes

**`F0AiFormRegistry.tsx`**

- New union type `AvailableFormDefinitionItem` — accepts `F0AiAvailableFormDefinition`, `F0FormDefinitionSingleSchema`, or `F0FormDefinitionPerSection`.
- `isF0FormDefinition` type guard — discriminates by `_brand` field.
- `toAvailableFormDefinition` normalizer — converts any `AvailableFormDefinitionItem` into an `F0AiAvailableFormDefinition`:
  - Single-schema definitions pass through the schema directly.
  - Per-section definitions merge section shapes into a flat `z.object`.
  - The typed `onSubmit({ data })` signature is adapted to the untyped `(values) => void` signature the registry expects.
- `defineAvailableForm` — added overload accepting `F0FormDefinitionSingleSchema<TSchema>`.
- `F0AiFormRegistryProvider` — `availableFormDefinitions` prop now accepts `AvailableFormDefinitionItem[]`. Items are normalized via `useMemo` to keep the reference stable and avoid re-render loops.

**`F0Form/index.tsx`**

- Exports the new `AvailableFormDefinitionItem` type.

### Usage

```tsx
// Before — plain definition object
<F0AiFormRegistryProvider availableFormDefinitions={[plainDef]} />

// After — can also pass useF0FormDefinition results directly
const formDef = useF0FormDefinition({ name: "employee", schema, onSubmit, ... })
<F0AiFormRegistryProvider availableFormDefinitions={[formDef]} />

// Or via defineAvailableForm
const available = defineAvailableForm(formDef)
```