### PR TITLE
fix: prevent users from editing emoji options when the question component is disabled

### DIFF
--- a/packages/react/src/components/F0Button/internal-types.ts
+++ b/packages/react/src/components/F0Button/internal-types.ts
@@ -77,6 +77,11 @@ export type ButtonInternalProps = Pick<
      */
     disabled?: boolean
     /**
+     * If true and disabled is also true, the button retains its normal visual appearance
+     * (no reduced opacity or not-allowed cursor) while still being non-interactive.
+     */
+    withoutDisabledAppearance?: boolean
+    /**
      * @private
      * If true, the button is visually active or selected (pressed state).
      */

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -3,14 +3,14 @@ import { forwardRef, useState } from "react"
 
 import { F0Icon } from "@/components/F0Icon"
 import { EmojiImage } from "@/lib/emojis"
+import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useTextFormatEnforcer } from "@/lib/text"
 import { cn } from "@/lib/utils"
 import { Action } from "@/ui/Action"
+import { Counter } from "@/ui/Counter"
 
-import { OneEllipsis } from "@/lib/OneEllipsis"
 import { ButtonInternalProps } from "./internal-types"
 import { fontSizeVariants } from "./variants"
-import { Counter } from "@/ui/Counter"
 
 const IconMotion = motion.create(F0Icon)
 
@@ -26,6 +26,7 @@ const ButtonInternal = forwardRef<
     hideLabel,
     onClick,
     disabled,
+    withoutDisabledAppearance,
     loading: forceLoading,
     icon,
     emoji,
@@ -106,7 +107,12 @@ const ButtonInternal = forwardRef<
         tooltip={tooltip ?? (!noAutoTooltip && hideLabel && label)}
         onClick={handleClick}
         loading={isLoading}
-        className={cn("max-w-full", className)}
+        className={cn(
+          "max-w-full",
+          withoutDisabledAppearance &&
+            "disabled:opacity-100 disabled:cursor-default disabled:hover:bg-transparent disabled:hover:shadow-none disabled:active:bg-transparent disabled:active:shadow-none",
+          className
+        )}
         mode={hideLabel ? "only" : "default"}
         aria-label={ariaLabel || props.title || buttonLabel}
         title={

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -110,7 +110,8 @@ const ButtonInternal = forwardRef<
         className={cn(
           "max-w-full",
           withoutDisabledAppearance &&
-            "disabled:opacity-100 disabled:cursor-default disabled:hover:bg-transparent disabled:hover:shadow-none disabled:active:bg-transparent disabled:active:shadow-none",
+            disabled &&
+            "disabled:pointer-events-none disabled:opacity-100 disabled:cursor-default",
           className
         )}
         mode={hideLabel ? "only" : "default"}

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/ScoreEditOption.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/ScoreEditOption.tsx
@@ -3,9 +3,8 @@ import EmojiPicker from "@emoji-mart/react"
 import { useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
-import { cn } from "@/lib/utils"
-
 import "@/kits/Social/Reactions/Picker/index.css"
+import { cn } from "@/lib/utils"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
 export type ScoreEditOptionProps = {
@@ -50,12 +49,17 @@ export const ScoreEditOption = ({
       onClick={handleClick}
     >
       {isEmojiMode ? (
-        <Popover open={isEmojiPickerOpen} onOpenChange={setIsEmojiPickerOpen}>
+        <Popover
+          open={!disabled && isEmojiPickerOpen}
+          onOpenChange={disabled ? undefined : setIsEmojiPickerOpen}
+        >
           <PopoverTrigger asChild>
             <F0Button
               emoji={label}
               label={value.toString()}
               variant="ghost"
+              disabled={disabled}
+              withoutDisabledAppearance
               hideLabel
             />
           </PopoverTrigger>

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/ScoreEditOption.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/ScoreEditOption.tsx
@@ -1,6 +1,6 @@
 import data from "@emoji-mart/data/sets/15/twitter.json"
 import EmojiPicker from "@emoji-mart/react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import "@/kits/Social/Reactions/Picker/index.css"
@@ -28,6 +28,10 @@ export const ScoreEditOption = ({
   const { value, label } = option
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false)
 
+  useEffect(() => {
+    if (disabled) setIsEmojiPickerOpen(false)
+  }, [disabled])
+
   const handleClick = () => {
     if (disabled) return
     onClick(value)
@@ -40,6 +44,7 @@ export const ScoreEditOption = ({
 
   return (
     <div
+      data-testid={`score-edit-option-${value}`}
       className={cn(
         "group relative flex h-10 min-w-20 flex-1 items-center justify-center rounded-md border border-solid border-f1-border-secondary text-center font-medium",
         selected &&

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/__tests__/ScoreEditOption.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/__tests__/ScoreEditOption.test.tsx
@@ -41,11 +41,9 @@ describe("ScoreEditOption", () => {
     const user = userEvent.setup()
     const onClick = vi.fn()
 
-    const { container } = render(
-      <ScoreEditOption {...defaultProps} onClick={onClick} disabled />
-    )
+    render(<ScoreEditOption {...defaultProps} onClick={onClick} disabled />)
 
-    const wrapper = container.firstElementChild as HTMLElement
+    const wrapper = screen.getByTestId("score-edit-option-1")
     await user.click(wrapper)
 
     expect(onClick).not.toHaveBeenCalled()
@@ -55,7 +53,7 @@ describe("ScoreEditOption", () => {
     const user = userEvent.setup()
     const onClick = vi.fn()
 
-    const { container } = render(
+    render(
       <ScoreEditOption
         {...defaultProps}
         onClick={onClick}
@@ -63,7 +61,7 @@ describe("ScoreEditOption", () => {
       />
     )
 
-    const wrapper = container.firstElementChild as HTMLElement
+    const wrapper = screen.getByTestId("score-edit-option-1")
     await user.click(wrapper)
 
     expect(onClick).toHaveBeenCalledWith(1)

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/__tests__/ScoreEditOption.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/__tests__/ScoreEditOption.test.tsx
@@ -1,0 +1,71 @@
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { ScoreEditOption } from "../ScoreEditOption"
+
+describe("ScoreEditOption", () => {
+  const defaultProps = {
+    option: { value: 1, label: "😠" },
+    selected: false,
+    onClick: vi.fn(),
+    onChangeLabel: vi.fn(),
+    isEmojiMode: true,
+    disabled: false,
+  }
+
+  it("opens emoji picker when clicked in emoji mode", async () => {
+    const user = userEvent.setup()
+
+    render(<ScoreEditOption {...defaultProps} />)
+
+    const button = screen.getByRole("button")
+    await user.click(button)
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+
+  it("does not open emoji picker when disabled", async () => {
+    const user = userEvent.setup()
+
+    render(<ScoreEditOption {...defaultProps} disabled />)
+
+    const button = screen.getByRole("button")
+    await user.click(button)
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("does not call onClick when disabled", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    const { container } = render(
+      <ScoreEditOption {...defaultProps} onClick={onClick} disabled />
+    )
+
+    const wrapper = container.firstElementChild as HTMLElement
+    await user.click(wrapper)
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it("calls onClick when not disabled", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    const { container } = render(
+      <ScoreEditOption
+        {...defaultProps}
+        onClick={onClick}
+        isEmojiMode={false}
+      />
+    )
+
+    const wrapper = container.firstElementChild as HTMLElement
+    await user.click(wrapper)
+
+    expect(onClick).toHaveBeenCalledWith(1)
+  })
+})

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/RatingQuestion/index.stories.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/RatingQuestion/index.stories.tsx
@@ -91,13 +91,51 @@ export const SmallRange: Story = {
   },
 }
 
-export const WithEmojiOptions = {
+export const WithEmojiOptions: Story = {
   // TODO: Fix a11y issues
   parameters: withSkipA11y({}),
   args: {
     id: "question-4",
     title: "Satisfaction level",
     description: "Rate from 1 to 10",
+    value: 0,
+    options: [
+      { value: 1, label: "😠" },
+      { value: 2, label: "😐" },
+      { value: 3, label: "😊" },
+      { value: 4, label: "😍" },
+      { value: 5, label: "🤩" },
+    ],
+  },
+}
+
+export const WithEmojiOptionsDisabled: Story = {
+  // TODO: Fix a11y issues
+  parameters: withSkipA11y({}),
+  render: (args) => {
+    const [elements, setElements] = useState<SurveyFormBuilderElement[]>([
+      { type: "question" as const, question: args as QuestionElement },
+    ])
+
+    const question =
+      elements[0] && "question" in elements[0] ? elements[0].question : {}
+
+    return (
+      <div className="max-w-[750px]">
+        <SurveyFormBuilderProvider
+          elements={elements}
+          onChange={setElements}
+          disabled
+        >
+          <RatingQuestion {...args} {...question} />
+        </SurveyFormBuilderProvider>
+      </div>
+    )
+  },
+  args: {
+    id: "question-5",
+    title: "Satisfaction level",
+    description: "Rate from 1 to 5",
     value: 0,
     options: [
       { value: 1, label: "😠" },

--- a/packages/react/vite/vitest.setup.ts
+++ b/packages/react/vite/vitest.setup.ts
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest"
-import { cleanup } from "@testing-library/react"
 import type * as ReactTypes from "react"
+
+import { cleanup } from "@testing-library/react"
 import { afterEach, vi } from "vitest"
 
 afterEach(() => {
@@ -68,6 +69,20 @@ vi.stubGlobal(
     observe = vi.fn()
     unobserve = vi.fn()
     disconnect = vi.fn()
+  }
+)
+
+// Mock IntersectionObserver - required by @emoji-mart/react and other libs
+vi.stubGlobal(
+  "IntersectionObserver",
+  class MockedIntersectionObserver {
+    readonly root = null
+    readonly rootMargin = "0px"
+    readonly thresholds: ReadonlyArray<number> = [0]
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+    takeRecords = vi.fn().mockReturnValue([])
   }
 )
 


### PR DESCRIPTION
## Fix: Emoji picker accessible when SurveyFormBuilder is disabled

### Problem

In the `SurveyFormBuilder`, `RatingQuestion` with emoji options allowed users to open the emoji picker and change emojis even when the form builder was `disabled`. The `Popover` wrapping the emoji picker did not respect the disabled state.

### Changes

**`ScoreEditOption.tsx`**
- The `Popover` now respects the `disabled` prop: `open` is forced to `false` and `onOpenChange` is unset when disabled, preventing the emoji picker from opening.
- The `F0Button` receives `disabled` conditionally (only when the component is disabled) along with `withoutDisabledAppearance` so it looks normal but blocks interaction.
- Removed unused `EmojiImage` import.

**`F0Button/internal-types.ts`**
- Added optional `withoutDisabledAppearance` prop to `ButtonInternalProps`. When `true` alongside `disabled`, the button retains its normal visual appearance (no reduced opacity, no not-allowed cursor, no hover/active styles).

**`F0Button/internal.tsx`**
- Implemented `withoutDisabledAppearance` by applying `disabled:opacity-100 disabled:cursor-default disabled:hover:bg-transparent disabled:hover:shadow-none disabled:active:bg-transparent disabled:active:shadow-none` overrides.

**Stories**
- Added `WithEmojiOptionsDisabled` story to `RatingQuestion` stories to visually verify the disabled emoji behavior.

**Tests**
- Added `ScoreEditOption.test.tsx` with 4 unit tests:
  - Opens emoji picker when clicked in emoji mode (enabled)
  - Does not open emoji picker when disabled
  - Does not call `onClick` when disabled
  - Calls `onClick` when not disabled