### PR TITLE
fix(F0AnalyticsDashboard): restore Excel/CSV download for collection items

### DIFF
--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useCollectionDownloadActions.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useCollectionDownloadActions.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { zeroRenderHook } from "@/testing/test-utils"
+
+import { useCollectionDownloadActions } from "../hooks/useCollectionDownloadActions"
+import * as downloadHelpers from "../utils/downloadHelpers"
+
+type Employee = {
+  id: string
+  name: string
+  email: string
+  salary: number
+}
+
+const records: Employee[] = [
+  { id: "1", name: "Ada Lovelace", email: "ada@example.com", salary: 1000 },
+  { id: "2", name: "Alan Turing", email: "alan@example.com", salary: 2000 },
+]
+
+function makeSource() {
+  return {
+    dataAdapter: {
+      paginationType: undefined,
+      fetchData: vi.fn().mockResolvedValue({ records }),
+    },
+    currentFilters: {},
+    currentSortings: null,
+    currentGrouping: null,
+    currentSearch: "",
+    currentNavigationFilters: {},
+  }
+}
+
+const columns = [
+  { id: "name", label: "Name" },
+  { id: "email", label: "Email" },
+  {
+    id: "salary",
+    label: "Salary",
+    render: (item: Employee) => `$${item.salary}`,
+  },
+]
+
+describe("useCollectionDownloadActions", () => {
+  beforeEach(() => {
+    vi.spyOn(downloadHelpers, "downloadAsExcel").mockImplementation(() => {})
+    vi.spyOn(downloadHelpers, "downloadAsCsv").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns Excel + CSV download actions when source is provided", () => {
+    const { result } = zeroRenderHook(() =>
+      useCollectionDownloadActions({
+        source: makeSource(),
+        title: "Employees",
+        columns,
+      })
+    )
+
+    const labels = result.current
+      .filter((item) => "label" in item)
+      .map((item) => item.label)
+
+    expect(labels).toContain("Download Excel")
+    expect(labels).toContain("Download CSV")
+  })
+
+  it("returns empty array when source is missing", () => {
+    const { result } = zeroRenderHook(() =>
+      useCollectionDownloadActions({
+        source: null,
+        title: "Employees",
+        columns,
+      })
+    )
+
+    expect(result.current).toEqual([])
+  })
+
+  it("invokes downloadAsExcel with rendered cell values", async () => {
+    const source = makeSource()
+    const { result } = zeroRenderHook(() =>
+      useCollectionDownloadActions({
+        source,
+        title: "Employees",
+        columns,
+      })
+    )
+
+    const excelAction = result.current.find(
+      (item) => "label" in item && item.label === "Download Excel"
+    ) as { onClick: () => Promise<void> }
+
+    await excelAction.onClick()
+
+    expect(downloadHelpers.downloadAsExcel).toHaveBeenCalledTimes(1)
+    const [headers, rows, filename, rowKeys] = (
+      downloadHelpers.downloadAsExcel as unknown as {
+        mock: { calls: unknown[][] }
+      }
+    ).mock.calls[0]
+    expect(headers).toEqual(["Name", "Email", "Salary"])
+    expect(rowKeys).toEqual(["name", "email", "salary"])
+    expect(filename).toBe("Employees")
+    // Rendered column should produce the formatted string, not the raw number.
+    expect(rows).toEqual([
+      { name: "Ada Lovelace", email: "ada@example.com", salary: "$1000" },
+      { name: "Alan Turing", email: "alan@example.com", salary: "$2000" },
+    ])
+  })
+
+  it("invokes downloadAsCsv with rendered cell values", async () => {
+    const source = makeSource()
+    const { result } = zeroRenderHook(() =>
+      useCollectionDownloadActions({
+        source,
+        title: "Employees",
+        columns,
+      })
+    )
+
+    const csvAction = result.current.find(
+      (item) => "label" in item && item.label === "Download CSV"
+    ) as { onClick: () => Promise<void> }
+
+    await csvAction.onClick()
+
+    expect(downloadHelpers.downloadAsCsv).toHaveBeenCalledTimes(1)
+  })
+
+  it("respects hidden columns from tableSettings", async () => {
+    const source = makeSource()
+    const { result } = zeroRenderHook(() =>
+      useCollectionDownloadActions({
+        source,
+        title: "Employees",
+        columns,
+        tableSettings: { hidden: ["email"] },
+      })
+    )
+
+    const excelAction = result.current.find(
+      (item) => "label" in item && item.label === "Download Excel"
+    ) as { onClick: () => Promise<void> }
+
+    await excelAction.onClick()
+
+    const [headers] = (
+      downloadHelpers.downloadAsExcel as unknown as {
+        mock: { calls: unknown[][] }
+      }
+    ).mock.calls[0]
+    expect(headers).toEqual(["Name", "Salary"])
+  })
+
+  it("does not download when there are no columns", async () => {
+    const source = makeSource()
+    const { result } = zeroRenderHook(() =>
+      useCollectionDownloadActions({
+        source,
+        title: "Empty",
+        columns: [],
+      })
+    )
+
+    const excelAction = result.current.find(
+      (item) => "label" in item && item.label === "Download Excel"
+    ) as { onClick: () => Promise<void> }
+
+    await excelAction.onClick()
+
+    expect(downloadHelpers.downloadAsExcel).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -69,14 +69,37 @@ export function CollectionItem<Filters extends FiltersDefinition>({
     order?: string[]
   }>()
 
-  // Columns as declared by the dashboard item. Stable w.r.t. user
-  // interactions — only re-computes when the item's schema changes.
-  const downloadableColumns = useMemo(
-    () =>
-      (item as unknown as { columns?: { id: string; label: string }[] })
-        .columns ?? [],
-    [item]
-  )
+  // Derive the column schema for the download from the item's table
+  // visualization (id/label/render). Collection items don't declare a separate
+  // `columns` list — the table viz is the source of truth, mirroring
+  // OneDataCollection's own `extractColumns` flow.
+  const downloadableColumns = useMemo(() => {
+    const tableViz = item.visualizations?.find(
+      (v) => (v as { type?: string })?.type === "table"
+    ) as
+      | {
+          options?: {
+            columns?: Array<{
+              id?: string
+              label?: string
+              render?: (item: RecordType) => unknown
+            }>
+          }
+        }
+      | undefined
+
+    return (tableViz?.options?.columns ?? [])
+      .filter(
+        (
+          c
+        ): c is {
+          id: string
+          label: string
+          render?: (i: RecordType) => unknown
+        } => typeof c?.id === "string" && typeof c?.label === "string"
+      )
+      .map((c) => ({ id: c.id, label: c.label, render: c.render }))
+  }, [item])
 
   const downloadActions = useCollectionDownloadActions({
     source: source as unknown as Parameters<

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useCollectionDownloadActions.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useCollectionDownloadActions.ts
@@ -12,6 +12,8 @@ import type {
   SortingsStateMultiple,
 } from "@/hooks/datasource"
 
+import { extractDisplayValue } from "@/patterns/OneDataCollection/utils/csvExport"
+
 import { downloadAsCsv, downloadAsExcel } from "../utils/downloadHelpers"
 
 // Mirrors the caps used by OneDataCollection's own `useExportAction` so the
@@ -47,6 +49,10 @@ type DownloadableSource = {
 export type DownloadableColumn = {
   id: string
   label: string
+  /** Optional renderer from the table visualization. When present, its output
+   *  is funneled through `extractDisplayValue` so typed cells (person, status,
+   *  tag, …) export as human-readable strings instead of raw objects. */
+  render?: (item: RecordType) => unknown
 }
 
 interface UseCollectionDownloadActionsOptions {
@@ -220,9 +226,23 @@ export function useCollectionDownloadActions({
         const headerLabels = exportColumns.map((c) => c.label)
         const rowKeys = exportColumns.map((c) => c.id)
 
+        // Pre-resolve each cell: when the column has a renderer, use it (and
+        // extract the display value) so typed cells like `{ type: "person",
+        // value: { firstName, lastName } }` come out as plain text. Otherwise
+        // fall back to the raw field lookup keyed by column id.
+        const transformedRows = records.map((record) => {
+          const row: Record<string, unknown> = {}
+          for (const col of exportColumns) {
+            row[col.id] = col.render
+              ? extractDisplayValue(col.render(record))
+              : record[col.id]
+          }
+          return row
+        })
+
         if (fmt === "excel")
-          downloadAsExcel(headerLabels, records, title, rowKeys)
-        else downloadAsCsv(headerLabels, records, title, rowKeys)
+          downloadAsExcel(headerLabels, transformedRows, title, rowKeys)
+        else downloadAsCsv(headerLabels, transformedRows, title, rowKeys)
       } finally {
         setIsExporting(false)
       }


### PR DESCRIPTION
## Summary
- `CollectionItem` was reading columns from a non-existent `item.columns` field (it lives on the table visualization's `options.columns`), so `downloadableColumns` was always empty and the Excel/CSV downloads silently no-op'd inside `useCollectionDownloadActions` (`if (exportColumns.length === 0) return`).
- Derive columns from the table visualization and forward each column's `render` so typed cells (person, status, tag, …) export as human-readable strings via `extractDisplayValue`, with a fallback to raw `row[id]` lookup when no renderer is defined.
- Added unit tests for `useCollectionDownloadActions` covering: actions presence, null source, rendered values, hidden columns from `tableSettings`, and the empty-columns guard.

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm vitest run src/patterns/F0AnalyticsDashboard/__tests__/` — 21/21 pass (6 new + 15 existing)
- [ ] Manual: open a collection dashboard item, click the 3-dot menu → Download → Excel and CSV produce a file with the visible columns and current filters/sort applied