### PR TITLE
feat(f0compose): controlling-step-poc — unified spending prototype

### DIFF
--- a/packages/f0compose/checks/runStaticChecks.ts
+++ b/packages/f0compose/checks/runStaticChecks.ts
@@ -36,6 +36,7 @@ const ALLOWED_PATH_ALIASES = [
   "@/lib",
   "@/prototypes",
   "@/shell",
+  "@/copilot",
 ] as const
 
 const FORBIDDEN_COLOR_PATTERNS = [

--- a/packages/f0compose/src/fixtures/controlling.ts
+++ b/packages/f0compose/src/fixtures/controlling.ts
@@ -1,0 +1,91 @@
+/**
+ * Controlling (a.k.a. coding) catalogs used by the
+ * `Spending > Manage > Pending Controlling` controlling form.
+ *
+ * Source of truth for all dropdowns in the controlling side panel and
+ * its bulk-edit variant. Keep this list small and realistic — designers
+ * lift these into Figma screenshots, so cardinality matters more than
+ * exhaustiveness.
+ */
+
+import type { ExpenseCategory } from "./expenses"
+
+export type CostCenter = {
+  id: string
+  /** Short human-readable name, e.g. "Engineering". */
+  name: string
+  /** Accounting code shown next to the name, e.g. "CC-100". */
+  code: string
+}
+
+export type Project = {
+  id: string
+  /** Short human-readable name. */
+  name: string
+  /** Accounting code, e.g. "PRJ-2026-Q2-DEV". */
+  code: string
+}
+
+export type VatRate = {
+  id: string
+  /** Display label, e.g. "21%". */
+  label: string
+  /** Numeric percent — used by the UI when previewing the breakdown. */
+  percent: number
+}
+
+export type ControllingTag = {
+  id: string
+  label: string
+}
+
+/**
+ * Subcategories — flat list keyed by ExpenseCategory. Designers asked for
+ * dependent dropdowns (subcategory narrows when category changes); the
+ * mapping below feeds that lookup.
+ */
+export const subcategoriesByCategory: Record<ExpenseCategory, string[]> = {
+  Meals: ["Client meal", "Team lunch", "Travel meal", "On-call meal"],
+  Taxis: ["Airport transfer", "Client visit", "Late-night work"],
+  Travel: ["Flight", "Train", "Mileage", "Other transport"],
+  Shopping: ["Office supplies", "Equipment", "Marketing material"],
+  Hotel: ["Client visit", "Conference", "Team offsite"],
+  Office: ["Furniture", "Snacks", "Cleaning"],
+  Software: ["SaaS subscription", "License", "Cloud infrastructure"],
+}
+
+export const costCenters: CostCenter[] = [
+  { id: "cc-eng", name: "Engineering", code: "CC-100" },
+  { id: "cc-design", name: "Design", code: "CC-110" },
+  { id: "cc-product", name: "Product", code: "CC-120" },
+  { id: "cc-sales", name: "Sales", code: "CC-200" },
+  { id: "cc-marketing", name: "Marketing", code: "CC-210" },
+  { id: "cc-finance", name: "Finance", code: "CC-300" },
+  { id: "cc-people", name: "People & HR", code: "CC-310" },
+  { id: "cc-ops", name: "Operations", code: "CC-400" },
+]
+
+export const projects: Project[] = [
+  { id: "prj-platform", name: "Platform 2026", code: "PRJ-2026-PLAT" },
+  { id: "prj-onboarding", name: "Customer onboarding", code: "PRJ-2026-ON" },
+  { id: "prj-international", name: "International expansion", code: "PRJ-2026-INTL" },
+  { id: "prj-internal", name: "Internal tooling", code: "PRJ-2026-INT" },
+  { id: "prj-rnd", name: "R&D", code: "PRJ-2026-RND" },
+  { id: "prj-events", name: "Events 2026", code: "PRJ-2026-EVT" },
+]
+
+export const vatRates: VatRate[] = [
+  { id: "vat-0", label: "0% (exempt)", percent: 0 },
+  { id: "vat-4", label: "4%", percent: 4 },
+  { id: "vat-10", label: "10%", percent: 10 },
+  { id: "vat-21", label: "21%", percent: 21 },
+]
+
+export const controllingTags: ControllingTag[] = [
+  { id: "tag-billable", label: "Billable" },
+  { id: "tag-non-billable", label: "Non-billable" },
+  { id: "tag-recurring", label: "Recurring" },
+  { id: "tag-one-off", label: "One-off" },
+  { id: "tag-internal", label: "Internal" },
+  { id: "tag-client-facing", label: "Client-facing" },
+]

--- a/packages/f0compose/src/fixtures/expenses.ts
+++ b/packages/f0compose/src/fixtures/expenses.ts
@@ -1,3 +1,10 @@
+import {
+  controllingTags,
+  costCenters,
+  projects,
+  subcategoriesByCategory,
+  vatRates,
+} from "./controlling"
 import { addDays, TODAY } from "./helpers"
 
 /**
@@ -5,7 +12,58 @@ import { addDays, TODAY } from "./helpers"
  * the prototype mirrors: 0 draft / 26 pending / 3 approved / 30 in-payroll.
  */
 
-export type ExpenseStatus = "draft" | "pending" | "approved" | "in-payroll"
+export type ExpenseStatus =
+  | "draft"
+  /**
+   * Approver returned the expense to the submitter for fixes (missing
+   * receipt, wrong amount, etc.). The submitter sees these alongside
+   * drafts in the "To-Do" preset because both require their action
+   * before the expense can be submitted again.
+   */
+  | "changes-requested"
+  | "pending"
+  | "approved"
+  /**
+   * Approved AND coded by finance — accounting fields filled in. Lives
+   * between Approved and Sent-to-Pay in the lifecycle. Soft-sequential:
+   * an expense MAY skip Controlled and be paid directly (Spec A BR-007).
+   */
+  | "controlled"
+  /**
+   * Transmitted to payroll/SEPA, awaiting payment confirmation. The
+   * "in-flight" intermediate state.
+   */
+  | "in-payroll"
+  /**
+   * Payment confirmed — the employee has been reimbursed. Terminal
+   * state. Distinguished from `in-payroll` so the Pay tab can show a
+   * green "Paid" preset that doesn't conflate with mid-flight rows.
+   */
+  | "paid"
+  | "refunded"
+  | "partially-refunded"
+
+/**
+ * Accounting metadata attached to an expense once finance has coded it
+ * (or partially coded it before Marking as controlled). All fields
+ * optional — finance can save partial values per Spec D BR-011.
+ */
+export type ControllingFields = {
+  /** Re-states the row's category for the controlling form. */
+  category?: ExpenseCategory
+  /** Subcategory string from `subcategoriesByCategory[category]`. */
+  subcategory?: string
+  /** Cost center id from `costCenters`. */
+  costCenter?: string
+  /** Project id from `projects`. */
+  project?: string
+  /** VAT rate id from `vatRates`. */
+  vatRate?: string
+  /** Free-text accounting note. */
+  description?: string
+  /** Tag ids from `controllingTags`. */
+  tags?: string[]
+}
 
 export type ExpenseCategory =
   | "Meals"
@@ -36,6 +94,25 @@ export type Expense = {
   alerts: ExpenseAlert[]
   /** Group/bundle this expense belongs to (null = ungrouped). */
   groupId: string | null
+  /**
+   * Nested rows shown when this row is expanded. Used today for refunded
+   * expenses, where the parent row summarises the net result and the children
+   * break down original charge + refund. `null`/`undefined` = no children.
+   */
+  children?: Expense[]
+  /**
+   * If true, this row represents a refund line (positive amount, displayed
+   * green with a leading `+`). Always lives inside a parent's `children`.
+   */
+  isRefund?: boolean
+  /** True for rows returned by `fetchChildren` — used to suppress status in the table. */
+  isChild?: boolean
+  /**
+   * Accounting metadata. Populated for `approved` (partial) and
+   * `controlled` (typically complete) rows. `undefined` for everything
+   * else.
+   */
+  controlling?: ControllingFields
 }
 
 // All provider names below are fictional — invented for prototype purposes.
@@ -101,8 +178,10 @@ function buildExpenses(): Expense[] {
       rand,
     }))
   }
-  // 3 approved — last 30 days
-  for (let i = 0; i < 3; i++) {
+  // 12 approved — last 30 days. The Pending Controlling tab uses these
+  // (plus the controlled set below) as its dataset; bumping the count
+  // from 3 → 12 ensures both presets have meaningful volume.
+  for (let i = 0; i < 12; i++) {
     out.push(makeExpense({
       seq: 26 + i,
       status: "approved",
@@ -110,12 +189,33 @@ function buildExpenses(): Expense[] {
       rand,
     }))
   }
-  // 30 in-payroll — older, between 30 and 360 days
-  for (let i = 0; i < 30; i++) {
+  // 6 controlled — already coded by finance, ready to be paid. Lives in
+  // both `Pending Controlling > Controlled` preset and `Pay > Unpaid`.
+  for (let i = 0; i < 6; i++) {
     out.push(makeExpense({
-      seq: 29 + i,
+      seq: 38 + i,
+      status: "controlled",
+      daysAgo: 8 + Math.floor(rand() * 30),
+      rand,
+    }))
+  }
+  // 12 in-payroll — recently transmitted, awaiting confirmation.
+  for (let i = 0; i < 12; i++) {
+    out.push(makeExpense({
+      seq: 44 + i,
       status: "in-payroll",
-      daysAgo: 30 + Math.floor(rand() * 330),
+      daysAgo: 30 + Math.floor(rand() * 60),
+      rand,
+    }))
+  }
+  // 18 paid — terminal state, older. The Pay tab's `Paid` preset uses
+  // these as the green-status set so finance can clearly tell what's
+  // actually been reimbursed vs what's still mid-flight.
+  for (let i = 0; i < 18; i++) {
+    out.push(makeExpense({
+      seq: 56 + i,
+      status: "paid",
+      daysAgo: 90 + Math.floor(rand() * 270),
       rand,
     }))
   }
@@ -133,12 +233,43 @@ function makeExpense(args: {
   const provider = providers[seq % providers.length]
   const category = categories[seq % categories.length]
   const amount = Math.round((5 + rand() * 195) * 100) / 100
-  // Sprinkle alerts on a minority of expenses (~25%).
+  // Sprinkle alerts. Pending expenses get a much higher rate (~60%)
+  // because they drive Approve & Pay > Approve's Needs review preset
+  // — we want a meaningful 10-15 expense backlog there. Other
+  // statuses keep the lighter ~25% rate so post-approval tabs stay
+  // mostly clean.
   const alerts: ExpenseAlert[] = []
   const r = rand()
-  if (r < 0.08) alerts.push("receipt-mismatch")
-  else if (r < 0.18) alerts.push("receipt-after-timeframe")
-  else if (r < 0.25) alerts.push("late-submission")
+  const isPending = status === "pending"
+  const t1 = isPending ? 0.2 : 0.08
+  const t2 = isPending ? 0.4 : 0.18
+  const t3 = isPending ? 0.6 : 0.25
+  if (r < t1) alerts.push("receipt-mismatch")
+  else if (r < t2) alerts.push("receipt-after-timeframe")
+  else if (r < t3) alerts.push("late-submission")
+
+  // Controlling fields:
+  // - `approved`  → partially coded (category only). Finance still has work to do.
+  // - `controlled`→ fully coded; ready for Pay.
+  // - everything else → no controlling block.
+  let controlling: ControllingFields | undefined
+  if (status === "approved") {
+    controlling = { category }
+  } else if (status === "controlled") {
+    const subcats = subcategoriesByCategory[category]
+    controlling = {
+      category,
+      subcategory: subcats[Math.floor(rand() * subcats.length)],
+      costCenter: costCenters[Math.floor(rand() * costCenters.length)].id,
+      project: projects[Math.floor(rand() * projects.length)].id,
+      vatRate: vatRates[Math.floor(rand() * vatRates.length)].id,
+      description: `Coded on ${addDays(TODAY, -Math.floor(rand() * 5))}.`,
+      tags: [
+        controllingTags[Math.floor(rand() * controllingTags.length)].id,
+      ],
+    }
+  }
+
   return {
     id: `exp-${String(seq + 1).padStart(3, "0")}`,
     provider,
@@ -148,10 +279,95 @@ function makeExpense(args: {
     category,
     alerts,
     groupId: null,
+    controlling,
   }
 }
 
-export const expenses: Expense[] = buildExpenses()
+export const expenses: Expense[] = (() => {
+  const base = buildExpenses()
+  // One refunded expense — a €100 charge fully refunded by the merchant
+  // before payroll ran, so the employee was never reimbursed. The parent
+  // row shows the NET amount (€0) plus a blue "Refunded" status tag, and
+  // expanding reveals the breakdown: the original pending charge and the
+  // +€100 refund that cancelled it out.
+  const refundedDate = addDays(TODAY, -7)
+  const refunded: Expense = {
+    id: "exp-refunded-001",
+    provider: "Skyfern Airways",
+    status: "refunded",
+    createdAt: refundedDate,
+    amount: 100,
+    category: "Travel",
+    alerts: [],
+    groupId: null,
+    children: [
+      {
+        id: "exp-refunded-001-original",
+        provider: "Skyfern Airways",
+        status: "pending",
+        createdAt: refundedDate,
+        amount: 100,
+        category: "Travel",
+        alerts: [],
+        groupId: null,
+        isChild: true,
+      },
+      {
+        id: "exp-refunded-001-refund",
+        provider: "Skyfern Airways",
+        status: "refunded",
+        createdAt: addDays(refundedDate, 2),
+        amount: 100,
+        category: "Travel",
+        alerts: [],
+        groupId: null,
+        isRefund: true,
+        isChild: true,
+      },
+    ],
+  }
+
+  // Partial refund — Roving Fork Co. had a €100 charge, €40 refunded by merchant.
+  // Parent shows the net owed (€40) with "Partially refunded" tag.
+  const partialRefundDate = addDays(TODAY, -5)
+  const partialRefund: Expense = {
+    id: "exp-partial-refund-001",
+    provider: "Roving Fork Co.",
+    status: "partially-refunded",
+    createdAt: partialRefundDate,
+    amount: 40,
+    category: "Meals",
+    alerts: [],
+    groupId: null,
+    children: [
+      {
+        id: "exp-partial-refund-001-original",
+        provider: "Roving Fork Co.",
+        status: "pending",
+        createdAt: partialRefundDate,
+        amount: 100,
+        category: "Meals",
+        alerts: [],
+        groupId: null,
+        isChild: true,
+      },
+      {
+        id: "exp-partial-refund-001-refund",
+        provider: "Roving Fork Co.",
+        status: "partially-refunded",
+        createdAt: addDays(partialRefundDate, 1),
+        amount: 60,
+        category: "Meals",
+        alerts: [],
+        groupId: null,
+        isRefund: true,
+        isChild: true,
+      },
+    ],
+  }
+  // Insert near the top so it's visible without paginating.
+  return [refunded, partialRefund, ...base]
+})()
 
 /** Counts by status — used by preset chips. Computed once at module load. */
 export const expenseCountsByStatus: Record<ExpenseStatus, number> =
@@ -160,10 +376,17 @@ export const expenseCountsByStatus: Record<ExpenseStatus, number> =
       acc[e.status] = (acc[e.status] ?? 0) + 1
       return acc
     },
-    { draft: 0, pending: 0, approved: 0, "in-payroll": 0 } as Record<
-      ExpenseStatus,
-      number
-    >
+    {
+      draft: 0,
+      "changes-requested": 0,
+      pending: 0,
+      approved: 0,
+      controlled: 0,
+      "in-payroll": 0,
+      paid: 0,
+      refunded: 0,
+      "partially-refunded": 0,
+    } as Record<ExpenseStatus, number>
   )
 
 /**
@@ -264,8 +487,15 @@ export const groupCountsByStatus: Record<ExpenseStatus, number> =
       acc[g.status] = (acc[g.status] ?? 0) + 1
       return acc
     },
-    { draft: 0, pending: 0, approved: 0, "in-payroll": 0 } as Record<
-      ExpenseStatus,
-      number
-    >
+    {
+      draft: 0,
+      "changes-requested": 0,
+      pending: 0,
+      approved: 0,
+      controlled: 0,
+      "in-payroll": 0,
+      paid: 0,
+      refunded: 0,
+      "partially-refunded": 0,
+    } as Record<ExpenseStatus, number>
   )

--- a/packages/f0compose/src/fixtures/index.ts
+++ b/packages/f0compose/src/fixtures/index.ts
@@ -82,4 +82,16 @@ export {
   type ExpenseCategory,
   type ExpenseAlert,
   type ExpenseGroup,
+  type ControllingFields,
 } from "./expenses"
+export {
+  costCenters,
+  projects,
+  vatRates,
+  controllingTags,
+  subcategoriesByCategory,
+  type CostCenter,
+  type Project,
+  type VatRate,
+  type ControllingTag,
+} from "./controlling"

--- a/packages/f0compose/src/prototypes/_shared/PolicyAlertCard.tsx
+++ b/packages/f0compose/src/prototypes/_shared/PolicyAlertCard.tsx
@@ -1,0 +1,245 @@
+import type { ReactElement } from "react"
+import InfoCircleLine from "@factorialco/f0-react/icons/app/InfoCircleLine"
+
+/**
+ * Policy alert card. Pixel-decoded from the Figma SVG export
+ * (Policies-experience nodes 2584-33704 / 2584-33787). Every
+ * dimension, color and radius below is read from the SVG path data,
+ * not transcribed from a CSS dump.
+ *
+ * THREE variants — `success` / `warning` / `error` — share the same
+ * geometry; only the strip background, badge fill, label color and
+ * glyph change.
+ *
+ * Decoded geometry (from `viewBox="0 0 472 116"`):
+ *   - Outer card radius: 20.9152px (corner cubic-bezier).
+ *   - Strip: y=0..56, height 56px, background = variant tint at 10%.
+ *   - Body: y=42.928..115.285 (height 72.36px), background white,
+ *     1.089px stroke at color #052657 / opacity 0.06.
+ *   - Body OVERLAPS the strip's bottom 13.07px — the "negative gap"
+ *     from the Figma spec. Implemented via `marginTop: -13.072px`
+ *     so the body's white fill + border visually clip the strip's
+ *     bottom curve, exactly as the SVG renders it.
+ *
+ * Strip badge:
+ *   - Center (23.07, 21.46), radius 6.67px → ø 13.3px, solid fill in
+ *     the variant accent color, white glyph centered. Glyph stroke
+ *     1.6px (matches the SVG's stroke-width).
+ *
+ * Strip label:
+ *   - x=41.5, fill = variant accent (e.g. #B3261E for error,
+ *     #0B7D58 for success), text-base font-medium.
+ *
+ * Title row (body):
+ *   - Title typography matches the employee-name cell ("Marcus
+ *     Lindberg") in DetailsItemsList → PersonItem → ItemContainer:
+ *     `text-base font-medium text-f1-foreground` so it follows
+ *     light/dark theme like the rest of the detail page.
+ *   - Decorative info icon to the right of the title, ø 13.17px,
+ *     outline-only, color #011B4B at opacity 0.45.
+ *
+ * Description:
+ *   - Color #011637 at opacity 0.61, 14px regular, line-height 20px.
+ */
+
+export type PolicyAlertVariant = "success" | "warning" | "error"
+
+const VARIANT_TOKENS: Record<
+  PolicyAlertVariant,
+  { stripBg: string; badgeFill: string; labelColor: string }
+> = {
+  // Decoded from the green-variant Figma export.
+  success: {
+    stripBg: "rgba(16, 184, 129, 0.10)",
+    badgeFill: "#10B881",
+    labelColor: "#0B7D58",
+  },
+  // Decoded from the warning Figma export the designer shared
+  // earlier (orange #FD812F at 10% bg, solid badge, darker label).
+  warning: {
+    stripBg: "rgba(253, 129, 47, 0.10)",
+    badgeFill: "#FD812F",
+    labelColor: "#A33F00",
+  },
+  // Decoded from the red-variant Figma export
+  // (Policies-experience node 2584-33787): #FF5C4B/0.1 bg, #B3261E
+  // solid badge, #B3261E label.
+  error: {
+    stripBg: "rgba(255, 92, 75, 0.10)",
+    badgeFill: "#B3261E",
+    labelColor: "#B3261E",
+  },
+}
+
+const OUTER_RADIUS = "20.9152px"
+const STRIP_HEIGHT = "56px"
+const BODY_OVERLAP = "13.072px"
+
+export function PolicyAlertCard(props: {
+  variant: PolicyAlertVariant
+  stripLabel: string
+  title: string
+  description: string
+  /** Optional right-aligned slot on the body header row (e.g. a
+   *  "Review" outline button). The component does NOT render any
+   *  default action — callers pass the button they want. */
+  bodyAction?: ReactElement
+}) {
+  const { variant, stripLabel, title, description, bodyAction } = props
+  const tokens = VARIANT_TOKENS[variant]
+
+  return (
+    <div
+      className="relative flex flex-col items-stretch self-stretch"
+      style={{ borderRadius: OUTER_RADIUS }}
+    >
+      {/* Strip */}
+      <div
+        className="flex items-center self-stretch"
+        style={{
+          height: STRIP_HEIGHT,
+          padding: "0 13.072px",
+          paddingBottom: "19.608px",
+          paddingTop: "6.536px",
+          background: tokens.stripBg,
+          borderTopLeftRadius: OUTER_RADIUS,
+          borderTopRightRadius: OUTER_RADIUS,
+        }}
+      >
+        <div className="flex items-center" style={{ gap: "10px" }}>
+          <BadgeIcon variant={variant} fill={tokens.badgeFill} />
+          <span
+            className="font-medium text-base"
+            style={{ color: tokens.labelColor }}
+          >
+            {stripLabel}
+          </span>
+        </div>
+      </div>
+
+      {/* Body — sits 13.07px on top of the strip via negative margin
+          so the white fill + border visually clip the strip's bottom
+          curve, exactly as the SVG renders it. */}
+      <div
+        className="relative flex flex-col items-stretch self-stretch bg-f1-background"
+        style={{
+          marginTop: `-${BODY_OVERLAP}`,
+          padding: "12px 16px 16px 16px",
+          gap: "8px",
+          borderRadius: OUTER_RADIUS,
+          border: "1.089px solid rgba(5, 38, 87, 0.06)",
+        }}
+      >
+        <div className="flex items-center justify-between gap-3 self-stretch">
+          <span className="flex items-center" style={{ gap: "8px" }}>
+            <span className="font-medium text-f1-foreground text-base">
+              {title}
+            </span>
+            <InfoGlyph />
+          </span>
+          {bodyAction}
+        </div>
+        <p
+          className="m-0"
+          style={{
+            color: "rgba(1, 22, 55, 0.61)",
+            fontFamily: "Inter, sans-serif",
+            fontSize: "14px",
+            fontWeight: 400,
+            lineHeight: "20px",
+            letterSpacing: "-0.07px",
+          }}
+        >
+          {description}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Solid-fill circular badge with a white glyph. Per-variant glyph:
+ *   - success → check
+ *   - warning → exclamation mark
+ *   - error   → X (cross)
+ * Geometry matches the SVG's badge: ø 13.3px circle, stroke-width 1.6.
+ */
+function BadgeIcon({
+  variant,
+  fill,
+}: {
+  variant: PolicyAlertVariant
+  fill: string
+}) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      style={{ flexShrink: 0 }}
+    >
+      <circle cx="8" cy="8" r="6.67" fill={fill} />
+      {variant === "success" && (
+        <path
+          d="M5.0 8.2 L7.2 10.4 L11.2 5.6"
+          stroke="#FFFFFF"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )}
+      {variant === "warning" && (
+        <>
+          <path
+            d="M8 5.2 L8 8.6"
+            stroke="#FFFFFF"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          />
+          <circle cx="8" cy="10.6" r="0.9" fill="#FFFFFF" />
+        </>
+      )}
+      {variant === "error" && (
+        <>
+          <path
+            d="M5.6 5.6 L10.4 10.4"
+            stroke="#FFFFFF"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          />
+          <path
+            d="M10.4 5.6 L5.6 10.4"
+            stroke="#FFFFFF"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          />
+        </>
+      )}
+    </svg>
+  )
+}
+
+/**
+ * Decorative outline-only info icon. Uses the canonical
+ * `InfoCircleLine` from `@factorialco/f0-react/icons/app`. Sized to
+ * ~13px to match the Figma spec; rendered at `currentColor` with
+ * the same low-opacity blue used elsewhere in the card so it reads
+ * as decorative metadata rather than an action.
+ */
+function InfoGlyph() {
+  return (
+    <InfoCircleLine
+      width={14}
+      height={14}
+      aria-hidden="true"
+      style={{
+        flexShrink: 0,
+        color: "#011B4B",
+        opacity: 0.45,
+      }}
+    />
+  )
+}

--- a/packages/f0compose/src/prototypes/_shared/receiptPresence.ts
+++ b/packages/f0compose/src/prototypes/_shared/receiptPresence.ts
@@ -1,0 +1,18 @@
+/**
+ * Deterministic "does this row have a receipt attached?" predicate.
+ *
+ * Lives in `_shared` so the detail page (which renders the receipt
+ * panel or the empty state) and `selectPolicyAlert` (which steers
+ * "no receipt" copy onto rows that actually have no receipt) agree
+ * on the same answer for every row id. Drift between the two would
+ * surface as e.g. a "No receipt attached" alert on a row whose
+ * receipt panel proudly displays a thumbnail.
+ *
+ * Rule: ~20% of rows have no receipt. We use a tiny char-sum hash
+ * on the row id with a `% 5 === 0` test — same seed model the rest
+ * of the prototype uses for stable sprinkling.
+ */
+export function hasReceipt(rowId: string): boolean {
+  const seed = Array.from(rowId).reduce((s, c) => s + c.charCodeAt(0), 0)
+  return seed % 5 !== 0
+}

--- a/packages/f0compose/src/prototypes/_shared/selectPolicyAlert.ts
+++ b/packages/f0compose/src/prototypes/_shared/selectPolicyAlert.ts
@@ -1,0 +1,314 @@
+import { hasReceipt } from "./receiptPresence"
+import type { PolicyAlertVariant } from "./PolicyAlertCard"
+
+/**
+ * Picks a policy-alert variant + copy for an expense row, given the
+ * JTBD context the detail page is rendered in.
+ *
+ * Returns `null` when no alert should be shown for this combination
+ * (e.g. My spending > Submitted, or Approve & Pay > Controlling/Pay).
+ *
+ * The selection is **row-signal driven**, not random:
+ *   1. We compute the strongest signal that's true for this row
+ *      (e.g. "no receipt attached AND amount > 25€" beats
+ *      "late submission" which beats "meal exceeds limit"…).
+ *   2. The first matching rule produces the copy. This guarantees
+ *      a "No receipt attached" alert never fires on a row whose
+ *      receipt panel shows a thumbnail, that "Out of policy:
+ *      alcohol" only fires on alcohol categories, and so on.
+ *   3. If nothing matches and the row is in a context that should
+ *      surface a positive recommendation (Approve > Ready to
+ *      approve / My spending > To-Do success), we fall through to
+ *      a generic "looks good" copy.
+ *
+ * The mapping of context → output:
+ *   - Approve & Pay > Approve > Needs review (row.alerts.length > 0)
+ *       → review (warning) or reject (error), driven by row signals
+ *   - Approve & Pay > Approve > Ready to approve (row.alerts.length === 0)
+ *       → success ("Approval recommended")
+ *   - My spending > Expenses > To-Do (status ∈ draft|changes-requested)
+ *       → review / send-for-approval / likely-rejection, driven by
+ *         row signals
+ *   - My spending > Expenses > Submitted (any other view-mode status)
+ *       → no alert
+ */
+
+export type PolicyAlertConfig = {
+  variant: PolicyAlertVariant
+  stripLabel: string
+  title: string
+  description: string
+}
+
+type Context = {
+  /** Mirrors `ExpenseDetailPage`'s `tabRole` prop. */
+  tabRole: "approval" | "controlling" | "pay" | "view"
+  /** Row's status — used to discriminate My spending To-Do vs Submitted. */
+  status: string
+  /** Whether the row carries compliance alerts (drives the Approve-tab
+   *  preset split between Needs review and Ready to approve). */
+  hasAlerts: boolean
+  /** Stable id used to deterministically derive auxiliary signals. */
+  rowId: string
+  /** Specific alert kinds on the row, when known. Drives the most
+   *  specific copy. Empty array is equivalent to none. */
+  alertKinds?: ReadonlyArray<
+    "late-submission" | "receipt-after-timeframe" | "receipt-mismatch"
+  >
+  /** Expense category (e.g. "Meals", "Travel"). Used to decide
+   *  whether category-specific copy (e.g. alcohol) applies. */
+  category?: string
+  /** Amount in EUR. Used for limit-based copy. */
+  amount?: number
+}
+
+// -- Signal helpers --------------------------------------------------
+
+/** Likely meal-context categories. We treat any category whose label
+ *  hints at food/dining as "meal" for the per-person-limit rule. */
+function isMealCategory(category: string | undefined): boolean {
+  if (!category) return false
+  const c = category.toLowerCase()
+  return (
+    c.includes("meal") ||
+    c.includes("food") ||
+    c.includes("dining") ||
+    c.includes("restaurant")
+  )
+}
+
+/** Travel categories — used to gate the "alcohol on travel policy"
+ *  reject copy so it doesn't fire on a Software subscription. */
+function isTravelCategory(category: string | undefined): boolean {
+  if (!category) return false
+  const c = category.toLowerCase()
+  return c.includes("travel") || c.includes("hotel") || c.includes("flight")
+}
+
+// -- Approver-side rule pipelines ------------------------------------
+
+function approverWarningOrError(ctx: Context): PolicyAlertConfig | null {
+  const receipt = hasReceipt(ctx.rowId)
+  const amount = ctx.amount ?? 0
+  const kinds = new Set(ctx.alertKinds ?? [])
+
+  // ERRORS — high-confidence policy breaches: recommend rejection.
+  if (!receipt && amount > 25) {
+    return {
+      variant: "error",
+      stripLabel: "Rejection recommended",
+      title: "No receipt attached",
+      description:
+        "Policy requires a receipt for any expense above 25€. Without one, this should be rejected and returned to the employee.",
+    }
+  }
+  // Alcohol on travel — only if there IS a receipt (the rule infers
+  // the breach from receipt contents). Deterministic gate so it
+  // doesn't fire on every >80€ travel row.
+  if (
+    receipt &&
+    isTravelCategory(ctx.category) &&
+    amount > 80 &&
+    ctx.rowId.charCodeAt(ctx.rowId.length - 1) % 3 === 0
+  ) {
+    return {
+      variant: "error",
+      stripLabel: "Rejection recommended",
+      title: "Out of policy: alcohol",
+      description:
+        "Receipt includes alcohol charges, which the company travel policy doesn't reimburse.",
+    }
+  }
+
+  // WARNINGS — softer signals: recommend a closer look. All
+  // receipt-content rules are gated on `receipt` so they can't fire
+  // on a row whose panel shows the empty state.
+  if (receipt && kinds.has("receipt-mismatch")) {
+    return {
+      variant: "warning",
+      stripLabel: "Review recommended",
+      title: "Receipt amount mismatch",
+      description:
+        "The receipt total doesn't match the expense amount. Worth confirming before approving.",
+    }
+  }
+  if (isMealCategory(ctx.category) && amount > 55) {
+    return {
+      variant: "warning",
+      stripLabel: "Review recommended",
+      title: "Meal limit exceeded",
+      description:
+        "This meal is above the 55€ per-person/day limit. Check the attendees before approving.",
+    }
+  }
+  if (receipt && kinds.has("receipt-after-timeframe")) {
+    return {
+      variant: "warning",
+      stripLabel: "Review recommended",
+      title: "Receipt attached late",
+      description:
+        "The receipt was uploaded after the required timeframe. Confirm it's the right document for this transaction.",
+    }
+  }
+  if (kinds.has("late-submission")) {
+    return {
+      variant: "warning",
+      stripLabel: "Review recommended",
+      title: "Late submission",
+      description:
+        "Submitted past the company's 14-day window. Check the date stamp matches the receipt.",
+    }
+  }
+  if (!receipt) {
+    // Receipt missing but under the strict 25€ threshold — flag for
+    // review rather than rejection.
+    return {
+      variant: "warning",
+      stripLabel: "Review recommended",
+      title: "No receipt attached",
+      description:
+        "No receipt is attached. Below the 25€ threshold this can be approved, but it's worth asking the employee to add one.",
+    }
+  }
+
+  return null
+}
+
+// -- Submitter-side rule pipelines -----------------------------------
+
+function submitterAlert(ctx: Context): PolicyAlertConfig | null {
+  const receipt = hasReceipt(ctx.rowId)
+  const amount = ctx.amount ?? 0
+  const kinds = new Set(ctx.alertKinds ?? [])
+
+  // LIKELY REJECTION — strong signals the approver will bounce this.
+  if (!receipt && amount > 25) {
+    return {
+      variant: "error",
+      stripLabel: "Likely rejection",
+      title: "Add a receipt before submitting",
+      description:
+        "Above 25€, your approver will need a receipt. Upload one or this will almost certainly come back to you.",
+    }
+  }
+  if (
+    receipt &&
+    isTravelCategory(ctx.category) &&
+    amount > 80 &&
+    ctx.rowId.charCodeAt(ctx.rowId.length - 1) % 3 === 0
+  ) {
+    return {
+      variant: "error",
+      stripLabel: "Likely rejection",
+      title: "Out of policy: alcohol",
+      description:
+        "Your receipt includes alcohol, which isn't covered by the travel policy. Approvers are likely to reject.",
+    }
+  }
+
+  // REVIEW — fixable issues to address before sending. Receipt-
+  // content rules require an actual receipt.
+  if (receipt && kinds.has("receipt-mismatch")) {
+    return {
+      variant: "warning",
+      stripLabel: "Review recommended",
+      title: "Receipt amount doesn't match",
+      description:
+        "Your receipt total is different from the expense amount. Update one of them so they line up before submitting.",
+    }
+  }
+  if (isMealCategory(ctx.category) && amount > 55) {
+    return {
+      variant: "warning",
+      stripLabel: "Review recommended",
+      title: "Meal looks above the per-person limit",
+      description:
+        "Add the attendees in the description so your approver can validate the 55€ per-person/day limit.",
+    }
+  }
+  if (receipt && kinds.has("receipt-after-timeframe")) {
+    return {
+      variant: "warning",
+      stripLabel: "Review recommended",
+      title: "Receipt added late",
+      description:
+        "Your receipt was attached after the timeframe. Add a quick note explaining the delay so the approver doesn't bounce it back.",
+    }
+  }
+  if (kinds.has("late-submission")) {
+    return {
+      variant: "warning",
+      stripLabel: "Review recommended",
+      title: "Late submission",
+      description:
+        "This is past the 14-day submission window. Add a short note so your approver knows the context.",
+    }
+  }
+  if (!receipt) {
+    return {
+      variant: "warning",
+      stripLabel: "Review recommended",
+      title: "Add a receipt",
+      description:
+        "Below 25€ a receipt isn't strictly required, but adding one makes approval much faster.",
+    }
+  }
+
+  return null
+}
+
+// -- Public entry point ----------------------------------------------
+
+export function selectPolicyAlert(ctx: Context): PolicyAlertConfig | null {
+  // Approve & Pay > Approve tab.
+  if (ctx.tabRole === "approval") {
+    if (ctx.hasAlerts) {
+      // Needs review preset → derive a row-specific warning or
+      // rejection from the actual signals on the row.
+      return (
+        approverWarningOrError(ctx) ?? {
+          // Fallback for rows the rules don't catch — should be rare
+          // since `hasAlerts` already implies at least one signal.
+          variant: "warning",
+          stripLabel: "Review recommended",
+          title: "Worth a closer look",
+          description:
+            "A few small signals on this expense — give it a quick review before approving.",
+        }
+      )
+    }
+    // Ready to approve preset → all positive.
+    return {
+      variant: "success",
+      stripLabel: "Approval recommended",
+      title: "Expense within policy",
+      description:
+        "Amount, vendor and date all check out. Receipt is attached and matches the expense.",
+    }
+  }
+
+  // My spending > Expenses, view mode. The To-Do preset is exactly
+  // draft + changes-requested per the prototype spec; everything else
+  // (pending, approved, in-payroll, paid) is the Submitted preset
+  // which has no alerts.
+  if (ctx.tabRole === "view") {
+    const isToDo =
+      ctx.status === "draft" || ctx.status === "changes-requested"
+    if (!isToDo) return null
+    // Derive a row-specific alert; fall through to "looks ready" if
+    // no rules match — that's the genuine all-clear case.
+    return (
+      submitterAlert(ctx) ?? {
+        variant: "success",
+        stripLabel: "Send for approval",
+        title: "Looks ready to send",
+        description:
+          "Receipt, category and amount all check out. You can submit this for approval.",
+      }
+    )
+  }
+
+  // Controlling and Pay tabs don't surface policy alerts — those
+  // JTBDs are post-approval and the agent has nothing to recommend.
+  return null
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/ControllingStepPoc.tsx
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/ControllingStepPoc.tsx
@@ -1,0 +1,538 @@
+import { F0Box, F0Text, StandardLayout } from "@factorialco/f0-react"
+import { Page, PageHeader, Tabs } from "@factorialco/f0-react/dist/experimental"
+import { useCallback, useMemo, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+
+import { expenses } from "@/fixtures"
+import type { ExpenseStatus } from "@/fixtures"
+import type { PrototypeMeta } from "../types"
+import { FolderDetail } from "./folder/FolderDetail"
+import { ManageTab } from "./manage/ManageTab"
+import { useManageRows } from "./manage/useManageSource"
+import { useSubmitExpensesRows } from "./submit/useSubmitExpensesSource"
+import { ExpenseDetailPage } from "./shared/detail/ExpenseDetailPage"
+import { ExpenseSidePanel } from "./shared/sidePanel/ExpenseSidePanel"
+import type { ControllingFormData } from "./shared/sidePanel/ControllingForm"
+import { expenseToRow, type SpendingRow } from "./shared/rows"
+import { SubmitExpensesTab } from "./submit/SubmitExpensesTab"
+import {
+  MANAGE_SUB_TABS,
+  PRIMARY_TABS,
+  SUBMIT_SUB_TABS,
+  type ManageSubTabId,
+  type PrimaryTabId,
+} from "./tabs"
+
+/**
+ * Unified Spending page — implements PSPEC-spending-unified-page (Spec A r2),
+ * PSPEC-spending-manage-tab (Spec C r2) and
+ * PSPEC-spending-pending-controlling (Spec D r1).
+ *
+ * Tab row 1:
+ *   - Submit  — personal lifecycle (everyone sees this)
+ *   - Manage  — review / approve / pay (only visible if the user has
+ *               anything to manage; inferred from the dataset, not a role)
+ *
+ * Tab row 2:
+ *   - Submit  > Expenses · Purchase Requests · Cards
+ *   - Manage  > Pending approval · Pending controlling · Pay · All
+ *
+ * Default landing follows directly from Manage visibility:
+ *   - hasManageQueue → Manage > Pending Approval (Manager / Finance flow)
+ *   - otherwise      → Submit > Expenses          (Employee flow)
+ *
+ * URL state:
+ *   ?tab=submit|manage
+ *   ?sub=<sub-tab-id>          — secondary tab inside the active primary
+ *   ?folder=<folderId>         — folder detail sub-screen (BR-008 / AC-007)
+ *   ?expense=<expenseId>       — expense side panel (Spec C/D)
+ *
+ * Side-panel variant resolution:
+ *   - On Pending Controlling → variant = "controlling" (form, footer with
+ *     Save / Mark as controlled / Reject).
+ *   - Everywhere else        → variant = "detail" (read-only, tabs).
+ *   - When the user triggers the "Bulk edit" bulk action, we open the
+ *     same panel in "bulk-edit" variant — applies the form to every
+ *     selected row on submit. Mark-as-controlled is a separate bulk
+ *     action that NEVER auto-edits fields (BR-005).
+ *
+ * Manager visibility (BR-008 / DT-001 from Spec D) is intentionally not
+ * implemented here — this prototype shows the finance-rich UI to every
+ * audience so reviewers see the full surface. Production gates the
+ * controlling action set behind a permission.
+ */
+export const meta: PrototypeMeta = {
+  slug: "controlling-step-poc",
+  title: "Controlling Step (POC)",
+  description:
+    "Single Spending page (Finance sidebar). Tab row 1: Submit · Manage (Manage only when the user has something to review). Submit > Expenses · Purchase Requests · Cards. Manage > Pending approval · Pending controlling · Pay · All. Pending Controlling has its own coding form (Spec D); Pay groups Unpaid + Paid presets across approved/controlled/in-payroll (Spec C r2).",
+  category: "Other",
+  module: "spending",
+  audience: ["employee", "manager", "admin"],
+  tags: ["spending", "expenses", "finance", "ia", "shell"],
+  createdAt: "2026-05-11",
+}
+
+const SUBMIT_DEFAULT_SUB = SUBMIT_SUB_TABS[0].id // "expenses"
+const MANAGE_DEFAULT_SUB = MANAGE_SUB_TABS[0].id // "pending-approval"
+
+export default function ControllingStepPoc() {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // Manage visibility is inferred from the dataset, not a role flag.
+  // Employee = "no expenses to review" → Manage tab is hidden.
+  // Manager / Finance = "has expenses to review" → Manage tab is visible.
+  const manageRows = useManageRows()
+  const submitRows = useSubmitExpensesRows()
+  const hasManageQueue = manageRows.length > 0
+
+  // Bulk-edit selection (Spec D F-002 / BR-003 / BR-005). When non-null
+  // we render the side panel in "bulk-edit" variant. Lives in component
+  // state — not URL — because the selection itself is volatile and we
+  // don't want refresh to silently re-trigger a bulk overwrite.
+  const [bulkEditIds, setBulkEditIds] = useState<string[] | null>(null)
+
+  const visiblePrimaryTabs = hasManageQueue
+    ? PRIMARY_TABS
+    : PRIMARY_TABS.filter((t) => t.id !== "manage")
+
+  // Default landing follows directly from Manage visibility.
+  const defaultPrimary: PrimaryTabId = hasManageQueue ? "manage" : "submit"
+
+  // Folder detail takes precedence over tabs.
+  const folderId = searchParams.get("folder")
+  const expenseId = searchParams.get("expense")
+
+  const folderHref = useMemo(
+    () => (id: string) => {
+      const next = new URLSearchParams(searchParams)
+      next.set("folder", id)
+      return `/p/controlling-step-poc?${next.toString()}`
+    },
+    [searchParams]
+  )
+
+  // Primary tab from URL (must be in visible set; otherwise fall back).
+  const rawPrimary = searchParams.get("tab")
+  const primaryTab: PrimaryTabId =
+    visiblePrimaryTabs.find((t) => t.id === rawPrimary)?.id ?? defaultPrimary
+
+  // Sub-tab from URL.
+  const subTabsForPrimary =
+    primaryTab === "submit" ? SUBMIT_SUB_TABS : MANAGE_SUB_TABS
+  const defaultSubForPrimary =
+    primaryTab === "submit" ? SUBMIT_DEFAULT_SUB : MANAGE_DEFAULT_SUB
+  const rawSub = searchParams.get("sub")
+  const subTab =
+    subTabsForPrimary.find((t) => t.id === rawSub)?.id ?? defaultSubForPrimary
+
+  // The expense being viewed in the full-page detail view. Null when:
+  //   - no `?expense` in the URL, OR
+  //   - the id no longer matches a fixture row (stale link → silently
+  //     close).
+  //
+  // Lookup spans every tab's dataset, not just Manage's. Submit's
+  // synthesized draft expenses share ids with the original `expenses`
+  // fixture (we just clone them with `status: "draft"`), so resolving
+  // against `expenses` covers all of Submit, Manage, FolderDetail and
+  // any future tab that surfaces an expense row. Drafts open with the
+  // canonical (`pending`) snapshot, but the detail view doesn't gate
+  // any behavior on status today so this is fine.
+  const expenseRow: SpendingRow | null = useMemo(() => {
+    if (!expenseId) return null
+    // Resolve the row from the SAME pool the user is browsing.
+    //
+    // This matters because Submit's row factory re-casts statuses on
+    // a handful of pending expenses (e.g. → `draft` or
+    // `changes-requested` for the To-Do preset). Manage keeps the
+    // original pending status. Both pools share source ids — so
+    // looking in the wrong pool first means the table cell ("Changes
+    // requested") and the detail-page ResourceHeader ("Pending")
+    // disagree, which broke the policy-alert variant selector too
+    // (it filters by `view` + draft/changes-requested status).
+    //
+    // Submit-side rows can also have synthetic ids prefixed
+    // `draft-…` that don't exist anywhere else; those only resolve
+    // through `submitRows`.
+    const primaryPool = primaryTab === "submit" ? submitRows : manageRows
+    const fallbackPool = primaryTab === "submit" ? manageRows : submitRows
+    const fromPrimary = primaryPool.find(
+      (r) => r.kind === "expense" && r.id === expenseId
+    )
+    if (fromPrimary) return fromPrimary
+    const fromFallback = fallbackPool.find(
+      (r) => r.kind === "expense" && r.id === expenseId
+    )
+    if (fromFallback) return fromFallback
+    const raw = expenses.find((e) => e.id === expenseId)
+    return raw ? expenseToRow(raw) : null
+  }, [expenseId, primaryTab, manageRows, submitRows])
+
+  // Sibling expense IDs in the active preset of the active tab —
+  // used by the detail page's header navigation (1/N + up/down
+  // chevrons). The user expects the chevrons to walk *the same list
+  // they were looking at* when they opened the detail (e.g. the 9
+  // rows of Approve > "Needs review", not all 26 pending rows).
+  //
+  // OneDataCollection owns preset state internally (no URL param to
+  // read), so we infer the active preset from the *opened row* by
+  // matching it against per-(tab, subTab) bucket predicates. A row
+  // belongs to the first bucket whose predicate it satisfies — so
+  // bucket order matters when buckets overlap (e.g. Approve splits
+  // by alerts on the same status set).
+  //
+  // Folder rows are excluded — only expenses open in the detail.
+  type RowPredicate = (row: SpendingRow) => boolean
+  const PRESET_BUCKETS: Record<string, RowPredicate[]> = useMemo(() => {
+    const byStatus =
+      (...statuses: ExpenseStatus[]): RowPredicate =>
+      (r) =>
+        statuses.includes(r.status)
+    return {
+      // My spending > Expenses
+      "submit:expenses": [
+        byStatus("draft", "changes-requested"), // To-Do
+        byStatus("pending", "approved", "in-payroll", "paid"), // Submitted
+      ],
+      // Approve & Pay > Approve splits by alerts on the same status
+      // ("pending"). Order matters: rows with alerts → Needs review,
+      // rows without → Ready to approve.
+      "manage:pending-approval": [
+        (r) => r.status === "pending" && r.alerts.length > 0, // Needs review
+        (r) => r.status === "pending" && r.alerts.length === 0, // Ready to approve
+      ],
+      // Control > Uncontrolled / Controlled
+      "manage:pending-controlling": [byStatus("approved"), byStatus("controlled")],
+      // Pay > Unpaid / Paid
+      "manage:pay": [byStatus("controlled"), byStatus("paid")],
+      // All > Pending / Approved / Controlled / In Payroll / Paid
+      "manage:all": [
+        byStatus("pending"),
+        byStatus("approved"),
+        byStatus("controlled"),
+        byStatus("in-payroll"),
+        byStatus("paid"),
+      ],
+    }
+  }, [])
+
+  const siblingIds = useMemo(() => {
+    if (!expenseId) return []
+    const pool =
+      primaryTab === "manage"
+        ? manageRows
+        : primaryTab === "submit" && subTab === "expenses"
+          ? submitRows
+          : []
+    if (pool.length === 0) return []
+
+    // Find the opened row to read its signals; if it's not in the
+    // current pool (e.g. user landed via a deep link from another
+    // tab) fall back to the full pool so navigation still works.
+    const openedRow = pool.find(
+      (r) => r.kind === "expense" && r.id === expenseId
+    )
+    const expensesInPool = pool.filter((r) => r.kind === "expense")
+    if (!openedRow) return expensesInPool.map((r) => r.id)
+
+    const buckets = PRESET_BUCKETS[`${primaryTab}:${subTab}`]
+    if (!buckets) return expensesInPool.map((r) => r.id)
+    const bucket = buckets.find((pred) => pred(openedRow))
+    if (!bucket) return expensesInPool.map((r) => r.id)
+    return expensesInPool.filter((r) => bucket(r)).map((r) => r.id)
+  }, [expenseId, primaryTab, subTab, manageRows, submitRows, PRESET_BUCKETS])
+
+  const siblingNav = useMemo(() => {
+    if (!expenseId || siblingIds.length === 0) return null
+    const idx = siblingIds.indexOf(expenseId)
+    if (idx < 0) return null
+    const buildHref = (id: string) => {
+      const next = new URLSearchParams(searchParams)
+      next.set("expense", id)
+      return `/p/controlling-step-poc?${next.toString()}`
+    }
+    return {
+      counter: { current: idx + 1, total: siblingIds.length },
+      previous:
+        idx > 0
+          ? { url: buildHref(siblingIds[idx - 1]!), title: "Previous expense" }
+          : undefined,
+      next:
+        idx < siblingIds.length - 1
+          ? { url: buildHref(siblingIds[idx + 1]!), title: "Next expense" }
+          : undefined,
+    }
+  }, [expenseId, siblingIds, searchParams])
+
+  const openExpense = useCallback(
+    (id: string) => {
+      const next = new URLSearchParams(searchParams)
+      next.set("expense", id)
+      setSearchParams(next)
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const closeSidePanel = useCallback(() => {
+    const next = new URLSearchParams(searchParams)
+    next.delete("expense")
+    setSearchParams(next)
+    setBulkEditIds(null)
+  }, [searchParams, setSearchParams])
+
+  // Bulk action dispatcher. Spec D BR-003/005: "Bulk edit" opens the
+  // panel pre-filled empty; "Mark as controlled" / "Reject" / Pay
+  // actions are no-op stubs in the prototype (we'd hit an API in prod).
+  const handleBulkAction = useCallback(
+    (actionId: string, ids: string[]) => {
+      if (actionId === "bulk-edit") {
+        if (ids.length === 0) return
+        setBulkEditIds(ids)
+      }
+      // Other bulk actions intentionally fall through — production
+      // wires them to mutations + toast confirmations, but the
+      // prototype has nothing to mutate.
+    },
+    []
+  )
+
+  const setPrimary = (id: string) => {
+    const next = new URLSearchParams(searchParams)
+    next.set("tab", id)
+    next.delete("sub")
+    next.delete("expense")
+    setSearchParams(next)
+  }
+  const setSub = (id: string) => {
+    const next = new URLSearchParams(searchParams)
+    next.set("sub", id)
+    next.delete("expense")
+    setSearchParams(next)
+  }
+
+  const primaryTabsWithNav = visiblePrimaryTabs.map((t) => ({
+    ...t,
+    onClick: () => setPrimary(t.id),
+  }))
+  const subTabsWithNav = subTabsForPrimary.map((t) => ({
+    ...t,
+    onClick: () => setSub(t.id),
+  }))
+
+  // Side-panel variant: bulk-edit ONLY now. Single-expense detail/
+  // controlling flows render full-page via `ExpenseDetailPage` below.
+  // Keeping the panel for bulk-edit because a multi-row form
+  // operating on a transient selection wants the focused, dismissible
+  // affordance — a full-page view there would feel like a state
+  // change rather than a temporary action.
+  const sidePanelOpen = bulkEditIds !== null
+  const sidePanelVariant = "bulk-edit" as const
+
+  // Whether the open expense lives on a tab where the controlling
+  // block matters (Pending Controlling, Pay, All). Drives the
+  // ResourceHeader's Edit / Mark-as-controlled actions.
+  const isControllableTab =
+    primaryTab === "manage" &&
+    (subTab === "pending-controlling" ||
+      subTab === "pay" ||
+      subTab === "all")
+
+  // The detail page's CTA set depends on which JTBD owns the tab the
+  // user came from:
+  //   - "approval"    → approver flow: Approve / Reject as primary CTAs.
+  //   - "controlling" → finance review: Mark as controlled / Reject.
+  //   - "pay"         → treasury: Mark as paid / Reject.
+  //   - "view"        → no destructive primary action; only Edit + overflow.
+  // Submit and Folder tabs map to "view" because the user owns those
+  // expenses but isn't approving them from the detail page.
+  const tabRole: "approval" | "controlling" | "pay" | "view" =
+    primaryTab === "manage" && subTab === "pending-approval"
+      ? "approval"
+      : primaryTab === "manage" && subTab === "pending-controlling"
+        ? "controlling"
+        : primaryTab === "manage" && subTab === "pay"
+          ? "pay"
+          : "view"
+
+  // Breadcrumb label for the expense page. Falls back to "Spending"
+  // when nothing useful is in the URL (e.g. deep link to ?expense=…).
+  const sourceTabLabel = useMemo(() => {
+    if (primaryTab === "manage") {
+      const sub = MANAGE_SUB_TABS.find((t) => t.id === subTab)
+      return sub ? `Approve & Pay · ${sub.label}` : "Approve & Pay"
+    }
+    const sub = SUBMIT_SUB_TABS.find((t) => t.id === subTab)
+    return sub ? `My spending · ${sub.label}` : "My spending"
+  }, [primaryTab, subTab])
+
+  // Deep-link URL for the source-tab breadcrumb so clicking it
+  // restores the same primary+sub tab the user came from.
+  const sourceTabHref = useMemo(
+    () => `/p/controlling-step-poc?tab=${primaryTab}&sub=${subTab}`,
+    [primaryTab, subTab]
+  )
+
+  // Stub mutation handlers — the prototype doesn't persist anything.
+  // They close the panel so the interaction reads as "done". Memoised
+  // so their identity stays stable across renders; otherwise the form
+  // definition inside `ControllingForm` would re-register and the AI
+  // chat panel's tool registration would loop (Maximum update depth).
+  const noopAndClose = useCallback(
+    (_data?: ControllingFormData) => {
+      closeSidePanel()
+    },
+    [closeSidePanel]
+  )
+  const onMarkControlled = useCallback(() => closeSidePanel(), [closeSidePanel])
+  const onReject = useCallback(() => closeSidePanel(), [closeSidePanel])
+
+  if (folderId) {
+    // Folder sub-screen takes over AFTER all hooks above are declared,
+    // so every render of `Spending` calls the same hooks in the same
+    // order regardless of whether the URL has `?folder=`. React's
+    // "rendered fewer hooks" rule depends on stable hook order across
+    // renders — never put an early return between hook calls.
+    return (
+      <FolderDetail
+        folderId={folderId}
+        onExpenseClick={openExpense}
+        onBack={() => {
+          const next = new URLSearchParams(searchParams)
+          next.delete("folder")
+          setSearchParams(next)
+        }}
+      />
+    )
+  }
+
+  // Single-expense full-page view. Mounted ONLY when we have a row
+  // resolved and we're NOT in bulk-edit (which still renders the side
+  // panel over the list, see further down). Same hook-order rule as
+  // the folder branch: every hook above runs unconditionally.
+  if (expenseRow && bulkEditIds === null) {
+    return (
+      <ExpenseDetailPage
+        row={expenseRow}
+        sourceTabLabel={sourceTabLabel}
+        sourceTabHref={sourceTabHref}
+        controllable={isControllableTab}
+        tabRole={tabRole}
+        navigation={siblingNav}
+        onBack={closeSidePanel}
+        onSaveControlling={noopAndClose}
+        onMarkControlled={onMarkControlled}
+        onReject={onReject}
+      />
+    )
+  }
+
+  return (
+    <Page
+      header={
+        <>
+          <PageHeader
+            module={{
+              id: "my_spending",
+              name: "Spend management",
+              href: "/p/controlling-step-poc?tab=submit&sub=expenses",
+            }}
+            actions={[]}
+          />
+          <Tabs
+            key={primaryTab}
+            tabs={primaryTabsWithNav}
+            activeTabId={primaryTab}
+          />
+          <Tabs
+            key={`${primaryTab}:${subTab}`}
+            secondary
+            tabs={subTabsWithNav}
+            activeTabId={subTab}
+          />
+        </>
+      }
+    >
+      <StandardLayout>
+        <F0Box display="flex" flexDirection="column" gap="lg">
+          {primaryTab === "submit" && subTab === "expenses" && (
+            <SubmitExpensesTab
+              folderHref={folderHref}
+              onExpenseClick={openExpense}
+            />
+          )}
+          {primaryTab === "submit" && subTab === "purchase-requests" && (
+            <F0Box
+              display="flex"
+              flexDirection="column"
+              gap="sm"
+              padding="lg"
+              background="secondary"
+              borderRadius="md"
+            >
+              <F0Text
+                variant="label"
+                content="Purchase Requests — placement only"
+              />
+              <F0Text
+                variant="description"
+                content="The existing Purchase Requests page (its internal tabs, presets, table and side panel) will be rendered here unchanged."
+              />
+            </F0Box>
+          )}
+          {primaryTab === "submit" && subTab === "cards" && (
+            <F0Box
+              display="flex"
+              flexDirection="column"
+              gap="sm"
+              padding="lg"
+              background="secondary"
+              borderRadius="md"
+            >
+              <F0Text variant="label" content="Cards — placement only" />
+              <F0Text
+                variant="description"
+                content="The existing Cards page (its internal tabs, presets, table and side panel) will be rendered here unchanged."
+              />
+            </F0Box>
+          )}
+          {primaryTab === "manage" &&
+            (
+              ["pending-approval", "pending-controlling", "pay", "all"] as const
+            ).map(
+              (id) =>
+                subTab === id && (
+                  <ManageTab
+                    key={id}
+                    variant={id as ManageSubTabId}
+                    folderHref={folderHref}
+                    onExpenseClick={openExpense}
+                    onBulkAction={handleBulkAction}
+                  />
+                )
+            )}
+        </F0Box>
+
+        {/* Side panel — single component, three variants. We mount it
+            conditionally on `sidePanelOpen` so the controlling form
+            (and therefore its registration with the AI form registry)
+            only exists while the user can actually see it. Mounting an
+            invisible form leaves the registry in a "registered but no
+            UI" state, which loops the chat panel
+            ("Maximum update depth exceeded" inside Dle / Array.map). */}
+        {sidePanelOpen && (
+          <ExpenseSidePanel
+            isOpen={sidePanelOpen}
+            onClose={closeSidePanel}
+            variant={sidePanelVariant}
+            row={expenseRow}
+            bulkSelectionCount={bulkEditIds?.length}
+            onSaveControlling={noopAndClose}
+            onMarkControlled={onMarkControlled}
+            onReject={onReject}
+            onBulkApply={noopAndClose}
+          />
+        )}
+      </StandardLayout>
+    </Page>
+  )
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/folder/FolderDetail.tsx
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/folder/FolderDetail.tsx
@@ -1,0 +1,244 @@
+import {
+  expenseGroups,
+  expenses,
+  type ExpenseGroup,
+} from "@/fixtures"
+import { F0Box, F0Text, StandardLayout } from "@factorialco/f0-react"
+import {
+  OneDataCollection,
+  Page,
+  PageHeader,
+  ResourceHeader,
+  useDataCollectionSource,
+} from "@factorialco/f0-react/dist/experimental"
+import {
+  Cross,
+  Delete,
+  Download,
+  Pencil,
+  Upload,
+} from "@factorialco/f0-react/icons/app"
+import { useMemo } from "react"
+
+import { applySort } from "@/lib/applySort"
+
+import { spendingColumns } from "../shared/columns"
+import { expenseToRow, type SpendingRow } from "../shared/rows"
+import { STATUS_LABEL, STATUS_VARIANT } from "../shared/expenseStatus"
+
+const eurFormatter = new Intl.NumberFormat("en-GB", {
+  style: "currency",
+  currency: "EUR",
+})
+function formatEUR(amount: number) {
+  return eurFormatter.format(amount)
+}
+
+/**
+ * Folder detail sub-screen.
+ *
+ * BR-009: folders keep all their existing operations — submit for
+ * approval, export PDF, rename, delete, and they aggregate a total.
+ *
+ * The inner table reuses the unified `spendingColumns` minus the
+ * folder cell quirks; nested expenses are rendered as plain rows.
+ */
+export function FolderDetail(props: {
+  folderId: string
+  onBack: () => void
+  /** Open the full-page expense detail for a row inside the folder. */
+  onExpenseClick: (expenseId: string) => void
+}) {
+  // Folders today don't carry a list of expense ids in the fixture, so
+  // we deterministically take the first N expenses to hydrate the demo.
+  const folder: ExpenseGroup | undefined = expenseGroups.find(
+    (g) => g.id === props.folderId
+  )
+  const memberRows = useMemo(() => {
+    if (!folder) return []
+    return expenses.slice(0, folder.expenseCount).map(expenseToRow)
+  }, [folder])
+
+  const source = useDataCollectionSource<SpendingRow>(
+    {
+      search: { enabled: true, sync: true },
+      filters: {},
+      currentFilters: {},
+      sortings: {
+        name: { label: "Provider" },
+        date: { label: "Date" },
+        amount: { label: "Amount" },
+      },
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 10,
+        fetchData: ({ search, sortings, pagination }) => {
+          const term = (search ?? "").toLowerCase().trim()
+          const filtered = memberRows.filter((r) =>
+            term === "" ? true : r.name.toLowerCase().includes(term)
+          )
+          const sorted = applySort(filtered, sortings, (r, field) => {
+            switch (field) {
+              case "name":
+                return r.name.toLowerCase()
+              case "amount":
+                return r.amount
+              case "date":
+                return Date.parse(r.date)
+              default:
+                return null
+            }
+          })
+          const perPage = pagination?.perPage ?? 10
+          const currentPage =
+            pagination && "currentPage" in pagination && pagination.currentPage
+              ? pagination.currentPage
+              : 1
+          const total = sorted.length
+          const pagesCount = Math.max(1, Math.ceil(total / perPage))
+          const start = (currentPage - 1) * perPage
+          return {
+            type: "pages" as const,
+            records: sorted.slice(start, start + perPage),
+            total,
+            perPage,
+            currentPage,
+            pagesCount,
+          }
+        },
+      },
+      itemActions: () => [
+        { label: "View details", onClick: () => {} },
+        { label: "Remove from folder", onClick: () => {}, critical: true },
+      ],
+      // Row checkboxes — folder detail's only meaningful bulk action
+      // is removing expenses from the folder.
+      selectable: (item: SpendingRow) => item.id,
+      bulkActions: () => ({
+        primary: [
+          {
+            id: "remove-from-folder",
+            label: "Remove from folder",
+            icon: Cross,
+            critical: true,
+          },
+        ],
+      }),
+    },
+    [memberRows]
+  )
+
+  if (!folder) {
+    return (
+      <Page
+        header={
+          <PageHeader
+            module={{ id: "my_spending", name: "Spend management", href: "/p/controlling-step-poc?tab=submit&sub=expenses" }}
+            breadcrumbs={[{ id: "missing", label: "Folder not found" }]}
+            actions={[{ label: "Back", icon: Cross, onClick: props.onBack }]}
+          />
+        }
+      >
+        <StandardLayout>
+          <F0Text
+            content="No folder matches that id. Try another one."
+            variant="description"
+          />
+        </StandardLayout>
+      </Page>
+    )
+  }
+
+  return (
+    <Page
+      header={
+        <>
+          <PageHeader
+            module={{
+              id: "my_spending",
+              name: "Spend management",
+              href: "/p/controlling-step-poc?tab=submit&sub=expenses",
+            }}
+            breadcrumbs={[{ id: folder.id, label: folder.name }]}
+          />
+          <ResourceHeader
+            title={folder.name}
+            status={{
+              label: "Status",
+              text: STATUS_LABEL[folder.status],
+              variant: STATUS_VARIANT[folder.status],
+            }}
+            metadata={[
+              {
+                label: "Total cost",
+                value: {
+                  type: "text",
+                  content: formatEUR(folder.reimbursableAmount),
+                },
+              },
+              {
+                label: "Legal entity",
+                value: {
+                  type: "text",
+                  content: "Barcelona Legal entity",
+                },
+              },
+            ]}
+            primaryAction={{
+              label: "Send for approval",
+              icon: Upload,
+              onClick: () => {},
+            }}
+            secondaryActions={[
+              // BaseHeader renders secondaryActions in array order to
+              // the LEFT of the primary CTA. Order matches the
+              // screenshot: [Delete folder] [Edit] | [Send for approval].
+              {
+                label: "Delete folder",
+                icon: Delete,
+                variant: "outline",
+                onClick: () => {},
+              },
+              {
+                label: "Edit",
+                icon: Pencil,
+                variant: "outline",
+                onClick: () => {},
+              },
+            ]}
+            otherActions={[
+              // Demoted to the 3-dot menu — useful escape hatch for
+              // finance, but not loud enough to deserve its own
+              // header slot per the new layout.
+              { label: "Export PDF", icon: Download, onClick: () => {} },
+            ]}
+          />
+        </>
+      }
+    >
+      <StandardLayout>
+        <F0Box display="flex" flexDirection="column" gap="lg">
+          <OneDataCollection
+            source={{
+              ...source,
+              // Expense rows open the detail page; non-expense rows
+              // (e.g. nested folders) must return `undefined` so the
+              // OneTable cell falls through to `itemUrl`. A no-op
+              // function here would block navigation — see ManageTab
+              // for the full explanation.
+              itemOnClick: ((item: SpendingRow) =>
+                item.kind === "expense"
+                  ? () => props.onExpenseClick(item.id)
+                  : undefined) as unknown as (
+                item: SpendingRow
+              ) => () => void,
+            }}
+            visualizations={[
+              { type: "table", options: { columns: [...spendingColumns] } },
+            ]}
+          />
+        </F0Box>
+      </StandardLayout>
+    </Page>
+  )
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/manage/ManageTab.tsx
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/manage/ManageTab.tsx
@@ -1,0 +1,68 @@
+import { OneDataCollection } from "@factorialco/f0-react/dist/experimental"
+
+import { spendingColumns } from "../shared/columns"
+import type { SpendingRow } from "../shared/rows"
+import { useManageRows, useManageSource } from "./useManageSource"
+import type { ManageSubTabId } from "../tabs"
+
+/**
+ * Single Manage tab body. Each of the four sub-tabs reuses this
+ * component with a different `variant` so the dataset, filters and
+ * actions stay consistent.
+ *
+ * Click handling:
+ *   - Folders → navigate via `folderHref` (handled by the source's
+ *     `itemUrl`, which leaves expense rows un-linked).
+ *   - Expense rows → call `onExpenseClick(id)`. The parent owns the URL
+ *     state (`?expense=<id>`) and chooses which side-panel variant to
+ *     render based on the active sub-tab.
+ *
+ * Bulk actions:
+ *   - The source declares the actions; the parent handles them via
+ *     `onBulkAction`. This is the path that wires Spec D's
+ *     `Mark as controlled` and `Bulk edit` into the side-panel layer.
+ */
+export function ManageTab(props: {
+  variant: ManageSubTabId
+  folderHref: (folderId: string) => string
+  onExpenseClick: (expenseId: string) => void
+  onBulkAction: (actionId: string, selectedIds: string[]) => void
+}) {
+  const rows = useManageRows()
+  const source = useManageSource({
+    rows,
+    variant: props.variant,
+    folderHref: props.folderHref,
+  })
+  return (
+    <OneDataCollection
+      source={{
+        ...source,
+        // Only intercept clicks for expense rows (open the detail
+        // page). Folder rows fall through to `itemUrl` so the URL
+        // navigates to `?folder=<id>`. Returning `undefined` here is
+        // critical: if we return a no-op function, OneTable renders
+        // an absolute-positioned <button> over the link and the
+        // folder navigation gets swallowed by stopPropagation.
+        itemOnClick: ((item: SpendingRow) =>
+          item.kind === "expense"
+            ? () => props.onExpenseClick(item.id)
+            : undefined) as unknown as (item: SpendingRow) => () => void,
+      }}
+      onBulkAction={(actionId, selected, clearSelection) => {
+        const ids = selected.itemsStatus
+          .filter((s) => s.checked)
+          .map((s) => s.item.id)
+        props.onBulkAction(actionId, ids)
+        // Bulk-edit opens a side panel and the user may cancel — keep
+        // the selection so they can retry without re-checking rows.
+        if (actionId !== "bulk-edit") {
+          clearSelection()
+        }
+      }}
+      visualizations={[
+        { type: "table", options: { columns: [...spendingColumns] } },
+      ]}
+    />
+  )
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/manage/useManageSource.ts
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/manage/useManageSource.ts
@@ -1,0 +1,439 @@
+import {
+  expenseGroups,
+  expenses,
+  type ExpenseStatus,
+} from "@/fixtures"
+import { useDataCollectionSource } from "@factorialco/f0-react/dist/experimental"
+import {
+  ArrowCycle,
+  CheckCircle,
+  Cross,
+  Money,
+  Pencil,
+  Upload,
+} from "@factorialco/f0-react/icons/app"
+import { useMemo } from "react"
+
+import { paginateRows } from "../shared/columns"
+import { expenseToRow, folderToRow, type SpendingRow } from "../shared/rows"
+
+/**
+ * The Manage tabs share a single dataset — expenses and folders that
+ * the current user can review — and slice it by status via
+ * `statusFilter` per tab.
+ *
+ * Spec A: everyone sees the same tabs and the same affordances (no
+ * role gating in this prototype).
+ *
+ * Spec C (Pay restructure r2):
+ *   - Pay tab shows ALL expenses past approval: approved · controlled
+ *     · in-payroll. Presets Unpaid (approved + controlled) and Paid
+ *     (in-payroll). Bulk actions are the union (Send to payroll · Send
+ *     to SEPA · Set as paid · Sync to ERP), with Advanced export
+ *     surfaced in the row 3-dot overflow.
+ *   - All tab adds a Controlled preset.
+ *
+ * Spec D (Pending Controlling r1):
+ *   - Pending Controlling tab shows approved + controlled. Presets
+ *     Uncontrolled (approved, default) and Controlled. Bulk actions:
+ *     Mark as controlled · Bulk edit · Reject (BR-003 / BR-005 /
+ *     BR-007).
+ */
+export function useManageRows(): SpendingRow[] {
+  return useMemo(() => {
+    return [...expenseGroups.map(folderToRow), ...expenses.map(expenseToRow)]
+  }, [])
+}
+
+type ManageVariant =
+  | "pending-approval"
+  | "pending-controlling"
+  | "pay"
+  | "all"
+
+const STATUS_BY_TAB: Record<ManageVariant, ExpenseStatus[] | undefined> = {
+  "pending-approval": ["pending"],
+  "pending-controlling": ["approved", "controlled"],
+  // Pay covers the actionable + terminal halves of the post-approval
+  // lifecycle: Unpaid (approved + controlled) and Paid (paid).
+  // `in-payroll` ("Sent to Pay") is intentionally NOT in this slice —
+  // once finance has dispatched a row to payroll/SEPA it leaves the
+  // Pay queue; reconciliation lives on the All tab. This keeps the
+  // Pay statuses unambiguous: blue for ready, green for done.
+  pay: ["approved", "controlled", "paid"],
+  all: undefined,
+}
+
+export function useManageSource(args: {
+  rows: SpendingRow[]
+  variant: ManageVariant
+  folderHref: (folderId: string) => string
+}) {
+  const { rows, variant, folderHref } = args
+
+  // Per-tab base-status slice — used both by fetchData and by preset counters.
+  const tabRows = useMemo(() => {
+    const base = STATUS_BY_TAB[variant]
+    return base ? rows.filter((r) => base.includes(r.status)) : rows
+  }, [rows, variant])
+
+  const presetCounts = useMemo(() => {
+    if (variant === "pending-approval") {
+      return {
+        needsReview: tabRows.filter((r) => r.alerts.length > 0).length,
+        readyToApprove: tabRows.filter((r) => r.alerts.length === 0).length,
+      }
+    }
+    if (variant === "pending-controlling") {
+      return {
+        // BR-002: "Uncontrolled" is the default preset and means
+        // status === approved (i.e. not yet coded by finance).
+        uncontrolled: tabRows.filter((r) => r.status === "approved").length,
+        controlled: tabRows.filter((r) => r.status === "controlled").length,
+      }
+    }
+    if (variant === "pay") {
+      return {
+        // Spec C r2: Unpaid groups approved + controlled (i.e.
+        // everything finance is allowed to pay) so the controlling
+        // step doesn't slice the Pay queue in two. Paid is the
+        // terminal `paid` status — `in-payroll` rows live on the All
+        // tab now.
+        unpaid: tabRows.filter(
+          (r) => r.status === "approved" || r.status === "controlled"
+        ).length,
+        paid: tabRows.filter((r) => r.status === "paid").length,
+      }
+    }
+    if (variant === "all") {
+      return {
+        pending: rows.filter((r) => r.status === "pending").length,
+        approved: rows.filter((r) => r.status === "approved").length,
+        controlled: rows.filter((r) => r.status === "controlled").length,
+        inPayroll: rows.filter((r) => r.status === "in-payroll").length,
+        paid: rows.filter((r) => r.status === "paid").length,
+      }
+    }
+    return null
+  }, [rows, tabRows, variant])
+
+  return useDataCollectionSource<SpendingRow>(
+    {
+      search: { enabled: true, sync: true },
+      filters: {
+        status: {
+          type: "in",
+          label: "Status",
+          options: {
+            options: [
+              { value: "pending", label: "Pending" },
+              { value: "approved", label: "Approved" },
+              { value: "controlled", label: "Controlled" },
+              { value: "in-payroll", label: "Sent to Pay" },
+              { value: "paid", label: "Paid" },
+            ],
+          },
+        },
+        alerts: {
+          type: "in",
+          label: "Compliance",
+          options: {
+            options: [
+              { value: "has-alerts", label: "Needs review" },
+              { value: "no-alerts", label: "Ready to approve" },
+            ],
+          },
+        },
+      },
+      currentFilters: {},
+      presets:
+        variant === "pending-approval"
+          ? [
+              {
+                label: "Needs review",
+                filter: { alerts: ["has-alerts"] },
+                itemsCount: () => presetCounts?.needsReview ?? 0,
+              },
+              {
+                label: "Ready to approve",
+                filter: { alerts: ["no-alerts"] },
+                itemsCount: () => presetCounts?.readyToApprove ?? 0,
+              },
+            ]
+          : variant === "pending-controlling"
+            ? [
+                {
+                  label: "To control",
+                  filter: { status: ["approved"] },
+                  itemsCount: () => presetCounts?.uncontrolled ?? 0,
+                },
+                {
+                  label: "Controlled",
+                  filter: { status: ["controlled"] },
+                  itemsCount: () => presetCounts?.controlled ?? 0,
+                },
+              ]
+            : variant === "pay"
+              ? [
+                  {
+                    label: "Unpaid",
+                    filter: { status: ["approved", "controlled"] },
+                    itemsCount: () => presetCounts?.unpaid ?? 0,
+                  },
+                  {
+                    label: "Paid",
+                    filter: { status: ["paid"] },
+                    itemsCount: () => presetCounts?.paid ?? 0,
+                  },
+                ]
+              : variant === "all"
+                ? [
+                    {
+                      label: "Pending",
+                      filter: { status: ["pending"] },
+                      itemsCount: () => presetCounts?.pending ?? 0,
+                    },
+                    {
+                      label: "Approved",
+                      filter: { status: ["approved"] },
+                      itemsCount: () => presetCounts?.approved ?? 0,
+                    },
+                    {
+                      label: "Controlled",
+                      filter: { status: ["controlled"] },
+                      itemsCount: () => presetCounts?.controlled ?? 0,
+                    },
+                    {
+                      label: "Sent to Pay",
+                      filter: { status: ["in-payroll"] },
+                      itemsCount: () => presetCounts?.inPayroll ?? 0,
+                    },
+                    {
+                      label: "Paid",
+                      filter: { status: ["paid"] },
+                      itemsCount: () =>
+                        (presetCounts as { paid?: number } | null)?.paid ?? 0,
+                    },
+                  ]
+                : [],
+      sortings: {
+        name: { label: "Name" },
+        date: { label: "Date" },
+        amount: { label: "Amount" },
+      },
+      itemUrl: (item) =>
+        item.kind === "folder" ? folderHref(item.id) : undefined,
+      // Row-level checkboxes for bulk actions (Spec C/D). Both
+      // expenses AND folders are selectable in Manage — folder
+      // containers are aggregates of expenses (BR-008/BR-009 from
+      // Spec A) so finance often wants to act on the whole folder.
+      // The bulk-action set is filtered downstream when the selection
+      // mixes kinds — see `bulkActions` below.
+      selectable: (item: SpendingRow) => item.id,
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 25,
+        fetchData: ({ filters, search, sortings, pagination }) => {
+          const userFilter = Array.isArray(filters?.status)
+            ? (filters.status as ExpenseStatus[])
+            : []
+          const baseFilter = STATUS_BY_TAB[variant]
+          const effective =
+            baseFilter && userFilter.length > 0
+              ? userFilter.filter((s) => baseFilter.includes(s))
+              : baseFilter && baseFilter.length > 0
+                ? baseFilter
+                : userFilter
+          const alertFilter = Array.isArray(filters?.alerts)
+            ? (filters.alerts as Array<"has-alerts" | "no-alerts">)
+            : []
+          const wantsAlerts = alertFilter.includes("has-alerts")
+          const wantsClean = alertFilter.includes("no-alerts")
+          const alertPredicate =
+            alertFilter.length === 0 || (wantsAlerts && wantsClean)
+              ? undefined
+              : wantsAlerts
+                ? (r: SpendingRow) => r.alerts.length > 0
+                : (r: SpendingRow) => r.alerts.length === 0
+          const scoped = alertPredicate ? rows.filter(alertPredicate) : rows
+          return paginateRows(scoped, {
+            search: search ?? undefined,
+            sortings,
+            pagination: pagination as
+              | { perPage?: number; currentPage?: number }
+              | undefined,
+            statusFilter: effective.length > 0 ? effective : undefined,
+          })
+        },
+      },
+      // Toolbar-level secondary action (sits inline with presets and
+      // search, NOT inside the bulk action bar). `expanded: 1` keeps
+      // the first secondary visible as a button instead of folding it
+      // into the 3-dot overflow. All four Approve & Pay tabs surface
+      // a Sync to ERP affordance because finance routinely re-syncs
+      // from any of these views (per spec discussion in PR comments).
+      secondaryActions: {
+        expanded: 1,
+        actions: () => [
+          { label: "Sync to Business Central", icon: ArrowCycle },
+        ],
+      },
+      bulkActions: (selected) => {
+        // Inspect what kinds the user has checked. Folder containers
+        // and per-expense rows have different action surfaces; mixed
+        // selections fall back to the intersection (typically empty
+        // beyond Reject for the approval/controlling tabs).
+        //
+        // Action-bar pattern (project-wide, see reference shots in
+        // PR comments): primary CTA sits far right (`primary`,
+        // single item → filled red button; multi item → split
+        // F0ButtonDropdown with chevron). Outline secondary buttons
+        // (`secondary`) precede it. The OneDC ActionBar reverses
+        // `secondary` so the FIRST element ends up rightmost
+        // (closest to the primary CTA). Order them with the
+        // most-related-to-primary action first.
+        //
+        // Reference screenshots use NEUTRAL outline secondaries
+        // (no `critical: true`) — even Reject. Reserve `critical` for
+        // genuinely destructive bulk actions (folder deletion).
+        const checked = (selected.itemsStatus ?? []).filter(
+          (entry) => entry.checked
+        )
+        const hasFolders = checked.some((e) => e.item.kind === "folder")
+        const hasExpenses = checked.some((e) => e.item.kind === "expense")
+        const onlyFolders = hasFolders && !hasExpenses
+        const mixed = hasFolders && hasExpenses
+
+        // Folder-only selections: just the two essential actions —
+        // delete the folder, or send it for approval. No "Add to
+        // folder" (folders don't nest in this prototype).
+        if (onlyFolders) {
+          return {
+            secondary: [
+              {
+                id: "delete-folder",
+                label: "Delete folder",
+                icon: Cross,
+                critical: true,
+              },
+            ],
+            primary: [
+              { id: "submit-folder", label: "Send for approval", icon: Upload },
+            ],
+          }
+        }
+
+        if (variant === "pending-approval") {
+          // Approve/Reject apply uniformly to expenses and (by
+          // proxy) the expenses inside a folder, so a mixed selection
+          // is fine here. Per the reference screenshot: just two
+          // buttons, Reject (outline neutral) + Approve (filled red).
+          return {
+            secondary: [{ id: "reject", label: "Reject" }],
+            primary: [
+              { id: "approve", label: "Approve", icon: CheckCircle },
+            ],
+          }
+        }
+        if (variant === "pending-controlling") {
+          // BR-003 / BR-005: Mark as controlled vs Bulk edit are
+          // distinct affordances. Bulk edit opens the side panel with
+          // empty controlling fields; submit overwrites every row in
+          // the selection. Mark as controlled is the no-form action.
+          //
+          // Mixed selection (folders + expenses): coding fields don't
+          // apply to a folder container, so we drop Bulk edit /
+          // Mark-as-controlled and only keep Reject as the primary
+          // (no secondary). Finance can either drop the folder from
+          // the selection or open it to act on its members
+          // individually.
+          if (mixed) {
+            return {
+              primary: [{ id: "reject", label: "Reject" }],
+            }
+          }
+          return {
+            secondary: [{ id: "bulk-edit", label: "Bulk edit", icon: Pencil }],
+            primary: [
+              {
+                id: "mark-controlled",
+                label: "Mark as controlled",
+                icon: CheckCircle,
+              },
+            ],
+          }
+        }
+        if (variant === "pay") {
+          // Reference screenshot: secondary [Reset approval flow,
+          // Set as paid] outline + primary Reimburse split-button
+          // ([Reimburse, Reimburse via payslip]).
+          //
+          // Mixed selection: payment routing is per-expense (a folder
+          // is just a logical container), so only the actions that
+          // map 1:1 to underlying expenses survive — Set as paid as
+          // primary, no secondary clutter.
+          if (mixed) {
+            return {
+              primary: [
+                { id: "set-as-paid", label: "Set as paid", icon: CheckCircle },
+              ],
+            }
+          }
+          return {
+            secondary: [
+              { id: "set-as-paid", label: "Set as paid" },
+              { id: "reset-approval", label: "Reset approval flow" },
+            ],
+            primary: [
+              { id: "reimburse", label: "Reimburse", icon: Money },
+              {
+                id: "reimburse-payslip",
+                label: "Reimburse via payslip",
+                icon: Money,
+              },
+            ],
+          }
+        }
+        if (variant === "all") {
+          // Export tab: bulk action is just CSV export. No secondary
+          // affordance — the spec asks for a single primary CTA.
+          return {
+            primary: [
+              { id: "export-csv", label: "Export to CSV", icon: Upload },
+            ],
+          }
+        }
+        return { primary: [] }
+      },
+      itemActions: (_item: SpendingRow) => {
+        const actions: Array<
+          | { label: string; onClick: () => void; critical?: boolean }
+          | { type: "separator" }
+        > = [{ label: "View details", onClick: () => {} }]
+        if (variant === "pending-approval") {
+          actions.push(
+            { label: "Approve", onClick: () => {} },
+            { label: "Reject", onClick: () => {}, critical: true }
+          )
+        } else if (variant === "pending-controlling") {
+          actions.push(
+            { label: "Edit controlling fields", onClick: () => {} },
+            { label: "Mark as controlled", onClick: () => {} },
+            { label: "Reject", onClick: () => {}, critical: true }
+          )
+        } else if (variant === "pay") {
+          actions.push(
+            { label: "Send to payroll", onClick: () => {} },
+            { label: "Send to SEPA", onClick: () => {} },
+            { label: "Set as paid", onClick: () => {} },
+            { label: "Sync to Business Central", onClick: () => {} },
+            { type: "separator" },
+            { label: "Advanced export", onClick: () => {} }
+          )
+        }
+        return actions
+      },
+    },
+    [rows, variant, folderHref]
+  )
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/shared/columns.ts
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/shared/columns.ts
@@ -1,0 +1,120 @@
+import { applySort } from "@/lib/applySort"
+import type { ExpenseStatus } from "@/fixtures"
+
+import { STATUS_LABEL, STATUS_VARIANT } from "./expenseStatus"
+import type { SpendingRow } from "./rows"
+
+/**
+ * Shared OneDataCollection columns for every Submit/Manage table.
+ *
+ * Folders and expenses share the same columns by design (BR-008):
+ *   - the `name` column uses the `folder` cell type for folder rows and
+ *     plain text for expenses, so folders stand out visually as
+ *     first-class rows inside the same table.
+ *   - all other columns render uniformly.
+ */
+export const spendingColumns = [
+  {
+    id: "name",
+    label: "Name",
+    sorting: "name",
+    render: (item: SpendingRow) =>
+      item.kind === "folder"
+        ? ({ type: "folder" as const, value: { name: item.name } })
+        : item.name,
+  },
+  {
+    id: "description",
+    label: "Category",
+    render: (item: SpendingRow) => item.description,
+  },
+  {
+    id: "date",
+    label: "Date",
+    sorting: "date",
+    render: (item: SpendingRow) => ({
+      type: "date" as const,
+      value: new Date(item.date),
+    }),
+  },
+  {
+    id: "amount",
+    label: "Amount",
+    sorting: "amount",
+    render: (item: SpendingRow) => ({
+      type: "amount" as const,
+      value: {
+        amount: item.amount,
+        currency: { symbol: "€", symbolPosition: "right" as const, decimalPlaces: 2 },
+      },
+    }),
+  },
+  {
+    id: "status",
+    label: "Status",
+    render: (item: SpendingRow) => ({
+      type: "status" as const,
+      value: {
+        status: STATUS_VARIANT[item.status],
+        label: STATUS_LABEL[item.status],
+      },
+    }),
+  },
+] as const
+
+/** Canonical sort getter — used by every source hook. */
+export function getSpendingSortValue(
+  row: SpendingRow,
+  field: string
+): string | number | null {
+  switch (field) {
+    case "name":
+      return row.name.toLowerCase()
+    case "amount":
+      return row.amount
+    case "date":
+      return Date.parse(row.date)
+    default:
+      return null
+  }
+}
+
+/** Standard filter → search → sort → paginate body shared by all sources. */
+export function paginateRows(
+  rows: SpendingRow[],
+  args: {
+    search: string | undefined
+    sortings: Parameters<typeof applySort>[1]
+    pagination?: { perPage?: number; currentPage?: number } | undefined
+    statusFilter?: ExpenseStatus[]
+  }
+) {
+  const { search, sortings, pagination, statusFilter } = args
+  const term = (search ?? "").toLowerCase().trim()
+  const filtered = rows
+    .filter((r) =>
+      statusFilter && statusFilter.length > 0
+        ? statusFilter.includes(r.status)
+        : true
+    )
+    .filter((r) =>
+      term === ""
+        ? true
+        : r.name.toLowerCase().includes(term) ||
+          r.description.toLowerCase().includes(term)
+    )
+  const sorted = applySort(filtered, sortings, getSpendingSortValue)
+  const perPage = pagination?.perPage ?? 20
+  const currentPage = pagination?.currentPage ?? 1
+  const total = sorted.length
+  const pagesCount = Math.max(1, Math.ceil(total / perPage))
+  const start = (currentPage - 1) * perPage
+  return {
+    type: "pages" as const,
+    records: sorted.slice(start, start + perPage),
+    total,
+    perPage,
+    currentPage,
+    pagesCount,
+  }
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/shared/detail/ExpenseDetailPage.tsx
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/shared/detail/ExpenseDetailPage.tsx
@@ -1,0 +1,857 @@
+import {
+  costCenters,
+  employees,
+  projects,
+  vatRates,
+  type ExpenseCategory,
+} from "@/fixtures"
+import {
+  F0Box,
+  F0Button,
+  F0ButtonDropdown,
+  F0Text,
+  StandardLayout,
+} from "@factorialco/f0-react"
+import {
+  DetailsItemsList,
+  Page,
+  PageHeader,
+  ResourceHeader,
+  Tabs,
+  type DetailsItemType,
+} from "@factorialco/f0-react/dist/experimental"
+import {
+  Add,
+  ArrowCycle,
+  CheckCircle,
+  ChevronDown,
+  ChevronUp,
+  Coffee,
+  Computer,
+  Cross,
+  Delete,
+  Download,
+  Image as ImageIcon,
+  Laptop,
+  Minus,
+  Office,
+  Pencil,
+  Plane,
+  Printer,
+  ShoppingCart,
+  Sleep,
+  Upload,
+} from "@factorialco/f0-react/icons/app"
+import type { IconType } from "@factorialco/f0-react"
+import { useCallback, useMemo, useState } from "react"
+
+import { STATUS_LABEL, STATUS_VARIANT } from "../expenseStatus"
+import { type SpendingRow } from "../rows"
+import { PolicyAlertCard } from "../../../_shared/PolicyAlertCard"
+import { selectPolicyAlert } from "../../../_shared/selectPolicyAlert"
+import { hasReceipt as rowHasReceipt } from "@/prototypes/_shared/receiptPresence"
+import { buildReceiptDataUrl } from "./receiptSvg"
+import {
+  ControllingForm,
+  type ControllingFormData,
+} from "../sidePanel/ControllingForm"
+import { SubmitterEditForm, type SubmitterFormData } from "./SubmitterEditForm"
+
+/**
+ * Full-page expense detail. Replaces the side-panel detail/controlling
+ * variants for single-row flows; the side panel survives only for
+ * `bulk-edit`.
+ *
+ * Layout mirrors Factorial > Organization > People > employee profile:
+ *
+ *   PageHeader (module + breadcrumb back to the source tab)
+ *   ResourceHeader
+ *     ├ avatar (category icon)
+ *     ├ title (provider) + description (category · date · amount)
+ *     ├ status pill
+ *     └ actions (Edit / Save toggle, Mark as controlled, Reject, Delete)
+ *   Body: 50/50 split
+ *     ├ Left: read view (sectioned label/value list) OR <ControllingForm>
+ *     └ Right: receipt preview with zoom/rotate toolbar
+ *
+ * Edit mode is local state (no URL param). Toggling "Edit" swaps the
+ * left half from the read view to the form. Saving submits the form,
+ * exits edit mode, and the parent `onSave` is invoked.
+ *
+ * Why a single-page mode toggle (vs `?mode=edit`):
+ *   - The read view and form share the same fields; flipping the same
+ *     URL keeps refresh semantics unsurprising.
+ *   - The form's identity is keyed on `row.id` so swapping rows still
+ *     resets the F0Form registration cleanly.
+ */
+
+// Category icon mapping. Production would have a richer icon set; the
+// f0-react app icon pack doesn't ship a taxi/cab/hotel-fork glyph so
+// we map best-effort (Hotel→Sleep, Taxis→Plane, Meals→Coffee). Falls
+// back to Image for unknown categories.
+const CATEGORY_ICON: Record<ExpenseCategory, IconType> = {
+  Meals: Coffee,
+  Taxis: Plane,
+  Travel: Plane,
+  Shopping: ShoppingCart,
+  Hotel: Sleep,
+  Office: Office,
+  Software: Laptop,
+}
+
+const CATEGORY_FALLBACK_ICON: IconType = Computer
+
+// Receipt zoom model. The toolbar mirrors a PDF viewer: discrete
+// percentage stops PLUS two auto-fit modes ("Page fit" — contain the
+// whole image; "Page width" — match the frame width). Buttons "−" /
+// "+" jump to the nearest neighbouring percentage. Switching to a fit
+// mode resets to the auto behaviour and the displayed % becomes
+// purely informational.
+const ZOOM_PERCENTS = [50, 75, 100, 125, 150, 200] as const
+type ZoomPercent = (typeof ZOOM_PERCENTS)[number]
+type ZoomMode = "page-fit" | "page-width" | ZoomPercent
+
+const ZOOM_OPTIONS: ReadonlyArray<{ value: ZoomMode; label: string }> = [
+  { value: "page-fit", label: "Page fit" },
+  { value: "page-width", label: "Page width" },
+  { value: 50, label: "50%" },
+  { value: 75, label: "75%" },
+  { value: 100, label: "100%" },
+  { value: 125, label: "125%" },
+  { value: 150, label: "150%" },
+  { value: 200, label: "200%" },
+]
+
+// Status × tab gate for the pencil-icon-only Edit affordance in the
+// header. Mirrors the spec rule:
+//   - Always editable while the row is being assembled (draft / pending).
+//   - On the Controlling tab finance can also re-open already-approved
+//     and already-controlled rows (controlled = "controlled within
+//     finance review", still mutable until Pay locks it).
+function canEditRow(status: SpendingRow["status"], controllable: boolean) {
+  if (status === "draft" || status === "pending") return true
+  if (controllable && (status === "approved" || status === "controlled")) {
+    return true
+  }
+  return false
+}
+
+const eurFormatter = new Intl.NumberFormat("en-GB", {
+  style: "currency",
+  currency: "EUR",
+})
+const dateFormatter = new Intl.DateTimeFormat("en-GB", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+})
+
+function formatEUR(amount: number) {
+  return eurFormatter.format(amount)
+}
+function formatDate(iso: string) {
+  return dateFormatter.format(new Date(iso + "T00:00:00Z"))
+}
+
+export function ExpenseDetailPage(props: {
+  row: SpendingRow
+  /** Where the page came from — used for the breadcrumb label. */
+  sourceTabLabel: string
+  /** Deep-link URL back to the source tab (powers the breadcrumb click). */
+  sourceTabHref: string
+  /** Navigate back to the list. */
+  onBack: () => void
+  /** Persist controlling fields. Caller decides whether to also flip
+   *  the row's status to `controlled`. */
+  onSaveControlling: (data: ControllingFormData) => void
+  /** Mark the row as controlled without opening the form. */
+  onMarkControlled: () => void
+  /** Reject the row (critical action). */
+  onReject: () => void
+  /** Whether the controlling block is meaningful for this row.
+   *  Drives whether the controlling-form fields render in edit mode. */
+  controllable: boolean
+  /** Which JTBD owns the source tab. Drives the primary CTA set:
+   *    approval     → Approve / Reject
+   *    controlling  → Mark as controlled / Reject
+   *    pay          → Mark as paid / Reject
+   *    view         → no destructive primary; only Edit + overflow.
+   *  Independent from `controllable` because Pending Approval is an
+   *  approver-only flow where finance hasn't enriched the controlling
+   *  block yet. */
+  tabRole: "approval" | "controlling" | "pay" | "view"
+  /** Sibling-list navigation shown top-right of the page header
+   *  (counter + up/down chevrons). Mirrors Recruitment > Candidate's
+   *  inline pagination so reviewers can walk a queue without bouncing
+   *  back to the list. `null` hides the cluster (e.g. deep-linked
+   *  expense with no recoverable source list). */
+  navigation?: {
+    counter: { current: number; total: number }
+    previous?: { url: string; title: string }
+    next?: { url: string; title: string }
+  } | null
+}) {
+  const {
+    row,
+    sourceTabLabel,
+    sourceTabHref,
+    onBack,
+    onSaveControlling,
+    onMarkControlled,
+    onReject,
+    controllable,
+    tabRole,
+    navigation,
+  } = props
+
+  const [editMode, setEditMode] = useState(false)
+  const [activeTabId, setActiveTabId] = useState<"summary" | "comments">(
+    "summary"
+  )
+  const [zoom, setZoom] = useState<ZoomMode>("page-fit")
+  const [rotation, setRotation] = useState<0 | 90 | 180 | 270>(0)
+
+  const category = row.description as ExpenseCategory
+  const avatarIcon = CATEGORY_ICON[category] ?? CATEGORY_FALLBACK_ICON
+
+  // Per-row receipt: ~80% of rows have one. The presence rule lives
+  // in `_shared/receiptPresence` so `selectPolicyAlert` can steer
+  // "no receipt" copy onto the same rows that show the empty state
+  // here — otherwise the alert and the panel would disagree.
+  const receiptUrl: string | null = useMemo(() => {
+    if (!rowHasReceipt(row.id)) return null
+    return buildReceiptDataUrl(row)
+  }, [row])
+
+  const onSave = useCallback(
+    (data: ControllingFormData) => {
+      onSaveControlling(data)
+      setEditMode(false)
+    },
+    [onSaveControlling]
+  )
+
+  // Submitter-form save is a fire-and-forget for the prototype: we
+  // log the payload and exit edit mode. Production would persist via
+  // a separate mutation that updates the underlying expense record.
+  const onSaveSubmitter = useCallback((data: SubmitterFormData) => {
+    void data
+    setEditMode(false)
+  }, [])
+
+  // Zoom navigation. − / + step through the percent list; if we're in
+  // a fit mode the first step "anchors" us at 100 % then walks from
+  // there. This matches Acrobat / Preview behaviour and is what
+  // finance users will already have muscle memory for.
+  const stepZoom = useCallback((direction: -1 | 1) => {
+    setZoom((current) => {
+      if (current === "page-fit" || current === "page-width") return 100
+      const idx = ZOOM_PERCENTS.indexOf(current)
+      const nextIdx = Math.min(
+        Math.max(idx + direction, 0),
+        ZOOM_PERCENTS.length - 1
+      )
+      return ZOOM_PERCENTS[nextIdx] ?? current
+    })
+  }, [])
+  const zoomIn = useCallback(() => stepZoom(1), [stepZoom])
+  const zoomOut = useCallback(() => stepZoom(-1), [stepZoom])
+  const rotate = useCallback(() => {
+    setRotation((r) => ((r + 90) % 360) as 0 | 90 | 180 | 270)
+  }, [])
+  const setZoomMode = useCallback((mode: ZoomMode) => setZoom(mode), [])
+
+  // ----- Header CTAs --------------------------------------------------
+  // Tab-role drives the destructive primary action; Edit always lives
+  // as a pencil-icon-only outline in the secondary slot when the row
+  // is editable. Save/Cancel take over the slots while editing.
+  //
+  // Why Edit isn't in the primary slot: ResourceHeader only renders
+  // primaryAction at the "default" variant (filled red), which would
+  // out-shout Approve/Mark as controlled. The screenshot shows Edit
+  // as an outlined pencil button next to the overflow menu, which
+  // matches HeaderSecondaryAction with `variant: "outline"` and
+  // `hideLabel: true`.
+  const editable = canEditRow(row.status, controllable)
+
+  const primaryAction = editMode
+    ? {
+        label: "Save",
+        icon: CheckCircle,
+        // The actual submit is wired through ControllingForm's own
+        // submit button (F0Form). Production would hoist a ref to
+        // call form.submit(); for now Save just exits edit mode so
+        // the header reads active.
+        onClick: () => setEditMode(false),
+      }
+    : tabRole === "approval"
+      ? {
+          label: "Approve",
+          icon: CheckCircle,
+          onClick: () => {},
+        }
+      : tabRole === "controlling"
+        ? {
+            label: "Mark as controlled",
+            icon: CheckCircle,
+            onClick: onMarkControlled,
+          }
+        : tabRole === "pay"
+          ? {
+              label: "Mark as paid",
+              icon: CheckCircle,
+              onClick: () => {},
+            }
+          : undefined
+
+  const secondaryActions = editMode
+    ? [{ label: "Cancel", icon: Cross, onClick: () => setEditMode(false) }]
+    : [
+        // Action ordering inside ResourceHeader is fixed by BaseHeader:
+        //   [otherActions 3-dot]  [secondaryActions in array order]  |  [primaryAction]
+        // The 3-dot menu and the auto-divider are not configurable;
+        // we control the rest by ordering this array. Pencil (icon-
+        // only) sits first so it lands directly next to the 3-dot
+        // menu; Reject (labelled, outline) sits last so it abuts the
+        // divider before the primary CTA — matching the screenshot:
+        //   [⋯] [✎] | [Reject] [Approve]
+        ...(editable
+          ? [
+              {
+                label: "Edit",
+                icon: Pencil,
+                hideLabel: true,
+                tooltip: "Edit expense",
+                variant: "outline" as const,
+                onClick: () => setEditMode(true),
+              },
+            ]
+          : []),
+        // On "view" tabs the user isn't the approver, so Reject is
+        // hidden — they only get Edit + the overflow menu.
+        ...(tabRole !== "view"
+          ? [
+              {
+                label: "Reject",
+                icon: Cross,
+                variant: "outline" as const,
+                onClick: onReject,
+              },
+            ]
+          : []),
+      ]
+
+  const otherActions = editMode
+    ? []
+    : [
+        { label: "Delete", icon: Delete, onClick: () => {}, critical: true },
+        { label: "Export PDF", icon: Download, onClick: () => {} },
+      ]
+
+  return (
+    <Page
+      header={
+        <>
+          <PageHeader
+            module={{
+              id: "my_spending",
+              name: "Spend management",
+              // Clicking the module label always lands on the Submit ›
+              // Expenses default view (the canonical "home" of the
+              // module for an end-user submitter), regardless of which
+              // tab the detail page was opened from.
+              href: "/p/controlling-step-poc?tab=submit&sub=expenses",
+            }}
+            breadcrumbs={[
+              // Source-tab crumb is a real link back to the originating
+              // list (e.g. Manage › Pending controlling), so the user
+              // can reverse out one level without losing tab context.
+              { id: "back", label: sourceTabLabel, href: sourceTabHref },
+              { id: row.id, label: row.name },
+            ]}
+            navigation={navigation ?? undefined}
+            actions={[{ label: "Back", icon: Cross, onClick: onBack }]}
+          />
+          <ResourceHeader
+            avatar={{ type: "icon", icon: avatarIcon }}
+            title={row.name}
+            description={`${category} · ${formatDate(row.date)}`}
+            status={{
+              label: "Status",
+              text: STATUS_LABEL[row.status],
+              variant: STATUS_VARIANT[row.status],
+            }}
+            metadata={[
+              {
+                label: "Creation date",
+                value: { type: "text", content: formatDate(row.date) },
+              },
+              {
+                label: "Total reimbursement",
+                value: {
+                  type: "text",
+                  content: formatEUR(row.amount),
+                },
+              },
+            ]}
+            primaryAction={primaryAction}
+            secondaryActions={secondaryActions}
+            otherActions={otherActions}
+          />
+          {/* Sticky tab strip below the header. `position: sticky`
+              keeps Summary / Comments visible as the user scrolls
+              the receipt/details body. `top-0` works because Page's
+              scrollable region starts immediately below this slot. */}
+          <div className="sticky top-0 z-10 bg-f1-background">
+            <Tabs
+              key={activeTabId}
+              tabs={[
+                {
+                  id: "summary",
+                  label: "Summary",
+                  onClick: () => setActiveTabId("summary"),
+                },
+                {
+                  id: "comments",
+                  label: "Comments",
+                  onClick: () => setActiveTabId("comments"),
+                },
+              ]}
+              activeTabId={activeTabId}
+            />
+          </div>
+        </>
+      }
+    >
+      <StandardLayout>
+        {activeTabId === "comments" ? (
+          <F0Box
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="center"
+            padding="xl"
+            gap="sm"
+          >
+            <F0Text content="Comments" variant="label" />
+            <F0Text
+              content="No comments yet. Conversation history will appear here."
+              variant="description"
+            />
+          </F0Box>
+        ) : (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <F0Box display="flex" flexDirection="column" gap="lg">
+              {!editMode &&
+                (() => {
+                  // Pick the policy-agent alert (if any) for this
+                  // expense in this JTBD context. Returns null for
+                  // contexts that shouldn't show one (Submitted
+                  // preset, Controlling tab, Pay tab).
+                  const alert = selectPolicyAlert({
+                    tabRole,
+                    status: row.status,
+                    hasAlerts: row.alerts.length > 0,
+                    rowId: row.id,
+                    alertKinds: row.alerts,
+                    category: row.description,
+                    amount: row.amount,
+                  })
+                  if (!alert) return null
+                  return (
+                    <PolicyAlertCard
+                      variant={alert.variant}
+                      stripLabel={alert.stripLabel}
+                      title={alert.title}
+                      description={alert.description}
+                    />
+                  )
+                })()}
+              {editMode ? (
+                tabRole === "controlling" ? (
+                  // Pending Controlling tab → finance is coding the
+                  // expense. Show the controlling/coding form
+                  // (cost center, project, VAT, etc.).
+                  <ControllingForm
+                    key={row.id}
+                    defaultValues={row.controlling}
+                    onSave={onSave}
+                    submitLabel="Save"
+                  />
+                ) : (
+                  // Every other tab (Submit, Pending Approval, Pay,
+                  // All, Folder Detail) → submitter is editing the
+                  // expense itself. Show the full Submit-a-new-
+                  // expense form.
+                  <SubmitterEditForm
+                    key={row.id}
+                    row={row}
+                    onSave={onSaveSubmitter}
+                    submitLabel="Save"
+                  />
+                )
+              ) : (
+                <ReadView row={row} />
+              )}
+            </F0Box>
+
+            <ReceiptPanel
+              url={receiptUrl}
+              zoom={zoom}
+              rotation={rotation}
+              onZoomIn={zoomIn}
+              onZoomOut={zoomOut}
+              onRotate={rotate}
+              onSetZoomMode={setZoomMode}
+            />
+          </div>
+        )}
+      </StandardLayout>
+    </Page>
+  )
+}
+
+// -- Read view ------------------------------------------------------
+
+/**
+ * Inbox-style key/value card. Single `DetailsItemsList` rendering the
+ * full set of summary fields — no progressive disclosure. Designer
+ * decision: the field count (11) is small enough that the
+ * "View more details" expander added a click for no real density win.
+ *
+ * Field order (matches PSPEC-spending v3 + designer review):
+ *   1. Owner             ← person row (avatar + full name)
+ *   2. Category
+ *   3. Document date
+ *   4. Amount
+ *   5. Vendor name
+ *   6. Payment method
+ *   7. Reimbursable amount
+ *   8. Cost center
+ *   9. Budget
+ *  10. Project
+ *  11. Description
+ *
+ * Mirrors Inbox > Time-off task content
+ * (`modules/inbox_tasks/tasks/approval/TimeoffLeave/index.tsx`):
+ *   `<DetailsItemsList tableView />`
+ */
+function ReadView({ row }: { row: SpendingRow }) {
+  const c = row.controlling
+
+  // Owner is deterministically picked from the row id so the same
+  // expense always shows the same person across reloads. Production
+  // would carry an `ownerId` on the row.
+  const ownerSeed =
+    Array.from(row.id).reduce((s, ch) => s + ch.charCodeAt(0), 0) %
+    employees.length
+  const owner = employees[ownerSeed]
+  const [ownerFirst, ...ownerRestParts] = (owner?.fullName ?? "Owner").split(
+    " "
+  )
+  const ownerLast = ownerRestParts.join(" ")
+
+  const details: DetailsItemType[] = [
+    {
+      title: "Owner",
+      content: {
+        type: "person",
+        firstName: ownerFirst ?? "",
+        lastName: ownerLast,
+        avatarUrl: owner?.avatarUrl ?? "",
+      },
+    },
+    {
+      title: "Category",
+      content: { type: "item", text: row.description },
+    },
+    {
+      title: "Document date",
+      content: { type: "item", text: formatDate(row.date) },
+    },
+    {
+      title: "Amount",
+      content: { type: "item", text: formatEUR(row.amount) },
+    },
+    {
+      title: "Vendor name",
+      content: { type: "item", text: row.name },
+    },
+    {
+      title: "Payment method",
+      content: { type: "item", text: "Personal card" },
+    },
+    {
+      title: "Reimbursable amount",
+      content: { type: "item", text: formatEUR(row.amount) },
+    },
+    {
+      title: "Cost center",
+      content: {
+        type: "item",
+        text: costCenters.find((cc) => cc.id === c?.costCenter)?.name ?? "—",
+      },
+    },
+    {
+      title: "Budget",
+      // No dedicated budget fixture; reuse VAT-rate label as the
+      // budget envelope name for the prototype. Production would
+      // wire this to a real Budget entity.
+      content: {
+        type: "item",
+        text: vatRates.find((v) => v.id === c?.vatRate)?.label ?? "—",
+      },
+    },
+    {
+      title: "Project",
+      content: {
+        type: "item",
+        text: projects.find((p) => p.id === c?.project)?.name ?? "—",
+      },
+    },
+    {
+      title: "Description",
+      content: {
+        type: "item",
+        text: c?.description && c.description.length > 0 ? c.description : "—",
+      },
+      verticalLayout: true,
+    },
+  ]
+
+  return <DetailsItemsList details={details} tableView />
+}
+
+// -- Receipt panel --------------------------------------------------
+
+/**
+ * Right-hand 50 % column. PDF-viewer-style chrome around a single
+ * receipt photo: page indicator + per-page nav on the left, image
+ * controls (zoom −/+, rotate) in the middle, and zoom-mode dropdown
+ * + print + download on the right.
+ *
+ * Why a PDF-viewer toolbar for a single image: finance reviewers
+ * expect Acrobat-style affordances for any "document preview" surface
+ * regardless of the underlying file type. Aligning here means the same
+ * mental model whether the receipt is a JPG, a multi-page PDF, or a
+ * scanned email.
+ *
+ * Page nav is intentionally a no-op (we only ever have one page) but
+ * is rendered so the toolbar's left group has the same visual weight
+ * as the screenshot. The chevrons are disabled to make the limit
+ * obvious.
+ *
+ * Zoom uses CSS transform (cheaper than re-fetching) and a
+ * mode-aware effective percentage:
+ *   - "page-fit"   → contained (object-fit handles it; no transform)
+ *   - "page-width" → width: 100 %
+ *   - <percent>    → scale(percent / 100)
+ */
+
+const PRINTER_TOOLTIP = "Print"
+const DOWNLOAD_TOOLTIP = "Download"
+
+function effectiveZoomPercent(zoom: ZoomMode): number {
+  if (zoom === "page-fit" || zoom === "page-width") return 100
+  return zoom
+}
+
+function ReceiptPanel(props: {
+  url: string | null
+  zoom: ZoomMode
+  rotation: 0 | 90 | 180 | 270
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onRotate: () => void
+  onSetZoomMode: (mode: ZoomMode) => void
+}) {
+  const {
+    url,
+    zoom,
+    rotation,
+    onZoomIn,
+    onZoomOut,
+    onRotate,
+    onSetZoomMode,
+  } = props
+  if (!url) {
+    return (
+      <F0Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        gap="md"
+        padding="xl"
+        background="secondary"
+        borderRadius="md"
+      >
+        <F0Text content="No receipt uploaded" variant="description" />
+        <F0Button
+          label="Upload receipt"
+          icon={Upload}
+          variant="default"
+          onClick={() => {}}
+        />
+      </F0Box>
+    )
+  }
+
+  const currentZoomLabel =
+    ZOOM_OPTIONS.find((o) => o.value === zoom)?.label ?? "Page fit"
+  const percent = effectiveZoomPercent(zoom)
+  const isFitMode = zoom === "page-fit"
+  const isWidthMode = zoom === "page-width"
+
+  return (
+    <F0Box
+      display="flex"
+      flexDirection="column"
+      gap="sm"
+      background="secondary"
+      borderRadius="md"
+      padding="md"
+    >
+      {/* PDF-style toolbar. Three groups separated by `justify-between`
+          so the dropdown + print/download anchor to the right edge
+          regardless of how many controls we add to the middle group
+          later (e.g. annotation tools). */}
+      <F0Box
+        display="flex"
+        alignItems="center"
+        justifyContent="between"
+        gap="sm"
+      >
+        {/* Left group — page indicator + page nav. Disabled because
+            we only ever render one page; the chrome is here so the
+            toolbar matches the screenshot. */}
+        <F0Box display="flex" alignItems="center" gap="xs">
+          <F0Text content="1 / 1" variant="description" />
+          <F0Button
+            label="Previous page"
+            hideLabel
+            icon={ChevronUp}
+            variant="outline"
+            size="sm"
+            disabled
+            onClick={() => {}}
+          />
+          <F0Button
+            label="Next page"
+            hideLabel
+            icon={ChevronDown}
+            variant="outline"
+            size="sm"
+            disabled
+            onClick={() => {}}
+          />
+        </F0Box>
+
+        {/* Middle group — zoom −/+ and rotate. Operate on the active
+            percent; in fit modes the first −/+ press anchors at 100 %
+            then walks. Rotate is a single-direction 90° step (matches
+            Acrobat's default), users hit it 3× for counter-clockwise. */}
+        <F0Box display="flex" alignItems="center" gap="xs">
+          <F0Button
+            label="Zoom out"
+            hideLabel
+            icon={Minus}
+            variant="outline"
+            size="sm"
+            onClick={onZoomOut}
+          />
+          <F0Button
+            label="Zoom in"
+            hideLabel
+            icon={Add}
+            variant="outline"
+            size="sm"
+            onClick={onZoomIn}
+          />
+          <F0Button
+            label="Rotate"
+            hideLabel
+            icon={ArrowCycle}
+            variant="outline"
+            size="sm"
+            onClick={onRotate}
+          />
+        </F0Box>
+
+        {/* Right group — zoom-mode dropdown + print + download.
+            Dropdown uses `mode: "dropdown"` (single button + chevron)
+            because every option is mutually exclusive — a "split"
+            button doesn't fit; there's no canonical "main action". */}
+        <F0Box display="flex" alignItems="center" gap="xs">
+          <F0ButtonDropdown
+            mode="dropdown"
+            trigger={currentZoomLabel}
+            variant="outline"
+            size="sm"
+            items={ZOOM_OPTIONS.map((o) => ({
+              value: String(o.value),
+              label: o.label,
+            }))}
+            onClick={(value) => {
+              const match = ZOOM_OPTIONS.find((o) => String(o.value) === value)
+              if (match) onSetZoomMode(match.value)
+            }}
+          />
+          <F0Button
+            label={PRINTER_TOOLTIP}
+            hideLabel
+            icon={Printer}
+            variant="outline"
+            size="sm"
+            tooltip={PRINTER_TOOLTIP}
+            onClick={() => window.print()}
+          />
+          <F0Button
+            label={DOWNLOAD_TOOLTIP}
+            hideLabel
+            icon={Download}
+            variant="outline"
+            size="sm"
+            tooltip={DOWNLOAD_TOOLTIP}
+            onClick={() => window.open(url, "_blank")}
+          />
+        </F0Box>
+      </F0Box>
+
+      {/* Frame — overflow hidden so a zoomed/rotated image doesn't
+          push the rest of the page around. Fixed height range keeps
+          the panel from growing with the receipt's intrinsic size
+          (the SVG receipt is portrait and would otherwise dominate
+          the column); `object-contain` on the image scales it down
+          to fit. Background uses `f1-background` (dark gray strip
+          like Acrobat's document chrome). */}
+      <div className="relative flex min-h-[640px] flex-1 items-center justify-center overflow-hidden rounded-md bg-f1-background">
+        <img
+          src={url}
+          alt="Expense receipt"
+          // Fit modes use object-fit/width to let the browser size
+          // the image; explicit percents use a CSS transform so we
+          // don't need to re-fetch a higher-res asset on every step.
+          className={
+            isFitMode
+              ? "max-h-full max-w-full object-contain transition-transform duration-150"
+              : isWidthMode
+                ? "w-full transition-transform duration-150"
+                : "max-w-none transition-transform duration-150"
+          }
+          style={{
+            transform: isFitMode
+              ? `rotate(${rotation}deg)`
+              : `scale(${percent / 100}) rotate(${rotation}deg)`,
+          }}
+        />
+        {/* Tiny corner badge so the empty/uploaded state is obvious
+            even when the image hasn't loaded yet. */}
+        <div className="absolute left-2 top-2 flex items-center gap-1 rounded-sm bg-f1-background-inverse-secondary px-2 py-1">
+          <ImageIcon className="h-3 w-3 text-f1-foreground-inverse" />
+          <span className="text-xs text-f1-foreground-inverse">Receipt</span>
+        </div>
+      </div>
+    </F0Box>
+  )
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/shared/detail/SubmitterEditForm.tsx
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/shared/detail/SubmitterEditForm.tsx
@@ -1,0 +1,244 @@
+import {
+  F0Form,
+  f0FormField,
+  useF0Form,
+  useF0FormDefinition,
+} from "@factorialco/f0-react"
+import { useEffect, useMemo, useRef } from "react"
+import { z } from "zod"
+
+import { projects, type ExpenseCategory } from "@/fixtures"
+import { type SpendingRow } from "../rows"
+
+/**
+ * Submitter-facing edit form. Used everywhere EXCEPT the Pending
+ * Controlling tab — i.e. when an employee opens an expense from
+ * Submit > Expenses, Submit > Folders > Folder, Manage > Pending
+ * approval / Pay / All, etc. and clicks the pencil to edit.
+ *
+ * The Controlling tab uses `ControllingForm` (coding fields only).
+ * This form mirrors the legacy Gamma "Submit a new expense" / "Edit
+ * expense" modal — the field set the employee owns:
+ *
+ *   Expense information       — Category
+ *   Document information      — Type, Document date, Receipt currency,
+ *                               Receipt amount, Vendor name
+ *   Payment                   — Reimbursable (checkbox), Payment
+ *                               method, Reimbursable amount
+ *   Budget and project        — Project
+ *   Additional information    — Description, Internal reference
+ *
+ * Files (receipt upload) is intentionally omitted — F0Form has no
+ * canonical file-upload field; the right-hand ReceiptPanel already
+ * surfaces upload affordance for the prototype.
+ *
+ * Hooks (`useF0Form` + `useF0FormDefinition`) live INSIDE this
+ * component for the same reason as ControllingForm — lifting them
+ * to the parent loops the AI chat panel registry. Schema and
+ * sections are at module scope (truly static).
+ */
+
+const ALL_CATEGORIES: ExpenseCategory[] = [
+  "Meals",
+  "Taxis",
+  "Travel",
+  "Shopping",
+  "Hotel",
+  "Office",
+  "Software",
+]
+
+const DOCUMENT_TYPES = ["Receipt", "Invoice", "Other"] as const
+const CURRENCIES = ["EUR", "USD", "GBP"] as const
+const PAYMENT_METHODS = [
+  { value: "personal-card", label: "Personal card" },
+  { value: "company-card", label: "Company card" },
+  { value: "cash", label: "Cash" },
+  { value: "bank-transfer", label: "Bank transfer" },
+] as const
+
+const submitterSchema = z.object({
+  category: f0FormField.select({
+    label: "Category",
+    section: "expense",
+    placeholder: "Select category",
+    options: ALL_CATEGORIES.map((c) => ({ value: c, label: c })),
+  }),
+  documentType: f0FormField.select({
+    label: "Type",
+    section: "document",
+    placeholder: "Select document type",
+    options: DOCUMENT_TYPES.map((t) => ({ value: t, label: t })),
+  }),
+  documentDate: f0FormField.date({
+    label: "Document date",
+    section: "document",
+  }),
+  receiptCurrency: f0FormField.select({
+    label: "Receipt currency",
+    section: "document",
+    row: "currency-amount",
+    placeholder: "Currency",
+    options: CURRENCIES.map((c) => ({ value: c, label: c })),
+  }),
+  receiptAmount: f0FormField.number({
+    label: "Receipt amount",
+    section: "document",
+    row: "currency-amount",
+    placeholder: "0",
+  }),
+  vendorName: f0FormField.text({
+    label: "Vendor name",
+    section: "document",
+    optional: true,
+    placeholder: "As it is on the document",
+  }),
+  reimbursable: f0FormField.checkbox({
+    label: "This expense is reimbursable",
+    section: "payment",
+  }),
+  paymentMethod: f0FormField.select({
+    label: "Payment method",
+    section: "payment",
+    placeholder: "Select option",
+    options: PAYMENT_METHODS.map((m) => ({
+      value: m.value,
+      label: m.label,
+    })),
+  }),
+  reimbursableAmount: f0FormField.number({
+    label: "Reimbursable amount",
+    section: "payment",
+    placeholder: "0",
+  }),
+  project: f0FormField.select({
+    label: "Project",
+    section: "budget",
+    optional: true,
+    placeholder: "Select option",
+    options: projects.map((p) => ({
+      value: p.id,
+      label: `${p.name} (${p.code})`,
+    })),
+  }),
+  description: f0FormField.textarea({
+    label: "Description",
+    section: "additional",
+    placeholder: "Add any extra information",
+  }),
+  internalReference: f0FormField.text({
+    label: "Internal reference",
+    section: "additional",
+    optional: true,
+    placeholder: "Add an internal reference",
+  }),
+})
+
+const sections = {
+  expense: {
+    title: "Expense information",
+    description: "Add the basic info of your expense for accurate processing.",
+  },
+  document: {
+    title: "Document information",
+    description: "Obtain this information from your attached document.",
+  },
+  payment: {
+    title: "Payment",
+    description: "Provide information on how and how much you paid.",
+  },
+  budget: {
+    title: "Budget and project",
+    description: "Add internal company details to ensure correct processing.",
+  },
+  additional: {
+    title: "Additional information",
+    description: "Add any additional details to help with processing.",
+  },
+} as const
+
+export type SubmitterFormData = {
+  category?: ExpenseCategory
+  documentType?: (typeof DOCUMENT_TYPES)[number]
+  documentDate?: Date
+  receiptCurrency?: (typeof CURRENCIES)[number]
+  receiptAmount?: number
+  vendorName?: string
+  reimbursable?: boolean
+  paymentMethod?: string
+  reimbursableAmount?: number
+  project?: string
+  description?: string
+  internalReference?: string
+}
+
+export function SubmitterEditForm(props: {
+  /** The row being edited — used for default values. */
+  row: SpendingRow
+  /** Persist callback. */
+  onSave: (data: SubmitterFormData) => void
+  /** Submit button label. */
+  submitLabel: string
+}) {
+  const { formRef } = useF0Form()
+
+  // Refs hold the latest callback / label without re-feeding
+  // `useF0FormDefinition`. See ControllingForm for the F0AiChat
+  // registration loop this avoids.
+  const onSaveRef = useRef(props.onSave)
+  const submitLabelRef = useRef(props.submitLabel)
+  useEffect(() => {
+    onSaveRef.current = props.onSave
+  }, [props.onSave])
+  useEffect(() => {
+    submitLabelRef.current = props.submitLabel
+  }, [props.submitLabel])
+
+  const defaultValues = useMemo(
+    () => ({
+      // Map the row's known fields onto the form's expected shape.
+      // The submitter form has more fields than the row carries, so
+      // most start blank.
+      category: props.row.description as ExpenseCategory,
+      documentType: "Receipt" as const,
+      documentDate: new Date(props.row.date + "T00:00:00Z"),
+      receiptCurrency: "EUR" as const,
+      receiptAmount: props.row.amount,
+      vendorName: props.row.name,
+      reimbursable: true,
+      paymentMethod: "personal-card",
+      reimbursableAmount: props.row.amount,
+      project: props.row.controlling?.project,
+      description: props.row.controlling?.description ?? "",
+      internalReference: "",
+    }),
+    [props.row]
+  )
+
+  const onSubmit = useMemo(
+    () =>
+      async ({ data }: { data: unknown }) => {
+        onSaveRef.current(data as SubmitterFormData)
+        return { success: true as const, message: "Expense updated." }
+      },
+    []
+  )
+
+  // Stable submit-config object (label captured once at mount; see
+  // ControllingForm for the rationale).
+  const submitConfig = useMemo(
+    () => ({ label: submitLabelRef.current }),
+    []
+  )
+
+  const formDefinition = useF0FormDefinition({
+    name: "expense-submitter",
+    schema: submitterSchema,
+    sections,
+    defaultValues,
+    submitConfig,
+    onSubmit,
+  })
+
+  return <F0Form formRef={formRef} formDefinition={formDefinition} />
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/shared/detail/receiptSvg.ts
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/shared/detail/receiptSvg.ts
@@ -1,0 +1,541 @@
+/**
+ * Per-expense receipt generator.
+ *
+ * Builds a thermal-printer-style SVG receipt that mirrors the row's
+ * actual data (vendor, category, amount, date) and serializes it to a
+ * `data:image/svg+xml` URL so the existing image-based ReceiptPanel
+ * (zoom / rotate / print / download) keeps working unchanged.
+ *
+ * Deterministic by `row.id`: line items, ticket number, card last-4,
+ * paper skew, all derived from the same hash so reviewers see the
+ * same receipt on every reload.
+ *
+ * Language: Spanish for vendors that read as Spanish-y (heuristic on
+ * vendor name or category=Meals/Taxis defaulting to ES); English
+ * otherwise. Each receipt is wholly one language.
+ */
+
+import type { SpendingRow } from "../rows"
+
+type Lang = "en" | "es"
+
+type LineItem = {
+  qty: number
+  label: string
+  amount: number
+}
+
+const ITEM_TEMPLATES: Record<
+  string,
+  Record<Lang, ReadonlyArray<readonly [string, number]>>
+> = {
+  Meals: {
+    es: [
+      ["MENU DEL DIA", 0.35],
+      ["ENTRANTE", 0.12],
+      ["SEGUNDO PLATO", 0.18],
+      ["BEBIDA", 0.08],
+      ["AGUA MINERAL", 0.05],
+      ["VINO COPA", 0.1],
+      ["CAFE SOLO", 0.05],
+      ["POSTRE CASERO", 0.12],
+      ["PAN", 0.04],
+      ["ENSALADA MIXTA", 0.1],
+      ["TAPA DE LA CASA", 0.09],
+      ["RACION JAMON", 0.18],
+    ],
+    en: [
+      ["LUNCH SPECIAL", 0.35],
+      ["STARTER", 0.12],
+      ["MAIN COURSE", 0.18],
+      ["SOFT DRINK", 0.08],
+      ["MINERAL WATER", 0.05],
+      ["GLASS OF WINE", 0.1],
+      ["ESPRESSO", 0.05],
+      ["DESSERT", 0.12],
+      ["BREAD BASKET", 0.04],
+      ["SIDE SALAD", 0.1],
+      ["APPETIZER", 0.09],
+      ["CHEESE PLATE", 0.18],
+    ],
+  },
+  Taxis: {
+    es: [
+      ["TRAYECTO BASE", 0.55],
+      ["BAJADA DE BANDERA", 0.08],
+      ["SUPLEMENTO AEROPUERTO", 0.12],
+      ["RECARGO NOCTURNO", 0.08],
+      ["EQUIPAJE", 0.05],
+      ["ESPERA", 0.06],
+      ["PEAJE", 0.06],
+    ],
+    en: [
+      ["BASE FARE", 0.55],
+      ["FLAG DROP", 0.08],
+      ["AIRPORT SURCHARGE", 0.12],
+      ["NIGHT SURCHARGE", 0.08],
+      ["LUGGAGE FEE", 0.05],
+      ["WAITING TIME", 0.06],
+      ["TOLL CHARGE", 0.06],
+    ],
+  },
+  Travel: {
+    es: [
+      ["BILLETE PRINCIPAL", 0.6],
+      ["RESERVA ASIENTO", 0.08],
+      ["EQUIPAJE FACTURADO", 0.1],
+      ["TASAS AEROPORTUARIAS", 0.12],
+      ["SEGURO DE VIAJE", 0.05],
+      ["PRIORITY BOARDING", 0.05],
+    ],
+    en: [
+      ["TICKET FARE", 0.6],
+      ["SEAT RESERVATION", 0.08],
+      ["CHECKED BAGGAGE", 0.1],
+      ["AIRPORT TAXES", 0.12],
+      ["TRAVEL INSURANCE", 0.05],
+      ["PRIORITY BOARDING", 0.05],
+    ],
+  },
+  Hotel: {
+    es: [
+      ["HABITACION DOBLE", 0.55],
+      ["DESAYUNO BUFFET", 0.1],
+      ["MINIBAR", 0.05],
+      ["LAVANDERIA", 0.06],
+      ["PARKING", 0.06],
+      ["WIFI PREMIUM", 0.04],
+      ["TASA TURISTICA", 0.06],
+      ["LATE CHECK-OUT", 0.08],
+    ],
+    en: [
+      ["DOUBLE ROOM", 0.55],
+      ["BREAKFAST BUFFET", 0.1],
+      ["MINIBAR", 0.05],
+      ["LAUNDRY SERVICE", 0.06],
+      ["PARKING", 0.06],
+      ["PREMIUM WIFI", 0.04],
+      ["CITY TAX", 0.06],
+      ["LATE CHECK-OUT", 0.08],
+    ],
+  },
+  Shopping: {
+    es: [
+      ["CAMISA OXFORD", 0.25],
+      ["PANTALON CHINO", 0.22],
+      ["JERSEY LANA", 0.18],
+      ["CINTURON CUERO", 0.1],
+      ["CALCETINES PACK 3", 0.08],
+      ["CORBATA SEDA", 0.1],
+      ["BOLSA ALGODON", 0.07],
+    ],
+    en: [
+      ["OXFORD SHIRT", 0.25],
+      ["CHINO TROUSERS", 0.22],
+      ["WOOL SWEATER", 0.18],
+      ["LEATHER BELT", 0.1],
+      ["SOCKS PACK 3", 0.08],
+      ["SILK TIE", 0.1],
+      ["COTTON TOTE", 0.07],
+    ],
+  },
+  Office: {
+    es: [
+      ["FOLIOS A4 500UD", 0.18],
+      ["BOLIGRAFOS PACK 10", 0.12],
+      ["CARPETAS ANILLAS", 0.15],
+      ["TONER IMPRESORA", 0.25],
+      ["POST-IT SURTIDO", 0.1],
+      ["GRAPADORA", 0.08],
+      ["CLIPS METALICOS", 0.05],
+      ["IMPRESION COLOR", 0.07],
+    ],
+    en: [
+      ["A4 PAPER 500CT", 0.18],
+      ["PEN PACK OF 10", 0.12],
+      ["RING BINDERS", 0.15],
+      ["PRINTER TONER", 0.25],
+      ["STICKY NOTES SET", 0.1],
+      ["STAPLER", 0.08],
+      ["PAPER CLIPS", 0.05],
+      ["COLOR PRINTING", 0.07],
+    ],
+  },
+  Software: {
+    es: [
+      ["LICENCIA ANUAL", 0.7],
+      ["MODULO PREMIUM", 0.15],
+      ["USUARIOS ADICIONALES", 0.08],
+      ["SOPORTE 24/7", 0.07],
+    ],
+    en: [
+      ["ANNUAL LICENSE", 0.7],
+      ["PREMIUM ADD-ON", 0.15],
+      ["EXTRA SEATS", 0.08],
+      ["24/7 SUPPORT", 0.07],
+    ],
+  },
+}
+
+const VENDOR_LOCATIONS: Record<string, { line1: string; city: string }> = {
+  // Spanish vendors get real-ish Spanish addresses (matches the
+  // El Corte Inglés vibe). Anything not listed falls back below.
+  "Birch & Beam Café": { line1: "CARRER DE BALMES, 142", city: "08008 BARCELONA" },
+  "Lakeside Bistro": { line1: "PASEO DE LA CASTELLANA, 88", city: "28046 MADRID" },
+  "Tide Lane Eatery": { line1: "GRAN VIA, 23", city: "28013 MADRID" },
+  "Quickline Cabs Ltd.": { line1: "AV. AMERICA TERMINAL", city: "28027 MADRID" },
+  "Northwind Taxi Co.": { line1: "PLAZA CATALUNYA", city: "08002 BARCELONA" },
+  "The Brindle Hotel": { line1: "C/ DE FUENCARRAL, 110", city: "28004 MADRID" },
+  "Cobblestone Inn": { line1: "RAMBLA CATALUNYA, 45", city: "08007 BARCELONA" },
+}
+
+const ENGLISH_FALLBACK_LOCATION = { line1: "221 BAKER STREET", city: "LONDON NW1" }
+
+/**
+ * Heuristic: a receipt is rendered in Spanish when the vendor sits in
+ * the curated Spanish-vendor table OR when the category is one of the
+ * meal/taxi categories (which feel local). Everything else stays in
+ * English so the prototype skews ~70/30 EN as requested.
+ */
+function pickLanguage(row: SpendingRow): Lang {
+  if (VENDOR_LOCATIONS[row.name]) return "es"
+  // Software and Hotel chains read English-y; Meals/Taxis often local.
+  // Use the row id as a tiebreaker so the same vendor across multiple
+  // rows can vary (a generic "Lakeside Bistro" might be in either lang).
+  const seed = hash(row.id)
+  if (row.description === "Meals" || row.description === "Taxis") {
+    return seed % 3 === 0 ? "en" : "es"
+  }
+  return seed % 4 === 0 ? "es" : "en"
+}
+
+function hash(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) >>> 0
+  }
+  return h
+}
+
+function pickLocation(row: SpendingRow, lang: Lang) {
+  if (VENDOR_LOCATIONS[row.name]) return VENDOR_LOCATIONS[row.name]!
+  if (lang === "es") {
+    // Generic Spanish fallback so non-curated vendors still feel local.
+    return { line1: "C/ MAYOR, 12", city: "28013 MADRID" }
+  }
+  return ENGLISH_FALLBACK_LOCATION
+}
+
+/**
+ * Synthesize a list of line items that sum to `total`.
+ * Picks 1–3 items from the category template, distributes the total
+ * across them by weight, and pushes the rounding remainder onto the
+ * last item so the math reconciles exactly.
+ */
+function buildItems(
+  category: string,
+  total: number,
+  seed: number,
+  lang: Lang
+): LineItem[] {
+  // Defensive lookup — categories outside the curated list (or any
+  // future fixture additions) gracefully fall back to the generic
+  // Shopping template instead of crashing the receipt.
+  const langTable = ITEM_TEMPLATES[category] ?? ITEM_TEMPLATES.Shopping!
+  const tmpl = langTable[lang] ?? langTable.en ?? ITEM_TEMPLATES.Shopping!.en
+  if (!tmpl || tmpl.length === 0) {
+    // Final safety net: a single line item that absorbs the full total.
+    return [{ qty: 1, label: lang === "es" ? "ARTICULO" : "ITEM", amount: total }]
+  }
+  // Choose between 5 and 8 items so receipts have enough vertical
+  // weight to fill the preview frame. Software is the only category
+  // that legitimately stays terse (typically 1–2 lines).
+  const isTerseCategory = category === "Software"
+  const minCount = isTerseCategory ? 1 : 5
+  const maxCount = isTerseCategory
+    ? Math.min(2, tmpl.length)
+    : Math.min(8, tmpl.length)
+  const range = Math.max(1, maxCount - minCount + 1)
+  const count = minCount + (seed % range)
+  // Pick `count` items starting from a seed-derived offset.
+  const offset = (seed >> 3) % tmpl.length
+  const picked: Array<readonly [string, number]> = []
+  for (let i = 0; i < count; i++) {
+    const entry = tmpl[(offset + i) % tmpl.length]
+    if (entry) picked.push(entry)
+  }
+  if (picked.length === 0) {
+    return [{ qty: 1, label: lang === "es" ? "ARTICULO" : "ITEM", amount: total }]
+  }
+  // Renormalize weights so they sum to 1 across the picked subset.
+  const weightSum = picked.reduce((s, [, w]) => s + w, 0)
+  const items: LineItem[] = picked.map(([label, w], i) => {
+    const raw = (total * w) / weightSum
+    const rounded = Math.round(raw * 100) / 100
+    // Quantity is usually 1; ~20 % chance of 2 for non-Software, makes
+    // the receipt feel less uniform.
+    const qty = category !== "Software" && (seed >> (i + 4)) % 5 === 0 ? 2 : 1
+    return { qty, label, amount: rounded }
+  })
+  // Reconcile rounding error onto the last item.
+  const sum = items.reduce((s, it) => s + it.amount, 0)
+  const drift = Math.round((total - sum) * 100) / 100
+  if (drift !== 0 && items.length > 0) {
+    items[items.length - 1]!.amount = Math.round(
+      (items[items.length - 1]!.amount + drift) * 100
+    ) / 100
+  }
+  return items
+}
+
+function syntheticPayment(
+  _row: SpendingRow,
+  seed: number,
+  lang: Lang
+): { method: string; lastFour?: string } {
+  // 60% card, 25% cash, 15% transfer.
+  const bucket = seed % 100
+  if (bucket < 60) {
+    const lastFour = String(1000 + ((seed * 7919) % 9000))
+    return {
+      method: lang === "es" ? `VISA ****${lastFour}` : `VISA ****${lastFour}`,
+      lastFour,
+    }
+  }
+  if (bucket < 85) {
+    return { method: lang === "es" ? "EFECTIVO" : "CASH" }
+  }
+  return { method: lang === "es" ? "TRANSFERENCIA" : "BANK TRANSFER" }
+}
+
+function formatDate(iso: string, lang: Lang): string {
+  // Input "YYYY-MM-DD" → "DD/MM/YYYY" for ES, "MM/DD/YYYY" for EN.
+  const [y, m, d] = iso.split("-")
+  if (!y || !m || !d) return iso
+  return lang === "es" ? `${d}/${m}/${y}` : `${m}/${d}/${y}`
+}
+
+function formatTime(seed: number): string {
+  const h = (seed % 14) + 8 // business hours 08–21
+  const m = (seed >> 4) % 60
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`
+}
+
+/**
+ * Build the receipt SVG markup. Width is fixed at 360px (typical
+ * thermal-receipt feel); height grows with the line-item count.
+ *
+ * Text is monospace so columns line up the same way a real
+ * dot-matrix printer would. The whole receipt sits on a paper-colored
+ * rect with a soft shadow + light skew applied to the outer group so
+ * it reads as a photograph rather than a flat document.
+ */
+export function buildReceiptDataUrl(row: SpendingRow): string {
+  const seed = hash(row.id)
+  const lang = pickLanguage(row)
+  const loc = pickLocation(row, lang)
+  const items = buildItems(row.description, row.amount, seed, lang)
+  const payment = syntheticPayment(row, seed, lang)
+  const ticket = `T${String((seed % 900000) + 100000)}/${(seed >> 5) % 1000}`
+  const dateStr = formatDate(row.date, lang)
+  const timeStr = formatTime(seed)
+  const baseRate = row.description === "Meals" ? 0.1 : 0.21
+  const base = Math.round((row.amount / (1 + baseRate)) * 100) / 100
+  const iva = Math.round((row.amount - base) * 100) / 100
+  const ivaLabel = lang === "es" ? `IVA ${Math.round(baseRate * 100)}%` : `VAT ${Math.round(baseRate * 100)}%`
+
+  // Localized strings.
+  const STR =
+    lang === "es"
+      ? {
+          uds: "UDS",
+          desc: "DESCRIPCION",
+          pvp: "PVP",
+          imp: "IMPORTE",
+          total: "TOTAL",
+          base: "BASE IMP",
+          cuota: "CUOTA",
+          paid: "PAGADO CON",
+          thanks: "*** GRACIAS POR SU VISITA ***",
+          attended: "ATENDIDO POR",
+          notValid: "NO VALIDO COMO FACTURA",
+        }
+      : {
+          uds: "QTY",
+          desc: "DESCRIPTION",
+          pvp: "PRICE",
+          imp: "AMOUNT",
+          total: "TOTAL",
+          base: "SUBTOTAL",
+          cuota: "TAX",
+          paid: "PAID WITH",
+          thanks: "*** THANK YOU FOR YOUR VISIT ***",
+          attended: "SERVED BY",
+          notValid: "NOT A VALID INVOICE",
+        }
+
+  const cashier = lang === "es" ? "KEYTI OVIEDO" : "ALEX MORGAN"
+  const tableNo = (seed >> 7) % 40 + 1
+
+  // Layout — fixed column x positions in pixel units inside the SVG
+  // viewBox. We use a 360-wide canvas with 24px outer padding.
+  const W = 360
+  const PAD = 24
+  const LH = 16 // line height
+  const fontMono = "ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace"
+
+  // Build text rows top-down, accumulating y so we know the final
+  // canvas height.
+  type Row = { y: number; render: string }
+  const rows: Row[] = []
+  let y = PAD + 14
+
+  const push = (text: string, opts: { bold?: boolean; size?: number; align?: "center" | "left"; spacing?: number } = {}) => {
+    const size = opts.size ?? 12
+    const weight = opts.bold ? 700 : 400
+    const x = opts.align === "center" ? W / 2 : PAD
+    const anchor = opts.align === "center" ? "middle" : "start"
+    rows.push({
+      y,
+      render: `<text x="${x}" y="${y}" font-family="${fontMono}" font-size="${size}" font-weight="${weight}" text-anchor="${anchor}" fill="#1a1a1a">${escapeXml(text)}</text>`,
+    })
+    y += opts.spacing ?? LH
+  }
+
+  // Header
+  push(row.name.toUpperCase(), { bold: true, size: 14, align: "center" })
+  push(loc.line1, { align: "center", size: 11 })
+  push(loc.city, { align: "center", size: 11, spacing: LH + 4 })
+
+  // Ticket meta — two columns.
+  const metaLeft = `${ticket}`
+  const metaRight = lang === "es" ? `${dateStr} ${timeStr}` : `${dateStr}  ${timeStr}`
+  rows.push({
+    y,
+    render: `<text x="${PAD}" y="${y}" font-family="${fontMono}" font-size="11" fill="#1a1a1a">${escapeXml(metaLeft)}</text><text x="${W - PAD}" y="${y}" text-anchor="end" font-family="${fontMono}" font-size="11" fill="#1a1a1a">${escapeXml(metaRight)}</text>`,
+  })
+  y += LH
+  rows.push({
+    y,
+    render: `<text x="${W - PAD}" y="${y}" text-anchor="end" font-family="${fontMono}" font-size="11" fill="#1a1a1a">${escapeXml((lang === "es" ? "MESA " : "TABLE ") + tableNo)}</text>`,
+  })
+  y += LH + 4
+
+  // Column header.
+  rows.push({
+    y,
+    render:
+      `<text x="${PAD}" y="${y}" font-family="${fontMono}" font-size="11" font-weight="700" fill="#1a1a1a">${STR.uds} ${STR.desc}</text>` +
+      `<text x="${W - PAD - 70}" y="${y}" font-family="${fontMono}" font-size="11" font-weight="700" fill="#1a1a1a" text-anchor="end">${STR.pvp}</text>` +
+      `<text x="${W - PAD}" y="${y}" font-family="${fontMono}" font-size="11" font-weight="700" fill="#1a1a1a" text-anchor="end">${STR.imp}</text>`,
+  })
+  y += LH
+
+  // Divider.
+  rows.push({
+    y,
+    render: `<line x1="${PAD}" y1="${y - 6}" x2="${W - PAD}" y2="${y - 6}" stroke="#1a1a1a" stroke-width="0.5" stroke-dasharray="2 2" />`,
+  })
+
+  // Line items.
+  for (const item of items) {
+    const unit = Math.round((item.amount / item.qty) * 100) / 100
+    rows.push({
+      y,
+      render:
+        `<text x="${PAD}" y="${y}" font-family="${fontMono}" font-size="11" fill="#1a1a1a">${item.qty}  ${escapeXml(item.label)}</text>` +
+        `<text x="${W - PAD - 70}" y="${y}" font-family="${fontMono}" font-size="11" fill="#1a1a1a" text-anchor="end">${unit.toFixed(2)}</text>` +
+        `<text x="${W - PAD}" y="${y}" font-family="${fontMono}" font-size="11" fill="#1a1a1a" text-anchor="end">${item.amount.toFixed(2)} ${currencySymbol(lang)}</text>`,
+    })
+    y += LH
+  }
+
+  y += 6
+  rows.push({
+    y,
+    render: `<line x1="${PAD}" y1="${y - 6}" x2="${W - PAD}" y2="${y - 6}" stroke="#1a1a1a" stroke-width="0.5" stroke-dasharray="2 2" />`,
+  })
+
+  // Totals block.
+  rows.push({
+    y,
+    render:
+      `<text x="${PAD}" y="${y}" font-family="${fontMono}" font-size="11" fill="#1a1a1a">${STR.base} ${ivaLabel} ${STR.cuota}</text>` +
+      `<text x="${W - PAD}" y="${y}" font-family="${fontMono}" font-size="13" font-weight="700" fill="#1a1a1a" text-anchor="end">${STR.total} ${row.amount.toFixed(2)} ${currencySymbol(lang)}</text>`,
+  })
+  y += LH
+  rows.push({
+    y,
+    render: `<text x="${PAD}" y="${y}" font-family="${fontMono}" font-size="11" fill="#1a1a1a">${base.toFixed(2)}  ${(baseRate * 100).toFixed(0)}%  ${iva.toFixed(2)}</text>`,
+  })
+  y += LH + 6
+
+  // Payment.
+  push(`${STR.paid}: ${payment.method}`, { size: 11 })
+  y += 4
+
+  // Footer.
+  push(STR.notValid, { align: "center", size: 11 })
+  push(STR.thanks, { align: "center", size: 11 })
+  push(`${STR.attended}: ${cashier}`, { align: "center", size: 11 })
+
+  const H = y + PAD
+
+  // Slight skew + drop shadow on the outer group makes the SVG read
+  // as a photographed receipt instead of a flat document. The skew is
+  // seed-derived so different expenses tilt at different angles.
+  const skew = ((seed % 5) - 2) * 0.6 // -1.2° .. +1.2°
+
+  // Fixed canvas aspect (~3:4 portrait) so every receipt renders at
+  // the same intrinsic size regardless of how many line items it has.
+  // The white paper sheet fills the full canvas; the actual receipt
+  // text is centered vertically inside it. This guarantees the
+  // ReceiptPanel frame is always filled — short receipts no longer
+  // float as a tiny block in a sea of dark chrome.
+  const OUTER = 24
+  const TARGET_H = Math.max(H + OUTER * 2, Math.round(W * 1.5))
+  const VBW = W + OUTER * 2
+  const VBH = TARGET_H
+
+  // Center the receipt content vertically inside the paper sheet.
+  const contentTop = Math.max(OUTER, (VBH - H) / 2)
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${VBW} ${VBH}" width="${VBW}" height="${VBH}" preserveAspectRatio="xMidYMid meet">
+  <defs>
+    <filter id="paperShadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" />
+      <feOffset dx="2" dy="4" result="offsetblur" />
+      <feComponentTransfer><feFuncA type="linear" slope="0.35" /></feComponentTransfer>
+      <feMerge><feMergeNode /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+    <pattern id="paperGrain" patternUnits="userSpaceOnUse" width="4" height="4">
+      <rect width="4" height="4" fill="#fafaf6" />
+      <circle cx="1" cy="1" r="0.3" fill="#e9e6dc" opacity="0.6" />
+      <circle cx="3" cy="3" r="0.2" fill="#efece2" opacity="0.5" />
+    </pattern>
+  </defs>
+  <g transform="rotate(${skew} ${VBW / 2} ${VBH / 2})" filter="url(#paperShadow)">
+    <rect x="${OUTER}" y="${OUTER}" width="${W}" height="${VBH - OUTER * 2}" fill="url(#paperGrain)" rx="2" />
+    <g transform="translate(${OUTER} ${contentTop - OUTER})">
+      ${rows.map((r) => r.render).join("\n      ")}
+    </g>
+  </g>
+</svg>`
+
+  // SVG -> data URL. We use UTF-8 percent-encoding so non-ASCII
+  // characters (€, accented letters) survive without base64 bloat.
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+}
+
+function currencySymbol(lang: Lang): string {
+  return lang === "es" ? "€" : "EUR"
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/shared/expenseStatus.ts
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/shared/expenseStatus.ts
@@ -1,0 +1,46 @@
+import type { ExpenseStatus } from "@/fixtures"
+
+/**
+ * Maps the existing fixture statuses (`draft`, `pending`, `approved`,
+ * `in-payroll`, `refunded`, `partially-refunded`) into the labels and
+ * F0TagStatus variants used across the unified Spending page.
+ */
+export type StatusVariant =
+  | "neutral"
+  | "info"
+  | "positive"
+  | "warning"
+  | "critical"
+
+export const STATUS_LABEL: Record<ExpenseStatus, string> = {
+  draft: "Draft",
+  "changes-requested": "Changes requested",
+  pending: "Pending",
+  approved: "Approved",
+  controlled: "Controlled",
+  "in-payroll": "Sent to Pay",
+  paid: "Paid",
+  refunded: "Refunded",
+  "partially-refunded": "Partially refunded",
+}
+
+export const STATUS_VARIANT: Record<ExpenseStatus, StatusVariant> = {
+  draft: "neutral",
+  // Approver returned the expense to the submitter for fixes — orange
+  // warning so it sits visually next to Pending in the table.
+  "changes-requested": "warning",
+  pending: "warning",
+  approved: "positive",
+  // Controlled is a "ready for accounting" milestone. Originally green
+  // for visual progression, recolored to info (blue) so green is
+  // reserved for the terminal `paid` state — otherwise the Pay tab is
+  // a sea of green and finance can't tell mid-flight rows from
+  // confirmed reimbursements.
+  controlled: "info",
+  // In-flight: transmitted to payroll/SEPA, not yet confirmed paid.
+  "in-payroll": "info",
+  // Terminal state — payment confirmed. The only green status.
+  paid: "positive",
+  refunded: "info",
+  "partially-refunded": "info",
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/shared/rows.ts
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/shared/rows.ts
@@ -1,0 +1,77 @@
+import type {
+  ControllingFields,
+  Expense,
+  ExpenseAlert,
+  ExpenseGroup,
+  ExpenseStatus,
+} from "@/fixtures"
+
+/**
+ * The unified row type for the Submit / Manage data collections.
+ *
+ * BR-008: folders are first-class rows that live INSIDE the expenses
+ * data collection — not in a separate sibling tab. Visually the row
+ * shows the folder icon (via the `folder` cell type) and clicking it
+ * opens the folder detail sub-screen.
+ */
+export type SpendingRowKind = "expense" | "folder"
+
+export type SpendingRow = {
+  id: string
+  kind: SpendingRowKind
+  /** Provider name (expense) or folder name. */
+  name: string
+  /** Expense category (expense rows only) — folders show "Folder · N expenses". */
+  description: string
+  status: ExpenseStatus
+  /** Amount in EUR — for folders, this is the aggregated total (BR-009). */
+  amount: number
+  /** ISO YYYY-MM-DD. */
+  date: string
+  /** Number of contained expenses (folders only). */
+  expenseCount?: number
+  /** Compliance alerts on the row — drives Manage's Needs review preset. */
+  alerts: ExpenseAlert[]
+  /**
+   * Accounting metadata once finance has begun coding. `undefined` for
+   * folder rows and for any expense not yet in `approved`/`controlled`.
+   * The Pending Controlling side panel reads/writes this block.
+   */
+  controlling?: ControllingFields
+}
+
+export function expenseToRow(e: Expense): SpendingRow {
+  return {
+    id: e.id,
+    kind: "expense",
+    name: e.provider,
+    description: e.category,
+    status: e.status,
+    amount: e.amount,
+    date: e.createdAt,
+    alerts: e.alerts,
+    controlling: e.controlling,
+  }
+}
+
+export function folderToRow(g: ExpenseGroup): SpendingRow {
+  return {
+    id: g.id,
+    kind: "folder",
+    name: g.name,
+    description: `Folder · ${g.expenseCount} expense${g.expenseCount === 1 ? "" : "s"}`,
+    status: g.status,
+    amount: g.amount,
+    date: g.reportDate,
+    expenseCount: g.expenseCount,
+    alerts: [],
+  }
+}
+
+/** Filter a row list to a set of allowed statuses. */
+export function rowsInStatus(
+  rows: SpendingRow[],
+  statuses: ExpenseStatus[]
+): SpendingRow[] {
+  return rows.filter((r) => statuses.includes(r.status))
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/shared/sidePanel/ControllingForm.tsx
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/shared/sidePanel/ControllingForm.tsx
@@ -1,0 +1,216 @@
+import {
+  F0Form,
+  f0FormField,
+  useF0Form,
+  useF0FormDefinition,
+} from "@factorialco/f0-react"
+import { useEffect, useMemo, useRef } from "react"
+import { z } from "zod"
+
+import {
+  costCenters,
+  projects,
+  subcategoriesByCategory,
+  vatRates,
+  type ControllingFields,
+  type ExpenseCategory,
+} from "@/fixtures"
+
+/**
+ * The controlling (coding) form rendered inside the expense side panel
+ * when an expense is opened from `Manage > Pending Controlling`
+ * (PSPEC-spending-pending-controlling, BR-001 / BR-002 / BR-009).
+ *
+ * Schema, sections and default-builder are at module scope (truly
+ * static). Hooks live INSIDE the component so they're paired with the
+ * `<F0Form>` they produce — registering the form in a parent that
+ * doesn't also render it loops the AI chat panel
+ * (see f0-prototype skill, "form co-creation").
+ */
+
+const ALL_CATEGORIES: ExpenseCategory[] = [
+  "Meals",
+  "Taxis",
+  "Travel",
+  "Shopping",
+  "Hotel",
+  "Office",
+  "Software",
+]
+
+// Build a single flat subcategory list — every subcategory across every
+// category. The runtime form doesn't enforce category→subcategory
+// dependency (EDGE-001 acknowledged); finance picks freely.
+const ALL_SUBCATEGORIES = Array.from(
+  new Set(
+    Object.values(subcategoriesByCategory).flatMap((list) => list)
+  )
+)
+
+const controllingSchema = z.object({
+  category: f0FormField.select({
+    label: "Category",
+    section: "classification",
+    row: "cat-sub",
+    optional: true,
+    placeholder: "Select a category",
+    options: ALL_CATEGORIES.map((c) => ({ value: c, label: c })),
+  }),
+  subcategory: f0FormField.select({
+    label: "Subcategory",
+    section: "classification",
+    row: "cat-sub",
+    optional: true,
+    placeholder: "Select a subcategory",
+    options: ALL_SUBCATEGORIES.map((s) => ({ value: s, label: s })),
+  }),
+  costCenter: f0FormField.select({
+    label: "Cost center",
+    section: "allocation",
+    row: "cost-proj",
+    optional: true,
+    placeholder: "Select a cost center",
+    options: costCenters.map((c) => ({
+      value: c.id,
+      label: `${c.name} (${c.code})`,
+    })),
+  }),
+  project: f0FormField.select({
+    label: "Project",
+    section: "allocation",
+    row: "cost-proj",
+    optional: true,
+    placeholder: "Select a project",
+    options: projects.map((p) => ({
+      value: p.id,
+      label: `${p.name} (${p.code})`,
+    })),
+  }),
+  vatRate: f0FormField.select({
+    label: "VAT rate",
+    section: "tax",
+    optional: true,
+    placeholder: "Select a VAT rate",
+    options: vatRates.map((v) => ({ value: v.id, label: v.label })),
+  }),
+  description: f0FormField.textarea({
+    label: "Description",
+    section: "notes",
+    optional: true,
+    placeholder: "Accounting note (optional)",
+  }),
+  // BISECT: tags multiSelect temporarily removed to test whether the
+  // multiSelect field is what destabilizes the form registration and
+  // loops the AI chat panel. Re-add once diagnosed.
+  //
+  // Outcome (2026-05-11): keeping `tags` removed because adding it back
+  // reproduces "Maximum update depth exceeded" inside F0AiChat
+  // (`Dle` / Array.map cascade in F0AiChat-CqAcgo3K.js) the moment the
+  // user opens the multiSelect dropdown — even with module-scope
+  // schema/sections, stable refs, memoized submit/defaults, and the
+  // panel mounted only when open with a key on variant+id. Bisecting
+  // by replacing the entire form with bare HTML inputs shows the loop
+  // disappears, confirming F0Form ↔ AI form registry as the trigger.
+  // The full BR-002 / BR-003 field list specifies tags but the
+  // prototype intentionally omits it pending an upstream fix in
+  // packages/react.
+})
+
+const sections = {
+  classification: { title: "Classification" },
+  allocation: { title: "Allocation" },
+  tax: { title: "Tax" },
+  notes: { title: "Notes" },
+} as const
+
+/** Submitted shape — mirrors `ControllingFields`. */
+export type ControllingFormData = {
+  category?: ExpenseCategory
+  subcategory?: string
+  costCenter?: string
+  project?: string
+  vatRate?: string
+  description?: string
+  tags?: string[]
+}
+
+export function ControllingForm(props: {
+  /**
+   * Pre-fill values. For single-row editing this is the row's existing
+   * `controlling` block. For bulk-edit, pass `undefined` so finance
+   * starts from a clean slate (BR-005: bulk-edit overwrites).
+   */
+  defaultValues: ControllingFields | undefined
+  /**
+   * Triggered when finance clicks the form's submit button. Caller
+   * decides whether to also flip the row to `controlled` (per-row
+   * "Mark as controlled") or just persist (Save / bulk-edit Apply).
+   */
+  onSave: (data: ControllingFormData) => void
+  /** Submit button label — the only piece that varies between
+   *  Save / Mark as controlled / Apply to selected. */
+  submitLabel: string
+}) {
+  const { formRef } = useF0Form()
+
+  // Refs keep the latest callback / label without re-feeding them into
+  // `useF0FormDefinition`'s dependency array. The chat panel registers
+  // form tools off the definition's identity (see F0AiChat:12292) — if
+  // the definition changes every render the registration loops and we
+  // hit "Maximum update depth exceeded".
+  const onSaveRef = useRef(props.onSave)
+  const submitLabelRef = useRef(props.submitLabel)
+  useEffect(() => {
+    onSaveRef.current = props.onSave
+  }, [props.onSave])
+  useEffect(() => {
+    submitLabelRef.current = props.submitLabel
+  }, [props.submitLabel])
+
+  // Defaults change only when the row identity changes. The shallow
+  // primitive comparison below is enough: every `ControllingFields`
+  // value is a string / string[] which we compare by reference.
+  const defaultValues = useMemo(
+    () => ({
+      category: props.defaultValues?.category,
+      subcategory: props.defaultValues?.subcategory,
+      costCenter: props.defaultValues?.costCenter,
+      project: props.defaultValues?.project,
+      vatRate: props.defaultValues?.vatRate,
+      description: props.defaultValues?.description ?? "",
+    }),
+    [props.defaultValues]
+  )
+
+  // Stable `onSubmit` closure — reads the latest handler from the ref.
+  const onSubmit = useMemo(
+    () =>
+      async ({ data }: { data: unknown }) => {
+        onSaveRef.current(data as ControllingFormData)
+        return { success: true as const, message: "Controlling fields saved." }
+      },
+    []
+  )
+
+  // Stable submit-config object. `getLabel` lets us still pick up the
+  // ref-tracked label without changing object identity.
+  const submitConfig = useMemo(
+    () => ({ label: submitLabelRef.current }),
+    // Intentionally excluding submitLabelRef.current — see comment above.
+    // Re-rendering with a different label is a UX nicety we trade for
+    // stability. In practice the variant (and therefore the label) is
+    // fixed for the lifetime of any given form mount.
+    []
+  )
+
+  const formDefinition = useF0FormDefinition({
+    name: "expense-controlling",
+    schema: controllingSchema,
+    sections,
+    defaultValues,
+    submitConfig,
+    onSubmit,
+  })
+
+  return <F0Form formRef={formRef} formDefinition={formDefinition} />
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/shared/sidePanel/ExpenseSidePanel.tsx
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/shared/sidePanel/ExpenseSidePanel.tsx
@@ -1,0 +1,318 @@
+import { F0Box, F0Button, F0Dialog, F0TagStatus, F0Text } from "@factorialco/f0-react"
+import { Tabs } from "@factorialco/f0-react/dist/experimental"
+import { useMemo, useState } from "react"
+
+import { STATUS_LABEL, STATUS_VARIANT } from "../expenseStatus"
+import type { SpendingRow } from "../rows"
+import { ControllingForm, type ControllingFormData } from "./ControllingForm"
+
+/**
+ * Unified expense side panel.
+ *
+ * Mirrors the panel the f0 team is building behind the
+ * `dev_expenses_f0_sidepanel` feature flag: a wide, right-anchored
+ * `F0Dialog` with secondary tabs (Detail · Comments · Alerts ·
+ * Accounting/Controlling). Background list stays interactive so finance
+ * can keep selecting rows while the panel is open.
+ *
+ * The single component covers two contexts (Spec D BR-001, INV-004 —
+ * "same chrome, different form"):
+ *
+ *   - `variant === "detail"`: read-only summary used everywhere except
+ *     Pending Controlling. Default tab is Detail.
+ *
+ *   - `variant === "controlling"`: editable controlling form replaces
+ *     the Accounting tab; default tab is Controlling. Footer surfaces
+ *     `Save changes`, `Mark as controlled` and `Reject` actions.
+ *
+ *   - `variant === "bulk-edit"`: same controlling form, but pre-filled
+ *     empty and applied to every selected row on submit
+ *     (Spec D F-002 / BR-003 / BR-005). Header swaps to a "Editing N
+ *     expenses" badge so finance knows the scope.
+ */
+
+export type ExpenseSidePanelVariant = "detail" | "controlling" | "bulk-edit"
+
+const tabsForVariant: Record<
+  ExpenseSidePanelVariant,
+  Array<{ id: string; label: string }>
+> = {
+  detail: [
+    { id: "detail", label: "Detail" },
+    { id: "comments", label: "Comments" },
+    { id: "alerts", label: "Alerts" },
+    { id: "accounting", label: "Accounting" },
+  ],
+  controlling: [
+    { id: "controlling", label: "Controlling" },
+    { id: "detail", label: "Detail" },
+    { id: "comments", label: "Comments" },
+    { id: "alerts", label: "Alerts" },
+  ],
+  "bulk-edit": [{ id: "controlling", label: "Bulk edit" }],
+}
+
+const defaultTabFor: Record<ExpenseSidePanelVariant, string> = {
+  detail: "detail",
+  controlling: "controlling",
+  "bulk-edit": "controlling",
+}
+
+export function ExpenseSidePanel(props: {
+  /**
+   * For `detail`/`controlling`: the row being viewed/edited.
+   * For `bulk-edit`: representative row (used only for the header badge).
+   */
+  row: SpendingRow | null
+  variant: ExpenseSidePanelVariant
+  /** For `bulk-edit` only — count of rows the apply will hit. */
+  bulkSelectionCount?: number
+  isOpen: boolean
+  onClose: () => void
+  /** Save controlling fields without changing state (BR-005, BR-011). */
+  onSaveControlling?: (data: ControllingFormData) => void
+  /** Mark the row(s) as controlled — fires EV-001 (Spec D). */
+  onMarkControlled?: () => void
+  /** Reject — transitions to Rejected and closes the panel (BR-007). */
+  onReject?: () => void
+  /** Apply controlling values to every selected row (bulk-edit variant). */
+  onBulkApply?: (data: ControllingFormData) => void
+}) {
+  const {
+    row,
+    variant,
+    bulkSelectionCount,
+    isOpen,
+    onClose,
+    onSaveControlling,
+    onMarkControlled,
+    onReject,
+    onBulkApply,
+  } = props
+
+  const tabs = tabsForVariant[variant]
+  const [activeTab, setActiveTab] = useState<string>(defaultTabFor[variant])
+
+  const headerTitle = useMemo(() => {
+    if (variant === "bulk-edit") {
+      return `Editing ${bulkSelectionCount ?? 0} expenses`
+    }
+    return row?.name ?? ""
+  }, [variant, bulkSelectionCount, row])
+
+  const headerDescription = useMemo(() => {
+    if (variant === "bulk-edit") {
+      return "Changes apply to every selected expense. Marking as controlled is a separate action."
+    }
+    if (!row) return ""
+    return `${row.description} · ${formatEUR(row.amount)}`
+  }, [variant, row])
+
+  return (
+    <F0Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      position="right"
+      width="lg"
+      title={headerTitle}
+      description={headerDescription}
+    >
+      <F0Box display="flex" flexDirection="column" gap="none">
+        {/* Status badge — only meaningful when a single row is in scope. */}
+        {variant !== "bulk-edit" && row && (
+          <F0Box padding="md">
+            <F0TagStatus
+              text={STATUS_LABEL[row.status]}
+              variant={STATUS_VARIANT[row.status]}
+            />
+          </F0Box>
+        )}
+
+        {/* Tabs — per-tab onClick + remount on activeTabId change so the
+            URL-sync gotcha (skill: f0-prototype) doesn't bite us. */}
+        <Tabs
+          key={activeTab}
+          secondary
+          tabs={tabs.map((t) => ({
+            ...t,
+            onClick: () => setActiveTab(t.id),
+          }))}
+          activeTabId={activeTab}
+        />
+
+        {/* Tab content */}
+        <F0Box padding="md">
+          {activeTab === "detail" && row && <DetailPane row={row} />}
+          {activeTab === "comments" && <CommentsPane />}
+          {activeTab === "alerts" && row && <AlertsPane row={row} />}
+          {activeTab === "accounting" && row && (
+            <AccountingPane row={row} />
+          )}
+          {activeTab === "controlling" && isOpen && (
+            <ControllingForm
+              // Remount the form when we switch between bulk-edit and
+              // per-row editing — the AI form registry treats the same
+              // form name + different defaultValues as a new
+              // registration, and a clean remount is cheaper than
+              // diffing the in-flight form state.
+              key={variant === "bulk-edit" ? "bulk" : row?.id ?? "none"}
+              defaultValues={
+                variant === "bulk-edit"
+                  ? undefined
+                  : row?.controlling
+              }
+              submitLabel={
+                variant === "bulk-edit"
+                  ? `Apply to ${bulkSelectionCount ?? 0} expenses`
+                  : "Save changes"
+              }
+              onSave={(data) => {
+                if (variant === "bulk-edit") {
+                  onBulkApply?.(data)
+                } else {
+                  onSaveControlling?.(data)
+                }
+              }}
+            />
+          )}
+        </F0Box>
+
+        {/* Per-row controlling footer — Mark as controlled / Reject.
+            BR-005: bulk-edit MUST NOT auto-mark; so this footer is
+            hidden for the bulk variant. */}
+        {variant === "controlling" && (
+          <F0Box
+            display="flex"
+            flexDirection="row"
+            gap="sm"
+            padding="md"
+            justifyContent="end"
+            borderTop="default"
+          >
+            <F0Button
+              label="Reject"
+              variant="critical"
+              onClick={onReject ?? (() => {})}
+            />
+            <F0Button
+              label="Mark as controlled"
+              variant="default"
+              onClick={onMarkControlled ?? (() => {})}
+            />
+          </F0Box>
+        )}
+      </F0Box>
+    </F0Dialog>
+  )
+}
+
+// ---------------------------------------------------------------------
+// Tab panes — small, JSX-free helpers stay in the same file because
+// they're tiny and only consumed here.
+// ---------------------------------------------------------------------
+
+function DetailPane({ row }: { row: SpendingRow }) {
+  return (
+    <F0Box display="flex" flexDirection="column" gap="lg">
+      <DetailRow label="Amount" value={formatEUR(row.amount)} />
+      <DetailRow label="Category" value={row.description} />
+      <DetailRow label="Date" value={formatDate(row.date)} />
+      <DetailRow label="Status" value={STATUS_LABEL[row.status]} />
+    </F0Box>
+  )
+}
+
+function CommentsPane() {
+  return (
+    <F0Text
+      content="No comments yet. Comments from the approval flow will appear here."
+      variant="description"
+    />
+  )
+}
+
+function AlertsPane({ row }: { row: SpendingRow }) {
+  if (row.alerts.length === 0) {
+    return (
+      <F0Text
+        content="No alerts on this expense."
+        variant="description"
+      />
+    )
+  }
+  return (
+    <F0Box display="flex" flexDirection="column" gap="sm">
+      {row.alerts.map((a) => (
+        <F0Box
+          key={a}
+          padding="sm"
+          background="warning"
+          borderRadius="md"
+        >
+          <F0Text content={alertLabel(a)} variant="body" />
+        </F0Box>
+      ))}
+    </F0Box>
+  )
+}
+
+function AccountingPane({ row }: { row: SpendingRow }) {
+  if (!row.controlling) {
+    return (
+      <F0Text
+        content="No accounting data yet — finance has not coded this expense."
+        variant="description"
+      />
+    )
+  }
+  const c = row.controlling
+  return (
+    <F0Box display="flex" flexDirection="column" gap="lg">
+      <DetailRow label="Category" value={c.category ?? "—"} />
+      <DetailRow label="Subcategory" value={c.subcategory ?? "—"} />
+      <DetailRow label="Cost center" value={c.costCenter ?? "—"} />
+      <DetailRow label="Project" value={c.project ?? "—"} />
+      <DetailRow label="VAT rate" value={c.vatRate ?? "—"} />
+      <DetailRow label="Description" value={c.description ?? "—"} />
+    </F0Box>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <F0Box display="flex" flexDirection="column" gap="xs">
+      <F0Text content={label} variant="label" />
+      <F0Text content={value} variant="body" />
+    </F0Box>
+  )
+}
+
+const eurFormatter = new Intl.NumberFormat("en-GB", {
+  style: "currency",
+  currency: "EUR",
+})
+function formatEUR(amount: number) {
+  return eurFormatter.format(amount)
+}
+
+const dateFormatter = new Intl.DateTimeFormat("en-GB", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+})
+function formatDate(iso: string) {
+  return dateFormatter.format(new Date(iso + "T00:00:00Z"))
+}
+
+function alertLabel(a: string) {
+  switch (a) {
+    case "late-submission":
+      return "Late expense submission"
+    case "receipt-after-timeframe":
+      return "Receipt submitted after required timeframe"
+    case "receipt-mismatch":
+      return "Receipt amount does not match the expense"
+    default:
+      return a
+  }
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/submit/SubmitExpensesTab.tsx
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/submit/SubmitExpensesTab.tsx
@@ -1,0 +1,57 @@
+import { OneDataCollection } from "@factorialco/f0-react/dist/experimental"
+
+import { spendingColumns } from "../shared/columns"
+import type { SpendingRow } from "../shared/rows"
+import {
+  useSubmitExpensesRows,
+  useSubmitExpensesSource,
+} from "./useSubmitExpensesSource"
+
+/**
+ * Submit > Expenses tab — single view for the user's whole personal
+ * expense lifecycle. Drafts / Submitted / Pending / Approved / Paid
+ * live as presets above the table.
+ *
+ * Click handling mirrors Manage:
+ *   - Folder rows navigate via `folderHref` (handled by the source's
+ *     `itemUrl`).
+ *   - Expense rows call `onExpenseClick(id)` so the parent can set
+ *     `?expense=<id>` and render the full-page detail view. Without
+ *     this wiring expense rows in Submit looked clickable (cursor
+ *     change from `selectable`) but did nothing — the cause of the
+ *     "I can't click on expenses in Submit" report.
+ */
+export function SubmitExpensesTab(props: {
+  folderHref: (folderId: string) => string
+  onExpenseClick: (expenseId: string) => void
+}) {
+  const rows = useSubmitExpensesRows()
+  const source = useSubmitExpensesSource({
+    rows,
+    onNewExpense: () => {},
+    onNewMileage: () => {},
+    onNewPerDiem: () => {},
+    onNewFolder: () => {},
+    folderHref: props.folderHref,
+  })
+  return (
+    <OneDataCollection
+      source={{
+        ...source,
+        // Expense rows open the detail page; folder rows fall through
+        // to `itemUrl` (returning `undefined` here is critical, see
+        // ManageTab for context — a no-op handler blocks navigation).
+        itemOnClick: ((item: SpendingRow) =>
+          item.kind === "expense"
+            ? () => props.onExpenseClick(item.id)
+            : undefined) as unknown as (item: SpendingRow) => () => void,
+      }}
+      visualizations={[
+        {
+          type: "table",
+          options: { columns: [...spendingColumns] },
+        },
+      ]}
+    />
+  )
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/submit/useSubmitExpensesSource.ts
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/submit/useSubmitExpensesSource.ts
@@ -1,0 +1,270 @@
+import { expenseGroups, expenses, type ExpenseStatus } from "@/fixtures"
+import { useDataCollectionSource } from "@factorialco/f0-react/dist/experimental"
+import {
+  Add,
+  CheckCircle,
+  Delete,
+  Folder,
+  LogoTravelperk,
+  PalmTree,
+} from "@factorialco/f0-react/icons/app"
+import { useMemo } from "react"
+
+import { paginateRows } from "../shared/columns"
+import { expenseToRow, folderToRow, type SpendingRow } from "../shared/rows"
+
+/**
+ * Submit > Expenses source — a single "my expenses" view that covers
+ * the whole personal lifecycle. Drafts and Submitted (Pending /
+ * Approved / Paid) are exposed as presets so users can jump between
+ * stages without switching tabs.
+ *
+ * BR-010 / AC-008: the four "New" affordances (Regular expense,
+ * Mileage, Per diem, Folder) are above the table — Regular as primary,
+ * the other three as secondary actions.
+ *
+ * BR-008 / AC-007: folders appear inline as first-class rows; clicking
+ * a folder opens its detail view via `itemUrl`.
+ */
+const STATUS_FILTER_KEY = "status"
+
+export function useSubmitExpensesRows(): SpendingRow[] {
+  return useMemo(() => {
+    const folders = expenseGroups.map(folderToRow)
+    // To-Do groups two cohorts that both require submitter action:
+    //   1. Drafts — expenses the user started but hasn't submitted yet.
+    //      The bulk of the To-Do backlog. We synthesize ~13 of them
+    //      with `draft-` prefixed ids so they don't collide with any
+    //      real fixture row, then re-cast their status to `draft`.
+    //   2. Changes requested — a small handful (~3) the approver
+    //      bounced back. Pulled from the pending pool, preferring
+    //      clean (no-alert) rows so we don't drain Approve & Pay >
+    //      Approve > Needs review.
+    //
+    // Both cohorts feed `selectPolicyAlert` for "view" + To-Do, which
+    // matches statuses `draft` | `changes-requested` and rotates
+    // review / send-for-approval / likely-rejection copy by row id.
+    //
+    // We dedupe by source id so the same expense never appears in
+    // both To-Do (re-cast) and Submitted (original).
+    const consumedSourceIds = new Set<string>()
+    const pendingPool = expenses
+      .filter((e) => e.status === "pending")
+      .slice()
+      .sort((a, b) => a.alerts.length - b.alerts.length)
+
+    // 13 drafts — re-cast pending rows with synthetic ids so the
+    // table cell and detail page both render `draft` for these.
+    const draftExpenses = pendingPool
+      .slice(0, 13)
+      .map((e) => {
+        consumedSourceIds.add(e.id)
+        return {
+          ...e,
+          id: `draft-${e.id}`,
+          status: "draft" as const,
+        }
+      })
+      .map(expenseToRow)
+
+    // 3 changes-requested — approver bounced these back to the
+    // submitter for fixes.
+    const changesRequestedExpenses = pendingPool
+      .slice(13, 16)
+      .map((e) => {
+        consumedSourceIds.add(e.id)
+        return { ...e, status: "changes-requested" as const }
+      })
+      .map(expenseToRow)
+
+    // Submitted shows the rest. Skip any source row we've already
+    // consumed above so the same id never shows in two presets with
+    // conflicting statuses.
+    const realExpenses = expenses
+      .filter(
+        (e) =>
+          ["pending", "approved", "in-payroll"].includes(e.status as string) &&
+          !consumedSourceIds.has(e.id)
+      )
+      .map(expenseToRow)
+
+    return [
+      ...folders,
+      ...draftExpenses,
+      ...changesRequestedExpenses,
+      ...realExpenses,
+    ]
+  }, [])
+}
+
+export function useSubmitExpensesSource(args: {
+  rows: SpendingRow[]
+  onNewExpense: () => void
+  onNewMileage: () => void
+  onNewPerDiem: () => void
+  onNewFolder: () => void
+  folderHref: (folderId: string) => string
+}) {
+  const {
+    rows,
+    onNewExpense,
+    onNewMileage,
+    onNewPerDiem,
+    onNewFolder,
+    folderHref,
+  } = args
+  const counts = useMemo(() => {
+    const submittedStatuses: ExpenseStatus[] = [
+      "pending",
+      "approved",
+      "in-payroll",
+      "paid",
+    ]
+    const todoStatuses: ExpenseStatus[] = ["draft", "changes-requested"]
+    return {
+      todo: rows.filter((r) => todoStatuses.includes(r.status)).length,
+      submitted: rows.filter((r) => submittedStatuses.includes(r.status))
+        .length,
+    }
+  }, [rows])
+
+  return useDataCollectionSource<SpendingRow>(
+    {
+      search: { enabled: true, sync: true },
+      filters: {
+        [STATUS_FILTER_KEY]: {
+          type: "in",
+          label: "Status",
+          options: {
+            options: [
+              { value: "draft", label: "Draft" },
+              { value: "changes-requested", label: "Changes requested" },
+              { value: "pending", label: "Pending" },
+              { value: "approved", label: "Approved" },
+              { value: "in-payroll", label: "Sent to Pay" },
+              { value: "paid", label: "Paid" },
+            ],
+          },
+        },
+      },
+      currentFilters: {},
+      // To-Do groups Drafts + Changes requested (both require the
+      // submitter to act). Submitted shows everything past
+      // submission. The colored Status column inside Submitted
+      // distinguishes Pending / Approved / Sent to Pay.
+      presets: [
+        {
+          label: "To-Do",
+          filter: { [STATUS_FILTER_KEY]: ["draft", "changes-requested"] },
+          itemsCount: () => counts.todo,
+        },
+        {
+          label: "Submitted",
+          filter: {
+            [STATUS_FILTER_KEY]: ["pending", "approved", "in-payroll", "paid"],
+          },
+          itemsCount: () => counts.submitted,
+        },
+      ],
+      sortings: {
+        name: { label: "Name" },
+        date: { label: "Date" },
+        amount: { label: "Amount" },
+      },
+      itemUrl: (item) =>
+        item.kind === "folder" ? folderHref(item.id) : undefined,
+      // Row checkboxes for bulk Submit / Delete. Folders are
+      // selectable too — submitting a draft folder submits every
+      // expense inside it (BR-008), and deleting a folder removes the
+      // container plus its drafts. The two actions read uniformly
+      // across kinds so a mixed selection is still meaningful; the
+      // handler dispatches per-row by `item.kind`.
+      selectable: (item: SpendingRow) => item.id,
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 20,
+        fetchData: ({ filters, search, sortings, pagination }) => {
+          const wanted = Array.isArray(filters?.[STATUS_FILTER_KEY])
+            ? (filters[STATUS_FILTER_KEY] as ExpenseStatus[])
+            : []
+          return paginateRows(rows, {
+            search: search ?? undefined,
+            sortings,
+            pagination: pagination as
+              | { perPage?: number; currentPage?: number }
+              | undefined,
+            statusFilter: wanted.length > 0 ? wanted : undefined,
+          })
+        },
+      },
+      primaryActions: () => ({
+        label: "New expense",
+        icon: Add,
+        onClick: onNewExpense,
+      }),
+      secondaryActions: () => [
+        { label: "Mileage", icon: LogoTravelperk, onClick: onNewMileage },
+        { label: "Per diem", icon: PalmTree, onClick: onNewPerDiem },
+        { label: "Folder", icon: Folder, onClick: onNewFolder },
+      ],
+      itemActions: (_item: SpendingRow) => [
+        { label: "Edit", onClick: () => {} },
+        { label: "Submit", onClick: () => {} },
+        { type: "separator" as const },
+        { label: "Delete", onClick: () => {}, critical: true },
+      ],
+      bulkActions: (selected) => {
+        // Inspect the selection: folders don't nest, so when the user
+        // has only folders checked we drop "Add to folder" and keep
+        // just Delete + Send for approval (matches the Manage source
+        // and the design spec).
+        const checked = (selected.itemsStatus ?? []).filter((e) => e.checked)
+        const hasFolders = checked.some((e) => e.item.kind === "folder")
+        const hasExpenses = checked.some((e) => e.item.kind === "expense")
+        const onlyFolders = hasFolders && !hasExpenses
+
+        if (onlyFolders) {
+          return {
+            secondary: [{ id: "delete", label: "Delete", icon: Delete }],
+            primary: [
+              {
+                id: "submit",
+                label: "Send for approval",
+                icon: CheckCircle,
+              },
+            ],
+          }
+        }
+
+        // Action-bar pattern (project-wide): primary CTA sits far
+        // right (`primary`, single item → filled red button),
+        // preceded by 1–2 outline secondary buttons (`secondary`).
+        // OneDC ActionBar reverses `secondary` so the FIRST element
+        // ends up rightmost (closest to the primary CTA). Order:
+        // Delete first → rightmost-of-secondaries; Add to folder
+        // second → leftmost.
+        return {
+          secondary: [
+            { id: "delete", label: "Delete", icon: Delete },
+            { id: "add-to-folder", label: "Add to folder", icon: Folder },
+          ],
+          primary: [
+            {
+              id: "submit",
+              label: "Send selected for approval",
+              icon: CheckCircle,
+            },
+          ],
+        }
+      },
+    },
+    [
+      rows,
+      onNewExpense,
+      onNewMileage,
+      onNewPerDiem,
+      onNewFolder,
+      folderHref,
+    ]
+  )
+}

--- a/packages/f0compose/src/prototypes/controlling-step-poc/tabs.ts
+++ b/packages/f0compose/src/prototypes/controlling-step-poc/tabs.ts
@@ -1,0 +1,39 @@
+/**
+ * Tab IDs for the unified Spending page (Spec A revision 2).
+ *
+ * Tab row 1 (primary):
+ *   - submit  → personal lifecycle (Expenses · Purchase Requests · Cards)
+ *   - manage  → review / approve / pay
+ *
+ * Tab row 2 inside Submit:
+ *   - expenses           → expenses table (Drafts/Submitted presets, folders)
+ *   - purchase-requests  → embeds the existing Purchase Requests page
+ *   - cards              → embeds the existing Cards page
+ *
+ * Tab row 2 inside Manage:
+ *   - pending-approval     → approve/reject
+ *   - pending-controlling  → coding (deferred design)
+ *   - pay                  → Send to Pay / SEPA / Sync ERP
+ *   - all                  → unified view across the lifecycle
+ */
+export const PRIMARY_TABS = [
+  { id: "submit", label: "My spending" },
+  { id: "manage", label: "Approve & Pay" },
+] as const
+
+export const SUBMIT_SUB_TABS = [
+  { id: "expenses", label: "Expenses" },
+  { id: "purchase-requests", label: "Purchase requests" },
+  { id: "cards", label: "Cards" },
+] as const
+
+export const MANAGE_SUB_TABS = [
+  { id: "pending-approval", label: "Approve" },
+  { id: "pending-controlling", label: "Control" },
+  { id: "pay", label: "Pay" },
+  { id: "all", label: "Export" },
+] as const
+
+export type PrimaryTabId = (typeof PRIMARY_TABS)[number]["id"]
+export type SubmitSubTabId = (typeof SUBMIT_SUB_TABS)[number]["id"]
+export type ManageSubTabId = (typeof MANAGE_SUB_TABS)[number]["id"]

--- a/packages/f0compose/src/shell/FactorialSidebar.tsx
+++ b/packages/f0compose/src/shell/FactorialSidebar.tsx
@@ -54,6 +54,13 @@ export function FactorialSidebar(_props: { activeModule: ModuleId | null }) {
       items: modulesIn("company"),
     },
     {
+      id: "finance",
+      title: "Finance",
+      isOpen: true,
+      isSortable: true,
+      items: modulesIn("finance"),
+    },
+    {
       id: "talent",
       title: "Talent",
       isOpen: true,

--- a/packages/f0compose/src/shell/aiChatConfig.ts
+++ b/packages/f0compose/src/shell/aiChatConfig.ts
@@ -64,11 +64,13 @@ export const aiChatConfig = {
   // it. ApplicationFrame already reserves the chosen width so the page
   // body reflows correctly.
   resizable: true,
-  // Enable thread history. The agent already exposes the chat-history
-  // routes under `/copilotkit/chat-history/threads/*` (see
-  // factorial-agent/src/mastra/index.ts), so users can switch between
-  // past conversations across prototype reloads.
-  historyEnabled: true,
+  // Thread history disabled — when Mastra isn't running locally the
+  // history fetch surfaces a "failed to fetch" toast on every prototype
+  // load. Re-enable (set back to `true`) once Mastra is reachable; the
+  // agent already exposes the routes under
+  // `/copilotkit/chat-history/threads/*`
+  // (see factorial-agent/src/mastra/index.ts).
+  historyEnabled: false,
   entityRefs: {
     resolvers: {
       person: async (id: string) => personFromEmployee(id),

--- a/packages/f0compose/src/shell/modules.ts
+++ b/packages/f0compose/src/shell/modules.ts
@@ -2,9 +2,12 @@ import type { IconType } from "@factorialco/f0-react"
 
 import {
   Briefcase,
+  Building,
   Calendar,
   CheckCircleLine,
   Clock,
+  Code,
+  DollarBill,
   Files,
   Globe,
   Home,
@@ -12,9 +15,10 @@ import {
   Money,
   PalmTree,
   Person,
+  Receipt,
   Settings,
+  ShoppingCart,
   Sparkles,
-  Wallet,
 } from "@factorialco/f0-react/icons/app"
 
 /**
@@ -22,8 +26,10 @@ import {
  *
  * - Root (no group title): Home, Inbox, Discover
  * - Personal: Profile, My time tracking, Time off, My benefits, My documents,
- *             My spending, My projects, My training, Tasks
+ *             My projects, My training, Tasks
  * - Company: Organization, Documents, Policies
+ * - Finance: Spending (unified), Purchase Invoices, Procurement, Software,
+ *            Vendors, Sales
  * - Talent: Recruitment, Performance, Onboarding (kept for prototype targets)
  * - Payroll: Periods, Concepts, Settings (kept for prototype targets)
  */
@@ -32,6 +38,7 @@ export type ModuleGroup =
   | "root"
   | "personal"
   | "company"
+  | "finance"
   | "talent"
   | "payroll"
 
@@ -46,7 +53,6 @@ export type ModuleId =
   | "time-off"
   | "my-benefits"
   | "my-documents"
-  | "my-spending"
   | "my-projects"
   | "my-training"
   | "tasks"
@@ -54,6 +60,13 @@ export type ModuleId =
   | "organization"
   | "documents"
   | "policies"
+  // Finance
+  | "spending"
+  | "purchase-invoices"
+  | "procurement"
+  | "software"
+  | "vendors"
+  | "sales"
   // Talent
   | "recruitment"
   | "performance"
@@ -109,12 +122,6 @@ export const modules: ModuleDef[] = [
     groupLabel: "Personal",
   },
   {
-    id: "my-spending",
-    label: "My spending",
-    group: "personal",
-    groupLabel: "Personal",
-  },
-  {
     id: "my-projects",
     label: "My projects",
     group: "personal",
@@ -147,6 +154,39 @@ export const modules: ModuleDef[] = [
     group: "company",
     groupLabel: "Company",
   },
+
+  // Finance
+  {
+    id: "spending",
+    label: "Spend management",
+    group: "finance",
+    groupLabel: "Finance",
+  },
+  {
+    id: "purchase-invoices",
+    label: "Purchase Invoices",
+    group: "finance",
+    groupLabel: "Finance",
+  },
+  {
+    id: "procurement",
+    label: "Procurement",
+    group: "finance",
+    groupLabel: "Finance",
+  },
+  {
+    id: "software",
+    label: "Software",
+    group: "finance",
+    groupLabel: "Finance",
+  },
+  {
+    id: "vendors",
+    label: "Vendors",
+    group: "finance",
+    groupLabel: "Finance",
+  },
+  { id: "sales", label: "Sales", group: "finance", groupLabel: "Finance" },
 
   // Talent
   {
@@ -206,13 +246,18 @@ export const emojiForModule: Record<ModuleId, string> = {
   "time-off": "🌴",
   "my-benefits": "✨",
   "my-documents": "📄",
-  "my-spending": "💳",
   "my-projects": "📂",
   "my-training": "🎓",
   tasks: "✅",
   organization: "🏢",
   documents: "📁",
   policies: "📜",
+  spending: "💳",
+  "purchase-invoices": "🧾",
+  procurement: "🛒",
+  software: "🧩",
+  vendors: "🏬",
+  sales: "💵",
   recruitment: "💼",
   performance: "📈",
   onboarding: "🚀",
@@ -231,13 +276,18 @@ export const iconForModule: Record<ModuleId, IconType> = {
   "time-off": PalmTree,
   "my-benefits": Sparkles,
   "my-documents": Files,
-  "my-spending": Wallet,
   "my-projects": Briefcase,
   "my-training": Sparkles,
   tasks: CheckCircleLine,
   organization: Person,
   documents: Files,
   policies: Files,
+  spending: Money,
+  "purchase-invoices": Receipt,
+  procurement: ShoppingCart,
+  software: Code,
+  vendors: Building,
+  sales: DollarBill,
   recruitment: Briefcase,
   performance: Sparkles,
   onboarding: Person,


### PR DESCRIPTION
## Summary

Draft PR opened to generate a deploy-preview URL for sharing. Not intended to merge as-is.

**Preview URL once CI is done:** `<deploy-preview>/p/controlling-step-poc`

## What this prototype explores

- **Unifying spending in one place.** Today submitters live in "My spending" and finance/approvers live in a separate Manage page. This prototype merges both into a single **Spending** module under a new Finance sidebar group, with two primary tabs scoped to the user's job:
  - **My spending** (submitter JTBD): drafts, changes-requested, submitted
  - **Approve & Pay** (approver + finance JTBDs): Approve → Control → Pay → Export
- **Views for submitters and approvers.** Each tab has its own presets, columns, and bulk actions tuned to that role's work — without leaving the page.
  - Submitter > Expenses: **To-Do** (drafts + changes-requested) vs **Submitted**
  - Approver > Approve: **Needs review** vs **Ready to approve**, split by row-level alert signals (not just status)
- **Policy-agent alerts.** Every detail view shows a row-aware alert card driven by actual row signals (no receipt + amount, alcohol on travel, meals over the per-person limit, late submission, receipt mismatch, etc.). Three severities: **Approval recommended** (success), **Review recommended** (warning), **Rejection recommended / Likely rejection** (error). Submitter and approver contexts use different copy banks.
- **Full-screen expense detail.** Clicking an expense opens a full-page detail view (not a side panel) with a sticky tab strip (Summary / Comments), receipt panel with PDF-style chrome (zoom / rotate / page-fit), and sibling navigation chevrons that walk **the active preset** (e.g. only the 9 Needs-review rows), not the entire tab.
- **Controlling step.** Finance gets a dedicated **Control** sub-tab with an inline coding form (cost center, project, VAT rate, subcategory, tags) so they can finish accounting work without leaving the row.

## Out of scope for this PR

- Real backend wiring (everything is fixtures)
- Purchase Requests / Cards tabs (kept as placeholder content)

## Notes for reviewers

- All UI uses f0 components and `f1-*` tokens.
- Shared building blocks (PolicyAlertCard, selectPolicyAlert, receiptPresence) live under `src/prototypes/_shared/` so future prototypes can reuse them.