### PR TITLE
feat(F0Tabs): make tab id type generic

### DIFF
--- a/packages/react-native/src/components/F0Tabs/F0Tabs.md
+++ b/packages/react-native/src/components/F0Tabs/F0Tabs.md
@@ -73,6 +73,19 @@ import { F0Tabs } from "@factorialco/f0-react-native"
 
 // Embedded — renders only the first tab as plain text, no interaction
 <F0Tabs tabs={tabs} embedded />
+
+// Typed tab ids — narrow `id` to a string-literal union
+type ScreenTab = "overview" | "settings"
+const tabs: F0TabItem<ScreenTab>[] = [
+  { id: "overview", label: "Overview" },
+  { id: "settings", label: "Settings" },
+]
+const [activeTab, setActiveTab] = useState<ScreenTab>("overview")
+<F0Tabs<ScreenTab>
+  tabs={tabs}
+  activeTabId={activeTab}
+  setActiveTabId={setActiveTab}
+/>
 ```
 
 ## Props
@@ -104,6 +117,7 @@ import { F0Tabs } from "@factorialco/f0-react-native"
 ## Architecture Notes
 
 - Single flat component — no namespace variants needed for this use case
+- Generic over the tab `id` type via `F0TabItem<T>` and `F0TabsProps<T>`. `T extends string` and defaults to `string` for backward compatibility. `React.memo` does not preserve generics, so the public export is cast to a generic call signature; runtime behaviour is unchanged.
 - Animation: Reanimated `useSharedValue` + `withSpring` for the underline; pill is a static `View` toggled instantly (mirrors web CSS class toggle)
 - Both controlled and uncontrolled modes share a single `useState` initialised from `activeTabId ?? tabs[0].id`
 - Tab layout positions collected via `onLayout` on each tab `View`; first active-tab layout sets indicator position directly without spring to avoid slide-from-zero on mount

--- a/packages/react-native/src/components/F0Tabs/F0Tabs.tsx
+++ b/packages/react-native/src/components/F0Tabs/F0Tabs.tsx
@@ -21,7 +21,7 @@ import {
 } from "./F0Tabs.styles"
 import type { F0TabsProps } from "./F0Tabs.types"
 
-type AnyF0TabsProps = F0TabsProps<string>
+type F0TabsBaseProps = F0TabsProps<string>
 
 const SPRING_CONFIG: WithSpringConfig = {
   damping: 20,
@@ -58,7 +58,7 @@ const F0TabsBase = React.memo(function F0Tabs({
   separatorWidth = "container",
   contentInset = "sm",
   embedded = false,
-}: AnyF0TabsProps) {
+}: F0TabsBaseProps) {
   const firstTab = tabs[0]
 
   const [activeId, setActiveId] = useState(
@@ -271,10 +271,6 @@ const F0TabsBase = React.memo(function F0Tabs({
  * cast the memoized component to a generic call signature. At runtime this is
  * the exact same component; only the public type surface differs.
  */
-export const F0Tabs: <T extends string = string>(
+export const F0Tabs = F0TabsBase as unknown as <T extends string = string>(
   props: F0TabsProps<T>
-) => ReturnType<typeof F0TabsBase> = F0TabsBase as unknown as <
-  T extends string = string,
->(
-  props: F0TabsProps<T>
-) => ReturnType<typeof F0TabsBase>
+) => React.ReactElement | null

--- a/packages/react-native/src/components/F0Tabs/F0Tabs.tsx
+++ b/packages/react-native/src/components/F0Tabs/F0Tabs.tsx
@@ -21,6 +21,8 @@ import {
 } from "./F0Tabs.styles"
 import type { F0TabsProps } from "./F0Tabs.types"
 
+type AnyF0TabsProps = F0TabsProps<string>
+
 const SPRING_CONFIG: WithSpringConfig = {
   damping: 20,
   stiffness: 200,
@@ -45,7 +47,7 @@ const SPRING_CONFIG: WithSpringConfig = {
  * // Secondary
  * <F0Tabs tabs={tabs} secondary activeTabId={activeTab} setActiveTabId={setActiveTab} />
  */
-export const F0Tabs = React.memo(function F0Tabs({
+const F0TabsBase = React.memo(function F0Tabs({
   tabs,
   activeTabId: controlledActiveTabId,
   setActiveTabId: onChangeActiveTabId,
@@ -56,7 +58,7 @@ export const F0Tabs = React.memo(function F0Tabs({
   separatorWidth = "container",
   contentInset = "sm",
   embedded = false,
-}: F0TabsProps) {
+}: AnyF0TabsProps) {
   const firstTab = tabs[0]
 
   const [activeId, setActiveId] = useState(
@@ -261,3 +263,18 @@ export const F0Tabs = React.memo(function F0Tabs({
     </ScrollView>
   )
 })
+
+/**
+ * Generic-preserving public export of `F0Tabs`.
+ *
+ * `React.memo` does not preserve generics through its inferred type, so we
+ * cast the memoized component to a generic call signature. At runtime this is
+ * the exact same component; only the public type surface differs.
+ */
+export const F0Tabs: <T extends string = string>(
+  props: F0TabsProps<T>
+) => ReturnType<typeof F0TabsBase> = F0TabsBase as unknown as <
+  T extends string = string,
+>(
+  props: F0TabsProps<T>
+) => ReturnType<typeof F0TabsBase>

--- a/packages/react-native/src/components/F0Tabs/F0Tabs.types.ts
+++ b/packages/react-native/src/components/F0Tabs/F0Tabs.types.ts
@@ -3,9 +3,13 @@ import type { Dispatch } from "react"
 /**
  * A single tab item passed to `F0Tabs`.
  * Mirrors the web `TabItem` type (minus `href` and `DataAttributes`).
+ *
+ * Generic over the `id` type so consumers can use string-literal unions
+ * (e.g. `"my_courses" | "catalogue"`) without casting. Defaults to `string`
+ * to preserve backward compatibility.
  */
-export type F0TabItem = {
-  id: string
+export type F0TabItem<T extends string = string> = {
+  id: T
   label: string
   /** Accepted for API parity with web `index` prop; currently not used for sorting in React Native. */
   index?: boolean
@@ -23,17 +27,21 @@ export type F0TabsContentInset = (typeof F0_TABS_CONTENT_INSETS)[number]
 
 /**
  * Props for `F0Tabs`.
- * Mirrors the web `TabsProps` exactly.
+ * Mirrors the web `TabsProps` (with the addition of an `id` type parameter
+ * for stronger typing in controlled mode).
  *
  * - Primary (`secondary=false`): animated pill background + sliding underline below the active tab.
  * - Secondary (`secondary=true`): animated pill background only, no underline.
+ *
+ * The `T` parameter is inferred from the `tabs` array when `id` values are
+ * string literals. Defaults to `string` for backward compatibility.
  */
-export interface F0TabsProps {
-  tabs: F0TabItem[]
+export interface F0TabsProps<T extends string = string> {
+  tabs: F0TabItem<T>[]
   /** Controlled active tab id. When provided the component is in controlled mode. */
-  activeTabId?: string
+  activeTabId?: T
   /** Called with the new tab id when a tab is pressed. Mirrors the web `setActiveTabId` prop. */
-  setActiveTabId?: Dispatch<string>
+  setActiveTabId?: Dispatch<T>
   /** When `true`, uses the secondary visual style (pill only, no underline). */
   secondary?: boolean
   /** When `true`, all tabs become non-interactive and render with disabled visual treatment. */


### PR DESCRIPTION
## Summary

- Make `F0TabItem` and `F0TabsProps` generic over the tab `id` type (`T extends string`, defaults to `string`).
- Consumers can now use string-literal unions for tab ids and get fully typed `activeTabId` / `setActiveTabId` without casts.
- `React.memo` does not preserve generics, so the memoized component is internally typed as `F0TabsProps<string>` and the public export is cast to a generic call signature. Runtime behaviour is unchanged.

## Motivation

Today, mobile/web consumers with a typed tab id union (e.g. `"my_courses" | "catalogue"`) must cast `setActiveTabId={handleSetActiveTabId as (id: string) => void}` because `F0Tabs` only accepts `Dispatch<string>`. Making the component generic removes the cast and prevents typos in `activeTabId`.

## API

```tsx
type ScreenTab = "overview" | "settings"
const tabs: F0TabItem<ScreenTab>[] = [
  { id: "overview", label: "Overview" },
  { id: "settings", label: "Settings" },
]
const [activeTab, setActiveTab] = useState<ScreenTab>("overview")

<F0Tabs<ScreenTab>
  tabs={tabs}
  activeTabId={activeTab}
  setActiveTabId={setActiveTab}
/>
```

The type parameter is inferred from the `tabs` array when literal `id` values are used; explicit annotation (as above) is only needed when callers want to enforce a specific union.

## Backward compatibility

`T extends string = string`, so all existing call sites compile unchanged. The 21 existing F0Tabs tests pass without modification.

## Caveats

- Web `TabsProps` is not currently generic; this introduces a small API divergence (RN is stricter when consumers opt in). The web component can be made generic later with the same pattern if desired.
- Because `React.memo` does not preserve generics, the public export uses an `as unknown as <T>(...) => ...` cast. This is purely a type-level wrapper — there is no runtime change.

## Validation

- `pnpm tsc` — no new errors introduced (pre-existing `F0BlurView` / `expo-blur` errors unrelated to this change).
- `pnpm test -- --watchman=false --testPathPatterns=F0Tabs` — 21/21 passing.
- `pnpm lint` — 0 warnings, 0 errors.
- `pnpm format:check` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-surface-only change with a small export type cast; runtime behavior and rendering logic are unchanged, so risk is limited to potential TypeScript typing edge cases for consumers.
> 
> **Overview**
> `F0TabItem` and `F0TabsProps` are updated to be generic over the tab `id` type (`T extends string = string`), so `activeTabId`/`setActiveTabId` can be fully typed when consumers use string-literal unions.
> 
> Because `React.memo` drops generic inference, the memoized component is now internalized as `F0TabsProps<string>` and the public `F0Tabs` export is cast back to a generic call signature; runtime behavior is unchanged. Docs were updated with a typed-id usage example and notes about the generic/memo typing caveat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecf1a3a8315e95e4404001be13e2bc16e2d3a27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->