### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.474.2",
+  "packages/react": "1.475.0",
   "packages/react-native": "0.53.0",
   "packages/core": "1.50.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.475.0](https://github.com/factorialco/f0/compare/f0-react-v1.474.2...f0-react-v1.475.0) (2026-05-07)
+
+
+### Features
+
+* **F0AiChat:** add before-send hook ([#4087](https://github.com/factorialco/f0/issues/4087)) ([6861019](https://github.com/factorialco/f0/commit/6861019a43b2960a38a5ce40a7a9d4e637e289fb))
+
 ## [1.474.2](https://github.com/factorialco/f0/compare/f0-react-v1.474.1...f0-react-v1.474.2) (2026-05-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.474.2",
+  "version": "1.475.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.475.0</summary>

## [1.475.0](https://github.com/factorialco/f0/compare/f0-react-v1.474.2...f0-react-v1.475.0) (2026-05-07)


### Features

* **F0AiChat:** add before-send hook ([#4087](https://github.com/factorialco/f0/issues/4087)) ([6861019](https://github.com/factorialco/f0/commit/6861019a43b2960a38a5ce40a7a9d4e637e289fb))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).