### PR TITLE
feat(F0AiChat): add before-send hook

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
@@ -40,6 +40,8 @@ const F0AiChatProviderComponent = ({
   fileAttachments,
   onThumbsUp,
   onThumbsDown,
+  onBeforeSendMessage,
+  runtimeFetch,
   children,
   agent,
   tracking,
@@ -52,6 +54,8 @@ const F0AiChatProviderComponent = ({
       initialMessage={initialMessage}
       onThumbsUp={onThumbsUp}
       onThumbsDown={onThumbsDown}
+      onBeforeSendMessage={onBeforeSendMessage}
+      runtimeFetch={runtimeFetch}
       agent={agent}
       welcomeScreenSuggestions={welcomeScreenSuggestions}
       disclaimer={disclaimer}

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/persistClarifyingResolution.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/persistClarifyingResolution.ts
@@ -16,6 +16,7 @@ export interface PersistClarifyingResolutionParams {
   /** Unique tool call id emitted by the backend */
   toolCallId: string
   /** Updated args to persist on the tool call */
+  runtimeFetch?: typeof fetch
   args: {
     steps: unknown
     isResolved: true
@@ -43,9 +44,10 @@ export async function persistClarifyingResolution({
   threadId,
   toolCallId,
   args,
+  runtimeFetch = fetch,
 }: PersistClarifyingResolutionParams): Promise<void> {
   try {
-    await fetch(
+    await runtimeFetch(
       `${chatApiEndpoint}/chat-history/threads/${encodeURIComponent(
         threadId
       )}/tool-calls/${encodeURIComponent(toolCallId)}`,

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/useClarifyingQuestionAction.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/clarifyingQuestion/useClarifyingQuestionAction.tsx
@@ -102,7 +102,7 @@ function ClarifyingQuestionController({
 }) {
   const translation = useI18n()
 
-  const { sendMessage, setClarifyingQuestion } = useAiChat()
+  const { sendMessage, setClarifyingQuestion, runtimeFetch } = useAiChat()
   const { threadId } = useCopilotChatInternal()
   const { copilotApiConfig } = useCopilotContext()
 
@@ -239,6 +239,7 @@ function ClarifyingQuestionController({
         headers: copilotApiConfig.headers as Record<string, string> | undefined,
         threadId,
         toolCallId,
+        runtimeFetch,
         args: {
           steps: rawSteps,
           isResolved: true,
@@ -317,6 +318,7 @@ function ClarifyingQuestionController({
         headers: copilotApiConfig.headers as Record<string, string> | undefined,
         threadId,
         toolCallId,
+        runtimeFetch,
         args: {
           steps: rawSteps,
           isResolved: true,

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/displayDashboard/useDisplayDashboardAction.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/displayDashboard/useDisplayDashboardAction.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react"
 
 import type { ChatDashboardConfig } from "../../../canvas/entities/dashboard/types"
 import { DashboardCard } from "../../../canvas/entities/dashboard/DashboardCard"
+import { useAiChat } from "../../../providers/AiChatStateProvider"
 
 /**
  * Hook to register the displayDashboard copilot action.
@@ -23,13 +24,15 @@ import { DashboardCard } from "../../../canvas/entities/dashboard/DashboardCard"
  */
 export const useDisplayDashboardAction = () => {
   const { copilotApiConfig } = useCopilotContext()
+  const { runtimeFetch } = useAiChat()
 
   const apiConfig = useMemo(
     () => ({
       baseUrl: copilotApiConfig.chatApiEndpoint,
       headers: copilotApiConfig.headers as Record<string, string>,
+      runtimeFetch,
     }),
-    [copilotApiConfig.chatApiEndpoint, copilotApiConfig.headers]
+    [copilotApiConfig.chatApiEndpoint, copilotApiConfig.headers, runtimeFetch]
   )
 
   useCopilotAction({

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardCard.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardCard.tsx
@@ -18,7 +18,11 @@ export type DashboardCardProps = {
   /** The original dashboard config from the agent */
   config: ChatDashboardConfig
   /** API config for server-side dashboard computation */
-  apiConfig: { baseUrl: string; headers: Record<string, string> }
+  apiConfig: {
+    baseUrl: string
+    headers: Record<string, string>
+    runtimeFetch?: typeof fetch
+  }
   /** Present when the dashboard is a pre-saved dashboard */
   savedDashboardId?: string
   /** Category of the saved dashboard */

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/DashboardContent.tsx
@@ -191,7 +191,11 @@ const COLLECTION_PER_PAGE = 20
 
 export interface ChatDashboardProps {
   config: ChatDashboardConfig
-  apiConfig: { baseUrl: string; headers: Record<string, string> }
+  apiConfig: {
+    baseUrl: string
+    headers: Record<string, string>
+    runtimeFetch?: typeof fetch
+  }
   refreshKey?: number
   /** Incrementing counter that forces the grid to reset to initial layout */
   resetKey?: number

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/useDashboardCompute.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/useDashboardCompute.ts
@@ -44,6 +44,7 @@ type ComputeResponse = {
 type ApiConfig = {
   baseUrl: string
   headers: Record<string, string>
+  runtimeFetch?: typeof fetch
 }
 
 // ---------------------------------------------------------------------------
@@ -108,6 +109,7 @@ export function useDashboardCompute(
       const controller = new AbortController()
       const cfg = configRef.current
       const api = apiConfigRef.current
+      const runtimeFetch = api.runtimeFetch ?? fetch
 
       // Convert filterValues to string[]
       const stringFilterValues: Record<string, string[]> = {}
@@ -134,7 +136,7 @@ export function useDashboardCompute(
           : undefined,
       }
 
-      const promise = fetch(`${api.baseUrl}/dashboard/compute`, {
+      const promise = runtimeFetch(`${api.baseUrl}/dashboard/compute`, {
         method: "POST",
         credentials: "include",
         headers: {

--- a/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/useSaveDashboardConfig.ts
+++ b/packages/react/src/sds/ai/F0AiChat/canvas/entities/dashboard/useSaveDashboardConfig.ts
@@ -9,6 +9,7 @@ import type { ChatDashboardConfig } from "./types"
 export function useSaveDashboardConfig(apiConfig: {
   baseUrl: string
   headers: Record<string, string>
+  runtimeFetch?: typeof fetch
 }): (
   threadId: string,
   toolCallId: string | undefined,
@@ -20,25 +21,29 @@ export function useSaveDashboardConfig(apiConfig: {
       toolCallId: string | undefined,
       config: ChatDashboardConfig
     ) => {
-      const response = await fetch(`${apiConfig.baseUrl}/dashboard/config`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          ...apiConfig.headers,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          threadId,
-          ...(toolCallId ? { toolCallId } : {}),
-          toolName: "displayDashboard",
-          config,
-        }),
-      })
+      const runtimeFetch = apiConfig.runtimeFetch ?? fetch
+      const response = await runtimeFetch(
+        `${apiConfig.baseUrl}/dashboard/config`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            ...apiConfig.headers,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            threadId,
+            ...(toolCallId ? { toolCallId } : {}),
+            toolName: "displayDashboard",
+            config,
+          }),
+        }
+      )
 
       if (!response.ok) {
         throw new Error(`Failed to save dashboard config: ${response.status}`)
       }
     },
-    [apiConfig.baseUrl, apiConfig.headers]
+    [apiConfig.baseUrl, apiConfig.headers, apiConfig.runtimeFetch]
   )
 }

--- a/packages/react/src/sds/ai/F0AiChat/components/history/useChatHistory.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/history/useChatHistory.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react"
 
 import { useCopilotContext } from "@copilotkit/react-core"
 
+import { useAiChat } from "../../providers/AiChatStateProvider"
 import {
   readFromLocalStorage,
   writeToLocalStorage,
@@ -52,6 +53,7 @@ export function useChatHistory({
   enabled = false,
 }: { enabled?: boolean } = {}): UseChatHistoryReturn {
   const { copilotApiConfig } = useCopilotContext()
+  const { runtimeFetch } = useAiChat()
   const baseUrl = copilotApiConfig.chatApiEndpoint
 
   const [threads, setThreads] = useState<ChatThread[]>([])
@@ -64,7 +66,7 @@ export function useChatHistory({
     setError(null)
 
     try {
-      const response = await fetch(`${baseUrl}/chat-history/threads`, {
+      const response = await runtimeFetch(`${baseUrl}/chat-history/threads`, {
         credentials: "include",
         headers: {
           ...copilotApiConfig.headers,
@@ -85,7 +87,7 @@ export function useChatHistory({
     } finally {
       setIsLoading(false)
     }
-  }, [baseUrl, copilotApiConfig.headers])
+  }, [baseUrl, copilotApiConfig.headers, runtimeFetch])
 
   useEffect(() => {
     if (enabled) {
@@ -114,13 +116,16 @@ export function useChatHistory({
   const deleteThread = useCallback(
     async (id: string) => {
       try {
-        const response = await fetch(`${baseUrl}/chat-history/threads/${id}`, {
-          method: "DELETE",
-          credentials: "include",
-          headers: {
-            ...copilotApiConfig.headers,
-          },
-        })
+        const response = await runtimeFetch(
+          `${baseUrl}/chat-history/threads/${id}`,
+          {
+            method: "DELETE",
+            credentials: "include",
+            headers: {
+              ...copilotApiConfig.headers,
+            },
+          }
+        )
 
         if (!response.ok && response.status !== 204) {
           throw new Error(`Failed to delete thread: ${response.status}`)
@@ -142,7 +147,7 @@ export function useChatHistory({
         void fetchThreads()
       }
     },
-    [baseUrl, copilotApiConfig.headers, fetchThreads]
+    [baseUrl, copilotApiConfig.headers, fetchThreads, runtimeFetch]
   )
 
   return {

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ActionBar.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ActionBar.tsx
@@ -19,6 +19,7 @@ interface ActionBarProps {
   inProgress?: boolean
   hasDataToSend: boolean
   isUploading: boolean
+  isPreSending?: boolean
   submitLabel?: string
 }
 
@@ -34,6 +35,7 @@ export const ActionBar = ({
   inProgress,
   hasDataToSend,
   isUploading,
+  isPreSending,
   submitLabel,
 }: ActionBarProps) => {
   const translation = useI18n()
@@ -86,8 +88,8 @@ export const ActionBar = ({
         ) : (
           <ButtonInternal
             type="submit"
-            disabled={!hasDataToSend || isUploading}
-            variant={hasDataToSend && !isUploading ? "default" : "neutral"}
+            disabled={!hasDataToSend || isUploading || isPreSending}
+            variant={hasDataToSend && !isUploading && !isPreSending ? "default" : "neutral"}
             label={submitLabel || translation.ai.sendMessage}
             icon={submitLabel ? undefined : ArrowUp}
             hideLabel={!submitLabel}

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ActionBar.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ActionBar.tsx
@@ -89,7 +89,11 @@ export const ActionBar = ({
           <ButtonInternal
             type="submit"
             disabled={!hasDataToSend || isUploading || isPreSending}
-            variant={hasDataToSend && !isUploading && !isPreSending ? "default" : "neutral"}
+            variant={
+              hasDataToSend && !isUploading && !isPreSending
+                ? "default"
+                : "neutral"
+            }
             label={submitLabel || translation.ai.sendMessage}
             icon={submitLabel ? undefined : ArrowUp}
             hideLabel={!submitLabel}

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
@@ -165,7 +165,7 @@ export const ChatTextarea = ({
     mentions.close()
     if (inProgress) {
       handleStop()
-    } else if (hasDataToSend && !isUploading) {
+    } else if (hasDataToSend && !isUploading && !isPreSending) {
       if (onBeforeSendMessage) {
         setIsPreSending(true)
         try {

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
@@ -78,6 +78,7 @@ export const ChatTextarea = ({
     pendingQuote,
     setPendingQuote,
     setProcessDroppedFilesFunction,
+    onBeforeSendMessage,
   } = useAiChat()
   const translation = useI18n()
   const shouldReduceMotion = useReducedMotion()
@@ -154,7 +155,7 @@ export const ChatTextarea = ({
   const isUploading = attachedFiles.some((f) => f.status === "uploading")
   const hasDataToSend = inputValue.trim().length > 0
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     // When clarifying, form submit is a no-op — the panel handles its own confirm
@@ -164,6 +165,11 @@ export const ChatTextarea = ({
     if (inProgress) {
       handleStop()
     } else if (hasDataToSend && !isUploading) {
+      if (onBeforeSendMessage && (await onBeforeSendMessage()) === false) {
+        textareaRef.current?.focus()
+        return
+      }
+
       const transformed = mentions.transformMentions(inputValue.trim())
       // Escape markdown/HTML in the user's own text so `*hola*` stays literal
       // and only features we control (quote blockquote, @mentions, tool
@@ -213,11 +219,14 @@ export const ChatTextarea = ({
         if (pendingContext) setPendingContext(null)
         if (pendingQuote) setPendingQuote(null)
 
-        sendMessage({
-          id: crypto.randomUUID(),
-          role: "user",
-          content: contentParts,
-        })
+        sendMessage(
+          {
+            id: crypto.randomUUID(),
+            role: "user",
+            content: contentParts,
+          },
+          { skipBeforeSend: true }
+        )
       } else {
         if (pendingQuote) setPendingQuote(null)
         onSend(withQuote)

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
@@ -84,6 +84,7 @@ export const ChatTextarea = ({
   const shouldReduceMotion = useReducedMotion()
   const [inputValue, setInputValue] = useState("")
   const [cursorPosition, setCursorPosition] = useState(0)
+  const [isPreSending, setIsPreSending] = useState(false)
   const formRef = useRef<HTMLFormElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const highlightRef = useRef<HTMLDivElement>(null)
@@ -165,9 +166,16 @@ export const ChatTextarea = ({
     if (inProgress) {
       handleStop()
     } else if (hasDataToSend && !isUploading) {
-      if (onBeforeSendMessage && (await onBeforeSendMessage()) === false) {
-        textareaRef.current?.focus()
-        return
+      if (onBeforeSendMessage) {
+        setIsPreSending(true)
+        try {
+          if ((await onBeforeSendMessage()) === false) {
+            textareaRef.current?.focus()
+            return
+          }
+        } finally {
+          setIsPreSending(false)
+        }
       }
 
       const transformed = mentions.transformMentions(inputValue.trim())
@@ -385,6 +393,7 @@ export const ChatTextarea = ({
                 inProgress={inProgress}
                 hasDataToSend={hasDataToSend}
                 isUploading={isUploading}
+                isPreSending={isPreSending}
                 submitLabel={submitLabel}
               />
             </motion.div>

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
@@ -219,14 +219,11 @@ export const ChatTextarea = ({
         if (pendingContext) setPendingContext(null)
         if (pendingQuote) setPendingQuote(null)
 
-        sendMessage(
-          {
-            id: crypto.randomUUID(),
-            role: "user",
-            content: contentParts,
-          },
-          { skipBeforeSend: true }
-        )
+        sendMessage({
+          id: crypto.randomUUID(),
+          role: "user",
+          content: contentParts,
+        })
       } else {
         if (pendingQuote) setPendingQuote(null)
         onSend(withQuote)

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/ChatTextarea.beforeSend.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/ChatTextarea.beforeSend.test.tsx
@@ -1,0 +1,94 @@
+import { userEvent } from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  fireEvent,
+  zeroRender as render,
+  screen,
+  waitFor,
+} from "@/testing/test-utils"
+
+interface TextareaFieldMockProps {
+  inputValue: string
+  onInputChange: (value: string, cursorPosition: number) => void
+}
+
+vi.mock("../TextareaField", () => ({
+  TextareaField: ({ inputValue, onInputChange }: TextareaFieldMockProps) => (
+    <>
+      <textarea aria-label="Message" value={inputValue} readOnly />
+      <button
+        type="button"
+        onClick={() => onInputChange("Show me my time off", 19)}
+      >
+        Fill message
+      </button>
+    </>
+  ),
+}))
+
+const sendMessageMock = vi.fn()
+const appendMessagesMock = vi.fn()
+const setActiveToolHintMock = vi.fn()
+const setPendingContextMock = vi.fn()
+const setPendingQuoteMock = vi.fn()
+const setProcessDroppedFilesFunctionMock = vi.fn()
+const onBeforeSendMessageMock = vi.fn()
+
+vi.mock("../../../../providers/AiChatStateProvider", () => ({
+  useAiChat: () => ({
+    placeholders: ["Ask anything"],
+    entityRefs: undefined,
+    toolHints: undefined,
+    activeToolHint: null,
+    setActiveToolHint: setActiveToolHintMock,
+    fileAttachments: undefined,
+    sendMessage: sendMessageMock,
+    appendMessages: appendMessagesMock,
+    clarifyingQuestion: null,
+    pendingContext: null,
+    setPendingContext: setPendingContextMock,
+    pendingQuote: null,
+    setPendingQuote: setPendingQuoteMock,
+    setProcessDroppedFilesFunction: setProcessDroppedFilesFunctionMock,
+    onBeforeSendMessage: onBeforeSendMessageMock,
+  }),
+}))
+
+import { ChatTextarea } from "../ChatTextarea"
+
+describe("ChatTextarea before-send hook", () => {
+  beforeEach(() => {
+    sendMessageMock.mockClear()
+    appendMessagesMock.mockClear()
+    setActiveToolHintMock.mockClear()
+    setPendingContextMock.mockClear()
+    setPendingQuoteMock.mockClear()
+    setProcessDroppedFilesFunctionMock.mockClear()
+    onBeforeSendMessageMock.mockReset()
+  })
+
+  it("does not send a text message when the before-send hook blocks submission", async () => {
+    onBeforeSendMessageMock.mockResolvedValue(false)
+    const onSend = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ChatTextarea submitLabel="Send" onSend={onSend} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Fill message" }))
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+        "Show me my time off"
+      )
+    )
+    await user.click(screen.getByRole("button", { name: "Send" }))
+
+    await waitFor(() =>
+      expect(onBeforeSendMessageMock).toHaveBeenCalledTimes(1)
+    )
+    expect(onSend).not.toHaveBeenCalled()
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "Show me my time off"
+    )
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/components/shared/CopilotFunctionBridge.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/shared/CopilotFunctionBridge.tsx
@@ -64,6 +64,7 @@ export const CopilotFunctionBridge = () => {
     setSendMessageFunction,
     setAppendMessagesFunction,
     setReplaceMessagesFunction,
+    runtimeFetch,
   } = useAiChat()
   const { reset, messages, setMessages, sendMessage, threadId } =
     useCopilotChatInternal()
@@ -97,7 +98,8 @@ export const CopilotFunctionBridge = () => {
         copilotApiConfig.chatApiEndpoint,
         copilotApiConfig.headers,
         threadId,
-        actions as Record<string, { render?: (...args: any[]) => any }>
+        actions as Record<string, { render?: (...args: any[]) => any }>,
+        runtimeFetch
       )
         .then(
           (msgs) => setMessages(msgs),
@@ -115,6 +117,7 @@ export const CopilotFunctionBridge = () => {
     setIsLoadingThread,
     copilotApiConfig,
     actions,
+    runtimeFetch,
   ])
 
   // Send message
@@ -155,7 +158,7 @@ export const CopilotFunctionBridge = () => {
       const currentThreadId = threadIdRef.current
       const persistable = filterPersistableMessages(hydrated)
       if (currentThreadId && persistable.length > 0) {
-        void fetch(
+        void runtimeFetch(
           `${copilotApiConfig.chatApiEndpoint}/chat-history/threads/${currentThreadId}/messages`,
           {
             method: "POST",
@@ -172,7 +175,7 @@ export const CopilotFunctionBridge = () => {
     return () => {
       setAppendMessagesFunction(null)
     }
-  }, [setAppendMessagesFunction, setMessages, copilotApiConfig])
+  }, [setAppendMessagesFunction, setMessages, copilotApiConfig, runtimeFetch])
 
   // Replace messages (clear + append atomically)
   // Unlike calling reset() then setMessages(), this does a single
@@ -191,7 +194,7 @@ export const CopilotFunctionBridge = () => {
       const currentThreadId = threadIdRef.current
       const persistable = filterPersistableMessages(hydrated)
       if (currentThreadId && persistable.length > 0) {
-        void fetch(
+        void runtimeFetch(
           `${copilotApiConfig.chatApiEndpoint}/chat-history/threads/${currentThreadId}/messages`,
           {
             method: "POST",
@@ -208,7 +211,13 @@ export const CopilotFunctionBridge = () => {
     return () => {
       setReplaceMessagesFunction(null)
     }
-  }, [setReplaceMessagesFunction, setMessages, setThreadId, copilotApiConfig])
+  }, [
+    setReplaceMessagesFunction,
+    setMessages,
+    setThreadId,
+    copilotApiConfig,
+    runtimeFetch,
+  ])
 
   return null
 }

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -52,6 +52,10 @@ export interface AiChatState {
     { threadId, feedback }: { threadId: string; feedback: string }
   ) => void
   tracking?: AiChatTrackingOptions
+  /**
+   * Optional hook called before a user message is sent. Return false to block submission.
+   */
+  onBeforeSendMessage?: () => boolean | Promise<boolean>
 }
 
 /**
@@ -88,6 +92,10 @@ export type AiChatProviderReturnValue = {
   ) => void
   tracking?: AiChatTrackingOptions
   /**
+   * Optional hook called before a user message is sent. Return false to block submission.
+   */
+  onBeforeSendMessage?: () => boolean | Promise<boolean>
+  /**
    * Clear/reset the chat conversation
    */
   clear: () => void
@@ -117,7 +125,10 @@ export type AiChatProviderReturnValue = {
    * Send a message to the chat
    * @param message - The message content as a string, or a full Message object
    */
-  sendMessage: (message: string | Message) => void
+  sendMessage: (
+    message: string | Message,
+    options?: { skipBeforeSend?: boolean }
+  ) => void
   /**
    * Internal function to set the sendMessage function from CopilotKit
    * @internal

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -56,6 +56,10 @@ export interface AiChatState {
    * Optional hook called before a user message is sent. Return false to block submission.
    */
   onBeforeSendMessage?: () => boolean | Promise<boolean>
+  /**
+   * Optional fetch implementation for AI runtime requests owned by F0.
+   */
+  runtimeFetch?: typeof fetch
 }
 
 /**
@@ -96,6 +100,10 @@ export type AiChatProviderReturnValue = {
    */
   onBeforeSendMessage?: () => boolean | Promise<boolean>
   /**
+   * Fetch implementation for AI runtime requests owned by F0.
+   */
+  runtimeFetch: typeof fetch
+  /**
    * Clear/reset the chat conversation
    */
   clear: () => void
@@ -125,10 +133,7 @@ export type AiChatProviderReturnValue = {
    * Send a message to the chat
    * @param message - The message content as a string, or a full Message object
    */
-  sendMessage: (
-    message: string | Message,
-    options?: { skipBeforeSend?: boolean }
-  ) => void
+  sendMessage: (message: string | Message) => void
   /**
    * Internal function to set the sendMessage function from CopilotKit
    * @internal

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -108,6 +108,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   onThumbsDown,
   onThumbsUp,
   tracking,
+  onBeforeSendMessage,
   ...rest
 }) => {
   const [footer, setFooter] = useState<ReactNode | undefined>(initialFooter)
@@ -349,26 +350,39 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     setChatWidth(DEFAULT_CHAT_WIDTH)
   }
 
-  const sendMessage = (message: string | Message) => {
+  const sendMessage: AiChatProviderReturnValue["sendMessage"] = (
+    message,
+    options
+  ) => {
     if (!sendMessageFunctionRef.current) {
       return
     }
 
-    // Ensure chat is open when sending a message
-    if (!open) {
-      setOpen(true)
-    }
+    void (async () => {
+      if (
+        !options?.skipBeforeSend &&
+        onBeforeSendMessage &&
+        (await onBeforeSendMessage()) === false
+      ) {
+        return
+      }
 
-    const messageToSend: Message =
-      typeof message === "string"
-        ? {
-            id: randomId(),
-            role: "user",
-            content: message,
-          }
-        : message
+      // Ensure chat is open when sending a message
+      if (!open) {
+        setOpen(true)
+      }
 
-    sendMessageFunctionRef.current?.(messageToSend)
+      const messageToSend: Message =
+        typeof message === "string"
+          ? {
+              id: randomId(),
+              role: "user",
+              content: message,
+            }
+          : message
+
+      sendMessageFunctionRef.current?.(messageToSend)
+    })()
   }
 
   useEffect(() => {
@@ -473,6 +487,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         setChatWidth,
         resetChatWidth,
         tracking,
+        onBeforeSendMessage,
         entityRefs,
         canvasActions,
         toolHints,
@@ -556,6 +571,7 @@ export function useAiChat(): AiChatProviderReturnValue {
       setChatWidth: noopFn,
       resetChatWidth: noopFn,
       tracking: undefined,
+      onBeforeSendMessage: undefined,
       entityRefs: undefined,
       canvasActions: undefined,
       toolHints: undefined,

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -109,6 +109,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   onThumbsUp,
   tracking,
   onBeforeSendMessage,
+  runtimeFetch = fetch,
   ...rest
 }) => {
   const [footer, setFooter] = useState<ReactNode | undefined>(initialFooter)
@@ -350,20 +351,13 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     setChatWidth(DEFAULT_CHAT_WIDTH)
   }
 
-  const sendMessage: AiChatProviderReturnValue["sendMessage"] = (
-    message,
-    options
-  ) => {
+  const sendMessage: AiChatProviderReturnValue["sendMessage"] = (message) => {
     if (!sendMessageFunctionRef.current) {
       return
     }
 
     void (async () => {
-      if (
-        !options?.skipBeforeSend &&
-        onBeforeSendMessage &&
-        (await onBeforeSendMessage()) === false
-      ) {
+      if (onBeforeSendMessage && (await onBeforeSendMessage()) === false) {
         return
       }
 
@@ -488,6 +482,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         resetChatWidth,
         tracking,
         onBeforeSendMessage,
+        runtimeFetch,
         entityRefs,
         canvasActions,
         toolHints,
@@ -572,6 +567,7 @@ export function useAiChat(): AiChatProviderReturnValue {
       resetChatWidth: noopFn,
       tracking: undefined,
       onBeforeSendMessage: undefined,
+      runtimeFetch: fetch,
       entityRefs: undefined,
       canvasActions: undefined,
       toolHints: undefined,

--- a/packages/react/src/sds/ai/F0AiChat/providers/__tests__/AiChatStateProvider.beforeSend.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/__tests__/AiChatStateProvider.beforeSend.test.tsx
@@ -1,0 +1,57 @@
+import { userEvent } from "@testing-library/user-event"
+import { useEffect } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
+
+import { AiChatStateProvider, useAiChat } from "../AiChatStateProvider"
+
+const rawSendMessageMock = vi.fn()
+const onBeforeSendMessageMock = vi.fn()
+
+const SendMessageProbe = () => {
+  const { sendMessage, setSendMessageFunction } = useAiChat()
+
+  useEffect(() => {
+    setSendMessageFunction(rawSendMessageMock)
+    return () => setSendMessageFunction(null)
+  }, [setSendMessageFunction])
+
+  return <button onClick={() => sendMessage("hello")}>Send probe</button>
+}
+
+const renderWithProvider = () => {
+  const providerProps = {
+    enabled: true,
+    onBeforeSendMessage: onBeforeSendMessageMock,
+  } as React.ComponentProps<typeof AiChatStateProvider> & {
+    onBeforeSendMessage: () => Promise<boolean>
+  }
+
+  render(
+    <AiChatStateProvider {...providerProps}>
+      <SendMessageProbe />
+    </AiChatStateProvider>
+  )
+}
+
+describe("AiChatStateProvider before-send hook", () => {
+  beforeEach(() => {
+    rawSendMessageMock.mockClear()
+    onBeforeSendMessageMock.mockReset()
+  })
+
+  it("blocks sending when the before-send hook resolves false", async () => {
+    onBeforeSendMessageMock.mockResolvedValue(false)
+    const user = userEvent.setup()
+
+    renderWithProvider()
+
+    await user.click(screen.getByRole("button", { name: "Send probe" }))
+
+    await waitFor(() =>
+      expect(onBeforeSendMessageMock).toHaveBeenCalledTimes(1)
+    )
+    expect(rawSendMessageMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -100,7 +100,11 @@ export type CanvasContentBase = {
 export type DashboardCanvasContent = CanvasContentBase & {
   type: "dashboard"
   config: ChatDashboardConfig
-  apiConfig: { baseUrl: string; headers: Record<string, string> }
+  apiConfig: {
+    baseUrl: string
+    headers: Record<string, string>
+    runtimeFetch?: typeof fetch
+  }
   /** Present when the dashboard is a pre-saved dashboard */
   savedDashboardId?: string
   /** Category of the saved dashboard */
@@ -324,6 +328,10 @@ export type AiChatProviderProps = {
    * Optional hook called before a user message is sent. Return false to block submission.
    */
   onBeforeSendMessage?: () => boolean | Promise<boolean>
+  /**
+   * Optional fetch implementation for AI runtime requests owned by F0.
+   */
+  runtimeFetch?: typeof fetch
 } & Pick<
   CopilotKitProps,
   | "agent"

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -320,6 +320,10 @@ export type AiChatProviderProps = {
     { threadId, feedback }: { threadId: string; feedback: string }
   ) => void
   tracking?: AiChatTrackingOptions
+  /**
+   * Optional hook called before a user message is sent. Return false to block submission.
+   */
+  onBeforeSendMessage?: () => boolean | Promise<boolean>
 } & Pick<
   CopilotKitProps,
   | "agent"

--- a/packages/react/src/sds/ai/F0AiChat/utils/__tests__/fetchThreadMessages.test.ts
+++ b/packages/react/src/sds/ai/F0AiChat/utils/__tests__/fetchThreadMessages.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { convertBackendMessage } from "../fetchThreadMessages"
+import {
+  convertBackendMessage,
+  fetchThreadMessages,
+} from "../fetchThreadMessages"
 
 describe("convertBackendMessage", () => {
   it("converts a simple user text message", () => {
@@ -317,5 +320,35 @@ describe("convertBackendMessage", () => {
         mimeType: "application/pdf",
       },
     ])
+  })
+})
+
+describe("fetchThreadMessages", () => {
+  it("uses the provided runtime fetch", async () => {
+    const runtimeFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          messages: [{ id: "msg_1", role: "user", content: "Hello" }],
+        }),
+        { status: 200 }
+      )
+    )
+
+    const messages = await fetchThreadMessages(
+      "https://api.example.com/copilotkit",
+      { "X-Test": "true" },
+      "thread-1",
+      undefined,
+      runtimeFetch
+    )
+
+    expect(runtimeFetch).toHaveBeenCalledWith(
+      "https://api.example.com/copilotkit/chat-history/threads/thread-1/messages",
+      {
+        credentials: "include",
+        headers: { "X-Test": "true" },
+      }
+    )
+    expect(messages).toEqual([{ id: "msg_1", role: "user", content: "Hello" }])
   })
 })

--- a/packages/react/src/sds/ai/F0AiChat/utils/fetchThreadMessages.ts
+++ b/packages/react/src/sds/ai/F0AiChat/utils/fetchThreadMessages.ts
@@ -193,9 +193,10 @@ export async function fetchThreadMessages(
   baseUrl: string,
   headers: Record<string, string>,
   threadId: string,
-  actions?: Record<string, ActionWithRender>
+  actions?: Record<string, ActionWithRender>,
+  runtimeFetch: typeof fetch = fetch
 ): Promise<Message[]> {
-  const response = await fetch(
+  const response = await runtimeFetch(
     `${baseUrl}/chat-history/threads/${threadId}/messages`,
     {
       credentials: "include",


### PR DESCRIPTION
## What

Adds two generic F0 AI chat lifecycle extension points:

- `onBeforeSendMessage?: () => boolean | Promise<boolean>`
  - Called before user message submission.
  - Returning `false` blocks submission.
  - Used by host apps to guard CopilotKit-owned runtime sends.
- `runtimeFetch?: typeof fetch`
  - Used by F0-owned AI runtime HTTP calls.
  - Falls back to global `fetch`.
  - Covers chat history, thread-message persistence, clarifying-question persistence, and dashboard compute/config endpoints.

## Why

Host apps using cookie-based auth may need to refresh/validate auth before AI runtime requests. CopilotKit only exposes headers/credentials for its internal requests, and F0 also owns several direct runtime fetches. These hooks keep product-specific auth logic outside F0 while allowing host apps to centralize request handling.

This is being used as temporary plumbing while One moves toward a more robust delegated runtime auth model.

## Related

- Factorial temporary force-refresh PR: https://github.com/factorialco/factorial/pull/98003

## Verification

- `pnpm vitest:ci src/sds/ai/F0AiChat/utils/__tests__/fetchThreadMessages.test.ts src/sds/ai/F0AiChat/providers/__tests__/AiChatStateProvider.beforeSend.test.tsx src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/ChatTextarea.beforeSend.test.tsx`
- `pnpm format:check` on changed files
- `pnpm lint` on changed files
- `pnpm tsc --noEmit`
- `pnpm --filter @factorialco/f0-react build:types`
