### PR TITLE
fix: prevent form from being submitted from canva mode when it has validation errors

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/actions/core/forms/__tests__/formActions.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/forms/__tests__/formActions.test.tsx
@@ -195,7 +195,7 @@ describe("useFormSubmitAction handler", () => {
     expect(mockCloseCanvas).toHaveBeenCalled()
   })
 
-  it("calls clearActiveForm and closeCanvas even when submit fails", async () => {
+  it("does NOT call clearActiveForm or closeCanvas when submit fails validation", async () => {
     await setupWithDefinitions([
       {
         name: "user-form",
@@ -209,9 +209,9 @@ describe("useFormSubmitAction handler", () => {
       return handler({ formName: "user-form" } as never)
     })
 
-    // Submit fails validation but cleanup still happens in finally block
+    // Canvas stays open so the user can fix the errors
     expect(result).toMatchObject({ success: false })
-    expect(mockCloseCanvas).toHaveBeenCalled()
+    expect(mockCloseCanvas).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/forms/useFormSubmitAction.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/forms/useFormSubmitAction.ts
@@ -53,6 +53,9 @@ export const useFormSubmitAction = () => {
         if (Object.keys(errors).length > 0) {
           return { success: false, errors }
         }
+        registry.clearActiveForm()
+        closeCanvas()
+        registry.rebuildDescriptions()
         return { success: true }
       } catch {
         const errors = ref.getErrors()
@@ -60,10 +63,6 @@ export const useFormSubmitAction = () => {
           success: false,
           errors,
         }
-      } finally {
-        registry.clearActiveForm()
-        closeCanvas()
-        registry.rebuildDescriptions()
       }
     },
   })

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCanvasContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCanvasContent.tsx
@@ -59,13 +59,16 @@ function WizardCanvasContent({
   formDefinition,
   formRef,
   isSubmitting,
+  hasErrors,
   onSubmit,
 }: {
   formDefinition: F0FormDefinitionSingleSchema<F0FormSchema>
   formRef: ReturnType<typeof useF0Form>["formRef"]
   isSubmitting: boolean
+  hasErrors: boolean
   onSubmit: () => void
 }) {
+  const errorTriggerMode = formDefinition.errorTriggerMode ?? "on-blur"
   const CanvasForm = useCanvasFormComponent()
 
   return (
@@ -88,6 +91,7 @@ function WizardCanvasContent({
           <F0Button
             variant="default"
             onClick={onSubmit}
+            disabled={hasErrors && errorTriggerMode !== "on-submit"}
             label={formDefinition.submitConfig?.label ?? "Submit"}
           />
         </div>
@@ -102,13 +106,16 @@ function PlainFormContent({
   formDefinition,
   formRef,
   isSubmitting,
+  hasErrors,
   onSubmit,
 }: {
   formDefinition: F0FormDefinitionSingleSchema<F0FormSchema>
   formRef: ReturnType<typeof useF0Form>["formRef"]
   isSubmitting: boolean
+  hasErrors: boolean
   onSubmit: () => void
 }) {
+  const errorTriggerMode = formDefinition.errorTriggerMode ?? "on-blur"
   const CanvasForm = useCanvasFormComponent()
   const showSectionsSidepanel = !!(
     formDefinition.sections && Object.keys(formDefinition.sections).length > 2
@@ -139,6 +146,7 @@ function PlainFormContent({
           <F0Button
             variant="default"
             onClick={onSubmit}
+            disabled={hasErrors && errorTriggerMode !== "on-submit"}
             label={formDefinition.submitConfig?.label ?? "Submit"}
           />
         </div>
@@ -159,7 +167,7 @@ function PlainFormContent({
  * Previous/Next/Submit navigation.
  */
 function VirtualFormContent() {
-  const { formRef } = useF0Form()
+  const { formRef, hasErrors } = useF0Form()
   const { agent: agentName, closeCanvas } = useAiChat()
   const registry = useF0AiFormRegistry()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -186,7 +194,9 @@ function VirtualFormContent() {
   }, [formName, JSON.stringify(currentValues)])
 
   const handleSubmit = useCallback(() => {
-    formRef.current?.submit()
+    formRef.current?.submit().catch(() => {
+      // Validation errors are displayed by the form
+    })
   }, [formRef])
 
   const formDefinition = useF0FormDefinition({
@@ -224,6 +234,7 @@ function VirtualFormContent() {
         formDefinition={formDefinition}
         formRef={formRef}
         isSubmitting={isSubmitting}
+        hasErrors={hasErrors}
         onSubmit={handleSubmit}
       />
     )
@@ -234,6 +245,7 @@ function VirtualFormContent() {
       formDefinition={formDefinition}
       formRef={formRef}
       isSubmitting={isSubmitting}
+      hasErrors={hasErrors}
       onSubmit={handleSubmit}
     />
   )

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCanvasContent.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCanvasContent.test.tsx
@@ -1,13 +1,14 @@
-import { describe, expect, it, vi, beforeEach } from "vitest"
-import "@testing-library/jest-dom/vitest"
 import { act } from "react"
+import "@testing-library/jest-dom/vitest"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { z } from "zod"
 
 import type {
   F0FormCommonProps,
   F0FormLikeComponent,
 } from "@/patterns/F0Form/types"
+
 import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
-import { z } from "zod"
 
 // ---- Mock state ----
 
@@ -41,6 +42,8 @@ const mockResetFillVersion = vi.fn()
 const mockClearActiveForm = vi.fn()
 const mockCloseCanvas = vi.fn()
 
+let mockHasErrors = false
+
 vi.mock("@copilotkit/react-core", () => ({
   useCoAgent: () => ({ state: mockCoAgentState }),
 }))
@@ -67,7 +70,7 @@ vi.mock("@/patterns/F0Form/F0AiFormRegistry", () => ({
 }))
 
 vi.mock("@/patterns/F0Form/useF0Form", () => ({
-  useF0Form: () => ({ formRef: mockFormRef }),
+  useF0Form: () => ({ formRef: mockFormRef, hasErrors: mockHasErrors }),
 }))
 
 // Capture the formDefinition passed to F0Form so we can inspect submitConfig and call onSubmit
@@ -124,6 +127,7 @@ describe("FormCanvasContent", () => {
     mockRegistryEntry = undefined
     capturedFormDefinition = null
     mockFormComponent = undefined
+    mockHasErrors = false
   })
 
   describe("when no active form", () => {
@@ -540,6 +544,66 @@ describe("FormCanvasContent", () => {
       }
       render(<FormContent />)
       expect(receivedProps.formRef).toBeDefined()
+    })
+  })
+
+  // ==========================================================================
+  // Submit button disabled state — errorTriggerMode
+  // ==========================================================================
+
+  describe("submit button disabled state based on errorTriggerMode", () => {
+    beforeEach(() => {
+      mockCoAgentState = {
+        activeForm: { formName: "test-form", formValues: {} },
+      }
+    })
+
+    it("enables button when there are no errors (any mode)", () => {
+      mockHasErrors = false
+      mockRegistryEntry = makeEntry()
+      render(<FormContent />)
+      expect(screen.getByRole("button", { name: "Submit" })).not.toBeDisabled()
+    })
+
+    it("disables button when hasErrors and errorTriggerMode is the default (on-blur)", () => {
+      mockHasErrors = true
+      mockRegistryEntry = makeEntry()
+      render(<FormContent />)
+      expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled()
+    })
+
+    it("disables button when hasErrors and errorTriggerMode is on-change", () => {
+      mockHasErrors = true
+      mockRegistryEntry = makeEntry({ errorTriggerMode: "on-change" })
+      render(<FormContent />)
+      expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled()
+    })
+
+    it("does not disable button when hasErrors and errorTriggerMode is on-submit", () => {
+      mockHasErrors = true
+      mockRegistryEntry = makeEntry({ errorTriggerMode: "on-submit" })
+      render(<FormContent />)
+      expect(screen.getByRole("button", { name: "Submit" })).not.toBeDisabled()
+    })
+
+    it("disables wizard submit button when hasErrors and errorTriggerMode is on-blur", () => {
+      mockHasErrors = true
+      mockRegistryEntry = makeEntry({
+        steps: [{ title: "Step 1", sectionIds: ["a"] }],
+        errorTriggerMode: "on-blur",
+      })
+      render(<FormContent />)
+      expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled()
+    })
+
+    it("does not disable wizard submit button when hasErrors and errorTriggerMode is on-submit", () => {
+      mockHasErrors = true
+      mockRegistryEntry = makeEntry({
+        steps: [{ title: "Step 1", sectionIds: ["a"] }],
+        errorTriggerMode: "on-submit",
+      })
+      render(<FormContent />)
+      expect(screen.getByRole("button", { name: "Submit" })).not.toBeDisabled()
     })
   })
 })


### PR DESCRIPTION
## Summary

Fixes two related issues with AI canvas forms:

1. **Submit button respects validation errors** — the Submit button in the canvas form footer is now disabled when the form has validation errors. The behaviour respects `errorTriggerMode`:
   - `"on-blur"` / `"on-change"` (default): button disables as soon as errors are visible.
   - `"on-submit"`: button stays enabled so the user can click it to trigger validation, then re-submit after fixing errors.

2. **`submitForm` AI action no longer closes the canvas on failure** — previously the `forms.submitForm` tool always closed the canvas in a `finally` block, even when validation failed. It now only clears the active form and closes the canvas on success, keeping it open so the user can correct errors.

3. **`activeForm.formValues` / `formErrors` stay in sync with user edits** — the AI registry's form snapshot (`formValues`, `formErrors`) was only updated when the AI called `fillForm` or `submitForm`. Manual user input was never reflected. `F0Form` now subscribes to `form.watch()` and calls `rebuildDescriptions()` debounced (300 ms) on every field change, plus immediately whenever `hasErrors` changes (covers on-blur validation that doesn't trigger a value change).

## Changes

- `FormCanvasContent.tsx` — disable submit button based on `hasErrors` + `errorTriggerMode`; catch the rejected promise from `formRef.submit()` when validation fails
- `useFormSubmitAction.ts` — move `clearActiveForm` / `closeCanvas` / `rebuildDescriptions` out of `finally` into the success path only
- `F0Form.tsx` — add debounced `form.watch()` subscription and `hasErrors` effect to keep the AI registry snapshot up to date

## Tests

- Added a `"submit button disabled state based on errorTriggerMode"` test suite to `FormCanvasContent.test.tsx` covering all three modes for both plain and wizard forms
- Updated stale assertion in `formActions.test.tsx`: the test that expected `closeCanvas` to be called on validation failure now asserts the opposite