### PR TITLE
docs(F0Heading): add Storybook MDX documentation

### DIFF
--- a/packages/react/src/components/F0Heading/__stories__/Heading.mdx
+++ b/packages/react/src/components/F0Heading/__stories__/Heading.mdx
@@ -1,0 +1,117 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as Stories from "./Heading.stories"
+
+<Meta of={Stories} />
+
+# F0Heading
+
+> **Before using this component**, check if a higher-level component covers your use case:
+>
+> - **`ResourceHeader`** — entity pages (employee, team, company). Includes avatar, metadata, status, and actions.
+> - **`SectionHeader`** — sections inside a page or form. Includes description, help center link, separator, and action button.
+>
+> `F0Heading` is a low-level typography primitive. Use it only when neither of the above fits.
+
+Renders a heading with consistent typographic scale. It separates visual style (via `variant`) from semantic structure (via `as`), allowing the correct HTML heading level to be set independently of the size.
+
+---
+
+## Overview
+
+### Purpose
+
+- Establishes visual hierarchy in pages, panels, and cards through a two-level size scale
+- Decouples visual weight from HTML semantics — the same visual style can render as any `h1`–`h6` tag
+- Ensures headings stay aligned with design tokens regardless of context
+- Provides ellipsis truncation for headings in space-constrained layouts
+
+### Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+### Variants
+
+#### Type
+
+<Canvas of={Stories.Variants} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Variant</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">When to use</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>heading</code>
+        </td>
+        <td>Standard heading size</td>
+        <td>Section titles, card headers, panel titles, list group headers</td>
+      </tr>
+      <tr>
+        <td>
+          <code>heading-large</code>
+        </td>
+        <td>Larger, more prominent heading</td>
+        <td>Top-level page or dashboard titles — the main title of a view</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- Use `heading` for section and panel titles within a page — the default for most use cases
+- Use `heading-large` for the primary title of a page or dashboard view — typically appears once per screen at the top of the content area
+- Always pair the visual variant with the correct `as` tag to maintain a logical document outline
+
+#### When NOT to use
+
+- Do not use `F0Heading` for body copy, descriptions, or labels: use `F0Text` instead
+- Do not use `F0Heading` to build a resource page header (employee, team, company): use `ResourceHeader` instead — it handles avatar, metadata, status, and actions
+- Do not use `F0Heading` to build a section header inside a form or content block: use `SectionHeader` instead — it handles description, help link, separator, and action
+- Do not use `heading-large` for section titles inside a page — it creates false visual hierarchy
+- Do not omit the `as` prop when the heading level matters for accessibility — the default rendering tag may not match the document structure
+
+#### How to use
+
+- Always set `as` explicitly to match the heading's position in the page outline — `variant` is visual only and does not affect the rendered HTML tag
+- `heading-large` should appear once per view, at the top of the content area
+- `heading` is the right choice for any section title, card header, or panel title below the page title
+
+### Content best practices
+
+- Keep headings short and descriptive — one line is the target
+- Use sentence case: "Team members", not "Team Members"
+- Avoid punctuation at the end of headings
+  - **Correct:** "Team members", "Monthly report"
+  - **Incorrect:** "Team members:", "Monthly report."
+
+### Accessibility
+
+- Always set the `as` prop to the correct heading level (`h1`–`h6`) for the position in the page outline — the visual variant does not determine the semantic level
+- A page should have exactly one `h1`. Use `as="h1"` only for the top-level page title
+- Do not skip heading levels (e.g., going from `h1` directly to `h3`) — this breaks screen reader navigation
+- When `ellipsis={true}` is used, ensure the full heading text is accessible (e.g., via a tooltip or `aria-label`)
+
+---
+
+## Behavior
+
+### Ellipsis truncation
+
+When `ellipsis={true}`, the heading truncates to a single line with `…`. The component must be placed in a container with a constrained width.
+
+<Canvas of={Stories.HeadingEllipsis} />

--- a/packages/react/src/components/F0Heading/__stories__/Heading.stories.tsx
+++ b/packages/react/src/components/F0Heading/__stories__/Heading.stories.tsx
@@ -10,7 +10,7 @@ import { F0Heading } from "../index"
 const meta = {
   component: F0Heading,
   title: "Heading",
-  tags: ["stable"],
+  tags: ["!autodocs", "stable"],
   argTypes: {
     variant: {
       options: ["heading", "heading-large"],

--- a/packages/react/src/components/F0Heading/__stories__/Heading.stories.tsx
+++ b/packages/react/src/components/F0Heading/__stories__/Heading.stories.tsx
@@ -10,7 +10,7 @@ import { F0Heading } from "../index"
 const meta = {
   component: F0Heading,
   title: "Heading",
-  tags: ["autodocs", "stable"],
+  tags: ["stable"],
   argTypes: {
     variant: {
       options: ["heading", "heading-large"],
@@ -54,6 +54,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
+  tags: ["!dev"],
   args: {
     variant: "heading",
     content: "This is a heading",
@@ -73,6 +74,7 @@ export const WithDataTestId: Story = {
 }
 
 export const Variants: Story = {
+  tags: ["!dev"],
   args: {
     content: "",
   },
@@ -102,6 +104,7 @@ export const HeadingAlignment: Story = {
 }
 
 export const HeadingEllipsis: Story = {
+  tags: ["!dev"],
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -121,6 +124,7 @@ export const HeadingEllipsis: Story = {
 }
 
 export const Snapshot: Story = {
+  tags: ["!dev"],
   parameters: withSnapshot({}),
   args: {
     content: "",


### PR DESCRIPTION
## Summary

- Add `Heading.mdx` with full Storybook documentation for `F0Heading`
- Documents `heading` vs `heading-large` variants with when-to-use guidance
- Prominent notice at the top recommending `ResourceHeader` and `SectionHeader` over direct `F0Heading` usage for entity pages and form sections
- Guidelines cover `as` prop semantics (visual vs semantic level), sentence case, and accessibility (heading outline, no skipped levels)
- Behavior section with Canvas for ellipsis truncation
- Remove `autodocs` tag and add `!dev` to stories referenced in docs

Implemented-with: factorial-f0