### PR TITLE
fix(PageHeader): fix embedded back button not navigating

### DIFF
--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -8,13 +8,13 @@ import { F0Button } from "@/components/F0Button"
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { IconType } from "@/components/F0Icon"
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
-import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
 import { OneSwitch as OnePromotionSwitch } from "@/experimental/AiPromotionChat/OneSwitch"
 import { Dropdown } from "@/experimental/Navigation/Dropdown"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { ChevronDown, ChevronLeft, ChevronUp, Menu } from "@/icons/app"
 import { Link } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
+import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
 import { F0OneSwitch } from "@/sds/ai/F0OneSwitch"
 import { Skeleton } from "@/ui/skeleton"
 
@@ -134,13 +134,14 @@ export function PageHeader({
     ...breadcrumbs,
   ]
   const hasStatus = statusTag && Object.keys(statusTag).length !== 0
-  const hasNavigation = breadcrumbs.length > 0
+  const hasNavigation = embedded && breadcrumbs.length > 0
   const hasActions = !embedded && actions.length > 0
   const hasProductUpdates = !embedded && !!productUpdates?.isVisible
   const lastBreadcrumb = breadcrumbsTree[breadcrumbsTree.length - 1]
-  const parentBreadcrumb = hasNavigation
-    ? breadcrumbsTree[breadcrumbsTree.length - 2]
-    : null
+  const nav =
+    "navigation" in window ? (window as Record<string, any>).navigation : null
+  const canGoBack =
+    embedded && (nav ? !!nav.canGoBack : window.history.length > 1)
 
   return (
     <div
@@ -172,26 +173,21 @@ export function PageHeader({
         <div
           className={cn(
             "flex flex-grow items-center gap-2",
-            embedded && hasNavigation && "justify-center"
+            canGoBack && "justify-center"
           )}
         >
-          {embedded &&
-            hasNavigation &&
-            parentBreadcrumb &&
-            !("loading" in parentBreadcrumb) && (
-              <div className="absolute left-4">
-                <Link href={parentBreadcrumb.href}>
-                  <F0Button
-                    variant="ghost"
-                    hideLabel
-                    label="Back"
-                    icon={ChevronLeft}
-                    onClick={(e) => e.preventDefault()}
-                  />
-                </Link>
-              </div>
-            )}
-          {embedded && hasNavigation ? (
+          {embedded && canGoBack && (
+            <div className="absolute left-4">
+              <F0Button
+                variant="ghost"
+                hideLabel
+                label="Back"
+                icon={ChevronLeft}
+                onClick={() => window.history.back()}
+              />
+            </div>
+          )}
+          {canGoBack || hasNavigation ? (
             <div className="text-lg font-semibold text-f1-foreground">
               {"loading" in lastBreadcrumb ? (
                 <Skeleton className="h-4 w-24" />


### PR DESCRIPTION
## Problem

The embedded back button in `PageHeader` (shown when `embedded=true`, i.e. inside the mobile WebView) had two issues:

### 1. Button did nothing when clicked
The button had `onClick={(e) => e.preventDefault()}` which blocked the `<Link>` wrapper's navigation. This was added in commit 0e6d9f27 (PR #1835, May 2025) to fix page reloads for `PageNavigationLink` and `PageAction`. Those components used `ref.current?.click()` to delegate navigation back to the Link — but the embedded back button was missing that delegation, leaving it as a no-op.

### 2. Wrong navigation target
The back button used the parent breadcrumb `href` (route hierarchy) instead of the user's actual navigation history. For example, navigating from `/goals/employees/5` to `/goals/groups/11` would go back to `/goals` (parent breadcrumb) instead of `/goals/employees/5` (where the user came from).

## Fix

- Replace breadcrumb-based back navigation with `history.back()` only when the component is embedded in a webview.
- Use the Navigation API (`window.navigation.canGoBack`) to show/hide the back button based on actual browser history, with a fallback to `history.length` for older browsers
- Remove unused `parentBreadcrumb` variable
- Scope `hasNavigation` to embedded mode only

## Behavior

| Scenario | Back button | Action |
|---|---|---|
| Entry page (no history) | Hidden | Native mobile header handles back to Hub |
| Navigated deeper (has history) | Visible | `history.back()` — goes to previous page |
| After going back to entry | Hidden (Navigation API) | Correct — no history to go back to |

## Impact

**- Only affects embedded mode (`embedded=true`)**
- `embedded=true` is only set when `window.ReactNativeWebView` exists (mobile WebView)
- Affected screens: Goals, Performance Reviews, Performance Process
- No impact on desktop/browser — the embedded code path is never reached
- Navigation API supported in Chrome 102+, Safari 17.4+, Android WebView, iOS WKWebView 17.4+
- Fallback to `history.length > 1` for older browsers (minor: button stays visible after going back, but `history.back()` is harmless at start of history so no access to undesired previous breadcrumb page)

## Verification

- Tested in browser with `window.ReactNativeWebView = { postMessage: () => {} }` to simulate embedded mode
- Tested in iOS simulator via mobile WebView
- Back button hidden on entry page, appears after navigation, correctly returns to previous page



Fixes [FCT-51544](https://factorialmakers.atlassian.net/browse/FCT-51544)


https://github.com/user-attachments/assets/efe43291-08af-4a2f-a8bd-7433130fe1dd



[FCT-51544]: https://factorialmakers.atlassian.net/browse/FCT-51544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ