### PR TITLE
feat(editable-table): null values in number cells, fix input focus loss and action column width

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/BaseCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/BaseCell.test.tsx
@@ -133,4 +133,27 @@ describe("BaseCell", () => {
     const cell = container.firstChild as HTMLElement
     expect(cell.className).toContain("bg-f1-background-secondary")
   })
+
+  it("preserves input focus when error transitions from undefined to a string", async () => {
+    const user = userEvent.setup()
+
+    const { rerender } = render(
+      <BaseCell>
+        <input data-testid="cell-input" />
+      </BaseCell>
+    )
+
+    const input = screen.getByTestId("cell-input")
+    await user.click(input)
+    expect(input).toHaveFocus()
+
+    // Simulate error appearing (e.g. after onCellChange rejects)
+    rerender(
+      <BaseCell error="Invalid value">
+        <input data-testid="cell-input" />
+      </BaseCell>
+    )
+
+    expect(screen.getByTestId("cell-input")).toHaveFocus()
+  })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
@@ -34,11 +34,11 @@ describe("NumberCell", () => {
     expect(input).toHaveValue("42000")
   })
 
-  it("renders 0 when value is an empty string", () => {
+  it("renders empty when value is an empty string", () => {
     render(<NumberCell {...defaultProps} value="" />)
 
     const input = screen.getByRole("textbox")
-    expect(input).toHaveValue("0")
+    expect(input).toHaveValue("")
   })
 
   it("calls onChange with the serialized string value", async () => {
@@ -53,7 +53,7 @@ describe("NumberCell", () => {
     expect(onChange).toHaveBeenCalledWith("5")
   })
 
-  it("calls onChange with '0' when value is cleared", async () => {
+  it("calls onChange with null when value is cleared", async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
 
@@ -62,7 +62,7 @@ describe("NumberCell", () => {
     const input = screen.getByRole("textbox")
     await user.clear(input)
 
-    expect(onChange).toHaveBeenCalledWith("0")
+    expect(onChange).toHaveBeenCalledWith(null)
   })
 
   it("does not call onChange when value is unchanged", () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/EditableCellRenderer.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/EditableCellRenderer.tsx
@@ -2,10 +2,9 @@ import type { RecordType, SortingsDefinition } from "@/hooks/datasource"
 
 import type { SummariesDefinition } from "../../../../summary"
 import type { CellRendererProps } from "../../Table/types"
-import type { EditableTableColumnDefinition } from "../types"
-
 import { editableCellMap } from "../consts"
 import { useEditableRow } from "../context/EditableRowContext"
+import type { EditableTableColumnDefinition } from "../types"
 import { NonEditableCell } from "./cells/status/NonEditableCell"
 
 /**
@@ -62,7 +61,7 @@ export function EditableCellRenderer<
 
   const hasId = editableColumn.id !== undefined
 
-  const onChange = (value: string) => {
+  const onChange = (value: string | null) => {
     if (editableColumn.id !== undefined) {
       handleCellChange(editableColumn.id, value)
     }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
@@ -45,11 +45,7 @@ export function BaseCell({
         readonly && "bg-f1-background-secondary"
       )}
     >
-      {error ? (
-        <ErrorTooltip message={error}>{children}</ErrorTooltip>
-      ) : (
-        children
-      )}
+      <ErrorTooltip message={error}>{children}</ErrorTooltip>
     </div>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ErrorTooltip.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ErrorTooltip.tsx
@@ -12,20 +12,22 @@ import {
 } from "@/ui/tooltip"
 
 interface ErrorTooltipProps {
-  message: string
+  message?: string
   children: ReactNode
 }
 
 export function ErrorTooltip({ message, children }: ErrorTooltipProps) {
   const [open, setOpen] = useState(false)
 
-  const handleFocusCapture = useCallback(() => setOpen(true), [])
+  const handleFocusCapture = useCallback(() => {
+    if (message) setOpen(true)
+  }, [message])
   const handleBlurCapture = useCallback(() => setOpen(false), [])
 
   return (
     <div className="relative h-full w-full">
       <TooltipProvider delayDuration={100} disableHoverableContent>
-        <Tooltip open={open} onOpenChange={setOpen}>
+        <Tooltip open={open && !!message} onOpenChange={setOpen}>
           <TooltipTrigger asChild className="pointer-events-auto h-full w-full">
             <div
               className="flex h-full w-full items-center"
@@ -35,15 +37,17 @@ export function ErrorTooltip({ message, children }: ErrorTooltipProps) {
               {children}
             </div>
           </TooltipTrigger>
-          <TooltipContent
-            side="top"
-            className="flex items-center gap-1 border-black/10 bg-[#fff] shadow-md"
-          >
-            <F0Icon icon={AlertCircle} color="critical" size="sm" />
-            <span className="text-sm font-medium text-f1-foreground-critical">
-              {message}
-            </span>
-          </TooltipContent>
+          {message && (
+            <TooltipContent
+              side="top"
+              className="flex items-center gap-1 border-black/10 bg-[#fff] shadow-md"
+            >
+              <F0Icon icon={AlertCircle} color="critical" size="sm" />
+              <span className="text-sm font-medium text-f1-foreground-critical">
+                {message}
+              </span>
+            </TooltipContent>
+          )}
         </Tooltip>
       </TooltipProvider>
     </div>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ErrorTooltip.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ErrorTooltip.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react"
-
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import { F0Icon } from "@/components/F0Icon"
 import { AlertCircle } from "@/icons/app"
@@ -22,7 +21,12 @@ export function ErrorTooltip({ message, children }: ErrorTooltipProps) {
   const handleFocusCapture = useCallback(() => {
     if (message) setOpen(true)
   }, [message])
+
   const handleBlurCapture = useCallback(() => setOpen(false), [])
+
+  useEffect(() => {
+    if (!message) setOpen(false)
+  }, [message])
 
   return (
     <div className="relative h-full w-full">
@@ -40,7 +44,7 @@ export function ErrorTooltip({ message, children }: ErrorTooltipProps) {
           {message && (
             <TooltipContent
               side="top"
-              className="flex items-center gap-1 border-black/10 bg-[#fff] shadow-md"
+              className="border-black/10 flex items-center gap-1 bg-[#fff] shadow-md"
             >
               <F0Icon icon={AlertCircle} color="critical" size="sm" />
               <span className="text-sm font-medium text-f1-foreground-critical">

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -5,7 +5,6 @@ import { RecordType } from "@/hooks/datasource/types/records.typings"
 import { cn } from "@/lib/utils"
 
 import type { EditableCellProps } from "."
-
 import { BaseCell } from "./BaseCell"
 import { useNumberCellLayout } from "./hooks/useNumberCellLayout"
 
@@ -24,7 +23,7 @@ export function NumberCell<R extends RecordType>({
 
   const trimmed = typeof value === "string" ? value.trim() : value
   const parsed = trimmed !== "" && trimmed != null ? Number(trimmed) : NaN
-  const numericValue: number | null = isFinite(parsed) ? parsed : 0
+  const numericValue: number | null = isFinite(parsed) ? parsed : null
 
   const { ref, width, locale, units, unitsBefore } = useNumberCellLayout(
     config,
@@ -32,7 +31,11 @@ export function NumberCell<R extends RecordType>({
   )
 
   const handleChange = (newValue: number | null) => {
-    let clamped = newValue ?? 0
+    if (newValue == null) {
+      if (value !== "") onChange(null)
+      return
+    }
+    let clamped = newValue
     if (config?.min != null && clamped < config.min) clamped = config.min
     if (config?.max != null && clamped > config.max) clamped = config.max
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -35,6 +35,7 @@ export function NumberCell<R extends RecordType>({
       if (value !== "") onChange(null)
       return
     }
+
     let clamped = newValue
     if (config?.min != null && clamped < config.min) clamped = config.min
     if (config?.max != null && clamped > config.max) clamped = config.max

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
@@ -1,7 +1,6 @@
 import type { RecordType, SortingsDefinition } from "@/hooks/datasource"
 
 import type { SummariesDefinition } from "../../../../../summary"
-
 import { EditableTableColumnDefinition } from "../../types"
 
 /**
@@ -17,7 +16,7 @@ export type EditableCellProps<R extends RecordType> = {
   inputPlaceholder?: string
   error?: string
   loading?: boolean
-  onChange: (value: string) => void
+  onChange: (value: string | null) => void
   item: R
   isLastColumn?: boolean
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -534,6 +534,7 @@ export const TableCollection = <
                 (isEditableTable ? (
                   <TableHead
                     key="actions"
+                    width="fit"
                     sticky={{ right: 0 }}
                     className="border-0 border-l-[1px] border-solid border-f1-border-secondary"
                   >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -34,11 +34,6 @@ import { useDataCollectionSettings } from "@/patterns/OneDataCollection/Settings
 import { GroupHeader } from "@/ui/GroupHeader/index"
 import { Skeleton } from "@/ui/skeleton.tsx"
 
-import type {
-  TableCustomizationProps,
-  TableVisualizationOptions,
-} from "./types"
-
 import { PrimaryActionItemDefinition } from "../../../actions"
 import { useDataCollectionData } from "../../../hooks/useDataCollectionData"
 import { useInfiniteScrollPagination } from "../../../hooks/useInfiniteScrollPagination"
@@ -52,6 +47,10 @@ import { Row } from "./components/Row"
 import { useColumns } from "./hooks/useColums"
 import { groupBorderClass, useHeaderGroups } from "./hooks/useHeaderGroups"
 import { NestedDataProvider } from "./providers/NestedProvider"
+import type {
+  TableCustomizationProps,
+  TableVisualizationOptions,
+} from "./types"
 import { useSticky } from "./useSticky"
 export * from "./settings/SettingsRenderer"
 
@@ -435,6 +434,7 @@ export const TableCollection = <
                   (isEditableTable ? (
                     <TableHead
                       key="actions"
+                      width="fit"
                       sticky={{ right: 0 }}
                       className="border-0 border-l-[1px] border-solid border-f1-border-secondary"
                     >


### PR DESCRIPTION
## Description

Support empty (null) values in editable table number/money cells, fix action column width, and fix input focus loss when error state changes.

## Screenshots (if applicable)

### Before

<img width="944" height="320" alt="Screenshot 2026-04-27 at 16 48 18" src="https://github.com/user-attachments/assets/3b258a5e-98f6-4a4b-9952-159b0bbaccf7" />

### After
<img width="954" height="328" alt="Screenshot 2026-04-27 at 16 56 54" src="https://github.com/user-attachments/assets/dcc7dfe1-c8a2-42cb-8643-0bf8bcbd2026" />

## Implementation details

### Null value support for number/money cells
- `NumberCell` emits `onChange(null)` when the user clears the input, instead of coercing to `"0"`
- `NumberCell` renders empty for null values instead of displaying `0`
- Enables consumers to distinguish between "user entered 0" and "user cleared the field"

### Action column too wide
- Added `width="fit"` on action column `<TableHead>` to shrink to content instead of expanding to fill available space

### Input focus loss on error
- `BaseCell` now always renders `<ErrorTooltip>` wrapper regardless of error state, preserving DOM structure across error transitions
- Previously, toggling from no-error to error caused React to unmount/remount the input (different tree structures), losing focus


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes editable-table cell edit value semantics by allowing `null` for cleared number inputs and adjusts tooltip wrapping to avoid focus loss; consumers relying on previous "0" coercion or tooltip behavior may need updates.
> 
> **Overview**
> Enables *true empty values* in editable table number cells: `NumberCell` now renders cleared/invalid values as empty and emits `onChange(null)` when the user clears the input (instead of coercing to `"0"`), with the `EditableCellProps.onChange` contract widened to `string | null`.
> 
> Fixes focus loss when cell errors appear by keeping the DOM structure stable: `BaseCell` always wraps children in `ErrorTooltip`, while `ErrorTooltip` is updated to accept optional messages and only open/render content when an error exists.
> 
> Adjusts editable-table action column headers to `width="fit"` so the actions column no longer expands unnecessarily, and updates tests to cover the new behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342a4b9892a01a99685bac952fa41379cc23a6d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->