### PR TITLE
fix(ai): render custom placeholder when placeholders array has single element

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/TextareaField.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/TextareaField.tsx
@@ -96,7 +96,9 @@ export const TextareaField = ({
             "overflow-hidden text-ellipsis whitespace-nowrap"
           )}
         >
-          {resolvedDefaultPlaceholder}
+          {placeholders.length === 1
+            ? placeholders[0]
+            : resolvedDefaultPlaceholder}
         </p>
       )}
       <textarea

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/TextareaField.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/TextareaField.test.tsx
@@ -1,0 +1,77 @@
+import { createRef } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { TextareaField } from "../TextareaField"
+
+vi.mock("../../TypewriterPlaceholder", () => ({
+  TypewriterPlaceholder: ({ placeholders }: { placeholders: string[] }) => (
+    <p data-testid="typewriter-placeholder">{placeholders.join(", ")}</p>
+  ),
+}))
+
+const defaultProps = {
+  textareaRef: createRef<HTMLTextAreaElement>(),
+  highlightRef: createRef<HTMLDivElement>(),
+  inputValue: "",
+  onInputChange: vi.fn(),
+  onKeyDown: vi.fn(),
+  onCursorUpdate: vi.fn(),
+  onScroll: vi.fn(),
+  highlightSegments: [],
+  hasOverlay: false,
+  multiplePlaceholders: false,
+  placeholders: [] as string[],
+  resolvedDefaultPlaceholder: "Ask me anything",
+  inProgress: false,
+}
+
+describe("TextareaField placeholder rendering", () => {
+  it("renders the default placeholder when placeholders array is empty", () => {
+    render(<TextareaField {...defaultProps} placeholders={[]} />)
+
+    expect(screen.getByText("Ask me anything")).toBeInTheDocument()
+    expect(
+      screen.queryByTestId("typewriter-placeholder")
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders the custom placeholder when placeholders array has a single element", () => {
+    render(
+      <TextareaField
+        {...defaultProps}
+        placeholders={["What is my time off balance?"]}
+      />
+    )
+
+    expect(screen.getByText("What is my time off balance?")).toBeInTheDocument()
+    expect(screen.queryByText("Ask me anything")).not.toBeInTheDocument()
+  })
+
+  it("renders the TypewriterPlaceholder when there are multiple placeholders", () => {
+    render(
+      <TextareaField
+        {...defaultProps}
+        multiplePlaceholders={true}
+        placeholders={["First placeholder", "Second placeholder"]}
+      />
+    )
+
+    expect(screen.getByTestId("typewriter-placeholder")).toBeInTheDocument()
+    expect(screen.queryByText("Ask me anything")).not.toBeInTheDocument()
+  })
+
+  it("does not render any placeholder when there is input value", () => {
+    render(
+      <TextareaField
+        {...defaultProps}
+        inputValue="hello"
+        placeholders={["Custom placeholder"]}
+      />
+    )
+
+    expect(screen.queryByText("Custom placeholder")).not.toBeInTheDocument()
+    expect(screen.queryByText("Ask me anything")).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes a bug where `ChatTextarea` ignored the custom placeholder when the `placeholders` array from `useAiChat` contained exactly one element, always showing the default i18n placeholder instead.

## Problem

The placeholder rendering in `TextareaField` has two paths:

1. **Static `<p>` tag** — renders when `!multiplePlaceholders` (i.e. array length <= 1)
2. **`TypewriterPlaceholder`** — renders only when `multiplePlaceholders` (array length > 1)

When `placeholders` has exactly 1 item:
- `multiplePlaceholders` is `false` (since `1 > 1` is `false`)
- The static path fires but always renders `resolvedDefaultPlaceholder` (the i18n default text)
- The custom placeholder value is never used

## Fix

The static placeholder now checks if there's a single custom placeholder and displays it instead of the default:

```tsx
{placeholders.length === 1
  ? placeholders[0]
  : resolvedDefaultPlaceholder}
```

This keeps existing behavior intact:
- **0 placeholders** → default i18n text (static)
- **1 placeholder** → custom text (static) ← fixed
- **2+ placeholders** → typewriter animation cycling through all items

<img width="1179" height="566" alt="Screenshot 2026-05-18 at 08 34 59" src="https://github.com/user-attachments/assets/90e13d66-bac5-4aa9-aabe-af13f5d30706" />


[Task](https://factorialmakers.atlassian.net/browse/FCT-54127)