### PR TITLE
feat(F0AiChat): cap file attachments with transient error banner

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -406,6 +406,7 @@ export const defaultTranslations = {
     attachFile: "Attach file",
     removeFile: "Remove",
     fileUploadError: "Upload failed",
+    tooManyFilesError: "You can attach up to {{maxFiles}} files at once",
     dropFilesHere: "Drop your files here",
     reply: "Reply",
     removeQuote: "Remove quote",

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -430,6 +430,7 @@ const meta: Meta<typeof ApplicationFrame> = {
       },
       fileAttachments: {
         onUploadFiles: mockUploadFiles,
+        maxFiles: 5,
       },
       disclaimer: {
         text: "One works within your permissions.",
@@ -975,6 +976,7 @@ export const FullscreenWithActions: Story = {
       },
       fileAttachments: {
         onUploadFiles: mockUploadFiles,
+        maxFiles: 5,
       },
       disclaimer: {
         text: "One works within your permissions.",

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ActionBar.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ActionBar.tsx
@@ -10,6 +10,7 @@ import { ToolHintSelector } from "../ToolHintSelector"
 interface ActionBarProps {
   onUploadFiles: ((files: File[]) => Promise<unknown>) | undefined
   isAtMaxFiles: boolean
+  maxFiles: number | undefined
   acceptValue: string | undefined
   fileInputRef: RefObject<HTMLInputElement>
   handleFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
@@ -26,6 +27,7 @@ interface ActionBarProps {
 export const ActionBar = ({
   onUploadFiles,
   isAtMaxFiles,
+  maxFiles,
   acceptValue,
   fileInputRef,
   handleFileSelect,
@@ -61,7 +63,10 @@ export const ActionBar = ({
             <input
               ref={fileInputRef}
               type="file"
-              multiple
+              // Native picker only honors a binary "single vs multiple"
+              // selection — no per-N cap. We still validate the count in JS.
+              multiple={maxFiles !== 1}
+              disabled={isAtMaxFiles}
               accept={acceptValue}
               className="hidden"
               onChange={handleFileSelect}

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, motion } from "motion/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
+import { F0AvatarAlert } from "@/components/avatars/F0AvatarAlert"
 import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
@@ -97,10 +98,12 @@ export const ChatTextarea = ({
     onUploadFiles,
     acceptValue,
     isAtMaxFiles,
+    maxFiles,
     processFiles,
     handleFileSelect,
     handleRemoveFile,
     clearFiles,
+    transientError,
   } = useFileAttachments(fileAttachments)
 
   const mentions = useMentions({
@@ -355,6 +358,38 @@ export const ChatTextarea = ({
                 />
               )}
 
+              <AnimatePresence initial={false}>
+                {transientError && (
+                  <motion.div
+                    key="transient-error"
+                    role="alert"
+                    aria-live="polite"
+                    className="p-1"
+                    initial={{ opacity: 0, y: -4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -4 }}
+                    transition={{
+                      duration: shouldReduceMotion ? 0 : 0.2,
+                      ease: "easeOut",
+                    }}
+                  >
+                    <div
+                      className={cn(
+                        "flex w-full flex-row items-center gap-2 rounded-md p-2 pr-3",
+                        "bg-f1-background-critical text-f1-foreground"
+                      )}
+                    >
+                      <div className="h-6 w-6 flex-shrink-0">
+                        <F0AvatarAlert type="critical" size="sm" />
+                      </div>
+                      <p className="font-medium text-f1-foreground-critical">
+                        {transientError}
+                      </p>
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
               <AttachedFilesList
                 attachedFiles={attachedFiles}
                 isUploading={isUploading}
@@ -384,6 +419,7 @@ export const ChatTextarea = ({
               <ActionBar
                 onUploadFiles={onUploadFiles}
                 isAtMaxFiles={isAtMaxFiles}
+                maxFiles={maxFiles}
                 acceptValue={acceptValue}
                 fileInputRef={fileInputRef}
                 handleFileSelect={handleFileSelect}

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/useFileAttachments.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/useFileAttachments.test.tsx
@@ -1,0 +1,122 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { I18nProvider } from "@/lib/providers/i18n"
+import { defaultTranslations } from "@/lib/providers/i18n/i18n-provider-defaults"
+
+import { type AiChatFileAttachmentConfig } from "../../../../types"
+import { useFileAttachments } from "../useFileAttachments"
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <I18nProvider translations={defaultTranslations}>{children}</I18nProvider>
+)
+
+const makeFiles = (count: number) =>
+  Array.from(
+    { length: count },
+    (_, i) => new File(["x"], `file-${i}.txt`, { type: "text/plain" })
+  )
+
+const makeUploaded = (files: File[]) =>
+  files.map((f) => ({
+    id: f.name,
+    url: `https://example.com/${f.name}`,
+    filename: f.name,
+    mimetype: f.type,
+  }))
+
+describe("useFileAttachments maxFiles", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does not cap uploads when maxFiles is omitted", async () => {
+    const onUploadFiles = vi.fn(async (files: File[]) => makeUploaded(files))
+    const config: AiChatFileAttachmentConfig = { onUploadFiles }
+
+    const { result } = renderHook(() => useFileAttachments(config), {
+      wrapper,
+    })
+
+    await act(async () => {
+      await result.current.processFiles(makeFiles(15))
+    })
+
+    expect(result.current.attachedFiles).toHaveLength(15)
+    expect(onUploadFiles).toHaveBeenCalledTimes(1)
+    expect(result.current.transientError).toBeNull()
+    expect(result.current.isAtMaxFiles).toBe(false)
+  })
+
+  it("rejects the whole batch and surfaces a transient error when the explicit cap is exceeded", async () => {
+    const onUploadFiles = vi.fn(async (files: File[]) => makeUploaded(files))
+    const config: AiChatFileAttachmentConfig = { onUploadFiles, maxFiles: 10 }
+
+    const { result } = renderHook(() => useFileAttachments(config), {
+      wrapper,
+    })
+
+    await act(async () => {
+      await result.current.processFiles(makeFiles(15))
+    })
+
+    expect(result.current.attachedFiles).toHaveLength(0)
+    expect(onUploadFiles).not.toHaveBeenCalled()
+    expect(result.current.transientError).toBe(
+      "You can attach up to 10 files at once"
+    )
+
+    // Banner clears itself after the timeout window.
+    await act(async () => {
+      vi.advanceTimersByTime(4000)
+    })
+    expect(result.current.transientError).toBeNull()
+  })
+
+  it("accepts the batch when the total stays at or below the explicit cap", async () => {
+    const onUploadFiles = vi.fn(async (files: File[]) => makeUploaded(files))
+    const config: AiChatFileAttachmentConfig = { onUploadFiles, maxFiles: 10 }
+
+    const { result } = renderHook(() => useFileAttachments(config), {
+      wrapper,
+    })
+
+    await act(async () => {
+      await result.current.processFiles(makeFiles(10))
+    })
+
+    expect(result.current.attachedFiles).toHaveLength(10)
+    expect(onUploadFiles).toHaveBeenCalledTimes(1)
+    expect(result.current.transientError).toBeNull()
+    expect(result.current.isAtMaxFiles).toBe(true)
+  })
+
+  it("rejects the batch when adding to existing files would exceed the cap", async () => {
+    const onUploadFiles = vi.fn(async (files: File[]) => makeUploaded(files))
+    const config: AiChatFileAttachmentConfig = { onUploadFiles, maxFiles: 5 }
+
+    const { result } = renderHook(() => useFileAttachments(config), {
+      wrapper,
+    })
+
+    // Seed with 3 files, leaving room for 2 more.
+    await act(async () => {
+      await result.current.processFiles(makeFiles(3))
+    })
+    expect(result.current.attachedFiles).toHaveLength(3)
+
+    // Adding 4 more would land at 7 — over the cap, so reject everything new.
+    await act(async () => {
+      await result.current.processFiles(makeFiles(4))
+    })
+
+    expect(result.current.attachedFiles).toHaveLength(3)
+    expect(result.current.transientError).toBe(
+      "You can attach up to 5 files at once"
+    )
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/useFileAttachments.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/useFileAttachments.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { useI18n } from "@/lib/providers/i18n"
 
@@ -6,10 +6,16 @@ import { type AiChatFileAttachmentConfig } from "../../../types"
 import { type AttachedFile } from "./types"
 import { filterByMimeType } from "./file-utils"
 
+const TRANSIENT_ERROR_MS = 4000
+
 export function useFileAttachments(
   fileAttachments: AiChatFileAttachmentConfig | undefined
 ) {
   const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([])
+  const [transientError, setTransientError] = useState<string | null>(null)
+  const transientErrorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  )
   const fileInputRef = useRef<HTMLInputElement>(null)
   const translation = useI18n()
 
@@ -26,17 +32,47 @@ export function useFileAttachments(
   const isAtMaxFiles =
     maxFiles !== undefined && attachedFiles.length >= maxFiles
 
+  const showTransientError = useCallback((message: string) => {
+    if (transientErrorTimeoutRef.current) {
+      clearTimeout(transientErrorTimeoutRef.current)
+    }
+    setTransientError(message)
+    transientErrorTimeoutRef.current = setTimeout(() => {
+      setTransientError(null)
+      transientErrorTimeoutRef.current = null
+    }, TRANSIENT_ERROR_MS)
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (transientErrorTimeoutRef.current) {
+        clearTimeout(transientErrorTimeoutRef.current)
+      }
+    },
+    []
+  )
+
   const processFiles = useCallback(
     async (rawFiles: File[]) => {
       if (rawFiles.length === 0 || !onUploadFiles) return
 
-      let files = filterByMimeType(rawFiles, allowedMimeTypes)
+      const files = filterByMimeType(rawFiles, allowedMimeTypes)
       if (files.length === 0) return
 
-      if (maxFiles !== undefined) {
-        const remaining = maxFiles - attachedFiles.length
-        if (remaining <= 0) return
-        files = files.slice(0, remaining)
+      // Reject the whole batch when it would exceed the cap — surfacing a
+      // transient banner is friendlier than silently truncating the user's
+      // selection.
+      if (
+        maxFiles !== undefined &&
+        attachedFiles.length + files.length > maxFiles
+      ) {
+        showTransientError(
+          translation.ai.tooManyFilesError.replace(
+            "{{maxFiles}}",
+            String(maxFiles)
+          )
+        )
+        return
       }
 
       const newAttached: AttachedFile[] = files.map((file) => ({
@@ -82,7 +118,15 @@ export function useFileAttachments(
         )
       }
     },
-    [onUploadFiles, maxFiles, attachedFiles.length, allowedMimeTypes]
+    [
+      onUploadFiles,
+      maxFiles,
+      attachedFiles.length,
+      allowedMimeTypes,
+      translation.ai.tooManyFilesError,
+      translation.ai.fileUploadError,
+      showTransientError,
+    ]
   )
 
   const handleFileSelect = useCallback(
@@ -107,9 +151,11 @@ export function useFileAttachments(
     onUploadFiles,
     acceptValue,
     isAtMaxFiles,
+    maxFiles,
     processFiles,
     handleFileSelect,
     handleRemoveFile,
     clearFiles,
+    transientError,
   }
 }


### PR DESCRIPTION
## Summary
- Reject the whole batch — instead of silently truncating — when `fileAttachments.maxFiles` would be exceeded, and surface an inline critical banner that auto-clears after 4s.
- The banner mimics the `F0Alert` critical look (same bg, same `F0AvatarAlert`, same typography) but renders inline so no `description` is required.
- Tighten the native `<input type="file">`: drop `multiple` when `maxFiles === 1` and disable the input when `isAtMaxFiles`.
- Set `maxFiles: 5` in the `ApplicationFrame` story so the new behaviour is visible in Storybook.
- New `tooManyFilesError` translation key with `{{maxFiles}}` interpolation.

## Test plan
- [ ] `pnpm exec vitest run src/sds/ai/F0AiChat` — 277 passing (4 new in `useFileAttachments.test.tsx` covering: no cap when omitted, batch rejected when over cap, batch accepted when at cap, batch rejected when previous + new exceed cap).
- [ ] `pnpm exec tsc --noEmit` — clean.
- [ ] Verify in Storybook (`ApplicationFrame`): attaching >5 files at once shows the red banner and no files are uploaded; banner disappears after ~4s.
- [ ] Verify single-file mode (`maxFiles: 1`): native picker no longer allows multi-selection.