### PR TITLE
chore(F0Link): mark as stable

### DIFF
--- a/packages/react/src/components/F0Link/F0Link.tsx
+++ b/packages/react/src/components/F0Link/F0Link.tsx
@@ -73,4 +73,6 @@ const _F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
   )
 })
 
+_F0Link.displayName = "F0Link"
+
 export const F0Link = withDataTestId(_F0Link)


### PR DESCRIPTION
## Description

Marks **F0Link** as fully stable by closing the last remaining automated DoD gap: an explicit \`displayName\` on the \`forwardRef\` component.

After this PR, F0Link passes every automated criterion checked by the lifecycle dashboard for a stable component (story present, MDX docs, tags consistent, unit tests, snapshot story, no \`any\`, no default export, F0 prefix, no direct Radix import, etc.).

## Implementation details

\`packages/react/src/components/F0Link/F0Link.tsx\` — add one line after the \`forwardRef\` block:

\`\`\`tsx
_F0Link.displayName = "F0Link"
\`\`\`

Without it, React DevTools and stack traces label the component as \"Link\" (the inner function name) instead of \"F0Link\". The \`f0-code-review\` rule \"If forwardRef is used, displayName is set\" treats the missing assignment as a blocking issue for stable components.

## Validation

| Check | Result |
| --- | --- |
| \`pnpm format\` | ✅ |
| \`pnpm tsc\` | ✅ no new errors |
| \`pnpm lint\` | ✅ 0 warnings |
| \`pnpm vitest:ci src/components/F0Link\` | ✅ 7 passed |
| Lifecycle dashboard | ✅ F0Link → 0 issues (was 1: \`forwardref_displayname\`) |

## Out of scope

Other components still missing \`displayName\` (\`F0Icon\`) will be addressed in separate PRs as we continue the stabilisation pass per component.