### PR TITLE
feat: exlusive nested filters

### DIFF
--- a/packages/react/src/patterns/OneFilterPicker/components/FilterContent.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FilterContent.tsx
@@ -87,6 +87,7 @@ export function FilterContent<Definition extends FiltersDefinition>({
         isCompactMode?: boolean
         onFilterChange?: (key: string, value: unknown) => void
         allFiltersValue?: Record<string, unknown>
+        filterKey?: string
       }) => React.ReactNode
     )({
       schema,
@@ -95,6 +96,7 @@ export function FilterContent<Definition extends FiltersDefinition>({
       isCompactMode,
       onFilterChange: handleSiblingFilterChange,
       allFiltersValue: tempFilters as Record<string, unknown>,
+      filterKey: selectedFilterKey as string,
     })
   }
 

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/InFilter.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/InFilter.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { F0Checkbox } from "@/components/F0Checkbox"
 import { OneEllipsis } from "@/lib/OneEllipsis"
@@ -15,7 +15,9 @@ import { FilterTypeComponentProps } from "../types"
 import { InFilterFlatOption } from "./components/InFilterFlatOption"
 import { InFilterOptionRow } from "./components/InFilterOptionRow"
 import {
+  buildInterlockIndex,
   collectNestedFilterKeys,
+  InterlockIndex,
   optionMatchesSearch,
 } from "./components/option-utils"
 import { InFilterOptionItem, InFilterOptions } from "./types"
@@ -29,11 +31,20 @@ import {
 /**
  * Props for the InFilter component.
  * @template T - The type of values that can be selected
+ *
+ * `nestedSelection` lives on `InFilterDefinition` but the base
+ * FilterTypeComponentProps narrows the schema to `{ label, options }`. We
+ * widen it here so callers (and Storybook stories) can pass the flag with
+ * type-checking.
  */
 type InFilterComponentProps<
   T = unknown,
   R extends RecordType = RecordType,
-> = FilterTypeComponentProps<T[], InFilterOptions<T, R>>
+> = Omit<FilterTypeComponentProps<T[], InFilterOptions<T, R>>, "schema"> & {
+  schema: FilterTypeComponentProps<T[], InFilterOptions<T, R>>["schema"] & {
+    nestedSelection?: "independent" | "exclusive"
+  }
+}
 
 /**
  * A multi-select filter component that allows users to select multiple options from a predefined list.
@@ -91,7 +102,9 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
   isCompactMode,
   onFilterChange,
   allFiltersValue,
+  filterKey,
 }: InFilterComponentProps<T, R>) {
+  const isExclusive = schema.nestedSelection === "exclusive"
   const i18n = useI18n()
 
   const [searchTerm, setSearchTerm] = useState("")
@@ -115,13 +128,13 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
     const populateNestedCache = (parentOptions: InFilterOptionItem<T>[]) => {
       for (const option of parentOptions) {
         if (option.children) {
-          const { filterKey, options: childOptions } = option.children
-          const childValues = (allFiltersValue[filterKey] as T[]) ?? []
+          const { filterKey: childKey, options: childOptions } = option.children
+          const childValues = (allFiltersValue[childKey] as T[]) ?? []
 
           for (const child of childOptions) {
             if (childValues.includes(child.value as T)) {
               const contextualLabel = `${option.label} > ${child.label}`
-              cacheNestedLabel(filterKey, child.value, contextualLabel)
+              cacheNestedLabel(childKey, child.value, contextualLabel)
               cacheLabel(cacheKey, child.value, child.label)
             }
             // Recurse for deeper nesting
@@ -170,6 +183,71 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
   const nestedFilterKeys = useMemo(
     () => collectNestedFilterKeys(schema.options),
     [schema.options]
+  )
+
+  // Index used by exclusive-nesting interlock to know, for any (filterKey,
+  // value), which ancestors and descendants to clear when it is selected.
+  // Built from the loaded `options` (which mirrors the schema's option tree).
+  const interlockIndex = useMemo<InterlockIndex<T> | null>(() => {
+    if (!isExclusive || !filterKey) return null
+    return buildInterlockIndex<T>(
+      filterKey,
+      options as Array<InFilterOptionItem<T>>
+    )
+  }, [isExclusive, filterKey, options])
+
+  // Reads the current value for a given filter key, preferring our own
+  // `value` prop for the widget's own key (since it reflects the freshest
+  // intended state from this render's onChange caller).
+  const readKey = useCallback(
+    (key: string): T[] => {
+      if (key === filterKey) return value
+      const v = allFiltersValue?.[key]
+      return Array.isArray(v) ? (v as T[]) : []
+    },
+    [filterKey, value, allFiltersValue]
+  )
+
+  // Routes a write to the correct setter: own filterKey → onChange,
+  // anything else → onFilterChange (sibling/nested setter).
+  const writeKey = useCallback(
+    (key: string, next: T[]) => {
+      if (key === filterKey) onChange(next)
+      else onFilterChange?.(key, next)
+    },
+    [filterKey, onChange, onFilterChange]
+  )
+
+  // Clear the selected option's ancestors and descendants from their
+  // respective filter keys. Fires only on user-driven *additions*; callers
+  // must not invoke this on deselection.
+  const applyExclusiveInterlock = useCallback(
+    (selectedKey: string, selectedValue: T) => {
+      if (!interlockIndex) return
+      const ctx = interlockIndex.get(selectedKey)?.get(selectedValue)
+      if (!ctx) return
+      // Group drops by filter key so each key is read once and written once.
+      // Otherwise sibling drops at the same key would each compute against the
+      // same render-time snapshot and the last write would clobber the rest.
+      const dropsByKey = new Map<string, Set<T>>()
+      for (const { filterKey: k, value: v } of [
+        ...ctx.ancestors,
+        ...ctx.descendants,
+      ]) {
+        let set = dropsByKey.get(k)
+        if (!set) {
+          set = new Set()
+          dropsByKey.set(k, set)
+        }
+        set.add(v)
+      }
+      for (const [k, drops] of dropsByKey) {
+        const current = readKey(k)
+        const filtered = current.filter((x) => !drops.has(x))
+        if (filtered.length !== current.length) writeKey(k, filtered)
+      }
+    },
+    [interlockIndex, readKey, writeKey]
   )
 
   const nestedSelectionsCount = useMemo(
@@ -274,6 +352,9 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
         ? value.filter((v) => v !== optionValue)
         : [...value, optionValue]
     )
+    if (!isSelected && isExclusive && filterKey) {
+      applyExclusiveInterlock(filterKey, optionValue)
+    }
   }
 
   const totalSelected = value.length + nestedSelectionsCount
@@ -354,6 +435,9 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
                 cacheKey={cacheKey}
                 searchTerm={searchTermLower}
                 autoExpand={autoExpand}
+                onAfterSelect={
+                  isExclusive ? applyExclusiveInterlock : undefined
+                }
               />
             ))
           : filteredOptions.map((option) => (

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__stories__/InFilter.stories.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__stories__/InFilter.stories.tsx
@@ -398,3 +398,115 @@ export const WithDataSource: Story = {
     onChange: () => {},
   },
 }
+
+// --- Hierarchical / nested-selection examples ----------------------------
+//
+// A 3-level options tree (family → function → role). Each level lives under a
+// different `filterKey`, which is how the widget keeps selections at different
+// depths in separate `FiltersState` entries.
+const jobStructureOptions: InFilterOptionItem<string>[] = [
+  {
+    value: "engineering",
+    label: "Engineering",
+    children: {
+      filterKey: "function",
+      options: [
+        {
+          value: "backend",
+          label: "Backend",
+          children: {
+            filterKey: "role",
+            options: [
+              { value: "be-senior", label: "Senior" },
+              { value: "be-junior", label: "Junior" },
+            ],
+          },
+        },
+        {
+          value: "frontend",
+          label: "Frontend",
+          children: {
+            filterKey: "role",
+            options: [
+              { value: "fe-senior", label: "Senior" },
+              { value: "fe-junior", label: "Junior" },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  {
+    value: "marketing",
+    label: "Marketing",
+    children: {
+      filterKey: "function",
+      options: [
+        { value: "growth", label: "Growth" },
+        { value: "brand", label: "Brand" },
+      ],
+    },
+  },
+]
+
+/**
+ * Mounts InFilter for a hierarchical tree by maintaining a tiny `FiltersState`
+ * locally and routing both the own-key setter (`onChange`) and the
+ * sibling-key setter (`onFilterChange`) back into the same state map. This
+ * mirrors how FiltersControls wires the real picker.
+ */
+const HierarchicalHarness = ({
+  nestedSelection,
+}: {
+  nestedSelection?: "independent" | "exclusive"
+}) => {
+  const ownKey = "family"
+  const [state, setState] = useState<Record<string, string[]>>({})
+
+  const writeKey = (key: string, value: unknown) =>
+    setState((prev) => ({ ...prev, [key]: value as string[] }))
+
+  return (
+    <div className="flex flex-col gap-2">
+      <InFilter<string>
+        schema={{
+          label: "Job structure",
+          nestedSelection,
+          options: { options: jobStructureOptions },
+        }}
+        value={state[ownKey] ?? []}
+        onChange={(v) => writeKey(ownKey, v)}
+        onFilterChange={writeKey}
+        allFiltersValue={state}
+        filterKey={ownKey}
+      />
+      <pre className="text-f1-foreground-secondary rounded bg-f1-background-secondary p-2 text-xs">
+        {JSON.stringify(state, null, 2)}
+      </pre>
+    </div>
+  )
+}
+
+export const HierarchicalIndependent: Story = {
+  render: () => <HierarchicalHarness />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Default behavior (`nestedSelection: 'independent'`). Selections at each level are stored independently — picking 'Engineering' and 'Engineering > Backend' leaves both in state, which produces redundant chips and forces consumers to dedupe downstream. Use the JSON readout under the widget to inspect `FiltersState` as you click.",
+      },
+    },
+  },
+}
+
+export const HierarchicalExclusive: Story = {
+  render: () => <HierarchicalHarness nestedSelection="exclusive" />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "With `nestedSelection: 'exclusive'`, selecting an option auto-clears its ancestors and descendants from their respective filter keys. Pick 'Engineering', then expand and pick 'Backend' — the family entry empties. Pick 'Engineering' again — the function entry empties. Sibling subtrees (e.g. Marketing) are not touched.",
+      },
+    },
+  },
+}

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterOptionRow.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterOptionRow.tsx
@@ -23,6 +23,10 @@ export type InFilterOptionRowProps<T extends string> = {
   cacheKey: string
   searchTerm: string
   autoExpand: boolean
+  /** Called after a *selection* (not a deselection) so the parent widget can
+   *  apply the exclusive-nesting interlock by clearing ancestors and
+   *  descendants of the just-selected option. */
+  onAfterSelect?: (selectedFilterKey: string, selectedValue: T) => void
 }
 
 export function InFilterOptionRow<T extends string>({
@@ -36,6 +40,7 @@ export function InFilterOptionRow<T extends string>({
   cacheKey,
   searchTerm,
   autoExpand,
+  onAfterSelect,
 }: InFilterOptionRowProps<T>) {
   const [expanded, setExpanded] = useState(false)
   const hasChildren = !!option.children?.options.length
@@ -62,8 +67,18 @@ export function InFilterOptionRow<T extends string>({
         ? childValues.filter((v) => v !== childValue)
         : [...childValues, childValue]
       onFilterChange(childFilterKey, newValues)
+      if (!isChildSelected) {
+        onAfterSelect?.(childFilterKey, childValue)
+      }
     },
-    [childFilterKey, childValues, onFilterChange, cacheKey, option.label]
+    [
+      childFilterKey,
+      childValues,
+      onFilterChange,
+      cacheKey,
+      option.label,
+      onAfterSelect,
+    ]
   )
 
   const optionId = `option-${String(option.value)}-d${depth}`
@@ -147,6 +162,7 @@ export function InFilterOptionRow<T extends string>({
                   cacheKey={cacheKey}
                   searchTerm={searchTerm}
                   autoExpand={autoExpand}
+                  onAfterSelect={onAfterSelect}
                 />
               )
             })}

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/option-utils.ts
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/option-utils.ts
@@ -1,5 +1,18 @@
 import { InFilterOptionItem, InFilterOptions } from "../types"
 
+/** A (filterKey, value) pair identifying an option in the hierarchical tree. */
+export type InterlockTuple<T> = { filterKey: string; value: T }
+
+/** For a given option, the other options whose selection should be cleared
+ *  when this one is picked under `nestedSelection: 'exclusive'`. */
+export type InterlockEntry<T> = {
+  ancestors: Array<InterlockTuple<T>>
+  descendants: Array<InterlockTuple<T>>
+}
+
+/** Index keyed by (filterKey, value) → interlock context. */
+export type InterlockIndex<T> = Map<string, Map<T, InterlockEntry<T>>>
+
 /**
  * Recursively checks whether an option or any of its nested children
  * match the search term.
@@ -59,4 +72,77 @@ export function collectNestedFilterKeys<T>(
   }
 
   return [...keys]
+}
+
+/**
+ * Builds a flat index mapping every (filterKey, value) in the option tree to
+ * the ancestors and descendants that should be cleared when it is selected
+ * under `nestedSelection: 'exclusive'`.
+ *
+ * - `rootFilterKey` is the filter key the top-level options live under (i.e.
+ *   the widget's own filter key).
+ * - Ancestors are listed root-first (matches FiltersState traversal order).
+ * - Descendants include every option in the selected node's subtree, at any
+ *   depth.
+ */
+export function buildInterlockIndex<T>(
+  rootFilterKey: string,
+  topLevelOptions: Array<InFilterOptionItem<T>>
+): InterlockIndex<T> {
+  const index: InterlockIndex<T> = new Map()
+  const bucket = (filterKey: string) => {
+    let m = index.get(filterKey)
+    if (!m) {
+      m = new Map()
+      index.set(filterKey, m)
+    }
+    return m
+  }
+
+  const collectDescendants = (
+    options: Array<InFilterOptionItem<T>>,
+    filterKey: string,
+    out: Array<InterlockTuple<T>>
+  ) => {
+    for (const option of options) {
+      out.push({ filterKey, value: option.value })
+      if (option.children) {
+        collectDescendants(
+          option.children.options,
+          option.children.filterKey,
+          out
+        )
+      }
+    }
+  }
+
+  const walk = (
+    options: Array<InFilterOptionItem<T>>,
+    filterKey: string,
+    ancestors: ReadonlyArray<InterlockTuple<T>>
+  ) => {
+    for (const option of options) {
+      const descendants: Array<InterlockTuple<T>> = []
+      if (option.children) {
+        collectDescendants(
+          option.children.options,
+          option.children.filterKey,
+          descendants
+        )
+      }
+      bucket(filterKey).set(option.value, {
+        ancestors: [...ancestors],
+        descendants,
+      })
+      if (option.children) {
+        walk(option.children.options, option.children.filterKey, [
+          ...ancestors,
+          { filterKey, value: option.value },
+        ])
+      }
+    }
+  }
+
+  walk(topLevelOptions, rootFilterKey, [])
+  return index
 }

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/index.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/index.tsx
@@ -122,4 +122,17 @@ export type InFilterDefinition<
   R extends RecordType = RecordType,
 > = BaseFilterDefinition<"in"> & {
   options: InFilterOptions<T, R>
+  /**
+   * Controls how selections interact across nested levels of the option tree.
+   *
+   * - `"independent"` (default): selections at each level are stored
+   *   independently. Ancestor and descendant can be selected simultaneously,
+   *   and the chip strip will show both.
+   * - `"exclusive"`: selecting an option auto-clears any of its ancestors
+   *   and descendants from their respective filter keys. The widget keeps
+   *   `FiltersState` minimal so consumers don't have to dedupe downstream.
+   *   The interlock only fires on user-driven selection (not on deselection
+   *   and not on initial state), so deep links keep working as written.
+   */
+  nestedSelection?: "independent" | "exclusive"
 }

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/types.ts
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/types.ts
@@ -31,6 +31,10 @@ export type FilterTypeComponentProps<
   onFilterChange?: (key: string, value: unknown) => void
   /** Current values of all filters (used to read sibling filter state) */
   allFiltersValue?: Record<string, unknown>
+  /** The key of this filter in the FiltersDefinition. Needed by filters that
+   * need to read or write their own entry in `allFiltersValue` by key (e.g.
+   * InFilter's hierarchical interlock). */
+  filterKey?: string
 }
 
 export type FilterTypeContext<Options extends object = never> = {
@@ -77,6 +81,7 @@ export type FilterTypeDefinition<
     isCompactMode?: boolean
     onFilterChange?: (key: string, value: unknown) => void
     allFiltersValue?: Record<string, unknown>
+    filterKey?: string
   }) => React.ReactNode
   /**
    * The value label to display in the filter chips


### PR DESCRIPTION
## Description

Adds a `nestedSelection: 'exclusive'` flag to `InFilterDefinition`. When enabled, selecting an option in a hierarchical option tree (e.g. family → function → role) auto-clears its ancestors and descendants from their respective filter keys, so `FiltersState` never holds redundant entries that mean the same thing to the backend.

**Why:** `InFilterOptionItem` already supports infinite recursive nesting through `children: { filterKey, options }`, but selection at each level is stored independently. That means ancestor and descendant can be selected simultaneously, which produces redundant chips in the UI and forces every consumer to hand-roll the same dedup/leaf-expansion code on the way to the backend (currently duplicated across the employees role filter and the cost-centers job-structure filter). The right behavior — selecting an ancestor implicitly covers its descendants and vice versa — is a property of the widget's selection semantics, not of any one domain, so it belongs in f0-react.

**Behavior:**
- Selecting an option clears any of its ancestors in the tree from all parent `filterKey` entries.
- Selecting an option clears any of its descendants from all child `filterKey` entries.
- Siblings and unrelated subtrees are untouched.
- Deselecting never mutates other entries.

https://github.com/user-attachments/assets/84bfa80f-039f-4ba1-a063-345c42f5cc8c

**Backward compatibility:** `nestedSelection` defaults to `'independent'` (current behavior). No consumer breaks. Opt-in per filter.

## Implementation details
- Added `filterKey?: string` to `FilterTypeComponentProps` so the widget knows its own key (needed to clear ancestors that live in the own filter key). Optional; other filter types ignore it.
- New `buildInterlockIndex(rootFilterKey, options)` in `option-utils.ts` returns a flat `(filterKey, value) → { ancestors, descendants }` map, built once per options change.
- `InFilter` reads the flag, builds the index, and runs a single `applyExclusiveInterlock` that batches per-key drops to avoid same-render-snapshot clobbering when multiple sibling values need clearing from the same key.
- Interlock fires on add only (per spec); deselection is left alone.
- `InFilterOptionRow` gets a new `onAfterSelect` callback, forwarded through recursion so arbitrarily deep nested toggles trigger the interlock.

**Stories added:**
- `HierarchicalIndependent` — baseline showing today's default and the redundant-chip problem.
- `HierarchicalExclusive` — same tree with the flag on; demonstrates the interlock in both directions and that sibling subtrees are untouched.
