### PR TITLE
docs(storybook): make manual MDX docs visible in sidebar

### DIFF
--- a/packages/react/.skills/f0-storybook-stories/SKILL.md
+++ b/packages/react/.skills/f0-storybook-stories/SKILL.md
@@ -43,7 +43,14 @@ type Story = StoryObj<typeof meta>;
 
 ### Snapshots are OFF by default
 
-Chromatic snapshots are globally disabled. Every story that should be captured must opt in:
+**Why**: Chromatic charges per snapshot and visual-diff reviews get noisy when
+the same component produces many captures. The policy is **one consolidated
+snapshot per component** — a single image that shows every meaningful variant
+in a flex layout — so a visual change produces exactly one diff to review.
+
+**Rule**: every component has exactly **one** story exported as `Snapshot`
+that opts in with `withSnapshot({})`. Do **not** scatter `withSnapshot()`
+across multiple stories; consolidate all variants into the `Snapshot` story.
 
 ```tsx
 export const Snapshot: Story = {
@@ -64,6 +71,14 @@ export const Snapshot: Story = {
 | `"no-sidebar"`   | Hide story from sidebar | Hidden from Storybook navigation           |
 
 > **Note:** Storybook applies `tags: ["autodocs"]` globally via `.storybook/preview.tsx`. To opt out of autodocs when a manual MDX page exists, add `"!autodocs"` to the meta tags. Removing `"autodocs"` alone is not enough.
+
+### Manual MDX requires a visible first story
+
+When a component has a manual MDX file (`F0Example.mdx` with `<Meta of={Stories} />`), Storybook attaches the MDX docs entry to the **first exported story** and inherits its tags onto the docs entry.
+
+**Consequence**: if the first exported story has `tags: ["no-sidebar"]`, the Documentation page also gets `no-sidebar` and disappears from the sidebar — the MDX is still served but unreachable through navigation.
+
+**Rule**: with manual MDX, the **first exported story must NOT include `no-sidebar`**. Conventionally that first story is `Default`, and it must remain visible in the sidebar. Hidden helper stories (`no-sidebar`) referenced by `<Canvas of={...} />` come after.
 
 ### ArgTypes for union props
 

--- a/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
+++ b/packages/react/src/components/F0Button/__stories__/F0Button.stories.tsx
@@ -120,7 +120,6 @@ type Story = StoryObj<typeof meta>
 
 // Basic Variants
 export const Default: Story = {
-  tags: ["no-sidebar"],
   args: {
     variant: "default",
     label: "Default Button",
@@ -136,7 +135,6 @@ export const Default: Story = {
 
 // Basic Variants
 export const WithHref: Story = {
-  tags: ["no-sidebar"],
   parameters: {
     docs: {
       description: {
@@ -159,9 +157,121 @@ export const WithHref: Story = {
   },
 }
 
-export const Variants: Story = {
+export const Snapshot: Story = {
   tags: ["no-sidebar"],
   parameters: withSnapshot({}),
+  render: (args) => (
+    <div className="flex flex-col gap-8">
+      <div>
+        <div style={{ fontWeight: 600, marginBottom: 8 }}>Variants</div>
+        <div className="flex gap-2">
+          <F0Button {...args} variant="default" label="Default" />
+          <F0Button {...args} variant="outline" label="Outline" />
+          <F0Button {...args} variant="neutral" label="Neutral" />
+          <F0Button {...args} variant="ghost" label="Ghost" />
+          <F0Button {...args} variant="critical" label="Critical" />
+          <F0Button {...args} variant="promote" label="Promote" />
+        </div>
+      </div>
+      <div>
+        <div style={{ fontWeight: 600, marginBottom: 8 }}>With icon</div>
+        <div className="flex gap-2">
+          <F0Button {...args} variant="default" label="Default" icon={Add} />
+          <F0Button {...args} variant="outline" label="Outline" icon={Add} />
+          <F0Button
+            {...args}
+            variant="neutral"
+            label="Neutral"
+            icon={Archive}
+          />
+          <F0Button {...args} variant="ghost" label="Ghost" icon={Save} />
+          <F0Button
+            {...args}
+            variant="critical"
+            label="Critical"
+            icon={Delete}
+          />
+          <F0Button {...args} variant="promote" label="Promote" icon={Add} />
+        </div>
+      </div>
+      <div>
+        <div style={{ fontWeight: 600, marginBottom: 8 }}>Only icon</div>
+        <div className="flex gap-2">
+          <F0Button
+            {...args}
+            variant="default"
+            label="Default"
+            icon={Add}
+            hideLabel
+          />
+          <F0Button
+            {...args}
+            variant="outline"
+            label="Outline"
+            icon={Add}
+            hideLabel
+          />
+          <F0Button
+            {...args}
+            variant="neutral"
+            label="Neutral"
+            icon={Archive}
+            hideLabel
+          />
+          <F0Button
+            {...args}
+            variant="ghost"
+            label="Ghost"
+            icon={Save}
+            hideLabel
+          />
+          <F0Button
+            {...args}
+            variant="critical"
+            label="Critical"
+            icon={Delete}
+            hideLabel
+          />
+          <F0Button
+            {...args}
+            variant="promote"
+            label="Promote"
+            icon={Add}
+            hideLabel
+          />
+        </div>
+      </div>
+      <div>
+        <div style={{ fontWeight: 600, marginBottom: 8 }}>Only emoji</div>
+        <div className="flex gap-2">
+          <F0Button {...args} emoji="🥰" label="Emoji" variant="neutral" />
+        </div>
+      </div>
+      <div>
+        <div style={{ fontWeight: 600, marginBottom: 8 }}>Sizes</div>
+        <div className="flex items-center gap-4">
+          <F0Button {...args} size="lg" label="Large" />
+          <F0Button {...args} size="md" label="Medium" />
+          <F0Button {...args} size="sm" label="Small" />
+        </div>
+      </div>
+      <div>
+        <div style={{ fontWeight: 600, marginBottom: 8 }}>States</div>
+        <div className="flex gap-2">
+          <F0Button {...args} label="Default" />
+          <F0Button {...args} label="Disabled" disabled />
+          <F0Button {...args} label="Loading" loading />
+        </div>
+      </div>
+    </div>
+  ),
+}
+
+// MDX helpers — hidden from sidebar, referenced by F0Button.mdx via <Canvas of={...} />.
+// Not opted-in to Chromatic (see Snapshot above for the consolidated capture).
+
+export const Variants: Story = {
+  tags: ["no-sidebar"],
   render: (args) => (
     <div className="flex gap-2">
       <F0Button {...args} variant="default" label="Default" />
@@ -176,7 +286,6 @@ export const Variants: Story = {
 
 export const IconVariants: Story = {
   tags: ["no-sidebar"],
-  parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex flex-col gap-6">
       <div>
@@ -234,7 +343,7 @@ export const IconVariants: Story = {
           <F0Button
             {...args}
             variant="critical"
-            label="Critical "
+            label="Critical"
             icon={Delete}
             hideLabel
           />
@@ -257,10 +366,8 @@ export const IconVariants: Story = {
   ),
 }
 
-// Size Variants
 export const Sizes: Story = {
   tags: ["no-sidebar"],
-  parameters: withSnapshot({}),
   render: (args) => (
     <div className="flex items-center gap-4">
       <F0Button {...args} size="lg" label="Large" tooltip="Large button" />
@@ -270,15 +377,39 @@ export const Sizes: Story = {
   ),
 }
 
+export const States: Story = {
+  tags: ["no-sidebar"],
+  render: (args) => {
+    const [asyncLoading, setAsyncLoading] = React.useState(false)
+    return (
+      <div className="flex gap-2">
+        <F0Button {...args} label="Disabled" disabled />
+        <F0Button {...args} label="Loading" loading />
+        <F0Button
+          {...args}
+          label={asyncLoading ? "Saving..." : "Async Loading"}
+          loading={asyncLoading}
+          onClick={async () => {
+            setAsyncLoading(true)
+            await new Promise((resolve) => setTimeout(resolve, 1500))
+            setAsyncLoading(false)
+            alert("Async action completed!")
+          }}
+        />
+      </div>
+    )
+  },
+}
+
 export const Ellipsis: Story = {
-  parameters: withSnapshot({
+  parameters: {
     docs: {
       description: {
         story:
           "A button that will truncate the label if it is too long, to allow for better readability and usability.",
       },
     },
-  }),
+  },
   render: (args) => (
     <div
       className="flex max-w-[120px] flex-col items-center gap-4 p-3"
@@ -374,7 +505,6 @@ export const AsyncAction: Story = {
 }
 
 export const IconButtonGroup: Story = {
-  parameters: withSnapshot({}),
   render: () => (
     <div className="flex items-center gap-2">
       <F0Button variant="ghost" icon={Add} hideLabel label="Add" />
@@ -390,31 +520,6 @@ export const OnlyEmoji: Story = {
     label: "Emoji",
     variant: "neutral",
     hideLabel: true,
-  },
-}
-
-export const States: Story = {
-  tags: ["no-sidebar"],
-  parameters: withSnapshot({}),
-  render: (args) => {
-    const [asyncLoading, setAsyncLoading] = React.useState(false)
-    return (
-      <div className="flex gap-2">
-        <F0Button {...args} label="Disabled" disabled />
-        <F0Button {...args} label="Loading" loading />
-        <F0Button
-          {...args}
-          label={asyncLoading ? "Saving..." : "Async Loading"}
-          loading={asyncLoading}
-          onClick={async () => {
-            setAsyncLoading(true)
-            await new Promise((resolve) => setTimeout(resolve, 1500))
-            setAsyncLoading(false)
-            alert("Async action completed!")
-          }}
-        />
-      </div>
-    )
   },
 }
 

--- a/packages/react/src/components/F0ButtonDropdown/__stories__/F0ButtonDropdown.stories.tsx
+++ b/packages/react/src/components/F0ButtonDropdown/__stories__/F0ButtonDropdown.stories.tsx
@@ -100,7 +100,6 @@ type Story = StoryObj<typeof meta>
 
 // Basic Variants
 export const Default: Story = {
-  tags: ["no-sidebar"],
   args: {
     variant: "default",
     items: [


### PR DESCRIPTION
## Description

Two stable components (**F0Button** and **F0ButtonDropdown**) had a manual MDX docs file (`F0*.mdx` with `<Meta of={Stories} />`) whose **Documentation** entry was hidden from the Storybook sidebar. The MDX was still being served by direct URL, but unreachable through navigation.

This PR fixes the visibility and documents the underlying convention in the `f0-storybook-stories` skill so it doesn't happen again.

## Root cause

When MDX is attached via `<Meta of={Stories} />`, Storybook attaches the docs entry to the **first exported story** and inherits its tags. Both components had `Default` as the first story with `tags: ["no-sidebar"]`, so the docs entry also inherited `no-sidebar` and disappeared from the sidebar.

You can verify this by inspecting `/index.json` before the fix:

```
components-button-button--documentation -> ['autodocs', 'stable', 'no-sidebar', 'play-fn', 'attached-mdx']
                                                                  ^^^^^^^^^^^^^ inherited from Default
```

## Screenshots (if applicable)

<!-- TODO: drag the two Storybook sidebar screenshots here in GitHub web -->

[Link to Figma Design](N/A — internal docs)

## Implementation details

### 1. `F0Button` and `F0ButtonDropdown` — remove `no-sidebar` from `Default`

Both first stories now stay visible in the sidebar, so the attached MDX docs entry is reachable. This matches the convention already used by F0Alert, F0BigNumber, F0Heading, F0Link, etc.

### 2. `F0Button` — consolidate `withSnapshot()` calls

Per the existing **one consolidated Snapshot per component** policy (Chromatic cost + diff noise reduction), F0Button had scattered `withSnapshot()` across 6 stories. They are now consolidated into a single `Snapshot` story exporting all meaningful variants (variants, icon, only-icon, only-emoji, sizes, states) in a flex layout.

Hidden helper stories (`Variants`, `IconVariants`, `Sizes`, `States`) remain in the file because the MDX file references them via `<Canvas of={Stories.X} />`. They are tagged `no-sidebar` and do **not** opt in to Chromatic.

### 3. `f0-storybook-stories` skill — document the rules

Two rule sections added/expanded in `packages/react/.skills/f0-storybook-stories/SKILL.md`:

- **Snapshots are OFF by default** — adds the *Why* (Chromatic cost, diff noise) and an explicit *Rule* statement (one `Snapshot` per component, do not scatter).
- **Manual MDX requires a visible first story** (new) — explains the tag inheritance behavior and mandates that, when MDX exists, the first exported story (conventionally `Default`) must not have `no-sidebar`.

## Validation

| Check | Result |
| --- | --- |
| \`pnpm format\` | ✅ |
| \`pnpm tsc\` | ✅ no new errors |
| \`pnpm lint\` | ✅ 0 warnings |
| \`pnpm vitest:ci\` (F0Button + F0ButtonDropdown) | ✅ 117 passed, 1 skipped |
| Storybook sidebar | ✅ Documentation entries now visible for both components (see screenshots) |

## How to verify locally

\`\`\`bash
pnpm --filter @factorialco/f0-react storybook dev
\`\`\`

Then open:

- http://localhost:6006/?path=/docs/components-button-button--documentation
- http://localhost:6006/?path=/docs/components-button-buttondropdown--documentation

Confirm the **Documentation** entry appears in the sidebar under Button → Button and Button → ButtonDropdown.

## Out of scope

- `sds-upsellingkit-productcard--documentation` is also affected by the same pattern but is an internal SDS component not exposed publicly; left as-is for now. Will be addressed when that area is touched.