### PR TITLE
docs(F0Text): add Storybook MDX documentation

### DIFF
--- a/packages/react/src/components/F0Text/__stories__/Text.mdx
+++ b/packages/react/src/components/F0Text/__stories__/Text.mdx
@@ -113,14 +113,16 @@ Renders body copy, descriptions, code snippets, and labels across the interface.
 ### Content best practices
 
 - Keep text concise — prefer one idea per sentence
-- Use `label` variant with `as="label"` when the text is associated with a form control to get correct HTML semantics
+- Use `label` variant with `as="label"` when the text is associated with a form control to get correct HTML semantics — wrap the input inside the label element rather than using `htmlFor`, since `F0Text` does not accept `htmlFor` as a prop:
+  - **Correct:** `<F0Text as="label" variant="label" content="Name"><input type="text" /></F0Text>`
+  - **Incorrect:** `<F0Text as="label" variant="label" htmlFor="name-input" content="Name" />`
 - Avoid writing markdown in strings that don't need it — set `markdown={false}` to prevent unexpected formatting
-  - **Correct:** `<F0Text content="Price: $10" markdown={false} />`
-  - **Incorrect:** `<F0Text content="Price: $10" />` — the `$` could be misinterpreted in some markdown parsers
+  - **Correct:** `<F0Text content="Status: **active**" markdown={false} />`
+  - **Incorrect:** `<F0Text content="Status: **active**" />` — the `**` asterisks will be rendered as bold
 
 ### Accessibility
 
-- The `label` variant should use `as="label"` and a `htmlFor` prop when associated with a form input — this links the label to the control for screen readers
+- The `label` variant should use `as="label"` when associated with a form input — wrap the input inside the label for correct HTML semantics, since `F0Text` does not accept a `htmlFor` prop
 - The `inverse` variant does not change contrast automatically — ensure the background provides sufficient contrast (WCAG AA: 4.5:1 for normal text)
 - Use `ellipsis` only when the full text is accessible through another means (tooltip, expanded view) — truncated text without a disclosure is an accessibility gap
 
@@ -130,7 +132,7 @@ Renders body copy, descriptions, code snippets, and labels across the interface.
 
 ### Markdown is enabled by default
 
-`F0Text` renders its `content` prop as markdown by default (`markdown={true}`). Set `markdown={false}` explicitly for plain-text values where markdown syntax characters could appear in data (prices, codes, identifiers).
+`F0Text` renders its `content` prop as markdown by default (`markdown={true}`). Only a limited subset is supported: **bold** (`**text**`) and _italic_ (`*text*`). Other markdown structures (links, headings, lists) are stripped by the sanitizer. Set `markdown={false}` explicitly for plain-text values where markdown syntax characters could appear in data.
 
 <Canvas of={Stories.Markdown} />
 

--- a/packages/react/src/components/F0Text/__stories__/Text.mdx
+++ b/packages/react/src/components/F0Text/__stories__/Text.mdx
@@ -1,0 +1,147 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as Stories from "./Text.stories"
+
+<Meta of={Stories} />
+
+# F0Text
+
+Renders body copy, descriptions, code snippets, and labels across the interface. It wraps all text content that is not a heading.
+
+---
+
+## Overview
+
+### Purpose
+
+- Provides a consistent typographic system for all non-heading text content
+- Supports markdown rendering by default, enabling lightweight rich text without extra components
+- Covers every text role: body copy, secondary descriptions, small captions, inline code, and form labels
+- Enforces design tokens so text style stays in sync with the design system
+
+### Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+### Variants
+
+#### Type
+
+<Canvas of={Stories.Variants} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Variant</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">When to use</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>body</code>
+        </td>
+        <td>Default text size and weight</td>
+        <td>Main content, paragraphs, general-purpose text</td>
+      </tr>
+      <tr>
+        <td>
+          <code>description</code>
+        </td>
+        <td>Slightly smaller, lower contrast</td>
+        <td>Supporting information, subtitles, helper text below a title</td>
+      </tr>
+      <tr>
+        <td>
+          <code>small</code>
+        </td>
+        <td>Smallest text size</td>
+        <td>Captions, timestamps, metadata, footnotes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>code</code>
+        </td>
+        <td>Monospace font</td>
+        <td>Inline code snippets, technical values, identifiers</td>
+      </tr>
+      <tr>
+        <td>
+          <code>label</code>
+        </td>
+        <td>Bold, compact size</td>
+        <td>Form field labels, section labels, any UI label</td>
+      </tr>
+      <tr>
+        <td>
+          <code>inverse</code>
+        </td>
+        <td>Light-colored text for dark backgrounds</td>
+        <td>
+          Text placed on dark or colored backgrounds (banners, dark cards,
+          toasts)
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- Use `body` for any general text content in the interface
+- Use `description` for secondary information that supports a title or heading — not as a standalone block
+- Use `small` for metadata, timestamps, and captions where space is limited
+- Use `code` for technical strings, identifiers, or short inline snippets
+- Use `label` for any UI label: form fields, stat labels, filter labels, column headers in compact layouts
+- Use `inverse` only when text appears on a dark or strongly colored background
+
+#### When NOT to use
+
+- Do not use `F0Text` for page titles or section headings: use `F0Heading` instead
+- Do not use `description` as the only text in a section — it lacks the visual weight to stand alone
+- Do not use `inverse` on light backgrounds: the contrast will fail accessibility requirements
+
+### Content best practices
+
+- Keep text concise — prefer one idea per sentence
+- Use `label` variant with `as="label"` when the text is associated with a form control to get correct HTML semantics
+- Avoid writing markdown in strings that don't need it — set `markdown={false}` to prevent unexpected formatting
+  - **Correct:** `<F0Text content="Price: $10" markdown={false} />`
+  - **Incorrect:** `<F0Text content="Price: $10" />` — the `$` could be misinterpreted in some markdown parsers
+
+### Accessibility
+
+- The `label` variant should use `as="label"` and a `htmlFor` prop when associated with a form input — this links the label to the control for screen readers
+- The `inverse` variant does not change contrast automatically — ensure the background provides sufficient contrast (WCAG AA: 4.5:1 for normal text)
+- Use `ellipsis` only when the full text is accessible through another means (tooltip, expanded view) — truncated text without a disclosure is an accessibility gap
+
+---
+
+## Behavior
+
+### Markdown is enabled by default
+
+`F0Text` renders its `content` prop as markdown by default (`markdown={true}`). Set `markdown={false}` explicitly for plain-text values where markdown syntax characters could appear in data (prices, codes, identifiers).
+
+<Canvas of={Stories.Markdown} />
+
+### Required marker
+
+When `variant="label"` and `required={true}` are combined, the component appends a visual required marker to the label.
+
+<Canvas of={Stories.Required} />
+
+### Ellipsis truncation
+
+When `ellipsis={true}`, the text truncates to a single line with `…`. The component must be placed in a container with a constrained width for the truncation to take effect.
+
+<Canvas of={Stories.TextEllipsis} />

--- a/packages/react/src/components/F0Text/__stories__/Text.stories.tsx
+++ b/packages/react/src/components/F0Text/__stories__/Text.stories.tsx
@@ -10,7 +10,7 @@ import { F0Text } from "../index"
 const meta = {
   component: F0Text,
   title: "Text",
-  tags: ["experimental"],
+  tags: ["!autodocs", "experimental"],
   argTypes: {
     variant: {
       options: ["body", "description", "small", "inverse", "code", "label"],
@@ -96,6 +96,9 @@ export const Variants: Story = {
       <F0Text variant="small" content="This is a small text." />
       <F0Text variant="code" content="const example = 'code text';" />
       <F0Text variant="label" content="Label text" />
+      <div className="rounded bg-f1-background-inverse p-2">
+        <F0Text variant="inverse" content="Inverse text on dark background" />
+      </div>
     </div>
   ),
 }

--- a/packages/react/src/components/F0Text/__stories__/Text.stories.tsx
+++ b/packages/react/src/components/F0Text/__stories__/Text.stories.tsx
@@ -10,7 +10,7 @@ import { F0Text } from "../index"
 const meta = {
   component: F0Text,
   title: "Text",
-  tags: ["autodocs", "experimental"],
+  tags: ["experimental"],
   argTypes: {
     variant: {
       options: ["body", "description", "small", "inverse", "code", "label"],
@@ -62,6 +62,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
+  tags: ["!dev"],
   args: {
     variant: "body",
     content: "This is a text wrapped in the Text component.",
@@ -81,6 +82,7 @@ export const WithDataTestId: Story = {
 }
 
 export const Variants: Story = {
+  tags: ["!dev"],
   args: {
     content: "",
   },
@@ -116,6 +118,7 @@ export const TextAlignment: Story = {
 }
 
 export const TextEllipsis: Story = {
+  tags: ["!dev"],
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -135,12 +138,14 @@ export const TextEllipsis: Story = {
 }
 
 export const Markdown: Story = {
+  tags: ["!dev"],
   args: {
     content: "This is a **bold** text and this is a *italic* text.",
   },
 }
 
 export const MarkdownWithEllipsis: Story = {
+  tags: ["!dev"],
   args: {
     content:
       "This is a **bold** text and this is a *italic* text and this is a **bold** text and this is a *italic* text.",
@@ -149,6 +154,7 @@ export const MarkdownWithEllipsis: Story = {
 }
 
 export const Required: Story = {
+  tags: ["!dev"],
   args: {
     variant: "label",
     content: "Label text",
@@ -158,6 +164,7 @@ export const Required: Story = {
 }
 
 export const Snapshot: Story = {
+  tags: ["!dev"],
   parameters: withSnapshot({}),
   args: {
     content: "",


### PR DESCRIPTION
## Summary

- Add `Text.mdx` with full Storybook documentation for `F0Text`
- Documents all 6 variants (`body`, `description`, `small`, `code`, `label`, `inverse`) with visual table and Canvas
- Guidelines cover markdown-by-default footgun, label semantics, and accessibility
- Behavior section with Canvas examples for markdown rendering, required marker, and ellipsis truncation
- Remove `autodocs` tag and add `!dev` to stories referenced in docs to keep sidebar clean

Implemented-with: factorial-f0