### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.468.0",
+  "packages/react": "1.468.1",
   "packages/react-native": "0.52.1",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.468.1](https://github.com/factorialco/f0/compare/f0-react-v1.468.0...f0-react-v1.468.1) (2026-04-28)
+
+
+### Bug Fixes
+
+* **OneDataCollection:** preserve selection across infinite-scroll loadMore ([#4000](https://github.com/factorialco/f0/issues/4000)) ([c83c164](https://github.com/factorialco/f0/commit/c83c1648f358a0c1591b0be0aa1d6d7e6a7a70be))
+
 ## [1.468.0](https://github.com/factorialco/f0/compare/f0-react-v1.467.0...f0-react-v1.468.0) (2026-04-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.468.0",
+  "version": "1.468.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.468.1</summary>

## [1.468.1](https://github.com/factorialco/f0/compare/f0-react-v1.468.0...f0-react-v1.468.1) (2026-04-28)


### Bug Fixes

* **OneDataCollection:** preserve selection across infinite-scroll loadMore ([#4000](https://github.com/factorialco/f0/issues/4000)) ([c83c164](https://github.com/factorialco/f0/commit/c83c1648f358a0c1591b0be0aa1d6d7e6a7a70be))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).