### PR TITLE
feat(entityRef): enrich jobPosting hover card

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -328,6 +328,12 @@ export const defaultTranslations = {
         reason: "Reason",
         status: "Status",
       },
+      jobPosting: {
+        vacancies: "Vacancies",
+        vacanciesProgress: "{{filled}} of {{total}} vacancies filled",
+        published: "Published",
+        status: "Status",
+      },
     },
     credits: {
       title: "Credits",

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/jobPosting/JobPostingEntityRef.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/jobPosting/JobPostingEntityRef.tsx
@@ -1,13 +1,19 @@
 import { forwardRef, useMemo } from "react"
 
 import type { F0CardProps } from "@/components/F0Card"
+import { F0TagStatus } from "@/components/tags/F0TagStatus"
+import { getColor } from "@/kits/Charts/utils/colors"
 
 import { useI18n } from "@/lib/providers/i18n"
+import { useL10n } from "@/lib/providers/l10n"
 import { cn, focusRing } from "@/lib/utils"
+import { Progress } from "@/ui/progress"
 
 import type { JobPostingProfile } from "./types"
 
 import { useAiChat } from "../../../../../providers/AiChatStateProvider"
+import type { EntityRefDetailRow } from "../../components/EntityRefDetails"
+import { EntityRefDetails } from "../../components/EntityRefDetails"
 import { EntityRefHoverCard } from "../../components/EntityRefHoverCard"
 
 const JobPostingTrigger = forwardRef<HTMLButtonElement, { label: string }>(
@@ -27,13 +33,52 @@ const JobPostingTrigger = forwardRef<HTMLButtonElement, { label: string }>(
 )
 JobPostingTrigger.displayName = "JobPostingTrigger"
 
-/**
- * Inline job posting entity reference with a hover card showing posting details.
- *
- * Renders the trigger as a styled link. On hover, lazily fetches
- * the job posting data via `entityRefs.resolvers.jobPosting` and displays
- * title, status, and location. Optionally links via `entityRefs.urls.jobPosting`.
- */
+function formatPublishedAt(value: string, locale: string): string {
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  const date = dateOnly
+    ? new Date(
+        Number(dateOnly[1]),
+        Number(dateOnly[2]) - 1,
+        Number(dateOnly[3])
+      )
+    : new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  return date.toLocaleDateString(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+}
+
+function VacanciesProgress({
+  filled,
+  total,
+  ariaLabel,
+}: {
+  filled: number
+  total: number
+  ariaLabel: string
+}) {
+  const rawPercentage = total > 0 ? (filled / total) * 100 : 0
+  const percentage = Math.min(100, Math.max(0, rawPercentage))
+  return (
+    <div className="flex w-full items-center gap-2">
+      <Progress
+        value={percentage}
+        max={100}
+        className="h-1.5 w-1/2"
+        color={getColor("categorical-1")}
+        aria-label={ariaLabel}
+      />
+      <span className="shrink-0 tabular-nums">
+        {filled}/{total}
+      </span>
+    </div>
+  )
+}
+
 export function JobPostingEntityRef({
   id,
   label,
@@ -44,24 +89,71 @@ export function JobPostingEntityRef({
   const { entityRefs } = useAiChat()
   const resolver = entityRefs?.resolvers?.jobPosting
   const i18n = useI18n()
+  const { locale } = useL10n()
 
   const jobPostingUrl = entityRefs?.urls?.jobPosting?.(id)
 
   const mapToCard = useMemo(
     () =>
-      (profile: JobPostingProfile): F0CardProps => ({
-        title: profile.title,
-        description: [profile.status, profile.location]
-          .filter(Boolean)
-          .join(" · "),
-        ...(jobPostingUrl && {
-          secondaryActions: {
-            label: i18n.t("ai.view"),
-            href: jobPostingUrl,
-          },
-        }),
-      }),
-    [i18n, jobPostingUrl]
+      (profile: JobPostingProfile): F0CardProps => {
+        const filled = profile.vacanciesFilled ?? 0
+        const total = profile.vacanciesTotal ?? 0
+
+        const candidateRows: Array<EntityRefDetailRow | undefined> = [
+          profile.status
+            ? {
+                label: i18n.t("ai.entityRef.jobPosting.status"),
+                value: (
+                  <div className="flex items-center pt-1">
+                    <F0TagStatus
+                      text={profile.status}
+                      variant={profile.statusVariant ?? "neutral"}
+                    />
+                  </div>
+                ),
+              }
+            : undefined,
+          profile.publishedAt
+            ? {
+                label: i18n.t("ai.entityRef.jobPosting.published"),
+                value: formatPublishedAt(profile.publishedAt, locale),
+              }
+            : undefined,
+          total > 0
+            ? {
+                label: i18n.t("ai.entityRef.jobPosting.vacancies"),
+                value: (
+                  <VacanciesProgress
+                    filled={filled}
+                    total={total}
+                    ariaLabel={i18n.t(
+                      "ai.entityRef.jobPosting.vacanciesProgress",
+                      { filled, total }
+                    )}
+                  />
+                ),
+              }
+            : undefined,
+        ]
+        const rows = candidateRows.filter(
+          (row): row is EntityRefDetailRow => row !== undefined
+        )
+
+        return {
+          title: profile.title,
+          ...(profile.location && { description: profile.location }),
+          ...(rows.length > 0 && {
+            children: <EntityRefDetails rows={rows} />,
+          }),
+          ...(jobPostingUrl && {
+            secondaryActions: {
+              label: i18n.t("ai.view"),
+              href: jobPostingUrl,
+            },
+          }),
+        }
+      },
+    [i18n, jobPostingUrl, locale]
   )
 
   const fallbackCard = useMemo(

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/jobPosting/__tests__/JobPostingEntityRef.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/jobPosting/__tests__/JobPostingEntityRef.test.tsx
@@ -29,7 +29,11 @@ const profile: JobPostingProfile = {
   id: "99",
   title: "Senior Engineer",
   status: "Open",
+  statusVariant: "positive",
   location: "Barcelona",
+  publishedAt: "2024-01-15",
+  vacanciesFilled: 1,
+  vacanciesTotal: 3,
 }
 
 describe("JobPostingEntityRef", () => {
@@ -66,8 +70,96 @@ describe("JobPostingEntityRef", () => {
     await waitFor(() => {
       // Title appears both in the trigger and the card heading
       expect(screen.getAllByText("Senior Engineer")).toHaveLength(2)
-      expect(screen.getByText("Open · Barcelona")).toBeInTheDocument()
+      expect(screen.getByText("Open")).toBeInTheDocument()
     })
+  })
+
+  it("renders location as the card description and status with a label", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+
+    render(<JobPostingEntityRef id="99" label="Senior Engineer" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Barcelona")).toBeInTheDocument()
+      expect(screen.getByText("Open")).toBeInTheDocument()
+    })
+
+    expect(screen.getByText("Status")).toBeInTheDocument()
+    expect(screen.queryByText("Location")).not.toBeInTheDocument()
+  })
+
+  it("renders published and vacancies rows with labels", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+
+    render(<JobPostingEntityRef id="99" label="Senior Engineer" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Published")).toBeInTheDocument()
+      // publishedAt is formatted via toLocaleDateString; assert the label only.
+      expect(screen.getByText("Vacancies")).toBeInTheDocument()
+      expect(screen.getByText("1/3")).toBeInTheDocument()
+    })
+  })
+
+  it("applies the statusVariant to the rendered status tag", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+
+    render(<JobPostingEntityRef id="99" label="Senior Engineer" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    const statusTag = await waitFor(() =>
+      screen.getByText("Open").closest('[class*="bg-f1-background-positive"]')
+    )
+    expect(statusTag).toBeInTheDocument()
+  })
+
+  it("falls back to the neutral variant when statusVariant is missing", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue({
+      id: "99",
+      title: "Senior Engineer",
+      status: "Pending",
+    })
+
+    render(<JobPostingEntityRef id="99" label="Senior Engineer" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    const statusTag = await waitFor(() =>
+      screen
+        .getByText("Pending")
+        .closest('[class*="bg-f1-background-secondary"]')
+    )
+    expect(statusTag).toBeInTheDocument()
+  })
+
+  it("omits rows when optional fields are missing", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue({
+      id: "99",
+      title: "Senior Engineer",
+    })
+
+    render(<JobPostingEntityRef id="99" label="Senior Engineer" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Senior Engineer")).toHaveLength(2)
+    })
+
+    expect(screen.queryByText("Status")).not.toBeInTheDocument()
+    expect(screen.queryByText("Published")).not.toBeInTheDocument()
+    expect(screen.queryByText("Vacancies")).not.toBeInTheDocument()
+    expect(screen.queryByText("Barcelona")).not.toBeInTheDocument()
   })
 
   it("caches profile — resolver is called only once per id", async () => {

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/jobPosting/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/jobPosting/types.ts
@@ -1,10 +1,12 @@
-/**
- * Profile data for a job posting entity (ATS opening), resolved asynchronously
- * and displayed in the entity reference hover card.
- */
+import type { StatusVariant } from "@/components/tags/F0TagStatus"
+
 export type JobPostingProfile = {
   id: string | number
   title: string
   status?: string
+  statusVariant?: StatusVariant
   location?: string
+  publishedAt?: string
+  vacanciesFilled?: number
+  vacanciesTotal?: number
 }


### PR DESCRIPTION
## Summary
- Adds location, published date, and vacancies progress (filled/total) rows to the jobPosting entity-ref hover card.
- Shows status as `F0TagStatus` under the title via new `statusVariant` field.
- Adds `ai.entityRef.jobPosting.{location,published,vacancies}` translation keys.
- 
<img width="342" height="551" alt="Screenshot 2026-04-24 at 14 21 42" src="https://github.com/user-attachments/assets/40b57f1f-5cf8-4c0c-a124-b5d1e7339b83" />
