### PR TITLE
fix(F0Select): fix collapsible groups hiding records and improve group UX

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -600,6 +600,7 @@ const F0SelectComponent = forwardRef(function Select<
     }
   }, [localSource.currentFilters, disableSelectAll])
 
+  const collapsible = localSource.grouping?.collapsible ?? false
   const defaultOpenGroups = localSource.grouping?.defaultOpenGroups
   const { openGroups, setGroupOpen } = useGroups(
     data?.type === "grouped" ? data.groups : [],
@@ -615,6 +616,8 @@ const F0SelectComponent = forwardRef(function Select<
         return mappedOption.type === "separator"
           ? {
               height: 1,
+              key: `separator-${index}`,
+              type: "separator",
               item: (
                 <SelectSeparator
                   key={`separator-${index}`}
@@ -624,6 +627,8 @@ const F0SelectComponent = forwardRef(function Select<
             }
           : {
               height: mappedOption.description ? 64 : 32,
+              key: `item-${mappedOption.value}`,
+              type: "item",
               item: (
                 <SelectItem
                   key={String(mappedOption.value)}
@@ -644,22 +649,49 @@ const F0SelectComponent = forwardRef(function Select<
       const items: VirtualItem[] = []
       data.groups.map((group) => {
         items.push({
-          height: 30,
+          height: 36,
+          key: `group-header-${group.key}`,
+          type: "group-header",
           item: (
             <GroupHeader
               label={group.label}
               itemCount={group.itemCount}
+              showOpenChange={collapsible}
               onOpenChange={(open) => setGroupOpen(group.key, open)}
               open={openGroups[group.key]}
+              chevronPosition="leading"
+              closedRotation={-90}
+              openRotation={0}
+              className="relative cursor-pointer rounded px-3 py-2 outline-none transition-colors after:absolute after:inset-x-1 after:inset-y-0 after:z-0 after:rounded after:bg-f1-background-hover after:opacity-0 after:transition-opacity after:duration-75 after:content-[''] hover:after:opacity-100 [&_*]:z-10"
             />
           ),
         })
-        items.push(...getItems(group.records))
+        if (!collapsible || openGroups[group.key]) {
+          items.push(
+            ...getItems(group.records).map((vi) => ({
+              ...vi,
+              key: `${group.key}:${vi.key}`,
+              item: collapsible ? (
+                <div className="pl-5">{vi.item}</div>
+              ) : (
+                vi.item
+              ),
+            }))
+          )
+        }
       })
       return items
     }
     return getItems(data.records)
-  }, [data.records, data.type, data.groups, getItems, openGroups, setGroupOpen])
+  }, [
+    data.records,
+    data.type,
+    data.groups,
+    getItems,
+    openGroups,
+    setGroupOpen,
+    collapsible,
+  ])
 
   const handleScrollBottom = () => {
     loadMore()

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -715,6 +715,119 @@ export const WithDataSourceGrouping: Story = {
   },
 }
 
+export const WithDataSourceGroupingDefaultOpen: Story = {
+  args: {
+    label: "Data Source Grouping (Default Open)",
+    placeholder: "Select a value",
+    showSearchBox: true,
+    onChange: fn(),
+    value: "option-2",
+    source: createDataSourceDefinition<MockItem>({
+      grouping: {
+        mandatory: true,
+        collapsible: true,
+        defaultOpenGroups: true,
+        groupBy: {
+          role: {
+            name: "Role",
+            label: (groupId) => `${groupId}`,
+            itemCount: (groupId) =>
+              mockItems.filter((item) => item.role === groupId).length,
+          },
+        },
+      },
+      dataAdapter: {
+        paginationType: "infinite-scroll",
+        fetchData: (options) => {
+          const { search, pagination } = options
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              const pageSize = pagination.perPage ?? 10
+              const cursor = "cursor" in pagination ? pagination.cursor : null
+              const nextCursor = cursor ? Number(cursor) + pageSize : pageSize
+              const results = mockItems.filter(
+                (item) =>
+                  !search ||
+                  item.label.toLowerCase().includes(search.toLowerCase())
+              )
+              resolve({
+                type: "infinite-scroll" as const,
+                cursor: String(nextCursor),
+                perPage: pageSize,
+                hasMore: nextCursor < results.length,
+                records: results.slice(cursor ? Number(cursor) : 0, nextCursor),
+                total: results.length,
+              })
+            }, 100)
+          })
+        },
+      },
+    }),
+    mapOptions: (item: MockItem) => ({
+      value: item.value,
+      label: item.label,
+      avatar: item.avatar,
+      description: item.description,
+    }),
+  },
+}
+
+export const WithManyCollapsibleGroups: Story = {
+  args: {
+    label: "Many Collapsible Groups",
+    placeholder: "Select a value",
+    showSearchBox: true,
+    onChange: fn(),
+    source: createDataSourceDefinition<MockItem>({
+      grouping: {
+        mandatory: true,
+        collapsible: true,
+        defaultOpenGroups: false,
+        groupBy: {
+          role: {
+            name: "Role",
+            label: (groupId) => `${groupId}`,
+            itemCount: (groupId) =>
+              mockItems.filter((item) => item.role === groupId).length,
+          },
+        },
+      },
+      dataAdapter: {
+        paginationType: "infinite-scroll",
+        fetchData: (options) => {
+          const { search, pagination } = options
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              const pageSize = pagination.perPage ?? 50
+              const cursor = "cursor" in pagination ? pagination.cursor : null
+              const nextCursor = cursor ? Number(cursor) + pageSize : pageSize
+              const results = mockItems.filter(
+                (item) =>
+                  !search ||
+                  item.label.toLowerCase().includes(search.toLowerCase())
+              )
+              resolve({
+                type: "infinite-scroll" as const,
+                cursor: String(nextCursor),
+                perPage: pageSize,
+                hasMore: nextCursor < results.length,
+                records: results.slice(cursor ? Number(cursor) : 0, nextCursor),
+                total: results.length,
+              })
+            }, 100)
+          })
+        },
+      },
+    }),
+    mapOptions: (item: MockItem) => ({
+      value: item.value,
+      label: item.label,
+      avatar: item.avatar,
+      description: item.description,
+    }),
+  },
+}
+
 export const MultipleNotPaginated: Story = {
   args: {
     label: "Select Team Members",

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event"
 import "@testing-library/jest-dom/vitest"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import type { RecordType } from "@/hooks/datasource"
+import { createDataSourceDefinition, type RecordType } from "@/hooks/datasource"
 
 import { zeroRender as render } from "@/testing/test-utils"
 
@@ -421,6 +421,133 @@ describe("Select", () => {
     })
     await waitFor(() => {
       expect(handleChangeSelectedOption).toHaveBeenCalledWith(undefined, false)
+    })
+  })
+
+  describe("collapsible groups", () => {
+    type GroupedItem = {
+      value: string
+      label: string
+      role: string
+    }
+
+    const groupedItems: GroupedItem[] = [
+      { value: "a1", label: "Alice", role: "Engineer" },
+      { value: "a2", label: "Bob", role: "Engineer" },
+      { value: "b1", label: "Carol", role: "Designer" },
+      { value: "b2", label: "Dan", role: "Designer" },
+    ]
+
+    const buildSource = (defaultOpenGroups: boolean) =>
+      createDataSourceDefinition<GroupedItem>({
+        grouping: {
+          mandatory: true,
+          collapsible: true,
+          defaultOpenGroups,
+          groupBy: {
+            role: {
+              name: "Role",
+              label: (groupId) => `${groupId}`,
+              itemCount: (groupId) =>
+                groupedItems.filter((item) => item.role === groupId).length,
+            },
+          },
+        },
+        dataAdapter: {
+          paginationType: "infinite-scroll",
+          fetchData: () =>
+            Promise.resolve({
+              type: "infinite-scroll" as const,
+              cursor: "100",
+              perPage: 100,
+              hasMore: false,
+              records: groupedItems,
+              total: groupedItems.length,
+            }),
+        },
+      })
+
+    const mapOptions = (item: GroupedItem) => ({
+      value: item.value,
+      label: item.label,
+    })
+
+    it("shows group headers when all groups are collapsed (no false empty state)", async () => {
+      const user = userEvent.setup()
+      render(
+        <F0Select
+          {...defaultSelectProps}
+          source={buildSource(false)}
+          mapOptions={mapOptions}
+          searchEmptyMessage="No results found"
+          onChange={() => {}}
+        />
+      )
+
+      await openSelect(user)
+
+      // Group headers must be visible even though no items contribute a value
+      await waitFor(() => {
+        expect(screen.getByText("Engineer")).toBeInTheDocument()
+      })
+      expect(screen.getByText("Designer")).toBeInTheDocument()
+
+      // Records remain hidden while groups are closed
+      expect(screen.queryByText("Alice")).not.toBeInTheDocument()
+      expect(screen.queryByText("Carol")).not.toBeInTheDocument()
+
+      // Empty-state message must NOT show — group headers count as content
+      expect(screen.queryByText("No results found")).not.toBeInTheDocument()
+    })
+
+    it("shows group headers and records when groups are open by default", async () => {
+      const user = userEvent.setup()
+      render(
+        <F0Select
+          {...defaultSelectProps}
+          source={buildSource(true)}
+          mapOptions={mapOptions}
+          onChange={() => {}}
+        />
+      )
+
+      await openSelect(user)
+
+      await waitFor(() => {
+        expect(screen.getByText("Engineer")).toBeInTheDocument()
+      })
+      expect(screen.getByText("Alice")).toBeInTheDocument()
+      expect(screen.getByText("Bob")).toBeInTheDocument()
+      expect(screen.getByText("Carol")).toBeInTheDocument()
+      expect(screen.getByText("Dan")).toBeInTheDocument()
+    })
+
+    it("reveals records when a closed group header is clicked", async () => {
+      const user = userEvent.setup()
+      render(
+        <F0Select
+          {...defaultSelectProps}
+          source={buildSource(false)}
+          mapOptions={mapOptions}
+          onChange={() => {}}
+        />
+      )
+
+      await openSelect(user)
+
+      await waitFor(() => {
+        expect(screen.getByText("Engineer")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Alice")).not.toBeInTheDocument()
+
+      await user.click(screen.getByText("Engineer"))
+
+      await waitFor(() => {
+        expect(screen.getByText("Alice")).toBeInTheDocument()
+      })
+      expect(screen.getByText("Bob")).toBeInTheDocument()
+      // The other group remains collapsed
+      expect(screen.queryByText("Carol")).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/react/src/hooks/datasource/__test__/useGroups.test.ts
+++ b/packages/react/src/hooks/datasource/__test__/useGroups.test.ts
@@ -1,0 +1,89 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { GroupRecord } from "../useData"
+import { useGroups } from "../useGroups"
+
+type TestRecord = { id: number; name: string }
+
+const buildGroups = (keys: string[]): GroupRecord<TestRecord>[] =>
+  keys.map((key) => ({
+    key,
+    label: key,
+    itemCount: 0,
+    records: [],
+  }))
+
+describe("useGroups", () => {
+  describe("initial render (no flicker)", () => {
+    it("opens all groups synchronously when defaultOpenGroups=true", () => {
+      const groups = buildGroups(["a", "b", "c"])
+      const { result } = renderHook(() => useGroups(groups, true))
+
+      expect(result.current.openGroups).toEqual({
+        a: true,
+        b: true,
+        c: true,
+      })
+    })
+
+    it("closes all groups synchronously when defaultOpenGroups=false", () => {
+      const groups = buildGroups(["a", "b"])
+      const { result } = renderHook(() => useGroups(groups, false))
+
+      expect(result.current.openGroups).toEqual({ a: false, b: false })
+    })
+
+    it("opens only listed groups synchronously when defaultOpenGroups is an array", () => {
+      const groups = buildGroups(["a", "b", "c"])
+      const { result } = renderHook(() => useGroups(groups, ["a", "c"]))
+
+      expect(result.current.openGroups).toEqual({
+        a: true,
+        b: false,
+        c: true,
+      })
+    })
+
+    it("closes all groups synchronously when defaultOpenGroups is omitted (defaults to [])", () => {
+      const groups = buildGroups(["a", "b"])
+      const { result } = renderHook(() => useGroups(groups))
+
+      expect(result.current.openGroups).toEqual({ a: false, b: false })
+    })
+
+    it("returns an empty map when groups is empty", () => {
+      const { result } = renderHook(() => useGroups<TestRecord>([], true))
+
+      expect(result.current.openGroups).toEqual({})
+    })
+  })
+
+  describe("setGroupOpen", () => {
+    it("toggles a single group's open state without affecting others", () => {
+      const groups = buildGroups(["a", "b"])
+      const { result } = renderHook(() => useGroups(groups, true))
+
+      act(() => {
+        result.current.setGroupOpen("a", false)
+      })
+
+      expect(result.current.openGroups).toEqual({ a: false, b: true })
+    })
+  })
+
+  describe("when groups arrive asynchronously", () => {
+    it("populates defaults once groups become non-empty", () => {
+      const { result, rerender } = renderHook(
+        ({ groups }) => useGroups(groups, true),
+        { initialProps: { groups: [] as GroupRecord<TestRecord>[] } }
+      )
+
+      expect(result.current.openGroups).toEqual({})
+
+      rerender({ groups: buildGroups(["x", "y"]) })
+
+      expect(result.current.openGroups).toEqual({ x: true, y: true })
+    })
+  })
+})

--- a/packages/react/src/hooks/datasource/useGroups.ts
+++ b/packages/react/src/hooks/datasource/useGroups.ts
@@ -3,23 +3,31 @@ import { useEffect, useState } from "react"
 import { RecordType } from "./types/records.typings"
 import { GroupRecord } from "./useData"
 
+const computeDefaultOpenGroups = <R extends RecordType>(
+  groups: GroupRecord<R>[],
+  defaultOpenGroups: boolean | GroupRecord<R>["key"][]
+): Record<string, boolean> =>
+  groups.reduce(
+    (acc, group) => {
+      acc[group.key] =
+        typeof defaultOpenGroups === "boolean"
+          ? defaultOpenGroups
+          : defaultOpenGroups.includes(group.key)
+      return acc
+    },
+    {} as Record<string, boolean>
+  )
+
 export const useGroups = <R extends RecordType>(
   groups: GroupRecord<R>[],
   defaultOpenGroups: boolean | GroupRecord<R>["key"][] = []
 ) => {
-  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({})
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() =>
+    computeDefaultOpenGroups(groups, defaultOpenGroups)
+  )
 
   useEffect(() => {
-    const defaultValue = groups.reduce(
-      (acc, group) => {
-        acc[group.key] =
-          typeof defaultOpenGroups === "boolean"
-            ? defaultOpenGroups
-            : defaultOpenGroups.includes(group.key)
-        return acc
-      },
-      {} as Record<string, boolean>
-    )
+    const defaultValue = computeDefaultOpenGroups(groups, defaultOpenGroups)
     if (Object.values(defaultValue).length > 0) {
       setOpenGroups(defaultValue)
     }

--- a/packages/react/src/lib/Await/Await.tsx
+++ b/packages/react/src/lib/Await/Await.tsx
@@ -17,23 +17,29 @@ const _Await = <T,>({
   children,
   dataTestId,
 }: AwaitProps<T> & { dataTestId?: string }): ReactNode => {
-  const [resolvedValue, setResolvedValue] = useState<T | null>(null)
+  const [resolvedValue, setResolvedValue] = useState<T | null>(() =>
+    resolve instanceof Promise ? null : (resolve as T)
+  )
   const [error, setError] = useState<Error | null>(null)
   const [isPending, setIsPending] = useState(false)
 
   useEffect(() => {
     if (resolve instanceof Promise) {
       setIsPending(true)
+      let cancelled = false
       resolve
         .then((value) => {
-          setResolvedValue(value)
+          if (!cancelled) setResolvedValue(value)
         })
         .catch((error) => {
-          setError(error)
+          if (!cancelled) setError(error)
         })
         .finally(() => {
-          setIsPending(false)
+          if (!cancelled) setIsPending(false)
         })
+      return () => {
+        cancelled = true
+      }
     } else {
       setResolvedValue(resolve)
       setIsPending(false)

--- a/packages/react/src/lib/Await/Await.tsx
+++ b/packages/react/src/lib/Await/Await.tsx
@@ -26,6 +26,8 @@ const _Await = <T,>({
   useEffect(() => {
     if (resolve instanceof Promise) {
       setIsPending(true)
+      setError(null)
+      setResolvedValue(null)
       let cancelled = false
       resolve
         .then((value) => {
@@ -42,6 +44,7 @@ const _Await = <T,>({
       }
     } else {
       setResolvedValue(resolve)
+      setError(null)
       setIsPending(false)
     }
   }, [resolve])

--- a/packages/react/src/ui/ChevronToggle/ChevronToggle.tsx
+++ b/packages/react/src/ui/ChevronToggle/ChevronToggle.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react"
 
 import { F0Icon } from "@/components/F0Icon"
 import { ChevronDown } from "@/icons/app"
+import { useReducedMotion } from "@/lib/a11y"
 import { cn } from "@/lib/utils"
 
 export type ChevronToggleProps = {
@@ -10,6 +11,8 @@ export type ChevronToggleProps = {
   onClick?: () => void
   disabled?: boolean
   size?: "xs" | "sm"
+  closedRotation?: number
+  openRotation?: number
 }
 
 export const ChevronToggle = ({
@@ -18,11 +21,16 @@ export const ChevronToggle = ({
   onClick,
   disabled,
   size = "xs",
+  closedRotation = 0,
+  openRotation = 180,
 }: ChevronToggleProps) => {
+  const shouldReduceMotion = useReducedMotion()
+  const rotation = open ? openRotation : closedRotation
   return (
     <motion.div
-      animate={{ rotate: open ? 180 : 0 }}
-      transition={{ duration: 0.2 }}
+      initial={{ rotate: rotation }}
+      animate={{ rotate: rotation }}
+      transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
       className={cn(
         "flex h-3 w-3 shrink-0 items-center justify-center",
         disabled && "cursor-not-allowed opacity-50",

--- a/packages/react/src/ui/GroupHeader/GroupHeader.tsx
+++ b/packages/react/src/ui/GroupHeader/GroupHeader.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react"
 import { F0Checkbox } from "@/components/F0Checkbox"
 import { Await } from "@/lib/Await"
 import { Counter } from "@/ui/Counter"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import { ChevronToggle } from "@/ui/ChevronToggle/ChevronToggle"
 import { Skeleton } from "@/ui/skeleton"
 
@@ -17,6 +17,9 @@ type GroupHeaderProps = {
   select?: true | false | "indeterminate"
   onSelectChange?: (selected: boolean) => void
   className?: string
+  chevronPosition?: "leading" | "trailing"
+  closedRotation?: number
+  openRotation?: number
 }
 
 export const GroupHeader = ({
@@ -29,6 +32,9 @@ export const GroupHeader = ({
   select,
   onSelectChange,
   className,
+  chevronPosition = "trailing",
+  closedRotation,
+  openRotation,
 }: GroupHeaderProps) => {
   const [isOpen, setIsOpen] = useState(open)
 
@@ -49,11 +55,41 @@ export const GroupHeader = ({
     }
   }
 
+  const chevron = showOpenChange && (
+    <span className="text-f1-icon-secondary" data-testid="group-header-chevron">
+      <ChevronToggle
+        open={isOpen}
+        size="sm"
+        closedRotation={closedRotation}
+        openRotation={openRotation}
+      />
+    </span>
+  )
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      if (e.key === " ") e.preventDefault()
+      handleGroupClick()
+    }
+  }
+
+  const isInteractive = showOpenChange || selectable
+
   return (
     <div
-      className={cn("pointer-events-auto flex items-center gap-2", className)}
+      className={cn(
+        "pointer-events-auto flex items-center gap-2",
+        isInteractive && focusRing("rounded"),
+        className
+      )}
       onClick={handleGroupClick}
+      {...(isInteractive && {
+        role: "button",
+        tabIndex: 0,
+        onKeyDown: handleKeyDown,
+      })}
     >
+      {chevronPosition === "leading" && chevron}
       {selectable && (
         <F0Checkbox
           checked={!!select}
@@ -74,11 +110,7 @@ export const GroupHeader = ({
       <Await resolve={itemCount} fallback={<Skeleton className="h-4 w-5" />}>
         {(count) => count !== undefined && <Counter value={count} />}
       </Await>
-      {showOpenChange && (
-        <span className="text-f1-icon-secondary">
-          <ChevronToggle open={isOpen} size="sm" />
-        </span>
-      )}
+      {chevronPosition === "trailing" && chevron}
     </div>
   )
 }

--- a/packages/react/src/ui/GroupHeader/__tests__/GroupHeader.test.tsx
+++ b/packages/react/src/ui/GroupHeader/__tests__/GroupHeader.test.tsx
@@ -1,5 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
 
 import { GroupHeader } from "../GroupHeader"
 
@@ -17,11 +19,9 @@ describe("GroupHeader", () => {
 
     render(<GroupHeader label={labelPromise} itemCount={countPromise} />)
 
-    // Initially shows skeletons
     const skeletons = screen.getAllByTestId("skeleton")
     expect(skeletons).toHaveLength(2)
 
-    // Wait for promises to resolve and verify content
     await vi.waitFor(() => {
       expect(screen.queryAllByTestId("skeleton")).toHaveLength(0)
     })
@@ -78,9 +78,68 @@ describe("GroupHeader", () => {
     const countPromise = Promise.resolve(undefined)
     render(<GroupHeader label="Test Group" itemCount={countPromise} />)
 
-    // Wait for promise to resolve
     await vi.waitFor(() => {
       expect(screen.queryByRole("status")).not.toBeInTheDocument()
     })
+  })
+
+  it("renders chevron after label by default (trailing)", () => {
+    render(
+      <GroupHeader
+        label="Test Group"
+        itemCount={5}
+        showOpenChange
+        open={false}
+      />
+    )
+
+    const label = screen.getByText("Test Group")
+    const chevron = screen.getByTestId("group-header-chevron")
+    expect(
+      label.compareDocumentPosition(chevron) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it("renders chevron before label when chevronPosition is leading", () => {
+    render(
+      <GroupHeader
+        label="Test Group"
+        itemCount={5}
+        showOpenChange
+        open={false}
+        chevronPosition="leading"
+      />
+    )
+
+    const label = screen.getByText("Test Group")
+    const chevron = screen.getByTestId("group-header-chevron")
+    expect(
+      label.compareDocumentPosition(chevron) & Node.DOCUMENT_POSITION_PRECEDING
+    ).toBeTruthy()
+  })
+
+  it("supports keyboard activation with Enter and Space", () => {
+    const onOpenChange = vi.fn()
+
+    render(
+      <GroupHeader
+        label="Test Group"
+        itemCount={5}
+        open={false}
+        onOpenChange={onOpenChange}
+        showOpenChange
+      />
+    )
+
+    const header = screen
+      .getByText("Test Group")
+      .closest("[role='button']") as HTMLElement
+
+    fireEvent.keyDown(header, { key: "Enter" })
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+
+    onOpenChange.mockClear()
+    fireEvent.keyDown(header, { key: " " })
+    expect(onOpenChange).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/react/src/ui/Select/__stories__/select.stories.tsx
+++ b/packages/react/src/ui/Select/__stories__/select.stories.tsx
@@ -71,6 +71,7 @@ const SelectWithHooks = ({
     () =>
       (options || []).map((option) => ({
         value: option.value,
+        key: `item-${option.value}`,
         height: 40,
         item: <SelectItem value={option.value}>{option.label}</SelectItem>,
       })),

--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -101,7 +101,9 @@ const SelectContent = forwardRef<
 
     const isEmpty = useMemo(() => {
       if (isVirtual) {
-        return items.filter((item) => item.value).length === 0
+        return items.every(
+          (item) => !item.value && item.type !== "group-header"
+        )
       }
       return !children
     }, [isVirtual, items, children])
@@ -137,7 +139,12 @@ const SelectContent = forwardRef<
       count: items?.length || 0,
       getScrollElement: () => parentRef.current,
       estimateSize: (i: number) => items?.[i]?.height || 0,
+      getItemKey: (i: number) => items?.[i]?.key ?? i,
       overscan: 5,
+      // Round measured heights to whole pixels. Sub-pixel values from
+      // getBoundingClientRect() accumulate into translateY drift that is
+      // visible as jitter while scrolling up.
+      measureElement: (el) => Math.round(el.getBoundingClientRect().height),
       // If the content is a list, we need to check if the animation is enabled
       enabled: asList || prefersReducedMotion || animationStarted,
     })
@@ -151,8 +158,8 @@ const SelectContent = forwardRef<
     }, [open])
 
     useEffect(() => {
-      // Measure the items when the animation is finished
-      // Skip measurement when asList is true to prevent layout shifts from tooltips
+      // Measure the items when the animation is finished.
+      // Skip measurement when asList is true to prevent layout shifts from tooltips.
       if (!asList) {
         virtualizer.measure()
       }

--- a/packages/react/src/ui/Select/typings.ts
+++ b/packages/react/src/ui/Select/typings.ts
@@ -1,7 +1,11 @@
 import { ReactNode } from "react"
 
+export type VirtualItemType = "item" | "separator" | "group-header"
+
 export type VirtualItem = {
   height: number
   value?: string
+  key: string
   item: ReactNode
+  type?: VirtualItemType
 }


### PR DESCRIPTION
Fixes collapsible group rendering in F0Select — records were always visible regardless of open/closed state.

Changes
- F0Select: gate getItems(group.records) on openGroups[group.key] when collapsible is true; stable virtualizer keys; hover style on group headers; pl-5 indent for grouped items
- GroupHeader: add chevronPosition (leading/trailing), closedRotation, openRotation as independent props
- ChevronToggle: parameterize closedRotation/openRotation (defaults: 0°/180°)
- SelectContent: support key on VirtualItem for stable virtualizer identity

<img width="419" height="420" alt="Screenshot 2026-04-26 at 22 14 53" src="https://github.com/user-attachments/assets/867f063d-dabb-4945-8c4e-6e243cc1b50c" />
