### PR TITLE
fix(EditableTable): allow decimal separator in NumberCell

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { useCallback } from "react"
 
 import { NumberInput } from "@/experimental/Forms/Fields/NumberInput"
 import { RecordType } from "@/hooks/datasource/types/records.typings"
@@ -17,10 +17,6 @@ export function NumberCell<R extends RecordType>({
   item,
 }: EditableCellProps<R>) {
   const config = editableColumn.numberConfig
-  // When clamping produces the same value the parent already holds,
-  // NumberInput's internal state won't re-sync (the prop didn't change).
-  // Bumping a key forces a re-mount so the displayed text resets.
-  const [resetKey, setResetKey] = useState(0)
 
   const trimmed = typeof value === "string" ? value.trim() : value
   const parsed = trimmed !== "" && trimmed != null ? Number(trimmed) : NaN
@@ -45,8 +41,6 @@ export function NumberCell<R extends RecordType>({
     const stringValue = String(clamped)
     if (stringValue !== value) {
       onChange(stringValue)
-    } else {
-      setResetKey((k) => k + 1)
     }
   }
 
@@ -86,7 +80,6 @@ export function NumberCell<R extends RecordType>({
         >
           {unitsBefore && unitsSpan}
           <NumberInput
-            key={resetKey}
             label={editableColumn.label}
             hideLabel
             value={numericValue}


### PR DESCRIPTION
## Description

Fixes a bug where users couldn't type decimal numbers (e.g. `12.5`) in number/money editable table cells. Typing `12.` would immediately revert to `12` because the `resetKey` mechanism force-remounted `NumberInput`, destroying its intermediate typing state.

## Implementation details

**Root cause**: `NumberCell` used a `resetKey` state + `key={resetKey}` on `<NumberInput>` to force remounts when clamping produced the same numeric value. On every keystroke where `String(clampedValue) === currentValue`, it bumped the key — causing a full remount that destroyed NumberInput's internal `fieldValue` (which correctly held `"12."` as an intermediate value).

**Fix**: Remove the `resetKey` mechanism entirely. It was redundant because NumberInput's own `handleChange` already clamps and reformats via `setFieldValue()` internally before calling `onChange`. The displayed value is always correct without an external remount.

**Change**: 1 file, 1 insertion, 8 deletions — just removes unused state, the else branch, and the `key` prop.