### PR TITLE
feat(F0DataChart): add empty state to data charts

### DIFF
--- a/packages/react/src/kits/F0DataChart/F0DataChart.tsx
+++ b/packages/react/src/kits/F0DataChart/F0DataChart.tsx
@@ -1,14 +1,25 @@
 import type { F0DataChartProps } from "./types"
 
 import { BarChart } from "./components/BarChart/BarChart"
+import { DataChartEmptyStateView } from "./components/EmptyState/DataChartEmptyStateView"
 import { FunnelChart } from "./components/FunnelChart/FunnelChart"
 import { GaugeChart } from "./components/GaugeChart/GaugeChart"
 import { HeatmapChart } from "./components/HeatmapChart/HeatmapChart"
 import { LineChart } from "./components/LineChart/LineChart"
 import { PieChart } from "./components/PieChart/PieChart"
 import { RadarChart } from "./components/RadarChart/RadarChart"
+import { isDataChartEmpty } from "./utils/isDataChartEmpty"
 
 export const F0DataChart = (props: F0DataChartProps) => {
+  if (!props.emptyState?.disabled && isDataChartEmpty(props)) {
+    return (
+      <DataChartEmptyStateView
+        chartType={props.type}
+        emptyState={props.emptyState}
+      />
+    )
+  }
+
   switch (props.type) {
     case "bar":
       return <BarChart {...props} />

--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -325,3 +325,16 @@ export const ScrollableLegend: Story = {
     />
   ),
 }
+
+/**
+ * No data — the empty state takes over so the chart never renders as a
+ * bare axis. See `F0DataChart/Empty states` for full coverage.
+ */
+export const Empty: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: [],
+    series: [],
+  },
+}

--- a/packages/react/src/kits/F0DataChart/__stories__/EmptyStates.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/EmptyStates.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useState } from "react"
+
+import { F0DataChart } from "../index"
+import { ChartDecorator } from "./decorators"
+
+const meta = {
+  component: F0DataChart,
+  title: "F0DataChart/Empty states",
+  tags: ["autodocs", "experimental"],
+  decorators: [ChartDecorator],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "When `F0DataChart` receives empty data (empty `series`, empty `data`, all-zero values, or missing `value` for gauges), it auto-renders a styled empty-state card so the chart never appears as a bare axis. Use the `emptyState` prop to override copy, attach a CTA, or escape-hatch with a custom render.",
+      },
+    },
+  },
+} satisfies Meta<typeof F0DataChart>
+
+export default meta
+type Story = StoryObj<typeof F0DataChart>
+
+// ---------------------------------------------------------------------------
+// One story per variant — what the default empty state looks like
+// ---------------------------------------------------------------------------
+
+export const EmptyBar: Story = {
+  args: { type: "bar", categories: [], series: [] },
+}
+
+export const EmptyLine: Story = {
+  args: { type: "line", categories: [], series: [] },
+}
+
+export const EmptyPie: Story = {
+  args: { type: "pie", series: { name: "", data: [] } },
+}
+
+export const EmptyFunnel: Story = {
+  args: { type: "funnel", series: { name: "", data: [] } },
+}
+
+export const EmptyRadar: Story = {
+  args: { type: "radar", indicators: [], series: [] },
+}
+
+export const EmptyGauge: Story = {
+  // Undefined value triggers the empty state — a gauge with `value: 0` is NOT
+  // empty (0% is a legitimate state).
+  args: { type: "gauge" },
+}
+
+export const EmptyHeatmap: Story = {
+  args: {
+    type: "heatmap",
+    xCategories: [],
+    yCategories: [],
+    data: [],
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Behavior showcases
+// ---------------------------------------------------------------------------
+
+/**
+ * `type: "no-results"` swaps the copy to "No results match your filters" and
+ * supports an action for clearing them. This is the typical analytics
+ * dashboard scenario — a date filter returned zero rows.
+ */
+export const NoResultsWithClearFilters: Story = {
+  render: (args) => {
+    const [hasFilters, setHasFilters] = useState(true)
+    return (
+      <F0DataChart
+        {...args}
+        type="bar"
+        categories={hasFilters ? [] : ["Q1", "Q2"]}
+        series={hasFilters ? [] : [{ name: "Revenue", data: [120, 180] }]}
+        emptyState={{
+          type: "no-results",
+          action: {
+            label: "Clear filters",
+            onClick: () => setHasFilters(false),
+          },
+        }}
+      />
+    )
+  },
+}
+
+/** Override `title` and `description` to surface domain-specific copy. */
+export const CustomCopy: Story = {
+  args: {
+    type: "line",
+    categories: [],
+    series: [],
+    emptyState: {
+      title: "No expenses to show",
+      description:
+        "Submit an expense from the Expenses tab to see it tracked here.",
+    },
+  },
+}
+
+/** `render` is an escape hatch — it replaces the default UI completely. */
+export const RenderPropEscapeHatch: Story = {
+  args: {
+    type: "bar",
+    categories: [],
+    series: [],
+    emptyState: {
+      render: () => (
+        <div className="flex h-full w-full items-center justify-center rounded-md border border-dashed border-f1-border-critical bg-f1-background-critical text-f1-foreground-critical">
+          Custom render — full control
+        </div>
+      ),
+    },
+  },
+}
+
+/**
+ * `disabled: true` opts out of detection — useful when zero values are
+ * legitimate (e.g. an "errors per day" timeline that's expected to show
+ * zeros).
+ */
+export const Disabled: Story = {
+  args: {
+    type: "bar",
+    categories: ["Mon", "Tue", "Wed"],
+    series: [{ name: "Errors", data: [0, 0, 0] }],
+    emptyState: { disabled: true },
+  },
+}

--- a/packages/react/src/kits/F0DataChart/__stories__/EmptyStates.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/EmptyStates.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { useState } from "react"
-
 import { F0DataChart } from "../index"
 import { ChartDecorator } from "./decorators"
 
@@ -14,7 +12,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "When `F0DataChart` receives empty data (empty `series`, empty `data`, all-zero values, or missing `value` for gauges), it auto-renders a styled empty-state card so the chart never appears as a bare axis. Use the `emptyState` prop to override copy, attach a CTA, or escape-hatch with a custom render.",
+          "When `F0DataChart` receives empty data (empty `series`, empty `data`, all-zero values, or missing `value` for gauges), it auto-renders a faded chart skeleton + centered message so the chart never appears as a bare axis. Use the `emptyState` prop to override copy, escape-hatch with a custom render, or skip detection entirely.",
       },
     },
   },
@@ -65,32 +63,6 @@ export const EmptyHeatmap: Story = {
 // ---------------------------------------------------------------------------
 // Behavior showcases
 // ---------------------------------------------------------------------------
-
-/**
- * `type: "no-results"` swaps the copy to "No results match your filters" and
- * supports an action for clearing them. This is the typical analytics
- * dashboard scenario — a date filter returned zero rows.
- */
-export const NoResultsWithClearFilters: Story = {
-  render: (args) => {
-    const [hasFilters, setHasFilters] = useState(true)
-    return (
-      <F0DataChart
-        {...args}
-        type="bar"
-        categories={hasFilters ? [] : ["Q1", "Q2"]}
-        series={hasFilters ? [] : [{ name: "Revenue", data: [120, 180] }]}
-        emptyState={{
-          type: "no-results",
-          action: {
-            label: "Clear filters",
-            onClick: () => setHasFilters(false),
-          },
-        }}
-      />
-    )
-  },
-}
 
 /** Override `title` and `description` to surface domain-specific copy. */
 export const CustomCopy: Story = {

--- a/packages/react/src/kits/F0DataChart/__stories__/EmptyStates.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/EmptyStates.stories.tsx
@@ -1,5 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import type { F0DataChartProps } from "../types"
+
 import { F0DataChart } from "../index"
 import { ChartDecorator } from "./decorators"
 
@@ -95,15 +99,65 @@ export const RenderPropEscapeHatch: Story = {
 }
 
 /**
- * `disabled: true` opts out of detection — useful when zero values are
- * legitimate (e.g. an "errors per day" timeline that's expected to show
- * zeros).
+ * `disabled: true` opts out of detection — render the chart frame even
+ * when there is no data. Rarely useful (the default detection only fires
+ * on genuinely empty data — all-zero datasets already render normally),
+ * but kept as an escape hatch for unusual cases.
  */
 export const Disabled: Story = {
   args: {
     type: "bar",
-    categories: ["Mon", "Tue", "Wed"],
-    series: [{ name: "Errors", data: [0, 0, 0] }],
+    categories: [],
+    series: [],
     emptyState: { disabled: true },
   },
+}
+
+// ---------------------------------------------------------------------------
+// Chromatic snapshot — covers every variant in a single shot
+// ---------------------------------------------------------------------------
+
+const SNAPSHOT_VARIANTS: { label: string; props: F0DataChartProps }[] = [
+  { label: "Bar", props: { type: "bar", categories: [], series: [] } },
+  { label: "Line", props: { type: "line", categories: [], series: [] } },
+  { label: "Pie", props: { type: "pie", series: { name: "", data: [] } } },
+  {
+    label: "Funnel",
+    props: { type: "funnel", series: { name: "", data: [] } },
+  },
+  {
+    label: "Radar",
+    props: { type: "radar", indicators: [], series: [] },
+  },
+  // Gauge: undefined value is the empty case.
+  { label: "Gauge", props: { type: "gauge" } as F0DataChartProps },
+  {
+    label: "Heatmap",
+    props: {
+      type: "heatmap",
+      xCategories: [],
+      yCategories: [],
+      data: [],
+    },
+  },
+]
+
+/** Chromatic-only matrix that covers every empty variant in one snapshot. */
+export const Snapshot: Story = {
+  parameters: withSnapshot({}),
+  decorators: [(Story) => <Story />],
+  render: () => (
+    <div className="grid grid-cols-2 gap-6 p-6">
+      {SNAPSHOT_VARIANTS.map(({ label, props }) => (
+        <div key={label} className="flex flex-col gap-2">
+          <span className="text-xs font-medium uppercase tracking-wide text-f1-foreground-secondary">
+            {label}
+          </span>
+          <div className="h-[260px] w-[420px] rounded-md border border-solid border-f1-border-secondary bg-f1-background">
+            <F0DataChart {...props} />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
 }

--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -37,31 +37,24 @@ All variants share an optional `emptyState` prop — see [Empty states](#empty-s
 
 ## Empty states
 
-When data is empty (empty `series`, empty `data`, all-zero values, or a missing gauge `value`), `F0DataChart` auto-renders a styled empty-state card so you never see a bare axis. No prop is required to enable this — it is the default behavior.
+When data is empty (empty `series`, empty `data`, all-zero values, or a missing gauge `value`), `F0DataChart` auto-renders a faded chart skeleton with a centered message so you never see a bare axis. No prop is required — it is the default behavior.
+
+Default copy is **"No data available"** / **"Try a different date or fewer filters"**.
 
 <Canvas of={EmptyStatesStories.EmptyBar} />
 
-Use the `emptyState` prop to customize copy, attach a CTA, or replace the rendered UI entirely:
+Use the `emptyState` prop to customize copy, replace the UI entirely, or skip detection:
 
 ```ts
 type F0DataChartEmptyStateProps = {
-  /** @default "no-data" */
-  type?: "no-data" | "no-results"
   title?: string
   description?: string
-  action?: { label: string; onClick: () => void; icon?: IconType }
   /** Render-prop escape hatch — replaces the entire UI. */
   render?: () => ReactNode
   /** Skip empty detection and render the chart as usual. */
   disabled?: boolean
 }
 ```
-
-### No results + clear filters
-
-The most common analytics case: filters are active and returned nothing. Switch the `type` to `"no-results"` and pass an `action` to expose a clear-filters CTA.
-
-<Canvas of={EmptyStatesStories.NoResultsWithClearFilters} />
 
 ### Custom copy
 

--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -7,6 +7,7 @@ import * as RadarStories from "./Radar.stories"
 import * as GaugeStories from "./Gauge.stories"
 import * as HeatmapStories from "./Heatmap.stories"
 import * as SkeletonsStories from "./Skeletons.stories"
+import * as EmptyStatesStories from "./EmptyStates.stories"
 
 <Meta title="F0DataChart/Overview" />
 
@@ -29,6 +30,52 @@ import { F0DataChart } from "@factorialco/f0-react"
 | `radar`   | Multi-dimensional comparisons        | `series`, `indicators`, `showArea`                         |
 | `gauge`   | Single KPI / progress indicator      | `value`, `min`, `max`, `name`                              |
 | `heatmap` | Density across two dimensions        | `data`, `xCategories`, `yCategories`, `showLabels`         |
+
+All variants share an optional `emptyState` prop — see [Empty states](#empty-states).
+
+---
+
+## Empty states
+
+When data is empty (empty `series`, empty `data`, all-zero values, or a missing gauge `value`), `F0DataChart` auto-renders a styled empty-state card so you never see a bare axis. No prop is required to enable this — it is the default behavior.
+
+<Canvas of={EmptyStatesStories.EmptyBar} />
+
+Use the `emptyState` prop to customize copy, attach a CTA, or replace the rendered UI entirely:
+
+```ts
+type F0DataChartEmptyStateProps = {
+  /** @default "no-data" */
+  type?: "no-data" | "no-results"
+  title?: string
+  description?: string
+  action?: { label: string; onClick: () => void; icon?: IconType }
+  /** Render-prop escape hatch — replaces the entire UI. */
+  render?: () => ReactNode
+  /** Skip empty detection and render the chart as usual. */
+  disabled?: boolean
+}
+```
+
+### No results + clear filters
+
+The most common analytics case: filters are active and returned nothing. Switch the `type` to `"no-results"` and pass an `action` to expose a clear-filters CTA.
+
+<Canvas of={EmptyStatesStories.NoResultsWithClearFilters} />
+
+### Custom copy
+
+<Canvas of={EmptyStatesStories.CustomCopy} />
+
+### Render-prop escape hatch
+
+<Canvas of={EmptyStatesStories.RenderPropEscapeHatch} />
+
+### Disabling detection
+
+For charts where zero values are legitimate (e.g. a "0 errors per day" timeline), set `emptyState.disabled` to bypass detection.
+
+<Canvas of={EmptyStatesStories.Disabled} />
 
 ---
 

--- a/packages/react/src/kits/F0DataChart/__stories__/Funnel.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Funnel.stories.tsx
@@ -134,3 +134,11 @@ export const NoColorScale: Story = {
     },
   },
 }
+
+/** No data — empty state takes over. See `F0DataChart/Empty states`. */
+export const Empty: Story = {
+  args: {
+    type: "funnel",
+    series: { name: "", data: [] },
+  },
+}

--- a/packages/react/src/kits/F0DataChart/__stories__/Gauge.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Gauge.stories.tsx
@@ -78,3 +78,14 @@ export const ResponsiveSnapshotMatrix: Story = {
   decorators: [(Story) => <Story />],
   render: () => <ResponsiveSnapshot getProps={responsiveGaugeProps} />,
 }
+
+/**
+ * No data — undefined `value` triggers the empty state. (A gauge with
+ * `value: 0` is NOT empty — 0% is a legitimate state.)
+ * See `F0DataChart/Empty states`.
+ */
+export const Empty: Story = {
+  // Undefined value triggers the empty state — `value: 0` would NOT be empty
+  // since 0% is a legitimate gauge state.
+  args: { type: "gauge" },
+}

--- a/packages/react/src/kits/F0DataChart/__stories__/Heatmap.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Heatmap.stories.tsx
@@ -105,3 +105,13 @@ export const ResponsiveSnapshotMatrix: Story = {
   decorators: [(Story) => <Story />],
   render: () => <ResponsiveSnapshot getProps={responsiveHeatmapProps} />,
 }
+
+/** No data — empty state takes over. See `F0DataChart/Empty states`. */
+export const Empty: Story = {
+  args: {
+    type: "heatmap",
+    xCategories: [],
+    yCategories: [],
+    data: [],
+  },
+}

--- a/packages/react/src/kits/F0DataChart/__stories__/Line.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Line.stories.tsx
@@ -276,3 +276,16 @@ export const ScrollableLegend: Story = {
     />
   ),
 }
+
+/**
+ * No data — the empty state takes over with the line-chart illustration.
+ * See `F0DataChart/Empty states` for full coverage.
+ */
+export const Empty: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "line",
+    categories: [],
+    series: [],
+  },
+}

--- a/packages/react/src/kits/F0DataChart/__stories__/Pie.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Pie.stories.tsx
@@ -136,3 +136,11 @@ export const ResponsiveSnapshotMatrix: Story = {
   decorators: [(Story) => <Story />],
   render: () => <ResponsiveSnapshot getProps={responsivePieProps} />,
 }
+
+/** No data — empty state takes over. See `F0DataChart/Empty states`. */
+export const Empty: Story = {
+  args: {
+    type: "pie",
+    series: { name: "", data: [] },
+  },
+}

--- a/packages/react/src/kits/F0DataChart/__stories__/Radar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Radar.stories.tsx
@@ -157,3 +157,12 @@ export const ResponsiveSnapshotMatrix: Story = {
   decorators: [(Story) => <Story />],
   render: () => <ResponsiveSnapshot getProps={responsiveRadarProps} />,
 }
+
+/** No data — empty state takes over. See `F0DataChart/Empty states`. */
+export const Empty: Story = {
+  args: {
+    type: "radar",
+    indicators: [],
+    series: [],
+  },
+}

--- a/packages/react/src/kits/F0DataChart/__tests__/F0DataChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/F0DataChart.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import "@testing-library/jest-dom/vitest"
 import { zeroRender as render } from "@/testing/test-utils"
@@ -142,5 +143,94 @@ describe("F0DataChart", () => {
       />
     )
     expect(container.textContent).toContain("50.0%")
+  })
+
+  describe("empty state", () => {
+    it("renders default empty state when bar series is empty", () => {
+      const { getByText } = render(
+        <F0DataChart type="bar" categories={[]} series={[]} />
+      )
+      expect(getByText("No data available")).toBeInTheDocument()
+      expect(
+        getByText("Try a different date or fewer filters")
+      ).toBeInTheDocument()
+    })
+
+    it("renders CTA and fires the action handler", () => {
+      const onClick = vi.fn()
+      const { getByRole } = render(
+        <F0DataChart
+          type="bar"
+          categories={[]}
+          series={[]}
+          emptyState={{
+            type: "no-results",
+            action: { label: "Clear filters", onClick },
+          }}
+        />
+      )
+      const button = getByRole("button", { name: /clear filters/i })
+      fireEvent.click(button)
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it("uses overrides for title and description", () => {
+      const { getByText } = render(
+        <F0DataChart
+          type="line"
+          categories={[]}
+          series={[]}
+          emptyState={{
+            title: "Nothing here yet",
+            description: "Try a different range",
+          }}
+        />
+      )
+      expect(getByText("Nothing here yet")).toBeInTheDocument()
+      expect(getByText("Try a different range")).toBeInTheDocument()
+    })
+
+    it("render-prop short-circuits the default UI", () => {
+      const { getByTestId, queryByText } = render(
+        <F0DataChart
+          type="bar"
+          categories={[]}
+          series={[]}
+          emptyState={{
+            render: () => <div data-testid="custom">Custom</div>,
+          }}
+        />
+      )
+      expect(getByTestId("custom")).toBeInTheDocument()
+      expect(queryByText("No data available")).not.toBeInTheDocument()
+    })
+
+    it("disabled: true bypasses empty-state detection", () => {
+      const { queryByText } = render(
+        <F0DataChart
+          type="bar"
+          categories={[]}
+          series={[]}
+          emptyState={{ disabled: true }}
+        />
+      )
+      expect(queryByText("No data available")).not.toBeInTheDocument()
+    })
+
+    it("does not render empty state when data is present", () => {
+      const { queryByText } = render(
+        <F0DataChart
+          type="bar"
+          categories={["Q1"]}
+          series={[{ name: "Revenue", data: [100] }]}
+        />
+      )
+      expect(queryByText("No data available")).not.toBeInTheDocument()
+    })
+
+    it("treats gauge with value 0 as non-empty", () => {
+      const { queryByText } = render(<F0DataChart type="gauge" value={0} />)
+      expect(queryByText("No data available")).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/F0DataChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/F0DataChart.test.tsx
@@ -1,4 +1,3 @@
-import { fireEvent } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import "@testing-library/jest-dom/vitest"
 import { zeroRender as render } from "@/testing/test-utils"
@@ -154,24 +153,6 @@ describe("F0DataChart", () => {
       expect(
         getByText("Try a different date or fewer filters")
       ).toBeInTheDocument()
-    })
-
-    it("renders CTA and fires the action handler", () => {
-      const onClick = vi.fn()
-      const { getByRole } = render(
-        <F0DataChart
-          type="bar"
-          categories={[]}
-          series={[]}
-          emptyState={{
-            type: "no-results",
-            action: { label: "Clear filters", onClick },
-          }}
-        />
-      )
-      const button = getByRole("button", { name: /clear filters/i })
-      fireEvent.click(button)
-      expect(onClick).toHaveBeenCalledTimes(1)
     })
 
     it("uses overrides for title and description", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/isDataChartEmpty.test.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/isDataChartEmpty.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest"
+
+import type { F0DataChartProps } from "../types"
+import { isDataChartEmpty } from "../utils/isDataChartEmpty"
+
+describe("isDataChartEmpty", () => {
+  describe("bar / line", () => {
+    it.each(["bar", "line"] as const)("%s — empty series array", (type) => {
+      expect(
+        isDataChartEmpty({
+          type,
+          categories: ["A"],
+          series: [],
+        } as F0DataChartProps)
+      ).toBe(true)
+    })
+
+    it.each(["bar", "line"] as const)(
+      "%s — empty data within all series",
+      (type) => {
+        expect(
+          isDataChartEmpty({
+            type,
+            categories: ["A"],
+            series: [{ name: "s1", data: [] }],
+          } as F0DataChartProps)
+        ).toBe(true)
+      }
+    )
+
+    it.each(["bar", "line"] as const)("%s — all zeros", (type) => {
+      expect(
+        isDataChartEmpty({
+          type,
+          categories: ["A", "B"],
+          series: [
+            { name: "s1", data: [0, 0] },
+            { name: "s2", data: [{ value: 0 }, 0] },
+          ],
+        } as F0DataChartProps)
+      ).toBe(true)
+    })
+
+    it.each(["bar", "line"] as const)("%s — single non-zero", (type) => {
+      expect(
+        isDataChartEmpty({
+          type,
+          categories: ["A", "B"],
+          series: [{ name: "s1", data: [0, 1] }],
+        } as F0DataChartProps)
+      ).toBe(false)
+    })
+
+    it.each(["bar", "line"] as const)("%s — null-safe", (type) => {
+      expect(
+        isDataChartEmpty({
+          type,
+          categories: ["A"],
+          // @ts-expect-error testing malformed input
+          series: undefined,
+        })
+      ).toBe(true)
+    })
+  })
+
+  describe("funnel / pie", () => {
+    it.each(["funnel", "pie"] as const)("%s — empty data", (type) => {
+      expect(
+        isDataChartEmpty({
+          type,
+          series: { name: "s", data: [] },
+        } as F0DataChartProps)
+      ).toBe(true)
+    })
+
+    it.each(["funnel", "pie"] as const)("%s — all-zero values", (type) => {
+      expect(
+        isDataChartEmpty({
+          type,
+          series: {
+            name: "s",
+            data: [
+              { value: 0, name: "x" },
+              { value: 0, name: "y" },
+            ],
+          },
+        } as F0DataChartProps)
+      ).toBe(true)
+    })
+
+    it.each(["funnel", "pie"] as const)("%s — one non-zero value", (type) => {
+      expect(
+        isDataChartEmpty({
+          type,
+          series: {
+            name: "s",
+            data: [
+              { value: 0, name: "x" },
+              { value: 1, name: "y" },
+            ],
+          },
+        } as F0DataChartProps)
+      ).toBe(false)
+    })
+  })
+
+  describe("radar", () => {
+    it("empty series", () => {
+      expect(
+        isDataChartEmpty({
+          type: "radar",
+          indicators: [{ name: "a" }, { name: "b" }],
+          series: [],
+        })
+      ).toBe(true)
+    })
+
+    it("all-zero data", () => {
+      expect(
+        isDataChartEmpty({
+          type: "radar",
+          indicators: [{ name: "a" }, { name: "b" }],
+          series: [{ name: "s", data: [0, 0] }],
+        })
+      ).toBe(true)
+    })
+
+    it("single non-zero", () => {
+      expect(
+        isDataChartEmpty({
+          type: "radar",
+          indicators: [{ name: "a" }, { name: "b" }],
+          series: [{ name: "s", data: [0, 1] }],
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe("gauge", () => {
+    it("undefined value is empty", () => {
+      expect(
+        // @ts-expect-error testing missing required prop
+        isDataChartEmpty({ type: "gauge" })
+      ).toBe(true)
+    })
+
+    it("0 is NOT empty (legitimate state)", () => {
+      expect(isDataChartEmpty({ type: "gauge", value: 0 })).toBe(false)
+    })
+
+    it("positive value is not empty", () => {
+      expect(isDataChartEmpty({ type: "gauge", value: 42 })).toBe(false)
+    })
+  })
+
+  describe("heatmap", () => {
+    it("empty data", () => {
+      expect(
+        isDataChartEmpty({
+          type: "heatmap",
+          xCategories: ["a"],
+          yCategories: ["b"],
+          data: [],
+        })
+      ).toBe(true)
+    })
+
+    it("all-zero values", () => {
+      expect(
+        isDataChartEmpty({
+          type: "heatmap",
+          xCategories: ["a", "b"],
+          yCategories: ["c", "d"],
+          data: [
+            [0, 0, 0],
+            [1, 1, 0],
+          ],
+        })
+      ).toBe(true)
+    })
+
+    it("one non-zero tuple is not empty", () => {
+      expect(
+        isDataChartEmpty({
+          type: "heatmap",
+          xCategories: ["a", "b"],
+          yCategories: ["c", "d"],
+          data: [
+            [0, 0, 0],
+            [1, 1, 5],
+          ],
+        })
+      ).toBe(false)
+    })
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/isDataChartEmpty.test.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/isDataChartEmpty.test.ts
@@ -28,18 +28,18 @@ describe("isDataChartEmpty", () => {
       }
     )
 
-    it.each(["bar", "line"] as const)("%s — all zeros", (type) => {
-      expect(
-        isDataChartEmpty({
-          type,
-          categories: ["A", "B"],
-          series: [
-            { name: "s1", data: [0, 0] },
-            { name: "s2", data: [{ value: 0 }, 0] },
-          ],
-        } as F0DataChartProps)
-      ).toBe(true)
-    })
+    it.each(["bar", "line"] as const)(
+      "%s — all-zero values are NOT empty (legitimate render)",
+      (type) => {
+        expect(
+          isDataChartEmpty({
+            type,
+            categories: ["A", "B"],
+            series: [{ name: "s1", data: [0, 0] }],
+          } as F0DataChartProps)
+        ).toBe(false)
+      }
+    )
 
     it.each(["bar", "line"] as const)("%s — single non-zero", (type) => {
       expect(
@@ -73,20 +73,23 @@ describe("isDataChartEmpty", () => {
       ).toBe(true)
     })
 
-    it.each(["funnel", "pie"] as const)("%s — all-zero values", (type) => {
-      expect(
-        isDataChartEmpty({
-          type,
-          series: {
-            name: "s",
-            data: [
-              { value: 0, name: "x" },
-              { value: 0, name: "y" },
-            ],
-          },
-        } as F0DataChartProps)
-      ).toBe(true)
-    })
+    it.each(["funnel", "pie"] as const)(
+      "%s — all-zero values are NOT empty",
+      (type) => {
+        expect(
+          isDataChartEmpty({
+            type,
+            series: {
+              name: "s",
+              data: [
+                { value: 0, name: "x" },
+                { value: 0, name: "y" },
+              ],
+            },
+          } as F0DataChartProps)
+        ).toBe(false)
+      }
+    )
 
     it.each(["funnel", "pie"] as const)("%s — one non-zero value", (type) => {
       expect(
@@ -115,14 +118,14 @@ describe("isDataChartEmpty", () => {
       ).toBe(true)
     })
 
-    it("all-zero data", () => {
+    it("all-zero data is NOT empty", () => {
       expect(
         isDataChartEmpty({
           type: "radar",
           indicators: [{ name: "a" }, { name: "b" }],
           series: [{ name: "s", data: [0, 0] }],
         })
-      ).toBe(true)
+      ).toBe(false)
     })
 
     it("single non-zero", () => {
@@ -165,7 +168,7 @@ describe("isDataChartEmpty", () => {
       ).toBe(true)
     })
 
-    it("all-zero values", () => {
+    it("all-zero values are NOT empty", () => {
       expect(
         isDataChartEmpty({
           type: "heatmap",
@@ -176,7 +179,7 @@ describe("isDataChartEmpty", () => {
             [1, 1, 0],
           ],
         })
-      ).toBe(true)
+      ).toBe(false)
     })
 
     it("one non-zero tuple is not empty", () => {

--- a/packages/react/src/kits/F0DataChart/components/EmptyState/DataChartEmptyStateView.tsx
+++ b/packages/react/src/kits/F0DataChart/components/EmptyState/DataChartEmptyStateView.tsx
@@ -34,9 +34,6 @@ export const DataChartEmptyStateView = ({
       chartType={chartType}
       content={emptyState?.title ?? DEFAULT_COPY.title}
       description={emptyState?.description ?? DEFAULT_COPY.description}
-      buttonLabel={emptyState?.action?.label}
-      buttonIcon={emptyState?.action?.icon}
-      buttonAction={emptyState?.action?.onClick}
     />
   )
 }

--- a/packages/react/src/kits/F0DataChart/components/EmptyState/DataChartEmptyStateView.tsx
+++ b/packages/react/src/kits/F0DataChart/components/EmptyState/DataChartEmptyStateView.tsx
@@ -1,0 +1,42 @@
+import type { F0DataChartEmptyStateProps, F0DataChartProps } from "../../types"
+
+import { DataChartEmptyState } from "./EmptyState"
+
+interface DataChartEmptyStateViewProps {
+  /** The chart variant — drives the background skeleton illustration. */
+  chartType: F0DataChartProps["type"]
+  emptyState?: F0DataChartEmptyStateProps
+}
+
+/**
+ * Default copy for the chart empty state. Hardcoded (not i18n) to keep the
+ * chart-specific phrasing decoupled from the broader collections empty-state
+ * copy. Consumers can override via `emptyState.title` / `emptyState.description`.
+ */
+const DEFAULT_COPY = {
+  title: "No data available",
+  description: "Try a different date or fewer filters",
+}
+
+/**
+ * Resolves an `F0DataChartEmptyStateProps` config (defaults + overrides +
+ * render-prop) into rendered output. Used internally by `F0DataChart` and
+ * reused by dashboard wrappers when data is absent.
+ */
+export const DataChartEmptyStateView = ({
+  chartType,
+  emptyState,
+}: DataChartEmptyStateViewProps) => {
+  if (emptyState?.render) return <>{emptyState.render()}</>
+
+  return (
+    <DataChartEmptyState
+      chartType={chartType}
+      content={emptyState?.title ?? DEFAULT_COPY.title}
+      description={emptyState?.description ?? DEFAULT_COPY.description}
+      buttonLabel={emptyState?.action?.label}
+      buttonIcon={emptyState?.action?.icon}
+      buttonAction={emptyState?.action?.onClick}
+    />
+  )
+}

--- a/packages/react/src/kits/F0DataChart/components/EmptyState/DataChartEmptyStateView.tsx
+++ b/packages/react/src/kits/F0DataChart/components/EmptyState/DataChartEmptyStateView.tsx
@@ -1,3 +1,5 @@
+import { useI18n } from "@/lib/providers/i18n"
+
 import type { F0DataChartEmptyStateProps, F0DataChartProps } from "../../types"
 
 import { DataChartEmptyState } from "./EmptyState"
@@ -9,31 +11,25 @@ interface DataChartEmptyStateViewProps {
 }
 
 /**
- * Default copy for the chart empty state. Hardcoded (not i18n) to keep the
- * chart-specific phrasing decoupled from the broader collections empty-state
- * copy. Consumers can override via `emptyState.title` / `emptyState.description`.
- */
-const DEFAULT_COPY = {
-  title: "No data available",
-  description: "Try a different date or fewer filters",
-}
-
-/**
- * Resolves an `F0DataChartEmptyStateProps` config (defaults + overrides +
- * render-prop) into rendered output. Used internally by `F0DataChart` and
+ * Resolves an `F0DataChartEmptyStateProps` config (i18n defaults + overrides
+ * + render-prop) into rendered output. Used internally by `F0DataChart` and
  * reused by dashboard wrappers when data is absent.
  */
 export const DataChartEmptyStateView = ({
   chartType,
   emptyState,
 }: DataChartEmptyStateViewProps) => {
+  const i18n = useI18n()
+
   if (emptyState?.render) return <>{emptyState.render()}</>
+
+  const defaults = i18n.dataChart.emptyState
 
   return (
     <DataChartEmptyState
       chartType={chartType}
-      content={emptyState?.title ?? DEFAULT_COPY.title}
-      description={emptyState?.description ?? DEFAULT_COPY.description}
+      content={emptyState?.title ?? defaults.title}
+      description={emptyState?.description ?? defaults.description}
     />
   )
 }

--- a/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
+++ b/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,94 @@
+import { forwardRef, type ReactNode } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { IconType } from "@/components/F0Icon"
+import { withDataTestId } from "@/lib/data-testid"
+
+import type { F0DataChartProps } from "../../types"
+
+import {
+  BarChartSkeleton,
+  FunnelChartSkeleton,
+  GaugeChartSkeleton,
+  HeatmapChartSkeleton,
+  LineChartSkeleton,
+  PieChartSkeleton,
+  RadarChartSkeleton,
+} from "../../skeletons"
+
+export interface DataChartEmptyStateProps {
+  /** Headline text — the prominent message the user reads first. */
+  content: string
+  /** Optional supporting copy shown below the headline. */
+  description?: string
+  /** Optional CTA button label. */
+  buttonLabel?: string
+  buttonIcon?: IconType
+  buttonAction?: () => void
+  /** Drives the background skeleton illustration. */
+  chartType: F0DataChartProps["type"]
+}
+
+const skeletonByType: Record<F0DataChartProps["type"], () => ReactNode> = {
+  bar: () => <BarChartSkeleton showLegend={false} />,
+  line: () => <LineChartSkeleton showLegend={false} />,
+  funnel: () => <FunnelChartSkeleton showLegend={false} />,
+  pie: () => <PieChartSkeleton showLegend={false} />,
+  radar: () => <RadarChartSkeleton showLegend={false} />,
+  gauge: () => <GaugeChartSkeleton />,
+  heatmap: () => <HeatmapChartSkeleton />,
+}
+
+/**
+ * Card-less empty state used internally by `F0DataChart`. Renders the matching
+ * chart skeleton (statically — animation disabled) as a faded background, with
+ * the message centered on top. Designed to drop inside any wrapper (e.g.
+ * `DashboardItem`) without producing card-in-card framing.
+ */
+const _DataChartEmptyState = forwardRef<
+  HTMLDivElement,
+  DataChartEmptyStateProps
+>(function DataChartEmptyState(
+  { content, description, buttonLabel, buttonIcon, buttonAction, chartType },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className="relative flex h-full w-full items-center justify-center overflow-hidden"
+    >
+      {/*
+        The skeleton is rendered statically here — `[&_*]:animate-none`
+        disables the `animate-pulse` baked into both the skeleton wrappers
+        and the underlying `<Skeleton>` primitives. The lack of pulse is
+        what tells the user "this isn't loading, it's empty".
+      */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-50 [&_*]:animate-none"
+      >
+        {skeletonByType[chartType]()}
+      </div>
+      <div className="relative flex flex-col items-center gap-1 px-6 text-center">
+        <p className="text-lg font-medium text-f1-foreground">{content}</p>
+        {description && (
+          <p className="text-md max-w-sm text-f1-foreground-secondary">
+            {description}
+          </p>
+        )}
+        {buttonLabel && (
+          <div className="mt-3">
+            <F0Button
+              label={buttonLabel}
+              icon={buttonIcon}
+              variant="default"
+              onClick={buttonAction}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+})
+
+export const DataChartEmptyState = withDataTestId(_DataChartEmptyState)

--- a/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
+++ b/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
@@ -1,7 +1,5 @@
 import { forwardRef, type ReactNode } from "react"
 
-import { F0Button } from "@/components/F0Button"
-import { IconType } from "@/components/F0Icon"
 import { withDataTestId } from "@/lib/data-testid"
 
 import type { F0DataChartProps } from "../../types"
@@ -21,10 +19,6 @@ export interface DataChartEmptyStateProps {
   content: string
   /** Optional supporting copy shown below the headline. */
   description?: string
-  /** Optional CTA button label. */
-  buttonLabel?: string
-  buttonIcon?: IconType
-  buttonAction?: () => void
   /** Drives the background skeleton illustration. */
   chartType: F0DataChartProps["type"]
 }
@@ -48,10 +42,7 @@ const skeletonByType: Record<F0DataChartProps["type"], () => ReactNode> = {
 const _DataChartEmptyState = forwardRef<
   HTMLDivElement,
   DataChartEmptyStateProps
->(function DataChartEmptyState(
-  { content, description, buttonLabel, buttonIcon, buttonAction, chartType },
-  ref
-) {
+>(function DataChartEmptyState({ content, description, chartType }, ref) {
   return (
     <div
       ref={ref}
@@ -62,12 +53,18 @@ const _DataChartEmptyState = forwardRef<
         disables the `animate-pulse` baked into both the skeleton wrappers
         and the underlying `<Skeleton>` primitives. The lack of pulse is
         what tells the user "this isn't loading, it's empty".
+
+        We cap the skeleton size so a fullscreen dashboard tile doesn't
+        stretch the illustration to absurd proportions. The wrapper is
+        centered absolutely; on small chart cards it still fills normally.
       */}
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-50 [&_*]:animate-none"
+        className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-50 [&_*]:animate-none"
       >
-        {skeletonByType[chartType]()}
+        <div className="h-full max-h-[360px] w-full max-w-[720px]">
+          {skeletonByType[chartType]()}
+        </div>
       </div>
       <div className="relative flex flex-col items-center gap-1 px-6 text-center">
         <p className="text-lg font-medium text-f1-foreground">{content}</p>
@@ -75,16 +72,6 @@ const _DataChartEmptyState = forwardRef<
           <p className="text-md max-w-sm text-f1-foreground-secondary">
             {description}
           </p>
-        )}
-        {buttonLabel && (
-          <div className="mt-3">
-            <F0Button
-              label={buttonLabel}
-              icon={buttonIcon}
-              variant="default"
-              onClick={buttonAction}
-            />
-          </div>
         )}
       </div>
     </div>

--- a/packages/react/src/kits/F0DataChart/index.ts
+++ b/packages/react/src/kits/F0DataChart/index.ts
@@ -6,6 +6,7 @@ export type {
   F0DataChartBarDataPoint,
   F0DataChartBarProps,
   F0DataChartBarSeries,
+  F0DataChartEmptyStateProps,
   F0DataChartFunnelDataPoint,
   F0DataChartFunnelProps,
   F0DataChartFunnelSeries,
@@ -24,6 +25,7 @@ export type {
   F0DataChartRadarSeries,
 } from "./types"
 
+export { DataChartEmptyStateView } from "./components/EmptyState/DataChartEmptyStateView"
 export { type ChartColorToken, chartColorTokens } from "./utils/colors"
 export type { ChartTheme } from "./utils/theme"
 export {

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -1,8 +1,6 @@
 import type * as echarts from "echarts"
 import type { ReactNode } from "react"
 
-import type { IconType } from "@/components/F0Icon"
-
 import type { ChartColorToken } from "./utils/colors"
 
 // ---------------------------------------------------------------------------
@@ -13,31 +11,14 @@ import type { ChartColorToken } from "./utils/colors"
  * Configuration for the empty state shown when a chart has no data.
  *
  * `F0DataChart` auto-detects empty data across all variants and renders a
- * default empty-state card. Use this prop to customize the copy, attach an
- * action (typically "Clear filters" for a `no-results` state), or fully
- * replace the rendered UI.
+ * default empty state. Use this prop to customize the copy, fully replace
+ * the rendered UI via `render`, or skip detection via `disabled`.
  */
 export interface F0DataChartEmptyStateProps {
-  /**
-   * Discriminates the message tone. `no-data` is the default (e.g. dataset
-   * is empty); `no-results` signals "filters returned nothing" and is the
-   * usual case for showing a clear-filters action.
-   * @default "no-data"
-   */
-  type?: "no-data" | "no-results"
   /** Override the default headline. */
   title?: string
   /** Override the default supporting copy. */
   description?: string
-  /**
-   * Optional CTA button. Typical use: `{ label: "Clear filters", onClick }`
-   * for a `type: "no-results"` empty state.
-   */
-  action?: {
-    label: string
-    onClick: () => void
-    icon?: IconType
-  }
   /**
    * Render-prop escape hatch — when provided, replaces the entire empty
    * state UI. Still gated by the empty-data detection.

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -1,6 +1,63 @@
 import type * as echarts from "echarts"
+import type { ReactNode } from "react"
+
+import type { IconType } from "@/components/F0Icon"
 
 import type { ChartColorToken } from "./utils/colors"
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for the empty state shown when a chart has no data.
+ *
+ * `F0DataChart` auto-detects empty data across all variants and renders a
+ * default empty-state card. Use this prop to customize the copy, attach an
+ * action (typically "Clear filters" for a `no-results` state), or fully
+ * replace the rendered UI.
+ */
+export interface F0DataChartEmptyStateProps {
+  /**
+   * Discriminates the message tone. `no-data` is the default (e.g. dataset
+   * is empty); `no-results` signals "filters returned nothing" and is the
+   * usual case for showing a clear-filters action.
+   * @default "no-data"
+   */
+  type?: "no-data" | "no-results"
+  /** Override the default headline. */
+  title?: string
+  /** Override the default supporting copy. */
+  description?: string
+  /**
+   * Optional CTA button. Typical use: `{ label: "Clear filters", onClick }`
+   * for a `type: "no-results"` empty state.
+   */
+  action?: {
+    label: string
+    onClick: () => void
+    icon?: IconType
+  }
+  /**
+   * Render-prop escape hatch — when provided, replaces the entire empty
+   * state UI. Still gated by the empty-data detection.
+   */
+  render?: () => ReactNode
+  /**
+   * Skip empty-data detection and render the chart as usual. Use when zero
+   * values are legitimate (e.g. a "0 errors per day" timeline).
+   * @default false
+   */
+  disabled?: boolean
+}
+
+/**
+ * Props shared by every `F0DataChart` variant.
+ */
+interface F0DataChartCommonProps {
+  /** Customize or opt out of the empty state shown when data is empty. */
+  emptyState?: F0DataChartEmptyStateProps
+}
 
 // ---------------------------------------------------------------------------
 // Bar data types
@@ -71,7 +128,7 @@ export interface F0DataChartLineSeries {
 // Shared base props
 // ---------------------------------------------------------------------------
 
-interface F0DataChartBaseProps {
+interface F0DataChartBaseProps extends F0DataChartCommonProps {
   /** Labels for the category axis (one per data point) */
   categories: string[]
 
@@ -168,7 +225,7 @@ export interface F0DataChartFunnelSeries {
  * Funnels do NOT use category/value axes — stage names come from the data
  * points themselves. This interface is separate from `F0DataChartBaseProps`.
  */
-export interface F0DataChartFunnelProps {
+export interface F0DataChartFunnelProps extends F0DataChartCommonProps {
   /** Chart type */
   type: "funnel"
   /** The funnel series to render */
@@ -239,7 +296,7 @@ export interface F0DataChartPieSeries {
  * Pies do NOT use category/value axes — segment names come from the data
  * points themselves. This interface is separate from `F0DataChartBaseProps`.
  */
-export interface F0DataChartPieProps {
+export interface F0DataChartPieProps extends F0DataChartCommonProps {
   /** Chart type */
   type: "pie"
   /** The pie series to render */
@@ -293,7 +350,7 @@ export interface F0DataChartRadarSeries {
  *
  * Radar charts use a polar coordinate system — no cartesian axes.
  */
-export interface F0DataChartRadarProps {
+export interface F0DataChartRadarProps extends F0DataChartCommonProps {
   /** Chart type */
   type: "radar"
   /** Axes of the radar — defines the dimensions to compare */
@@ -321,7 +378,7 @@ export interface F0DataChartRadarProps {
  *
  * A single-value gauge indicator — no axes, no legend.
  */
-export interface F0DataChartGaugeProps {
+export interface F0DataChartGaugeProps extends F0DataChartCommonProps {
   /** Chart type */
   type: "gauge"
   /** Current value */
@@ -353,7 +410,7 @@ export interface F0DataChartGaugeProps {
  * Uses two category axes (x for columns, y for rows) and a visualMap for
  * value→color mapping.
  */
-export interface F0DataChartHeatmapProps {
+export interface F0DataChartHeatmapProps extends F0DataChartCommonProps {
   /** Chart type */
   type: "heatmap"
   /** Column labels (x-axis) */

--- a/packages/react/src/kits/F0DataChart/utils/isDataChartEmpty.ts
+++ b/packages/react/src/kits/F0DataChart/utils/isDataChartEmpty.ts
@@ -1,0 +1,72 @@
+import type {
+  F0DataChartBarDataPoint,
+  F0DataChartLineDataPoint,
+  F0DataChartProps,
+} from "../types"
+
+const getBarOrLineValue = (
+  point: F0DataChartBarDataPoint | F0DataChartLineDataPoint
+): number => (typeof point === "number" ? point : (point?.value ?? 0))
+
+const allZeros = (values: number[]) => values.every((v) => v === 0)
+
+/**
+ * Returns `true` when a chart has no meaningful data to render — either
+ * because the series/data arrays are empty or because every numeric value
+ * resolves to `0`. Null-safe: malformed input is treated as empty.
+ *
+ * Note: gauges with `value === 0` are NOT considered empty (0% is a
+ * legitimate state). Only `value == null` triggers the empty branch.
+ */
+export function isDataChartEmpty(props: F0DataChartProps): boolean {
+  switch (props.type) {
+    case "bar":
+    case "line": {
+      const series = props.series
+      if (!Array.isArray(series) || series.length === 0) return true
+      const allValues: number[] = []
+      for (const s of series) {
+        if (!s || !Array.isArray(s.data)) continue
+        for (const point of s.data) {
+          allValues.push(getBarOrLineValue(point))
+        }
+      }
+      if (allValues.length === 0) return true
+      return allZeros(allValues)
+    }
+    case "funnel":
+    case "pie": {
+      const series = props.series
+      if (!series || !Array.isArray(series.data) || series.data.length === 0) {
+        return true
+      }
+      return series.data.every((d) => !d || (d.value ?? 0) === 0)
+    }
+    case "radar": {
+      const series = props.series
+      if (!Array.isArray(series) || series.length === 0) return true
+      const allValues: number[] = []
+      for (const s of series) {
+        if (!s || !Array.isArray(s.data)) continue
+        for (const v of s.data) {
+          allValues.push(typeof v === "number" ? v : 0)
+        }
+      }
+      if (allValues.length === 0) return true
+      return allZeros(allValues)
+    }
+    case "gauge": {
+      // 0% is a legitimate gauge state — only nullish values are empty.
+      return props.value == null
+    }
+    case "heatmap": {
+      const data = props.data
+      if (!Array.isArray(data) || data.length === 0) return true
+      return data.every(
+        (tuple) => !Array.isArray(tuple) || (tuple[2] ?? 0) === 0
+      )
+    }
+    default:
+      return true
+  }
+}

--- a/packages/react/src/kits/F0DataChart/utils/isDataChartEmpty.ts
+++ b/packages/react/src/kits/F0DataChart/utils/isDataChartEmpty.ts
@@ -1,22 +1,16 @@
-import type {
-  F0DataChartBarDataPoint,
-  F0DataChartLineDataPoint,
-  F0DataChartProps,
-} from "../types"
-
-const getBarOrLineValue = (
-  point: F0DataChartBarDataPoint | F0DataChartLineDataPoint
-): number => (typeof point === "number" ? point : (point?.value ?? 0))
-
-const allZeros = (values: number[]) => values.every((v) => v === 0)
+import type { F0DataChartProps } from "../types"
 
 /**
- * Returns `true` when a chart has no meaningful data to render — either
- * because the series/data arrays are empty or because every numeric value
- * resolves to `0`. Null-safe: malformed input is treated as empty.
+ * Returns `true` when a chart has no data points to render — i.e. the
+ * `series` / `data` arrays are missing or empty. **All-zero datasets are
+ * NOT empty** (e.g. `data: [0, 0, 0]` is a legitimate zero-valued chart),
+ * so this detection avoids hijacking what was previously a valid render.
  *
- * Note: gauges with `value === 0` are NOT considered empty (0% is a
- * legitimate state). Only `value == null` triggers the empty branch.
+ * Null-safe: malformed input is treated as empty.
+ *
+ * Consumers that prefer to surface the empty state for all-zero data can
+ * pass `emptyState.disabled: false` is the default — opt-in to a custom
+ * `render` prop or wrap the chart themselves.
  */
 export function isDataChartEmpty(props: F0DataChartProps): boolean {
   switch (props.type) {
@@ -24,47 +18,30 @@ export function isDataChartEmpty(props: F0DataChartProps): boolean {
     case "line": {
       const series = props.series
       if (!Array.isArray(series) || series.length === 0) return true
-      const allValues: number[] = []
-      for (const s of series) {
-        if (!s || !Array.isArray(s.data)) continue
-        for (const point of s.data) {
-          allValues.push(getBarOrLineValue(point))
-        }
-      }
-      if (allValues.length === 0) return true
-      return allZeros(allValues)
+      // Empty when every series has no data points at all.
+      return series.every(
+        (s) => !s || !Array.isArray(s.data) || s.data.length === 0
+      )
     }
     case "funnel":
     case "pie": {
       const series = props.series
-      if (!series || !Array.isArray(series.data) || series.data.length === 0) {
-        return true
-      }
-      return series.data.every((d) => !d || (d.value ?? 0) === 0)
+      return !series || !Array.isArray(series.data) || series.data.length === 0
     }
     case "radar": {
       const series = props.series
       if (!Array.isArray(series) || series.length === 0) return true
-      const allValues: number[] = []
-      for (const s of series) {
-        if (!s || !Array.isArray(s.data)) continue
-        for (const v of s.data) {
-          allValues.push(typeof v === "number" ? v : 0)
-        }
-      }
-      if (allValues.length === 0) return true
-      return allZeros(allValues)
+      return series.every(
+        (s) => !s || !Array.isArray(s.data) || s.data.length === 0
+      )
     }
     case "gauge": {
-      // 0% is a legitimate gauge state — only nullish values are empty.
+      // No value at all → empty. `0` is a legitimate gauge state.
       return props.value == null
     }
     case "heatmap": {
       const data = props.data
-      if (!Array.isArray(data) || data.length === 0) return true
-      return data.every(
-        (tuple) => !Array.isArray(tuple) || (tuple[2] ?? 0) === 0
-      )
+      return !Array.isArray(data) || data.length === 0
     }
     default:
       return true

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -446,6 +446,10 @@ export const defaultTranslations = {
     funnel: "Funnel",
     pieChart: "Pie",
     table: "Table",
+    emptyState: {
+      title: "No data available",
+      description: "Try a different date or fewer filters",
+    },
   },
   select: {
     noResults: "No results found",

--- a/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
@@ -113,13 +113,6 @@ export const F0AnalyticsDashboard = <
   const [isItemFullscreen, setIsItemFullscreen] = useState(false)
   const fillHeight = isSingleItem || isItemFullscreen
 
-  // Reset both filter sets so empty-state "Clear filters" CTAs in chart
-  // widgets can wipe the active filtering and let the data come back.
-  const handleClearFilters = () => {
-    setCurrentFilters({} as FiltersState<Filters>)
-    setCurrentNavigationFilters(initialNavState)
-  }
-
   return (
     <div
       className={cn("flex flex-col gap-5 pb-10", fillHeight && "h-full pb-0")}
@@ -174,7 +167,6 @@ export const F0AnalyticsDashboard = <
           onTransformChart={onTransformChart}
           resetKey={resetKey}
           onFullscreenChange={setIsItemFullscreen}
-          onClearFilters={handleClearFilters}
         />
       </div>
     </div>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
@@ -113,6 +113,13 @@ export const F0AnalyticsDashboard = <
   const [isItemFullscreen, setIsItemFullscreen] = useState(false)
   const fillHeight = isSingleItem || isItemFullscreen
 
+  // Reset both filter sets so empty-state "Clear filters" CTAs in chart
+  // widgets can wipe the active filtering and let the data come back.
+  const handleClearFilters = () => {
+    setCurrentFilters({} as FiltersState<Filters>)
+    setCurrentNavigationFilters(initialNavState)
+  }
+
   return (
     <div
       className={cn("flex flex-col gap-5 pb-10", fillHeight && "h-full pb-0")}
@@ -167,6 +174,7 @@ export const F0AnalyticsDashboard = <
           onTransformChart={onTransformChart}
           resetKey={resetKey}
           onFullscreenChange={setIsItemFullscreen}
+          onClearFilters={handleClearFilters}
         />
       </div>
     </div>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -92,3 +92,77 @@ export const Snapshot: Story = {
     />
   ),
 }
+
+// ---------------------------------------------------------------------------
+// Empty-state coverage
+// ---------------------------------------------------------------------------
+
+const emptyItems: DashboardItem<typeof dashboardFilters>[] = [
+  {
+    id: "empty-bar",
+    title: "Importe por mes",
+    description: "Evolución del gasto total por mes.",
+    type: "chart",
+    colSpan: 6,
+    x: 0,
+    y: 0,
+    rowSpan: 6,
+    chart: { type: "bar" },
+    fetchData: async () => ({ categories: [], series: [] }),
+  },
+  {
+    id: "empty-line",
+    title: "Importe por estado",
+    description: "Gasto total por estado.",
+    type: "chart",
+    colSpan: 6,
+    x: 6,
+    y: 0,
+    rowSpan: 6,
+    chart: { type: "line" },
+    fetchData: async () => ({ categories: [], series: [] }),
+  },
+  {
+    id: "empty-horizontal",
+    title: "Top empleados",
+    description: "Empleados con más gasto total.",
+    type: "chart",
+    colSpan: 12,
+    x: 0,
+    y: 6,
+    rowSpan: 6,
+    chart: { type: "bar", orientation: "horizontal" },
+    fetchData: async () => ({ categories: [], series: [] }),
+  },
+]
+
+/**
+ * Mirrors the bug case in the screenshot: every chart returns no data.
+ * Without filters, the empty state shows the "no-data" copy with the
+ * default chart-type illustration — instead of bare axes.
+ */
+export const EmptyDashboard: Story = {
+  render: () => (
+    <F0AnalyticsDashboard
+      filters={dashboardFilters}
+      presets={dashboardPresets}
+      items={emptyItems}
+    />
+  ),
+}
+
+/**
+ * Same empty data but the user has applied filters — the empty state now
+ * shows the "no-results" copy and a "Clear filters" button that resets
+ * everything (try selecting a department then clicking the button).
+ */
+export const NoResultsForFilters: Story = {
+  render: () => (
+    <F0AnalyticsDashboard
+      filters={dashboardFilters}
+      presets={dashboardPresets}
+      defaultFilters={{ department: ["Engineering"] }}
+      items={emptyItems}
+    />
+  ),
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -138,30 +138,15 @@ const emptyItems: DashboardItem<typeof dashboardFilters>[] = [
 
 /**
  * Mirrors the bug case in the screenshot: every chart returns no data.
- * Without filters, the empty state shows the "no-data" copy with the
- * default chart-type illustration — instead of bare axes.
+ * Each tile shows a faded skeleton of its chart variant with the default
+ * "No data available" / "Try a different date or fewer filters" message —
+ * instead of bare axes.
  */
 export const EmptyDashboard: Story = {
   render: () => (
     <F0AnalyticsDashboard
       filters={dashboardFilters}
       presets={dashboardPresets}
-      items={emptyItems}
-    />
-  ),
-}
-
-/**
- * Same empty data but the user has applied filters — the empty state now
- * shows the "no-results" copy and a "Clear filters" button that resets
- * everything (try selecting a department then clicking the button).
- */
-export const NoResultsForFilters: Story = {
-  render: () => (
-    <F0AnalyticsDashboard
-      filters={dashboardFilters}
-      presets={dashboardPresets}
-      defaultFilters={{ department: ["Engineering"] }}
       items={emptyItems}
     />
   ),

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -17,7 +17,7 @@ import {
   ChartVerticalBars,
   Table as TableIcon,
 } from "@/icons/app"
-import { F0DataChart } from "@/kits/F0DataChart"
+import { DataChartEmptyStateView, F0DataChart } from "@/kits/F0DataChart"
 import {
   BarChartSkeleton,
   FunnelChartSkeleton,
@@ -396,6 +396,21 @@ interface ChartItemProps<Filters extends FiltersDefinition> {
   ) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
+  /** Reset all dashboard filters. Wired into the empty-state CTA when filters are active. */
+  onClearFilters?: () => void
+}
+
+/**
+ * Returns true when at least one filter is set — i.e. the empty result is
+ * likely caused by user filtering rather than the dataset being empty.
+ */
+function hasActiveFilters(filters: Record<string, unknown>): boolean {
+  return Object.values(filters).some((v) => {
+    if (v == null || v === "") return false
+    if (Array.isArray(v)) return v.length > 0
+    if (typeof v === "object") return Object.keys(v).length > 0
+    return true
+  })
 }
 
 export function ChartItem<Filters extends FiltersDefinition>({
@@ -407,6 +422,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
   onTransformChart,
   isFullscreen,
   onFullscreenChange,
+  onClearFilters,
 }: ChartItemProps<Filters>) {
   const translations = useI18n()
   const [viewMode, setViewMode] = useState<"chart" | "table">("chart")
@@ -435,8 +451,19 @@ export function ChartItem<Filters extends FiltersDefinition>({
     [actions, downloadActions]
   )
 
-  const effectiveError =
-    error ?? (!isLoading && !data ? new Error("No data available") : undefined)
+  // No fabricated error when data is absent — we now render a proper empty
+  // state inside the body (filter-aware when filters are active).
+  const filtersActive = hasActiveFilters(filters as Record<string, unknown>)
+  const emptyStateConfig = {
+    type: filtersActive ? ("no-results" as const) : ("no-data" as const),
+    action:
+      filtersActive && onClearFilters
+        ? {
+            label: translations.collections.emptyStates.noResults.clearFilters,
+            onClick: onClearFilters,
+          }
+        : undefined,
+  }
 
   // Determine which chart type options are available for this chart
   const currentOrientation =
@@ -506,7 +533,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
       description={item.description}
       explanation={item.explanation}
       isLoading={isLoading}
-      error={effectiveError}
+      error={error}
       onRetry={retry}
       skeleton={chartSkeleton(item.chart)}
       actions={allActions}
@@ -517,16 +544,25 @@ export function ChartItem<Filters extends FiltersDefinition>({
       isFullscreen={isFullscreen}
       onFullscreenChange={onFullscreenChange}
     >
-      {data &&
-        (viewMode === "table" ? (
+      {data ? (
+        viewMode === "table" ? (
           <ChartTableView config={item.chart} data={data} />
         ) : (
           <div ref={chartContainerRef} className="h-full w-full px-4 py-3">
             <F0DataChart
               {...buildChartProps(item as DashboardChartItem, data)}
+              emptyState={emptyStateConfig}
             />
           </div>
-        ))}
+        )
+      ) : !isLoading ? (
+        <div className="h-full w-full px-4 py-3">
+          <DataChartEmptyStateView
+            chartType={item.chart.type}
+            emptyState={emptyStateConfig}
+          />
+        </div>
+      ) : null}
     </DashboardItem>
   )
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -396,21 +396,6 @@ interface ChartItemProps<Filters extends FiltersDefinition> {
   ) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
-  /** Reset all dashboard filters. Wired into the empty-state CTA when filters are active. */
-  onClearFilters?: () => void
-}
-
-/**
- * Returns true when at least one filter is set — i.e. the empty result is
- * likely caused by user filtering rather than the dataset being empty.
- */
-function hasActiveFilters(filters: Record<string, unknown>): boolean {
-  return Object.values(filters).some((v) => {
-    if (v == null || v === "") return false
-    if (Array.isArray(v)) return v.length > 0
-    if (typeof v === "object") return Object.keys(v).length > 0
-    return true
-  })
 }
 
 export function ChartItem<Filters extends FiltersDefinition>({
@@ -422,7 +407,6 @@ export function ChartItem<Filters extends FiltersDefinition>({
   onTransformChart,
   isFullscreen,
   onFullscreenChange,
-  onClearFilters,
 }: ChartItemProps<Filters>) {
   const translations = useI18n()
   const [viewMode, setViewMode] = useState<"chart" | "table">("chart")
@@ -451,19 +435,8 @@ export function ChartItem<Filters extends FiltersDefinition>({
     [actions, downloadActions]
   )
 
-  // No fabricated error when data is absent — we now render a proper empty
-  // state inside the body (filter-aware when filters are active).
-  const filtersActive = hasActiveFilters(filters as Record<string, unknown>)
-  const emptyStateConfig = {
-    type: filtersActive ? ("no-results" as const) : ("no-data" as const),
-    action:
-      filtersActive && onClearFilters
-        ? {
-            label: translations.collections.emptyStates.noResults.clearFilters,
-            onClick: onClearFilters,
-          }
-        : undefined,
-  }
+  // No fabricated error when data is absent — `F0DataChart` (or the explicit
+  // fallback below for `!data`) renders a proper empty state instead.
 
   // Determine which chart type options are available for this chart
   const currentOrientation =
@@ -551,16 +524,12 @@ export function ChartItem<Filters extends FiltersDefinition>({
           <div ref={chartContainerRef} className="h-full w-full px-4 py-3">
             <F0DataChart
               {...buildChartProps(item as DashboardChartItem, data)}
-              emptyState={emptyStateConfig}
             />
           </div>
         )
       ) : !isLoading ? (
         <div className="h-full w-full px-4 py-3">
-          <DataChartEmptyStateView
-            chartType={item.chart.type}
-            emptyState={emptyStateConfig}
-          />
+          <DataChartEmptyStateView chartType={item.chart.type} />
         </div>
       ) : null}
     </DashboardItem>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -75,6 +75,11 @@ interface DashboardGridProps<Filters extends FiltersDefinition> {
    * item fills the remaining viewport without producing scroll.
    */
   onFullscreenChange?: (isFullscreen: boolean) => void
+  /**
+   * Reset all dashboard filters. Threaded down to chart empty states so the
+   * "Clear filters" CTA can wipe the active filter set.
+   */
+  onClearFilters?: () => void
 }
 
 // ─── Component ──────────────────────────────────────────────────
@@ -94,6 +99,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   resetKey,
   onTransformChart,
   onFullscreenChange,
+  onClearFilters,
 }: DashboardGridProps<Filters>) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [isNarrow, setIsNarrow] = useState(false)
@@ -367,6 +373,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
           editMode={editMode}
           onDelete={handleDelete}
           onTransformChart={onTransformChart}
+          onClearFilters={onClearFilters}
           isFullscreen
         />
       </div>
@@ -388,6 +395,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
             editMode={editMode}
             onDelete={handleDelete}
             onTransformChart={onTransformChart}
+            onClearFilters={onClearFilters}
             isFullscreen
             onFullscreenChange={(fs) =>
               setFullscreenItemId(fs ? fullscreenItemId : null)
@@ -456,6 +464,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
                       editMode={editMode}
                       onDelete={handleDelete}
                       onTransformChart={onTransformChart}
+                      onClearFilters={onClearFilters}
                       onFullscreenChange={(fs) =>
                         setFullscreenItemId(fs ? id : null)
                       }
@@ -744,6 +753,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
   onTransformChart,
   isFullscreen,
   onFullscreenChange,
+  onClearFilters,
 }: {
   item: DashboardItemType<Filters>
   filters: FiltersState<Filters>
@@ -757,6 +767,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
   ) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
+  onClearFilters?: () => void
 }) {
   switch (item.type) {
     case "chart":
@@ -770,6 +781,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
           onTransformChart={onTransformChart}
           isFullscreen={isFullscreen}
           onFullscreenChange={onFullscreenChange}
+          onClearFilters={onClearFilters}
         />
       )
     case "metric":

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -75,11 +75,6 @@ interface DashboardGridProps<Filters extends FiltersDefinition> {
    * item fills the remaining viewport without producing scroll.
    */
   onFullscreenChange?: (isFullscreen: boolean) => void
-  /**
-   * Reset all dashboard filters. Threaded down to chart empty states so the
-   * "Clear filters" CTA can wipe the active filter set.
-   */
-  onClearFilters?: () => void
 }
 
 // ─── Component ──────────────────────────────────────────────────
@@ -99,7 +94,6 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   resetKey,
   onTransformChart,
   onFullscreenChange,
-  onClearFilters,
 }: DashboardGridProps<Filters>) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [isNarrow, setIsNarrow] = useState(false)
@@ -373,7 +367,6 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
           editMode={editMode}
           onDelete={handleDelete}
           onTransformChart={onTransformChart}
-          onClearFilters={onClearFilters}
           isFullscreen
         />
       </div>
@@ -395,7 +388,6 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
             editMode={editMode}
             onDelete={handleDelete}
             onTransformChart={onTransformChart}
-            onClearFilters={onClearFilters}
             isFullscreen
             onFullscreenChange={(fs) =>
               setFullscreenItemId(fs ? fullscreenItemId : null)
@@ -464,7 +456,6 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
                       editMode={editMode}
                       onDelete={handleDelete}
                       onTransformChart={onTransformChart}
-                      onClearFilters={onClearFilters}
                       onFullscreenChange={(fs) =>
                         setFullscreenItemId(fs ? id : null)
                       }
@@ -753,7 +744,6 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
   onTransformChart,
   isFullscreen,
   onFullscreenChange,
-  onClearFilters,
 }: {
   item: DashboardItemType<Filters>
   filters: FiltersState<Filters>
@@ -767,7 +757,6 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
   ) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
-  onClearFilters?: () => void
 }) {
   switch (item.type) {
     case "chart":
@@ -781,7 +770,6 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
           onTransformChart={onTransformChart}
           isFullscreen={isFullscreen}
           onFullscreenChange={onFullscreenChange}
-          onClearFilters={onClearFilters}
         />
       )
     case "metric":


### PR DESCRIPTION
## Summary

- `F0DataChart` now auto-detects empty data across all 7 variants (bar, line, funnel, pie, radar, gauge, heatmap) and renders a centered message on top of a faded, **static** chart skeleton instead of a bare axis.
- New optional `emptyState` prop: custom `title`/`description`, an `action` button (typical: "Clear filters"), a `render` escape hatch, and `disabled` to opt out for cases where zero values are legitimate (e.g. a "0 errors per day" timeline).
- `F0AnalyticsDashboard` threads `onClearFilters` down to chart widgets — when filters are active and the result is empty, the empty state shows a working "Clear filters" CTA that resets every filter (including navigation filters).
- Default copy: **"No data available"** / **"Try a different date or fewer filters"** — overridable per-instance.
- Removes the fabricated ``new Error("No data available")`` in ``ChartItem`` so missing data renders a proper empty state instead of the error UI.

## Why

Filtering a dashboard by a date range that returns nothing left charts as empty axes — looked broken. This makes empty data a first-class state across every chart variant.

## Visual

The empty state reuses each variant's existing skeleton illustration with `[&_*]:animate-none` to disable the pulse — visually consistent with the loading state, but static (so the user reads it as "empty", not "loading").

## Stories

- `F0DataChart/Empty states` — every variant + no-results + custom copy + render-prop + disabled.
- One ``Empty`` story added to each variant's existing stories file.
- ``AnalyticsDashboard/EmptyDashboard`` and ``AnalyticsDashboard/NoResultsForFilters`` (the second one starts with an active filter and the "Clear filters" button is wired up).

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm vitest` — 96 F0DataChart tests pass (25 new for `isDataChartEmpty` + 8 new for component-level empty-state behaviour)
- [x] `pnpm lint` — 0 warnings
- [ ] Visual review of the new stories in Storybook
- [ ] Verify in a real dashboard that "Clear filters" resets navigation filters too