### PR TITLE
RFC: F0 Slack Support Agent (proposal, not for merge)

### DIFF
--- a/briefs/README.md
+++ b/briefs/README.md
@@ -1,0 +1,23 @@
+# Briefs
+
+Structured captures from conversations, Slack threads, Jira tickets, and meetings.
+
+Each subfolder is a self-contained brief. Start with `brief.md` in any folder.
+
+## File Reference
+
+| File | Required | Purpose |
+|---|---|---|
+| `brief.md` | Yes | Summary, status, key takeaways |
+| `background.md` | No | Raw context, quotes, links |
+| `concerns.md` | No | Risks, open questions, dependencies |
+| `wip.md` | No | Evolving thinking, scratch notes |
+| `tasks.md` | No | Concrete next steps with checkboxes |
+| `decisions.md` | No | Choices made + rationale |
+| `tech-spec.md` | No | Implementation-level design (moves to `factorial/tech_specs/` once impl starts) |
+
+## Status Values
+
+- **raw** — just captured, not yet reviewed
+- **processed** — reviewed, tasks extracted, ready to act on
+- **archived** — done or no longer relevant

--- a/briefs/f0-slack-support-agent/background.md
+++ b/briefs/f0-slack-support-agent/background.md
@@ -1,0 +1,41 @@
+# Background
+
+## Source
+
+**Channel/Thread:** Conversación opencode con Desi, 2026-05-15
+**Participants:** Desi (PM/Designer F0), agent
+
+## Raw Context
+
+Desi propuso:
+
+> "Podemos crear un agente que conteste las dudas de f0 por slack por los diseñadores de f0 segun a quien le toque contestar cada semana? que filtre las peticiones y si no las puede contestar que haga ping @ al diseñador que este te firefighting esa semana?"
+
+Aclaraciones recogidas en la conversación:
+
+- **Canal:** `#f0-support`
+- **Equipo F0:** 2 diseñadores + 2 devs (4 personas en rotación)
+- **Fuente de info:** Storybook MCP + código fuente del repo
+- **Criterio de escalado:** Confianza baja **y** clasificación (design_decision siempre escala)
+- **Forma de escalar:** Mención al firefighter + resumen de lo investigado
+- **Rotación:** Quería algo "sencillo y automático"
+
+## Estado actual del repo F0
+
+- Repo: `factorialco/factorial-one` (monorepo pnpm con `packages/react`, `packages/react-native`, `packages/core`, `packages/one`)
+- Storybook MCP server ya configurado en `.mcp.json` (root) → `http://localhost:6006/mcp`
+- Toolsets MCP disponibles:
+  - `docs` (local + publicado): `list-all-documentation`, `get-documentation`, `get-documentation-for-story`
+  - `dev` (solo local): `get-storybook-story-instructions`, `preview-stories`
+  - `test` (solo local): `run-story-tests`
+- AGENTS.md ya instruye explícitamente: "Never hallucinate component properties. Before using any prop on an F0 component, query `get-documentation`"
+
+Eso es exactamente lo que el agente debe hacer también.
+
+## Related Links
+
+- AGENTS.md: `/AGENTS.md`
+- MCP config: `/.mcp.json`
+- Storybook MCP docs: ver sección "Storybook MCP Server" en AGENTS.md
+- Skill `factorial-ai`: para crear el skill v3 en factorial-agent
+- Skill `factorial-specs`: workflow del tech spec

--- a/briefs/f0-slack-support-agent/brief.md
+++ b/briefs/f0-slack-support-agent/brief.md
@@ -1,0 +1,35 @@
+# F0 Slack Support Agent
+
+**Created:** 2026-05-15
+**Source:** Conversación con Desi (opencode session)
+**Status:** raw
+**Owner:** Desi (a confirmar entre los 4 stakeholders)
+
+---
+
+## Summary
+
+Crear un Slack bot **propiedad del equipo F0** que viva en el canal [`#f0-support`](https://factorialteam.slack.com/archives/C082ZNKS403) (`C082ZNKS403`) y conteste dudas sobre el design system F0 (componentes, props, ejemplos de uso). Cuando el bot no tenga suficiente confianza o la pregunta sea una decisión de diseño, debe escalar haciendo `@mention` al **dev experto en el componente afectado** (vía `git blame`) o, en su defecto, al **firefighter de la semana** (rotación entre 2 diseñadores y 2 devs), incluyendo un resumen de lo que ya investigó.
+
+El bot es una app **Slack Bolt JS** (TypeScript) que vive en `apps/slack-support/` de este repo, se despliega en **Google Cloud Run**, usa **Claude Sonnet** como LLM, y consulta el **Storybook MCP de F0** + el código fuente del repo.
+
+**Importante:** este bot NO tiene relación con Factorial One (el producto agentic de Factorial). Es una herramienta interna del equipo F0, completamente independiente, mantenida por F0.
+
+## Key Takeaways
+
+- **Plataforma:** Slack Bolt JS app standalone en `apps/slack-support/` de este repo (NO en factorial-agent / Factorial One)
+- **Hosting:** Google Cloud Run (scale-to-zero, deploy desde GitHub Actions)
+- **LLM:** Anthropic Claude Sonnet vía API directa
+- **Canal:** Solo [`#f0-support`](https://factorialteam.slack.com/archives/C082ZNKS403) (`C082ZNKS403`), invocado por mención al bot
+- **Fuente de verdad:** Storybook MCP de F0 (`http://localhost:6006/mcp` en local, Azure SWA en producción) + lectura del código fuente del repo
+- **Rotación:** Archivo `f0-rotation.yml` versionado en la raíz de este repo, con 4 personas (2 diseñadores + 2 devs), cálculo automático por semana ISO + overrides para vacaciones
+- **Criterio de escalado:** Clasificación de pregunta + score de confianza
+  - Escala si: `design_decision`, `bug_or_issue`, o confianza < umbral
+  - Responde si: `component_usage` con confianza alta y match en docs
+- **Routing inteligente:** Antes de pingar al firefighter, busca en `git log` quién ha tocado más recientemente el componente sobre el que se pregunta (últimos 90 días). Si ese dev pertenece al equipo F0, se le hace ping. Si no o está OOO, fallback al firefighter de la rota. Para `design_decision` siempre va al designer firefighter (ignora git blame).
+- **Forma de escalar:** Reply en el mismo thread con `@mention` + resumen estructurado de lo investigado
+- **Idioma:** Bot responde en el idioma de la pregunta (auto-detect ES/EN)
+
+## Próximos pasos
+
+Ver [`tasks.md`](./tasks.md) y [`tech-spec.md`](./tech-spec.md).

--- a/briefs/f0-slack-support-agent/concerns.md
+++ b/briefs/f0-slack-support-agent/concerns.md
@@ -1,0 +1,34 @@
+# Concerns
+
+## Open Questions
+
+- [ ] ¿Quiénes son exactamente los 4 stakeholders? (nombres + Slack IDs + GitHub handles para el routing inteligente)
+- [x] ~~¿El canal `#f0-support` ya existe?~~ → Sí, `C082ZNKS403`
+- [ ] ¿One ya está instalado en el workspace de Slack y tiene acceso a `#f0-support` (`C082ZNKS403`)?
+- [ ] ¿La rotación es semanal estricta (lunes-domingo ISO)? ¿O empieza en otro día?
+- [ ] ¿Cómo se maneja la rotación en holidays/vacaciones? ¿Auto-skip o swap manual via `overrides:`?
+- [ ] ¿El MCP server de F0 publicado (Azure SWA) es accesible desde la infraestructura donde corre One? Si no, hay que decidir si One se conecta al MCP local de cada PR de F0 o a uno hosteado.
+- [ ] ¿Queremos métricas? (cuántas preguntas contesta el bot vs escala, tiempo de respuesta del firefighter, satisfacción)
+- [ ] ¿El agente debe responder en hilo siempre, o también en mensajes nuevos del canal?
+- [x] ~~¿Idioma?~~ → Responde en el idioma de la pregunta (auto-detect)
+- [ ] Para el routing por git blame: ¿la ventana de 90 días es razonable? ¿Pesamos por número de commits, líneas tocadas, o último commit?
+- [ ] ¿Excluir bots/dependabot del análisis de git blame? (sí, claramente, pero confirmar)
+
+## Risks
+
+- [ ] **Confianza calibrada mal** → si el umbral es bajo, el bot escala todo (inútil); si es alto, contesta cosas mal y degrada la confianza del equipo en él
+- [ ] **MCP no disponible en producción** → si el endpoint de F0 MCP cae o no es accesible desde One, el agente queda inservible. Necesitamos health-check + fallback claro
+- [ ] **Hallucination de props** → ya documentado en AGENTS.md como riesgo conocido. El skill DEBE forzar consulta MCP antes de citar cualquier prop
+- [ ] **Spam al firefighter** → si el agente escala mal, una persona recibe 20 pings en una semana
+- [ ] **Drift de la rotación** → si nadie mantiene `f0-rotation.yml`, la rotación queda obsoleta. Mitigación: validador en CI que avise si el anchor lleva > 6 meses sin actualizar
+- [ ] **Privacidad** → el agente lee mensajes de Slack. Asegurarse de que no hay PII sensible en `#f0-support` o que One ya cumple con las políticas
+- [ ] **Versión de F0** → el código fuente del repo es `main`. Si un usuario pregunta sobre la versión publicada (npm), puede haber drift. ¿Citamos versión?
+- [ ] **Ping al "experto" sin consentimiento** → el routing por git blame puede pingar a alguien que no esté preparado para ser support (vacaciones, otra tarea urgente). Mitigación: respetar `oof:` flag en `f0-rotation.yml`, y permitir opt-out con un comando `/f0-support exclude-me 7d`
+
+## Dependencies
+
+- Factorial One con integración Slack funcional en producción
+- MCP server de F0 accesible desde donde corre One (local Storybook **o** Azure SWA)
+- Repo `factorial-one` accesible para el skill (lectura de código de `packages/react`, `packages/react-native`, **y de `git log` para routing inteligente**)
+- Slack API permisos: `chat:write`, `app_mentions:read`, `users:read` para resolver Slack IDs
+- Mapeo GitHub handle → Slack ID para los 4 stakeholders (necesario para el routing inteligente; va en `f0-rotation.yml`)

--- a/briefs/f0-slack-support-agent/decisions.md
+++ b/briefs/f0-slack-support-agent/decisions.md
@@ -1,0 +1,96 @@
+# Decisions
+
+## 2026-05-15 — Plataforma: Slack Bolt JS standalone en este repo (NO Factorial One)
+
+**Decision:** El bot es una app Slack Bolt JS independiente, vive en `apps/slack-support/` dentro del repo `factorial-one`, y NO se mete en Factorial One (factorial-agent).
+
+**Context:** En la primera versión de este brief se había propuesto meterlo como skill v3 en factorial-agent. Desi señaló correctamente que mezcla dos cosas que no tienen nada que ver: Factorial One es un producto para clientes, esto es una herramienta interna del equipo F0.
+
+**Alternatives Considered:**
+- Skill v3 en Factorial One (factorial-agent) — **rechazado**: acopla una herramienta interna a un producto cliente. Cualquier cambio requeriría coordinar con el equipo de plataforma AI, competir con prioridades de producto, y dividir la lógica entre dos repos.
+- GitHub Action triggered by Slack — rechazado: latencia mayor (10-30s), límites de tiempo de ejecución, peor DX para iterar
+- Slack Workflow + servicio AI externo (n8n/Make) — rechazado: menos control, más dependencias externas
+- Repo nuevo dedicado — rechazado: overhead inicial, pierde la ventaja de tener bot + componentes en el mismo PR
+
+**Rationale:** Equipo F0 dueño total. Iteración a la velocidad de F0. Bot, rotación y código de los componentes que documenta viven en el mismo repo (un solo PR puede tocar todo). Despliegue independiente.
+
+---
+
+## 2026-05-15 — Hosting: Google Cloud Run
+
+**Decision:** Despliegue en Google Cloud Run vía GitHub Actions con Dockerfile.
+
+**Rationale:** Scale-to-zero (no cuesta cuando no se usa), HTTPS gestionado, Factorial ya usa GCP, deploy automático desde GH Action con un workflow simple.
+
+---
+
+## 2026-05-15 — LLM: Anthropic Claude Sonnet
+
+**Decision:** Claude Sonnet vía API directa de Anthropic para clasificación y respuesta.
+
+**Rationale:** Buen razonamiento, soporte multilenguaje fuerte, fácil de cambiar luego (abstrayendo provider). Sin acoplar el bot a la infra IA de Factorial.
+
+---
+
+## 2026-05-15 — Invocación: solo por @mención en #f0-support
+
+**Decision:** El bot solo escucha cuando se le menciona explícitamente en `#f0-support` (`C082ZNKS403`). No auto-detecta preguntas.
+
+**Alternatives Considered:**
+- Multi-canal — diferido: empezar con un canal acota el riesgo
+- Auto-detección — rechazado: requiere `message.channels` scope, mucho ruido, mucho coste de tokens
+
+**Rationale:** Mención explícita = intención clara del usuario, scope mínimo de Slack, menos falsos positivos.
+
+---
+
+## 2026-05-15 — Fuente de conocimiento: Storybook MCP + código fuente
+
+**Decision:** El bot usa el Storybook MCP de F0 como fuente primaria y lee código de `packages/react` / `packages/react-native` como fuente secundaria.
+
+**Context:** AGENTS.md ya documenta el MCP server y prohíbe explícitamente alucinar props.
+
+**Rationale:** El MCP es la fuente canónica de docs/stories. El código cubre los huecos. Notion/Confluence se añade solo si hay demanda.
+
+---
+
+## 2026-05-15 — Rotación: f0-rotation.yml en la raíz del repo
+
+**Decision:** La rotación se define en `f0-rotation.yml` en la raíz del repo `factorial-one`, con cálculo automático por semana ISO y overrides puntuales.
+
+**Alternatives Considered:**
+- Google Calendar — rechazado: requiere OAuth/API extra, no versionable
+- Slack User Group dinámico — rechazado: requiere job que actualice el grupo cada semana
+- PagerDuty/OpsGenie — rechazado: overkill para 4 personas
+
+**Rationale:** YAML versionado = PR-friendly, auditable, cero infra. Cálculo por semana ISO es determinista. `overrides:` cubre vacaciones sin cambiar la rota base. Lectura del archivo desde el bot vía la GitHub API o checkout en el container.
+
+---
+
+## 2026-05-15 — Escalado: clasificación + confianza, con resumen estructurado
+
+**Decision:** El bot escala si la pregunta es `design_decision`, `bug_or_issue`, o si la confianza es < umbral (inicial 0.7). Al escalar, postea reply en el mismo thread con `@mention` al target y un resumen de lo investigado.
+
+**Rationale:** Doble criterio reduce tanto falsos positivos (responder mal) como falsos negativos (escalar lo trivial). El resumen estructurado ahorra tiempo a quien recibe el ping.
+
+---
+
+## 2026-05-15 — Routing inteligente vía git blame antes que rota
+
+**Decision:** Antes de hacer ping al firefighter de la rota, el bot identifica el/los componentes mencionados en la pregunta y busca en `git log` qué dev del equipo F0 ha tocado ese código en los últimos 90 días. Si hay match, se hace ping a ese dev. Si no o está OOO, fallback al firefighter de la rota.
+
+**Reglas:**
+1. Si el dev "experto" no está en el equipo F0 → ignorar y usar firefighter
+2. Si el dev "experto" está en `oof:` → ignorar y usar firefighter
+3. Si hay empate, elegir al que tiene commits más recientes
+4. **`design_decision` siempre ignora git blame y va al designer firefighter** (las decisiones de diseño no las decide quien tocó el código)
+
+**Rationale:** Combina lo predecible de la rota con la intuición de "quién sabe más de esto ahora mismo". Mejor experiencia para quien pregunta y para el resto del equipo.
+
+---
+
+## 2026-05-15 — Idioma de respuesta
+
+**Decision:** El bot detecta el idioma de la pregunta y responde en el mismo idioma. Soporta español e inglés inicialmente.
+
+**Rationale:** UX > convención de código. Forzar inglés en Slack reduce adopción.

--- a/briefs/f0-slack-support-agent/tasks.md
+++ b/briefs/f0-slack-support-agent/tasks.md
@@ -1,0 +1,71 @@
+# Tasks
+
+## Bloqueantes (necesitamos input del equipo F0 antes de implementar)
+
+- [ ] Confirmar lista de los 4 stakeholders (2 diseñadores + 2 devs) con: **nombre, Slack ID, GitHub handle**
+- [ ] Confirmar que `#f0-support` (`C082ZNKS403`) está disponible para añadir un bot
+- [ ] Crear/elegir Google Cloud project para hostear el bot (¿reutilizamos uno existente del equipo F0 o creamos `f0-tooling`?)
+- [ ] Conseguir API key de Anthropic (¿hay cuenta corporativa o creamos una para F0?)
+- [ ] Decidir umbral de confianza inicial (sugerencia: 0.7 sobre 1.0)
+- [ ] Decidir ventana del routing inteligente (sugerencia: 90 días)
+
+## Implementación — Fase 1: Rotación (en este repo, sin bot todavía)
+
+- [ ] Crear `f0-rotation.yml` en la raíz del repo con la rota inicial
+- [ ] Crear `scripts/whos-on-call.ts` que lea el YAML y print el firefighter de la semana actual
+- [ ] Test unit del cálculo de rotación (semanas ISO, overrides, OOF)
+- [ ] Documentar en el header del YAML cómo editar (rota, overrides, oof)
+- [ ] Commit + PR
+
+## Implementación — Fase 2: Slack app (sin LLM todavía)
+
+- [ ] Crear app de Slack en api.slack.com:
+  - Nombre: `F0 Support`
+  - Scopes: `app_mentions:read`, `chat:write`, `users:read`, `reactions:read`
+  - Event Subscriptions: `app_mention`
+  - Instalar en el workspace
+- [ ] Crear `apps/slack-support/` con scaffold Bolt JS + TypeScript
+- [ ] Implementar listener de `app_mention` que responda "echo" en thread
+- [ ] Crear `Dockerfile` y verificar build local
+- [ ] Configurar GitHub Actions workflow `deploy-slack-support.yml`:
+  - Trigger: push a `main` que toque `apps/slack-support/**` o `f0-rotation.yml`
+  - Build + push a Google Artifact Registry
+  - Deploy a Cloud Run
+- [ ] Hacer un primer deploy de prueba en Cloud Run y verificar que el `app_mention` llega
+
+## Implementación — Fase 3: Investigación + clasificación
+
+- [ ] Implementar `mcp-client.ts` (cliente MCP al endpoint de F0 Storybook publicado)
+- [ ] Implementar `git-blame.ts` (clona el repo en el container o usa GitHub API para `git log`)
+- [ ] Implementar `classifier.ts` (Claude Sonnet, prompt que devuelve `{type, confidence, components, language}`)
+- [ ] Implementar `investigator.ts` (orquesta MCP + lectura de código según los componentes)
+- [ ] Implementar `rotation.ts` (lee `f0-rotation.yml`, calcula firefighter para semana actual)
+- [ ] Implementar `router.ts` (decisión: responder vs escalar, target del escalado)
+- [ ] Implementar `responder.ts` (genera respuesta final en el idioma detectado)
+- [ ] Implementar `slack-templates.ts` (mensajes ES/EN para escalado y respuesta)
+
+## Implementación — Fase 4: Wire-up + tests
+
+- [ ] Conectar todo en `index.ts`: app_mention → classifier → investigator → router → responder
+- [ ] Tests unitarios de cada módulo
+- [ ] Tests de integración con golden questions del tech-spec
+- [ ] Health check endpoint para Cloud Run
+- [ ] Logs estructurados (JSON) para debug en Cloud Logging
+
+## Implementación — Fase 5: Rollout
+
+- [ ] Beta con los 4 stakeholders en `#f0-support` (1 semana)
+- [ ] Recoger feedback (👍/👎 reactions + thread replies)
+- [ ] Ajustar umbral de confianza y prompts según feedback
+- [ ] Anunciar en compañía
+- [ ] Dashboard de métricas: % respondidas vs escaladas, satisfacción, tiempo de respuesta del firefighter
+
+## Métricas y observabilidad
+
+- [ ] Loggear cada interacción a Cloud Logging: clasificación, confianza, decisión, target, latencia
+- [ ] Opt-in a un sheet o dashboard simple para que el equipo F0 vea métricas semanales
+- [ ] Alerta si error rate > 5% o si el bot escala > 80% de las preguntas (señal de que el umbral está mal)
+
+## Completed
+
+<!-- Move tasks here when done, with date -->

--- a/briefs/f0-slack-support-agent/tech-spec.md
+++ b/briefs/f0-slack-support-agent/tech-spec.md
@@ -1,0 +1,275 @@
+# Tech Spec — F0 Slack Support Agent
+
+**Status:** draft
+**Owner:** TBD
+**Reviewers:** Equipo F0 (2 diseñadores + 2 devs)
+
+---
+
+## 1. Goal
+
+Reducir la carga de soporte 1:1 sobre el equipo F0 contestando automáticamente las dudas de uso de componentes en `#f0-support`, y enrutando lo no trivial al dev experto en el componente afectado o, en su defecto, al firefighter de la semana, siempre con contexto de lo ya investigado.
+
+## 2. Non-goals
+
+- No es un agente de generación de código (no produce componentes nuevos).
+- No reemplaza la review de diseño ni decisiones de roadmap.
+- No escucha mensajes sin mención explícita.
+- No responde en DMs (solo en thread del canal).
+- No tiene relación con Factorial One (producto agentic de Factorial). Es una herramienta interna del equipo F0.
+
+## 3. High-level architecture
+
+```
+Usuario en #f0-support (C082ZNKS403)
+        │ @F0Support ¿Cómo uso F0Form con un wizard?
+        ▼
+  Slack Events API → POST /slack/events
+        │
+        ▼
+  Cloud Run service (Slack Bolt JS, TypeScript)
+        │
+        ├─► classifier.ts (Claude Sonnet)
+        │     └─► { type: "component_usage", confidence: 0.9,
+        │           components: ["F0Form","F0WizardForm"], language: "es" }
+        │
+        ├─► investigator.ts
+        │     ├─► mcp-client.ts → MCP F0 Storybook (list/get-documentation)
+        │     └─► git-blame.ts (si necesita leer código fuente)
+        │
+        ├─► router.ts
+        │     ├─► confianza ≥ 0.7 + answerable → responder
+        │     └─► escalar:
+        │           1. design_decision → designer firefighter
+        │           2. else → git-blame del componente
+        │              ├─ experto F0 + no OOO → ping al experto
+        │              └─ else → dev firefighter
+        │
+        └─► responder.ts → Slack Web API (chat.postMessage en thread, idioma detectado)
+```
+
+## 4. Project layout
+
+```
+factorial-one/  (este repo)
+├── f0-rotation.yml                       # Rotación + equipo + OOF (raíz, visible)
+├── apps/
+│   └── slack-support/
+│       ├── package.json                  # Workspace pnpm
+│       ├── tsconfig.json
+│       ├── Dockerfile
+│       ├── README.md
+│       ├── src/
+│       │   ├── index.ts                  # Bolt app + listener app_mention
+│       │   ├── config.ts                 # env vars (zod-validated)
+│       │   ├── classifier.ts             # Claude Sonnet wrapper
+│       │   ├── investigator.ts           # Orquesta MCP + código
+│       │   ├── router.ts                 # Decisión escalado + target
+│       │   ├── responder.ts              # Genera respuesta final
+│       │   ├── rotation.ts               # Lee f0-rotation.yml
+│       │   ├── git-blame.ts              # Tool: dev experto por componente
+│       │   ├── mcp-client.ts             # Cliente MCP F0
+│       │   └── slack-templates.ts        # Mensajes ES/EN
+│       └── tests/
+│           ├── classifier.test.ts
+│           ├── rotation.test.ts
+│           ├── router.test.ts
+│           └── golden-questions.test.ts  # Test scenarios end-to-end
+└── scripts/
+    └── whos-on-call.ts                   # CLI: print firefighter de la semana actual
+```
+
+## 5. Key components
+
+### 5.1 `f0-rotation.yml` (raíz del repo)
+
+```yaml
+# Rotación semanal de firefighter del design system F0.
+# El bot calcula la semana ISO actual y hace módulo sobre las listas
+# para determinar quién está on-call.
+#
+# Para cambiar la rota base: edita las listas y avanza `anchor_iso_week`.
+# Para overrides puntuales (vacaciones, swaps): añade entrada en `overrides:`.
+# Para opt-out temporal del routing inteligente: añade el slack_id a `oof:`.
+
+# Equipo completo de F0. Todos pueden ser pingados por el routing inteligente
+# (git blame), no solo los que estén on-call esta semana.
+team:
+  designers:
+    - { name: "TBD-Designer-A", slack_id: "U_TBD_1", github: "tbd-designer-a" }
+    - { name: "TBD-Designer-B", slack_id: "U_TBD_2", github: "tbd-designer-b" }
+  devs:
+    - { name: "TBD-Dev-A", slack_id: "U_TBD_3", github: "tbd-dev-a" }
+    - { name: "TBD-Dev-B", slack_id: "U_TBD_4", github: "tbd-dev-b" }
+
+# Rotación: orden en el que se asigna el firefighter semanal.
+rotation:
+  designers: ["U_TBD_1", "U_TBD_2"]
+  devs: ["U_TBD_3", "U_TBD_4"]
+
+# Semana ISO desde la que el índice 0 está on-call. Format: YYYY-Www
+anchor_iso_week: "2026-W21"
+
+# Overrides puntuales. Key = semana ISO. Cualquier rol omitido usa la rota base.
+overrides:
+  # "2026-W30": { designer: "U_TBD_2", dev: "U_TBD_4" }
+
+# Opt-out temporal del routing inteligente.
+oof:
+  # - { slack_id: "U_TBD_3", until: "2026-08-15", reason: "vacaciones" }
+```
+
+**Algoritmo de cálculo del firefighter:**
+
+```
+weeks_since_anchor = current_iso_week - anchor_iso_week
+designer_index = weeks_since_anchor % len(rotation.designers)
+dev_index = weeks_since_anchor % len(rotation.devs)
+```
+
+Si la semana actual está en `overrides`, ese valor toma precedencia.
+
+**Algoritmo de routing inteligente (para `bug_or_issue` y `component_usage` con baja confianza):**
+
+```
+1. Extraer componentes mencionados (ej: ["F0Form"])
+2. Para cada componente, resolver path: packages/react/src/.../F0Form.tsx
+3. git log --since="90 days ago" --format="%ae" -- <path>
+4. Filtrar autores ∈ team.devs (mapeado github → slack_id)
+5. Filtrar autores ∈ oof
+6. Rankear por número de commits (desc), desempate por commit más reciente
+7. Si hay ganador → ese es el target
+8. Si no → fallback al firefighter dev de la semana
+```
+
+### 5.2 Slack app
+
+- **Nombre visible:** `F0 Support`
+- **Scopes (bot):** `app_mentions:read`, `chat:write`, `users:read`, `reactions:read`
+- **Event Subscriptions:** `app_mention` → `https://<cloud-run-url>/slack/events`
+- **Instalada en:** `factorialteam` workspace, añadida solo a `#f0-support` (`C082ZNKS403`)
+- **Modo:** HTTP mode (no Socket Mode), porque Cloud Run expone HTTPS
+
+### 5.3 LLM (Claude Sonnet)
+
+- Provider: Anthropic API directa (`@anthropic-ai/sdk`)
+- Modelo: `claude-sonnet-4` (configurable vía env `ANTHROPIC_MODEL`)
+- Dos llamadas por interacción:
+  1. **Clasificación** (~200 input tokens, ~100 output): devuelve JSON `{type, confidence, components, language}`
+  2. **Respuesta** (~2-5k input con contexto MCP, ~500 output): genera respuesta final en idioma detectado
+- Coste estimado: <$0.05 por interacción → $50/mes para 1000 preguntas
+
+### 5.4 MCP F0 client
+
+- Endpoint: env `F0_MCP_URL` (por defecto el publicado en Azure SWA)
+- Toolset usado: `docs` (`list-all-documentation`, `get-documentation`, `get-documentation-for-story`)
+- Health check al boot del container; si MCP cae, el bot escala todo con tag `mcp_unavailable`
+
+### 5.5 Git blame tool
+
+- En el container, el código está disponible (multi-stage Dockerfile copia el repo o monta volumen)
+- Mejor: usa GitHub API (`GET /repos/{owner}/{repo}/commits?path=...&since=...`) para no necesitar checkout completo
+- Cache de 1h por componente para no hacer rate-limit
+
+## 6. Decisión de escalado y routing (pseudo-código)
+
+```ts
+const { type, confidence, components, language } = await classifier(question)
+
+const ESCALATE_TYPES = ["design_decision", "bug_or_issue"]
+const CONFIDENCE_THRESHOLD = 0.7
+const shouldEscalate =
+  ESCALATE_TYPES.includes(type) || confidence < CONFIDENCE_THRESHOLD
+
+if (!shouldEscalate) {
+  return answer(investigationResult, { language })
+}
+
+let target: string
+let routingReason: string
+
+if (type === "design_decision") {
+  // Decisiones de diseño SIEMPRE al designer firefighter
+  const ff = await getFirefighter()
+  target = ff.designer_slack_id
+  routingReason = "design_decision → designer firefighter"
+} else {
+  // bug_or_issue / low_confidence → routing inteligente
+  const expert = await findRelevantDev(components)
+  const oof = await getOofList()
+
+  if (expert && !oof.includes(expert.slack_id)) {
+    target = expert.slack_id
+    routingReason = `experto en ${components.join(", ")} (${expert.recent_commits} commits últimos 90d)`
+  } else {
+    const ff = await getFirefighter()
+    target = ff.dev_slack_id
+    routingReason = expert
+      ? "experto OOO, fallback a firefighter"
+      : "sin experto identificable, firefighter"
+  }
+}
+
+return escalate({ target, summary, reason: routingReason, language })
+```
+
+## 7. Mensaje de escalado (templates)
+
+**Español:**
+```
+👋 Hola <@target>, te paso esta consulta porque {routing_reason}.
+
+*Pregunta:* {pregunta resumida en 1 línea}
+
+*Por qué escalo:* {design_decision | potential_bug | low_confidence (0.4)}
+
+*Lo que ya investigué:*
+• Componentes relevantes: {F0Form, F0Dialog}
+• Docs consultadas: {links}
+• Código revisado: {packages/react/src/.../X.tsx:42}
+
+{breve análisis o hipótesis si la hay}
+```
+
+**English:** misma estructura traducida. Selección por `language` del clasificador.
+
+## 8. Deployment
+
+- **Hosting:** Google Cloud Run (project: TBD)
+- **Build:** GitHub Actions workflow `.github/workflows/deploy-slack-support.yml`
+  - Trigger: push a `main` que toque `apps/slack-support/**` o `f0-rotation.yml`
+  - Steps: build Docker → push a Artifact Registry → deploy a Cloud Run
+- **Secrets** (Cloud Run runtime):
+  - `SLACK_BOT_TOKEN` (xoxb-...)
+  - `SLACK_SIGNING_SECRET`
+  - `ANTHROPIC_API_KEY`
+  - `GITHUB_TOKEN` (para git-blame via GitHub API)
+- **Observability:** Cloud Logging (logs JSON estructurados), Cloud Run metrics
+
+## 9. Test scenarios
+
+| ID | Pregunta | Esperado |
+|----|----------|----------|
+| T-1 | "¿Qué props tiene F0Dialog?" | Responde con lista de props del MCP, confianza ≥ 0.8 |
+| T-2 | "El EmployeeSelector no carga, ¿bug?" | Escala al dev experto / firefighter con tag `potential_bug` |
+| T-3 | "¿Deberíamos hacer un componente nuevo de Timeline?" | Escala al designer firefighter con tag `design_decision` |
+| T-4 | "Hola, ¿cómo va el día?" | Tipo=`other`, responde cortésmente sin escalar |
+| T-5 | "¿Cómo uso F0Form?" pero MCP cae | Escala con tag `low_confidence` + nota `mcp_unavailable` |
+| T-6 | Pregunta en español | Responde en español |
+| T-7 | Pregunta en inglés | Responde en inglés |
+| T-8 | Override de la semana | Hace ping a la persona del override, no a la rota base |
+| T-9 | "Bug en F0Form" → DevA tiene 8 commits últimos 90d, DevB tiene 2 | Pinga a DevA (experto), no al firefighter |
+| T-10 | "Bug en F0Form" → único experto está OOO | Fallback al firefighter dev |
+| T-11 | "¿Deberíamos cambiar color de F0Button?" → DevA es experto en F0Button | Pinga al designer firefighter (design_decision ignora git blame) |
+| T-12 | Pregunta sobre componente que nadie ha tocado en 90d | Pinga al firefighter dev |
+
+## 10. Rollout plan
+
+1. **Semana 1:** `f0-rotation.yml` + `scripts/whos-on-call.ts` + tests de cálculo. PR a main. Validar manualmente que la rota da quien debe.
+2. **Semana 2:** Scaffold `apps/slack-support/` con Bolt JS. Listener `app_mention` que responde "echo en thread". Dockerfile + GH Action de deploy. Primer deploy a Cloud Run y verificar que llegan eventos.
+3. **Semana 3:** Implementar classifier + investigator + router + responder. Tests unitarios + golden questions. Beta cerrada con los 4 stakeholders.
+4. **Semana 4:** Iterar umbral de confianza y prompts según feedback. Anunciar a la compañía. Dashboard de métricas básico.
+
+## 11. Open questions
+
+Ver [`concerns.md`](./concerns.md).


### PR DESCRIPTION
## What is this

Proposal (RFC) to build a **Slack support bot owned by the F0 team** that lives in [`#f0-support`](https://factorialteam.slack.com/archives/C082ZNKS403) (`C082ZNKS403`). It answers F0 component usage questions automatically and escalates non-trivial ones to the right person on the team — with full context of what it already investigated.

> **This PR is not for merging.** It only adds documentation under `briefs/` so we can review the proposal here on GitHub line-by-line. Once approved we'll open separate PRs per implementation phase.

## Why a brief / why this format

Captured using the [`factorial-brief`](https://github.com/factorialco/factorial-skills) skill so we have:
- Decisions with rationale and rejected alternatives (auditable)
- Open concerns and risks separated from decisions
- A concrete tech spec ready to implement once we agree
- A task list broken into 5 phases

## Read in this order

1. [`brief.md`](../blob/feat/f0-slack-support-agent/briefs/f0-slack-support-agent/brief.md) — 1 min summary + key takeaways
2. [`decisions.md`](../blob/feat/f0-slack-support-agent/briefs/f0-slack-support-agent/decisions.md) — what we chose and why
3. [`tech-spec.md`](../blob/feat/f0-slack-support-agent/briefs/f0-slack-support-agent/tech-spec.md) — architecture, project layout, deployment
4. [`tasks.md`](../blob/feat/f0-slack-support-agent/briefs/f0-slack-support-agent/tasks.md) — implementation roadmap
5. [`concerns.md`](../blob/feat/f0-slack-support-agent/briefs/f0-slack-support-agent/concerns.md) — open questions & risks
6. [`background.md`](../blob/feat/f0-slack-support-agent/briefs/f0-slack-support-agent/background.md) — origin of the idea

## Architecture in one paragraph

Standalone **Slack Bolt JS** app in `apps/slack-support/`, deployed to **Google Cloud Run** via GitHub Actions. Uses **Claude Sonnet** for classification + response, the **F0 Storybook MCP** + repo source as knowledge base. Weekly rotation lives in **`f0-rotation.yml`** at the repo root. Routing is smart: if the question is about a component someone on the team has touched recently (git blame, 90d window), they get pinged directly; otherwise the firefighter of the week. \`design_decision\` questions always go to the designer firefighter regardless. Bot replies in the language of the question (ES/EN auto-detect).

**It is NOT related to Factorial One (the agentic product).** It's an internal F0 team tool, fully owned and deployed by F0.

## What I need from reviewers

- [ ] Sanity check on the architecture (any obvious mistake or simpler alternative?)
- [ ] Confirm the 4 stakeholders (2 designers + 2 devs) — names, Slack IDs, GitHub handles
- [ ] Confirm Google Cloud project to host (reuse existing or create \`f0-tooling\`?)
- [ ] Confirm Anthropic API key access (corporate account?)
- [ ] Sanity check on the rotation/routing rules (\`decisions.md\` § routing)
- [ ] Check the test scenarios in tech-spec § 9 cover what you'd expect

## What happens next

In parallel to this review, I'll build a small **CLI prototype** (no Slack, no deploy) that hits the F0 MCP + Claude to validate the riskiest assumption: that the classifier and the MCP actually give us useful answers. If that works, we move forward with Phase 1 (\`f0-rotation.yml\` + tests).

---

🤖 Implemented-with: factorial-brief, factorial-specs