### PR TITLE
feat: fix number input min cap onblur

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/NumberInput/__tests__/NumberInput.test.tsx
+++ b/packages/react/src/experimental/Forms/Fields/NumberInput/__tests__/NumberInput.test.tsx
@@ -181,5 +181,123 @@ describe("NumberInput", () => {
       expect(input).toHaveValue("17,")
       expect(onChange).toHaveBeenLastCalledWith(17)
     })
+
+    test("normalizes trailing separator on blur", async () => {
+      const onChange = vi.fn()
+      render(
+        <NumberInput
+          locale="en-US"
+          maxDecimals={2}
+          onChange={onChange}
+          label="Number Input"
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "17.")
+      expect(input).toHaveValue("17.")
+
+      await userEvent.tab()
+      expect(input).toHaveValue("17")
+    })
+  })
+
+  describe("min/max clamp on blur", () => {
+    test("allows typing values below min during editing", async () => {
+      const onChange = vi.fn()
+      render(
+        <NumberInput
+          locale="en-US"
+          min={100}
+          onChange={onChange}
+          label="Number Input"
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "5")
+
+      expect(input).toHaveValue("5")
+      expect(onChange).toHaveBeenLastCalledWith(5)
+    })
+
+    test("clamps value to min on blur", async () => {
+      const onChange = vi.fn()
+      render(
+        <NumberInput
+          locale="en-US"
+          min={100}
+          onChange={onChange}
+          label="Number Input"
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "5")
+      expect(input).toHaveValue("5")
+
+      await userEvent.tab()
+      expect(input).toHaveValue("100")
+      expect(onChange).toHaveBeenLastCalledWith(100)
+    })
+
+    test("allows typing values above max during editing", async () => {
+      const onChange = vi.fn()
+      render(
+        <NumberInput
+          locale="en-US"
+          max={50}
+          onChange={onChange}
+          label="Number Input"
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "999")
+
+      expect(input).toHaveValue("999")
+      expect(onChange).toHaveBeenLastCalledWith(999)
+    })
+
+    test("clamps value to max on blur", async () => {
+      const onChange = vi.fn()
+      render(
+        <NumberInput
+          locale="en-US"
+          max={50}
+          onChange={onChange}
+          label="Number Input"
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "999")
+      expect(input).toHaveValue("999")
+
+      await userEvent.tab()
+      expect(input).toHaveValue("50")
+      expect(onChange).toHaveBeenLastCalledWith(50)
+    })
+
+    test("does not clamp values within bounds on blur", async () => {
+      const onChange = vi.fn()
+      render(
+        <NumberInput
+          locale="en-US"
+          min={10}
+          max={100}
+          onChange={onChange}
+          label="Number Input"
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "50")
+      expect(input).toHaveValue("50")
+
+      await userEvent.tab()
+      expect(input).toHaveValue("50")
+      expect(onChange).toHaveBeenLastCalledWith(50)
+    })
   })
 })

--- a/packages/react/src/experimental/Forms/Fields/NumberInput/internal.tsx
+++ b/packages/react/src/experimental/Forms/Fields/NumberInput/internal.tsx
@@ -39,9 +39,15 @@ export const NumberInputInternal = forwardRef<
     value != null ? formatValue(value, locale, maxDecimals) : ""
   )
 
+  const {
+    onBlur: externalOnBlur,
+    onPressEnter: externalOnPressEnter,
+    ...restProps
+  } = props
+
   const localHint = useMemo(() => {
-    if (props.hint !== undefined) {
-      return props.hint
+    if (restProps.hint !== undefined) {
+      return restProps.hint
     }
     if (min != null && max != null) {
       return i18n.t("numberInput.between", { min, max })
@@ -54,7 +60,7 @@ export const NumberInputInternal = forwardRef<
     }
     return undefined
     // eslint-disable-next-line react-hooks/exhaustive-deps -- We don't need to re-render when the i18n changes
-  }, [min, max, props.hint])
+  }, [min, max, restProps.hint])
 
   const handleBeforeInput = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
@@ -80,40 +86,53 @@ export const NumberInputInternal = forwardRef<
 
   const handleChange = (value: string) => {
     const extractedData = extractNumber(value, { maxDecimals })
-    if (!extractedData) {
-      return
-    }
+    if (!extractedData) return
 
     const { value: parsedValue } = extractedData
 
-    /**
-     * Apply min and max constraints
-     */
     if (parsedValue === null) {
       setFieldValue("")
       onChange?.(null)
       return
     }
 
+    // Preserve raw input during typing. Min/max constraints are applied
+    // on blur/enter so the user can type intermediate values freely.
+    setFieldValue(extractedData.formattedValue)
+    onChange?.(parsedValue)
+  }
+
+  // Clamp and reformat when the user commits (blur or Enter).
+  // Normalizes trailing separators (e.g. "17." → "17") and enforces min/max.
+  const commitValue = useCallback(() => {
+    const extractedData = extractNumber(fieldValue, { maxDecimals })
+    if (extractedData?.value == null) return
+
     const clampedValue = Math.max(
       min ?? -Infinity,
-      Math.min(max ?? Infinity, parsedValue)
+      Math.min(max ?? Infinity, extractedData.value)
     )
 
-    // When clamping didn't change the value, preserve the user's raw input
-    // (e.g. "17." stays as "17." instead of being reformatted to "17").
-    if (clampedValue === parsedValue) {
-      setFieldValue(extractedData.formattedValue)
-      onChange?.(parsedValue)
-      return
+    setFieldValue(formatValue(clampedValue, locale, maxDecimals))
+    if (clampedValue !== extractedData.value) {
+      onChange?.(clampedValue)
     }
+  }, [fieldValue, maxDecimals, min, max, onChange, locale])
 
-    const clampedData = extractNumber(clampedValue.toString(), {
-      maxDecimals,
-    })
-    setFieldValue(clampedData?.formattedValue ?? "")
-    onChange?.(clampedData?.value ?? null)
-  }
+  const handleBlur = useCallback(() => {
+    commitValue()
+    externalOnBlur?.()
+  }, [commitValue, externalOnBlur])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        commitValue()
+        externalOnPressEnter?.()
+      }
+    },
+    [commitValue, externalOnPressEnter]
+  )
 
   const handleStep = (type: "increase" | "decrease") => () => {
     if (!step) return
@@ -147,7 +166,9 @@ export const NumberInputInternal = forwardRef<
         value={fieldValue}
         inputMode={maxDecimals === 0 ? "numeric" : "decimal"}
         onChange={handleChange}
-        {...props}
+        {...restProps}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
         onBeforeInput={handleBeforeInput}
         hint={localHint}
         appendTag={units}
@@ -155,7 +176,7 @@ export const NumberInputInternal = forwardRef<
           step ? (
             <Arrows
               step={step}
-              disabled={props.disabled}
+              disabled={restProps.disabled}
               onClickArrow={handleStep}
             />
           ) : undefined


### PR DESCRIPTION
## Description

Defer min/max clamping to blur instead of applying it on every keystroke. Previously, NumberInput enforced min/max constraints in `handleChange`, which made it impossible to type intermediate values (e.g., deleting digits from "2283" to type "3000" would instantly clamp "2" back to "2283"). Now users can type freely and constraints are enforced on commit (blur or Enter).

Fixes FCT-54384: goal progress value snaps back to original when startValue != 0.

## Screenshots (if applicable)

N/A — behavioral fix, no visual changes.

## Implementation details

- Removed real-time clamping from `handleChange` — it now preserves raw input and emits the unclamped value via `onChange`.
- Added `commitValue()` that clamps + reformats on blur and Enter (also normalizes trailing decimal separators like "17." → "17").
- Wired `onPressEnter` handling via `onKeyDown` since the raw `Input` component doesn't accept `onPressEnter` directly.
- Step buttons still validate bounds before calling `handleChange` (no behavior change there).
- Added tests for: typing below min during editing, clamping on blur (min/max), trailing separator normalization on blur.