### PR TITLE
feat(ClarifyingQuestionPanel): implement auto-advance on selection in…

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/ClarifyingQuestionPanel.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/ClarifyingQuestionPanel.tsx
@@ -93,6 +93,19 @@ const ClarifyingQuestionContent = ({
   const canProceed =
     hasSelection || (isCustomAnswerActive && hasCustomText) || optional === true
 
+  // In single-select mode, auto-advance on selection when this is not the
+  // last step — avoids requiring an explicit "Next" click. Only advance when
+  // the toggle results in a selection (not a deselect).
+  const handleToggleOption = (optionId: string) => {
+    const isDeselecting =
+      mode === "single" && selectedOptionIds.includes(optionId)
+    toggleOption(optionId)
+    if (mode === "single" && !isFinalStep && !isDeselecting) {
+      // Defer confirm() until after toggleOption's synchronous work completes.
+      Promise.resolve().then(confirm)
+    }
+  }
+
   const confirmButtonLabel = isFinalStep
     ? translation.ai.clarifyingQuestion.submit
     : translation.ai.clarifyingQuestion.next
@@ -158,7 +171,7 @@ const ClarifyingQuestionContent = ({
               canProceed={canProceed}
               customInputRef={customInputRef}
               autoFocus
-              onToggleOption={toggleOption}
+              onToggleOption={handleToggleOption}
               onActivateCustom={handleActivateCustom}
               onChangeCustomText={setCustomAnswerText}
               onToggleCustomActive={setCustomAnswerActive}


### PR DESCRIPTION
**feat(ai): auto-advance in single-select clarifying question steps**

## Description

Adds auto-advance behavior to `ClarifyingQuestionPanel` for single-select, non-final steps. When a user selects an option, the panel automatically advances to the next step without requiring an explicit "Next" click, reducing friction in multi-step clarifying question flows.

> NOTE: ir only applies to `single-select` not `custom` answer or `multi-select`


## Screenshots

https://www.loom.com/share/2454e7805ccf4c0eb32b8b551b004656

https://www.loom.com/share/3146947a1d8e4700a429bc808564c3b2
## Implementation details

- Added `handleToggleOption` in `ClarifyingQuestionContent` that wraps `toggleOption` and defers `confirm()` via `Promise.resolve().then(confirm)` after a selection is made.
- Auto-advance is skipped when the toggle results in a **deselect** (i.e. the user clicks an already-selected option) — this prevents advancing with an empty selection, which is important for optional steps where "no selection" enables the Skip action.
- Auto-advance is also skipped on the final step, where an explicit "Submit" click is intentional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to `ClarifyingQuestionPanel` option selection flow; main risk is unintended step advancement timing in single-select steps.
> 
> **Overview**
> **Clarifying question single-select steps now auto-advance.** In `ClarifyingQuestionPanel`, selecting an option in *single-select* mode automatically triggers `confirm()` to move to the next step when it’s not the final step.
> 
> Auto-advance is intentionally suppressed when the user is *deselecting* the currently-selected option (to avoid advancing with an empty selection) and still requires explicit submission on the final step; `confirm()` is deferred via a microtask to run after `toggleOption` completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e85e399565c70856612f3397ad772bc6882f9a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->