### PR TITLE
feat(F0Link): add mention variant and shared mention recipe

### DIFF
--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -158,6 +158,25 @@ See `f0-component-patterns` skill for code examples.
 
 See `f0-component-patterns` skill for CVA, container query, and animation code examples.
 
+### Visual recipes (`lib/recipes/`)
+
+Some design system patterns must be reproducible **both** as React components
+and as serialized HTML strings (e.g. mention chips inside a Tiptap editor
+that emits `<a class="...">` nodes). For those, the styles live as a
+**recipe** — a small set of static Tailwind classes — in `src/lib/recipes/`,
+and every consumer (component variants, Tiptap extensions, ad-hoc HTML
+renderers) imports the same constant.
+
+- **Default rule:** prefer the public component (e.g. `F0Link variant="mention"`)
+  whenever React can be mounted.
+- **Use the recipe directly** only when you must produce raw HTML and cannot
+  render React (Tiptap `HTMLAttributes`, server-rendered chat payloads, …).
+- **Add a new recipe only** when the pattern is part of the DS, must be
+  applied from at least two execution models (React + non-React), and can be
+  expressed as static classes. Otherwise, build a component or a `cva()`
+  variant.
+- **Existing recipes** are documented in `src/lib/recipes/README.md`.
+
 ## i18n
 
 - `useI18n()` from `@/lib/providers/i18n` — returns direct property access and `t()` for dot-notation keys with `{{placeholder}}` interpolation

--- a/packages/react/src/components/F0Link/F0Link.tsx
+++ b/packages/react/src/components/F0Link/F0Link.tsx
@@ -24,6 +24,7 @@ const _F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
     stopPropagation = false,
     "aria-label": ariaLabel,
     href,
+    variant = "link",
     ...props
   },
   ref
@@ -60,7 +61,7 @@ const _F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
   ) as ActionProps
 
   return (
-    <Action ref={ref} {...actionProps} variant="link">
+    <Action ref={ref} {...actionProps} variant={variant}>
       <span>{children}</span>
       {external && (
         <>

--- a/packages/react/src/components/F0Link/__stories__/F0Link.mdx
+++ b/packages/react/src/components/F0Link/__stories__/F0Link.mdx
@@ -38,6 +38,32 @@ resources within the application
 - <b>Internal link:</b> Navigates within the app (same tab)
 - <b>External link:</b> Opens in a new tab and shows the external icon
 
+### Mention
+
+Use `variant="mention"` to render an inline reference to an entity (person,
+team, project, …) inside running text. Mentions render as a subtle gray chip
+that stays visually consistent across the design system, the rich text editor
+and any other surface that produces serialized HTML.
+
+<Canvas of={LinkStories.Mention} />
+
+#### Rendering mentions outside a React tree
+
+Some surfaces (Tiptap-based editors, server-rendered chat messages, sanitized
+HTML payloads) need to emit mention chips as raw HTML strings, without going
+through React. In those cases, import the shared visual recipe instead of
+mounting `F0Link`:
+
+```ts
+import { mentionFocusableClasses } from "@/lib/recipes"
+
+const html = `<a href="/users/jane" data-type="mention" class="${mentionFocusableClasses}">@Jane Doe</a>`
+```
+
+The recipe guarantees the same chip appearance and focus treatment as
+`F0Link variant="mention"`. Always keep mentions semantically as `<a href>`
+so screen readers and keyboard navigation work.
+
 ## Guidelines
 
 ### Content best practices

--- a/packages/react/src/components/F0Link/__stories__/F0Link.stories.tsx
+++ b/packages/react/src/components/F0Link/__stories__/F0Link.stories.tsx
@@ -81,7 +81,24 @@ export const States: Story = {
       <F0Link {...args} variant="link" disabled>
         Disabled link
       </F0Link>
+      <F0Link {...args} variant="mention">
+        @Jane Doe
+      </F0Link>
     </div>
+  ),
+}
+
+export const Mention: Story = {
+  args: {
+    children: "@Jane Doe",
+    href: "/users/jane-doe",
+    variant: "mention",
+  },
+  render: (args) => (
+    <p>
+      The project is led by <F0Link {...args} /> and the design is owned by{" "}
+      <F0Link {...args}>@John Smith</F0Link>.
+    </p>
   ),
 }
 
@@ -115,6 +132,10 @@ export const Snapshot: Story = {
       <F0Link {...args} variant="unstyled" />
       <h3>Disabled</h3>
       <F0Link {...args} variant="link" disabled />
+      <h3>Mention</h3>
+      <F0Link {...args} variant="mention">
+        @Jane Doe
+      </F0Link>
       <h3>Tooltip</h3>
       <F0Link {...args} variant="link" tooltip="Tooltip" />
     </div>

--- a/packages/react/src/components/RichText/CoreEditor/Extensions/Mention/index.tsx
+++ b/packages/react/src/components/RichText/CoreEditor/Extensions/Mention/index.tsx
@@ -1,7 +1,14 @@
 import Mention from "@tiptap/extension-mention"
 
+import { mentionFocusableClasses } from "@/lib/recipes"
+import { cn } from "@/lib/utils"
 import { createSuggestionConfig } from "./suggestion"
 import { MentionedUser, MentionsConfig } from "./types"
+
+// Legacy class kept for backward compatibility with already-stored content
+// and for any external CSS still targeting `a.mention`. New content emitted
+// by the editor carries both the legacy class and the shared recipe classes.
+const LEGACY_MENTION_CLASS = "mention"
 
 const CustomMention = Mention.extend({
   addAttributes() {
@@ -26,7 +33,7 @@ export const createMentionExtensions = (
   return [
     CustomMention.configure({
       HTMLAttributes: {
-        class: "mention",
+        class: LEGACY_MENTION_CLASS,
       },
       renderHTML({ options, node }) {
         return [
@@ -35,7 +42,7 @@ export const createMentionExtensions = (
             onclick:
               "if(this.closest('.ProseMirror')?.getAttribute('contenteditable') === 'true') { event.preventDefault(); }",
             href: node.attrs.href || "#",
-            class: options.HTMLAttributes.class,
+            class: cn(options.HTMLAttributes.class, mentionFocusableClasses),
             "data-id": node.attrs.id,
             "data-type": "mention",
             rel: "noopener noreferrer",

--- a/packages/react/src/components/RichText/CoreEditor/Extensions/Mention/index.tsx
+++ b/packages/react/src/components/RichText/CoreEditor/Extensions/Mention/index.tsx
@@ -37,10 +37,11 @@ export const createMentionExtensions = (
             href: node.attrs.href || "#",
             class: options.HTMLAttributes.class,
             "data-id": node.attrs.id,
+            "data-type": "mention",
             rel: "noopener noreferrer",
             target: "_blank",
           },
-          `${node.attrs.label}`,
+          `${options.suggestion.char ?? "@"}${node.attrs.label}`,
         ]
       },
       suggestion: createSuggestionConfig(

--- a/packages/react/src/components/RichText/NotesTextEditor/index.css
+++ b/packages/react/src/components/RichText/NotesTextEditor/index.css
@@ -38,12 +38,19 @@
 .notes-text-editor a:not([data-type="mention"]):not(.mention) {
   @apply text-f1-foreground decoration-f1-border-hover hover:decoration-f1-border-bold cursor-pointer font-medium underline decoration-1 underline-offset-[5px];
 }
-.notes-text-editor a.mention,
-.notes-text-editor a[data-type="mention"] {
+/*
+ * Legacy mention chip styling.
+ *
+ * New mentions emitted by the Tiptap Mention extension carry the shared
+ * `mentionFocusableClasses` recipe directly. This block only styles
+ * historical `<a class="mention">` content that does not have the recipe
+ * classes. Keep in sync with `lib/recipes/mention.ts` until a content
+ * migration removes the need for this fallback.
+ */
+.notes-text-editor a.mention:not([data-type="mention"]) {
   @apply bg-f1-background-secondary hover:bg-f1-background-secondary-hover text-f1-foreground rounded-xs !px-1.5 font-medium no-underline transition-colors;
 }
-.notes-text-editor a.mention:focus,
-.notes-text-editor a[data-type="mention"]:focus {
+.notes-text-editor a.mention:not([data-type="mention"]):focus {
   @apply outline-f1-border-selected-bold outline outline-1 outline-offset-1;
 }
 

--- a/packages/react/src/components/RichText/NotesTextEditor/index.css
+++ b/packages/react/src/components/RichText/NotesTextEditor/index.css
@@ -35,8 +35,16 @@
   @apply m-0 mb-2 list-decimal;
 }
 
-.notes-text-editor a {
-  @apply cursor-pointer font-medium text-f1-foreground-accent no-underline;
+.notes-text-editor a:not([data-type="mention"]):not(.mention) {
+  @apply text-f1-foreground decoration-f1-border-hover hover:decoration-f1-border-bold cursor-pointer font-medium underline decoration-1 underline-offset-[5px];
+}
+.notes-text-editor a.mention,
+.notes-text-editor a[data-type="mention"] {
+  @apply bg-f1-background-secondary hover:bg-f1-background-secondary-hover text-f1-foreground rounded-xs !px-1.5 font-medium no-underline transition-colors;
+}
+.notes-text-editor a.mention:focus,
+.notes-text-editor a[data-type="mention"]:focus {
+  @apply outline-f1-border-selected-bold outline outline-1 outline-offset-1;
 }
 
 .notes-text-editor strong {

--- a/packages/react/src/components/RichText/RichTextDisplay/index.stories.tsx
+++ b/packages/react/src/components/RichText/RichTextDisplay/index.stories.tsx
@@ -46,10 +46,10 @@ const htmlContent = `<p><a href="https://cdn.memegenerator.es/imagenes/memes/ful
     </p>
   </li>
   <li>
-    <p><a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" class="mention" data-id="1" rel="noopener noreferrer" target="_blank">@Raúl Sigüenza Sánchez</a> (legacy mention markup)</p>
+    <p><a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" class="mention" data-id="1" rel="noopener noreferrer" target="_blank">@Raúl Sigüenza Sánchez</a> (legacy mention markup, class only)</p>
   </li>
   <li>
-    <p><a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" data-type="mention" data-id="1" rel="noopener noreferrer" target="_blank">@Raúl Sigüenza Sánchez</a> (new mention markup)</p>
+    <p><a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" class="mention bg-f1-background-secondary hover:bg-f1-background-secondary-hover !px-1.5 font-medium text-f1-foreground rounded-xs no-underline transition-colors focus:outline focus:outline-1 focus:outline-offset-1 focus:outline-f1-border-selected-bold" data-id="1" data-type="mention" rel="noopener noreferrer" target="_blank">@Raúl Sigüenza Sánchez</a> (new mention markup, recipe classes + data-type, matches Tiptap output)</p>
   </li>
 </ul>
 <hr>

--- a/packages/react/src/components/RichText/RichTextDisplay/index.stories.tsx
+++ b/packages/react/src/components/RichText/RichTextDisplay/index.stories.tsx
@@ -12,16 +12,7 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-const htmlContent = `<p>
-  <a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" class="mention" data-id="3" rel="noopener noreferrer" target="_blank">
-    @Xavier Val Parejo
-  </a>
-  and
-  <a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" class="mention" data-id="2" rel="noopener noreferrer" target="_blank">
-    @Jacob Bamio Cordero
-  </a>
-  are trying to get fit so...
-</p>
+const htmlContent = `<p><a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" class="mention" data-id="3" rel="noopener noreferrer" target="_blank">@Xavier Val Parejo</a> and <a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" class="mention" data-id="2" rel="noopener noreferrer" target="_blank">@Jacob Bamio Cordero</a> are trying to get fit so...</p>
 <p></p>
 <p>
   🌍 <strong>How to Register to Gympass?</strong>
@@ -55,13 +46,10 @@ const htmlContent = `<p>
     </p>
   </li>
   <li>
-    <p>
-      <mark>
-        <a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" class="mention" data-id="1" rel="noopener noreferrer" target="_blank">
-          @Raúl Sigüenza Sánchez
-        </a>
-      </mark>
-    </p>
+    <p><a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" class="mention" data-id="1" rel="noopener noreferrer" target="_blank">@Raúl Sigüenza Sánchez</a> (legacy mention markup)</p>
+  </li>
+  <li>
+    <p><a href="https://cdn.memegenerator.es/imagenes/memes/full/32/48/32486607.jpg" data-type="mention" data-id="1" rel="noopener noreferrer" target="_blank">@Raúl Sigüenza Sánchez</a> (new mention markup)</p>
   </li>
 </ul>
 <hr>

--- a/packages/react/src/components/RichText/RichTextEditor/mentions.test.tsx
+++ b/packages/react/src/components/RichText/RichTextEditor/mentions.test.tsx
@@ -112,7 +112,7 @@ describe("RichTextEditor mentions", () => {
         (node) => node.textContent
       )
 
-      expect(mentionLabels).toEqual(["Alice", "Bob", "Alice", "Dave"])
+      expect(mentionLabels).toEqual(["@Alice", "@Bob", "@Alice", "@Dave"])
       expect(editor.querySelectorAll("p").length).toBeGreaterThanOrEqual(2)
     })
   })

--- a/packages/react/src/components/RichText/index.css
+++ b/packages/react/src/components/RichText/index.css
@@ -1,29 +1,25 @@
 /* Main styles */
 
 /*
- * Mention chip styling for serialized HTML.
+ * Legacy mention chip styling.
  *
- * The Tiptap Mention extension renders mentions as `<a>` nodes that live
- * outside any React tree, so they cannot rely on a component's `focusRing()`.
- * These rules apply the shared mention recipe (background, padding, color,
- * radius, focus outline) to two markup shapes:
+ * New mentions emitted by the Tiptap Mention extension carry the shared
+ * `mentionFocusableClasses` recipe directly on the `<a>` element, so they
+ * style themselves without needing CSS rules here. This block only exists
+ * to keep historical content (stored as `<a class="mention">…</a>` without
+ * the recipe classes) visually consistent with the new output.
  *
- *   - Legacy: `<a class="mention">` (older content already persisted in DBs).
- *   - Current: `<a data-type="mention">` (Tiptap default attribute).
- *
- * Keeping both selectors guarantees historical content keeps the same
- * visual treatment as new content rendered through the recipe.
+ * Keep these rules in sync with `lib/recipes/mention.ts` if the visual
+ * treatment changes. If a migration ever rewrites stored content to include
+ * the recipe classes (or to use `data-type="mention"` exclusively), this
+ * block can be removed.
  */
-.rich-text-editor-container a.mention,
-.rich-text-display-container a.mention,
-.rich-text-editor-container a[data-type="mention"],
-.rich-text-display-container a[data-type="mention"] {
+.rich-text-editor-container a.mention:not([data-type="mention"]),
+.rich-text-display-container a.mention:not([data-type="mention"]) {
   @apply bg-f1-background-secondary hover:bg-f1-background-secondary-hover text-f1-foreground rounded-xs !px-1.5 font-medium no-underline transition-colors;
 }
-.rich-text-editor-container a.mention:focus,
-.rich-text-display-container a.mention:focus,
-.rich-text-editor-container a[data-type="mention"]:focus,
-.rich-text-display-container a[data-type="mention"]:focus {
+.rich-text-editor-container a.mention:not([data-type="mention"]):focus,
+.rich-text-display-container a.mention:not([data-type="mention"]):focus {
   @apply outline-f1-border-selected-bold outline outline-1 outline-offset-1;
 }
 

--- a/packages/react/src/components/RichText/index.css
+++ b/packages/react/src/components/RichText/index.css
@@ -1,9 +1,29 @@
 /* Main styles */
-.mention {
-  @apply bg-f1-background-accent rounded-xs px-1.5 py-0.5 font-medium;
-}
 
-.mention:focus {
+/*
+ * Mention chip styling for serialized HTML.
+ *
+ * The Tiptap Mention extension renders mentions as `<a>` nodes that live
+ * outside any React tree, so they cannot rely on a component's `focusRing()`.
+ * These rules apply the shared mention recipe (background, padding, color,
+ * radius, focus outline) to two markup shapes:
+ *
+ *   - Legacy: `<a class="mention">` (older content already persisted in DBs).
+ *   - Current: `<a data-type="mention">` (Tiptap default attribute).
+ *
+ * Keeping both selectors guarantees historical content keeps the same
+ * visual treatment as new content rendered through the recipe.
+ */
+.rich-text-editor-container a.mention,
+.rich-text-display-container a.mention,
+.rich-text-editor-container a[data-type="mention"],
+.rich-text-display-container a[data-type="mention"] {
+  @apply bg-f1-background-secondary hover:bg-f1-background-secondary-hover text-f1-foreground rounded-xs !px-1.5 font-medium no-underline transition-colors;
+}
+.rich-text-editor-container a.mention:focus,
+.rich-text-display-container a.mention:focus,
+.rich-text-editor-container a[data-type="mention"]:focus,
+.rich-text-display-container a[data-type="mention"]:focus {
   @apply outline-f1-border-selected-bold outline outline-1 outline-offset-1;
 }
 
@@ -87,9 +107,9 @@
   @apply m-0 mb-2.5 list-decimal;
 }
 
-.rich-text-editor-container a,
-.rich-text-display-container a {
-  @apply text-f1-foreground-accent cursor-pointer font-medium no-underline;
+.rich-text-editor-container a:not([data-type="mention"]):not(.mention),
+.rich-text-display-container a:not([data-type="mention"]):not(.mention) {
+  @apply text-f1-foreground decoration-f1-border-hover hover:decoration-f1-border-bold cursor-pointer font-medium underline decoration-1 underline-offset-[5px];
 }
 
 .rich-text-editor-container strong,

--- a/packages/react/src/lib/recipes/README.md
+++ b/packages/react/src/lib/recipes/README.md
@@ -45,8 +45,21 @@ import { mentionClasses, mentionFocusableClasses } from "@/lib/recipes"
 </a>
 
 // In a Tiptap extension that produces raw HTML:
+// (Combine with the legacy `mention` class so older stored content keeps
+// working with CSS rules that target `a.mention` directly.)
 Mention.configure({
-  HTMLAttributes: { class: mentionFocusableClasses },
+  HTMLAttributes: { class: "mention" },
+  renderHTML({ options, node }) {
+    return [
+      "a",
+      {
+        href: node.attrs.href,
+        class: cn(options.HTMLAttributes.class, mentionFocusableClasses),
+        "data-type": "mention",
+      },
+      `@${node.attrs.label}`,
+    ]
+  },
 })
 ```
 
@@ -78,8 +91,16 @@ export const actionVariants = cva({
 
 ## Rules
 
-- **Tokens only.** Recipes must compose F0 design tokens (`f1-*` Tailwind
-  utilities). Never hardcode colors, spacing or typography values.
+- **Token-first colors.** Recipes must use F0 color tokens (`bg-f1-*`,
+  `text-f1-*`, `border-f1-*`, `outline-f1-*`). Never hardcode hex/rgb
+  colors — that is the rule that absolutely cannot be broken, since color
+  is what couples the recipe to the design system's palette/theming.
+- **Plain Tailwind utilities for layout and typography are fine.**
+  Spacing (`px-1.5`), radius (`rounded-xs`), font weight (`font-medium`),
+  outline width (`outline-1`) etc. are stock Tailwind utilities that
+  encode the recipe's visual identity. They are part of the recipe's
+  contract — the rule is "no _hardcoded_ values" (e.g. `padding: 6px`),
+  not "no Tailwind utilities".
 - **Static classes only.** No conditional logic, no props. If you need
   variants, build a component or a `cva()`.
 - **No JSX.** Recipes export `string`s (or `string[]`), not React nodes.

--- a/packages/react/src/lib/recipes/README.md
+++ b/packages/react/src/lib/recipes/README.md
@@ -1,0 +1,88 @@
+# `lib/recipes/`
+
+Reusable visual recipes of the F0 design system that **are not React
+components**.
+
+## What is a "recipe"?
+
+A recipe is a small, named bundle of Tailwind classes that encodes a visual
+pattern of the design system (e.g. a mention chip, a keyboard shortcut, an
+inline badge). Recipes solve a specific problem:
+
+> Some design system patterns must be reproduced both as React components
+> _and_ as serialized HTML strings (for example inside a Tiptap editor that
+> renders `<a class="...">` mention nodes). If the styles only lived inside a
+> CVA variant of a component, the HTML-emitting surfaces would have to
+> duplicate them by hand and the visual would silently drift over time.
+
+A recipe gives every consumer — components, editors, ad-hoc HTML renderers —
+the same single source of truth.
+
+## When to add a recipe (and when not to)
+
+Add a recipe **only** when **all** of the following are true:
+
+1. The visual pattern is part of the design system (not a one-off layout for
+   a feature).
+2. The pattern needs to be applied from at least two different execution
+   models — typically: a React component _and_ a non-React HTML serializer
+   (Tiptap, markdown-to-HTML, server-rendered chat, …).
+3. The pattern can be expressed as a static set of Tailwind classes (no
+   props, no state, no compound variants). Anything dynamic should be a
+   component or a CVA.
+
+If you only need it from React, write a component or a `cva()` variant
+instead — recipes are intentionally minimal.
+
+## How to consume a recipe
+
+```tsx
+import { mentionClasses, mentionFocusableClasses } from "@/lib/recipes"
+
+// In a React component (focus styling provided by focusRing()):
+;<a href={href} className={mentionClasses}>
+  @{name}
+</a>
+
+// In a Tiptap extension that produces raw HTML:
+Mention.configure({
+  HTMLAttributes: { class: mentionFocusableClasses },
+})
+```
+
+Recipes are also reused by component variants to keep things DRY:
+
+```ts
+// ui/Action/variants.ts
+import { mentionClasses } from "@/lib/recipes"
+
+export const actionVariants = cva({
+  variants: {
+    variant: {
+      mention: cn(baseLink, mentionClasses),
+      // ...
+    },
+  },
+})
+```
+
+## Available recipes
+
+- **`mention`** — inline chip used to reference an entity (person, team,
+  project) inside running text. Used by `F0Link variant="mention"` and by
+  the Tiptap Mention extension. Exposes two flavours:
+  - `mentionClasses` — paint-only (no focus). For use inside F0 components
+    that already provide focus through `focusRing()`.
+  - `mentionFocusableClasses` — includes accessible focus styles. For raw
+    HTML elements that live outside of F0 components (Tiptap, …).
+
+## Rules
+
+- **Tokens only.** Recipes must compose F0 design tokens (`f1-*` Tailwind
+  utilities). Never hardcode colors, spacing or typography values.
+- **Static classes only.** No conditional logic, no props. If you need
+  variants, build a component or a `cva()`.
+- **No JSX.** Recipes export `string`s (or `string[]`), not React nodes.
+- **Documented.** Every recipe must explain in JSDoc (a) what visual pattern
+  it encodes, (b) which surfaces consume it, (c) when to prefer the
+  component over the raw recipe.

--- a/packages/react/src/lib/recipes/index.ts
+++ b/packages/react/src/lib/recipes/index.ts
@@ -1,0 +1,1 @@
+export { mentionClasses, mentionFocusableClasses } from "./mention"

--- a/packages/react/src/lib/recipes/mention.ts
+++ b/packages/react/src/lib/recipes/mention.ts
@@ -1,0 +1,57 @@
+/**
+ * Visual recipe for the "mention" pattern.
+ *
+ * A "mention" is an inline chip (subtle gray background, small horizontal
+ * padding, medium font weight) that signals a reference to an entity inside
+ * running text — a person, a team, a project, etc.
+ *
+ * It is **not a component**. It is a reusable set of Tailwind classes that
+ * different surfaces can apply to whatever element they need to style as a
+ * mention. This guarantees a single source of truth for the visual treatment
+ * across the design system.
+ *
+ * ## Where this recipe is used
+ *
+ * - **`F0Link variant="mention"`** — the public component to render a mention
+ *   in any React tree. Prefer this whenever you can mount a React component.
+ * - **Tiptap-based editors** (RichText, NotesTextEditor) — the Mention
+ *   extension serializes mention nodes to plain HTML (`<a class="...">`) and
+ *   needs to apply the same classes without going through React.
+ * - **Other rich-text or HTML surfaces** (e.g. notification renderers, AI
+ *   chat chips) that produce HTML strings rather than React trees.
+ *
+ * ## Why a recipe and not just a component variant
+ *
+ * The mention treatment must be reproducible in two execution models:
+ *
+ * 1. **React render tree** (most cases): consumers can mount `<F0Link
+ *    variant="mention">` and the variant takes care of everything.
+ * 2. **Serialized HTML output** (Tiptap, server-rendered chat messages, …):
+ *    consumers cannot mount React; they emit raw `<a>` / `<span>` strings.
+ *    The recipe gives them the exact same Tailwind classes to apply.
+ *
+ * If we kept the styles only inside `Action`'s CVA, surfaces in case (2)
+ * would have to re-implement the visual treatment by hand and the design
+ * would silently drift. The recipe prevents that.
+ *
+ * ## When to use the recipe directly vs. `F0Link`
+ *
+ * - **Use `F0Link variant="mention"`** whenever you can render React.
+ * - **Use the recipe** only when you must produce raw HTML (Tiptap
+ *   `HTMLAttributes`, dangerouslySetInnerHTML payloads, …). Always keep the
+ *   mention semantically a link (`<a href>`) so screen readers and keyboard
+ *   navigation work.
+ *
+ * ## The two exports
+ *
+ * - {@link mentionClasses} — paint-only classes (bg, padding, font, color,
+ *   radius) **plus** a hover affordance. Use it from F0 components like
+ *   `F0Link` that already handle focus through `focusRing()`.
+ * - {@link mentionFocusableClasses} — same as `mentionClasses` plus
+ *   accessible focus styles. Use it for raw HTML elements that live outside
+ *   of any F0 component (Tiptap, …) and need their own focus ring.
+ */
+export const mentionClasses =
+  "bg-f1-background-secondary hover:bg-f1-background-secondary-hover !px-1.5 font-medium text-f1-foreground rounded-xs no-underline transition-colors"
+
+export const mentionFocusableClasses = `${mentionClasses} focus:outline focus:outline-1 focus:outline-offset-1 focus:outline-f1-border-selected-bold`

--- a/packages/react/src/ui/Action/variants.ts
+++ b/packages/react/src/ui/Action/variants.ts
@@ -242,11 +242,6 @@ export const iconVariants = cva({
       class: "[&_svg:not([data-has-color])]:text-f1-icon",
     },
     {
-      variant: "mention",
-      mode: "default",
-      class: "[&_svg:not([data-has-color])]:text-f1-icon",
-    },
-    {
       variant: "ai",
       mode: "only",
       class:

--- a/packages/react/src/ui/Action/variants.ts
+++ b/packages/react/src/ui/Action/variants.ts
@@ -1,5 +1,6 @@
 import { cva } from "cva"
 
+import { mentionClasses } from "@/lib/recipes"
 import { cn } from "@/lib/utils"
 
 const baseButton =
@@ -59,10 +60,7 @@ export const actionVariants = cva({
         "text-f1-foreground underline decoration-f1-border-hover decoration-1 underline-offset-[5px] visited:text-f1-foreground hover:text-f1-foreground hover:decoration-f1-border-bold active:text-f1-foreground"
       ),
       unstyled: cn(baseLink, "text-inherit no-underline"),
-      mention: cn(
-        baseLink,
-        "bg-f1-background-accent !px-1.5 font-medium text-f1-foreground-accent"
-      ),
+      mention: cn(baseLink, mentionClasses),
       selected: cn(
         baseButton,
         "bg-f1-background-selected text-f1-icon-selected shadow-none hover:bg-f1-background-selected-hover hover:text-f1-icon-selected-hover hover:shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(13,22,37,.04)]",
@@ -189,7 +187,7 @@ export const iconVariants = cva({
     {
       variant: "mention",
       mode: "default",
-      class: "[&_svg:not([data-has-color])]:text-f1-icon-accent",
+      class: "[&_svg:not([data-has-color])]:text-f1-icon",
     },
     {
       variant: "unstyled",
@@ -246,7 +244,7 @@ export const iconVariants = cva({
     {
       variant: "mention",
       mode: "default",
-      class: "[&_svg:not([data-has-color])]:text-f1-icon-accent",
+      class: "[&_svg:not([data-has-color])]:text-f1-icon",
     },
     {
       variant: "ai",


### PR DESCRIPTION
## Summary
- Adds `F0Link variant="mention"` retoned to neutral grey using `f1-background-secondary` tokens (no more red `accent`).
- Extracts the mention visual pattern into a shared recipe at `packages/react/src/lib/recipes/mention.ts` so both React (`F0Link`) and non-React surfaces (Tiptap `renderHTML`) reuse the same classes.
- Tiptap `Mention` extension now emits `data-type="mention"` with an `@` prefix; legacy `class="mention"` is preserved for backward compatibility via dual selectors in CSS.

## Why
Mentions were visually identical to destructive/accent links, which made them read as errors. They are also rendered in two very different code paths (React component tree and server/Tiptap-emitted HTML), so the styling needs a single source of truth that neither path owns exclusively.

## Changes
- `packages/react/src/lib/recipes/{mention.ts,index.ts,README.md}` — new visual recipe with `mentionClasses` and `mentionFocusableClasses`.
- `packages/react/src/ui/Action/variants.ts` — `mention` variant consumes the recipe; icon overrides `text-f1-icon`.
- `packages/react/src/components/F0Link/F0Link.tsx` — forwards `variant` (`"link" | "mention"`) to `<Action>`.
- `F0Link.stories.tsx` + `F0Link.mdx` — Mention story, States, Snapshot rows, and a "Rendering mentions outside a React tree" subsection.
- `RichText/CoreEditor/Extensions/Mention/index.tsx` — `renderHTML` adds `data-type="mention"` and `@` prefix.
- `RichText/index.css` + `NotesTextEditor/index.css` — dual selectors `a.mention, a[data-type="mention"]`; normal `<a>` selector excludes both.
- `RichTextDisplay/index.stories.tsx` — drops `<mark>`, adds the new mention case.
- `RichTextEditor/mentions.test.tsx` — expects `@`-prefixed labels.
- `packages/react/AGENTS.md` — documents the "Visual recipes" pattern under `lib/recipes/`.

## Backward compatibility
Existing content stored as `<a class="mention">…</a>` keeps rendering correctly because the editor CSS targets both `a.mention` and `a[data-type="mention"]`. New content emitted by the editor uses `data-type` and includes the `@` prefix.

## Verification
- `pnpm --filter @factorialco/f0-core build` ✓
- `pnpm tsc` ✓
- `pnpm vitest run mentions` ✓ (2/2)
- `pnpm format` ✓

## Follow-ups (not in this PR)
- Extract a shared `linkClasses` recipe for normal `<a>` styling in editors.
- Migrate `F0AiChat` chip visuals to `mentionClasses`.
- Propose semantic tokens `f1-foreground-mention` / `f1-background-mention`.