### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.471.0",
-  "packages/react-native": "0.52.1",
+  "packages/react-native": "0.53.0",
   "packages/core": "1.50.1"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.53.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.52.1...f0-react-native-v0.53.0) (2026-04-30)
+
+
+### Features
+
+* **F0Tabs:** make tab id type generic ([a0f43e9](https://github.com/factorialco/f0/commit/a0f43e920f34c71866cc0d8254ce3a58bc4f2794))
+
 ## [0.52.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.52.0...f0-react-native-v0.52.1) (2026-04-24)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.53.0</summary>

## [0.53.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.52.1...f0-react-native-v0.53.0) (2026-04-30)


### Features

* **F0Tabs:** make tab id type generic ([a0f43e9](https://github.com/factorialco/f0/commit/a0f43e920f34c71866cc0d8254ce3a58bc4f2794))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).