### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.465.0",
+  "packages/react": "1.466.0",
   "packages/react-native": "0.52.1",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.466.0](https://github.com/factorialco/f0/compare/f0-react-v1.465.0...f0-react-v1.466.0) (2026-04-27)
+
+
+### Features
+
+* add support to resolve defaultValuesParams coming from One ([#4036](https://github.com/factorialco/f0/issues/4036)) ([6aaf334](https://github.com/factorialco/f0/commit/6aaf3343a45bd2d846b55ef702dd726f9a76dfc4))
+
 ## [1.465.0](https://github.com/factorialco/f0/compare/f0-react-v1.464.3...f0-react-v1.465.0) (2026-04-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.465.0",
+  "version": "1.466.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.466.0</summary>

## [1.466.0](https://github.com/factorialco/f0/compare/f0-react-v1.465.0...f0-react-v1.466.0) (2026-04-27)


### Features

* add support to resolve defaultValuesParams coming from One ([#4036](https://github.com/factorialco/f0/issues/4036)) ([6aaf334](https://github.com/factorialco/f0/commit/6aaf3343a45bd2d846b55ef702dd726f9a76dfc4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).