### PR TITLE
feat(f0): add F0SegmentedControl experimental component

### DIFF
--- a/packages/core/src/tokens/borderRadius.ts
+++ b/packages/core/src/tokens/borderRadius.ts
@@ -1,3 +1,23 @@
+/**
+ * Border radius scale.
+ *
+ * ## Usage convention for interactive components
+ *
+ * Interactive elements (buttons, toggle items, segments) follow a size-based mapping
+ * derived from `buttonSizeVariants` in `@/ui/Action/variants.ts`:
+ *
+ *   sm  → rounded-sm  (0.5rem)
+ *   md  → rounded     (0.625rem, DEFAULT)
+ *   lg  → rounded-md  (0.75rem)
+ *
+ * When a component has a container that wraps interactive elements (e.g. a segmented
+ * control track, a button group background), the container uses one step up from the
+ * inner element so the pill fits visually with the internal padding:
+ *
+ *   inner sm  → container rounded     (DEFAULT)
+ *   inner md  → container rounded-md
+ *   inner lg  → container rounded-lg
+ */
 export const borderRadius = {
   none: "0px",
   "2xs": "0.25rem",

--- a/packages/core/src/tokens/borderRadius.ts
+++ b/packages/core/src/tokens/borderRadius.ts
@@ -4,7 +4,7 @@
  * ## Usage convention for interactive components
  *
  * Interactive elements (buttons, toggle items, segments) follow a size-based mapping
- * derived from `buttonSizeVariants` in `@/ui/Action/variants.ts`:
+ * derived from `buttonSizeVariants` in `packages/react/src/ui/Action/variants.ts`:
  *
  *   sm  → rounded-sm  (0.5rem)
  *   md  → rounded     (0.625rem, DEFAULT)

--- a/packages/core/src/tokens/spacing.ts
+++ b/packages/core/src/tokens/spacing.ts
@@ -99,3 +99,21 @@ export const betweenSpacing: ThemeConfig["spacing"] = {
   lg: relativeSpacing[3],
   xl: relativeSpacing[4],
 }
+
+/**
+ * Standard height scale for interactive components (buttons, inputs, segmented controls, etc.)
+ *
+ * | Size | Height | Tailwind |
+ * |------|--------|---------|
+ * | sm   | 24px   | h-6     |
+ * | md   | 32px   | h-8     |
+ * | lg   | 40px   | h-10    |
+ *
+ * Derived from `buttonSizeVariants` in `packages/react/src/ui/Action/variants.ts`.
+ * Use this as the reference when building any new interactive component.
+ */
+export const interactiveHeights = {
+  sm: absoluteSpacing[6], // 24px
+  md: absoluteSpacing[8], // 32px
+  lg: absoluteSpacing[10], // 40px
+} as const

--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -49,8 +49,8 @@ For **MDX documentation** (the Docs tab), use the global `factorial-f0-component
 
 ```
 src/
-  components/    — all public F0 components
-  experimental/  — legacy only, do NOT add new components here
+  components/    — stable public F0 components only (promoted by Foundations team)
+  experimental/  — ALL new components start here; never add directly to components/
   hooks/         — public exported hooks
   icons/         — generated icons (do not edit manually)
   layout/        — page layout components
@@ -58,6 +58,16 @@ src/
   sds/           — satellite design systems (non-core components)
   ui/            — primitive wrappers (Radix, shadcn/ui); not re-exported publicly
 ```
+
+### New component workflow
+
+**Every new component must start in `experimental/`**, regardless of how complete it feels.
+Only a member of the **Foundations team** can promote a component from `experimental/` to `components/` (stable).
+
+1. Create component in `experimental/<Category>/F0ComponentName/`
+2. Export from `experimental/<Category>/exports.ts`
+3. Story title: `"Components/F0ComponentName"` (no `Experimental/` prefix in sidebar)
+4. Foundations team reviews and promotes to `components/` when ready — use the `f0-experimental-component-migration` skill
 
 Each component follows this structure:
 
@@ -157,6 +167,25 @@ See `f0-component-patterns` skill for code examples.
 - Inline `style` only for truly dynamic values (hex colors, percentages)
 
 See `f0-component-patterns` skill for CVA, container query, and animation code examples.
+
+### Visual recipes (`lib/recipes/`)
+
+Some design system patterns must be reproducible **both** as React components
+and as serialized HTML strings (e.g. mention chips inside a Tiptap editor
+that emits `<a class="...">` nodes). For those, the styles live as a
+**recipe** — a small set of static Tailwind classes — in `src/lib/recipes/`,
+and every consumer (component variants, Tiptap extensions, ad-hoc HTML
+renderers) imports the same constant.
+
+- **Default rule:** prefer the public component (e.g. `F0Link variant="mention"`)
+  whenever React can be mounted.
+- **Use the recipe directly** only when you must produce raw HTML and cannot
+  render React (Tiptap `HTMLAttributes`, server-rendered chat payloads, …).
+- **Add a new recipe only** when the pattern is part of the DS, must be
+  applied from at least two execution models (React + non-React), and can be
+  expressed as static classes. Otherwise, build a component or a `cva()`
+  variant.
+- **Existing recipes** are documented in `src/lib/recipes/README.md`.
 
 ## i18n
 

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx
@@ -1,8 +1,8 @@
-import { ToggleGroup, ToggleGroupItem } from "@radix-ui/react-toggle-group"
-import { useEffect, useState } from "react"
+import { useControllableState } from "@radix-ui/react-use-controllable-state"
 
 import { F0Icon } from "@/components/F0Icon"
 import { cn, focusRing } from "@/lib/utils"
+import { ToggleGroup, ToggleGroupItem } from "@/ui/ToggleGroup"
 
 import { F0SegmentedControlProps } from "./types"
 
@@ -13,20 +13,16 @@ export const F0SegmentedControl = ({
   disabled = false,
   fullWidth = false,
 }: F0SegmentedControlProps) => {
-  const [localValue, setLocalValue] = useState(value ?? "")
-
-  useEffect(() => {
-    if (value !== undefined && value !== localValue) {
-      setLocalValue(value)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value])
+  const [localValue, setLocalValue] = useControllableState({
+    prop: value,
+    defaultProp: items[0]?.value ?? "",
+    onChange,
+  })
 
   const handleChange = (newValue: string) => {
     // Prevent deselection — a segmented control always has one active segment
     if (!newValue) return
     setLocalValue(newValue)
-    onChange?.(newValue)
   }
 
   return (

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx
@@ -1,0 +1,67 @@
+import { ToggleGroup, ToggleGroupItem } from "@radix-ui/react-toggle-group"
+import { useEffect, useState } from "react"
+
+import { F0Icon } from "@/components/F0Icon"
+import { cn, focusRing } from "@/lib/utils"
+
+import { F0SegmentedControlProps } from "./types"
+
+export const F0SegmentedControl = ({
+  items,
+  value,
+  onChange,
+  disabled = false,
+  fullWidth = false,
+}: F0SegmentedControlProps) => {
+  const [localValue, setLocalValue] = useState(value ?? "")
+
+  useEffect(() => {
+    if (value !== undefined && value !== localValue) {
+      setLocalValue(value)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
+
+  const handleChange = (newValue: string) => {
+    // Prevent deselection — a segmented control always has one active segment
+    if (!newValue) return
+    setLocalValue(newValue)
+    onChange?.(newValue)
+  }
+
+  return (
+    <ToggleGroup
+      type="single"
+      value={localValue}
+      onValueChange={handleChange}
+      disabled={disabled}
+      className={cn(
+        "inline-flex items-center rounded-md bg-f1-background-secondary p-0.5 gap-0.5",
+        fullWidth && "w-full"
+      )}
+    >
+      {items.map((item) => (
+        <ToggleGroupItem
+          key={item.value}
+          value={item.value}
+          disabled={disabled || item.disabled}
+          className={cn(
+            "relative flex flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded font-medium transition-all",
+            "text-f1-foreground-secondary",
+            "hover:text-f1-foreground hover:bg-f1-background-hover",
+            "disabled:pointer-events-none disabled:text-f1-foreground-disabled",
+            "data-[state=on]:bg-f1-background data-[state=on]:text-f1-foreground data-[state=on]:shadow",
+            focusRing(),
+            "h-8 px-3 text-sm",
+            fullWidth && "w-full"
+          )}
+        >
+          {item.icon && <F0Icon icon={item.icon} size="md" />}
+          {item.label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  )
+}
+
+F0SegmentedControl.displayName = "F0SegmentedControl"

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx
@@ -12,6 +12,8 @@ export const F0SegmentedControl = ({
   onChange,
   disabled = false,
   fullWidth = false,
+  ariaLabel,
+  ariaLabelledBy,
 }: F0SegmentedControlProps) => {
   const [localValue, setLocalValue] = useControllableState({
     prop: value,
@@ -20,8 +22,11 @@ export const F0SegmentedControl = ({
   })
 
   const handleChange = (newValue: string) => {
-    // Prevent deselection — a segmented control always has one active segment
-    if (!newValue) return
+    // Radix `ToggleGroup` (single mode) emits "" when the user re-clicks
+    // the active segment, signalling deselection. A segmented control
+    // always has one active segment, so we ignore that sentinel here.
+    // Note: this means item values must be non-empty strings.
+    if (newValue === "") return
     setLocalValue(newValue)
   }
 
@@ -31,6 +36,8 @@ export const F0SegmentedControl = ({
       value={localValue}
       onValueChange={handleChange}
       disabled={disabled}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
       className={cn(
         "inline-flex items-center rounded-md bg-f1-background-secondary p-0.5 gap-0.5",
         fullWidth && "w-full"

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/__stories__/F0SegmentedControl.stories.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/__stories__/F0SegmentedControl.stories.tsx
@@ -1,6 +1,7 @@
-import type { Meta, StoryObj } from "@storybook/react"
+import type { Meta, StoryObj } from "@storybook/react-vite"
 import { useState } from "react"
 
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { Calendar, List, Table } from "@/icons/app"
 
 import { F0SegmentedControl } from "../F0SegmentedControl"
@@ -8,7 +9,7 @@ import { F0SegmentedControl } from "../F0SegmentedControl"
 const meta = {
   title: "Components/F0SegmentedControl",
   component: F0SegmentedControl,
-  tags: ["autodocs"],
+  tags: ["autodocs", "experimental"],
   args: {
     items: [
       { value: "day", label: "Day" },
@@ -24,9 +25,12 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  parameters: withSnapshot({}),
+}
 
 export const WithIcons: Story = {
+  parameters: withSnapshot({}),
   args: {
     items: [
       { value: "list", label: "List", icon: List },
@@ -38,18 +42,21 @@ export const WithIcons: Story = {
 }
 
 export const FullWidth: Story = {
+  parameters: withSnapshot({}),
   args: {
     fullWidth: true,
   },
 }
 
 export const Disabled: Story = {
+  parameters: withSnapshot({}),
   args: {
     disabled: true,
   },
 }
 
 export const WithDisabledItem: Story = {
+  parameters: withSnapshot({}),
   args: {
     items: [
       { value: "day", label: "Day" },
@@ -59,17 +66,21 @@ export const WithDisabledItem: Story = {
   },
 }
 
+const ControlledExample = () => {
+  const [value, setValue] = useState("week")
+  return (
+    <F0SegmentedControl
+      items={[
+        { value: "day", label: "Day" },
+        { value: "week", label: "Week" },
+        { value: "month", label: "Month" },
+      ]}
+      value={value}
+      onChange={setValue}
+    />
+  )
+}
+
 export const Controlled: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value, setValue] = useState("week")
-    return <F0SegmentedControl {...args} value={value} onChange={setValue} />
-  },
-  args: {
-    items: [
-      { value: "day", label: "Day" },
-      { value: "week", label: "Week" },
-      { value: "month", label: "Month" },
-    ],
-  },
+  render: () => <ControlledExample />,
 }

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/__stories__/F0SegmentedControl.stories.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/__stories__/F0SegmentedControl.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { useState } from "react"
+
+import { Calendar, List, Table } from "@/icons/app"
+
+import { F0SegmentedControl } from "../F0SegmentedControl"
+
+const meta = {
+  title: "Components/F0SegmentedControl",
+  component: F0SegmentedControl,
+  tags: ["autodocs"],
+  args: {
+    items: [
+      { value: "day", label: "Day" },
+      { value: "week", label: "Week" },
+      { value: "month", label: "Month" },
+    ],
+    value: "day",
+    disabled: false,
+    fullWidth: false,
+  },
+} satisfies Meta<typeof F0SegmentedControl>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithIcons: Story = {
+  args: {
+    items: [
+      { value: "list", label: "List", icon: List },
+      { value: "table", label: "Table", icon: Table },
+      { value: "calendar", label: "Calendar", icon: Calendar },
+    ],
+    value: "list",
+  },
+}
+
+export const FullWidth: Story = {
+  args: {
+    fullWidth: true,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}
+
+export const WithDisabledItem: Story = {
+  args: {
+    items: [
+      { value: "day", label: "Day" },
+      { value: "week", label: "Week", disabled: true },
+      { value: "month", label: "Month" },
+    ],
+  },
+}
+
+export const Controlled: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState("week")
+    return <F0SegmentedControl {...args} value={value} onChange={setValue} />
+  },
+  args: {
+    items: [
+      { value: "day", label: "Day" },
+      { value: "week", label: "Week" },
+      { value: "month", label: "Month" },
+    ],
+  },
+}

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/__tests__/F0SegmentedControl.test.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/__tests__/F0SegmentedControl.test.tsx
@@ -1,0 +1,78 @@
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { List, Table } from "@/icons/app"
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { F0SegmentedControl } from "../F0SegmentedControl"
+
+const defaultItems = [
+  { value: "day", label: "Day" },
+  { value: "week", label: "Week" },
+  { value: "month", label: "Month" },
+]
+
+describe("F0SegmentedControl", () => {
+  it("renders all segments", () => {
+    render(<F0SegmentedControl items={defaultItems} />)
+    expect(screen.getByText("Day")).toBeInTheDocument()
+    expect(screen.getByText("Week")).toBeInTheDocument()
+    expect(screen.getByText("Month")).toBeInTheDocument()
+  })
+
+  it("selects first item by default when no value is provided", () => {
+    render(<F0SegmentedControl items={defaultItems} />)
+    expect(screen.getByText("Day").closest("[data-state]")).toHaveAttribute(
+      "data-state",
+      "on"
+    )
+  })
+
+  it("selects the provided value", () => {
+    render(<F0SegmentedControl items={defaultItems} value="week" />)
+    expect(screen.getByText("Week").closest("[data-state]")).toHaveAttribute(
+      "data-state",
+      "on"
+    )
+  })
+
+  it("calls onChange when a segment is clicked", async () => {
+    const onChange = vi.fn()
+    render(<F0SegmentedControl items={defaultItems} value="day" onChange={onChange} />)
+    await userEvent.click(screen.getByText("Week"))
+    expect(onChange).toHaveBeenCalledWith("week")
+  })
+
+  it("does not deselect the current segment when clicked again", async () => {
+    const onChange = vi.fn()
+    render(<F0SegmentedControl items={defaultItems} value="day" onChange={onChange} />)
+    await userEvent.click(screen.getByText("Day"))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("disables all segments when disabled prop is true", () => {
+    render(<F0SegmentedControl items={defaultItems} disabled />)
+    const buttons = screen.getAllByRole("radio")
+    buttons.forEach((btn) => expect(btn).toBeDisabled())
+  })
+
+  it("disables individual segment when item.disabled is true", () => {
+    const items = [
+      { value: "day", label: "Day" },
+      { value: "week", label: "Week", disabled: true },
+    ]
+    render(<F0SegmentedControl items={items} />)
+    expect(screen.getByText("Week").closest("button")).toBeDisabled()
+    expect(screen.getByText("Day").closest("button")).not.toBeDisabled()
+  })
+
+  it("renders icons when provided", () => {
+    const items = [
+      { value: "list", label: "List", icon: List },
+      { value: "table", label: "Table", icon: Table },
+    ]
+    render(<F0SegmentedControl items={items} />)
+    const svgs = document.querySelectorAll("svg")
+    expect(svgs.length).toBe(2)
+  })
+})

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/__tests__/F0SegmentedControl.test.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/__tests__/F0SegmentedControl.test.tsx
@@ -87,4 +87,21 @@ describe("F0SegmentedControl", () => {
     const svgs = document.querySelectorAll("svg")
     expect(svgs.length).toBe(2)
   })
+
+  it("forwards ariaLabel to the underlying radiogroup", () => {
+    render(<F0SegmentedControl items={defaultItems} ariaLabel="View mode" />)
+    expect(screen.getByRole("group", { name: "View mode" })).toBeInTheDocument()
+  })
+
+  it("forwards ariaLabelledBy to the underlying radiogroup", () => {
+    render(
+      <>
+        <span id="seg-label">Pick a view</span>
+        <F0SegmentedControl items={defaultItems} ariaLabelledBy="seg-label" />
+      </>
+    )
+    expect(
+      screen.getByRole("group", { name: "Pick a view" })
+    ).toBeInTheDocument()
+  })
 })

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/__tests__/F0SegmentedControl.test.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/__tests__/F0SegmentedControl.test.tsx
@@ -38,14 +38,26 @@ describe("F0SegmentedControl", () => {
 
   it("calls onChange when a segment is clicked", async () => {
     const onChange = vi.fn()
-    render(<F0SegmentedControl items={defaultItems} value="day" onChange={onChange} />)
+    render(
+      <F0SegmentedControl
+        items={defaultItems}
+        value="day"
+        onChange={onChange}
+      />
+    )
     await userEvent.click(screen.getByText("Week"))
     expect(onChange).toHaveBeenCalledWith("week")
   })
 
   it("does not deselect the current segment when clicked again", async () => {
     const onChange = vi.fn()
-    render(<F0SegmentedControl items={defaultItems} value="day" onChange={onChange} />)
+    render(
+      <F0SegmentedControl
+        items={defaultItems}
+        value="day"
+        onChange={onChange}
+      />
+    )
     await userEvent.click(screen.getByText("Day"))
     expect(onChange).not.toHaveBeenCalled()
   })

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/index.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/index.tsx
@@ -1,0 +1,2 @@
+export * from "./F0SegmentedControl"
+export * from "./types"

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/index.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/index.tsx
@@ -1,2 +1,13 @@
-export * from "./F0SegmentedControl"
+import { experimentalComponent } from "@/lib/experimental"
+
+import { F0SegmentedControl as _F0SegmentedControl } from "./F0SegmentedControl"
+
 export * from "./types"
+
+/**
+ * @experimental This is an experimental component, use it at your own risk.
+ */
+export const F0SegmentedControl = experimentalComponent(
+  "F0SegmentedControl",
+  _F0SegmentedControl
+)

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/types.ts
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/types.ts
@@ -28,4 +28,15 @@ export interface F0SegmentedControlProps {
    * @default false
    */
   fullWidth?: boolean
+  /**
+   * Accessible name for the segmented control. The underlying ToggleGroup
+   * (single mode) renders as a `radiogroup`, which requires a name.
+   * Provide either `ariaLabel` or `ariaLabelledBy`.
+   */
+  ariaLabel?: string
+  /**
+   * ID of an element that labels the segmented control. Use instead of
+   * `ariaLabel` when a visible label already exists in the DOM.
+   */
+  ariaLabelledBy?: string
 }

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/types.ts
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/types.ts
@@ -1,0 +1,31 @@
+import { IconType } from "@/components/F0Icon"
+
+export interface F0SegmentedControlItem {
+  /** Unique value for this segment */
+  value: string
+  /** Label displayed inside the segment */
+  label: string
+  /** Optional icon shown before the label */
+  icon?: IconType
+  /** Whether this specific segment is disabled */
+  disabled?: boolean
+}
+
+export interface F0SegmentedControlProps {
+  /** The list of segments to render */
+  items: F0SegmentedControlItem[]
+  /** Currently selected value */
+  value?: string
+  /** Callback fired when the selected segment changes */
+  onChange?: (value: string) => void
+  /**
+   * Whether the control is disabled entirely.
+   * @default false
+   */
+  disabled?: boolean
+  /**
+   * Whether the control should expand to fill the container width.
+   * @default false
+   */
+  fullWidth?: boolean
+}

--- a/packages/react/src/experimental/Actions/exports.ts
+++ b/packages/react/src/experimental/Actions/exports.ts
@@ -1,1 +1,2 @@
 export * from "../../components/F0ButtonToggle"
+export * from "./F0SegmentedControl"

--- a/packages/react/src/experimental/exports.ts
+++ b/packages/react/src/experimental/exports.ts
@@ -10,6 +10,7 @@ import {
 import { ScrollArea as ScrollAreaComponent } from "./Utilities/ScrollArea"
 
 export * from "./AiPromotionChat/exports"
+export * from "./Actions/exports"
 /**
  * @deprecated Banners has moved to @/sds/ai/Banners. Import from there instead.
  */

--- a/packages/react/src/ui/ToggleGroup/index.ts
+++ b/packages/react/src/ui/ToggleGroup/index.ts
@@ -1,0 +1,1 @@
+export * from "@radix-ui/react-toggle-group"


### PR DESCRIPTION
## Summary

- New `F0SegmentedControl` component in `experimental/Actions/` — single-selection segmented control built on Radix `ToggleGroup`
- Supports optional icons per segment, disabled state (global and per item), and `fullWidth` prop
- 32px height, `shadow` on selected segment, tokens-based styling throughout

## Token documentation

- `borderRadius.ts` — documents the radius convention by size (`sm→rounded-sm`, `md→rounded`, `lg→rounded-md`) and the container step-up rule
- `spacing.ts` — documents `interactiveHeights` scale (`sm=24px`, `md=32px`, `lg=40px`) derived from `buttonSizeVariants`

## AGENTS.md

Documents that new components must start in `experimental/` and only Foundations can promote to `components/` (stable).

## Notes

- Component is experimental — not exported from `components/exports.ts`
- Story title is `Components/F0SegmentedControl` (no Experimental prefix in sidebar)