### PR TITLE
docs(f0-docs): add authoring principles learned from F0Button MDX

### DIFF
--- a/packages/react/.skills/f0-docs/SKILL.md
+++ b/packages/react/.skills/f0-docs/SKILL.md
@@ -93,7 +93,7 @@ If a subsection would only contain redundant info, omit it. If the component has
 
 ### Inline Correct / Incorrect for copy rules — pair with a visual DoDonts
 
-For wording and copy rules in `### Content best practices`, use **inline `**Correct:** / **Incorrect:**` bullets** for the rules themselves — more scannable than prose for textual examples. Use plain bold; never emojis (✅ / ❌).
+For wording and copy rules in `### Content best practices`, use inline **Correct:** / **Incorrect:** bullets for the rules themselves — more scannable than prose for textual examples. Use plain bold; never emojis (✅ / ❌).
 
 ```mdx
 - Use imperative verbs

--- a/packages/react/.skills/f0-docs/SKILL.md
+++ b/packages/react/.skills/f0-docs/SKILL.md
@@ -70,6 +70,41 @@ Full template + workflow: [`references/mdx-authoring.md`](./references/mdx-autho
 
 ---
 
+## Authoring Principles
+
+These rules apply across the workflow. Violating them produces redundant, drift-prone, or low-quality docs.
+
+### Refactor without losing value
+
+When reorganizing an existing MDX into a new structure, **audit what already exists in that section first**. Do not delete a valuable visual or example just because you are changing the surrounding format. Combine them when they serve different purposes (e.g. scannable text bullets + visual `<DoDonts>` reference).
+
+### `### Behavior` is non-obvious runtime behavior
+
+`### Behavior` (inside `## Guidelines`) is for information that is **specific to this component AND not visible elsewhere in the doc**. Apply this filter:
+
+- ❌ Skip if `<Controls>` already shows it (props, defaults, types of individual props)
+- ❌ Skip if it's component-global behavior (e.g., `data-testid` support via `withDataTestId` applies to ALL components)
+- ❌ Skip if Modes / Variants tables in `## Anatomy` or `### Design best practices` already cover it
+- ✅ Include non-obvious runtime behavior — async `onClick` auto-loading, polymorphic rendering when an `href` is passed, controlled/uncontrolled rules, ref typing for polymorphic components, focus management specific to this component
+- ❌ Do NOT add a "Related components" section — it is not visual nor relevant on the Docs page; cross-references belong in the 1–2 sentence intro under `# ComponentName`
+- ❌ Do NOT call this section "Code", "Patterns", or "Advanced" — these aren't usage patterns, they are runtime behaviors
+
+If a subsection would only contain redundant info, omit it. If the component has no non-obvious behavior, omit `### Behavior` entirely.
+
+### Inline Correct / Incorrect for copy rules — pair with a visual DoDonts
+
+For wording and copy rules in `### Content best practices`, use **inline `**Correct:** / **Incorrect:**` bullets** for the rules themselves — more scannable than prose for textual examples. Use plain bold; never emojis (✅ / ❌).
+
+```mdx
+- Use imperative verbs
+  - **Correct:** "Save changes", "Delete account", "Export data"
+  - **Incorrect:** "Saved", "Deletion", "Exportation"
+```
+
+**Always pair the bullets with a `<DoDonts>` visual** showing one representative good vs bad label rendered as the actual component. The bullets give scannable rules; the DoDonts gives a real visual reference. The two formats complement each other — never drop the visual when adding the inline pattern.
+
+---
+
 ## Documentation is a Blocking Requirement
 
 A component is not considered done until its MDX file exists and covers all public props and variants. The `f0-quality-gate` enforces this:

--- a/packages/react/.skills/f0-docs/references/mdx-authoring.md
+++ b/packages/react/.skills/f0-docs/references/mdx-authoring.md
@@ -166,14 +166,16 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts";
   - **Correct:** "Save changes", "Delete account", "Export data"
   - **Incorrect:** "Saved", "Deletion", "Exportation"
 
+> Adapt the rendered JSX to the component's real API. Use children, `label`, or other props only if that component actually supports them.
+
 <DoDonts
   do={{
     description: "Use clear, action-oriented labels",
-    children: <F0ComponentName label="Save changes" />,
+    children: <F0ComponentName>Save changes</F0ComponentName>,
   }}
   dont={{
     description: "Don't use vague or generic labels",
-    children: <F0ComponentName label="OK" />,
+    children: <F0ComponentName>OK</F0ComponentName>,
   }}
 />
 
@@ -181,7 +183,7 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts";
 
 <!--
   Non-obvious runtime behavior specific to this component. Apply the inclusion filter
-  from SKILL.md → Authoring Principles → '### Behavior is non-obvious runtime behavior':
+  from SKILL.md → Authoring Principles → `### Behavior`:
   skip if Controls / Variants / global behavior already covers it. Omit the section
   entirely if the component has no non-obvious behavior.
 -->
@@ -746,7 +748,7 @@ Before marking MDX as done:
 - [ ] "When not to use" rows in the "Use instead" column name a **concrete component** (`F0Dialog`) or established pattern ("toast notification") — never abstract instructions
 - [ ] `<DoDonts>` used in Do's and don'ts subsection
 - [ ] DoDonts `children` used only when the do/don't contrast is **semantically unambiguous** — a viewer must not be able to argue the "don't" example is valid. Text-only DoDonts are preferred when the distinction requires explanation.
-- [ ] `### Content best practices` rules with textual examples use the **inline `**Correct:** / **Incorrect:**` bullet pattern** (no emojis), AND are paired with a `<DoDonts>` visual showing one representative good vs bad label
+- [ ] `### Content best practices` rules with textual examples use inline **Correct:** / **Incorrect:** bullets (no emojis), AND are paired with a `<DoDonts>` visual showing one representative good vs bad label
 - [ ] `### Behavior` (under `## Guidelines`) only contains non-obvious runtime behavior specific to this component (async loading, polymorphic rendering, controlled/uncontrolled rules, ref typing). Section is omitted entirely if the component has no such behavior. No "Related components" section. Section is not renamed to "Code", "Patterns", or "Advanced".
 - [ ] When restructuring an existing MDX file, valuable visuals/examples from the previous version are preserved (combined with new patterns when they serve different purposes — e.g. scannable text + visual reference) — **don't lose value when refactoring**
 - [ ] Components rendered as JSX in MDX (e.g. inside `<DoDonts children>`) are imported via relative path (`from "../F0Component"`), never from `@factorialco/f0-react` (causes module fetch error in dev)

--- a/packages/react/.skills/f0-docs/references/mdx-authoring.md
+++ b/packages/react/.skills/f0-docs/references/mdx-authoring.md
@@ -153,13 +153,40 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts";
 
 ### Content best practices
 
-- [Copywriting rule: capitalization, punctuation, tone]
+<!--
+  Copywriting and tone rules. For each rule that includes textual examples, use the
+  inline Correct/Incorrect bullet pattern (more scannable than prose) AND pair it with a
+  <DoDonts> visual showing one representative good vs bad label rendered as the actual
+  component. Bullets and DoDonts complement each other — never drop the visual.
+-->
+
+- [Capitalization, punctuation, tone rule]
 - [Length limit or character guidance]
+- Use imperative verbs
+  - **Correct:** "Save changes", "Delete account", "Export data"
+  - **Incorrect:** "Saved", "Deletion", "Exportation"
+
+<DoDonts
+  do={{
+    description: "Use clear, action-oriented labels",
+    children: <F0ComponentName label="Save changes" />,
+  }}
+  dont={{
+    description: "Don't use vague or generic labels",
+    children: <F0ComponentName label="OK" />,
+  }}
+/>
 
 ### Behavior
 
-- [Layout or responsive behavior]
-- [State transitions]
+<!--
+  Non-obvious runtime behavior specific to this component. Apply the inclusion filter
+  from SKILL.md → Authoring Principles → '### Behavior is non-obvious runtime behavior':
+  skip if Controls / Variants / global behavior already covers it. Omit the section
+  entirely if the component has no non-obvious behavior.
+-->
+
+- [Async handler auto-loading, polymorphic rendering driven by an href, controlled/uncontrolled rules, focus management]
 - [Generic type note — if the component is generic (`F0Component<T>`): document the type parameter, what it controls, and the full signature of any typed callback (e.g. `onClick: (value: T, item: Item<T>) => void`). Mention that `T` defaults to `string` and that callers can pass a union, enum, or literal type.]
 
 ### Usage examples
@@ -719,6 +746,9 @@ Before marking MDX as done:
 - [ ] "When not to use" rows in the "Use instead" column name a **concrete component** (`F0Dialog`) or established pattern ("toast notification") — never abstract instructions
 - [ ] `<DoDonts>` used in Do's and don'ts subsection
 - [ ] DoDonts `children` used only when the do/don't contrast is **semantically unambiguous** — a viewer must not be able to argue the "don't" example is valid. Text-only DoDonts are preferred when the distinction requires explanation.
+- [ ] `### Content best practices` rules with textual examples use the **inline `**Correct:** / **Incorrect:**` bullet pattern** (no emojis), AND are paired with a `<DoDonts>` visual showing one representative good vs bad label
+- [ ] `### Behavior` (under `## Guidelines`) only contains non-obvious runtime behavior specific to this component (async loading, polymorphic rendering, controlled/uncontrolled rules, ref typing). Section is omitted entirely if the component has no such behavior. No "Related components" section. Section is not renamed to "Code", "Patterns", or "Advanced".
+- [ ] When restructuring an existing MDX file, valuable visuals/examples from the previous version are preserved (combined with new patterns when they serve different purposes — e.g. scannable text + visual reference) — **don't lose value when refactoring**
 - [ ] Components rendered as JSX in MDX (e.g. inside `<DoDonts children>`) are imported via relative path (`from "../F0Component"`), never from `@factorialco/f0-react` (causes module fetch error in dev)
 - [ ] Components that require a provider (e.g. `useI18n`) are NOT rendered as inline JSX in MDX — instead, dedicated stories with `tags: ["no-sidebar"]` are created and used as `<Canvas of={Stories.X} sourceState="none" />` inside DoDonts `children`
 - [ ] `## Accessibility` included only when the component type requires it — complex interactive (required), simple interactive (only if non-obvious), static display (only for live region or icon meaning), layout/typography (omit entirely)


### PR DESCRIPTION
## Description

Codifies three authoring principles surfaced while writing the F0Button MDX documentation page (#4019). All three produced real, observable problems during that work — they belong in the skill so future component documentation does not repeat them. Also ports the still-useful pieces of the soon-to-be-removed global \`factorial-f0/component-documentation/\` tree (factorialco/factorial-skills#158) so nothing is lost.

## Implementation details

- feat: add **Refactor without losing value** principle — when restructuring an existing MDX, audit the section's existing content first and combine valuable visuals with new patterns instead of deleting them
- feat: add explicit inclusion filter for **\`### Behavior\`** — skip when \`<Controls>\` / Variants / global behavior already covers it; include only non-obvious runtime behavior (async loading, polymorphic rendering, controlled/uncontrolled rules, ref typing); never rename to \"Code\", \"Patterns\", or \"Advanced\"; no \"Related components\" subsection
- feat: add **Inline Correct / Incorrect for copy rules** pattern under \`### Content best practices\` — scannable \`**Correct:**\` / \`**Incorrect:**\` bullets paired with a visual \`<DoDonts>\` rendering the actual component; bullets and DoDonts complement each other, never replace each other
- chore: extend the validation checklist in \`mdx-authoring.md\` with matching items so the new principles are enforced during review

## Companion PRs

- factorialco/f0#4019 — applies these principles to F0Button MDX
- factorialco/factorial-skills#158 — removes the duplicated global tree