### PR TITLE
feat: support per-row dynamic units in editable table number columns

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -1196,3 +1196,197 @@ export const EditableTableWithIconOnlyActions: Story = {
     )
   },
 }
+
+/**
+ * Demonstrates dynamic per-row units via `numberConfig.units` as a function.
+ * Roles show "h" (hours), simple items show "u" (units).
+ */
+export const DynamicUnitsPerRow: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows numberConfig.units as a per-row function with nested rows. Parent phases show "h" (hours), child tasks show "u" (units) and child roles show "h" (hours).',
+      },
+    },
+  },
+  render: () => {
+    type LineItem = RecordType & {
+      name: string
+      email: string
+      department: (typeof import("@/mocks").DEPARTMENTS_MOCK)[number]
+      itemType: "phase" | "task" | "role"
+      quantity: number
+      children?: LineItem[]
+    }
+
+    const makeItem = (
+      overrides: Pick<LineItem, "id" | "name" | "itemType" | "quantity"> & {
+        children?: LineItem[]
+      }
+    ): LineItem => ({
+      index: 0,
+      email: "",
+      department: "Engineering",
+      ...overrides,
+    })
+
+    const initialItems: LineItem[] = [
+      makeItem({
+        id: "phase-1",
+        name: "Design phase",
+        itemType: "phase",
+        quantity: 40,
+        children: [
+          makeItem({
+            id: "task-1",
+            name: "Wireframes",
+            itemType: "task",
+            quantity: 16,
+          }),
+          makeItem({
+            id: "role-1",
+            name: "Senior Designer",
+            itemType: "role",
+            quantity: 24,
+          }),
+        ],
+      }),
+      makeItem({
+        id: "phase-2",
+        name: "Development phase",
+        itemType: "phase",
+        quantity: 120,
+        children: [
+          makeItem({
+            id: "task-2",
+            name: "Computers",
+            itemType: "task",
+            quantity: 80,
+          }),
+          makeItem({
+            id: "role-2",
+            name: "Senior Developer",
+            itemType: "role",
+            quantity: 40,
+          }),
+        ],
+      }),
+      makeItem({
+        id: "phase-3",
+        name: "QA phase",
+        itemType: "phase",
+        quantity: 30,
+      }),
+    ]
+
+    const [items, setItems] = useState<LineItem[]>(initialItems)
+    const itemsRef = useRef(items)
+    itemsRef.current = items
+
+    const onCellChange = async (updatedItem: LineItem) => {
+      action("onCellChange")(updatedItem)
+      setItems((prev) =>
+        prev.map((i) => (i.id === updatedItem.id ? updatedItem : i))
+      )
+    }
+
+    const dataAdapter = useMemo(() => {
+      const adapter = createDataAdapter({
+        data: items,
+        paginationType: "pages",
+        perPage: 10,
+      })
+      adapter.fetchData = (fetchOptions: unknown) => {
+        const currentAdapter = createDataAdapter({
+          data: itemsRef.current,
+          paginationType: "pages",
+          perPage: 10,
+        })
+        return currentAdapter.fetchData(fetchOptions as never)
+      }
+      return adapter
+    }, [items])
+
+    const source = useDataCollectionSource<
+      LineItem,
+      Record<string, never>,
+      never,
+      never,
+      never,
+      never,
+      never
+    >({
+      dataAdapter,
+      itemsWithChildren: (item) => !!item?.children?.length,
+      childrenCount: ({ item }) => item?.children?.length,
+      fetchChildren: async ({ item }) => {
+        await new Promise((resolve) => setTimeout(resolve, 300))
+        return item.children
+          ? {
+              records: item.children,
+              type: "basic" as const,
+              paginationInfo: {
+                cursor: "",
+                total: item.children.length,
+                perPage: 10,
+                currentPage: 1,
+                pagesCount: 1,
+                hasMore: false,
+              },
+            }
+          : { records: [] }
+      },
+    })
+
+    return (
+      <OneDataCollection
+        source={source}
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              columns: [
+                {
+                  label: "Name",
+                  id: "name",
+                  width: 250,
+                  editType: () => "text" as const,
+                  render: (item: LineItem) => item.name,
+                },
+                {
+                  label: "Type",
+                  id: "itemType",
+                  editType: () => "display-only" as const,
+                  render: (item: LineItem) => item.itemType,
+                },
+                {
+                  label: "Quantity",
+                  id: "quantity",
+                  align: "right" as const,
+                  editType: (item: LineItem) =>
+                    item.itemType === "phase"
+                      ? ("disabled" as const)
+                      : ("number" as const),
+                  numberConfig: {
+                    min: 0,
+                    units: (item: LineItem) =>
+                      item.itemType === "role" || item.itemType === "phase"
+                        ? "h"
+                        : "u",
+                  },
+                  render: (item: LineItem) =>
+                    item.quantity !== undefined
+                      ? `${item.quantity} ${item.itemType === "role" || item.itemType === "phase" ? "h" : "u"}`
+                      : "",
+                },
+              ],
+              onCellChange,
+            },
+          },
+        ]}
+        id="editable-table-dynamic-units/v1"
+      />
+    )
+  },
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/MoneyCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/MoneyCell.test.tsx
@@ -138,4 +138,41 @@ describe("MoneyCell", () => {
     expect(passedProps.loading).toBe(true)
     expect(passedProps.onChange).toBe(onChange)
   })
+
+  it("resolves units from a function based on the item", () => {
+    render(
+      <MoneyCell
+        {...baseProps}
+        item={{ id: "1", currency: "€" }}
+        editableColumn={{
+          ...baseColumn,
+          numberConfig: {
+            units: (item: { id: string; currency: string }) => item.currency,
+          },
+        }}
+      />
+    )
+
+    const passedProps = numberCellProps.mock.lastCall?.[0]
+    expect(passedProps.editableColumn.numberConfig.units).toBe("€")
+  })
+
+  it("resolves unitsPosition from locale when units is a function returning a currency code", () => {
+    render(
+      <MoneyCell
+        {...baseProps}
+        item={{ id: "1", currency: "USD" }}
+        editableColumn={{
+          ...baseColumn,
+          numberConfig: {
+            units: (item: { id: string; currency: string }) => item.currency,
+          },
+        }}
+      />
+    )
+
+    const passedProps = numberCellProps.mock.lastCall?.[0]
+    expect(passedProps.editableColumn.numberConfig.units).toBe("USD")
+    expect(passedProps.editableColumn.numberConfig.unitsPosition).toBe("before")
+  })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
@@ -7,7 +7,7 @@ import { zeroRender as render } from "../../../../../../testing/test-utils"
 import { EditableCellProps } from "../components/cells"
 import { NumberCell } from "../components/cells/NumberCell"
 
-type TestRecord = { id: string; salary: number }
+type TestRecord = { id: string; salary: number; currency?: string }
 
 function makeEditableColumn(
   overrides: Partial<EditableCellProps<TestRecord>["editableColumn"]> = {}
@@ -143,6 +143,22 @@ describe("NumberCell", () => {
     )
 
     expect(screen.getByRole("textbox")).toHaveValue("0")
+    expect(screen.getByText("€")).toBeInTheDocument()
+  })
+
+  it("resolves units from a function based on the item", () => {
+    render(
+      <NumberCell
+        {...defaultProps}
+        item={{ id: "1", salary: 42000, currency: "€" }}
+        editableColumn={makeEditableColumn({
+          numberConfig: {
+            units: (item: TestRecord) => item.currency,
+          },
+        })}
+      />
+    )
+
     expect(screen.getByText("€")).toBeInTheDocument()
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/MoneyCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/MoneyCell.tsx
@@ -5,6 +5,7 @@ import { useL10n } from "@/lib/providers/l10n"
 
 import type { EditableCellProps } from "."
 
+import { resolveUnits } from "./hooks/useNumberCellLayout"
 import { NumberCell } from "./NumberCell"
 
 const isUnitBeforeNumber = (
@@ -29,14 +30,16 @@ export function MoneyCell<R extends RecordType>(props: EditableCellProps<R>) {
   const config = props.editableColumn.numberConfig
   const locale = config?.locale ?? contextLocale
 
+  const resolvedUnits = resolveUnits(config, props.item)
+
   const unitsBefore = useMemo(
     () =>
-      config?.units
-        ? config.unitsPosition
+      resolvedUnits
+        ? config?.unitsPosition
           ? config.unitsPosition === "before"
-          : isUnitBeforeNumber(locale, config.units)
+          : isUnitBeforeNumber(locale, resolvedUnits)
         : false,
-    [locale, config?.units]
+    [locale, resolvedUnits, config?.unitsPosition]
   )
 
   return (
@@ -46,7 +49,7 @@ export function MoneyCell<R extends RecordType>(props: EditableCellProps<R>) {
         ...props.editableColumn,
         numberConfig: {
           ...config,
-          units: config?.units ?? "$",
+          units: resolvedUnits ?? "$",
           unitsPosition: unitsBefore ? "before" : "after",
         },
       }}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -15,6 +15,7 @@ export function NumberCell<R extends RecordType>({
   error,
   loading,
   onChange,
+  item,
 }: EditableCellProps<R>) {
   const config = editableColumn.numberConfig
   // When clamping produces the same value the parent already holds,
@@ -28,7 +29,8 @@ export function NumberCell<R extends RecordType>({
 
   const { ref, width, locale, units, unitsBefore } = useNumberCellLayout(
     config,
-    numericValue
+    numericValue,
+    item
   )
 
   const handleChange = (newValue: number | null) => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/hooks/useNumberCellLayout.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/hooks/useNumberCellLayout.ts
@@ -1,23 +1,36 @@
 import { useMemo } from "react"
 
+import { RecordType } from "@/hooks/datasource/types/records.typings"
 import { useL10n } from "@/lib/providers/l10n"
 
 import { NumberCellConfig } from "../../../types"
 import { useInputTextWidth } from "./useInputTextWidth"
 
 /**
+ * Resolve `units` from config, which can be a static string or a per-row function.
+ */
+export function resolveUnits<R extends RecordType>(
+  config: NumberCellConfig<R> | undefined,
+  item: R
+): string | undefined {
+  if (!config?.units) return undefined
+  return typeof config.units === "function" ? config.units(item) : config.units
+}
+
+/**
  * Encapsulates formatting, units placement, and width measurement
  * for number/money cells so the component only deals with rendering.
  */
-export function useNumberCellLayout(
-  config: NumberCellConfig | undefined,
-  numericValue: number | null
+export function useNumberCellLayout<R extends RecordType>(
+  config: NumberCellConfig<R> | undefined,
+  numericValue: number | null,
+  item: R
 ) {
   const { locale: contextLocale } = useL10n()
   const locale = config?.locale ?? contextLocale
 
-  const units = config?.units
-  const unitsBefore = units ? config.unitsPosition === "before" : false
+  const units = resolveUnits(config, item)
+  const unitsBefore = units ? config?.unitsPosition === "before" : false
   const formatter = useMemo(
     () =>
       new Intl.NumberFormat(locale, {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -31,13 +31,18 @@ export type AddRowActionsResult =
 
 export type EditableTableVisualizationSettings = TableVisualizationSettings
 
-export type NumberCellConfig = {
+export type NumberCellConfig<R extends RecordType = RecordType> = {
   min?: number
   max?: number
   step?: number
   maxDecimals?: number
   locale?: string
-  units?: string
+  /**
+   * Unit label displayed next to the number input.
+   * Can be a static string (e.g. `"h"`) or a function that receives the
+   * current row item to return a per-row unit (e.g. `(item) => item.type === "role" ? "h" : "u"`).
+   */
+  units?: string | ((item: R) => string | undefined)
   unitsPosition?: "before" | "after"
 }
 
@@ -118,7 +123,7 @@ export type EditableTableColumnDefinition<
    * stepping (`step`), formatting (`maxDecimals`, `locale`), and units.
    * Falls back to sensible defaults when omitted.
    */
-  numberConfig?: NumberCellConfig
+  numberConfig?: NumberCellConfig<R>
 }
 
 export type EditableTableVisualizationOptions<


### PR DESCRIPTION
numberConfig.units was a static string per column, but some use cases need different units per row (e.g. "h" for roles, "u" for simple items in quote line items). Units now accepts string | ((item) => string | undefined), following the same pattern as editType. The change is non-breaking — existing static units: "h" continues to work. 

Includes unit tests for both NumberCell and MoneyCell, and a Storybook story demonstrating per-row units with nested rows

story

<img width="1864" height="666" alt="dynamic units story" src="https://github.com/user-attachments/assets/139252df-29ec-4ae9-81dc-ff8ff7c7b92d" />

example use case factorial

<img width="1391" height="644" alt="dynamic units example factorial" src="https://github.com/user-attachments/assets/51e2ce2c-ee27-4801-942d-ffe4ea7b45b4" />

🏡 Context
[💼 Jira](https://factorialmakers.atlassian.net/browse/FCT-52485)