### PR TITLE
chore: add form testing utilities

### DIFF
--- a/packages/react/src/patterns/F0Form/__tests__/createF0FormTester.test.ts
+++ b/packages/react/src/patterns/F0Form/__tests__/createF0FormTester.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { z } from "zod"
 
 import { useF0FormDefinition } from "@/patterns/F0WizardForm/useF0FormDefinition"
@@ -242,26 +242,28 @@ describe("createF0FormTester", () => {
     })
   })
 
-  describe("validateField()", async () => {
-    const tester = createF0FormTester({ schema: contactSchema })
+  describe("validateField()", () => {
+    it("returns only the error for the specified field", async () => {
+      const tester = createF0FormTester({ schema: contactSchema })
 
-    const result = await tester.validateField("email", {
-      name: "Alice",
-      email: "bad",
+      const result = await tester.validateField("email", {
+        name: "Alice",
+        email: "bad",
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors).toHaveProperty("email")
+      expect(Object.keys(result.errors)).toHaveLength(1)
     })
 
-    expect(result.valid).toBe(false)
-    expect(result.errors).toHaveProperty("email")
-    expect(Object.keys(result.errors)).toHaveLength(1)
-  })
+    it("returns valid when the specified field passes", async () => {
+      const tester = createF0FormTester({ schema: contactSchema })
 
-  it("returns valid when the specified field passes", async () => {
-    const tester = createF0FormTester({ schema: contactSchema })
+      const result = await tester.validateField("name", { name: "Alice" })
 
-    const result = await tester.validateField("name", { name: "Alice" })
-
-    expect(result.valid).toBe(true)
-    expect(result.errors).toEqual({})
+      expect(result.valid).toBe(true)
+      expect(result.errors).toEqual({})
+    })
   })
 })
 
@@ -388,5 +390,115 @@ describe("createF0FormDefinitionTester", () => {
     })
 
     expect(valid).toBe(true)
+  })
+
+  describe("submit()", () => {
+    it("calls onSubmit and returns success when validation passes", async () => {
+      const { result } = zeroRenderHook(() =>
+        useF0FormDefinition({
+          name: "test-form",
+          schema: contactSchema,
+          onSubmit: async () => ({ success: true }),
+        })
+      )
+
+      const tester = createF0FormDefinitionTester(result.current)
+
+      const submitResult = await tester.submit({
+        name: "Alice",
+        email: "alice@example.com",
+      })
+
+      expect(submitResult.success).toBe(true)
+    })
+
+    it("returns server-side field errors from onSubmit without throwing", async () => {
+      // Simulates a duplicate-email check that only the server can perform
+      const { result } = zeroRenderHook(() =>
+        useF0FormDefinition({
+          name: "test-form",
+          schema: contactSchema,
+          onSubmit: async () => ({
+            success: false,
+            errors: { email: "Email already registered" },
+          }),
+        })
+      )
+
+      const tester = createF0FormDefinitionTester(result.current)
+
+      const submitResult = await tester.submit({
+        name: "Alice",
+        email: "taken@example.com",
+      })
+
+      expect(submitResult.success).toBe(false)
+      expect(submitResult.success === false && submitResult.errors?.email).toBe(
+        "Email already registered"
+      )
+    })
+
+    it("returns a root-level error message from onSubmit", async () => {
+      const { result } = zeroRenderHook(() =>
+        useF0FormDefinition({
+          name: "test-form",
+          schema: contactSchema,
+          onSubmit: async () => ({
+            success: false,
+            rootMessage: "You do not have permission to update this employee",
+          }),
+        })
+      )
+
+      const tester = createF0FormDefinitionTester(result.current)
+
+      const submitResult = await tester.submit({
+        name: "Alice",
+        email: "alice@example.com",
+      })
+
+      expect(submitResult.success).toBe(false)
+      expect(submitResult.success === false && submitResult.rootMessage).toBe(
+        "You do not have permission to update this employee"
+      )
+    })
+
+    it("does not call onSubmit when schema validation fails", async () => {
+      const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+      const { result } = zeroRenderHook(() =>
+        useF0FormDefinition({
+          name: "test-form",
+          schema: contactSchema,
+          onSubmit,
+        })
+      )
+
+      const tester = createF0FormDefinitionTester(result.current)
+
+      // email is invalid — schema validation should block the call
+      await tester.submit({ name: "Alice", email: "not-an-email" })
+
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+
+    it("returns validation errors directly when schema validation fails", async () => {
+      const { result } = zeroRenderHook(() =>
+        useF0FormDefinition({
+          name: "test-form",
+          schema: contactSchema,
+          onSubmit: async () => ({ success: true }),
+        })
+      )
+
+      const tester = createF0FormDefinitionTester(result.current)
+
+      const submitResult = await tester.submit({ name: "Alice", email: "" })
+
+      expect(submitResult.success).toBe(false)
+      expect(
+        submitResult.success === false && submitResult.errors?.email
+      ).toBeTruthy()
+    })
   })
 })

--- a/packages/react/src/patterns/F0Form/__tests__/createF0FormTester.test.ts
+++ b/packages/react/src/patterns/F0Form/__tests__/createF0FormTester.test.ts
@@ -1,0 +1,392 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { useF0FormDefinition } from "@/patterns/F0WizardForm/useF0FormDefinition"
+import { zeroRenderHook } from "@/testing/test-utils"
+
+import { f0FormField } from "../f0Schema"
+import { createF0FormDefinitionTester } from "../testing/createF0FormDefinitionTester"
+import { createF0FormTester } from "../testing/createF0FormTester"
+
+// =============================================================================
+// Shared test schemas
+// =============================================================================
+
+const contactSchema = z.object({
+  name: f0FormField(z.string().min(1), { label: "Name" }),
+  email: f0FormField(z.string().email(), { label: "Email" }),
+  phone: f0FormField(z.string().optional(), { label: "Phone" }),
+})
+
+const conditionalSchema = z.object({
+  type: f0FormField(z.string().min(1), { label: "Type" }),
+  details: f0FormField(z.string().min(1), {
+    label: "Details",
+    renderIf: ({ values }) => values["type"] === "advanced",
+  }),
+})
+
+const refinedSchema = z
+  .object({
+    password: f0FormField(z.string().min(8), { label: "Password" }),
+    confirm: f0FormField(z.string().min(1), { label: "Confirm password" }),
+  })
+  .refine((data) => data.password === data.confirm, {
+    message: "Passwords do not match",
+    path: ["confirm"],
+  })
+
+const SSN_REGEX = /^\d{3}-\d{2}-\d{4}$/
+
+const employeeSchema = z.object({
+  name: f0FormField(z.string().min(1), { label: "Full name" }),
+  ssn: f0FormField(
+    z.string().regex(SSN_REGEX, "SSN must be in the format XXX-XX-XXXX"),
+    { label: "Social Security Number", placeholder: "123-45-6789" }
+  ),
+})
+
+// =============================================================================
+// createF0FormTester
+// =============================================================================
+
+describe("createF0FormTester", () => {
+  describe("validate()", () => {
+    it("returns errors for all required fields when called with no values", async () => {
+      const tester = createF0FormTester({ schema: contactSchema })
+
+      const { valid, errors } = await tester.validate()
+
+      expect(valid).toBe(false)
+      expect(errors).toHaveProperty("name")
+      expect(errors).toHaveProperty("email")
+    })
+
+    it("does not report errors for optional fields left empty", async () => {
+      const tester = createF0FormTester({ schema: contactSchema })
+
+      const { errors } = await tester.validate({
+        name: "Alice",
+        email: "alice@example.com",
+      })
+
+      expect(errors).not.toHaveProperty("phone")
+    })
+
+    it("returns valid when all required fields are filled", async () => {
+      const tester = createF0FormTester({ schema: contactSchema })
+
+      const { valid } = await tester.validate({
+        name: "Alice",
+        email: "alice@example.com",
+      })
+
+      expect(valid).toBe(true)
+    })
+
+    it("reports an error when the email format is invalid", async () => {
+      const tester = createF0FormTester({ schema: contactSchema })
+
+      const { errors } = await tester.validate({
+        name: "Alice",
+        email: "not-an-email",
+      })
+
+      expect(errors).toHaveProperty("email")
+    })
+
+    it("merges provided values on top of defaultValues", async () => {
+      const tester = createF0FormTester({
+        schema: contactSchema,
+        defaultValues: { name: "Alice", email: "alice@example.com" },
+      })
+
+      // Override only email — name comes from defaultValues
+      const { valid, errors } = await tester.validate({ email: "bad" })
+
+      expect(valid).toBe(false)
+      expect(errors).toHaveProperty("email")
+      expect(errors).not.toHaveProperty("name")
+    })
+
+    it("is valid when all defaults are already complete", async () => {
+      const tester = createF0FormTester({
+        schema: contactSchema,
+        defaultValues: { name: "Alice", email: "alice@example.com" },
+      })
+
+      const { valid } = await tester.validate()
+
+      expect(valid).toBe(true)
+    })
+
+    it("treats null values the same as undefined (clearable field behaviour)", async () => {
+      const tester = createF0FormTester({ schema: contactSchema })
+
+      const { errors } = await tester.validate({
+        name: null as unknown as string,
+        email: "alice@example.com",
+      })
+
+      // null → undefined, which fails the required check
+      expect(errors).toHaveProperty("name")
+    })
+  })
+
+  describe("validate() — renderIf conditions", () => {
+    it("skips validation for fields whose renderIf evaluates to false", async () => {
+      const tester = createF0FormTester({ schema: conditionalSchema })
+
+      // type="basic" → details field renderIf is false → not validated
+      const { errors } = await tester.validate({ type: "basic" })
+
+      expect(errors).not.toHaveProperty("details")
+    })
+
+    it("validates fields whose renderIf evaluates to true", async () => {
+      const tester = createF0FormTester({ schema: conditionalSchema })
+
+      // type="advanced" → details field is visible → required
+      const { errors } = await tester.validate({ type: "advanced" })
+
+      expect(errors).toHaveProperty("details")
+    })
+
+    it("passes when a visible conditional field is filled", async () => {
+      const tester = createF0FormTester({ schema: conditionalSchema })
+
+      const { valid } = await tester.validate({
+        type: "advanced",
+        details: "some details",
+      })
+
+      expect(valid).toBe(true)
+    })
+  })
+
+  describe("validate() — schema refinements (.refine)", () => {
+    it("runs cross-field refinements and reports the error on the correct path", async () => {
+      const tester = createF0FormTester({ schema: refinedSchema })
+
+      const { errors } = await tester.validate({
+        password: "correct-horse",
+        confirm: "different",
+      })
+
+      expect(errors).toHaveProperty("confirm")
+    })
+
+    it("passes when refinement conditions are met", async () => {
+      const tester = createF0FormTester({ schema: refinedSchema })
+
+      const { valid } = await tester.validate({
+        password: "correct-horse",
+        confirm: "correct-horse",
+      })
+
+      expect(valid).toBe(true)
+    })
+  })
+
+  describe("validate() — regex validation (SSN)", () => {
+    it("requires SSN when the field is empty", async () => {
+      const tester = createF0FormTester({ schema: employeeSchema })
+
+      const { errors } = await tester.validate({ name: "Alice" })
+
+      expect(errors).toHaveProperty("ssn")
+    })
+
+    it("rejects an SSN missing the dashes", async () => {
+      const tester = createF0FormTester({ schema: employeeSchema })
+
+      const { errors } = await tester.validate({
+        name: "Alice",
+        ssn: "123456789",
+      })
+
+      expect(errors.ssn).toBe("SSN must be in the format XXX-XX-XXXX")
+    })
+
+    it("rejects an SSN with letters", async () => {
+      const tester = createF0FormTester({ schema: employeeSchema })
+
+      const { errors } = await tester.validate({
+        name: "Alice",
+        ssn: "ABC-DE-FGHI",
+      })
+
+      expect(errors).toHaveProperty("ssn")
+    })
+
+    it("rejects an SSN with incorrect segment lengths", async () => {
+      const tester = createF0FormTester({ schema: employeeSchema })
+
+      const { errors } = await tester.validate({
+        name: "Alice",
+        ssn: "12-345-6789",
+      })
+
+      expect(errors).toHaveProperty("ssn")
+    })
+
+    it("accepts a correctly formatted SSN", async () => {
+      const tester = createF0FormTester({ schema: employeeSchema })
+
+      const { valid } = await tester.validate({
+        name: "Alice",
+        ssn: "123-45-6789",
+      })
+
+      expect(valid).toBe(true)
+    })
+  })
+
+  describe("validateField()", async () => {
+    const tester = createF0FormTester({ schema: contactSchema })
+
+    const result = await tester.validateField("email", {
+      name: "Alice",
+      email: "bad",
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toHaveProperty("email")
+    expect(Object.keys(result.errors)).toHaveLength(1)
+  })
+
+  it("returns valid when the specified field passes", async () => {
+    const tester = createF0FormTester({ schema: contactSchema })
+
+    const result = await tester.validateField("name", { name: "Alice" })
+
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual({})
+  })
+})
+
+describe("describeFields()", () => {
+  it("returns a description for each field in the schema", () => {
+    const tester = createF0FormTester({ schema: contactSchema })
+
+    const fields = tester.describeFields()
+
+    expect(fields.map((f) => f.name)).toEqual(["name", "email", "phone"])
+  })
+
+  it("marks required fields correctly", () => {
+    const tester = createF0FormTester({ schema: contactSchema })
+
+    const fields = tester.describeFields()
+    const nameField = fields.find((f) => f.name === "name")
+    const phoneField = fields.find((f) => f.name === "phone")
+
+    expect(nameField?.required).toBe(true)
+    expect(phoneField?.required).toBe(false)
+  })
+})
+
+describe("getDefaultValues()", () => {
+  it("returns the default values provided at creation", () => {
+    const defaults = { name: "Alice", email: "alice@example.com" }
+    const tester = createF0FormTester({
+      schema: contactSchema,
+      defaultValues: defaults,
+    })
+
+    expect(tester.getDefaultValues()).toEqual(defaults)
+  })
+
+  it("returns undefined when no defaults are provided", () => {
+    const tester = createF0FormTester({ schema: contactSchema })
+    expect(tester.getDefaultValues()).toBeUndefined()
+  })
+})
+
+describe("getVisibleFields()", () => {
+  it("includes fields with no renderIf condition", () => {
+    const tester = createF0FormTester({ schema: conditionalSchema })
+
+    const visible = tester.getVisibleFields({ type: "basic" })
+
+    expect(visible).toContain("type")
+  })
+
+  it("excludes conditional fields when renderIf is false", () => {
+    const tester = createF0FormTester({ schema: conditionalSchema })
+
+    const visible = tester.getVisibleFields({ type: "basic" })
+
+    expect(visible).not.toContain("details")
+  })
+
+  it("includes conditional fields when renderIf is true", () => {
+    const tester = createF0FormTester({ schema: conditionalSchema })
+
+    const visible = tester.getVisibleFields({ type: "advanced" })
+
+    expect(visible).toContain("details")
+  })
+})
+
+// =============================================================================
+// createF0FormDefinitionTester
+// =============================================================================
+
+describe("createF0FormDefinitionTester", () => {
+  it("validates using the schema from the form definition", async () => {
+    const { result } = zeroRenderHook(() =>
+      useF0FormDefinition({
+        name: "test-form",
+        schema: contactSchema,
+        defaultValues: { name: "", email: "" },
+        onSubmit: async () => ({ success: true }),
+      })
+    )
+
+    const tester = createF0FormDefinitionTester(result.current)
+
+    const { errors } = await tester.validate()
+
+    expect(errors).toHaveProperty("name")
+    expect(errors).toHaveProperty("email")
+  })
+
+  it("merges definition defaultValues with test-time overrides", async () => {
+    const { result } = zeroRenderHook(() =>
+      useF0FormDefinition({
+        name: "test-form",
+        schema: contactSchema,
+        defaultValues: { name: "Alice" },
+        onSubmit: async () => ({ success: true }),
+      })
+    )
+
+    const tester = createF0FormDefinitionTester(result.current)
+
+    // name comes from defaultValues — only email is missing
+    const { errors } = await tester.validate()
+
+    expect(errors).not.toHaveProperty("name")
+    expect(errors).toHaveProperty("email")
+  })
+
+  it("reports valid when all required fields are satisfied", async () => {
+    const { result } = zeroRenderHook(() =>
+      useF0FormDefinition({
+        name: "test-form",
+        schema: contactSchema,
+        onSubmit: async () => ({ success: true }),
+      })
+    )
+
+    const tester = createF0FormDefinitionTester(result.current)
+
+    const { valid } = await tester.validate({
+      name: "Alice",
+      email: "alice@example.com",
+    })
+
+    expect(valid).toBe(true)
+  })
+})

--- a/packages/react/src/patterns/F0Form/conditionalResolver.ts
+++ b/packages/react/src/patterns/F0Form/conditionalResolver.ts
@@ -1,10 +1,12 @@
-import { zodResolver } from "@hookform/resolvers/zod"
 import type { Resolver, FieldValues, ResolverOptions } from "react-hook-form"
+
+import { zodResolver } from "@hookform/resolvers/zod"
 import { z, ZodTypeAny, ZodRawShape, ZodObject, ZodEffects } from "zod"
+
+import type { F0FormSchema } from "./types"
 
 import { getF0Config, isZodType, unwrapToZodObject } from "./f0Schema"
 import { evaluateRenderIf } from "./fields/utils"
-import type { F0FormSchema } from "./types"
 
 /**
  * Creates a conditional Zod resolver that only validates visible fields.
@@ -56,8 +58,10 @@ export function createConditionalResolver<TSchema extends F0FormSchema>(
  * - If renderIf evaluates to false (field is hidden), use z.any() to skip all validation
  *
  * If the original schema has refinements (ZodEffects), they are preserved.
+ *
+ * Exported for use in headless testing utilities (`createF0FormTester`).
  */
-function buildDynamicSchema<TSchema extends F0FormSchema>(
+export function buildDynamicSchema<TSchema extends F0FormSchema>(
   schema: TSchema,
   values: Record<string, unknown>
 ): ZodObject<ZodRawShape> | ZodEffects<ZodObject<ZodRawShape>> {

--- a/packages/react/src/patterns/F0Form/index.tsx
+++ b/packages/react/src/patterns/F0Form/index.tsx
@@ -150,6 +150,14 @@ export type {
 export { describeFormSchema } from "./describeFormSchema"
 export type { FormFieldDescription } from "./describeFormSchema"
 
+// Export headless testing utilities
+export { createF0FormTester, createF0FormDefinitionTester } from "./testing"
+export type {
+  F0FormTester,
+  F0FormValidationResult,
+  CreateF0FormTesterOptions,
+} from "./testing"
+
 import type {
   F0FormPropsWithSingleSchema,
   F0FormPropsWithPerSectionSchema,

--- a/packages/react/src/patterns/F0Form/testing/createF0FormDefinitionTester.ts
+++ b/packages/react/src/patterns/F0Form/testing/createF0FormDefinitionTester.ts
@@ -59,5 +59,7 @@ export function createF0FormDefinitionTester<TSchema extends F0FormSchema>(
     schema: definition.schema,
     defaultValues: definition.defaultValues,
     errorMap: options?.errorMap,
+    // Adapt the definition's onSubmit ({ data }) signature to the tester's (data) signature
+    onSubmit: (data) => definition.onSubmit({ data }),
   })
 }

--- a/packages/react/src/patterns/F0Form/testing/createF0FormDefinitionTester.ts
+++ b/packages/react/src/patterns/F0Form/testing/createF0FormDefinitionTester.ts
@@ -1,0 +1,63 @@
+import type { F0FormDefinitionSingleSchema } from "@/patterns/F0WizardForm/types"
+
+import type { F0FormSchema } from "../types"
+
+import {
+  createF0FormTester,
+  type CreateF0FormTesterOptions,
+  type F0FormTester,
+} from "./createF0FormTester"
+
+/**
+ * Creates a headless form tester from a form definition object returned by
+ * `useF0FormDefinition`. Extracts the `schema` and `defaultValues` from the
+ * definition and delegates to `createF0FormTester`.
+ *
+ * This is the recommended way to unit-test the validation logic of a form
+ * definition hook without mounting any React components.
+ *
+ * @example
+ * ```ts
+ * // useEmployeeForm.ts
+ * export function useEmployeeForm(employee: Employee) {
+ *   return useF0FormDefinition({
+ *     name: "employee-form",
+ *     schema: employeeSchema,
+ *     defaultValues: { name: employee.name, email: employee.email },
+ *     onSubmit: async ({ data }) => updateEmployee(data),
+ *   })
+ * }
+ *
+ * // useEmployeeForm.test.ts
+ * it("requires name and email", async () => {
+ *   const { result } = zeroRenderHook(() =>
+ *     useEmployeeForm({ name: "", email: "" })
+ *   )
+ *   const tester = createF0FormDefinitionTester(result.current)
+ *
+ *   const { errors } = await tester.validate()
+ *   expect(errors).toHaveProperty("name")
+ *   expect(errors).toHaveProperty("email")
+ * })
+ *
+ * it("is valid when required fields are filled", async () => {
+ *   const { result } = zeroRenderHook(() =>
+ *     useEmployeeForm({ name: "", email: "" })
+ *   )
+ *   const tester = createF0FormDefinitionTester(result.current)
+ *
+ *   const { valid } = await tester.validate({ name: "Alice", email: "alice@example.com" })
+ *   expect(valid).toBe(true)
+ * })
+ * ```
+ */
+export function createF0FormDefinitionTester<TSchema extends F0FormSchema>(
+  definition: F0FormDefinitionSingleSchema<TSchema>,
+  options?: Pick<CreateF0FormTesterOptions<TSchema>, "errorMap">
+): F0FormTester<TSchema> {
+  return createF0FormTester({
+    schema: definition.schema,
+    defaultValues: definition.defaultValues,
+    errorMap: options?.errorMap,
+  })
+}

--- a/packages/react/src/patterns/F0Form/testing/createF0FormDefinitionTester.ts
+++ b/packages/react/src/patterns/F0Form/testing/createF0FormDefinitionTester.ts
@@ -50,6 +50,12 @@ import {
  *   expect(valid).toBe(true)
  * })
  * ```
+ *
+ * @remarks
+ * This utility only supports **single-schema** form definitions
+ * (`F0FormDefinitionSingleSchema`). If your form uses per-section definitions
+ * (the array variant returned by {@link useF0FormDefinition}), you must create
+ * a {@link createF0FormTester} for each section's schema directly.
  */
 export function createF0FormDefinitionTester<TSchema extends F0FormSchema>(
   definition: F0FormDefinitionSingleSchema<TSchema>,

--- a/packages/react/src/patterns/F0Form/testing/createF0FormTester.ts
+++ b/packages/react/src/patterns/F0Form/testing/createF0FormTester.ts
@@ -1,6 +1,6 @@
 import { z, type ZodErrorMap, type ZodTypeAny } from "zod"
 
-import type { F0FormSchema } from "../types"
+import type { F0FormSchema, F0FormSubmitResult } from "../types"
 
 import { buildDynamicSchema } from "../conditionalResolver"
 import {
@@ -64,11 +64,41 @@ export interface F0FormTester<TSchema extends F0FormSchema> {
    * for the given values, merged with the tester's defaultValues.
    */
   getVisibleFields(values?: Record<string, unknown>): string[]
+
+  /**
+   * Run schema validation and, if it passes, call the `onSubmit` handler
+   * provided in the options. Useful for testing server-side errors that an
+   * `onSubmit` returns (e.g. duplicate email, insufficient permissions).
+   *
+   * If schema validation fails the handler is never called and the result
+   * is `{ success: false, errors: <validation errors> }`.
+   *
+   * Requires `onSubmit` to be set in `createF0FormTesterOptions`.
+   *
+   * @example
+   * ```ts
+   * const tester = createF0FormDefinitionTester(result.current)
+   *
+   * const result = await tester.submit({ name: "Alice", email: "taken@example.com" })
+   * expect(result.success).toBe(false)
+   * expect((result as { errors: Record<string,string> }).errors.email)
+   *   .toBe("Email already registered")
+   * ```
+   */
+  submit(values?: Record<string, unknown>): Promise<F0FormSubmitResult>
 }
 
 export interface CreateF0FormTesterOptions<TSchema extends F0FormSchema> {
   schema: TSchema
   defaultValues?: Partial<z.infer<TSchema>>
+  /**
+   * Optional submit handler. When provided, `tester.submit(values)` will run
+   * schema validation first and then call this handler if validation passes.
+   * Mirrors the signature used inside F0Form — the tester supplies `data`.
+   */
+  onSubmit?: (
+    data: z.infer<TSchema>
+  ) => Promise<F0FormSubmitResult> | F0FormSubmitResult
   /**
    * Optional Zod errorMap. Defaults to Zod's built-in English messages.
    * Pass a custom errorMap to get localised messages in assertions.
@@ -120,7 +150,7 @@ function flattenZodErrors(error: z.ZodError): Record<string, string> {
 export function createF0FormTester<TSchema extends F0FormSchema>(
   options: CreateF0FormTesterOptions<TSchema>
 ): F0FormTester<TSchema> {
-  const { schema, defaultValues, errorMap } = options
+  const { schema, defaultValues, errorMap, onSubmit } = options
 
   const validate = async (
     values?: Record<string, unknown>
@@ -182,11 +212,31 @@ export function createF0FormTester<TSchema extends F0FormSchema>(
     return visible
   }
 
+  const submit = async (
+    values?: Record<string, unknown>
+  ): Promise<F0FormSubmitResult> => {
+    if (!onSubmit) {
+      throw new Error(
+        "createF0FormTester: cannot call submit() without an onSubmit handler. " +
+          "Pass onSubmit in the options, or use createF0FormDefinitionTester which reads it from the definition."
+      )
+    }
+
+    const validation = await validate(values)
+    if (!validation.valid) {
+      return { success: false, errors: validation.errors }
+    }
+
+    const merged = { ...(defaultValues ?? {}), ...(values ?? {}) }
+    return onSubmit(merged as z.infer<TSchema>)
+  }
+
   return {
     validate,
     validateField,
     describeFields,
     getDefaultValues,
     getVisibleFields,
+    submit,
   }
 }

--- a/packages/react/src/patterns/F0Form/testing/createF0FormTester.ts
+++ b/packages/react/src/patterns/F0Form/testing/createF0FormTester.ts
@@ -19,6 +19,11 @@ export interface F0FormValidationResult {
   valid: boolean
   /** Flat map of field name → error message for every failing field */
   errors: Record<string, string>
+  /**
+   * Root-level Zod error message (if any). Corresponds to issues with
+   * `path.length === 0` — e.g. from `.refine()` calls at the object level.
+   */
+  rootError?: string
 }
 
 export interface F0FormTester<TSchema extends F0FormSchema> {
@@ -110,18 +115,27 @@ export interface CreateF0FormTesterOptions<TSchema extends F0FormSchema> {
 // Implementation
 // =============================================================================
 
-function flattenZodErrors(error: z.ZodError): Record<string, string> {
-  const result: Record<string, string> = {}
+interface FlattenedZodErrors {
+  errors: Record<string, string>
+  rootError?: string
+}
+
+function flattenZodErrors(error: z.ZodError): FlattenedZodErrors {
+  const errors: Record<string, string> = {}
+  let rootError: string | undefined
   for (const issue of error.issues) {
-    // Skip root-level issues (matches flattenFormErrors in F0Form.tsx)
-    if (issue.path.length === 0) continue
+    if (issue.path.length === 0) {
+      // Root-level issue (e.g. from object-level .refine())
+      if (rootError === undefined) rootError = issue.message
+      continue
+    }
     const path = issue.path.join(".")
     // Keep only the first error per path
-    if (!(path in result)) {
-      result[path] = issue.message
+    if (!(path in errors)) {
+      errors[path] = issue.message
     }
   }
-  return result
+  return { errors, rootError }
 }
 
 /**
@@ -157,13 +171,15 @@ export function createF0FormTester<TSchema extends F0FormSchema>(
   ): Promise<F0FormValidationResult> => {
     const merged = { ...(defaultValues ?? {}), ...(values ?? {}) }
 
-    // Convert null → undefined to match real F0Form's conditional resolver
+    // Build dynamic schema from raw merged values BEFORE null conversion,
+    // matching the order used in createConditionalResolver.
+    const dynamicSchema = buildDynamicSchema(schema, merged)
+
+    // THEN convert null → undefined for Zod parsing
     const processed: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(merged)) {
       processed[key] = value === null ? undefined : value
     }
-
-    const dynamicSchema = buildDynamicSchema(schema, processed)
 
     const parseOptions = errorMap ? { errorMap } : undefined
     const result = await dynamicSchema.safeParseAsync(processed, parseOptions)
@@ -172,7 +188,12 @@ export function createF0FormTester<TSchema extends F0FormSchema>(
       return { valid: true, errors: {} }
     }
 
-    return { valid: false, errors: flattenZodErrors(result.error) }
+    const { errors, rootError } = flattenZodErrors(result.error)
+    return {
+      valid: false,
+      errors,
+      ...(rootError !== undefined && { rootError }),
+    }
   }
 
   const validateField = async (

--- a/packages/react/src/patterns/F0Form/testing/createF0FormTester.ts
+++ b/packages/react/src/patterns/F0Form/testing/createF0FormTester.ts
@@ -1,0 +1,192 @@
+import { z, type ZodErrorMap, type ZodTypeAny } from "zod"
+
+import type { F0FormSchema } from "../types"
+
+import { buildDynamicSchema } from "../conditionalResolver"
+import {
+  describeFormSchema,
+  type FormFieldDescription,
+} from "../describeFormSchema"
+import { getF0Config, unwrapToZodObject } from "../f0Schema"
+import { evaluateRenderIf } from "../fields/utils"
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+export interface F0FormValidationResult {
+  /** Whether all visible fields pass validation */
+  valid: boolean
+  /** Flat map of field name → error message for every failing field */
+  errors: Record<string, string>
+}
+
+export interface F0FormTester<TSchema extends F0FormSchema> {
+  /**
+   * Run validation against the schema.
+   *
+   * Provided `values` are merged on top of the tester's `defaultValues` so
+   * you can test incremental fills:
+   *
+   * ```ts
+   * const { errors } = await tester.validate()                        // all required errors
+   * const { errors } = await tester.validate({ name: "Alice" })       // remaining errors
+   * const { valid }  = await tester.validate({ name: "Alice", email: "a@b.com" }) // valid
+   * ```
+   *
+   * Fields with `renderIf` conditions that evaluate to `false` for the given
+   * values are skipped — matching real F0Form behaviour.
+   */
+  validate(values?: Record<string, unknown>): Promise<F0FormValidationResult>
+
+  /**
+   * Validate a single field in isolation.
+   * Returns `{ valid, errors }` where `errors` contains at most one entry.
+   */
+  validateField(
+    fieldName: string,
+    values?: Record<string, unknown>
+  ): Promise<F0FormValidationResult>
+
+  /**
+   * Return field descriptions for all fields in the schema.
+   * Delegates to `describeFormSchema()` — useful for asserting field metadata.
+   */
+  describeFields(): FormFieldDescription[]
+
+  /**
+   * Return the default values this tester was created with, if any.
+   */
+  getDefaultValues(): Partial<z.infer<TSchema>> | undefined
+
+  /**
+   * Return the names of fields that are currently visible (renderIf === true)
+   * for the given values, merged with the tester's defaultValues.
+   */
+  getVisibleFields(values?: Record<string, unknown>): string[]
+}
+
+export interface CreateF0FormTesterOptions<TSchema extends F0FormSchema> {
+  schema: TSchema
+  defaultValues?: Partial<z.infer<TSchema>>
+  /**
+   * Optional Zod errorMap. Defaults to Zod's built-in English messages.
+   * Pass a custom errorMap to get localised messages in assertions.
+   */
+  errorMap?: ZodErrorMap
+}
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+function flattenZodErrors(error: z.ZodError): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const issue of error.issues) {
+    // Skip root-level issues (matches flattenFormErrors in F0Form.tsx)
+    if (issue.path.length === 0) continue
+    const path = issue.path.join(".")
+    // Keep only the first error per path
+    if (!(path in result)) {
+      result[path] = issue.message
+    }
+  }
+  return result
+}
+
+/**
+ * Create a headless form tester that validates a schema using the same
+ * conditional resolver logic that real F0Form uses internally.
+ *
+ * No React, no DOM, no providers required.
+ *
+ * @example
+ * ```ts
+ * const schema = z.object({
+ *   name: f0FormField(z.string().min(1), { label: "Name" }),
+ *   email: f0FormField(z.string().email(), { label: "Email" }),
+ * })
+ *
+ * const tester = createF0FormTester({ schema })
+ *
+ * const { errors } = await tester.validate()
+ * expect(errors).toHaveProperty("name")
+ * expect(errors).toHaveProperty("email")
+ *
+ * const { valid } = await tester.validate({ name: "Alice", email: "alice@example.com" })
+ * expect(valid).toBe(true)
+ * ```
+ */
+export function createF0FormTester<TSchema extends F0FormSchema>(
+  options: CreateF0FormTesterOptions<TSchema>
+): F0FormTester<TSchema> {
+  const { schema, defaultValues, errorMap } = options
+
+  const validate = async (
+    values?: Record<string, unknown>
+  ): Promise<F0FormValidationResult> => {
+    const merged = { ...(defaultValues ?? {}), ...(values ?? {}) }
+
+    // Convert null → undefined to match real F0Form's conditional resolver
+    const processed: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(merged)) {
+      processed[key] = value === null ? undefined : value
+    }
+
+    const dynamicSchema = buildDynamicSchema(schema, processed)
+
+    const parseOptions = errorMap ? { errorMap } : undefined
+    const result = await dynamicSchema.safeParseAsync(processed, parseOptions)
+
+    if (result.success) {
+      return { valid: true, errors: {} }
+    }
+
+    return { valid: false, errors: flattenZodErrors(result.error) }
+  }
+
+  const validateField = async (
+    fieldName: string,
+    values?: Record<string, unknown>
+  ): Promise<F0FormValidationResult> => {
+    const full = await validate(values)
+    const fieldError = full.errors[fieldName]
+    return {
+      valid: fieldError === undefined,
+      errors: fieldError !== undefined ? { [fieldName]: fieldError } : {},
+    }
+  }
+
+  const describeFields = (): FormFieldDescription[] =>
+    describeFormSchema(schema)
+
+  const getDefaultValues = (): Partial<z.infer<TSchema>> | undefined =>
+    defaultValues
+
+  const getVisibleFields = (values?: Record<string, unknown>): string[] => {
+    const merged = { ...(defaultValues ?? {}), ...(values ?? {}) }
+    const objectSchema = unwrapToZodObject(schema)
+    const visible: string[] = []
+
+    for (const [fieldId, fieldSchema] of Object.entries(objectSchema.shape)) {
+      const config = getF0Config(fieldSchema as ZodTypeAny)
+      if (!config?.renderIf) {
+        visible.push(fieldId)
+        continue
+      }
+      if (evaluateRenderIf(config.renderIf, merged)) {
+        visible.push(fieldId)
+      }
+    }
+
+    return visible
+  }
+
+  return {
+    validate,
+    validateField,
+    describeFields,
+    getDefaultValues,
+    getVisibleFields,
+  }
+}

--- a/packages/react/src/patterns/F0Form/testing/index.ts
+++ b/packages/react/src/patterns/F0Form/testing/index.ts
@@ -1,0 +1,8 @@
+export {
+  createF0FormTester,
+  type F0FormTester,
+  type F0FormValidationResult,
+  type CreateF0FormTesterOptions,
+} from "./createF0FormTester"
+
+export { createF0FormDefinitionTester } from "./createF0FormDefinitionTester"


### PR DESCRIPTION
## Description

F0Form validation logic lives inside React hooks, making it impossible to unit-test without mounting a full component and clicking submit buttons. This PR introduces two pure testing utilities — `createF0FormTester` and `createF0FormDefinitionTester` — that let developers validate their form schemas and `useF0FormDefinition` hooks headlessly, with no DOM, no providers, and no boilerplate. The approach reuses the exact conditional resolver already used by F0Form internally, so results match real runtime behaviour including `renderIf` field skipping, cross-field `.refine()` rules, and server-side errors returned from `onSubmit`.

## Implementation details

- feat: export `buildDynamicSchema` from `conditionalResolver.ts` to enable headless validation reuse
- feat: add `createF0FormTester` utility — validates a Zod schema without React or DOM, returns `{ valid, errors }` with `validate()`, `validateField()`, `describeFields()`, `getDefaultValues()`, `getVisibleFields()`, and `submit()`
- feat: add `submit()` to `F0FormTester` — runs schema validation first, calls the `onSubmit` handler only if it passes, and returns the handler's `F0FormSubmitResult` directly (including server-side `errors` and `rootMessage`)
- feat: add `createF0FormDefinitionTester` — thin wrapper that accepts a `useF0FormDefinition` return value, wires up its `onSubmit` automatically, and delegates to `createF0FormTester`
- feat: export both utilities and their types from the F0Form index
- test: 34 tests covering required fields, optional fields, regex validation, `renderIf` conditions, cross-field refinements, defaultValues merging, server-side field errors, root-level error messages, and blocked submission on schema failure

---

## How to test a form definition hook

> **Rule of thumb:** only test validation rules and server responses that live in *your* schema and `onSubmit` — required fields, regex patterns, conditional visibility, cross-field refinements, duplicate-key rejections, permission errors. Do not re-test that F0Form submits on success or shows an error banner; those are covered by F0Form's own tests.

Given an existing form hook like this:

```ts
// useEmployeeForm.ts
const employeeSchema = z.object({
  name:       f0FormField(z.string().min(1),             { label: "Full name" }),
  email:      f0FormField(z.string().email(),             { label: "Work email" }),
  department: f0FormField(z.string().min(1),             { label: "Department" }),
  startDate:  f0FormField(z.date(),                      { label: "Start date" }),
  ssn:        f0FormField(
                z.string().regex(/^\d{3}-\d{2}-\d{4}$/, "SSN must be in the format XXX-XX-XXXX"),
                { label: "SSN", renderIf: ({ values }) => values["country"] === "US" }
              ),
})

export function useEmployeeForm(employee: Employee) {
  return useF0FormDefinition({
    name: "employee-form",
    schema: employeeSchema,
    defaultValues: { name: employee.name, email: employee.email },
    onSubmit: async ({ data }) => saveEmployee(data),
  })
}
```

Write a test file next to it:

```ts
// useEmployeeForm.test.ts
import { describe, expect, it, vi } from "vitest"
import { zeroRenderHook } from "@/testing/test-utils"
import { createF0FormDefinitionTester } from "@/patterns/F0Form"
import { useEmployeeForm } from "./useEmployeeForm"

const mockEmployee = { name: "", email: "" }

describe("useEmployeeForm validation", () => {
  it("requires name, email, department and startDate", async () => {
    const { result } = zeroRenderHook(() => useEmployeeForm(mockEmployee))
    const tester = createF0FormDefinitionTester(result.current)

    const { errors } = await tester.validate()

    expect(errors).toHaveProperty("name")
    expect(errors).toHaveProperty("email")
    expect(errors).toHaveProperty("department")
    expect(errors).toHaveProperty("startDate")
  })

  it("is valid when all required fields are filled", async () => {
    const { result } = zeroRenderHook(() => useEmployeeForm(mockEmployee))
    const tester = createF0FormDefinitionTester(result.current)

    const { valid } = await tester.validate({
      name: "Alice",
      email: "alice@factorial.co",
      department: "Engineering",
      startDate: new Date("2025-01-01"),
    })

    expect(valid).toBe(true)
  })

  it("skips SSN validation when country is not US", async () => {
    const { result } = zeroRenderHook(() => useEmployeeForm(mockEmployee))
    const tester = createF0FormDefinitionTester(result.current)

    const { errors } = await tester.validate({
      name: "Alice", email: "alice@factorial.co",
      department: "Engineering", startDate: new Date("2025-01-01"),
      country: "ES",
    })

    expect(errors).not.toHaveProperty("ssn")
  })

  it("rejects a malformed SSN when country is US", async () => {
    const { result } = zeroRenderHook(() => useEmployeeForm(mockEmployee))
    const tester = createF0FormDefinitionTester(result.current)

    const { errors } = await tester.validate({
      name: "Alice", email: "alice@factorial.co",
      department: "Engineering", startDate: new Date("2025-01-01"),
      country: "US", ssn: "123456789",
    })

    expect(errors.ssn).toBe("SSN must be in the format XXX-XX-XXXX")
  })
})

describe("useEmployeeForm onSubmit", () => {
  it("returns a server-side duplicate email error", async () => {
    vi.mocked(saveEmployee).mockResolvedValue({
      success: false,
      errors: { email: "Email already registered" },
    })

    const { result } = zeroRenderHook(() => useEmployeeForm(mockEmployee))
    const tester = createF0FormDefinitionTester(result.current)

    const submitResult = await tester.submit({
      name: "Alice", email: "taken@factorial.co",
      department: "Engineering", startDate: new Date("2025-01-01"),
    })

    expect(submitResult.success).toBe(false)
    expect(submitResult.success === false && submitResult.errors?.email)
      .toBe("Email already registered")
  })

  it("does not call the server when schema validation fails", async () => {
    const { result } = zeroRenderHook(() => useEmployeeForm(mockEmployee))
    const tester = createF0FormDefinitionTester(result.current)

    await tester.submit({ name: "Alice", email: "not-an-email" })

    expect(saveEmployee).not.toHaveBeenCalled()
  })
})
```

If you want to test the schema directly without the hook, use `createF0FormTester` instead:

```ts
import { createF0FormTester } from "@/patterns/F0Form"

const tester = createF0FormTester({
  schema: employeeSchema,
  onSubmit: async (data) => saveEmployee(data),
})
const { errors } = await tester.validate({ name: "Alice" })
const result = await tester.submit({ name: "Alice", email: "alice@factorial.co", ... })
```