### PR TITLE
feat: add ExpenseEntityRef component for entity-ref hover cards

### DIFF
--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -17,6 +17,7 @@ import { Sidebar } from "@/patterns/Navigation/Sidebar/Sidebar"
 import { useAiChat } from "@/sds/ai/F0AiChat"
 import {
   type CandidateProfile,
+  type ExpenseProfile,
   type JobPostingProfile,
   type RequisitionProfile,
   type PersonProfile,
@@ -268,6 +269,46 @@ const mockRequisitionResolver = (id: string): Promise<RequisitionProfile> =>
   })
 
 /**
+ * Mock expenses database for entity-ref hover cards in Storybook.
+ */
+const mockExpenses: ExpenseProfile[] = [
+  {
+    id: "91",
+    description: "Per diem — New York",
+    amount: "€331.00",
+    status: "Approved",
+  },
+  {
+    id: "97",
+    description: "Lunch with a friend",
+    amount: "€174.50",
+    status: "Approved",
+  },
+  {
+    id: "188",
+    description: "Per diem — New York",
+    amount: "€331.00",
+    status: "Pending",
+  },
+]
+
+/**
+ * Mock expense resolver — looks up from mockExpenses, falls back to generic profile.
+ */
+const mockExpenseResolver = (id: string): Promise<ExpenseProfile> =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      const expense = mockExpenses.find((e) => String(e.id) === id)
+      resolve(
+        expense ?? {
+          id,
+          description: `Expense #${id}`,
+        }
+      )
+    }, 600)
+  })
+
+/**
  * Mock fetchCreditsUsage — simulates a 500ms API call returning usage data.
  */
 const mockFetchCreditsUsage = () =>
@@ -365,6 +406,7 @@ const meta: Meta<typeof ApplicationFrame> = {
         resolvers: {
           person: mockPersonResolver,
           candidate: mockCandidateResolver,
+          expense: mockExpenseResolver,
           jobPosting: mockJobPostingResolver,
           vacancy: mockVacancyResolver,
           requisition: mockRequisitionResolver,
@@ -373,6 +415,7 @@ const meta: Meta<typeof ApplicationFrame> = {
         urls: {
           person: (id) => `/employees/${id}`,
           candidate: (id) => `/recruitment/candidates/${id}/applications`,
+          expense: (id) => `/expenses/${id}`,
           jobPosting: (id) => `/recruitment/jobs/${id}/applications`,
           vacancy: (id) => `/recruitment/hiring-plan/vacancies/${id}`,
           requisition: (id) => `/recruitment/hiring-plan/requisitions/${id}`,
@@ -908,6 +951,7 @@ export const FullscreenWithActions: Story = {
         resolvers: {
           person: mockPersonResolver,
           candidate: mockCandidateResolver,
+          expense: mockExpenseResolver,
           jobPosting: mockJobPostingResolver,
           vacancy: mockVacancyResolver,
           requisition: mockRequisitionResolver,
@@ -916,6 +960,7 @@ export const FullscreenWithActions: Story = {
         urls: {
           person: (id) => `/employees/${id}`,
           candidate: (id) => `/recruitment/candidates/${id}/applications`,
+          expense: (id) => `/expenses/${id}`,
           jobPosting: (id) => `/recruitment/jobs/${id}/applications`,
           vacancy: (id) => `/recruitment/hiring-plan/vacancies/${id}`,
           requisition: (id) => `/recruitment/hiring-plan/requisitions/${id}`,

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/components/entityRefRegistry.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/components/entityRefRegistry.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "react"
 
 import { CandidateEntityRef } from "../entities/candidate/CandidateEntityRef"
+import { ExpenseEntityRef } from "../entities/expense/ExpenseEntityRef"
 import { JobPostingEntityRef } from "../entities/jobPosting/JobPostingEntityRef"
 import { RequisitionEntityRef } from "../entities/requisition/RequisitionEntityRef"
 import { PersonEntityRef } from "../entities/person/PersonEntityRef"
@@ -12,6 +13,7 @@ export type EntityRefRenderer = ComponentType<EntityRefRendererProps>
 const entityRefRenderers: Record<string, EntityRefRenderer> = {
   person: PersonEntityRef,
   candidate: CandidateEntityRef,
+  expense: ExpenseEntityRef,
   "job-posting": JobPostingEntityRef,
   requisition: RequisitionEntityRef,
   vacancy: VacancyEntityRef,

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/expense/ExpenseEntityRef.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/expense/ExpenseEntityRef.tsx
@@ -1,0 +1,92 @@
+import { forwardRef, useMemo } from "react"
+
+import type { F0CardProps } from "@/components/F0Card"
+import { Money } from "@/icons/app"
+
+import { useI18n } from "@/lib/providers/i18n"
+import { cn, focusRing } from "@/lib/utils"
+
+import type { ExpenseProfile } from "./types"
+
+import { useAiChat } from "../../../../../providers/AiChatStateProvider"
+import { EntityRefHoverCard } from "../../components/EntityRefHoverCard"
+
+const ExpenseTrigger = forwardRef<HTMLButtonElement, { label: string }>(
+  ({ label, ...props }, ref) => (
+    <button
+      ref={ref}
+      type="button"
+      className={cn(
+        "cursor-pointer font-medium text-f1-foreground-secondary hover:text-f1-foreground",
+        focusRing()
+      )}
+      {...props}
+    >
+      {label}
+    </button>
+  )
+)
+ExpenseTrigger.displayName = "ExpenseTrigger"
+
+/**
+ * Inline expense entity reference with a hover card showing expense details.
+ *
+ * Renders the trigger as a styled link. On hover, lazily fetches
+ * the expense profile via `entityRefs.resolvers.expense` and displays
+ * description, amount, and status. Optionally links via `entityRefs.urls.expense`.
+ */
+export function ExpenseEntityRef({ id, label }: { id: string; label: string }) {
+  const { entityRefs } = useAiChat()
+  const resolver = entityRefs?.resolvers?.expense
+  const i18n = useI18n()
+
+  const expenseUrl = entityRefs?.urls?.expense?.(id)
+
+  const mapToCard = useMemo(
+    () =>
+      (profile: ExpenseProfile): F0CardProps => ({
+        avatar: {
+          type: "icon",
+          icon: Money,
+        },
+        title: profile.description || `Expense #${profile.id}`,
+        description: [profile.amount, profile.status]
+          .filter(Boolean)
+          .join(" · "),
+        ...(expenseUrl && {
+          secondaryActions: {
+            label: i18n.t("ai.view"),
+            href: expenseUrl,
+          },
+        }),
+      }),
+    [i18n, expenseUrl]
+  )
+
+  const fallbackCard = useMemo(
+    (): F0CardProps => ({
+      title: label,
+      ...(expenseUrl && {
+        secondaryActions: {
+          label: i18n.t("ai.view"),
+          href: expenseUrl,
+        },
+      }),
+    }),
+    [label, i18n, expenseUrl]
+  )
+
+  if (!resolver) {
+    return <span>{label}</span>
+  }
+
+  return (
+    <EntityRefHoverCard
+      id={id}
+      trigger={<ExpenseTrigger label={label} />}
+      resolver={resolver}
+      mapToCard={mapToCard}
+      fallbackCard={fallbackCard}
+    />
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/expense/__tests__/ExpenseEntityRef.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/expense/__tests__/ExpenseEntityRef.test.tsx
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import {
+  zeroRender as render,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/testing/test-utils"
+
+import type { ExpenseProfile } from "../types"
+
+const mockResolver = vi.fn<(id: string) => Promise<ExpenseProfile>>()
+let mockEntityRefs: {
+  resolvers?: { expense?: typeof mockResolver }
+  urls?: { expense?: (id: string) => string }
+} = {
+  resolvers: { expense: mockResolver },
+}
+
+vi.mock("../../../../../../providers/AiChatStateProvider", () => ({
+  useAiChat: () => ({
+    entityRefs: mockEntityRefs,
+  }),
+}))
+
+import { ExpenseEntityRef } from "../ExpenseEntityRef"
+
+const profile: ExpenseProfile = {
+  id: "559",
+  description: "Team lunch",
+  amount: "€45.00",
+  status: "pending",
+}
+
+describe("ExpenseEntityRef", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEntityRefs = { resolvers: { expense: mockResolver } }
+  })
+
+  it("renders the trigger button without @ prefix", () => {
+    render(<ExpenseEntityRef id="559" label="Expense #559" />)
+    const button = screen.getByRole("button")
+    expect(button).toHaveTextContent("Expense #559")
+    expect(button.textContent).not.toMatch(/^@/)
+  })
+
+  it("renders label as plain text when no resolver is available", () => {
+    mockEntityRefs = {}
+
+    const { container } = render(
+      <ExpenseEntityRef id="559" label="Expense #559" />
+    )
+    expect(container.querySelector("span")).toHaveTextContent("Expense #559")
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("shows hover card with profile data on hover", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+
+    render(<ExpenseEntityRef id="559" label="Expense #559" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Team lunch")).toBeInTheDocument()
+      expect(screen.getByText("€45.00 · pending")).toBeInTheDocument()
+    })
+  })
+
+  it("caches profile — resolver is called only once per id", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue(profile)
+
+    render(<ExpenseEntityRef id="559" label="Expense #559" />)
+
+    const trigger = screen.getByText("Expense #559")
+
+    await user.hover(trigger)
+    await waitFor(() => {
+      expect(mockResolver).toHaveBeenCalledTimes(1)
+    })
+
+    await user.unhover(trigger)
+    await user.hover(trigger)
+
+    expect(mockResolver).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows skeleton while loading", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockReturnValue(new Promise(() => {}))
+
+    render(<ExpenseEntityRef id="559" label="Expense #559" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(document.querySelector("[class*='animate']")).toBeInTheDocument()
+    })
+  })
+
+  it("shows fallback card on error", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockRejectedValue(new Error("Network error"))
+
+    render(<ExpenseEntityRef id="559" label="Expense #559" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Expense #559")).toBeInTheDocument()
+    })
+  })
+
+  it("uses expense id as title when description is missing", async () => {
+    const user = userEvent.setup()
+    mockResolver.mockResolvedValue({ id: "559" })
+
+    render(<ExpenseEntityRef id="559" label="Expense #559" />)
+
+    await user.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Expense #559")).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/expense/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/entities/expense/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Profile data for an expense entity, resolved asynchronously
+ * and displayed in the entity reference hover card.
+ */
+export type ExpenseProfile = {
+  id: string | number
+  description?: string
+  amount?: string
+  status?: string
+}

--- a/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/markdownRenderers/entityRef/types.ts
@@ -1,4 +1,5 @@
 import type { CandidateProfile } from "./entities/candidate/types"
+import type { ExpenseProfile } from "./entities/expense/types"
 import type { JobPostingProfile } from "./entities/jobPosting/types"
 import type { RequisitionProfile } from "./entities/requisition/types"
 import type { PersonProfile } from "./entities/person/types"
@@ -14,6 +15,7 @@ import type { VacancyProfile } from "./entities/vacancy/types"
 export type EntityResolvers = {
   person?: (id: string) => Promise<PersonProfile>
   candidate?: (id: string) => Promise<CandidateProfile>
+  expense?: (id: string) => Promise<ExpenseProfile>
   jobPosting?: (id: string) => Promise<JobPostingProfile>
   requisition?: (id: string) => Promise<RequisitionProfile>
   vacancy?: (id: string) => Promise<VacancyProfile>
@@ -34,6 +36,7 @@ export type EntityResolvers = {
 export type EntityUrlBuilders = {
   person?: (id: string) => string
   candidate?: (id: string) => string
+  expense?: (id: string) => string
   jobPosting?: (id: string) => string
   requisition?: (id: string) => string
   vacancy?: (id: string) => string

--- a/packages/react/src/sds/ai/F0AiChat/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/index.ts
@@ -13,6 +13,7 @@ export type {
   AppendToolCall,
   CandidateProfile,
   CanvasContent,
+  ExpenseProfile,
   CanvasContentBase,
   CreditsUsage,
   DashboardCanvasContent,

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -14,6 +14,7 @@ export type { CandidateProfile } from "./components/markdownRenderers/entityRef/
 export type { JobPostingProfile } from "./components/markdownRenderers/entityRef/entities/jobPosting/types"
 export type { RequisitionProfile } from "./components/markdownRenderers/entityRef/entities/requisition/types"
 export type { VacancyProfile } from "./components/markdownRenderers/entityRef/entities/vacancy/types"
+export type { ExpenseProfile } from "./components/markdownRenderers/entityRef/entities/expense/types"
 export type {
   EntityResolvers,
   EntityUrlBuilders,


### PR DESCRIPTION
## Summary
- Add `ExpenseEntityRef` component with hover card showing description, amount, and status
- Register expense in entity ref registry with `Money` icon
- Export `ExpenseProfile` type from f0-react
- Add mock expense resolver + URL to Storybook ApplicationFrame stories

## Screenshots
This is needed to allow us to do:

### Bulk creation
<img width="351" height="789" alt="Screenshot 2026-05-04 at 13 43 50" src="https://github.com/user-attachments/assets/0ca2b1b3-d421-4c45-afdf-c4399f2a7961" />

### Expenses skill
<img width="345" height="789" alt="Screenshot 2026-05-04 at 14 35 44" src="https://github.com/user-attachments/assets/5c639e4f-2271-4fc0-b4db-aba63b639328" />



