### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.468.1",
+  "packages/react": "1.468.2",
   "packages/react-native": "0.52.1",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.468.2](https://github.com/factorialco/f0/compare/f0-react-v1.468.1...f0-react-v1.468.2) (2026-04-28)
+
+
+### Bug Fixes
+
+* prevent users from editing emoji options when the question component is disabled ([#4052](https://github.com/factorialco/f0/issues/4052)) ([0042917](https://github.com/factorialco/f0/commit/0042917279f94ab01d8fba8be5c51ba4423f28d7))
+
 ## [1.468.1](https://github.com/factorialco/f0/compare/f0-react-v1.468.0...f0-react-v1.468.1) (2026-04-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.468.1",
+  "version": "1.468.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.468.2</summary>

## [1.468.2](https://github.com/factorialco/f0/compare/f0-react-v1.468.1...f0-react-v1.468.2) (2026-04-28)


### Bug Fixes

* prevent users from editing emoji options when the question component is disabled ([#4052](https://github.com/factorialco/f0/issues/4052)) ([0042917](https://github.com/factorialco/f0/commit/0042917279f94ab01d8fba8be5c51ba4423f28d7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).