### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.460.0",
+  "packages/react": "1.461.0",
   "packages/react-native": "0.52.0",
   "packages/core": "1.50.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.461.0](https://github.com/factorialco/f0/compare/f0-react-v1.460.0...f0-react-v1.461.0) (2026-04-23)
+
+
+### Features
+
+* add support to define initial files resolution through f0 form definition ([#4006](https://github.com/factorialco/f0/issues/4006)) ([50ec9af](https://github.com/factorialco/f0/commit/50ec9afeb35f53b232053ced1c2a8d761597c76d))
+
 ## [1.460.0](https://github.com/factorialco/f0/compare/f0-react-v1.459.1...f0-react-v1.460.0) (2026-04-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.460.0",
+  "version": "1.461.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.461.0</summary>

## [1.461.0](https://github.com/factorialco/f0/compare/f0-react-v1.460.0...f0-react-v1.461.0) (2026-04-23)


### Features

* add support to define initial files resolution through f0 form definition ([#4006](https://github.com/factorialco/f0/issues/4006)) ([50ec9af](https://github.com/factorialco/f0/commit/50ec9afeb35f53b232053ced1c2a8d761597c76d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).