### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.462.0",
+  "packages/react": "1.463.0",
   "packages/react-native": "0.52.0",
   "packages/core": "1.50.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.463.0](https://github.com/factorialco/f0/compare/f0-react-v1.462.0...f0-react-v1.463.0) (2026-04-23)
+
+
+### Features
+
+* add F0Form field shortcuts ([#4014](https://github.com/factorialco/f0/issues/4014)) ([e39812f](https://github.com/factorialco/f0/commit/e39812f14a42948123e5de6d04e008848ba6c877))
+
 ## [1.462.0](https://github.com/factorialco/f0/compare/f0-react-v1.461.1...f0-react-v1.462.0) (2026-04-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.462.0",
+  "version": "1.463.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.463.0</summary>

## [1.463.0](https://github.com/factorialco/f0/compare/f0-react-v1.462.0...f0-react-v1.463.0) (2026-04-23)


### Features

* add F0Form field shortcuts ([#4014](https://github.com/factorialco/f0/issues/4014)) ([e39812f](https://github.com/factorialco/f0/commit/e39812f14a42948123e5de6d04e008848ba6c877))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).