### PR TITLE
fix(NestedCell): height for editable text inputs in nested table rows

### DIFF
--- a/packages/react/src/experimental/OneTable/TableCell/NestedCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/NestedCell/index.tsx
@@ -2,9 +2,9 @@ import { ChevronDown, ChevronRight } from "lucide-react"
 
 import { F0Button } from "@/components/F0Button"
 import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
-import { NestedRowProps } from "@/patterns/OneDataCollection/visualizations/collection/Table/components/Row"
 import { Add, ArrowDown } from "@/icons/app"
 import { cn } from "@/lib/utils"
+import { NestedRowProps } from "@/patterns/OneDataCollection/visualizations/collection/Table/components/Row"
 
 import {
   CHEVRON_PARENT_SIZE,
@@ -201,7 +201,7 @@ export const NestedCell = ({
           </div>
           <div
             className={cn(
-              firstCellWithChildren && "min-w-0 w-full",
+              firstCellWithChildren && "min-w-0 w-full h-full",
               firstCellWithNoChildrenAndTableChildren &&
                 "pl-[var(--spacing-factor)]",
               "relative"


### PR DESCRIPTION
Parent rows with an editable text input in the first column had very small top/bottom padding — the input appeared cramped instead of filling the full 48px row height. Added h-full to the content wrapper div in NestedCell so the editable cell content stretches to fill the available height

before

<img width="560" height="256" alt="height before" src="https://github.com/user-attachments/assets/13c8b867-2c98-4825-8751-3cc13f7d9362" />

after

<img width="563" height="338" alt="height after" src="https://github.com/user-attachments/assets/34c3f3cc-6972-4b9c-b779-189573d7d384" />

🏡 Context
[💼 Jira](https://factorialmakers.atlassian.net/browse/FCT-52468)