### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "2.6.1",
-  "packages/react-native": "0.53.0",
+  "packages/react-native": "0.54.0",
   "packages/core": "1.50.3"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.54.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.53.0...f0-react-native-v0.54.0) (2026-05-18)
+
+
+### Features
+
+* **react-native:** add F0WizardSteps component ([#4141](https://github.com/factorialco/f0/issues/4141)) ([a4f11e9](https://github.com/factorialco/f0/commit/a4f11e93a007c72cd7d521f34b440f0b141c12a1))
+
 ## [0.53.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.52.1...f0-react-native-v0.53.0) (2026-04-30)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.54.0</summary>

## [0.54.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.53.0...f0-react-native-v0.54.0) (2026-05-18)


### Features

* **react-native:** add F0WizardSteps component ([#4141](https://github.com/factorialco/f0/issues/4141)) ([a4f11e9](https://github.com/factorialco/f0/commit/a4f11e93a007c72cd7d521f34b440f0b141c12a1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).