### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.471.0",
+  "packages/react": "1.471.1",
   "packages/react-native": "0.53.0",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.471.1](https://github.com/factorialco/f0/compare/f0-react-v1.471.0...f0-react-v1.471.1) (2026-04-30)
+
+
+### Bug Fixes
+
+* **EditableTable:** allow decimal separator in NumberCell ([#4067](https://github.com/factorialco/f0/issues/4067)) ([878f934](https://github.com/factorialco/f0/commit/878f934797e341345cda4e57c0b18018eae9269a))
+
 ## [1.471.0](https://github.com/factorialco/f0/compare/f0-react-v1.470.2...f0-react-v1.471.0) (2026-04-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.471.0",
+  "version": "1.471.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.471.1</summary>

## [1.471.1](https://github.com/factorialco/f0/compare/f0-react-v1.471.0...f0-react-v1.471.1) (2026-04-30)


### Bug Fixes

* **EditableTable:** allow decimal separator in NumberCell ([#4067](https://github.com/factorialco/f0/issues/4067)) ([878f934](https://github.com/factorialco/f0/commit/878f934797e341345cda4e57c0b18018eae9269a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).