### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.467.0",
+  "packages/react": "1.468.0",
   "packages/react-native": "0.52.1",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.468.0](https://github.com/factorialco/f0/compare/f0-react-v1.467.0...f0-react-v1.468.0) (2026-04-28)
+
+
+### Features
+
+* support per-row dynamic units in editable table number columns ([#4047](https://github.com/factorialco/f0/issues/4047)) ([3737b3e](https://github.com/factorialco/f0/commit/3737b3eb95aa407c553aec0e8eaeeae73694db0a))
+
 ## [1.467.0](https://github.com/factorialco/f0/compare/f0-react-v1.466.1...f0-react-v1.467.0) (2026-04-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.467.0",
+  "version": "1.468.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.468.0</summary>

## [1.468.0](https://github.com/factorialco/f0/compare/f0-react-v1.467.0...f0-react-v1.468.0) (2026-04-28)


### Features

* support per-row dynamic units in editable table number columns ([#4047](https://github.com/factorialco/f0/issues/4047)) ([3737b3e](https://github.com/factorialco/f0/commit/3737b3eb95aa407c553aec0e8eaeeae73694db0a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).