### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.458.1",
+  "packages/react": "1.458.2",
   "packages/react-native": "0.52.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.458.2](https://github.com/factorialco/f0/compare/f0-react-v1.458.1...f0-react-v1.458.2) (2026-04-21)
+
+
+### Bug Fixes
+
+* author not looking good on community post ([#3994](https://github.com/factorialco/f0/issues/3994)) ([3e6c4e3](https://github.com/factorialco/f0/commit/3e6c4e3d04344abd37b19a7494c4c9fcfe035ec1))
+
 ## [1.458.1](https://github.com/factorialco/f0/compare/f0-react-v1.458.0...f0-react-v1.458.1) (2026-04-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.458.1",
+  "version": "1.458.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.458.2</summary>

## [1.458.2](https://github.com/factorialco/f0/compare/f0-react-v1.458.1...f0-react-v1.458.2) (2026-04-21)


### Bug Fixes

* author not looking good on community post ([#3994](https://github.com/factorialco/f0/issues/3994)) ([3e6c4e3](https://github.com/factorialco/f0/commit/3e6c4e3d04344abd37b19a7494c4c9fcfe035ec1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).