### PR TITLE
feat(F0Card): add alert prop with controlled visibility

### DIFF
--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type ReactNode, forwardRef, useRef } from "react"
+import { type ReactNode, forwardRef, useRef } from "react"
 
 import { F0Link } from "@/components/F0Link"
 import { Image } from "@/components/Utilities/Image"
@@ -250,17 +250,14 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
           link &&
             "focus-within:border-f1-border-hover focus-within:shadow-md hover:border-f1-border-hover hover:shadow-md",
           selected &&
-            "border-f1-border-selected bg-f1-background-selected-secondary",
-          alert &&
-            alert.visible !== false &&
-            !selected &&
-            "border-2 border-[var(--alert-border-color)]"
+            "border-f1-border-selected bg-f1-background-selected-secondary"
         )}
         style={
           alert && alert.visible !== false && !selected
-            ? ({
-                "--alert-border-color": alertBorderColor[alert.variant],
-              } as CSSProperties)
+            ? {
+                borderColor: alertBorderColor[alert.variant],
+                borderWidth: "2px",
+              }
             : undefined
         }
         onClick={onClick}

--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -20,10 +20,14 @@ import {
   type CardSecondaryAction,
   type CardSecondaryLink,
 } from "./components/CardActions"
+import { CardAlertWrapper, alertBorderColor } from "./components/CardAlert"
 import { CardAvatar, type CardAvatarVariant } from "./components/CardAvatar"
 import { CardMetadata } from "./components/CardMetadata"
 import { CardOptions } from "./components/CardOptions"
-import { type CardMetadata as CardMetadataType } from "./types"
+import {
+  type CardAlertProps,
+  type CardMetadata as CardMetadataType,
+} from "./types"
 
 export const cardImageFits = [
   "contain", // Show entire image, no crop
@@ -168,6 +172,13 @@ export interface CardInternalProps {
    * can manage drag-and-drop while still allowing click navigation via onClick
    */
   disableOverlayLink?: boolean
+
+  /**
+   * Alert banner displayed above the card, wrapping the card visually.
+   * Supports info, warning, critical, and positive variants with a default icon per variant.
+   * Optionally dismissible with a translateY + fade animation.
+   */
+  alert?: CardAlertProps
 }
 
 const imageFitClassMap: Record<CardImageFit, string> = {
@@ -210,6 +221,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
       forceVerticalMetadata = false,
       fullHeight = false,
       disableOverlayLink = false,
+      alert,
     },
     ref
   ) {
@@ -223,7 +235,10 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
       e.preventDefault()
       e.stopPropagation()
     }
-    return (
+
+    // The card body — extracted so it can be placed inside either the plain root
+    // or the alert wrapper without duplication.
+    const cardBody = (
       <Card
         className={cn(
           "group relative bg-f1-background shadow-none transition-all",
@@ -237,9 +252,17 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
           selected &&
             "border-f1-border-selected bg-f1-background-selected-secondary"
         )}
+        style={
+          alert && alert.visible !== false
+            ? {
+                borderColor: alertBorderColor[alert.variant],
+                borderWidth: "2px",
+              }
+            : undefined
+        }
         onClick={onClick}
         data-testid="card"
-        ref={ref}
+        ref={alert ? undefined : ref}
       >
         {link && !disableOverlayLink && (
           <F0Link
@@ -393,6 +416,16 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
         />
       </Card>
     )
+
+    if (alert) {
+      return (
+        <CardAlertWrapper ref={ref} alert={alert} fullHeight={fullHeight}>
+          {cardBody}
+        </CardAlertWrapper>
+      )
+    }
+
+    return cardBody
   }
 )
 

--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -174,9 +174,9 @@ export interface CardInternalProps {
   disableOverlayLink?: boolean
 
   /**
-   * Alert banner displayed above the card, wrapping the card visually.
+   * Alert banner displayed above the card with a coloured header strip and matching border.
    * Supports info, warning, critical, and positive variants with a default icon per variant.
-   * Optionally dismissible with a translateY + fade animation.
+   * Use `visible` + `onDismiss` for controlled dismiss behaviour.
    */
   alert?: CardAlertProps
 }
@@ -253,7 +253,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
             "border-f1-border-selected bg-f1-background-selected-secondary"
         )}
         style={
-          alert && alert.visible !== false
+          alert && alert.visible !== false && !selected
             ? {
                 borderColor: alertBorderColor[alert.variant],
                 borderWidth: "2px",
@@ -262,7 +262,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
         }
         onClick={onClick}
         data-testid="card"
-        ref={alert ? undefined : ref}
+        ref={alert && alert.visible !== false ? undefined : ref}
       >
         {link && !disableOverlayLink && (
           <F0Link
@@ -417,7 +417,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
       </Card>
     )
 
-    if (alert) {
+    if (alert && alert.visible !== false) {
       return (
         <CardAlertWrapper ref={ref} alert={alert} fullHeight={fullHeight}>
           {cardBody}

--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, forwardRef, useRef } from "react"
+import { type CSSProperties, type ReactNode, forwardRef, useRef } from "react"
 
 import { F0Link } from "@/components/F0Link"
 import { Image } from "@/components/Utilities/Image"
@@ -250,14 +250,17 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
           link &&
             "focus-within:border-f1-border-hover focus-within:shadow-md hover:border-f1-border-hover hover:shadow-md",
           selected &&
-            "border-f1-border-selected bg-f1-background-selected-secondary"
+            "border-f1-border-selected bg-f1-background-selected-secondary",
+          alert &&
+            alert.visible !== false &&
+            !selected &&
+            "border-2 border-[var(--alert-border-color)]"
         )}
         style={
           alert && alert.visible !== false && !selected
-            ? {
-                borderColor: alertBorderColor[alert.variant],
-                borderWidth: "2px",
-              }
+            ? ({
+                "--alert-border-color": alertBorderColor[alert.variant],
+              } as CSSProperties)
             : undefined
         }
         onClick={onClick}

--- a/packages/react/src/components/F0Card/F0Card.tsx
+++ b/packages/react/src/components/F0Card/F0Card.tsx
@@ -21,6 +21,8 @@ export type F0CardProps = Omit<CardInternalProps, (typeof privateProps)[number]>
 
 export { cardImageAspectRatios, cardImageFits, cardImageSizes }
 export type { CardImageAspectRatio, CardImageFit, CardImageSize }
+export { cardAlertVariants } from "./types"
+export type { CardAlertProps, CardAlertVariant } from "./types"
 
 const F0CardBase = forwardRef<HTMLDivElement, F0CardProps>((props, ref) => {
   const publicProps = privateProps.reduce((acc, key) => {

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -28,9 +28,11 @@ import { Switch } from "@/ui/switch"
 import { Text } from "@/ui/Text"
 
 import {
+  cardAlertVariants,
   cardImageFits,
   cardImageSizes,
   F0Card,
+  type CardAlertVariant,
   type CardImageFit,
   type CardImageSize,
 } from "../F0Card"
@@ -104,7 +106,7 @@ const meta = {
       },
     },
     ...dataTestIdArgs,
-  },
+  } as never,
   args: {
     imageFit: "fit-width",
     imageSize: "sm",
@@ -659,6 +661,70 @@ export const ImageFitOptions: StoryObj<
   },
 }
 
+export const WithAlert: Story = {
+  args: {
+    ...Default.args,
+    alert: {
+      variant: "warning",
+      title: "This record has pending changes",
+    },
+  },
+}
+
+export const WithDismissibleAlert: Story = {
+  render: (args) => {
+    const [visible, setVisible] = useState(true)
+    return (
+      <div className="flex flex-col gap-3">
+        <F0Card
+          {...args}
+          alert={{
+            variant: "critical",
+            title: "Contract expires soon",
+            dismissible: true,
+            visible,
+            onDismiss: () => setVisible(false),
+          }}
+        />
+        {!visible && (
+          <button
+            className="self-start text-sm text-f1-foreground-secondary underline"
+            onClick={() => setVisible(true)}
+          >
+            Restore alert
+          </button>
+        )}
+      </div>
+    )
+  },
+  args: {
+    ...Default.args,
+  },
+}
+
+export const AlertVariants: Story = {
+  parameters: {
+    docs: {
+      story: { inline: false, height: "1400px" },
+    },
+    noMetaLayout: true,
+  },
+  render: () => (
+    <div className="mx-auto flex max-w-[372px] flex-col gap-4 p-4">
+      {(cardAlertVariants as readonly CardAlertVariant[]).map((variant) => (
+        <F0Card
+          key={variant}
+          {...Default.args}
+          alert={{
+            variant,
+            title: `${variant.charAt(0).toUpperCase()}${variant.slice(1)} alert`,
+          }}
+        />
+      ))}
+    </div>
+  ),
+}
+
 export const Snapshot: Story = {
   parameters: withSnapshot({}),
   render: () => (
@@ -672,6 +738,22 @@ export const Snapshot: Story = {
       <F0Card {...WithImage.args} />
       <F0Card {...WithProgressBar.args} />
       <F0Card {...WithProgressBarCustomColor.args} />
+      <F0Card
+        {...Default.args}
+        alert={{ variant: "info", title: "Info alert" }}
+      />
+      <F0Card
+        {...Default.args}
+        alert={{ variant: "warning", title: "Warning alert" }}
+      />
+      <F0Card
+        {...Default.args}
+        alert={{ variant: "critical", title: "Critical alert" }}
+      />
+      <F0Card
+        {...Default.args}
+        alert={{ variant: "positive", title: "Positive alert" }}
+      />
     </div>
   ),
 }

--- a/packages/react/src/components/F0Card/__tests__/Card.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/Card.test.tsx
@@ -203,4 +203,87 @@ describe("F0Card Component", () => {
       expect(screen.getByRole("tooltip")).toHaveTextContent("Job title")
     })
   })
+
+  describe("alert prop", () => {
+    it("renders the alert banner when alert is provided", () => {
+      render(
+        <F0Card
+          title="Card with alert"
+          alert={{ variant: "warning", title: "Watch out!" }}
+        />
+      )
+
+      expect(screen.getByText("Watch out!")).toBeInTheDocument()
+    })
+
+    it("renders alert banner for each variant", () => {
+      const variants = ["info", "warning", "critical", "positive"] as const
+
+      variants.forEach((variant) => {
+        const { unmount } = render(
+          <F0Card title="Card" alert={{ variant, title: `${variant} alert` }} />
+        )
+        expect(screen.getByText(`${variant} alert`)).toBeInTheDocument()
+        unmount()
+      })
+    })
+
+    it("does not render the alert banner when visible is false", () => {
+      render(
+        <F0Card
+          title="Card"
+          alert={{ variant: "info", title: "Hidden alert", visible: false }}
+        />
+      )
+
+      expect(screen.queryByText("Hidden alert")).not.toBeInTheDocument()
+    })
+
+    it("renders alert without dismiss button when dismissible is not set", () => {
+      render(
+        <F0Card title="Card" alert={{ variant: "info", title: "Info alert" }} />
+      )
+
+      expect(
+        screen.queryByRole("button", { name: /close/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it("renders dismiss button when dismissible is true", () => {
+      const onDismiss = vi.fn()
+      render(
+        <F0Card
+          title="Card"
+          alert={{
+            variant: "info",
+            title: "Dismissible alert",
+            dismissible: true,
+            onDismiss,
+          }}
+        />
+      )
+
+      expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument()
+    })
+
+    it("calls onDismiss when the dismiss button is clicked", async () => {
+      const user = userEvent.setup()
+      const onDismiss = vi.fn()
+
+      render(
+        <F0Card
+          title="Card"
+          alert={{
+            variant: "critical",
+            title: "Critical alert",
+            dismissible: true,
+            onDismiss,
+          }}
+        />
+      )
+
+      await user.click(screen.getByRole("button", { name: /close/i }))
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/packages/react/src/components/F0Card/components/CardAlert.tsx
+++ b/packages/react/src/components/F0Card/components/CardAlert.tsx
@@ -62,11 +62,7 @@ const alertDefaultIcon: Record<CardAlertVariant, IconType> = {
  * The coloured header strip that sits above the card.
  * It has no background of its own — the outer container's bg shows through.
  *
- * Layout from Figma:
- *   border-radius: 12px 12px 0 0
- *   padding: 6px 12px 2px
- *   gap: 12px
- *   height: 32px (hug)
+ * Applied classes: pt-2 (8px) pb-1 (4px) px-3 (12px) gap-1 (4px), rounded-t-xl
  */
 function CardAlertHeader({
   variant,

--- a/packages/react/src/components/F0Card/components/CardAlert.tsx
+++ b/packages/react/src/components/F0Card/components/CardAlert.tsx
@@ -21,10 +21,11 @@ const alertBgClass: Record<CardAlertVariant, string> = {
 }
 
 /**
- * Raw CSS color values for the card's 2px border — must match the alert bg token.
- * We use inline style because Tailwind has no border-f1-background-{variant} utility.
- * These values mirror the `background.{variant}.DEFAULT` token in core/src/tokens/colors.ts:
- *   hsl(var(--{variant}-50) / 0.1)
+ * Raw CSS color values for the card's 2px border — intentionally slightly stronger
+ * than the alert bg token (0.12 vs 0.10) to give the border enough visibility.
+ * These use the same base variable as `background.{variant}.DEFAULT` in colors.ts:
+ *   hsl(var(--{variant}-50) / 0.1) — bg token
+ *   hsl(var(--{variant}-50) / 0.12) — border (slightly more opaque)
  */
 export const alertBorderColor: Record<CardAlertVariant, string> = {
   info: "hsl(var(--info-50) / 0.12)",
@@ -165,3 +166,5 @@ export const CardAlertWrapper = forwardRef<
     </div>
   )
 })
+
+CardAlertWrapper.displayName = "CardAlertWrapper"

--- a/packages/react/src/components/F0Card/components/CardAlert.tsx
+++ b/packages/react/src/components/F0Card/components/CardAlert.tsx
@@ -1,0 +1,167 @@
+import { forwardRef } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { F0Icon, type IconType } from "@/components/F0Icon"
+import { AlertCircle, CheckCircle, InfoCircle, Warning } from "@/icons/app"
+import { Cross } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n/i18n-provider"
+import { cn } from "@/lib/utils"
+
+import type { CardAlertProps, CardAlertVariant } from "../types"
+
+/**
+ * Tailwind bg classes for the outer container.
+ * The outer bg "bleeds through" the header strip area since the strip has no own bg.
+ */
+const alertBgClass: Record<CardAlertVariant, string> = {
+  info: "bg-f1-background-info",
+  warning: "bg-f1-background-warning",
+  critical: "bg-f1-background-critical",
+  positive: "bg-f1-background-positive",
+}
+
+/**
+ * Raw CSS color values for the card's 2px border — must match the alert bg token.
+ * We use inline style because Tailwind has no border-f1-background-{variant} utility.
+ * These values mirror the `background.{variant}.DEFAULT` token in core/src/tokens/colors.ts:
+ *   hsl(var(--{variant}-50) / 0.1)
+ */
+export const alertBorderColor: Record<CardAlertVariant, string> = {
+  info: "hsl(var(--info-50) / 0.12)",
+  warning: "hsl(var(--warning-50) / 0.12)",
+  critical: "hsl(var(--critical-50) / 0.12)",
+  positive: "hsl(var(--positive-50) / 0.12)",
+}
+
+const alertTitleColorClass: Record<CardAlertVariant, string> = {
+  info: "text-f1-foreground-info",
+  warning: "text-f1-foreground-warning",
+  critical: "text-f1-foreground-critical",
+  positive: "text-f1-foreground-positive",
+}
+
+const alertIconColor: Record<
+  CardAlertVariant,
+  "critical" | "warning" | "info" | "positive"
+> = {
+  critical: "critical",
+  warning: "warning",
+  info: "info",
+  positive: "positive",
+}
+
+const alertDefaultIcon: Record<CardAlertVariant, IconType> = {
+  critical: AlertCircle,
+  warning: Warning,
+  info: InfoCircle,
+  positive: CheckCircle,
+}
+
+/**
+ * The coloured header strip that sits above the card.
+ * It has no background of its own — the outer container's bg shows through.
+ *
+ * Layout from Figma:
+ *   border-radius: 12px 12px 0 0
+ *   padding: 6px 12px 2px
+ *   gap: 12px
+ *   height: 32px (hug)
+ */
+function CardAlertHeader({
+  variant,
+  title,
+  icon,
+  dismissible = false,
+  onDismiss,
+}: CardAlertProps) {
+  const { actions } = useI18n()
+  const alertRole =
+    variant === "critical" || variant === "warning" ? "alert" : "status"
+
+  return (
+    <div
+      role={alertRole}
+      className="flex items-center gap-1 rounded-t-xl px-3 pb-1 pt-2"
+    >
+      <div className="flex h-5 w-5 shrink-0 items-center justify-center">
+        <F0Icon
+          icon={icon ?? alertDefaultIcon[variant]}
+          size="md"
+          color={alertIconColor[variant]}
+        />
+      </div>
+
+      <span
+        className={cn(
+          "flex-1 text-base font-medium",
+          alertTitleColorClass[variant]
+        )}
+      >
+        {title}
+      </span>
+
+      {dismissible && (
+        <F0Button
+          icon={Cross}
+          label={actions.close}
+          hideLabel
+          variant="ghost"
+          size="md"
+          onClick={onDismiss}
+          type="button"
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Wraps the card with an alert header sitting on top.
+ *
+ * Design (Figma 6042:19084):
+ *
+ *   ┌─────────────────────────────────┐  ← outer div, alert bg color, rounded-xl
+ *   │ ⚠ Title                      ✕ │  ← header strip (no bg — inherits outer)
+ *   ├─────────────────────────────────┤
+ *   │  ┌───────────────────────────┐  │  ← card (white, 2px border matching alert bg,
+ *   │  │  card body                │  │    full rounded-xl)
+ *   │  └───────────────────────────┘  │
+ *   └─────────────────────────────────┘
+ *
+ * Dismiss is fully controlled: the consumer removes the alert by passing alert={undefined}
+ * (or omitting it) in response to the onDismiss callback.
+ */
+export const CardAlertWrapper = forwardRef<
+  HTMLDivElement,
+  {
+    alert: CardAlertProps
+    fullHeight?: boolean
+    children: React.ReactNode
+  }
+>(function CardAlertWrapper({ alert, fullHeight, children }, ref) {
+  const isVisible = alert.visible !== false
+
+  if (isVisible) {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "rounded-xl",
+          alertBgClass[alert.variant],
+          fullHeight && "flex h-full flex-col"
+        )}
+      >
+        <CardAlertHeader {...alert} />
+        <div className={cn(fullHeight && "flex flex-1 flex-col")}>
+          {children}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div ref={ref} className={cn(fullHeight && "h-full")}>
+      {children}
+    </div>
+  )
+})

--- a/packages/react/src/components/F0Card/types.ts
+++ b/packages/react/src/components/F0Card/types.ts
@@ -12,7 +12,7 @@ export const cardAlertVariants = [
 
 export type CardAlertVariant = (typeof cardAlertVariants)[number]
 
-export interface CardAlertProps {
+interface CardAlertBase {
   /**
    * The visual variant of the alert, which determines the color scheme and default icon.
    */
@@ -31,17 +31,24 @@ export interface CardAlertProps {
    *   alert={{ ..., visible, dismissible: true, onDismiss: () => setVisible(false) }}
    */
   visible?: boolean
-  /**
-   * When true, renders a dismiss (×) button. The consumer controls visibility
-   * by passing or removing the alert prop in response to this callback.
-   */
-  dismissible?: boolean
+}
+
+type CardAlertDismissible = CardAlertBase & {
+  /** Renders a dismiss (×) button. Requires onDismiss. */
+  dismissible: true
   /**
    * Called when the dismiss (×) button is clicked.
    * The consumer is responsible for hiding the alert (e.g. by setting visible: false).
    */
-  onDismiss?: () => void
+  onDismiss: () => void
 }
+
+type CardAlertNonDismissible = CardAlertBase & {
+  dismissible?: false
+  onDismiss?: never
+}
+
+export type CardAlertProps = CardAlertDismissible | CardAlertNonDismissible
 
 /**
  * Card metadata property renderers.

--- a/packages/react/src/components/F0Card/types.ts
+++ b/packages/react/src/components/F0Card/types.ts
@@ -3,6 +3,46 @@ import { valueDisplayRenderers } from "@/ui/value-display"
 
 import { CardPropertyType } from "./components/CardMetadata"
 
+export const cardAlertVariants = [
+  "info",
+  "warning",
+  "critical",
+  "positive",
+] as const
+
+export type CardAlertVariant = (typeof cardAlertVariants)[number]
+
+export interface CardAlertProps {
+  /**
+   * The visual variant of the alert, which determines the color scheme and default icon.
+   */
+  variant: CardAlertVariant
+  /**
+   * The title text displayed in the alert banner.
+   */
+  title: string
+  /**
+   * Optional custom icon. When omitted, defaults to the icon that best represents the variant.
+   */
+  icon?: IconType
+  /**
+   * Controls whether the alert is visible. Defaults to true.
+   * Use this together with onDismiss for controlled dismiss behaviour:
+   *   alert={{ ..., visible, dismissible: true, onDismiss: () => setVisible(false) }}
+   */
+  visible?: boolean
+  /**
+   * When true, renders a dismiss (×) button. The consumer controls visibility
+   * by passing or removing the alert prop in response to this callback.
+   */
+  dismissible?: boolean
+  /**
+   * Called when the dismiss (×) button is clicked.
+   * The consumer is responsible for hiding the alert (e.g. by setting visible: false).
+   */
+  onDismiss?: () => void
+}
+
 /**
  * Card metadata property renderers.
  * Each metadata item consists of an icon and a property with its data.


### PR DESCRIPTION
## Description

Add an `alert` prop to `F0Card` that renders a coloured header strip above the card, visually connecting them with a matching border colour. The alert supports info, warning, critical, and positive variants with controlled visibility.

## Figma Design
<img width="504" height="393" alt="Screenshot 2026-05-19 at 22 33 31" src="https://github.com/user-attachments/assets/0a68b6e7-8f00-4d6f-bed0-045ab7cdaf3d" />

## Recording

https://github.com/user-attachments/assets/256bd805-f6f4-4b0d-862a-efb2e2290e87




[Link to Figma Design](https://www.figma.com/design/SqIAXKMbJVUbwRYBvTILqW/Sidepanel-revamp?node-id=6042-19084)

## Implementation details

- New `alert?: CardAlertProps` prop on `F0Card` / `CardInternal`
- `CardAlertProps`: `variant`, `title`, `icon?`, `visible?` (default `true`), `dismissible?`, `onDismiss?`
- `CardAlertWrapper` renders a coloured outer container (`bg-f1-background-{variant}`) with the header strip sitting above the card; the card gets a matching 2px border (`hsl(var(--{variant}-50) / 0.12)`)
- Dismiss is fully controlled via `visible` + `onDismiss` — no internal state; consumer drives visibility
- Default variant icons use plain `F0Icon` (no border) with correct `color` prop
- Stories added: `WithAlert`, `WithDismissibleAlert`, `AlertVariants`, updated `Snapshot`