### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.459.0",
+  "packages/react": "1.459.1",
   "packages/react-native": "0.52.0",
   "packages/core": "1.49.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.459.1](https://github.com/factorialco/f0/compare/f0-react-v1.459.0...f0-react-v1.459.1) (2026-04-22)
+
+
+### Bug Fixes
+
+* prevent form from being submitted from canva mode when it has validation errors ([#4001](https://github.com/factorialco/f0/issues/4001)) ([7afa840](https://github.com/factorialco/f0/commit/7afa840dc9a68bd20cf235557c1e51cfdea0d558))
+
 ## [1.459.0](https://github.com/factorialco/f0/compare/f0-react-v1.458.3...f0-react-v1.459.0) (2026-04-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.459.0",
+  "version": "1.459.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.459.1</summary>

## [1.459.1](https://github.com/factorialco/f0/compare/f0-react-v1.459.0...f0-react-v1.459.1) (2026-04-22)


### Bug Fixes

* prevent form from being submitted from canva mode when it has validation errors ([#4001](https://github.com/factorialco/f0/issues/4001)) ([7afa840](https://github.com/factorialco/f0/commit/7afa840dc9a68bd20cf235557c1e51cfdea0d558))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).