### PR TITLE
docs(F0Button): add MDX documentation page

### DIFF
--- a/packages/react/src/components/F0Button/__stories__/F0Button.mdx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.mdx
@@ -91,7 +91,7 @@ Triggers user actions or navigates to other parts of the application. Supports i
 
 Icons reinforce the label meaning. Use leading icons for the most common case, trailing icons when the icon represents the result of the action (e.g. an external link arrow). Use `hideLabel` for icon-only buttons in toolbars or dense surfaces where context makes the action self-explanatory — the `label` prop is still required and becomes the accessible name and tooltip.
 
-### Sizes
+#### Sizes
 
 <Canvas of={Stories.Sizes} />
 
@@ -133,7 +133,7 @@ Icons reinforce the label meaning. Use leading icons for the most common case, t
   </table>
 </Unstyled>
 
-### States
+#### States
 
 <Canvas of={Stories.States} />
 

--- a/packages/react/src/components/F0Button/__stories__/F0Button.mdx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.mdx
@@ -43,32 +43,53 @@ A button component that triggers actions or navigates to different parts of the 
     </thead>
     <tbody>
       <tr>
-        <td><code>default</code></td>
+        <td>
+          <code>default</code>
+        </td>
         <td>Primary filled button, high visual emphasis</td>
         <td>Primary actions — the main call to action on a page or modal</td>
       </tr>
       <tr>
-        <td><code>outline</code></td>
+        <td>
+          <code>outline</code>
+        </td>
         <td>Bordered button, medium emphasis</td>
         <td>Secondary actions alongside a primary button</td>
       </tr>
       <tr>
-        <td><code>neutral</code></td>
+        <td>
+          <code>neutral</code>
+        </td>
         <td>Subtle grey button</td>
-        <td>Tertiary or less important options within the interface — offers an extra level of hierarchy</td>
+        <td>
+          Tertiary or less important options within the interface — offers an
+          extra level of hierarchy
+        </td>
       </tr>
       <tr>
-        <td><code>ghost</code></td>
+        <td>
+          <code>ghost</code>
+        </td>
         <td>No background or border, blends with content</td>
-        <td>Secondary actions, blending subtly with content and standing out only on hover or focus</td>
+        <td>
+          Secondary actions, blending subtly with content and standing out only
+          on hover or focus
+        </td>
       </tr>
       <tr>
-        <td><code>critical</code></td>
+        <td>
+          <code>critical</code>
+        </td>
         <td>Red/destructive styling, high visual weight</td>
-        <td>Irreversible destructive actions (delete, remove, revoke). Always behind a confirmation step</td>
+        <td>
+          Irreversible destructive actions (delete, remove, revoke). Always
+          behind a confirmation step
+        </td>
       </tr>
       <tr>
-        <td><code>promote</code></td>
+        <td>
+          <code>promote</code>
+        </td>
         <td>Highlighted promotional styling</td>
         <td>Upsell, upgrade, or promotional calls to action</td>
       </tr>
@@ -95,17 +116,23 @@ A button component that triggers actions or navigates to different parts of the 
     </thead>
     <tbody>
       <tr>
-        <td><code>lg</code></td>
+        <td>
+          <code>lg</code>
+        </td>
         <td>Large touch target</td>
         <td>Mobile interfaces or prominent desktop CTAs</td>
       </tr>
       <tr>
-        <td><code>md</code></td>
+        <td>
+          <code>md</code>
+        </td>
         <td>Standard desktop size</td>
         <td>Default for most desktop actions</td>
       </tr>
       <tr>
-        <td><code>sm</code></td>
+        <td>
+          <code>sm</code>
+        </td>
         <td>Compact size</td>
         <td>Secondary actions, dense layouts, or inline controls</td>
       </tr>
@@ -128,14 +155,24 @@ A button component that triggers actions or navigates to different parts of the 
     </thead>
     <tbody>
       <tr>
-        <td><code>disabled</code></td>
+        <td>
+          <code>disabled</code>
+        </td>
         <td>Inactive — does not respond to interaction</td>
-        <td>Reduced opacity, not-allowed cursor, remains focusable for assistive tech</td>
+        <td>
+          Reduced opacity, not-allowed cursor, remains focusable for assistive
+          tech
+        </td>
       </tr>
       <tr>
-        <td><code>loading</code></td>
+        <td>
+          <code>loading</code>
+        </td>
         <td>Action in progress</td>
-        <td>Spinner icon, interaction blocked, announced via <code>aria-busy</code></td>
+        <td>
+          Spinner icon, interaction blocked, announced via{" "}
+          <code>aria-busy</code>
+        </td>
       </tr>
     </tbody>
   </table>
@@ -194,11 +231,13 @@ A button component that triggers actions or navigates to different parts of the 
 
 <DoDonts
   do={{
-    description: "Use clear, action-oriented labels: 'Save changes', 'Add employee', 'Delete request'",
+    description:
+      "Use clear, action-oriented labels: 'Save changes', 'Add employee', 'Delete request'",
     children: <F0Button label="Save changes" />,
   }}
   dont={{
-    description: "Use vague or generic labels: 'OK', 'Yes', 'Click here', 'Submit'",
+    description:
+      "Use vague or generic labels: 'OK', 'Yes', 'Click here', 'Submit'",
     children: <F0Button label="OK" />,
   }}
 />
@@ -212,7 +251,8 @@ A button component that triggers actions or navigates to different parts of the 
 
 <DoDonts
   do={{
-    description: "Pair a primary button with a secondary outline for cancel-style actions",
+    description:
+      "Pair a primary button with a secondary outline for cancel-style actions",
     guidelines: [
       "Place the primary action on the right",
       "Use consistent sizing across all buttons in the group",
@@ -225,7 +265,8 @@ A button component that triggers actions or navigates to different parts of the 
     ),
   }}
   dont={{
-    description: "Stack multiple primary buttons in the same group — it dilutes the hierarchy",
+    description:
+      "Stack multiple primary buttons in the same group — it dilutes the hierarchy",
     children: (
       <div className="flex gap-2">
         <F0Button label="Save" />

--- a/packages/react/src/components/F0Button/__stories__/F0Button.mdx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.mdx
@@ -1,0 +1,265 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as Stories from "./F0Button.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import { F0Button } from "@/components/F0Button"
+
+<Meta of={Stories} />
+
+# F0Button
+
+A button component that triggers actions or navigates to different parts of the application. Supports icons, loading states, and href-based navigation.
+
+---
+
+## Overview
+
+### Purpose
+
+- Trigger user actions such as submitting forms, confirming dialogs, or performing operations
+- Navigate to internal routes or external URLs when an `href` prop is provided
+- Provide clear visual feedback through variants, sizes, and states (loading, disabled)
+- Support icon-only or emoji-only modes while remaining accessible to screen readers
+
+### Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+### Variants
+
+#### Type
+
+<Canvas of={Stories.Variants} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Type</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">When to use</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>default</code></td>
+        <td>Primary filled button, high visual emphasis</td>
+        <td>Primary actions — the main call to action on a page or modal</td>
+      </tr>
+      <tr>
+        <td><code>outline</code></td>
+        <td>Bordered button, medium emphasis</td>
+        <td>Secondary actions alongside a primary button</td>
+      </tr>
+      <tr>
+        <td><code>neutral</code></td>
+        <td>Subtle grey button</td>
+        <td>Tertiary or less important options within the interface — offers an extra level of hierarchy</td>
+      </tr>
+      <tr>
+        <td><code>ghost</code></td>
+        <td>No background or border, blends with content</td>
+        <td>Secondary actions, blending subtly with content and standing out only on hover or focus</td>
+      </tr>
+      <tr>
+        <td><code>critical</code></td>
+        <td>Red/destructive styling, high visual weight</td>
+        <td>Irreversible destructive actions (delete, remove, revoke). Always behind a confirmation step</td>
+      </tr>
+      <tr>
+        <td><code>promote</code></td>
+        <td>Highlighted promotional styling</td>
+        <td>Upsell, upgrade, or promotional calls to action</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+#### Icon
+
+<Canvas of={Stories.IconVariants} />
+
+#### Sizes
+
+<Canvas of={Stories.Sizes} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Size</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">When to use</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>lg</code></td>
+        <td>Large touch target</td>
+        <td>Mobile interfaces or prominent desktop CTAs</td>
+      </tr>
+      <tr>
+        <td><code>md</code></td>
+        <td>Standard desktop size</td>
+        <td>Default for most desktop actions</td>
+      </tr>
+      <tr>
+        <td><code>sm</code></td>
+        <td>Compact size</td>
+        <td>Secondary actions, dense layouts, or inline controls</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+#### States
+
+<Canvas of={Stories.States} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">State</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Behavior</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>disabled</code></td>
+        <td>Inactive — does not respond to interaction</td>
+        <td>Reduced opacity, not-allowed cursor, remains focusable for assistive tech</td>
+      </tr>
+      <tr>
+        <td><code>loading</code></td>
+        <td>Action in progress</td>
+        <td>Spinner icon, interaction blocked, announced via <code>aria-busy</code></td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- Use a button to trigger an action that has an immediate effect (save, delete, submit)
+- Use a button with `href` when you need navigation that benefits from browser link behaviors (right-click, open in tab)
+
+#### When NOT to use
+
+- Do not use buttons for navigation-only links without an action context: use `F0Link` instead
+- Avoid `loading` on buttons that do not trigger async operations — it creates false expectations
+
+#### How to use
+
+- Always provide a meaningful `label` even when using `hideLabel` — it is used by screen readers and auto-generated tooltips
+- Use `icon` to reinforce the label meaning, not as decoration
+- Pair `emoji` with a descriptive `label` when the emoji alone may be ambiguous
+- Use a single primary (`default`) button per section to guide the user toward the main action
+- Reserve `critical` for **irreversible** actions only (delete, remove, revoke). Reversible actions like Archive, Hide, or Unpublish should use `default` or `outline`
+- A `critical` button must always trigger a confirmation step (dialog or inline confirm) — never execute the destructive action on the first click
+- At most one `critical` button visible per context, and never as the primary CTA of a normal screen — it belongs in confirmation dialogs, contextual menus, or row actions
+
+<DoDonts
+  do={{
+    description: "Use critical only for irreversible actions, named explicitly",
+    children: <F0Button variant="critical" label="Delete employee" />,
+  }}
+  dont={{
+    description: "Don't use critical for reversible or generic actions",
+    children: <F0Button variant="critical" label="Archive" />,
+  }}
+/>
+
+### Content best practices
+
+- Use sentence case, not title case
+- Keep labels short — 1–3 words is ideal; avoid sentence-length labels
+- Use imperative verbs
+  - **Correct:** "Save changes", "Delete account", "Export data"
+  - **Incorrect:** "Saved", "Deletion", "Exportation"
+- Be specific and actionable
+  - **Correct:** "Create employee", "Submit request", "Download report"
+  - **Incorrect:** "OK", "Yes", "Click here", "Submit"
+- For destructive actions, name the object
+  - **Correct:** "Delete employee", "Remove request"
+  - **Incorrect:** "Delete", "Remove"
+
+<DoDonts
+  do={{
+    description: "Use clear, action-oriented labels: 'Save changes', 'Add employee', 'Delete request'",
+    children: <F0Button label="Save changes" />,
+  }}
+  dont={{
+    description: "Use vague or generic labels: 'OK', 'Yes', 'Click here', 'Submit'",
+    children: <F0Button label="OK" />,
+  }}
+/>
+
+### Layout
+
+- Buttons adapt their width to their content by default — avoid fixed widths unless in a form context
+- When multiple buttons are grouped, use consistent sizing and maintain adequate spacing (`gap-2` minimum)
+- Icon-only buttons (`hideLabel`) must be placed in toolbars or areas where context makes them self-explanatory
+- In mobile layouts, prefer `lg` size for adequate touch targets (minimum 44×44px)
+
+<DoDonts
+  do={{
+    description: "Pair a primary button with a secondary outline for cancel-style actions",
+    guidelines: [
+      "Place the primary action on the right",
+      "Use consistent sizing across all buttons in the group",
+    ],
+    children: (
+      <div className="flex gap-2">
+        <F0Button variant="outline" label="Cancel" />
+        <F0Button label="Save changes" />
+      </div>
+    ),
+  }}
+  dont={{
+    description: "Stack multiple primary buttons in the same group — it dilutes the hierarchy",
+    children: (
+      <div className="flex gap-2">
+        <F0Button label="Save" />
+        <F0Button label="Confirm" />
+        <F0Button label="Continue" />
+      </div>
+    ),
+  }}
+/>
+
+### Accessibility
+
+- The `label` prop is always required — it is used as the accessible name even when visually hidden
+- When `hideLabel` is true, the label is rendered as `sr-only` and also used as the auto-generated tooltip
+- `loading` state should be communicated via `aria-busy` and `aria-live` — this is handled internally
+- Disabled buttons remain focusable and readable by assistive technologies
+- Navigation buttons (`href`) render as `<a>` elements — screen readers announce them as links
+
+---
+
+## Behavior
+
+### Async action
+
+If the `onClick` handler returns a Promise, the button automatically enters the `loading` state until the promise resolves — no need to manage loading state manually.
+
+<Canvas of={Stories.AsyncAction} />
+
+### Navigation link
+
+When `href` is provided, the component renders as an `<a>` element instead of a `<button>`, preserving native link behaviors (right-click, open in new tab, middle click).
+
+<Canvas of={Stories.WithHref} />
+
+### Polymorphic ref
+
+The forwarded `ref` is typed as `HTMLButtonElement | HTMLAnchorElement` to reflect the polymorphic rendering driven by `href`. Narrow the type at the call site if you need to access element-specific APIs.

--- a/packages/react/src/components/F0Button/__stories__/F0Button.mdx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.mdx
@@ -79,6 +79,16 @@ Triggers user actions or navigates to other parts of the application. Supports i
         <td>Highlighted promotional styling</td>
         <td>Upsell, upgrade, or promotional calls to action</td>
       </tr>
+      <tr>
+        <td>
+          <code>outlinePromote</code>
+        </td>
+        <td>Bordered promotional styling, medium emphasis</td>
+        <td>
+          Promotional or upgrade actions that should stand out, but with less
+          emphasis than the filled <code>promote</code> button
+        </td>
+      </tr>
     </tbody>
   </table>
 </Unstyled>
@@ -151,8 +161,8 @@ Icons reinforce the label meaning. Use leading icons for the most common case, t
         </td>
         <td>Inactive — does not respond to interaction</td>
         <td>
-          Reduced opacity, not-allowed cursor, remains focusable for assistive
-          tech
+          Reduced opacity, not-allowed cursor, removed from interaction and
+          keyboard focus
         </td>
       </tr>
       <tr>
@@ -289,7 +299,7 @@ The forwarded `ref` is typed as `HTMLButtonElement | HTMLAnchorElement` to refle
 
 - The `label` prop is always required — it is used as the accessible name even when visually hidden via `hideLabel`
 - When `hideLabel` is true, the label is rendered as `sr-only` and also used as the auto-generated tooltip
-- `loading` state is communicated via `aria-busy` and `aria-live` — handled internally; no consumer setup required
-- Disabled buttons remain focusable so assistive technologies can announce them
+- `loading` state is communicated via `aria-busy` — handled internally; no consumer setup required
+- Disabled state uses the element's native disabled semantics — buttons are removed from tab order, disabled links render as non-interactive elements
 - Buttons rendered with `href` are exposed as `<a>` elements and announced as links by screen readers
 - Icon-only buttons (`hideLabel`) rely entirely on the `label` for screen reader output — never use icon-only without a meaningful label

--- a/packages/react/src/components/F0Button/__stories__/F0Button.mdx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.mdx
@@ -1,26 +1,15 @@
 import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
 import * as Stories from "./F0Button.stories"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
-import { F0Button } from "@/components/F0Button"
+import { F0Button } from "../F0Button"
 
 <Meta of={Stories} />
 
 # F0Button
 
-A button component that triggers actions or navigates to different parts of the application. Supports icons, loading states, and href-based navigation.
+Triggers user actions or navigates to other parts of the application. Supports icons, async loading, href-based navigation, and several visual variants for different levels of emphasis. For navigation-only purposes without an action context, use `F0Link`.
 
----
-
-## Overview
-
-### Purpose
-
-- Trigger user actions such as submitting forms, confirming dialogs, or performing operations
-- Navigate to internal routes or external URLs when an `href` prop is provided
-- Provide clear visual feedback through variants, sizes, and states (loading, disabled)
-- Support icon-only or emoji-only modes while remaining accessible to screen readers
-
-### Anatomy
+## Anatomy
 
 <Canvas of={Stories.Default} />
 
@@ -28,16 +17,13 @@ A button component that triggers actions or navigates to different parts of the 
 
 ### Variants
 
-#### Type
-
 <Canvas of={Stories.Variants} />
 
 <Unstyled>
   <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
     <thead>
       <tr>
-        <th className="text-left">Type</th>
-        <th className="text-left">Description</th>
+        <th className="text-left">Variant</th>
         <th className="text-left">When to use</th>
       </tr>
     </thead>
@@ -46,41 +32,36 @@ A button component that triggers actions or navigates to different parts of the 
         <td>
           <code>default</code>
         </td>
-        <td>Primary filled button, high visual emphasis</td>
         <td>Primary actions — the main call to action on a page or modal</td>
       </tr>
       <tr>
         <td>
           <code>outline</code>
         </td>
-        <td>Bordered button, medium emphasis</td>
         <td>Secondary actions alongside a primary button</td>
       </tr>
       <tr>
         <td>
           <code>neutral</code>
         </td>
-        <td>Subtle grey button</td>
         <td>
-          Tertiary or less important options within the interface — offers an
-          extra level of hierarchy
+          Tertiary or less important options — adds a level of hierarchy below
+          outline
         </td>
       </tr>
       <tr>
         <td>
           <code>ghost</code>
         </td>
-        <td>No background or border, blends with content</td>
         <td>
-          Secondary actions, blending subtly with content and standing out only
-          on hover or focus
+          Secondary actions that should blend with content and stand out only on
+          hover or focus
         </td>
       </tr>
       <tr>
         <td>
           <code>critical</code>
         </td>
-        <td>Red/destructive styling, high visual weight</td>
         <td>
           Irreversible destructive actions (delete, remove, revoke). Always
           behind a confirmation step
@@ -90,18 +71,13 @@ A button component that triggers actions or navigates to different parts of the 
         <td>
           <code>promote</code>
         </td>
-        <td>Highlighted promotional styling</td>
         <td>Upsell, upgrade, or promotional calls to action</td>
       </tr>
     </tbody>
   </table>
 </Unstyled>
 
-#### Icon
-
-<Canvas of={Stories.IconVariants} />
-
-#### Sizes
+### Sizes
 
 <Canvas of={Stories.Sizes} />
 
@@ -111,98 +87,108 @@ A button component that triggers actions or navigates to different parts of the 
       <tr>
         <th className="text-left">Size</th>
         <th className="text-left">Description</th>
-        <th className="text-left">When to use</th>
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>
-          <code>lg</code>
-        </td>
-        <td>Large touch target</td>
-        <td>Mobile interfaces or prominent desktop CTAs</td>
-      </tr>
-      <tr>
-        <td>
-          <code>md</code>
-        </td>
-        <td>Standard desktop size</td>
-        <td>Default for most desktop actions</td>
-      </tr>
       <tr>
         <td>
           <code>sm</code>
         </td>
-        <td>Compact size</td>
-        <td>Secondary actions, dense layouts, or inline controls</td>
-      </tr>
-    </tbody>
-  </table>
-</Unstyled>
-
-#### States
-
-<Canvas of={Stories.States} />
-
-<Unstyled>
-  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
-    <thead>
-      <tr>
-        <th className="text-left">State</th>
-        <th className="text-left">Description</th>
-        <th className="text-left">Behavior</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
         <td>
-          <code>disabled</code>
-        </td>
-        <td>Inactive — does not respond to interaction</td>
-        <td>
-          Reduced opacity, not-allowed cursor, remains focusable for assistive
-          tech
+          Reduced height and padding. Fits in dense surfaces like toolbars,
+          inline table actions, or compact filter bars.
         </td>
       </tr>
       <tr>
         <td>
-          <code>loading</code>
+          <code>md</code> (default)
         </td>
-        <td>Action in progress</td>
+        <td>Standard height and padding. The default for most contexts.</td>
+      </tr>
+      <tr>
         <td>
-          Spinner icon, interaction blocked, announced via{" "}
-          <code>aria-busy</code>
+          <code>lg</code>
+        </td>
+        <td>
+          Increased height and padding. Use for prominent CTAs and on touch
+          surfaces where a larger target is preferable (minimum 44×44px).
         </td>
       </tr>
     </tbody>
   </table>
 </Unstyled>
-
----
 
 ## Guidelines
 
 ### Design best practices
 
-#### When to use
+**When to use**
 
-- Use a button to trigger an action that has an immediate effect (save, delete, submit)
-- Use a button with `href` when you need navigation that benefits from browser link behaviors (right-click, open in tab)
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use F0Button when</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Trigger an action with immediate effect</td>
+        <td>Save, delete, submit, or any operation that mutates state</td>
+      </tr>
+      <tr>
+        <td>Async operation with feedback</td>
+        <td>
+          The handler returns a Promise — the button shows a spinner until it
+          resolves
+        </td>
+      </tr>
+      <tr>
+        <td>Navigation that benefits from native link behaviors</td>
+        <td>
+          Use the <code>href</code> prop so right-click, middle-click and
+          open-in-tab work natively
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
 
-#### When NOT to use
+**When not to use**
 
-- Do not use buttons for navigation-only links without an action context: use `F0Link` instead
-- Avoid `loading` on buttons that do not trigger async operations — it creates false expectations
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use instead</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Pure navigation without action context (inline text link)</td>
+        <td>
+          <code>F0Link</code>
+        </td>
+      </tr>
+      <tr>
+        <td>Toggle on/off state</td>
+        <td>
+          <code>F0Toggle</code> or <code>F0Switch</code>
+        </td>
+      </tr>
+      <tr>
+        <td>Show a menu of actions from a single trigger</td>
+        <td>
+          <code>F0ButtonDropdown</code>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
 
-#### How to use
-
-- Always provide a meaningful `label` even when using `hideLabel` — it is used by screen readers and auto-generated tooltips
-- Use `icon` to reinforce the label meaning, not as decoration
-- Pair `emoji` with a descriptive `label` when the emoji alone may be ambiguous
-- Use a single primary (`default`) button per section to guide the user toward the main action
-- Reserve `critical` for **irreversible** actions only (delete, remove, revoke). Reversible actions like Archive, Hide, or Unpublish should use `default` or `outline`
-- A `critical` button must always trigger a confirmation step (dialog or inline confirm) — never execute the destructive action on the first click
-- At most one `critical` button visible per context, and never as the primary CTA of a normal screen — it belongs in confirmation dialogs, contextual menus, or row actions
+**Do's and don'ts**
 
 <DoDonts
   do={{
@@ -214,40 +200,6 @@ A button component that triggers actions or navigates to different parts of the 
     children: <F0Button variant="critical" label="Archive" />,
   }}
 />
-
-### Content best practices
-
-- Use sentence case, not title case
-- Keep labels short — 1–3 words is ideal; avoid sentence-length labels
-- Use imperative verbs
-  - **Correct:** "Save changes", "Delete account", "Export data"
-  - **Incorrect:** "Saved", "Deletion", "Exportation"
-- Be specific and actionable
-  - **Correct:** "Create employee", "Submit request", "Download report"
-  - **Incorrect:** "OK", "Yes", "Click here", "Submit"
-- For destructive actions, name the object
-  - **Correct:** "Delete employee", "Remove request"
-  - **Incorrect:** "Delete", "Remove"
-
-<DoDonts
-  do={{
-    description:
-      "Use clear, action-oriented labels: 'Save changes', 'Add employee', 'Delete request'",
-    children: <F0Button label="Save changes" />,
-  }}
-  dont={{
-    description:
-      "Use vague or generic labels: 'OK', 'Yes', 'Click here', 'Submit'",
-    children: <F0Button label="OK" />,
-  }}
-/>
-
-### Layout
-
-- Buttons adapt their width to their content by default — avoid fixed widths unless in a form context
-- When multiple buttons are grouped, use consistent sizing and maintain adequate spacing (`gap-2` minimum)
-- Icon-only buttons (`hideLabel`) must be placed in toolbars or areas where context makes them self-explanatory
-- In mobile layouts, prefer `lg` size for adequate touch targets (minimum 44×44px)
 
 <DoDonts
   do={{
@@ -266,7 +218,7 @@ A button component that triggers actions or navigates to different parts of the 
   }}
   dont={{
     description:
-      "Stack multiple primary buttons in the same group — it dilutes the hierarchy",
+      "Don't stack multiple primary buttons in the same group — it dilutes the hierarchy",
     children: (
       <div className="flex gap-2">
         <F0Button label="Save" />
@@ -277,30 +229,66 @@ A button component that triggers actions or navigates to different parts of the 
   }}
 />
 
-### Accessibility
+### Content best practices
 
-- The `label` prop is always required — it is used as the accessible name even when visually hidden
-- When `hideLabel` is true, the label is rendered as `sr-only` and also used as the auto-generated tooltip
-- `loading` state should be communicated via `aria-busy` and `aria-live` — this is handled internally
-- Disabled buttons remain focusable and readable by assistive technologies
-- Navigation buttons (`href`) render as `<a>` elements — screen readers announce them as links
+- Sentence case, no trailing period
+- Keep labels short — 1–3 words; avoid sentence-length labels
+- Use imperative verbs ("Save changes", not "Saved" or "Saving")
+- Be specific and actionable ("Create employee", not "OK" or "Submit")
+- For destructive actions, name the object ("Delete employee", not "Delete")
 
----
+<DoDonts
+  do={{
+    description:
+      "Use clear, action-oriented labels: 'Save changes', 'Add employee', 'Delete request'",
+    children: <F0Button label="Save changes" />,
+  }}
+  dont={{
+    description:
+      "Don't use vague or generic labels: 'OK', 'Yes', 'Click here', 'Submit'",
+    children: <F0Button label="OK" />,
+  }}
+/>
 
-## Behavior
+### Behavior
 
-### Async action
+- **Critical confirmation** — A `critical` button must always trigger a confirmation step (dialog or inline confirm), never execute the destructive action on the first click. At most one `critical` button visible per context, and never as the primary CTA of a normal screen — it belongs in confirmation dialogs, contextual menus, or row actions.
+- **Async loading** — When `onClick` returns a Promise, the button automatically enters the `loading` state until the promise resolves; the consumer does not need to manage loading state manually.
+- **Polymorphic rendering** — When `href` is provided, the component renders as an `<a>` element instead of `<button>`, preserving native link behaviors (right-click, open in tab, middle click). The forwarded `ref` is typed as `HTMLButtonElement | HTMLAnchorElement` — narrow the type at the call site if you need element-specific APIs.
+- **Layout** — Buttons adapt their width to content by default; avoid fixed widths unless inside a form. When grouped, use consistent sizing and `gap-2` minimum spacing.
 
-If the `onClick` handler returns a Promise, the button automatically enters the `loading` state until the promise resolves — no need to manage loading state manually.
+### Usage examples
+
+**Async action with automatic loading**
+
+When the `onClick` handler returns a Promise, the button shows a spinner and blocks further interaction until it resolves.
 
 <Canvas of={Stories.AsyncAction} />
 
-### Navigation link
+**Navigation link**
 
-When `href` is provided, the component renders as an `<a>` element instead of a `<button>`, preserving native link behaviors (right-click, open in new tab, middle click).
+Pass `href` to render the button as an `<a>` element while preserving the visual style.
 
 <Canvas of={Stories.WithHref} />
 
-### Polymorphic ref
+**Icon usage**
 
-The forwarded `ref` is typed as `HTMLButtonElement | HTMLAnchorElement` to reflect the polymorphic rendering driven by `href`. Narrow the type at the call site if you need to access element-specific APIs.
+Icons reinforce the label meaning. Pair leading or trailing icons with a descriptive label, or use `hideLabel` for icon-only buttons in toolbars where context makes the action self-explanatory.
+
+<Canvas of={Stories.IconVariants} />
+
+**Runtime states**
+
+Disabled buttons remain focusable for assistive technologies. Loading state announces progress via `aria-busy` and is set automatically for async handlers.
+
+<Canvas of={Stories.States} />
+
+## Accessibility
+
+### Screen reader behavior
+
+- The `label` prop is always required — it is used as the accessible name even when visually hidden via `hideLabel`
+- When `hideLabel` is true, the label is rendered as `sr-only` and also used as the auto-generated tooltip
+- `loading` state is communicated via `aria-busy` and `aria-live` — handled internally
+- Disabled buttons remain focusable so assistive technologies can announce them
+- Buttons rendered with `href` are exposed as `<a>` elements and announced as links by screen readers

--- a/packages/react/src/components/F0Button/__stories__/F0Button.mdx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.mdx
@@ -7,7 +7,7 @@ import { F0Button } from "../F0Button"
 
 # F0Button
 
-Triggers user actions or navigates to other parts of the application. Supports icons, async loading, href-based navigation, and several visual variants for different levels of emphasis. For navigation-only purposes without an action context, use `F0Link`.
+Triggers user actions or navigates to other parts of the application. Supports icons, async loading, href-based navigation, and several visual variants for different levels of emphasis. For navigation-only links without an action context, use `F0Link`.
 
 ## Anatomy
 
@@ -17,13 +17,16 @@ Triggers user actions or navigates to other parts of the application. Supports i
 
 ### Variants
 
+#### Type
+
 <Canvas of={Stories.Variants} />
 
 <Unstyled>
   <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
     <thead>
       <tr>
-        <th className="text-left">Variant</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Description</th>
         <th className="text-left">When to use</th>
       </tr>
     </thead>
@@ -32,27 +35,30 @@ Triggers user actions or navigates to other parts of the application. Supports i
         <td>
           <code>default</code>
         </td>
+        <td>Primary filled button, high visual emphasis</td>
         <td>Primary actions — the main call to action on a page or modal</td>
       </tr>
       <tr>
         <td>
           <code>outline</code>
         </td>
+        <td>Bordered button, medium emphasis</td>
         <td>Secondary actions alongside a primary button</td>
       </tr>
       <tr>
         <td>
           <code>neutral</code>
         </td>
+        <td>Subtle grey button</td>
         <td>
-          Tertiary or less important options — adds a level of hierarchy below
-          outline
+          Tertiary or less important options — adds an extra level of hierarchy
         </td>
       </tr>
       <tr>
         <td>
           <code>ghost</code>
         </td>
+        <td>No background or border, blends with content</td>
         <td>
           Secondary actions that should blend with content and stand out only on
           hover or focus
@@ -62,6 +68,7 @@ Triggers user actions or navigates to other parts of the application. Supports i
         <td>
           <code>critical</code>
         </td>
+        <td>Red/destructive styling, high visual weight</td>
         <td>
           Irreversible destructive actions (delete, remove, revoke). Always
           behind a confirmation step
@@ -71,11 +78,18 @@ Triggers user actions or navigates to other parts of the application. Supports i
         <td>
           <code>promote</code>
         </td>
+        <td>Highlighted promotional styling</td>
         <td>Upsell, upgrade, or promotional calls to action</td>
       </tr>
     </tbody>
   </table>
 </Unstyled>
+
+#### Icon
+
+<Canvas of={Stories.IconVariants} />
+
+Icons reinforce the label meaning. Use leading icons for the most common case, trailing icons when the icon represents the result of the action (e.g. an external link arrow). Use `hideLabel` for icon-only buttons in toolbars or dense surfaces where context makes the action self-explanatory — the `label` prop is still required and becomes the accessible name and tooltip.
 
 ### Sizes
 
@@ -87,31 +101,70 @@ Triggers user actions or navigates to other parts of the application. Supports i
       <tr>
         <th className="text-left">Size</th>
         <th className="text-left">Description</th>
+        <th className="text-left">When to use</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>
-          <code>sm</code>
+          <code>lg</code>
         </td>
+        <td>Large touch target</td>
         <td>
-          Reduced height and padding. Fits in dense surfaces like toolbars,
-          inline table actions, or compact filter bars.
+          Mobile interfaces or prominent desktop CTAs (minimum 44×44px touch
+          target)
         </td>
       </tr>
       <tr>
         <td>
           <code>md</code> (default)
         </td>
-        <td>Standard height and padding. The default for most contexts.</td>
+        <td>Standard desktop size</td>
+        <td>Default for most desktop actions</td>
       </tr>
       <tr>
         <td>
-          <code>lg</code>
+          <code>sm</code>
         </td>
+        <td>Compact size</td>
+        <td>Secondary actions, dense layouts, toolbars or inline controls</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### States
+
+<Canvas of={Stories.States} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">State</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Behavior</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
         <td>
-          Increased height and padding. Use for prominent CTAs and on touch
-          surfaces where a larger target is preferable (minimum 44×44px).
+          <code>disabled</code>
+        </td>
+        <td>Inactive — does not respond to interaction</td>
+        <td>
+          Reduced opacity, not-allowed cursor, remains focusable for assistive
+          tech
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>loading</code>
+        </td>
+        <td>Action in progress</td>
+        <td>
+          Spinner icon, interaction blocked, announced via{" "}
+          <code>aria-busy</code>
         </td>
       </tr>
     </tbody>
@@ -124,71 +177,22 @@ Triggers user actions or navigates to other parts of the application. Supports i
 
 **When to use**
 
-<Unstyled>
-  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
-    <thead>
-      <tr>
-        <th className="text-left">Situation</th>
-        <th className="text-left">Use F0Button when</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Trigger an action with immediate effect</td>
-        <td>Save, delete, submit, or any operation that mutates state</td>
-      </tr>
-      <tr>
-        <td>Async operation with feedback</td>
-        <td>
-          The handler returns a Promise — the button shows a spinner until it
-          resolves
-        </td>
-      </tr>
-      <tr>
-        <td>Navigation that benefits from native link behaviors</td>
-        <td>
-          Use the <code>href</code> prop so right-click, middle-click and
-          open-in-tab work natively
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</Unstyled>
+- Use a button to trigger an action with an immediate effect (save, delete, submit)
+- Use a button with `href` when you need navigation that benefits from native link behaviors (right-click, open in tab, middle click)
+- Use a single primary (`default`) button per section to guide the user toward the main action
 
 **When not to use**
 
-<Unstyled>
-  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
-    <thead>
-      <tr>
-        <th className="text-left">Situation</th>
-        <th className="text-left">Use instead</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Pure navigation without action context (inline text link)</td>
-        <td>
-          <code>F0Link</code>
-        </td>
-      </tr>
-      <tr>
-        <td>Toggle on/off state</td>
-        <td>
-          <code>F0Toggle</code> or <code>F0Switch</code>
-        </td>
-      </tr>
-      <tr>
-        <td>Show a menu of actions from a single trigger</td>
-        <td>
-          <code>F0ButtonDropdown</code>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</Unstyled>
+- Pure navigation without an action context — use `F0Link` instead
+- Toggle on/off state — use `F0Toggle` or `F0Switch`
+- A menu of actions from a single trigger — use `F0ButtonDropdown`
+- `loading` on buttons that do not trigger async operations — it creates false expectations
 
-**Do's and don'ts**
+**Critical variant rules**
+
+- Reserve `critical` for **irreversible** actions only (delete, remove, revoke). Reversible actions like Archive, Hide, or Unpublish should use `default` or `outline`
+- A `critical` button must always trigger a confirmation step (dialog or inline confirm) — never execute the destructive action on the first click
+- At most one `critical` button visible per context, and never as the primary CTA of a normal screen — it belongs in confirmation dialogs, contextual menus, or row actions
 
 <DoDonts
   do={{
@@ -200,6 +204,13 @@ Triggers user actions or navigates to other parts of the application. Supports i
     children: <F0Button variant="critical" label="Archive" />,
   }}
 />
+
+**Layout and grouping**
+
+- Buttons adapt their width to their content by default — avoid fixed widths unless inside a form
+- When grouped, use consistent sizing and maintain adequate spacing (`gap-2` minimum)
+- In mobile layouts, prefer `lg` size for adequate touch targets (minimum 44×44px)
+- Place the primary action on the right when paired with a cancel-style secondary action
 
 <DoDonts
   do={{
@@ -231,11 +242,17 @@ Triggers user actions or navigates to other parts of the application. Supports i
 
 ### Content best practices
 
-- Sentence case, no trailing period
-- Keep labels short — 1–3 words; avoid sentence-length labels
-- Use imperative verbs ("Save changes", not "Saved" or "Saving")
-- Be specific and actionable ("Create employee", not "OK" or "Submit")
-- For destructive actions, name the object ("Delete employee", not "Delete")
+- Sentence case, not title case
+- Keep labels short — 1–3 words is ideal; avoid sentence-length labels
+- Use imperative verbs
+  - **Correct:** "Save changes", "Delete account", "Export data"
+  - **Incorrect:** "Saved", "Deletion", "Exportation"
+- Be specific and actionable
+  - **Correct:** "Create employee", "Submit request", "Download report"
+  - **Incorrect:** "OK", "Yes", "Click here", "Submit"
+- For destructive actions, name the object
+  - **Correct:** "Delete employee", "Remove request"
+  - **Incorrect:** "Delete", "Remove"
 
 <DoDonts
   do={{
@@ -252,36 +269,21 @@ Triggers user actions or navigates to other parts of the application. Supports i
 
 ### Behavior
 
-- **Critical confirmation** — A `critical` button must always trigger a confirmation step (dialog or inline confirm), never execute the destructive action on the first click. At most one `critical` button visible per context, and never as the primary CTA of a normal screen — it belongs in confirmation dialogs, contextual menus, or row actions.
-- **Async loading** — When `onClick` returns a Promise, the button automatically enters the `loading` state until the promise resolves; the consumer does not need to manage loading state manually.
-- **Polymorphic rendering** — When `href` is provided, the component renders as an `<a>` element instead of `<button>`, preserving native link behaviors (right-click, open in tab, middle click). The forwarded `ref` is typed as `HTMLButtonElement | HTMLAnchorElement` — narrow the type at the call site if you need element-specific APIs.
-- **Layout** — Buttons adapt their width to content by default; avoid fixed widths unless inside a form. When grouped, use consistent sizing and `gap-2` minimum spacing.
+**Async action**
 
-### Usage examples
-
-**Async action with automatic loading**
-
-When the `onClick` handler returns a Promise, the button shows a spinner and blocks further interaction until it resolves.
+If the `onClick` handler returns a Promise, the button automatically enters the `loading` state until the promise resolves — no need to manage loading state manually.
 
 <Canvas of={Stories.AsyncAction} />
 
 **Navigation link**
 
-Pass `href` to render the button as an `<a>` element while preserving the visual style.
+When `href` is provided, the component renders as an `<a>` element instead of a `<button>`, preserving native link behaviors (right-click, open in new tab, middle click).
 
 <Canvas of={Stories.WithHref} />
 
-**Icon usage**
+**Polymorphic ref**
 
-Icons reinforce the label meaning. Pair leading or trailing icons with a descriptive label, or use `hideLabel` for icon-only buttons in toolbars where context makes the action self-explanatory.
-
-<Canvas of={Stories.IconVariants} />
-
-**Runtime states**
-
-Disabled buttons remain focusable for assistive technologies. Loading state announces progress via `aria-busy` and is set automatically for async handlers.
-
-<Canvas of={Stories.States} />
+The forwarded `ref` is typed as `HTMLButtonElement | HTMLAnchorElement` to reflect the polymorphic rendering driven by `href`. Narrow the type at the call site if you need to access element-specific APIs.
 
 ## Accessibility
 
@@ -289,6 +291,7 @@ Disabled buttons remain focusable for assistive technologies. Loading state anno
 
 - The `label` prop is always required — it is used as the accessible name even when visually hidden via `hideLabel`
 - When `hideLabel` is true, the label is rendered as `sr-only` and also used as the auto-generated tooltip
-- `loading` state is communicated via `aria-busy` and `aria-live` — handled internally
+- `loading` state is communicated via `aria-busy` and `aria-live` — handled internally; no consumer setup required
 - Disabled buttons remain focusable so assistive technologies can announce them
 - Buttons rendered with `href` are exposed as `<a>` elements and announced as links by screen readers
+- Icon-only buttons (`hideLabel`) rely entirely on the `label` for screen reader output — never use icon-only without a meaningful label

--- a/packages/react/src/components/F0Button/__stories__/F0Button.mdx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.mdx
@@ -15,9 +15,7 @@ Triggers user actions or navigates to other parts of the application. Supports i
 
 <Controls of={Stories.Default} />
 
-### Variants
-
-#### Type
+### Type
 
 <Canvas of={Stories.Variants} />
 
@@ -85,13 +83,13 @@ Triggers user actions or navigates to other parts of the application. Supports i
   </table>
 </Unstyled>
 
-#### Icon
+### Icon
 
 <Canvas of={Stories.IconVariants} />
 
 Icons reinforce the label meaning. Use leading icons for the most common case, trailing icons when the icon represents the result of the action (e.g. an external link arrow). Use `hideLabel` for icon-only buttons in toolbars or dense surfaces where context makes the action self-explanatory — the `label` prop is still required and becomes the accessible name and tooltip.
 
-#### Sizes
+### Sizes
 
 <Canvas of={Stories.Sizes} />
 
@@ -133,7 +131,7 @@ Icons reinforce the label meaning. Use leading icons for the most common case, t
   </table>
 </Unstyled>
 
-#### States
+### States
 
 <Canvas of={Stories.States} />
 

--- a/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
@@ -30,7 +30,7 @@ const meta = {
       },
     },
   },
-  tags: ["autodocs", "stable"],
+  tags: ["stable", "!autodocs"],
   args: {
     variant: "default",
     onClick: () => {
@@ -120,7 +120,7 @@ type Story = StoryObj<typeof meta>
 
 // Basic Variants
 export const Default: Story = {
-  tags: ["no-sidebar"],
+  tags: ["!dev"],
   args: {
     variant: "default",
     label: "Default Button",
@@ -136,7 +136,7 @@ export const Default: Story = {
 
 // Basic Variants
 export const WithHref: Story = {
-  tags: ["no-sidebar"],
+  tags: ["!dev"],
   parameters: {
     docs: {
       description: {
@@ -160,7 +160,7 @@ export const WithHref: Story = {
 }
 
 export const Variants: Story = {
-  tags: ["no-sidebar"],
+  tags: ["!dev"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex gap-2">
@@ -175,7 +175,7 @@ export const Variants: Story = {
 }
 
 export const IconVariants: Story = {
-  tags: ["no-sidebar"],
+  tags: ["!dev"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex flex-col gap-6">
@@ -259,7 +259,7 @@ export const IconVariants: Story = {
 
 // Size Variants
 export const Sizes: Story = {
-  tags: ["no-sidebar"],
+  tags: ["!dev"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex items-center gap-4">
@@ -358,7 +358,7 @@ export const Loading: Story = {
 
 // Interactive Examples
 export const AsyncAction: Story = {
-  tags: ["no-sidebar"],
+  tags: ["!dev"],
   args: {
     label: "Save Changes",
     icon: Save,
@@ -394,7 +394,7 @@ export const OnlyEmoji: Story = {
 }
 
 export const States: Story = {
-  tags: ["no-sidebar"],
+  tags: ["!dev"],
   parameters: withSnapshot({}),
   render: (args) => {
     const [asyncLoading, setAsyncLoading] = React.useState(false)

--- a/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
@@ -120,7 +120,7 @@ type Story = StoryObj<typeof meta>
 
 // Basic Variants
 export const Default: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   args: {
     variant: "default",
     label: "Default Button",
@@ -136,7 +136,7 @@ export const Default: Story = {
 
 // Basic Variants
 export const WithHref: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   parameters: {
     docs: {
       description: {
@@ -160,7 +160,7 @@ export const WithHref: Story = {
 }
 
 export const Variants: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex gap-2">
@@ -175,7 +175,7 @@ export const Variants: Story = {
 }
 
 export const IconVariants: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex flex-col gap-6">
@@ -259,7 +259,7 @@ export const IconVariants: Story = {
 
 // Size Variants
 export const Sizes: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex items-center gap-4">
@@ -358,7 +358,7 @@ export const Loading: Story = {
 
 // Interactive Examples
 export const AsyncAction: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   args: {
     label: "Save Changes",
     icon: Save,
@@ -394,7 +394,7 @@ export const OnlyEmoji: Story = {
 }
 
 export const States: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   parameters: withSnapshot({}),
   render: (args) => {
     const [asyncLoading, setAsyncLoading] = React.useState(false)

--- a/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
@@ -30,7 +30,7 @@ const meta = {
       },
     },
   },
-  tags: ["!autodocs", "stable"],
+  tags: ["autodocs", "stable"],
   args: {
     variant: "default",
     onClick: () => {

--- a/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
@@ -30,7 +30,7 @@ const meta = {
       },
     },
   },
-  tags: ["stable"],
+  tags: ["!autodocs", "stable"],
   args: {
     variant: "default",
     onClick: () => {
@@ -120,7 +120,7 @@ type Story = StoryObj<typeof meta>
 
 // Basic Variants
 export const Default: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   args: {
     variant: "default",
     label: "Default Button",
@@ -136,7 +136,7 @@ export const Default: Story = {
 
 // Basic Variants
 export const WithHref: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   parameters: {
     docs: {
       description: {
@@ -160,7 +160,7 @@ export const WithHref: Story = {
 }
 
 export const Variants: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex gap-2">
@@ -175,7 +175,7 @@ export const Variants: Story = {
 }
 
 export const IconVariants: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex flex-col gap-6">
@@ -259,7 +259,7 @@ export const IconVariants: Story = {
 
 // Size Variants
 export const Sizes: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex items-center gap-4">
@@ -358,7 +358,7 @@ export const Loading: Story = {
 
 // Interactive Examples
 export const AsyncAction: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   args: {
     label: "Save Changes",
     icon: Save,
@@ -394,7 +394,7 @@ export const OnlyEmoji: Story = {
 }
 
 export const States: Story = {
-  tags: ["!dev"],
+  tags: ["no-sidebar"],
   parameters: withSnapshot({}),
   render: (args) => {
     const [asyncLoading, setAsyncLoading] = React.useState(false)

--- a/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
@@ -30,7 +30,7 @@ const meta = {
       },
     },
   },
-  tags: ["autodocs", "stable"],
+  tags: ["stable"],
   args: {
     variant: "default",
     onClick: () => {
@@ -120,6 +120,7 @@ type Story = StoryObj<typeof meta>
 
 // Basic Variants
 export const Default: Story = {
+  tags: ["!dev"],
   args: {
     variant: "default",
     label: "Default Button",
@@ -135,6 +136,7 @@ export const Default: Story = {
 
 // Basic Variants
 export const WithHref: Story = {
+  tags: ["!dev"],
   parameters: {
     docs: {
       description: {
@@ -158,6 +160,7 @@ export const WithHref: Story = {
 }
 
 export const Variants: Story = {
+  tags: ["!dev"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex gap-2">
@@ -172,6 +175,7 @@ export const Variants: Story = {
 }
 
 export const IconVariants: Story = {
+  tags: ["!dev"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex flex-col gap-6">
@@ -255,6 +259,7 @@ export const IconVariants: Story = {
 
 // Size Variants
 export const Sizes: Story = {
+  tags: ["!dev"],
   parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex items-center gap-4">
@@ -353,6 +358,7 @@ export const Loading: Story = {
 
 // Interactive Examples
 export const AsyncAction: Story = {
+  tags: ["!dev"],
   args: {
     label: "Save Changes",
     icon: Save,
@@ -388,6 +394,7 @@ export const OnlyEmoji: Story = {
 }
 
 export const States: Story = {
+  tags: ["!dev"],
   parameters: withSnapshot({}),
   render: (args) => {
     const [asyncLoading, setAsyncLoading] = React.useState(false)

--- a/packages/react/src/lib/storybook-utils/do-donts.tsx
+++ b/packages/react/src/lib/storybook-utils/do-donts.tsx
@@ -19,7 +19,7 @@ export const DoDonts: FC<DoDontsProps> = ({
   do: doExample,
   dont: dontExample,
 }) => (
-  <div className="grid gap-4 md:grid-cols-2">
+  <div className="mb-4 grid gap-4 last:mb-0 md:grid-cols-2">
     <div className="flex flex-col gap-4 rounded-lg bg-f1-background-tertiary p-5">
       <div className="w-fit">
         <F0TagStatus text="Do" variant="positive" />


### PR DESCRIPTION
## Description

Adds a complete MDX documentation page for `F0Button` following the canonical [`f0-docs` skill](packages/react/.skills/f0-docs/) conventions: top-level sections are `## Anatomy` / `## Guidelines` / `## Accessibility`, and the auto-generated docs are disabled in favour of curated content with do/don't visuals, copy rules, and runtime examples.

## Final structure

```
## Anatomy            (Canvas Default + Controls)
  ### Type            (Canvas Variants + Type/Description/When-to-use table)
  ### Icon            (Canvas IconVariants + Layout DoDonts)
  ### Sizes           (Canvas Sizes + Size/Use case/Notes table)
  ### States          (Canvas States + State/Description/When table)
## Guidelines
  ### Design best practices   (critical variant rules + DoDonts)
  ### Content best practices  (Correct/Incorrect bullets paired with DoDonts)
  ### Behavior                (Async / Navigation / Polymorphic ref)
## Accessibility
  ### Screen reader behavior
```

Type / Icon / Sizes / States are siblings directly under `## Anatomy` (no intermediate `Variants` container) — only Type is technically a variant prop; Sizes is `size` and States are runtime states (`disabled`, `loading`).

## Implementation details

- feat: add `F0Button.mdx` with the structure above
- feat: document the strict rules for the `critical` variant (irreversible only, requires confirmation, max one per context, never a primary CTA) paired with a Do/Don't visual
- chore: set `tags: [\"!autodocs\", \"stable\"]` on the meta to disable the global autodocs and `tags: [\"no-sidebar\"]` on the 7 doc-only stories so they don't pollute the sidebar
- fix: add `mb-4 last:mb-0` to the `DoDonts` root for vertical spacing between consecutive instances within an MDX section

## Verification

- Visit `Components / Button / Button / Documentation` in Storybook
- Right-side TOC shows the structure above with no empty containers
- Sidebar shows only the `Documentation` entry under `Button / Button` (the 7 doc-only stories are hidden)
- All `<Canvas>` blocks render their stories; the `Show code` button is the source of truth (no manual code blocks)

## Skill alignment

Built against the repo-local skill at `packages/react/.skills/f0-docs/`. Improvements to that skill discovered while writing this PR (e.g. \"refactor without losing value\", `### Behavior` inclusion filter, inline Correct/Incorrect copy rules) ship in PR #4021.