### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.464.0",
+  "packages/react": "1.464.1",
   "packages/react-native": "0.52.0",
   "packages/core": "1.50.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.464.1](https://github.com/factorialco/f0/compare/f0-react-v1.464.0...f0-react-v1.464.1) (2026-04-24)
+
+
+### Bug Fixes
+
+* **TableHead:** show tooltip on truncated column headers via OneEllipsis ([#4025](https://github.com/factorialco/f0/issues/4025)) ([ece5621](https://github.com/factorialco/f0/commit/ece5621374e585cdcc9914c9af9d51561348633b))
+
 ## [1.464.0](https://github.com/factorialco/f0/compare/f0-react-v1.463.2...f0-react-v1.464.0) (2026-04-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.464.0",
+  "version": "1.464.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.464.1</summary>

## [1.464.1](https://github.com/factorialco/f0/compare/f0-react-v1.464.0...f0-react-v1.464.1) (2026-04-24)


### Bug Fixes

* **TableHead:** show tooltip on truncated column headers via OneEllipsis ([#4025](https://github.com/factorialco/f0/issues/4025)) ([ece5621](https://github.com/factorialco/f0/commit/ece5621374e585cdcc9914c9af9d51561348633b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).