### PR TITLE
feat(ResourceHeader): add secondary dropdown support

### DIFF
--- a/packages/react/src/components/RichText/NotesTextEditor/Header/index.tsx
+++ b/packages/react/src/components/RichText/NotesTextEditor/Header/index.tsx
@@ -4,7 +4,10 @@ import { F0Button } from "@/components/F0Button"
 import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
 import { F0Icon, IconType } from "@/components/F0Icon"
 import { OneEllipsis } from "@/lib/OneEllipsis"
-import { HeaderSecondaryAction } from "@/experimental/Information/Headers/BaseHeader"
+import {
+  HeaderSecondaryAction,
+  isSecondaryDropdownAction,
+} from "@/experimental/Information/Headers/BaseHeader"
 import {
   Metadata,
   MetadataItem,
@@ -95,18 +98,32 @@ const Header = ({
           {metadata && metadata.length > 0 && <Metadata items={metadata} />}
           <div className="flex flex-shrink-0 flex-row items-center gap-2">
             {hasOtherActions && <Dropdown items={visibleOtherActions} />}
-            {visibleSecondaryActions.map((action, index) => (
-              <F0Button
-                key={index}
-                onClick={action.onClick}
-                variant={action.variant || "outline"}
-                label={action.label}
-                icon={action.icon}
-                hideLabel={action.hideLabel}
-                disabled={action.disabled}
-                tooltip={action.tooltip}
-              />
-            ))}
+            {visibleSecondaryActions.map((action, index) =>
+              isSecondaryDropdownAction(action) ? (
+                <F0ButtonDropdown
+                  key={index}
+                  items={action.items}
+                  onClick={action.onClick}
+                  variant={action.variant ?? "outline"}
+                  value={action.value}
+                  size="md"
+                  disabled={action.disabled}
+                  tooltip={action.tooltip}
+                  loading={action.loading}
+                />
+              ) : (
+                <F0Button
+                  key={index}
+                  onClick={action.onClick}
+                  variant={action.variant || "outline"}
+                  label={action.label}
+                  icon={action.icon}
+                  hideLabel={action.hideLabel}
+                  disabled={action.disabled}
+                  tooltip={action.tooltip}
+                />
+              )
+            )}
             {isPrimaryActionVisible &&
               (hasSecondaryActions || hasOtherActions) && (
                 <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />

--- a/packages/react/src/components/RichText/NotesTextEditor/Header/index.tsx
+++ b/packages/react/src/components/RichText/NotesTextEditor/Header/index.tsx
@@ -121,6 +121,7 @@ const Header = ({
                   hideLabel={action.hideLabel}
                   disabled={action.disabled}
                   tooltip={action.tooltip}
+                  loading={action.loading}
                 />
               )
             )}

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -2,10 +2,7 @@ import { Fragment } from "react"
 
 import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Button } from "@/components/F0Button"
-import {
-  ButtonDropdownItem,
-  F0ButtonDropdown,
-} from "@/components/F0ButtonDropdown"
+import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
 import { StatusVariant } from "@/components/tags/F0TagStatus"
 import { Description } from "@/experimental/Information/Headers/BaseHeader/Description"
 import {
@@ -30,10 +27,7 @@ export type HeaderSecondaryButtonAction = SecondaryAction & {
   hideLabel?: boolean
 }
 
-export type HeaderSecondaryDropdownAction = PrimaryAction & {
-  items: ButtonDropdownItem<string>[]
-  value?: string
-  onClick: (value: string, item: ButtonDropdownItem<string>) => void
+export type HeaderSecondaryDropdownAction = PrimaryDropdownAction<string> & {
   variant?: "outline"
 }
 

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -105,10 +105,15 @@ export function BaseHeader({
     return !!action && "label" in action && !("items" in action)
   }
 
-  const getSecondaryActionKey = (action: HeaderSecondaryAction) => {
-    return isSecondaryDropdownAction(action)
-      ? action.items.map((item) => item.value).join("-")
+  const getSecondaryActionKey = (
+    action: HeaderSecondaryAction,
+    index: number
+  ) => {
+    const actionKey = isSecondaryDropdownAction(action)
+      ? `${action.value ?? "default"}-${action.items.map((item) => item.value).join("-")}`
       : action.label
+
+    return `${actionKey}-${index}`
   }
 
   return (
@@ -186,8 +191,8 @@ export function BaseHeader({
             </div>
           )}
 
-          {visibleSecondaryActions.map((action) => (
-            <Fragment key={getSecondaryActionKey(action)}>
+          {visibleSecondaryActions.map((action, index) => (
+            <Fragment key={getSecondaryActionKey(action, index)}>
               <div className="w-full md:hidden [&>*]:w-full [&>span]:block [&>span_div]:w-full">
                 {isSecondaryDropdownAction(action) ? (
                   <F0ButtonDropdown
@@ -230,8 +235,8 @@ export function BaseHeader({
               <Dropdown items={visibleOtherActions} />
             </div>
           )}
-          {visibleSecondaryActions.map((action) => (
-            <Fragment key={getSecondaryActionKey(action)}>
+          {visibleSecondaryActions.map((action, index) => (
+            <Fragment key={getSecondaryActionKey(action, index)}>
               <div className="hidden md:block">
                 {isSecondaryDropdownAction(action) ? (
                   <F0ButtonDropdown

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -2,7 +2,10 @@ import { Fragment } from "react"
 
 import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Button } from "@/components/F0Button"
-import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
+import {
+  ButtonDropdownItem,
+  F0ButtonDropdown,
+} from "@/components/F0ButtonDropdown"
 import { StatusVariant } from "@/components/tags/F0TagStatus"
 import { Description } from "@/experimental/Information/Headers/BaseHeader/Description"
 import {
@@ -23,9 +26,21 @@ import {
 } from "@/experimental/Navigation/Dropdown"
 import { cn } from "@/lib/utils"
 
-export type HeaderSecondaryAction = SecondaryAction & {
+export type HeaderSecondaryButtonAction = SecondaryAction & {
   hideLabel?: boolean
 }
+
+export type HeaderSecondaryDropdownAction = PrimaryAction & {
+  items: ButtonDropdownItem<string>[]
+  value?: string
+  onClick: (value: string, item: ButtonDropdownItem<string>) => void
+  variant?: "outline"
+}
+
+export type HeaderSecondaryAction =
+  | HeaderSecondaryButtonAction
+  | HeaderSecondaryDropdownAction
+
 interface BaseHeaderProps {
   title: string
   deactivated?: boolean
@@ -94,6 +109,12 @@ export function BaseHeader({
     action: PrimaryAction | undefined
   ): action is PrimaryActionButton => {
     return !!action && "label" in action && !("items" in action)
+  }
+
+  const getSecondaryActionKey = (action: HeaderSecondaryAction) => {
+    return isSecondaryDropdownAction(action)
+      ? action.items.map((item) => item.value).join("-")
+      : action.label
   }
 
   return (
@@ -172,19 +193,32 @@ export function BaseHeader({
           )}
 
           {visibleSecondaryActions.map((action) => (
-            <Fragment key={action.label}>
+            <Fragment key={getSecondaryActionKey(action)}>
               <div className="w-full md:hidden [&>*]:w-full [&>span]:block [&>span_div]:w-full">
-                <F0Button
-                  label={action.label}
-                  onClick={action.onClick}
-                  variant={action.variant ?? "outline"}
-                  icon={action.icon}
-                  size="lg"
-                  hideLabel={action.hideLabel}
-                  disabled={action.disabled}
-                  tooltip={action.tooltip}
-                  loading={action.loading}
-                />
+                {isSecondaryDropdownAction(action) ? (
+                  <F0ButtonDropdown
+                    items={action.items}
+                    onClick={action.onClick}
+                    variant={action.variant ?? "outline"}
+                    value={action.value}
+                    size="lg"
+                    disabled={action.disabled}
+                    tooltip={action.tooltip}
+                    loading={action.loading}
+                  />
+                ) : (
+                  <F0Button
+                    label={action.label}
+                    onClick={action.onClick}
+                    variant={action.variant ?? "outline"}
+                    icon={action.icon}
+                    size="lg"
+                    hideLabel={action.hideLabel}
+                    disabled={action.disabled}
+                    tooltip={action.tooltip}
+                    loading={action.loading}
+                  />
+                )}
               </div>
             </Fragment>
           ))}
@@ -203,18 +237,31 @@ export function BaseHeader({
             </div>
           )}
           {visibleSecondaryActions.map((action) => (
-            <Fragment key={action.label}>
+            <Fragment key={getSecondaryActionKey(action)}>
               <div className="hidden md:block">
-                <F0Button
-                  label={action.label}
-                  onClick={action.onClick}
-                  variant={action.variant ?? "outline"}
-                  icon={action.icon}
-                  hideLabel={action.hideLabel}
-                  disabled={action.disabled}
-                  tooltip={action.tooltip}
-                  loading={action.loading}
-                />
+                {isSecondaryDropdownAction(action) ? (
+                  <F0ButtonDropdown
+                    items={action.items}
+                    onClick={action.onClick}
+                    variant={action.variant ?? "outline"}
+                    value={action.value}
+                    size="md"
+                    disabled={action.disabled}
+                    tooltip={action.tooltip}
+                    loading={action.loading}
+                  />
+                ) : (
+                  <F0Button
+                    label={action.label}
+                    onClick={action.onClick}
+                    variant={action.variant ?? "outline"}
+                    icon={action.icon}
+                    hideLabel={action.hideLabel}
+                    disabled={action.disabled}
+                    tooltip={action.tooltip}
+                    loading={action.loading}
+                  />
+                )}
               </div>
             </Fragment>
           ))}
@@ -258,4 +305,10 @@ export function BaseHeader({
       )}
     </div>
   )
+}
+
+export const isSecondaryDropdownAction = (
+  action: HeaderSecondaryAction
+): action is HeaderSecondaryDropdownAction => {
+  return "items" in action
 }

--- a/packages/react/src/patterns/ResourceHeader/__tests__/ResourceHeader.test.tsx
+++ b/packages/react/src/patterns/ResourceHeader/__tests__/ResourceHeader.test.tsx
@@ -36,10 +36,23 @@ describe("ResourceHeader", () => {
       expect.objectContaining({ value: "excel", label: "Export Excel" })
     )
 
-    await user.click(screen.getAllByRole("button", { name: "More" })[0])
+    await user.click(screen.getAllByTestId("button-menu")[0])
 
-    expect(
-      await screen.findByRole("menuitem", { name: "Export CSV" })
-    ).toBeInTheDocument()
+    const csvOption = await screen.findByRole("menuitem", {
+      name: "Export CSV",
+    })
+    await user.click(csvOption)
+
+    await vi.waitFor(() =>
+      expect(onExport).toHaveBeenCalledWith(
+        "csv",
+        expect.objectContaining({ value: "csv", label: "Export CSV" })
+      )
+    )
+
+    expect(onExport).toHaveBeenLastCalledWith(
+      "csv",
+      expect.objectContaining({ value: "csv", label: "Export CSV" })
+    )
   })
 })

--- a/packages/react/src/patterns/ResourceHeader/__tests__/ResourceHeader.test.tsx
+++ b/packages/react/src/patterns/ResourceHeader/__tests__/ResourceHeader.test.tsx
@@ -6,7 +6,7 @@ import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
 import { ResourceHeader } from "../index"
 
 describe("ResourceHeader", () => {
-  it("renders a secondary dropdown action and calls the selected action", async () => {
+  it("renders secondary dropdown actions and calls the selected actions", async () => {
     const user = userEvent.setup()
     const onExport = vi.fn()
 
@@ -26,22 +26,36 @@ describe("ResourceHeader", () => {
       />
     )
 
-    const [mainButton] = screen.getAllByRole("button", {
+    const mainButtons = screen.getAllByRole("button", {
       name: "Export Excel",
     })
-    await user.click(mainButton)
+    const menuButtons = screen.getAllByTestId("button-menu")
+
+    expect(mainButtons).toHaveLength(2)
+    expect(menuButtons).toHaveLength(2)
+
+    await user.click(mainButtons[0])
 
     expect(onExport).toHaveBeenCalledWith(
       "excel",
       expect.objectContaining({ value: "excel", label: "Export Excel" })
     )
 
-    await user.click(screen.getAllByTestId("button-menu")[0])
+    await user.click(mainButtons[1])
 
-    const csvOption = await screen.findByRole("menuitem", {
+    expect(onExport).toHaveBeenCalledWith(
+      "excel",
+      expect.objectContaining({ value: "excel", label: "Export Excel" })
+    )
+
+    onExport.mockClear()
+
+    await user.click(menuButtons[0])
+
+    const firstCsvOption = await screen.findByRole("menuitem", {
       name: "Export CSV",
     })
-    await user.click(csvOption)
+    await user.click(firstCsvOption)
 
     await vi.waitFor(() =>
       expect(onExport).toHaveBeenCalledWith(
@@ -50,9 +64,20 @@ describe("ResourceHeader", () => {
       )
     )
 
-    expect(onExport).toHaveBeenLastCalledWith(
-      "csv",
-      expect.objectContaining({ value: "csv", label: "Export CSV" })
+    onExport.mockClear()
+
+    await user.click(menuButtons[1])
+
+    const secondCsvOption = await screen.findByRole("menuitem", {
+      name: "Export CSV",
+    })
+    await user.click(secondCsvOption)
+
+    await vi.waitFor(() =>
+      expect(onExport).toHaveBeenCalledWith(
+        "csv",
+        expect.objectContaining({ value: "csv", label: "Export CSV" })
+      )
     )
   })
 })

--- a/packages/react/src/patterns/ResourceHeader/__tests__/ResourceHeader.test.tsx
+++ b/packages/react/src/patterns/ResourceHeader/__tests__/ResourceHeader.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { Download } from "@/icons/app"
+import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
+
+import { ResourceHeader } from "../index"
+
+describe("ResourceHeader", () => {
+  it("renders a secondary dropdown action and calls the selected action", async () => {
+    const user = userEvent.setup()
+    const onExport = vi.fn()
+
+    render(
+      <ResourceHeader
+        title="Reports"
+        secondaryActions={[
+          {
+            items: [
+              { value: "excel", label: "Export Excel", icon: Download },
+              { value: "csv", label: "Export CSV", icon: Download },
+            ],
+            value: "excel",
+            onClick: onExport,
+          },
+        ]}
+      />
+    )
+
+    const [mainButton] = screen.getAllByRole("button", {
+      name: "Export Excel",
+    })
+    await user.click(mainButton)
+
+    expect(onExport).toHaveBeenCalledWith(
+      "excel",
+      expect.objectContaining({ value: "excel", label: "Export Excel" })
+    )
+
+    await user.click(screen.getAllByRole("button", { name: "More" })[0])
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Export CSV" })
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/patterns/ResourceHeader/index.stories.tsx
+++ b/packages/react/src/patterns/ResourceHeader/index.stories.tsx
@@ -284,6 +284,29 @@ export const WithDropdownAction: Story = {
   },
 }
 
+export const WithSecondaryDropdownAction: Story = {
+  tags: ["!dev"],
+  args: {
+    ...Default.args,
+    secondaryActions: [
+      {
+        label: "Edit",
+        icon: Icon.Pencil,
+        onClick: fn(),
+      },
+      {
+        items: [
+          { label: "Export Excel", value: "excel", icon: Icon.Download },
+          { label: "Export CSV", value: "csv", icon: Icon.Download },
+        ],
+        value: "excel",
+        onClick: fn(),
+        variant: "outline",
+      },
+    ],
+  },
+}
+
 export const CompanyHeader: Story = {
   tags: ["!dev"],
   args: {
@@ -599,6 +622,9 @@ export const Snapshot: Story = {
           {...(WithLongDescription.args as ResourceHeaderProps)}
         />
         <ResourceHeader {...(WithDropdownAction.args as ResourceHeaderProps)} />
+        <ResourceHeader
+          {...(WithSecondaryDropdownAction.args as ResourceHeaderProps)}
+        />
         <ResourceHeader {...(PersonHeader.args as ResourceHeaderProps)} />
         <ResourceHeader
           {...(DeactivatedEmployee.args as ResourceHeaderProps)}


### PR DESCRIPTION
## Summary
- Add secondary dropdown action support to `BaseHeader`, so `ResourceHeader.secondaryActions` can render `F0ButtonDropdown` split dropdowns.
- Preserve existing secondary button behavior and render dropdown secondary actions in both mobile and desktop layouts.
- Add ResourceHeader Storybook and unit coverage for an Excel/CSV export dropdown.

## Validation
- `pnpm vitest:ci src/components/F0ButtonDropdown/__tests__/F0ButtonDropdown.test.tsx src/patterns/ResourceHeader/__tests__/ResourceHeader.test.tsx` — 13 passed, 1 skipped
- `pnpm format:check src/experimental/Information/Headers/BaseHeader/index.tsx src/components/F0ButtonDropdown/types.ts src/components/RichText/NotesTextEditor/Header/index.tsx src/patterns/ResourceHeader/index.stories.tsx src/patterns/ResourceHeader/__tests__/ResourceHeader.test.tsx`
- `pnpm lint src/experimental/Information/Headers/BaseHeader/index.tsx src/components/F0ButtonDropdown/types.ts src/components/RichText/NotesTextEditor/Header/index.tsx src/patterns/ResourceHeader/index.stories.tsx src/patterns/ResourceHeader/__tests__/ResourceHeader.test.tsx`

## Notes
- `pnpm tsc` was attempted but is currently blocked by an unrelated existing `String.prototype.replaceAll` lib-target error in `src/sds/ai/F0AiChat/canvas/entities/dataDownload/DataDownloadCard.tsx:40`.