### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.471.2",
+  "packages/react": "1.472.0",
   "packages/react-native": "0.53.0",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.472.0](https://github.com/factorialco/f0/compare/f0-react-v1.471.2...f0-react-v1.472.0) (2026-05-04)
+
+
+### Features
+
+* add ExpenseEntityRef component for entity-ref hover cards ([#4073](https://github.com/factorialco/f0/issues/4073)) ([ce2662e](https://github.com/factorialco/f0/commit/ce2662ebb00de90eee295785198f15481575d274))
+
 ## [1.471.2](https://github.com/factorialco/f0/compare/f0-react-v1.471.1...f0-react-v1.471.2) (2026-05-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.471.2",
+  "version": "1.472.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.472.0</summary>

## [1.472.0](https://github.com/factorialco/f0/compare/f0-react-v1.471.2...f0-react-v1.472.0) (2026-05-04)


### Features

* add ExpenseEntityRef component for entity-ref hover cards ([#4073](https://github.com/factorialco/f0/issues/4073)) ([ce2662e](https://github.com/factorialco/f0/commit/ce2662ebb00de90eee295785198f15481575d274))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).