### PR TITLE
feat(F0AiChat): enrich requisition entity ref card

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -323,6 +323,11 @@ export const defaultTranslations = {
         source: "Source",
         applied: "Applied on",
       },
+      requisition: {
+        lineManager: "Line manager",
+        reason: "Reason",
+        status: "Status",
+      },
     },
     credits: {
       title: "Credits",

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/components/EntityRefDetails.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/components/EntityRefDetails.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react"
+
+export type EntityRefDetailRow = {
+  label?: string
+  value: ReactNode
+}
+
+type EntityRefDetailsProps = {
+  rows: EntityRefDetailRow[]
+}
+
+export function EntityRefDetails({ rows }: EntityRefDetailsProps) {
+  if (rows.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {rows.map((row, index) => (
+        <div key={row.label ?? index} className="flex flex-col">
+          {row.label && (
+            <p className="text-f1-foreground-secondary">{row.label}</p>
+          )}
+          <div className="flex items-center gap-1.5 font-medium text-f1-foreground">
+            {row.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/components/__tests__/EntityRefDetails.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/components/__tests__/EntityRefDetails.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import "@testing-library/jest-dom/vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { EntityRefDetails } from "../EntityRefDetails"
+
+describe("EntityRefDetails", () => {
+  it("returns null when rows is empty", () => {
+    const { container } = render(<EntityRefDetails rows={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders each row label and value", () => {
+    render(
+      <EntityRefDetails
+        rows={[
+          { label: "Location", value: "Remote" },
+          {
+            label: "Line Manager",
+            value: <span data-testid="lm">Jane Doe</span>,
+          },
+        ]}
+      />
+    )
+    expect(screen.getByText("Location")).toBeInTheDocument()
+    expect(screen.getByText("Remote")).toBeInTheDocument()
+    expect(screen.getByText("Line Manager")).toBeInTheDocument()
+    expect(screen.getByTestId("lm")).toHaveTextContent("Jane Doe")
+  })
+
+  it("renders a row whose value is a ReactNode (e.g., status tag)", () => {
+    render(
+      <EntityRefDetails
+        rows={[
+          { label: "Reason", value: "New Position" },
+          {
+            label: "Status",
+            value: <span data-testid="status">Approved</span>,
+          },
+        ]}
+      />
+    )
+    expect(screen.getByText("Reason")).toBeInTheDocument()
+    expect(screen.getByText("New Position")).toBeInTheDocument()
+    expect(screen.getByText("Status")).toBeInTheDocument()
+    expect(screen.getByTestId("status")).toHaveTextContent("Approved")
+  })
+
+  it("renders a row with no label (value only)", () => {
+    render(
+      <EntityRefDetails
+        rows={[
+          { label: "Reason", value: "New Position" },
+          { value: <span data-testid="pill">Approved</span> },
+        ]}
+      />
+    )
+    expect(screen.queryByText("Status")).not.toBeInTheDocument()
+    expect(screen.getByTestId("pill")).toHaveTextContent("Approved")
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/requisition/RequisitionEntityRef.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/requisition/RequisitionEntityRef.tsx
@@ -1,6 +1,8 @@
 import { forwardRef, useMemo } from "react"
 
+import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
 import type { F0CardProps } from "@/components/F0Card"
+import { F0TagStatus } from "@/components/tags/F0TagStatus"
 
 import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils"
@@ -8,6 +10,8 @@ import { cn, focusRing } from "@/lib/utils"
 import type { RequisitionProfile } from "./types"
 
 import { useAiChat } from "../../../../../providers/AiChatStateProvider"
+import type { EntityRefDetailRow } from "../../components/EntityRefDetails"
+import { EntityRefDetails } from "../../components/EntityRefDetails"
 import { EntityRefHoverCard } from "../../components/EntityRefHoverCard"
 
 const RequisitionTrigger = forwardRef<HTMLButtonElement, { label: string }>(
@@ -27,13 +31,6 @@ const RequisitionTrigger = forwardRef<HTMLButtonElement, { label: string }>(
 )
 RequisitionTrigger.displayName = "RequisitionTrigger"
 
-/**
- * Inline requisition entity reference with a hover card showing requisition details.
- *
- * Renders the trigger as a styled link. On hover, lazily fetches
- * the requisition data via `entityRefs.resolvers.requisition` and displays
- * title, status, and reason. Optionally links via `entityRefs.urls.requisition`.
- */
 export function RequisitionEntityRef({
   id,
   label,
@@ -49,18 +46,66 @@ export function RequisitionEntityRef({
 
   const mapToCard = useMemo(
     () =>
-      (profile: RequisitionProfile): F0CardProps => ({
-        title: profile.title,
-        description: [profile.status, profile.reason]
-          .filter(Boolean)
-          .join(" · "),
-        ...(requisitionUrl && {
-          secondaryActions: {
-            label: i18n.t("ai.view"),
-            href: requisitionUrl,
-          },
-        }),
-      }),
+      (profile: RequisitionProfile): F0CardProps => {
+        const lineManagerName = profile.lineManager
+          ? `${profile.lineManager.firstName} ${profile.lineManager.lastName}`
+          : undefined
+
+        const candidateRows: Array<EntityRefDetailRow | undefined> = [
+          profile.status
+            ? {
+                label: i18n.t("ai.entityRef.requisition.status"),
+                value: (
+                  <div className="flex items-center pt-1">
+                    <F0TagStatus
+                      text={profile.status}
+                      variant={profile.statusVariant ?? "neutral"}
+                    />
+                  </div>
+                ),
+              }
+            : undefined,
+          profile.lineManager
+            ? {
+                label: i18n.t("ai.entityRef.requisition.lineManager"),
+                value: (
+                  <div className="flex items-center gap-1.5 pt-1">
+                    <F0AvatarPerson
+                      firstName={profile.lineManager.firstName}
+                      lastName={profile.lineManager.lastName}
+                      src={profile.lineManager.avatarUrl}
+                      size="xs"
+                    />
+                    <span>{lineManagerName}</span>
+                  </div>
+                ),
+              }
+            : undefined,
+          profile.reason
+            ? {
+                label: i18n.t("ai.entityRef.requisition.reason"),
+                value: profile.reason,
+              }
+            : undefined,
+        ]
+        const rows = candidateRows.filter(
+          (row): row is EntityRefDetailRow => row !== undefined
+        )
+
+        return {
+          title: profile.title,
+          ...(profile.location && { description: profile.location }),
+          ...(rows.length > 0 && {
+            children: <EntityRefDetails rows={rows} />,
+          }),
+          ...(requisitionUrl && {
+            secondaryActions: {
+              label: i18n.t("ai.view"),
+              href: requisitionUrl,
+            },
+          }),
+        }
+      },
     [i18n, requisitionUrl]
   )
 

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/requisition/__tests__/RequisitionEntityRef.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/requisition/__tests__/RequisitionEntityRef.test.tsx
@@ -29,7 +29,14 @@ const profile: RequisitionProfile = {
   id: "88",
   title: "Backend Engineer",
   status: "Approved",
+  statusVariant: "positive",
   reason: "New Position",
+  location: "Remote",
+  lineManager: {
+    firstName: "Jane",
+    lastName: "Doe",
+    avatarUrl: "https://example.com/jane.png",
+  },
 }
 
 describe("RequisitionEntityRef", () => {
@@ -67,8 +74,60 @@ describe("RequisitionEntityRef", () => {
 
     await waitFor(() => {
       expect(screen.getAllByText("Backend Engineer")).toHaveLength(2)
-      expect(screen.getByText("Approved · New Position")).toBeInTheDocument()
+      expect(screen.getByText("Approved")).toBeInTheDocument()
+      expect(screen.getByText("New Position")).toBeInTheDocument()
     })
+  })
+
+  it("renders location and lineManager rows with avatar", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+
+    render(<RequisitionEntityRef id="88" label="Backend Engineer" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Remote")).toBeInTheDocument()
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument()
+    })
+  })
+
+  it("renders location as the card description and status with a label", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+
+    render(<RequisitionEntityRef id="88" label="Backend Engineer" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Remote")).toBeInTheDocument()
+      expect(screen.getByText("Approved")).toBeInTheDocument()
+    })
+
+    expect(screen.getByText("Status")).toBeInTheDocument()
+    expect(screen.queryByText("Location")).not.toBeInTheDocument()
+  })
+
+  it("omits rows when optional fields are missing", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue({
+      id: "88",
+      title: "Backend Engineer",
+    })
+
+    render(<RequisitionEntityRef id="88" label="Backend Engineer" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Backend Engineer")).toHaveLength(2)
+    })
+
+    expect(screen.queryByText("Remote")).not.toBeInTheDocument()
+    expect(screen.queryByText("Approved")).not.toBeInTheDocument()
+    expect(screen.queryByText("New Position")).not.toBeInTheDocument()
   })
 
   it("caches profile — resolver is called only once per id", async () => {

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/requisition/__tests__/RequisitionEntityRef.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/requisition/__tests__/RequisitionEntityRef.test.tsx
@@ -110,6 +110,42 @@ describe("RequisitionEntityRef", () => {
     expect(screen.queryByText("Location")).not.toBeInTheDocument()
   })
 
+  it("applies the statusVariant to the rendered status tag", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+
+    render(<RequisitionEntityRef id="88" label="Backend Engineer" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    const statusTag = await waitFor(() =>
+      screen
+        .getByText("Approved")
+        .closest('[class*="bg-f1-background-positive"]')
+    )
+    expect(statusTag).toBeInTheDocument()
+  })
+
+  it("falls back to the neutral variant when statusVariant is missing", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue({
+      id: "88",
+      title: "Backend Engineer",
+      status: "Pending",
+    })
+
+    render(<RequisitionEntityRef id="88" label="Backend Engineer" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    const statusTag = await waitFor(() =>
+      screen
+        .getByText("Pending")
+        .closest('[class*="bg-f1-background-secondary"]')
+    )
+    expect(statusTag).toBeInTheDocument()
+  })
+
   it("omits rows when optional fields are missing", async () => {
     const user = userEvent.setup()
     mockResolver.mockResolvedValue({

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/requisition/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/requisition/types.ts
@@ -1,10 +1,15 @@
-/**
- * Profile data for a requisition entity (ATS requisition), resolved asynchronously
- * and displayed in the entity reference hover card.
- */
+import type { StatusVariant } from "@/components/tags/F0TagStatus"
+
 export type RequisitionProfile = {
   id: string | number
   title: string
   status?: string
+  statusVariant?: StatusVariant
   reason?: string
+  location?: string
+  lineManager?: {
+    firstName: string
+    lastName: string
+    avatarUrl?: string
+  }
 }


### PR DESCRIPTION
Enriches the requisition entity ref hover card: adds a status tag (with variant), a location shown as the card description, and detail rows for line manager and reason. Introduces an `EntityRefDetails` subcomponent intended for reuse across entity ref cards; currently consumed only by `RequisitionEntityRef`.