### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.470.1",
+  "packages/react": "1.470.2",
   "packages/react-native": "0.52.1",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.470.2](https://github.com/factorialco/f0/compare/f0-react-v1.470.1...f0-react-v1.470.2) (2026-04-29)
+
+
+### Bug Fixes
+
+* **F0AiChat:** remove DinoGame easter egg ([#4062](https://github.com/factorialco/f0/issues/4062)) ([1d52cc4](https://github.com/factorialco/f0/commit/1d52cc42a2445a0f81e6ee6b73875b7836e629c2))
+
 ## [1.470.1](https://github.com/factorialco/f0/compare/f0-react-v1.470.0...f0-react-v1.470.1) (2026-04-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.470.1",
+  "version": "1.470.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.470.2</summary>

## [1.470.2](https://github.com/factorialco/f0/compare/f0-react-v1.470.1...f0-react-v1.470.2) (2026-04-29)


### Bug Fixes

* **F0AiChat:** remove DinoGame easter egg ([#4062](https://github.com/factorialco/f0/issues/4062)) ([1d52cc4](https://github.com/factorialco/f0/commit/1d52cc42a2445a0f81e6ee6b73875b7836e629c2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).