### PR TITLE
feat: support justified absences in hour distribution

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.477.0",
+  "version": "1.477.1-justified-absence.0",
   "private": false,
   "files": [
     "assets",

--- a/packages/react/src/f0.ts
+++ b/packages/react/src/f0.ts
@@ -10,3 +10,7 @@ export type {
   WithDataTestIdPropsOf,
   WithDataTestIdReturnType,
 } from "./lib/data-testid"
+export type {
+  HourDistributionCellValue,
+  HourDistributionDataPoint,
+} from "./ui/value-display/types/hourDistribution"

--- a/packages/react/src/ui/value-display/types/barSeries/barSeries.test.tsx
+++ b/packages/react/src/ui/value-display/types/barSeries/barSeries.test.tsx
@@ -96,4 +96,50 @@ describe("BarSeriesCell", () => {
     const bar = container.querySelector('[aria-label="Label: x – 10 units"]')
     expect(bar).toBeInTheDocument()
   })
+
+  it("renders neutral value as a separate segment without adding it to worked value", () => {
+    const args: BarSeriesCellValue = {
+      dataPoints: [
+        {
+          label: "Partial",
+          value: 240,
+          secondaryValue: 480,
+          neutralValue: 120,
+        },
+      ],
+      formatValue: (v) => `${v}m`,
+      formatTooltip: ({ formattedLabel, formattedValue, point }) =>
+        `${formattedLabel} - Worked ${formattedValue}, Neutral ${point.neutralValue}m`,
+    }
+
+    const { container } = render(BarSeriesCell(args, defaultMeta))
+
+    expect(
+      container.querySelector(
+        '[role="img"][aria-label="Partial - Worked 240m, Neutral 120m"]'
+      )
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector(".bg-f1-border-secondary")
+    ).toBeInTheDocument()
+  })
+
+  it("renders neutral full-height bars", () => {
+    const args: BarSeriesCellValue = {
+      dataPoints: [
+        {
+          label: "Full",
+          value: 0,
+          secondaryValue: 480,
+          neutralFullHeight: true,
+        },
+      ],
+    }
+
+    const { container } = render(BarSeriesCell(args, defaultMeta))
+
+    const neutralBar = container.querySelector(".bg-f1-border-secondary")
+    expect(neutralBar).toBeInTheDocument()
+    expect(neutralBar).toHaveStyle({ height: "52px" })
+  })
 })

--- a/packages/react/src/ui/value-display/types/barSeries/barSeries.tsx
+++ b/packages/react/src/ui/value-display/types/barSeries/barSeries.tsx
@@ -86,11 +86,15 @@ function BarWithTooltip({
 
   const heightValuePx =
     scaleMax > 0 ? Math.round(CHART_HEIGHT_PX * (value / scaleMax)) : 0
-  const heightNeutralPx = neutralFullHeight
+  const heightNeutralPxRaw = neutralFullHeight
     ? CHART_HEIGHT_PX
     : scaleMax > 0
       ? Math.round(CHART_HEIGHT_PX * (neutralSegmentValue / scaleMax))
       : 0
+  const heightNeutralPx = Math.min(
+    heightNeutralPxRaw,
+    CHART_HEIGHT_PX - heightValuePx
+  )
   const heightPlannedPx =
     secondaryValue != null && scaleMax > 0 && !isUnder
       ? Math.round(
@@ -246,8 +250,7 @@ export const BarSeriesCell = (
     ...dataPoints.map((p) =>
       Math.max(
         p.value + Math.max(p.neutralValue ?? 0, 0),
-        p.secondaryValue ?? 0,
-        p.neutralFullHeight ? CHART_HEIGHT_PX : 0
+        p.secondaryValue ?? 0
       )
     ),
     0

--- a/packages/react/src/ui/value-display/types/barSeries/barSeries.tsx
+++ b/packages/react/src/ui/value-display/types/barSeries/barSeries.tsx
@@ -33,12 +33,19 @@ export interface BarSeriesDataPoint {
   label: string
   value: number
   secondaryValue?: number
+  neutralValue?: number
+  neutralFullHeight?: boolean
 }
 
 export interface BarSeriesCellValue {
   dataPoints: BarSeriesDataPoint[]
   formatLabel?: (label: string) => string
   formatValue?: (value: number) => string
+  formatTooltip?: (args: {
+    point: BarSeriesDataPoint
+    formattedLabel: string
+    formattedValue: string
+  }) => string
   /** Optional max for scale; if not set, derived from data. */
   scaleMax?: number
 }
@@ -56,22 +63,34 @@ function BarWithTooltip({
   scaleMax,
   formatLabel,
   formatValue,
+  formatTooltip,
 }: {
   point: BarSeriesDataPoint
   scaleMax: number
   formatLabel: (label: string) => string
   formatValue: (value: number) => string
+  formatTooltip?: BarSeriesCellValue["formatTooltip"]
 }) {
-  const { label, value, secondaryValue } = point
+  const { label, value, secondaryValue, neutralValue, neutralFullHeight } =
+    point
   const formattedLabel = formatLabel(label)
   const valueStr = formatValue(value)
-  const tooltipLabel = `${formattedLabel} – ${valueStr}`
+  const tooltipLabel =
+    formatTooltip?.({ point, formattedLabel, formattedValue: valueStr }) ??
+    `${formattedLabel} – ${valueStr}`
 
-  const isUnder = secondaryValue != null && value < secondaryValue
+  const neutralSegmentValue = Math.max(neutralValue ?? 0, 0)
+  const coveredValue = value + neutralSegmentValue
+  const isUnder = secondaryValue != null && coveredValue < secondaryValue
   const isOver = secondaryValue != null && value > secondaryValue
 
   const heightValuePx =
     scaleMax > 0 ? Math.round(CHART_HEIGHT_PX * (value / scaleMax)) : 0
+  const heightNeutralPx = neutralFullHeight
+    ? CHART_HEIGHT_PX
+    : scaleMax > 0
+      ? Math.round(CHART_HEIGHT_PX * (neutralSegmentValue / scaleMax))
+      : 0
   const heightPlannedPx =
     secondaryValue != null && scaleMax > 0 && !isUnder
       ? Math.round(
@@ -82,7 +101,7 @@ function BarWithTooltip({
     ? Math.round(CHART_HEIGHT_PX * ((value - (secondaryValue ?? 0)) / scaleMax))
     : 0
 
-  const isEmpty = value === 0
+  const isEmpty = value === 0 && heightNeutralPx === 0
 
   return (
     <TooltipProvider delayDuration={100} disableHoverableContent>
@@ -111,15 +130,38 @@ function BarWithTooltip({
                   minHeight: EMPTY_BAR_BORDER_HEIGHT_PX,
                 }}
               />
-            ) : isUnder ? (
+            ) : neutralFullHeight ? (
               <div
+                className="rounded-sm bg-f1-border-secondary"
                 style={{
                   width: BAR_WIDTH_PX,
-                  height: heightValuePx,
-                  backgroundColor: getColor(COLOR_UNDER),
-                  borderRadius: 2,
+                  height: CHART_HEIGHT_PX,
+                  minHeight: CHART_HEIGHT_PX,
                 }}
               />
+            ) : isUnder ? (
+              <>
+                {heightValuePx > 0 && (
+                  <div
+                    style={{
+                      width: BAR_WIDTH_PX,
+                      height: heightValuePx,
+                      backgroundColor: getColor(COLOR_UNDER),
+                      borderRadius: heightNeutralPx > 0 ? "2px 2px 0 0" : 2,
+                    }}
+                  />
+                )}
+                {heightNeutralPx > 0 && (
+                  <div
+                    className="bg-f1-border-secondary"
+                    style={{
+                      width: BAR_WIDTH_PX,
+                      height: heightNeutralPx,
+                      borderRadius: heightValuePx > 0 ? "0 0 2px 2px" : 2,
+                    }}
+                  />
+                )}
+              </>
             ) : isOver && heightOvertimePx > 0 ? (
               <>
                 <div
@@ -140,14 +182,28 @@ function BarWithTooltip({
                 />
               </>
             ) : (
-              <div
-                style={{
-                  width: BAR_WIDTH_PX,
-                  height: heightValuePx,
-                  backgroundColor: getColor(COLOR_PLANNED, LIGHTER_OPACITY),
-                  borderRadius: 2,
-                }}
-              />
+              <>
+                {heightValuePx > 0 && (
+                  <div
+                    style={{
+                      width: BAR_WIDTH_PX,
+                      height: heightValuePx,
+                      backgroundColor: getColor(COLOR_PLANNED, LIGHTER_OPACITY),
+                      borderRadius: heightNeutralPx > 0 ? "2px 2px 0 0" : 2,
+                    }}
+                  />
+                )}
+                {heightNeutralPx > 0 && (
+                  <div
+                    className="bg-f1-border-secondary"
+                    style={{
+                      width: BAR_WIDTH_PX,
+                      height: heightNeutralPx,
+                      borderRadius: heightValuePx > 0 ? "0 0 2px 2px" : 2,
+                    }}
+                  />
+                )}
+              </>
             )}
           </div>
         </TooltipTrigger>
@@ -187,7 +243,13 @@ export const BarSeriesCell = (
   const formatValue = args.formatValue ?? defaultFormatValue
 
   const maxFromData = Math.max(
-    ...dataPoints.map((p) => Math.max(p.value, p.secondaryValue ?? 0)),
+    ...dataPoints.map((p) =>
+      Math.max(
+        p.value + Math.max(p.neutralValue ?? 0, 0),
+        p.secondaryValue ?? 0,
+        p.neutralFullHeight ? CHART_HEIGHT_PX : 0
+      )
+    ),
     0
   )
   const scaleMax = args.scaleMax ?? Math.max(maxFromData, 1)
@@ -214,6 +276,7 @@ export const BarSeriesCell = (
             scaleMax={scaleMax}
             formatLabel={formatLabel}
             formatValue={formatValue}
+            formatTooltip={args.formatTooltip}
           />
         </div>
       ))}

--- a/packages/react/src/ui/value-display/types/hourDistribution/__stories__/hourDistribution.stories.tsx
+++ b/packages/react/src/ui/value-display/types/hourDistribution/__stories__/hourDistribution.stories.tsx
@@ -90,6 +90,36 @@ export const HourDistributionWithPlanned: Story = {
   },
 }
 
+export const HourDistributionWithJustifiedAbsences: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Hour distribution",
+      render: () => ({
+        type: "hourDistribution",
+        value: {
+          dataPoints: [
+            { date: "2025-12-16", value: 480, plannedValue: 480 },
+            {
+              date: "2025-12-17",
+              value: 0,
+              plannedValue: 480,
+              justifiedAbsenceFullDay: true,
+            },
+            {
+              date: "2025-12-18",
+              value: 240,
+              plannedValue: 480,
+              justifiedAbsenceValue: 120,
+            },
+            { date: "2025-12-19", value: 0, plannedValue: 480 },
+          ],
+        },
+      }),
+    },
+  },
+}
+
 export const HourDistributionEmpty: Story = {
   args: {
     item: mockItem,

--- a/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.test.tsx
+++ b/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.test.tsx
@@ -123,4 +123,30 @@ describe("HourDistributionCell", () => {
       )
     ).toBeInTheDocument()
   })
+
+  it("uses custom labels for tooltip when provided", () => {
+    const args: HourDistributionCellValue = {
+      dataPoints: [
+        {
+          date: "2025-12-18",
+          value: 240,
+          plannedValue: 480,
+          justifiedAbsenceValue: 120,
+        },
+      ],
+      workedLabel: "Trabajado",
+      justifiedAbsenceLabel: "Ausencia justificada",
+    }
+
+    const { container } = render(HourDistributionCell(args, defaultMeta))
+
+    expect(
+      container.querySelector('[role="img"][aria-label*="Trabajado 4h"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector(
+        '[role="img"][aria-label*="Ausencia justificada 2h"]'
+      )
+    ).toBeInTheDocument()
+  })
 })

--- a/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.test.tsx
+++ b/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.test.tsx
@@ -74,4 +74,53 @@ describe("HourDistributionCell", () => {
       container.querySelector('[role="img"][aria-label*="0h"]')
     ).toBeInTheDocument()
   })
+
+  it("renders full-day justified absences through bar series", () => {
+    const args: HourDistributionCellValue = {
+      dataPoints: [
+        {
+          date: "2025-12-18",
+          value: 0,
+          plannedValue: 480,
+          justifiedAbsenceFullDay: true,
+        },
+      ],
+    }
+
+    const { container } = render(HourDistributionCell(args, defaultMeta))
+
+    expect(
+      container.querySelector('[data-cell-type="barSeries"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[role="img"][aria-label*="Justified absence"]')
+    ).toBeInTheDocument()
+  })
+
+  it("renders partial justified absences without treating the missing time as worked", () => {
+    const args: HourDistributionCellValue = {
+      dataPoints: [
+        {
+          date: "2025-12-18",
+          value: 240,
+          plannedValue: 480,
+          justifiedAbsenceValue: 120,
+        },
+      ],
+    }
+
+    const { container } = render(HourDistributionCell(args, defaultMeta))
+
+    expect(
+      container.querySelector('[data-cell-type="barSeries"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[role="img"][aria-label*="Worked 4h"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector(
+        '[role="img"][aria-label*="Justified absence 2h"]'
+      )
+    ).toBeInTheDocument()
+  })
 })

--- a/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.tsx
+++ b/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.tsx
@@ -17,6 +17,10 @@ export interface HourDistributionDataPoint {
   value: number
   /** When set, used for two-tone coloring and underworked (value < plannedValue) = orange. */
   plannedValue?: number
+  /** Justified absence minutes rendered as a neutral segment. Missing time without this remains transparent. */
+  justifiedAbsenceValue?: number
+  /** Renders a full-height neutral bar for justified non-working days without a minute baseline. */
+  justifiedAbsenceFullDay?: boolean
 }
 
 export interface HourDistributionCellValue {
@@ -54,13 +58,25 @@ function toBarSeriesDataPoint(
     ...(point.plannedValue != null
       ? { secondaryValue: point.plannedValue }
       : {}),
+    ...(point.justifiedAbsenceValue != null
+      ? { neutralValue: point.justifiedAbsenceValue }
+      : {}),
+    ...(point.justifiedAbsenceFullDay
+      ? { neutralFullHeight: point.justifiedAbsenceFullDay }
+      : {}),
   }
 }
 
 function toBarSeriesValue(args: HourDistributionCellValue): BarSeriesCellValue {
   const dataPoints = args.dataPoints.map(toBarSeriesDataPoint)
   const maxMinutes = Math.max(
-    ...args.dataPoints.map((p) => Math.max(p.value, p.plannedValue ?? 0)),
+    ...args.dataPoints.map((p) =>
+      Math.max(
+        p.value + Math.max(p.justifiedAbsenceValue ?? 0, 0),
+        p.plannedValue ?? 0,
+        p.justifiedAbsenceFullDay ? MAX_MINUTES_FOR_SCALE : 0
+      )
+    ),
     MAX_MINUTES_FOR_SCALE * 0.1
   )
   const scaleMax = Math.min(maxMinutes, MAX_MINUTES_FOR_SCALE)
@@ -68,6 +84,17 @@ function toBarSeriesValue(args: HourDistributionCellValue): BarSeriesCellValue {
     dataPoints,
     formatLabel: formatDateForTooltip,
     formatValue: formatHours,
+    formatTooltip: ({ point, formattedLabel, formattedValue }) => {
+      const parts = [`Worked ${formattedValue}`]
+
+      if (point.neutralFullHeight) {
+        parts.push("Justified absence")
+      } else if (point.neutralValue != null && point.neutralValue > 0) {
+        parts.push(`Justified absence ${formatHours(point.neutralValue)}`)
+      }
+
+      return `${formattedLabel} - ${parts.join(", ")}`
+    },
     scaleMax,
   }
 }

--- a/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.tsx
+++ b/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.tsx
@@ -25,6 +25,10 @@ export interface HourDistributionDataPoint {
 
 export interface HourDistributionCellValue {
   dataPoints: HourDistributionDataPoint[]
+  /** Label for worked time in tooltips. Defaults to "Worked". */
+  workedLabel?: string
+  /** Label for justified absence in tooltips. Defaults to "Justified absence". */
+  justifiedAbsenceLabel?: string
 }
 
 const MAX_MINUTES_FOR_SCALE = 8 * 60 // 8 hours
@@ -69,12 +73,13 @@ function toBarSeriesDataPoint(
 
 function toBarSeriesValue(args: HourDistributionCellValue): BarSeriesCellValue {
   const dataPoints = args.dataPoints.map(toBarSeriesDataPoint)
+  const workedLabel = args.workedLabel ?? "Worked"
+  const absenceLabel = args.justifiedAbsenceLabel ?? "Justified absence"
   const maxMinutes = Math.max(
     ...args.dataPoints.map((p) =>
       Math.max(
         p.value + Math.max(p.justifiedAbsenceValue ?? 0, 0),
-        p.plannedValue ?? 0,
-        p.justifiedAbsenceFullDay ? MAX_MINUTES_FOR_SCALE : 0
+        p.plannedValue ?? 0
       )
     ),
     MAX_MINUTES_FOR_SCALE * 0.1
@@ -85,12 +90,12 @@ function toBarSeriesValue(args: HourDistributionCellValue): BarSeriesCellValue {
     formatLabel: formatDateForTooltip,
     formatValue: formatHours,
     formatTooltip: ({ point, formattedLabel, formattedValue }) => {
-      const parts = [`Worked ${formattedValue}`]
+      const parts = [`${workedLabel} ${formattedValue}`]
 
       if (point.neutralFullHeight) {
-        parts.push("Justified absence")
+        parts.push(absenceLabel)
       } else if (point.neutralValue != null && point.neutralValue > 0) {
-        parts.push(`Justified absence ${formatHours(point.neutralValue)}`)
+        parts.push(`${absenceLabel} ${formatHours(point.neutralValue)}`)
       }
 
       return `${formattedLabel} - ${parts.join(", ")}`


### PR DESCRIPTION
## Summary
- Adds neutral justified-absence segments to F0 bar series/hour distribution.
- Keeps hour distribution as a thin preset over bar series with custom tooltip copy.
- Includes stories and unit coverage for full-day and partial justified absences.

## Changes
- **barSeries**: New `neutralValue` / `neutralFullHeight` fields on `BarSeriesDataPoint` for rendering grey neutral segments. Custom `formatTooltip` callback for full tooltip control.
- **hourDistribution**: Maps `justifiedAbsenceValue` / `justifiedAbsenceFullDay` into neutral bar segments. Accepts `workedLabel` / `justifiedAbsenceLabel` for i18n (English defaults as fallback).
- **Scale fix**: `neutralFullHeight` no longer pollutes the value-domain scale — renders at full chart height unconditionally.
- **Overflow clamp**: Stacked `value + neutral` segments are clamped to never exceed `CHART_HEIGHT_PX`.

## Testing
- Unit tests for neutral segments, full-height bars, and custom i18n labels.
- Storybook variant for justified absence scenarios.

Implemented-with: factorial-pr