### PR TITLE
feat: qa table changes

### DIFF
--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -449,6 +449,76 @@ export const WithPersonTags: Story = {
   },
 }
 
+export const WithStatusTags: Story = {
+  args: {
+    label: "Status",
+    placeholder: "Select a status",
+    onChange: fn(),
+    value: "pending",
+    options: [
+      {
+        value: "draft",
+        label: "Draft",
+        tag: { type: "status", text: "Draft", variant: "neutral" },
+      },
+      {
+        value: "pending",
+        label: "Pending",
+        tag: { type: "status", text: "Pending", variant: "warning" },
+      },
+      {
+        value: "approved",
+        label: "Approved",
+        tag: { type: "status", text: "Approved", variant: "positive" },
+      },
+      {
+        value: "rejected",
+        label: "Rejected",
+        tag: { type: "status", text: "Rejected", variant: "critical" },
+      },
+    ],
+  },
+}
+
+export const WithPersonAvatar: Story = {
+  args: {
+    label: "Select a reviewer",
+    placeholder: "Select a reviewer",
+    onChange: fn(),
+    value: "isabella",
+    options: [
+      {
+        value: "isabella",
+        label: "Isabella Tangari",
+        description: "Product Designer",
+        avatar: {
+          type: "person",
+          firstName: "Isabella",
+          lastName: "Tangari",
+        },
+      },
+      {
+        value: "saul",
+        label: "Saul Dominguez",
+        avatar: {
+          type: "person",
+          firstName: "Saul",
+          lastName: "Dominguez",
+        },
+      },
+      {
+        value: "marta",
+        label: "Marta Serrano",
+        avatar: {
+          type: "person",
+          firstName: "Marta",
+          lastName: "Serrano",
+        },
+      },
+    ],
+  },
+}
+
 export const WithPlaceholder: Story = {
   args: {
     label: "Select a theme",

--- a/packages/react/src/components/F0Select/components/SelectItem.tsx
+++ b/packages/react/src/components/F0Select/components/SelectItem.tsx
@@ -4,6 +4,8 @@ import { OneEllipsis } from "@/lib/OneEllipsis"
 import { F0TagDot } from "@/components/tags/F0TagDot"
 import { F0TagPerson } from "@/components/tags/F0TagPerson"
 import { F0TagRaw } from "@/components/tags/F0TagRaw"
+import { F0TagStatus } from "@/components/tags/F0TagStatus"
+import type { StatusVariant } from "@/components/tags/F0TagStatus/types"
 import { SelectItem as SelectItemPrimitive } from "@/ui/Select"
 
 import { F0SelectItemObject } from "../types"
@@ -13,6 +15,29 @@ export const SelectItem = <T extends string, R>({
 }: {
   item: F0SelectItemObject<T, R>
 }) => {
+  const isStatusOnly =
+    item.tag &&
+    typeof item.tag !== "string" &&
+    item.tag.type === "status" &&
+    !item.avatar &&
+    !item.icon &&
+    !item.description
+
+  if (isStatusOnly) {
+    const tag = item.tag as {
+      type: "status"
+      text: string
+      variant: StatusVariant
+    }
+    return (
+      <SelectItemPrimitive value={String(item.value)} disabled={item.disabled}>
+        <div className="flex w-full items-center">
+          <F0TagStatus text={tag.text} variant={tag.variant} />
+        </div>
+      </SelectItemPrimitive>
+    )
+  }
+
   return (
     <SelectItemPrimitive value={String(item.value)} disabled={item.disabled}>
       <div
@@ -44,6 +69,8 @@ export const SelectItem = <T extends string, R>({
               <F0TagRaw text={item.tag} />
             ) : item.tag.type === "dot" ? (
               <F0TagDot {...item.tag} />
+            ) : item.tag.type === "status" ? (
+              <F0TagStatus text={item.tag.text} variant={item.tag.variant} />
             ) : (
               <F0TagPerson name={item.tag.name} src={item.tag.src} />
             )}

--- a/packages/react/src/components/F0Select/components/SelectedItems.tsx
+++ b/packages/react/src/components/F0Select/components/SelectedItems.tsx
@@ -1,6 +1,8 @@
 import { forwardRef } from "react"
 
+import { F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Icon } from "@/components/F0Icon"
+import { F0TagStatus } from "@/components/tags/F0TagStatus"
 import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 
@@ -115,8 +117,28 @@ export const SelectedItems = forwardRef<HTMLDivElement, SelectValueProps>(
       return null
     }
 
+    if (
+      selectedItem.tag &&
+      typeof selectedItem.tag !== "string" &&
+      selectedItem.tag.type === "status"
+    ) {
+      return (
+        <div className="flex min-w-0 flex-1 justify-start" ref={ref}>
+          <F0TagStatus
+            text={selectedItem.tag.text}
+            variant={selectedItem.tag.variant}
+          />
+        </div>
+      )
+    }
+
     return (
       <div className="flex min-w-0 flex-1 justify-start gap-1.5" ref={ref}>
+        {selectedItem.avatar && (
+          <div className="flex shrink-0 items-center">
+            <F0Avatar avatar={selectedItem.avatar} size="xs" />
+          </div>
+        )}
         {selectedItem.icon && (
           <div className="h-5 shrink-0 text-f1-icon">
             <F0Icon icon={selectedItem.icon} />

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -1,6 +1,7 @@
 import type { AvatarVariant } from "@/components/avatars/F0Avatar"
 import type { IconType } from "@/components/F0Icon"
 import type { NewColor } from "@/components/tags/F0TagDot/types"
+import type { StatusVariant } from "@/components/tags/F0TagStatus/types"
 import type {
   DataSourceDefinition,
   FiltersDefinition,
@@ -180,6 +181,7 @@ export type F0SelectTagProp =
   | string
   | { type: "dot"; text: string; color: NewColor }
   | { type: "person"; name: string; src?: string }
+  | { type: "status"; text: string; variant: StatusVariant }
 
 export type F0SelectItemObject<T, R = unknown> = {
   type?: "item"

--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -46,6 +46,13 @@ interface TableCellProps {
   width?: number | "auto"
 
   /**
+   * Optional minimum width for the cell. When provided, overrides the
+   * minWidth derived from `width`, allowing the cell to shrink no further
+   * than this value.
+   */
+  minWidth?: number | "auto"
+
+  /**
    * When true, the header cell will stick in the specified position when scrolling horizontally
    * @default undefined
    */
@@ -99,6 +106,7 @@ export function TableCell({
   href,
   onClick,
   width = "auto",
+  minWidth,
   firstCell = false,
   sticky,
   colSpan,
@@ -118,6 +126,7 @@ export function TableCell({
   const stickyRight = sticky?.right
 
   const colWidth = getColWidth(width)
+  const colMinWidth = minWidth !== undefined ? getColWidth(minWidth) : colWidth
 
   const linkRef = useRef<HTMLAnchorElement>(null)
   const depth = nestedRowProps?.depth ?? 0
@@ -146,7 +155,7 @@ export function TableCell({
       style={{
         width: colWidth,
         maxWidth: colWidth,
-        minWidth: colWidth,
+        minWidth: colMinWidth,
         left: stickyLeft,
         right: stickyRight,
       }}

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -21,6 +21,13 @@ interface TableHeadProps {
   width?: ColumnWidth
 
   /**
+   * Optional minimum width for the header cell. When provided, overrides the
+   * minWidth derived from `width`, allowing the column to grow past `width`
+   * while never shrinking below this value.
+   */
+  minWidth?: ColumnWidth
+
+  /**
    * When true, the header cell will stick in the specified position when scrolling horizontally
    * @default undefined
    */
@@ -77,6 +84,7 @@ interface TableHeadProps {
 export function TableHead({
   children,
   width = "auto",
+  minWidth,
   sortState = "none",
   onSortClick,
   info,
@@ -187,6 +195,7 @@ export function TableHead({
   )
 
   const colWidth = getColWidth(width)
+  const colMinWidth = minWidth !== undefined ? getColWidth(minWidth) : colWidth
 
   return (
     <TableHeadRoot
@@ -206,7 +215,7 @@ export function TableHead({
       style={{
         width: colWidth,
         maxWidth: colWidth,
-        minWidth: colWidth,
+        minWidth: colMinWidth,
         left: stickyLeft,
         right: stickyRight,
       }}

--- a/packages/react/src/experimental/OneTable/index.stories.tsx
+++ b/packages/react/src/experimental/OneTable/index.stories.tsx
@@ -84,6 +84,31 @@ const sampleData = [
   },
 ]
 
+export const MinWidth: Story = {
+  render: () => (
+    <OneTable>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead minWidth={500}>Role (minWidth 500)</TableHead>
+          <TableHead>Manager</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {sampleData.map((row) => (
+          <TableRow key={row.id}>
+            <TableCell>{row.name}</TableCell>
+            <TableCell>{row.email}</TableCell>
+            <TableCell>{row.role}</TableCell>
+            <TableCell>{row.manager}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </OneTable>
+  ),
+}
+
 export const Default: Story = {
   render: () => (
     <OneTable>

--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -113,6 +113,13 @@ export type DataSourceDefinition<
     item: R
     pagination?: ChildrenPaginationInfo
   }) => number | undefined
+  /**
+   * Item ids that start expanded on first render. Rows matched here have
+   * their children fetched eagerly. Only rows whose `item.id` is in this
+   * list are auto-expanded — nested descendants are not, unless their own id
+   * is also included. Defaults to none.
+   */
+  defaultExpandedIds?: Array<string | number>
 }
 
 /**

--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -1326,6 +1326,7 @@ export const ExampleComponent = ({
   tmpFullWidth,
   nestedRecords = false,
   nestedRecordsType = "basic",
+  defaultExpandedIds,
   csvExport,
 }: {
   useObservable?: boolean
@@ -1382,6 +1383,7 @@ export const ExampleComponent = ({
   tmpFullWidth?: boolean
   nestedRecords?: boolean
   nestedRecordsType?: "basic" | "detailed" | "mixed"
+  defaultExpandedIds?: Array<string | number>
   csvExport?: boolean | { filename?: string }
 }) => {
   // Create a cache instance to simulate Apollo cache behavior
@@ -1517,6 +1519,7 @@ export const ExampleComponent = ({
             }
           : { records: [] }
       },
+      defaultExpandedIds,
       lanes: [
         { id: "eng", filters: { department: ["Engineering"] } },
         { id: "prod", filters: { department: ["Product"] } },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -1069,6 +1069,79 @@ export const EditableTableWithDateCell: Story = {
   },
 }
 
+export const EditableTableWithDateCellMinMax: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Editable date cells constrained with `dateConfig.minDate` / `dateConfig.maxDate`. Dates outside the range are disabled in the picker.",
+      },
+    },
+  },
+  render: () => {
+    const { dataAdapter, onCellChange } = useEditableTableData()
+
+    const baseOptions = (
+      getMockVisualizations().editableTable as Extract<
+        ReturnType<typeof getMockVisualizations>["editableTable"],
+        { type: "editableTable" }
+      >
+    ).options
+
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const oneYearOut = new Date(today)
+    oneYearOut.setFullYear(oneYearOut.getFullYear() + 1)
+
+    return (
+      <ExampleComponent
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              ...baseOptions,
+              columns: [
+                {
+                  label: "Name",
+                  render: (item: MockUser) => ({
+                    type: "person" as const,
+                    value: {
+                      firstName: item.name.split(" ")[0],
+                      lastName: item.name.split(" ")[1],
+                    },
+                  }),
+                  id: "name",
+                },
+                {
+                  label: "Start date (no past dates)",
+                  id: "startDate",
+                  render: (item: MockUser) =>
+                    format(item.joinedAt, "yyyy-MM-dd"),
+                  editType: () => "date" as const,
+                  inputPlaceholder: "DD/MM/YYYY",
+                  dateConfig: { minDate: today },
+                },
+                {
+                  label: "End date (today → +1y)",
+                  id: "endDate",
+                  render: (item: MockUser) =>
+                    format(item.joinedAt, "yyyy-MM-dd"),
+                  editType: () => "date" as const,
+                  inputPlaceholder: "DD/MM/YYYY",
+                  dateConfig: { minDate: today, maxDate: oneYearOut },
+                },
+              ],
+              onCellChange,
+            },
+          },
+        ]}
+        dataAdapter={dataAdapter}
+        id="editable-table-date-min-max/v1"
+      />
+    )
+  },
+}
+
 export const TableAndEditableTable: Story = {
   parameters: {
     docs: {
@@ -1418,6 +1491,120 @@ export const DynamicUnitsPerRow: Story = {
           },
         ]}
         id="editable-table-dynamic-units/v1"
+      />
+    )
+  },
+}
+
+/**
+ * Shows a select column whose options carry a `status` tag. The cell trigger
+ * renders the matching status pill (instead of plain text), and each option in
+ * the dropdown is shown with its pill — a "pill picker" UX.
+ */
+export const EditableTableWithStatusPillSelect: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Select column where each option carries a `tag: { type: 'status' }`. The closed cell trigger renders a status pill (matching what a non-editable `type: 'status'` cell would show), and the dropdown options show pills too.",
+      },
+    },
+  },
+  render: () => {
+    type RequestStatus = "draft" | "pending" | "approved" | "rejected"
+
+    const STATUS_LABEL: Record<RequestStatus, string> = {
+      draft: "Draft",
+      pending: "Pending",
+      approved: "Approved",
+      rejected: "Rejected",
+    }
+    const STATUS_VARIANT: Record<
+      RequestStatus,
+      "neutral" | "warning" | "positive" | "critical"
+    > = {
+      draft: "neutral",
+      pending: "warning",
+      approved: "positive",
+      rejected: "critical",
+    }
+    const STATUS_VALUES: RequestStatus[] = [
+      "draft",
+      "pending",
+      "approved",
+      "rejected",
+    ]
+
+    const initialItems = [
+      { id: "r-1", index: 0, name: "Headcount #1", status: "draft" },
+      { id: "r-2", index: 1, name: "Headcount #2", status: "pending" },
+      { id: "r-3", index: 2, name: "Headcount #3", status: "approved" },
+      { id: "r-4", index: 3, name: "Headcount #4", status: "rejected" },
+    ] as unknown as MockUser[]
+
+    const { dataAdapter, onCellChange } = useEditableTableData(initialItems)
+
+    return (
+      <ExampleComponent
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              columns: [
+                {
+                  label: "Name",
+                  id: "name",
+                  editType: () => "text" as const,
+                  render: (item: MockUser) => item.name,
+                },
+                {
+                  label: "Status",
+                  id: "status",
+                  width: 200,
+                  editType: () => "select" as const,
+                  render: (item: MockUser) => {
+                    const status = item.status as RequestStatus
+                    return {
+                      type: "status" as const,
+                      value: {
+                        label: STATUS_LABEL[status],
+                        status: STATUS_VARIANT[status],
+                      },
+                    }
+                  },
+                  selectConfig: {
+                    placeholder: "Status",
+                    showSearchBox: false,
+                    options: STATUS_VALUES.map((id) => ({
+                      value: id,
+                      label: STATUS_LABEL[id],
+                      tag: {
+                        type: "status" as const,
+                        text: STATUS_LABEL[id],
+                        variant: STATUS_VARIANT[id],
+                      },
+                    })),
+                    defaultItem: (item: MockUser) => {
+                      const status = item.status as RequestStatus
+                      return {
+                        value: status,
+                        label: STATUS_LABEL[status],
+                        tag: {
+                          type: "status" as const,
+                          text: STATUS_LABEL[status],
+                          variant: STATUS_VARIANT[status],
+                        },
+                      }
+                    },
+                  },
+                },
+              ],
+              onCellChange,
+            },
+          },
+        ]}
+        dataAdapter={dataAdapter}
+        id="editable-table-status-pill-select/v1"
       />
     )
   },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -176,6 +176,42 @@ export const TableWithMixedNestedRecords: Story = {
   },
 }
 
+export const TableWithDefaultExpandedIds: Story = {
+  render: () => {
+    const mockVisualizations = getMockVisualizations({
+      table: {
+        noSorting: true,
+        allowColumnHiding: true,
+        allowColumnReordering: true,
+        nestedRecords: true,
+        applyLongText: false,
+      },
+    })
+
+    return (
+      <ExampleComponent
+        frozenColumns={2}
+        tableAllowColumnReordering
+        tableAllowColumnHiding
+        noSorting
+        storage={false}
+        visualizations={[mockVisualizations.table]}
+        id="employees/v1"
+        nestedRecords
+        defaultExpandedIds={["user-1", "user-2"]}
+      />
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When `defaultExpandedIds` is set on the source, only the rows whose `item.id` is in the list start expanded on first render (children fetched eagerly). Nested descendants are not auto-expanded unless their own id is also included.",
+      },
+    },
+  },
+}
+
 export const TableWithSelectableNestedRecords: Story = {
   render: () => {
     const mockVisualizations = getMockVisualizations({

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/DateCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/DateCell.tsx
@@ -23,6 +23,8 @@ export function DateCell<R extends RecordType>({
   onChange,
   hint,
 }: EditableCellProps<R>) {
+  const dateConfig = editableColumn.dateConfig
+
   const datePickerValue = useMemo<DatePickerValue | undefined>(() => {
     if (!value) return undefined
     const date = parseISO(value)
@@ -63,6 +65,8 @@ export function DateCell<R extends RecordType>({
           value={datePickerValue}
           onChange={handleChange}
           loading={loading}
+          minDate={dateConfig?.minDate}
+          maxDate={dateConfig?.maxDate}
         />
       </div>
     </BaseCell>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -32,6 +32,13 @@ export type AddRowActionsResult =
 
 export type EditableTableVisualizationSettings = TableVisualizationSettings
 
+export type DateCellConfig = {
+  /** Earliest selectable date. Dates before this are disabled in the picker. */
+  minDate?: Date
+  /** Latest selectable date. Dates after this are disabled in the picker. */
+  maxDate?: Date
+}
+
 export type NumberCellConfig<R extends RecordType = RecordType> = {
   min?: number
   max?: number
@@ -125,6 +132,11 @@ export type EditableTableColumnDefinition<
    * Falls back to sensible defaults when omitted.
    */
   numberConfig?: NumberCellConfig<R>
+  /**
+   * Configuration for `"date"` cells. Accepts `minDate` / `maxDate` to
+   * restrict the selectable date range in the picker.
+   */
+  dateConfig?: DateCellConfig
 
   /**
    * Called after this cell's value changes. Use to compute derived values

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "motion/react"
-import { Fragment, useEffect, useMemo, useState } from "react"
+import { Fragment, ReactNode, useEffect, useMemo, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
@@ -383,7 +383,13 @@ export const TableCollection = <
       ? i18n.status.selected.singular
       : i18n.status.selected.plural
 
-  const TableWrapper = tableWithChildren ? NestedDataProvider : Fragment
+  const TableWrapper = tableWithChildren
+    ? ({ children }: { children: ReactNode }) => (
+        <NestedDataProvider defaultExpandedIds={source.defaultExpandedIds}>
+          {children}
+        </NestedDataProvider>
+      )
+    : Fragment
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
@@ -430,6 +436,7 @@ export const TableCollection = <
                         align="right"
                         className={borderClass}
                         width={columns[entry.columnIndices[0]].width}
+                        minWidth={columns[entry.columnIndices[0]].minWidth}
                         key={`header-ungrouped-${entry.columnIndices[0]}`}
                         sticky={getStickyPosition(entry.columnIndices[0])}
                       >
@@ -824,6 +831,7 @@ export const TableCollection = <
                           key={`summary-${String(column.label)}`}
                           firstCell={cellIndex === 0}
                           width={column.width}
+                          minWidth={column.minWidth}
                           sticky={getStickyPosition(cellIndex)}
                         >
                           {cellIndex === 0 &&

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -16,7 +16,7 @@
  *
  */
 
-import { forwardRef, useCallback, useRef } from "react"
+import { forwardRef, useCallback, useEffect, useRef } from "react"
 
 import type { TableVisualizationType } from "@/patterns/OneDataCollection/types"
 
@@ -129,8 +129,13 @@ const NestedRowContent = <
 
   const rowId = `${props.nestedRowProps?.depth ?? 0}-${"id" in props.item ? props.item.id + "-" + props.index : props.index}`
 
-  const { expandedRowIds, setRowExpanded } = useNestedDataContext()
-  const open = expandedRowIds[rowId] ?? false
+  const { expandedRowIds, setRowExpanded, defaultExpandedIds } =
+    useNestedDataContext()
+  const itemId = "id" in props.item ? props.item.id : undefined
+  const isDefaultExpanded =
+    itemId !== undefined &&
+    (defaultExpandedIds?.includes(itemId as string | number) ?? false)
+  const open = expandedRowIds[rowId] ?? isDefaultExpanded
 
   /**
    * useLoadChildren hook manages:
@@ -206,6 +211,18 @@ const NestedRowContent = <
       loadChildren()
     }
   }
+
+  // When defaultExpandAllRows is set, rows render with `open === true` on
+  // first mount without any user interaction — so handleExpand never fires.
+  // Trigger the initial fetch here so children load eagerly.
+  const didInitialLoadRef = useRef(false)
+  useEffect(() => {
+    if (didInitialLoadRef.current) return
+    if (open && !children.length && !isLoading) {
+      didInitialLoadRef.current = true
+      loadChildren()
+    }
+  }, [open, children.length, isLoading, loadChildren])
 
   const sharedNestedRowProps = {
     depth: props.nestedRowProps?.depth ?? 0,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -298,6 +298,7 @@ const RowComponentInner = <
             href={itemHref}
             onClick={itemOnClick}
             width={column.width}
+            minWidth={column.minWidth}
             sticky={getStickyPosition(cellIndex)}
             loading={loading}
             nestedRowProps={{

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
@@ -16,6 +16,8 @@ interface NestedDataContextValue<R extends RecordType> {
   /** Persisted expansion state so rows stay open across parent re-renders (e.g. GraphQL refetch) */
   expandedRowIds: Record<string, boolean>
   setRowExpanded: (rowId: string, expanded: boolean) => void
+  /** Item ids that start expanded on first render */
+  defaultExpandedIds?: Array<string | number>
 }
 
 const NestedDataContext = createContext<
@@ -24,8 +26,10 @@ const NestedDataContext = createContext<
 
 export const NestedDataProvider = <R extends RecordType>({
   children,
+  defaultExpandedIds,
 }: {
   children: ReactNode
+  defaultExpandedIds?: Array<string | number>
 }) => {
   const [fetchedData, setFetchedData] = useState<
     Record<string, ChildrenResponse<R>>
@@ -51,12 +55,7 @@ export const NestedDataProvider = <R extends RecordType>({
   }, [])
 
   const setRowExpanded = useCallback((rowId: string, expanded: boolean) => {
-    setExpandedRowIdsState((prev) => {
-      if (expanded) return { ...prev, [rowId]: true }
-      const next = { ...prev }
-      delete next[rowId]
-      return next
-    })
+    setExpandedRowIdsState((prev) => ({ ...prev, [rowId]: expanded }))
   }, [])
 
   return (
@@ -68,6 +67,7 @@ export const NestedDataProvider = <R extends RecordType>({
           clearFetchedData,
           expandedRowIds,
           setRowExpanded,
+          defaultExpandedIds,
         } as NestedDataContextValue<RecordType>
       }
     >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -35,6 +35,13 @@ export type WithOptionalSorting<
    * The width of the column. If not provided, the width will be "auto"
    */
   width?: number
+
+  /**
+   * Optional minimum width for the column in pixels. When provided, overrides
+   * the minWidth derived from `width`. Useful for columns with no fixed
+   * `width` that should not shrink below a given size.
+   */
+  minWidth?: number
 }
 
 export type ColId = string
@@ -46,7 +53,7 @@ export type TableColumnDefinition<
 > = WithOptionalSorting<R, Sortings> &
   Pick<
     ComponentProps<typeof TableHead>,
-    "hidden" | "info" | "infoIcon" | "sticky" | "width"
+    "hidden" | "info" | "infoIcon" | "sticky" | "width" | "minWidth"
   > & {
     /**
      * Optional summary configuration for this column


### PR DESCRIPTION
## Description

This PR bundles several enhancements across `F0Select`, `OneTable`, and `OneDataCollection`:

**F0Select — status tag support**
- Adds a new `status` variant to `F0SelectTagProp`, allowing options to carry a `{ type: "status", text, variant }` tag.
- `SelectItem` renders a status pill inline; status-only items render as a standalone pill.
- `SelectedItems` renders the status pill in the trigger and also gains avatar rendering for selected options.
- New stories: `WithStatusTags`, `WithPersonAvatar`.
<img width="1911" height="1080" alt="Screenshot 2026-05-18 at 14 20 27" src="https://github.com/user-attachments/assets/b8635ee9-c229-46ec-b606-7c64d40c55b6" />
<img width="1924" height="1080" alt="Screenshot 2026-05-18 at 14 21 20" src="https://github.com/user-attachments/assets/7e1f705d-e62a-41da-bc59-e7579c00ca39" />

**OneTable — column `minWidth`**
- `TableHead` and `TableCell` accept an optional `minWidth` prop that overrides the minWidth derived from `width`, letting columns grow past `width` without shrinking below a floor.
- New `MinWidth` story.
<img width="1918" height="1080" alt="Screenshot 2026-05-18 at 14 21 57" src="https://github.com/user-attachments/assets/ac3e5a33-21a1-4672-8f48-483e04f90d8b" />

**OneDataCollection Table — `defaultExpandedIds`**
- New `defaultExpandedIds` field on `DataSourceDefinition`: rows whose `item.id` matches start expanded on first render, with children fetched eagerly. Nested descendants are not auto-expanded unless their own id is included.
- Plumbed through `NestedDataProvider` → `NestedRow`, which triggers the initial child load via `useEffect` on mount (since `handleExpand` never fires for rows that mount already open).
- `setRowExpanded` simplified to always store the boolean instead of deleting collapsed entries.
- Column `minWidth` plumbed through `TableColumnDefinition`, `Table.tsx`, and `Row.tsx`.
- New `TableWithDefaultExpandedIds` story and a new `NestedProvider` test.
<img width="1919" height="1078" alt="Screenshot 2026-05-18 at 14 22 43" src="https://github.com/user-attachments/assets/0e436083-2094-486d-9309-0d406644cb37" />

**OneDataCollection EditableTable — date range + status-pill select**
- New `DateCellConfig` (`minDate` / `maxDate`) on editable column definitions; `DateCell` forwards these to the date picker to disable out-of-range dates.
- New stories: `EditableTableWithDateCellMinMax` and `EditableTableWithStatusPillSelect` (select column whose options carry status tags, rendering pills in both the closed trigger and the dropdown).
<img width="1921" height="1080" alt="Screenshot 2026-05-18 at 14 23 37" src="https://github.com/user-attachments/assets/64a98748-b9a8-4781-873e-3f24da90e936" />
<img width="1922" height="1080" alt="Screenshot 2026-05-18 at 14 24 33" src="https://github.com/user-attachments/assets/8e047529-554d-4a5a-92fb-2382020b3531" />

[Link to Figma Design](https://www.figma.com/design/A4204Nlu1QulvPCR8nr6GM/Headcount-planning?node-id=10382-87109&p=f&t=B5lO21aEFsYpdR5u-0)

## Implementation details

### F0Select — `status` tag variant

- **`types.ts`**: Extended `F0SelectTagProp` union with `{ type: "status"; text: string; variant: StatusVariant }`, imported from `F0TagStatus/types`.
- **`SelectItem.tsx`**: Added an `isStatusOnly` short-circuit — when an item has only a status tag (no avatar/icon/description), render just a centered `F0TagStatus`. In the standard layout, added a `tag.type === "status"` branch alongside the existing `dot` / `person` / raw string branches.
- **`SelectedItems.tsx`**: Added an early return when the selected item's tag is a status tag, so the trigger renders the pill directly. Separately, added avatar rendering (`F0Avatar` at `size="xs"`) at the start of the standard layout, mirroring the existing `icon` slot.

### OneTable — column `minWidth`

- **`TableCell/index.tsx` and `TableHead/index.tsx`**: Added optional `minWidth` prop (`number | "auto"` and `ColumnWidth` respectively). When set, it overrides the `minWidth` style that previously always equaled `width`. Implemented as `colMinWidth = minWidth !== undefined ? getColWidth(minWidth) : colWidth` so existing behavior is preserved when the prop is omitted.
- **Why**: Previously `minWidth === width === maxWidth`, which prevented columns from growing past their declared width. The new prop decouples the lower bound so a column can flex upward while keeping a floor.

### OneDataCollection Table — `defaultExpandedIds`

- **`datasource.typings.ts`**: Added `defaultExpandedIds?: Array<string | number>` on `DataSourceDefinition`, documented as opt-in per-row (no recursion to descendants).
- **`NestedProvider.tsx`**: Threaded `defaultExpandedIds` through the provider props and context value. Also simplified `setRowExpanded` to always write `{ ...prev, [rowId]: expanded }` instead of deleting the key on collapse — this was necessary so a user-collapse of a default-expanded row sticks (otherwise the missing key would fall back to `isDefaultExpanded` and re-open).
- **`NestedRow.tsx`**: The `open` state now falls back to `isDefaultExpanded` (matched by `item.id`) when no explicit expansion state exists. Added a `useEffect` guarded by `didInitialLoadRef` that calls `loadChildren()` once on mount when the row is open with no children — necessary because `handleExpand` only fires on user toggle, so default-expanded rows would otherwise render empty.
- **`Table.tsx`**: `TableWrapper` rewritten from a bare `NestedDataProvider` reference into a wrapper component that passes `source.defaultExpandedIds` through. Also forwards `column.minWidth` to header cells and summary cells.
- **Column-level `minWidth`**: Added `minWidth?: number` to `WithOptionalSorting` and exposed it via `TableColumnDefinition`'s `Pick<...>`. Passed through in `Row.tsx` to per-cell `TableCell`.

### OneDataCollection EditableTable — date range + status-pill select

- **`EditableTable/types.ts`**: New `DateCellConfig` type (`minDate?`, `maxDate?`) and a `dateConfig?: DateCellConfig` field on `EditableTableColumnDefinition`, mirroring the existing `numberConfig` pattern.
- **`DateCell.tsx`**: Reads `editableColumn.dateConfig` and forwards `minDate` / `maxDate` to the underlying date picker so out-of-range dates are disabled.
- **Status-pill select**: No new component code — the existing `selectConfig.options` already accept a `tag` field on each option, which now flows through the new `F0Select` status tag support to render pills in both the closed cell trigger and the dropdown items. Demonstrated end-to-end via the new story.

### Stories

- New F0Select stories: `WithStatusTags`, `WithPersonAvatar`.
- New OneTable story: `MinWidth`.
- New OneDataCollection table story: `TableWithDefaultExpandedIds`.
- New EditableTable stories: `EditableTableWithDateCellMinMax`, `EditableTableWithStatusPillSelect`.
- Threaded `defaultExpandedIds` through `mockData.tsx`'s `ExampleComponent` so the story can wire it onto the source.
