### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.458.0",
-  "packages/react-native": "0.51.0",
+  "packages/react-native": "0.52.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.52.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.51.0...f0-react-native-v0.52.0) (2026-04-21)
+
+
+### Features
+
+* **F0Button:** changes to F0Button and added new icons ([#3969](https://github.com/factorialco/f0/issues/3969)) ([15d9e88](https://github.com/factorialco/f0/commit/15d9e88f90f74a94adfb93d36cb263fc42427aa2))
+
 ## [0.51.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.50.0...f0-react-native-v0.51.0) (2026-04-16)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.52.0</summary>

## [0.52.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.51.0...f0-react-native-v0.52.0) (2026-04-21)


### Features

* **F0Button:** changes to F0Button and added new icons ([#3969](https://github.com/factorialco/f0/issues/3969)) ([15d9e88](https://github.com/factorialco/f0/commit/15d9e88f90f74a94adfb93d36cb263fc42427aa2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).