### PR TITLE
feat(community): make post descriptions expandable

### DIFF
--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import PushPin from "@/icons/app/PushPin"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { CommunityPost } from "./index"
 
@@ -230,6 +231,7 @@ export const LongUnspacedText: Story = {
 
 export const ExpandableDescription: Story = {
   decorators: Default.decorators,
+  parameters: withSnapshot({}),
   args: {
     ...Default.args,
     event: undefined,

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
@@ -228,6 +228,17 @@ export const LongUnspacedText: Story = {
   },
 }
 
+export const ExpandableDescription: Story = {
+  decorators: Default.decorators,
+  args: {
+    ...Default.args,
+    event: undefined,
+    mediaUrl: undefined,
+    descriptionExpandable: true,
+    description: `<p class="TextEditorTheme__paragraph" dir="ltr"><span>This ticket comment contains enough context that consumers may want to keep the post compact until someone asks to read it in full. The first visible lines should stay clamped, and the inline See more control expands the rich text body without opening the post.</span></p><p class="TextEditorTheme__paragraph" dir="ltr"><span>Additional details can include troubleshooting steps, links, mentions, and follow-up notes from the requester.</span></p><p class="TextEditorTheme__paragraph" dir="ltr"><span>Once expanded, focus moves to the description so keyboard users keep their place.</span></p>`,
+  },
+}
+
 type SkeletonStory = StoryObj<typeof CommunityPost.Skeleton>
 
 export const Skeleton: SkeletonStory = {

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
@@ -237,7 +237,7 @@ export const ExpandableDescription: Story = {
     event: undefined,
     mediaUrl: undefined,
     descriptionExpandable: true,
-    description: `<p class="TextEditorTheme__paragraph" dir="ltr"><span>This ticket comment contains enough context that consumers may want to keep the post compact until someone asks to read it in full. The first visible lines should stay clamped, and the inline See more control expands the rich text body without opening the post.</span></p><p class="TextEditorTheme__paragraph" dir="ltr"><span>Additional details can include troubleshooting steps, links, mentions, and follow-up notes from the requester.</span></p><p class="TextEditorTheme__paragraph" dir="ltr"><span>Once expanded, focus moves to the description so keyboard users keep their place.</span></p>`,
+    description: `<p class="TextEditorTheme__paragraph" dir="ltr"><span>This ticket comment contains enough context that consumers may want to keep the post compact until someone asks to read it in full. The first visible lines should stay clamped, and the See more control expands the rich text body without opening the post.</span></p><p class="TextEditorTheme__paragraph" dir="ltr"><span>Additional details can include troubleshooting steps, links, mentions, and follow-up notes from the requester.</span></p><p class="TextEditorTheme__paragraph" dir="ltr"><span>Once expanded, the full description remains visible for reading.</span></p>`,
   },
 }
 

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
@@ -1,0 +1,55 @@
+import { expect, test, vi } from "vitest"
+
+import { screen, userEvent, zeroRender as render } from "@/testing/test-utils"
+import { BaseCommunityPost, CommunityPostProps } from "./index"
+
+const defaultProps: CommunityPostProps = {
+  id: "post-1",
+  author: {
+    firstName: "Ada",
+    lastName: "Lovelace",
+  },
+  group: {
+    title: "Engineering",
+    onClick: vi.fn(),
+  },
+  createdAt: new Date("2026-01-01T10:00:00Z"),
+  title: "Post title",
+  description: "<p>Long post description</p>",
+  counters: {
+    comments: "0",
+  },
+  inLabel: "in",
+  comment: {
+    label: "Comment",
+    onClick: vi.fn(),
+  },
+  onClick: vi.fn(),
+}
+
+test("does not show description expansion controls by default", () => {
+  render(<BaseCommunityPost {...defaultProps} />)
+
+  expect(screen.queryByRole("button", { name: "See more" })).toBeNull()
+})
+
+test("expands the description when enabled", async () => {
+  const onClick = vi.fn()
+  render(
+    <BaseCommunityPost
+      {...defaultProps}
+      onClick={onClick}
+      descriptionExpandable
+    />
+  )
+
+  const description = document.querySelector(".FactorialOneTextEditor")
+  expect(description).toHaveClass("line-clamp-5")
+
+  await userEvent.click(screen.getByRole("button", { name: "See more" }))
+
+  expect(description).not.toHaveClass("line-clamp-5")
+  expect(description).toHaveFocus()
+  expect(screen.queryByRole("button", { name: "See more" })).toBeNull()
+  expect(onClick).not.toHaveBeenCalled()
+})

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
@@ -90,3 +90,23 @@ test("does not show description expansion controls when the description fits", (
 
   expect(screen.queryByRole("button", { name: "See more" })).toBeNull()
 })
+
+test("collapses the description when expansion is disabled after expanding", async () => {
+  mockDescriptionDimensions({ scrollHeight: 120, clientHeight: 100 })
+
+  const { rerender } = render(
+    <BaseCommunityPost {...defaultProps} descriptionExpandable />
+  )
+
+  const description = document.querySelector(".FactorialOneTextEditor")
+
+  await userEvent.click(await screen.findByRole("button", { name: "See more" }))
+  expect(description).not.toHaveClass("line-clamp-5")
+
+  rerender(
+    <BaseCommunityPost {...defaultProps} descriptionExpandable={false} />
+  )
+
+  expect(description).toHaveClass("line-clamp-5")
+  expect(screen.queryByRole("button", { name: "See more" })).toBeNull()
+})

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
@@ -75,7 +75,12 @@ test("expands the description when enabled", async () => {
   const description = document.querySelector(".FactorialOneTextEditor")
   expect(description).toHaveClass("line-clamp-5")
 
-  await userEvent.click(await screen.findByRole("button", { name: "See more" }))
+  const expandButton = await screen.findByRole("button", { name: "See more" })
+  const title = screen.getByText("Post title")
+  expect(expandButton).toHaveAccessibleDescription("Post title")
+  expect(expandButton).toHaveAttribute("aria-describedby", title.id)
+
+  await userEvent.click(expandButton)
 
   expect(description).not.toHaveClass("line-clamp-5")
   expect(description).toHaveFocus()

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
@@ -78,6 +78,7 @@ test("expands the description when enabled", async () => {
   await userEvent.click(await screen.findByRole("button", { name: "See more" }))
 
   expect(description).not.toHaveClass("line-clamp-5")
+  expect(description).toHaveFocus()
   expect(screen.queryByRole("button", { name: "See more" })).toBeNull()
   expect(onClick).not.toHaveBeenCalled()
 })

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
@@ -78,7 +78,6 @@ test("expands the description when enabled", async () => {
   await userEvent.click(await screen.findByRole("button", { name: "See more" }))
 
   expect(description).not.toHaveClass("line-clamp-5")
-  expect(description).toHaveFocus()
   expect(screen.queryByRole("button", { name: "See more" })).toBeNull()
   expect(onClick).not.toHaveBeenCalled()
 })
@@ -91,7 +90,7 @@ test("does not show description expansion controls when the description fits", (
   expect(screen.queryByRole("button", { name: "See more" })).toBeNull()
 })
 
-test("collapses the description when expansion is disabled after expanding", async () => {
+test("resets expanded state when disabled, re-enabled, or reused for another post", async () => {
   mockDescriptionDimensions({ scrollHeight: 120, clientHeight: 100 })
 
   const { rerender } = render(
@@ -109,4 +108,24 @@ test("collapses the description when expansion is disabled after expanding", asy
 
   expect(description).toHaveClass("line-clamp-5")
   expect(screen.queryByRole("button", { name: "See more" })).toBeNull()
+
+  rerender(<BaseCommunityPost {...defaultProps} descriptionExpandable />)
+
+  expect(description).toHaveClass("line-clamp-5")
+  expect(screen.getByRole("button", { name: "See more" })).toBeInTheDocument()
+
+  await userEvent.click(await screen.findByRole("button", { name: "See more" }))
+  expect(description).not.toHaveClass("line-clamp-5")
+
+  rerender(
+    <BaseCommunityPost
+      {...defaultProps}
+      id="post-2"
+      description="<p>Another long post description</p>"
+      descriptionExpandable
+    />
+  )
+
+  expect(description).toHaveClass("line-clamp-5")
+  expect(screen.getByRole("button", { name: "See more" })).toBeInTheDocument()
 })

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.test.tsx
@@ -1,4 +1,4 @@
-import { expect, test, vi } from "vitest"
+import { afterEach, beforeAll, expect, test, vi } from "vitest"
 
 import { screen, userEvent, zeroRender as render } from "@/testing/test-utils"
 import { BaseCommunityPost, CommunityPostProps } from "./index"
@@ -27,6 +27,33 @@ const defaultProps: CommunityPostProps = {
   onClick: vi.fn(),
 }
 
+beforeAll(() => {
+  global.ResizeObserver = class MockResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as typeof ResizeObserver
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const mockDescriptionDimensions = ({
+  scrollHeight,
+  clientHeight,
+}: {
+  scrollHeight: number
+  clientHeight: number
+}) => {
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(
+    scrollHeight
+  )
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(
+    clientHeight
+  )
+}
+
 test("does not show description expansion controls by default", () => {
   render(<BaseCommunityPost {...defaultProps} />)
 
@@ -35,6 +62,8 @@ test("does not show description expansion controls by default", () => {
 
 test("expands the description when enabled", async () => {
   const onClick = vi.fn()
+  mockDescriptionDimensions({ scrollHeight: 120, clientHeight: 100 })
+
   render(
     <BaseCommunityPost
       {...defaultProps}
@@ -46,10 +75,18 @@ test("expands the description when enabled", async () => {
   const description = document.querySelector(".FactorialOneTextEditor")
   expect(description).toHaveClass("line-clamp-5")
 
-  await userEvent.click(screen.getByRole("button", { name: "See more" }))
+  await userEvent.click(await screen.findByRole("button", { name: "See more" }))
 
   expect(description).not.toHaveClass("line-clamp-5")
   expect(description).toHaveFocus()
   expect(screen.queryByRole("button", { name: "See more" })).toBeNull()
   expect(onClick).not.toHaveBeenCalled()
+})
+
+test("does not show description expansion controls when the description fits", () => {
+  mockDescriptionDimensions({ scrollHeight: 100, clientHeight: 100 })
+
+  render(<BaseCommunityPost {...defaultProps} descriptionExpandable />)
+
+  expect(screen.queryByRole("button", { name: "See more" })).toBeNull()
 })

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -22,10 +22,12 @@ import { PostEvent, PostEventProps } from "../PostEvent"
 import { isVideo } from "./video"
 
 const ExpandDescriptionButton = ({
+  describedBy,
   controls,
   expanded,
   onClick,
 }: {
+  describedBy: string
   controls: string
   expanded: boolean
   onClick: (event: React.MouseEvent<HTMLElement>) => void
@@ -41,6 +43,7 @@ const ExpandDescriptionButton = ({
           focusRing()
         )}
         aria-controls={controls}
+        aria-describedby={describedBy}
         aria-expanded={expanded}
         onClick={onClick}
       >
@@ -121,12 +124,13 @@ export const BaseCommunityPost = ({
   noReactionsButton = false,
   descriptionExpandable = false,
 }: CommunityPostProps) => {
+  const titleId = useId()
   const descriptionId = useId()
   const descriptionRef = useRef<HTMLDivElement>(null)
-  const descriptionExpansionKey = `${id}:${description ?? ""}`
-  const [expandedDescriptionKey, setExpandedDescriptionKey] = useState<
-    string | null
-  >(null)
+  const [expandedDescription, setExpandedDescription] = useState<{
+    id: string
+    description: PostDescriptionProps["content"]
+  } | null>(null)
   const [isDescriptionOverflowing, setIsDescriptionOverflowing] =
     useState(false)
   const countersDisplay = [counters.views, counters.comments]
@@ -134,7 +138,9 @@ export const BaseCommunityPost = ({
     .join(" · ")
 
   const descriptionExpanded =
-    descriptionExpandable && expandedDescriptionKey === descriptionExpansionKey
+    descriptionExpandable &&
+    expandedDescription?.id === id &&
+    expandedDescription.description === description
   const descriptionCollapsed = !descriptionExpanded
   const date = getDisplayDateBasedOnDuration(createdAt)
 
@@ -150,10 +156,13 @@ export const BaseCommunityPost = ({
     ? `${author.firstName} ${author.lastName}`
     : undefined
 
-  const handleToggleDescription = (event: React.MouseEvent<HTMLElement>) => {
+  const handleExpandDescription = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault()
     event.stopPropagation()
-    setExpandedDescriptionKey(descriptionExpansionKey)
+
+    if (!description) return
+
+    setExpandedDescription({ id, description })
   }
 
   useEffect(() => {
@@ -163,7 +172,7 @@ export const BaseCommunityPost = ({
   }, [descriptionExpanded])
 
   useEffect(() => {
-    if (!descriptionExpandable) setExpandedDescriptionKey(null)
+    if (!descriptionExpandable) setExpandedDescription(null)
   }, [descriptionExpandable])
 
   useEffect(() => {
@@ -309,6 +318,7 @@ export const BaseCommunityPost = ({
           </span>
           <div className="flex min-w-0 flex-col gap-1 text-f1-foreground">
             <p
+              id={titleId}
               className={cn(
                 "text-xl font-semibold",
                 "line-clamp-2 break-words"
@@ -330,9 +340,10 @@ export const BaseCommunityPost = ({
                   isDescriptionOverflowing &&
                   !descriptionExpanded && (
                     <ExpandDescriptionButton
+                      describedBy={titleId}
                       controls={descriptionId}
                       expanded={descriptionExpanded}
-                      onClick={handleToggleDescription}
+                      onClick={handleExpandDescription}
                     />
                   )}
               </>

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -130,7 +130,8 @@ export const BaseCommunityPost = ({
     .filter(Boolean)
     .join(" · ")
 
-  const descriptionCollapsed = !isDescriptionExpanded
+  const descriptionExpanded = descriptionExpandable && isDescriptionExpanded
+  const descriptionCollapsed = !descriptionExpanded
   const date = getDisplayDateBasedOnDuration(createdAt)
 
   const handleClick = () => {
@@ -152,19 +153,15 @@ export const BaseCommunityPost = ({
   }
 
   useEffect(() => {
-    if (isDescriptionExpanded) {
+    if (descriptionExpanded) {
       descriptionRef.current?.focus()
     }
-  }, [isDescriptionExpanded])
+  }, [descriptionExpanded])
 
   useEffect(() => {
     const descriptionElement = descriptionRef.current
 
-    if (
-      !descriptionExpandable ||
-      !descriptionElement ||
-      isDescriptionExpanded
-    ) {
+    if (!descriptionExpandable || !descriptionElement || descriptionExpanded) {
       setIsDescriptionOverflowing(false)
       return
     }
@@ -183,7 +180,7 @@ export const BaseCommunityPost = ({
     resizeObserver.observe(descriptionElement)
 
     return () => resizeObserver.disconnect()
-  }, [descriptionExpandable, isDescriptionExpanded, description])
+  }, [descriptionExpandable, descriptionExpanded, description])
 
   return (
     <div
@@ -318,15 +315,15 @@ export const BaseCommunityPost = ({
                   id={descriptionId}
                   content={description}
                   collapsed={descriptionCollapsed}
-                  tabIndex={isDescriptionExpanded ? -1 : undefined}
-                  className={cn(isDescriptionExpanded && focusRing())}
+                  tabIndex={descriptionExpanded ? -1 : undefined}
+                  className={cn(descriptionExpanded && focusRing())}
                 />
                 {descriptionExpandable &&
                   isDescriptionOverflowing &&
-                  !isDescriptionExpanded && (
+                  !descriptionExpanded && (
                     <ExpandDescriptionButton
                       controls={descriptionId}
-                      expanded={isDescriptionExpanded}
+                      expanded={descriptionExpanded}
                       onClick={handleToggleDescription}
                     />
                   )}

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -124,6 +124,8 @@ export const BaseCommunityPost = ({
   const descriptionId = useId()
   const descriptionRef = useRef<HTMLDivElement>(null)
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
+  const [isDescriptionOverflowing, setIsDescriptionOverflowing] =
+    useState(false)
   const countersDisplay = [counters.views, counters.comments]
     .filter(Boolean)
     .join(" · ")
@@ -154,6 +156,34 @@ export const BaseCommunityPost = ({
       descriptionRef.current?.focus()
     }
   }, [isDescriptionExpanded])
+
+  useEffect(() => {
+    const descriptionElement = descriptionRef.current
+
+    if (
+      !descriptionExpandable ||
+      !descriptionElement ||
+      isDescriptionExpanded
+    ) {
+      setIsDescriptionOverflowing(false)
+      return
+    }
+
+    const updateDescriptionOverflow = () => {
+      setIsDescriptionOverflowing(
+        descriptionElement.scrollHeight > descriptionElement.clientHeight
+      )
+    }
+
+    updateDescriptionOverflow()
+
+    if (typeof ResizeObserver === "undefined") return
+
+    const resizeObserver = new ResizeObserver(updateDescriptionOverflow)
+    resizeObserver.observe(descriptionElement)
+
+    return () => resizeObserver.disconnect()
+  }, [descriptionExpandable, isDescriptionExpanded, description])
 
   return (
     <div
@@ -291,13 +321,15 @@ export const BaseCommunityPost = ({
                   tabIndex={isDescriptionExpanded ? -1 : undefined}
                   className={cn(isDescriptionExpanded && focusRing())}
                 />
-                {descriptionExpandable && !isDescriptionExpanded && (
-                  <ExpandDescriptionButton
-                    controls={descriptionId}
-                    expanded={isDescriptionExpanded}
-                    onClick={handleToggleDescription}
-                  />
-                )}
+                {descriptionExpandable &&
+                  isDescriptionOverflowing &&
+                  !isDescriptionExpanded && (
+                    <ExpandDescriptionButton
+                      controls={descriptionId}
+                      expanded={isDescriptionExpanded}
+                      onClick={handleToggleDescription}
+                    />
+                  )}
               </>
             )}
           </div>

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -11,9 +11,11 @@ import {
   Person as PersonIcon,
 } from "@/icons/app"
 import { getDisplayDateBasedOnDuration } from "@/lib/date"
+import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import { withSkeleton } from "@/lib/skeleton"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import { Skeleton } from "@/ui/skeleton"
+import { useEffect, useId, useRef, useState } from "react"
 
 import { PostDescription, PostDescriptionProps } from "../PostDescription"
 import { PostEvent, PostEventProps } from "../PostEvent"
@@ -67,6 +69,8 @@ export type CommunityPostProps = {
   noReactionsButton?: boolean
 
   dropdownItems?: DropdownItem[]
+
+  descriptionExpandable?: boolean
 }
 
 export const BaseCommunityPost = ({
@@ -86,12 +90,17 @@ export const BaseCommunityPost = ({
   actions,
   dropdownItems,
   noReactionsButton = false,
+  descriptionExpandable = false,
 }: CommunityPostProps) => {
+  const i18n = useI18n()
+  const descriptionId = useId()
+  const descriptionRef = useRef<HTMLDivElement>(null)
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
   const countersDisplay = [counters.views, counters.comments]
     .filter(Boolean)
     .join(" · ")
 
-  const collapsed = true
+  const descriptionCollapsed = !isDescriptionExpanded
   const date = getDisplayDateBasedOnDuration(createdAt)
 
   const handleClick = () => {
@@ -105,6 +114,18 @@ export const BaseCommunityPost = ({
   const authorFullName = author
     ? `${author.firstName} ${author.lastName}`
     : undefined
+
+  const handleToggleDescription = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDescriptionExpanded(true)
+  }
+
+  useEffect(() => {
+    if (isDescriptionExpanded) {
+      descriptionRef.current?.focus()
+    }
+  }, [isDescriptionExpanded])
 
   return (
     <div
@@ -227,13 +248,38 @@ export const BaseCommunityPost = ({
             <p
               className={cn(
                 "text-xl font-semibold",
-                collapsed && "line-clamp-2 break-words"
+                "line-clamp-2 break-words"
               )}
             >
               {title}
             </p>
             {description && (
-              <PostDescription content={description} collapsed={collapsed} />
+              <>
+                <PostDescription
+                  ref={descriptionRef}
+                  id={descriptionId}
+                  content={description}
+                  collapsed={descriptionCollapsed}
+                  tabIndex={isDescriptionExpanded ? -1 : undefined}
+                  className={cn(isDescriptionExpanded && focusRing())}
+                />
+                {descriptionExpandable && !isDescriptionExpanded && (
+                  <div className="text-base text-f1-foreground">
+                    <button
+                      type="button"
+                      className={cn(
+                        "inline cursor-pointer rounded-none border-0 bg-transparent p-0 text-base text-f1-foreground underline underline-offset-2 hover:text-f1-foreground-secondary",
+                        focusRing()
+                      )}
+                      aria-controls={descriptionId}
+                      aria-expanded={isDescriptionExpanded}
+                      onClick={handleToggleDescription}
+                    >
+                      {i18n.actions.seeMore}
+                    </button>
+                  </div>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -21,6 +21,35 @@ import { PostDescription, PostDescriptionProps } from "../PostDescription"
 import { PostEvent, PostEventProps } from "../PostEvent"
 import { isVideo } from "./video"
 
+const ExpandDescriptionButton = ({
+  controls,
+  expanded,
+  onClick,
+}: {
+  controls: string
+  expanded: boolean
+  onClick: (event: React.MouseEvent<HTMLElement>) => void
+}) => {
+  const i18n = useI18n()
+
+  return (
+    <div className="text-base text-f1-foreground">
+      <button
+        type="button"
+        className={cn(
+          "inline cursor-pointer rounded-none border-0 bg-transparent p-0 text-base text-f1-foreground underline underline-offset-2 hover:text-f1-foreground-secondary",
+          focusRing()
+        )}
+        aria-controls={controls}
+        aria-expanded={expanded}
+        onClick={onClick}
+      >
+        {i18n.actions.seeMore}
+      </button>
+    </div>
+  )
+}
+
 export type CommunityPostAction = {
   label?: string
   icon?: IconType
@@ -92,7 +121,6 @@ export const BaseCommunityPost = ({
   noReactionsButton = false,
   descriptionExpandable = false,
 }: CommunityPostProps) => {
-  const i18n = useI18n()
   const descriptionId = useId()
   const descriptionRef = useRef<HTMLDivElement>(null)
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
@@ -264,20 +292,11 @@ export const BaseCommunityPost = ({
                   className={cn(isDescriptionExpanded && focusRing())}
                 />
                 {descriptionExpandable && !isDescriptionExpanded && (
-                  <div className="text-base text-f1-foreground">
-                    <button
-                      type="button"
-                      className={cn(
-                        "inline cursor-pointer rounded-none border-0 bg-transparent p-0 text-base text-f1-foreground underline underline-offset-2 hover:text-f1-foreground-secondary",
-                        focusRing()
-                      )}
-                      aria-controls={descriptionId}
-                      aria-expanded={isDescriptionExpanded}
-                      onClick={handleToggleDescription}
-                    >
-                      {i18n.actions.seeMore}
-                    </button>
-                  </div>
+                  <ExpandDescriptionButton
+                    controls={descriptionId}
+                    expanded={isDescriptionExpanded}
+                    onClick={handleToggleDescription}
+                  />
                 )}
               </>
             )}

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -157,6 +157,12 @@ export const BaseCommunityPost = ({
   }
 
   useEffect(() => {
+    if (descriptionExpanded) {
+      descriptionRef.current?.focus()
+    }
+  }, [descriptionExpanded])
+
+  useEffect(() => {
     if (!descriptionExpandable) setExpandedDescriptionKey(null)
   }, [descriptionExpandable])
 
@@ -317,6 +323,8 @@ export const BaseCommunityPost = ({
                   id={descriptionId}
                   content={description}
                   collapsed={descriptionCollapsed}
+                  tabIndex={descriptionExpanded ? -1 : undefined}
+                  className={cn(descriptionExpanded && focusRing())}
                 />
                 {descriptionExpandable &&
                   isDescriptionOverflowing &&

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -123,14 +123,18 @@ export const BaseCommunityPost = ({
 }: CommunityPostProps) => {
   const descriptionId = useId()
   const descriptionRef = useRef<HTMLDivElement>(null)
-  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
+  const descriptionExpansionKey = `${id}:${description ?? ""}`
+  const [expandedDescriptionKey, setExpandedDescriptionKey] = useState<
+    string | null
+  >(null)
   const [isDescriptionOverflowing, setIsDescriptionOverflowing] =
     useState(false)
   const countersDisplay = [counters.views, counters.comments]
     .filter(Boolean)
     .join(" · ")
 
-  const descriptionExpanded = descriptionExpandable && isDescriptionExpanded
+  const descriptionExpanded =
+    descriptionExpandable && expandedDescriptionKey === descriptionExpansionKey
   const descriptionCollapsed = !descriptionExpanded
   const date = getDisplayDateBasedOnDuration(createdAt)
 
@@ -149,14 +153,12 @@ export const BaseCommunityPost = ({
   const handleToggleDescription = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault()
     event.stopPropagation()
-    setIsDescriptionExpanded(true)
+    setExpandedDescriptionKey(descriptionExpansionKey)
   }
 
   useEffect(() => {
-    if (descriptionExpanded) {
-      descriptionRef.current?.focus()
-    }
-  }, [descriptionExpanded])
+    if (!descriptionExpandable) setExpandedDescriptionKey(null)
+  }, [descriptionExpandable])
 
   useEffect(() => {
     const descriptionElement = descriptionRef.current
@@ -315,8 +317,6 @@ export const BaseCommunityPost = ({
                   id={descriptionId}
                   content={description}
                   collapsed={descriptionCollapsed}
-                  tabIndex={descriptionExpanded ? -1 : undefined}
-                  className={cn(descriptionExpanded && focusRing())}
                 />
                 {descriptionExpandable &&
                   isDescriptionOverflowing &&

--- a/packages/react/src/sds/Home/Communities/Post/PostDescription/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/PostDescription/index.tsx
@@ -12,12 +12,14 @@ export type PostDescriptionProps = {
   content: HTMLString
   collapsed?: boolean
   id?: string
+  className?: string
+  tabIndex?: number
 }
 export const BasePostDescription = forwardRef<
   HTMLDivElement,
   PostDescriptionProps
 >(function BasePostDescription(
-  { content, collapsed, id }: PostDescriptionProps,
+  { content, collapsed, id, className, tabIndex }: PostDescriptionProps,
   ref
 ) {
   return (
@@ -25,9 +27,11 @@ export const BasePostDescription = forwardRef<
       ref={ref}
       id={id}
       content={content}
+      tabIndex={tabIndex}
       className={cn(
         "FactorialOneTextEditor",
-        collapsed && "line-clamp-5 break-words"
+        collapsed && "line-clamp-5 break-words",
+        className
       )}
     />
   )

--- a/packages/react/src/sds/Home/Communities/Post/PostDescription/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/PostDescription/index.tsx
@@ -37,6 +37,8 @@ export const BasePostDescription = forwardRef<
   )
 })
 
+BasePostDescription.displayName = "BasePostDescription"
+
 export const PostDescriptionSkeleton = () => (
   <div className="flex flex-col justify-around gap-3 py-2">
     <Skeleton className="h-2.5 w-1/2 rounded-2xs" />

--- a/packages/react/src/sds/Home/Communities/Post/PostDescription/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/PostDescription/index.tsx
@@ -12,14 +12,12 @@ export type PostDescriptionProps = {
   content: HTMLString
   collapsed?: boolean
   id?: string
-  className?: string
-  tabIndex?: number
 }
 export const BasePostDescription = forwardRef<
   HTMLDivElement,
   PostDescriptionProps
 >(function BasePostDescription(
-  { content, collapsed, id, className, tabIndex }: PostDescriptionProps,
+  { content, collapsed, id }: PostDescriptionProps,
   ref
 ) {
   return (
@@ -27,11 +25,9 @@ export const BasePostDescription = forwardRef<
       ref={ref}
       id={id}
       content={content}
-      tabIndex={tabIndex}
       className={cn(
         "FactorialOneTextEditor",
-        collapsed && "line-clamp-5 break-words",
-        className
+        collapsed && "line-clamp-5 break-words"
       )}
     />
   )

--- a/packages/react/src/sds/Home/Communities/Post/PostDescription/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/PostDescription/index.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from "react"
+
 import { RichTextDisplay } from "@/components/RichText/RichTextDisplay"
 import { Skeleton } from "@/ui/skeleton"
 
@@ -9,21 +11,31 @@ type HTMLString = string
 export type PostDescriptionProps = {
   content: HTMLString
   collapsed?: boolean
+  id?: string
+  className?: string
+  tabIndex?: number
 }
-export const BasePostDescription = ({
-  content,
-  collapsed,
-}: PostDescriptionProps) => {
+export const BasePostDescription = forwardRef<
+  HTMLDivElement,
+  PostDescriptionProps
+>(function BasePostDescription(
+  { content, collapsed, id, className, tabIndex }: PostDescriptionProps,
+  ref
+) {
   return (
     <RichTextDisplay
+      ref={ref}
+      id={id}
       content={content}
+      tabIndex={tabIndex}
       className={cn(
         "FactorialOneTextEditor",
-        collapsed && "line-clamp-5 break-words"
+        collapsed && "line-clamp-5 break-words",
+        className
       )}
     />
   )
-}
+})
 
 export const PostDescriptionSkeleton = () => (
   <div className="flex flex-col justify-around gap-3 py-2">


### PR DESCRIPTION
## Summary
- Add an opt-in `descriptionExpandable` prop to CommunityPost so consumers can expand clamped rich text descriptions.
- Add unit coverage and a Storybook example for expandable descriptions.

## Validation
- pnpm vitest:ci "src/sds/Home/Communities/Post/CommunityPost/index.test.tsx" "src/sds/Home/Communities/Post/PostDescription/index.spec.tsx"
- pnpm --filter @factorialco/f0-core build && pnpm tsc
- pnpm lint "src/sds/Home/Communities/Post/CommunityPost/index.tsx" "src/sds/Home/Communities/Post/PostDescription/index.tsx" "src/sds/Home/Communities/Post/CommunityPost/index.test.tsx" "src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx"