### PR TITLE
feat(F0Alert): make description prop optional

### DIFF
--- a/packages/react/src/components/F0Alert/F0Alert.tsx
+++ b/packages/react/src/components/F0Alert/F0Alert.tsx
@@ -87,7 +87,12 @@ const _F0Alert = ({
       >
         <div className="flex flex-row gap-2">
           <div className="flex flex-1 flex-col items-start gap-3 @xs:flex-row @xs:items-center @xs:justify-between">
-            <div className="flex flex-row gap-2">
+            <div
+              className={cn(
+                "flex flex-row gap-2",
+                !description && "items-center"
+              )}
+            >
               <div className="h-6 w-6 flex-shrink-0">
                 {variant === "neutral" ? (
                   <F0AvatarIcon icon={icon || Placeholder} size="sm" />
@@ -97,9 +102,11 @@ const _F0Alert = ({
               </div>
               <div className="flex flex-col gap-0.5">
                 <p className={titleVariants({ variant })}>{title}</p>
-                <p className="text-base text-f1-foreground-secondary">
-                  {description}
-                </p>
+                {description && (
+                  <p className="text-base text-f1-foreground-secondary">
+                    {description}
+                  </p>
+                )}
               </div>
             </div>
             {(action || link) && (

--- a/packages/react/src/components/F0Alert/types.ts
+++ b/packages/react/src/components/F0Alert/types.ts
@@ -12,7 +12,7 @@ export type AlertVariant = (typeof alertVariantOptions)[number]
 
 export interface F0AlertProps {
   title: string
-  description: string
+  description?: string
   action?: {
     label: string
     disabled?: boolean


### PR DESCRIPTION
## Summary

- Makes the `description` prop on `F0Alert` optional so consumers can render a title-only alert.
- When `description` is omitted, the title vertically centers with the avatar icon to avoid an off-center single-line layout; the original top alignment is preserved when a description is present.

## Changes

- `packages/react/src/components/F0Alert/types.ts` — `description: string` → `description?: string`.
- `packages/react/src/components/F0Alert/F0Alert.tsx` — conditionally render the description paragraph and apply `items-center` to the avatar+text row only when there's no description.

## Notes

- Non-breaking: loosens a required prop to optional.
- Format, typecheck, lint and existing F0Alert tests all pass locally.