### PR TITLE
feat: add support to define initial files resolution through f0 form definition

### DIFF
--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -117,6 +117,7 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
     errorTriggerMode = "on-blur",
     styling,
     initialFiles,
+    isLoadingInitialFiles,
     renderCustomField,
     isLoading: isFormLoading,
     useUpload,
@@ -182,6 +183,7 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
               submitConfig={perSectionSubmitConfig}
               errorTriggerMode={errorTriggerMode}
               initialFiles={initialFiles}
+              isLoadingInitialFiles={isLoadingInitialFiles}
               renderCustomField={renderCustomField}
               isLoading={isFormLoading}
               useUpload={useUpload}
@@ -417,6 +419,7 @@ function F0FormFromSingleDefinition<TSchema extends F0FormSchema>({
       styling={styling}
       formRef={formRef}
       initialFiles={def.initialFiles ?? initialFiles}
+      isLoadingInitialFiles={def.isLoadingInitialFiles}
       renderCustomField={renderCustomField}
       useUpload={useUpload}
       isLoading={isLoading}
@@ -478,6 +481,7 @@ function F0FormFromPerSectionDefinition<T extends F0PerSectionSchema>({
       styling={styling}
       formRef={formRef}
       initialFiles={def.initialFiles ?? initialFiles}
+      isLoadingInitialFiles={def.isLoadingInitialFiles}
       renderCustomField={renderCustomField}
       useUpload={useUpload}
       isLoading={isLoading}
@@ -874,6 +878,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
     () => ({
       formName: name,
       initialFiles: props.initialFiles,
+      isLoadingInitialFiles: props.isLoadingInitialFiles,
       renderCustomField: props.renderCustomField,
       isLoading: isFormLoading,
       useUpload,
@@ -881,6 +886,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
     [
       name,
       props.initialFiles,
+      props.isLoadingInitialFiles,
       props.renderCustomField,
       isFormLoading,
       useUpload,
@@ -932,7 +938,10 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
             return (
               <div
                 key={groupedItem.item.field.id}
-                className={cn(fieldGapClass, "empty:hidden")}
+                className={cn(
+                  fieldGapClass,
+                  "empty:hidden [&>span.hidden]:hidden"
+                )}
               >
                 {fieldContent}
               </div>

--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -195,14 +195,14 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
   if (showSectionsSidepanel && tocItems.length > 0) {
     return (
       <div className="flex w-full overflow-scroll">
-        <div className="sticky top-0 h-fit shrink-0 self-start pt-2 mr-4">
+        <div className="sticky top-0 mr-4 h-fit shrink-0 self-start pt-2">
           <F0TableOfContent
             items={tocItems}
             activeItem={activeSection}
             scrollable={false}
           />
         </div>
-        <div className="w-px sticky top-0 bottom-0 bg-f1-border-secondary" />
+        <div className="sticky bottom-0 top-0 w-px bg-f1-border-secondary" />
         {content}
       </div>
     )
@@ -416,7 +416,7 @@ function F0FormFromSingleDefinition<TSchema extends F0FormSchema>({
       className={className}
       styling={styling}
       formRef={formRef}
-      initialFiles={initialFiles}
+      initialFiles={def.initialFiles ?? initialFiles}
       renderCustomField={renderCustomField}
       useUpload={useUpload}
       isLoading={isLoading}
@@ -477,7 +477,7 @@ function F0FormFromPerSectionDefinition<T extends F0PerSectionSchema>({
       className={className}
       styling={styling}
       formRef={formRef}
-      initialFiles={initialFiles}
+      initialFiles={def.initialFiles ?? initialFiles}
       renderCustomField={renderCustomField}
       useUpload={useUpload}
       isLoading={isLoading}
@@ -995,7 +995,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
             </div>
 
             {/* Separator */}
-            <div className="w-px sticky top-0 bottom-0 bg-f1-border-secondary mr-4" />
+            <div className="sticky bottom-0 top-0 mr-4 w-px bg-f1-border-secondary" />
 
             {/* Form content - centered in available space */}
             {formContent}

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -1402,13 +1402,21 @@ export const FileFieldsWithInitialFiles: Story = {
 }
 
 /**
- * Same as `FileFieldsWithInitialFiles` but the file list is fetched
- * asynchronously — simulating a real API call. The form renders in a loading
- * state until the files resolve, then hydrates the file fields.
+ * Mix of regular and file fields where both `defaultValues` and `initialFiles`
+ * are fetched asynchronously. Default values resolve in ~800 ms; file metadata
+ * resolves in ~1 500 ms. The form stays in a full loading state until the
+ * slower of the two (initial files) finishes.
  */
 export const FileFieldsWithAsyncInitialFiles: Story = {
   render() {
     const formSchema = z.object({
+      title: f0FormField(z.string().min(1, "Required"), {
+        label: "Document Title",
+      }),
+      notes: f0FormField(z.string().optional(), {
+        label: "Notes",
+        fieldType: "textarea",
+      }),
       document: f0FormField(z.string().min(1, "Please upload a file"), {
         label: "Contract Document",
         fieldType: "file",
@@ -1429,9 +1437,14 @@ export const FileFieldsWithAsyncInitialFiles: Story = {
     const formDefinition = useF0FormDefinition({
       name: "file-initial-async",
       schema: formSchema,
-      defaultValues: {
-        document: "signed_contract_2024.pdf",
-        attachments: ["signed_invoice.pdf", "signed_receipt.png"],
+      defaultValues: async (_signal) => {
+        await sleep(800)
+        return {
+          title: "Q1 2024 Contract",
+          notes: "Reviewed and approved by legal.",
+          document: "signed_contract_2024.pdf",
+          attachments: ["signed_invoice.pdf", "signed_receipt.png"],
+        }
       },
       onSubmit: async ({ data }) => {
         await sleep(1000)

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -4,10 +4,10 @@ import { useState, useCallback, useRef } from "react"
 import { z } from "zod"
 
 import { F0Button } from "@/components/F0Button"
-import { F0Dialog } from "@/patterns/F0Dialog"
-import { useF0FormDefinition } from "@/patterns/F0WizardForm"
 import { createDataSourceDefinition } from "@/hooks/datasource"
 import { ExternalLink, Plus, Settings } from "@/icons/app"
+import { F0Dialog } from "@/patterns/F0Dialog"
+import { useF0FormDefinition } from "@/patterns/F0WizardForm"
 
 import type {
   FileUploadHookReturn,
@@ -1375,13 +1375,73 @@ export const FileFieldsWithInitialFiles: Story = {
         return { success: true, message: "Document updated" }
       },
       submitConfig: { label: "Update Document" },
+      initialFiles: [
+        {
+          value: "signed_contract_2024.pdf",
+          name: "contract_2024.pdf",
+          type: "application/pdf",
+          size: 2_500_000,
+        },
+        {
+          value: "signed_invoice.pdf",
+          name: "invoice_march.pdf",
+          type: "application/pdf",
+          size: 1_200_000,
+        },
+        {
+          value: "signed_receipt.png",
+          name: "receipt_photo.png",
+          type: "image/png",
+          size: 850_000,
+        },
+      ],
     })
 
-    return (
-      <F0Form
-        formDefinition={formDefinition}
-        useUpload={useMockUpload}
-        initialFiles={[
+    return <F0Form formDefinition={formDefinition} useUpload={useMockUpload} />
+  },
+}
+
+/**
+ * Same as `FileFieldsWithInitialFiles` but the file list is fetched
+ * asynchronously — simulating a real API call. The form renders in a loading
+ * state until the files resolve, then hydrates the file fields.
+ */
+export const FileFieldsWithAsyncInitialFiles: Story = {
+  render() {
+    const formSchema = z.object({
+      document: f0FormField(z.string().min(1, "Please upload a file"), {
+        label: "Contract Document",
+        fieldType: "file",
+        accept: ["application/pdf"],
+      }),
+      attachments: f0FormField(
+        z.array(z.string()).min(1, "Upload at least one file"),
+        {
+          label: "Supporting Documents",
+          fieldType: "file",
+          multiple: true,
+          accept: ["application/pdf", "image"],
+          maxSizeMB: 50,
+        }
+      ),
+    })
+
+    const formDefinition = useF0FormDefinition({
+      name: "file-initial-async",
+      schema: formSchema,
+      defaultValues: {
+        document: "signed_contract_2024.pdf",
+        attachments: ["signed_invoice.pdf", "signed_receipt.png"],
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true, message: "Document updated" }
+      },
+      submitConfig: { label: "Update Document" },
+      initialFiles: async (_signal) => {
+        await sleep(1500)
+        return [
           {
             value: "signed_contract_2024.pdf",
             name: "contract_2024.pdf",
@@ -1400,9 +1460,11 @@ export const FileFieldsWithInitialFiles: Story = {
             type: "image/png",
             size: 850_000,
           },
-        ]}
-      />
-    )
+        ]
+      },
+    })
+
+    return <F0Form formDefinition={formDefinition} useUpload={useMockUpload} />
   },
 }
 

--- a/packages/react/src/patterns/F0Form/components/F0FormSection.tsx
+++ b/packages/react/src/patterns/F0Form/components/F0FormSection.tsx
@@ -3,10 +3,10 @@ import { DefaultValues, Path, useForm } from "react-hook-form"
 import { z } from "zod"
 
 import { F0Button } from "@/components/F0Button"
-import { SectionHeader } from "@/patterns/SectionHeader"
 import { Save } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import { cn } from "@/lib/utils"
+import { SectionHeader } from "@/patterns/SectionHeader"
 import { Form as FormProvider } from "@/ui/form"
 
 import type {
@@ -80,6 +80,8 @@ interface F0FormSectionProps<TSchema extends F0FormSchema> {
   errorTriggerMode: F0FormErrorTriggerMode
   className?: string
   initialFiles?: import("../fields/file/types").InitialFile[]
+  /** Whether async initialFiles are still being resolved */
+  isLoadingInitialFiles?: boolean
   formRef?: React.MutableRefObject<F0FormRef | null>
   renderCustomField?: RenderCustomFieldFunction
   /** Upload hook shared by all file fields */
@@ -103,6 +105,7 @@ export function F0FormSection<TSchema extends F0FormSchema>({
   errorTriggerMode,
   className,
   initialFiles,
+  isLoadingInitialFiles,
   formRef,
   renderCustomField,
   useUpload,
@@ -260,11 +263,19 @@ export function F0FormSection<TSchema extends F0FormSchema>({
     () => ({
       formName,
       initialFiles,
+      isLoadingInitialFiles,
       renderCustomField,
       isLoading: isFormLoading,
       useUpload,
     }),
-    [formName, initialFiles, renderCustomField, isFormLoading, useUpload]
+    [
+      formName,
+      initialFiles,
+      isLoadingInitialFiles,
+      renderCustomField,
+      isFormLoading,
+      useUpload,
+    ]
   )
 
   const title = sectionConfig?.title ?? sectionId

--- a/packages/react/src/patterns/F0Form/context.ts
+++ b/packages/react/src/patterns/F0Form/context.ts
@@ -8,6 +8,8 @@ interface F0FormContextValue {
   formName: string
   /** Shared pool of pre-existing file metadata for file fields */
   initialFiles?: InitialFile[]
+  /** Whether async initialFiles are still being resolved */
+  isLoadingInitialFiles?: boolean
   /** Callback that renders custom fields identified by customFieldName */
   renderCustomField?: RenderCustomFieldFunction
   /** Whether async defaultValues are still being resolved */

--- a/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { ControllerRenderProps, FieldValues } from "react-hook-form"
 
 import type { InputFieldStatusType } from "@/ui/InputField/types"
@@ -174,6 +174,7 @@ export function FileFieldRenderer({
   const context = useOptionalF0FormContext()
   const resolvedUseUpload = context?.useUpload ?? field.useUpload
   const initialFilesPool = initialFiles ?? context?.initialFiles
+  const isLoadingInitialFiles = context?.isLoadingInitialFiles ?? false
   const inputId = useId()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [isDragOver, setIsDragOver] = useState(false)
@@ -181,6 +182,24 @@ export function FileFieldRenderer({
   const [entries, setEntries] = useState<FileEntry[]>(() =>
     resolveInitialEntries(initialFilesPool, formField.value, isMultiple)
   )
+  const initialFilesApplied = useRef(initialFilesPool != null)
+  useEffect(() => {
+    if (initialFilesApplied.current) return
+    if (initialFilesPool == null) return
+
+    // Wait for form values to be populated (e.g. after async defaultValues reset)
+    // before resolving entries — avoids a race where the pool arrives before
+    // react-hook-form has applied the reset values.
+    const hasFormValue = isMultiple
+      ? Array.isArray(formField.value) && formField.value.length > 0
+      : !!formField.value
+    if (!hasFormValue) return
+
+    initialFilesApplied.current = true
+    setEntries(
+      resolveInitialEntries(initialFilesPool, formField.value, isMultiple)
+    )
+  }, [initialFilesPool, formField.value, isMultiple])
   const [validationError, setValidationError] = useState<string | null>(null)
 
   const translations = forms.file
@@ -433,7 +452,13 @@ export function FileFieldRenderer({
 
   return (
     <div className="flex flex-col gap-4">
-      {showDropzone && (
+      {isLoadingInitialFiles && !hasFiles && (
+        <div className="flex animate-pulse flex-col gap-2 rounded-xl border border-dashed border-f1-border px-4 py-10">
+          <div className="mx-auto h-8 w-8 rounded-full bg-f1-background-secondary" />
+          <div className="mx-auto h-4 w-32 rounded bg-f1-background-secondary" />
+        </div>
+      )}
+      {!isLoadingInitialFiles && showDropzone && (
         <div
           role="button"
           tabIndex={field.disabled ? -1 : 0}

--- a/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
@@ -1,8 +1,9 @@
 import userEvent from "@testing-library/user-event"
 import React from "react"
-import { describe, expect, it, vi } from "vitest"
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
 import { z } from "zod"
 
+import { useF0FormDefinition } from "@/patterns/F0WizardForm/useF0FormDefinition"
 import {
   zeroRender as render,
   screen,
@@ -13,6 +14,7 @@ import {
 import type {
   FileUploadResult,
   FileUploadStatus,
+  InitialFile,
   UseFileUpload,
 } from "../types"
 
@@ -790,5 +792,224 @@ describe("FileFieldRenderer", () => {
     await waitFor(() =>
       expect(screen.getByText("Maximum 2 files")).toBeInTheDocument()
     )
+  })
+})
+
+// =============================================================================
+// Async initialFiles tests
+// =============================================================================
+
+const fileSchema = z.object({
+  document: f0FormField(z.string().min(1), {
+    label: "Contract",
+    fieldType: "file",
+  }),
+  attachments: f0FormField(z.array(z.string()), {
+    label: "Attachments",
+    fieldType: "file",
+    multiple: true,
+  }),
+})
+
+function AsyncInitialFilesForm({
+  initialFiles,
+  defaultValues,
+}: {
+  initialFiles:
+    | InitialFile[]
+    | ((signal: AbortSignal) => Promise<InitialFile[]>)
+  defaultValues:
+    | Partial<z.infer<typeof fileSchema>>
+    | ((signal: AbortSignal) => Promise<Partial<z.infer<typeof fileSchema>>>)
+}) {
+  const formDefinition = useF0FormDefinition({
+    name: "async-files-test",
+    schema: fileSchema,
+    defaultValues,
+    initialFiles,
+    onSubmit: async () => ({ success: true }),
+  })
+  return (
+    <F0Form
+      formDefinition={formDefinition}
+      useUpload={createMockUploadHook()}
+    />
+  )
+}
+
+describe("FileFieldRenderer — async initialFiles", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("shows a loading skeleton while initialFiles are resolving", async () => {
+    const initialFiles = () =>
+      new Promise<InitialFile[]>((resolve) =>
+        setTimeout(
+          () =>
+            resolve([
+              {
+                value: "contract.pdf",
+                name: "contract_2024.pdf",
+                type: "application/pdf",
+                size: 2_500_000,
+              },
+            ]),
+          1000
+        )
+      )
+
+    render(
+      <AsyncInitialFilesForm
+        defaultValues={{ document: "contract.pdf", attachments: [] }}
+        initialFiles={initialFiles}
+      />
+    )
+
+    // Dropzone is hidden while loading
+    expect(
+      screen.queryByText("Drag and drop a file, or click to select")
+    ).not.toBeInTheDocument()
+
+    // File attachment is not shown yet
+    expect(screen.queryByText("contract_2024.pdf")).not.toBeInTheDocument()
+  })
+
+  it("displays file entries after async initialFiles resolve", async () => {
+    const initialFiles = () =>
+      Promise.resolve([
+        {
+          value: "contract.pdf",
+          name: "contract_2024.pdf",
+          type: "application/pdf",
+          size: 2_500_000,
+        },
+      ])
+
+    render(
+      <AsyncInitialFilesForm
+        defaultValues={{ document: "contract.pdf", attachments: [] }}
+        initialFiles={initialFiles}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument()
+    })
+
+    // Dropzone should be hidden in single-file mode once a file is loaded
+    expect(
+      screen.queryByText("Drag and drop a file, or click to select")
+    ).not.toBeInTheDocument()
+  })
+
+  it("waits for both async defaultValues and async initialFiles before showing files", async () => {
+    // defaultValues resolve faster (50ms) than initialFiles (200ms)
+    const defaultValues = () =>
+      new Promise<Partial<z.infer<typeof fileSchema>>>((resolve) =>
+        setTimeout(
+          () =>
+            resolve({
+              document: "contract.pdf",
+              attachments: ["invoice.pdf"],
+            }),
+          50
+        )
+      )
+
+    const initialFiles = () =>
+      new Promise<InitialFile[]>((resolve) =>
+        setTimeout(
+          () =>
+            resolve([
+              {
+                value: "contract.pdf",
+                name: "contract_2024.pdf",
+                type: "application/pdf",
+                size: 2_500_000,
+              },
+              {
+                value: "invoice.pdf",
+                name: "invoice_march.pdf",
+                type: "application/pdf",
+                size: 1_200_000,
+              },
+            ]),
+          200
+        )
+      )
+
+    render(
+      <AsyncInitialFilesForm
+        defaultValues={defaultValues}
+        initialFiles={initialFiles}
+      />
+    )
+
+    // Nothing resolved yet — no file names visible
+    expect(screen.queryByText("contract_2024.pdf")).not.toBeInTheDocument()
+    expect(screen.queryByText("invoice_march.pdf")).not.toBeInTheDocument()
+
+    // Advance past defaultValues (50ms) but before initialFiles (200ms)
+    vi.advanceTimersByTime(100)
+
+    // Still not visible — waiting for initialFiles
+    expect(screen.queryByText("contract_2024.pdf")).not.toBeInTheDocument()
+
+    // Advance past initialFiles resolution
+    vi.advanceTimersByTime(200)
+
+    await waitFor(() => {
+      expect(screen.getByText("contract_2024.pdf")).toBeInTheDocument()
+    })
+    await waitFor(() => {
+      expect(screen.getByText("invoice_march.pdf")).toBeInTheDocument()
+    })
+  })
+
+  it("does not overwrite user-added files after initialFiles resolve", async () => {
+    // Start loading, will resolve after user interaction
+    let resolveFiles!: (v: InitialFile[]) => void
+    const initialFiles = () =>
+      new Promise<InitialFile[]>((resolve) => (resolveFiles = resolve))
+
+    render(
+      <AsyncInitialFilesForm
+        defaultValues={{ document: "", attachments: [] }}
+        initialFiles={initialFiles}
+      />
+    )
+
+    // While loading, the user uploads a file manually
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    await userEvent.upload(input, createFile("user_upload.pdf"))
+
+    await waitFor(() =>
+      expect(screen.getByText("user_upload.pdf")).toBeInTheDocument()
+    )
+
+    // Now resolve initial files — user upload should not be replaced
+    resolveFiles([
+      {
+        value: "some_id",
+        name: "server_file.pdf",
+        type: "application/pdf",
+        size: 500_000,
+      },
+    ])
+
+    await waitFor(() => {
+      // User file still present
+      expect(screen.getByText("user_upload.pdf")).toBeInTheDocument()
+    })
+
+    // Server file NOT injected since user already added a file
+    expect(screen.queryByText("server_file.pdf")).not.toBeInTheDocument()
   })
 })

--- a/packages/react/src/patterns/F0Form/types.ts
+++ b/packages/react/src/patterns/F0Form/types.ts
@@ -384,6 +384,11 @@ export interface F0FormPropsWithSingleSchema<TSchema extends F0FormSchema> {
    */
   initialFiles?: InitialFile[]
   /**
+   * Whether async `initialFiles` are still being resolved.
+   * When true, file fields show a skeleton until the files arrive.
+   */
+  isLoadingInitialFiles?: boolean
+  /**
    * Upload hook shared by all file fields in the form.
    * Called once per file to obtain an independent upload instance.
    */
@@ -490,6 +495,11 @@ export interface F0FormPropsWithPerSectionSchema<T extends F0PerSectionSchema> {
    * `defaultValues` against `InitialFile.value`.
    */
   initialFiles?: InitialFile[]
+  /**
+   * Whether async `initialFiles` are still being resolved.
+   * When true, file fields show a skeleton until the files arrive.
+   */
+  isLoadingInitialFiles?: boolean
   /**
    * Upload hook shared by all file fields in the form.
    */

--- a/packages/react/src/patterns/F0WizardForm/types.ts
+++ b/packages/react/src/patterns/F0WizardForm/types.ts
@@ -1,6 +1,7 @@
 import { z, ZodRawShape, ZodEffects, type ZodType } from "zod"
 
 import type { ModuleId } from "@/components/avatars/F0AvatarModule"
+import type { InitialFile } from "@/patterns/F0Form/fields/file/types"
 import type {
   F0FormErrorTriggerMode,
   F0FormSubmitConfig,
@@ -83,6 +84,8 @@ export interface F0FormDefinitionSingleSchema<TSchema extends F0FormSchema> {
   defaultValuesFn?: (
     params: Record<string, unknown>
   ) => Promise<Partial<z.infer<TSchema>>>
+  /** Pre-existing file metadata for file fields — resolved before the form renders */
+  initialFiles?: InitialFile[]
   /** Wizard steps — when present, F0WizardForm uses these instead of auto-deriving from sections */
   steps?: F0WizardFormStep[]
 }
@@ -111,6 +114,8 @@ export interface F0FormDefinitionPerSection<T extends F0PerSectionSchema> {
   defaultValuesFn?: (
     params: Record<string, unknown>
   ) => Promise<{ [K in keyof T]?: Partial<z.infer<T[K]>> }>
+  /** Pre-existing file metadata for file fields — resolved before the form renders */
+  initialFiles?: InitialFile[]
   /** Wizard steps — when present, F0WizardForm uses these instead of auto-deriving from sections */
   steps?: F0WizardFormStep[]
 }

--- a/packages/react/src/patterns/F0WizardForm/types.ts
+++ b/packages/react/src/patterns/F0WizardForm/types.ts
@@ -86,6 +86,8 @@ export interface F0FormDefinitionSingleSchema<TSchema extends F0FormSchema> {
   ) => Promise<Partial<z.infer<TSchema>>>
   /** Pre-existing file metadata for file fields — resolved before the form renders */
   initialFiles?: InitialFile[]
+  /** Whether async initialFiles are still being resolved */
+  isLoadingInitialFiles?: boolean
   /** Wizard steps — when present, F0WizardForm uses these instead of auto-deriving from sections */
   steps?: F0WizardFormStep[]
 }
@@ -116,6 +118,8 @@ export interface F0FormDefinitionPerSection<T extends F0PerSectionSchema> {
   ) => Promise<{ [K in keyof T]?: Partial<z.infer<T[K]>> }>
   /** Pre-existing file metadata for file fields — resolved before the form renders */
   initialFiles?: InitialFile[]
+  /** Whether async initialFiles are still being resolved */
+  isLoadingInitialFiles?: boolean
   /** Wizard steps — when present, F0WizardForm uses these instead of auto-deriving from sections */
   steps?: F0WizardFormStep[]
 }

--- a/packages/react/src/patterns/F0WizardForm/useF0FormDefinition.ts
+++ b/packages/react/src/patterns/F0WizardForm/useF0FormDefinition.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { z, type ZodType } from "zod"
 
 import type { ModuleId } from "@/components/avatars/F0AvatarModule"
+import type { InitialFile } from "@/patterns/F0Form/fields/file/types"
 import type {
   F0FormErrorTriggerMode,
   F0FormSubmitConfig,
@@ -57,6 +58,12 @@ interface UseF0FormDefinitionSingleSchemaInputBase<
   ) => Promise<F0FormSubmitResult> | F0FormSubmitResult
   submitConfig?: F0FormSubmitConfig
   errorTriggerMode?: F0FormErrorTriggerMode
+  /**
+   * Pre-existing file metadata for file fields.
+   * Accepts a static array or an async function `(signal: AbortSignal) => Promise<InitialFile[]>`
+   * that resolves the list at mount time.
+   */
+  initialFiles?: AsyncOrSync<InitialFile[]>
   /** Wizard steps — when present, F0WizardForm uses these instead of auto-deriving from sections */
   steps?: F0WizardFormStep[]
 }
@@ -101,6 +108,12 @@ interface UseF0FormDefinitionPerSectionInputBase<T extends F0PerSectionSchema> {
   ) => Promise<F0FormSubmitResult> | F0FormSubmitResult
   submitConfig?: F0PerSectionSubmitConfig
   errorTriggerMode?: F0FormErrorTriggerMode
+  /**
+   * Pre-existing file metadata for file fields.
+   * Accepts a static array or an async function `(signal: AbortSignal) => Promise<InitialFile[]>`
+   * that resolves the list at mount time.
+   */
+  initialFiles?: AsyncOrSync<InitialFile[]>
   /** Wizard steps — when present, F0WizardForm uses these instead of auto-deriving from sections */
   steps?: F0WizardFormStep[]
 }
@@ -265,6 +278,7 @@ export function useF0FormDefinition(
     module,
   } = input
 
+  const initialFiles = "initialFiles" in input ? input.initialFiles : undefined
   const steps = "steps" in input ? input.steps : undefined
 
   // Store the raw function for the AI registry to call with actual params
@@ -281,6 +295,10 @@ export function useF0FormDefinition(
     hasParamsSchema
   )
 
+  const { resolved: resolvedInitialFiles } = useAsyncDefaultValues<
+    InitialFile[]
+  >(initialFiles, false)
+
   return useMemo(() => {
     const brand = isZodSchema(schema) ? "single" : "per-section"
     return {
@@ -296,6 +314,7 @@ export function useF0FormDefinition(
       isLoading,
       defaultValuesParamsSchema,
       defaultValuesFn,
+      initialFiles: resolvedInitialFiles,
       steps,
       _brand: brand,
     } as
@@ -315,6 +334,7 @@ export function useF0FormDefinition(
     isLoading,
     defaultValuesParamsSchema,
     defaultValuesFn,
+    resolvedInitialFiles,
     steps,
   ])
 }

--- a/packages/react/src/patterns/F0WizardForm/useF0FormDefinition.ts
+++ b/packages/react/src/patterns/F0WizardForm/useF0FormDefinition.ts
@@ -295,9 +295,8 @@ export function useF0FormDefinition(
     hasParamsSchema
   )
 
-  const { resolved: resolvedInitialFiles } = useAsyncDefaultValues<
-    InitialFile[]
-  >(initialFiles, false)
+  const { resolved: resolvedInitialFiles, isLoading: isLoadingInitialFiles } =
+    useAsyncDefaultValues<InitialFile[]>(initialFiles, false)
 
   return useMemo(() => {
     const brand = isZodSchema(schema) ? "single" : "per-section"
@@ -311,10 +310,11 @@ export function useF0FormDefinition(
       onSubmit,
       submitConfig,
       errorTriggerMode,
-      isLoading,
+      isLoading: isLoading || isLoadingInitialFiles,
       defaultValuesParamsSchema,
       defaultValuesFn,
       initialFiles: resolvedInitialFiles,
+      isLoadingInitialFiles,
       steps,
       _brand: brand,
     } as
@@ -335,6 +335,7 @@ export function useF0FormDefinition(
     defaultValuesParamsSchema,
     defaultValuesFn,
     resolvedInitialFiles,
+    isLoadingInitialFiles,
     steps,
   ])
 }


### PR DESCRIPTION
## What

Adds support for defining `initialFiles` directly in `useF0FormDefinition`, with full async resolution and a coordinated loading state that gates the entire form until both `defaultValues` **and** `initialFiles` have resolved.

## Why

Previously `initialFiles` could only be passed as a direct prop on `<F0Form>`, separate from the form definition. This forced consumers to manage file metadata outside the definition object and made it impossible to lazily fetch file metadata from an API (e.g. GET `/files/:id`) in the same place as other async defaults.

## Changes

### `useF0FormDefinition` — async `initialFiles` support
- Added `initialFiles?: AsyncOrSync<InitialFile[]>` to both `UseF0FormDefinitionSingleSchemaInputBase` and `UseF0FormDefinitionPerSectionInputBase`
- Resolved via a second `useAsyncDefaultValues` call — accepts a static array or `async (signal: AbortSignal) => Promise<InitialFile[]>`
- The definition-level `isLoading` is now `isLoading || isLoadingInitialFiles`, so the form stays in a full loading state until the slower of the two async operations finishes
- `isLoadingInitialFiles` is also returned on the definition object for downstream consumers

### `types.ts` (F0WizardForm + F0Form)
- `initialFiles?: InitialFile[]` and `isLoadingInitialFiles?: boolean` added to `F0FormDefinitionSingleSchema`, `F0FormDefinitionPerSection`, `F0FormPropsWithSingleSchema`, and `F0FormPropsWithPerSectionSchema`

### `context.ts`
- `isLoadingInitialFiles?: boolean` added to `F0FormContextValue`

### `F0Form.tsx` + `F0FormSection.tsx`
- Both adapters (`F0FormFromSingleDefinition`, `F0FormFromPerSectionDefinition`) pass `def.isLoadingInitialFiles` through
- `F0FormSingleSchema` and `F0FormSection` include it in their React context value

### `FileFieldRenderer.tsx` — loading skeleton + race condition fix
- Reads `isLoadingInitialFiles` from context; while loading and no user-added files exist, renders an animated skeleton placeholder instead of the dropzone
- Fixed a race condition where `initialFilesPool` could arrive before `form.reset()` had applied the async `defaultValues`, causing `resolveInitialEntries` to match against `undefined` and mark itself as applied — blocking a later correct resolution. The effect now waits until `formField.value` is non-empty before applying initial files, and marks itself applied only then

### `F0Form.stories.tsx`
- `FileFieldsWithInitialFiles` — migrated `initialFiles` from the `<F0Form>` prop into `useF0FormDefinition`
- `FileFieldsWithAsyncInitialFiles` _(new)_ — mixed form with regular fields + file fields; `defaultValues` resolves in ~800 ms, `initialFiles` in ~1 500 ms; the form stays in full loading state until both settle

### `FileFieldRenderer.test.tsx`
Four new tests under `"FileFieldRenderer — async initialFiles"`:
1. **Loading skeleton shown** — dropzone and file names hidden while files are resolving
2. **Files displayed after resolution** — entries appear and dropzone hides once the promise settles
3. **Both async sources must resolve** — uses fake timers to assert files aren't shown after only `defaultValues` resolve; appear only after `initialFiles` resolve
4. **User edits not overwritten** — a file uploaded by the user during the async load is preserved when the server files later resolve

## Usage

```tsx
// Static
const def = useF0FormDefinition({
  initialFiles: [
    { value: "contract.pdf", name: "contract_2024.pdf", type: "application/pdf", size: 2_500_000 },
  ],
  // ...
})

// Async — fetch metadata from API
const def = useF0FormDefinition({
  initialFiles: async (signal) => {
    const files = await api.getFileMetadata({ signal })
    return files.map((f) => ({ value: f.id, name: f.filename, type: f.mimeType, size: f.size }))
  },
  // ...
})
```