### PR TITLE
refactor: prevent cross-visualization filter contamination

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -232,6 +232,7 @@ const OneDataCollectionComp = <
     sourceSetCurrentFilters: setCurrentFilters,
     visualizations,
     currentVisualization,
+    storageKey: id,
   })
 
   // Patched source with per-viz currentFilters to avoid stale filters during transitions

--- a/packages/react/src/patterns/OneDataCollection/hooks/__tests__/usePerVisualizationFilters.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/__tests__/usePerVisualizationFilters.test.ts
@@ -45,7 +45,7 @@ const allFilters = {
 type AllFilters = typeof allFilters
 
 describe("usePerVisualizationFilters", () => {
-  describe("when no visualization has filter overrides", () => {
+  describe("when source has a single visualization", () => {
     it("should pass through source filters and presets", () => {
       const sourceSetCurrentFilters = vi.fn()
 
@@ -57,10 +57,7 @@ describe("usePerVisualizationFilters", () => {
           ],
           sourceCurrentFilters: {},
           sourceSetCurrentFilters,
-          visualizations: [
-            { type: "table", options: {} },
-            { type: "card", options: {} },
-          ],
+          visualizations: [{ type: "table", options: {} }],
           currentVisualization: 0,
         })
       )
@@ -97,6 +94,35 @@ describe("usePerVisualizationFilters", () => {
       expect(sourceSetCurrentFilters).toHaveBeenCalledWith({
         department: ["Engineering"],
       })
+    })
+  })
+
+  describe("when source has 2+ visualizations without filter overrides", () => {
+    it("enables per-visualization scoping (always-on for 2+ vizs)", () => {
+      const sourceSetCurrentFilters = vi.fn()
+
+      const { result } = renderHook(() =>
+        usePerVisualizationFilters<AllFilters>({
+          sourceFilters: allFilters,
+          sourcePresets: [
+            { label: "Eng", filter: { department: ["Engineering"] } },
+          ],
+          sourceCurrentFilters: {},
+          sourceSetCurrentFilters,
+          visualizations: [
+            { type: "table", options: {} },
+            { type: "card", options: {} },
+          ],
+          currentVisualization: 0,
+        })
+      )
+
+      expect(result.current.hasPerVisualizationFilters).toBe(true)
+      expect(result.current.effectiveFilters).toBe(allFilters)
+      expect(result.current.effectivePresets).toEqual([
+        { label: "Eng", filter: { department: ["Engineering"] } },
+      ])
+      expect(result.current.allVisualizationFilters).toEqual({ "0": {} })
     })
   })
 
@@ -741,6 +767,102 @@ describe("usePerVisualizationFilters", () => {
       expect(sourceSetCurrentFilters).toHaveBeenCalledWith({})
     })
 
+    it("never persists the previous viz's filters under the new viz's storage slot during a transition", () => {
+      const sourceSetCurrentFilters = vi.fn()
+
+      const { result, rerender } = renderHook(
+        ({ currentViz, sourceCurrentFilters }) =>
+          usePerVisualizationFilters<AllFilters>({
+            sourceFilters: allFilters,
+            sourcePresets: undefined,
+            sourceCurrentFilters,
+            sourceSetCurrentFilters,
+            visualizations: [
+              {
+                type: "table",
+                options: {},
+                filters: { department: departmentFilter.department },
+              },
+              {
+                type: "card",
+                options: {},
+                filters: { salary: salaryFilter.salary },
+              },
+            ],
+            currentVisualization: currentViz,
+          }),
+        {
+          initialProps: {
+            currentViz: 0,
+            sourceCurrentFilters: {} as Record<string, unknown>,
+          },
+        }
+      )
+
+      const stored = {
+        "0": { department: ["Engineering"] },
+        "1": { salary: { mode: "single" as const, value: 75000 } },
+      }
+      act(() => {
+        result.current.setAllVisualizationFilters(stored)
+      })
+
+      rerender({
+        currentViz: 0,
+        sourceCurrentFilters: { department: ["Engineering"] },
+      })
+
+      // Switch to viz 1 — sourceCurrentFilters is still previous viz
+      rerender({
+        currentViz: 1,
+        sourceCurrentFilters: { department: ["Engineering"] },
+      })
+
+      expect(result.current.allVisualizationFilters["1"]).toEqual({
+        salary: { mode: "single", value: 75000 },
+      })
+      expect(
+        "department" in (result.current.allVisualizationFilters["1"] ?? {})
+      ).toBe(false)
+    })
+
+    it("setCurrentFilters writes through to allVisualizationFilters at the active viz's slot", () => {
+      const sourceSetCurrentFilters = vi.fn()
+
+      const { result } = renderHook(() =>
+        usePerVisualizationFilters<AllFilters>({
+          sourceFilters: allFilters,
+          sourcePresets: undefined,
+          sourceCurrentFilters: {},
+          sourceSetCurrentFilters,
+          visualizations: [
+            {
+              type: "table",
+              options: {},
+              filters: { department: departmentFilter.department },
+            },
+            {
+              type: "card",
+              options: {},
+              filters: { salary: salaryFilter.salary },
+            },
+          ],
+          currentVisualization: 0,
+        })
+      )
+
+      act(() => {
+        result.current.setCurrentFilters({ department: ["Marketing"] })
+      })
+
+      expect(sourceSetCurrentFilters).toHaveBeenCalledWith({
+        department: ["Marketing"],
+      })
+      expect(result.current.allVisualizationFilters["0"]).toEqual({
+        department: ["Marketing"],
+      })
+    })
+
     it("should not fall back to source presets when viz defines empty presets array", () => {
       const sourceSetCurrentFilters = vi.fn()
       const globalPresets = [
@@ -780,6 +902,413 @@ describe("usePerVisualizationFilters", () => {
 
       // presets: [] means "I explicitly want no presets" — should NOT fall back to globalPresets[0]
       expect(sourceSetCurrentFilters).toHaveBeenCalledWith({})
+    })
+  })
+
+  describe("hydration sanitization (defence against pre-existing contamination)", () => {
+    it("strips keys a viz does not own from its stored entry on hydration", () => {
+      const sourceSetCurrentFilters = vi.fn()
+
+      const { result, rerender } = renderHook(
+        ({ currentViz }) =>
+          usePerVisualizationFilters<AllFilters>({
+            sourceFilters: allFilters,
+            sourcePresets: undefined,
+            sourceCurrentFilters: {},
+            sourceSetCurrentFilters,
+            visualizations: [
+              {
+                type: "table",
+                options: {},
+                filters: { department: departmentFilter.department },
+              },
+              {
+                type: "card",
+                options: {},
+                filters: { salary: salaryFilter.salary },
+              },
+            ],
+            currentVisualization: currentViz,
+          }),
+        { initialProps: { currentViz: 1 } }
+      )
+
+      const contaminated = {
+        "0": { department: ["Engineering"] },
+        "1": {
+          salary: { mode: "single" as const, value: 50000 },
+          // Leaked from viz 0 — must be stripped on hydration
+          department: ["Engineering"],
+        },
+      }
+
+      act(() => {
+        result.current.setAllVisualizationFilters(contaminated)
+      })
+
+      rerender({ currentViz: 1 })
+
+      expect(sourceSetCurrentFilters).toHaveBeenCalledWith({
+        salary: { mode: "single", value: 50000 },
+      })
+      expect(result.current.allVisualizationFilters["1"]).toEqual({
+        salary: { mode: "single", value: 50000 },
+      })
+    })
+
+    it("falls back to source filter schema when a viz declares no overrides", () => {
+      const sourceSetCurrentFilters = vi.fn()
+
+      const { result, rerender } = renderHook(
+        ({ currentViz }) =>
+          usePerVisualizationFilters<AllFilters>({
+            sourceFilters: { department: departmentFilter.department },
+            sourcePresets: undefined,
+            sourceCurrentFilters: {},
+            sourceSetCurrentFilters,
+            visualizations: [
+              { type: "table", options: {} },
+              { type: "card", options: {} },
+            ],
+            currentVisualization: currentViz,
+          }),
+        { initialProps: { currentViz: 1 } }
+      )
+
+      const contaminated = {
+        "0": { department: ["Engineering"] },
+        "1": {
+          department: ["Marketing"],
+          applicationPhaseId: ["leaked"],
+        },
+      }
+
+      act(() => {
+        result.current.setAllVisualizationFilters(
+          contaminated as unknown as Parameters<
+            typeof result.current.setAllVisualizationFilters
+          >[0]
+        )
+      })
+
+      rerender({ currentViz: 1 })
+
+      expect(result.current.allVisualizationFilters["1"]).toEqual({
+        department: ["Marketing"],
+      })
+    })
+  })
+
+  describe("setAllVisualizationFilters with corrupted payloads", () => {
+    const buildHook = () => {
+      const sourceSetCurrentFilters = vi.fn()
+      return renderHook(() =>
+        usePerVisualizationFilters<AllFilters>({
+          sourceFilters: allFilters,
+          sourcePresets: undefined,
+          sourceCurrentFilters: {},
+          sourceSetCurrentFilters,
+          visualizations: [
+            {
+              type: "table",
+              options: {},
+              filters: { department: departmentFilter.department },
+            },
+            {
+              type: "card",
+              options: {},
+              filters: { salary: salaryFilter.salary },
+            },
+          ],
+          currentVisualization: 0,
+        })
+      )
+    }
+
+    it("does not throw when states is null", () => {
+      const { result } = buildHook()
+      expect(() => {
+        act(() => {
+          result.current.setAllVisualizationFilters(
+            null as unknown as Parameters<
+              typeof result.current.setAllVisualizationFilters
+            >[0]
+          )
+        })
+      }).not.toThrow()
+    })
+
+    it("does not throw when states is not an object", () => {
+      const { result: r1 } = buildHook()
+      expect(() => {
+        act(() => {
+          r1.current.setAllVisualizationFilters(
+            "garbage" as unknown as Parameters<
+              typeof r1.current.setAllVisualizationFilters
+            >[0]
+          )
+        })
+      }).not.toThrow()
+
+      const { result: r2 } = buildHook()
+      expect(() => {
+        act(() => {
+          r2.current.setAllVisualizationFilters(
+            42 as unknown as Parameters<
+              typeof r2.current.setAllVisualizationFilters
+            >[0]
+          )
+        })
+      }).not.toThrow()
+    })
+
+    it("does not throw when states is an array", () => {
+      const { result } = buildHook()
+      expect(() => {
+        act(() => {
+          result.current.setAllVisualizationFilters(
+            [] as unknown as Parameters<
+              typeof result.current.setAllVisualizationFilters
+            >[0]
+          )
+        })
+      }).not.toThrow()
+    })
+
+    it("replaces a null entry with {}", () => {
+      const { result } = buildHook()
+      act(() => {
+        result.current.setAllVisualizationFilters({
+          "0": null,
+        } as unknown as Parameters<
+          typeof result.current.setAllVisualizationFilters
+        >[0])
+      })
+      expect(result.current.allVisualizationFilters["0"]).toEqual({})
+    })
+
+    it("replaces a non-object entry with {}", () => {
+      const { result } = buildHook()
+      act(() => {
+        result.current.setAllVisualizationFilters({
+          "0": "garbage",
+        } as unknown as Parameters<
+          typeof result.current.setAllVisualizationFilters
+        >[0])
+      })
+      expect(result.current.allVisualizationFilters["0"]).toEqual({})
+    })
+
+    it("still marks hydration as initialized after a corrupted payload", () => {
+      const { result } = buildHook()
+      act(() => {
+        result.current.setAllVisualizationFilters(
+          null as unknown as Parameters<
+            typeof result.current.setAllVisualizationFilters
+          >[0]
+        )
+      })
+      // Second call with valid data is ignored (idempotent — already initialized)
+      act(() => {
+        result.current.setAllVisualizationFilters({
+          "0": { department: ["Engineering"] },
+        } as unknown as Parameters<
+          typeof result.current.setAllVisualizationFilters
+        >[0])
+      })
+      expect(result.current.allVisualizationFilters["0"]).toEqual({})
+    })
+  })
+
+  describe("setCurrentFilters function-updater branch", () => {
+    it("writes through to source state and the active viz's slot", () => {
+      let sourceState: Record<string, unknown> = {
+        department: ["Engineering"],
+      }
+      const sourceSetCurrentFilters = vi.fn(
+        (
+          updater:
+            | Record<string, unknown>
+            | ((prev: Record<string, unknown>) => Record<string, unknown>)
+        ) => {
+          sourceState =
+            typeof updater === "function" ? updater(sourceState) : updater
+        }
+      )
+
+      const { result, rerender } = renderHook(
+        ({ sourceCurrentFilters }) =>
+          usePerVisualizationFilters<AllFilters>({
+            sourceFilters: allFilters,
+            sourcePresets: undefined,
+            sourceCurrentFilters,
+            sourceSetCurrentFilters,
+            visualizations: [
+              {
+                type: "table",
+                options: {},
+                filters: { department: departmentFilter.department },
+              },
+              {
+                type: "card",
+                options: {},
+                filters: { salary: salaryFilter.salary },
+              },
+            ],
+            currentVisualization: 0,
+          }),
+        {
+          initialProps: {
+            sourceCurrentFilters: sourceState as Record<string, unknown>,
+          },
+        }
+      )
+
+      act(() => {
+        result.current.setCurrentFilters((prev) => ({
+          ...prev,
+          department: [...((prev.department as string[]) ?? []), "Marketing"],
+        }))
+      })
+
+      // Source state was updated via the function form
+      expect(sourceState).toEqual({ department: ["Engineering", "Marketing"] })
+
+      // Push the new source value back into the hook (mirrors a real rerender)
+      rerender({ sourceCurrentFilters: sourceState })
+
+      expect(result.current.allVisualizationFilters["0"]).toEqual({
+        department: ["Engineering", "Marketing"],
+      })
+    })
+  })
+
+  describe("storageKey reset (collection swap re-hydration)", () => {
+    it("re-hydrates persisted filters when storageKey changes", () => {
+      const sourceSetCurrentFilters = vi.fn()
+
+      const { result, rerender } = renderHook(
+        ({ currentViz, storageKey }) =>
+          usePerVisualizationFilters<AllFilters>({
+            sourceFilters: allFilters,
+            sourcePresets: undefined,
+            sourceCurrentFilters: {},
+            sourceSetCurrentFilters,
+            visualizations: [
+              {
+                type: "table",
+                options: {},
+                filters: { department: departmentFilter.department },
+              },
+              {
+                type: "card",
+                options: {},
+                filters: { salary: salaryFilter.salary },
+              },
+            ],
+            currentVisualization: currentViz,
+            storageKey,
+          }),
+        { initialProps: { currentViz: 0, storageKey: "collection-a/v1" } }
+      )
+
+      // First hydration: scope A
+      act(() => {
+        result.current.setAllVisualizationFilters({
+          "0": { department: ["Engineering"] },
+        })
+      })
+      rerender({ currentViz: 0, storageKey: "collection-a/v1" })
+
+      expect(sourceSetCurrentFilters).toHaveBeenCalledWith({
+        department: ["Engineering"],
+      })
+
+      sourceSetCurrentFilters.mockClear()
+
+      // Storage scope changes (e.g. user navigates to a different collection).
+      // The hook must accept the next hydration payload instead of staying
+      // frozen on scope A's filters.
+      rerender({ currentViz: 0, storageKey: "collection-b/v1" })
+
+      // Map and locks are reset before the next hydration arrives — the
+      // previous scope's persisted entry must NOT survive the storage swap
+      expect(result.current.allVisualizationFilters["0"]).not.toEqual({
+        department: ["Engineering"],
+      })
+
+      act(() => {
+        result.current.setAllVisualizationFilters({
+          "0": { department: ["Marketing"] },
+        })
+      })
+      rerender({ currentViz: 0, storageKey: "collection-b/v1" })
+
+      expect(sourceSetCurrentFilters).toHaveBeenCalledWith({
+        department: ["Marketing"],
+      })
+    })
+  })
+
+  describe("source-driven filter updates (bypassing wrapped setter)", () => {
+    it("mirrors stable sourceCurrentFilters changes into the persisted map", () => {
+      const sourceSetCurrentFilters = vi.fn()
+
+      const { result, rerender } = renderHook(
+        ({ currentViz, sourceCurrentFilters }) =>
+          usePerVisualizationFilters<AllFilters>({
+            sourceFilters: allFilters,
+            sourcePresets: undefined,
+            sourceCurrentFilters,
+            sourceSetCurrentFilters,
+            visualizations: [
+              {
+                type: "table",
+                options: {},
+                filters: { department: departmentFilter.department },
+              },
+              {
+                type: "card",
+                options: {},
+                filters: { salary: salaryFilter.salary },
+              },
+            ],
+            currentVisualization: currentViz,
+          }),
+        {
+          initialProps: {
+            currentViz: 0,
+            sourceCurrentFilters: { department: ["Engineering"] } as Record<
+              string,
+              unknown
+            >,
+          },
+        }
+      )
+
+      // Hydrate so initialization completes — the slot for viz 0 now exists.
+      act(() => {
+        result.current.setAllVisualizationFilters({
+          "0": { department: ["Engineering"] },
+        })
+      })
+      rerender({
+        currentViz: 0,
+        sourceCurrentFilters: { department: ["Engineering"] },
+      })
+
+      // Simulate an update that bypasses the wrapped setter (e.g. controlled
+      // currentFilters prop sync inside useDataSource, or a direct external
+      // dataSource.setCurrentFilters call). The persisted map for the active
+      // viz must reflect the new value, not stay stuck on the old one.
+      rerender({
+        currentViz: 0,
+        sourceCurrentFilters: { department: ["Marketing"] },
+      })
+
+      expect(result.current.allVisualizationFilters["0"]).toEqual({
+        department: ["Marketing"],
+      })
     })
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/__tests__/useDataCollectionLanesData.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/__tests__/useDataCollectionLanesData.test.tsx
@@ -1,0 +1,127 @@
+import { waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  FiltersDefinition,
+  GroupingDefinition,
+  PaginatedFetchOptions,
+  RecordType,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
+import { ItemActionsDefinition } from "@/patterns/OneDataCollection/item-actions"
+import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
+import { SummariesDefinition } from "@/patterns/OneDataCollection/summary"
+import { zeroRender } from "@/testing/test-utils"
+
+import { KanbanCollection } from "../../../visualizations/collection/Kanban/Kanban"
+
+type Person = RecordType & {
+  id: number | string
+  name: string
+  stage: string
+}
+
+type TestFilters = FiltersDefinition
+type TestNavigationFilters = NavigationFiltersDefinition
+
+const people: Person[] = [
+  { id: 1, name: "John", stage: "todo" },
+  { id: 2, name: "Jane", stage: "doing" },
+  { id: 3, name: "Alice", stage: "todo" },
+]
+
+type FetchOptions = PaginatedFetchOptions<TestFilters> & {
+  navigationFilters?: unknown
+}
+
+describe("useDataCollectionLanesData — lane-authoritative merge", () => {
+  it("each lane queries its own filter when global currentFilters is disjoint", async () => {
+    const fetchData = vi.fn(async (_options: FetchOptions) => ({
+      records: people,
+      total: people.length,
+      perPage: people.length,
+      type: "infinite-scroll" as const,
+      cursor: null,
+      hasMore: false,
+    }))
+
+    const source: DataCollectionSource<
+      Person,
+      TestFilters,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Person>,
+      TestNavigationFilters,
+      GroupingDefinition<Person>
+    > = {
+      currentFilters: { stage: ["todo"] },
+      setCurrentFilters: vi.fn(),
+      currentSortings: null,
+      setCurrentSortings: vi.fn(),
+      currentNavigationFilters: {},
+      setCurrentNavigationFilters: vi.fn(),
+      navigationFilters: undefined,
+      currentSearch: undefined,
+      debouncedCurrentSearch: undefined,
+      setCurrentSearch: vi.fn(),
+      isLoading: false,
+      setIsLoading: vi.fn(),
+      currentGrouping: undefined,
+      setCurrentGrouping: vi.fn(),
+      dataAdapter: {
+        fetchData,
+        paginationType: "infinite-scroll",
+        perPage: 10,
+      },
+      idProvider: (item: Person) => item.id,
+      lanes: [
+        { id: "todo", filters: { stage: ["todo"] } },
+        { id: "doing", filters: { stage: ["doing"] } },
+        { id: "done", filters: { stage: ["done"] } },
+      ],
+    }
+
+    zeroRender(
+      <KanbanCollection<
+        Person,
+        TestFilters,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        TestNavigationFilters,
+        GroupingDefinition<Person>
+      >
+        lanes={[
+          { id: "todo", title: "Todo" },
+          { id: "doing", title: "Doing" },
+          { id: "done", title: "Done" },
+        ]}
+        title={(p) => p.name}
+        description={(p) => p.name}
+        metadata={() => []}
+        source={source}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(fetchData.mock.calls.length).toBeGreaterThanOrEqual(3)
+    })
+
+    const stagesByCall = fetchData.mock.calls
+      .map(([options]) => options.filters as { stage?: string[] })
+      .map((f) => f.stage)
+
+    for (const stage of stagesByCall) {
+      expect(stage).toBeDefined()
+      expect(Array.isArray(stage)).toBe(true)
+      expect(stage!.length).toBeGreaterThan(0)
+    }
+
+    const stageSet = new Set(stagesByCall.flatMap((s) => s ?? []))
+    expect(stageSet).toEqual(new Set(["todo", "doing", "done"]))
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/__tests__/utils.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/__tests__/utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import { mergeFiltersWithIntersection } from "../utils"
+
+describe("mergeFiltersWithIntersection", () => {
+  it("intersects overlapping array filters", () => {
+    expect(
+      mergeFiltersWithIntersection<{ k: number[] }>(
+        { k: [1, 2, 3] },
+        { k: [2, 3, 4] }
+      )
+    ).toEqual({ k: [2, 3] })
+  })
+
+  it("falls back to the lane's own filter when arrays are disjoint", () => {
+    // Regression: previously the disjoint case produced `{ k: [] }`, which
+    // many backends collapse to "no filter" — silently widening the lane's
+    // query to the whole dataset. Lane is authoritative for its own filter.
+    expect(
+      mergeFiltersWithIntersection<{ k: number[] }>({ k: [99] }, { k: [42] })
+    ).toEqual({ k: [42] })
+  })
+
+  it("uses the lane filter when the global value is missing", () => {
+    expect(
+      mergeFiltersWithIntersection<{ k: number[]; o?: string }>(
+        {} as { k: number[] },
+        { k: [42] }
+      )
+    ).toEqual({ k: [42] })
+  })
+
+  it("uses the lane filter when the global value is an empty array", () => {
+    expect(
+      mergeFiltersWithIntersection<{ k: number[] }>({ k: [] }, { k: [42] })
+    ).toEqual({ k: [42] })
+  })
+
+  it("preserves global filter keys not present in lane filters", () => {
+    expect(
+      mergeFiltersWithIntersection<{ a: number[]; b: number[] }>(
+        { a: [1, 2], b: [9] },
+        { a: [2, 3] } as { a: number[]; b: number[] }
+      )
+    ).toEqual({ a: [2], b: [9] })
+  })
+
+  it("for non-array filter types, lane wins", () => {
+    expect(
+      mergeFiltersWithIntersection<{ k: { mode: string; value: number } }>(
+        { k: { mode: "single", value: 1 } },
+        { k: { mode: "single", value: 2 } }
+      )
+    ).toEqual({ k: { mode: "single", value: 2 } })
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/utils.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/utils.ts
@@ -1,11 +1,8 @@
 /**
- * Merges global filters with lane-specific filters using intersection logic.
- * For array-based filters (like InFilter), it finds the intersection of values.
- * For other filter types, lane filters override global filters.
- *
- * @param globalFilters - The global filters applied to all lanes
- * @param laneFilters - The lane-specific filters
- * @returns The merged filters with proper intersection logic
+ * Merges global (source-level) filters with lane-specific filters by
+ * intersecting array filters. On disjoint arrays the lane's own values win,
+ * since downstream adapters collapse `[]` to "no filter" rather than "match
+ * nothing". For non-array filters the lane wins.
  */
 export function mergeFiltersWithIntersection<T extends Record<string, unknown>>(
   globalFilters: T,
@@ -16,20 +13,17 @@ export function mergeFiltersWithIntersection<T extends Record<string, unknown>>(
   for (const [key, laneValue] of Object.entries(laneFilters)) {
     const globalValue = globalFilters[key]
 
-    // If both values exist and are arrays (InFilter case), find intersection
     if (
       Array.isArray(globalValue) &&
       Array.isArray(laneValue) &&
       globalValue.length > 0 &&
       laneValue.length > 0
     ) {
-      // Find intersection of the two arrays
       const intersection = globalValue.filter((item) =>
         laneValue.includes(item)
       )
-      result[key] = intersection
+      result[key] = intersection.length > 0 ? intersection : laneValue
     } else {
-      // For non-array filters or when one is empty, lane filter takes precedence
       result[key] = laneValue
     }
   }

--- a/packages/react/src/patterns/OneDataCollection/hooks/usePerVisualizationFilters.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/usePerVisualizationFilters.ts
@@ -21,6 +21,12 @@ type UsePerVisualizationFiltersArgs<Filters extends FiltersDefinition> = {
   >
   visualizations: ReadonlyArray<VisualizationWithFilterOverrides<Filters>>
   currentVisualization: number
+  /**
+   * Identity of the underlying storage scope (typically the collection `id`).
+   * Used to reset hydration locks so a re-mount-free collection swap reapplies
+   * the new scope's persisted filters instead of being stuck on the first one.
+   */
+  storageKey?: string
 }
 
 type UsePerVisualizationFiltersResult<Filters extends FiltersDefinition> = {
@@ -35,13 +41,8 @@ type UsePerVisualizationFiltersResult<Filters extends FiltersDefinition> = {
   hasPerVisualizationFilters: boolean
 }
 
-const hasAnyVisualizationFilters = <Filters extends FiltersDefinition>(
-  visualizations: ReadonlyArray<VisualizationWithFilterOverrides<Filters>>
-): boolean => {
-  return visualizations.some(
-    (viz) => viz.filters !== undefined || viz.presets !== undefined
-  )
-}
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v)
 
 // Index-based key (visualization type can repeat)
 const getVisualizationKey = (index: number): string => String(index)
@@ -71,9 +72,42 @@ const getDefaultFiltersForVisualization = <Filters extends FiltersDefinition>(
 }
 
 /**
- * Manages independent filter state per visualization.
- * Pass-through when no visualization declares overrides. Otherwise each
- * view gets its own currentFilters, and switching saves/restores state.
+ * Filter keys a viz may own; falls back to the source schema. Returns null
+ * when no schema is known (caller should preserve the entry as-is).
+ */
+const getOwnedFilterKeys = <Filters extends FiltersDefinition>(
+  vizIndex: number,
+  visualizations: ReadonlyArray<VisualizationWithFilterOverrides<Filters>>,
+  sourceFilters: Filters | undefined
+): Set<string> | null => {
+  const viz = visualizations[vizIndex]
+  if (viz?.filters) return new Set(Object.keys(viz.filters))
+  if (sourceFilters) return new Set(Object.keys(sourceFilters))
+  return null
+}
+
+/** Drop keys a viz does not own from a stored entry. */
+const sanitizeStoredEntryForViz = <Filters extends FiltersDefinition>(
+  vizIndex: number,
+  entry: FiltersState<Filters>,
+  visualizations: ReadonlyArray<VisualizationWithFilterOverrides<Filters>>,
+  sourceFilters: Filters | undefined
+): FiltersState<Filters> => {
+  if (!isPlainObject(entry)) return {} as FiltersState<Filters>
+  const allowed = getOwnedFilterKeys(vizIndex, visualizations, sourceFilters)
+  if (!allowed) return entry
+  const sanitized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(entry as Record<string, unknown>)) {
+    if (allowed.has(key)) sanitized[key] = value
+  }
+  return sanitized as FiltersState<Filters>
+}
+
+/**
+ * Manages independent filter state per visualization. Per-viz scoping is on
+ * whenever `visualizations.length > 1`: each viz gets its own currentFilters
+ * slot in storage, and switching viz saves the previous viz's filters and
+ * restores the new viz's.
  */
 export const usePerVisualizationFilters = <Filters extends FiltersDefinition>({
   sourceFilters,
@@ -82,10 +116,12 @@ export const usePerVisualizationFilters = <Filters extends FiltersDefinition>({
   sourceSetCurrentFilters,
   visualizations,
   currentVisualization,
+  storageKey,
 }: UsePerVisualizationFiltersArgs<Filters>): UsePerVisualizationFiltersResult<Filters> => {
-  const hasOverrides = useMemo(
-    () => hasAnyVisualizationFilters(visualizations),
-    [visualizations]
+  const hasPerVisualization = visualizations.length > 1
+
+  const hasAnyOverrides = visualizations.some(
+    (viz) => viz.filters !== undefined || viz.presets !== undefined
   )
 
   const [visualizationFiltersMap, setVisualizationFiltersMap] = useState<
@@ -106,8 +142,33 @@ export const usePerVisualizationFilters = <Filters extends FiltersDefinition>({
   const prevSourceFiltersRef =
     useRef<FiltersState<Filters>>(sourceCurrentFilters)
 
+  // Always-current refs for use inside callbacks with stable identity
+  // (e.g. setAllVisualizationFilters runs after storage hydration on every
+  // scope reset and must see the latest schema, not the captured one).
+  const visualizationsRef = useRef(visualizations)
+  visualizationsRef.current = visualizations
+
+  const sourceFiltersRef = useRef(sourceFilters)
+  sourceFiltersRef.current = sourceFilters
+
+  // Storage scope reset: when the underlying storage key (e.g. collection id)
+  // changes, useDataCollectionStorage will rehydrate with a different blob.
+  // Reset hydration locks and clear the persisted map so setAllVisualizationFilters
+  // accepts the next payload instead of being stuck on the previous scope.
+  useLayoutEffect(() => {
+    initializedRef.current = false
+    appliedInitRef.current = false
+    pendingFiltersRef.current = null
+    prevVisualizationRef.current = currentVisualization
+    prevSourceFiltersRef.current = sourceCurrentFilters
+    setVisualizationFiltersMap((prev) =>
+      Object.keys(prev).length > 0 ? {} : prev
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only react to storage scope changes
+  }, [storageKey])
+
   // Synchronous transition detection
-  if (hasOverrides && appliedInitRef.current) {
+  if (hasPerVisualization && appliedInitRef.current) {
     const prevKey = getVisualizationKey(prevVisualizationRef.current)
     const nextKey = getVisualizationKey(currentVisualization)
 
@@ -135,7 +196,7 @@ export const usePerVisualizationFilters = <Filters extends FiltersDefinition>({
   // One-shot: apply stored filters for the active viz after storage restoration.
   // Uses layout effect to avoid stale closure over currentVisualization.
   useLayoutEffect(() => {
-    if (!hasOverrides) return
+    if (!hasPerVisualization) return
     if (!initializedRef.current) return
     if (appliedInitRef.current) return
 
@@ -151,12 +212,12 @@ export const usePerVisualizationFilters = <Filters extends FiltersDefinition>({
     )
     appliedInitRef.current = true
     // eslint-disable-next-line react-hooks/exhaustive-deps -- One-shot initialization after storage restore
-  }, [hasOverrides, currentVisualization, visualizationFiltersMap])
+  }, [hasPerVisualization, currentVisualization, visualizationFiltersMap])
 
   // Save previous viz's filters, restore new viz's filters on switch.
   // Layout effect ensures filters apply before paint (no stale frame for children).
   useLayoutEffect(() => {
-    if (!hasOverrides) return
+    if (!hasPerVisualization) return
 
     if (initializedRef.current && !appliedInitRef.current) {
       // Skip storage-driven viz changes (init effect hasn't run yet)
@@ -187,10 +248,10 @@ export const usePerVisualizationFilters = <Filters extends FiltersDefinition>({
 
     prevVisualizationRef.current = currentVisualization
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Only react to visualization changes
-  }, [currentVisualization, hasOverrides])
+  }, [currentVisualization, hasPerVisualization])
 
   const effectiveFilters = useMemo(() => {
-    if (!hasOverrides) return sourceFilters
+    if (!hasAnyOverrides) return sourceFilters
 
     const viz = visualizations[currentVisualization]
     if (viz?.filters) {
@@ -198,12 +259,12 @@ export const usePerVisualizationFilters = <Filters extends FiltersDefinition>({
     }
 
     return sourceFilters
-  }, [hasOverrides, sourceFilters, visualizations, currentVisualization])
+  }, [hasAnyOverrides, sourceFilters, visualizations, currentVisualization])
 
   // Viz presets replace source presets entirely.
   // If only filters overridden, source presets filtered to matching keys.
   const effectivePresets = useMemo(() => {
-    if (!hasOverrides) return sourcePresets
+    if (!hasAnyOverrides) return sourcePresets
 
     const viz = visualizations[currentVisualization]
     const vizPresets = viz?.presets
@@ -226,43 +287,165 @@ export const usePerVisualizationFilters = <Filters extends FiltersDefinition>({
 
     return sourcePresets
   }, [
-    hasOverrides,
+    hasPerVisualization,
     sourcePresets,
     visualizations,
     currentVisualization,
     effectiveFilters,
+    hasAnyOverrides,
   ])
 
   const allVisualizationFilters = useMemo(() => {
-    if (!hasOverrides) return {}
+    if (!hasPerVisualization) return {}
 
     const currentKey = getVisualizationKey(currentVisualization)
-    return {
-      ...visualizationFiltersMap,
-      [currentKey]: sourceCurrentFilters,
+    if (currentKey in visualizationFiltersMap) return visualizationFiltersMap
+
+    // Don't auto-seed mid-transition: sourceCurrentFilters is still the previous viz's value.
+    if (prevVisualizationRef.current !== currentVisualization) {
+      return visualizationFiltersMap
     }
+
+    return { ...visualizationFiltersMap, [currentKey]: sourceCurrentFilters }
   }, [
-    hasOverrides,
+    hasPerVisualization,
     visualizationFiltersMap,
     currentVisualization,
     sourceCurrentFilters,
   ])
 
-  // Restore from storage; no-op after first call
+  // Mirror "bypass" source-filter changes into the persisted map for the
+  // active viz. Without this, updates that arrive through paths other than
+  // the wrapped `setCurrentFilters` (e.g. controlled `currentFilters` prop
+  // sync inside useDataSource, direct external `dataSource.setCurrentFilters`
+  // calls) would never reach `visualizationFiltersMap` once the slot was
+  // populated, leaving storage and `onStateChange.visualizationFilters`
+  // stale for the active viz.
+  //
+  // Detection uses a deep-compare baseline tracked per-visualization. On a
+  // viz switch we re-establish the baseline without mirroring (the
+  // transition layout effect is responsible for that frame). On subsequent
+  // renders within the same viz, a deep change in `sourceCurrentFilters`
+  // signals an external bypass write and is reflected into the map.
+  const sourceTrackerRef = useRef<{ viz: number; json: string }>({
+    viz: currentVisualization,
+    json: JSON.stringify(sourceCurrentFilters),
+  })
+
+  useLayoutEffect(() => {
+    if (!hasPerVisualization) return
+    if (!appliedInitRef.current) return
+
+    const tracker = sourceTrackerRef.current
+
+    // Viz changed: re-baseline and let the transition effect own this frame.
+    if (tracker.viz !== currentVisualization) {
+      sourceTrackerRef.current = {
+        viz: currentVisualization,
+        json: JSON.stringify(sourceCurrentFilters),
+      }
+      return
+    }
+
+    const json = JSON.stringify(sourceCurrentFilters)
+    if (json === tracker.json) return
+    tracker.json = json
+
+    const currentKey = getVisualizationKey(currentVisualization)
+    setVisualizationFiltersMap((prev) => {
+      const existing = prev[currentKey]
+      if (existing === sourceCurrentFilters) return prev
+      if (existing !== undefined && JSON.stringify(existing) === json) {
+        return prev
+      }
+      return { ...prev, [currentKey]: sourceCurrentFilters }
+    })
+  }, [hasPerVisualization, currentVisualization, sourceCurrentFilters])
+
+  // Mirror stable filter changes into the persisted map for the active viz.
+  const setCurrentFilters: React.Dispatch<
+    React.SetStateAction<FiltersState<Filters>>
+  > = useCallback(
+    (updater) => {
+      if (!hasPerVisualization) {
+        sourceSetCurrentFilters(updater)
+        return
+      }
+
+      const currentKey = getVisualizationKey(currentVisualization)
+
+      if (typeof updater === "function") {
+        const fnUpdater = updater as (
+          prev: FiltersState<Filters>
+        ) => FiltersState<Filters>
+        sourceSetCurrentFilters((prev) => {
+          const next = fnUpdater(prev)
+          setVisualizationFiltersMap((mapPrev) => {
+            if (mapPrev[currentKey] === next) return mapPrev
+            return { ...mapPrev, [currentKey]: next }
+          })
+          return next
+        })
+      } else {
+        sourceSetCurrentFilters(updater)
+        setVisualizationFiltersMap((mapPrev) => {
+          if (mapPrev[currentKey] === updater) return mapPrev
+          return { ...mapPrev, [currentKey]: updater }
+        })
+      }
+    },
+    [hasPerVisualization, sourceSetCurrentFilters, currentVisualization]
+  )
+
+  // Restore from storage. Runs every time storage hydrates (the storageKey
+  // reset effect clears `initializedRef` when the scope changes), but ignores
+  // repeated calls within the same scope.
+  //
+  // `visualizations` and `sourceFilters` are read through refs because the
+  // callback identity is stable but it can fire mid-session after a scope
+  // reset, when the captured-at-mount values would be stale.
   const setAllVisualizationFilters = useCallback(
     (states: Record<string, FiltersState<Filters>>) => {
       if (initializedRef.current) return
       initializedRef.current = true
 
-      setVisualizationFiltersMap(states)
+      const currentVisualizations = visualizationsRef.current
+      const currentSourceFilters = sourceFiltersRef.current
+
+      const safeStates = isPlainObject(states as unknown)
+        ? (states as unknown as Record<string, unknown>)
+        : {}
+      const sanitized: Record<string, FiltersState<Filters>> = {}
+      for (const [key, entry] of Object.entries(safeStates)) {
+        const safeEntry = isPlainObject(entry)
+          ? (entry as FiltersState<Filters>)
+          : ({} as FiltersState<Filters>)
+        const idx = Number(key)
+        if (
+          Number.isInteger(idx) &&
+          idx >= 0 &&
+          idx < currentVisualizations.length
+        ) {
+          sanitized[key] = sanitizeStoredEntryForViz(
+            idx,
+            safeEntry,
+            currentVisualizations,
+            currentSourceFilters
+          )
+        } else {
+          sanitized[key] = safeEntry
+        }
+      }
+
+      setVisualizationFiltersMap(sanitized)
     },
     []
   )
 
-  if (!hasOverrides) {
+  if (!hasPerVisualization) {
     return {
-      effectiveFilters: sourceFilters,
-      effectivePresets: sourcePresets,
+      effectiveFilters,
+      effectivePresets,
       currentFilters: sourceCurrentFilters,
       setCurrentFilters: sourceSetCurrentFilters,
       allVisualizationFilters: {},
@@ -277,7 +460,7 @@ export const usePerVisualizationFilters = <Filters extends FiltersDefinition>({
     effectiveFilters,
     effectivePresets,
     currentFilters: activeCurrentFilters,
-    setCurrentFilters: sourceSetCurrentFilters,
+    setCurrentFilters,
     allVisualizationFilters,
     setAllVisualizationFilters,
     hasPerVisualizationFilters: true,


### PR DESCRIPTION
## Description

Fixes a bug where filters set on one visualization (e.g. Table) bleed into sibling visualizations (e.g. Kanban) and corrupt their queries. Most visible symptom: kanban lanes returning the entire dataset instead of their own slice.

## Implementation details

- utils.ts — lane-authoritative merge. On disjoint global/lane arrays, fall back to the lane's value instead of []. The lane owns its own slice.
- usePerVisualizationFilters.ts — per-viz state scoping. For 2+ visualizations: each viz gets its own storage slot, the setter writes through to a persisted map (single source of truth), and hydration sanitises stored entries against each viz's filter schema. Single-viz consumers are pass-through and unchanged.
