### PR TITLE
feat(react-native): inline F0Metadata horizontal mode + calendar date icon

### DIFF
--- a/packages/react-native/src/components/F0Metadata/F0Metadata.md
+++ b/packages/react-native/src/components/F0Metadata/F0Metadata.md
@@ -73,7 +73,7 @@ import { F0Metadata } from "@factorialco/f0-react-native"
 | `data-list`    | `data: string[]`                                                                                                                                  | Multiple `F0Text` items stacked |
 | `tag-list`     | `tags: string[]`                                                                                                                                  | `F0TagList` type="raw"          |
 | `dot-tag`      | `label: string`, `color: F0TagDotColor`                                                                                                           | `F0Tag.Dot`                     |
-| `date`         | `formattedDate: string`, `icon?: "warning"\|"critical"`                                                                                           | `F0Text` + optional `F0Icon`    |
+| `date`         | `formattedDate: string`, `icon?: "warning"\|"critical"\|"calendar"`                                                                               | `F0Text` + optional `F0Icon`    |
 | `progress-bar` | `value: number`, `max?`, `label?`                                                                                                                 | `F0Progress` (linear)           |
 
 ## Orientations

--- a/packages/react-native/src/components/F0Metadata/F0Metadata.styles.ts
+++ b/packages/react-native/src/components/F0Metadata/F0Metadata.styles.ts
@@ -31,7 +31,7 @@ export const metadataLabelVariants = tv({
   variants: {
     orientation: {
       vertical: "",
-      horizontal: "w-20 shrink-0",
+      horizontal: "shrink-0",
     },
   },
   defaultVariants: {

--- a/packages/react-native/src/components/F0Metadata/F0Metadata.styles.ts
+++ b/packages/react-native/src/components/F0Metadata/F0Metadata.styles.ts
@@ -31,7 +31,7 @@ export const metadataLabelVariants = tv({
   variants: {
     orientation: {
       vertical: "",
-      horizontal: "w-28 shrink-0",
+      horizontal: "w-20 shrink-0",
     },
   },
   defaultVariants: {

--- a/packages/react-native/src/components/F0Metadata/F0Metadata.types.ts
+++ b/packages/react-native/src/components/F0Metadata/F0Metadata.types.ts
@@ -28,7 +28,11 @@ export type MetadataItemValue =
   | { type: "data-list"; data: string[] }
   | { type: "tag-list"; tags: string[] }
   | { type: "dot-tag"; label: string; color: F0TagDotColor }
-  | { type: "date"; formattedDate: string; icon?: "warning" | "critical" }
+  | {
+      type: "date"
+      formattedDate: string
+      icon?: "warning" | "critical" | "calendar"
+    }
   | {
       type: "progress-bar"
       value: number

--- a/packages/react-native/src/components/F0Metadata/F0MetadataValue.tsx
+++ b/packages/react-native/src/components/F0Metadata/F0MetadataValue.tsx
@@ -12,11 +12,12 @@ import { F0Text } from "../primitives/F0Text"
 
 import type { MetadataItemValue } from "./F0Metadata.types"
 
-const { Warning, AlertCircle } = AppIcons
+const { Warning, AlertCircle, Calendar } = AppIcons
 
 const DATE_ICON_CONFIG = {
   warning: { icon: Warning, color: "warning" as const },
   critical: { icon: AlertCircle, color: "critical" as const },
+  calendar: { icon: Calendar, color: "secondary" as const },
 } as const
 
 /**

--- a/packages/react-native/src/components/F0Metadata/F0MetadataValue.tsx
+++ b/packages/react-native/src/components/F0Metadata/F0MetadataValue.tsx
@@ -15,9 +15,21 @@ import type { MetadataItemValue } from "./F0Metadata.types"
 const { Warning, AlertCircle, Calendar } = AppIcons
 
 const DATE_ICON_CONFIG = {
-  warning: { icon: Warning, color: "warning" as const },
-  critical: { icon: AlertCircle, color: "critical" as const },
-  calendar: { icon: Calendar, color: "secondary" as const },
+  warning: {
+    icon: Warning,
+    color: "warning" as const,
+    textColor: "warning" as const,
+  },
+  critical: {
+    icon: AlertCircle,
+    color: "critical" as const,
+    textColor: "critical" as const,
+  },
+  calendar: {
+    icon: Calendar,
+    color: "secondary" as const,
+    textColor: "default" as const,
+  },
 } as const
 
 /**
@@ -118,11 +130,11 @@ export function F0MetadataValue({ value }: { value: MetadataItemValue }) {
       if (!value.icon) {
         return <F0Text variant="body-sm-default">{value.formattedDate}</F0Text>
       }
-      const { icon, color } = DATE_ICON_CONFIG[value.icon]
+      const { icon, color, textColor } = DATE_ICON_CONFIG[value.icon]
       return (
         <View className="flex-row items-center gap-0.5">
           <F0Icon icon={icon} color={color} size="sm" />
-          <F0Text variant="body-sm-default" color={color}>
+          <F0Text variant="body-sm-default" color={textColor}>
             {value.formattedDate}
           </F0Text>
         </View>

--- a/packages/react-native/src/components/F0Metadata/__tests__/F0Metadata.spec.tsx
+++ b/packages/react-native/src/components/F0Metadata/__tests__/F0Metadata.spec.tsx
@@ -147,6 +147,17 @@ describe("F0Metadata", () => {
         },
       },
       {
+        name: "date — calendar icon",
+        item: {
+          label: "Created",
+          value: {
+            type: "date",
+            formattedDate: "May 14, 2026",
+            icon: "calendar",
+          },
+        },
+      },
+      {
         name: "progress-bar",
         item: {
           label: "Progress",

--- a/packages/react-native/src/components/F0Metadata/__tests__/__snapshots__/F0Metadata.spec.tsx.snap
+++ b/packages/react-native/src/components/F0Metadata/__tests__/__snapshots__/F0Metadata.spec.tsx.snap
@@ -575,7 +575,7 @@ exports[`F0Metadata Snapshots — value types Snapshot — date — calendar ico
         </RNSVGGroup>
       </RNSVGSvgView>
       <Text
-        className="no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
+        className="no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground text-left"
       >
         May 14, 2026
       </Text>

--- a/packages/react-native/src/components/F0Metadata/__tests__/__snapshots__/F0Metadata.spec.tsx.snap
+++ b/packages/react-native/src/components/F0Metadata/__tests__/__snapshots__/F0Metadata.spec.tsx.snap
@@ -497,6 +497,93 @@ exports[`F0Metadata Snapshots — value types Snapshot — data-list 1`] = `
 </View>
 `;
 
+exports[`F0Metadata Snapshots — value types Snapshot — date — calendar icon 1`] = `
+<View
+  className="flex flex-col gap-3"
+>
+  <View
+    className="flex flex-col gap-0.5"
+  >
+    <Text
+      className="no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
+    >
+      Created
+    </Text>
+    <View
+      className="flex-row items-center gap-0.5"
+    >
+      <RNSVGSvgView
+        align="xMidYMid"
+        bbHeight="100%"
+        bbWidth="100%"
+        className="shrink-0 w-4 h-4 stroke-sm text-f0-icon-secondary"
+        fill="none"
+        focusable={false}
+        meetOrSlice={0}
+        minX={0}
+        minY={0}
+        style={
+          [
+            {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            [
+              {},
+            ],
+            {
+              "flex": 0,
+              "height": "100%",
+              "width": "100%",
+            },
+          ]
+        }
+        vbHeight={24}
+        vbWidth={24}
+      >
+        <RNSVGGroup
+          fill={null}
+          propList={
+            [
+              "fill",
+            ]
+          }
+        >
+          <RNSVGPath
+            d="M15 3v2m0 2V5m0 0H9m6 0h1a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H8a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h1m0 0V3m0 2v2M5 10h14"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+            propList={
+              [
+                "stroke",
+                "strokeLinecap",
+                "strokeLinejoin",
+              ]
+            }
+            stroke={
+              {
+                "type": 2,
+              }
+            }
+            strokeLinecap={1}
+            strokeLinejoin={1}
+          />
+        </RNSVGGroup>
+      </RNSVGSvgView>
+      <Text
+        className="no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
+      >
+        May 14, 2026
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`F0Metadata Snapshots — value types Snapshot — date — critical icon 1`] = `
 <View
   className="flex flex-col gap-3"

--- a/packages/react-native/src/components/F0Metadata/__tests__/__snapshots__/F0Metadata.spec.tsx.snap
+++ b/packages/react-native/src/components/F0Metadata/__tests__/__snapshots__/F0Metadata.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`F0Metadata Snapshots — orientations Snapshot — horizontal orientati
     className="flex min-h-8 flex-row items-center gap-2"
   >
     <Text
-      className="w-28 shrink-0 no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
+      className="w-20 shrink-0 no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
     >
       Status
     </Text>
@@ -77,7 +77,7 @@ exports[`F0Metadata Snapshots — orientations Snapshot — horizontal orientati
     className="flex min-h-8 flex-row items-center gap-2"
   >
     <Text
-      className="w-28 shrink-0 no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
+      className="w-20 shrink-0 no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
     >
       Department
     </Text>

--- a/packages/react-native/src/components/F0Metadata/__tests__/__snapshots__/F0Metadata.spec.tsx.snap
+++ b/packages/react-native/src/components/F0Metadata/__tests__/__snapshots__/F0Metadata.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`F0Metadata Snapshots — orientations Snapshot — horizontal orientati
     className="flex min-h-8 flex-row items-center gap-2"
   >
     <Text
-      className="w-20 shrink-0 no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
+      className="shrink-0 no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
     >
       Status
     </Text>
@@ -77,7 +77,7 @@ exports[`F0Metadata Snapshots — orientations Snapshot — horizontal orientati
     className="flex min-h-8 flex-row items-center gap-2"
   >
     <Text
-      className="w-20 shrink-0 no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
+      className="shrink-0 no-underline normal-case tracking-normal text-[14px] leading-[20px] font-normal text-f0-foreground-secondary text-left"
     >
       Department
     </Text>


### PR DESCRIPTION
## Description

Improvements to `F0Metadata` for inline horizontal usage in resource detail headers.

### 1. Drop fixed-width label column (horizontal mode)
The original `w-28` (112px) and intermediate `w-20` (80px) fixed-width labels still produced visible gaps on short labels like `Created`. Remove the fixed width entirely so labels render at content width; spacing between label and value is controlled by the existing item-level `gap-2`.

### 2. Add calendar icon to the `date` value type
Extend the `date` value type with a third icon literal `"calendar"` so a date can render with a neutral calendar glyph alongside the formatted text — useful for created/updated rows where `"warning"` and `"critical"` are not semantically appropriate.

## Implementation details

### Label width
- `F0Metadata.styles.ts`: `metadataLabelVariants.horizontal` — `w-20 shrink-0` → `shrink-0`
- Snapshot updated

### Calendar icon
- `F0Metadata.types.ts`: `date` value `icon?` now accepts `"warning" | "critical" | "calendar"`
- `F0MetadataValue.tsx`: `DATE_ICON_CONFIG.calendar` renders `AppIcons.Calendar` with `color: "secondary"`
- `F0Metadata.md`: docs table updated
- New snapshot test: `date — calendar icon`

No API breakage — `"calendar"` is purely additive.

## Trade-off

Cross-row label alignment in horizontal mode is no longer possible — labels are now content-width. Inline usage (the main use case) is unaffected. If a future caller needs aligned columns, a `labelWidth` prop can be exposed.
