### PR TITLE
fix(OneDataCollection): prevent summary value from being silently clipped

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -27,6 +27,7 @@ import {
   useSelectable,
 } from "@/hooks/datasource"
 import { Add } from "@/icons/app"
+import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { PagesPagination } from "@/patterns/OneDataCollection/components/PagesPagination"
@@ -847,11 +848,13 @@ export const TableCollection = <
                                 }
 
                                 return (
-                                  <div className="flex gap-1">
-                                    <span className="text-f1-foreground-secondary">
+                                  <div className="flex min-w-0 gap-1">
+                                    <span className="shrink-0 text-f1-foreground-secondary">
                                       {i18n.collections.summaries.types.sum}
                                     </span>
-                                    {`${summaryValue}`}
+                                    <OneEllipsis className="min-w-0">
+                                      {`${summaryValue}`}
+                                    </OneEllipsis>
                                   </div>
                                 )
                               }


### PR DESCRIPTION
## Description

Summary row values in DataCollection (used for expense/compensation totals) were being silently clipped when the column had a fixed width. Large numbers (e.g. `1,234,567.89 EUR`) combined with translated labels could easily overflow narrow columns — with no visual indication that content was hidden.

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

- Added `min-w-0` to the summary value flex container so it can shrink below its content size (flex items default to `min-width: auto`, which blocked shrinking)
- Added `shrink-0` to the "Sum" label so it stays fully visible — the numeric value is always the first element to truncate
- Wrapped the numeric value in `OneEllipsis` (already used across the codebase for this exact pattern) — applies CSS truncation with ellipsis and shows a tooltip with the full value only when content is actually being cut off