### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.466.1",
+  "packages/react": "1.467.0",
   "packages/react-native": "0.52.1",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.467.0](https://github.com/factorialco/f0/compare/f0-react-v1.466.1...f0-react-v1.467.0) (2026-04-27)
+
+
+### Features
+
+* **docs:** add F0ButtonDropdown Storybook documentation ([#3916](https://github.com/factorialco/f0/issues/3916)) ([fb00abb](https://github.com/factorialco/f0/commit/fb00abbfc9ecb7d8be7145f9ce06083ea3bc0864))
+
 ## [1.466.1](https://github.com/factorialco/f0/compare/f0-react-v1.466.0...f0-react-v1.466.1) (2026-04-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.466.1",
+  "version": "1.467.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.467.0</summary>

## [1.467.0](https://github.com/factorialco/f0/compare/f0-react-v1.466.1...f0-react-v1.467.0) (2026-04-27)


### Features

* **docs:** add F0ButtonDropdown Storybook documentation ([#3916](https://github.com/factorialco/f0/issues/3916)) ([fb00abb](https://github.com/factorialco/f0/commit/fb00abbfc9ecb7d8be7145f9ce06083ea3bc0864))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).