### PR TITLE
feat: number input decimal separator fix allowing decimals

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/NumberInput/__tests__/NumberInput.test.tsx
+++ b/packages/react/src/experimental/Forms/Fields/NumberInput/__tests__/NumberInput.test.tsx
@@ -144,4 +144,42 @@ describe("NumberInput", () => {
       expect(input).toHaveValue("1")
     })
   })
+
+  describe("trailing decimal separator preservation", () => {
+    test("preserves trailing dot while typing", async () => {
+      const onChange = vi.fn()
+      render(
+        <NumberInput
+          locale="en-US"
+          maxDecimals={2}
+          onChange={onChange}
+          label="Number Input"
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "17.")
+
+      expect(input).toHaveValue("17.")
+      expect(onChange).toHaveBeenLastCalledWith(17)
+    })
+
+    test("preserves trailing comma while typing", async () => {
+      const onChange = vi.fn()
+      render(
+        <NumberInput
+          locale="es-ES"
+          maxDecimals={2}
+          onChange={onChange}
+          label="Number Input"
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "17,")
+
+      expect(input).toHaveValue("17,")
+      expect(onChange).toHaveBeenLastCalledWith(17)
+    })
+  })
 })

--- a/packages/react/src/experimental/Forms/Fields/NumberInput/internal.tsx
+++ b/packages/react/src/experimental/Forms/Fields/NumberInput/internal.tsx
@@ -95,20 +95,24 @@ export const NumberInputInternal = forwardRef<
       return
     }
 
-    /**
-     * Reformat the number to the correct format
-     */
-    const finalValue = Math.max(
+    const clampedValue = Math.max(
       min ?? -Infinity,
       Math.min(max ?? Infinity, parsedValue)
     )
 
-    const finalExtractedData = extractNumber(finalValue.toString(), {
+    // When clamping didn't change the value, preserve the user's raw input
+    // (e.g. "17." stays as "17." instead of being reformatted to "17").
+    if (clampedValue === parsedValue) {
+      setFieldValue(extractedData.formattedValue)
+      onChange?.(parsedValue)
+      return
+    }
+
+    const clampedData = extractNumber(clampedValue.toString(), {
       maxDecimals,
     })
-    setFieldValue(finalExtractedData?.formattedValue ?? "")
-
-    onChange?.(finalExtractedData?.value ?? null)
+    setFieldValue(clampedData?.formattedValue ?? "")
+    onChange?.(clampedData?.value ?? null)
   }
 
   const handleStep = (type: "increase" | "decrease") => () => {


### PR DESCRIPTION
## Description

Fix NumberInput reformatting intermediate values during typing, which causes cursor jumps on mobile keyboards (Android WebView). When a user types "17." or "17,", the onChange handler was converting the value to a number and back via `toString()`, losing the trailing decimal separator and disrupting cursor position.

## Screenshots (if applicable)

N/A — behavioral fix, no visual changes.

## Implementation details

`handleChange` in `NumberInputInternal` always re-parsed the clamped value via `extractNumber(clampedValue.toString())`, which strips trailing separators (e.g. "17." → "17"). Now, when clamping doesn't change the value, we preserve the original `formattedValue` from the first parse instead of re-formatting. The clamped path remains unchanged.

Added two tests verifying trailing dot and comma preservation during typing.
