### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "2.11.1",
-  "packages/react-native": "0.54.0",
+  "packages/react-native": "0.55.0",
   "packages/core": "1.50.3"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.55.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.54.0...f0-react-native-v0.55.0) (2026-05-20)
+
+
+### Features
+
+* **react-native:** add calendar icon support to F0Metadata date value ([8e37190](https://github.com/factorialco/f0/commit/8e371909bb8435530765f4fde8a37eb5969e38c9))
+
+
+### Bug Fixes
+
+* **react-native:** drop fixed-width label column in F0Metadata horizontal mode ([da6d392](https://github.com/factorialco/f0/commit/da6d3929b95cb57636c8f8a518681ab29d2d284f))
+* **react-native:** keep date text color independent of icon color in F0Metadata ([7a80fce](https://github.com/factorialco/f0/commit/7a80fce9fb9c28b9913d5ad87b3b888b387fcd6a))
+* **react-native:** tighten F0Metadata horizontal label width ([f36c64f](https://github.com/factorialco/f0/commit/f36c64fcf876d00cd02d46a5c50ed8c7da1e9ae5))
+
 ## [0.54.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.53.0...f0-react-native-v0.54.0) (2026-05-18)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.55.0</summary>

## [0.55.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.54.0...f0-react-native-v0.55.0) (2026-05-20)


### Features

* **react-native:** add calendar icon support to F0Metadata date value ([8e37190](https://github.com/factorialco/f0/commit/8e371909bb8435530765f4fde8a37eb5969e38c9))


### Bug Fixes

* **react-native:** drop fixed-width label column in F0Metadata horizontal mode ([da6d392](https://github.com/factorialco/f0/commit/da6d3929b95cb57636c8f8a518681ab29d2d284f))
* **react-native:** keep date text color independent of icon color in F0Metadata ([7a80fce](https://github.com/factorialco/f0/commit/7a80fce9fb9c28b9913d5ad87b3b888b387fcd6a))
* **react-native:** tighten F0Metadata horizontal label width ([f36c64f](https://github.com/factorialco/f0/commit/f36c64fcf876d00cd02d46a5c50ed8c7da1e9ae5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).