### PR TITLE
fix: editable table QA

### DIFF
--- a/packages/react/src/experimental/OneTable/TableCell/NestedCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/NestedCell/index.tsx
@@ -91,7 +91,10 @@ export const NestedCell = ({
     >
       {onAddRow ? (
         <div
-          className={cn("pointer-events-auto flex items-center w-full h-full")}
+          className={cn(
+            "pointer-events-auto flex items-center w-full h-full",
+            detailedVariant && "pl-3"
+          )}
         >
           {onAddRow.actions.length === 1 ? (
             <F0Button

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/MoneyCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/MoneyCell.tsx
@@ -32,15 +32,15 @@ export function MoneyCell<R extends RecordType>(props: EditableCellProps<R>) {
 
   const resolvedUnits = resolveUnits(config, props.item)
 
-  const unitsBefore = useMemo(
-    () =>
-      resolvedUnits
-        ? config?.unitsPosition
-          ? config.unitsPosition === "before"
-          : isUnitBeforeNumber(locale, resolvedUnits)
-        : false,
-    [locale, resolvedUnits, config?.unitsPosition]
-  )
+  const unitsBefore = useMemo(() => {
+    if (!resolvedUnits) return false
+
+    if (config?.unitsPosition) {
+      return config.unitsPosition === "before"
+    }
+
+    return isUnitBeforeNumber(locale, resolvedUnits)
+  }, [locale, resolvedUnits, config?.unitsPosition])
 
   return (
     <NumberCell

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -171,11 +171,12 @@ const NestedRowContent = <
    * the vertical line connecting them to their parent
    */
   const { calculatedHeight, setFirstChildRef, setLastChildRef } =
-    useCalculateConectorHeight(
-      childrenType,
-      !!shouldShowLoadMore || hasAddRowActions,
-      isSticky
-    )
+    useCalculateConectorHeight({
+      nestedVariant: childrenType,
+      withHasMore: !!shouldShowLoadMore,
+      withAddRowActions: hasAddRowActions,
+      isSticky,
+    })
 
   /**
    * Combine internal and external refs
@@ -238,7 +239,8 @@ const NestedRowContent = <
           // If nestedRowProps.parentHasChildren is not provided, we need to set it to true if the parent has children
           // This nestedRowProps.parentHasChildren is provided on children iteration
           parentHasChildren:
-            props.nestedRowProps?.parentHasChildren ?? children.length > 0,
+            (props.nestedRowProps?.parentHasChildren ?? children.length > 0) ||
+            hasAddRowActions,
           hasLoadedChildren: false,
           isLastChild,
           stickyRow: isSticky,
@@ -417,7 +419,10 @@ const NestedRowContent = <
           rowRef={internalRowRef}
           addRowActions={addRowActions}
           addRowLabel={addRow?.addNestedRowActionsLabel}
-          ref={setLastChildRef}
+          ref={(el: HTMLTableRowElement | null) => {
+            if (children.length === 0) setFirstChildRef(el)
+            setLastChildRef(el)
+          }}
           nestedRowProps={{
             ...props.nestedRowProps,
             parentHasChildren: true,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useCalculateConectorHeight.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useCalculateConectorHeight.ts
@@ -8,11 +8,19 @@ import { NestedVariant } from "@/hooks/datasource/types/nested.typings"
 
 import { subscribeToScroll } from "../lib/scroll"
 
-export const useCalculateConectorHeight = (
-  nestedVariant: NestedVariant,
-  withHasMore: boolean,
+interface Props {
+  nestedVariant: NestedVariant
+  withHasMore: boolean
+  withAddRowActions: boolean
   isSticky?: boolean
-) => {
+}
+
+export const useCalculateConectorHeight = ({
+  nestedVariant,
+  withHasMore,
+  withAddRowActions,
+  isSticky,
+}: Props) => {
   const [firstRow, setFirstRow] = useState<HTMLTableRowElement | null>(null)
   const [lastRow, setLastRow] = useState<HTMLTableRowElement | null>(null)
   const [calculatedHeight, setCalculatedHeight] = useState(0)
@@ -78,6 +86,18 @@ export const useCalculateConectorHeight = (
       return withHasMore && nestedVariant === "basic" ? BUTTON_PADDING : 0
     }
 
+    const hasAddRowHeight = () => {
+      if (withAddRowActions) {
+        if (withHasMore && nestedVariant === "basic") {
+          return -BUTTON_PADDING
+        }
+
+        return 0
+      }
+
+      return 0
+    }
+
     const calculateHeight = () => {
       const lastRowHeight =
         nestedVariant === "basic"
@@ -85,7 +105,11 @@ export const useCalculateConectorHeight = (
           : heightForLastDetailedRow()
 
       const height =
-        lastRowHeight - firstRowTop() + previousRowHeight() + hasMoreHeight()
+        lastRowHeight -
+        firstRowTop() +
+        previousRowHeight() +
+        hasMoreHeight() +
+        hasAddRowHeight()
 
       // When the parent row is sticky and children scroll above it,
       // reduce the connector height by the amount the first child


### PR DESCRIPTION
## Why
Fix nested row connector rendering when add-row actions are the only visible child, and clean up money unit positioning logic in editable table cells.

## What
- Update nested row connector height handling to support add-row actions without relying on loaded child rows
- Mark add-row actions as child content so the vertical connector is rendered correctly
- Assign connector refs when `AddRowRow` is the first and only visible child
- Simplify `MoneyCell` unit position resolution while preserving locale-based fallback behavior

## Verification
- Manually verified the connector is shown when `AddRowRow` is the only child row
- Ran formatting and lint checks