### PR TITLE
fix(F0AiChat): preserve final streamed delta in ordered message parts

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/providers/OrderedMessagePartsProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/OrderedMessagePartsProvider.tsx
@@ -130,18 +130,26 @@ export const OrderedMessagePartsProvider = ({
         event: TextMessageContentEvent
         textMessageBuffer: string
       }) => {
-        // textMessageBuffer is the accumulated text for the current open
-        // text message. We mutate the latest text part in place rather than
-        // appending — text deltas accumulate into the same segment.
+        // AG-UI's defaultApplyEvents invokes this subscriber BEFORE
+        // appending the current delta to the stored message content, so
+        // `textMessageBuffer` contains the text accumulated up to but
+        // not including `event.delta`. We must combine both to capture
+        // the full running text — otherwise the very last streamed
+        // delta is never stored (no later content event arrives to
+        // carry it in its buffer, and the end event does not refresh
+        // the text), producing trailing 1–2 character truncation in
+        // the rendered assistant message.
         const messageId = event.messageId ?? openTextMessageIdRef.current
         if (!messageId) return
+        const delta = event.delta ?? ""
+        const nextText = textMessageBuffer + delta
         const parts = getParts(messageId)
         const last = parts[parts.length - 1]
         if (last && last.kind === "text") {
-          last.text = textMessageBuffer
+          last.text = nextText
         } else {
           // Defensive: missed the start event, open a new text part.
-          parts.push({ kind: "text", text: textMessageBuffer })
+          parts.push({ kind: "text", text: nextText })
           openTextMessageIdRef.current = messageId
         }
         bump()

--- a/packages/react/src/sds/ai/F0AiChat/providers/__tests__/OrderedMessagePartsProvider.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/__tests__/OrderedMessagePartsProvider.test.tsx
@@ -172,6 +172,46 @@ describe("OrderedMessagePartsProvider", () => {
     })
   })
 
+  it("accumulates every streamed delta, including the final one", () => {
+    // AG-UI's defaultApplyEvents dispatches onTextMessageContentEvent
+    // BEFORE appending the current delta to the message content. So
+    // `textMessageBuffer` is always the text-so-far WITHOUT the delta
+    // that just arrived. The provider must include `event.delta`
+    // itself, otherwise the very last delta is never captured (because
+    // no subsequent content event arrives to carry it in its buffer).
+    //
+    // Regression test for truncation of the final 1–2 symbols of
+    // streamed assistant replies (trailing "*", ")", "*)", etc.).
+    const seen: (OrderedPart[] | null)[] = []
+    renderWithProvider(
+      <Probe messageId="msg-stream" onParts={(p) => seen.push(p)} />
+    )
+
+    const sub = subscriberRef.current!
+
+    const deltas = ["Hello ", "how ", "are ", "you", "*)"]
+    const expected = deltas.join("")
+
+    act(() => {
+      sub.onTextMessageStartEvent?.({ event: { messageId: "msg-stream" } })
+
+      let accumulated = ""
+      for (const delta of deltas) {
+        sub.onTextMessageContentEvent?.({
+          event: { messageId: "msg-stream", delta },
+          textMessageBuffer: accumulated,
+        })
+        accumulated += delta
+      }
+
+      sub.onTextMessageEndEvent?.({ event: { messageId: "msg-stream" } })
+    })
+
+    const last = seen[seen.length - 1]
+    expect(last).toHaveLength(1)
+    expect(last?.[0]).toMatchObject({ kind: "text", text: expected })
+  })
+
   it("getOrderedParts returns a defensive copy that consumers cannot mutate back", () => {
     const seen: (OrderedPart[] | null)[] = []
     renderWithProvider(


### PR DESCRIPTION
## Summary

Fixes trailing 1–2 character truncation of streamed assistant replies in F0AiChat (users reported losing final `*`, `)`, `*)`, `.`, etc.).

## Root cause

AG-UI's `defaultApplyEvents` invokes `onTextMessageContentEvent` **before** appending the current delta to the stored message content, so `textMessageBuffer` contains the text accumulated up to but **not** including `event.delta`:

```ts
// @ag-ui/client 0.0.47 (what pnpm-lock.yaml resolves to)
subscriber.onTextMessageContentEvent({
  event,                                 // contains event.delta
  textMessageBuffer: message.content,    // ← content BEFORE this delta
})
message.content = message.content + event.delta   // ← appended AFTER
```

Verified the same semantics in 0.0.35 (a transitive resolution still present in some installs) — this is the library contract, not a version quirk.

`OrderedMessagePartsProvider` was doing `last.text = textMessageBuffer`, i.e. always one delta behind. `onTextMessageEndEvent` does not refresh the text either, so the last streamed delta was never captured.

Since `MessagesContainer.tsx` prefers `getOrderedParts` over `legacyExpansion` whenever any parts exist, the rendered assistant message was missing the last streamed delta — typically a small trailing token, which is why users saw the last 1–2 symbols cut off.

Verified against the actual installed `@ag-ui/client 0.0.47`:

| last delta | before fix (ordered parts) | after fix |
| --- | --- | --- |
| `"*)"` | `"Hello how are you"` | `"Hello how are you*)"` |
| `"*"`  | `"Here is a point"`   | `"Here is a point*"` |
| `")"`  | `"Done."`             | `"Done.)"` |
| `"single"` | `""` | `"single"` |
| `"."`  | `"multi-chunk ending"` | `"multi-chunk ending."` |
| `"**bold**"` | `"line1\n"` | `"line1\n**bold**"` |

## Fix

Combine `textMessageBuffer` with `event.delta` so the provider tracks the same running text the underlying `agent.messages[i].content` does.

## Regression window

Introduced in #3895 (2026-04-14, commit `47130c909` — “feat(F0AiChat): render assistant messages in true streaming order”). This is a misuse of the AG-UI subscriber contract, not a version issue — no upgrade would fix it.

## Tests

- New regression test `"accumulates every streamed delta, including the final one"` in `OrderedMessagePartsProvider.test.tsx` drives realistic sequential deltas with pre-delta buffers.
- Existing 5 provider tests still pass.
- Full F0AiChat test run has the same 4 unrelated pre-existing transform failures (f0Schema / form tests) as `main`.
- TSC shows the same 51 pre-existing errors as `main` — no new ones.
- Lint and format clean on the changed file.

