### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.472.0",
+  "packages/react": "1.472.1",
   "packages/react-native": "0.53.0",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.472.1](https://github.com/factorialco/f0/compare/f0-react-v1.472.0...f0-react-v1.472.1) (2026-05-04)
+
+
+### Bug Fixes
+
+* editable table QA ([#4055](https://github.com/factorialco/f0/issues/4055)) ([ac8fc10](https://github.com/factorialco/f0/commit/ac8fc103cbff32387dce0090f055535432b7e07b))
+
 ## [1.472.0](https://github.com/factorialco/f0/compare/f0-react-v1.471.2...f0-react-v1.472.0) (2026-05-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.472.0",
+  "version": "1.472.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.472.1</summary>

## [1.472.1](https://github.com/factorialco/f0/compare/f0-react-v1.472.0...f0-react-v1.472.1) (2026-05-04)


### Bug Fixes

* editable table QA ([#4055](https://github.com/factorialco/f0/issues/4055)) ([ac8fc10](https://github.com/factorialco/f0/commit/ac8fc103cbff32387dce0090f055535432b7e07b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).