### PR TITLE
fix(ai): add unit tests for auto-advance in ClarifyingQuestionPanel

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/__tests__/ClarifyingQuestionPanel.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/__tests__/ClarifyingQuestionPanel.test.tsx
@@ -114,4 +114,75 @@ describe("ClarifyingQuestionPanel", () => {
     expect(screen.getByRole("radiogroup")).toBeInTheDocument()
     expect(screen.getAllByRole("radio")).toHaveLength(3)
   })
+
+  describe("auto-advance in single-select mode", () => {
+    it("calls confirm() after selecting an option on a non-final step", async () => {
+      const state = buildState({ currentStepIndex: 0, totalSteps: 2 })
+      render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
+      await userEvent.click(screen.getByRole("radio", { name: "This month" }))
+      // confirm() is deferred via microtask — flush before asserting
+      await Promise.resolve()
+      expect(state.confirm).toHaveBeenCalledOnce()
+    })
+
+    it("does not call confirm() when clicking an already-selected option (deselect)", async () => {
+      const state = buildState(
+        { currentStepIndex: 0, totalSteps: 2 },
+        { selectedOptionIds: ["this-month"] }
+      )
+      render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
+      await userEvent.click(screen.getByRole("radio", { name: "This month" }))
+      await Promise.resolve()
+      expect(state.confirm).not.toHaveBeenCalled()
+    })
+
+    it("does not call confirm() when selecting an option on the final step", async () => {
+      // currentStepIndex === totalSteps - 1 means final step
+      const state = buildState({ currentStepIndex: 1, totalSteps: 2 })
+      render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
+      await userEvent.click(screen.getByRole("radio", { name: "This month" }))
+      await Promise.resolve()
+      expect(state.confirm).not.toHaveBeenCalled()
+    })
+
+    it("does not call confirm() on option click in multi-select mode", async () => {
+      const state = buildState(
+        { currentStepIndex: 0, totalSteps: 2 },
+        { selectionMode: "multi" }
+      )
+      render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: "This month" })
+      )
+      await Promise.resolve()
+      expect(state.confirm).not.toHaveBeenCalled()
+    })
+
+    it("calls confirm() when selecting a predefined option even if custom answer was active", async () => {
+      const state = buildState(
+        { currentStepIndex: 0, totalSteps: 2 },
+        {
+          allowCustomAnswer: true,
+          isCustomAnswerActive: true,
+          customAnswerText: "my custom answer",
+        }
+      )
+      render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
+      await userEvent.click(screen.getByRole("radio", { name: "This month" }))
+      await Promise.resolve()
+      expect(state.confirm).toHaveBeenCalledOnce()
+    })
+
+    it("does not call confirm() when typing in the custom answer input", async () => {
+      const state = buildState(
+        { currentStepIndex: 0, totalSteps: 2 },
+        { allowCustomAnswer: true }
+      )
+      render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "hello")
+      await Promise.resolve()
+      expect(state.confirm).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/__tests__/ClarifyingQuestionPanel.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ClarifyingQuestionPanel/__tests__/ClarifyingQuestionPanel.test.tsx
@@ -122,6 +122,7 @@ describe("ClarifyingQuestionPanel", () => {
       await userEvent.click(screen.getByRole("radio", { name: "This month" }))
       // confirm() is deferred via microtask — flush before asserting
       await Promise.resolve()
+      expect(state.toggleOption).toHaveBeenCalledExactlyOnceWith("this-month")
       expect(state.confirm).toHaveBeenCalledOnce()
     })
 
@@ -133,6 +134,7 @@ describe("ClarifyingQuestionPanel", () => {
       render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
       await userEvent.click(screen.getByRole("radio", { name: "This month" }))
       await Promise.resolve()
+      expect(state.toggleOption).toHaveBeenCalledExactlyOnceWith("this-month")
       expect(state.confirm).not.toHaveBeenCalled()
     })
 
@@ -142,19 +144,21 @@ describe("ClarifyingQuestionPanel", () => {
       render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
       await userEvent.click(screen.getByRole("radio", { name: "This month" }))
       await Promise.resolve()
+      expect(state.toggleOption).toHaveBeenCalledExactlyOnceWith("this-month")
       expect(state.confirm).not.toHaveBeenCalled()
     })
 
-    it("does not call confirm() on option click in multi-select mode", async () => {
+    it("does not call confirm() on option click in multiple-selection mode", async () => {
       const state = buildState(
         { currentStepIndex: 0, totalSteps: 2 },
-        { selectionMode: "multi" }
+        { selectionMode: "multiple" }
       )
       render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
       await userEvent.click(
         screen.getByRole("checkbox", { name: "This month" })
       )
       await Promise.resolve()
+      expect(state.toggleOption).toHaveBeenCalledExactlyOnceWith("this-month")
       expect(state.confirm).not.toHaveBeenCalled()
     })
 
@@ -170,6 +174,7 @@ describe("ClarifyingQuestionPanel", () => {
       render(<ClarifyingQuestionPanel clarifyingQuestion={state} />)
       await userEvent.click(screen.getByRole("radio", { name: "This month" }))
       await Promise.resolve()
+      expect(state.toggleOption).toHaveBeenCalledExactlyOnceWith("this-month")
       expect(state.confirm).toHaveBeenCalledOnce()
     })
 
@@ -182,6 +187,7 @@ describe("ClarifyingQuestionPanel", () => {
       const input = screen.getByRole("textbox")
       await userEvent.type(input, "hello")
       await Promise.resolve()
+      expect(state.toggleOption).not.toHaveBeenCalled()
       expect(state.confirm).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
## Description

Tests for this [PR](https://github.com/factorialco/f0/pull/4093)

## Implementation details
Tests cover:
- Selecting an option on a non-final step triggers confirm()
- Clicking an already-selected option (deselect) does not trigger confirm()
- Final step does not auto-advance
- Multi-select mode does not auto-advance
- Selecting a predefined option while custom answer is active still auto-advances
- Typing in the custom answer input does not auto-advance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add coverage around `confirm()` auto-advance behavior; no production logic is modified.
> 
> **Overview**
> Adds a new test suite for `ClarifyingQuestionPanel` that verifies *single-select auto-advance* behavior.
> 
> Covers that selecting an option on a non-final step triggers a deferred `confirm()`, while deselecting, being on the final step, using multi-select mode, or typing a custom answer does **not** auto-advance (including when switching from an active custom answer back to a predefined option).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c8df990ab354a062c35070db564c9f85b3407b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->