### PR TITLE
fix: disable scroll lock for Select inside dialogs to prevent pointer-events stuck on body

### DIFF
--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -13,6 +13,7 @@ import {
 
 import { useReducedMotion } from "@/lib/a11y"
 import { cn } from "@/lib/utils"
+import { F0DialogContext } from "@/patterns/F0Dialog"
 import { ScrollArea } from "@/ui/scrollarea"
 import { Spinner } from "@/ui/Spinner"
 
@@ -94,6 +95,22 @@ const SelectContent = forwardRef<
     },
     ref
   ) => {
+    // If inside a dialog and no portalContainer is provided, use the dialog's container
+    // only for center/fullscreen dialogs (which have focus trap).
+    // For side panels (left/right), render in body to prevent clipping.
+    const dialogContext = useContext(F0DialogContext)
+    const shouldUseDialogContainer =
+      dialogContext.portalContainer &&
+      (dialogContext.position === "center" ||
+        dialogContext.position === "fullscreen")
+
+    const effectivePortalContainer =
+      portalContainer !== undefined
+        ? portalContainer
+        : shouldUseDialogContainer
+          ? dialogContext.portalContainer
+          : undefined
+
     // ----------- Virtual list -----------
     // The scrollable element for your list
     const parentRef = useRef(null)
@@ -225,7 +242,7 @@ const SelectContent = forwardRef<
       <SelectPrimitive.Content
         ref={ref}
         asChild={asChild}
-        disableScrollLock={asList}
+        disableScrollLock={asList || !!effectivePortalContainer}
         className={cn(
           "relative z-50 text-f1-foreground",
           asList
@@ -356,14 +373,14 @@ const SelectContent = forwardRef<
     return asList ? (
       content
     ) : (
-      <SelectPrimitive.Portal container={portalContainer}>
+      <SelectPrimitive.Portal container={effectivePortalContainer}>
         <>
           {/*
             Overlay to prevent clicks from propagating.
             Only render when NOT using a custom portal container to avoid
             conflicts with modal focus management.
           */}
-          {open && !portalContainer && (
+          {open && !effectivePortalContainer && (
             <div
               className="pointer-events-auto fixed inset-0 z-40"
               onClick={(e) => {


### PR DESCRIPTION
## Summary

- Fixes a bug where closing a dialog (or navigating away) while a Select dropdown is open leaves `pointer-events: none` on `<body>`, making the entire page unclickable
- Adds `|| !!effectivePortalContainer` to the `disableScrollLock` prop in `SelectContent`, so Selects rendered inside dialogs don't add their own body-level pointer-events blocking (which is redundant since the dialog already handles it)

## Root Cause

Both Radix Dialog and the forked Radix Select use `@radix-ui/react-dismissable-layer` with `disableOutsidePointerEvents=true`. On simultaneous unmount (e.g. route change), React's effect cleanup ordering causes a race where neither layer restores `body.style.pointerEvents`.

## Fix

When a Select is inside an F0Dialog (`effectivePortalContainer` is set), we disable its scroll lock — which also disables its `disableOutsidePointerEvents`. This is safe because the dialog already blocks outside interactions.

Before:

https://github.com/user-attachments/assets/f6dd5966-841c-400d-a1bc-5d8edc4c40a0

After:

https://github.com/user-attachments/assets/2b3537ff-fd27-4f06-8efd-2aa41d7a8581


