### PR TITLE
fix(disabled): make Switch and Dropdown disabled state behave correctly inside the monolith

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Switch/__tests__/Switch.test.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Switch/__tests__/Switch.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { Switch } from "../index"
+
+describe("Switch (experimental)", () => {
+  it("renders a switch role and is enabled by default", () => {
+    render(<Switch title="Notifications" />)
+    const sw = screen.getByRole("switch")
+    expect(sw).toBeEnabled()
+    expect(sw.className).not.toMatch(/!cursor-not-allowed/)
+    expect(sw.className).not.toMatch(/opacity-50/)
+  })
+
+  it("applies !cursor-not-allowed and opacity-50 when disabled", () => {
+    // The `!` important variant is required to defend against consumer CSS
+    // resets (e.g. ress.css `[disabled]{cursor:default}`) that otherwise win
+    // due to identical specificity.
+    render(<Switch title="Notifications" disabled />)
+    const sw = screen.getByRole("switch")
+    expect(sw).toBeDisabled()
+    expect(sw.className).toMatch(/!cursor-not-allowed/)
+    expect(sw.className).toMatch(/opacity-50/)
+  })
+
+  it("propagates disabled cursor styles to the label", () => {
+    render(<Switch title="Notifications" disabled />)
+    const label = screen.getByText("Notifications")
+    expect(label.className).toMatch(/!cursor-not-allowed/)
+    expect(label.className).toMatch(/opacity-50/)
+  })
+})

--- a/packages/react/src/experimental/Navigation/Dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/__tests__/Dropdown.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { Add, Pencil } from "@/icons/app"
+import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
+
+import { Dropdown } from "../index"
+
+const items = [
+  { label: "Create", onClick: vi.fn(), icon: Add },
+  { label: "Edit", onClick: vi.fn(), icon: Pencil },
+]
+
+describe("Dropdown (experimental) — disabled", () => {
+  it("renders the default trigger as a disabled button", () => {
+    render(<Dropdown items={items} disabled />)
+    const trigger = screen.getByRole("button")
+    expect(trigger).toBeDisabled()
+  })
+
+  it("does not open on click when disabled (default trigger)", async () => {
+    render(<Dropdown items={items} disabled />)
+    const trigger = screen.getByRole("button")
+    await userEvent.click(trigger)
+    expect(screen.queryByText("Create")).not.toBeInTheDocument()
+  })
+
+  it("does not open on keyboard activation when disabled", async () => {
+    render(<Dropdown items={items} disabled />)
+    const trigger = screen.getByRole("button")
+    trigger.focus()
+    await userEvent.keyboard("{Enter}")
+    await userEvent.keyboard(" ")
+    await userEvent.keyboard("{ArrowDown}")
+    expect(screen.queryByText("Create")).not.toBeInTheDocument()
+  })
+
+  it("forwards disabled and aria-disabled to a custom React element trigger", () => {
+    render(
+      <Dropdown items={items} disabled>
+        <button aria-label="Open menu">Custom</button>
+      </Dropdown>
+    )
+    const trigger = screen.getByRole("button", { name: "Open menu" })
+    expect(trigger).toBeDisabled()
+    expect(trigger).toHaveAttribute("aria-disabled", "true")
+  })
+
+  it("does not open on click when custom trigger is disabled", async () => {
+    render(
+      <Dropdown items={items} disabled>
+        <button aria-label="Open menu">Custom</button>
+      </Dropdown>
+    )
+    const trigger = screen.getByRole("button", { name: "Open menu" })
+    await userEvent.click(trigger)
+    expect(screen.queryByText("Create")).not.toBeInTheDocument()
+  })
+
+  it("respects consumer-supplied disabled value when rendering a custom trigger", () => {
+    render(
+      <Dropdown items={items} disabled>
+        <button aria-label="Open menu" disabled={false}>
+          Custom
+        </button>
+      </Dropdown>
+    )
+    const trigger = screen.getByRole("button", { name: "Open menu" })
+    expect(trigger).not.toBeDisabled()
+  })
+
+  it("ignores controlled open=true when disabled", () => {
+    const onOpenChange = vi.fn()
+    render(<Dropdown items={items} disabled open onOpenChange={onOpenChange} />)
+    expect(screen.queryByText("Create")).not.toBeInTheDocument()
+  })
+
+  it("calls onOpenChange(false) when disabled flips to true while controlled open=true", () => {
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <Dropdown items={items} open onOpenChange={onOpenChange} />
+    )
+    expect(screen.getByText("Create")).toBeInTheDocument()
+    rerender(
+      <Dropdown items={items} disabled open onOpenChange={onOpenChange} />
+    )
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("does not reopen after disable→enable cycle (uncontrolled)", async () => {
+    const { rerender } = render(<Dropdown items={items} />)
+    const trigger = screen.getByRole("button")
+    await userEvent.click(trigger)
+    expect(await screen.findByText("Create")).toBeInTheDocument()
+    rerender(<Dropdown items={items} disabled />)
+    expect(screen.queryByText("Create")).not.toBeInTheDocument()
+    rerender(<Dropdown items={items} />)
+    expect(screen.queryByText("Create")).not.toBeInTheDocument()
+  })
+})
+
+describe("Dropdown (experimental) — enabled regression", () => {
+  it("opens on click when enabled (default trigger)", async () => {
+    render(<Dropdown items={items} />)
+    const trigger = screen.getByRole("button")
+    expect(trigger).not.toBeDisabled()
+    await userEvent.click(trigger)
+    expect(await screen.findByText("Create")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/experimental/Navigation/Dropdown/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/index.stories.tsx
@@ -4,22 +4,32 @@ import { expect, userEvent, within } from "storybook/test"
 
 import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
 import * as Icons from "@/icons/app"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { Dropdown, MobileDropdown as MobileDropdownComponent } from "./index"
 
-const meta: Meta<typeof Dropdown> = {
+const meta = {
   title: "Dropdown",
   component: Dropdown,
   tags: ["autodocs", "experimental"],
-}
+  argTypes: {
+    disabled: {
+      control: "boolean",
+      description:
+        "Disables the trigger and prevents the menu from opening, regardless of controlled `open` state.",
+      defaultValue: { summary: false },
+    },
+  },
+} satisfies Meta<typeof Dropdown>
 
 export default meta
 
-type Story = StoryObj<typeof Dropdown>
+type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
     label: "",
+    disabled: false,
     items: [
       {
         label: "Create",
@@ -225,6 +235,81 @@ export const WithLabels: Story = {
   },
 }
 
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    items: [
+      {
+        label: "Create",
+        onClick: () => console.log("Create clicked"),
+        icon: Icons.Add,
+      },
+      {
+        label: "Edit",
+        onClick: () => console.log("Edit clicked"),
+        icon: Icons.Pencil,
+      },
+    ],
+  },
+  parameters: {
+    a11y: {
+      skipCi: true,
+      disable: true,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.closest("body")!)
+    const trigger = page.getByRole("button")
+    await expect(trigger).toBeDisabled()
+    await userEvent.click(trigger)
+    await expect(page.queryByText("Create")).not.toBeInTheDocument()
+  },
+}
+
+export const DisabledWithCustomTrigger: Story = {
+  args: {
+    disabled: true,
+    items: [
+      {
+        label: "Upload new avatar",
+        onClick: () => console.log("Create clicked"),
+      },
+      {
+        label: "Delete current avatar",
+        onClick: () => console.log("Delete clicked"),
+        critical: true,
+      },
+    ],
+  },
+  render: (args) => (
+    <Dropdown {...args}>
+      <button aria-label="Open user menu">
+        <F0AvatarPerson
+          src="/avatars/person04.jpg"
+          firstName="Dani"
+          lastName="Moreno"
+          size="lg"
+        />
+      </button>
+    </Dropdown>
+  ),
+  parameters: {
+    a11y: {
+      config: {
+        rules: [],
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.closest("body")!)
+    const trigger = page.getByRole("button", { name: "Open user menu" })
+    await expect(trigger).toHaveAttribute("aria-disabled", "true")
+    await expect(trigger).toBeDisabled()
+    await userEvent.click(trigger)
+    await expect(page.queryByText("Upload new avatar")).not.toBeInTheDocument()
+  },
+}
+
 export const MobileDropdown: Story = {
   args: {
     items: [
@@ -280,4 +365,30 @@ export const WithDataTestId: Story = {
     const canvas = within(canvasElement)
     await expect(canvas.getByTestId("dropdown-test-id")).toBeInTheDocument()
   },
+}
+
+export const Snapshot: Story = {
+  parameters: withSnapshot({}),
+  args: {
+    items: [
+      { label: "Create", icon: Icons.Add },
+      { label: "Edit", icon: Icons.Pencil },
+    ],
+  },
+  render: (args) => (
+    <div className="flex items-start gap-6">
+      <Dropdown {...args} />
+      <Dropdown {...args} disabled />
+      <Dropdown {...args} disabled>
+        <button aria-label="Open user menu">
+          <F0AvatarPerson
+            src="/avatars/person04.jpg"
+            firstName="Dani"
+            lastName="Moreno"
+            size="lg"
+          />
+        </button>
+      </Dropdown>
+    </div>
+  ),
 }

--- a/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 
 import { AvatarVariant } from "@/components/avatars/F0Avatar"
 import { F0ButtonProps } from "@/components/F0Button"
@@ -46,6 +46,15 @@ export type DropdownInternalProps = {
   open?: boolean
   onOpenChange?: (open: boolean) => void
   label?: string
+  /**
+   * Whether the dropdown trigger is disabled. When true, the menu cannot be
+   * opened via click, keyboard, or focus and the trigger receives
+   * `aria-disabled="true"`. When a custom trigger is provided via `children`,
+   * `disabled` is forwarded to it via `cloneElement` if it is a single React
+   * element; consumer-supplied `disabled` / `aria-disabled` always win.
+   * @default false
+   */
+  disabled?: boolean
 } & DataAttributes
 
 const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
@@ -130,6 +139,7 @@ export function DropdownInternal({
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
   label,
+  disabled,
   ...rest
 }: DropdownInternalProps) {
   const i18n = useI18n()
@@ -137,26 +147,64 @@ export function DropdownInternal({
 
   const isControlled =
     controlledOpen !== undefined && controlledOnOpenChange !== undefined
-  const open = isControlled ? controlledOpen : internalOpen
-  const onOpenChange = isControlled ? controlledOnOpenChange : setInternalOpen
+  const rawOpen = isControlled ? controlledOpen : internalOpen
+  const setOpen = isControlled ? controlledOnOpenChange : setInternalOpen
+  // When `disabled` flips to true while the menu is open, reset both
+  // controlled and uncontrolled state so the menu cannot reappear when
+  // `disabled` flips back to false. In controlled mode this fires the
+  // consumer's `onOpenChange(false)` — a disabled menu must never stay open.
+  useEffect(() => {
+    if (disabled && rawOpen) setOpen(false)
+  }, [disabled, rawOpen, setOpen])
+  // Mask the value passed to Radix during render so a disabled menu cannot
+  // flash open before the effect above commits the state reset.
+  const open = disabled ? false : rawOpen
+  const onOpenChange = (next: boolean) => {
+    setOpen(next)
+  }
+
+  const trigger = children ? (
+    React.isValidElement(children) ? (
+      React.cloneElement(
+        children as React.ReactElement<{
+          disabled?: boolean
+          "aria-disabled"?: boolean | "true" | "false"
+        }>,
+        {
+          // Consumer-supplied values always win.
+          disabled:
+            (children.props as { disabled?: boolean }).disabled ?? disabled,
+          "aria-disabled":
+            (
+              children.props as {
+                "aria-disabled"?: boolean | "true" | "false"
+              }
+            )["aria-disabled"] ?? (disabled ? true : undefined),
+        }
+      )
+    ) : (
+      children
+    )
+  ) : (
+    <ButtonInternal
+      {...rest}
+      hideLabel={!label}
+      icon={icon}
+      size={size}
+      label={label ?? i18n.actions.toggleDropdownMenu}
+      variant="outline"
+      pressed={open}
+      compact={!label}
+      noAutoTooltip
+      noTitle
+      disabled={disabled}
+    />
+  )
 
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
-      <DropdownMenuTrigger asChild>
-        {children || (
-          <ButtonInternal
-            {...rest}
-            hideLabel={!label}
-            icon={icon}
-            size={size}
-            label={label ?? i18n.actions.toggleDropdownMenu}
-            variant="outline"
-            pressed={open}
-            compact={!label}
-            noAutoTooltip
-            noTitle
-          />
-        )}
+      <DropdownMenuTrigger asChild disabled={disabled}>
+        {trigger}
       </DropdownMenuTrigger>
       <DropdownMenuContent align={align}>
         {items.map((item, index) => renderDropdownItem(item, index))}

--- a/packages/react/src/ui/switch.tsx
+++ b/packages/react/src/ui/switch.tsx
@@ -26,7 +26,11 @@ const Switch = React.forwardRef<
         aria-label={props.title ?? "Switch"}
         className={cn(
           "relative h-5 w-[1.875rem] rounded-full bg-f1-border hover:bg-f1-border-hover data-[state=checked]:bg-f1-background-selected-bold",
-          disabled && "cursor-not-allowed opacity-50",
+          // `!cursor-not-allowed` defends against consumer CSS resets (e.g. ress.css)
+          // that target `[disabled]` / `[aria-disabled='true']` with the same
+          // specificity as `.cursor-not-allowed` and would otherwise win when
+          // loaded after F0 styles.
+          disabled && "!cursor-not-allowed opacity-50",
           focusRing(),
           className
         )}
@@ -43,7 +47,8 @@ const Switch = React.forwardRef<
           htmlFor={switchId}
           className={cn(
             "flex items-center justify-center pl-2.5 text-current",
-            disabled && "cursor-not-allowed opacity-50 hover:cursor-not-allowed"
+            disabled &&
+              "!cursor-not-allowed opacity-50 hover:!cursor-not-allowed"
           )}
         >
           {props.title}


### PR DESCRIPTION
## Summary

- Switch in disabled state now forces `cursor: not-allowed` so the affordance survives consumer global resets.
- Dropdown gains a typed `disabled` prop that wires `disabled` and `aria-disabled` through default and custom triggers, force-closes the menu when disabled, and ignores `onOpenChange` while disabled.
- New unit tests for both components and `Disabled` + `DisabledWithCustomTrigger` stories with play tests.

Related Jira: [FCT-53736](https://factorialmakers.atlassian.net/browse/FCT-53736)

## Problem

Consumers using F0 inside the monolith reported two issues:

1. A disabled Switch still showed the regular cursor instead of `not-allowed`.
2. There was no declarative way to disable a Dropdown trigger.

## Root cause

The monolith loads `ress.css` after F0 styles, with global rules:

```css
[disabled]            { cursor: default }
[aria-disabled='true']{ cursor: default }
```

These rules have the same specificity (0,1,0) as Tailwind's `.cursor-not-allowed`, so the later rule wins and overrides the F0 disabled cursor. The collision is only visible inside consumers that ship a global reset alongside F0; it cannot be reproduced in Storybook in isolation.

## Changes

### Switch (`packages/react/src/ui/switch.tsx`)
- Adds `!cursor-not-allowed` on the Radix root and the surrounding `<label>` so the disabled cursor wins over any global `[disabled]` / `[aria-disabled]` reset. Includes an explanatory comment.

### Dropdown (`packages/react/src/experimental/Navigation/Dropdown/internal.tsx`)
- New `disabled?: boolean` prop, JSDocumented.
- Default `ButtonInternal` trigger receives `disabled` natively.
- Custom triggers receive `disabled` and `aria-disabled` via `React.cloneElement` (only when the child is a valid element). Consumer-supplied values always take precedence.
- Force-closes the menu when disabled, even if `open` is controlled.
- Early-returns from `onOpenChange` when transitioning to `open` while disabled.
- Forwarded to Radix `DropdownMenuTrigger`.

### Stories (`packages/react/src/experimental/Navigation/Dropdown/index.stories.tsx`)
- `argTypes.disabled` added to the meta with default `false`.
- New `Disabled` and `DisabledWithCustomTrigger` stories with play tests.

### Tests
- `packages/react/src/experimental/Forms/Fields/Switch/__tests__/Switch.test.tsx` (3 tests): disabled `className` includes `!cursor-not-allowed` and `opacity-50` on root and label; enabled does not.
- `packages/react/src/experimental/Navigation/Dropdown/__tests__/Dropdown.test.tsx` (8 tests): default trigger disabled, click + keyboard (Enter/Space/ArrowDown) do not open, custom React element trigger receives `disabled` + `aria-disabled`, consumer `disabled={false}` wins, controlled `open=true` ignored while disabled, enabled regression opens on click.

### Demo (factorial-monolith)

https://github.com/user-attachments/assets/c2c36c9f-5d00-46d8-8555-d93178be9d9c


## Quality gate

- `pnpm run tsc`: clean
- `pnpm run lint`: 0 warnings / 0 errors
- `pnpm run test` (vitest): 11 / 11 new tests passing
- CI test-storybook flow run locally against built static: 310 suites / 1672 tests passing in ~141s
- Manually validated inside the monolith via `pnpm pack` + local install on `~/code/factorial/frontend`

## Migration

- Switch change is a CSS-only fix, no API change.
- Dropdown `disabled` is purely additive/optional, no breaking change. Consumers that want disabled behavior can opt in by passing `disabled={true}`.


[FCT-53736]: https://factorialmakers.atlassian.net/browse/FCT-53736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ