### PR TITLE
fix(colors): adjust secondary border color for improved contrast

### DIFF
--- a/packages/core/src/tokens/colors.ts
+++ b/packages/core/src/tokens/colors.ts
@@ -188,7 +188,7 @@ export const f1Colors = {
   border: {
     DEFAULT: "hsl(var(--neutral-30))",
     hover: "hsl(var(--neutral-40))",
-    secondary: "hsl(var(--neutral-10))",
+    secondary: "hsl(var(--neutral-20))",
     inverse: "hsl(var(--neutral-0) / 0.2)",
     bold: "hsl(var(--neutral-100))",
     promote: {


### PR DESCRIPTION
This pull request makes a minor update to the `f1Colors` color tokens in `colors.ts`. The `border.secondary` color has been changed from `--neutral-10` to `--neutral-20` to improve visual consistency.

* Updated the `border.secondary` color value in `f1Colors` from `--neutral-10` to `--neutral-20` in `colors.ts`.