### PR TITLE
feat: add bulk selection functionality to Kanban component

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -74,6 +74,8 @@ export const defaultTranslations = {
       allOnPage: "All {{count}} items on this page are selected",
       selectAllItems: "Select all {{total}} items",
       allItemsSelected: "All {{total}} items selected",
+      allLoadedInLane: "All {{count}} loaded items selected",
+      selectAllInLane: "Select all {{total}} in this lane",
     },
     noItemsSelected: "No items selected",
   },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
@@ -9,6 +9,7 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as DataCollectionStories from "./index.stories"
 import * as ActionDataCollectionStories from "./actions/collection-actions.stories"
+import * as KanbanStories from "./visualizations/kanban.stories"
 
 <Meta title="Data collection/Selectable and bulk actions" />
 
@@ -168,6 +169,19 @@ once every loaded row is checked.
   of={DataCollectionStories.WithInfiniteScrollSelection}
   meta={DataCollectionStories}
 />
+
+**Kanban (per-lane two-level selection):**
+
+The Kanban visualization mirrors the Table's two-level selection model, scoped to
+each lane. The lane header exposes a select-all checkbox that toggles every loaded
+card in that lane. When `allPagesSelection: true` is set on the data source AND
+every loaded card in a lane is selected AND the lane has more items beyond the
+current page, a secondary banner appears directly under the lane header offering
+a "Select all N in this lane" CTA. Clicking it promotes the selection across
+every page of that lane only — other lanes are unaffected. Once active, the
+banner switches to a steady-state "All N items selected" copy.
+
+<Canvas of={KanbanStories.KanbanWithBulkSelectAllPages} meta={KanbanStories} />
 
 #### Examples
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/kanban.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/kanban.stories.tsx
@@ -149,6 +149,60 @@ export const BasicKanbanVisualization: Story = {
   },
 }
 
+export const KanbanWithBulkSelect: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Kanban with per-lane bulk selection. Each lane header shows a checkbox that selects (or deselects) every loaded card in that lane. The checkbox reflects the lane's selection state (unchecked / indeterminate / checked) and is disabled for empty lanes.",
+      },
+    },
+  },
+  render: () => {
+    const [items] = useState<MockUser[]>(() => generateMockUsers(24))
+    const mockVisualizations = getMockVisualizations({})
+
+    const dataAdapter = useMemo(
+      () =>
+        createDataAdapter({
+          data: items,
+          paginationType: "infinite-scroll",
+          perPage: 10,
+        }),
+      [items]
+    )
+
+    return (
+      <ExampleComponent
+        visualizations={[mockVisualizations.kanban]}
+        dataAdapter={dataAdapter}
+        selectable={(el) => el.id}
+        bulkActions={() => ({
+          primary: [
+            {
+              label: "Edit",
+              icon: Pencil,
+              onClick: fn(),
+              id: "edit-item",
+            },
+          ],
+          secondary: [
+            {
+              label: "Remove",
+              icon: Delete,
+              onClick: fn(),
+              critical: true,
+              id: "remove-item",
+            },
+          ],
+        })}
+        paginationType="infinite-scroll"
+        fullHeight={true}
+      />
+    )
+  },
+}
+
 export const KanbanWithCreateActions: Story = {
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/kanban.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/kanban.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test"
 
 import { granularityDefinitions } from "@/components/OneCalendar/granularities"
 import { Delete, Pencil, Plus } from "@/icons/app"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import {
   createDataAdapter,
@@ -157,6 +158,7 @@ export const KanbanWithBulkSelect: Story = {
           "Kanban with per-lane bulk selection. Each lane header shows a checkbox that selects (or deselects) every loaded card in that lane. The checkbox reflects the lane's selection state (unchecked / indeterminate / checked) and is disabled for empty lanes.",
       },
     },
+    ...withSnapshot({}),
   },
   render: () => {
     const [items] = useState<MockUser[]>(() => generateMockUsers(24))
@@ -181,6 +183,64 @@ export const KanbanWithBulkSelect: Story = {
           primary: [
             {
               label: "Edit",
+              icon: Pencil,
+              onClick: fn(),
+              id: "edit-item",
+            },
+          ],
+          secondary: [
+            {
+              label: "Remove",
+              icon: Delete,
+              onClick: fn(),
+              critical: true,
+              id: "remove-item",
+            },
+          ],
+        })}
+        paginationType="infinite-scroll"
+        fullHeight={true}
+      />
+    )
+  },
+}
+
+export const KanbanWithBulkSelectAllPages: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Kanban with per-lane bulk selection AND `allPagesSelection: true`. After selecting every loaded card in a lane, a banner appears under the header offering a 'Select all N in this lane' Gmail-style CTA so the user can extend the selection across every page of that lane.",
+      },
+    },
+    ...withSnapshot({}),
+  },
+  render: () => {
+    const [items] = useState<MockUser[]>(() => generateMockUsers(120))
+    const mockVisualizations = getMockVisualizations({})
+
+    const dataAdapter = useMemo(
+      () =>
+        createDataAdapter({
+          data: items,
+          paginationType: "infinite-scroll",
+          perPage: 10,
+        }),
+      [items]
+    )
+
+    return (
+      <ExampleComponent
+        visualizations={[mockVisualizations.kanban]}
+        dataAdapter={dataAdapter}
+        selectable={(el) => el.id}
+        allPagesSelection={true}
+        bulkActions={({ allSelected, selectedCount }) => ({
+          primary: [
+            {
+              label: allSelected
+                ? "Edit all items"
+                : `Edit ${selectedCount} selected`,
               icon: Pencil,
               onClick: fn(),
               id: "edit-item",

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -7,6 +7,7 @@ import type {
 import type { IconType } from "@/components/F0Icon"
 import type { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
 import type { KanbanProps } from "@/ui/Kanban/types"
+import type { LaneSelectAllItemsConfig, LaneSelection } from "@/ui/Lane/types"
 
 import { useDataCollectionLanesData } from "@/patterns/OneDataCollection/hooks/useDataCollectionData/useDataCollectionLanesData"
 import { useSelectableLanes } from "@/patterns/OneDataCollection/hooks/useSelectableLanes"
@@ -171,6 +172,54 @@ export const KanbanCollection = <
         loadedSelectableIds.some((id) => laneSel?.selectedItems.has(id)) &&
         !selected
 
+      const selectedCount = laneSel?.allSelectedStatus.selectedCount ?? 0
+      const totalLaneItems =
+        laneData?.paginationInfo?.total !== undefined
+          ? laneData.paginationInfo.total
+          : 0
+      const allItemsSelectedStatus = !!(
+        laneSel?.allSelectedStatus.checked &&
+        !laneSel?.allSelectedStatus.indeterminate
+      )
+      const showSelectAllItemsBanner =
+        !!source.allPagesSelection &&
+        (allItemsSelectedStatus ||
+          (selected &&
+            laneData?.paginationInfo?.total !== undefined &&
+            totalLaneItems > selectedCount))
+
+      const selection: LaneSelection | undefined =
+        isSelectable && laneSel
+          ? {
+              onSelectAll: (checked: boolean) =>
+                laneSel.handleSelectAll(checked),
+              selectAllLabel: i18n.actions.selectAll,
+              selected,
+              indeterminate,
+            }
+          : undefined
+
+      const selectAllItems: LaneSelectAllItemsConfig | undefined =
+        showSelectAllItemsBanner && laneSel
+          ? {
+              onSelectAllItems: () => laneSel.handleSelectAllItems(true),
+              selectAllItemsLabel: i18n.t("status.selected.selectAllInLane", {
+                total: totalLaneItems,
+              }),
+              loadedSelectionLabel: i18n.t("status.selected.allLoadedInLane", {
+                count: loadedSelectableIds.length,
+              }),
+              allItemsSelectedLabel: i18n.t(
+                "status.selected.allItemsSelected",
+                {
+                  total: totalLaneItems,
+                }
+              ),
+              allItemsSelected: allItemsSelectedStatus,
+              totalItems: totalLaneItems,
+            }
+          : undefined
+
       return {
         id: l.id,
         title: l.title,
@@ -181,20 +230,8 @@ export const KanbanCollection = <
         loading: laneData?.isLoading || false,
         loadingMore: laneData?.isLoadingMore || false,
         fetchMore: hasMore ? () => laneData.loadMore() : undefined,
-        selectable: isSelectable,
-        selected,
-        indeterminate,
-        onSelectAll: (checked: boolean) => {
-          if (!laneSel) {
-            console.warn(
-              "[OneDataCollection/Kanban] onSelectAll called but laneSel is missing for lane",
-              l.id
-            )
-            return
-          }
-          laneSel.handleSelectAll(checked)
-        },
-        selectAllLabel: i18n.actions.selectAll,
+        selection,
+        selectAllItems,
       }
     }),
     loading: Object.values(lanesHooks).some(

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/hooks/datasource"
 import { createAtlaskitDriver } from "@/lib/dnd/atlaskitDriver"
 import { DndProvider } from "@/lib/dnd/context"
+import { useI18n } from "@/lib/providers/i18n"
 import { useIsDev } from "@/lib/providers/user-platafform"
 import { Kanban } from "@/ui/Kanban"
 import { KanbanCard } from "@/ui/Kanban/components/KanbanCard"
@@ -111,6 +112,39 @@ export const KanbanCollection = <
     return Boolean(paginationInfo && paginationInfo.type === "infinite-scroll")
   }
 
+  /**
+   * Selection
+   */
+  const i18n = useI18n()
+
+  const lanesDef = useMemo(() => {
+    return lanes.map((lane) => ({
+      id: lane.id,
+      data: lanesHooks[lane.id]?.data || {
+        type: "flat",
+        records: [],
+        groups: [],
+      },
+      paginationInfo: lanesHooks[lane.id]?.paginationInfo || null,
+    }))
+  }, [lanes, lanesHooks])
+
+  const { lanesSelectProvider, lanesUseSelectable } = useSelectableLanes<
+    R,
+    Filters,
+    Sortings,
+    Summaries,
+    NavigationFilters,
+    Grouping
+  >(lanesDef, source, (selectItemsStatus, clearCallback) => {
+    onSelectItems?.(selectItemsStatus, clearCallback)
+  })
+
+  // Fine-grained reorder only when no sort order is applied
+  const allowReorder = source.currentSortings === null
+
+  const isSelectable = source.selectable !== undefined
+
   const kanbanProps: KanbanProps<R> = {
     lanes: laneItems.map((l) => {
       const laneData = lanesHooks[l.id]
@@ -119,6 +153,24 @@ export const KanbanCollection = <
       const hasMore =
         isInfiniteScrollPaginationInfo(laneData?.paginationInfo) &&
         laneData?.paginationInfo?.hasMore
+
+      const laneSel = lanesUseSelectable.get(l.id)
+      const laneRecords = laneData?.data?.records || []
+      const loadedSelectableIds = source.selectable
+        ? laneRecords
+            .map((record) => source.selectable!(record))
+            .filter(
+              (id): id is string | number =>
+                typeof id === "string" || typeof id === "number"
+            )
+        : []
+      const selected =
+        loadedSelectableIds.length > 0 &&
+        loadedSelectableIds.every((id) => laneSel?.selectedItems.has(id))
+      const indeterminate =
+        loadedSelectableIds.some((id) => laneSel?.selectedItems.has(id)) &&
+        !selected
+
       return {
         id: l.id,
         title: l.title,
@@ -129,6 +181,20 @@ export const KanbanCollection = <
         loading: laneData?.isLoading || false,
         loadingMore: laneData?.isLoadingMore || false,
         fetchMore: hasMore ? () => laneData.loadMore() : undefined,
+        selectable: isSelectable,
+        selected,
+        indeterminate,
+        onSelectAll: (checked: boolean) => {
+          if (!laneSel) {
+            console.warn(
+              "[OneDataCollection/Kanban] onSelectAll called but laneSel is missing for lane",
+              l.id
+            )
+            return
+          }
+          laneSel.handleSelectAll(checked)
+        },
+        selectAllLabel: i18n.actions.selectAll,
       }
     }),
     loading: Object.values(lanesHooks).some(
@@ -229,8 +295,6 @@ export const KanbanCollection = <
   }, [totalItemsAggregated, isInitialLoadingAggregated])
 
   // Fine-grained reorder only when no sort order is applied
-  const allowReorder = source.currentSortings === null
-
   // Build index maps per lane when needed
   const laneIndexMaps = useMemo(() => {
     const maps = new Map<string, Map<string, number>>()
@@ -256,33 +320,6 @@ export const KanbanCollection = <
     },
     onMove: onMove,
   }
-
-  /**
-   * Selection
-   */
-
-  const lanesDef = useMemo(() => {
-    return lanes.map((lane) => ({
-      id: lane.id,
-      data: lanesHooks[lane.id]?.data || {
-        type: "flat",
-        records: [],
-        groups: [],
-      },
-      paginationInfo: lanesHooks[lane.id]?.paginationInfo || null,
-    }))
-  }, [lanes, lanesHooks])
-
-  const { lanesSelectProvider, lanesUseSelectable } = useSelectableLanes<
-    R,
-    Filters,
-    Sortings,
-    Summaries,
-    NavigationFilters,
-    Grouping
-  >(lanesDef, source, (selectItemsStatus, clearCallback) => {
-    onSelectItems?.(selectItemsStatus, clearCallback)
-  })
 
   return (
     <>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
@@ -249,4 +249,179 @@ describe("KanbanCollection - lane select-all", () => {
       expect(boxes[0].getAttribute("aria-checked")).toBe("true")
     })
   })
+
+  // -------------------------------------------------------------------------
+  // Cross-page "select all items in lane" banner
+  // -------------------------------------------------------------------------
+
+  const renderKanbanWithBanner = (opts: {
+    allPagesSelection: boolean
+    total: number
+  }) => {
+    const people: Person[] = [
+      { id: 1, name: "John" },
+      { id: 2, name: "Jane" },
+    ]
+
+    const source: DataCollectionSource<
+      Person,
+      TestFilters,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Person>,
+      TestNavigationFilters,
+      GroupingDefinition<Person>
+    > & {
+      lanes: Array<{ id: string; filters: Record<string, unknown> }>
+      allPagesSelection?: boolean
+    } = {
+      ...createSource(people),
+      selectable: (p: Person) => p.id,
+      allPagesSelection: opts.allPagesSelection,
+      lanes: [
+        { id: "todo", filters: {} },
+        { id: "doing", filters: {} },
+      ],
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: people.length,
+        fetchData: async () => ({
+          records: people,
+          total: opts.total,
+          currentPage: 1,
+          perPage: people.length,
+          pagesCount: 1,
+          type: "pages" as const,
+        }),
+      },
+    }
+
+    zeroRender(
+      <KanbanCollection<
+        Person,
+        TestFilters,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        TestNavigationFilters,
+        GroupingDefinition<Person>
+      >
+        lanes={[
+          { id: "todo", title: "Todo" },
+          { id: "doing", title: "Doing" },
+        ]}
+        title={(p) => p.name}
+        description={(p) => p.name}
+        metadata={() => []}
+        source={source}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+  }
+
+  it("does not render the cross-page banner when allPagesSelection is not configured, even after selecting all loaded records", async () => {
+    const user = userEvent.setup()
+    renderKanbanWithBanner({ allPagesSelection: false, total: 10 })
+
+    await screen.findAllByTestId("card")
+    const selectAllBoxes = screen.getAllByRole("checkbox", {
+      name: "Select all",
+    })
+    await user.click(selectAllBoxes[0])
+
+    await waitFor(() => {
+      expect(selectAllBoxes[0].getAttribute("aria-checked")).toBe("true")
+    })
+
+    expect(
+      screen.queryByRole("button", { name: /select all .* in this lane/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders the cross-page banner with the correct CTA when all loaded records are selected and total > loaded count", async () => {
+    const user = userEvent.setup()
+    renderKanbanWithBanner({ allPagesSelection: true, total: 5 })
+
+    await screen.findAllByTestId("card")
+    const selectAllBoxes = screen.getAllByRole("checkbox", {
+      name: "Select all",
+    })
+    await user.click(selectAllBoxes[0])
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Select all 5 in this lane" })
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("switches the banner to the steady-state 'all items selected' copy after the CTA is clicked", async () => {
+    const user = userEvent.setup()
+    renderKanbanWithBanner({ allPagesSelection: true, total: 5 })
+
+    await screen.findAllByTestId("card")
+    const selectAllBoxes = screen.getAllByRole("checkbox", {
+      name: "Select all",
+    })
+    await user.click(selectAllBoxes[0])
+
+    const cta = await screen.findByRole("button", {
+      name: "Select all 5 in this lane",
+    })
+    await user.click(cta)
+
+    await waitFor(() => {
+      expect(screen.getByText("All 5 items selected")).toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: /select all .* in this lane/i })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("does not show the banner in lane A when only lane B has all records selected", async () => {
+    const user = userEvent.setup()
+    renderKanbanWithBanner({ allPagesSelection: true, total: 5 })
+
+    await screen.findAllByTestId("card")
+    const selectAllBoxes = screen.getAllByRole("checkbox", {
+      name: "Select all",
+    })
+    // Click lane B (second lane)
+    await user.click(selectAllBoxes[1])
+
+    await waitFor(() => {
+      // Exactly one CTA in the document — the one in lane B
+      expect(
+        screen.getAllByRole("button", { name: "Select all 5 in this lane" })
+      ).toHaveLength(1)
+    })
+  })
+
+  it("does not render the banner when total === selectedCount (no extra pages to extend selection over)", async () => {
+    const user = userEvent.setup()
+    renderKanbanWithBanner({ allPagesSelection: true, total: 2 })
+
+    await screen.findAllByTestId("card")
+    const selectAllBoxes = screen.getAllByRole("checkbox", {
+      name: "Select all",
+    })
+    // No banner expected: handleSelectAll (the per-lane checkbox handler) was
+    // called, NOT handleSelectAllItems — so useSelectable's allSelectedStatus.checked
+    // stays false. With total === selectedCount the "more pages to select" branch
+    // is also false. Both banner conditions miss → banner not rendered.
+    await user.click(selectAllBoxes[0])
+
+    await waitFor(() => {
+      expect(selectAllBoxes[0].getAttribute("aria-checked")).toBe("true")
+    })
+
+    expect(
+      screen.queryByRole("button", { name: /select all .* in this lane/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/All \d+ items selected/i)
+    ).not.toBeInTheDocument()
+  })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react"
+import { screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
@@ -115,5 +115,138 @@ describe("KanbanCollection - item click", () => {
     expect(onItemClick).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1, name: "John" })
     )
+  })
+})
+
+describe("KanbanCollection - lane select-all", () => {
+  const renderKanban = (extra?: {
+    onSelectItems?: ReturnType<typeof vi.fn>
+    selectable?: boolean
+  }) => {
+    const people: Person[] = [
+      { id: 1, name: "John" },
+      { id: 2, name: "Jane" },
+    ]
+
+    const baseSource = createSource(people)
+    const source = {
+      ...baseSource,
+      lanes: [
+        { id: "todo", filters: {} },
+        { id: "doing", filters: {} },
+      ],
+      ...(extra?.selectable === false
+        ? {}
+        : { selectable: (p: Person) => p.id }),
+    }
+
+    zeroRender(
+      <KanbanCollection<
+        Person,
+        TestFilters,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        TestNavigationFilters,
+        GroupingDefinition<Person>
+      >
+        lanes={[
+          { id: "todo", title: "Todo" },
+          { id: "doing", title: "Doing" },
+        ]}
+        title={(p) => p.name}
+        description={(p) => p.name}
+        metadata={() => []}
+        source={source}
+        onSelectItems={extra?.onSelectItems ?? vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+  }
+
+  it("renders one select-all checkbox per lane only when source.selectable is defined", async () => {
+    renderKanban()
+    // Wait for content to render
+    await screen.findAllByTestId("card")
+    const selectAllBoxes = screen.getAllByRole("checkbox", {
+      name: "Select all",
+    })
+    expect(selectAllBoxes).toHaveLength(2)
+  })
+
+  it("does not render lane select-all checkboxes when source.selectable is undefined", async () => {
+    renderKanban({ selectable: false })
+    await screen.findAllByTestId("card")
+    const selectAllBoxes = screen.queryAllByRole("checkbox", {
+      name: "Select all",
+    })
+    expect(selectAllBoxes).toHaveLength(0)
+  })
+
+  it("calls onSelectItems with all lane records when the lane select-all is clicked", async () => {
+    const user = userEvent.setup()
+    const onSelectItems = vi.fn()
+    renderKanban({ onSelectItems })
+
+    await screen.findAllByTestId("card")
+    const selectAllBoxes = screen.getAllByRole("checkbox", {
+      name: "Select all",
+    })
+    await user.click(selectAllBoxes[0])
+
+    await waitFor(() => {
+      expect(onSelectItems).toHaveBeenCalled()
+    })
+
+    const lastCall = onSelectItems.mock.calls.at(-1)?.[0] as {
+      allSelected?: boolean
+      itemsStatus?: ReadonlyArray<{
+        item: { id: number | string; name: string }
+        checked: boolean
+      }>
+    }
+    expect(lastCall).toBeDefined()
+    expect(Array.isArray(lastCall.itemsStatus)).toBe(true)
+
+    const selectedIds = (lastCall.itemsStatus ?? [])
+      .filter((entry) => entry.checked)
+      .map((entry) => entry.item.id)
+      .sort()
+    // The lane's loaded records are John (id=1) and Jane (id=2). Both must
+    // appear in itemsStatus with checked=true after a select-all click.
+    expect(selectedIds).toEqual([1, 2])
+  })
+
+  it("becomes checked after selecting all cards in a lane (indeterminate state is wired but Radix maps it to aria-checked='false' due to a known DS gap)", async () => {
+    const user = userEvent.setup()
+    renderKanban()
+
+    const cards = await screen.findAllByTestId("card")
+    expect(cards.length).toBeGreaterThanOrEqual(2)
+
+    const allCheckboxes = screen.getAllByRole("checkbox")
+    const cardCheckboxes = allCheckboxes.filter(
+      (el) => el.getAttribute("title") !== "Select all"
+    )
+    expect(cardCheckboxes.length).toBeGreaterThanOrEqual(2)
+
+    // Select first card in the first lane: lane select-all stays not-checked
+    // (F0Checkbox does not currently forward indeterminate to Radix's
+    // aria-checked='mixed' — see Table.test.tsx for the same documented gap).
+    await user.click(cardCheckboxes[0])
+
+    await waitFor(() => {
+      const boxes = screen.getAllByRole("checkbox", { name: "Select all" })
+      expect(boxes[0].getAttribute("aria-checked")).toBe("false")
+    })
+
+    // Selecting the second card flips lane select-all to checked
+    await user.click(cardCheckboxes[1])
+
+    await waitFor(() => {
+      const boxes = screen.getAllByRole("checkbox", { name: "Select all" })
+      expect(boxes[0].getAttribute("aria-checked")).toBe("true")
+    })
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
@@ -5,6 +5,7 @@ import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useData
 import {
   FiltersDefinition,
   GroupingDefinition,
+  OnSelectItemsCallback,
   RecordType,
   SortingsDefinition,
 } from "@/hooks/datasource"
@@ -120,7 +121,7 @@ describe("KanbanCollection - item click", () => {
 
 describe("KanbanCollection - lane select-all", () => {
   const renderKanban = (extra?: {
-    onSelectItems?: ReturnType<typeof vi.fn>
+    onSelectItems?: OnSelectItemsCallback<Person, TestFilters>
     selectable?: boolean
   }) => {
     const people: Person[] = [
@@ -158,7 +159,10 @@ describe("KanbanCollection - lane select-all", () => {
         description={(p) => p.name}
         metadata={() => []}
         source={source}
-        onSelectItems={extra?.onSelectItems ?? vi.fn()}
+        onSelectItems={
+          extra?.onSelectItems ??
+          (vi.fn() as unknown as OnSelectItemsCallback<Person, TestFilters>)
+        }
         onLoadData={vi.fn()}
         onLoadError={vi.fn()}
       />

--- a/packages/react/src/ui/Kanban/Kanban.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.tsx
@@ -303,14 +303,15 @@ export function Kanban<TRecord extends RecordType>(
             return localLanes.map(
               (lane: KanbanLaneAttributes<TRecord>, laneIndex: number) => {
                 const total = lane.total ?? lane.items.length
-                const propsLane = lane.id
-                  ? propsLaneMap.get(lane.id)
-                  : undefined
-                const selectable = propsLane?.selectable
-                const selected = propsLane?.selected
-                const indeterminate = propsLane?.indeterminate
-                const onSelectAll = propsLane?.onSelectAll
-                const selectAllLabel = propsLane?.selectAllLabel
+                // Selection-related props are read out-of-band from the latest
+                // `lanes` prop because `localLanes` is cached based on item
+                // identity to support optimistic DnD updates. When a lane has
+                // no `id` we cannot look it up in the map, so we fall back to
+                // the `lane` itself (which already carries the latest props).
+                const propsLane =
+                  (lane.id ? propsLaneMap.get(lane.id) : undefined) ?? lane
+                const selection = propsLane.selection
+                const selectAllItems = propsLane.selectAllItems
                 return (
                   <div
                     key={lane.id ?? String(laneIndex)}
@@ -349,11 +350,8 @@ export function Kanban<TRecord extends RecordType>(
                           ? () => onCreate(lane.id!)
                           : undefined
                       }
-                      selectable={selectable}
-                      selected={selected}
-                      indeterminate={indeterminate}
-                      onSelectAll={onSelectAll}
-                      selectAllLabel={selectAllLabel}
+                      selection={selection}
+                      selectAllItems={selectAllItems}
                     />
                   </div>
                 )

--- a/packages/react/src/ui/Kanban/Kanban.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.tsx
@@ -298,48 +298,68 @@ export function Kanban<TRecord extends RecordType>(
         viewportRef={viewportRef}
       >
         <div className="relative mb-2 flex h-full items-start gap-2">
-          {localLanes.map(
-            (lane: KanbanLaneAttributes<TRecord>, laneIndex: number) => {
-              const total = lane.total ?? lane.items.length
-              return (
-                <div
-                  key={lane.id ?? String(laneIndex)}
-                  className="relative shrink-0"
-                  data-testid={`lane-${lane.id ?? String(laneIndex)}`}
-                >
-                  <KanbanLane<TRecord>
-                    id={lane.id}
-                    getLaneResourceIndexById={
-                      lane.id
-                        ? (id) => getIndexById(lane.id as string, id)
-                        : undefined
-                    }
-                    onMove={onMove}
-                    title={lane.title}
-                    items={lane.items}
-                    getKey={(item, index) => getKey(item, index, lane.id)}
-                    renderCard={(item, index) => {
-                      const node = renderCard(item, index, total, lane.id)
-                      return node
-                    }}
-                    emptyState={lane.emptyState}
-                    loading={loading || lane.loading}
-                    variant={lane.variant}
-                    total={total}
-                    hasMore={lane.hasMore}
-                    loadingMore={lane.loadingMore}
-                    fetchMore={lane.fetchMore}
-                    onPrimaryAction={
-                      onCreate && lane.id ? () => onCreate(lane.id!) : undefined
-                    }
-                    onFooterAction={
-                      onCreate && lane.id ? () => onCreate(lane.id!) : undefined
-                    }
-                  />
-                </div>
-              )
-            }
-          )}
+          {(() => {
+            const propsLaneMap = new Map(lanes.map((l) => [l.id, l]))
+            return localLanes.map(
+              (lane: KanbanLaneAttributes<TRecord>, laneIndex: number) => {
+                const total = lane.total ?? lane.items.length
+                const propsLane = lane.id
+                  ? propsLaneMap.get(lane.id)
+                  : undefined
+                const selectable = propsLane?.selectable
+                const selected = propsLane?.selected
+                const indeterminate = propsLane?.indeterminate
+                const onSelectAll = propsLane?.onSelectAll
+                const selectAllLabel = propsLane?.selectAllLabel
+                return (
+                  <div
+                    key={lane.id ?? String(laneIndex)}
+                    className="relative shrink-0"
+                    data-testid={`lane-${lane.id ?? String(laneIndex)}`}
+                  >
+                    <KanbanLane<TRecord>
+                      id={lane.id}
+                      getLaneResourceIndexById={
+                        lane.id
+                          ? (id) => getIndexById(lane.id as string, id)
+                          : undefined
+                      }
+                      onMove={onMove}
+                      title={lane.title}
+                      items={lane.items}
+                      getKey={(item, index) => getKey(item, index, lane.id)}
+                      renderCard={(item, index) => {
+                        const node = renderCard(item, index, total, lane.id)
+                        return node
+                      }}
+                      emptyState={lane.emptyState}
+                      loading={loading || lane.loading}
+                      variant={lane.variant}
+                      total={total}
+                      hasMore={lane.hasMore}
+                      loadingMore={lane.loadingMore}
+                      fetchMore={lane.fetchMore}
+                      onPrimaryAction={
+                        onCreate && lane.id
+                          ? () => onCreate(lane.id!)
+                          : undefined
+                      }
+                      onFooterAction={
+                        onCreate && lane.id
+                          ? () => onCreate(lane.id!)
+                          : undefined
+                      }
+                      selectable={selectable}
+                      selected={selected}
+                      indeterminate={indeterminate}
+                      onSelectAll={onSelectAll}
+                      selectAllLabel={selectAllLabel}
+                    />
+                  </div>
+                )
+              }
+            )
+          })()}
         </div>
       </ScrollArea>
       {/* Horizontal edge zones (invisible during drag) */}

--- a/packages/react/src/ui/Kanban/types.ts
+++ b/packages/react/src/ui/Kanban/types.ts
@@ -2,6 +2,9 @@ import type { ReactNode } from "react"
 
 import type { Variant } from "@/components/tags/F0TagStatus"
 import type { RecordType } from "@/hooks/datasource"
+import type { LaneSelectAllItemsConfig, LaneSelection } from "@/ui/Lane/types"
+
+export type { LaneSelectAllItemsConfig, LaneSelection }
 
 export type KanbanLaneAttributes<TRecord extends RecordType> = {
   id?: string
@@ -21,16 +24,10 @@ export type KanbanLaneAttributes<TRecord extends RecordType> = {
   total?: number
   /** Future: filters that would be applied to the shared data source */
   filters?: Partial<Record<string, unknown>>
-  /** Whether the lane should expose a select-all checkbox in its header. */
-  selectable?: boolean
-  /** Whether the lane select-all checkbox is checked. */
-  selected?: boolean
-  /** Whether the lane select-all checkbox is in indeterminate state. */
-  indeterminate?: boolean
-  /** Callback fired when the lane select-all checkbox is toggled. */
-  onSelectAll?: (checked: boolean) => void
-  /** Accessible label for the select-all checkbox (visually hidden). */
-  selectAllLabel?: string
+  /** Per-lane select-all configuration. Presence enables the header checkbox. */
+  selection?: LaneSelection
+  /** Secondary "select all items across pages" banner shown under the header. */
+  selectAllItems?: LaneSelectAllItemsConfig
 }
 
 export interface KanbanProps<TRecord extends RecordType> {

--- a/packages/react/src/ui/Kanban/types.ts
+++ b/packages/react/src/ui/Kanban/types.ts
@@ -21,6 +21,16 @@ export type KanbanLaneAttributes<TRecord extends RecordType> = {
   total?: number
   /** Future: filters that would be applied to the shared data source */
   filters?: Partial<Record<string, unknown>>
+  /** Whether the lane should expose a select-all checkbox in its header. */
+  selectable?: boolean
+  /** Whether the lane select-all checkbox is checked. */
+  selected?: boolean
+  /** Whether the lane select-all checkbox is in indeterminate state. */
+  indeterminate?: boolean
+  /** Callback fired when the lane select-all checkbox is toggled. */
+  onSelectAll?: (checked: boolean) => void
+  /** Accessible label for the select-all checkbox (visually hidden). */
+  selectAllLabel?: string
 }
 
 export interface KanbanProps<TRecord extends RecordType> {

--- a/packages/react/src/ui/Lane/Lane.tsx
+++ b/packages/react/src/ui/Lane/Lane.tsx
@@ -12,6 +12,7 @@ import { Plus } from "@/icons/app"
 import { cn } from "@/lib/utils"
 
 import { LaneHeader } from "./components/LaneHeader"
+import { LaneSelectAllItemsBanner } from "./components/LaneSelectAllItemsBanner"
 import { LoadingSkeleton } from "./components/LoadingSkeleton"
 import { LaneProps } from "./types"
 
@@ -30,11 +31,8 @@ export function Lane<Record extends RecordType>({
   onPrimaryAction,
   onFooterAction,
   dropPlaceholderIndex,
-  selectable,
-  selected,
-  indeterminate,
-  onSelectAll,
-  selectAllLabel,
+  selection,
+  selectAllItems,
 }: LaneProps<Record>) {
   // Create pagination info for infinite scroll
   const paginationInfo = {
@@ -62,12 +60,10 @@ export function Lane<Record extends RecordType>({
         variant={variant}
         count={total ?? items.length}
         onPrimaryAction={onPrimaryAction}
-        selectable={selectable}
-        selected={selected}
-        indeterminate={indeterminate}
-        onSelectAll={onSelectAll}
-        selectAllLabel={selectAllLabel}
+        selection={selection}
       />
+
+      {selectAllItems && <LaneSelectAllItemsBanner config={selectAllItems} />}
 
       <div
         className={cn(

--- a/packages/react/src/ui/Lane/Lane.tsx
+++ b/packages/react/src/ui/Lane/Lane.tsx
@@ -30,6 +30,11 @@ export function Lane<Record extends RecordType>({
   onPrimaryAction,
   onFooterAction,
   dropPlaceholderIndex,
+  selectable,
+  selected,
+  indeterminate,
+  onSelectAll,
+  selectAllLabel,
 }: LaneProps<Record>) {
   // Create pagination info for infinite scroll
   const paginationInfo = {
@@ -57,6 +62,11 @@ export function Lane<Record extends RecordType>({
         variant={variant}
         count={total ?? items.length}
         onPrimaryAction={onPrimaryAction}
+        selectable={selectable}
+        selected={selected}
+        indeterminate={indeterminate}
+        onSelectAll={onSelectAll}
+        selectAllLabel={selectAllLabel}
       />
 
       <div

--- a/packages/react/src/ui/Lane/__stories__/Lane.stories.tsx
+++ b/packages/react/src/ui/Lane/__stories__/Lane.stories.tsx
@@ -521,7 +521,7 @@ export const SelectableUnchecked: Story = {
     docs: {
       description: {
         story:
-          "Lane with `selectable` enabled. The header checkbox is unchecked when no items in the lane are selected.",
+          "Lane with a `selection` object passed in to enable the header checkbox. The checkbox is unchecked when no items in the lane are selected.",
       },
     },
   },

--- a/packages/react/src/ui/Lane/__stories__/Lane.stories.tsx
+++ b/packages/react/src/ui/Lane/__stories__/Lane.stories.tsx
@@ -12,6 +12,7 @@ import { ArrowUp, Clock, Delete, Pencil, Person, Search } from "@/icons/app"
 import { createAtlaskitDriver } from "@/lib/dnd/atlaskitDriver"
 import { DndProvider } from "@/lib/dnd/context"
 import { useDroppableList } from "@/lib/dnd/hooks"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import type { LaneProps } from "../types"
 
@@ -528,11 +529,12 @@ export const SelectableUnchecked: Story = {
     title: "To do",
     items: mockTasks,
     getKey: (task: RecordType) => (task as MockTask).id,
-    selectable: true,
-    selected: false,
-    indeterminate: false,
-    selectAllLabel: "Select all",
-    onSelectAll: fn(),
+    selection: {
+      onSelectAll: fn(),
+      selectAllLabel: "Select all",
+      selected: false,
+      indeterminate: false,
+    },
     renderCard: (task: RecordType) => (
       <F0Card
         title={(task as MockTask).title}
@@ -553,7 +555,12 @@ export const SelectableIndeterminate: Story = {
   },
   args: {
     ...SelectableUnchecked.args,
-    indeterminate: true,
+    selection: {
+      onSelectAll: fn(),
+      selectAllLabel: "Select all",
+      selected: false,
+      indeterminate: true,
+    },
   },
 }
 
@@ -568,7 +575,139 @@ export const SelectableChecked: Story = {
   },
   args: {
     ...SelectableUnchecked.args,
-    selected: true,
+    selection: {
+      onSelectAll: fn(),
+      selectAllLabel: "Select all",
+      selected: true,
+      indeterminate: false,
+    },
+  },
+}
+
+export const SelectableWithSelectAllBanner: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When all loaded items are selected and more pages exist, a secondary banner offers a 'Select all N in this lane' CTA.",
+      },
+    },
+  },
+  args: {
+    ...SelectableUnchecked.args,
+    selection: {
+      onSelectAll: fn(),
+      selectAllLabel: "Select all",
+      selected: true,
+      indeterminate: false,
+    },
+    selectAllItems: {
+      onSelectAllItems: fn(),
+      selectAllItemsLabel: "Select all 200 in this lane",
+      loadedSelectionLabel: "All 25 loaded selected",
+    },
+  },
+}
+
+export const SelectableAllItemsSelected: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Steady-state banner when every item across every page of the lane is selected.",
+      },
+    },
+  },
+  args: {
+    ...SelectableUnchecked.args,
+    selection: {
+      onSelectAll: fn(),
+      selectAllLabel: "Select all",
+      selected: true,
+      indeterminate: false,
+    },
+    selectAllItems: {
+      onSelectAllItems: fn(),
+      selectAllItemsLabel: "Select all 200 in this lane",
+      loadedSelectionLabel: "All 25 loaded selected",
+      allItemsSelected: true,
+      allItemsSelectedLabel: "All 200 items selected",
+    },
+  },
+}
+
+export const SelectableSnapshot: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Chromatic snapshot covering all selectable visual states side-by-side.",
+      },
+    },
+    ...withSnapshot({}),
+  },
+  args: {
+    items: [],
+    getKey: () => "",
+    renderCard: () => null,
+  },
+  render: () => {
+    const renderCard = (task: RecordType) => (
+      <F0Card
+        title={(task as MockTask).title}
+        description={(task as MockTask).description}
+      />
+    )
+    const baseArgs = {
+      title: "To do",
+      items: mockTasks,
+      getKey: (task: RecordType) => (task as MockTask).id,
+      renderCard,
+    }
+    const baseSelection = {
+      onSelectAll: fn(),
+      selectAllLabel: "Select all",
+    }
+    return (
+      <div className="flex gap-2">
+        <Lane
+          {...baseArgs}
+          selection={{
+            ...baseSelection,
+            selected: false,
+            indeterminate: false,
+          }}
+        />
+        <Lane
+          {...baseArgs}
+          selection={{ ...baseSelection, selected: false, indeterminate: true }}
+        />
+        <Lane
+          {...baseArgs}
+          selection={{ ...baseSelection, selected: true, indeterminate: false }}
+        />
+        <Lane
+          {...baseArgs}
+          selection={{ ...baseSelection, selected: true, indeterminate: false }}
+          selectAllItems={{
+            onSelectAllItems: fn(),
+            selectAllItemsLabel: "Select all 200 in this lane",
+            loadedSelectionLabel: "All 25 loaded selected",
+          }}
+        />
+        <Lane
+          {...baseArgs}
+          selection={{ ...baseSelection, selected: true, indeterminate: false }}
+          selectAllItems={{
+            onSelectAllItems: fn(),
+            selectAllItemsLabel: "Select all 200 in this lane",
+            loadedSelectionLabel: "All 25 loaded selected",
+            allItemsSelected: true,
+            allItemsSelectedLabel: "All 200 items selected",
+          }}
+        />
+      </div>
+    )
   },
 }
 

--- a/packages/react/src/ui/Lane/__stories__/Lane.stories.tsx
+++ b/packages/react/src/ui/Lane/__stories__/Lane.stories.tsx
@@ -515,6 +515,63 @@ export const TwoLanesDnD: Story = {
   },
 }
 
+export const SelectableUnchecked: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Lane with `selectable` enabled. The header checkbox is unchecked when no items in the lane are selected.",
+      },
+    },
+  },
+  args: {
+    title: "To do",
+    items: mockTasks,
+    getKey: (task: RecordType) => (task as MockTask).id,
+    selectable: true,
+    selected: false,
+    indeterminate: false,
+    selectAllLabel: "Select all",
+    onSelectAll: fn(),
+    renderCard: (task: RecordType) => (
+      <F0Card
+        title={(task as MockTask).title}
+        description={(task as MockTask).description}
+      />
+    ),
+  },
+}
+
+export const SelectableIndeterminate: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Lane header checkbox renders an indeterminate state when only some loaded items are selected.",
+      },
+    },
+  },
+  args: {
+    ...SelectableUnchecked.args,
+    indeterminate: true,
+  },
+}
+
+export const SelectableChecked: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Lane header checkbox is checked when every loaded item in the lane is selected.",
+      },
+    },
+  },
+  args: {
+    ...SelectableUnchecked.args,
+    selected: true,
+  },
+}
+
 // Types are kept inline in the effect to avoid unused warnings
 
 function MoveMonitor({

--- a/packages/react/src/ui/Lane/components/LaneHeader.tsx
+++ b/packages/react/src/ui/Lane/components/LaneHeader.tsx
@@ -4,16 +4,14 @@ import { F0TagStatus, Variant } from "@/components/tags/F0TagStatus"
 import { Counter } from "@/ui/Counter"
 import { Plus } from "@/icons/app"
 
+import type { LaneSelection } from "../types"
+
 type LaneHeaderProps = {
   label: string
   variant?: Variant
   count: number
   onPrimaryAction?: () => void
-  selectable?: boolean
-  selected?: boolean
-  indeterminate?: boolean
-  onSelectAll?: (checked: boolean) => void
-  selectAllLabel?: string
+  selection?: LaneSelection
 }
 
 export const LaneHeader = ({
@@ -21,23 +19,19 @@ export const LaneHeader = ({
   variant,
   count,
   onPrimaryAction,
-  selectable = false,
-  selected = false,
-  indeterminate = false,
-  onSelectAll,
-  selectAllLabel,
+  selection,
 }: LaneHeaderProps) => {
   const showPrimary = Boolean(onPrimaryAction)
 
   return (
     <div className="flex items-center gap-2 px-1 pb-0.5 pt-2">
-      {selectable && (
+      {selection && (
         <F0Checkbox
-          title={selectAllLabel}
+          title={selection.selectAllLabel}
           hideLabel
-          checked={selected}
-          indeterminate={indeterminate}
-          onCheckedChange={onSelectAll}
+          checked={selection.selected ?? false}
+          indeterminate={selection.indeterminate ?? false}
+          onCheckedChange={selection.onSelectAll}
           disabled={count === 0}
         />
       )}

--- a/packages/react/src/ui/Lane/components/LaneHeader.tsx
+++ b/packages/react/src/ui/Lane/components/LaneHeader.tsx
@@ -1,4 +1,5 @@
 import { F0Button } from "@/components/F0Button"
+import { F0Checkbox } from "@/components/F0Checkbox"
 import { F0TagStatus, Variant } from "@/components/tags/F0TagStatus"
 import { Counter } from "@/ui/Counter"
 import { Plus } from "@/icons/app"
@@ -8,6 +9,11 @@ type LaneHeaderProps = {
   variant?: Variant
   count: number
   onPrimaryAction?: () => void
+  selectable?: boolean
+  selected?: boolean
+  indeterminate?: boolean
+  onSelectAll?: (checked: boolean) => void
+  selectAllLabel?: string
 }
 
 export const LaneHeader = ({
@@ -15,11 +21,26 @@ export const LaneHeader = ({
   variant,
   count,
   onPrimaryAction,
+  selectable = false,
+  selected = false,
+  indeterminate = false,
+  onSelectAll,
+  selectAllLabel,
 }: LaneHeaderProps) => {
   const showPrimary = Boolean(onPrimaryAction)
 
   return (
     <div className="flex items-center gap-2 px-1 pb-0.5 pt-2">
+      {selectable && (
+        <F0Checkbox
+          title={selectAllLabel}
+          hideLabel
+          checked={selected}
+          indeterminate={indeterminate}
+          onCheckedChange={onSelectAll}
+          disabled={count === 0}
+        />
+      )}
       <F0TagStatus text={label} variant={variant || "neutral"} />
       <Counter size="md" type="default" value={count} />
       {showPrimary && (

--- a/packages/react/src/ui/Lane/components/LaneSelectAllItemsBanner.tsx
+++ b/packages/react/src/ui/Lane/components/LaneSelectAllItemsBanner.tsx
@@ -29,7 +29,9 @@ export const LaneSelectAllItemsBanner = ({
       )}
     >
       <span>
-        {allItemsSelected ? allItemsSelectedLabel : loadedSelectionLabel}
+        {allItemsSelected
+          ? (allItemsSelectedLabel ?? loadedSelectionLabel)
+          : loadedSelectionLabel}
       </span>
       {!allItemsSelected && selectAllItemsLabel && (
         <F0Button

--- a/packages/react/src/ui/Lane/components/LaneSelectAllItemsBanner.tsx
+++ b/packages/react/src/ui/Lane/components/LaneSelectAllItemsBanner.tsx
@@ -1,0 +1,44 @@
+import { F0Button } from "@/components/F0Button"
+import { cn } from "@/lib/utils"
+
+import type { LaneSelectAllItemsConfig } from "../types"
+
+type LaneSelectAllItemsBannerProps = {
+  config: LaneSelectAllItemsConfig
+}
+
+export const LaneSelectAllItemsBanner = ({
+  config,
+}: LaneSelectAllItemsBannerProps) => {
+  const {
+    allItemsSelected,
+    allItemsSelectedLabel,
+    loadedSelectionLabel,
+    selectAllItemsLabel,
+    onSelectAllItems,
+  } = config
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "flex items-center justify-between gap-2 px-3 py-1.5",
+        "bg-f1-background-secondary",
+        "text-f1-sm text-f1-foreground-secondary"
+      )}
+    >
+      <span>
+        {allItemsSelected ? allItemsSelectedLabel : loadedSelectionLabel}
+      </span>
+      {!allItemsSelected && selectAllItemsLabel && (
+        <F0Button
+          variant="outline"
+          size="sm"
+          label={selectAllItemsLabel}
+          onClick={onSelectAllItems}
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/react/src/ui/Lane/types.ts
+++ b/packages/react/src/ui/Lane/types.ts
@@ -4,6 +4,26 @@ import type { IconType } from "@/components/F0Icon"
 import type { Variant } from "@/components/tags/F0TagStatus"
 import type { RecordType } from "@/hooks/datasource"
 
+export interface LaneSelection {
+  /** Required: callback fired when the header checkbox toggles. */
+  onSelectAll: (checked: boolean) => void
+  /** Required: visually-hidden accessible label for the checkbox. */
+  selectAllLabel: string
+  /** Whether the checkbox is checked (all loaded items in lane selected). */
+  selected?: boolean
+  /** Whether the checkbox is in indeterminate state (partial selection). */
+  indeterminate?: boolean
+}
+
+export interface LaneSelectAllItemsConfig {
+  onSelectAllItems: () => void
+  selectAllItemsLabel: string
+  loadedSelectionLabel: string
+  allItemsSelectedLabel?: string
+  allItemsSelected?: boolean
+  totalItems?: number
+}
+
 export interface LaneProps<Record extends RecordType> {
   /**
    * The title of the card
@@ -79,23 +99,13 @@ export interface LaneProps<Record extends RecordType> {
   dropPlaceholderIndex?: number
 
   /**
-   * Whether the lane should expose a select-all checkbox in its header.
+   * Per-lane select-all configuration. Presence enables the header checkbox.
+   * `onSelectAll` and `selectAllLabel` are required when provided.
    */
-  selectable?: boolean
+  selection?: LaneSelection
   /**
-   * Whether the select-all checkbox in the header is checked.
+   * Secondary "select all items across pages" banner shown under the header.
+   * Only rendered when this object is provided.
    */
-  selected?: boolean
-  /**
-   * Whether the select-all checkbox in the header is in indeterminate state.
-   */
-  indeterminate?: boolean
-  /**
-   * Callback fired when the select-all checkbox is toggled.
-   */
-  onSelectAll?: (checked: boolean) => void
-  /**
-   * Accessible label for the select-all checkbox (visually hidden).
-   */
-  selectAllLabel?: string
+  selectAllItems?: LaneSelectAllItemsConfig
 }

--- a/packages/react/src/ui/Lane/types.ts
+++ b/packages/react/src/ui/Lane/types.ts
@@ -77,4 +77,25 @@ export interface LaneProps<Record extends RecordType> {
    * If undefined, no placeholder is shown.
    */
   dropPlaceholderIndex?: number
+
+  /**
+   * Whether the lane should expose a select-all checkbox in its header.
+   */
+  selectable?: boolean
+  /**
+   * Whether the select-all checkbox in the header is checked.
+   */
+  selected?: boolean
+  /**
+   * Whether the select-all checkbox in the header is in indeterminate state.
+   */
+  indeterminate?: boolean
+  /**
+   * Callback fired when the select-all checkbox is toggled.
+   */
+  onSelectAll?: (checked: boolean) => void
+  /**
+   * Accessible label for the select-all checkbox (visually hidden).
+   */
+  selectAllLabel?: string
 }


### PR DESCRIPTION
## Description
Adds a "select all" checkbox to each Kanban lane header in OneDataCollection, so you can bulk-select every loaded record in a lane with one click instead of ticking cards one by one.

## Screenshots (if applicable)
<img width="337" height="475" alt="Captura de pantalla 2026-05-13 a les 9 58 13" src="https://github.com/user-attachments/assets/9aa65cab-e752-486e-8e61-2810969678fe" />


## Implementation details
- New optional selection props on the Lane and Kanban UI primitives (selectable, selected, indeterminate, onSelectAll, selectAllLabel)
- LaneHeader renders an F0Checkbox when selectable is on; disabled when the lane is empty
- OneDataCollection's Kanban visualization wires the checkbox to the existing per-lane useSelectable hooks — no new selection mechanism
- Indeterminate state when some (but not all) loaded records in the lane are selected
- Tests + stories (KanbanWithBulkSelect, plus three lane states in Storybook)
