### PR TITLE
feat: add support to resolve defaultValuesParams coming from One

### DIFF
--- a/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
+++ b/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
@@ -50,7 +50,7 @@ export interface F0AiFormEntry {
   defaultValuesFn?: (
     params: Record<string, unknown>
   ) => Promise<Record<string, unknown>>
-  /** The params most recently used to pre-populate this form via defaultValuesFn */
+  /** The params most recently used to pre-populate this form (updated via updateActiveFormDefaultValuesParams through coagent state sync) */
   defaultValuesParams?: Record<string, unknown>
   /** Field names explicitly set via setValue/setValues on a virtual ref */
   dirtyFields?: Set<string>
@@ -79,12 +79,14 @@ export interface F0AiAvailableFormDefinition<
   schema: F0FormSchema
   /**
    * Default values for the form fields.
-   * Can be a static object or a function that receives params (supplied by the AI)
-   * and returns the defaults.
+   * Can be a static object, a sync function, or an async function that
+   * receives params (supplied by the AI) and returns the defaults.
    */
   defaultValues?:
     | Record<string, unknown>
-    | ((params: TParams) => Record<string, unknown>)
+    | ((
+        params: TParams
+      ) => Record<string, unknown> | Promise<Record<string, unknown>>)
   /**
    * Zod schema that describes the params accepted by a functional `defaultValues`.
    * When provided, the AI will see this schema and can supply params.
@@ -319,17 +321,27 @@ export function defineAvailableForm(
 }
 
 /**
- * Resolves defaultValues from a definition, handling both static objects and functions.
+ * Resolves defaultValues from a definition, handling static objects and functions.
+ * When the function returns a Promise (async defaults), returns {} synchronously —
+ * async resolution is handled by defaultValuesFn in the canvas.
  */
 function resolveDefaultValues(
   defaultValues:
     | Record<string, unknown>
-    | ((params: Record<string, unknown>) => Record<string, unknown>)
+    | ((
+        params: Record<string, unknown>
+      ) => Record<string, unknown> | Promise<Record<string, unknown>>)
     | undefined,
   params: Record<string, unknown> = {}
 ): Record<string, unknown> {
   if (typeof defaultValues === "function") {
-    return defaultValues(params)
+    const result = defaultValues(params)
+    // If the function returns a Promise (async defaults with params),
+    // return empty — async resolution is handled by defaultValuesFn.
+    if (result && typeof (result as Promise<unknown>).then === "function") {
+      return {}
+    }
+    return result as Record<string, unknown>
   }
   return defaultValues ?? {}
 }
@@ -578,11 +590,17 @@ interface F0AiFormRegistryContextValue {
   /** Mark a form as currently resolving async default values (fills will be queued) */
   markDefaultValuesResolving: (formName: string) => void
   /** Mark a form's default values as resolved and flush any queued fill actions */
-  markDefaultValuesResolved: (formName: string) => void
+  markDefaultValuesResolved: (
+    formName: string,
+    paramsKey?: string | null
+  ) => void
   /** Queue a fill callback to run after a form's defaults are resolved */
   queueFillAction: (formName: string, action: () => void) => void
   /** Whether a form's async defaults have ever been resolved (persists across canvas close/reopen) */
-  hasDefaultValuesEverResolved: (formName: string) => boolean
+  hasDefaultValuesEverResolved: (
+    formName: string,
+    paramsKey?: string | null
+  ) => boolean
 }
 
 const F0AiFormRegistryContext =
@@ -624,7 +642,7 @@ export function F0AiFormRegistryProvider({
   const lastDescriptionsJsonRef = useRef<string>("")
   const fillVersionsRef = useRef<Map<string, number>>(new Map())
   const defaultValuesResolvingRef = useRef<Set<string>>(new Set())
-  const defaultsEverResolvedRef = useRef<Set<string>>(new Set())
+  const defaultsEverResolvedRef = useRef<Map<string, string | null>>(new Map())
   const fillQueueRef = useRef<Map<string, Array<() => void>>>(new Map())
 
   // Three-field state replacing the old flat formDescriptions array.
@@ -823,8 +841,17 @@ export function F0AiFormRegistryProvider({
         )
         const virtualDefDefaultValuesFn =
           typeof virtualDef.defaultValues === "function"
-            ? async (params: Record<string, unknown>) =>
-                resolveDefaultValues(virtualDef.defaultValues, params)
+            ? (() => {
+                const fn = virtualDef.defaultValues
+                return async (params: Record<string, unknown>) => {
+                  const result = fn(params as never)
+                  return (
+                    typeof (result as Promise<unknown>)?.then === "function"
+                      ? await result
+                      : result
+                  ) as Record<string, unknown>
+                }
+              })()
             : undefined
         registryRef.current.set(name, {
           ref: virtualRef,
@@ -930,9 +957,9 @@ export function F0AiFormRegistryProvider({
   }, [])
 
   const markDefaultValuesResolved = useCallback(
-    (formName: string) => {
+    (formName: string, paramsKey?: string | null) => {
       defaultValuesResolvingRef.current.delete(formName)
-      defaultsEverResolvedRef.current.add(formName)
+      defaultsEverResolvedRef.current.set(formName, paramsKey ?? null)
       const queue = fillQueueRef.current.get(formName)
       if (queue?.length) {
         fillQueueRef.current.delete(formName)
@@ -954,9 +981,14 @@ export function F0AiFormRegistryProvider({
     []
   )
 
-  const hasDefaultValuesEverResolved = useCallback((formName: string) => {
-    return defaultsEverResolvedRef.current.has(formName)
-  }, [])
+  const hasDefaultValuesEverResolved = useCallback(
+    (formName: string, paramsKey?: string | null) => {
+      if (!defaultsEverResolvedRef.current.has(formName)) return false
+      if (paramsKey === undefined) return true
+      return defaultsEverResolvedRef.current.get(formName) === paramsKey
+    },
+    []
+  )
 
   // Sync virtual form definitions: register forms that aren't rendered,
   // skip if a rendered (non-virtual) form with the same name already exists.
@@ -980,8 +1012,17 @@ export function F0AiFormRegistryProvider({
       )
       const defDefaultValuesFn =
         typeof def.defaultValues === "function"
-          ? async (params: Record<string, unknown>) =>
-              resolveDefaultValues(def.defaultValues, params)
+          ? (() => {
+              const fn = def.defaultValues
+              return async (params: Record<string, unknown>) => {
+                const result = fn(params as never)
+                return (
+                  typeof (result as Promise<unknown>)?.then === "function"
+                    ? await result
+                    : result
+                ) as Record<string, unknown>
+              }
+            })()
           : undefined
       registryRef.current.set(def.name, {
         ref: virtualRef,

--- a/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
+++ b/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
@@ -50,6 +50,8 @@ export interface F0AiFormEntry {
   defaultValuesFn?: (
     params: Record<string, unknown>
   ) => Promise<Record<string, unknown>>
+  /** The params most recently used to pre-populate this form via defaultValuesFn */
+  defaultValuesParams?: Record<string, unknown>
   /** Field names explicitly set via setValue/setValues on a virtual ref */
   dirtyFields?: Set<string>
   /** Consumer submit callback (from availableFormDefinition). Preserved across virtual ↔ rendered transitions. */
@@ -525,6 +527,8 @@ export interface F0AiFormDescription {
   isDirty: boolean
   /** JSON Schema of defaultValuesParams (only for forms with defaultValuesParamsSchema) */
   defaultValuesParamsSchema?: Record<string, unknown>
+  /** The params most recently used to pre-populate this form (set when fillForm is called with defaultValuesParams) */
+  defaultValuesParams?: Record<string, unknown>
 }
 
 interface F0AiFormRegistryContextValue {
@@ -558,6 +562,11 @@ interface F0AiFormRegistryContextValue {
   ) => { success: boolean; error?: string }
   /** Clear the active co-editing form (e.g. after submit) */
   clearActiveForm: () => void
+  /** Write defaultValuesParams onto a registry entry (called when Mastra sets them in shared state) */
+  updateActiveFormDefaultValuesParams: (
+    formName: string,
+    params: Record<string, unknown> | undefined
+  ) => void
   /** Bump the fill-version counter for a form (called after fillForm succeeds) */
   incrementFillVersion: (formName: string) => void
   /** Reset the fill-version counter for a form (e.g. after submit) */
@@ -662,6 +671,9 @@ export function F0AiFormRegistryProvider({
                   ) as Record<string, unknown>,
                 }
               : {}),
+            ...(entry.defaultValuesParams
+              ? { defaultValuesParams: entry.defaultValuesParams }
+              : {}),
           })
         } else {
           // Rendered forms → full runtime state for formsOnCurrentPage
@@ -686,6 +698,9 @@ export function F0AiFormRegistryProvider({
                     entry.defaultValuesParamsSchema
                   ) as Record<string, unknown>,
                 }
+              : {}),
+            ...(entry.defaultValuesParams
+              ? { defaultValuesParams: entry.defaultValuesParams }
               : {}),
           })
         }
@@ -715,6 +730,9 @@ export function F0AiFormRegistryProvider({
                     entry.defaultValuesParamsSchema
                   ) as Record<string, unknown>,
                 }
+              : {}),
+            ...(entry.defaultValuesParams
+              ? { defaultValuesParams: entry.defaultValuesParams }
               : {}),
           }
         }
@@ -757,8 +775,10 @@ export function F0AiFormRegistryProvider({
         description,
         module,
         sections,
-        defaultValuesParamsSchema,
-        defaultValuesFn,
+        defaultValuesParamsSchema:
+          defaultValuesParamsSchema ?? existingEntry?.defaultValuesParamsSchema,
+        defaultValuesFn: defaultValuesFn ?? existingEntry?.defaultValuesFn,
+        defaultValuesParams: existingEntry?.defaultValuesParams,
         onSubmit: existingEntry?.onSubmit,
         steps: existingEntry?.steps,
         submitConfig: existingEntry?.submitConfig,
@@ -788,6 +808,11 @@ export function F0AiFormRegistryProvider({
           mergedDefaults,
           virtualDef.onSubmit
         )
+        const virtualDefDefaultValuesFn =
+          typeof virtualDef.defaultValues === "function"
+            ? async (params: Record<string, unknown>) =>
+                resolveDefaultValues(virtualDef.defaultValues, params)
+            : undefined
         registryRef.current.set(name, {
           ref: virtualRef,
           schema: virtualDef.schema,
@@ -796,6 +821,8 @@ export function F0AiFormRegistryProvider({
           sections: virtualDef.sections,
           virtual: true,
           defaultValuesParamsSchema: virtualDef.defaultValuesParamsSchema,
+          defaultValuesFn: virtualDefDefaultValuesFn,
+          defaultValuesParams: entry?.defaultValuesParams,
           dirtyFields,
           onSubmit: virtualDef.onSubmit,
           steps: virtualDef.steps,
@@ -852,6 +879,19 @@ export function F0AiFormRegistryProvider({
     rebuildDescriptions()
   }, [rebuildDescriptions])
 
+  const updateActiveFormDefaultValuesParams = useCallback(
+    (formName: string, params: Record<string, unknown> | undefined) => {
+      const entry = registryRef.current.get(formName)
+      if (!entry) return
+      entry.defaultValuesParams = params
+      // No rebuildDescriptions here — writing to the entry is enough.
+      // The params will appear in the next natural rebuild (e.g. fillForm).
+      // Triggering a rebuild here would cause a re-render cascade:
+      // rebuild → registry state change → coagent sync → setState → re-render.
+    },
+    []
+  )
+
   const incrementFillVersion = useCallback((formName: string) => {
     const current = fillVersionsRef.current.get(formName) ?? 0
     fillVersionsRef.current.set(formName, current + 1)
@@ -885,6 +925,11 @@ export function F0AiFormRegistryProvider({
         resolveDefaultValues(def.defaultValues),
         def.onSubmit
       )
+      const defDefaultValuesFn =
+        typeof def.defaultValues === "function"
+          ? async (params: Record<string, unknown>) =>
+              resolveDefaultValues(def.defaultValues, params)
+          : undefined
       registryRef.current.set(def.name, {
         ref: virtualRef,
         schema: def.schema,
@@ -893,6 +938,7 @@ export function F0AiFormRegistryProvider({
         sections: def.sections,
         virtual: true,
         defaultValuesParamsSchema: def.defaultValuesParamsSchema,
+        defaultValuesFn: defDefaultValuesFn,
         dirtyFields,
         onSubmit: def.onSubmit,
         steps: def.steps,
@@ -926,21 +972,40 @@ export function F0AiFormRegistryProvider({
     }
   }, [availableFormDefinitions, rebuildDescriptions])
 
-  const value: F0AiFormRegistryContextValue = {
-    register,
-    unregister,
-    get,
-    getFormNames,
-    rebuildDescriptions,
-    formsOnCurrentPage,
-    availableForms,
-    activeForm,
-    setActiveForm,
-    clearActiveForm,
-    incrementFillVersion,
-    resetFillVersion,
-    getFillVersion,
-  }
+  const value: F0AiFormRegistryContextValue = useMemo(
+    () => ({
+      register,
+      unregister,
+      get,
+      getFormNames,
+      rebuildDescriptions,
+      formsOnCurrentPage,
+      availableForms,
+      activeForm,
+      setActiveForm,
+      clearActiveForm,
+      updateActiveFormDefaultValuesParams,
+      incrementFillVersion,
+      resetFillVersion,
+      getFillVersion,
+    }),
+    [
+      register,
+      unregister,
+      get,
+      getFormNames,
+      rebuildDescriptions,
+      formsOnCurrentPage,
+      availableForms,
+      activeForm,
+      setActiveForm,
+      clearActiveForm,
+      updateActiveFormDefaultValuesParams,
+      incrementFillVersion,
+      resetFillVersion,
+      getFillVersion,
+    ]
+  )
 
   return (
     <F0AiFormRegistryContext.Provider value={value}>

--- a/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
+++ b/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
@@ -581,6 +581,8 @@ interface F0AiFormRegistryContextValue {
   markDefaultValuesResolved: (formName: string) => void
   /** Queue a fill callback to run after a form's defaults are resolved */
   queueFillAction: (formName: string, action: () => void) => void
+  /** Whether a form's async defaults have ever been resolved (persists across canvas close/reopen) */
+  hasDefaultValuesEverResolved: (formName: string) => boolean
 }
 
 const F0AiFormRegistryContext =
@@ -622,6 +624,7 @@ export function F0AiFormRegistryProvider({
   const lastDescriptionsJsonRef = useRef<string>("")
   const fillVersionsRef = useRef<Map<string, number>>(new Map())
   const defaultValuesResolvingRef = useRef<Set<string>>(new Set())
+  const defaultsEverResolvedRef = useRef<Set<string>>(new Set())
   const fillQueueRef = useRef<Map<string, Array<() => void>>>(new Map())
 
   // Three-field state replacing the old flat formDescriptions array.
@@ -910,6 +913,7 @@ export function F0AiFormRegistryProvider({
   const resetFillVersion = useCallback((formName: string) => {
     fillVersionsRef.current.delete(formName)
     defaultValuesResolvingRef.current.delete(formName)
+    defaultsEverResolvedRef.current.delete(formName)
     fillQueueRef.current.delete(formName)
   }, [])
 
@@ -928,6 +932,7 @@ export function F0AiFormRegistryProvider({
   const markDefaultValuesResolved = useCallback(
     (formName: string) => {
       defaultValuesResolvingRef.current.delete(formName)
+      defaultsEverResolvedRef.current.add(formName)
       const queue = fillQueueRef.current.get(formName)
       if (queue?.length) {
         fillQueueRef.current.delete(formName)
@@ -948,6 +953,10 @@ export function F0AiFormRegistryProvider({
     },
     []
   )
+
+  const hasDefaultValuesEverResolved = useCallback((formName: string) => {
+    return defaultsEverResolvedRef.current.has(formName)
+  }, [])
 
   // Sync virtual form definitions: register forms that aren't rendered,
   // skip if a rendered (non-virtual) form with the same name already exists.
@@ -1036,6 +1045,7 @@ export function F0AiFormRegistryProvider({
       markDefaultValuesResolving,
       markDefaultValuesResolved,
       queueFillAction,
+      hasDefaultValuesEverResolved,
     }),
     [
       register,
@@ -1056,6 +1066,7 @@ export function F0AiFormRegistryProvider({
       markDefaultValuesResolving,
       markDefaultValuesResolved,
       queueFillAction,
+      hasDefaultValuesEverResolved,
     ]
   )
 

--- a/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
+++ b/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
@@ -573,6 +573,14 @@ interface F0AiFormRegistryContextValue {
   resetFillVersion: (formName: string) => void
   /** Get the fill-version counter for a form (0 = never filled) */
   getFillVersion: (formName: string) => number
+  /** Whether a form's async default values have been resolved (true unless actively resolving) */
+  isDefaultValuesResolved: (formName: string) => boolean
+  /** Mark a form as currently resolving async default values (fills will be queued) */
+  markDefaultValuesResolving: (formName: string) => void
+  /** Mark a form's default values as resolved and flush any queued fill actions */
+  markDefaultValuesResolved: (formName: string) => void
+  /** Queue a fill callback to run after a form's defaults are resolved */
+  queueFillAction: (formName: string, action: () => void) => void
 }
 
 const F0AiFormRegistryContext =
@@ -613,6 +621,8 @@ export function F0AiFormRegistryProvider({
   const registryRef = useRef<Map<string, F0AiFormEntry>>(new Map())
   const lastDescriptionsJsonRef = useRef<string>("")
   const fillVersionsRef = useRef<Map<string, number>>(new Map())
+  const defaultValuesResolvingRef = useRef<Set<string>>(new Set())
+  const fillQueueRef = useRef<Map<string, Array<() => void>>>(new Map())
 
   // Three-field state replacing the old flat formDescriptions array.
   // formsOnCurrentPage: full runtime state for rendered (non-virtual) forms
@@ -899,11 +909,45 @@ export function F0AiFormRegistryProvider({
 
   const resetFillVersion = useCallback((formName: string) => {
     fillVersionsRef.current.delete(formName)
+    defaultValuesResolvingRef.current.delete(formName)
+    fillQueueRef.current.delete(formName)
   }, [])
 
   const getFillVersion = useCallback((formName: string) => {
     return fillVersionsRef.current.get(formName) ?? 0
   }, [])
+
+  const isDefaultValuesResolved = useCallback((formName: string) => {
+    return !defaultValuesResolvingRef.current.has(formName)
+  }, [])
+
+  const markDefaultValuesResolving = useCallback((formName: string) => {
+    defaultValuesResolvingRef.current.add(formName)
+  }, [])
+
+  const markDefaultValuesResolved = useCallback(
+    (formName: string) => {
+      defaultValuesResolvingRef.current.delete(formName)
+      const queue = fillQueueRef.current.get(formName)
+      if (queue?.length) {
+        fillQueueRef.current.delete(formName)
+        for (const action of queue) {
+          action()
+        }
+      }
+      rebuildDescriptions()
+    },
+    [rebuildDescriptions]
+  )
+
+  const queueFillAction = useCallback(
+    (formName: string, action: () => void) => {
+      const queue = fillQueueRef.current.get(formName) ?? []
+      queue.push(action)
+      fillQueueRef.current.set(formName, queue)
+    },
+    []
+  )
 
   // Sync virtual form definitions: register forms that aren't rendered,
   // skip if a rendered (non-virtual) form with the same name already exists.
@@ -988,6 +1032,10 @@ export function F0AiFormRegistryProvider({
       incrementFillVersion,
       resetFillVersion,
       getFillVersion,
+      isDefaultValuesResolved,
+      markDefaultValuesResolving,
+      markDefaultValuesResolved,
+      queueFillAction,
     }),
     [
       register,
@@ -1004,6 +1052,10 @@ export function F0AiFormRegistryProvider({
       incrementFillVersion,
       resetFillVersion,
       getFillVersion,
+      isDefaultValuesResolved,
+      markDefaultValuesResolving,
+      markDefaultValuesResolved,
+      queueFillAction,
     ]
   )
 

--- a/packages/react/src/patterns/F0Form/__tests__/F0AiFormRegistryAvailableDefinitions.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0AiFormRegistryAvailableDefinitions.test.tsx
@@ -1232,3 +1232,315 @@ describe("F0AiFormRegistryProvider with F0FormDefinition items", () => {
     expect(fieldNames).toContain("role")
   })
 })
+
+// =============================================================================
+// defaultValuesParams lifecycle tests
+// =============================================================================
+
+describe("defaultValuesParams lifecycle", () => {
+  const paramsSchema = z.object({
+    id: z.string().describe("Record id"),
+  })
+
+  const mockRecords: Record<string, { name: string; email: string }> = {
+    "rec-1": { name: "Alice", email: "alice@example.com" },
+    "rec-2": { name: "Bob", email: "bob@example.com" },
+  }
+
+  const definitionWithParams: F0AiAvailableFormDefinition = {
+    name: "edit-record",
+    schema: simpleSchema,
+    defaultValuesParamsSchema: paramsSchema,
+    defaultValues: (params) => {
+      const id = (params as { id: string }).id
+      const record = mockRecords[id]
+      return record ?? { name: "", email: "" }
+    },
+  }
+
+  it("updateActiveFormDefaultValuesParams writes params to the entry", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider
+        availableFormDefinitions={[definitionWithParams]}
+      >
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("edit-record")).toBeDefined()
+    })
+
+    act(() => {
+      capturedRegistry!.updateActiveFormDefaultValuesParams("edit-record", {
+        id: "rec-1",
+      })
+    })
+
+    const entry = capturedRegistry!.get("edit-record")
+    expect(entry!.defaultValuesParams).toEqual({ id: "rec-1" })
+  })
+
+  it("register() preserves defaultValuesParams from existing entry", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider
+        availableFormDefinitions={[definitionWithParams]}
+      >
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("edit-record")).toBeDefined()
+    })
+
+    // Write params to the entry
+    act(() => {
+      capturedRegistry!.updateActiveFormDefaultValuesParams("edit-record", {
+        id: "rec-1",
+      })
+    })
+
+    // Simulate what happens when F0Form mounts in canvas: register() is called
+    // with the same name but without defaultValuesParams
+    const mockRef = { current: null } as React.MutableRefObject<null>
+    act(() => {
+      capturedRegistry!.register("edit-record", mockRef, simpleSchema)
+    })
+
+    await waitFor(() => {
+      const entry = capturedRegistry!.get("edit-record")
+      expect(entry).toBeDefined()
+    })
+
+    const entry = capturedRegistry!.get("edit-record")
+    expect(entry!.defaultValuesParams).toEqual({ id: "rec-1" })
+  })
+
+  it("register() preserves defaultValuesFn from existing entry", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider
+        availableFormDefinitions={[definitionWithParams]}
+      >
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("edit-record")).toBeDefined()
+    })
+
+    const originalDefaultValuesFn =
+      capturedRegistry!.get("edit-record")!.defaultValuesFn
+    expect(originalDefaultValuesFn).toBeDefined()
+
+    // Re-register without providing defaultValuesFn (as canvas F0Form would)
+    const mockRef = { current: null } as React.MutableRefObject<null>
+    act(() => {
+      capturedRegistry!.register("edit-record", mockRef, simpleSchema)
+    })
+
+    await waitFor(() => {
+      const entry = capturedRegistry!.get("edit-record")
+      expect(entry).toBeDefined()
+    })
+
+    const entry = capturedRegistry!.get("edit-record")
+    expect(entry!.defaultValuesFn).toBe(originalDefaultValuesFn)
+  })
+
+  it("register() preserves defaultValuesParamsSchema from existing entry", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider
+        availableFormDefinitions={[definitionWithParams]}
+      >
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("edit-record")).toBeDefined()
+    })
+
+    const originalSchema =
+      capturedRegistry!.get("edit-record")!.defaultValuesParamsSchema
+    expect(originalSchema).toBeDefined()
+
+    // Re-register without providing defaultValuesParamsSchema
+    const mockRef = { current: null } as React.MutableRefObject<null>
+    act(() => {
+      capturedRegistry!.register("edit-record", mockRef, simpleSchema)
+    })
+
+    await waitFor(() => {
+      const entry = capturedRegistry!.get("edit-record")
+      expect(entry).toBeDefined()
+    })
+
+    const entry = capturedRegistry!.get("edit-record")
+    expect(entry!.defaultValuesParamsSchema).toBe(originalSchema)
+  })
+
+  it("unregister() preserves defaultValuesParams when recreating virtual entry", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider
+        availableFormDefinitions={[definitionWithParams]}
+      >
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("edit-record")).toBeDefined()
+    })
+
+    // Write params, then register as rendered (non-virtual), then unregister
+    act(() => {
+      capturedRegistry!.updateActiveFormDefaultValuesParams("edit-record", {
+        id: "rec-2",
+      })
+    })
+
+    const mockRef = { current: null } as React.MutableRefObject<null>
+    act(() => {
+      capturedRegistry!.register("edit-record", mockRef, simpleSchema)
+    })
+
+    act(() => {
+      capturedRegistry!.unregister("edit-record")
+    })
+
+    await waitFor(() => {
+      const entry = capturedRegistry!.get("edit-record")
+      expect(entry?.virtual).toBe(true)
+    })
+
+    const entry = capturedRegistry!.get("edit-record")
+    expect(entry!.defaultValuesParams).toEqual({ id: "rec-2" })
+  })
+
+  it("defaultValuesParams appear in activeForm description after rebuild", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider
+        availableFormDefinitions={[definitionWithParams]}
+      >
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("edit-record")).toBeDefined()
+    })
+
+    // Write params to entry, set as active, then trigger a rebuild
+    act(() => {
+      capturedRegistry!.updateActiveFormDefaultValuesParams("edit-record", {
+        id: "rec-1",
+      })
+    })
+
+    act(() => {
+      capturedRegistry!.setActiveForm("edit-record", {
+        cardTitle: "Edit",
+        cardDescription: "Edit record",
+      })
+    })
+
+    // rebuildDescriptions is called inside setActiveForm, which
+    // emits via queueMicrotask. Wait for the next description cycle.
+    await waitFor(() => {
+      expect(capturedRegistry!.activeForm).not.toBeNull()
+    })
+
+    expect(capturedRegistry!.activeForm!.defaultValuesParams).toEqual({
+      id: "rec-1",
+    })
+  })
+
+  it("defaultValuesFn resolves correct record when called with params", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider
+        availableFormDefinitions={[definitionWithParams]}
+      >
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry?.get("edit-record")).toBeDefined()
+    })
+
+    const entry = capturedRegistry!.get("edit-record")!
+    expect(entry.defaultValuesFn).toBeDefined()
+
+    const result = await entry.defaultValuesFn!({ id: "rec-2" })
+    expect(result).toEqual({ name: "Bob", email: "bob@example.com" })
+  })
+
+  it("updateActiveFormDefaultValuesParams does not crash for unknown form", async () => {
+    let capturedRegistry: ReturnType<typeof useF0AiFormRegistry> = null
+
+    render(
+      <F0AiFormRegistryProvider availableFormDefinitions={[]}>
+        <RegistryInspector
+          onRegistry={(r) => {
+            capturedRegistry = r
+          }}
+        />
+      </F0AiFormRegistryProvider>
+    )
+
+    await waitFor(() => {
+      expect(capturedRegistry).not.toBeNull()
+    })
+
+    // Should be a no-op, not throw
+    act(() => {
+      capturedRegistry!.updateActiveFormDefaultValuesParams("nonexistent", {
+        id: "x",
+      })
+    })
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx
@@ -1039,10 +1039,12 @@ const editAircraftFormDefinition: F0AiAvailableFormDefinition = {
         "Aircraft id. Available aircraft: ac-1 (EC-LVL, Airbus A320), ac-2 (EC-MXV, Boeing 737 MAX 8), ac-3 (EC-NQK, Airbus A350-900)"
       ),
   }),
-  defaultValues: (params) => {
+  defaultValues: (async (params: Record<string, unknown>) => {
     console.log("Received defaultValuesParams:", params)
     const id = params.id as string
     const aircraft = mockAircraft.find((a) => a.id === id)
+    // Simulate a slow API fetch (2 seconds)
+    await sleep(2000)
     if (!aircraft) {
       return {
         registration: "",
@@ -1069,7 +1071,7 @@ const editAircraftFormDefinition: F0AiAvailableFormDefinition = {
       activeRoute: aircraft.activeRoute,
       notes: aircraft.notes,
     }
-  },
+  }) as unknown as (params: Record<string, unknown>) => Record<string, unknown>,
   sections: {
     identity: {
       title: "Identity",

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx
@@ -1039,7 +1039,7 @@ const editAircraftFormDefinition: F0AiAvailableFormDefinition = {
         "Aircraft id. Available aircraft: ac-1 (EC-LVL, Airbus A320), ac-2 (EC-MXV, Boeing 737 MAX 8), ac-3 (EC-NQK, Airbus A350-900)"
       ),
   }),
-  defaultValues: (async (params: Record<string, unknown>) => {
+  defaultValues: async (params: Record<string, unknown>) => {
     console.log("Received defaultValuesParams:", params)
     const id = params.id as string
     const aircraft = mockAircraft.find((a) => a.id === id)
@@ -1071,7 +1071,7 @@ const editAircraftFormDefinition: F0AiAvailableFormDefinition = {
       activeRoute: aircraft.activeRoute,
       notes: aircraft.notes,
     }
-  }) as unknown as (params: Record<string, unknown>) => Record<string, unknown>,
+  },
   sections: {
     identity: {
       title: "Identity",

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx
@@ -902,3 +902,271 @@ export const AvailableForms: Story = {
     )
   },
 }
+
+// =============================================================================
+// Story: FormWithDefaultValuesParams — edit an existing aircraft record by id
+// =============================================================================
+
+// Mock "database" of aircraft the AI can edit
+const mockAircraft = [
+  {
+    id: "ac-1",
+    registration: "EC-LVL",
+    manufacturer: "airbus" as const,
+    model: "A320",
+    status: "active" as const,
+    capacity: 180,
+    rangeKm: 6150,
+    firstFlight: new Date("2012-05-10"),
+    maintenanceDue: new Date("2026-08-15"),
+    activeRoute: true,
+    notes: "Assigned to short-haul Mediterranean routes",
+  },
+  {
+    id: "ac-2",
+    registration: "EC-MXV",
+    manufacturer: "boeing" as const,
+    model: "737 MAX 8",
+    status: "maintenance" as const,
+    capacity: 162,
+    rangeKm: 6570,
+    firstFlight: new Date("2019-11-03"),
+    maintenanceDue: new Date("2026-05-20"),
+    activeRoute: false,
+    notes: "Scheduled engine inspection",
+  },
+  {
+    id: "ac-3",
+    registration: "EC-NQK",
+    manufacturer: "airbus" as const,
+    model: "A350-900",
+    status: "active" as const,
+    capacity: 369,
+    rangeKm: 15000,
+    firstFlight: new Date("2021-03-22"),
+    maintenanceDue: new Date("2027-01-10"),
+    activeRoute: true,
+    notes: "Long-haul intercontinental fleet",
+  },
+]
+
+const editAircraftSchema = z.object({
+  registration: f0FormField(z.string().min(1), {
+    label: "Registration",
+    placeholder: "e.g. EC-LVL",
+    section: "identity",
+    helpText: "Official ICAO aircraft registration code",
+  }),
+  manufacturer: f0FormField(
+    z.enum(["airbus", "boeing", "embraer", "bombardier", "other"]),
+    {
+      label: "Manufacturer",
+      section: "identity",
+      options: [
+        { value: "airbus", label: "Airbus" },
+        { value: "boeing", label: "Boeing" },
+        { value: "embraer", label: "Embraer" },
+        { value: "bombardier", label: "Bombardier" },
+        { value: "other", label: "Other" },
+      ],
+    }
+  ),
+  model: f0FormField(z.string().min(1), {
+    label: "Model",
+    placeholder: "e.g. A320",
+    section: "identity",
+    helpText: "Aircraft model designation",
+  }),
+  status: f0FormField(z.enum(["active", "maintenance", "retired"]), {
+    label: "Status",
+    section: "operations",
+    options: [
+      { value: "active", label: "Active" },
+      { value: "maintenance", label: "In Maintenance" },
+      { value: "retired", label: "Retired" },
+    ],
+  }),
+  capacity: f0FormField(z.number().int().min(1), {
+    label: "Passenger Capacity",
+    section: "specs",
+    placeholder: "e.g. 180",
+    helpText: "Maximum number of passengers",
+  }),
+  rangeKm: f0FormField(z.number().int().min(0), {
+    label: "Range (km)",
+    section: "specs",
+    placeholder: "e.g. 6150",
+    helpText: "Maximum flight range in kilometres",
+  }),
+  firstFlight: f0FormField(z.date(), {
+    label: "First Flight Date",
+    section: "specs",
+    granularities: ["day"],
+    helpText: "Date of the aircraft's maiden flight",
+  }),
+  maintenanceDue: f0FormField(z.date(), {
+    label: "Next Maintenance Due",
+    section: "operations",
+    granularities: ["day"],
+    helpText: "Scheduled date for the next maintenance check",
+  }),
+  activeRoute: f0FormField(z.boolean(), {
+    label: "On Active Route",
+    section: "operations",
+    fieldType: "switch",
+    helpText: "Enable if the aircraft is currently assigned to a route",
+  }),
+  notes: f0FormField(z.string().optional(), {
+    label: "Notes",
+    section: "additional",
+    fieldType: "textarea",
+    placeholder: "Any additional notes...",
+    rows: 3,
+    helpText: "Internal operational notes",
+  }),
+})
+
+const editAircraftFormDefinition: F0AiAvailableFormDefinition = {
+  name: "edit-aircraft",
+  title: "Edit Aircraft",
+  description: "Update an existing aircraft record",
+  module: "employees",
+  schema: editAircraftSchema,
+  defaultValuesParamsSchema: z.object({
+    id: z
+      .string()
+      .describe(
+        "Aircraft id. Available aircraft: ac-1 (EC-LVL, Airbus A320), ac-2 (EC-MXV, Boeing 737 MAX 8), ac-3 (EC-NQK, Airbus A350-900)"
+      ),
+  }),
+  defaultValues: (params) => {
+    console.log("Received defaultValuesParams:", params)
+    const id = params.id as string
+    const aircraft = mockAircraft.find((a) => a.id === id)
+    if (!aircraft) {
+      return {
+        registration: "",
+        manufacturer: undefined,
+        model: "",
+        status: undefined,
+        capacity: undefined,
+        rangeKm: undefined,
+        firstFlight: undefined,
+        maintenanceDue: undefined,
+        activeRoute: false,
+        notes: "",
+      }
+    }
+    return {
+      registration: aircraft.registration,
+      manufacturer: aircraft.manufacturer,
+      model: aircraft.model,
+      status: aircraft.status,
+      capacity: aircraft.capacity,
+      rangeKm: aircraft.rangeKm,
+      firstFlight: aircraft.firstFlight,
+      maintenanceDue: aircraft.maintenanceDue,
+      activeRoute: aircraft.activeRoute,
+      notes: aircraft.notes,
+    }
+  },
+  sections: {
+    identity: {
+      title: "Identity",
+      description: "Registration and manufacturer",
+    },
+    specs: { title: "Specifications", description: "Capacity and range" },
+    operations: { title: "Operations", description: "Status and scheduling" },
+    additional: { title: "Additional", description: "Internal notes" },
+  },
+  onSubmit: async (values) => {
+    await sleep(1500)
+    // eslint-disable-next-line no-console
+    console.info("Aircraft updated:", JSON.stringify(values, null, 2))
+  },
+  submitConfig: { label: "Save Changes" },
+}
+
+const availableFormDefinitions = [editAircraftFormDefinition]
+
+/**
+ * Demonstrates `defaultValuesParamsSchema`: the AI asks for an aircraft id,
+ * looks it up in the mock fleet, and pre-populates the edit form with that
+ * aircraft's current data.
+ *
+ * Three aircraft are available: `ac-1`, `ac-2`, `ac-3`.
+ *
+ * Try prompts like:
+ * - "Edit aircraft ac-1"
+ * - "Open the edit form for the A350"
+ * - "Set ac-2 status to active"
+ */
+export const FormWithDefaultValuesParams: Story = {
+  render() {
+    return (
+      <F0AiFormRegistryProvider
+        availableFormDefinitions={availableFormDefinitions}
+      >
+        <F0AiChatProvider
+          enabled
+          runtimeUrl="https://mastra.local.factorial.dev/copilotkit"
+          agent="one-workflow"
+          credentials="include"
+          showDevConsole={false}
+          greeting="Hello! I can open an aircraft edit form pre-populated with its current data. Try: 'Edit aircraft ac-1' or 'Open the edit form for the A350'."
+        >
+          <AutoOpenChat>
+            <ApplicationFrame
+              {...applicationFrameProps}
+              sidebar={<Sidebar {...SidebarStories.default.args} />}
+            >
+              <Page header={<PageHeader module={storyModule} />}>
+                <div className="mx-auto h-screen overflow-hidden p-8">
+                  <h1 className="font-bold mb-2 text-2xl text-f1-foreground">
+                    Fleet Management (defaultValuesParamsSchema)
+                  </h1>
+                  <p className="mb-4 text-sm text-f1-foreground-secondary">
+                    The AI form uses{" "}
+                    <code className="rounded bg-f1-background-tertiary px-1 py-0.5 text-xs">
+                      defaultValuesParamsSchema
+                    </code>{" "}
+                    to receive an aircraft id and pre-populate the edit form
+                    with its current data.
+                  </p>
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-f1-foreground-secondary">
+                        <th className="pb-2 pr-4">ID</th>
+                        <th className="pb-2 pr-4">Registration</th>
+                        <th className="pb-2 pr-4">Manufacturer</th>
+                        <th className="pb-2 pr-4">Model</th>
+                        <th className="pb-2">Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {mockAircraft.map((ac) => (
+                        <tr key={ac.id} className="border-b text-f1-foreground">
+                          <td className="font-mono py-2 pr-4 text-xs text-f1-foreground-secondary">
+                            {ac.id}
+                          </td>
+                          <td className="py-2 pr-4">{ac.registration}</td>
+                          <td className="py-2 pr-4">{ac.manufacturer}</td>
+                          <td className="py-2 pr-4">{ac.model}</td>
+                          <td className="py-2">{ac.status}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  <p className="mt-6 text-sm text-f1-foreground-secondary">
+                    Open the AI chat and ask it to edit one of the aircraft
+                    above.
+                  </p>
+                </div>
+              </Page>
+            </ApplicationFrame>
+          </AutoOpenChat>
+        </F0AiChatProvider>
+      </F0AiFormRegistryProvider>
+    )
+  },
+}

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/forms/useF0AiFormActions.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/forms/useF0AiFormActions.ts
@@ -1,11 +1,18 @@
 import { useCoAgent } from "@copilotkit/react-core"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { useAiChat } from "@/ai"
 import { useF0AiFormRegistry } from "@/patterns/F0Form/F0AiFormRegistry"
 
 import { useFormFillAction } from "./useFormFillAction"
 import { useFormSubmitAction } from "./useFormSubmitAction"
+
+interface CoAgentFormState {
+  activeForm?: {
+    formName?: string
+    defaultValuesParams?: Record<string, unknown>
+  } | null
+}
 
 /**
  * Hook that registers all AI form interaction tools and pushes
@@ -22,7 +29,7 @@ export const useF0AiFormActions = () => {
 
   // Sync form state into the co-agent shared state so the
   // backend agent can see what forms are active on the page.
-  const { setState, running } = useCoAgent({
+  const { setState, running, state } = useCoAgent<CoAgentFormState>({
     name: agentName || "one-workflow",
   })
 
@@ -34,6 +41,24 @@ export const useF0AiFormActions = () => {
     }
   }, [running, runningForFirstTime])
 
+  // Sync defaultValuesParams from Mastra shared state → registry entry so that
+  // rebuildDescriptions emits them without needing a preservation workaround.
+  const prevParamsKeyRef = useRef("")
+  useEffect(() => {
+    if (!registry) return
+    const formName = state?.activeForm?.formName
+    const params = state?.activeForm?.defaultValuesParams
+    if (!formName) return
+    const paramsKey = `${formName}:${JSON.stringify(params)}`
+    if (prevParamsKeyRef.current === paramsKey) return
+    prevParamsKeyRef.current = paramsKey
+    registry.updateActiveFormDefaultValuesParams(formName, params)
+  }, [
+    registry,
+    state?.activeForm?.formName,
+    JSON.stringify(state?.activeForm?.defaultValuesParams),
+  ])
+
   useEffect(() => {
     if (!runningForFirstTime) return
 
@@ -41,12 +66,35 @@ export const useF0AiFormActions = () => {
     const availableForms = registry?.availableForms || []
     const activeForm = registry?.activeForm || null
 
-    setState((currentState: Record<string, unknown>) => ({
-      ...currentState,
-      formsOnCurrentPage,
-      availableForms,
-      activeForm,
-    }))
+    setState((currentState) => {
+      // Preserve defaultValuesParams that Mastra wrote into the coagent state.
+      // The registry entry stores them but they may not appear in the rebuilt
+      // description yet (updateActiveFormDefaultValuesParams skips rebuild to
+      // avoid a re-render cascade). Carry them forward until a natural rebuild
+      // (e.g. fillForm) includes them.
+      const prevActiveForm = (
+        currentState as Record<string, unknown> | undefined
+      )?.activeForm as Record<string, unknown> | null | undefined
+      const mergedActiveForm =
+        activeForm &&
+        prevActiveForm?.defaultValuesParams &&
+        !activeForm.defaultValuesParams
+          ? {
+              ...activeForm,
+              defaultValuesParams: prevActiveForm.defaultValuesParams as Record<
+                string,
+                unknown
+              >,
+            }
+          : activeForm
+
+      return {
+        ...(currentState ?? {}),
+        formsOnCurrentPage,
+        availableForms,
+        activeForm: mergedActiveForm,
+      }
+    })
   }, [
     runningForFirstTime,
     JSON.stringify(registry?.formsOnCurrentPage),

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/forms/useFormFillAction.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/forms/useFormFillAction.ts
@@ -249,9 +249,9 @@ export const useFormFillAction = () => {
       // If async default values haven't resolved yet, queue the fill
       // so it runs after resolution — preventing defaults from overwriting AI values.
       if (!registry.isDefaultValuesResolved(formName)) {
-        return new Promise<Record<string, unknown>>((resolve) => {
+        return new Promise<Record<string, unknown>>((resolve, reject) => {
           registry.queueFillAction(formName, () => {
-            executeFill().then(resolve)
+            void executeFill().then(resolve, reject)
           })
         })
       }

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/forms/useFormFillAction.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/forms/useFormFillAction.ts
@@ -212,30 +212,51 @@ export const useFormFillAction = () => {
         }
       }
 
-      const valuesToSet: Record<string, unknown> = {}
-      const shape = getSchemaShape(entry.schema)
-      for (const { fieldName, value } of values) {
-        const fieldSchema = shape?.[fieldName]
-        valuesToSet[fieldName] = fieldSchema
-          ? coerceValue(value, fieldSchema)
-          : value
+      const executeFill = async () => {
+        // Re-look up the ref in case it changed while queued (e.g. virtual → rendered)
+        const currentEntry = registry.get(formName)
+        const currentRef = currentEntry?.ref.current ?? ref
+
+        const valuesToSet: Record<string, unknown> = {}
+        const shape = getSchemaShape(currentEntry?.schema ?? entry.schema)
+        for (const { fieldName, value } of values) {
+          const fieldSchema = shape?.[fieldName]
+          valuesToSet[fieldName] = fieldSchema
+            ? coerceValue(value, fieldSchema)
+            : value
+        }
+
+        currentRef.setValues(valuesToSet, {
+          shouldValidate: false,
+          shouldDirty: true,
+        })
+        await currentRef.trigger()
+
+        // Refresh the registry snapshot so the co-agent picks up new values
+        registry.rebuildDescriptions()
+        registry.incrementFillVersion(formName)
+
+        const errors = currentRef.getErrors()
+        const hasErrors = Object.keys(errors).length > 0
+        const result = {
+          success: !hasErrors,
+          ...(hasErrors ? { errors } : {}),
+          currentValues: currentRef.getValues(),
+        }
+        return result
       }
 
-      ref.setValues(valuesToSet, { shouldValidate: false, shouldDirty: true })
-      await ref.trigger()
-
-      // Refresh the registry snapshot so the co-agent picks up new values
-      registry.rebuildDescriptions()
-      registry.incrementFillVersion(formName)
-
-      const errors = ref.getErrors()
-      const hasErrors = Object.keys(errors).length > 0
-
-      return {
-        success: !hasErrors,
-        ...(hasErrors ? { errors } : {}),
-        currentValues: ref.getValues(),
+      // If async default values haven't resolved yet, queue the fill
+      // so it runs after resolution — preventing defaults from overwriting AI values.
+      if (!registry.isDefaultValuesResolved(formName)) {
+        return new Promise<Record<string, unknown>>((resolve) => {
+          registry.queueFillAction(formName, () => {
+            executeFill().then(resolve)
+          })
+        })
       }
+
+      return executeFill()
     },
   })
 }

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCanvasContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCanvasContent.tsx
@@ -241,10 +241,14 @@ function VirtualFormContent() {
     const name = formNameRef.current
     const params = defaultValuesParamsRef.current
 
-    // If defaults were already resolved on a previous mount, skip re-fetching.
-    // This prevents a slow async call when the canvas closes and reopens.
-    // Reset happens on submit via resetFillVersion.
-    if (name && registryRef.current?.hasDefaultValuesEverResolved?.(name)) {
+    // If defaults were already resolved on a previous mount with the same
+    // params, skip re-fetching. This prevents a slow async call when the
+    // canvas closes and reopens. Reset happens on submit via resetFillVersion.
+    const paramsKey = params ? JSON.stringify(params) : null
+    if (
+      name &&
+      registryRef.current?.hasDefaultValuesEverResolved?.(name, paramsKey)
+    ) {
       return Promise.resolve(
         e?.ref.current?.getValues() ?? currentValuesRef.current
       )
@@ -254,22 +258,29 @@ function VirtualFormContent() {
       // Capture AI-set values before async resolution — form.reset() after
       // defaults load would otherwise overwrite them.
       const virtualValues = e.ref.current?.getValues() ?? {}
+      const fallbackValues = { ...virtualValues }
       const dirty = e.dirtyFields ?? new Set<string>()
       // Signal that async resolution is in progress — any concurrent
       // fillForm calls will be queued until resolution completes.
       if (name) registryRef.current?.markDefaultValuesResolving?.(name)
-      return e.defaultValuesFn(params).then((values) => {
-        // Merge AI-filled fields on top of resolved defaults so
-        // F0Form's reset() preserves values set by fillForm.
-        const merged = { ...values }
-        for (const field of dirty) {
-          if (field in virtualValues) {
-            merged[field] = virtualValues[field]
+      return e
+        .defaultValuesFn(params)
+        .then((values) => {
+          // Merge AI-filled fields on top of resolved defaults so
+          // F0Form's reset() preserves values set by fillForm.
+          const merged = { ...values }
+          for (const field of dirty) {
+            if (field in virtualValues) {
+              merged[field] = virtualValues[field]
+            }
           }
-        }
-        if (name) registryRef.current?.markDefaultValuesResolved?.(name)
-        return merged
-      })
+          return merged
+        })
+        .catch(() => fallbackValues)
+        .finally(() => {
+          if (name)
+            registryRef.current?.markDefaultValuesResolved?.(name, paramsKey)
+        })
     }
     return Promise.resolve(currentValuesRef.current)
   }, [])

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCanvasContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCanvasContent.tsx
@@ -240,6 +240,16 @@ function VirtualFormContent() {
     const e = entryRef.current
     const name = formNameRef.current
     const params = defaultValuesParamsRef.current
+
+    // If defaults were already resolved on a previous mount, skip re-fetching.
+    // This prevents a slow async call when the canvas closes and reopens.
+    // Reset happens on submit via resetFillVersion.
+    if (name && registryRef.current?.hasDefaultValuesEverResolved?.(name)) {
+      return Promise.resolve(
+        e?.ref.current?.getValues() ?? currentValuesRef.current
+      )
+    }
+
     if (e?.defaultValuesFn && params) {
       // Capture AI-set values before async resolution — form.reset() after
       // defaults load would otherwise overwrite them.

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCanvasContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCanvasContent.tsx
@@ -29,6 +29,7 @@ interface CoAgentFormState {
     description?: string
     module?: ModuleId
     formValues?: Record<string, unknown>
+    defaultValuesParams?: Record<string, unknown>
   } | null
 }
 
@@ -188,10 +189,46 @@ function VirtualFormContent() {
   const entry = formName ? registry?.get(formName) : undefined
   const ref = entry?.ref.current
   const currentValues = activeForm?.formValues ?? {}
+  // Prefer params from the registry entry (written by useF0AiFormActions) as the
+  // canonical source; fall back to coagent state for the brief window before sync.
+  const defaultValuesParams =
+    entry?.defaultValuesParams ?? activeForm?.defaultValuesParams
 
+  // Keep refs so callbacks always capture the latest values without
+  // changing identity (which would cause useF0FormDefinition to recompute).
+  const entryRef = useRef(entry)
+  entryRef.current = entry
+  const defaultValuesParamsRef = useRef(defaultValuesParams)
+  defaultValuesParamsRef.current = defaultValuesParams
+  const currentValuesRef = useRef(currentValues)
+  currentValuesRef.current = currentValues
+  const registryRef = useRef(registry)
+  registryRef.current = registry
+  const formNameRef = useRef(formName)
+  formNameRef.current = formName
+  const closeCanvasRef = useRef(closeCanvas)
+  closeCanvasRef.current = closeCanvas
+
+  // Only apply values once when the canvas first opens for this form.
+  // After the initial population, the rendered F0Form manages its own state and
+  // AI fills go through fillForm → ref.setValues() directly.
+  // Re-applying formValues continuously from coagent state would cause a loop:
+  // form renders → rebuildDescriptions → coagent sync → setValues → re-render.
+  const initializedFormRef = useRef("")
   useEffect(() => {
-    ref?.setValues(currentValues, { shouldDirty: true, shouldValidate: false })
-  }, [formName, JSON.stringify(currentValues)])
+    if (!ref || !formName) return
+    if (initializedFormRef.current === formName) return
+    initializedFormRef.current = formName
+    // If the AI has already filled values on the virtual ref (fillVersion > 0),
+    // use the virtual ref values (which include AI-filled fields) rather than
+    // the coagent formValues snapshot (which may still reflect original defaults).
+    const valuesToApply = registry?.getFillVersion?.(formName)
+      ? (entry?.ref.current?.getValues() ?? currentValues)
+      : currentValues
+    const existing = ref.getValues()
+    if (JSON.stringify(existing) === JSON.stringify(valuesToApply)) return
+    ref.setValues(valuesToApply, { shouldDirty: true, shouldValidate: false })
+  }, [ref, formName, JSON.stringify(currentValues)])
 
   const handleSubmit = useCallback(() => {
     formRef.current?.submit().catch(() => {
@@ -199,10 +236,33 @@ function VirtualFormContent() {
     })
   }, [formRef])
 
+  const resolvedDefaultValues = useCallback(() => {
+    const e = entryRef.current
+    const params = defaultValuesParamsRef.current
+    if (e?.defaultValuesFn && params) {
+      return e.defaultValuesFn(params)
+    }
+    return Promise.resolve(currentValuesRef.current)
+  }, [])
+
+  const onSubmit = useCallback(
+    async ({ data }: { data: Record<string, unknown> }) => {
+      setIsSubmitting(true)
+      await entryRef.current?.onSubmit?.(data)
+      closeTimerRef.current = setTimeout(() => {
+        registryRef.current?.resetFillVersion(formNameRef.current)
+        registryRef.current?.clearActiveForm()
+        closeCanvasRef.current()
+      }, 1500)
+      return { success: true }
+    },
+    []
+  )
+
   const formDefinition = useF0FormDefinition({
     name: formName || "form",
     schema: entry?.schema ?? FALLBACK_SCHEMA,
-    defaultValues: currentValues,
+    defaultValues: resolvedDefaultValues,
     sections: entry?.sections,
     steps: entry?.steps,
     module: entry?.module,
@@ -214,16 +274,7 @@ function VirtualFormContent() {
       hideActionBar: true,
       ...(entry?.submitConfig?.label && { label: entry.submitConfig.label }),
     },
-    onSubmit: async ({ data }) => {
-      setIsSubmitting(true)
-      await entry?.onSubmit?.(data as Record<string, unknown>)
-      closeTimerRef.current = setTimeout(() => {
-        registry?.resetFillVersion(formName)
-        registry?.clearActiveForm()
-        closeCanvas()
-      }, 1500)
-      return { success: true }
-    },
+    onSubmit,
   })
 
   if (!activeForm || !entry) return null

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCanvasContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/FormCanvasContent.tsx
@@ -238,9 +238,28 @@ function VirtualFormContent() {
 
   const resolvedDefaultValues = useCallback(() => {
     const e = entryRef.current
+    const name = formNameRef.current
     const params = defaultValuesParamsRef.current
     if (e?.defaultValuesFn && params) {
-      return e.defaultValuesFn(params)
+      // Capture AI-set values before async resolution — form.reset() after
+      // defaults load would otherwise overwrite them.
+      const virtualValues = e.ref.current?.getValues() ?? {}
+      const dirty = e.dirtyFields ?? new Set<string>()
+      // Signal that async resolution is in progress — any concurrent
+      // fillForm calls will be queued until resolution completes.
+      if (name) registryRef.current?.markDefaultValuesResolving?.(name)
+      return e.defaultValuesFn(params).then((values) => {
+        // Merge AI-filled fields on top of resolved defaults so
+        // F0Form's reset() preserves values set by fillForm.
+        const merged = { ...values }
+        for (const field of dirty) {
+          if (field in virtualValues) {
+            merged[field] = virtualValues[field]
+          }
+        }
+        if (name) registryRef.current?.markDefaultValuesResolved?.(name)
+        return merged
+      })
     }
     return Promise.resolve(currentValuesRef.current)
   }, [])

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCanvasContent.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCanvasContent.test.tsx
@@ -793,7 +793,10 @@ describe("FormCanvasContent", () => {
         name: "AI Filled Name",
         email: "server@default.com",
       })
-      expect(mockMarkDefaultValuesResolved).toHaveBeenCalledWith("test-form")
+      expect(mockMarkDefaultValuesResolved).toHaveBeenCalledWith(
+        "test-form",
+        '{"employeeId":"42"}'
+      )
       vi.useRealTimers()
     })
 
@@ -908,7 +911,10 @@ describe("FormCanvasContent", () => {
 
       // Both have been called — resolving was signaled before resolved
       expect(mockMarkDefaultValuesResolving).toHaveBeenCalledWith("test-form")
-      expect(mockMarkDefaultValuesResolved).toHaveBeenCalledWith("test-form")
+      expect(mockMarkDefaultValuesResolved).toHaveBeenCalledWith(
+        "test-form",
+        '{"id":"1"}'
+      )
       expect(mockMarkDefaultValuesResolving).toHaveBeenCalledBefore(
         mockMarkDefaultValuesResolved
       )

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCanvasContent.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCanvasContent.test.tsx
@@ -42,7 +42,9 @@ let mockRegistryEntry: Record<string, unknown> | undefined
 const mockResetFillVersion = vi.fn()
 const mockClearActiveForm = vi.fn()
 const mockGetFillVersion = vi.fn().mockReturnValue(0)
+const mockMarkDefaultValuesResolving = vi.fn()
 const mockMarkDefaultValuesResolved = vi.fn()
+const mockHasDefaultValuesEverResolved = vi.fn().mockReturnValue(false)
 const mockCloseCanvas = vi.fn()
 
 let mockHasErrors = false
@@ -70,7 +72,9 @@ vi.mock("@/patterns/F0Form/F0AiFormRegistry", () => ({
     resetFillVersion: mockResetFillVersion,
     clearActiveForm: mockClearActiveForm,
     getFillVersion: mockGetFillVersion,
+    markDefaultValuesResolving: mockMarkDefaultValuesResolving,
     markDefaultValuesResolved: mockMarkDefaultValuesResolved,
+    hasDefaultValuesEverResolved: mockHasDefaultValuesEverResolved,
   }),
 }))
 
@@ -134,6 +138,7 @@ describe("FormCanvasContent", () => {
     mockFormComponent = undefined
     mockHasErrors = false
     mockGetFillVersion.mockReturnValue(0)
+    mockHasDefaultValuesEverResolved.mockReturnValue(false)
     mockFormRef.current.getValues.mockReturnValue({})
   })
 
@@ -731,6 +736,253 @@ describe("FormCanvasContent", () => {
         { name: "John", email: "john@test.com" },
         { shouldDirty: true, shouldValidate: false }
       )
+    })
+  })
+
+  // ==========================================================================
+  // Slow async defaultValues — AI-filled dirty fields survive resolution
+  // ==========================================================================
+
+  describe("slow async defaultValues preserve AI-filled dirty fields", () => {
+    it("merges AI-filled dirty fields on top of resolved defaults (2s delay)", async () => {
+      vi.useFakeTimers()
+      let resolveFn!: (v: Record<string, unknown>) => void
+      const defaultValuesFn = vi.fn(
+        () =>
+          new Promise<Record<string, unknown>>((resolve) => {
+            resolveFn = resolve
+          })
+      )
+      // Simulate AI having filled "name" before defaults resolve
+      const dirtyFields = new Set(["name"])
+      mockFormRef.current.getValues.mockReturnValue({
+        name: "AI Filled Name",
+        email: "",
+      })
+      mockRegistryEntry = makeEntry({
+        defaultValuesFn,
+        defaultValuesParams: { employeeId: "42" },
+        dirtyFields,
+      })
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: { name: "AI Filled Name", email: "" },
+          defaultValuesParams: { employeeId: "42" },
+        },
+      }
+      render(<FormContent />)
+
+      // Trigger the async defaultValues callback
+      const resultPromise = capturedFormDefinition.defaultValues()
+
+      // Verify resolving was signaled
+      expect(mockMarkDefaultValuesResolving).toHaveBeenCalledWith("test-form")
+
+      // Simulate 2 seconds passing, then resolve with server defaults
+      await vi.advanceTimersByTimeAsync(2000)
+      resolveFn({
+        name: "Server Default Name",
+        email: "server@default.com",
+      })
+
+      const result = await resultPromise
+
+      // AI-filled "name" survives; server "email" is used since it wasn't dirty
+      expect(result).toEqual({
+        name: "AI Filled Name",
+        email: "server@default.com",
+      })
+      expect(mockMarkDefaultValuesResolved).toHaveBeenCalledWith("test-form")
+      vi.useRealTimers()
+    })
+
+    it("uses all server defaults when no dirty fields exist", async () => {
+      vi.useFakeTimers()
+      let resolveFn!: (v: Record<string, unknown>) => void
+      const defaultValuesFn = vi.fn(
+        () =>
+          new Promise<Record<string, unknown>>((resolve) => {
+            resolveFn = resolve
+          })
+      )
+      mockFormRef.current.getValues.mockReturnValue({
+        name: "",
+        email: "",
+      })
+      mockRegistryEntry = makeEntry({
+        defaultValuesFn,
+        defaultValuesParams: { employeeId: "42" },
+        // No dirtyFields → empty set
+      })
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: { name: "", email: "" },
+          defaultValuesParams: { employeeId: "42" },
+        },
+      }
+      render(<FormContent />)
+
+      const resultPromise = capturedFormDefinition.defaultValues()
+
+      await vi.advanceTimersByTimeAsync(2000)
+      resolveFn({
+        name: "Server Name",
+        email: "server@test.com",
+      })
+
+      const result = await resultPromise
+
+      // No dirty fields → all server defaults are used
+      expect(result).toEqual({
+        name: "Server Name",
+        email: "server@test.com",
+      })
+      vi.useRealTimers()
+    })
+
+    it("preserves multiple AI-filled fields when defaults resolve", async () => {
+      vi.useFakeTimers()
+      let resolveFn!: (v: Record<string, unknown>) => void
+      const defaultValuesFn = vi.fn(
+        () =>
+          new Promise<Record<string, unknown>>((resolve) => {
+            resolveFn = resolve
+          })
+      )
+      const dirtyFields = new Set(["name", "email"])
+      mockFormRef.current.getValues.mockReturnValue({
+        name: "AI Name",
+        email: "ai@filled.com",
+      })
+      mockRegistryEntry = makeEntry({
+        defaultValuesFn,
+        defaultValuesParams: { employeeId: "42" },
+        dirtyFields,
+      })
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: { name: "AI Name", email: "ai@filled.com" },
+          defaultValuesParams: { employeeId: "42" },
+        },
+      }
+      render(<FormContent />)
+
+      const resultPromise = capturedFormDefinition.defaultValues()
+
+      await vi.advanceTimersByTimeAsync(2000)
+      resolveFn({
+        name: "Server Name",
+        email: "server@test.com",
+      })
+
+      const result = await resultPromise
+
+      // Both AI-filled fields survive
+      expect(result).toEqual({
+        name: "AI Name",
+        email: "ai@filled.com",
+      })
+      vi.useRealTimers()
+    })
+
+    it("calls markDefaultValuesResolving before the async call starts", async () => {
+      const defaultValuesFn = vi.fn().mockResolvedValue({ name: "Default" })
+      mockRegistryEntry = makeEntry({
+        defaultValuesFn,
+        defaultValuesParams: { id: "1" },
+      })
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: {},
+          defaultValuesParams: { id: "1" },
+        },
+      }
+      render(<FormContent />)
+
+      // Kick off async resolution and wait for it to complete
+      await capturedFormDefinition.defaultValues()
+
+      // Both have been called — resolving was signaled before resolved
+      expect(mockMarkDefaultValuesResolving).toHaveBeenCalledWith("test-form")
+      expect(mockMarkDefaultValuesResolved).toHaveBeenCalledWith("test-form")
+      expect(mockMarkDefaultValuesResolving).toHaveBeenCalledBefore(
+        mockMarkDefaultValuesResolved
+      )
+    })
+  })
+
+  // ==========================================================================
+  // Close and reopen — defaults should NOT re-resolve
+  // ==========================================================================
+
+  describe("skips re-resolving defaults on canvas reopen", () => {
+    it("returns current values instead of calling defaultValuesFn when defaults were already resolved", async () => {
+      const defaultValuesFn = vi.fn().mockResolvedValue({
+        name: "Server Name",
+        email: "server@test.com",
+      })
+      mockFormRef.current.getValues.mockReturnValue({
+        name: "AI Filled",
+        email: "ai@test.com",
+      })
+      // Defaults were resolved on the first open
+      mockHasDefaultValuesEverResolved.mockReturnValue(true)
+      mockRegistryEntry = makeEntry({
+        defaultValuesFn,
+        defaultValuesParams: { employeeId: "42" },
+      })
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: { name: "AI Filled", email: "ai@test.com" },
+          defaultValuesParams: { employeeId: "42" },
+        },
+      }
+      render(<FormContent />)
+
+      const result = await capturedFormDefinition.defaultValues()
+
+      // defaultValuesFn should NOT be called again
+      expect(defaultValuesFn).not.toHaveBeenCalled()
+      // Should return current virtual ref values
+      expect(result).toEqual({
+        name: "AI Filled",
+        email: "ai@test.com",
+      })
+    })
+
+    it("still resolves defaults on first open when defaults have never been resolved", async () => {
+      const defaultValuesFn = vi.fn().mockResolvedValue({
+        name: "Server Name",
+        email: "server@test.com",
+      })
+      mockFormRef.current.getValues.mockReturnValue({})
+      mockHasDefaultValuesEverResolved.mockReturnValue(false)
+      mockRegistryEntry = makeEntry({
+        defaultValuesFn,
+        defaultValuesParams: { employeeId: "42" },
+      })
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: {},
+          defaultValuesParams: { employeeId: "42" },
+        },
+      }
+      render(<FormContent />)
+
+      const result = await capturedFormDefinition.defaultValues()
+
+      // defaultValuesFn IS called on first open
+      expect(defaultValuesFn).toHaveBeenCalledWith({ employeeId: "42" })
+      expect(result).toEqual({
+        name: "Server Name",
+        email: "server@test.com",
+      })
     })
   })
 })

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCanvasContent.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/form/__tests__/FormCanvasContent.test.tsx
@@ -18,7 +18,7 @@ const mockFormRef = {
     submit: mockSubmit,
     reset: vi.fn(),
     isDirty: () => false,
-    getValues: () => ({}),
+    getValues: vi.fn().mockReturnValue({}),
     setValue: vi.fn(),
     setValues: vi.fn(),
     trigger: vi.fn().mockResolvedValue(true),
@@ -33,6 +33,7 @@ let mockCoAgentState: {
   activeForm?: {
     formName: string
     formValues?: Record<string, unknown>
+    defaultValuesParams?: Record<string, unknown>
   } | null
 } = {}
 
@@ -40,6 +41,8 @@ let mockRegistryEntry: Record<string, unknown> | undefined
 
 const mockResetFillVersion = vi.fn()
 const mockClearActiveForm = vi.fn()
+const mockGetFillVersion = vi.fn().mockReturnValue(0)
+const mockMarkDefaultValuesResolved = vi.fn()
 const mockCloseCanvas = vi.fn()
 
 let mockHasErrors = false
@@ -66,6 +69,8 @@ vi.mock("@/patterns/F0Form/F0AiFormRegistry", () => ({
     get: () => mockRegistryEntry,
     resetFillVersion: mockResetFillVersion,
     clearActiveForm: mockClearActiveForm,
+    getFillVersion: mockGetFillVersion,
+    markDefaultValuesResolved: mockMarkDefaultValuesResolved,
   }),
 }))
 
@@ -128,6 +133,8 @@ describe("FormCanvasContent", () => {
     capturedFormDefinition = null
     mockFormComponent = undefined
     mockHasErrors = false
+    mockGetFillVersion.mockReturnValue(0)
+    mockFormRef.current.getValues.mockReturnValue({})
   })
 
   describe("when no active form", () => {
@@ -604,6 +611,126 @@ describe("FormCanvasContent", () => {
       })
       render(<FormContent />)
       expect(screen.getByRole("button", { name: "Submit" })).not.toBeDisabled()
+    })
+  })
+
+  // ==========================================================================
+  // resolvedDefaultValues — defaultValuesFn + defaultValuesParams
+  // ==========================================================================
+
+  describe("resolvedDefaultValues with defaultValuesParams", () => {
+    it("calls defaultValuesFn with params when both are available", async () => {
+      const defaultValuesFn = vi.fn().mockResolvedValue({
+        name: "Resolved Name",
+        email: "resolved@test.com",
+      })
+      mockRegistryEntry = makeEntry({
+        defaultValuesFn,
+        defaultValuesParams: { employeeId: "123" },
+      })
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: { name: "", email: "" },
+          defaultValuesParams: { employeeId: "123" },
+        },
+      }
+      render(<FormContent />)
+
+      const result = await capturedFormDefinition.defaultValues()
+      expect(defaultValuesFn).toHaveBeenCalledWith({ employeeId: "123" })
+      expect(result).toEqual({
+        name: "Resolved Name",
+        email: "resolved@test.com",
+      })
+    })
+
+    it("falls back to currentValues when no defaultValuesFn", async () => {
+      mockRegistryEntry = makeEntry()
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: { name: "John", email: "john@test.com" },
+        },
+      }
+      render(<FormContent />)
+
+      const result = await capturedFormDefinition.defaultValues()
+      expect(result).toEqual({ name: "John", email: "john@test.com" })
+    })
+
+    it("falls back to currentValues when defaultValuesFn exists but no params", async () => {
+      const defaultValuesFn = vi.fn().mockResolvedValue({
+        name: "Should Not Resolve",
+      })
+      mockRegistryEntry = makeEntry({ defaultValuesFn })
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: { name: "John", email: "john@test.com" },
+        },
+      }
+      render(<FormContent />)
+
+      const result = await capturedFormDefinition.defaultValues()
+      expect(defaultValuesFn).not.toHaveBeenCalled()
+      expect(result).toEqual({ name: "John", email: "john@test.com" })
+    })
+
+    it("always returns a thenable to prevent TypeError in useAsyncDefaultValues", () => {
+      mockRegistryEntry = makeEntry()
+      mockCoAgentState = {
+        activeForm: { formName: "test-form", formValues: {} },
+      }
+      render(<FormContent />)
+
+      const result = capturedFormDefinition.defaultValues()
+      expect(typeof result.then).toBe("function")
+    })
+  })
+
+  // ==========================================================================
+  // fillForm after resolving defaults — fillVersion guard
+  // ==========================================================================
+
+  describe("fillForm after resolving defaults preserves AI-filled values", () => {
+    it("does not overwrite virtual ref values when fillVersion > 0", () => {
+      mockGetFillVersion.mockReturnValue(1)
+      mockFormRef.current.getValues.mockReturnValue({
+        name: "AI Filled",
+        email: "ai@test.com",
+      })
+      mockRegistryEntry = makeEntry()
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: { name: "original", email: "original@test.com" },
+        },
+      }
+      render(<FormContent />)
+
+      // fillVersion > 0 → effect reads getValues() for both valuesToApply and
+      // existing — they match, so setValues is NOT called.
+      // The form keeps the AI-filled values.
+      expect(mockFormRef.current.setValues).not.toHaveBeenCalled()
+    })
+
+    it("applies coagent formValues when fillVersion is 0", () => {
+      mockGetFillVersion.mockReturnValue(0)
+      mockFormRef.current.getValues.mockReturnValue({})
+      mockRegistryEntry = makeEntry()
+      mockCoAgentState = {
+        activeForm: {
+          formName: "test-form",
+          formValues: { name: "John", email: "john@test.com" },
+        },
+      }
+      render(<FormContent />)
+
+      expect(mockFormRef.current.setValues).toHaveBeenCalledWith(
+        { name: "John", email: "john@test.com" },
+        { shouldDirty: true, shouldValidate: false }
+      )
     })
   })
 })


### PR DESCRIPTION
## Add support for resolving `defaultValuesParams` from One

Enables forms with `defaultValuesParamsSchema` to receive params from the AI agent and use them to asynchronously resolve default values before rendering in the canvas (e.g. "edit aircraft ac-1" → fetch that aircraft's data → render pre-populated form).

### Changes

**`defaultValuesParams` sync pipeline**
- `useF0AiFormActions` watches coagent state for `defaultValuesParams` changes and syncs them to the registry via new `updateActiveFormDefaultValuesParams` method.
- `F0AiFormDescription` now includes `defaultValuesParams` in all rebuild paths. `register()` preserves params/fn from existing virtual entries.

**Async default resolution in canvas**
- `FormCanvasContent` passes an async `resolvedDefaultValues` callback (instead of static values) to `useF0FormDefinition`, calling `defaultValuesFn(params)` when available.
- One-time init guard (`initializedFormRef`) prevents the render loop where form → rebuild → coagent sync → setValues → re-render.

**Fill queue to prevent race conditions**
- `markDefaultValuesResolving` / `markDefaultValuesResolved` tracks the async window. `queueFillAction` queues any `fillForm` calls during that window, flushed after resolution.
- Before calling `defaultValuesFn`, captures dirty fields from the virtual ref and merges them on top of resolved defaults — prevents `form.reset()` from overwriting AI-filled values.

**Skip re-resolution on canvas reopen**
- `hasDefaultValuesEverResolved` flag persists across mount/unmount. Reopening the canvas returns current ref values immediately instead of re-fetching.

### Story

New `FormWithDefaultValuesParams` story with a mock aircraft fleet and 2s async delay.

### Tests

+24 tests across `FormCanvasContent.test.tsx` and `F0AiFormRegistryAvailableDefinitions.test.tsx` covering async resolution, dirty field preservation, fill queuing, reopen skip, and lifecycle ordering.