### PR TITLE
feat(ticketing): add ticket canvas entity + confirmTicketCreation action

### DIFF
--- a/packages/react/src/sds/TicketingKit/ai/F0TicketCard/useConfirmTicketCreationAction.tsx
+++ b/packages/react/src/sds/TicketingKit/ai/F0TicketCard/useConfirmTicketCreationAction.tsx
@@ -1,0 +1,56 @@
+import { useCopilotAction } from "@copilotkit/react-core"
+
+import { TicketCard } from "../../../ai/F0AiChat/canvas/entities/ticket/TicketCard"
+import type { TicketCardProps } from "../../../ai/F0AiChat/canvas/entities/ticket/TicketCard"
+
+/**
+ * Copilot action that renders a ticket preview card inline in the chat.
+ * The card auto-opens a canvas panel with full ticket details.
+ */
+export const useConfirmTicketCreationAction = () => {
+  useCopilotAction({
+    name: "confirmTicketCreation",
+    description:
+      "Display a ticket preview card with category, priority, and description. Opens a canvas panel for review.",
+    parameters: [
+      {
+        name: "title",
+        type: "string",
+        description: "The ticket title",
+        required: true,
+      },
+      {
+        name: "categoryName",
+        type: "string",
+        description: "The ticket category name",
+        required: true,
+      },
+      {
+        name: "priority",
+        type: "string",
+        description: "The ticket priority (critical, high, medium, low)",
+        required: false,
+      },
+      {
+        name: "description",
+        type: "string",
+        description: "The ticket description",
+        required: true,
+      },
+    ],
+    available: "frontend",
+    render: (props) => {
+      const args = props.args as Partial<TicketCardProps>
+      if (!args.title || !args.categoryName) return <></>
+
+      return (
+        <TicketCard
+          title={args.title}
+          categoryName={args.categoryName}
+          priority={args.priority}
+          description={args.description}
+        />
+      )
+    },
+  })
+}

--- a/packages/react/src/sds/ai/F0AiChat/actions/registry.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/registry.ts
@@ -3,6 +3,7 @@ import { useDemoCardAction } from "../../../UpsellingKit/ai/F0DemoCard/useDemoCa
 import { useFAQCardAction } from "../../../UpsellingKit/ai/F0FAQCard/useFAQCardAction"
 import { useModuleCardAction } from "../../../UpsellingKit/ai/F0ModuleCard/useModuleCardAction"
 import { useQuestionCardAction } from "../../../UpsellingKit/ai/F0QuestionCard/useQuestionCardAction"
+import { useConfirmTicketCreationAction } from "../../../TicketingKit/ai/F0TicketCard/useConfirmTicketCreationAction"
 import { useClarifyingQuestionAction } from "./core/clarifyingQuestion/useClarifyingQuestionAction"
 import { useDataDownloadAction } from "./core/dataDownload/useDataDownloadAction"
 import { useDisplayDashboardAction } from "./core/displayDashboard/useDisplayDashboardAction"
@@ -26,4 +27,5 @@ export const copilotActions: ActionFactory[] = [
   useFAQCardAction,
   useMessageCreditsWarningAction,
   useF0AiFormActions,
+  useConfirmTicketCreationAction,
 ]

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/ticket/TicketCard.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/ticket/TicketCard.tsx
@@ -1,0 +1,98 @@
+import type { TicketCanvasContent } from "../../../types"
+
+import type { DetailsItemContent } from "@/experimental/Lists/DetailsItem"
+import { DetailsItemsList } from "@/experimental/Lists/DetailsItemsList"
+
+import { useToolCallId } from "../../../components/messages/AssistantMessage"
+import { useAutoOpenCanvas } from "../../../hooks/useAutoOpenCanvas"
+import { useAiChat } from "../../../providers/AiChatStateProvider"
+import { CanvasCard } from "../../components/CanvasCard"
+
+export type TicketCardProps = {
+  title: string
+  categoryName: string
+  priority?: string | null
+  description?: string
+  status?: "preview" | "created"
+}
+
+export function TicketCard({
+  title,
+  categoryName,
+  priority,
+  description,
+  status = "preview",
+}: TicketCardProps) {
+  const toolCallId = useToolCallId()
+  const { canvasContent, openCanvas, closeCanvas } = useAiChat()
+
+  const isActive =
+    canvasContent?.type === "ticket" &&
+    canvasContent.toolCallId != null &&
+    canvasContent.toolCallId === toolCallId
+
+  const handleOpen = () =>
+    openCanvas({
+      type: "ticket",
+      title,
+      description,
+      categoryName,
+      priority,
+      status,
+      toolCallId,
+    } satisfies TicketCanvasContent)
+
+  useAutoOpenCanvas(toolCallId, handleOpen)
+
+  const fields: Array<{
+    title: string
+    content: DetailsItemContent
+  }> = [
+    {
+      title: "Category",
+      content: { type: "item", text: categoryName },
+    },
+    ...(priority
+      ? [
+          {
+            title: "Priority",
+            content: { type: "item" as const, text: priority },
+          },
+        ]
+      : []),
+    ...(description
+      ? [
+          {
+            title: "Description",
+            content: {
+              type: "item" as const,
+              text:
+                description.length > 200
+                  ? `${description.slice(0, 200)}…`
+                  : description,
+            },
+          },
+        ]
+      : []),
+  ]
+
+  return (
+    <CanvasCard
+      module="ai_ticketing"
+      title={title}
+      description={categoryName}
+      onOpen={handleOpen}
+      onClose={() => closeCanvas()}
+      isActive={isActive}
+      showOpenButton={isActive}
+    >
+      {fields.length > 0 && !isActive && (
+        <div className="-mx-3 flex w-full flex-col overflow-hidden pb-1">
+          <DetailsItemsList details={fields} tableView />
+        </div>
+      )}
+    </CanvasCard>
+  )
+}
+
+TicketCard.displayName = "TicketCard"

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/ticket/TicketContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/ticket/TicketContent.tsx
@@ -1,0 +1,33 @@
+import type { TicketCanvasContent } from "../../../types"
+
+import { DetailsItemsList } from "@/experimental/Lists/DetailsItemsList"
+
+export function TicketContent({ content }: { content: TicketCanvasContent }) {
+  const details = [
+    {
+      title: "Category",
+      content: { type: "item" as const, text: content.categoryName },
+    },
+    content.priority
+      ? {
+          title: "Priority",
+          content: { type: "item" as const, text: content.priority },
+        }
+      : null,
+    content.description
+      ? {
+          title: "Description",
+          content: { type: "item" as const, text: content.description },
+        }
+      : null,
+  ].filter(Boolean) as Array<{
+    title: string
+    content: { type: "item"; text: string }
+  }>
+
+  return (
+    <div className="flex flex-col gap-4 p-5">
+      <DetailsItemsList details={details} tableView />
+    </div>
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/ticket/TicketHeader.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/ticket/TicketHeader.tsx
@@ -1,0 +1,24 @@
+import { OneEllipsis } from "@/lib/OneEllipsis"
+
+import { CloseCanvasButton } from "../../components/CloseCanvasButton"
+import type { TicketCanvasContent } from "../../../types"
+
+export function TicketHeader({
+  content,
+  onClose,
+}: {
+  content: TicketCanvasContent
+  onClose: () => void
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-f1-border-secondary p-5">
+      <OneEllipsis
+        tag="h2"
+        className="min-w-0 flex-1 text-2xl font-semibold text-f1-foreground"
+      >
+        {content.title}
+      </OneEllipsis>
+      <CloseCanvasButton onClick={onClose} />
+    </div>
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/ticket/index.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/ticket/index.tsx
@@ -1,0 +1,17 @@
+import type { CanvasEntityDefinition } from "../../types"
+
+import { TicketContent } from "./TicketContent"
+import { TicketHeader } from "./TicketHeader"
+import type { TicketCanvasContent } from "../../../types"
+
+export const ticketCanvasEntity: CanvasEntityDefinition<TicketCanvasContent> = {
+  type: "ticket",
+  renderContent: ({ content }) => <TicketContent content={content} />,
+  renderHeader: ({ content, onClose }) => (
+    <TicketHeader content={content} onClose={onClose} />
+  ),
+}
+
+export type { TicketCanvasContent } from "../../../types"
+export { TicketCard } from "./TicketCard"
+export type { TicketCardProps } from "./TicketCard"

--- a/packages/react/src/sds/ai/F0AiChat/canvas/registry.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/registry.ts
@@ -3,12 +3,14 @@ import type { CanvasEntityDefinition } from "./types"
 import { dashboardCanvasEntity } from "./entities/dashboard"
 import { formCanvasEntity } from "./entities/form"
 import { dataDownloadCanvasEntity } from "./entities/dataDownload"
+import { ticketCanvasEntity } from "./entities/ticket"
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const canvasEntities: Record<string, CanvasEntityDefinition<any>> = {
   dashboard: dashboardCanvasEntity,
   form: formCanvasEntity,
   dataDownload: dataDownloadCanvasEntity,
+  ticket: ticketCanvasEntity,
 }
 
 /**

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -129,6 +129,13 @@ export type DataDownloadCanvasContent = CanvasContentBase & {
   markdown?: string
 }
 
+export type TicketCanvasContent = CanvasContentBase & {
+  type: "ticket"
+  categoryName: string
+  priority?: string | null
+  status?: "preview" | "created"
+}
+
 /**
  * Discriminated union for canvas panel content.
  * Add new entity types to this union as they are implemented.
@@ -137,6 +144,7 @@ export type CanvasContent =
   | DashboardCanvasContent
   | FormCanvasContent
   | DataDownloadCanvasContent
+  | TicketCanvasContent
 
 /**
  * A tool hint that can be activated to prepend invisible context to the user's


### PR DESCRIPTION
## What

Adds a new canvas entity for ticketing that renders a ticket preview card inline in the AI chat, with a canvas panel for full details.

## Changes

### New: `canvas/entities/ticket/`
- `TicketCard.tsx` — Inline card using `CanvasCard` + `DetailsItemsList` (same pattern as `FormCard`)
- `TicketContent.tsx` — Canvas panel body with field details
- `TicketHeader.tsx` — Canvas panel header with close button
- `index.tsx` — Exports `ticketCanvasEntity: CanvasEntityDefinition<TicketCanvasContent>`

### New: `TicketingKit/ai/F0TicketCard/`
- `useConfirmTicketCreationAction.tsx` — Domain-specific copilot action registered in the actions registry

### Modified
- `F0AiChat/types.ts` — Added `TicketCanvasContent` to the `CanvasContent` union
- `canvas/registry.ts` — Registered `ticket: ticketCanvasEntity`
- `actions/registry.ts` — Registered `useConfirmTicketCreationAction`

## How it works

1. Agent calls `emitFrontendTool({ toolName: 'confirmTicketCreation', args })`
2. CopilotKit matches to the registered action → renders `<TicketCard>`
3. `TicketCard` shows inline summary (title, category, priority, description) using `DetailsItemsList`
4. `useAutoOpenCanvas` opens the canvas panel with full ticket details
5. User reviews and confirms via chat

## Context

Part of the AI-powered ticket creation flow. The agent gathers information via clarifying questions, then presents this card for the user to review before creating the ticket.