### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.464.1",
+  "packages/react": "1.464.2",
   "packages/react-native": "0.52.0",
   "packages/core": "1.50.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.464.2](https://github.com/factorialco/f0/compare/f0-react-v1.464.1...f0-react-v1.464.2) (2026-04-24)
+
+
+### Bug Fixes
+
+* **OneDataCollection:** add allPagesSelection banner below header and fix indeterminate state ([#4023](https://github.com/factorialco/f0/issues/4023)) ([696d66a](https://github.com/factorialco/f0/commit/696d66a139416f673e7fe2052bd1cc38adb331fc))
+
 ## [1.464.1](https://github.com/factorialco/f0/compare/f0-react-v1.464.0...f0-react-v1.464.1) (2026-04-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.464.1",
+  "version": "1.464.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.464.2</summary>

## [1.464.2](https://github.com/factorialco/f0/compare/f0-react-v1.464.1...f0-react-v1.464.2) (2026-04-24)


### Bug Fixes

* **OneDataCollection:** add allPagesSelection banner below header and fix indeterminate state ([#4023](https://github.com/factorialco/f0/issues/4023)) ([696d66a](https://github.com/factorialco/f0/commit/696d66a139416f673e7fe2052bd1cc38adb331fc))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).