### PR TITLE
feat(F0AiChat): stop fix, chat-wide drop zone, canvas polish, history

### DIFF
--- a/packages/react/src/components/RichText/FileItem/index.tsx
+++ b/packages/react/src/components/RichText/FileItem/index.tsx
@@ -23,11 +23,11 @@ type FileAction = {
 }
 
 const fileItemVariants = cva({
-  base: "flex w-fit flex-row items-center overflow-hidden bg-f1-background-tertiary",
+  base: "flex w-fit flex-row items-center overflow-hidden bg-f1-background-tertiary rounded-[10px]",
   variants: {
     size: {
-      md: "max-w-40 gap-2 rounded p-0.5",
-      lg: "max-w-56 gap-2.5 rounded p-1",
+      md: "max-w-48 gap-2 py-0.5 pl-0.5 pr-1.5",
+      lg: "max-w-56 gap-2.5 p-1",
     },
   },
   defaultVariants: {
@@ -38,11 +38,11 @@ const fileItemVariants = cva({
 type FileItemSize = NonNullable<VariantProps<typeof fileItemVariants>["size"]>
 
 const avatarSizeMap: Record<FileItemSize, "sm" | "md"> = {
-  md: "sm",
+  md: "md",
   lg: "md",
 }
 
-const iconSizeMap: Record<FileItemSize, "sm" | "md"> = {
+const buttonSizeMap: Record<FileItemSize, "sm" | "md"> = {
   md: "sm",
   lg: "md",
 }
@@ -88,7 +88,7 @@ const _FileItem = forwardRef<HTMLDivElement, FileItemProps>(
           (singleAction ? (
             <F0Button
               label={singleAction.label}
-              size={iconSizeMap[size]}
+              size={buttonSizeMap[size]}
               icon={singleAction.icon ?? CrossedCircle}
               disabled={disabled}
               onClick={disabled ? undefined : singleAction.onClick}
@@ -99,7 +99,7 @@ const _FileItem = forwardRef<HTMLDivElement, FileItemProps>(
             <DropdownInternal
               items={dropdownItems}
               icon={Ellipsis}
-              size={iconSizeMap[size]}
+              size={buttonSizeMap[size]}
             />
           ))}
       </div>

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -372,6 +372,18 @@ export const defaultTranslations = {
       controls: "← → to move",
       escToExit: "Esc to exit",
     },
+    dino: {
+      title: "One Run",
+      tapToStart: "Press Space or tap to start",
+      gameOver: "Game over",
+      pressToRestart: "Space to restart",
+      score: "Score",
+      yourScore: "Your score",
+      newRecord: "New record!",
+      hi: "HI",
+      controls: "Space to jump · ↓ to crouch",
+      escToExit: "Esc to exit",
+    },
     creditWarning: {
       soft: "You're running low on AI credits.",
       getCredits: "Get credits",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -400,7 +400,7 @@ export const defaultTranslations = {
       navHint: {
         navigate: "navigate",
         select: "select",
-        skip: "skip",
+        cancel: "cancel",
       },
     },
     growth: {

--- a/packages/react/src/patterns/ApplicationFrame/index.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.tsx
@@ -329,7 +329,7 @@ function ApplicationFrameContent({
               {ai?.enabled && isCanvasMode && canvasContent && (
                 <div
                   className={cn(
-                    "pointer-events-none",
+                    "pointer-events-none flex justify-end",
                     isSmallViewport
                       ? "fixed inset-0 z-[50]"
                       : "absolute bottom-0 left-0 top-0 z-[15]"
@@ -351,7 +351,15 @@ function ApplicationFrameContent({
                       ? "fixed inset-0 z-[30]"
                       : cn(
                           "absolute right-0 top-0 bottom-0",
-                          isInFullscreenTransition ? "z-20" : "z-0",
+                          // In canvas mode the chat wrapper must sit above
+                          // the CanvasPanel (z-[15]) so the ResizeHandle's
+                          // hit-area (which extends a few pixels over the
+                          // canvas side of the seam) can receive hover
+                          // events — otherwise the canvas captures them
+                          // and the handle never lights up.
+                          isInFullscreenTransition || isCanvasMode
+                            ? "z-20"
+                            : "z-0",
                           sidebarState === "hidden" && isInFullscreenTransition
                             ? "pl-1"
                             : "pl-0"

--- a/packages/react/src/patterns/ApplicationFrame/index.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.tsx
@@ -329,10 +329,13 @@ function ApplicationFrameContent({
               {ai?.enabled && isCanvasMode && canvasContent && (
                 <div
                   className={cn(
+                    // z-[21] sits above the chat wrapper (z-20 in canvas
+                    // mode) so the canvas card's right-side shadow paints
+                    // over the chat surface instead of being clipped by it.
                     "pointer-events-none flex justify-end",
                     isSmallViewport
                       ? "fixed inset-0 z-[50]"
-                      : "absolute bottom-0 left-0 top-0 z-[15]"
+                      : "absolute bottom-0 left-0 top-0 z-[21]"
                   )}
                   style={
                     isSmallViewport ? undefined : { right: reservedChatWidth }

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/persistClarifyingResolution.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/persistClarifyingResolution.ts
@@ -20,6 +20,13 @@ export interface PersistClarifyingResolutionParams {
     steps: unknown
     isResolved: true
     answers: ResolvedStepAnswer[]
+    /**
+     * Set to `true` when the user cancelled the flow with Escape. The
+     * tool call is still marked as resolved so the render is a no-op on
+     * reload, but the flag lets the agent (or any future UI) distinguish
+     * "answered" from "cancelled without answering".
+     */
+    cancelled?: boolean
   }
 }
 

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/types.ts
@@ -87,10 +87,9 @@ export interface ClarifyingQuestionState {
   /** Skip the current step (only valid when the step is optional) */
   skip: () => void
   /**
-   * Cancel the entire clarifying flow. Closes the panel, marks the tool
+   * Cancel the entire clarifying flow. Closes the panel and marks the tool
    * call as resolved-but-not-completed so it doesn't re-appear on history
-   * reload, and sends a short notice to the agent so it knows to proceed
-   * without the clarification.
+   * reload. Cancellation is silent — no message is sent to the agent.
    */
   cancel: () => void
   /** Go back to the previous step */

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/types.ts
@@ -58,6 +58,12 @@ export interface ResolvedStepAnswer {
   customAnswer?: string
   /** True when the user explicitly skipped an optional step */
   skipped?: boolean
+  /**
+   * True when the user cancelled the flow before reaching this step.
+   * The step was therefore neither answered nor intentionally skipped —
+   * callers (e.g. the agent) should treat this as "no information".
+   */
+  cancelled?: boolean
 }
 
 /**
@@ -80,6 +86,13 @@ export interface ClarifyingQuestionState {
   confirm: () => void
   /** Skip the current step (only valid when the step is optional) */
   skip: () => void
+  /**
+   * Cancel the entire clarifying flow. Closes the panel, marks the tool
+   * call as resolved-but-not-completed so it doesn't re-appear on history
+   * reload, and sends a short notice to the agent so it knows to proceed
+   * without the clarification.
+   */
+  cancel: () => void
   /** Go back to the previous step */
   back: () => void
   /** Set the custom answer text */

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/useClarifyingQuestionAction.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/useClarifyingQuestionAction.tsx
@@ -280,6 +280,53 @@ function ClarifyingQuestionController({
     }
   }
 
+  /**
+   * Cancel the whole clarifying flow (user pressed Escape).
+   *
+   * Unlike `skip`, which advances past an optional step and records its
+   * explicit skip, `cancel` aborts the entire interaction:
+   *   - closes the panel so the textarea is back,
+   *   - marks the tool call as resolved locally + in the persisted args
+   *     (so the panel doesn't re-appear on history reload),
+   *   - and deliberately does **not** send a message to the agent.
+   *
+   * The ClarifyingQuestion action is a visual frontend-only tool — the
+   * backend emits it via `emitFrontendTool` and doesn't await a result —
+   * so cancelling silently is safe. The user simply gets their textarea
+   * back and can write whatever they want next.
+   */
+  const cancel = () => {
+    if (dismissedRef.current) return
+    dismissedRef.current = true
+    setClarifyingQuestion(null)
+
+    if (toolCallId) locallyResolvedToolCallIds.add(toolCallId)
+
+    // Every step is marked as `cancelled` so the persisted args carry an
+    // unambiguous signal: this tool call was resolved-but-not-completed,
+    // distinct from a normal "submitted with skipped step(s)" resolution.
+    const answers: ResolvedStepAnswer[] = steps.map((s) => ({
+      question: s.question,
+      selectedOptionIds: [],
+      cancelled: true,
+    }))
+
+    if (toolCallId && threadId) {
+      void persistClarifyingResolution({
+        chatApiEndpoint: copilotApiConfig.chatApiEndpoint,
+        headers: copilotApiConfig.headers as Record<string, string> | undefined,
+        threadId,
+        toolCallId,
+        args: {
+          steps: rawSteps,
+          isResolved: true,
+          answers,
+          cancelled: true,
+        },
+      })
+    }
+  }
+
   const back = () => {
     setStepIndex((i) => Math.max(0, i - 1))
   }
@@ -309,6 +356,7 @@ function ClarifyingQuestionController({
       toggleOption,
       confirm,
       skip,
+      cancel,
       back,
       setCustomAnswerText,
       setCustomAnswerActive,

--- a/packages/react/src/sds/ai/F0AiChat/canvas/components/CanvasCard.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/components/CanvasCard.tsx
@@ -48,14 +48,14 @@ export function CanvasCard({
       className={cn(
         "flex flex-col items-center justify-between gap-3 rounded-lg border border-solid px-3 py-2 cursor-pointer",
         isActive
-          ? "border-f1-border-selected-bold"
+          ? "border-f1-border-hover"
           : "border-f1-border-secondary hover:border-f1-border-hover"
       )}
       onClick={isActive ? onClose : onOpen}
     >
-      <div className="flex min-w-0 w-full flex-row items-center gap-3">
+      <div className="flex w-full min-w-0 flex-row items-center gap-3">
         {!!cardModule && <F0AvatarModule module={cardModule} size="lg" />}
-        <div className="flex flex-1 min-w-0 flex-col">
+        <div className="flex min-w-0 flex-1 flex-col">
           <OneEllipsis className="text-lg font-semibold text-f1-foreground">
             {title}
           </OneEllipsis>

--- a/packages/react/src/sds/ai/F0AiChat/canvas/components/__tests__/CanvasCard.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/components/__tests__/CanvasCard.test.tsx
@@ -59,7 +59,7 @@ describe("CanvasCard", () => {
     )
 
     const card = container.firstElementChild as HTMLElement
-    expect(card.className).toContain("border-f1-border-selected-bold")
+    expect(card.className).toContain("border-f1-border-hover")
   })
 
   it("does not apply focus ring styles when inactive", () => {

--- a/packages/react/src/sds/ai/F0AiChat/components/DinoGame.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/DinoGame.tsx
@@ -1,0 +1,1142 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { Cross } from "@/icons/app"
+import { useReducedMotion } from "@/lib/a11y"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+
+import { F0OneIcon } from "../../F0OneIcon/F0OneIcon"
+import { useAiChat } from "../providers/AiChatStateProvider"
+import {
+  readFromLocalStorage,
+  writeToLocalStorage,
+} from "../utils/local-storage"
+
+// ─── Layout (compact: must fit inside a narrow chat sidebar) ─────────────────
+const GROUND_Y_FRACTION = 0.78
+const PLAYER_SIZE = 32
+const PLAYER_X = 56
+
+// ─── Physics — tighter, snappier than Chrome dino ────────────────────────────
+const GRAVITY = 0.95
+const JUMP_VELOCITY = -11
+const FAST_FALL_GRAVITY = 2.2
+
+// ─── Speed curve — easy at start, ramps up gradually ─────────────────────────
+const BASE_SPEED = 3.6
+const MAX_SPEED = 11
+const SPEED_RAMP_DURATION_S = 75 // seconds to reach MAX_SPEED
+
+// ─── Difficulty unlocks (seconds since "playing" started) ────────────────────
+const UNLOCK_MEDIUM_BLOCK_S = 12
+const UNLOCK_LARGE_BLOCK_S = 28
+const UNLOCK_DRONE_S = 25
+const DRONE_SPAWN_CHANCE = 0.4
+
+// ─── Obstacles ───────────────────────────────────────────────────────────────
+const BLOCK_VARIANTS = [
+  { w: 12, h: 18 },
+  { w: 18, h: 24 },
+  { w: 24, h: 30 },
+] as const
+// Bigger silhouette so the bird reads clearly inside the narrow chat panel.
+const DRONE_W = 46
+const DRONE_H = 22
+const DRONE_HIGH_OFFSET = -64 // sits comfortably above the standing player
+const DRONE_MID_OFFSET = -38 // forces a clean jump (crouch still passes under)
+
+// Spawn gaps (px) — easier at start, tighter at max speed
+const SPAWN_GAP_EASY = [340, 520] as const
+const SPAWN_GAP_HARD = [180, 320] as const
+
+// ─── Particles ───────────────────────────────────────────────────────────────
+const DUST_COUNT = 14
+const DUST_LIFE_FRAMES = 42
+
+// ─── Persistence ─────────────────────────────────────────────────────────────
+const HIGHSCORE_KEY = "ONE-ai-onerun-highscore"
+
+// ─── Score (meters traveled) ─────────────────────────────────────────────────
+const PIXELS_PER_METER = 18
+
+// ─── Player rotation physics ─────────────────────────────────────────────────
+// The player is a "rolling wheel": as the world scrolls leftward (player moves
+// right relative to the ground), a wheel must rotate clockwise — i.e. positive
+// degrees in CSS. Angular velocity tracks forward speed on the ground; in the
+// air friction decays it; jumps add a forward-flip impulse on top.
+const ROLL_FACTOR = 2.4 // deg/frame per px/frame of forward speed (clockwise)
+const SPIN_GROUND_EASE = 0.12 // how quickly ground angVel reaches the target
+const SPIN_AIR_FRICTION = 0.992
+const JUMP_SPIN_BONUS = 8 // forward-flip impulse on jump (additive, clockwise)
+const IDLE_SPIN_VELOCITY = 2.5 // gentle forward roll while waiting to start
+const GAMEOVER_SPIN_VELOCITY = 28 // forward tumble after death
+const CROUCH_SPIN_BOOST = 1.4 // smaller ball ⇒ spins faster (visual feedback)
+
+// Forgiveness inset on collision rectangles
+const COLLISION_INSET = 3
+
+type Rect = { x: number; y: number; w: number; h: number }
+export type Obstacle = {
+  id: number
+  type: "block" | "drone"
+  x: number
+  y: number
+  w: number
+  h: number
+  flap: number
+}
+type DustParticle = {
+  id: number
+  x: number
+  y: number
+  vx: number
+  vy: number
+  life: number
+  size: number
+}
+type GamePhase = "ready" | "playing" | "gameover"
+type DinoGameProps = { onClose: () => void }
+
+export function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value))
+}
+
+// AABB overlap with a small inset so a near-miss doesn't kill the player.
+export function aabbOverlap(a: Rect, b: Rect): boolean {
+  return (
+    a.x + COLLISION_INSET < b.x + b.w - COLLISION_INSET &&
+    a.x + a.w - COLLISION_INSET > b.x + COLLISION_INSET &&
+    a.y + COLLISION_INSET < b.y + b.h - COLLISION_INSET &&
+    a.y + a.h - COLLISION_INSET > b.y + COLLISION_INSET
+  )
+}
+
+export function applyJumpPhysics(
+  y: number,
+  vy: number,
+  dt: number,
+  fastFall: boolean
+): { y: number; vy: number } {
+  const g = fastFall ? FAST_FALL_GRAVITY : GRAVITY
+  return { y: y + vy * dt, vy: vy + g * dt }
+}
+
+// Speed ramp: linear interpolation, capped at MAX.
+export function speedAt(elapsedSec: number): number {
+  const t = clamp(elapsedSec / SPEED_RAMP_DURATION_S, 0, 1)
+  return BASE_SPEED + (MAX_SPEED - BASE_SPEED) * t
+}
+
+// Spawn-gap range tightens with difficulty.
+export function spawnGapRange(elapsedSec: number): readonly [number, number] {
+  const t = clamp(elapsedSec / SPEED_RAMP_DURATION_S, 0, 1)
+  return [
+    SPAWN_GAP_EASY[0] + (SPAWN_GAP_HARD[0] - SPAWN_GAP_EASY[0]) * t,
+    SPAWN_GAP_EASY[1] + (SPAWN_GAP_HARD[1] - SPAWN_GAP_EASY[1]) * t,
+  ] as const
+}
+
+function loadHighScore(): number {
+  if (typeof window === "undefined") return 0
+  const stored = readFromLocalStorage<number | null>(HIGHSCORE_KEY, null)
+  return typeof stored === "number" && stored >= 0 ? stored : 0
+}
+
+function saveHighScore(value: number): void {
+  if (typeof window === "undefined") return
+  writeToLocalStorage(HIGHSCORE_KEY, value)
+}
+
+let obstacleIdCounter = 0
+function nextObstacleId() {
+  obstacleIdCounter += 1
+  return obstacleIdCounter
+}
+
+// Convert raw pixel distance to displayed meters.
+export function pixelsToMeters(distancePx: number): number {
+  return Math.max(0, Math.floor(distancePx / PIXELS_PER_METER))
+}
+
+function spawnObstacle(
+  x: number,
+  groundY: number,
+  elapsedSec: number
+): Obstacle {
+  // Drones unlock earlier and spawn more often than blocks once unlocked.
+  if (elapsedSec >= UNLOCK_DRONE_S && Math.random() < DRONE_SPAWN_CHANCE) {
+    const high = Math.random() > 0.5
+    const offset = high ? DRONE_HIGH_OFFSET : DRONE_MID_OFFSET
+    return {
+      id: nextObstacleId(),
+      type: "drone",
+      x,
+      y: groundY + offset,
+      w: DRONE_W,
+      h: DRONE_H,
+      flap: 0,
+    }
+  }
+
+  // Block sizes unlock progressively
+  const maxIdx =
+    elapsedSec < UNLOCK_MEDIUM_BLOCK_S
+      ? 0
+      : elapsedSec < UNLOCK_LARGE_BLOCK_S
+        ? 1
+        : 2
+  const idx = Math.floor(Math.random() * (maxIdx + 1))
+  const variant = BLOCK_VARIANTS[idx]
+  return {
+    id: nextObstacleId(),
+    type: "block",
+    x,
+    y: groundY - variant.h,
+    w: variant.w,
+    h: variant.h,
+    flap: 0,
+  }
+}
+
+export const DinoGame = ({ onClose }: DinoGameProps) => {
+  const translations = useI18n()
+  const shouldReduceMotion = useReducedMotion()
+  const { activeGame } = useAiChat()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null)
+
+  // Game-loop refs (mutation-friendly)
+  const playerRef = useRef({ y: 0, vy: 0, onGround: true })
+  const crouchingRef = useRef(false)
+  const obstaclesRef = useRef<Obstacle[]>([])
+  const dustRef = useRef<DustParticle[]>([])
+  const dustIdRef = useRef(0)
+  const speedRef = useRef(BASE_SPEED)
+  const distanceRef = useRef(0) // total pixels traveled (used as meter score)
+  const phaseRef = useRef<GamePhase>("ready")
+  const shakeRef = useRef(0)
+  const nextSpawnXRef = useRef(0)
+  const groundOffsetRef = useRef(0)
+  const elapsedRef = useRef(0) // seconds spent in "playing"
+  const lastTimeRef = useRef(0)
+  const animationRef = useRef(0)
+  const containerSize = useRef({ width: 0, height: 0 })
+  const groundYRef = useRef(0)
+  const highScoreRef = useRef(0)
+  const keysPressed = useRef(new Set<string>())
+  // Body rotation: physics-based — angular velocity decays in air, snaps on land.
+  const playerAngleRef = useRef(0)
+  const playerVRotRef = useRef(0)
+
+  // Render state
+  const [playerY, setPlayerY] = useState(0)
+  const [playerCrouching, setPlayerCrouching] = useState(false)
+  const [playerAngle, setPlayerAngle] = useState(0)
+  const [obstacles, setObstacles] = useState<Obstacle[]>([])
+  const [dust, setDust] = useState<DustParticle[]>([])
+  const [meters, setMeters] = useState(0)
+  const [highScore, setHighScore] = useState(0)
+  const [phase, setPhase] = useState<GamePhase>("ready")
+  const [shake, setShake] = useState(0)
+  const [groundOffset, setGroundOffset] = useState(0)
+
+  const resetGame = useCallback(() => {
+    const { width, height } = containerSize.current
+    const groundY = height * GROUND_Y_FRACTION
+    groundYRef.current = groundY
+    playerRef.current = {
+      y: groundY - PLAYER_SIZE,
+      vy: 0,
+      onGround: true,
+    }
+    crouchingRef.current = false
+    obstaclesRef.current = []
+    dustRef.current = []
+    speedRef.current = BASE_SPEED
+    distanceRef.current = 0
+    elapsedRef.current = 0
+    nextSpawnXRef.current = width + 80
+    groundOffsetRef.current = 0
+    shakeRef.current = 0
+    playerAngleRef.current = 0
+    playerVRotRef.current = 0
+    setPlayerY(groundY - PLAYER_SIZE)
+    setPlayerCrouching(false)
+    setPlayerAngle(0)
+    setObstacles([])
+    setDust([])
+    setMeters(0)
+    setShake(0)
+  }, [])
+
+  const triggerGameOver = useCallback(() => {
+    if (phaseRef.current === "gameover") return
+    phaseRef.current = "gameover"
+    setPhase("gameover")
+
+    const finalMeters = pixelsToMeters(distanceRef.current)
+    if (finalMeters > highScoreRef.current) {
+      highScoreRef.current = finalMeters
+      saveHighScore(finalMeters)
+      setHighScore(finalMeters)
+    }
+
+    // Death tumble: snap to a strong angular velocity that decays naturally.
+    playerVRotRef.current = GAMEOVER_SPIN_VELOCITY
+
+    if (shouldReduceMotion) return
+    shakeRef.current = 10
+    const p = playerRef.current
+    const cx = PLAYER_X + PLAYER_SIZE / 2
+    const cy = p.y + PLAYER_SIZE / 2
+    for (let i = 0; i < DUST_COUNT; i++) {
+      dustRef.current.push({
+        id: ++dustIdRef.current,
+        x: cx,
+        y: cy,
+        vx: (Math.random() - 0.5) * 5,
+        vy: -1 - Math.random() * 4,
+        life: DUST_LIFE_FRAMES,
+        size: 3 + Math.random() * 5,
+      })
+    }
+  }, [shouldReduceMotion])
+
+  const startGame = useCallback(() => {
+    resetGame()
+    phaseRef.current = "playing"
+    setPhase("playing")
+  }, [resetGame])
+
+  const jump = useCallback(() => {
+    if (phaseRef.current === "ready") {
+      startGame()
+      return
+    }
+    if (phaseRef.current === "gameover") {
+      startGame()
+      return
+    }
+    if (playerRef.current.onGround) {
+      playerRef.current.vy = JUMP_VELOCITY
+      playerRef.current.onGround = false
+      // Kick adds to current rolling spin so the player keeps coherent motion.
+      playerVRotRef.current += JUMP_SPIN_BONUS
+      crouchingRef.current = false
+      setPlayerCrouching(false)
+    }
+  }, [startGame])
+
+  // High score on mount + focus capture for restore on close
+  useEffect(() => {
+    const hs = loadHighScore()
+    highScoreRef.current = hs
+    setHighScore(hs)
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null
+    return () => {
+      previouslyFocusedRef.current?.focus?.()
+    }
+  }, [])
+
+  // Keyboard — bound only while the game is the active overlay
+  useEffect(() => {
+    if (activeGame !== "dino") return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation()
+        onClose()
+        return
+      }
+      if (e.key === " " || e.key === "ArrowUp" || e.code === "Space") {
+        e.preventDefault()
+        e.stopPropagation()
+        jump()
+        return
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        e.stopPropagation()
+        keysPressed.current.add("ArrowDown")
+        if (phaseRef.current === "playing" && playerRef.current.onGround) {
+          crouchingRef.current = true
+          setPlayerCrouching(true)
+        }
+      }
+    }
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        keysPressed.current.delete("ArrowDown")
+        crouchingRef.current = false
+        setPlayerCrouching(false)
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown, true)
+    window.addEventListener("keyup", handleKeyUp, true)
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true)
+      window.removeEventListener("keyup", handleKeyUp, true)
+    }
+  }, [activeGame, jump, onClose])
+
+  // Main game loop
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const measure = () => {
+      const rect = container.getBoundingClientRect()
+      containerSize.current = { width: rect.width, height: rect.height }
+      groundYRef.current = rect.height * GROUND_Y_FRACTION
+      // Reposition the player on the new ground if not started yet
+      if (phaseRef.current === "ready") {
+        playerRef.current.y = groundYRef.current - PLAYER_SIZE
+        setPlayerY(playerRef.current.y)
+      }
+    }
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(container)
+
+    resetGame()
+    container.focus({ preventScroll: true })
+
+    const handlePointerDown = (e: PointerEvent) => {
+      e.preventDefault()
+      jump()
+    }
+    container.addEventListener("pointerdown", handlePointerDown)
+
+    const gameLoop = (timestamp: number) => {
+      if (!lastTimeRef.current) lastTimeRef.current = timestamp
+      const rawDt = (timestamp - lastTimeRef.current) / 16.667
+      const dt = Math.min(rawDt, 3)
+      lastTimeRef.current = timestamp
+
+      const { width } = containerSize.current
+      const groundY = groundYRef.current
+
+      // Shake decay (always)
+      if (shakeRef.current > 0) {
+        shakeRef.current *= 0.85
+        if (shakeRef.current < 0.5) shakeRef.current = 0
+      }
+
+      // Body rotation: physics-based, "rolling wheel" feel.
+      // - Ready / playing on ground: angVel eases toward target = -speed * ROLL_FACTOR
+      // - In air: angVel keeps its value with mild friction (carries jump impulse)
+      // - Game over: tumble decays with friction
+      if (phaseRef.current === "gameover") {
+        playerVRotRef.current *= SPIN_AIR_FRICTION
+      } else if (playerRef.current.onGround) {
+        const baseTarget =
+          phaseRef.current === "playing"
+            ? speedRef.current * ROLL_FACTOR
+            : IDLE_SPIN_VELOCITY
+        const target = crouchingRef.current
+          ? baseTarget * CROUCH_SPIN_BOOST
+          : baseTarget
+        playerVRotRef.current +=
+          (target - playerVRotRef.current) * SPIN_GROUND_EASE * dt
+      } else {
+        playerVRotRef.current *= SPIN_AIR_FRICTION
+      }
+      playerAngleRef.current =
+        (playerAngleRef.current + playerVRotRef.current * dt) % 360
+
+      if (phaseRef.current === "playing") {
+        elapsedRef.current += dt / 60
+        speedRef.current = speedAt(elapsedRef.current)
+
+        // Player physics
+        const p = playerRef.current
+        if (!p.onGround) {
+          const fastFall = keysPressed.current.has("ArrowDown") && p.vy > 0
+          const next = applyJumpPhysics(p.y, p.vy, dt, fastFall)
+          p.y = next.y
+          p.vy = next.vy
+          const groundTop = groundY - PLAYER_SIZE
+          if (p.y >= groundTop) {
+            p.y = groundTop
+            p.vy = 0
+            p.onGround = true
+            if (keysPressed.current.has("ArrowDown")) {
+              crouchingRef.current = true
+              setPlayerCrouching(true)
+            }
+          }
+        } else {
+          // Snap player to ground for current pose height
+          p.y = groundY - PLAYER_SIZE
+        }
+
+        // Move and cull obstacles
+        const moveBy = speedRef.current * dt
+        // Distance traveled — drives the meter score.
+        distanceRef.current += moveBy
+        for (const o of obstaclesRef.current) {
+          o.x -= moveBy
+          // ~2.4 Hz wing flap @60fps — calm, dignified, not a panicked blur.
+          if (o.type === "drone") o.flap += dt * 0.04
+        }
+        obstaclesRef.current = obstaclesRef.current.filter(
+          (o) => o.x + o.w > -20
+        )
+
+        // Spawn new obstacles
+        nextSpawnXRef.current -= moveBy
+        while (nextSpawnXRef.current < width) {
+          const obs = spawnObstacle(width + 30, groundY, elapsedRef.current)
+          obstaclesRef.current.push(obs)
+          const [min, max] = spawnGapRange(elapsedRef.current)
+          nextSpawnXRef.current += min + Math.random() * (max - min)
+        }
+
+        // Ground scroll
+        groundOffsetRef.current = (groundOffsetRef.current + moveBy) % 16
+
+        // Collisions (drones don't trigger collide while crouching well below)
+        const playerH = PLAYER_SIZE
+        const playerRect: Rect = {
+          x: PLAYER_X,
+          y: p.y,
+          w: PLAYER_SIZE,
+          h: crouchingRef.current ? playerH * 0.55 : playerH,
+        }
+        // When crouching, hitbox starts lower
+        if (crouchingRef.current) {
+          playerRect.y = p.y + playerH * 0.45
+        }
+        for (const o of obstaclesRef.current) {
+          if (aabbOverlap(playerRect, o)) {
+            triggerGameOver()
+            break
+          }
+        }
+      }
+
+      // Particles always update (death cloud animates after game over)
+      if (dustRef.current.length > 0) {
+        for (const dp of dustRef.current) {
+          dp.x += dp.vx * dt
+          dp.y += dp.vy * dt
+          dp.vy += 0.4 * dt
+          dp.life -= dt
+        }
+        dustRef.current = dustRef.current.filter((p) => p.life > 0)
+      }
+
+      // Commit render state
+      setPlayerY(playerRef.current.y)
+      setPlayerAngle(playerAngleRef.current)
+      setObstacles([...obstaclesRef.current])
+      setDust([...dustRef.current])
+      setMeters(pixelsToMeters(distanceRef.current))
+      setShake(shakeRef.current)
+      setGroundOffset(groundOffsetRef.current)
+
+      animationRef.current = requestAnimationFrame(gameLoop)
+    }
+
+    lastTimeRef.current = 0
+    animationRef.current = requestAnimationFrame(gameLoop)
+
+    return () => {
+      cancelAnimationFrame(animationRef.current)
+      container.removeEventListener("pointerdown", handlePointerDown)
+      ro.disconnect()
+    }
+  }, [jump, resetGame, triggerGameOver])
+
+  const shakeX = shake > 0.5 ? (Math.random() - 0.5) * shake : 0
+  const shakeY = shake > 0.5 ? (Math.random() - 0.5) * shake : 0
+
+  return (
+    <div
+      className="absolute inset-0 z-[60] flex flex-col bg-f1-special-page"
+      role="dialog"
+      aria-label={translations.ai.dino.title}
+    >
+      {/* Header — same shape as PongGame for consistency */}
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-base font-medium text-f1-foreground">
+          {translations.ai.dino.title}
+        </span>
+        <F0Button
+          icon={Cross}
+          label={translations.actions.close}
+          onClick={onClose}
+          variant="ghost"
+          hideLabel
+        />
+      </div>
+
+      {/* Game area */}
+      <div
+        ref={containerRef}
+        tabIndex={-1}
+        className="relative flex-1 overflow-hidden outline-none"
+        style={{
+          touchAction: "none",
+          transform: `translate(${shakeX}px, ${shakeY}px)`,
+          cursor: "pointer",
+        }}
+      >
+        <BrandGlow />
+        <Ground offset={groundOffset} groundY={groundYRef.current || 0} />
+        <Player
+          y={playerY}
+          crouching={playerCrouching}
+          angle={playerAngle}
+          dead={phase === "gameover"}
+        />
+        {obstacles.map((o) =>
+          o.type === "block" ? (
+            <Block key={o.id} obstacle={o} />
+          ) : (
+            <Drone key={o.id} obstacle={o} />
+          )
+        )}
+        {dust.map((p) => (
+          <DustDot key={p.id} particle={p} />
+        ))}
+        <ScorePanel
+          meters={meters}
+          highScore={highScore}
+          hiLabel={translations.ai.dino.hi}
+          scoreLabel={translations.ai.dino.score}
+        />
+        {phase === "ready" && (
+          <Overlay text={translations.ai.dino.tapToStart} />
+        )}
+        {phase === "gameover" && (
+          <GameOverOverlay
+            title={translations.ai.dino.gameOver}
+            restartHint={translations.ai.dino.pressToRestart}
+            meters={meters}
+            highScore={highScore}
+            isNewRecord={meters > 0 && meters >= highScore}
+            newRecordLabel={translations.ai.dino.newRecord}
+            yourScoreLabel={translations.ai.dino.yourScore}
+          />
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-center gap-4 border-0 border-t border-solid border-f1-border-secondary px-3 py-3 text-sm font-medium text-f1-foreground-secondary">
+        <span>{translations.ai.dino.controls}</span>
+        <span aria-hidden>·</span>
+        <span>{translations.ai.dino.escToExit}</span>
+      </div>
+    </div>
+  )
+}
+
+DinoGame.displayName = "DinoGame"
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function BrandGlow() {
+  // Soft brand-color glow at the horizon for atmosphere — never too loud.
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-x-0 bottom-0 h-1/3"
+      style={{
+        background:
+          "radial-gradient(ellipse at 50% 100%, rgba(229, 86, 25, 0.10), transparent 65%)",
+      }}
+    />
+  )
+}
+
+function Ground({ offset, groundY }: { offset: number; groundY: number }) {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-x-0"
+      style={{ top: groundY, height: 16 }}
+    >
+      <div className="absolute inset-x-0 top-0 h-px bg-f1-foreground/70" />
+      <svg
+        className="absolute left-0 top-0 h-4 w-[200%]"
+        style={{ transform: `translateX(${-offset}px)`, opacity: 0.45 }}
+      >
+        <defs>
+          <pattern
+            id="onerun-ground"
+            x="0"
+            y="0"
+            width="16"
+            height="16"
+            patternUnits="userSpaceOnUse"
+          >
+            <rect
+              x="0"
+              y="4"
+              width="9"
+              height="2"
+              fill="currentColor"
+              opacity="0.55"
+            />
+            <rect
+              x="11"
+              y="9"
+              width="3"
+              height="2"
+              fill="currentColor"
+              opacity="0.4"
+            />
+          </pattern>
+        </defs>
+        <rect
+          width="100%"
+          height="100%"
+          fill="url(#onerun-ground)"
+          className="text-f1-foreground"
+        />
+      </svg>
+    </div>
+  )
+}
+
+// ─── Player ──────────────────────────────────────────────────────────────────
+// Wraps the canonical F0OneIcon — its conic-gradient + 4-petal silhouette
+// IS the brand. We sit it inside a sized wrapper that rotates as a rigid
+// body, while the icon's own gradient continues its slow internal animation.
+export function Player({
+  y,
+  crouching,
+  angle,
+  dead,
+  size = PLAYER_SIZE,
+  x = PLAYER_X,
+}: {
+  y: number
+  crouching: boolean
+  angle: number
+  dead: boolean
+  size?: number
+  x?: number
+}) {
+  // Crouch: just render the icon smaller, anchored to the ground line.
+  const CROUCH_SCALE = 0.6
+  const renderSize = crouching ? size * CROUCH_SCALE : size
+  const top = crouching ? y + (size - renderSize) : y
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute"
+      style={{
+        left: x + (size - renderSize) / 2,
+        top,
+        width: renderSize,
+        height: renderSize,
+        transform: `rotate(${angle}deg)`,
+        transformOrigin: "center",
+        willChange: "transform",
+        opacity: dead ? 0.7 : 1,
+        filter: dead ? "saturate(0.6)" : undefined,
+      }}
+    >
+      {/* `!h-full !w-full` overrides F0OneIcon's fixed size variant so the
+          icon fills our sized wrapper. */}
+      <F0OneIcon size="md" className="!h-full !w-full" />
+    </div>
+  )
+}
+
+// ─── Block (jumpable obstacle) ───────────────────────────────────────────────
+// Video-game "hazard crate": chunky dark border, brand gradient body, a
+// horizontal panel divider that suggests stacked bricks, and — for taller
+// blocks — corner rivets plus a center "!" mark in pixel-art style.
+export function Block({
+  obstacle,
+  absolute = true,
+}: {
+  obstacle: Obstacle
+  absolute?: boolean
+}) {
+  const { w, h, id } = obstacle
+  const isMedium = h >= 22
+  const isLarge = h >= 28
+  const borderColor = "#8B0F25"
+  const borderWidth = isMedium ? 1.5 : 1
+  // Panel divider runs across the middle (slight bias upwards so taller
+  // blocks read as a smaller "cap" stacked on a larger base).
+  const dividerY = Math.round(h * 0.42)
+  return (
+    <div
+      aria-hidden
+      className={cn("pointer-events-none", absolute && "absolute")}
+      style={{
+        left: absolute ? obstacle.x : undefined,
+        top: absolute ? obstacle.y : undefined,
+        width: w,
+        height: h,
+      }}
+    >
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        width={w}
+        height={h}
+        style={{ display: "block" }}
+      >
+        <defs>
+          <linearGradient id={`onerun-block-${id}`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#FF7B3D" />
+            <stop offset="55%" stopColor="#E55619" />
+            <stop offset="100%" stopColor="#E51943" />
+          </linearGradient>
+        </defs>
+
+        {/* Body */}
+        <rect
+          x="0"
+          y="0"
+          width={w}
+          height={h}
+          rx="2"
+          fill={`url(#onerun-block-${id})`}
+        />
+
+        {/* Top highlight stripe — bevel-light on the upper face */}
+        <rect
+          x="2"
+          y="2"
+          width={Math.max(0, w - 4)}
+          height="1.5"
+          rx="0.75"
+          fill="rgba(255,255,255,0.55)"
+        />
+
+        {/* Panel divider — dark line + 1px light line below = "brick mortar" */}
+        <rect x="0" y={dividerY} width={w} height="1" fill="rgba(0,0,0,0.28)" />
+        <rect
+          x="0"
+          y={dividerY + 1}
+          width={w}
+          height="1"
+          fill="rgba(255,255,255,0.22)"
+        />
+
+        {/* Center "!" mark — pixel-art glyph for tall crates */}
+        {isLarge && (
+          <g fill="rgba(255,255,255,0.95)">
+            <rect
+              x={w / 2 - 1}
+              y={dividerY + 4}
+              width="2"
+              height={Math.max(4, h - dividerY - 9)}
+            />
+            <rect x={w / 2 - 1} y={h - 4} width="2" height="2" />
+          </g>
+        )}
+
+        {/* Corner rivets for medium+ — classic crate hardware */}
+        {isMedium && (
+          <g fill="rgba(0,0,0,0.45)">
+            <rect x="2.5" y="2.5" width="1.5" height="1.5" />
+            <rect x={w - 4} y="2.5" width="1.5" height="1.5" />
+            <rect x="2.5" y={h - 4} width="1.5" height="1.5" />
+            <rect x={w - 4} y={h - 4} width="1.5" height="1.5" />
+          </g>
+        )}
+
+        {/* Crisp outer border — strokes are inset by half their width so
+            they sit cleanly inside the rounded rectangle. */}
+        <rect
+          x={borderWidth / 2}
+          y={borderWidth / 2}
+          width={w - borderWidth}
+          height={h - borderWidth}
+          rx="2"
+          fill="none"
+          stroke={borderColor}
+          strokeWidth={borderWidth}
+        />
+      </svg>
+    </div>
+  )
+}
+
+// ─── Drone (flying obstacle) ─────────────────────────────────────────────────
+// A stylized swallow-like bird: streamlined two-tone body, forked tail,
+// smoothly-animating wings (continuous sin interpolation, not toggled poses),
+// gentle vertical bob on each downstroke, distinct head with eye + beak.
+export function Drone({
+  obstacle,
+  absolute = true,
+}: {
+  obstacle: Obstacle
+  absolute?: boolean
+}) {
+  // Continuous wing phase: -1 (full down) → +1 (full up).
+  const phase = Math.sin(obstacle.flap * Math.PI * 2)
+  // Body bobs slightly — rises on downstroke (lift), sinks on upstroke.
+  const bodyBob = -phase * 0.06
+  // Wing tip vertical offset relative to body center
+  const wingY = -phase * 0.42
+  // Eye blink runs faster than the flap so it stays perceptible.
+  const blinkOn = Math.sin(obstacle.flap * Math.PI * 2 * 3.2) > -0.4
+  const w = obstacle.w
+  const h = obstacle.h
+  // Pre-computed Y coordinates in viewBox space
+  const cy = h * 0.5
+  const tipY = cy + wingY * h
+  return (
+    <div
+      aria-hidden
+      className={cn("pointer-events-none", absolute && "absolute")}
+      style={{
+        left: absolute ? obstacle.x : undefined,
+        top: absolute ? obstacle.y : undefined,
+        width: w,
+        height: h,
+        transform: `translateY(${bodyBob * h}px)`,
+        willChange: "transform",
+      }}
+    >
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        width={w}
+        height={h}
+        style={{ display: "block" }}
+      >
+        <defs>
+          <linearGradient
+            id={`onerun-drone-body-${obstacle.id}`}
+            x1="0"
+            y1="0"
+            x2="0"
+            y2="1"
+          >
+            <stop offset="0%" stopColor="#5862A8" />
+            <stop offset="55%" stopColor="#7C8AD6" />
+            <stop offset="100%" stopColor="#C8D2EC" />
+          </linearGradient>
+          <linearGradient
+            id={`onerun-drone-wing-${obstacle.id}`}
+            x1="0"
+            y1="0"
+            x2="1"
+            y2="0"
+          >
+            <stop offset="0%" stopColor="#5862A8" />
+            <stop offset="100%" stopColor="#A1ADE5" />
+          </linearGradient>
+        </defs>
+
+        {/* Forked tail (drawn first so the body overlaps its base) */}
+        <path
+          d={`M ${w * 0.02} ${cy}
+              L ${w * 0.18} ${cy - h * 0.18}
+              L ${w * 0.24} ${cy}
+              L ${w * 0.18} ${cy + h * 0.18} Z`}
+          fill="#5862A8"
+        />
+
+        {/* Far wing — slightly behind, smaller, with continuous tip motion */}
+        <path
+          d={`M ${w * 0.46} ${cy}
+              Q ${w * 0.32} ${cy + (tipY - cy) * 0.7}
+                ${w * 0.16} ${tipY}
+              Q ${w * 0.34} ${cy + (tipY - cy) * 0.45}
+                ${w * 0.5} ${cy + 1.5} Z`}
+          fill={`url(#onerun-drone-wing-${obstacle.id})`}
+          opacity="0.7"
+        />
+
+        {/* Streamlined body — teardrop shape */}
+        <path
+          d={`M ${w * 0.2} ${cy}
+              Q ${w * 0.2} ${cy - h * 0.3}
+                ${w * 0.55} ${cy - h * 0.3}
+              Q ${w * 0.8} ${cy - h * 0.3}
+                ${w * 0.83} ${cy}
+              Q ${w * 0.8} ${cy + h * 0.3}
+                ${w * 0.55} ${cy + h * 0.3}
+              Q ${w * 0.2} ${cy + h * 0.3}
+                ${w * 0.2} ${cy} Z`}
+          fill={`url(#onerun-drone-body-${obstacle.id})`}
+        />
+
+        {/* Near wing — drawn over the body, larger, leads the motion */}
+        <path
+          d={`M ${w * 0.5} ${cy - h * 0.05}
+              Q ${w * 0.36} ${cy + (tipY - cy) * 0.85}
+                ${w * 0.2} ${tipY}
+              Q ${w * 0.4} ${cy + (tipY - cy) * 0.5}
+                ${w * 0.56} ${cy + h * 0.05} Z`}
+          fill={`url(#onerun-drone-wing-${obstacle.id})`}
+        />
+
+        {/* Head — slightly raised cap on top of the body */}
+        <ellipse
+          cx={w * 0.78}
+          cy={cy - h * 0.08}
+          rx={w * 0.13}
+          ry={h * 0.28}
+          fill="#5862A8"
+        />
+
+        {/* Beak — short pointed triangle */}
+        <path
+          d={`M ${w * 0.88} ${cy - h * 0.08}
+              L ${w * 1.0} ${cy - h * 0.02}
+              L ${w * 0.88} ${cy + h * 0.04} Z`}
+          fill="#E55619"
+        />
+
+        {/* Eye — white sclera + pupil + tiny highlight */}
+        <circle
+          cx={w * 0.82}
+          cy={cy - h * 0.16}
+          r={Math.max(1.4, h * 0.13)}
+          fill="white"
+        />
+        <circle
+          cx={w * 0.83}
+          cy={cy - h * 0.14}
+          r={Math.max(0.7, h * 0.07)}
+          fill={blinkOn ? "#1A1A2E" : "rgba(26,26,46,0.5)"}
+        />
+        <circle
+          cx={w * 0.835}
+          cy={cy - h * 0.17}
+          r={Math.max(0.3, h * 0.025)}
+          fill="white"
+        />
+
+        {/* Subtle belly highlight */}
+        <ellipse
+          cx={w * 0.5}
+          cy={cy + h * 0.15}
+          rx={w * 0.22}
+          ry={h * 0.08}
+          fill="rgba(255,255,255,0.25)"
+        />
+      </svg>
+    </div>
+  )
+}
+
+function DustDot({ particle }: { particle: DustParticle }) {
+  const opacity = clamp(particle.life / DUST_LIFE_FRAMES, 0, 1)
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute rounded-full bg-f1-foreground-secondary"
+      style={{
+        left: particle.x - particle.size / 2,
+        top: particle.y - particle.size / 2,
+        width: particle.size,
+        height: particle.size,
+        opacity: opacity * 0.55,
+      }}
+    />
+  )
+}
+
+function ScorePanel({
+  meters,
+  highScore,
+  hiLabel,
+  scoreLabel,
+}: {
+  meters: number
+  highScore: number
+  hiLabel: string
+  scoreLabel: string
+}) {
+  return (
+    <div className="font-mono pointer-events-none absolute right-6 top-3 flex items-baseline gap-3 text-xl font-semibold tabular-nums text-f1-foreground">
+      {highScore > 0 && (
+        <span className="text-base">
+          <span className="text-f1-foreground-tertiary">{hiLabel} </span>
+          {highScore.toString().padStart(5, "0")}
+          <span className="text-f1-foreground-tertiary">m</span>
+        </span>
+      )}
+      <span aria-label={scoreLabel}>
+        {meters.toString().padStart(5, "0")}
+        <span className="text-f1-foreground-tertiary">m</span>
+      </span>
+    </div>
+  )
+}
+
+function Overlay({ title, text }: { title?: string; text: string }) {
+  return (
+    <div className="pointer-events-none absolute inset-0 z-30 flex flex-col items-center justify-center gap-2 px-4 text-center">
+      {title && (
+        <span className="text-2xl font-semibold text-f1-foreground">
+          {title}
+        </span>
+      )}
+      <span
+        className={cn(
+          "text-base font-medium text-f1-foreground-secondary",
+          !title && "text-lg"
+        )}
+      >
+        {text}
+      </span>
+    </div>
+  )
+}
+
+function GameOverOverlay({
+  title,
+  restartHint,
+  meters,
+  highScore,
+  isNewRecord,
+  newRecordLabel,
+  yourScoreLabel,
+}: {
+  title: string
+  restartHint: string
+  meters: number
+  highScore: number
+  isNewRecord: boolean
+  newRecordLabel: string
+  yourScoreLabel: string
+}) {
+  return (
+    <div className="pointer-events-none absolute inset-0 z-30 flex flex-col items-center justify-center gap-2 px-4 text-center">
+      <span className="mb-5 text-4xl font-semibold text-f1-foreground">
+        {title}
+      </span>
+      <div className="flex flex-col items-center gap-1">
+        <span className="text-base font-semibold uppercase tracking-wide text-f1-foreground-tertiary">
+          {yourScoreLabel}
+        </span>
+        <span className="font-mono text-4xl font-semibold tabular-nums text-f1-foreground">
+          {meters.toString().padStart(5, "0")}
+          <span className="text-lg text-f1-foreground-secondary">m</span>
+        </span>
+        {isNewRecord ? (
+          <span
+            className="mt-1 rounded-full px-3 py-1 text-base font-semibold text-f1-background"
+            style={{
+              background:
+                "linear-gradient(90deg, #E55619 0%, #E51943 50%, #A1ADE5 100%)",
+            }}
+          >
+            {newRecordLabel}
+          </span>
+        ) : (
+          highScore > 0 && (
+            <span className="mt-2 text-base text-f1-foreground-secondary">
+              HI {highScore.toString().padStart(5, "0")}m
+            </span>
+          )
+        )}
+      </div>
+      <span className="mt-5 text-base font-medium text-f1-foreground-secondary">
+        {restartHint}
+      </span>
+    </div>
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChat/components/__stories__/OneRunSprites.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/__stories__/OneRunSprites.stories.tsx
@@ -1,0 +1,345 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useEffect, useState } from "react"
+
+import { Block, Drone, type Obstacle, Player } from "../DinoGame"
+
+/**
+ * Isolated previews of the One Run game sprites so we can iterate on the
+ * visuals (player, blocks, drones) without launching the full game.
+ *
+ * Each sprite is positioned absolutely inside a small staged box, mimicking
+ * the in-game layout: the world has a "ground line" at GROUND_Y_FRACTION and
+ * the player sits on it, drones fly above, blocks stand on the ground.
+ */
+
+const meta: Meta = {
+  title: "AI/F0AiChat/One Run sprites",
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+}
+export default meta
+type Story = StoryObj
+
+// ─── Stage helpers ───────────────────────────────────────────────────────────
+
+function Stage({
+  width = 220,
+  height = 140,
+  children,
+  label,
+}: {
+  width?: number
+  height?: number
+  children: React.ReactNode
+  label?: string
+}) {
+  // Same baseline as the in-game world (~78% from the top).
+  const groundY = Math.round(height * 0.78)
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        className="relative overflow-hidden rounded-md border border-solid border-f1-border-secondary bg-f1-special-page"
+        style={{ width, height }}
+      >
+        {/* Ground line for visual reference */}
+        <div
+          aria-hidden
+          className="absolute inset-x-0 h-px bg-f1-foreground/70"
+          style={{ top: groundY }}
+        />
+        {children}
+      </div>
+      {label && (
+        <span className="text-center text-xs font-medium text-f1-foreground-secondary">
+          {label}
+        </span>
+      )}
+    </div>
+  )
+}
+
+// Mini hook: drives a continuously increasing "flap" counter for animated drones.
+function useFlap(speed = 0.06) {
+  const [flap, setFlap] = useState(0)
+  useEffect(() => {
+    let raf = 0
+    let last = performance.now()
+    const tick = (t: number) => {
+      const dt = (t - last) / 16.667
+      last = t
+      setFlap((f) => f + speed * dt)
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [speed])
+  return flap
+}
+
+// Mini hook: rotates the player's body angle continuously for the spin preview.
+function useSpin(degPerFrame = 4) {
+  const [angle, setAngle] = useState(0)
+  useEffect(() => {
+    let raf = 0
+    let last = performance.now()
+    const tick = (t: number) => {
+      const dt = (t - last) / 16.667
+      last = t
+      setAngle((a) => (a + degPerFrame * dt) % 360)
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [degPerFrame])
+  return angle
+}
+
+// ─── Player stories ──────────────────────────────────────────────────────────
+
+export const Player_Idle: Story = {
+  name: "Player / idle on ground",
+  render: () => {
+    const stageH = 140
+    const groundY = Math.round(stageH * 0.78)
+    return (
+      <Stage height={stageH} label="Idle, upright on the ground">
+        <Player
+          y={groundY - 32}
+          crouching={false}
+          angle={0}
+          dead={false}
+          x={94}
+        />
+      </Stage>
+    )
+  },
+}
+
+export const Player_Crouching: Story = {
+  name: "Player / crouching",
+  render: () => {
+    const stageH = 140
+    const groundY = Math.round(stageH * 0.78)
+    return (
+      <Stage height={stageH} label="Crouching (↓ key)">
+        <Player
+          y={groundY - 32}
+          crouching={true}
+          angle={0}
+          dead={false}
+          x={94}
+        />
+      </Stage>
+    )
+  },
+}
+
+export const Player_Spinning: Story = {
+  name: "Player / spinning (jump animation)",
+  render: () => {
+    const angle = useSpin(6)
+    const stageH = 140
+    const groundY = Math.round(stageH * 0.78)
+    return (
+      <Stage height={stageH} label="Continuous rotation — body spin in flight">
+        <Player
+          y={groundY - 60}
+          crouching={false}
+          angle={angle}
+          dead={false}
+          x={94}
+        />
+      </Stage>
+    )
+  },
+}
+
+export const Player_Dead: Story = {
+  name: "Player / game over",
+  render: () => {
+    const stageH = 140
+    const groundY = Math.round(stageH * 0.78)
+    return (
+      <Stage height={stageH} label="Dead — drop shadow shifts to red">
+        <Player
+          y={groundY - 32}
+          crouching={false}
+          angle={18}
+          dead={true}
+          x={94}
+        />
+      </Stage>
+    )
+  },
+}
+
+export const Player_Sizes: Story = {
+  name: "Player / sizes",
+  render: () => (
+    <div className="flex items-end gap-4">
+      {[24, 32, 48, 64].map((size) => (
+        <Stage
+          key={size}
+          width={size + 60}
+          height={size + 60}
+          label={`${size}px`}
+        >
+          <Player
+            y={Math.round((size + 60) * 0.78) - size}
+            crouching={false}
+            angle={0}
+            dead={false}
+            size={size}
+            x={30}
+          />
+        </Stage>
+      ))}
+    </div>
+  ),
+}
+
+// ─── Block stories ───────────────────────────────────────────────────────────
+
+function blockObstacle(
+  w: number,
+  h: number,
+  x: number,
+  groundY: number
+): Obstacle {
+  return {
+    id: Math.floor(Math.random() * 1e6),
+    type: "block",
+    x,
+    y: groundY - h,
+    w,
+    h,
+    flap: 0,
+  }
+}
+
+export const Block_Sizes: Story = {
+  name: "Block / all sizes",
+  render: () => {
+    const stageH = 140
+    const groundY = Math.round(stageH * 0.78)
+    return (
+      <Stage width={260} height={stageH} label="Small · medium · large">
+        <Block obstacle={blockObstacle(12, 18, 50, groundY)} />
+        <Block obstacle={blockObstacle(18, 24, 110, groundY)} />
+        <Block obstacle={blockObstacle(24, 30, 180, groundY)} />
+      </Stage>
+    )
+  },
+}
+
+export const Block_Single: Story = {
+  name: "Block / single (zoomed)",
+  render: () => {
+    const stageH = 200
+    const groundY = Math.round(stageH * 0.78)
+    return (
+      <Stage width={200} height={stageH} label="Large block (24×30)">
+        <Block obstacle={blockObstacle(24, 30, 88, groundY)} />
+      </Stage>
+    )
+  },
+}
+
+// ─── Drone stories ───────────────────────────────────────────────────────────
+
+function droneObstacle(
+  flap: number,
+  x: number,
+  y: number,
+  w = 30,
+  h = 14
+): Obstacle {
+  return { id: 1, type: "drone", x, y, w, h, flap }
+}
+
+export const Drone_WingsUp: Story = {
+  name: "Drone / wings up",
+  render: () => (
+    <Stage label="Wings up pose (frozen for inspection)">
+      <Drone obstacle={droneObstacle(0.1, 95, 45)} />
+    </Stage>
+  ),
+}
+
+export const Drone_WingsDown: Story = {
+  name: "Drone / wings down",
+  render: () => (
+    <Stage label="Wings down pose (frozen for inspection)">
+      <Drone obstacle={droneObstacle(0.6, 95, 45)} />
+    </Stage>
+  ),
+}
+
+export const Drone_Animated: Story = {
+  name: "Drone / animated flap",
+  render: () => {
+    const flap = useFlap(0.08)
+    return (
+      <Stage label="Continuous flap + tilt + LED blink">
+        <Drone obstacle={droneObstacle(flap, 95, 45)} />
+      </Stage>
+    )
+  },
+}
+
+export const Drone_Sizes: Story = {
+  name: "Drone / sizes",
+  render: () => {
+    const flap = useFlap(0.08)
+    return (
+      <div className="flex items-center gap-3">
+        {[
+          [22, 12],
+          [30, 14],
+          [44, 20],
+          [60, 28],
+        ].map(([w, h]) => (
+          <Stage
+            key={`${w}x${h}`}
+            width={w + 70}
+            height={90}
+            label={`${w}×${h}`}
+          >
+            <Drone obstacle={droneObstacle(flap, 35, 35)} />
+          </Stage>
+        ))}
+      </div>
+    )
+  },
+}
+
+// ─── Combined parade ─────────────────────────────────────────────────────────
+
+export const ParadeLineup: Story = {
+  name: "All sprites in one stage",
+  render: () => {
+    const flap = useFlap(0.08)
+    const angle = useSpin(5)
+    const stageH = 180
+    const groundY = Math.round(stageH * 0.78)
+    return (
+      <Stage
+        width={420}
+        height={stageH}
+        label="Player (spinning), drone, three block sizes"
+      >
+        <Player
+          y={groundY - 32}
+          crouching={false}
+          angle={angle}
+          dead={false}
+          x={36}
+        />
+        <Drone obstacle={droneObstacle(flap, 110, 60)} />
+        <Block obstacle={blockObstacle(12, 18, 200, groundY)} />
+        <Block obstacle={blockObstacle(18, 24, 260, groundY)} />
+        <Block obstacle={blockObstacle(24, 30, 330, groundY)} />
+      </Stage>
+    )
+  },
+}

--- a/packages/react/src/sds/ai/F0AiChat/components/__tests__/DinoGame.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/__tests__/DinoGame.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  aabbOverlap,
+  applyJumpPhysics,
+  clamp,
+  pixelsToMeters,
+  spawnGapRange,
+  speedAt,
+} from "../DinoGame"
+
+describe("One Run helpers", () => {
+  describe("clamp", () => {
+    it("returns the value when within range", () => {
+      expect(clamp(5, 0, 10)).toBe(5)
+    })
+    it("clamps below the minimum", () => {
+      expect(clamp(-1, 0, 10)).toBe(0)
+    })
+    it("clamps above the maximum", () => {
+      expect(clamp(99, 0, 10)).toBe(10)
+    })
+  })
+
+  describe("aabbOverlap", () => {
+    const player = { x: 56, y: 100, w: 32, h: 32 }
+
+    it("detects clear overlap", () => {
+      const obstacle = { x: 60, y: 110, w: 24, h: 22 }
+      expect(aabbOverlap(player, obstacle)).toBe(true)
+    })
+
+    it("returns false for disjoint rects", () => {
+      const obstacle = { x: 200, y: 100, w: 20, h: 20 }
+      expect(aabbOverlap(player, obstacle)).toBe(false)
+    })
+
+    it("ignores near-misses within the fairness inset", () => {
+      // Obstacle just touching the player's edge — inset (3px) keeps it forgiving.
+      const obstacle = { x: 56 + 32 - 1, y: 100, w: 3, h: 32 }
+      expect(aabbOverlap(player, obstacle)).toBe(false)
+    })
+  })
+
+  describe("applyJumpPhysics", () => {
+    it("integrates velocity into position", () => {
+      const next = applyJumpPhysics(100, -10, 1, false)
+      expect(next.y).toBe(90)
+    })
+
+    it("accumulates gravity into velocity", () => {
+      const next = applyJumpPhysics(100, 0, 1, false)
+      expect(next.vy).toBeGreaterThan(0)
+    })
+
+    it("applies stronger gravity when fast-falling", () => {
+      const normal = applyJumpPhysics(100, 0, 1, false)
+      const fast = applyJumpPhysics(100, 0, 1, true)
+      expect(fast.vy).toBeGreaterThan(normal.vy)
+    })
+  })
+
+  describe("speedAt — difficulty curve", () => {
+    it("starts at the easy base speed", () => {
+      expect(speedAt(0)).toBeCloseTo(3.6)
+    })
+
+    it("ramps up over time", () => {
+      const early = speedAt(5)
+      const mid = speedAt(40)
+      const late = speedAt(80)
+      expect(mid).toBeGreaterThan(early)
+      expect(late).toBeGreaterThan(mid)
+    })
+
+    it("caps at MAX_SPEED", () => {
+      expect(speedAt(999)).toBeCloseTo(11)
+    })
+  })
+
+  describe("pixelsToMeters — distance score", () => {
+    it("returns 0 for zero pixels", () => {
+      expect(pixelsToMeters(0)).toBe(0)
+    })
+
+    it("never goes negative", () => {
+      expect(pixelsToMeters(-50)).toBe(0)
+    })
+
+    it("floors fractional meters", () => {
+      // 18 px = 1 m at the current PIXELS_PER_METER constant.
+      expect(pixelsToMeters(17)).toBe(0)
+      expect(pixelsToMeters(18)).toBe(1)
+      expect(pixelsToMeters(180)).toBe(10)
+    })
+
+    it("grows monotonically with distance", () => {
+      const a = pixelsToMeters(500)
+      const b = pixelsToMeters(1000)
+      const c = pixelsToMeters(2000)
+      expect(b).toBeGreaterThan(a)
+      expect(c).toBeGreaterThan(b)
+    })
+  })
+
+  describe("spawnGapRange — wider at start, tighter later", () => {
+    it("starts with the easy gap range", () => {
+      const [min, max] = spawnGapRange(0)
+      expect(min).toBe(340)
+      expect(max).toBe(520)
+    })
+
+    it("converges toward the hard range over time", () => {
+      const [minLate, maxLate] = spawnGapRange(999)
+      expect(minLate).toBe(180)
+      expect(maxLate).toBe(320)
+    })
+
+    it("interpolates monotonically", () => {
+      const [min0] = spawnGapRange(0)
+      const [min30] = spawnGapRange(30)
+      const [min60] = spawnGapRange(60)
+      expect(min0).toBeGreaterThan(min30)
+      expect(min30).toBeGreaterThan(min60)
+    })
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/components/history/__tests__/utils.test.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/history/__tests__/utils.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { formatThreadDate, getDateGroup } from "../utils"
+
+const labels = { today: "Today", yesterday: "Yesterday" }
+
+describe("formatThreadDate", () => {
+  beforeEach(() => {
+    // Pin "now" to a known weekday/time so all branches are deterministic
+    // regardless of when CI runs. 2026-04-28 14:00 (a Tuesday).
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-04-28T14:00:00Z"))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("formats today timestamps with the today label", () => {
+    const result = formatThreadDate("2026-04-28T11:51:00Z", labels)
+    expect(result.startsWith("Today, ")).toBe(true)
+  })
+
+  it("formats yesterday timestamps with the yesterday label", () => {
+    const result = formatThreadDate("2026-04-27T07:59:00Z", labels)
+    expect(result.startsWith("Yesterday, ")).toBe(true)
+  })
+
+  it("formats current-year timestamps as month + day, no year", () => {
+    const result = formatThreadDate("2026-04-23T11:51:00Z", labels)
+    // No year segment for the current year
+    expect(result).not.toMatch(/\b\d{4}\b/)
+    // Includes the month abbreviation and day
+    expect(result).toMatch(/Apr\s+23/)
+    expect(result).toContain(", ")
+  })
+
+  it("formats older timestamps with year included", () => {
+    const result = formatThreadDate("2025-04-06T11:51:00Z", labels)
+    expect(result).toContain("2025")
+    expect(result).toMatch(/Apr\s+6\s+2025/)
+    expect(result).toContain(", ")
+  })
+})
+
+describe("getDateGroup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-04-28T14:00:00Z"))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("returns 'today' for today's date", () => {
+    expect(getDateGroup("2026-04-28T09:00:00Z")).toBe("today")
+  })
+
+  it("returns 'yesterday' for yesterday's date", () => {
+    expect(getDateGroup("2026-04-27T09:00:00Z")).toBe("yesterday")
+  })
+
+  it("returns 'thisMonth' for an earlier date in the same month", () => {
+    expect(getDateGroup("2026-04-10T09:00:00Z")).toBe("thisMonth")
+  })
+
+  it("returns 'older' for previous months", () => {
+    expect(getDateGroup("2026-02-15T09:00:00Z")).toBe("older")
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/components/history/components/ThreadItem.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/history/components/ThreadItem.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react"
 
 import { F0Button } from "@/components/F0Button"
-import { OneEllipsis } from "@/lib/OneEllipsis"
 import {
   Dropdown,
   type DropdownItem as DropdownItemType,
@@ -9,11 +8,14 @@ import {
 import { EllipsisHorizontal } from "@/icons/app"
 import Delete from "@/icons/app/Delete"
 import PushPin from "@/icons/app/PushPin"
+import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils"
 
-import type { ChatThread } from "../useChatHistory"
 import type { ThreadActionHandlers } from "../types"
+import type { ChatThread } from "../useChatHistory"
+
+import { formatThreadDate } from "../utils"
 
 interface ThreadItemProps extends ThreadActionHandlers {
   thread: ChatThread
@@ -46,6 +48,15 @@ export function ThreadItem({
     [isPinned, thread.id, onPin, onUnpin, onDelete]
   )
 
+  const formattedDate = useMemo(
+    () =>
+      formatThreadDate(thread.updatedAt, {
+        today: translations.ai.today,
+        yesterday: translations.ai.yesterday,
+      }),
+    [thread.updatedAt, translations.ai.today, translations.ai.yesterday]
+  )
+
   return (
     <div
       className={cn(
@@ -62,14 +73,23 @@ export function ThreadItem({
       }}
     >
       <div
-        className="flex w-full items-center gap-2"
+        className="flex w-full min-w-0 items-center gap-1"
         onClick={() => onSelect(thread.id, thread.title)}
       >
         <OneEllipsis lines={1} className="text-left font-medium">
           {thread.title}
         </OneEllipsis>
+        <span className="shrink-0 font-medium text-f1-foreground-tertiary">
+          {`- ${formattedDate}`}
+        </span>
       </div>
-      <div className="flex items-center">
+      <div
+        className={cn(
+          "flex items-center opacity-0 transition-opacity duration-150",
+          "group-hover:opacity-100 focus-within:opacity-100",
+          "has-[[aria-expanded=true]]:opacity-100"
+        )}
+      >
         <Dropdown items={dropdownItems}>
           <F0Button
             icon={EllipsisHorizontal}

--- a/packages/react/src/sds/ai/F0AiChat/components/history/utils.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/history/utils.ts
@@ -1,19 +1,66 @@
+import { format, isSameMonth, isSameYear, isToday, isYesterday } from "date-fns"
+
+import { getLocale } from "@/components/OneCalendar/utils"
+
 import type { ChatThread } from "./useChatHistory"
 import type { DateGroup, ThreadGroup } from "./types"
+
+/** Resolve the browser's `date-fns` locale, falling back to the default. */
+function resolveLocale() {
+  if (typeof navigator === "undefined") return undefined
+  return getLocale(navigator.language)
+}
 
 export function getDateGroup(dateString: string): DateGroup {
   const date = new Date(dateString)
   const now = new Date()
 
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-  const yesterdayStart = new Date(todayStart)
-  yesterdayStart.setDate(yesterdayStart.getDate() - 1)
-  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1)
-
-  if (date >= todayStart) return "today"
-  if (date >= yesterdayStart) return "yesterday"
-  if (date >= monthStart) return "thisMonth"
+  if (isToday(date)) return "today"
+  if (isYesterday(date)) return "yesterday"
+  if (isSameMonth(date, now)) return "thisMonth"
   return "older"
+}
+
+/**
+ * Format a thread's timestamp for the history list next to its title.
+ *
+ * Output is humanised, locale-aware and matches the design:
+ *   - "Today, 11:51"
+ *   - "Yesterday, 7:59"
+ *   - "Apr 23, 11:51"    (within the current year)
+ *   - "Apr 6 2025, 11:51" (older — year differs from today)
+ *
+ * Uses a comma as the calendar/time separator instead of a natural-language
+ * word ("at", "a las", "um", …). Different languages have different
+ * connective grammars there — some don't use a preposition at all — so a
+ * punctuation separator keeps the format consistent and safe to use in any
+ * locale without per-language overrides.
+ *
+ * The month/day and time segments are produced by `date-fns` in the
+ * browser's locale (so "Apr" becomes "abr" in Spanish, time switches to
+ * 24h when the locale uses it, etc.). The calendar-day label ("Today",
+ * "Yesterday") still comes from the app's i18n so it matches whatever
+ * language the chat is currently running in.
+ */
+export function formatThreadDate(
+  dateString: string,
+  labels: { today: string; yesterday: string }
+): string {
+  const date = new Date(dateString)
+  const locale = resolveLocale()
+  // `p` = locale-aware short time (e.g. "7:59 AM" in en-US, "7:59" in es-ES).
+  const time = format(date, "p", { locale })
+
+  if (isToday(date)) return `${labels.today}, ${time}`
+  if (isYesterday(date)) return `${labels.yesterday}, ${time}`
+
+  const includeYear = !isSameYear(date, new Date())
+  // `MMM d` = short month + day (e.g. "Apr 23"). Add the year when the
+  // thread is from a previous year so the label is unambiguous.
+  const datePart = format(date, includeYear ? "MMM d yyyy" : "MMM d", {
+    locale,
+  })
+  return `${datePart}, ${time}`
 }
 
 export function groupThreadsByDate(threads: ChatThread[]): ThreadGroup[] {

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatInput.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatInput.tsx
@@ -3,8 +3,8 @@ import { InputProps } from "@copilotkit/react-ui"
 import { AnimatePresence, motion } from "motion/react"
 import { useEffect, useMemo, useRef } from "react"
 
-import { OneEllipsis } from "@/lib/OneEllipsis"
 import { Link } from "@/lib/linkHandler"
+import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
@@ -44,7 +44,7 @@ export const ChatInput = (props: InputProps) => {
     <div
       ref={containerRef}
       className={cn(
-        "flex flex-col items-center gap-2 px-4 pb-4 pt-2",
+        "flex flex-col items-center gap-2 px-4 pb-3 pt-2",
         fullscreenWelcome && "flex-1"
       )}
     >
@@ -77,7 +77,8 @@ export const ChatInput = (props: InputProps) => {
             )}
           </motion.div>
         ) : (
-          disclaimer?.text && (
+          disclaimer?.text &&
+          !fullscreenWelcome && (
             <motion.div
               key="chat-disclaimer"
               className="flex w-full max-w-[712px] flex-row items-center justify-center gap-1"

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatInput.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatInput.tsx
@@ -33,7 +33,6 @@ export const ChatInput = (props: InputProps) => {
   const fullscreenWelcome = fullscreen && isWelcomeScreen
 
   const isClarifying = clarifyingQuestion != null
-  const currentStepOptional = clarifyingQuestion?.currentStep.optional === true
 
   useEffect(() => {
     const textarea = containerRef.current?.querySelector("textarea")
@@ -69,12 +68,12 @@ export const ChatInput = (props: InputProps) => {
               <kbd className="font-sans">Enter</kbd>{" "}
               {translation.ai.clarifyingQuestion.navHint.select}
             </span>
-            {currentStepOptional && (
-              <span>
-                <kbd className="font-sans">Esc</kbd>{" "}
-                {translation.ai.clarifyingQuestion.navHint.skip}
-              </span>
-            )}
+            {/* Cancel is always available — not gated on the step being
+                optional — so the Esc hint is unconditional. */}
+            <span>
+              <kbd className="font-sans">Esc</kbd>{" "}
+              {translation.ai.clarifyingQuestion.navHint.cancel}
+            </span>
           </motion.div>
         ) : (
           disclaimer?.text &&

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/AttachedFilesList.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/AttachedFilesList.tsx
@@ -1,9 +1,9 @@
-import { FileItem } from "@/components/RichText/FileItem"
 import { F0Icon } from "@/components/F0Icon"
-import { AlertCircle, CrossedCircle } from "@/icons/app"
-import { Skeleton } from "@/ui/skeleton"
+import { FileItem } from "@/components/RichText/FileItem"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { AlertCircle, Cross } from "@/icons/app"
 import { focusRing } from "@/lib/utils"
+import { Skeleton } from "@/ui/skeleton"
 
 import { type AttachedFile } from "./types"
 
@@ -26,11 +26,11 @@ export const AttachedFilesList = ({
     <div
       aria-live="polite"
       aria-busy={isUploading}
-      className="flex flex-wrap gap-1.5 px-3 pt-3"
+      className="flex flex-wrap gap-1 px-1 pt-1"
     >
       {attachedFiles.map((att) =>
         att.status === "uploading" ? (
-          <Skeleton key={att.id} className="h-9 w-36 rounded-lg" />
+          <Skeleton key={att.id} className="h-9 w-36 rounded-[10px]" />
         ) : att.status === "error" ? (
           <ErrorFilePill
             key={att.id}
@@ -42,11 +42,11 @@ export const AttachedFilesList = ({
           <FileItem
             key={att.id}
             file={att.file}
-            size="lg"
+            size="md"
             actions={[
               {
                 label: removeLabel,
-                icon: CrossedCircle,
+                icon: Cross,
                 onClick: () => onRemove(att.id),
               },
             ]}
@@ -80,7 +80,7 @@ function ErrorFilePill({
         )}
         onClick={() => onRemove(att.id)}
       >
-        <F0Icon icon={CrossedCircle} size="md" aria-hidden="true" />
+        <F0Icon icon={Cross} size="md" aria-hidden="true" />
       </button>
     </div>
   )

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
@@ -1,5 +1,3 @@
-import { useCopilotChatInternal } from "@copilotkit/react-core"
-import { randomId } from "@copilotkit/shared"
 import { AnimatePresence, motion } from "motion/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
@@ -15,7 +13,6 @@ import { buildHighlightSegments } from "../utils"
 import { ActionBar } from "./ActionBar"
 import { AttachedFilesList } from "./AttachedFilesList"
 import { CreditWarningWrapper } from "./CreditWarningWrapper"
-import { DropOverlay } from "./DropOverlay"
 import { PendingQuoteChip } from "./PendingQuoteChip"
 import { TextareaField } from "./TextareaField"
 import {
@@ -74,18 +71,16 @@ export const ChatTextarea = ({
     setActiveToolHint,
     fileAttachments,
     sendMessage,
+    appendMessages,
     clarifyingQuestion,
-    fileDragOver,
     pendingContext,
     setPendingContext,
     pendingQuote,
     setPendingQuote,
+    setProcessDroppedFilesFunction,
   } = useAiChat()
-  const { messages, setMessages } = useCopilotChatInternal()
   const translation = useI18n()
   const shouldReduceMotion = useReducedMotion()
-  const messagesRef = useRef(messages)
-  messagesRef.current = messages
   const [inputValue, setInputValue] = useState("")
   const [cursorPosition, setCursorPosition] = useState(0)
   const formRef = useRef<HTMLFormElement>(null)
@@ -120,17 +115,39 @@ export const ChatTextarea = ({
     }
   }, [])
 
-  const handleStop = useCallback(async () => {
-    await onStop?.()
-    setMessages([
-      ...messagesRef.current,
-      {
-        id: randomId(),
-        role: "assistant" as const,
-        content: `*<!--response-stopped-->${translation.ai.responseStopped}*`,
-      },
-    ])
-  }, [onStop, setMessages, translation.ai.responseStopped])
+  // Register processFiles with the provider so the chat-wide DropOverlay
+  // (rendered in SidebarWindow) can dispatch file drops to this textarea's
+  // file-attachment state.
+  useEffect(() => {
+    setProcessDroppedFilesFunction((files) => {
+      void processFiles(files)
+    })
+    return () => {
+      setProcessDroppedFilesFunction(null)
+    }
+  }, [setProcessDroppedFilesFunction, processFiles])
+
+  const handleStop = useCallback(() => {
+    // Inject the stopped-indicator via appendMessages (which sanitizes the
+    // existing message list via JSON roundtrip before calling setMessages);
+    // calling useCopilotChatInternal's setMessages directly with the live
+    // messages fails under CopilotKit 1.54 because setMessages internally
+    // uses structuredClone and the resolved messages carry non-cloneable
+    // `generativeUI`/render function wrappers.
+    appendMessages(
+      [
+        {
+          role: "assistant",
+          content: `*<!--response-stopped-->${translation.ai.responseStopped}*`,
+        },
+      ],
+      { persist: false }
+    )
+    // Fire-and-forget: some agent implementations return a promise from
+    // abortRun() that only resolves after the stream drains, which would
+    // otherwise block the stopped-indicator from rendering.
+    void onStop?.()
+  }, [onStop, appendMessages, translation.ai.responseStopped])
 
   const resolvedDefaultPlaceholder = translation.ai.inputPlaceholder
   const uploadedFiles = attachedFiles.filter((f) => f.status === "uploaded")
@@ -255,13 +272,13 @@ export const ChatTextarea = ({
         className={cn(
           "relative isolate z-20",
           "flex flex-col items-stretch md:gap-3 gap-2",
-          "rounded-lg border border-solid border-f1-border has-[textarea:focus]:border-f1-border-secondary",
+          "rounded-lg border border-solid border-f1-border has-[textarea:focus]:border-f1-background-tertiary",
           "transition-all hover:cursor-text",
           "p-0",
           "before:pointer-events-none before:absolute before:inset-0 before:z-[-1]",
           "before:rounded-[inherit] before:bg-f1-background before:content-['']",
           "after:pointer-events-none after:absolute after:inset-0.5 after:z-[-2]",
-          "after:rounded-[inherit] after:blur-[5px] after:content-['']",
+          "after:rounded-md after:blur-[6px] after:content-['']",
           "after:scale-90 after:opacity-0",
           "after:bg-[conic-gradient(from_var(--gradient-angle),var(--tw-gradient-stops))]",
           "from-[#E55619] via-[#A1ADE5] to-[#E51943]",
@@ -289,12 +306,6 @@ export const ChatTextarea = ({
         }}
         onSubmit={handleSubmit}
       >
-        <DropOverlay
-          visible={fileDragOver}
-          onFilesDropped={(files) => {
-            void processFiles(files)
-          }}
-        />
         <MentionPopover
           isOpen={mentions.isOpen}
           results={mentions.results}

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
@@ -284,7 +284,8 @@ export const ChatTextarea = ({
           "from-[#E55619] via-[#A1ADE5] to-[#E51943]",
           "after:transition-all after:delay-200 after:duration-300",
           "has-[textarea:focus]:after:scale-100 has-[textarea:focus]:after:opacity-100",
-          isClarifying && "after:scale-100 after:opacity-100"
+          isClarifying &&
+            "after:scale-100 after:opacity-100 border-f1-background-tertiary"
         )}
         animate={{
           "--gradient-angle": ["0deg", "360deg"],

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/DropOverlay.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/DropOverlay.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react"
-
 import { F0Icon } from "@/components/F0Icon/F0Icon"
 import { Upload } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
@@ -12,42 +10,35 @@ interface DropOverlayProps {
 
 export const DropOverlay = ({ visible, onFilesDropped }: DropOverlayProps) => {
   const translation = useI18n()
-  const [isOver, setIsOver] = useState(false)
 
   return (
     <div
       className={cn(
-        "absolute -inset-x-1 -top-40 -bottom-7 z-50 flex flex-col items-center gap-2 justify-center rounded border-1 border-dashed border-f1-border-selected-bold backdrop-blur-lg",
-        "transition-opacity duration-150 ease-out motion-reduce:transition-none",
+        "absolute inset-1 z-50 flex flex-col items-center gap-2 justify-center rounded-[calc(theme(borderRadius.xl)-4px)] backdrop-blur bg-f1-background-tertiary/80 border border-dashed border-f1-border",
+        "transition-opacity duration-150 ease-out motion-reduce:transition-none dashed-lg",
         visible
           ? "opacity-100 pointer-events-auto"
-          : "pointer-events-none opacity-0",
-        isOver
-          ? "bg-f1-background-selected-hover"
-          : "bg-f1-background-selected-secondary"
+          : "pointer-events-none opacity-0"
       )}
       onDragEnter={(e) => {
         e.preventDefault()
-        setIsOver(true)
       }}
       onDragOver={(e) => {
         e.preventDefault()
       }}
       onDragLeave={(e) => {
         e.preventDefault()
-        setIsOver(false)
       }}
       onDrop={(e) => {
         e.preventDefault()
-        setIsOver(false)
         const files = Array.from(e.dataTransfer.files)
         if (files.length > 0) {
           onFilesDropped(files)
         }
       }}
     >
-      <F0Icon icon={Upload} size="lg" color="selected" />
-      <p className="text-base font-medium text-f1-foreground-selected">
+      <F0Icon icon={Upload} size="lg" color="bold" />
+      <p className="text-base font-normal text-f1-foreground">
         {translation.ai.dropFilesHere}
       </p>
     </div>

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/DropOverlay.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/DropOverlay.tsx
@@ -15,7 +15,7 @@ export const DropOverlay = ({ visible, onFilesDropped }: DropOverlayProps) => {
     <div
       className={cn(
         "absolute inset-1 z-50 flex flex-col items-center gap-2 justify-center rounded-[calc(theme(borderRadius.xl)-4px)] backdrop-blur bg-f1-background-tertiary/80 border border-dashed border-f1-border",
-        "transition-opacity duration-150 ease-out motion-reduce:transition-none dashed-lg",
+        "transition-opacity duration-150 ease-out motion-reduce:transition-none",
         visible
           ? "opacity-100 pointer-events-auto"
           : "pointer-events-none opacity-0"

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/PendingQuoteChip.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/PendingQuoteChip.tsx
@@ -29,14 +29,14 @@ export const PendingQuoteChip = ({
       <div
         className={cn(
           "flex items-start gap-2 justify-center",
-          "rounded-sm bg-f1-background-hover px-1"
+          "rounded-[10px] bg-f1-background-hover pl-2 py-1.5 pr-1.5"
         )}
       >
         <div className="flex items-center py-0.5">
-          <F0Icon icon={Reply} size="md" />
+          <F0Icon icon={Reply} size="md" color="default" />
         </div>
         <OneEllipsis
-          className="h-full flex-1 py-1 text-[12px] font-medium text-f1-foreground-secondary"
+          className="h-full flex-1 py-0.5 text-[12px] font-medium text-f1-foreground-secondary"
           lines={1}
         >
           {quote.text}

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/TextareaField.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/TextareaField.tsx
@@ -48,7 +48,7 @@ export const TextareaField = ({
           "min-h-[20px] max-h-[240px]",
           "whitespace-pre-wrap break-words",
           "text-[16px] sm:text-[14px] leading-[20px] font-normal text-f1-foreground",
-          "mt-3 px-3"
+          "my-3 px-3"
         )}
       >
         {inputValue.endsWith("\n") ? inputValue + "_" : inputValue}
@@ -63,7 +63,7 @@ export const TextareaField = ({
             "min-h-[20px] max-h-[240px]",
             "whitespace-pre-wrap break-words",
             "text-[16px] sm:text-[14px] leading-[20px] font-normal text-f1-foreground",
-            "mt-3 px-3",
+            "my-3 px-3",
             "overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           )}
         >

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/ClarifyingQuestionPanel.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/ClarifyingQuestionPanel.tsx
@@ -57,6 +57,7 @@ const ClarifyingQuestionContent = ({
     toggleOption,
     confirm,
     skip,
+    cancel,
     back,
     setCustomAnswerText,
     setCustomAnswerActive,
@@ -109,9 +110,14 @@ const ClarifyingQuestionContent = ({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === "Escape" && optional === true) {
+    // Escape always cancels the whole flow — this is independent of
+    // `optional`, which only controls whether the current step can be
+    // individually skipped (via the Skip button or the skip handler).
+    // Cancelling closes the panel and marks the tool call as
+    // resolved-but-not-completed, regardless of which step we're on.
+    if (e.key === "Escape") {
       e.preventDefault()
-      skip()
+      cancel()
     }
   }
 

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/StepHeader.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/StepHeader.tsx
@@ -27,7 +27,7 @@ export const StepHeader = ({
   return (
     <div className="flex items-start gap-2 pl-4 pr-3">
       <OneEllipsis
-        className="min-w-0 flex-1 text-base font-semibold text-f1-foreground"
+        className="min-w-0 flex-1 text-lg font-semibold text-f1-foreground"
         lines={3}
       >
         {question}

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/__tests__/ClarifyingQuestionPanel.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/__tests__/ClarifyingQuestionPanel.test.tsx
@@ -31,6 +31,7 @@ function buildState(
     toggleOption: vi.fn(),
     confirm: vi.fn(),
     skip: vi.fn(),
+    cancel: vi.fn(),
     back: vi.fn(),
     setCustomAnswerText: vi.fn(),
     setCustomAnswerActive: vi.fn(),
@@ -87,21 +88,23 @@ describe("ClarifyingQuestionPanel", () => {
     expect(state.toggleOption).toHaveBeenCalledWith("last-month")
   })
 
-  it("triggers skip on Escape when step is optional", async () => {
+  it("triggers cancel (not skip) on Escape when step is optional", async () => {
     const state = buildState({}, { optional: true })
     render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
     const radios = screen.getAllByRole("radio")
     radios[0].focus()
     await userEvent.keyboard("{Escape}")
-    expect(state.skip).toHaveBeenCalledOnce()
+    expect(state.cancel).toHaveBeenCalledOnce()
+    expect(state.skip).not.toHaveBeenCalled()
   })
 
-  it("does not trigger skip on Escape when step is required", async () => {
+  it("triggers cancel on Escape when step is required", async () => {
     const state = buildState()
     render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
     const radios = screen.getAllByRole("radio")
     radios[0].focus()
     await userEvent.keyboard("{Escape}")
+    expect(state.cancel).toHaveBeenCalledOnce()
     expect(state.skip).not.toHaveBeenCalled()
   })
 

--- a/packages/react/src/sds/ai/F0AiChat/components/input/__stories__/ClarifyingQuestion.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/__stories__/ClarifyingQuestion.stories.tsx
@@ -220,6 +220,7 @@ function useClarifyingQuestionStory(steps: StoryStep[]) {
       toggleOption,
       confirm,
       skip,
+      cancel: () => setClarifyingQuestion(null),
       back,
       setCustomAnswerText,
       setCustomAnswerActive,

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/CanvasPanel.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/CanvasPanel.tsx
@@ -88,7 +88,10 @@ export function CanvasPanel(): ReactNode {
             className={cn(
               "flex h-full w-full flex-col overflow-hidden",
               "bg-f1-special-page",
-              "md:rounded-lg md:border md:border-solid border-f1-border-secondary rounded-none border-none"
+              // The canvas sits flush against the chat panel's ResizeHandle
+              // on its right side; drop the right border so canvas+handle+
+              // chat add up to a single 1px seam instead of 1+1+1 = 3px.
+              "md:rounded-l-lg md:border md:border-r-0 md:border-solid border-f1-border-secondary rounded-none border-none"
             )}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/CanvasPanel.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/CanvasPanel.tsx
@@ -72,9 +72,12 @@ export function CanvasPanel(): ReactNode {
       {canvasContent && (
         <motion.div
           className={cn(
+            // No overflow on the outer wrappers so the inner card's
+            // box-shadow can escape rightward onto the chat. Setting any
+            // overflow-y here would force overflow-x to `auto` (CSS spec)
+            // and clip the shadow.
             "pointer-events-auto flex h-full flex-col",
-            "overflow-hidden",
-            "py-1 dark:bg-f1-background"
+            "md:py-1 dark:bg-f1-background p-0"
           )}
           initial={{ opacity: 0, width: 0 }}
           animate={{ opacity: 1, width: "100%" }}
@@ -84,24 +87,29 @@ export function CanvasPanel(): ReactNode {
             ease: [0, 0, 0.1, 1],
           }}
         >
-          <motion.div
-            className={cn(
-              "flex h-full w-full flex-col overflow-hidden",
-              "bg-f1-special-page",
-              // The canvas sits flush against the chat panel's ResizeHandle
-              // on its right side; drop the right border so canvas+handle+
-              // chat add up to a single 1px seam instead of 1+1+1 = 3px.
-              "md:rounded-l-lg md:border md:border-r-0 md:border-solid border-f1-border-secondary rounded-none border-none"
-            )}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{
-              delay: shouldReduceMotion ? 0 : 0.15,
-              duration: shouldReduceMotion ? 0 : 0.2,
-            }}
-          >
-            {renderInner()}
-          </motion.div>
+          <div className="flex h-full flex-col border border-r-0 border-solid border-f1-border-secondary bg-f1-special-page p-0 md:rounded-l-lg md:py-1 md:pl-1">
+            <motion.div
+              className={cn(
+                // overflow-hidden only on the inner card (where rounded
+                // corners clip content); the outer wrappers stay
+                // unconstrained so the shadow can paint past the seam.
+                "flex h-full w-full flex-col overflow-hidden",
+                "bg-f1-background",
+                // Directional shadow biased rightward so depth falls onto
+                // the adjacent chat surface.
+                "md:shadow-md shadow-none",
+                "rounded-none border-none md:rounded-md md:border md:border-solid border-f1-border-secondary"
+              )}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{
+                delay: shouldReduceMotion ? 0 : 0.15,
+                duration: shouldReduceMotion ? 0 : 0.2,
+              }}
+            >
+              {renderInner()}
+            </motion.div>
+          </div>
         </motion.div>
       )}
     </AnimatePresence>

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/ChatHeader.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/ChatHeader.tsx
@@ -1,18 +1,18 @@
-import { breakpoints } from "@factorialco/f0-core"
 import { useCopilotChatInternal } from "@copilotkit/react-core"
 import { useChatContext, type HeaderProps } from "@copilotkit/react-ui"
+import { breakpoints } from "@factorialco/f0-core"
 import { motion } from "motion/react"
 import { useCallback, useMemo, useState } from "react"
 import { useMediaQuery } from "usehooks-ts"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Icon } from "@/components/F0Icon"
-import { OneEllipsis } from "@/lib/OneEllipsis"
+import { New } from "@/icons/app"
 import ChevronDown from "@/icons/app/ChevronDown"
 import Cross from "@/icons/app/Cross"
 import Maximize from "@/icons/app/Maximize"
 import Minimize from "@/icons/app/Minimize"
-import { New } from "@/icons/app"
+import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { Action } from "@/ui/Action"
@@ -76,7 +76,7 @@ const ChatHeaderWithHistory = (props: HeaderProps) => {
     <>
       <header
         className={cn(
-          "flex justify-between px-4 py-3 w-full overflow-hidden gap-3"
+          "flex justify-between pl-2.5 pr-3 py-3 w-full overflow-hidden gap-3"
         )}
       >
         <div className="flex min-w-0 flex-1 items-center">

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -1,11 +1,14 @@
-import { breakpoints } from "@factorialco/f0-core"
 import { type WindowProps } from "@copilotkit/react-ui"
+import { breakpoints } from "@factorialco/f0-core"
 import { AnimatePresence, motion } from "motion/react"
 import { useCallback, useMemo, useRef, useState } from "react"
 import { useMediaQuery } from "usehooks-ts"
 
-import { MAX_CHAT_WIDTH, MIN_CHAT_WIDTH } from "../../utils/constants"
+import { cn } from "@/lib/utils"
+
 import { useAiChat } from "../../providers/AiChatStateProvider"
+import { MAX_CHAT_WIDTH, MIN_CHAT_WIDTH } from "../../utils/constants"
+import { DropOverlay } from "../input/ChatTextarea/DropOverlay"
 import { ResizeHandle } from "./ResizeHandle"
 
 export const SidebarWindow = ({ children }: WindowProps) => {
@@ -19,8 +22,12 @@ export const SidebarWindow = ({ children }: WindowProps) => {
     resetChatWidth,
     fileAttachments,
     clarifyingQuestion,
+    fileDragOver,
     setFileDragOver,
+    processDroppedFiles,
   } = useAiChat()
+  const isCanvasMode = visualizationMode === "canvas"
+
   const dragCounterRef = useRef(0)
   const canDrop =
     fileAttachments?.onUploadFiles != null && clarifyingQuestion === null
@@ -93,7 +100,7 @@ export const SidebarWindow = ({ children }: WindowProps) => {
       {open && (
         <motion.div
           key="chat-wrapper"
-          className="bg-f1-transparent pointer-events-auto relative ml-auto flex h-full md:py-1 md:pr-1 dark:bg-f1-background xs:rounded-xl"
+          className="bg-f1-transparent pointer-events-auto relative ml-auto flex h-full dark:bg-f1-background md:py-1 md:pr-1"
           initial={
             shouldPlayEntranceAnimation ? { opacity: 0, width: 0 } : false
           }
@@ -116,11 +123,19 @@ export const SidebarWindow = ({ children }: WindowProps) => {
               onReset={resetChatWidth}
               isResizing={isResizing}
               setIsResizing={setIsResizing}
+              narrow={isCanvasMode}
             />
           )}
           <div
             aria-hidden={!open}
-            className="relative flex h-full w-full flex-col overflow-hidden border border-solid border-f1-border-secondary bg-f1-special-page shadow xs:rounded-xl"
+            className={cn(
+              "relative flex h-full w-full flex-col overflow-hidden border border-solid border-f1-border-secondary bg-f1-special-page",
+              // In canvas mode the chat sits flush against the canvas with
+              // only the ResizeHandle (1px) between them. Dropping the left
+              // border avoids stacking canvas-border + handle + chat-border
+              // = 3px of visual separation; the handle is the single seam.
+              isCanvasMode ? "xs:rounded-r-xl border-l-0" : "xs:rounded-xl"
+            )}
             onDragEnter={handleDragEnter}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
@@ -139,6 +154,16 @@ export const SidebarWindow = ({ children }: WindowProps) => {
             >
               {children}
             </motion.div>
+            {canDrop && (
+              <DropOverlay
+                visible={fileDragOver}
+                onFilesDropped={(files) => {
+                  dragCounterRef.current = 0
+                  setFileDragOver(false)
+                  processDroppedFiles(files)
+                }}
+              />
+            )}
           </div>
         </motion.div>
       )}

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -8,6 +8,8 @@ import { cn } from "@/lib/utils"
 
 import { useAiChat } from "../../providers/AiChatStateProvider"
 import { MAX_CHAT_WIDTH, MIN_CHAT_WIDTH } from "../../utils/constants"
+import { DinoGame } from "../DinoGame"
+import { PongGame } from "../PongGame"
 import { DropOverlay } from "../input/ChatTextarea/DropOverlay"
 import { ResizeHandle } from "./ResizeHandle"
 
@@ -25,6 +27,8 @@ export const SidebarWindow = ({ children }: WindowProps) => {
     fileDragOver,
     setFileDragOver,
     processDroppedFiles,
+    activeGame,
+    closeGame,
   } = useAiChat()
   const isCanvasMode = visualizationMode === "canvas"
 
@@ -164,6 +168,8 @@ export const SidebarWindow = ({ children }: WindowProps) => {
                 }}
               />
             )}
+            {activeGame === "dino" && <DinoGame onClose={closeGame} />}
+            {activeGame === "pong" && <PongGame onClose={closeGame} />}
           </div>
         </motion.div>
       )}

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/CreditsPopover.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/CreditsPopover.tsx
@@ -2,19 +2,19 @@ import { motion } from "motion/react"
 import { useCallback, useState } from "react"
 
 import { F0AvatarCompany } from "@/components/avatars/F0AvatarCompany"
+import { F0Button } from "@/components/F0Button"
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { OneEllipsis } from "@/lib/OneEllipsis"
 import { Sliders, Upsell } from "@/icons/app"
+import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
 import type { CreditsUsage } from "../../types"
 
 import { useAiChat } from "../../providers/AiChatStateProvider"
-import { F0Button } from "@/components/F0Button"
 
 export function CreditsPopover() {
-  const { credits } = useAiChat()
+  const { credits, openGame } = useAiChat()
   const i18n = useI18n()
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
@@ -71,13 +71,22 @@ export function CreditsPopover() {
         className="flex w-[324px] flex-col gap-3 rounded-md border border-solid border-f1-border-secondary p-3"
       >
         {hasHeader && (
-          <div className="flex min-w-0 max-w-full flex-1 items-center gap-2 overflow-hidden rounded text-lg text-f1-foreground transition-colors">
+          // Easter egg: clicking the company logo launches the Dino mini-game.
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false)
+              openGame("dino")
+            }}
+            aria-label={credits.companyName ?? ""}
+            className="flex min-w-0 max-w-full flex-1 cursor-pointer items-center gap-2 overflow-hidden rounded text-left text-lg text-f1-foreground transition-colors hover:bg-f1-background-secondary"
+          >
             <F0AvatarCompany
               name={credits.companyName ?? ""}
               src={credits.companyLogoUrl}
               size="lg"
             />
-            <div className="flex flex-col">
+            <div className="flex min-w-0 flex-col">
               <OneEllipsis tag="span" className="font-medium">
                 {credits.companyName ?? ""}
               </OneEllipsis>
@@ -90,7 +99,7 @@ export function CreditsPopover() {
                 </OneEllipsis>
               )}
             </div>
-          </div>
+          </button>
         )}
         <div className="flex flex-col rounded border border-solid border-f1-border-secondary">
           <div className="flex flex-col gap-2 p-3">

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/ResizeHandle.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/ResizeHandle.tsx
@@ -80,7 +80,7 @@ export const ResizeHandle = ({
         // panel's edge captures the mouse events first.
         "group relative z-10 h-full flex-shrink-0 cursor-ew-resize",
         narrow
-          ? "w-1 bg-f1-background border border-x-0 border-solid border-f1-border-secondary"
+          ? "w-1 bg-f1-special-page border border-x-0 border-solid border-f1-border-secondary"
           : "w-1"
       )}
       onMouseDown={handleMouseDown}

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/ResizeHandle.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/ResizeHandle.tsx
@@ -2,16 +2,34 @@ import { useCallback, useEffect, useRef } from "react"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Resize handle between the canvas panel (when present) and the chat panel.
+ *
+ * Visual goals:
+ * - In the default chat-only layout, the handle is a 4-pixel hit strip with
+ *   a rounded indicator that lights up on hover / while dragging.
+ * - In canvas mode (`narrow=true`), the layout slot collapses to a thin
+ *   1-pixel vertical rule so canvas and chat look visually flush with a
+ *   hairline divider between them.
+ *
+ * Both modes use an invisible hit-area extension (`absolute -inset-x-1`) so
+ * the user never has to precisely target a 1-pixel line: the mouse grabs
+ * the handle anywhere within ~9-12 pixels. The visible line is positioned
+ * absolutely and centered, letting it grow from 1px to 4px on hover without
+ * reflowing the surrounding canvas/chat layout.
+ */
 export const ResizeHandle = ({
   onResize,
   onReset,
   isResizing,
   setIsResizing,
+  narrow,
 }: {
   onResize: (deltaX: number) => void
   onReset: () => void
   isResizing: boolean
   setIsResizing: (value: boolean) => void
+  narrow?: boolean
 }) => {
   const startXRef = useRef(0)
 
@@ -55,14 +73,36 @@ export const ResizeHandle = ({
   return (
     <div
       className={cn(
-        "flex h-full w-1 flex-shrink-0 cursor-ew-resize items-stretch justify-center transition-colors",
-        "[&>div]:hover:bg-f1-background-secondary-hover",
-        isResizing && "[&>div]:bg-f1-background-secondary-hover"
+        // z-10 so the handle — and its invisible hit-area extension —
+        // paints above the chat-content sibling (same flex row, later
+        // in DOM, no stacking context of its own). Without this, the
+        // `group-hover` never fires on the right side because the chat
+        // panel's edge captures the mouse events first.
+        "group relative z-10 h-full flex-shrink-0 cursor-ew-resize",
+        narrow ? "w-px bg-f1-background" : "w-1"
       )}
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}
     >
-      <div className="w-1 rounded-full" />
+      {/* Invisible hit-area extension so the 1-pixel line stays comfortable
+          to grab with a mouse without widening the visible gap between
+          canvas and chat. Extends a few pixels into each neighbour. */}
+      <div aria-hidden className="absolute -inset-x-1 inset-y-0" />
+
+      {/* Visible divider. Absolutely positioned and centered so it can grow
+          on hover without pushing the surrounding layout. In canvas mode it
+          starts as a 1px hairline rule; in chat-only mode it starts hidden
+          and only reveals on hover / while dragging. */}
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 rounded-full",
+          "transition-[width,background-color] duration-150 ease-out",
+          narrow ? "w-px bg-f1-border-secondary" : "w-1 bg-transparent",
+          "group-hover:w-1 group-hover:bg-f1-background-secondary-hover",
+          isResizing && "!w-1 !bg-f1-background-secondary-hover"
+        )}
+      />
     </div>
   )
 }

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/ResizeHandle.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/ResizeHandle.tsx
@@ -79,7 +79,9 @@ export const ResizeHandle = ({
         // `group-hover` never fires on the right side because the chat
         // panel's edge captures the mouse events first.
         "group relative z-10 h-full flex-shrink-0 cursor-ew-resize",
-        narrow ? "w-px bg-f1-background" : "w-1"
+        narrow
+          ? "w-1 bg-f1-background border border-x-0 border-solid border-f1-border-secondary"
+          : "w-1"
       )}
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}
@@ -98,7 +100,7 @@ export const ResizeHandle = ({
         className={cn(
           "pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 rounded-full",
           "transition-[width,background-color] duration-150 ease-out",
-          narrow ? "w-px bg-f1-border-secondary" : "w-1 bg-transparent",
+          narrow ? "w-0 bg-f1-background" : "w-1 bg-transparent",
           "group-hover:w-1 group-hover:bg-f1-background-secondary-hover",
           isResizing && "!w-1 !bg-f1-background-secondary-hover"
         )}

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/ResizeHandle.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/ResizeHandle.tsx
@@ -100,7 +100,7 @@ export const ResizeHandle = ({
         className={cn(
           "pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 rounded-full",
           "transition-[width,background-color] duration-150 ease-out",
-          narrow ? "w-0 bg-f1-background" : "w-1 bg-transparent",
+          narrow ? "w-px bg-f1-background" : "w-1 bg-transparent",
           "group-hover:w-1 group-hover:bg-f1-background-secondary-hover",
           isResizing && "!w-1 !bg-f1-background-secondary-hover"
         )}

--- a/packages/react/src/sds/ai/F0AiChat/components/messages/MessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/messages/MessagesContainer.tsx
@@ -395,7 +395,7 @@ const Messages = ({
         {!noShadows && (
           <>
             <ScrollShadow position="top" key="shadow-top" />
-            <ScrollShadow position="bottom" key="shadow-top" />
+            <ScrollShadow position="bottom" key="shadow-bottom" />
           </>
         )}
       </div>

--- a/packages/react/src/sds/ai/F0AiChat/components/messages/MessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/messages/MessagesContainer.tsx
@@ -252,7 +252,7 @@ const Messages = ({
       <div
         ref={isLastTurn ? lastTurnRef : undefined}
         className={cn(
-          "flex flex-col items-start justify-start gap-2",
+          "flex flex-col items-start justify-start gap-2 px-1",
           isLastTurn && "pb-5"
         )}
         key={`turn-${turnIndex}`}
@@ -395,6 +395,7 @@ const Messages = ({
         {!noShadows && (
           <>
             <ScrollShadow position="top" key="shadow-top" />
+            <ScrollShadow position="bottom" key="shadow-top" />
           </>
         )}
       </div>

--- a/packages/react/src/sds/ai/F0AiChat/components/messages/ScrollShadow.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/messages/ScrollShadow.tsx
@@ -6,7 +6,14 @@ export const ScrollShadow = ({ position }: { position: "top" | "bottom" }) => (
   <motion.div
     transition={{ duration: 0.2, ease: "easeOut" }}
     className={cn(
-      "pointer-events-none absolute inset-x-0 z-10  after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-f1-background-inverse-secondary after:opacity-[0.04] after:content-['']",
+      // Inset 1px on both sides so the gradient and the thin `::after` rule
+      // never sit flush against the chat panel's left/right edge. Matters in
+      // canvas mode: the chat has `border-l-0` there and the ResizeHandle
+      // (1px, transparent) lives right at that edge; without this inset the
+      // opaque top of the gradient paints next to the handle and visually
+      // swallows it. In non-canvas mode the 1px sits inside the chat's own
+      // border so the change is imperceptible.
+      "pointer-events-none absolute inset-x-px z-[5] after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-f1-background-inverse-secondary after:opacity-[0.04] after:content-['']",
       position === "top"
         ? [
             "top-0",

--- a/packages/react/src/sds/ai/F0AiChat/components/messages/WelcomeScreen.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/messages/WelcomeScreen.tsx
@@ -121,7 +121,7 @@ export const WelcomeScreen = ({
           )}
           {initialMessages.map((message) => (
             <motion.p
-              className="leading-[28px]text-f1-foreground text-2xl font-semibold"
+              className="text-2xl font-semibold leading-[28px] text-f1-foreground"
               key={message.id}
               initial={{ opacity: 0, filter: "blur(2px)", y: -8 }}
               animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}

--- a/packages/react/src/sds/ai/F0AiChat/components/messages/WelcomeScreen.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/messages/WelcomeScreen.tsx
@@ -5,7 +5,6 @@ import { useCallback, useMemo, useRef, useState } from "react"
 
 import { useAiChat } from "@/ai"
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { cn } from "@/lib/utils"
 
 import { F0OneIcon } from "../../../F0OneIcon"
 import { WelcomeScreenSuggestion } from "../../types"
@@ -49,9 +48,7 @@ export const WelcomeScreen = ({
 
   const { sendMessage } = useCopilotChatInternal()
 
-  const { visualizationMode, tracking } = useAiChat()
-
-  const isFullscreen = visualizationMode === "fullscreen"
+  const { tracking } = useAiChat()
 
   const pickedSuggestions = useMemo(
     () => pickRandomSuggestions(suggestions),
@@ -69,7 +66,7 @@ export const WelcomeScreen = ({
         className="flex w-full flex-1 flex-col justify-end gap-6 sm:gap-4"
         initial={{ opacity: 1 }}
       >
-        <div className={!isFullscreen ? "pl-3" : ""}>
+        <div className="px-1">
           <motion.div
             className="flex w-fit justify-center"
             initial={{ opacity: 0, scale: 0.8, filter: "blur(6px)" }}
@@ -108,9 +105,9 @@ export const WelcomeScreen = ({
               </motion.div>
             </div>
           </motion.div>
-          {greeting && !isFullscreen && (
+          {greeting && (
             <motion.p
-              className="text-lg font-semibold leading-[24px] text-f1-foreground-secondary"
+              className="text-2xl font-semibold leading-[28px] text-f1-foreground-tertiary"
               initial={{ opacity: 0, filter: "blur(2px)", y: -8 }}
               animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
               transition={{
@@ -124,10 +121,7 @@ export const WelcomeScreen = ({
           )}
           {initialMessages.map((message) => (
             <motion.p
-              className={cn(
-                "text-xl font-semibold leading-[24px] text-f1-foreground",
-                isFullscreen && "text-3xl"
-              )}
+              className="leading-[28px]text-f1-foreground text-2xl font-semibold"
               key={message.id}
               initial={{ opacity: 0, filter: "blur(2px)", y: -8 }}
               animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}

--- a/packages/react/src/sds/ai/F0AiChat/components/messages/WelcomeScreen.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/messages/WelcomeScreen.tsx
@@ -8,7 +8,6 @@ import { ButtonInternal } from "@/components/F0Button/internal"
 
 import { F0OneIcon } from "../../../F0OneIcon"
 import { WelcomeScreenSuggestion } from "../../types"
-import { PongGame } from "../PongGame"
 import { PongBall } from "../shared/PongBall"
 
 export type { WelcomeScreenSuggestion }
@@ -33,7 +32,6 @@ export const WelcomeScreen = ({
   initialMessages?: Message[]
   suggestions?: WelcomeScreenSuggestion[]
 }) => {
-  const [showPong, setShowPong] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
   const hoverTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -48,16 +46,12 @@ export const WelcomeScreen = ({
 
   const { sendMessage } = useCopilotChatInternal()
 
-  const { tracking } = useAiChat()
+  const { tracking, openGame } = useAiChat()
 
   const pickedSuggestions = useMemo(
     () => pickRandomSuggestions(suggestions),
     [suggestions]
   )
-
-  if (showPong) {
-    return <PongGame onClose={() => setShowPong(false)} />
-  }
 
   return (
     <AnimatePresence mode="popLayout">
@@ -79,7 +73,7 @@ export const WelcomeScreen = ({
           >
             <div
               className="relative cursor-pointer"
-              onClick={() => setShowPong(true)}
+              onClick={() => openGame("pong")}
               onMouseEnter={handleMouseEnter}
               onMouseLeave={handleMouseLeave}
             >

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -252,6 +252,12 @@ export type AiChatProviderReturnValue = {
     openCanvas: (content: CanvasContent) => void
     /** Close the canvas panel and restore the previous visualization mode */
     closeCanvas: () => void
+    /** The currently active mini-game (easter egg), or null */
+    activeGame: "dino" | "pong" | null
+    /** Launch a mini-game overlay */
+    openGame: (game: "dino" | "pong") => void
+    /** Close the active mini-game overlay */
+    closeGame: () => void
     /** The currently active tool hint, or null if none is selected */
     activeToolHint: AiChatToolHint | null
     /** Set the active tool hint (pass null to clear) */

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -211,6 +211,14 @@ export type AiChatProviderReturnValue = {
   /** @internal Set the file drag-over state */
   setFileDragOver: React.Dispatch<React.SetStateAction<boolean>>
   /**
+   * Process files that were dropped onto the chat. Delegates to the
+   * `processFiles` callback registered by `ChatTextarea`'s file-attachment
+   * hook. Used by the chat-wide DropOverlay rendered in `SidebarWindow`.
+   */
+  processDroppedFiles: (files: File[]) => void
+  /** @internal Registers the processFiles callback owned by ChatTextarea */
+  setProcessDroppedFilesFunction: (fn: ((files: File[]) => void) | null) => void
+  /**
    * Pre-loaded context shown as an empty state in the chat.
    * Prepended to the first user message as `<pending-context>`.
    */

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -36,6 +36,8 @@ import {
 const AiChatStateContext = createContext<AiChatProviderReturnValue | null>(null)
 
 const CHAT_WIDTH_STORAGE_KEY = "ONE-ai-chat-width"
+const CHAT_OPEN_STORAGE_KEY = "ONE-ai-chat-open"
+const CHAT_VISUALIZATION_MODE_STORAGE_KEY = "ONE-ai-chat-visualization-mode"
 
 const getStoredChatWidth = (): number => {
   if (typeof window === "undefined") return DEFAULT_CHAT_WIDTH
@@ -47,6 +49,41 @@ const getStoredChatWidth = (): number => {
     return stored
   }
   return DEFAULT_CHAT_WIDTH
+}
+
+/**
+ * Read the persisted open/closed state from localStorage.
+ * Falls back to `fallback` when there's no stored value or it's malformed.
+ * Because the AiChatStateProvider only mounts once `ai?.enabled === true`
+ * (see ApplicationFrame), reading in the `useState` initializer naturally
+ * handles a delayed activation of `ai.enabled`: as soon as the provider
+ * mounts, the persisted state is applied.
+ */
+const getStoredChatOpen = (fallback: boolean): boolean => {
+  if (typeof window === "undefined") return fallback
+  const stored = readFromLocalStorage<boolean | null>(
+    CHAT_OPEN_STORAGE_KEY,
+    null
+  )
+  if (typeof stored !== "boolean") return fallback
+  return stored
+}
+
+/**
+ * Read the persisted visualization mode. Only accepts the stable user-facing
+ * modes — "canvas" is transient and reverts to the previous mode on close,
+ * so it is never persisted.
+ */
+const getStoredVisualizationMode = (
+  fallback: VisualizationMode
+): VisualizationMode => {
+  if (typeof window === "undefined") return fallback
+  const stored = readFromLocalStorage<string | null>(
+    CHAT_VISUALIZATION_MODE_STORAGE_KEY,
+    null
+  )
+  if (stored === "sidepanel" || stored === "fullscreen") return stored
+  return fallback
 }
 
 export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
@@ -74,13 +111,28 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
 }) => {
   const [footer, setFooter] = useState<ReactNode | undefined>(initialFooter)
   const [enabledInternal, setEnabledInternal] = useState(enabled)
-  const [open, setOpen] = useState(defaultVisualizationMode === "fullscreen")
+  // Restore open/closed state and visualization mode from localStorage when
+  // the provider mounts. Falls back to `defaultVisualizationMode` when no
+  // prior state is stored. Because this provider only mounts once the host
+  // app sets `ai.enabled === true`, a delayed activation still applies the
+  // persisted state correctly (the `useState` initializers run on mount,
+  // not on the first render of the outer tree).
+  const fallbackVisualizationMode: VisualizationMode =
+    defaultVisualizationMode === "canvas"
+      ? "sidepanel"
+      : defaultVisualizationMode
+  const [open, setOpen] = useState(() =>
+    getStoredChatOpen(defaultVisualizationMode === "fullscreen")
+  )
   const [mode, setMode] = useState<AiChatMode>("chat")
   const [visualizationMode, setVisualizationMode] = useState<VisualizationMode>(
-    defaultVisualizationMode
+    () => getStoredVisualizationMode(fallbackVisualizationMode)
   )
   const [shouldPlayEntranceAnimation, setShouldPlayEntranceAnimation] =
-    useState(defaultVisualizationMode !== "fullscreen")
+    useState(
+      () =>
+        getStoredVisualizationMode(fallbackVisualizationMode) !== "fullscreen"
+    )
   const [agent, setAgent] = useState<string | undefined>(initialAgent)
   const [welcomeScreenSuggestions, setWelcomeScreenSuggestions] = useState<
     WelcomeScreenSuggestion[]
@@ -131,6 +183,25 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     writeToLocalStorage(CHAT_WIDTH_STORAGE_KEY, chatWidth)
   }, [chatWidth])
 
+  // Persist open/closed state so it survives reloads. Stored as a plain
+  // boolean; the provider's `useState` initializer reads it back on mount.
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    writeToLocalStorage(CHAT_OPEN_STORAGE_KEY, open)
+  }, [open])
+
+  // Persist the visualization mode, but only for the stable user-facing
+  // modes. "canvas" is a transient overlay (restored to the previous mode
+  // via `closeCanvas`) and should never be the restored-on-reload mode.
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (visualizationMode === "sidepanel" || visualizationMode === "fullscreen")
+      writeToLocalStorage(
+        CHAT_VISUALIZATION_MODE_STORAGE_KEY,
+        visualizationMode
+      )
+  }, [visualizationMode])
+
   // Store the reset function from CopilotKit
   const clearFunctionRef = useRef<(() => void) | null>(null)
   // Store the loadThread function from CopilotKit
@@ -148,6 +219,12 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   // Atomically replaces messages with a new thread (no race with reset)
   const replaceMessagesFunctionRef = useRef<
     ((messages: AppendMessage[]) => void) | null
+  >(null)
+  // Callback that processes files dropped onto the chat. Registered by
+  // ChatTextarea (which owns the file-attachment state) so the chat-wide
+  // DropOverlay rendered in SidebarWindow can dispatch drops to it.
+  const processDroppedFilesFunctionRef = useRef<
+    ((files: File[]) => void) | null
   >(null)
 
   const [currentThreadTitle, setCurrentThreadTitle] = useState<string | null>(
@@ -185,6 +262,16 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     fn: ((messages: AppendMessage[]) => void) | null
   ) => {
     replaceMessagesFunctionRef.current = fn
+  }
+
+  const setProcessDroppedFilesFunction = (
+    fn: ((files: File[]) => void) | null
+  ) => {
+    processDroppedFilesFunctionRef.current = fn
+  }
+
+  const processDroppedFiles = (files: File[]) => {
+    processDroppedFilesFunctionRef.current?.(files)
   }
 
   const appendMessages = (
@@ -374,6 +461,8 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         setClarifyingQuestion,
         fileDragOver,
         setFileDragOver,
+        processDroppedFiles,
+        setProcessDroppedFilesFunction,
         pendingContext,
         setPendingContext,
         pendingQuote,
@@ -453,6 +542,8 @@ export function useAiChat(): AiChatProviderReturnValue {
       setClarifyingQuestion: noopFn,
       fileDragOver: false,
       setFileDragOver: noopFn,
+      processDroppedFiles: noopFn,
+      setProcessDroppedFilesFunction: noopFn,
       pendingContext: null,
       setPendingContext: noopFn,
       pendingQuote: null,

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -129,11 +129,11 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     useState<VisualizationMode>(() =>
       getStoredVisualizationMode(fallbackVisualizationMode)
     )
+  // Derived from the initial visualizationMode so we don't re-read
+  // localStorage. `useState`'s initializer runs only on mount, so this
+  // captures the value at that moment.
   const [shouldPlayEntranceAnimation, setShouldPlayEntranceAnimation] =
-    useState(
-      () =>
-        getStoredVisualizationMode(fallbackVisualizationMode) !== "fullscreen"
-    )
+    useState(() => visualizationMode !== "fullscreen")
   const [agent, setAgent] = useState<string | undefined>(initialAgent)
   const [welcomeScreenSuggestions, setWelcomeScreenSuggestions] = useState<
     WelcomeScreenSuggestion[]
@@ -211,11 +211,15 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   // via `closeCanvas`) and should never be the restored-on-reload mode.
   useEffect(() => {
     if (typeof window === "undefined") return
-    if (visualizationMode === "sidepanel" || visualizationMode === "fullscreen")
+    if (
+      visualizationMode === "sidepanel" ||
+      visualizationMode === "fullscreen"
+    ) {
       writeToLocalStorage(
         CHAT_VISUALIZATION_MODE_STORAGE_KEY,
         visualizationMode
       )
+    }
   }, [visualizationMode])
 
   // Store the reset function from CopilotKit
@@ -413,6 +417,16 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     }
   }, [visualizationMode])
 
+  // Fullscreen mini-game overlay (easter egg). Lives in global state so any
+  // UI affordance — credits popover, welcome screen, future surfaces — can
+  // open the same game without prop drilling.
+  const [activeGame, setActiveGame] = useState<"dino" | "pong" | null>(null)
+  const openGame = useCallback(
+    (game: "dino" | "pong") => setActiveGame(game),
+    []
+  )
+  const closeGame = useCallback(() => setActiveGame(null), [])
+
   return (
     <AiChatStateContext.Provider
       value={{
@@ -471,6 +485,9 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         canvasContent,
         openCanvas,
         closeCanvas,
+        activeGame,
+        openGame,
+        closeGame,
         activeToolHint,
         setActiveToolHint,
         clarifyingQuestion,
@@ -552,6 +569,9 @@ export function useAiChat(): AiChatProviderReturnValue {
       canvasContent: null,
       openCanvas: noopFn,
       closeCanvas: noopFn,
+      activeGame: null,
+      openGame: noopFn,
+      closeGame: noopFn,
       activeToolHint: null,
       setActiveToolHint: noopFn,
       clarifyingQuestion: null,

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -125,9 +125,10 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     getStoredChatOpen(defaultVisualizationMode === "fullscreen")
   )
   const [mode, setMode] = useState<AiChatMode>("chat")
-  const [visualizationMode, setVisualizationMode] = useState<VisualizationMode>(
-    () => getStoredVisualizationMode(fallbackVisualizationMode)
-  )
+  const [visualizationMode, setVisualizationModeRaw] =
+    useState<VisualizationMode>(() =>
+      getStoredVisualizationMode(fallbackVisualizationMode)
+    )
   const [shouldPlayEntranceAnimation, setShouldPlayEntranceAnimation] =
     useState(
       () =>
@@ -160,6 +161,21 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   }, [])
 
   const [canvasContent, setCanvasContent] = useState<CanvasContent | null>(null)
+
+  // Wrap the raw setter so leaving canvas mode also clears `canvasContent`
+  // in the same render — otherwise the canvas card stays mounted under the
+  // new mode until something else (closeCanvas, reload…) clears it.
+  const setVisualizationMode = useCallback<
+    React.Dispatch<React.SetStateAction<VisualizationMode>>
+  >((next) => {
+    setVisualizationModeRaw((prev) => {
+      const resolved = typeof next === "function" ? next(prev) : next
+      if (prev === "canvas" && resolved !== "canvas") {
+        setCanvasContent(null)
+      }
+      return resolved
+    })
+  }, [])
 
   // Track the mode before canvas was opened so we can restore it on close
   const previousVisualizationModeRef = useRef<VisualizationMode>("sidepanel")


### PR DESCRIPTION
## Description

Grouped UX improvements across `F0AiChat` — stop button regression fix, chat-wide drop zone, canvas mode polish, history dates, and persistence of open/mode across reloads. All five are independent but land together because they touch the same provider surface.

## Implementation details

### Stop button
- `ChatTextarea.handleStop` now writes the "Response stopped" indicator through the provider's `appendMessages` (sanitised via a JSON roundtrip in `CopilotFunctionBridge`) instead of `useCopilotChatInternal`'s `setMessages`, which fails under CopilotKit 1.54 when the message list carries non-cloneable `generativeUI` wrappers (the list contents are run through `structuredClone` internally).
- `onStop` is now fire-and-forget (`void onStop?.()`) rather than awaited — some agent implementations return a promise from `abortRun()` that only resolves after the stream drains, which was blocking the indicator from ever rendering.
- **Requires the paired `factorial-agent` fix** that emits `RUN_FINISHED` + completes the subscriber after cancellation; otherwise the client's `isRunning` stays `true` forever.

### Chat-wide drop zone
- `DropOverlay` lifted out of the textarea form and into `SidebarWindow`, positioned `absolute inset-1` with a 4px inset so the aura sits inside the rounded chat window. Drag-and-drop now works anywhere inside the chat, not just over the input.
- Provider gained a `processDroppedFiles` method and a `setProcessDroppedFilesFunction` ref registration (same pattern already used for `sendMessage`, `clear`, etc.). `ChatTextarea` registers its `processFiles` on mount so the overlay can dispatch drops back to the file-attachment state.

### Canvas mode polish
- `ResizeHandle` renders as a 1px hairline in canvas mode with a wider invisible hit-area (`absolute -inset-x-1`) and grows to `w-1` on hover (`group-hover` + `transition-[width,background-color]`). The container gets `z-10` so the hit-area paints above the `chat-content` sibling on the right side.
- On the left side of the seam, the chat wrapper in `ApplicationFrame` is bumped to `z-20` in canvas mode (previously only in fullscreen transition) so the hit-area receives hover events over the `CanvasPanel` (which lives at `z-[15]`).
- Canvas and chat inner borders are dropped in canvas mode (`md:border-r-0` on the canvas panel, `border-l-0` on the chat content) — the 1px handle is the single seam. Previously canvas-border + handle + chat-border stacked into 3px of visible gap.
- Canvas opens **right-to-left**: the outer wrapper is now `flex justify-end`, so the `motion.div` animating `width: 0 → 100%` anchors to the right edge and the left edge is the one that moves outward — animating away from the chat toward the page.
- `ScrollShadow` inset by 1px (`inset-x-px`) and z-index lowered to `z-[5]` so it never sits at the same level as the handle. The opaque top of the gradient no longer visually swallows the handle on its left edge.

### History dialog
- Each thread row now shows a humanised, locale-aware timestamp next to its title: `Today, 7:59` · `Yesterday, 10:45` · `Apr 23, 11:51` · `Apr 6 2025, 11:51` (year added only when it differs from today).
- Implemented in `formatThreadDate` using `date-fns` (already in `packages/react/deps`) + `getLocale` from `OneCalendar/utils`. Month/day and time come from `format(date, "MMM d" | "p")` so they pick up the browser's locale automatically.
- **Comma separator instead of `"at"`** — different languages have different prepositional grammar there and some don't use a word at all. Punctuation keeps the format consistent without per-language overrides.
- Options `…` button is now visible only on hover, `focus-within`, or while the dropdown is open (`has-[[aria-expanded=true]]:opacity-100`). Uses `opacity` rather than `display` so the row layout stays stable and tab order is preserved.

### Persisted open / visualization mode
- Open/closed state and visualization mode (sidepanel / fullscreen) now survive reloads via localStorage, following the same pattern as `chatWidth`.
- Handles delayed `ai.enabled=true` naturally: `ApplicationFrame` only mounts the `F0AiChatProvider` once `ai.enabled` is truthy, and `useState` initializers read storage on mount, so the persisted state is applied whenever the provider first mounts.
- `canvas` mode is transient and is never persisted (`closeCanvas` already restores the previous mode).

### Visual tweaks
Small, isolated styling adjustments that were batched along the way: `ChatInput`, `ChatHeader`, `AttachedFilesList`, `PendingQuoteChip`, `TextareaField`, `StepHeader`, `MessagesContainer`, `WelcomeScreen`, and `FileItem`.

## Test plan

- [ ] Send a message and stop mid-generation → "Response stopped" appears, the activity indicator disappears (requires the paired `factorial-agent` server change).
- [ ] Drag a file anywhere inside the chat panel → drop overlay covers the whole window with a 4px inset.
- [ ] In canvas mode, hover near the seam between canvas and chat → handle grows from 1px to 4px, becomes draggable.
- [ ] Open canvas → it expands right-to-left, from the chat toward the page edge.
- [ ] Open chat history → each entry shows `Title - Date, Time` with locale-aware month/time; hovering reveals the `…` menu.
- [ ] Close the chat, reload the page → chat stays closed.
- [ ] Open the chat in fullscreen, reload → chat reopens in fullscreen. Switch to sidepanel, reload → chat reopens in sidepanel.
- [ ] Set `ai.enabled` after a delay (simulating a slow feature-flag) → when it flips true, chat mounts in the persisted state.
- [ ] `pnpm tsc` clean across `packages/react`.