### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.458.0",
+  "packages/react": "1.458.1",
   "packages/react-native": "0.52.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.458.1](https://github.com/factorialco/f0/compare/f0-react-v1.458.0...f0-react-v1.458.1) (2026-04-21)
+
+
+### Bug Fixes
+
+* rich text field not getting updated when co-editing form ([#3985](https://github.com/factorialco/f0/issues/3985)) ([b159bf7](https://github.com/factorialco/f0/commit/b159bf722bd57cb88f55ccf78462f5d0819590a9))
+
 ## [1.458.0](https://github.com/factorialco/f0/compare/f0-react-v1.457.1...f0-react-v1.458.0) (2026-04-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.458.0",
+  "version": "1.458.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.458.1</summary>

## [1.458.1](https://github.com/factorialco/f0/compare/f0-react-v1.458.0...f0-react-v1.458.1) (2026-04-21)


### Bug Fixes

* rich text field not getting updated when co-editing form ([#3985](https://github.com/factorialco/f0/issues/3985)) ([b159bf7](https://github.com/factorialco/f0/commit/b159bf722bd57cb88f55ccf78462f5d0819590a9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).