### PR TITLE
feat(CandidateEntityRef): show source and applied date rows

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -317,6 +317,12 @@ export const defaultTranslations = {
     ask: "Ask One",
     view: "View",
     tools: "Tools",
+    entityRef: {
+      candidate: {
+        source: "Source",
+        applied: "Applied on",
+      },
+    },
     credits: {
       title: "Credits",
       creditsLeft: "{{total}} left",

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/candidate/CandidateEntityRef.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/candidate/CandidateEntityRef.tsx
@@ -27,13 +27,10 @@ const CandidateTrigger = forwardRef<HTMLButtonElement, { label: string }>(
 )
 CandidateTrigger.displayName = "CandidateTrigger"
 
-/**
- * Inline candidate entity reference with a hover card showing profile details.
- *
- * Renders the trigger as a styled link. On hover, lazily fetches
- * the candidate profile via `entityRefs.resolvers.candidate` and displays
- * avatar, name, and source. Optionally links via `entityRefs.urls.candidate`.
- */
+type CandidateRow = {
+  title: string
+  value: React.ReactNode
+}
 export function CandidateEntityRef({
   id,
   label,
@@ -49,22 +46,53 @@ export function CandidateEntityRef({
 
   const mapToCard = useMemo(
     () =>
-      (profile: CandidateProfile): F0CardProps => ({
-        avatar: {
-          type: "person",
-          firstName: profile.firstName,
-          lastName: profile.lastName,
-          src: profile.avatarUrl,
-        },
-        title: `${profile.firstName} ${profile.lastName}`,
-        description: profile.source,
-        ...(candidateUrl && {
-          secondaryActions: {
-            label: i18n.t("ai.view"),
-            href: candidateUrl,
+      (profile: CandidateProfile): F0CardProps => {
+        const rows: CandidateRow[] = []
+
+        if (profile.source) {
+          rows.push({
+            title: i18n.t("ai.entityRef.candidate.source"),
+            value: profile.source,
+          })
+        }
+
+        if (profile.appliedAt) {
+          rows.push({
+            title: i18n.t("ai.entityRef.candidate.applied"),
+            value: profile.appliedAt,
+          })
+        }
+
+        return {
+          avatar: {
+            type: "person",
+            firstName: profile.firstName,
+            lastName: profile.lastName,
+            src: profile.avatarUrl,
           },
-        }),
-      }),
+          title: `${profile.firstName} ${profile.lastName}`,
+          ...(rows.length > 0 && {
+            children: (
+              <div className="flex flex-col gap-2">
+                {rows.map((row) => (
+                  <div key={row.title} className="flex flex-col">
+                    <p className="text-f1-foreground-secondary">{row.title}</p>
+                    <div className="flex items-center gap-1.5 font-medium text-f1-foreground">
+                      {row.value}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ),
+          }),
+          ...(candidateUrl && {
+            secondaryActions: {
+              label: i18n.t("ai.view"),
+              href: candidateUrl,
+            },
+          }),
+        }
+      },
     [i18n, candidateUrl]
   )
 

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/candidate/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/candidate/types.ts
@@ -8,4 +8,5 @@ export type CandidateProfile = {
   lastName: string
   avatarUrl?: string
   source?: string
+  appliedAt?: string
 }

--- a/packages/react/src/sds/ai/F0AiChat/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/index.ts
@@ -11,6 +11,7 @@ export type {
   AiChatToolHint,
   AppendMessage,
   AppendToolCall,
+  CandidateProfile,
   CanvasContent,
   CanvasContentBase,
   CreditsUsage,


### PR DESCRIPTION
Improve candidate hover card for candidate entity-ref
- Adds `appliedAt?: string` to `CandidateProfile` (pre-formatted by the consumer).
- Exports `CandidateProfile` from the package root.
- Adds `ai.entityRef.candidate.{source,applied}` i18n defaults.


<img width="318" height="346" alt="Screenshot 2026-04-22 at 11 33 29" src="https://github.com/user-attachments/assets/ac38a1f9-edd7-4241-9cdb-af6c9a5eacc4" />


