### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.461.0",
+  "packages/react": "1.461.1",
   "packages/react-native": "0.52.0",
   "packages/core": "1.50.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.461.1](https://github.com/factorialco/f0/compare/f0-react-v1.461.0...f0-react-v1.461.1) (2026-04-23)
+
+
+### Bug Fixes
+
+* **F0AiChat:** preserve final streamed delta in ordered message parts ([#4011](https://github.com/factorialco/f0/issues/4011)) ([7496f2e](https://github.com/factorialco/f0/commit/7496f2e134025b148b54eace4ebbbcee28912586))
+
 ## [1.461.0](https://github.com/factorialco/f0/compare/f0-react-v1.460.0...f0-react-v1.461.0) (2026-04-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.461.0",
+  "version": "1.461.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.461.1</summary>

## [1.461.1](https://github.com/factorialco/f0/compare/f0-react-v1.461.0...f0-react-v1.461.1) (2026-04-23)


### Bug Fixes

* **F0AiChat:** preserve final streamed delta in ordered message parts ([#4011](https://github.com/factorialco/f0/issues/4011)) ([7496f2e](https://github.com/factorialco/f0/commit/7496f2e134025b148b54eace4ebbbcee28912586))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).