### PR TITLE
fix(F0Select): preserve multi-select selections across search and filter changes

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -123,6 +123,7 @@ const F0SelectComponent = forwardRef(function Select<
     portalContainer,
     asList = false,
     showPreview = false,
+    preserveSelectionOnDatasetChange = true,
     dataTestId,
     ...props
   }: F0SelectProps<T, R>,
@@ -366,6 +367,7 @@ const F0SelectComponent = forwardRef(function Select<
     isSearchActive: !!currentSearch,
     allPagesSelection: true,
     resetOnPageChange: false,
+    preserveSelectionOnDatasetChange,
   })
 
   /**
@@ -594,13 +596,17 @@ const F0SelectComponent = forwardRef(function Select<
     const curr = JSON.stringify(localSource.currentFilters)
     if (prev !== curr) {
       previousFiltersRef.current = localSource.currentFilters
-      if (!disableSelectAll) {
+      if (!disableSelectAll && !preserveSelectionOnDatasetChange) {
         selectedItemsCache.current.clear()
         setLocalValue([])
         hasUserInteracted.current = true
       }
     }
-  }, [localSource.currentFilters, disableSelectAll])
+  }, [
+    localSource.currentFilters,
+    disableSelectAll,
+    preserveSelectionOnDatasetChange,
+  ])
 
   const collapsible = localSource.grouping?.collapsible ?? false
   const defaultOpenGroups = localSource.grouping?.defaultOpenGroups

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -1025,6 +1025,65 @@ export const MultipleManualSelectionOnly: Story = {
 }
 
 /**
+ * Multi-select with preserved selections (default behavior).
+ *
+ * Selections persist across search and filter changes — the normal
+ * selector workflow. Try this:
+ * 1. Select a few employees
+ * 2. Type in the search box to filter
+ * 3. Select another employee from the filtered results
+ * 4. Clear the search — all selections are still there
+ * 5. Use a filter (e.g. department) — selections still preserved
+ */
+export const MultiplePreserveSelections: Story = {
+  args: {
+    label: "Preserve Selections (default)",
+    placeholder: "Search employees...",
+    multiple: true,
+    clearable: true,
+    showSearchBox: true,
+    source: employeeNestedPaginatedSource,
+    mapOptions: (item: Employee) => ({
+      value: item.value,
+      label: item.label,
+      avatar: item.avatar,
+      description: `${item.jobTitle} · ${item.departmentName}`,
+    }),
+    onSelectItems: fn((selectionStatus) => {
+      console.log("selectionStatus", selectionStatus)
+    }),
+  },
+}
+
+/**
+ * Multi-select that clears selections on dataset changes.
+ *
+ * When `preserveSelectionOnDatasetChange` is false, selections are
+ * cleared whenever the user searches, filters, or sorts. Try the
+ * same workflow as above — selections will be lost on each change.
+ */
+export const MultipleClearSelectionsOnDatasetChange: Story = {
+  args: {
+    label: "Clear Selections on change",
+    placeholder: "Search employees...",
+    multiple: true,
+    clearable: true,
+    showSearchBox: true,
+    preserveSelectionOnDatasetChange: false,
+    source: employeeNestedPaginatedSource,
+    mapOptions: (item: Employee) => ({
+      value: item.value,
+      label: item.label,
+      avatar: item.avatar,
+      description: `${item.jobTitle} · ${item.departmentName}`,
+    }),
+    onSelectItems: fn((selectionStatus) => {
+      console.log("selectionStatus", selectionStatus)
+    }),
+  },
+}
+
+/**
  * Single select with paginated data and filters.
  * Use `defaultItem` to provide label for pre-selected value not in the first page.
  * Filter by department, office, or legal entity to narrow down results.

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -56,6 +56,14 @@ type F0SelectBaseProps<T extends string, R = unknown> = {
    * @default false
    */
   showPreview?: boolean
+  /**
+   * When true, preserves selections when the dataset changes (search, filters,
+   * or sortings). Useful for picker components where the user searches and
+   * filters to find items to add to an existing selection.
+   *
+   * @default true
+   */
+  preserveSelectionOnDatasetChange?: boolean
 } & WithDataTestIdProps
 
 /**

--- a/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
@@ -726,4 +726,351 @@ describe("useSelectable", () => {
       })
     })
   })
+
+  describe("preserveSelectionOnDatasetChange", () => {
+    const records = mockFlatData.slice(0, 5).map((item) => ({
+      ...item,
+      [GROUP_ID_SYMBOL]: undefined,
+    }))
+    const mockData: Data<TestRecord> = {
+      type: "flat",
+      records,
+      groups: [
+        {
+          key: "all",
+          label: "All",
+          records,
+          itemCount: records.length,
+        },
+      ],
+    }
+
+    it("should clear selections on search change by default", async () => {
+      const source = {
+        ...mockSource,
+        debouncedCurrentSearch: "",
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data: mockData,
+            paginationInfo: null,
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+          }),
+        { initialProps: { source } }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(0, true)
+        result.current.handleSelectItemChange(1, true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+
+      rerender({
+        source: {
+          ...source,
+          debouncedCurrentSearch: "test",
+        } as unknown as DataSource<TestRecord, never, never, never>,
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(0)
+      })
+    })
+
+    it("should clear selections on filter change by default", async () => {
+      const source = {
+        ...mockSource,
+        currentFilters: { status: ["active"] },
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data: mockData,
+            paginationInfo: null,
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+          }),
+        { initialProps: { source } }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(0, true)
+        result.current.handleSelectItemChange(1, true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+
+      rerender({
+        source: {
+          ...source,
+          currentFilters: { status: ["inactive"] },
+        } as unknown as DataSource<TestRecord, never, never, never>,
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(0)
+      })
+    })
+
+    it("should preserve selections on search change when preserveSelectionOnDatasetChange is true", async () => {
+      const source = {
+        ...mockSource,
+        debouncedCurrentSearch: "",
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data: mockData,
+            paginationInfo: null,
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            preserveSelectionOnDatasetChange: true,
+          }),
+        { initialProps: { source } }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(0, true)
+        result.current.handleSelectItemChange(1, true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+
+      rerender({
+        source: {
+          ...source,
+          debouncedCurrentSearch: "test",
+        } as unknown as DataSource<TestRecord, never, never, never>,
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+        expect(result.current.selectedItems.get(0)).toBeDefined()
+        expect(result.current.selectedItems.get(1)).toBeDefined()
+      })
+    })
+
+    it("should preserve selections on filter change when preserveSelectionOnDatasetChange is true", async () => {
+      const source = {
+        ...mockSource,
+        currentFilters: { status: ["active"] },
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data: mockData,
+            paginationInfo: null,
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            preserveSelectionOnDatasetChange: true,
+          }),
+        { initialProps: { source } }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(0, true)
+        result.current.handleSelectItemChange(1, true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+
+      rerender({
+        source: {
+          ...source,
+          currentFilters: { status: ["inactive"] },
+        } as unknown as DataSource<TestRecord, never, never, never>,
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+        expect(result.current.selectedItems.get(0)).toBeDefined()
+        expect(result.current.selectedItems.get(1)).toBeDefined()
+      })
+    })
+
+    it("should preserve selections when disableSelectAll is true even without preserveSelectionOnDatasetChange", async () => {
+      const source = {
+        ...mockSource,
+        debouncedCurrentSearch: "",
+        currentFilters: { status: ["active"] },
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data: mockData,
+            paginationInfo: null,
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            disableSelectAll: true,
+            preserveSelectionOnDatasetChange: false,
+          }),
+        { initialProps: { source } }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(0, true)
+        result.current.handleSelectItemChange(1, true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+
+      // Change both search and filters
+      rerender({
+        source: {
+          ...source,
+          debouncedCurrentSearch: "test",
+          currentFilters: { status: ["inactive"] },
+        } as unknown as DataSource<TestRecord, never, never, never>,
+      })
+
+      // disableSelectAll alone prevents clearing
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+    })
+
+    it("should preserve selections when both disableSelectAll and preserveSelectionOnDatasetChange are true", async () => {
+      const source = {
+        ...mockSource,
+        debouncedCurrentSearch: "",
+        currentFilters: { status: ["active"] },
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data: mockData,
+            paginationInfo: null,
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            disableSelectAll: true,
+            preserveSelectionOnDatasetChange: true,
+          }),
+        { initialProps: { source } }
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(0, true)
+        result.current.handleSelectItemChange(1, true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+
+      // Change both search and filters
+      rerender({
+        source: {
+          ...source,
+          debouncedCurrentSearch: "test",
+          currentFilters: { status: ["inactive"] },
+        } as unknown as DataSource<TestRecord, never, never, never>,
+      })
+
+      // Both flags prevent clearing
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+    })
+
+    it("should preserve selections across search, filter, and search again (selector workflow)", async () => {
+      const source = {
+        ...mockSource,
+        currentFilters: {},
+        debouncedCurrentSearch: "",
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data: mockData,
+            paginationInfo: null,
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            preserveSelectionOnDatasetChange: true,
+          }),
+        { initialProps: { source } }
+      )
+
+      // Step 1: Search "Mexico" and select 2 employees
+      rerender({
+        source: {
+          ...source,
+          debouncedCurrentSearch: "Mexico",
+        } as unknown as DataSource<TestRecord, never, never, never>,
+      })
+
+      act(() => {
+        result.current.handleSelectItemChange(0, true)
+        result.current.handleSelectItemChange(1, true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+
+      // Step 2: Clear search
+      rerender({
+        source: {
+          ...source,
+          debouncedCurrentSearch: "",
+        } as unknown as DataSource<TestRecord, never, never, never>,
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+
+      // Step 3: Filter by location "Barcelona"
+      rerender({
+        source: {
+          ...source,
+          currentFilters: { location: ["Barcelona"] },
+          debouncedCurrentSearch: "",
+        } as unknown as DataSource<TestRecord, never, never, never>,
+      })
+
+      // Mexico selections should still be there
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+      })
+
+      // Step 4: Select all Barcelona employees
+      act(() => {
+        result.current.handleSelectItemChange(2, true)
+        result.current.handleSelectItemChange(3, true)
+        result.current.handleSelectItemChange(4, true)
+      })
+
+      // All 5 selections preserved
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(5)
+      })
+    })
+  })
 })

--- a/packages/react/src/hooks/datasource/useSelectable/typings.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/typings.ts
@@ -80,6 +80,15 @@ export type UseSelectableProps<
    * across loadMore() calls regardless of this flag.
    */
   resetOnPageChange?: boolean
+  /**
+   * When true, preserves selection when the dataset identity changes
+   * (filters, sortings, or search query). Useful for select/picker
+   * components where the user searches and filters to find items to
+   * add to an existing selection, not to view a different dataset.
+   *
+   * @default false
+   */
+  preserveSelectionOnDatasetChange?: boolean
 }
 
 export type SelectionMeta<R extends RecordType> = {

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -40,6 +40,7 @@ export function useSelectable<
   isSearchActive = false,
   allPagesSelection,
   resetOnPageChange = true,
+  preserveSelectionOnDatasetChange = false,
 }: UseSelectableProps<R, Filters, Sortings, Grouping>): UseSelectableReturn<
   R,
   Filters
@@ -725,7 +726,10 @@ export function useSelectable<
       // When disableSelectAll is true, maintain the selection even when the
       // dataset changes because the user is manually selecting items and
       // expects them to persist across soft reloads.
-      if (!disableSelectAll) {
+      // When preserveSelectionOnDatasetChange is true, never clear on dataset
+      // changes — used by selectors where search/filter is for finding items
+      // to add to an existing selection.
+      if (!disableSelectAll && !preserveSelectionOnDatasetChange) {
         // Mark that we're clearing due to a dataset-identity change to prevent
         // the data-sync effect from restoring selections.
         justClearedByDatasetChange.current = true
@@ -741,6 +745,7 @@ export function useSelectable<
     debouncedCurrentSearch,
     clearSelectedItems,
     disableSelectAll,
+    preserveSelectionOnDatasetChange,
   ])
 
   // Clear selections when page changes, unless the user has triggered


### PR DESCRIPTION
## Why

When using a multi-select picker (e.g. the employee selector in Performance Reviews), users lost all their previous selections whenever they typed in the search box or changed a filter. This forced users to select employees one by one without ever using search — making large selections extremely tedious.

A typical broken workflow: a user needs to select Hellen from the search, then filter by Barcelona and select some employees, then search for Federico and select him. At each step, all previous selections were wiped.

## What

The root cause is in `useSelectable` — commit c83c1648f ("preserve selection across infinite-scroll loadMore") added search/filter/sorting changes to the dataset-identity clearing effect. This made sense for data collections (tables) where searching means "show me different data", but broke selectors where search means "help me find the next item to add".

### Changes

**`useSelectable`** — new `preserveSelectionOnDatasetChange` prop (default `false`, backward-compatible):
- When `true`, selections are preserved across search, filter, and sorting changes
- Added alongside the existing `disableSelectAll` guard — either flag prevents clearing
- 7 new tests covering all 4 flag combinations + real-world selector workflow

**`F0Select`** — sets `preserveSelectionOnDatasetChange: true` by default (selectors should always preserve):
- Exposed as a prop so consumers can override with `preserveSelectionOnDatasetChange={false}` if needed
- Updated the existing filter-clearing effect to respect the same flag
- 2 new Storybook stories to visually compare both behaviors

### No breaking changes
- `useSelectable` defaults to `false` → tables/data collections keep their current clearing behavior
- `F0Select` defaults to `true` → fixes the bug for all existing multi-select pickers
- Single select is unaffected — item replacement on click is handled separately

## Context

- Jira: [FCT-53403](https://factorialmakers.atlassian.net/browse/FCT-53403) — Performance Review Custom Selection clears previous selections when using search bar
- Regression introduced by: c83c1648f (`fix(OneDataCollection): preserve selection across infinite-scroll loadMore`)
- Related fix (partial, asList only): 6f57d6891 (`fix(F0Select): prevent search clear in asList mode`)


[FCT-53403]: https://factorialmakers.atlassian.net/browse/FCT-53403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


## Demo

https://github.com/user-attachments/assets/bef78c2e-a556-4884-9607-a6c776a231b4

https://github.com/user-attachments/assets/f97c2d13-55f0-480d-b377-d2dd41bc85f4

 