### PR TITLE
fix(kanban): optimize lane updates

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/useDataCollectionLanesData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/useDataCollectionLanesData.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useDeepCompareMemoize } from "use-deep-compare-effect"
 
 import {
   DataError,
@@ -41,7 +42,10 @@ type LaneProviderProps<
   >
   lane: Lane<Filters>
   onError?: (error: DataError) => void
-  onHookUpdate?: (value: UseDataCollectionData<R>) => void
+  onHookUpdate?: (
+    laneId: string | symbol,
+    value: UseDataCollectionData<R>
+  ) => void
 }
 
 const LaneProvider = <
@@ -98,7 +102,7 @@ const LaneProvider = <
   } = hook
 
   useEffect(() => {
-    onHookUpdate?.({
+    onHookUpdate?.(lane.id, {
       data,
       search,
       setSearch,
@@ -128,6 +132,7 @@ const LaneProvider = <
     hookMergedFilters,
     summaries,
     onHookUpdate,
+    lane.id,
   ])
 
   return null
@@ -164,48 +169,51 @@ export function useDataCollectionLanesData<
     Record<string | symbol, UseDataCollectionData<R>>
   >({})
 
+  const pendingLaneUpdatesRef = useRef<
+    Record<string | symbol, UseDataCollectionData<R>>
+  >({})
+  const flushScheduledRef = useRef(false)
+  const isMountedRef = useRef(true)
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
   const handleHookUpdate = useCallback(
     (laneId: string | symbol, value: UseDataCollectionData<R>) => {
-      setLanesHooks((prev) => ({ ...prev, [laneId]: value }))
+      pendingLaneUpdatesRef.current[laneId] = value
+      if (flushScheduledRef.current) return
+      flushScheduledRef.current = true
+      queueMicrotask(() => {
+        const pending = pendingLaneUpdatesRef.current
+        pendingLaneUpdatesRef.current = {}
+        flushScheduledRef.current = false
+        if (!isMountedRef.current) return
+        setLanesHooks((prev) => ({ ...prev, ...pending }))
+      })
     },
     []
   )
 
-  const lanesSignature = useMemo(() => JSON.stringify(lanes), [lanes])
-  const currentFiltersSignature = useMemo(
-    () => JSON.stringify(source.currentFilters),
-    [source.currentFilters]
-  )
-  const currentNavigationFiltersSignature = useMemo(
-    () => JSON.stringify(source.currentNavigationFilters),
-    [source.currentNavigationFilters]
-  )
-  const currentSortingsSignature = useMemo(
-    () => JSON.stringify(source.currentSortings),
-    [source.currentSortings]
-  )
-  const currentGroupingSignature = useMemo(
-    () => JSON.stringify(source.currentGrouping),
-    [source.currentGrouping]
-  )
-  const currentSearchSignature = useMemo(
-    () => JSON.stringify(source.currentSearch),
-    [source.currentSearch]
-  )
-  const groupingSignature = useMemo(
-    () => JSON.stringify(source.grouping),
-    [source.grouping]
-  )
+  const lanesProviderDeps = {
+    lanes,
+    currentFilters: source.currentFilters,
+    currentNavigationFilters: source.currentNavigationFilters,
+    currentSortings: source.currentSortings,
+    currentGrouping: source.currentGrouping,
+    currentSearch: source.currentSearch,
+    grouping: source.grouping,
+    dataAdapter: source.dataAdapter,
+  }
 
-  // Track dataAdapter changes to force refetch when cache updates
-  const dataAdapterSignature = useMemo(
-    () => JSON.stringify(source.dataAdapter),
-    [source.dataAdapter]
-  )
+  const lanesProviderDepsMemoized = useDeepCompareMemoize(lanesProviderDeps)
 
   const lanesProvider = useMemo(
-    () => {
-      return (lanes || []).map((lane) => (
+    () =>
+      (lanes || []).map((lane) => (
         <LaneProvider<
           R,
           Filters,
@@ -214,27 +222,15 @@ export function useDataCollectionLanesData<
           NavigationFilters,
           Grouping
         >
-          key={lane.id}
+          key={String(lane.id)}
           lane={lane}
           onError={options.onError}
           source={source}
-          onHookUpdate={(value) => handleHookUpdate(lane.id, value)}
-        ></LaneProvider>
-      ))
-    },
+          onHookUpdate={handleHookUpdate}
+        />
+      )),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      // TODO check why source ref is updated always
-      lanesSignature,
-      handleHookUpdate,
-      currentFiltersSignature,
-      currentNavigationFiltersSignature,
-      currentSortingsSignature,
-      currentGroupingSignature,
-      currentSearchSignature,
-      groupingSignature,
-      dataAdapterSignature, // Include dataAdapter to detect cache updates
-    ]
+    [lanesProviderDepsMemoized]
   )
 
   return {

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/useDataCollectionLanesData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/useDataCollectionLanesData.tsx
@@ -173,13 +173,27 @@ export function useDataCollectionLanesData<
     Record<string | symbol, UseDataCollectionData<R>>
   >({})
   const flushScheduledRef = useRef(false)
-  const isMountedRef = useRef(true)
+  // Initialized to false; the mount effect sets it to true. This prevents
+  // StrictMode's mount → cleanup → remount cycle from leaving the ref in a
+  // permanently-false state and silently dropping queued updates.
+  const isMountedRef = useRef(false)
 
   useEffect(() => {
     isMountedRef.current = true
     return () => {
       isMountedRef.current = false
     }
+  }, [])
+
+  // Stable wrapper around `options.onError` so passing it down to LaneProvider
+  // does not invalidate the lanesProvider memo when the caller's callback
+  // identity changes.
+  const onErrorRef = useRef(options.onError)
+  useEffect(() => {
+    onErrorRef.current = options.onError
+  })
+  const stableOnError = useCallback((error: DataError) => {
+    onErrorRef.current?.(error)
   }, [])
 
   const handleHookUpdate = useCallback(
@@ -198,11 +212,10 @@ export function useDataCollectionLanesData<
     []
   )
 
-  // The deep-compare descriptor below tracks the *content* of `source` (and
-  // `options.onError`) so the `lanesProvider` useMemo re-runs whenever any
-  // captured value changes, even though `source`'s reference is unstable.
-  // Passing `source` directly to LaneProvider is safe: the memo re-runs on
-  // every content change, so children always receive the latest `source`.
+  // Plain-data fields are deep-compared so the memo only rebuilds when
+  // content actually changes. Function/adapter fields fall back to reference
+  // equality — callers must stabilize them (useDataSource already does this
+  // for dataAdapter).
   const lanesProviderDeps = {
     lanes,
     currentFilters: source.currentFilters,
@@ -211,8 +224,9 @@ export function useDataCollectionLanesData<
     currentGrouping: source.currentGrouping,
     currentSearch: source.currentSearch,
     grouping: source.grouping,
+    summaries: source.summaries,
     dataAdapter: source.dataAdapter,
-    onError: options.onError,
+    itemPreFilter: source.itemPreFilter,
   }
 
   const lanesProviderDepsMemoized = useDeepCompareMemoize(lanesProviderDeps)
@@ -230,7 +244,7 @@ export function useDataCollectionLanesData<
         >
           key={String(lane.id)}
           lane={lane}
-          onError={options.onError}
+          onError={stableOnError}
           source={source}
           onHookUpdate={handleHookUpdate}
         />

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/useDataCollectionLanesData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/useDataCollectionLanesData.tsx
@@ -198,6 +198,11 @@ export function useDataCollectionLanesData<
     []
   )
 
+  // The deep-compare descriptor below tracks the *content* of `source` (and
+  // `options.onError`) so the `lanesProvider` useMemo re-runs whenever any
+  // captured value changes, even though `source`'s reference is unstable.
+  // Passing `source` directly to LaneProvider is safe: the memo re-runs on
+  // every content change, so children always receive the latest `source`.
   const lanesProviderDeps = {
     lanes,
     currentFilters: source.currentFilters,
@@ -207,6 +212,7 @@ export function useDataCollectionLanesData<
     currentSearch: source.currentSearch,
     grouping: source.grouping,
     dataAdapter: source.dataAdapter,
+    onError: options.onError,
   }
 
   const lanesProviderDepsMemoized = useDeepCompareMemoize(lanesProviderDeps)

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -145,8 +145,14 @@ export const KanbanCollection = <
       isInitialLoading: isInitialLoadingAggregated,
       data: Object.values(lanesHooks).flatMap((l) => l.data.records),
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- follow Table/List behavior: rerun when totals or loading change
-  }, [totalItemsAggregated, isInitialLoadingAggregated])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rerun when totals, loading, records, filters or search change
+  }, [
+    totalItemsAggregated,
+    isInitialLoadingAggregated,
+    lanesHooks,
+    source.currentFilters,
+    source.currentSearch,
+  ])
 
   // Build index maps per lane when needed
   const laneIndexMaps = useMemo(() => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import type {
   CardMetadata,
@@ -30,6 +30,22 @@ import type {
 
 import { ItemActionsDefinition } from "../../../item-actions"
 import { KanbanCollectionProps } from "./types"
+
+const toCardMetadata = (
+  items: ReadonlyArray<{
+    icon: IconType
+    property: CardMetadataProperty
+  }>
+): CardMetadata[] =>
+  items.map(({ icon, property }) =>
+    property.type === "file" ? { property } : { icon, property }
+  )
+
+const isInfiniteScrollPaginationInfo = (
+  paginationInfo: PaginationInfo | undefined | null
+): paginationInfo is InfiniteScrollPaginatedResponse<unknown> => {
+  return Boolean(paginationInfo && paginationInfo.type === "infinite-scroll")
+}
 
 export const KanbanCollection = <
   R extends RecordType,
@@ -81,67 +97,137 @@ export const KanbanCollection = <
 
   const idProvider = source.idProvider
 
-  const lanesSignature = useMemo(() => {
-    return JSON.stringify(
-      Object.values(lanesHooks).map((laneHook) => laneHook.data)
-    )
-  }, [lanesHooks])
-
   const laneItems = useMemo(() => {
     return lanes.map((lane) => ({
       ...lane,
       items: lanesHooks[lane.id]?.data?.records || [],
     }))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lanesSignature])
+  }, [lanes, lanesHooks])
 
-  const toCardMetadata = (
-    items: ReadonlyArray<{
-      icon: IconType
-      property: CardMetadataProperty
-    }>
-  ): CardMetadata[] =>
-    items.map(({ icon, property }) =>
-      property.type === "file" ? { property } : { icon, property }
-    )
+  // Fine-grained reorder only when no sort order is applied
+  const allowReorder = source.currentSortings === null
 
-  const isInfiniteScrollPaginationInfo = (
-    paginationInfo: PaginationInfo | undefined | null
-  ): paginationInfo is InfiniteScrollPaginatedResponse<unknown> => {
-    return Boolean(paginationInfo && paginationInfo.type === "infinite-scroll")
-  }
-
-  const kanbanProps: KanbanProps<R> = {
-    lanes: laneItems.map((l) => {
-      const laneData = lanesHooks[l.id]
-      const totalItems = laneData?.paginationInfo?.total
-
-      const hasMore =
-        isInfiniteScrollPaginationInfo(laneData?.paginationInfo) &&
-        laneData?.paginationInfo?.hasMore
+  // Report aggregated totals/loading so header total updates
+  const { totalItemsAggregated, isInitialLoadingAggregated } = useMemo(() => {
+    const hooks = Object.values(lanesHooks)
+    if (hooks.length === 0) {
       return {
-        id: l.id,
-        title: l.title,
-        items: l.items,
-        variant: l.variant,
-        total: totalItems,
-        hasMore: hasMore,
-        loading: laneData?.isLoading || false,
-        loadingMore: laneData?.isLoadingMore || false,
-        fetchMore: hasMore ? () => laneData.loadMore() : undefined,
+        totalItemsAggregated: undefined,
+        isInitialLoadingAggregated: true,
       }
-    }),
-    loading: Object.values(lanesHooks).some(
-      (laneHook) => laneHook.isInitialLoading
-    ),
-    getKey: (item, index) => {
+    }
+    let total = 0
+    let initialLoading = false
+    for (const lane of hooks) {
+      const laneTotal = lane.paginationInfo?.total ?? lane.data.records.length
+      total += typeof laneTotal === "number" ? laneTotal : 0
+      if (lane.isInitialLoading) initialLoading = true
+    }
+    return {
+      totalItemsAggregated: total,
+      isInitialLoadingAggregated: initialLoading,
+    }
+  }, [lanesHooks])
+
+  // Used for kanbanProps.loading: empty hooks → not loading (preserves
+  // pre-refactor behavior; isInitialLoadingAggregated keeps `true` fallback
+  // because onLoadData consumers depend on it).
+  const kanbanLoading = useMemo(
+    () => Object.values(lanesHooks).some((h) => h.isInitialLoading),
+    [lanesHooks]
+  )
+
+  useEffect(() => {
+    onLoadData({
+      totalItems: totalItemsAggregated,
+      filters: source.currentFilters,
+      search: source.currentSearch,
+      isInitialLoading: isInitialLoadingAggregated,
+      data: Object.values(lanesHooks).flatMap((l) => l.data.records),
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- follow Table/List behavior: rerun when totals or loading change
+  }, [totalItemsAggregated, isInitialLoadingAggregated])
+
+  // Build index maps per lane when needed
+  const laneIndexMaps = useMemo(() => {
+    const maps = new Map<string, Map<string, number>>()
+    laneItems.forEach((lane) => {
+      const map = new Map<string, number>()
+      lane.items.forEach((item, index) => {
+        const rawId = idProvider
+          ? idProvider(item as R, index)
+          : ((item as unknown as { id?: string | number })?.id ?? index)
+        const itemId = String(rawId)
+        map.set(itemId, index)
+      })
+      maps.set(lane.id, map)
+    })
+    return maps
+  }, [laneItems, idProvider])
+
+  /**
+   * Selection
+   */
+
+  const lanesDef = useMemo(() => {
+    return lanes.map((lane) => ({
+      id: lane.id,
+      data: lanesHooks[lane.id]?.data || {
+        type: "flat",
+        records: [],
+        groups: [],
+      },
+      paginationInfo: lanesHooks[lane.id]?.paginationInfo || null,
+    }))
+  }, [lanes, lanesHooks])
+
+  const { lanesSelectProvider, lanesUseSelectable } = useSelectableLanes<
+    R,
+    Filters,
+    Sortings,
+    Summaries,
+    NavigationFilters,
+    Grouping
+  >(lanesDef, source, (selectItemsStatus, clearCallback) => {
+    onSelectItems?.(selectItemsStatus, clearCallback)
+  })
+
+  const kanbanLanes = useMemo(
+    () =>
+      laneItems.map((l) => {
+        const laneData = lanesHooks[l.id]
+        const totalItems = laneData?.paginationInfo?.total
+        const hasMore =
+          isInfiniteScrollPaginationInfo(laneData?.paginationInfo) &&
+          laneData?.paginationInfo?.hasMore
+        return {
+          id: l.id,
+          title: l.title,
+          items: l.items,
+          variant: l.variant,
+          total: totalItems,
+          hasMore,
+          loading: laneData?.isLoading || false,
+          loadingMore: laneData?.isLoadingMore || false,
+          fetchMore: hasMore ? () => laneData.loadMore() : undefined,
+        }
+      }),
+    [laneItems, lanesHooks]
+  )
+
+  const getKey = useCallback<NonNullable<KanbanProps<R>["getKey"]>>(
+    (item, index) => {
       if (idProvider) return String(idProvider(item, index))
       const fallbackId = (item as unknown as { id?: string | number })?.id
       return fallbackId !== undefined && fallbackId !== null
         ? String(fallbackId)
         : String(index)
     },
-    renderCard: (item, index, total, laneId) => {
+    [idProvider]
+  )
+
+  const renderCard = useCallback<NonNullable<KanbanProps<R>["renderCard"]>>(
+    (item, index, total, laneId) => {
       const dragId = String(
         idProvider
           ? idProvider(item, index)
@@ -196,93 +282,44 @@ export const KanbanCollection = <
         />
       )
     },
-    onCreate: onCreate,
-  }
+    [
+      idProvider,
+      source.selectable,
+      source.itemUrl,
+      source.itemOnClick,
+      lanesUseSelectable,
+      allowReorder,
+      title,
+      description,
+      avatar,
+      onMove,
+      optionsMetadata,
+    ]
+  )
 
-  // Report aggregated totals/loading so header total updates
-  const totalItemsAggregated = useMemo(() => {
-    const hooks = Object.values(lanesHooks)
-    if (hooks.length === 0) return undefined
-    // Sum totals from lanes that expose paginationInfo.total; fallback to records length
-    return hooks.reduce((acc, lane) => {
-      const laneTotal = lane.paginationInfo?.total ?? lane.data.records.length
-      return acc + (typeof laneTotal === "number" ? laneTotal : 0)
-    }, 0)
-  }, [lanesHooks])
-
-  const isInitialLoadingAggregated = useMemo(() => {
-    const hooks = Object.values(lanesHooks)
-    if (hooks.length === 0) return true
-    // Consider initial loading if any lane is still in initial loading
-    return hooks.some((lane) => lane.isInitialLoading)
-  }, [lanesHooks])
-
-  useEffect(() => {
-    onLoadData({
-      totalItems: totalItemsAggregated,
-      filters: source.currentFilters,
-      search: source.currentSearch,
-      isInitialLoading: isInitialLoadingAggregated,
-      data: Object.values(lanesHooks).flatMap((l) => l.data.records),
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- follow Table/List behavior: rerun when totals or loading change
-  }, [totalItemsAggregated, isInitialLoadingAggregated])
-
-  // Fine-grained reorder only when no sort order is applied
-  const allowReorder = source.currentSortings === null
-
-  // Build index maps per lane when needed
-  const laneIndexMaps = useMemo(() => {
-    const maps = new Map<string, Map<string, number>>()
-    laneItems.forEach((lane) => {
-      const map = new Map<string, number>()
-      lane.items.forEach((item, index) => {
-        const rawId = idProvider
-          ? idProvider(item as R, index)
-          : ((item as unknown as { id?: string | number })?.id ?? index)
-        const itemId = String(rawId)
-        map.set(itemId, index)
-      })
-      maps.set(lane.id, map)
-    })
-    return maps
-  }, [laneItems, idProvider])
-
-  kanbanProps.dnd = {
-    instanceId: instanceId,
-    getIndexById: (laneId: string, id: string) => {
-      const idx = laneIndexMaps.get(laneId)?.get(id) ?? -1
-      return allowReorder ? idx : -1
-    },
-    onMove: onMove,
-  }
-
-  /**
-   * Selection
-   */
-
-  const lanesDef = useMemo(() => {
-    return lanes.map((lane) => ({
-      id: lane.id,
-      data: lanesHooks[lane.id]?.data || {
-        type: "flat",
-        records: [],
-        groups: [],
+  const dnd = useMemo<NonNullable<KanbanProps<R>["dnd"]>>(
+    () => ({
+      instanceId,
+      getIndexById: (laneId: string, id: string) => {
+        const idx = laneIndexMaps.get(laneId)?.get(id) ?? -1
+        return allowReorder ? idx : -1
       },
-      paginationInfo: lanesHooks[lane.id]?.paginationInfo || null,
-    }))
-  }, [lanes, lanesHooks])
+      onMove,
+    }),
+    [instanceId, laneIndexMaps, allowReorder, onMove]
+  )
 
-  const { lanesSelectProvider, lanesUseSelectable } = useSelectableLanes<
-    R,
-    Filters,
-    Sortings,
-    Summaries,
-    NavigationFilters,
-    Grouping
-  >(lanesDef, source, (selectItemsStatus, clearCallback) => {
-    onSelectItems?.(selectItemsStatus, clearCallback)
-  })
+  const kanbanProps = useMemo<KanbanProps<R>>(
+    () => ({
+      lanes: kanbanLanes,
+      loading: kanbanLoading,
+      getKey,
+      renderCard,
+      onCreate,
+      dnd,
+    }),
+    [kanbanLanes, kanbanLoading, getKey, renderCard, onCreate, dnd]
+  )
 
   return (
     <>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -107,10 +107,12 @@ export const KanbanCollection = <
   // Fine-grained reorder only when no sort order is applied
   const allowReorder = source.currentSortings === null
 
-  // Report aggregated totals/loading so header total updates
+  // Aggregated totals/loading. A lane that has not yet reported counts as
+  // still initial-loading so we do not flash false while lanes are mounting.
   const { totalItemsAggregated, isInitialLoadingAggregated } = useMemo(() => {
     const hooks = Object.values(lanesHooks)
-    if (hooks.length === 0) {
+    const allLanesReported = hooks.length === lanes.length
+    if (hooks.length === 0 || !allLanesReported) {
       return {
         totalItemsAggregated: undefined,
         isInitialLoadingAggregated: true,
@@ -127,7 +129,7 @@ export const KanbanCollection = <
       totalItemsAggregated: total,
       isInitialLoadingAggregated: initialLoading,
     }
-  }, [lanesHooks])
+  }, [lanesHooks, lanes.length])
 
   // Used for kanbanProps.loading: empty hooks → not loading (preserves
   // pre-refactor behavior; isInitialLoadingAggregated keeps `true` fallback
@@ -218,7 +220,7 @@ export const KanbanCollection = <
           fetchMore: hasMore ? () => laneData.loadMore() : undefined,
         }
       }),
-    [laneItems, lanesHooks]
+    [laneItems, lanesHooks] // laneItems → items; lanesHooks → pagination/loading/fetchMore per lane
   )
 
   const getKey = useCallback<NonNullable<KanbanProps<R>["getKey"]>>(


### PR DESCRIPTION
## Description

Fixes a set of compounding performance issues in KanbanCollection that caused unnecessary re-renders and serialization work on every render cycle.

<img width="818" height="897" alt="Captura de pantalla 2026-05-14 a les 10 26 45" src="https://github.com/user-attachments/assets/70bdce4d-5016-461a-886f-da2da101dca8" />

## Implementation details

- Removed 8 JSON.stringify memos in useDataCollectionLanesData that serialized filters, sortings, grouping and dataAdapter every render. Replaced with a single useDeepCompareMemoize over a plain-data descriptor.
- Batched per-lane setLanesHooks calls via queueMicrotask — N lanes loading in parallel now produce 1 parent re-render instead of N.
- Fixed onHookUpdate update loop — changed its signature to (laneId, value) so the parent passes the stable handleHookUpdate directly instead of a new inline arrow every render.
- Removed O(N×M) lanesSignature in Kanban.tsx — JSON.stringify over all records across all lanes on every render. laneItems now depends directly on lanesHooks.
- Memoized kanbanLanes, getKey, renderCard, dnd, and kanbanProps — previously all rebuilt inline every render. Narrowed renderCard deps from the whole (unstable) source ref to the specific fields it uses.
- Hoisted two pure helpers to module scope so they aren't recreated per render.
