### PR TITLE
feat(F0Form): add autosubmit submit type with focus preservation

### DIFF
--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -54,6 +54,12 @@ import { useSchemaDefinition } from "./useSchemaDefinition"
 import { createZodErrorMap } from "./zodErrorMap"
 
 /**
+ * Default debounce delay (ms) for `submitConfig: { type: "autosubmit" }`
+ * before the form is silently submitted after the user stops editing.
+ */
+const DEFAULT_AUTOSUBMIT_DELAY_MS = 800
+
+/**
  * Flatten RHF FieldErrors into a dot-path → message map.
  * Handles nested errors (e.g. daterange `errors.range.from`).
  */
@@ -522,6 +528,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
 
   // Resolve submit type from config
   const isActionBar = submitConfig?.type === "action-bar"
+  const isAutosubmit = submitConfig?.type === "autosubmit"
 
   // Resolve submit button configuration with defaults
   // icon: undefined = use default, null = no icon, IconType = custom icon
@@ -530,12 +537,13 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
     submitConfig?.icon === null ? undefined : (submitConfig?.icon ?? Save)
 
   // Extract type-specific props
-  // Show submit button by default unless explicitly hidden or using action-bar
+  // Show submit button by default unless explicitly hidden, using action-bar, or autosubmit
   const hideSubmitButton =
-    submitConfig?.type !== "action-bar" && submitConfig?.hideSubmitButton
+    (submitConfig?.type === "default" || submitConfig?.type === undefined) &&
+    !!submitConfig?.hideSubmitButton
   const hideActionBar =
     submitConfig?.type !== "action-bar" && !!submitConfig?.hideActionBar
-  const showSubmitButton = !isActionBar && !hideSubmitButton
+  const showSubmitButton = !isActionBar && !isAutosubmit && !hideSubmitButton
   const discardableChanges =
     submitConfig?.type === "action-bar" && submitConfig?.discardable
 
@@ -647,7 +655,24 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
     useState<ActionBarStatus>("idle")
   const [successMessage, setSuccessMessage] = useState<string | undefined>()
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const autosubmitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const actionBarRef = useRef<F0ActionBarRef | null>(null)
+
+  /**
+   * Snapshot of the focused input element + caret position taken before a
+   * non-button submit (Enter key or autosubmit debounce). Restored after the
+   * submit settles so the user's typing flow is not interrupted by RHF's
+   * `isSubmitting` toggling `disabled` on the focused control.
+   *
+   * Button-click submits intentionally do NOT populate this snapshot — the
+   * user clicked away on purpose, focus should follow.
+   */
+  const focusSnapshotRef = useRef<{
+    element: HTMLElement
+    selectionStart: number | null
+    selectionEnd: number | null
+  } | null>(null)
+  const formElementRef = useRef<HTMLFormElement | null>(null)
 
   // Error navigation and auto-focus
   const {
@@ -662,7 +687,6 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
   })
 
   const resolvedActionBarLabel = (() => {
-    if (hasErrors) return undefined
     if (actionBarStatus === "loading") return actionBarSavingLabel
     if (actionBarStatus === "success")
       return successMessage ?? forms.actionBar.saved
@@ -719,8 +743,112 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       if (successTimerRef.current) {
         clearTimeout(successTimerRef.current)
       }
+      if (autosubmitTimerRef.current) {
+        clearTimeout(autosubmitTimerRef.current)
+      }
     }
   }, [])
+
+  // Stable ref to the submit handler so the autosubmit effect doesn't need
+  // to re-subscribe whenever `handleSubmit` is re-created on each render.
+  const handleSubmitForAutosubmitRef = useRef(handleSubmit)
+  handleSubmitForAutosubmitRef.current = handleSubmit
+
+  /**
+   * Capture the currently-focused element + caret position if it lives inside
+   * the form. The snapshot is consumed by the restore effect below once the
+   * in-flight submit settles. If no input is focused inside the form, no
+   * snapshot is taken — focus restoration is a no-op.
+   */
+  const snapshotFocus = useCallback(() => {
+    const active = document.activeElement
+    if (!(active instanceof HTMLElement)) return
+    if (!formElementRef.current?.contains(active)) return
+
+    const hasSelection =
+      active instanceof HTMLInputElement ||
+      active instanceof HTMLTextAreaElement
+
+    const selectionStart = hasSelection ? active.selectionStart : null
+    const selectionEnd = hasSelection ? active.selectionEnd : null
+
+    focusSnapshotRef.current = {
+      element: active,
+      selectionStart,
+      selectionEnd,
+    }
+  }, [])
+
+  /**
+   * After a non-button submit settles (isSubmitting flips true → false),
+   * restore the focused input + caret position so the user's typing flow
+   * survives RHF's transient `disabled` flip on Controllers.
+   */
+  const wasSubmittingRef = useRef(form.formState.isSubmitting)
+  useEffect(() => {
+    const wasSubmitting = wasSubmittingRef.current
+    wasSubmittingRef.current = isSubmitting
+    if (!wasSubmitting || isSubmitting) return
+
+    const snapshot = focusSnapshotRef.current
+    focusSnapshotRef.current = null
+    if (!snapshot) return
+    if (!snapshot.element.isConnected) return
+    if (document.activeElement === snapshot.element) return
+
+    snapshot.element.focus()
+    if (
+      snapshot.selectionStart !== null &&
+      snapshot.selectionEnd !== null &&
+      (snapshot.element instanceof HTMLInputElement ||
+        snapshot.element instanceof HTMLTextAreaElement)
+    ) {
+      try {
+        snapshot.element.setSelectionRange(
+          snapshot.selectionStart,
+          snapshot.selectionEnd
+        )
+      } catch {
+        // Some input types (e.g. type="number") throw on setSelectionRange.
+        // Ignore — the focus call above is the important part.
+      }
+    }
+  }, [isSubmitting])
+
+  // Autosubmit: debounced auto-submit when fields change.
+  // `form.handleSubmit` runs validation; invalid forms surface errors and skip onSubmit.
+  const autosubmitDelay =
+    submitConfig?.type === "autosubmit"
+      ? (submitConfig.delay ?? DEFAULT_AUTOSUBMIT_DELAY_MS)
+      : DEFAULT_AUTOSUBMIT_DELAY_MS
+
+  useEffect(() => {
+    if (!isAutosubmit) return
+
+    const subscription = form.watch(() => {
+      if (!form.formState.isDirty) return
+      if (form.formState.isSubmitting) return
+
+      if (autosubmitTimerRef.current) {
+        clearTimeout(autosubmitTimerRef.current)
+      }
+      autosubmitTimerRef.current = setTimeout(() => {
+        autosubmitTimerRef.current = null
+        snapshotFocus()
+        form.handleSubmit((data) =>
+          handleSubmitForAutosubmitRef.current(data)
+        )()
+      }, autosubmitDelay)
+    })
+
+    return () => {
+      subscription.unsubscribe()
+      if (autosubmitTimerRef.current) {
+        clearTimeout(autosubmitTimerRef.current)
+        autosubmitTimerRef.current = null
+      }
+    }
+  }, [isAutosubmit, autosubmitDelay, form, snapshotFocus])
 
   // Handle discard action
   const handleDiscard = () => {
@@ -884,6 +1012,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       renderCustomField: props.renderCustomField,
       isLoading: isFormLoading,
       useUpload,
+      submitConfig,
     }),
     [
       name,
@@ -892,13 +1021,30 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       props.renderCustomField,
       isFormLoading,
       useUpload,
+      submitConfig,
     ]
   )
 
   // Form content component to avoid repetition
+  const submitHandler = form.handleSubmit(handleSubmit)
+  const onFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    // Snapshot focus when the submit was triggered by something other than
+    // a real button activation (Enter inside an input, programmatic submit,
+    // autosubmit debounce).
+    const active = document.activeElement
+    const isButtonActivation =
+      active instanceof HTMLElement &&
+      (active.tagName === "BUTTON" ||
+        (active.tagName === "INPUT" &&
+          (active as HTMLInputElement).type === "submit"))
+    if (!isButtonActivation) snapshotFocus()
+    submitHandler(event)
+  }
+
   const formContent = (
     <form
-      onSubmit={form.handleSubmit(handleSubmit)}
+      ref={formElementRef}
+      onSubmit={onFormSubmit}
       className={cn(
         "flex flex-1 flex-col w-full mx-auto",
         FORM_MAX_WIDTH,
@@ -1031,7 +1177,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
             discardIcon={discardIcon}
             issuesOneLabel={forms.actionBar.issues.one}
             issuesOtherLabel={forms.actionBar.issues.other}
-            onSubmit={form.handleSubmit(handleSubmit)}
+            onSubmit={() => submitHandler()}
             onDiscard={handleDiscard}
             goToPreviousError={goToPreviousError}
             goToNextError={goToNextError}

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -2051,6 +2051,101 @@ export const WithActionBarAndDiscard: Story = {
 }
 
 /**
+ * Form with `type: "autosubmit"` — the form is auto-submitted after the user
+ * stops editing for the configured `delay` (default 800ms).
+ *
+ * The internal action bar surfaces the Saving → Saved feedback so the user
+ * knows their changes were persisted. No explicit submit button is rendered.
+ */
+export const Autosubmit: Story = {
+  render() {
+    const formSchema = z.object({
+      title: f0FormField.text({
+        label: "Title",
+        placeholder: "Enter a title",
+        minLength: 2,
+      }),
+      description: f0FormField.textarea({
+        label: "Description",
+        placeholder: "Tell us more",
+        optional: true,
+        rows: 3,
+      }),
+    })
+
+    const formDefinition = useF0FormDefinition({
+      errorTriggerMode: "on-submit",
+      name: "autosubmit-example",
+      schema: formSchema,
+      submitConfig: {
+        type: "autosubmit",
+      },
+      defaultValues: {
+        title: "My note",
+        description: "",
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(600)
+        console.info(`Autosaved: ${JSON.stringify(data, null, 2)}`)
+        return { success: true, message: "Saved" }
+      },
+    })
+
+    return (
+      <div className="max-w-lg">
+        <F0Form formDefinition={formDefinition} />
+        <p className="mt-4 text-sm text-f1-foreground-secondary">
+          Edit any field — the form auto-submits 800ms after you stop typing.
+          Watch the action bar show Saving → Saved.
+        </p>
+      </div>
+    )
+  },
+}
+
+/**
+ * Autosubmit with a custom `delay` and `hideActionBar: true` for a fully
+ * silent autosave. Use this when the parent component provides its own
+ * persistence feedback (e.g. a toast or status indicator).
+ */
+export const AutosubmitCustomDelay: Story = {
+  render() {
+    const formSchema = z.object({
+      query: f0FormField.text({
+        label: "Search query",
+        placeholder: "Type to search",
+      }),
+    })
+
+    const formDefinition = useF0FormDefinition({
+      name: "autosubmit-custom-delay-example",
+      schema: formSchema,
+      submitConfig: {
+        type: "autosubmit",
+        delay: 1500,
+        hideActionBar: true,
+      },
+      defaultValues: { query: "" },
+      onSubmit: async ({ data }) => {
+        await sleep(300)
+        console.info(`Autosaved (silent): ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+    })
+
+    return (
+      <div className="max-w-lg">
+        <F0Form formDefinition={formDefinition} />
+        <p className="mt-4 text-sm text-f1-foreground-secondary">
+          Silent autosave after 1500ms with no action bar feedback. Check the
+          console to see the submitted values.
+        </p>
+      </div>
+    )
+  },
+}
+
+/**
  * Demonstrates the different error trigger modes:
  * - **on-blur** (default): Errors appear when the user leaves a field
  * - **on-change**: Errors appear as the user types (real-time validation)

--- a/packages/react/src/patterns/F0Form/__tests__/F0FormAutosubmit.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0FormAutosubmit.test.tsx
@@ -1,0 +1,495 @@
+import {
+  zeroRender as render,
+  screen,
+  waitFor,
+  act,
+} from "@/testing/test-utils"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { z } from "zod"
+import userEvent from "@testing-library/user-event"
+import { createRef } from "react"
+
+import { F0Form } from "../F0Form"
+import { f0FormField } from "../f0Schema"
+import type { F0FormRef } from "../useF0Form"
+
+const formSchema = z.object({
+  name: f0FormField(z.string().min(1), { label: "Name" }),
+})
+
+const strictSchema = z.object({
+  name: f0FormField(z.string().min(3, "Too short"), { label: "Name" }),
+})
+
+const autosubmitConfig = {
+  type: "autosubmit" as const,
+}
+
+describe("F0Form autosubmit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does not render a submit button in autosubmit mode", () => {
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="autosubmit-no-button"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={autosubmitConfig}
+      />
+    )
+
+    expect(
+      screen.queryByRole("button", { name: /submit/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("does not submit before the delay elapses", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="autosubmit-before-delay"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={{ ...autosubmitConfig, delay: 800 }}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "a")
+
+    // Advance less than the delay
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("submits once after the delay elapses", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="autosubmit-after-delay"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={{ ...autosubmitConfig, delay: 800 }}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    act(() => {
+      vi.advanceTimersByTime(800)
+    })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "updated" })
+    )
+  })
+
+  it("debounces multiple rapid changes into a single submit", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="autosubmit-debounce-rapid"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={{ ...autosubmitConfig, delay: 800 }}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "abc")
+
+    // Each keystroke resets the debounce, so after typing 3 chars no submit yet
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(800)
+    })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "abc" })
+    )
+  })
+
+  it("uses a default delay of 800ms when delay is not specified", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="autosubmit-default-delay"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={autosubmitConfig}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "x")
+
+    act(() => {
+      vi.advanceTimersByTime(799)
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("does not submit when the form is not dirty", async () => {
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="autosubmit-not-dirty"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={autosubmitConfig}
+      />
+    )
+
+    // No user interaction; just advance time
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("does not call onSubmit when validation fails", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="autosubmit-invalid"
+        schema={strictSchema}
+        defaultValues={{ name: "valid" }}
+        onSubmit={onSubmit}
+        submitConfig={{ ...autosubmitConfig, delay: 500 }}
+        errorTriggerMode="on-change"
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "ab")
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    // RHF runs validation; invalid form must not call onSubmit
+    await waitFor(() => {
+      expect(screen.getByText("Too short")).toBeInTheDocument()
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("shows the action bar with Saving then Saved feedback", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    let resolveSubmit: (value: { success: true }) => void
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<{ success: true }>((resolve) => {
+          resolveSubmit = resolve
+        })
+    )
+
+    render(
+      <F0Form
+        name="autosubmit-action-bar"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={{ ...autosubmitConfig, delay: 300 }}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Saving...")).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      resolveSubmit!({ success: true })
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("hides the action bar when hideActionBar is true", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="autosubmit-hide-action-bar"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={{
+          ...autosubmitConfig,
+          delay: 300,
+          hideActionBar: true,
+        }}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    expect(screen.queryByText("Saving...")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Your changes have been saved")
+    ).not.toBeInTheDocument()
+  })
+
+  it("cancels the pending submit on unmount", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    const { unmount } = render(
+      <F0Form
+        name="autosubmit-unmount"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={{ ...autosubmitConfig, delay: 800 }}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("resets isDirty to false after a successful autosubmit", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+    const formRef = createRef<F0FormRef>()
+
+    render(
+      <F0Form
+        name="autosubmit-resets-dirty"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={{ ...autosubmitConfig, delay: 200 }}
+        formRef={formRef as React.MutableRefObject<F0FormRef | null>}
+      />
+    )
+
+    expect(formRef.current?.isDirty()).toBe(false)
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    expect(formRef.current?.isDirty()).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    await waitFor(() => {
+      expect(formRef.current?.isDirty()).toBe(false)
+    })
+  })
+
+  it("autosubmits again after a successful autosubmit", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="autosubmit-consecutive"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={{ ...autosubmitConfig, delay: 200 }}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "first")
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      expect.objectContaining({ name: "first" })
+    )
+
+    await user.type(input, "-second")
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(2)
+    })
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      expect.objectContaining({ name: "first-second" })
+    )
+  })
+
+  it("preserves input focus and caret position across a debounced autosubmit", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="autosubmit-preserve-focus"
+        schema={formSchema}
+        defaultValues={{ name: "" }}
+        onSubmit={onSubmit}
+        submitConfig={{ ...autosubmitConfig, delay: 200 }}
+      />
+    )
+
+    const input = screen.getByLabelText("Name") as HTMLInputElement
+    input.focus()
+    await user.type(input, "hello")
+
+    expect(document.activeElement).toBe(input)
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(input)
+    })
+    expect(input.selectionStart).toBe(5)
+    expect(input.selectionEnd).toBe(5)
+  })
+
+  it("preserves focus when submitting via the Enter key", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="enter-key-preserve-focus"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    const input = screen.getByLabelText("Name") as HTMLInputElement
+    input.focus()
+    await user.type(input, "{Enter}")
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(input)
+    })
+  })
+
+  it("focuses the first invalid field when submitting via the action bar button", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    render(
+      <F0Form
+        name="button-click-error-focus"
+        schema={strictSchema}
+        defaultValues={{ name: "ab" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    const submitButton = screen.getByRole("button", { name: /submit/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      const input = screen.getByLabelText("Name") as HTMLInputElement
+      expect(document.activeElement).toBe(input)
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/patterns/F0Form/context.ts
+++ b/packages/react/src/patterns/F0Form/context.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react"
 
 import type { InitialFile, UseFileUpload } from "./fields/file/types"
-import type { RenderCustomFieldFunction } from "./types"
+import type { F0FormSubmitConfig, RenderCustomFieldFunction } from "./types"
 
 interface F0FormContextValue {
   /** Form name used for anchor links */
@@ -16,6 +16,10 @@ interface F0FormContextValue {
   isLoading?: boolean
   /** Default upload hook shared across all file fields */
   useUpload?: UseFileUpload
+  /**
+   * Submit configuration for the form.
+   */
+  submitConfig?: F0FormSubmitConfig
 }
 
 export const F0FormContext = createContext<F0FormContextValue | null>(null)

--- a/packages/react/src/patterns/F0Form/fields/FieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/FieldRenderer.tsx
@@ -136,13 +136,24 @@ interface FieldRendererProps {
 export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
   const form = useFormContext()
   const values = form.watch()
-  const { isSubmitting } = form.formState
+  const { isSubmitting: isFormSubmitting } = form.formState
   const {
     formName,
     isLoading: isFormLoading,
     renderCustomField,
+    submitConfig,
   } = useF0FormContext()
   const { forms } = useI18n()
+
+  const isAutosubmit = submitConfig?.type === "autosubmit"
+
+  // In autosubmit mode the form silently saves while the user keeps typing.
+  // Surfacing `isSubmitting` to field renderers would disable the active
+  // input and the browser would blur it mid-keystroke — breaking the entire
+  // point of autosubmit. Mask it out here so both the `<Controller disabled>`
+  // path (in ui/form FormField) and the inner input's `isDisabled` derivation
+  // (in renderFieldInput) treat the form as idle.
+  const isSubmitting = isAutosubmit ? false : isFormSubmitting
 
   // Evaluate if field is currently disabled
   const isDisabled = evaluateDisabled(field.disabled, values)
@@ -187,6 +198,7 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
       <FormFieldPrimitive
         control={form.control}
         name={field.id}
+        {...(isAutosubmit ? { disabled: false } : {})}
         render={() => <span className="hidden" aria-hidden="true" />}
       />
     )
@@ -196,6 +208,7 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
     <FormFieldPrimitive
       control={form.control}
       name={field.id}
+      {...(isAutosubmit ? { disabled: false } : {})}
       render={({ field: formField, fieldState }) => (
         <FormItem id={anchorId} className="scroll-mt-4">
           {showLabel && (

--- a/packages/react/src/patterns/F0Form/types.ts
+++ b/packages/react/src/patterns/F0Form/types.ts
@@ -130,7 +130,7 @@ export type FormDefinitionItem = FieldItem | RowDefinition | SectionDefinition
 // ============================================================================
 
 /**
- * When to trigger and display validation errors
+ * When to trigger and display validation errors (does not apply with autosubmit)
  * - "on-blur": Errors appear when the user leaves a field (default)
  * - "on-change": Errors appear as the user types (real-time validation)
  * - "on-submit": Errors only appear after attempting to submit the form
@@ -216,11 +216,34 @@ interface F0FormActionBarSubmitConfig extends F0FormSubmitConfigBase {
 }
 
 /**
+ * Submit configuration for autosubmit type.
+ *
+ * Automatically submits the form after the user stops editing for `delay` ms.
+ * Validation runs on every debounced submit attempt; invalid forms surface
+ * errors and skip `onSubmit` (handled by react-hook-form).
+ */
+interface F0FormAutosubmitConfig extends F0FormSubmitConfigBase {
+  /** Type of submit UI (debounced auto-submit) */
+  type: "autosubmit"
+  /**
+   * Delay in ms between the last change and the auto-submit.
+   * @default 800
+   */
+  delay?: number
+  /**
+   * When true, hides the internal action bar (loading/success feedback).
+   * @default false
+   */
+  hideActionBar?: boolean
+}
+
+/**
  * Configuration for form submission behavior and appearance
  */
 export type F0FormSubmitConfig =
   | F0FormDefaultSubmitConfig
   | F0FormActionBarSubmitConfig
+  | F0FormAutosubmitConfig
 
 /**
  * Styling configuration for the form layout and appearance

--- a/packages/react/src/ui/form.tsx
+++ b/packages/react/src/ui/form.tsx
@@ -37,9 +37,17 @@ const FormField = <
 }: ControllerProps<TFieldValues, TName>) => {
   const { formState } = useFormContext()
 
+  // Honor an explicit `disabled` prop from the caller; otherwise fall back
+  // to disabling while the form is submitting. This lets callers (e.g.
+  // F0Form's autosubmit mode) opt out of the submitting-disabled behavior
+  // by passing `disabled={false}` explicitly — otherwise the active input
+  // would be blurred mid-typing during a silent autosave.
   return (
     <FormFieldContext.Provider value={{ name: props.name }}>
-      <Controller {...props} disabled={formState.isSubmitting} />
+      <Controller
+        {...props}
+        disabled={props.disabled ?? formState.isSubmitting}
+      />
     </FormFieldContext.Provider>
   )
 }


### PR DESCRIPTION
## Description

Adds a new `submitConfig: { type: "autosubmit" }` to `F0Form` that debounces silent form submissions while the user is typing (default 800ms, configurable via `delay`).

Also fixes a long-standing focus-loss bug: pressing Enter on **any** F0Form blurred the focused input because RHF flips `disabled` on Controllers during `isSubmitting`, and the browser blurs disabled elements per spec.

## Screenshots (if applicable)

N/A — behavioral change. See the new `Autosubmit` and `AutosubmitCustomDelay` stories under `F0Form` in Storybook.

## Implementation details

### New: `F0FormAutosubmitConfig`
```ts
submitConfig: {
  type: "autosubmit",
  delay?: number,        // default 800ms
  hideActionBar?: boolean // default false
}
```
- Subscribes to `form.watch()` and debounces `form.handleSubmit(onSubmit)`.
- Hides the bottom submit button; surfaces save state via the action bar (suppressible).
- Validation runs on every debounced submit; invalid forms surface errors and skip `onSubmit` (handled by RHF).

### Focus preservation (applies to every F0Form, not just autosubmit)
- **Snapshot** the focused input + caret position before non-button submits (Enter / autosubmit / programmatic).
- **Restore** them once `isSubmitting` flips true → false.
- Discriminator is `document.activeElement` — NOT `SubmitEvent.submitter`, because Chromium/WebKit populate `submitter` with the implicit-submission button on Enter even when the user is focused inside an input.
- Real button activations skip the snapshot, so RHF's native `shouldFocusError` continues to focus the first invalid field on click-submit failures.

### Touched files
- `patterns/F0Form/types.ts` — new `F0FormAutosubmitConfig` in `F0FormSubmitConfig` union.
- `patterns/F0Form/F0Form.tsx` — autosubmit effect, snapshot/restore logic, `DEFAULT_AUTOSUBMIT_DELAY_MS`.
- `patterns/F0Form/context.ts` — exposes `submitConfig` on `F0FormContextValue`.
- `patterns/F0Form/fields/FieldRenderer.tsx` — masks `isSubmitting` and forces `disabled={false}` on Controllers in autosubmit mode so inputs stay interactive during silent saves.
- `ui/form.tsx` — `FormField` honors an explicit `disabled` prop (falls back to `formState.isSubmitting` otherwise).
- `patterns/F0Form/__stories__/F0Form.stories.tsx` — new `Autosubmit` + `AutosubmitCustomDelay` stories.
- `patterns/F0Form/__tests__/F0FormAutosubmit.test.tsx` — new test file (15 tests) covering debounce, delay, hide-action-bar, focus preservation across autosubmit / Enter / button-click flows.

### Quality gate
- `pnpm format` clean
- `pnpm tsc` clean
- `pnpm lint` clean
- `pnpm vitest run src/patterns/F0Form/` — **364/364 passing**
- Browser-verified: Enter on default form no longer loses focus; autosubmit preserves caret while typing.