### PR TITLE
feat(F0AiChat): add F0EmployeeCreditsWarning for per-employee credit caps [FCT-54242]

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -402,6 +402,10 @@ export const defaultTranslations = {
         description: "Your company has run out of AI credits.",
         actionLabel: "Get credits",
       },
+      employeeMessageBanner: {
+        title: "This response requires credits",
+        description: "You have run out of your assigned AI credits.",
+      },
     },
     attachFile: "Attach file",
     removeFile: "Remove",

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/employeeCreditsWarning/F0EmployeeCreditsWarning.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/employeeCreditsWarning/F0EmployeeCreditsWarning.tsx
@@ -1,0 +1,19 @@
+import { F0Alert } from "@/components/F0Alert"
+import { useI18n } from "@/lib/providers/i18n"
+
+import { F0EmployeeCreditsWarningProps } from "./types"
+
+export const F0EmployeeCreditsWarning = (
+  _props: F0EmployeeCreditsWarningProps
+) => {
+  const translations = useI18n()
+  const employeeBanner = translations?.ai?.creditWarning.employeeMessageBanner
+
+  return (
+    <F0Alert
+      title={employeeBanner?.title}
+      variant="warning"
+      description={employeeBanner?.description}
+    />
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/employeeCreditsWarning/__stories__/F0EmployeeCreditsWarning.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/employeeCreditsWarning/__stories__/F0EmployeeCreditsWarning.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { I18nProvider, defaultTranslations } from "@/lib/providers/i18n"
+
+import { F0EmployeeCreditsWarning } from "../index"
+
+const meta = {
+  title: "AI/Widgets/UpsellKit/F0EmployeeCreditsWarning",
+  component: F0EmployeeCreditsWarning,
+  decorators: [
+    (Story) => (
+      <I18nProvider translations={defaultTranslations}>
+        <div className="w-[780px] max-w-[90vw]">
+          <Story />
+        </div>
+      </I18nProvider>
+    ),
+  ],
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof F0EmployeeCreditsWarning>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/employeeCreditsWarning/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/employeeCreditsWarning/index.ts
@@ -1,0 +1,5 @@
+export { F0EmployeeCreditsWarning } from "./F0EmployeeCreditsWarning"
+export type {
+  F0EmployeeCreditsWarningArgs,
+  F0EmployeeCreditsWarningProps,
+} from "./types"

--- a/packages/react/src/sds/ai/F0AiChat/actions/core/employeeCreditsWarning/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/actions/core/employeeCreditsWarning/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Props for the F0EmployeeCreditsWarning component
+ */
+export interface F0EmployeeCreditsWarningProps {}
+
+/**
+ * Args for the per-employee credits warning copilot action
+ */
+export interface F0EmployeeCreditsWarningArgs {}

--- a/packages/react/src/sds/ai/F0AiChat/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/index.ts
@@ -83,6 +83,11 @@ export type {
   F0MessageCreditsWarningArgs,
   F0MessageCreditsWarningProps,
 } from "./actions/core/messageCreditsWarning"
+export { F0EmployeeCreditsWarning } from "./actions/core/employeeCreditsWarning"
+export type {
+  F0EmployeeCreditsWarningArgs,
+  F0EmployeeCreditsWarningProps,
+} from "./actions/core/employeeCreditsWarning"
 export type { OrchestratorThinkingResult } from "./actions/core/orchestratorThinking/types"
 
 // Clarifying question types (panel state is owned by useAiChat)


### PR DESCRIPTION
## Summary

- Adds a new `F0EmployeeCreditsWarning` component under `F0AiChat/actions/core/employeeCreditsWarning/` that renders an `F0Alert` (warning, no action button) when the **current employee** has exhausted their personal AI credit cap.
- Symmetric to the existing `F0MessageCreditsWarning` (company-level cap), but intentionally has no call-to-action since employees cannot self-serve more credits — the messaging is informational.
- Adds matching i18n defaults under `ai.creditWarning.employeeMessageBanner.{title,description}`.

## Why a separate component?

The existing `F0MessageCreditsWarning` is the company-wide upsell variant with an upgrade CTA. Per-employee caps (introduced in FCT-54258) require different copy and a different (no-op) interaction model. Splitting into a sibling component keeps each surface focused, avoids prop-discriminated unions, and lets the agent emit a distinct copilot action per scope.

## How it's used

The factorial-agent's `assertPaidAiCreditsAllowed` emits this widget (via the copilot tool `AiWidgets.UpsellKit.F0EmployeeCreditsWarning`) when the new per-employee gate blocks paid work with `reason: 'employee_credits_exhausted' | 'employee_missing_status'`. Company-side reasons continue to emit `F0MessageCreditsWarning`.

The matching copilot action in `factorial/frontend` will be wired up in a follow-up PR (depends on this PR's published alpha).

## Files

- `packages/react/src/sds/ai/F0AiChat/actions/core/employeeCreditsWarning/{F0EmployeeCreditsWarning.tsx,types.ts,index.ts,__stories__/...}` — new
- `packages/react/src/sds/ai/F0AiChat/index.ts` — re-exports
- `packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts` — new `employeeMessageBanner` keys

## Validation

- `pnpm --filter @factorialco/f0-react run format` ✅
- `pnpm --filter @factorialco/f0-react run tsc` ✅
- Storybook story added with default render

## Related

- factorial-agent branch: `feat/FCT-54242-enforce-employee-credits-in-agent` (uncommitted) — wires up the secondary gate and emits this widget.
- Backend: PR #99172 (FCT-54258) provides the `aiCredits.employeeCreditStatusesConnection` field the agent consumes.