### PR TITLE
refactor(UpsellingKit): simplify to outlinePromote only

### DIFF
--- a/packages/react/src/sds/UpsellingKit/ProductBlankslate/index.stories.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductBlankslate/index.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof ProductBlankslate> = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "no-sidebar"],
   argTypes: {
     benefits: {
       control: { type: "object" },
@@ -34,7 +34,7 @@ const defaultArgs = {
   title:
     "Optimize and centralize your sales processes with quotes and invoices",
   image: "https://placehold.co/280x328", // 3:4 ratio
-  variant: "promote" as const,
+  variant: "outlinePromote" as const,
   benefits: [
     "Track every sale from quote to final invoice.",
     "Customize with client data, taxes, and discounts.",

--- a/packages/react/src/sds/UpsellingKit/ProductBlankslate/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductBlankslate/index.tsx
@@ -115,4 +115,5 @@ const _ProductBlankslate = forwardRef<HTMLDivElement, ProductBlankslateProps>(
 
 _ProductBlankslate.displayName = "ProductBlankslate"
 
+/** @deprecated */
 export const ProductBlankslate = withDataTestId(_ProductBlankslate)

--- a/packages/react/src/sds/UpsellingKit/ProductCard/index.stories.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductCard/index.stories.tsx
@@ -7,7 +7,7 @@ import { ProductCard } from "./index"
 const meta: Meta<typeof ProductCard> = {
   title: "UpsellingKit/ProductCard",
   component: ProductCard,
-  tags: ["autodocs", "no-sidebar"],
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/packages/react/src/sds/UpsellingKit/ProductModal/ProductModal.stories.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductModal/ProductModal.stories.tsx
@@ -114,7 +114,7 @@ export const Default: Story = {
         await new Promise((resolve) => setTimeout(resolve, 1000))
       },
       icon: UpsellIcon,
-      variant: "promote",
+      variant: "outlinePromote",
     },
     secondaryAction: {
       label: "Learn more",

--- a/packages/react/src/sds/UpsellingKit/ProductModal/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductModal/index.tsx
@@ -176,4 +176,5 @@ function _ProductModal({
   )
 }
 
+/** @deprecated */
 export const ProductModal = withDataTestId(_ProductModal)

--- a/packages/react/src/sds/UpsellingKit/ProductWidget/index.stories.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductWidget/index.stories.tsx
@@ -26,7 +26,7 @@ export const Default: Story = {
     actions: [
       {
         type: "regular",
-        variant: "promote",
+        variant: "outlinePromote",
         label: "Learn more",
         onClick: () => {
           alert("clicked")
@@ -81,7 +81,7 @@ export const WithUpsellingButton: Story = {
     actions: [
       {
         type: "upsell",
-        variant: "promote",
+        variant: "outlinePromote",
         label: "Request Information",
         errorMessage: {
           title: "Request failed",

--- a/packages/react/src/sds/UpsellingKit/ProductWidget/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductWidget/index.tsx
@@ -20,7 +20,7 @@ type BaseAction = {
 
 type UpsellAction = BaseAction & {
   type: "upsell"
-  variant: "promote" | "outlinePromote"
+  variant: "outlinePromote"
   errorMessage: ErrorMessageProps
   successMessage: SuccessMessageProps
   loadingState: LoadingStateProps
@@ -156,4 +156,5 @@ function _ProductWidget({
   )
 }
 
+/** @deprecated */
 export const ProductWidget = withDataTestId(_ProductWidget)

--- a/packages/react/src/sds/UpsellingKit/UpsellRequestResponseDialog/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellRequestResponseDialog/index.tsx
@@ -110,7 +110,7 @@ const DialogActions = ({
       />
       {showSecondButton && (
         <F0Button
-          variant="promote"
+          variant="outlinePromote"
           label={successButtonLabel}
           onClick={() => {
             successButtonOnClick()
@@ -207,6 +207,7 @@ const _UpsellRequestResponseDialog = forwardRef<
 
 _UpsellRequestResponseDialog.displayName = "UpsellRequestResponseDialog"
 
+/** @deprecated */
 export const UpsellRequestResponseDialog = withDataTestId(
   _UpsellRequestResponseDialog
 )

--- a/packages/react/src/sds/UpsellingKit/UpsellingBanner/index.stories.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingBanner/index.stories.tsx
@@ -8,153 +8,67 @@ const meta: Meta<typeof UpsellingBanner> = {
   parameters: {
     layout: "padded",
   },
-  tags: ["autodocs", "no-sidebar"],
-  argTypes: {
-    isLoading: {
-      control: "boolean",
-      description: "Show skeleton loading state",
-    },
+  tags: ["autodocs"],
+  args: {
+    title: "Complete your financial picture",
+    subtitle:
+      "Without expenses, you're missing half the story. Add them to gain clarity and make better decisions.",
+    mediaUrl: "https://placehold.co/400x225",
     primaryAction: {
-      control: "object",
-      description: "Banner primary action",
+      label: "Request information",
+      onClick: () => alert("Request information"),
+      errorMessage: {
+        title: "Error",
+        description: "Something went wrong. Please try again later.",
+      },
+      successMessage: {
+        title: "Request submitted!",
+        description: "One of our experts will contact you as soon as possible.",
+        buttonLabel: "Discover more modules",
+        buttonOnClick: () => alert("Discover more"),
+      },
+      loadingState: {
+        label: "Processing...",
+      },
+      nextSteps: {
+        title: "Next steps",
+        items: [
+          { text: "Request information", isCompleted: true },
+          { text: "Product expert contacting you." },
+          { text: "Demo to answer all your questions" },
+        ],
+      },
+      closeLabel: "Close",
+      showIcon: true,
+      showConfirmation: true,
     },
-    secondaryAction: {
-      control: "object",
-      description: "Banner secondary actionr",
-    },
+    onClose: () => alert("Closed"),
+    isLoading: false,
   },
 }
 
 export default meta
 type Story = StoryObj<typeof UpsellingBanner>
 
-export const Default: Story = {
+export const Default: Story = {}
+
+export const WithSecondaryAction: Story = {
   args: {
-    title: "Complete your financial picture",
-    subtitle:
-      "Without expenses, you're missing half the story. Add them to gain clarity and make better decisions.",
-    mediaUrl: "https://placehold.co/400x225", // 16:9 ratio
-    primaryAction: {
-      variant: "default",
-      label: "Discover",
-      onClick: () => alert("Request information"),
-    },
     secondaryAction: {
-      variant: "default",
       label: "Learn more",
-      onClick: () => alert("Read more"),
+      onClick: () => alert("Learn more"),
     },
-    onClose: () => alert("Closed"),
-    isLoading: false,
-  },
-}
-
-export const Promote: Story = {
-  args: {
-    title: "Try our new feature!",
-    subtitle: "Experience the new dashboard with enhanced analytics.",
-    mediaUrl: "https://placehold.co/400x225",
-    primaryAction: {
-      variant: "promote",
-      label: "Request information",
-      onClick: () => alert("Try now"),
-      errorMessage: {
-        title: "Error",
-        description: "Something went wrong",
-      },
-      successMessage: {
-        title: "Success",
-        description: "Operation completed successfully",
-        buttonLabel: "Discover more modules",
-        buttonOnClick: () => alert("Close"),
-      },
-      loadingState: {
-        label: "Loading...",
-      },
-      nextSteps: {
-        title: "Next steps",
-        items: [
-          {
-            text: "Step 1",
-          },
-        ],
-      },
-      closeLabel: "Close",
-      showIcon: true,
-      showConfirmation: true,
-    },
-    secondaryAction: {
-      variant: "default",
-      label: "Discover more modules",
-      onClick: () => alert("Discover more modules"),
-    },
-    onClose: () => alert("Closed"),
-    isLoading: false,
-  },
-}
-
-export const OnlyPrimary: Story = {
-  args: {
-    title: "Upgrade your plan",
-    subtitle: "Access more features and better support.",
-    mediaUrl: "https://placehold.co/400x225",
-    primaryAction: {
-      variant: "promote",
-      label: "Start now",
-      onClick: () => alert("Upgrade"),
-      errorMessage: {
-        title: "Error",
-        description: "Something went wrong",
-      },
-      successMessage: {
-        title: "Success",
-        description: "Operation completed successfully",
-        buttonLabel: "Discover more modules",
-        buttonOnClick: () => alert("Close"),
-      },
-      loadingState: {
-        label: "Loading...",
-      },
-      nextSteps: {
-        title: "Next steps",
-        items: [
-          {
-            text: "Step 1",
-          },
-        ],
-      },
-      closeLabel: "Close",
-      showIcon: true,
-      showConfirmation: true,
-    },
-    onClose: () => alert("Closed"),
-    isLoading: false,
   },
 }
 
 export const Skeleton: Story = {
   args: {
-    title: "Loading banner...",
-    subtitle: "This content is being loaded",
-    mediaUrl: "https://placehold.co/400x225",
-    primaryAction: {
-      variant: "default",
-      label: "Primary Action",
-      onClick: () => {},
-    },
-    secondaryAction: {
-      variant: "default",
-      label: "Secondary",
-      onClick: () => {},
-    },
-    onClose: () => {},
     isLoading: true,
   },
   parameters: {
     docs: {
       description: {
-        story:
-          "Shows the skeleton loading state when data is being fetched or props are loading.",
+        story: "Shows the skeleton loading state when data is being fetched.",
       },
     },
   },

--- a/packages/react/src/sds/UpsellingKit/UpsellingBanner/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingBanner/index.tsx
@@ -2,19 +2,11 @@ import { forwardRef } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { withDataTestId } from "@/lib/data-testid"
-import { IconType } from "@/components/F0Icon"
-import {
-  BaseBanner,
-  type BannerAction,
-  type BaseBannerProps,
-} from "@/sds/ai/Banners/BaseBanner"
+import { BaseBanner, type BaseBannerProps } from "@/sds/ai/Banners/BaseBanner"
 
 import { UpsellingButton, type UpsellingButtonProps } from "../UpsellingButton"
 
-type DefaultAction = BannerAction
-
-type PromoteAction = {
-  variant: "promote"
+type UpsellAction = {
   label: string
   onClick: () => void
   errorMessage: UpsellingButtonProps["errorMessage"]
@@ -24,15 +16,19 @@ type PromoteAction = {
   closeLabel: UpsellingButtonProps["closeLabel"]
   showIcon?: boolean
   showConfirmation?: boolean
-  icon?: IconType
+}
+
+type GhostAction = {
+  label: string
+  onClick: () => void
 }
 
 type UpsellingBannerProps = Omit<
   BaseBannerProps,
   "primaryAction" | "secondaryAction" | "children"
 > & {
-  primaryAction?: DefaultAction | PromoteAction
-  secondaryAction?: DefaultAction | PromoteAction
+  primaryAction: UpsellAction
+  secondaryAction?: GhostAction
 }
 
 const _UpsellingBanner = forwardRef<HTMLDivElement, UpsellingBannerProps>(
@@ -40,52 +36,29 @@ const _UpsellingBanner = forwardRef<HTMLDivElement, UpsellingBannerProps>(
     { primaryAction, secondaryAction, ...baseProps },
     ref
   ) {
-    const renderAction = (action: DefaultAction | PromoteAction) => {
-      if (action.variant === "promote") {
-        return (
-          <UpsellingButton
-            label={action.label}
-            onRequest={async () => {
-              await action.onClick()
-            }}
-            errorMessage={action.errorMessage}
-            successMessage={action.successMessage}
-            loadingState={action.loadingState}
-            nextSteps={action.nextSteps}
-            closeLabel={action.closeLabel}
-            showIcon={action.showIcon}
-            showConfirmation={action.showConfirmation}
-            variant={action.variant}
-          />
-        )
-      }
-
-      return (
-        <F0Button
-          onClick={action.onClick}
-          label={action.label}
-          variant={action.variant || "default"}
-          size="md"
-          icon={action.icon}
-        />
-      )
-    }
-
-    const basePrimaryAction =
-      primaryAction?.variant !== "promote" ? primaryAction : undefined
-    const baseSecondaryAction =
-      secondaryAction?.variant !== "promote" ? secondaryAction : undefined
-
     return (
-      <BaseBanner
-        ref={ref}
-        {...baseProps}
-        primaryAction={basePrimaryAction}
-        secondaryAction={baseSecondaryAction}
-      >
-        {primaryAction?.variant === "promote" && renderAction(primaryAction)}
-        {secondaryAction?.variant === "promote" &&
-          renderAction(secondaryAction)}
+      <BaseBanner ref={ref} {...baseProps}>
+        <UpsellingButton
+          label={primaryAction.label}
+          onRequest={async () => {
+            await primaryAction.onClick()
+          }}
+          errorMessage={primaryAction.errorMessage}
+          successMessage={primaryAction.successMessage}
+          loadingState={primaryAction.loadingState}
+          nextSteps={primaryAction.nextSteps}
+          closeLabel={primaryAction.closeLabel}
+          showIcon={primaryAction.showIcon}
+          showConfirmation={primaryAction.showConfirmation}
+        />
+        {secondaryAction && (
+          <F0Button
+            variant="ghost"
+            label={secondaryAction.label}
+            onClick={secondaryAction.onClick}
+            size="md"
+          />
+        )}
       </BaseBanner>
     )
   }

--- a/packages/react/src/sds/UpsellingKit/UpsellingButton/index.stories.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingButton/index.stories.tsx
@@ -112,13 +112,6 @@ export const Disabled: Story = {
   },
 }
 
-export const OutlinePromote: Story = {
-  args: {
-    variant: "outlinePromote",
-    label: "Request Information",
-  },
-}
-
 export const Sizes: Story = {
   render: (args) => (
     <div className="flex items-center gap-4">

--- a/packages/react/src/sds/UpsellingKit/UpsellingButton/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingButton/index.tsx
@@ -15,6 +15,7 @@ export interface LoadingStateProps {
 }
 
 export interface UpsellingButtonProps extends Omit<F0ButtonProps, "icon"> {
+  /** @deprecated Use "outlinePromote" instead */
   variant?: "promote" | "outlinePromote"
   /**
    * The text to be displayed in the button
@@ -75,7 +76,7 @@ function _UpsellingButton({
   loadingState,
   nextSteps,
   closeLabel,
-  variant = "promote",
+  variant = "outlinePromote",
   onModalStateChange,
   portalContainer,
   ...props

--- a/packages/react/src/sds/UpsellingKit/UpsellingPopover/index.stories.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingPopover/index.stories.tsx
@@ -6,18 +6,11 @@ import { UpsellingPopover } from "."
 const meta: Meta<typeof UpsellingPopover> = {
   title: "UpsellingKit/UpsellingPopover",
   component: UpsellingPopover,
+  tags: ["autodocs"],
   argTypes: {
-    actions: {
-      control: "object",
-      description: "Custom actions component to display",
-    },
     label: {
       control: "text",
       description: "Label of the button that opens the popover",
-    },
-    icon: {
-      control: "object",
-      description: "Custom icon to display",
     },
     showIcon: {
       control: "boolean",
@@ -28,23 +21,10 @@ const meta: Meta<typeof UpsellingPopover> = {
       options: ["left", "right", "top", "bottom"],
       description: "Side of the popover",
     },
-    width: {
-      control: "text",
-      description: "Width of the popover",
-    },
-    trackVisibility: {
-      control: "object",
-      description: "Function to track visibility",
-    },
     align: {
       control: "select",
       options: ["start", "center", "end"],
       description: "Alignment of the popover",
-    },
-    variant: {
-      control: "select",
-      options: ["promote", "default"],
-      description: "Variant of the popover",
     },
     size: {
       control: "select",
@@ -72,8 +52,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    mediaUrl:
-      "https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4",
+    mediaUrl: "https://placehold.co/400x225",
     title: "More benefits to René & your team",
     description:
       "Enjoy greater savings through flexible benefits like meals, transport, and health insurance.",
@@ -87,11 +66,11 @@ export const Default: Story = {
           console.log("clicked")
         },
         type: "regular",
-        variant: "promote",
+        variant: "outlinePromote",
       },
     ],
   },
-  tags: ["autodocs", "no-sidebar"],
+  tags: ["autodocs"],
   render: (args) => {
     const [isOpen, setIsOpen] = useState(false)
 
@@ -101,7 +80,7 @@ export const Default: Story = {
         label="Add reaction"
         isOpen={isOpen}
         setIsOpen={setIsOpen}
-        variant="promote"
+        variant="outlinePromote"
         size="md"
         showIcon={true}
         mediaUrl={args.mediaUrl}
@@ -115,8 +94,7 @@ export const Default: Story = {
 }
 export const WithUpsellingButton: Story = {
   args: {
-    mediaUrl:
-      "https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4",
+    mediaUrl: "https://placehold.co/400x225",
     title: "More benefits to René & your team",
     description:
       "Enjoy greater savings through flexible benefits like meals, transport, and health insurance.",
@@ -126,7 +104,7 @@ export const WithUpsellingButton: Story = {
     actions: [
       {
         type: "upsell",
-        variant: "promote",
+        variant: "outlinePromote",
         label: "Request Information",
         showConfirmation: true,
         errorMessage: {
@@ -169,7 +147,7 @@ export const WithUpsellingButton: Story = {
       },
     ],
   },
-  tags: ["autodocs", "no-sidebar"],
+  tags: ["autodocs"],
   render: (args) => {
     const [isOpen, setIsOpen] = useState(false)
 
@@ -179,7 +157,7 @@ export const WithUpsellingButton: Story = {
         label="Add reaction"
         isOpen={isOpen}
         setIsOpen={setIsOpen}
-        variant="promote"
+        variant="outlinePromote"
         size="md"
         side="right"
         align="center"

--- a/packages/react/src/sds/UpsellingKit/UpsellingPopover/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingPopover/index.tsx
@@ -36,7 +36,7 @@ function _UpsellingPopover({
   isOpen,
   setIsOpen,
   label,
-  variant = "promote",
+  variant = "outlinePromote" as F0ButtonProps["variant"],
   size = "md",
   showIcon = true,
   side = "right",


### PR DESCRIPTION
## Summary

- Simplifies the UpsellingKit to use `outlinePromote` as the only active variant
- Deprecates `promote` variant in `UpsellingButton` (still works, shows deprecation warning)
- Simplifies `UpsellingBanner` API: `primaryAction` is always `UpsellAction`, `secondaryAction` is optional ghost-only
- Sets `outlinePromote` as default in `UpsellingButton` and `UpsellingPopover`
- Marks `ProductModal`, `ProductBlankslate`, `ProductWidget`, and `UpsellRequestResponseDialog` as deprecated
- Removes `no-sidebar` tag from all active UpsellingKit stories so they appear in Storybook sidebar