### PR TITLE
fix: restore solid background on F0AvatarIcon

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
@@ -27,7 +27,7 @@ export const F0AvatarIcon = ({
   return (
     <div
       className={cn(
-        "flex aspect-square items-center justify-center border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary dark:bg-f1-background-tertiary",
+        "flex aspect-square items-center justify-center border border-solid border-f1-border-secondary bg-f1-background dark:bg-f1-background-inverse-secondary",
         sizes[size]
       )}
       aria-label={ariaLabel}


### PR DESCRIPTION
## Problem

PR #3819 (`56afe21af`) accidentally changed the `F0AvatarIcon` background from `bg-f1-background` (solid white) to `bg-f1-background-inverse-secondary` (60% opacity white). This causes the icon avatar to appear translucent when rendered over images — e.g. in the Factorial Spaces overview page (`/spaces/overview`) where `F0Card` is used with both an image and an icon avatar.

## Fix
https://github.com/user-attachments/assets/d08c1834-6bb4-41ab-9321-5c86288ccfba

Restore the background classes to their original values:
- Light: `bg-f1-background` → `hsl(0 0% 100%)` (solid white)
- Dark: `bg-f1-background-inverse-secondary`


