### PR TITLE
fix(editable-table): first column alignment

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -100,6 +100,38 @@ export const BasicEditableTable: Story = {
   },
 }
 
+export const EditableTableWithSelectableRows: Story = {
+  render: () => {
+    const mockVisualizations = getMockVisualizations({
+      table: {
+        nestedRecords: true,
+      },
+    })
+    const { dataAdapter, onCellChange } = useEditableTableData()
+    return (
+      <ExampleComponent
+        selectable={() => ""}
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              ...(
+                mockVisualizations.editableTable as Extract<
+                  typeof mockVisualizations.editableTable,
+                  { type: "editableTable" }
+                >
+              ).options,
+              onCellChange,
+            },
+          },
+        ]}
+        dataAdapter={dataAdapter}
+        id="editable-table-selectable/v1"
+      />
+    )
+  },
+}
+
 export const EditableTableWithColumnSettings: Story = {
   render: () => {
     const mockVisualizations = getMockVisualizations({

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -222,7 +222,8 @@ const RowComponentInner = <
   const cellRenderedClass = CellRenderer
     ? cn(
         "h-[48px] p-0 align-middle last:pr-0",
-        !tableWithChildren && "first:pl-0"
+        !tableWithChildren &&
+          (fromVisualization === "editableTable" ? "first:pl-3" : "first:pl-0")
       )
     : undefined
 


### PR DESCRIPTION
The first column in editable tables had misaligned text — editable body cells started at 12px (from the input's internal px-3) while the header used 24px (from the base th first:pl-6).

Adds first:pl-3 to the first editable body cell so the td padding (12px) plus the input's internal padding (12px) totals 24px, matching both the header and the bottom action row. The fix is scoped to editableTable only via the fromVisualization prop.

Added an EditableTableWithSelectableRows story to verify alignment when the checkbox column is present.

## Screenshots

before

<img width="1901" height="812" alt="column alignment before" src="https://github.com/user-attachments/assets/b493de03-f1e7-4b39-87eb-f6528df109ab" />

after

<img width="1896" height="813" alt="column alignment after" src="https://github.com/user-attachments/assets/bc9a45be-f8c0-4aa8-b391-d4ad98f69618" />

case selectable:

<img width="1896" height="810" alt="selectable case" src="https://github.com/user-attachments/assets/36f35b05-406a-41b0-8f7a-51c26379d02b" />


