### PR TITLE
fix(TableHead): show tooltip on truncated column headers via OneEllipsis

### DIFF
--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -5,6 +5,7 @@ import { TableHead as TableHeadRoot } from "@/ui/table"
 
 import { F0Icon, IconType } from "../../../components/F0Icon"
 import { ArrowDown, InfoCircleLine } from "../../../icons/app"
+import { OneEllipsis } from "../../../lib/OneEllipsis"
 import { cn, focusRing } from "../../../lib/utils"
 import { getColWidth } from "../utils/colWidth"
 import { ColumnWidth } from "../utils/sizes"
@@ -105,9 +106,17 @@ export function TableHead({
           align === "right" && "flex-row-reverse"
         )}
       >
-        <div className={cn("truncate", width !== "auto" && "overflow-hidden")}>
-          {children}
-        </div>
+        {typeof children === "string" ? (
+          <OneEllipsis className={cn(width !== "auto" && "overflow-hidden")}>
+            {children}
+          </OneEllipsis>
+        ) : (
+          <div
+            className={cn("truncate", width !== "auto" && "overflow-hidden")}
+          >
+            {children}
+          </div>
+        )}
         {hasContent && (
           <div className="flex items-center">
             {info && (

--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
@@ -1682,6 +1682,104 @@ export const TableColumnProperties: Story = {
   },
 }
 
+export const LongColumnLabels: Story = {
+  render: () => {
+    const dataSource = useDataCollectionSource({
+      dataAdapter: createDataAdapter({ data: mockUsers, delay: 300 }),
+    })
+
+    return (
+      <OneDataCollection
+        source={dataSource}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              columns: [
+                {
+                  label: "Full Name",
+                  render: (item) => item.name,
+                  width: 120,
+                },
+                {
+                  label: "Annual Gross Compensation (Before Tax)",
+                  render: (item) => `$${(item.salary ?? 0).toLocaleString()}`,
+                  width: 120,
+                },
+                {
+                  label: "Primary Organizational Department",
+                  render: (item) => item.department,
+                  width: 120,
+                },
+                {
+                  label: "Current Employment Role And Position Title",
+                  render: (item) => item.role,
+                  width: 120,
+                },
+                {
+                  label: "Corporate Electronic Mail Address",
+                  render: (item) => item.email,
+                  width: 150,
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+  },
+}
+
+export const LongColumnLabelsWithInfo: Story = {
+  render: () => {
+    const dataSource = useDataCollectionSource({
+      dataAdapter: createDataAdapter({ data: mockUsers, delay: 300 }),
+    })
+
+    return (
+      <OneDataCollection
+        source={dataSource}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              columns: [
+                {
+                  label: "Full Name",
+                  render: (item) => item.name,
+                  width: 120,
+                },
+                {
+                  label: "Annual Gross Compensation (Before Tax)",
+                  render: (item) => `$${(item.salary ?? 0).toLocaleString()}`,
+                  width: 120,
+                  info: "Total yearly salary before any tax withholdings or benefit deductions are applied",
+                },
+                {
+                  label: "Primary Organizational Department",
+                  render: (item) => item.department,
+                  width: 120,
+                  info: "The business unit this employee is assigned to",
+                },
+                {
+                  label: "Current Employment Role And Position Title",
+                  render: (item) => item.role,
+                  width: 120,
+                },
+                {
+                  label: "Corporate Electronic Mail Address",
+                  render: (item) => item.email,
+                  width: 150,
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+  },
+}
+
 export const TableWithNoFiltersAndSearch: Story = {
   render: () => {
     const dataSource = useDataCollectionSource({


### PR DESCRIPTION
## Description

Long column label strings in `OneDataCollection` table headers were silently truncated (CSS `text-overflow: ellipsis`) with no way for the user to read the full text. This PR replaces the bare truncation `<div>` in `TableHead` with `OneEllipsis`, which automatically shows a tooltip on hover whenever the label is actually clipped.

## Screenshots

https://github.com/user-attachments/assets/a95863e7-653b-421a-bfa4-f74288296903

## Implementation details

### Problem

Users reported that long column names in `OneDataCollection` table headers break readability — the text is truncated but there is no tooltip to reveal the full string.

### What changed

- **`TableHead/index.tsx`** — Added `OneEllipsis` import. The inner truncation `<div>` is now conditionally replaced:
  - `string` children → `<OneEllipsis>` (truncation + auto-tooltip via `ResizeObserver` when text overflows)
  - Non-string children → original `<div className="truncate ...">` fallback (no regression for custom renderers)
- **`index.stories.tsx`** — Two new stories under `Data Collection/Miscellaneous`:
  - `LongColumnLabels` — columns with constrained widths and long labels, demonstrates the tooltip on truncation
  - `LongColumnLabelsWithInfo` — same but some columns also carry `info` props, confirms the ellipsis tooltip and info-icon tooltip coexist without collision

### Why `OneEllipsis` and not a custom `Tooltip`

`OneEllipsis` is the established F0 pattern for this exact problem. It uses a `ResizeObserver` to detect *actual* overflow before showing the tooltip — so the tooltip only appears when the label is genuinely clipped, not unconditionally.

### Tooltip collision with `info` prop

Not an issue — the two tooltips have **separate trigger elements** (label text vs. info icon), so they cannot fire simultaneously.