### PR TITLE
fix(OneDataCollection): preserve selection across infinite-scroll loadMore

### DIFF
--- a/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
@@ -491,7 +491,7 @@ describe("useSelectable", () => {
       const data = makeInfiniteData([1, 2])
       const sourceWithSortings = {
         ...mockSource,
-        currentSortings: { name: "asc" } as never,
+        currentSortings: { field: "name", order: "asc" } as never,
       }
 
       const { result, rerender } = renderHook(
@@ -516,7 +516,7 @@ describe("useSelectable", () => {
       rerender({
         source: {
           ...sourceWithSortings,
-          currentSortings: { name: "desc" } as never,
+          currentSortings: { field: "name", order: "desc" } as never,
         },
       })
 

--- a/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
-import { DataSourceDefinition, PaginationInfo } from "../types"
+import { DataSource, PaginationInfo } from "../types"
 import { Data, GROUP_ID_SYMBOL } from "../useData"
 import { useSelectable } from "../useSelectable/useSelectable"
 
@@ -528,7 +528,7 @@ describe("useSelectable", () => {
       const sourceWithSearch = {
         ...mockSource,
         debouncedCurrentSearch: "initial",
-      } as unknown as DataSourceDefinition<TestRecord, never, never, never>
+      } as unknown as DataSource<TestRecord, never, never, never>
 
       const { result, rerender } = renderHook(
         ({ source }) =>

--- a/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
@@ -76,6 +76,424 @@ describe("useSelectable", () => {
     })
   })
 
+  describe("Pagination — page-based", () => {
+    const makePagedData = (ids: number[]): Data<TestRecord> => {
+      const records = ids.map((id) => ({
+        id,
+        name: `Item ${id}`,
+        group: "group1",
+        [GROUP_ID_SYMBOL]: undefined,
+      }))
+      return {
+        type: "flat",
+        records,
+        groups: [
+          { key: "all", label: "All", records, itemCount: records.length },
+        ],
+      }
+    }
+
+    it("clears selection when navigating to a different page (default behaviour)", async () => {
+      const page1Info: PaginationInfo = {
+        type: "pages",
+        total: 4,
+        currentPage: 1,
+        perPage: 2,
+        pagesCount: 2,
+      }
+      const page2Info: PaginationInfo = {
+        type: "pages",
+        total: 4,
+        currentPage: 2,
+        perPage: 2,
+        pagesCount: 2,
+      }
+
+      const { result, rerender } = renderHook(
+        ({ data, paginationInfo }) =>
+          useSelectable({
+            data,
+            paginationInfo,
+            source: mockSource,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+          }),
+        {
+          initialProps: {
+            data: makePagedData([1, 2]),
+            paginationInfo: page1Info,
+          },
+        }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(
+          makePagedData([1, 2]).records[0],
+          true
+        )
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
+
+      // Navigate to page 2 — selection must be cleared
+      rerender({ data: makePagedData([3, 4]), paginationInfo: page2Info })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(0))
+    })
+
+    it("preserves selection across page changes when resetOnPageChange is false", async () => {
+      const page1Info: PaginationInfo = {
+        type: "pages",
+        total: 4,
+        currentPage: 1,
+        perPage: 2,
+        pagesCount: 2,
+      }
+      const page2Info: PaginationInfo = {
+        type: "pages",
+        total: 4,
+        currentPage: 2,
+        perPage: 2,
+        pagesCount: 2,
+      }
+
+      const { result, rerender } = renderHook(
+        ({ data, paginationInfo }) =>
+          useSelectable({
+            data,
+            paginationInfo,
+            source: mockSource,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            resetOnPageChange: false,
+          }),
+        {
+          initialProps: {
+            data: makePagedData([1, 2]),
+            paginationInfo: page1Info,
+          },
+        }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(
+          makePagedData([1, 2]).records[0],
+          true
+        )
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
+
+      // Navigate to page 2 — opt-out: selection must survive
+      rerender({ data: makePagedData([3, 4]), paginationInfo: page2Info })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
+    })
+
+    it("still clears selection on filter change regardless of resetOnPageChange", async () => {
+      const sourceWithFilters = {
+        ...mockSource,
+        currentFilters: { status: "active" } as never,
+      }
+      const paginationInfo: PaginationInfo = {
+        type: "pages",
+        total: 2,
+        currentPage: 1,
+        perPage: 2,
+        pagesCount: 1,
+      }
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data: makePagedData([1, 2]),
+            paginationInfo,
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+          }),
+        { initialProps: { source: sourceWithFilters } }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(
+          makePagedData([1, 2]).records[0],
+          true
+        )
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
+
+      // Change filter — selection must be cleared
+      rerender({
+        source: {
+          ...sourceWithFilters,
+          currentFilters: { status: "draft" } as never,
+        },
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(0))
+    })
+  })
+
+  describe("Pagination — infinite-scroll", () => {
+    const makeInfiniteData = (ids: number[]): Data<TestRecord> => {
+      const records = ids.map((id) => ({
+        id,
+        name: `Item ${id}`,
+        group: "group1",
+        [GROUP_ID_SYMBOL]: undefined,
+      }))
+      return {
+        type: "flat",
+        records,
+        groups: [
+          { key: "all", label: "All", records, itemCount: records.length },
+        ],
+      }
+    }
+
+    const makeCursorInfo = (cursor: string): PaginationInfo => ({
+      type: "infinite-scroll",
+      total: 100,
+      perPage: 2,
+      cursor,
+      hasMore: true,
+    })
+
+    it("preserves manual selection after loadMore (cursor change)", async () => {
+      const { result, rerender } = renderHook(
+        ({ data, paginationInfo }) =>
+          useSelectable({
+            data,
+            paginationInfo,
+            source: mockSource,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+          }),
+        {
+          initialProps: {
+            data: makeInfiniteData([1, 2]),
+            paginationInfo: makeCursorInfo("cursor-0"),
+          },
+        }
+      )
+
+      // Select row 1 on the initial load
+      act(() => {
+        result.current.handleSelectItemChange(
+          makeInfiniteData([1, 2]).records[0],
+          true
+        )
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
+
+      // Simulate loadMore: new page appended (ids 1-4 now in records), cursor advances
+      rerender({
+        data: makeInfiniteData([1, 2, 3, 4]),
+        paginationInfo: makeCursorInfo("cursor-1"),
+      })
+
+      // Row 1 must still be selected; cursor change must NOT clear
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(1)
+        expect(result.current.selectedItems.get(1)).toBeDefined()
+      })
+    })
+
+    it("preserves selection across multiple loadMore calls", async () => {
+      const { result, rerender } = renderHook(
+        ({ data, paginationInfo }) =>
+          useSelectable({
+            data,
+            paginationInfo,
+            source: mockSource,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+          }),
+        {
+          initialProps: {
+            data: makeInfiniteData([1, 2]),
+            paginationInfo: makeCursorInfo("cursor-0"),
+          },
+        }
+      )
+
+      // Select rows 1 and 2 on first page
+      act(() => {
+        result.current.handleSelectItemChange(
+          makeInfiniteData([1]).records[0],
+          true
+        )
+        result.current.handleSelectItemChange(
+          makeInfiniteData([2]).records[0],
+          true
+        )
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(2))
+
+      // loadMore page 2
+      rerender({
+        data: makeInfiniteData([1, 2, 3, 4]),
+        paginationInfo: makeCursorInfo("cursor-1"),
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(2))
+
+      // Select row 3 on page 2
+      act(() => {
+        result.current.handleSelectItemChange(
+          makeInfiniteData([3]).records[0],
+          true
+        )
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(3))
+
+      // loadMore page 3
+      rerender({
+        data: makeInfiniteData([1, 2, 3, 4, 5, 6]),
+        paginationInfo: makeCursorInfo("cursor-2"),
+      })
+
+      // All three selections from pages 1 and 2 must still be present
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(3)
+        expect(result.current.selectedItems.get(1)).toBeDefined()
+        expect(result.current.selectedItems.get(2)).toBeDefined()
+        expect(result.current.selectedItems.get(3)).toBeDefined()
+      })
+    })
+
+    it("header select-all survives loadMore; new rows arrive unchecked (no longer all-selected)", async () => {
+      const { result, rerender } = renderHook(
+        ({ data, paginationInfo }) =>
+          useSelectable({
+            data,
+            paginationInfo,
+            source: mockSource,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+          }),
+        {
+          initialProps: {
+            data: makeInfiniteData([1, 2]),
+            paginationInfo: makeCursorInfo("cursor-0"),
+          },
+        }
+      )
+
+      // Hit the header checkbox — select all currently loaded rows
+      act(() => {
+        result.current.handleSelectAll(true)
+      })
+
+      // All 2 loaded rows are selected; isAllSelected is true
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+        expect(result.current.isAllSelected).toBe(true)
+      })
+
+      // loadMore appends 2 new rows
+      rerender({
+        data: makeInfiniteData([1, 2, 3, 4]),
+        paginationInfo: makeCursorInfo("cursor-1"),
+      })
+
+      // Previously checked rows stay checked; new rows arrive unchecked.
+      // isAllSelected becomes false (2 of 4 selected), which is the correct
+      // UX: header checkbox moves to indeterminate state in the Table.
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+        expect(result.current.isAllSelected).toBe(false)
+        // Existing selections are preserved — only 2 checked, 2 new rows unchecked
+        expect(result.current.selectedItems.get(1)).toBeDefined()
+        expect(result.current.selectedItems.get(2)).toBeDefined()
+      })
+    })
+
+    it("Gmail-style select-all (handleSelectAllItems) survives loadMore unchanged", async () => {
+      const { result, rerender } = renderHook(
+        ({ data, paginationInfo }) =>
+          useSelectable({
+            data,
+            paginationInfo,
+            source: mockSource,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            allPagesSelection: true,
+          }),
+        {
+          initialProps: {
+            data: makeInfiniteData([1, 2]),
+            paginationInfo: makeCursorInfo("cursor-0"),
+          },
+        }
+      )
+
+      // Press "Select all N items" banner
+      act(() => {
+        result.current.handleSelectAllItems(true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+        expect(result.current.allSelectedStatus.checked).toBe(true)
+      })
+
+      // loadMore — new rows must also be selected via the data-sync effect
+      rerender({
+        data: makeInfiniteData([1, 2, 3, 4]),
+        paginationInfo: makeCursorInfo("cursor-1"),
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(4)
+        expect(result.current.allSelectedStatus.checked).toBe(true)
+      })
+    })
+
+    it("still clears selection on filter change in infinite-scroll mode", async () => {
+      const sourceWithFilters = {
+        ...mockSource,
+        currentFilters: { status: "active" } as never,
+      }
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data: makeInfiniteData([1, 2]),
+            paginationInfo: makeCursorInfo("cursor-0"),
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+          }),
+        { initialProps: { source: sourceWithFilters } }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(
+          makeInfiniteData([1]).records[0],
+          true
+        )
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
+
+      // Filter change must still wipe selection
+      rerender({
+        source: {
+          ...sourceWithFilters,
+          currentFilters: { status: "draft" } as never,
+        },
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(0))
+    })
+  })
+
   describe("Grouped data", () => {
     const mockGroupedData: Data<TestRecord> = {
       type: "grouped",

--- a/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
@@ -262,6 +262,11 @@ describe("useSelectable", () => {
     })
 
     it("preserves manual selection after loadMore (cursor change)", async () => {
+      // Hoist data so the same record instances are passed to both the hook
+      // and the selection call — avoids false passes if identity ever matters.
+      const initialData = makeInfiniteData([1, 2])
+      const page2Data = makeInfiniteData([1, 2, 3, 4])
+
       const { result, rerender } = renderHook(
         ({ data, paginationInfo }) =>
           useSelectable({
@@ -273,7 +278,7 @@ describe("useSelectable", () => {
           }),
         {
           initialProps: {
-            data: makeInfiniteData([1, 2]),
+            data: initialData,
             paginationInfo: makeCursorInfo("cursor-0"),
           },
         }
@@ -281,17 +286,14 @@ describe("useSelectable", () => {
 
       // Select row 1 on the initial load
       act(() => {
-        result.current.handleSelectItemChange(
-          makeInfiniteData([1, 2]).records[0],
-          true
-        )
+        result.current.handleSelectItemChange(initialData.records[0], true)
       })
 
       await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
 
       // Simulate loadMore: new page appended (ids 1-4 now in records), cursor advances
       rerender({
-        data: makeInfiniteData([1, 2, 3, 4]),
+        data: page2Data,
         paginationInfo: makeCursorInfo("cursor-1"),
       })
 
@@ -303,6 +305,10 @@ describe("useSelectable", () => {
     })
 
     it("preserves selection across multiple loadMore calls", async () => {
+      const page1Data = makeInfiniteData([1, 2])
+      const page2Data = makeInfiniteData([1, 2, 3, 4])
+      const page3Data = makeInfiniteData([1, 2, 3, 4, 5, 6])
+
       const { result, rerender } = renderHook(
         ({ data, paginationInfo }) =>
           useSelectable({
@@ -314,7 +320,7 @@ describe("useSelectable", () => {
           }),
         {
           initialProps: {
-            data: makeInfiniteData([1, 2]),
+            data: page1Data,
             paginationInfo: makeCursorInfo("cursor-0"),
           },
         }
@@ -322,21 +328,15 @@ describe("useSelectable", () => {
 
       // Select rows 1 and 2 on first page
       act(() => {
-        result.current.handleSelectItemChange(
-          makeInfiniteData([1]).records[0],
-          true
-        )
-        result.current.handleSelectItemChange(
-          makeInfiniteData([2]).records[0],
-          true
-        )
+        result.current.handleSelectItemChange(page1Data.records[0], true)
+        result.current.handleSelectItemChange(page1Data.records[1], true)
       })
 
       await waitFor(() => expect(result.current.selectedItems.size).toBe(2))
 
       // loadMore page 2
       rerender({
-        data: makeInfiniteData([1, 2, 3, 4]),
+        data: page2Data,
         paginationInfo: makeCursorInfo("cursor-1"),
       })
 
@@ -344,17 +344,14 @@ describe("useSelectable", () => {
 
       // Select row 3 on page 2
       act(() => {
-        result.current.handleSelectItemChange(
-          makeInfiniteData([3]).records[0],
-          true
-        )
+        result.current.handleSelectItemChange(page2Data.records[2], true)
       })
 
       await waitFor(() => expect(result.current.selectedItems.size).toBe(3))
 
       // loadMore page 3
       rerender({
-        data: makeInfiniteData([1, 2, 3, 4, 5, 6]),
+        data: page3Data,
         paginationInfo: makeCursorInfo("cursor-2"),
       })
 
@@ -456,6 +453,7 @@ describe("useSelectable", () => {
     })
 
     it("still clears selection on filter change in infinite-scroll mode", async () => {
+      const data = makeInfiniteData([1, 2])
       const sourceWithFilters = {
         ...mockSource,
         currentFilters: { status: "active" } as never,
@@ -464,7 +462,7 @@ describe("useSelectable", () => {
       const { result, rerender } = renderHook(
         ({ source }) =>
           useSelectable({
-            data: makeInfiniteData([1, 2]),
+            data,
             paginationInfo: makeCursorInfo("cursor-0"),
             source,
             onSelectItems: vi.fn(),
@@ -474,10 +472,7 @@ describe("useSelectable", () => {
       )
 
       act(() => {
-        result.current.handleSelectItemChange(
-          makeInfiniteData([1]).records[0],
-          true
-        )
+        result.current.handleSelectItemChange(data.records[0], true)
       })
 
       await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
@@ -487,6 +482,78 @@ describe("useSelectable", () => {
         source: {
           ...sourceWithFilters,
           currentFilters: { status: "draft" } as never,
+        },
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(0))
+    })
+
+    it("clears selection when sortings change in infinite-scroll mode", async () => {
+      const data = makeInfiniteData([1, 2])
+      const sourceWithSortings = {
+        ...mockSource,
+        currentSortings: { name: "asc" } as never,
+      }
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data,
+            paginationInfo: makeCursorInfo("cursor-0"),
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+          }),
+        { initialProps: { source: sourceWithSortings } }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(data.records[0], true)
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
+
+      // Sortings change resets the dataset — selection must be cleared
+      rerender({
+        source: {
+          ...sourceWithSortings,
+          currentSortings: { name: "desc" } as never,
+        },
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(0))
+    })
+
+    it("clears selection when search query changes in infinite-scroll mode", async () => {
+      const data = makeInfiniteData([1, 2])
+      const sourceWithSearch = {
+        ...mockSource,
+        debouncedCurrentSearch: "initial",
+      } as unknown as DataSourceDefinition<TestRecord, never, never, never>
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data,
+            paginationInfo: makeCursorInfo("cursor-0"),
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+          }),
+        { initialProps: { source: sourceWithSearch } }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(data.records[0], true)
+      })
+
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
+
+      // Search query change resets the dataset — selection must be cleared
+      rerender({
+        source: {
+          ...sourceWithSearch,
+          debouncedCurrentSearch: "new-query",
         },
       })
 

--- a/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
@@ -109,6 +109,10 @@ describe("useSelectable", () => {
         pagesCount: 2,
       }
 
+      // Hoist data so the same record instances are passed to both the hook
+      // and the selection call — avoids false passes if identity ever matters.
+      const page1Data = makePagedData([1, 2])
+
       const { result, rerender } = renderHook(
         ({ data, paginationInfo }) =>
           useSelectable({
@@ -120,17 +124,14 @@ describe("useSelectable", () => {
           }),
         {
           initialProps: {
-            data: makePagedData([1, 2]),
+            data: page1Data,
             paginationInfo: page1Info,
           },
         }
       )
 
       act(() => {
-        result.current.handleSelectItemChange(
-          makePagedData([1, 2]).records[0],
-          true
-        )
+        result.current.handleSelectItemChange(page1Data.records[0], true)
       })
 
       await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
@@ -157,6 +158,8 @@ describe("useSelectable", () => {
         pagesCount: 2,
       }
 
+      const page1Data = makePagedData([1, 2])
+
       const { result, rerender } = renderHook(
         ({ data, paginationInfo }) =>
           useSelectable({
@@ -169,17 +172,14 @@ describe("useSelectable", () => {
           }),
         {
           initialProps: {
-            data: makePagedData([1, 2]),
+            data: page1Data,
             paginationInfo: page1Info,
           },
         }
       )
 
       act(() => {
-        result.current.handleSelectItemChange(
-          makePagedData([1, 2]).records[0],
-          true
-        )
+        result.current.handleSelectItemChange(page1Data.records[0], true)
       })
 
       await waitFor(() => expect(result.current.selectedItems.size).toBe(1))
@@ -203,10 +203,12 @@ describe("useSelectable", () => {
         pagesCount: 1,
       }
 
+      const data = makePagedData([1, 2])
+
       const { result, rerender } = renderHook(
         ({ source }) =>
           useSelectable({
-            data: makePagedData([1, 2]),
+            data,
             paginationInfo,
             source,
             onSelectItems: vi.fn(),
@@ -216,10 +218,7 @@ describe("useSelectable", () => {
       )
 
       act(() => {
-        result.current.handleSelectItemChange(
-          makePagedData([1, 2]).records[0],
-          true
-        )
+        result.current.handleSelectItemChange(data.records[0], true)
       })
 
       await waitFor(() => expect(result.current.selectedItems.size).toBe(1))

--- a/packages/react/src/hooks/datasource/useSelectable/typings.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/typings.ts
@@ -70,9 +70,14 @@ export type UseSelectableProps<
    */
   allPagesSelection?: boolean
   /**
-   * When true (default), clears selection when the page changes
-   * (unless all items are selected). Set to false to persist
-   * selections across page changes unconditionally.
+   * When true (default), clears selection when navigating to a different page
+   * in page-based pagination (unless all items are selected via the
+   * "Select all N items" banner). Set to false to persist selections across
+   * page changes unconditionally.
+   *
+   * This flag has no effect on infinite-scroll pagination: loadMore() advances
+   * the cursor but the list is cumulative, so selections are always preserved
+   * across loadMore() calls regardless of this flag.
    */
   resetOnPageChange?: boolean
 }

--- a/packages/react/src/hooks/datasource/useSelectable/typings.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/typings.ts
@@ -1,5 +1,5 @@
 import {
-  DataSourceDefinition,
+  DataSource,
   FiltersDefinition,
   FiltersState,
   GroupingDefinition,
@@ -44,7 +44,7 @@ export type UseSelectableProps<
 > = {
   data: Data<R>
   paginationInfo: PaginationInfo | null
-  source: DataSourceDefinition<R, Filters, Sortings, Grouping>
+  source: DataSource<R, Filters, Sortings, Grouping>
   onSelectItems?: OnSelectItemsCallback<R, Filters>
   selectionMode?: "multi" | "single"
   selectedState?: SelectedItemsState<R>

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -722,9 +722,19 @@ export function useSelectable<
   }, [source.currentFilters, clearSelectedItems, disableSelectAll])
 
   // Clear selections when page changes, unless the user has triggered
-  // "select all items" (allSelectedCheck) or resetOnPageChange is disabled
+  // "select all items" (allSelectedCheck) or resetOnPageChange is disabled.
+  // NOTE: infinite-scroll pagination advances the cursor on every loadMore(),
+  // but the list is cumulative — previously-selected rows remain valid and the
+  // user has not navigated away. We never clear for infinite-scroll; the
+  // filter-change effect above handles the case where the dataset truly resets.
   useEffect(() => {
     if (!resetOnPageChange) return
+
+    // Infinite-scroll loadMore is not a page navigation — skip.
+    if (paginationInfo?.type === "infinite-scroll") {
+      previousPageIdentifierRef.current = currentPageIdentifier
+      return
+    }
 
     const previousPageIdentifier = previousPageIdentifierRef.current
 
@@ -745,6 +755,7 @@ export function useSelectable<
     allSelectedCheck,
     clearSelectedItems,
     resetOnPageChange,
+    paginationInfo?.type,
   ])
 
   // Store isAllSelected in ref to avoid circular dependencies

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -76,11 +76,7 @@ export function useSelectable<
   const isInitialMount = useRef(true)
   const previousFilters = useRef(source.currentFilters)
   const previousSortings = useRef(source.currentSortings)
-  // debouncedCurrentSearch lives on DataSource (the runtime object) but is not
-  // part of DataSourceDefinition (the narrower type used here). We cast to
-  // access it safely — the value is always present at runtime.
-  const debouncedCurrentSearch = (source as { debouncedCurrentSearch?: string })
-    .debouncedCurrentSearch
+  const debouncedCurrentSearch = source.debouncedCurrentSearch
   const previousSearch = useRef(debouncedCurrentSearch)
   const previousDataRecordsKey = useRef<string>("")
   const previousSelectionState = useRef<string>("")

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -75,6 +75,13 @@ export function useSelectable<
   const hasInitialized = useRef(false)
   const isInitialMount = useRef(true)
   const previousFilters = useRef(source.currentFilters)
+  const previousSortings = useRef(source.currentSortings)
+  // debouncedCurrentSearch lives on DataSource (the runtime object) but is not
+  // part of DataSourceDefinition (the narrower type used here). We cast to
+  // access it safely — the value is always present at runtime.
+  const debouncedCurrentSearch = (source as { debouncedCurrentSearch?: string })
+    .debouncedCurrentSearch
+  const previousSearch = useRef(debouncedCurrentSearch)
   const previousDataRecordsKey = useRef<string>("")
   const previousSelectionState = useRef<string>("")
   const isAllSelectedRef = useRef(false)
@@ -697,29 +704,48 @@ export function useSelectable<
     updateLocalSelectedState(selectedState)
   }, [selectedState, getSelectedStateKey, updateLocalSelectedState])
 
-  // Clear selections when filters change (only when selectAll is enabled)
+  // Clear selections when the dataset identity changes (filters, sortings, or
+  // search query). This applies to ALL pagination types. For infinite-scroll,
+  // the page-change effect skips cursor advances so this effect is the only
+  // mechanism that clears on a true dataset reset caused by sortings/search.
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false
       previousFilters.current = source.currentFilters
+      previousSortings.current = source.currentSortings
+      previousSearch.current = debouncedCurrentSearch
       return
     }
 
-    // Deep comparison of filters to detect changes
-    const currentFiltersKey = JSON.stringify(source.currentFilters)
-    const previousFiltersKey = JSON.stringify(previousFilters.current)
+    const filtersChanged =
+      JSON.stringify(source.currentFilters) !==
+      JSON.stringify(previousFilters.current)
+    const sortingsChanged =
+      JSON.stringify(source.currentSortings) !==
+      JSON.stringify(previousSortings.current)
+    const searchChanged = debouncedCurrentSearch !== previousSearch.current
 
-    if (currentFiltersKey !== previousFiltersKey) {
-      // When disableSelectAll is true, maintain the selection even when filters change
-      // because the user is manually selecting items and expects them to persist
+    if (filtersChanged || sortingsChanged || searchChanged) {
+      // When disableSelectAll is true, maintain the selection even when the
+      // dataset changes because the user is manually selecting items and
+      // expects them to persist across soft reloads.
       if (!disableSelectAll) {
-        // Mark that we're clearing due to filter change to prevent data sync from restoring selections
+        // Mark that we're clearing due to dataset change to prevent the
+        // data-sync effect from restoring selections.
         justClearedByFilterChange.current = true
         clearSelectedItems()
       }
       previousFilters.current = source.currentFilters
+      previousSortings.current = source.currentSortings
+      previousSearch.current = debouncedCurrentSearch
     }
-  }, [source.currentFilters, clearSelectedItems, disableSelectAll])
+  }, [
+    source.currentFilters,
+    source.currentSortings,
+    debouncedCurrentSearch,
+    clearSelectedItems,
+    disableSelectAll,
+  ])
 
   // Clear selections when page changes, unless the user has triggered
   // "select all items" (allSelectedCheck) or resetOnPageChange is disabled.

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -85,7 +85,7 @@ export function useSelectable<
   const previousDataRecordsKey = useRef<string>("")
   const previousSelectionState = useRef<string>("")
   const isAllSelectedRef = useRef(false)
-  const justClearedByFilterChange = useRef(false)
+  const justClearedByDatasetChange = useRef(false)
   const previousPageIdentifierRef = useRef<string | number | null | undefined>(
     undefined
   )
@@ -730,9 +730,9 @@ export function useSelectable<
       // dataset changes because the user is manually selecting items and
       // expects them to persist across soft reloads.
       if (!disableSelectAll) {
-        // Mark that we're clearing due to dataset change to prevent the
-        // data-sync effect from restoring selections.
-        justClearedByFilterChange.current = true
+        // Mark that we're clearing due to a dataset-identity change to prevent
+        // the data-sync effect from restoring selections.
+        justClearedByDatasetChange.current = true
         clearSelectedItems()
       }
       previousFilters.current = source.currentFilters
@@ -752,7 +752,7 @@ export function useSelectable<
   // NOTE: infinite-scroll pagination advances the cursor on every loadMore(),
   // but the list is cumulative — previously-selected rows remain valid and the
   // user has not navigated away. We never clear for infinite-scroll; the
-  // filter-change effect above handles the case where the dataset truly resets.
+  // dataset-identity effect above handles the case where the dataset truly resets.
   useEffect(() => {
     if (!resetOnPageChange) return
 
@@ -805,9 +805,9 @@ export function useSelectable<
     }
     previousDataRecordsKey.current = currentKey
 
-    // If we just cleared due to filter change, don't restore selections
-    if (justClearedByFilterChange.current) {
-      justClearedByFilterChange.current = false
+    // If we just cleared due to a dataset-identity change, don't restore selections
+    if (justClearedByDatasetChange.current) {
+      justClearedByDatasetChange.current = false
       return
     }
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
@@ -937,6 +937,38 @@ export const WithCrossPageSelection: Story = {
   },
 }
 
+export const WithInfiniteScrollSelection: Story = {
+  render: () => {
+    // Create a fixed set of paginated users so we're not regenerating them on every render
+    const paginatedMockUsers = generateMockUsers(50)
+
+    return (
+      <div style={{ height: "500px", overflow: "auto" }}>
+        <ExampleComponent
+          selectable={(item) => item.id}
+          // Infinite-scroll: manual selections persist across loadMore — new rows arrive unchecked
+          dataAdapter={createDataAdapter({
+            data: paginatedMockUsers,
+            delay: 500,
+            paginationType: "infinite-scroll",
+            perPage: 10,
+          })}
+          bulkActions={({ selectedCount }) => ({
+            primary: [
+              {
+                label: `Delete ${selectedCount} item${selectedCount > 1 ? "s" : ""}`,
+                icon: Delete,
+                id: "delete-selected",
+                critical: true,
+              },
+            ],
+          })}
+        />
+      </div>
+    )
+  },
+}
+
 export const WithSelectableAndDefaultSelectedItems: Story = {
   render: () => (
     <ExampleComponent

--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
@@ -939,11 +939,10 @@ export const WithCrossPageSelection: Story = {
 
 export const WithInfiniteScrollSelection: Story = {
   render: () => {
-    // Create a fixed set of paginated users so we're not regenerating them on every render
     const paginatedMockUsers = generateMockUsers(50)
 
     return (
-      <div style={{ height: "500px", overflow: "auto" }}>
+      <div className="h-[500px] overflow-auto">
         <ExampleComponent
           selectable={(item) => item.id}
           // Infinite-scroll: manual selections persist across loadMore — new rows arrive unchecked

--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
@@ -945,7 +945,10 @@ export const WithInfiniteScrollSelection: Story = {
       <div className="h-[500px] overflow-auto">
         <ExampleComponent
           selectable={(item) => item.id}
-          // Infinite-scroll: manual selections persist across loadMore — new rows arrive unchecked
+          allPagesSelection={true}
+          // Infinite-scroll + Gmail-style select-all: manual selections persist
+          // across loadMore, and the "Select all N items" banner appears once
+          // every loaded row is checked.
           dataAdapter={createDataAdapter({
             data: paginatedMockUsers,
             delay: 500,

--- a/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
@@ -149,6 +149,19 @@ for cross-page selection.
   meta={DataCollectionStories}
 />
 
+**Infinite-scroll selection:**
+
+In infinite-scroll mode, manual row selections persist across `loadMore` calls.
+New rows that arrive when the user scrolls down appear unchecked — no existing
+selection is ever cleared. Use `allPagesSelection: true` alongside infinite-scroll
+if you also want the Gmail-style "Select all N items" banner to appear after
+selecting all visible rows.
+
+<Canvas
+  of={DataCollectionStories.WithInfiniteScrollSelection}
+  meta={DataCollectionStories}
+/>
+
 #### Examples
 
 **Default selected items**

--- a/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
@@ -153,9 +153,9 @@ for cross-page selection.
 
 In infinite-scroll mode, manual row selections persist across `loadMore` calls.
 New rows that arrive when the user scrolls down appear unchecked — no existing
-selection is ever cleared. Use `allPagesSelection: true` alongside infinite-scroll
-if you also want the Gmail-style "Select all N items" banner to appear after
-selecting all visible rows.
+selection is ever cleared. The example below combines infinite-scroll with
+`allPagesSelection: true` so the Gmail-style "Select all N items" banner appears
+once every loaded row is checked.
 
 <Canvas
   of={DataCollectionStories.WithInfiniteScrollSelection}


### PR DESCRIPTION
## 🚪 Why?

When a `OneDataCollection` component uses infinite-scroll pagination, manually ticking rows across multiple `loadMore` calls was broken: the clear-on-page-change effect in `useSelectable` fired every time the pagination cursor advanced, wiping the entire selection as soon as new rows loaded.

Root cause: the effect that clears selection when `currentPageIdentifier` changes did not distinguish between **page navigation** (where clearing is correct) and **cumulative loadMore** (where it is not). The cursor advances on every `loadMore` in infinite-scroll, so selection was cleared after every scroll append.

A secondary bug was also identified and fixed: the original fix was too broad and also suppressed clearing when the cursor resets because sortings or search changed (a true dataset refresh). The dataset-identity effect was extended
to track `currentSortings` and `debouncedCurrentSearch` alongside `currentFilters`, so selection is cleared correctly on any dataset reset regardless of pagination type.

## 🔑 What?

- **`useSelectable.ts`** — added early return in the clear-on-page-change effect when `paginationInfo.type === "infinite-scroll"`, so cursor advances during loadMore never trigger a selection reset.
- **`useSelectable.ts`** — extended the dataset-identity effect to also track `source.currentSortings` and `source.debouncedCurrentSearch` alongside `source.currentFilters`. Any change to these fields now clears selection for all pagination types, including infinite-scroll.
- **`typings.ts`** — updated `resetOnPageChange` JSDoc to note that the option only applies to page-based pagination.
- **`useSelectable.test.tsx`** — 10 new test cases:
  - Manual selection survives `loadMore`
  - Selection accumulates across multiple `loadMore` calls
  - Header select-all survives `loadMore`; new rows arrive unchecked
  - Gmail-style `handleSelectAllItems` still auto-extends to new rows
  - Filter change still clears in infinite-scroll mode
  - **Sortings change clears selection in infinite-scroll mode** (regression guard)
  - **Search query change clears selection in infinite-scroll mode** (regression guard)
  - Page-based pagination regression guard (still clears on page change)
  - `resetOnPageChange: false` guard
  - Record instances in tests are now hoisted and reused to avoid false passes if identity ever matters
- **`index.stories.tsx`** — new `WithInfiniteScrollSelection` story demonstrating the fixed behaviour.
- **`selectable-bulk-actions.mdx`** — new "Infinite-scroll selection" section with Canvas referencing the new story.

**What this PR does NOT fix** (separate, known issues):

- **Selection payload is still scoped to the currently-loaded records.** When `allPagesSelection: false` (the default), the `onSelectItems` / `onBulkAction` callbacks only receive items from the pages that have been fetched so far. Fixing this would require all consumers to handle receiving items they haven't explicitly loaded — roughly 35 call-sites across the Factorial monorepo need auditing before this can land safely.

- **Bulk actions in infinite-scroll only operate on observable records.** A previous attempt (PR #2839) tried to make `useData` subscribe to all loaded pages simultaneously instead of just the latest page. That PR was closed without
  merging. Even if it were relanded, it would only fix data observation — the payload scoping described above would still limit which items are included in bulk action callbacks. Both fixes need to land together to fully solve
  multi-page bulk actions in infinite-scroll.

- **`allPagesSelection: true` does not preserve manual row-by-row selection across page navigation in page-based pagination.** The docs imply it does, but the clear-on-page-change effect is only suppressed when the Gmail-style "Select all N items" banner has been clicked (`allSelectedCheck`), not when `allPagesSelection` is simply enabled. This is a separate bug in page-based pagination; tracked for a follow-up PR. Update: changed docs in #4023.

## 🏡 Context

Before

https://github.com/user-attachments/assets/04e6854a-3092-435b-86d2-76e1087c7907

After

https://github.com/user-attachments/assets/41fc9bfe-c989-4c51-aecc-1d01e5024e71

---
Skills used: `factorial-f0`, `factorial-pr`