### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.471.1",
+  "packages/react": "1.471.2",
   "packages/react-native": "0.53.0",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.471.2](https://github.com/factorialco/f0/compare/f0-react-v1.471.1...f0-react-v1.471.2) (2026-05-04)
+
+
+### Bug Fixes
+
+* restore solid background on F0AvatarIcon ([#4069](https://github.com/factorialco/f0/issues/4069)) ([1e23b3e](https://github.com/factorialco/f0/commit/1e23b3e3be9ce7a76ef6f10a499a4a9439052e06))
+
 ## [1.471.1](https://github.com/factorialco/f0/compare/f0-react-v1.471.0...f0-react-v1.471.1) (2026-04-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.471.1",
+  "version": "1.471.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.471.2</summary>

## [1.471.2](https://github.com/factorialco/f0/compare/f0-react-v1.471.1...f0-react-v1.471.2) (2026-05-04)


### Bug Fixes

* restore solid background on F0AvatarIcon ([#4069](https://github.com/factorialco/f0/issues/4069)) ([1e23b3e](https://github.com/factorialco/f0/commit/1e23b3e3be9ce7a76ef6f10a499a4a9439052e06))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).