### PR TITLE
feat(RadarChart): interactive legend with hiddenSeries support

### DIFF
--- a/packages/react/src/kits/Charts/RadarChart/index.stories.tsx
+++ b/packages/react/src/kits/Charts/RadarChart/index.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta } from "@storybook/react-vite"
+
+import { RadarChart } from "./index"
+
+const meta: Meta = {
+  title: "Charts/RadarChart",
+  component: RadarChart,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="h-80 w-full max-w-md">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+
+const skillsDataConfig = {
+  alice: { label: "Alice" },
+  bob: { label: "Bob" },
+  carol: { label: "Carol" },
+}
+
+const skillsData = [
+  { label: "Communication", values: { alice: 80, bob: 65, carol: 90 } },
+  { label: "Technical", values: { alice: 95, bob: 88, carol: 72 } },
+  { label: "Leadership", values: { alice: 70, bob: 78, carol: 85 } },
+  { label: "Creativity", values: { alice: 85, bob: 60, carol: 92 } },
+  { label: "Teamwork", values: { alice: 90, bob: 82, carol: 88 } },
+]
+
+export const Default: Meta<typeof RadarChart<typeof skillsDataConfig>> = {
+  args: {
+    dataConfig: skillsDataConfig,
+    data: skillsData,
+  },
+}
+
+export const WithInitialHiddenSeries: Meta<
+  typeof RadarChart<typeof skillsDataConfig>
+> = {
+  args: {
+    dataConfig: skillsDataConfig,
+    data: skillsData,
+    hiddenSeries: ["carol"],
+  },
+}
+
+const singleDataConfig = {
+  score: { label: "Score" },
+}
+
+export const SingleSeries: Meta<typeof RadarChart<typeof singleDataConfig>> = {
+  args: {
+    dataConfig: singleDataConfig,
+    data: [
+      { label: "Speed", values: { score: 78 } },
+      { label: "Accuracy", values: { score: 85 } },
+      { label: "Endurance", values: { score: 62 } },
+      { label: "Agility", values: { score: 90 } },
+      { label: "Strength", values: { score: 71 } },
+    ],
+  },
+}

--- a/packages/react/src/kits/Charts/RadarChart/index.stories.tsx
+++ b/packages/react/src/kits/Charts/RadarChart/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta } from "@storybook/react-vite"
 
 import { RadarChart } from "./index"
 
-const meta: Meta = {
+const meta = {
   title: "Charts/RadarChart",
   component: RadarChart,
   tags: ["autodocs"],
@@ -13,7 +13,7 @@ const meta: Meta = {
       </div>
     ),
   ],
-}
+} satisfies Meta<typeof RadarChart>
 
 export default meta
 
@@ -44,7 +44,7 @@ export const WithInitialHiddenSeries: Meta<
   args: {
     dataConfig: skillsDataConfig,
     data: skillsData,
-    hiddenSeries: ["carol"],
+    defaultHiddenSeries: ["carol"],
   },
 }
 

--- a/packages/react/src/kits/Charts/RadarChart/index.stories.tsx
+++ b/packages/react/src/kits/Charts/RadarChart/index.stories.tsx
@@ -1,21 +1,22 @@
-import type { Meta } from "@storybook/react-vite"
+import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { RadarChart } from "./index"
 
-const meta = {
+const meta: Meta = {
   title: "Charts/RadarChart",
   component: RadarChart,
-  tags: ["autodocs"],
+  tags: ["autodocs", "stable"],
   decorators: [
     (Story) => (
-      <div className="h-80 w-full max-w-md">
+      <div className="h-80">
         <Story />
       </div>
     ),
   ],
-} satisfies Meta<typeof RadarChart>
+}
 
 export default meta
+type Story = StoryObj<typeof meta>
 
 const skillsDataConfig = {
   alice: { label: "Alice" },
@@ -31,16 +32,14 @@ const skillsData = [
   { label: "Teamwork", values: { alice: 90, bob: 82, carol: 88 } },
 ]
 
-export const Default: Meta<typeof RadarChart<typeof skillsDataConfig>> = {
+export const Default: Story = {
   args: {
     dataConfig: skillsDataConfig,
     data: skillsData,
   },
 }
 
-export const WithInitialHiddenSeries: Meta<
-  typeof RadarChart<typeof skillsDataConfig>
-> = {
+export const WithInitialHiddenSeries: Story = {
   args: {
     dataConfig: skillsDataConfig,
     data: skillsData,
@@ -52,15 +51,17 @@ const singleDataConfig = {
   score: { label: "Score" },
 }
 
-export const SingleSeries: Meta<typeof RadarChart<typeof singleDataConfig>> = {
+const singleData = [
+  { label: "Speed", values: { score: 78 } },
+  { label: "Accuracy", values: { score: 85 } },
+  { label: "Endurance", values: { score: 62 } },
+  { label: "Agility", values: { score: 90 } },
+  { label: "Strength", values: { score: 71 } },
+]
+
+export const SingleSeries: Story = {
   args: {
     dataConfig: singleDataConfig,
-    data: [
-      { label: "Speed", values: { score: 78 } },
-      { label: "Accuracy", values: { score: 85 } },
-      { label: "Endurance", values: { score: 62 } },
-      { label: "Agility", values: { score: 90 } },
-      { label: "Strength", values: { score: 71 } },
-    ],
+    data: singleData,
   },
 }

--- a/packages/react/src/kits/Charts/RadarChart/index.tsx
+++ b/packages/react/src/kits/Charts/RadarChart/index.tsx
@@ -20,7 +20,7 @@ import { getCategoricalColor, getColor } from "../utils/colors"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { ChartConfig, ChartItem } from "../utils/types"
 
-type RadarChartProps<K extends ChartConfig> = {
+export type RadarChartProps<K extends ChartConfig> = {
   dataConfig: K
   data: ChartItem<K>[]
   scaleMin?: number
@@ -32,7 +32,7 @@ type RadarChartProps<K extends ChartConfig> = {
 type InteractiveLegendProps<K extends ChartConfig> = {
   series: { key: string; color: string; label: ReactNode }[]
   hiddenKeys: Array<keyof K>
-  onToggle: (key: string) => void
+  onToggle: (key: keyof K) => void
 }
 
 const InteractiveLegend = <K extends ChartConfig>({
@@ -92,7 +92,7 @@ const _RadarChart = <K extends ChartConfig>(
     label: config.label,
   }))
 
-  const toggleSeries = (key: string) => {
+  const toggleSeries = (key: keyof K) => {
     setHiddenKeys((prev) => {
       if (prev.includes(key)) {
         return prev.filter((hiddenKey) => hiddenKey !== key)

--- a/packages/react/src/kits/Charts/RadarChart/index.tsx
+++ b/packages/react/src/kits/Charts/RadarChart/index.tsx
@@ -1,5 +1,4 @@
-import { without } from "lodash"
-import { ComponentProps, ForwardedRef, useState } from "react"
+import { ComponentProps, ForwardedRef, ReactNode, useState } from "react"
 import {
   PolarAngleAxis,
   PolarGrid,
@@ -9,7 +8,7 @@ import {
 } from "recharts"
 
 import { DataTestIdWrapper } from "@/lib/data-testid"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 
 import {
   ChartContainer,
@@ -21,26 +20,26 @@ import { getCategoricalColor, getColor } from "../utils/colors"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { ChartConfig, ChartItem } from "../utils/types"
 
-export type RadarChartProps<K extends ChartConfig> = {
+type RadarChartProps<K extends ChartConfig> = {
   dataConfig: K
   data: ChartItem<K>[]
   scaleMin?: number
   scaleMax?: number
   aspect?: ComponentProps<typeof ChartContainer>["aspect"]
-  hiddenSeries?: Array<keyof K>
+  defaultHiddenSeries?: Array<keyof K>
 }
 
-type InteractiveLegendProps<K extends ChartConfig> = {
-  series: { key: string; color: string; label: React.ReactNode }[]
+type InteractiveLegendProps = {
+  series: { key: string; color: string; label: ReactNode }[]
   hiddenKeys: Array<keyof K>
   onToggle: (key: string) => void
 }
 
-const InteractiveLegend = <K extends ChartConfig>({
+const InteractiveLegend = ({
   series,
   hiddenKeys,
   onToggle,
-}: InteractiveLegendProps<K>) => {
+}: InteractiveLegendProps) => {
   return (
     <div className="relative flex flex-wrap items-center justify-center gap-4 text-f1-foreground-secondary">
       {series.map(({ key, color, label }) => {
@@ -49,11 +48,14 @@ const InteractiveLegend = <K extends ChartConfig>({
         return (
           <button
             key={key}
+            type="button"
             className={cn(
               "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-f1-foreground",
+              focusRing(),
               isHidden ? "opacity-40" : "opacity-100"
             )}
             aria-label={typeof label === "string" ? label : undefined}
+            aria-pressed={!isHidden}
             onClick={() => onToggle(key)}
           >
             <span
@@ -75,28 +77,30 @@ const _RadarChart = <K extends ChartConfig>(
     scaleMin,
     scaleMax,
     aspect,
-    hiddenSeries,
+    defaultHiddenSeries,
     dataTestId,
   }: RadarChartProps<K> & { dataTestId?: string },
   ref: ForwardedRef<HTMLDivElement>
 ) => {
-  const items = Object.keys(dataConfig)
   const [hiddenKeys, setHiddenKeys] = useState<Array<keyof K>>(
-    hiddenSeries ?? []
+    defaultHiddenSeries ?? []
   )
 
-  const series = items.map((key, index) => ({
-    key,
-    color: dataConfig[key].color
-      ? getColor(dataConfig[key].color)
-      : getCategoricalColor(index),
-    label: dataConfig[key].label,
+  const series = Object.entries(dataConfig).map(([key, config], index) => ({
+    key: key,
+    color: config.color ? getColor(config.color) : getCategoricalColor(index),
+    label: config.label,
   }))
 
   const toggleSeries = (key: string) => {
     setHiddenKeys((prev) => {
-      if (prev.length === series.length - 1 && !prev.includes(key)) return prev
-      if (prev.includes(key)) return without(prev, key)
+      if (prev.includes(key)) {
+        return prev.filter((hiddenKey) => hiddenKey !== key)
+      }
+
+      if (prev.length >= series.length - 1) {
+        return prev
+      }
 
       return [...prev, key]
     })
@@ -144,7 +148,7 @@ const _RadarChart = <K extends ChartConfig>(
               />
             ))}
 
-          {Object.keys(dataConfig).length > 1 && (
+          {series.length > 1 && (
             <ChartLegend
               iconType="star"
               content={

--- a/packages/react/src/kits/Charts/RadarChart/index.tsx
+++ b/packages/react/src/kits/Charts/RadarChart/index.tsx
@@ -1,4 +1,5 @@
-import { ComponentProps, ForwardedRef, ReactElement } from "react"
+import { without } from "lodash"
+import { ComponentProps, ForwardedRef, useState } from "react"
 import {
   PolarAngleAxis,
   PolarGrid,
@@ -8,11 +9,11 @@ import {
 } from "recharts"
 
 import { DataTestIdWrapper } from "@/lib/data-testid"
+import { cn } from "@/lib/utils"
 
 import {
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from "../../../ui/chart"
@@ -26,20 +27,81 @@ export type RadarChartProps<K extends ChartConfig> = {
   scaleMin?: number
   scaleMax?: number
   aspect?: ComponentProps<typeof ChartContainer>["aspect"]
+  hiddenSeries?: Array<keyof K>
 }
 
-export const _RadarChart = <K extends ChartConfig>(
+type InteractiveLegendProps<K extends ChartConfig> = {
+  series: { key: string; color: string; label: React.ReactNode }[]
+  hiddenKeys: Array<keyof K>
+  onToggle: (key: string) => void
+}
+
+const InteractiveLegend = <K extends ChartConfig>({
+  series,
+  hiddenKeys,
+  onToggle,
+}: InteractiveLegendProps<K>) => {
+  return (
+    <div className="relative flex flex-wrap items-center justify-center gap-4 text-f1-foreground-secondary">
+      {series.map(({ key, color, label }) => {
+        const isHidden = hiddenKeys.includes(key)
+
+        return (
+          <button
+            key={key}
+            className={cn(
+              "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-f1-foreground",
+              isHidden ? "opacity-40" : "opacity-100"
+            )}
+            aria-label={typeof label === "string" ? label : undefined}
+            onClick={() => onToggle(key)}
+          >
+            <span
+              className="h-2 w-2 shrink-0 rounded-full"
+              style={{ backgroundColor: color }}
+            />
+            <span className="text-f1-foreground">{label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+const _RadarChart = <K extends ChartConfig>(
   {
     data,
     dataConfig,
     scaleMin,
     scaleMax,
     aspect,
+    hiddenSeries,
     dataTestId,
   }: RadarChartProps<K> & { dataTestId?: string },
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const items = Object.keys(dataConfig)
+  const [hiddenKeys, setHiddenKeys] = useState<Array<keyof K>>(
+    hiddenSeries ?? []
+  )
+
+  const series = items.map((key, index) => ({
+    key,
+    color: dataConfig[key].color
+      ? getColor(dataConfig[key].color)
+      : getCategoricalColor(index),
+    label: dataConfig[key].label,
+  }))
+
+  const toggleSeries = (key: string) => {
+    setHiddenKeys((prev) => {
+      if (prev.length === series.length - 1 && !prev.includes(key)) return prev
+      if (prev.includes(key)) return without(prev, key)
+
+      return [...prev, key]
+    })
+  }
+
   const preparedData = data.map((item) => ({
     subject: item.label,
     ...item.values,
@@ -67,29 +129,32 @@ export const _RadarChart = <K extends ChartConfig>(
             domain={[scaleMin ?? "dataMin", scaleMax ?? "dataMax"]}
           />
 
-          {items.map((key, index) => (
-            <Radar
-              key={key}
-              dataKey={key}
-              fill={
-                dataConfig[key].color
-                  ? getColor(dataConfig[key].color)
-                  : getCategoricalColor(index)
-              }
-              stroke={
-                dataConfig[key].color
-                  ? getColor(dataConfig[key].color)
-                  : getCategoricalColor(index)
-              }
-              strokeWidth={1.5}
-              fillOpacity={0.3}
-              label={dataConfig[key].label}
-              isAnimationActive={false}
-            />
-          ))}
+          {series
+            .filter(({ key }) => !hiddenKeys.includes(key))
+            .map(({ key, color, label }) => (
+              <Radar
+                key={key}
+                dataKey={key}
+                fill={color}
+                stroke={color}
+                strokeWidth={1.5}
+                fillOpacity={0.3}
+                label={label}
+                isAnimationActive={false}
+              />
+            ))}
 
           {Object.keys(dataConfig).length > 1 && (
-            <ChartLegend iconType="star" content={<ChartLegendContent />} />
+            <ChartLegend
+              iconType="star"
+              content={
+                <InteractiveLegend
+                  series={series}
+                  hiddenKeys={hiddenKeys}
+                  onToggle={toggleSeries}
+                />
+              }
+            />
           )}
         </RadarChartPrimitive>
       </ChartContainer>
@@ -97,10 +162,4 @@ export const _RadarChart = <K extends ChartConfig>(
   )
 }
 
-export const RadarChart = fixedForwardRef(_RadarChart) as <
-  K extends ChartConfig,
->(
-  props: RadarChartProps<K> & { dataTestId?: string } & {
-    ref?: ForwardedRef<HTMLDivElement>
-  }
-) => ReactElement | null
+export const RadarChart = fixedForwardRef(_RadarChart)

--- a/packages/react/src/kits/Charts/RadarChart/index.tsx
+++ b/packages/react/src/kits/Charts/RadarChart/index.tsx
@@ -29,17 +29,17 @@ type RadarChartProps<K extends ChartConfig> = {
   defaultHiddenSeries?: Array<keyof K>
 }
 
-type InteractiveLegendProps = {
+type InteractiveLegendProps<K extends ChartConfig> = {
   series: { key: string; color: string; label: ReactNode }[]
   hiddenKeys: Array<keyof K>
   onToggle: (key: string) => void
 }
 
-const InteractiveLegend = ({
+const InteractiveLegend = <K extends ChartConfig>({
   series,
   hiddenKeys,
   onToggle,
-}: InteractiveLegendProps) => {
+}: InteractiveLegendProps<K>) => {
   return (
     <div className="relative flex flex-wrap items-center justify-center gap-4 text-f1-foreground-secondary">
       {series.map(({ key, color, label }) => {

--- a/packages/react/src/kits/Charts/exports.ts
+++ b/packages/react/src/kits/Charts/exports.ts
@@ -7,6 +7,7 @@ import { ComboChart as ComboChartComponent } from "./ComboChart"
 import { LineChart as LineChartComponent } from "./LineChart"
 import { PieChart as PieChartComponent } from "./PieChart"
 import { ProgressBar as ProgressBarComponent } from "./ProgressChart"
+import { RadarChart as RadarChartComponent } from "./RadarChart"
 import { VerticalBarChart as VerticalBarChartComponent } from "./VerticalBarChart"
 
 export const AreaChart = withDataTestId(
@@ -47,4 +48,6 @@ export const ComboChart = withDataTestId(
   Component({ name: "ComboChart", type: "info" }, ComboChartComponent)
 )
 
-export * from "./RadarChart"
+export const RadarChart = withDataTestId(
+  Component({ name: "RadarChart", type: "info" }, RadarChartComponent)
+)


### PR DESCRIPTION
## Why

Currently performance is the only domain using the `RadarChart` and it's quite limited. It's not possible to click on the legend to select/unselect a "serie", so the user can compare only some specific set of data. Also, when we have many series, the chart becomes too overwhelmed.

## What

- **Clickable legend** — clicking a legend item toggles that series' visibility; at least 1 series always remains visible
- **`defaultHiddenSeries` prop** — accepts an array of `dataConfig` keys to hide on initial render
- **`exports.ts`** — registers `RadarChart` with `Component`/`withDataTestId` (was missing)
- **Storybook stories** — new `index.stories.tsx` with `Default`, `WithInitialHiddenSeries`, and `SingleSeries` stories

https://github.com/user-attachments/assets/72f991c6-7b0f-4988-819f-500169a7655b

<img width="1240" height="620" alt="Screenshot 2026-05-11 at 18 01 16" src="https://github.com/user-attachments/assets/cdbcd9e5-f017-42b4-8e58-a2cc99842a70" />
