### PR TITLE
fix(avatar): match ticketing icon to tasks

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarModule/modules.ts
+++ b/packages/react/src/components/avatars/F0AvatarModule/modules.ts
@@ -1,10 +1,9 @@
 import { IconType } from "@/components/F0Icon"
-import { CheckCircleLine } from "@/icons/app"
 import * as ModuleIcons from "@/icons/modules"
 
 export const modules = {
   "ai-reports": ModuleIcons.Reports,
-  ai_ticketing: CheckCircleLine,
+  ai_ticketing: ModuleIcons.Tasks,
   analytics: ModuleIcons.Reports,
   ats: ModuleIcons.Recruitment,
   benefits: ModuleIcons.Benefits,

--- a/packages/react/src/components/avatars/F0AvatarModule/modules.ts
+++ b/packages/react/src/components/avatars/F0AvatarModule/modules.ts
@@ -1,9 +1,10 @@
 import { IconType } from "@/components/F0Icon"
+import { CheckCircleLine } from "@/icons/app"
 import * as ModuleIcons from "@/icons/modules"
 
 export const modules = {
   "ai-reports": ModuleIcons.Reports,
-  ai_ticketing: ModuleIcons.Inbox,
+  ai_ticketing: CheckCircleLine,
   analytics: ModuleIcons.Reports,
   ats: ModuleIcons.Recruitment,
   benefits: ModuleIcons.Benefits,


### PR DESCRIPTION
## 🚪 Why?

### Problem
Ticketing needs to use the same icon as Tasks everywhere, including F0 module avatars.

### Root Cause
The F0AvatarModule module-id map pointed ai_ticketing to the inbox module icon instead of the same module icon used by tasks.

## 🔑 What?

### Changes
- Update the ai_ticketing module avatar mapping to use the same ModuleIcons.Tasks icon as tasks.

## ✅ Verification

### Tests
- git diff --check
- Formatted the changed file with oxfmt from the existing local checkout.
- pnpm --filter @factorialco/f0-react run tsc could not run in the clean worktree because node_modules is missing.

## 🏷️ Skill tags

`skill:pr`