### PR TITLE
feat(F0AiChat): self-heal dashboard recipes via /compute repair

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -386,9 +386,9 @@ export const defaultTranslations = {
       dataExplanation: "Where does this data come from?",
     },
     dashboardDatasetFailure: {
-      title: "Some data couldn’t be loaded",
+      title: "This dashboard is no longer valid",
       description:
-        "We couldn’t load this section of the dashboard. Details: {{reason}}",
+        "We're sorry. Please contact support or ask One to generate a dashboard from scratch.",
     },
     pong: {
       title: "Pong",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -385,6 +385,11 @@ export const defaultTranslations = {
       retry: "Retry",
       dataExplanation: "Where does this data come from?",
     },
+    dashboardDatasetFailure: {
+      title: "Some data couldn’t be loaded",
+      description:
+        "We couldn’t load this section of the dashboard. Details: {{reason}}",
+    },
     pong: {
       title: "Pong",
       youWin: "You win!",

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
@@ -35,6 +35,7 @@ import type {
 } from "./types"
 
 import { useDashboardCompute, type ItemResult } from "./useDashboardCompute"
+import type { DashboardRepairFailure } from "./useDashboardCompute"
 
 // ---------------------------------------------------------------------------
 // Minimum item height per type
@@ -209,6 +210,15 @@ export interface ChatDashboardProps {
   onLayoutChange?: (layout: DashboardItemLayout[]) => void
   onExportReady?: (exportFn: (() => Promise<void>) | undefined) => void
   exportFilename?: string
+  /**
+   * Invoked once when the agent's `/compute` response carries a self-healed
+   * recipe. Wrappers should swap `config.fetchSpecs` and trigger persistence
+   * via the canvas save callback so future opens skip the repair round-trip.
+   */
+  onRepairedSpecs?: (
+    repairedSpecs: ChatDashboardConfig["fetchSpecs"],
+    repairFailures: DashboardRepairFailure[] | undefined
+  ) => void
 }
 
 /**
@@ -228,11 +238,13 @@ export function ChatDashboard({
   onTransformChart,
   onExportReady,
   exportFilename,
+  onRepairedSpecs,
 }: ChatDashboardProps) {
   const { fetchItem, getFilterOptions } = useDashboardCompute(
     config,
     apiConfig,
-    refreshKey
+    refreshKey,
+    onRepairedSpecs
   )
 
   // Filter options from the first compute response
@@ -533,6 +545,76 @@ export function DashboardContent({
   // reference, which correctly bumps this key and triggers a real refetch.
   const dataRefreshKey = useMemo(() => Date.now(), [content.config.fetchSpecs])
 
+  // Self-heal persistence: when /compute returns a repaired recipe, swap the
+  // canvas config and (for already-saved dashboards) call the external save
+  // callback so the repaired recipe is persisted. Guarded by a ref so a single
+  // logical repair never triggers a save more than once even if multiple
+  // in-flight fetchItem calls share the same response.
+  const repairAppliedRef = useRef<string | null>(null)
+  // Reset the dedupe gate when the underlying recipe changes (new agent turn,
+  // user reopen, etc.) so a subsequent compute can apply a new repair.
+  useEffect(() => {
+    repairAppliedRef.current = null
+  }, [content.config.fetchSpecs, content.savedDashboardId])
+
+  const handleRepairedSpecs = useCallback(
+    (
+      repairedSpecs: ChatDashboardConfig["fetchSpecs"],
+      _repairFailures: DashboardRepairFailure[] | undefined
+    ) => {
+      const dedupeKey = `${content.savedDashboardId ?? "unsaved"}:${content.toolCallId ?? ""}`
+      if (repairAppliedRef.current === dedupeKey) return
+      repairAppliedRef.current = dedupeKey
+
+      const updatedConfig: ChatDashboardConfig = {
+        ...content.config,
+        fetchSpecs: repairedSpecs,
+      }
+
+      // Swap the canvas config so the next compute uses the healed recipe.
+      // savedDashboardUnsaved stays false because this is a server-side fix,
+      // not a user edit — there is nothing for the user to "save" manually.
+      openCanvas({ ...content, config: updatedConfig })
+
+      // Persist to chat history (best-effort) so re-opening from history also
+      // sees the healed recipe.
+      void saveConfigToHistory({
+        ...updatedConfig,
+        ...(content.savedDashboardId
+          ? {
+              savedDashboardId: content.savedDashboardId,
+              savedDashboardCategory: content.savedDashboardCategory,
+              savedDashboardDescription: content.savedDashboardDescription,
+              savedDashboardUnsaved: false,
+            }
+          : {}),
+      })
+
+      // For saved dashboards, also persist to the external store via the
+      // canvas action so future opens skip the repair round-trip entirely.
+      if (
+        content.savedDashboardId &&
+        content.savedDashboardCategory &&
+        canvasActions?.dashboard?.save
+      ) {
+        void canvasActions.dashboard
+          .save(
+            content.savedDashboardId,
+            content.savedDashboardCategory,
+            updatedConfig
+          )
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.warn(
+              "[Dashboard] Failed to persist self-healed recipe externally",
+              err
+            )
+          })
+      }
+    },
+    [canvasActions, content, openCanvas, saveConfigToHistory]
+  )
+
   return (
     <div className="flex h-full flex-col">
       {/*
@@ -565,6 +647,7 @@ export function DashboardContent({
           }}
           onExportReady={registerExport}
           exportFilename={content.title}
+          onRepairedSpecs={handleRepairedSpecs}
         />
       </div>
       {/* State A: New dashboard with canvasActions — always-visible Save bar */}
@@ -703,7 +786,10 @@ function mapChartItem(
     type: "chart",
     chart: toDashboardChartConfig(item.chart),
     fetchData: (filters: FiltersState<FiltersDefinition>) =>
-      fetchData(filters).then((r) => r.chart ?? { categories: [], series: [] }),
+      fetchData(filters).then((r) => {
+        if (r.error) throw new Error(r.error)
+        return r.chart ?? { categories: [], series: [] }
+      }),
   }
 }
 
@@ -737,7 +823,10 @@ function mapMetricItem(
     format: item.format,
     decimals: item.decimals,
     fetchData: (filters: FiltersState<FiltersDefinition>) =>
-      fetchData(filters).then((r) => r.metric ?? { value: 0 }),
+      fetchData(filters).then((r) => {
+        if (r.error) throw new Error(r.error)
+        return r.metric ?? { value: 0 }
+      }),
   }
 }
 
@@ -804,6 +893,7 @@ function mapCollectionItem(
       // Eagerly fetch data, then paginate client-side from the result
       let cachedRows: RecordType[] | null = null
       const dataPromise = fetchData(filters).then((r) => {
+        if (r.error) throw new Error(r.error)
         cachedRows = (r.collection?.rows ?? []) as RecordType[]
         return cachedRows
       })

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
@@ -24,6 +24,9 @@ import type {
 
 import { F0AnalyticsDashboard } from "@/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard"
 
+import { OneEmptyState } from "@/components/OneEmptyState"
+import { useI18n } from "@/lib/providers/i18n"
+
 import type {
   ChatDashboardChartConfig,
   ChatDashboardChartItem,
@@ -240,16 +243,20 @@ export function ChatDashboard({
   exportFilename,
   onRepairedSpecs,
 }: ChatDashboardProps) {
-  const { fetchItem, getFilterOptions } = useDashboardCompute(
-    config,
-    apiConfig,
-    refreshKey,
-    onRepairedSpecs
-  )
+  const { fetchItem, getFilterOptions, getDatasetFailures } =
+    useDashboardCompute(config, apiConfig, refreshKey, onRepairedSpecs)
+  const translations = useI18n()
 
   // Filter options from the first compute response
   const [filterOptions, setFilterOptions] = useState<
     Record<string, string[]> | undefined
+  >()
+
+  // Dataset-level failures surfaced by the agent's self-heal pass. When set,
+  // affected items are stripped from the grid (the banner above carries the
+  // error context so the per-item card would be redundant noise).
+  const [datasetFailures, setDatasetFailures] = useState<
+    Record<string, { reason: string; message: string }> | undefined
   >()
 
   // Update filter options when they become available
@@ -258,6 +265,7 @@ export function ChatDashboard({
   // Reset polling flag when refreshKey changes so filter options are re-polled
   useEffect(() => {
     filterOptionsPolledRef.current = false
+    setDatasetFailures(undefined)
   }, [refreshKey])
 
   useEffect(() => {
@@ -398,43 +406,92 @@ export function ChatDashboard({
               setFilterOptions(opts)
               filterOptionsPolledRef.current = true
             }
+            // Refresh dataset failures map regardless of polling state — the
+            // server can flip a previously failing dataset to healthy after a
+            // refetch and we want the banner / hidden items to update.
+            //
+            // NOTE: This is the only path that publishes the failures map to
+            // state. We piggy-back on `fetchItem` resolutions instead of
+            // polling because polling cannot distinguish "no response yet"
+            // from "response with zero failures" (both return `undefined`).
+            // If a future refactor introduces lazy / virtualized item mounts
+            // where some items never call `fetchData`, surface failures
+            // through a dedicated subscription on `useDashboardCompute`
+            // instead — otherwise the banner will silently stop appearing.
+            setDatasetFailures(getDatasetFailures())
             return result
           }
         )
       }
     },
-    [fetchItem, getFilterOptions, navigationFilterKeys]
+    [fetchItem, getFilterOptions, getDatasetFailures, navigationFilterKeys]
   )
 
   const items: DashboardItem<FiltersDefinition>[] = useMemo(
     () =>
-      config.items.map((item) => {
-        switch (item.type) {
-          case "chart":
-            return mapChartItem(item, makeFetchData(item.id))
-          case "metric":
-            return mapMetricItem(item, makeFetchData(item.id))
-          case "collection":
-            return mapCollectionItem(item, makeFetchData(item.id))
-        }
-      }),
-    [config.items, makeFetchData]
+      config.items
+        .filter(
+          (item) =>
+            !datasetFailures || !(item.computation.datasetId in datasetFailures)
+        )
+        .map((item) => {
+          switch (item.type) {
+            case "chart":
+              return mapChartItem(item, makeFetchData(item.id))
+            case "metric":
+              return mapMetricItem(item, makeFetchData(item.id))
+            case "collection":
+              return mapCollectionItem(item, makeFetchData(item.id))
+          }
+        }),
+    [config.items, datasetFailures, makeFetchData]
+  )
+
+  // Stable list of failed datasets for the banner above the grid. Each
+  // entry renders its own `OneEmptyState` so the user can see exactly which
+  // section is missing rather than one combined message.
+  const failedDatasetEntries = useMemo(
+    () =>
+      datasetFailures
+        ? Object.entries(datasetFailures).map(([datasetId, failure]) => ({
+            datasetId,
+            ...failure,
+          }))
+        : [],
+    [datasetFailures]
   )
 
   return (
-    <F0AnalyticsDashboard
-      key={refreshKey}
-      filters={filterDefinitions}
-      filtersLoading={filtersLoading}
-      navigationFilters={dashboardNavigationFilters}
-      items={items}
-      editMode={editMode}
-      onLayoutChange={onLayoutChange}
-      onTransformChart={onTransformChart}
-      onExportReady={onExportReady}
-      exportFilename={exportFilename}
-      resetKey={resetKey}
-    />
+    <div className="flex flex-col gap-4">
+      {failedDatasetEntries.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {failedDatasetEntries.map((entry) => (
+            <OneEmptyState
+              key={entry.datasetId}
+              variant="critical"
+              title={translations.ai.dashboardDatasetFailure.title}
+              description={translations.t(
+                "ai.dashboardDatasetFailure.description",
+                { reason: entry.message }
+              )}
+            />
+          ))}
+        </div>
+      )}
+      <F0AnalyticsDashboard
+        key={refreshKey}
+        filters={filterDefinitions}
+        filtersLoading={filtersLoading}
+        navigationFilters={dashboardNavigationFilters}
+        items={items}
+        editMode={editMode}
+        onLayoutChange={onLayoutChange}
+        onTransformChart={onTransformChart}
+        onExportReady={onExportReady}
+        exportFilename={exportFilename}
+        resetKey={resetKey}
+      />
+    </div>
   )
 }
 
@@ -446,7 +503,6 @@ ChatDashboard.displayName = "ChatDashboard"
 
 import { F0ActionBar } from "@/components/F0ActionBar"
 import { Save } from "@/icons/app"
-import { useI18n } from "@/lib/providers/i18n"
 
 import type { DashboardCanvasContent } from "../../../types"
 

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
@@ -475,7 +475,7 @@ export function ChatDashboard({
             <OneEmptyState
               key={entry.datasetId}
               variant="critical"
-              title={translations.ai.dashboardDatasetFailure.title}
+              title={translations.t("ai.dashboardDatasetFailure.title")}
               description={translations.t(
                 "ai.dashboardDatasetFailure.description",
                 { reason: entry.message }

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
@@ -477,8 +477,7 @@ export function ChatDashboard({
               variant="critical"
               title={translations.t("ai.dashboardDatasetFailure.title")}
               description={translations.t(
-                "ai.dashboardDatasetFailure.description",
-                { reason: entry.message }
+                "ai.dashboardDatasetFailure.description"
               )}
             />
           ))}

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
@@ -39,6 +39,7 @@ import type {
 
 import { useDashboardCompute, type ItemResult } from "./useDashboardCompute"
 import type { DashboardRepairFailure } from "./useDashboardCompute"
+import { readItemDatasetId } from "./useDashboardCompute"
 
 // ---------------------------------------------------------------------------
 // Minimum item height per type
@@ -430,10 +431,15 @@ export function ChatDashboard({
   const items: DashboardItem<FiltersDefinition>[] = useMemo(
     () =>
       config.items
-        .filter(
-          (item) =>
-            !datasetFailures || !(item.computation.datasetId in datasetFailures)
-        )
+        .filter((item) => {
+          if (!datasetFailures) return true
+          const datasetId = readItemDatasetId(item)
+          // Items without a resolvable datasetId (malformed / legacy) are
+          // kept so they can render their own per-item state rather than
+          // disappearing silently from the grid.
+          if (!datasetId) return true
+          return !(datasetId in datasetFailures)
+        })
         .map((item) => {
           switch (item.type) {
             case "chart":

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/__tests__/computeDatasetFailures.test.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/__tests__/computeDatasetFailures.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest"
+
+import type { ChatDashboardConfig, ChatDashboardMetricItem } from "../types"
+import {
+  computeDatasetFailures,
+  type ComputeResponse,
+} from "../useDashboardCompute"
+
+const metricItem = (
+  id: string,
+  datasetId: string
+): ChatDashboardMetricItem => ({
+  id,
+  type: "metric",
+  title: id,
+  computation: { datasetId, aggregation: "count" },
+})
+
+const config = (items: ChatDashboardConfig["items"]): ChatDashboardConfig => ({
+  title: "Test dashboard",
+  items,
+  fetchSpecs: {},
+})
+
+const response = (results: ComputeResponse["results"]): ComputeResponse => ({
+  results,
+})
+
+describe("computeDatasetFailures", () => {
+  it("returns undefined when there are no failures", () => {
+    const result = computeDatasetFailures(
+      response({
+        m1: { metric: { value: 42 } },
+      }),
+      config([metricItem("m1", "ds1")])
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it("excludes per-item errors that lack a structured reason", () => {
+    // A local SQL / handler failure (no `reason`) must NOT become a banner —
+    // it stays per-item so the user still sees a card with the message.
+    const result = computeDatasetFailures(
+      response({
+        m1: { error: "SQL syntax near 'FORM'" },
+      }),
+      config([metricItem("m1", "ds1")])
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it("groups dataset-level failures by datasetId", () => {
+    const result = computeDatasetFailures(
+      response({
+        m1: { error: "Repair failed", reason: "dataset_failed" },
+        m2: { error: "Unrepairable", reason: "unrepairable" },
+      }),
+      config([metricItem("m1", "dsA"), metricItem("m2", "dsB")])
+    )
+    expect(result).toEqual({
+      dsA: { reason: "dataset_failed", message: "Repair failed" },
+      dsB: { reason: "unrepairable", message: "Unrepairable" },
+    })
+  })
+
+  it("collapses multiple failing items targeting the same dataset", () => {
+    // Two items pointing at the same dataset both fail with the same payload
+    // (agent contract). The banner only needs one entry per dataset.
+    const result = computeDatasetFailures(
+      response({
+        m1: { error: "Repair failed", reason: "dataset_failed" },
+        m2: { error: "Repair failed", reason: "dataset_failed" },
+      }),
+      config([metricItem("m1", "dsA"), metricItem("m2", "dsA")])
+    )
+    expect(result).toEqual({
+      dsA: { reason: "dataset_failed", message: "Repair failed" },
+    })
+    expect(Object.keys(result ?? {})).toHaveLength(1)
+  })
+
+  it("keeps per-item errors out of the map even when a sibling has a dataset-level failure", () => {
+    // Mixed case: one dataset truly failed (banner), another item on a
+    // different dataset hit a local SQL error (stays per-item, no banner).
+    const result = computeDatasetFailures(
+      response({
+        m1: { error: "Repair failed", reason: "dataset_failed" },
+        m2: { error: "SQL syntax error" },
+        m3: { metric: { value: 1 } },
+      }),
+      config([
+        metricItem("m1", "dsA"),
+        metricItem("m2", "dsB"),
+        metricItem("m3", "dsC"),
+      ])
+    )
+    expect(result).toEqual({
+      dsA: { reason: "dataset_failed", message: "Repair failed" },
+    })
+  })
+
+  it("ignores result entries whose itemId is not in the config", () => {
+    // Defensive: the server should never return results for unknown items,
+    // but if it does we must not crash and must not invent a datasetId.
+    const result = computeDatasetFailures(
+      response({
+        ghost: { error: "boom", reason: "dataset_failed" },
+      }),
+      config([metricItem("m1", "dsA")])
+    )
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/__tests__/computeDatasetFailures.test.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/__tests__/computeDatasetFailures.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import type { ChatDashboardConfig, ChatDashboardMetricItem } from "../types"
+import type {
+  ChatDashboardChartItem,
+  ChatDashboardConfig,
+  ChatDashboardMetricItem,
+} from "../types"
 import {
   computeDatasetFailures,
   type ComputeResponse,
@@ -15,6 +19,23 @@ const metricItem = (
   title: id,
   computation: { datasetId, aggregation: "count" },
 })
+
+/**
+ * Mirrors the agent's persisted shape for chart items: the `datasetId`
+ * lives on `chart`, not on `computation`. The f0 type system declares
+ * `computation` on every variant but live data violates that — see
+ * `readItemDatasetId` in useDashboardCompute.ts.
+ */
+const chartItemAgentShape = (
+  id: string,
+  datasetId: string
+): ChatDashboardChartItem =>
+  ({
+    id,
+    type: "chart",
+    title: id,
+    chart: { type: "bar", datasetId },
+  }) as unknown as ChatDashboardChartItem
 
 const config = (items: ChatDashboardConfig["items"]): ChatDashboardConfig => ({
   title: "Test dashboard",
@@ -107,6 +128,39 @@ describe("computeDatasetFailures", () => {
         ghost: { error: "boom", reason: "dataset_failed" },
       }),
       config([metricItem("m1", "dsA")])
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it("reads datasetId from chart.datasetId when computation is absent (agent shape)", () => {
+    // Regression: live chart items lack `computation` — the agent persists
+    // chart datasetIds under `chart.datasetId`. The previous implementation
+    // crashed with "Cannot read properties of undefined (reading
+    // 'datasetId')" when filtering items.
+    const result = computeDatasetFailures(
+      response({
+        ch1: { error: "Cannot heal", reason: "unrepairable" },
+      }),
+      config([chartItemAgentShape("ch1", "dsChart")])
+    )
+    expect(result).toEqual({
+      dsChart: { reason: "unrepairable", message: "Cannot heal" },
+    })
+  })
+
+  it("does not crash on items missing both computation and chart.datasetId", () => {
+    // Worst-case malformed item: no resolvable datasetId at all. Must not
+    // throw and must not contribute to the failure map.
+    const malformed = {
+      id: "junk",
+      type: "metric",
+      title: "junk",
+    } as unknown as ChatDashboardMetricItem
+    const result = computeDatasetFailures(
+      response({
+        junk: { error: "boom", reason: "dataset_failed" },
+      }),
+      config([malformed])
     )
     expect(result).toBeUndefined()
   })

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/useDashboardCompute.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/useDashboardCompute.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from "react"
 
-import type { ChatDashboardConfig } from "./types"
+import type { ChatDashboardConfig, DashboardFetchSpec } from "./types"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,12 +33,43 @@ export type ItemResult = {
   chart?: ChartResult
   metric?: MetricResult
   collection?: CollectionResult
+  /** Per-item failure message. When set, the other slices are absent. */
   error?: string
+  /**
+   * Stable reason classifier so consumers can branch on failure mode without
+   * pattern-matching on `error` strings. Mirrors the agent contract:
+   *   - `dataset_failed`: a fetch / SQL / materialize error in the recipe
+   *   - `unrepairable`: the recipe references a tool the agent could not heal
+   */
+  reason?: "dataset_failed" | "unrepairable" | string
+}
+
+/**
+ * Per-source failure surfaced by the agent's self-heal pass. Mirrors the
+ * structure produced by `dashboard-recipe-repair` on the agent side.
+ */
+export type DashboardRepairFailure = {
+  datasetId: string
+  sourceIndex: number
+  toolId: string
+  reason: string
 }
 
 type ComputeResponse = {
   results: Record<string, ItemResult>
   filterOptions?: Record<string, string[]>
+  /**
+   * Present only when the agent's Phase 0 self-heal applied at least one
+   * change. Consumers should swap `config.fetchSpecs` to this value and
+   * re-persist the recipe so future opens skip the repair round-trip.
+   */
+  repairedSpecs?: Record<string, DashboardFetchSpec>
+  /**
+   * Present only when one or more sources could not be repaired. Items
+   * pointing at the affected datasets will surface as
+   * `{ error, reason: 'unrepairable' }` in `results`.
+   */
+  repairFailures?: DashboardRepairFailure[]
 }
 
 type ApiConfig = {
@@ -57,11 +88,19 @@ type ApiConfig = {
  *
  * Multiple concurrent calls with the same filter state share one request.
  * When filters change, a new request is made and the previous one is aborted.
+ *
+ * When the server responds with `repairedSpecs` (the agent's self-heal pass
+ * mutated the recipe), `onRepair` is invoked once per response so the caller
+ * can persist the new recipe via the existing dashboard save path.
  */
 export function useDashboardCompute(
   config: ChatDashboardConfig,
   apiConfig: ApiConfig,
-  refreshKey: number
+  refreshKey: number,
+  onRepair?: (
+    repairedSpecs: Record<string, DashboardFetchSpec>,
+    repairFailures: DashboardRepairFailure[] | undefined
+  ) => void
 ): {
   fetchItem: (
     itemId: string,
@@ -87,6 +126,8 @@ export function useDashboardCompute(
   apiConfigRef.current = apiConfig
   const refreshKeyRef = useRef(refreshKey)
   refreshKeyRef.current = refreshKey
+  const onRepairRef = useRef(onRepair)
+  onRepairRef.current = onRepair
 
   const fetchItem = useCallback(
     (
@@ -152,6 +193,17 @@ export function useDashboardCompute(
         }
         const data = (await res.json()) as ComputeResponse
         lastResponseRef.current = data
+        // Notify the caller about agent-side recipe repairs so it can persist
+        // the new recipe. Best-effort: a throw inside the callback must not
+        // poison the per-item result resolution chained below.
+        if (data.repairedSpecs && onRepairRef.current) {
+          try {
+            onRepairRef.current(data.repairedSpecs, data.repairFailures)
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.warn("[Dashboard] onRepair callback threw", err)
+          }
+        }
         return data
       })
 

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/useDashboardCompute.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/useDashboardCompute.ts
@@ -40,8 +40,11 @@ export type ItemResult = {
    * pattern-matching on `error` strings. Mirrors the agent contract:
    *   - `dataset_failed`: a fetch / SQL / materialize error in the recipe
    *   - `unrepairable`: the recipe references a tool the agent could not heal
+   *
+   * `(string & {})` preserves literal autocomplete on the known values while
+   * still accepting unknown future reasons added agent-side.
    */
-  reason?: "dataset_failed" | "unrepairable" | string
+  reason?: "dataset_failed" | "unrepairable" | (string & {})
 }
 
 /**
@@ -55,7 +58,22 @@ export type DashboardRepairFailure = {
   reason: string
 }
 
-type ComputeResponse = {
+/**
+ * Aggregated dataset-level failure exposed to consumers. Built by joining
+ * per-item `ItemResult` entries (those carrying a structured `reason`) with
+ * `config.items[].computation.datasetId` so the UI can render a single
+ * banner per dataset instead of N identical per-item error cards.
+ */
+export type DatasetFailure = {
+  reason: "dataset_failed" | "unrepairable" | (string & {})
+  message: string
+}
+
+/**
+ * Response shape returned by the `/dashboard/compute` endpoint. Exported for
+ * unit tests that exercise `computeDatasetFailures` directly.
+ */
+export type ComputeResponse = {
   results: Record<string, ItemResult>
   filterOptions?: Record<string, string[]>
   /**
@@ -83,6 +101,39 @@ type ApiConfig = {
 // ---------------------------------------------------------------------------
 
 /**
+ * Build a `{ datasetId → DatasetFailure }` map from a compute response. We
+ * include a dataset only when an item targeting it failed with a structured
+ * `reason` — those failures affect the whole dataset and warrant a single
+ * banner. Per-item errors without a `reason` (local SQL/handler failures)
+ * are intentionally excluded so they keep surfacing per-item.
+ *
+ * When the same dataset has multiple failing items the first one wins; all
+ * items of a failed dataset receive the same payload from the agent so the
+ * choice is moot in practice.
+ *
+ * Exported for unit testing.
+ */
+export function computeDatasetFailures(
+  data: ComputeResponse,
+  config: ChatDashboardConfig
+): Record<string, DatasetFailure> | undefined {
+  const byItemId = new Map<string, string>()
+  for (const item of config.items) {
+    byItemId.set(item.id, item.computation.datasetId)
+  }
+
+  const failures: Record<string, DatasetFailure> = {}
+  for (const [itemId, result] of Object.entries(data.results)) {
+    if (!result.error || !result.reason) continue
+    const datasetId = byItemId.get(itemId)
+    if (!datasetId || failures[datasetId]) continue
+    failures[datasetId] = { reason: result.reason, message: result.error }
+  }
+
+  return Object.keys(failures).length > 0 ? failures : undefined
+}
+
+/**
  * Provides a `fetchItem` function that triggers a batch compute request
  * and returns the result for a specific item.
  *
@@ -108,6 +159,18 @@ export function useDashboardCompute(
     navigationFilterValues?: Record<string, string[]>
   ) => Promise<ItemResult>
   getFilterOptions: () => Record<string, string[]> | undefined
+  /**
+   * Returns a map of `{ datasetId → { reason, message } }` derived from the
+   * latest compute response. A dataset is reported here when at least one
+   * item pointing at it failed with a structured `reason` (i.e. the failure
+   * affects the whole dataset, not just that item). Per-item errors without
+   * a `reason` are excluded — those are local failures and should keep being
+   * surfaced per-item.
+   *
+   * Used by consumers to render a single dataset-level banner and suppress
+   * the redundant per-item error cards.
+   */
+  getDatasetFailures: () => Record<string, DatasetFailure> | undefined
 } {
   // Track the in-flight request so concurrent fetchItem calls share it
   const inflightRef = useRef<{
@@ -117,7 +180,12 @@ export function useDashboardCompute(
   } | null>(null)
 
   // Cache last response for filter options
-  const lastResponseRef = useRef<ComputeResponse | undefined>()
+  const lastResponseRef = useRef<ComputeResponse | undefined>(undefined)
+
+  // Cache last computed dataset failures map; recomputed on each response.
+  const datasetFailuresRef = useRef<Record<string, DatasetFailure> | undefined>(
+    undefined
+  )
 
   // Stable refs
   const configRef = useRef(config)
@@ -193,6 +261,10 @@ export function useDashboardCompute(
         }
         const data = (await res.json()) as ComputeResponse
         lastResponseRef.current = data
+        datasetFailuresRef.current = computeDatasetFailures(
+          data,
+          configRef.current
+        )
         // Notify the caller about agent-side recipe repairs so it can persist
         // the new recipe. Best-effort: a throw inside the callback must not
         // poison the per-item result resolution chained below.
@@ -221,5 +293,7 @@ export function useDashboardCompute(
     []
   )
 
-  return { fetchItem, getFilterOptions }
+  const getDatasetFailures = useCallback(() => datasetFailuresRef.current, [])
+
+  return { fetchItem, getFilterOptions, getDatasetFailures }
 }

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/useDashboardCompute.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/useDashboardCompute.ts
@@ -101,6 +101,29 @@ type ApiConfig = {
 // ---------------------------------------------------------------------------
 
 /**
+ * Read the datasetId of a dashboard item across all three variants. The
+ * f0 TypeScript model declares `computation.datasetId` on every variant,
+ * but the agent's persisted shape — and the compute route on the agent
+ * side — stores chart datasetIds under `item.chart.datasetId` instead.
+ * Legacy / in-flight dashboards therefore lack `item.computation` on
+ * chart items, which crashed earlier consumers. Mirror the agent
+ * accessor here so we are tolerant of both shapes.
+ *
+ * Exported for use by `DashboardContent` when filtering items.
+ */
+export function readItemDatasetId(
+  item: ChatDashboardConfig["items"][number]
+): string | undefined {
+  const fromComputation = (item as { computation?: { datasetId?: unknown } })
+    .computation?.datasetId
+  if (typeof fromComputation === "string") return fromComputation
+  const fromChart = (item as { chart?: { datasetId?: unknown } }).chart
+    ?.datasetId
+  if (typeof fromChart === "string") return fromChart
+  return undefined
+}
+
+/**
  * Build a `{ datasetId → DatasetFailure }` map from a compute response. We
  * include a dataset only when an item targeting it failed with a structured
  * `reason` — those failures affect the whole dataset and warrant a single
@@ -119,7 +142,8 @@ export function computeDatasetFailures(
 ): Record<string, DatasetFailure> | undefined {
   const byItemId = new Map<string, string>()
   for (const item of config.items) {
-    byItemId.set(item.id, item.computation.datasetId)
+    const datasetId = readItemDatasetId(item)
+    if (datasetId) byItemId.set(item.id, datasetId)
   }
 
   const failures: Record<string, DatasetFailure> = {}


### PR DESCRIPTION
## Description

Wires the agent-side dashboard self-heal contract (`/dashboard/compute` may now return `repairedSpecs` and `repairFailures`) into the f0 chat dashboard. When the agent heals a stale recipe, the canvas swaps `config.fetchSpecs` and persists the repaired recipe via the existing dashboard save callback, so future opens skip the repair round-trip. Per-item `{ error }` slices are no longer silently coerced to empty defaults — the existing `DashboardItem` error UI now renders for `/compute` failures.

## Behavior change

Item-level errors returned by `/dashboard/compute` (`{ error }` on a single item) now render `DashboardItem`'s `OneEmptyState` "Error loading data" + retry card instead of an empty chart / zero metric / empty table.

This affects two pre-existing cases that have nothing to do with self-heal:

- The agent's per-item SQL failures, which already returned `{ error: message }` on `main`.
- `useDashboardCompute`'s synthesized `{ error: "No result for item" }` when an item id is missing from a successful response.

Both used to render silently as empty visuals; they now surface the error to the user. This is the same UI already shown by `useDashboardItemData` for non-chat `F0AnalyticsDashboard` consumers, so it's battle-tested.

No backend coupling: works against the current agent, the new fields (`repairedSpecs`, `repairFailures`) are gracefully ignored when absent.

## Implementation details

- feat: extend `ComputeResponse` with optional `repairedSpecs` and `repairFailures`, plus a structured `ItemResult.reason` classifier
- feat: add an `onRepair` callback to `useDashboardCompute`, fired (best-effort) when a repaired recipe is returned
- feat: wire `handleRepairedSpecs` in the canvas wrapper — updates canvas content, best-effort `saveConfigToHistory`, and calls `canvasActions.dashboard.save` for already-saved dashboards; idempotent via a ref keyed on `savedDashboardId:toolCallId` and reset when `fetchSpecs` reference changes
- fix: propagate per-item compute errors through chart/metric/collection adapters so `DashboardItem`'s `OneEmptyState` error branch renders instead of empty defaults

  <details>
  <summary>Why?</summary>

  The three adapters (`mapChartItem`, `mapMetricItem`, `mapCollectionItem`) previously read only `r.chart` / `r.metric` / `r.collection` and fell back to empty defaults with `??`, never inspecting `r.error`. This made `DashboardItem`'s error branch dead code for chat dashboards and hid backend failures behind empty charts / zero metrics / empty tables.
  </details>

## Notes for downstream

The agent contract is implemented in [factorial-agent](https://github.com/factorialco/factorial-agent) (PR pending). After this PR's CI publishes an alpha, the factorial monorepo's `@factorialco/f0-react` will be pinned to that alpha to validate the full round-trip end-to-end.