### PR TITLE
fix(ai-chat): make textarea sends customizable

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
@@ -38,6 +38,8 @@ const F0AiChatProviderComponent = ({
   credits,
   creditWarning,
   fileAttachments,
+  placeholder,
+  placeholders,
   onThumbsUp,
   onThumbsDown,
   onBeforeSendMessage,
@@ -72,6 +74,8 @@ const F0AiChatProviderComponent = ({
       credits={credits}
       creditWarning={creditWarning}
       fileAttachments={fileAttachments}
+      placeholder={placeholder}
+      placeholders={placeholders}
     >
       <AiChatKitWrapper {...copilotKitProps}>{children}</AiChatKitWrapper>
     </AiChatStateProvider>

--- a/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
@@ -38,7 +38,6 @@ const F0AiChatProviderComponent = ({
   credits,
   creditWarning,
   fileAttachments,
-  placeholder,
   placeholders,
   onThumbsUp,
   onThumbsDown,
@@ -74,7 +73,6 @@ const F0AiChatProviderComponent = ({
       credits={credits}
       creditWarning={creditWarning}
       fileAttachments={fileAttachments}
-      placeholder={placeholder}
       placeholders={placeholders}
     >
       <AiChatKitWrapper {...copilotKitProps}>{children}</AiChatKitWrapper>

--- a/packages/react/src/sds/ai/F0AiChat/F0AiFullscreenChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiFullscreenChat.tsx
@@ -1,20 +1,29 @@
+import { type Message } from "@copilotkit/shared"
 import { useCopilotChatInternal } from "@copilotkit/react-core"
 
 import { cn } from "@/lib/utils"
 
 import { useRegisteredActions } from "./actions"
 import { ChatTextarea } from "./components/input/ChatTextarea"
+import { type ChatTextareaOnSend } from "./components/input/ChatTextarea/types"
 import { CanvasPanel } from "./components/layout/CanvasPanel"
 import { MessagesContainer } from "./components/messages/MessagesContainer"
 import { useAiChat } from "./providers/AiChatStateProvider"
 
 const FullscreenChatInput = () => {
   const { sendMessage, inProgress, creditWarning } = useAiChat()
-  const { stopGeneration } = useCopilotChatInternal()
+  const { stopGeneration, sendMessage: sendCopilotMessage } =
+    useCopilotChatInternal()
 
-  const handleSend = async (text: string) => {
+  const handleSend: ChatTextareaOnSend = (text, context) => {
+    if (context) {
+      sendCopilotMessage(context.message)
+      return Promise.resolve(context.message)
+    }
+
     sendMessage(text)
-    return { id: "", role: "user" as const, content: text }
+    const message: Message = { id: "", role: "user", content: text }
+    return Promise.resolve(message)
   }
 
   const handleStop = () => {

--- a/packages/react/src/sds/ai/F0AiChat/F0AiFullscreenChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiFullscreenChat.tsx
@@ -11,7 +11,7 @@ import { MessagesContainer } from "./components/messages/MessagesContainer"
 import { useAiChat } from "./providers/AiChatStateProvider"
 
 const FullscreenChatInput = () => {
-  const { sendMessage, inProgress, creditWarning } = useAiChat()
+  const { inProgress, creditWarning } = useAiChat()
   const { stopGeneration, sendMessage: sendCopilotMessage } =
     useCopilotChatInternal()
 
@@ -21,8 +21,8 @@ const FullscreenChatInput = () => {
       return Promise.resolve(context.message)
     }
 
-    sendMessage(text)
     const message: Message = { id: "", role: "user", content: text }
+    sendCopilotMessage(message)
     return Promise.resolve(message)
   }
 

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatInput.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatInput.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils"
 import { filterNonRenderableMessages } from "../../internal-types"
 import { useAiChat } from "../../providers/AiChatStateProvider"
 import { ChatTextarea } from "./ChatTextarea"
+import { type ChatTextareaOnSend } from "./ChatTextarea/types"
 
 export const ChatInput = (props: InputProps) => {
   const {
@@ -22,7 +23,7 @@ export const ChatInput = (props: InputProps) => {
     clarifyingQuestion,
   } = useAiChat()
   const translation = useI18n()
-  const { messages } = useCopilotChatInternal()
+  const { messages, sendMessage } = useCopilotChatInternal()
   const containerRef = useRef<HTMLDivElement>(null)
   const filteredMessages = useMemo(
     () => filterNonRenderableMessages(messages),
@@ -33,6 +34,15 @@ export const ChatInput = (props: InputProps) => {
   const fullscreenWelcome = fullscreen && isWelcomeScreen
 
   const isClarifying = clarifyingQuestion != null
+
+  const handleSend: ChatTextareaOnSend = (text, context) => {
+    if (context) {
+      sendMessage(context.message)
+      return Promise.resolve(context.message)
+    }
+
+    return props.onSend(text)
+  }
 
   useEffect(() => {
     const textarea = containerRef.current?.querySelector("textarea")
@@ -48,7 +58,11 @@ export const ChatInput = (props: InputProps) => {
       )}
     >
       <div className="w-full max-w-[712px]">
-        <ChatTextarea {...props} creditWarning={creditWarning} />
+        <ChatTextarea
+          {...props}
+          onSend={handleSend}
+          creditWarning={creditWarning}
+        />
       </div>
       <AnimatePresence mode="wait" initial={false}>
         {isClarifying ? (

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
@@ -1,3 +1,4 @@
+import { type Message } from "@copilotkit/shared"
 import { AnimatePresence, motion } from "motion/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
@@ -63,15 +64,17 @@ export const ChatTextarea = ({
   onSend,
   onStop,
   creditWarning,
+  fileAttachments: fileAttachmentsProp,
+  placeholder,
+  placeholders: placeholdersProp,
 }: ChatTextareaProps) => {
   const {
-    placeholders,
+    placeholders: contextPlaceholders,
     entityRefs,
     toolHints,
     activeToolHint,
     setActiveToolHint,
-    fileAttachments,
-    sendMessage,
+    fileAttachments: contextFileAttachments,
     appendMessages,
     clarifyingQuestion,
     pendingContext,
@@ -91,6 +94,7 @@ export const ChatTextarea = ({
   const highlightRef = useRef<HTMLDivElement>(null)
 
   const isClarifying = clarifyingQuestion !== null
+  const resolvedFileAttachments = fileAttachmentsProp ?? contextFileAttachments
 
   const {
     attachedFiles,
@@ -104,7 +108,7 @@ export const ChatTextarea = ({
     handleRemoveFile,
     clearFiles,
     transientError,
-  } = useFileAttachments(fileAttachments)
+  } = useFileAttachments(resolvedFileAttachments)
 
   const mentions = useMentions({
     inputValue,
@@ -154,7 +158,14 @@ export const ChatTextarea = ({
     void onStop?.()
   }, [onStop, appendMessages, translation.ai.responseStopped])
 
-  const resolvedDefaultPlaceholder = translation.ai.inputPlaceholder
+  const resolvedPlaceholders = useMemo(() => {
+    if (placeholdersProp !== undefined) return placeholdersProp
+    if (placeholder !== undefined) return [placeholder]
+    return contextPlaceholders ?? []
+  }, [placeholder, placeholdersProp, contextPlaceholders])
+
+  const resolvedDefaultPlaceholder =
+    resolvedPlaceholders[0] ?? placeholder ?? translation.ai.inputPlaceholder
   const uploadedFiles = attachedFiles.filter((f) => f.status === "uploaded")
   const isUploading = attachedFiles.some((f) => f.status === "uploading")
   const hasDataToSend = inputValue.trim().length > 0
@@ -230,14 +241,19 @@ export const ChatTextarea = ({
         if (pendingContext) setPendingContext(null)
         if (pendingQuote) setPendingQuote(null)
 
-        sendMessage({
+        const message: Message = {
           id: crypto.randomUUID(),
           role: "user",
           content: contentParts,
+        }
+
+        void onSend(withQuote, {
+          message,
+          attachments: files,
         })
       } else {
         if (pendingQuote) setPendingQuote(null)
-        onSend(withQuote)
+        void onSend(withQuote)
       }
 
       setInputValue("")
@@ -269,7 +285,7 @@ export const ChatTextarea = ({
     }
   }
 
-  const multiplePlaceholders = (placeholders ?? []).length > 1
+  const multiplePlaceholders = resolvedPlaceholders.length > 1
 
   const highlightSegments = useMemo(() => {
     return buildHighlightSegments(inputValue, mentions.mentions, {
@@ -411,7 +427,7 @@ export const ChatTextarea = ({
                 highlightSegments={highlightSegments}
                 hasOverlay={hasOverlay}
                 multiplePlaceholders={multiplePlaceholders}
-                placeholders={placeholders ?? []}
+                placeholders={resolvedPlaceholders}
                 resolvedDefaultPlaceholder={resolvedDefaultPlaceholder}
                 inProgress={inProgress}
               />

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/ChatTextarea.tsx
@@ -65,7 +65,6 @@ export const ChatTextarea = ({
   onStop,
   creditWarning,
   fileAttachments: fileAttachmentsProp,
-  placeholder,
   placeholders: placeholdersProp,
 }: ChatTextareaProps) => {
   const {
@@ -160,12 +159,11 @@ export const ChatTextarea = ({
 
   const resolvedPlaceholders = useMemo(() => {
     if (placeholdersProp !== undefined) return placeholdersProp
-    if (placeholder !== undefined) return [placeholder]
     return contextPlaceholders ?? []
-  }, [placeholder, placeholdersProp, contextPlaceholders])
+  }, [placeholdersProp, contextPlaceholders])
 
   const resolvedDefaultPlaceholder =
-    resolvedPlaceholders[0] ?? placeholder ?? translation.ai.inputPlaceholder
+    resolvedPlaceholders[0] ?? translation.ai.inputPlaceholder
   const uploadedFiles = attachedFiles.filter((f) => f.status === "uploaded")
   const isUploading = attachedFiles.some((f) => f.status === "uploading")
   const hasDataToSend = inputValue.trim().length > 0

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/ChatTextarea.beforeSend.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/ChatTextarea.beforeSend.test.tsx
@@ -11,12 +11,18 @@ import {
 interface TextareaFieldMockProps {
   inputValue: string
   onInputChange: (value: string, cursorPosition: number) => void
+  resolvedDefaultPlaceholder: string
 }
 
 vi.mock("../TextareaField", () => ({
-  TextareaField: ({ inputValue, onInputChange }: TextareaFieldMockProps) => (
+  TextareaField: ({
+    inputValue,
+    onInputChange,
+    resolvedDefaultPlaceholder,
+  }: TextareaFieldMockProps) => (
     <>
       <textarea aria-label="Message" value={inputValue} readOnly />
+      <span>{resolvedDefaultPlaceholder}</span>
       <button
         type="button"
         onClick={() => onInputChange("Show me my time off", 19)}
@@ -90,5 +96,67 @@ describe("ChatTextarea before-send hook", () => {
     expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
       "Show me my time off"
     )
+  })
+
+  it("passes uploaded attachments to onSend", async () => {
+    const uploadedFile = {
+      url: "https://example.com/report.pdf",
+      filename: "report.pdf",
+      mimetype: "application/pdf",
+    }
+    const onUploadFiles = vi.fn().mockResolvedValue([uploadedFile])
+    const onSend = vi.fn()
+    const user = userEvent.setup()
+    const file = new File(["report"], "report.pdf", {
+      type: "application/pdf",
+    })
+
+    render(
+      <ChatTextarea
+        submitLabel="Send"
+        onSend={onSend}
+        fileAttachments={{ onUploadFiles }}
+      />
+    )
+
+    const input = document.querySelector("input[type='file']")
+    expect(input).toBeInstanceOf(HTMLInputElement)
+    await user.upload(input as HTMLInputElement, file)
+    await waitFor(() => expect(onUploadFiles).toHaveBeenCalledWith([file]))
+    fireEvent.click(screen.getByRole("button", { name: "Fill message" }))
+    await user.click(screen.getByRole("button", { name: "Send" }))
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1))
+    expect(onSend).toHaveBeenCalledWith(
+      "Show me my time off",
+      expect.objectContaining({
+        attachments: [uploadedFile],
+        message: expect.objectContaining({
+          role: "user",
+          content: expect.arrayContaining([
+            {
+              type: "binary",
+              url: uploadedFile.url,
+              filename: uploadedFile.filename,
+              mimeType: uploadedFile.mimetype,
+            },
+            { type: "text", text: "Show me my time off" },
+          ]),
+        }),
+      })
+    )
+    expect(sendMessageMock).not.toHaveBeenCalled()
+  })
+
+  it("uses the custom placeholder", () => {
+    render(
+      <ChatTextarea
+        submitLabel="Send"
+        onSend={vi.fn()}
+        placeholder="Ask about documents"
+      />
+    )
+
+    expect(screen.getByText("Ask about documents")).toBeInTheDocument()
   })
 })

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/ChatTextarea.beforeSend.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/ChatTextarea.beforeSend.test.tsx
@@ -153,7 +153,7 @@ describe("ChatTextarea before-send hook", () => {
       <ChatTextarea
         submitLabel="Send"
         onSend={vi.fn()}
-        placeholder="Ask about documents"
+        placeholders={["Ask about documents"]}
       />
     )
 

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/index.ts
@@ -1,1 +1,6 @@
 export { ChatTextarea } from "./ChatTextarea"
+export type {
+  ChatTextareaOnSend,
+  ChatTextareaProps,
+  ChatTextareaSendContext,
+} from "./types"

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/types.ts
@@ -22,7 +22,6 @@ export interface ChatTextareaProps extends Omit<InputProps, "onSend"> {
   submitLabel?: string
   creditWarning?: AiChatCreditWarning
   fileAttachments?: AiChatFileAttachmentConfig
-  placeholder?: string
   placeholders?: string[]
 }
 

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatTextarea/types.ts
@@ -1,10 +1,29 @@
+import { type Message } from "@copilotkit/shared"
 import { type InputProps } from "@copilotkit/react-ui"
 
-import { type AiChatCreditWarning } from "../../../types"
+import {
+  type AiChatCreditWarning,
+  type AiChatFileAttachmentConfig,
+  type UploadedFile,
+} from "../../../types"
 
-export type ChatTextareaProps = InputProps & {
+export interface ChatTextareaSendContext {
+  message: Message
+  attachments: UploadedFile[]
+}
+
+export type ChatTextareaOnSend = (
+  text: string,
+  context?: ChatTextareaSendContext
+) => ReturnType<InputProps["onSend"]> | void
+
+export interface ChatTextareaProps extends Omit<InputProps, "onSend"> {
+  onSend: ChatTextareaOnSend
   submitLabel?: string
   creditWarning?: AiChatCreditWarning
+  fileAttachments?: AiChatFileAttachmentConfig
+  placeholder?: string
+  placeholders?: string[]
 }
 
 export type AttachedFile = {

--- a/packages/react/src/sds/ai/F0AiChat/components/input/__stories__/ChatTextarea.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/__stories__/ChatTextarea.stories.tsx
@@ -113,6 +113,50 @@ const ChatTextareaWrapper = ({ placeholders }: { placeholders?: string[] }) => {
   )
 }
 
+const StandaloneChatTextareaWrapper = ({
+  placeholders,
+}: {
+  placeholders?: string[]
+}) => {
+  const [messages, setMessages] = useState<string[]>([])
+
+  const handleSend = async (message: string) => {
+    setMessages((prev) => [...prev, `User: ${message}`])
+
+    return {
+      id: `message-${Date.now()}`,
+      role: "assistant" as const,
+      content: "",
+    }
+  }
+
+  return (
+    <div className="w-96 space-y-4">
+      <div className="bg-gray-50 h-32 overflow-y-auto rounded-lg border p-4">
+        {messages.length === 0 ? (
+          <p className="text-gray-500 text-sm">
+            The placeholder is passed directly to ChatTextarea.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {messages.map((msg, index) => (
+              <div key={index} className="text-sm">
+                <span className="font-medium">{msg}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <ChatTextarea
+        inProgress={false}
+        onSend={handleSend}
+        placeholders={placeholders}
+      />
+    </div>
+  )
+}
+
 const meta = {
   title: "AI/F0AiChat/Input/ChatTextarea",
   component: ChatTextareaWrapper,
@@ -142,6 +186,14 @@ export const WithPlaceholders: Story = {
 
 export const WithOnePlaceholder: Story = {
   render: () => <ChatTextareaWrapper placeholders={[PLACEHOLDERS[0]]} />,
+}
+
+export const WithDirectPlaceholders: Story = {
+  render: () => (
+    <StandaloneChatTextareaWrapper
+      placeholders={["Ask about documents, policies, or uploaded files…"]}
+    />
+  ),
 }
 
 const CreditWarningExample = () => {

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -41,7 +41,6 @@ export interface AiChatState {
   credits?: AiChatCredits
   creditWarning?: AiChatCreditWarning
   fileAttachments?: AiChatFileAttachmentConfig
-  placeholder?: string
   placeholders?: string[]
   setPlaceholders?: React.Dispatch<React.SetStateAction<string[]>>
   onThumbsUp?: (
@@ -262,7 +261,6 @@ export type AiChatProviderReturnValue = {
   | "credits"
   | "creditWarning"
   | "fileAttachments"
-  | "placeholder"
 > & {
     /** The current canvas content, or null when canvas is closed */
     canvasContent: CanvasContent | null

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -41,6 +41,7 @@ export interface AiChatState {
   credits?: AiChatCredits
   creditWarning?: AiChatCreditWarning
   fileAttachments?: AiChatFileAttachmentConfig
+  placeholder?: string
   placeholders?: string[]
   setPlaceholders?: React.Dispatch<React.SetStateAction<string[]>>
   onThumbsUp?: (
@@ -261,6 +262,7 @@ export type AiChatProviderReturnValue = {
   | "credits"
   | "creditWarning"
   | "fileAttachments"
+  | "placeholder"
 > & {
     /** The current canvas content, or null when canvas is closed */
     canvasContent: CanvasContent | null

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -143,9 +143,10 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     WelcomeScreenSuggestion[]
   >(initialWelcomeScreenSuggestions)
   const i18n = useI18n()
+  const defaultPlaceholder = i18n.t("ai.inputPlaceholder")
   const [placeholders, setPlaceholders] = useState<string[]>(() => {
     if (initialPlaceholders !== undefined) return initialPlaceholders
-    return [i18n.t("ai.inputPlaceholder")]
+    return [defaultPlaceholder]
   })
 
   const [initialMessage, setInitialMessage] = useState<
@@ -166,8 +167,8 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
       return
     }
 
-    setPlaceholders([i18n.t("ai.inputPlaceholder")])
-  }, [i18n, initialPlaceholders])
+    setPlaceholders([defaultPlaceholder])
+  }, [defaultPlaceholder, initialPlaceholders])
 
   const [inProgress, setInProgressState] = useState(false)
   const setInProgress = useCallback((value: boolean) => {

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -163,8 +163,11 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   useEffect(() => {
     if (initialPlaceholders !== undefined) {
       setPlaceholders(initialPlaceholders)
+      return
     }
-  }, [initialPlaceholders])
+
+    setPlaceholders([i18n.t("ai.inputPlaceholder")])
+  }, [i18n, initialPlaceholders])
 
   const [inProgress, setInProgressState] = useState(false)
   const setInProgress = useCallback((value: boolean) => {

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -105,7 +105,6 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   toolHints,
   credits,
   fileAttachments,
-  placeholder,
   placeholders: initialPlaceholders,
   onThumbsDown,
   onThumbsUp,
@@ -146,7 +145,6 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   const i18n = useI18n()
   const [placeholders, setPlaceholders] = useState<string[]>(() => {
     if (initialPlaceholders !== undefined) return initialPlaceholders
-    if (placeholder !== undefined) return [placeholder]
     return [i18n.t("ai.inputPlaceholder")]
   })
 
@@ -165,13 +163,8 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   useEffect(() => {
     if (initialPlaceholders !== undefined) {
       setPlaceholders(initialPlaceholders)
-      return
     }
-
-    if (placeholder !== undefined) {
-      setPlaceholders([placeholder])
-    }
-  }, [placeholder, initialPlaceholders])
+  }, [initialPlaceholders])
 
   const [inProgress, setInProgressState] = useState(false)
   const setInProgress = useCallback((value: boolean) => {
@@ -503,7 +496,6 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         toolHints,
         credits,
         fileAttachments,
-        placeholder,
         inProgress,
         setInProgress,
         canvasContent,
@@ -590,7 +582,6 @@ export function useAiChat(): AiChatProviderReturnValue {
       credits: undefined,
       creditWarning: undefined,
       fileAttachments: undefined,
-      placeholder: undefined,
       inProgress: false,
       setInProgress: noopFn,
       canvasContent: null,

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -105,6 +105,8 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   toolHints,
   credits,
   fileAttachments,
+  placeholder,
+  placeholders: initialPlaceholders,
   onThumbsDown,
   onThumbsUp,
   tracking,
@@ -142,9 +144,11 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     WelcomeScreenSuggestion[]
   >(initialWelcomeScreenSuggestions)
   const i18n = useI18n()
-  const [placeholders, setPlaceholders] = useState<string[]>([
-    i18n.t("ai.inputPlaceholder"),
-  ])
+  const [placeholders, setPlaceholders] = useState<string[]>(() => {
+    if (initialPlaceholders !== undefined) return initialPlaceholders
+    if (placeholder !== undefined) return [placeholder]
+    return [i18n.t("ai.inputPlaceholder")]
+  })
 
   const [initialMessage, setInitialMessage] = useState<
     string | string[] | undefined
@@ -157,6 +161,17 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
       tracking?.onVisibility?.()
     }
   }, [open])
+
+  useEffect(() => {
+    if (initialPlaceholders !== undefined) {
+      setPlaceholders(initialPlaceholders)
+      return
+    }
+
+    if (placeholder !== undefined) {
+      setPlaceholders([placeholder])
+    }
+  }, [placeholder, initialPlaceholders])
 
   const [inProgress, setInProgressState] = useState(false)
   const setInProgress = useCallback((value: boolean) => {
@@ -488,6 +503,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         toolHints,
         credits,
         fileAttachments,
+        placeholder,
         inProgress,
         setInProgress,
         canvasContent,
@@ -574,6 +590,7 @@ export function useAiChat(): AiChatProviderReturnValue {
       credits: undefined,
       creditWarning: undefined,
       fileAttachments: undefined,
+      placeholder: undefined,
       inProgress: false,
       setInProgress: noopFn,
       canvasContent: null,

--- a/packages/react/src/sds/ai/F0AiChat/providers/__tests__/AiChatStateProvider.beforeSend.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/__tests__/AiChatStateProvider.beforeSend.test.tsx
@@ -8,6 +8,7 @@ import { AiChatStateProvider, useAiChat } from "../AiChatStateProvider"
 
 const rawSendMessageMock = vi.fn()
 const onBeforeSendMessageMock = vi.fn()
+const placeholdersProbeMock = vi.fn()
 
 const SendMessageProbe = () => {
   const { sendMessage, setSendMessageFunction } = useAiChat()
@@ -18,6 +19,16 @@ const SendMessageProbe = () => {
   }, [setSendMessageFunction])
 
   return <button onClick={() => sendMessage("hello")}>Send probe</button>
+}
+
+const PlaceholdersProbe = () => {
+  const { placeholders } = useAiChat()
+
+  useEffect(() => {
+    placeholdersProbeMock(placeholders)
+  }, [placeholders])
+
+  return null
 }
 
 const renderWithProvider = () => {
@@ -39,6 +50,7 @@ describe("AiChatStateProvider before-send hook", () => {
   beforeEach(() => {
     rawSendMessageMock.mockClear()
     onBeforeSendMessageMock.mockReset()
+    placeholdersProbeMock.mockClear()
   })
 
   it("blocks sending when the before-send hook resolves false", async () => {
@@ -53,5 +65,23 @@ describe("AiChatStateProvider before-send hook", () => {
       expect(onBeforeSendMessageMock).toHaveBeenCalledTimes(1)
     )
     expect(rawSendMessageMock).not.toHaveBeenCalled()
+  })
+
+  it("uses provider placeholders from props", async () => {
+    render(
+      <AiChatStateProvider
+        enabled
+        placeholders={["Ask about payroll", "Ask about docs"]}
+      >
+        <PlaceholdersProbe />
+      </AiChatStateProvider>
+    )
+
+    await waitFor(() =>
+      expect(placeholdersProbeMock).toHaveBeenLastCalledWith([
+        "Ask about payroll",
+        "Ask about docs",
+      ])
+    )
   })
 })

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -315,6 +315,15 @@ export type AiChatProviderProps = {
    * File attachment configuration. When provided, enables file uploads in the chat.
    */
   fileAttachments?: AiChatFileAttachmentConfig
+  /**
+   * Placeholder shown in the chat textarea when it is empty.
+   */
+  placeholder?: string
+  /**
+   * Placeholders shown in the chat textarea. Multiple values rotate with the typewriter animation.
+   * Takes precedence over `placeholder` when provided.
+   */
+  placeholders?: string[]
   onThumbsUp?: (
     message: AIMessage,
     { threadId, feedback }: { threadId: string; feedback: string }

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -316,12 +316,7 @@ export type AiChatProviderProps = {
    */
   fileAttachments?: AiChatFileAttachmentConfig
   /**
-   * Placeholder shown in the chat textarea when it is empty.
-   */
-  placeholder?: string
-  /**
    * Placeholders shown in the chat textarea. Multiple values rotate with the typewriter animation.
-   * Takes precedence over `placeholder` when provided.
    */
   placeholders?: string[]
   onThumbsUp?: (


### PR DESCRIPTION
## What\n- Call ChatTextarea onSend for attachment-backed sends and pass a ready multipart message in the optional context.\n- Add placeholder/placeholders customization to ChatTextarea and F0AiChatProvider.\n- Keep F0AiChat/Copilot wrappers responsible for dispatching multipart messages.\n\n## Why\n- Lets domain consumers reuse F0AiChatTextArea with file attachments without bypassing their onSend handler.\n- Makes placeholder text configurable without relying on provider internals.\n\n## Testing\n- pnpm --dir packages/react vitest --project=unit src/sds/ai/F0AiChat/components/input/ChatTextarea/__tests__/ChatTextarea.beforeSend.test.tsx src/sds/ai/F0AiChat/providers/__tests__/AiChatStateProvider.beforeSend.test.tsx\n- pnpm --filter @factorialco/f0-react run format\n- pnpm --filter @factorialco/f0-react run tsc