### PR TITLE
fix(F0Select): prevent search clear in asList mode that resets selection

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -477,7 +477,9 @@ const F0SelectComponent = forwardRef(function Select<
 
     // Only reset search in single select mode when dropdown is closed
     // Don't clear while user is still typing/searching with dropdown open
-    if (!multiple && !openLocal) {
+    // Don't clear in asList mode since openLocal is never true (no popover)
+    // and clearing would trigger useSelectable to reset the selection
+    if (!multiple && !openLocal && !asList) {
       setCurrentSearch(undefined)
     }
 

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -424,6 +424,93 @@ describe("Select", () => {
     })
   })
 
+  describe("asList mode", () => {
+    it("preserves selection after searching and clicking an item", async () => {
+      const handleChange = vi.fn()
+      const user = userEvent.setup()
+
+      const source = createDataSourceDefinition<RecordType>({
+        dataAdapter: {
+          paginationType: "infinite-scroll",
+          fetchData: ({ search }) => {
+            const allRecords = [
+              { id: "1", name: "Alice" },
+              { id: "2", name: "Bob" },
+              { id: "3", name: "Carol" },
+            ]
+            const filtered = search
+              ? allRecords.filter((r) =>
+                  r.name.toLowerCase().includes(search.toLowerCase())
+                )
+              : allRecords
+            return Promise.resolve({
+              type: "infinite-scroll" as const,
+              cursor: "100",
+              perPage: 100,
+              hasMore: false,
+              records: filtered,
+              total: filtered.length,
+            })
+          },
+        },
+      })
+
+      render(
+        <F0Select
+          {...defaultSelectProps}
+          source={source}
+          mapOptions={(item: RecordType) => ({
+            value: item.id as string,
+            label: item.name as string,
+          })}
+          onChange={handleChange}
+          asList
+          showSearchBox
+        />
+      )
+
+      // In asList mode, items are shown inline (no popover to open)
+      await waitFor(() => {
+        expect(screen.getAllByText("Alice").length).toBeGreaterThanOrEqual(1)
+      })
+
+      // Type in the search box to filter
+      const searchInput = screen.getByRole("searchbox")
+      await user.type(searchInput, "Ali")
+
+      // Wait for filtered results
+      await waitFor(() => {
+        expect(screen.getAllByText("Alice").length).toBeGreaterThanOrEqual(1)
+        expect(screen.queryByText("Bob")).not.toBeInTheDocument()
+      })
+
+      // Click the first "Alice" element to select it
+      await user.click(screen.getAllByText("Alice")[0])
+
+      // onChange should be called with the selected value
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith(
+          "1",
+          expect.objectContaining({ id: "1", name: "Alice" }),
+          expect.objectContaining({ value: "1", label: "Alice" })
+        )
+      })
+
+      // Wait a bit for any debounced effects to fire
+      await waitFor(
+        () => {
+          // onChange should NOT have been called with undefined (i.e., selection should not be cleared)
+          const calls = handleChange.mock.calls
+          const undefinedCall = calls.find(
+            (call: unknown[]) => call[0] === undefined
+          )
+          expect(undefinedCall).toBeUndefined()
+        },
+        { timeout: 1000 }
+      )
+    })
+  })
+
   describe("collapsible groups", () => {
     type GroupedItem = {
       value: string


### PR DESCRIPTION
## Summary

Fixes a bug where selecting an item after searching in `asList` mode immediately deselects it.

## Root cause

The bug was introduced by #4000 (April 28, 2026), which added `debouncedCurrentSearch` tracking to useSelectable's dataset-identity effect. This created a chain reaction in `asList` mode:

1. User searches for an item and clicks it → F0Select's `selectedState` effect fires
2. That effect has `if (!multiple && !openLocal) { setCurrentSearch(undefined) }` — in `asList` mode, `openLocal` is always `false` (no popover), so this always triggers after selection
3. `setCurrentSearch(undefined)` propagates through a 200ms debounce to `debouncedCurrentSearch`
4. useSelectable's dataset-identity effect detects `searchChanged = true` and calls `clearSelectedItems()`, wiping the selection

Before #4000, only filter/sorting changes cleared selection, so `setCurrentSearch(undefined)` was harmless. After #4000, search changes also clear selection, which broke `asList` mode without the `multiple`option.

Clicking without searching works fine because `debouncedCurrentSearch` stays `undefined` → no change → no clearing.


https://github.com/user-attachments/assets/37e81744-b7d5-461d-958d-6381a32e6a2b



## Fix

Added `&& !asList` to the condition that resets search after selection:

```diff
-    if (!multiple && !openLocal) {
+    if (!multiple && !openLocal && !asList) {
       setCurrentSearch(undefined)
     }
```

In `asList` mode there is no dropdown to close, so resetting the search term serves no purpose and only triggers the unwanted selection clearing.

## How to reproduce

1. Go to any page using `F0Select` in `asList` mode (e.g. Factorial's bulk-files page employee assigner)
2. Type a search term to filter options
3. Click an option to select it
4. **Before fix**: selection is immediately cleared
5. **After fix**: selection persists correctly