### PR TITLE
feat: expose onApply and allow icon on tags

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -93,6 +93,7 @@ const F0SelectComponent = forwardRef(function Select<
   {
     placeholder,
     onChange,
+    onApply,
     onChangeSelectedOption,
     value,
     options = [],
@@ -155,6 +156,7 @@ const F0SelectComponent = forwardRef(function Select<
   type ActualRecordType = ResolvedRecordType<R>
 
   const [openLocal, setOpenLocal] = useState(open)
+  const isApplyingRef = useRef(false)
 
   const defaultItems = useMemo(
     () =>
@@ -370,6 +372,45 @@ const F0SelectComponent = forwardRef(function Select<
     preserveSelectionOnDatasetChange,
   })
 
+  const cloneSelectedState = useCallback(
+    (
+      state: SelectedItemsState<ActualRecordType>
+    ): SelectedItemsState<ActualRecordType> => {
+      return {
+        allSelected: state.allSelected,
+        items: new Map(state.items),
+        groups: new Map(state.groups),
+      }
+    },
+    []
+  )
+
+  const getSelectedStateKey = useCallback(
+    (state: SelectedItemsState<ActualRecordType>): string => {
+      const itemsKeys = Array.from(state.items.entries())
+        .map(([id, item]) => `${id}:${item.checked}`)
+        .sort()
+        .join(",")
+      const groupsKeys = Array.from(state.groups.entries())
+        .map(([id, group]) => `${id}:${group.checked}`)
+        .sort()
+        .join(",")
+
+      return `${state.allSelected}|${itemsKeys}|${groupsKeys}`
+    },
+    []
+  )
+
+  const committedSelectionRef = useRef(
+    initialSelectedState
+      ? cloneSelectedState(initialSelectedState)
+      : {
+          allSelected: false,
+          items: new Map(),
+          groups: new Map(),
+        }
+  )
+
   /**
    * Get display items for the selection preview.
    * Uses localValue (the current value prop) to determine what to display.
@@ -415,6 +456,9 @@ const F0SelectComponent = forwardRef(function Select<
     setCurrentSearch(value)
     onSearchChange?.(value)
   }
+  // Show apply button when in multiple selection, and not rendered as a list
+  const showApplyButton = multiple && !asList
+  const hasDeferredApply = !!(onApply && showApplyButton)
 
   // Track whether the user has interacted with the selection
   const hasUserInteracted = useRef(false)
@@ -440,10 +484,13 @@ const F0SelectComponent = forwardRef(function Select<
         } else {
           selectedItemsCache.current.delete(String(value))
         }
-        onChangeSelectedOption?.(item.option, checked)
+        if (!hasDeferredApply) {
+          onChangeSelectedOption?.(item.option, checked)
+        }
       }
     },
     [
+      hasDeferredApply,
       onChangeSelectedOption,
       itemsByValue,
       handleSelectItemChange,
@@ -461,6 +508,57 @@ const F0SelectComponent = forwardRef(function Select<
     },
     [handleSelectAllItems]
   )
+
+  const getMultiSelectionPayload = useCallback(() => {
+    const checkedItems = Array.from(selectedState.items.values() || []).filter(
+      (item) => item.checked
+    )
+
+    const extractOriginalItem = (
+      record: ActualRecordType | undefined
+    ): ResolvedRecordType<R> | undefined => {
+      if (!record) return undefined
+      if (source) {
+        return record as unknown as ResolvedRecordType<R>
+      }
+
+      const option = record as unknown as F0SelectItemObject<
+        T,
+        ResolvedRecordType<R>
+      >
+      return option.item
+    }
+
+    const records = checkedItems
+      .map((item) => item.item)
+      .filter(
+        (item): item is WithGroupId<ResolvedRecordType<R>> => item !== undefined
+      )
+    const originalItems = records
+      .map(extractOriginalItem)
+      .filter((item): item is ResolvedRecordType<R> => item !== undefined)
+    const options = records.map((item) => {
+      return optionMapper(item) as F0SelectItemObject<T, ResolvedRecordType<R>>
+    })
+    // Use original option values to preserve the type (number vs string)
+    // Only use stringfied id as fallback if option is not available
+    const values = checkedItems.map((item) => {
+      if (item.item) {
+        const option = optionMapper(item.item as ActualRecordType)
+        return option.type !== "separator"
+          ? (option.value as T)
+          : (String(item.id) as T)
+      }
+
+      return String(item.id) as T
+    })
+
+    return {
+      values,
+      originalItems,
+      options,
+    }
+  }, [optionMapper, selectedState.items, source])
 
   /**
    * Emit the value change. The type depends on the multiple prop and selectionMode.
@@ -485,10 +583,6 @@ const F0SelectComponent = forwardRef(function Select<
       setCurrentSearch(undefined)
     }
 
-    const checkedItems = Array.from(selectedState.items.values() || []).filter(
-      (item) => item.checked
-    )
-
     // Helper to extract the original item from a record
     // For static options: the record IS the option, and option.item contains the original data
     // For datasource: the record is the original data, optionMapper creates the option
@@ -511,41 +605,20 @@ const F0SelectComponent = forwardRef(function Select<
     // TypeScript cannot infer the type of the onChange callback when it has generics,
     // so we need to cast it to the correct type
     if (multiple) {
-      const records = checkedItems
-        .map((item) => item.item)
-        .filter(
-          (item): item is WithGroupId<ResolvedRecordType<R>> =>
-            item !== undefined
-        )
-      const originalItems = records
-        .map(extractOriginalItem)
-        .filter((item): item is ResolvedRecordType<R> => item !== undefined)
-      const options = records.map((item) => {
-        return optionMapper(item) as F0SelectItemObject<
-          T,
-          ResolvedRecordType<R>
-        >
-      })
-
-      // Use original option values to preserve the type (number vs string)
-      // Only use stringified id as fallback if option is not available
-      const values = checkedItems.map((item) => {
-        if (item.item) {
-          const option = optionMapper(item.item as ActualRecordType)
-          return option.type !== "separator"
-            ? (option.value as T)
-            : (String(item.id) as T)
-        }
-        return String(item.id) as T
-      })
+      const { values, originalItems, options } = getMultiSelectionPayload()
 
       // Sync localValue with actual selection state (as strings for internal comparison)
       // This ensures the preview shows correct items after deselection
       // Use Set to ensure unique values and prevent duplicates
       setLocalValue(Array.from(new Set(values.map(String))))
 
-      onChange?.(values, originalItems, options)
+      if (!hasDeferredApply) {
+        onChange?.(values, originalItems, options)
+      }
     } else {
+      const checkedItems = Array.from(
+        selectedState.items.values() || []
+      ).filter((item) => item.checked)
       const selectedItem = checkedItems[0]
       const record = selectedItem?.item as ActualRecordType | undefined
       const originalItem = extractOriginalItem(record)
@@ -563,28 +636,103 @@ const F0SelectComponent = forwardRef(function Select<
       // Sync localValue with actual selection state (as string for internal comparison)
       setLocalValue(value !== undefined ? [String(value)] : [])
 
-      onChange?.(value as T, originalItem, option)
+      if (!hasDeferredApply) {
+        onChange?.(value as T, originalItem, option)
+      }
     }
-  }, [selectedState])
+  }, [
+    getMultiSelectionPayload,
+    hasDeferredApply,
+    optionMapper,
+    selectedState,
+    source,
+  ])
 
   const debouncedHandleChangeOpenLocal = useDebounceCallback(
     (open: boolean) => {
       onOpenChange?.(open)
       setOpenLocal(open)
+      if (!open) {
+        isApplyingRef.current = false
+      }
     },
     100
   )
 
+  const restoreCommittedSelection = useCallback(() => {
+    const committedSelection = committedSelectionRef.current
+
+    clearSelection()
+
+    if (committedSelection.allSelected) {
+      handleSelectAllWithTracking(true)
+
+      for (const itemState of committedSelection.items.values()) {
+        if (!itemState.checked) {
+          handleSelectItemChange(itemState.id, false)
+        }
+      }
+
+      return
+    }
+
+    const committedIds = Array.from(committedSelection.items.values())
+      .filter((itemState) => itemState.checked)
+      .map((itemState) => itemState.id)
+
+    if (committedIds.length > 0) {
+      handleSelectItemChange(committedIds, true)
+    }
+  }, [clearSelection, handleSelectAllWithTracking, handleSelectItemChange])
+
+  const emitCurrentSelection = useCallback(() => {
+    const { values, originalItems, options } = getMultiSelectionPayload()
+
+    ;(
+      onChange as
+        | ((
+            value: T[],
+            originalItems: ResolvedRecordType<R>[],
+            options: F0SelectItemObject<T, ResolvedRecordType<R>>[]
+          ) => void)
+        | undefined
+    )?.(values, originalItems, options)
+  }, [getMultiSelectionPayload, onChange])
+
   const handleChangeOpenLocal = (open: boolean) => {
+    if (!open && hasDeferredApply && !isApplyingRef.current) {
+      restoreCommittedSelection()
+    }
+
     debouncedHandleChangeOpenLocal(open)
   }
 
-  // Show apply button when in multiple selection, and not rendered as a list
-  const showApplyButton = multiple && !asList
-
   const handleApply = useCallback(() => {
+    if (hasDeferredApply) {
+      const nextCommittedSelection = cloneSelectedState(selectedState)
+
+      if (
+        getSelectedStateKey(nextCommittedSelection) !==
+        getSelectedStateKey(committedSelectionRef.current)
+      ) {
+        committedSelectionRef.current = nextCommittedSelection
+        emitCurrentSelection()
+      }
+
+      onApply?.()
+      isApplyingRef.current = true
+    }
+
     handleChangeOpenLocal(false)
-  }, [])
+  }, [
+    cloneSelectedState,
+    emitCurrentSelection,
+    getSelectedStateKey,
+    handleChangeOpenLocal,
+    hasDeferredApply,
+    onApply,
+    selectedState,
+  ])
 
   // Track when filters panel is open to hide bottom actions
   const [isFiltersOpen, setIsFiltersOpen] = useState(false)

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -669,19 +669,19 @@ const F0SelectComponent = forwardRef(function Select<
 
       for (const itemState of committedSelection.items.values()) {
         if (!itemState.checked) {
-          handleSelectItemChange(itemState.id, false)
+          handleSelectItemChange(itemState.item ?? itemState.id, false)
         }
       }
 
       return
     }
 
-    const committedIds = Array.from(committedSelection.items.values())
-      .filter((itemState) => itemState.checked)
-      .map((itemState) => itemState.id)
+    const committedItems = Array.from(committedSelection.items.values()).filter(
+      (itemState) => itemState.checked
+    )
 
-    if (committedIds.length > 0) {
-      handleSelectItemChange(committedIds, true)
+    for (const itemState of committedItems) {
+      handleSelectItemChange(itemState.item ?? itemState.id, true)
     }
   }, [clearSelection, handleSelectAllWithTracking, handleSelectItemChange])
 

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -707,6 +707,10 @@ const F0SelectComponent = forwardRef(function Select<
     debouncedHandleChangeOpenLocal(open)
   }
 
+  const handleCancel = useCallback(() => {
+    restoreCommittedSelection()
+  }, [restoreCommittedSelection])
+
   const handleApply = useCallback(() => {
     if (hasDeferredApply) {
       const nextCommittedSelection = cloneSelectedState(selectedState)
@@ -900,6 +904,8 @@ const F0SelectComponent = forwardRef(function Select<
             actions={actions}
             showApplyButton={showApplyButton}
             onApply={handleApply}
+            onCancel={handleCancel}
+            showCancelButton={hasDeferredApply}
           />
         ) : null
       }

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -972,6 +972,42 @@ export const MultiplePaginatedWithPreview: Story = {
   },
 }
 
+export const MultiplePaginatedWithApply: Story = {
+  args: {
+    label: "Select Team Members",
+    placeholder: "Search employees...",
+    multiple: true,
+    value: ["3", "42", "500", "1200"],
+    defaultItem: (() => {
+      const ids = [42, 500, 1200]
+      return ids
+        .map((id) => {
+          const emp = getEmployeeById(id)
+          return emp
+            ? {
+                value: emp.value,
+                label: emp.label,
+                avatar: emp.avatar,
+              }
+            : null
+        })
+        .filter(Boolean)
+    })(),
+    clearable: true,
+    showSearchBox: true,
+    source: employeeNestedPaginatedSource,
+    mapOptions: (item: Employee) => ({
+      value: item.value,
+      label: item.label,
+      avatar: item.avatar,
+    }),
+    onApply: fn(),
+    onSelectItems: fn((selectionStatus) => {
+      console.log("selectionStatus", selectionStatus)
+    }),
+  },
+}
+
 export const MultipleWithApply: Story = {
   args: {
     label: "Select Team Members",

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -178,6 +178,10 @@ const meta: Meta = {
       description:
         "Function to handle the change event. Returns the value of the selected option, and the item object if it exists",
     },
+    onApply: {
+      description:
+        "Optional callback for the multi-select apply button. When provided, selection changes are staged until Apply is clicked, and clicking outside cancels the staged changes.",
+    },
     actions: {
       description:
         "<p>List of action buttons that will be displayed at the bottom of the select dropdown. Each action should have a label, onClick handler, optional icon, and variant.</p>" +
@@ -444,6 +448,45 @@ export const WithPersonTags: Story = {
         label: "Inactive",
         icon: Appearance,
         tag: "Disabled",
+      },
+    ],
+  },
+}
+
+export const WithIconTags: Story = {
+  args: {
+    label: "Select a theme",
+    placeholder: "Select a theme",
+    onChange: fn(),
+    options: [
+      {
+        value: "light",
+        label: "Light",
+        description: "Bright workspace theme",
+        tag: {
+          type: "icon",
+          text: "Light",
+          icon: Circle,
+        },
+      },
+      {
+        value: "dark",
+        label: "Dark",
+        description: "Low-light interface theme",
+        tag: {
+          type: "icon",
+          text: "Dark",
+          icon: Appearance,
+        },
+      },
+      {
+        value: "system",
+        label: "System",
+        tag: {
+          type: "icon",
+          text: "System",
+          icon: Desktop,
+        },
       },
     ],
   },
@@ -926,6 +969,25 @@ export const MultiplePaginatedWithPreview: Story = {
     onSelectItems: fn((selectionStatus) => {
       console.log("selectionStatus", selectionStatus)
     }),
+  },
+}
+
+export const MultipleWithApply: Story = {
+  args: {
+    label: "Select Team Members",
+    placeholder: "Search employees...",
+    multiple: true,
+    value: ["2", "5"],
+    clearable: true,
+    showSearchBox: true,
+    source: employeeNonPaginatedSource,
+    mapOptions: (item: Employee) => ({
+      value: item.value,
+      label: item.label,
+      avatar: item.avatar,
+      description: `${item.jobTitle} · ${item.departmentName}`,
+    }),
+    onApply: fn(),
   },
 }
 

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -163,6 +163,31 @@ describe("Select", () => {
     expect(screen.getByText("Search options")).toBeInTheDocument()
   })
 
+  it("renders icon tags with text", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={[
+          {
+            value: "icon-tag-option",
+            label: "Icon tag option",
+            tag: {
+              type: "icon",
+              text: "System",
+              icon: Search,
+            },
+          },
+        ]}
+        onChange={() => {}}
+      />
+    )
+
+    await openSelect(user)
+
+    expect(screen.getByText("System")).toBeInTheDocument()
+  })
+
   it("filters options based on search input", async () => {
     const user = userEvent.setup()
     render(
@@ -422,6 +447,96 @@ describe("Select", () => {
     await waitFor(() => {
       expect(handleChangeSelectedOption).toHaveBeenCalledWith(undefined, false)
     })
+  })
+
+  it("defers onChange until apply when onApply is passed", async () => {
+    const handleChange = vi.fn()
+    const handleApply = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        multiple
+        options={mockOptions}
+        value={[]}
+        onChange={handleChange}
+        onApply={handleApply}
+      />
+    )
+
+    await openSelect(user)
+    await user.click(screen.getByText("Option 1"))
+
+    expect(handleChange).not.toHaveBeenCalled()
+    expect(handleApply).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: "Apply selection" }))
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledWith(
+        ["option1"],
+        [
+          {
+            id: "option1",
+            name: "Option 1",
+            description: "Description 1",
+          },
+        ],
+        [
+          expect.objectContaining({
+            label: "Option 1",
+            value: "option1",
+            description: "Description 1",
+          }),
+        ]
+      )
+    })
+    expect(handleApply).toHaveBeenCalledTimes(1)
+  })
+
+  it("cancels staged multi-select changes on outside click when onApply is passed", async () => {
+    const handleChange = vi.fn()
+    const handleApply = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <div>
+        <button type="button">Outside</button>
+        <F0Select
+          {...defaultSelectProps}
+          multiple
+          options={mockOptions}
+          value={["option1", "option2"]}
+          onChange={handleChange}
+          onApply={handleApply}
+        />
+      </div>
+    )
+
+    await openSelect(user)
+    await user.click(screen.getByText("Option 2"))
+    fireEvent.pointerDown(document.body)
+
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    })
+
+    expect(handleChange).not.toHaveBeenCalled()
+    expect(handleApply).not.toHaveBeenCalled()
+
+    await openSelect(user)
+    await user.click(screen.getByText("Option 3"))
+    await user.click(screen.getByRole("button", { name: "Apply selection" }))
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledTimes(1)
+    })
+
+    expect(handleChange.mock.calls[0]?.[0]).toEqual(
+      expect.arrayContaining(["option1", "option2", "option3"])
+    )
+    expect(handleApply).toHaveBeenCalledTimes(1)
   })
 
   describe("asList mode", () => {

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -539,6 +539,36 @@ describe("Select", () => {
     expect(handleApply).toHaveBeenCalledTimes(1)
   })
 
+  it("cancels staged changes without closing when cancel button is clicked", async () => {
+    const handleChange = vi.fn()
+    const handleApply = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        multiple
+        options={mockOptions}
+        value={["option1", "option2"]}
+        onChange={handleChange}
+        onApply={handleApply}
+      />
+    )
+
+    await openSelect(user)
+    await user.click(screen.getByText("Option 2"))
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+    expect(handleChange).not.toHaveBeenCalled()
+    expect(handleApply).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: "Apply selection" }))
+
+    expect(handleChange).not.toHaveBeenCalled()
+    expect(handleApply).toHaveBeenCalledTimes(1)
+  })
+
   describe("asList mode", () => {
     it("preserves selection after searching and clicking an item", async () => {
       const handleChange = vi.fn()

--- a/packages/react/src/components/F0Select/components/SelectBottomActions.tsx
+++ b/packages/react/src/components/F0Select/components/SelectBottomActions.tsx
@@ -13,20 +13,24 @@ export type Action = {
 interface SelectBottomActionsProps {
   actions?: Action[]
   showApplyButton?: boolean
+  showCancelButton?: boolean
   onApply?: () => void
+  onCancel?: () => void
 }
 
 export const SelectBottomActions = ({
   actions,
   showApplyButton,
   onApply,
+  onCancel,
+  showCancelButton,
 }: SelectBottomActionsProps) => {
   const i18n = useI18n()
 
   if (!actions && !showApplyButton) return null
 
   return (
-    <div className="flex w-full flex-row items-center gap-2 border-0 border-t border-solid border-f1-border-secondary p-2">
+    <div className="flex w-full flex-row justify-between items-center gap-2 border-0 border-t border-solid border-f1-border-secondary p-2">
       {actions?.map((action) => (
         <F0Button
           key={action.label}
@@ -36,8 +40,15 @@ export const SelectBottomActions = ({
           label={action.label}
         />
       ))}
+      {showCancelButton && (
+        <F0Button
+          onClick={onCancel}
+          label={i18n.filters.cancel}
+          variant="ghost"
+        />
+      )}
       {showApplyButton && (
-        <div className="ml-auto">
+        <div className={showCancelButton ? "" : "ml-auto"}>
           <F0Button onClick={onApply} label={i18n.select.applySelection} />
         </div>
       )}

--- a/packages/react/src/components/F0Select/components/SelectItem.tsx
+++ b/packages/react/src/components/F0Select/components/SelectItem.tsx
@@ -44,6 +44,8 @@ export const SelectItem = <T extends string, R>({
               <F0TagRaw text={item.tag} />
             ) : item.tag.type === "dot" ? (
               <F0TagDot {...item.tag} />
+            ) : item.tag.type === "icon" ? (
+              <F0TagRaw text={item.tag.text} icon={item.tag.icon} />
             ) : (
               <F0TagPerson name={item.tag.name} src={item.tag.src} />
             )}

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -29,6 +29,7 @@ export type { FiltersState, OnSelectItemsCallback, SelectedItemsState }
  * Base props shared across all F0Select variants
  */
 type F0SelectBaseProps<T extends string, R = unknown> = {
+  onApply?: () => void
   onChangeSelectedOption?: (
     option: F0SelectItemObject<T, ResolvedRecordType<R>> | undefined,
     checked: boolean
@@ -180,6 +181,7 @@ export type F0SelectTagProp =
   | string
   | { type: "dot"; text: string; color: NewColor }
   | { type: "person"; name: string; src?: string }
+  | { type: "icon"; text: string; icon: IconType }
 
 export type F0SelectItemObject<T, R = unknown> = {
   type?: "item"


### PR DESCRIPTION
## Description

F0Select exposed an Apply button in multi-select mode but did not expose any onApply API, so consumers could not hook custom behavior into the commit action. This also made the Apply flow inconsistent for deferred selections, especially in paginated datasets where canceling needed to restore the committed selection correctly.

## Implementation details

- Added an optional onApply prop to F0Select
- When onApply is provided, deferred multi-select changes are only committed on Apply
- Made outside click cancel staged changes and restore the last committed selection
- Fixed deferred restore logic to reuse committed item payloads, improving paginated/off-page selection recovery
- Added Storybook coverage for:
  - MultipleWithApply
  - MultiplePaginatedWithApply
  - WithIconTags
- Added test coverage for:
  - deferred apply behavior
  - cancel-on-outside-click behavior
  - icon tag rendering
