### PR TITLE
fix: some adjustments to F0 forms

### DIFF
--- a/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
+++ b/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
@@ -62,7 +62,7 @@ const _DataChartEmptyState = forwardRef<
         aria-hidden
         className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-50 [&_*]:animate-none"
       >
-        <div className="h-full max-h-[360px] w-full max-w-[720px]">
+        <div className="max-w-content h-full max-h-[360px] w-full">
           {skeletonByType[chartType]()}
         </div>
       </div>

--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -163,7 +163,7 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
   }, [sections, sectionIds, showSectionsSidepanel, handleSectionClick])
 
   const content = (
-    <div className={cn("flex w-full flex-col max-w-content", className)}>
+    <div className={cn("flex w-full flex-col max-w-content p-4", className)}>
       {sectionIds.map((sectionId, index) => {
         const sectionSchema = schema[sectionId]
         const sectionConfig = sections?.[sectionId]
@@ -1044,9 +1044,10 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       ref={formElementRef}
       onSubmit={onFormSubmit}
       className={cn(
-        "flex flex-col w-full mx-auto max-w-content",
+        "flex flex-col w-full mx-auto max-w-content p-4",
         className,
-        styling?.showSectionsSidepanel && "p-2 [&>div:last-child]:pb-6"
+        styling?.showSectionsSidepanel &&
+          "py-2 pl-0 pr-4 [&>div:last-child]:pb-6"
       )}
     >
       {/* Render definition items with switch grouping */}

--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -121,7 +121,7 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
     onSubmit,
     submitConfig,
     className,
-    errorTriggerMode = "on-blur",
+    errorTriggerMode = "on-submit",
     styling,
     initialFiles,
     isLoadingInitialFiles,
@@ -511,7 +511,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
     onSubmit,
     submitConfig,
     className,
-    errorTriggerMode = "on-blur",
+    errorTriggerMode = "on-submit",
     styling,
     formRef,
     isLoading: isFormLoading,
@@ -1085,10 +1085,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
             return (
               <div
                 key={groupedItem.item.field.id}
-                className={cn(
-                  fieldGapClass,
-                  "empty:hidden [&>span.hidden]:hidden"
-                )}
+                className={cn(fieldGapClass, "has-[>span.hidden]:hidden")}
               >
                 {fieldContent}
               </div>

--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -40,7 +40,7 @@ import { RowRenderer } from "./components/RowRenderer"
 import { SectionRenderer } from "./components/SectionRenderer"
 import { SwitchGroupRenderer } from "./components/SwitchGroupRenderer"
 import { createConditionalResolver } from "./conditionalResolver"
-import { FORM_MAX_WIDTH, SECTION_MARGIN } from "./constants"
+import { SECTION_MARGIN } from "./constants"
 import { F0FormContext, generateAnchorId } from "./context"
 import { useF0AiFormRegistry } from "./F0AiFormRegistry"
 import { CardSelectDepsContext } from "./fields/cardSelect/CardSelectDepsContext"
@@ -163,7 +163,7 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
   }, [sections, sectionIds, showSectionsSidepanel, handleSectionClick])
 
   const content = (
-    <div className={cn("flex w-full flex-col", FORM_MAX_WIDTH, className)}>
+    <div className={cn("flex w-full flex-col max-w-content", className)}>
       {sectionIds.map((sectionId, index) => {
         const sectionSchema = schema[sectionId]
         const sectionConfig = sections?.[sectionId]
@@ -1046,8 +1046,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       ref={formElementRef}
       onSubmit={onFormSubmit}
       className={cn(
-        "flex flex-col w-full mx-auto",
-        FORM_MAX_WIDTH,
+        "flex flex-col w-full mx-auto max-w-content",
         className,
         styling?.showSectionsSidepanel && "p-2 [&>div:last-child]:pb-6"
       )}

--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -15,7 +15,7 @@ import { ActionBarStatus, F0ActionBarRef } from "@/components/F0ActionBar"
 import { F0Button } from "@/components/F0Button"
 import { F0TableOfContent } from "@/experimental/Navigation/F0TableOfContent"
 import { TOCItem } from "@/experimental/Navigation/F0TableOfContent/types"
-import { Delete, Save } from "@/icons/app"
+import { Delete } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import { cn } from "@/lib/utils"
 import { Form as FormProvider } from "@/ui/form"
@@ -531,10 +531,8 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
   const isAutosubmit = submitConfig?.type === "autosubmit"
 
   // Resolve submit button configuration with defaults
-  // icon: undefined = use default, null = no icon, IconType = custom icon
   const submitLabel = submitConfig?.label ?? "Submit"
-  const submitIcon =
-    submitConfig?.icon === null ? undefined : (submitConfig?.icon ?? Save)
+  const submitIcon = submitConfig?.icon ?? undefined
 
   // Extract type-specific props
   // Show submit button by default unless explicitly hidden, using action-bar, or autosubmit
@@ -1120,7 +1118,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
 
       {/* Default submit button */}
       {!isActionBar && showSubmitButton && (
-        <div className="mt-4">
+        <div className="mt-4 flex justify-end">
           <F0Button
             type="submit"
             label={submitLabel}

--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -163,7 +163,7 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
   }, [sections, sectionIds, showSectionsSidepanel, handleSectionClick])
 
   const content = (
-    <div className={cn("flex w-full flex-col max-w-content p-4", className)}>
+    <div className={cn("flex w-full flex-col max-w-content", className)}>
       {sectionIds.map((sectionId, index) => {
         const sectionSchema = schema[sectionId]
         const sectionConfig = sections?.[sectionId]
@@ -212,12 +212,12 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
           />
         </div>
         <div className="sticky bottom-0 top-0 w-px bg-f1-border-secondary" />
-        {content}
+        <div className="flex w-full justify-center px-4 py-2">{content}</div>
       </div>
     )
   }
 
-  return content
+  return <div className="flex justify-center p-4">{content}</div>
 }
 
 /**
@@ -1044,10 +1044,9 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       ref={formElementRef}
       onSubmit={onFormSubmit}
       className={cn(
-        "flex flex-col w-full mx-auto max-w-content p-4",
+        "flex flex-col w-full mx-auto max-w-content",
         className,
-        styling?.showSectionsSidepanel &&
-          "py-2 pl-0 pr-4 [&>div:last-child]:pb-6"
+        styling?.showSectionsSidepanel && "[&>div:last-child]:pb-6"
       )}
     >
       {/* Render definition items with switch grouping */}
@@ -1150,10 +1149,12 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
             <div className="sticky bottom-0 top-0 mr-4 w-px bg-f1-border-secondary" />
 
             {/* Form content - centered in available space */}
-            {formContent}
+            <div className="flex w-full justify-center px-4 py-2">
+              {formContent}
+            </div>
           </div>
         ) : (
-          formContent
+          <div className="flex justify-center p-4">{formContent}</div>
         )}
 
         {!hideActionBar && (

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -1595,7 +1595,7 @@ export const CustomField: Story = {
         console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
         return { success: true }
       },
-      submitConfig: { label: "Create Task", icon: null },
+      submitConfig: { label: "Create Task" },
     })
 
     const renderCustomField = useCallback((props: RenderCustomFieldProps) => {
@@ -1723,7 +1723,7 @@ export const SelectWithCustomFieldName: Story = {
         console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
         return { success: true }
       },
-      submitConfig: { label: "Save", icon: null },
+      submitConfig: { label: "Save" },
     })
 
     const renderCustomField = useCallback(
@@ -1916,7 +1916,7 @@ export const VisualDesignExample: Story = {
         console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
         return { success: true }
       },
-      submitConfig: { label: "Create Survey", icon: null },
+      submitConfig: { label: "Create Survey" },
     })
 
     return (

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -2474,6 +2474,7 @@ export const FormInDialog: Story = {
             label: "Cancel",
             onClick: () => setOpen(false),
           }}
+          disableContentPadding
         >
           <F0Form formDefinition={formDefinition} formRef={formRef} />
         </F0Dialog>

--- a/packages/react/src/patterns/F0Form/__tests__/F0Form.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0Form.test.tsx
@@ -3448,3 +3448,70 @@ describe("F0Form sections sidepanel scroll", () => {
     expect(stickyElement).toHaveClass("top-0")
   })
 })
+
+describe("F0Form renderIf hidden field layout", () => {
+  it("wrapper div of a hidden field (renderIf=false) has the has-[>span.hidden]:hidden class so it does not impact layout", () => {
+    const formSchema = z.object({
+      status: f0FormField(z.string(), {
+        label: "Status",
+        options: [
+          { value: "active", label: "Active" },
+          { value: "archived", label: "Archived" },
+        ],
+      }),
+      conditionalField: f0FormField(z.string(), {
+        label: "Conditional Field",
+        renderIf: { fieldId: "status", equalsTo: "archived" },
+      }),
+    })
+
+    const { container } = render(
+      <F0Form
+        name="renderif-layout-test"
+        schema={formSchema}
+        defaultValues={{ status: "active", conditionalField: "" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // The conditional field label should not be visible
+    expect(screen.queryByLabelText("Conditional Field")).not.toBeInTheDocument()
+
+    // The hidden field renders a <span class="hidden"> inside a wrapper div.
+    // That wrapper div must have the has-[>span.hidden]:hidden class so it
+    // collapses (display:none via CSS :has()) and doesn't produce layout gaps.
+    const hiddenSpan = container.querySelector("span.hidden[aria-hidden]")
+    expect(hiddenSpan).toBeInTheDocument()
+
+    const wrapperDiv = hiddenSpan!.parentElement
+    expect(wrapperDiv).toHaveClass("has-[>span.hidden]:hidden")
+  })
+
+  it("wrapper div of a visible field (renderIf=true) does not have hidden class", async () => {
+    const formSchema = z.object({
+      status: f0FormField(z.string(), {
+        label: "Status",
+        options: [
+          { value: "active", label: "Active" },
+          { value: "archived", label: "Archived" },
+        ],
+      }),
+      conditionalField: f0FormField(z.string(), {
+        label: "Conditional Field",
+        renderIf: { fieldId: "status", equalsTo: "archived" },
+      }),
+    })
+
+    render(
+      <F0Form
+        name="renderif-visible-test"
+        schema={formSchema}
+        defaultValues={{ status: "archived", conditionalField: "" }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // The conditional field should be visible when condition is met
+    expect(screen.getByLabelText("Conditional Field")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/patterns/F0Form/__tests__/F0FormValidation.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0FormValidation.test.tsx
@@ -697,3 +697,82 @@ describe("F0Form datetime field validation", () => {
     })
   })
 })
+
+describe("F0Form default errorTriggerMode on-submit", () => {
+  it("does not show validation errors on blur when errorTriggerMode is omitted (single-schema)", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    const formSchema = z.object({
+      name: f0FormField(z.string().min(1, "Name is required"), {
+        label: "Name",
+      }),
+    })
+
+    render(
+      <F0Form
+        name="default-trigger-single"
+        schema={formSchema}
+        defaultValues={{ name: "" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    // Focus and blur the field without filling it
+    const input = screen.getByLabelText("Name")
+    await user.click(input)
+    await user.tab()
+
+    // Error should NOT appear on blur (default is on-submit)
+    expect(screen.queryByText("Name is required")).not.toBeInTheDocument()
+
+    // Submit the form
+    const submitButton = screen.getByText("Submit")
+    await user.click(submitButton)
+
+    // Error should appear after submit
+    await waitFor(() => {
+      expect(screen.getByText("Name is required")).toBeInTheDocument()
+    })
+  })
+
+  it("does not show validation errors on blur when errorTriggerMode is omitted (per-section)", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    const perSectionSchema = {
+      details: z.object({
+        title: f0FormField(z.string().min(1, "Title is required"), {
+          label: "Title",
+        }),
+      }),
+    }
+
+    render(
+      <F0Form
+        name="default-trigger-per-section"
+        schema={perSectionSchema}
+        sections={{ details: { title: "Details" } }}
+        defaultValues={{ details: { title: "" } }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    // Focus and blur the field without filling it
+    const input = screen.getByLabelText("Title")
+    await user.click(input)
+    await user.tab()
+
+    // Error should NOT appear on blur (default is on-submit)
+    expect(screen.queryByText("Title is required")).not.toBeInTheDocument()
+
+    // Submit the form
+    const submitButton = screen.getByText("Submit")
+    await user.click(submitButton)
+
+    // Error should appear after submit
+    await waitFor(() => {
+      expect(screen.getByText("Title is required")).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react/src/patterns/F0Form/__tests__/F0FormValidation.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0FormValidation.test.tsx
@@ -608,6 +608,7 @@ describe("F0Form datetime field validation", () => {
         defaultValues={{
           scheduledAt: new Date("2026-01-01T09:00:00"),
         }}
+        errorTriggerMode="on-blur"
         onSubmit={async () => ({ success: true })}
       />
     )
@@ -682,6 +683,7 @@ describe("F0Form datetime field validation", () => {
         defaultValues={{
           scheduledAt: new Date("2026-06-15T12:00:00"),
         }}
+        errorTriggerMode="on-blur"
         onSubmit={async () => ({ success: true })}
       />
     )

--- a/packages/react/src/patterns/F0Form/components/F0FormSection.tsx
+++ b/packages/react/src/patterns/F0Form/components/F0FormSection.tsx
@@ -3,7 +3,6 @@ import { DefaultValues, Path, useForm } from "react-hook-form"
 import { z } from "zod"
 
 import { F0Button } from "@/components/F0Button"
-import { Save } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import { cn } from "@/lib/utils"
 import { SectionHeader } from "@/patterns/SectionHeader"
@@ -118,8 +117,7 @@ export function F0FormSection<TSchema extends F0FormSchema>({
   const definition = useSchemaDefinition(schema)
 
   const submitLabel = submitConfig?.label ?? "Submit"
-  const submitIcon =
-    submitConfig?.icon === null ? undefined : (submitConfig?.icon ?? Save)
+  const submitIcon = submitConfig?.icon ?? undefined
   const showSubmitWhenDirty = submitConfig?.showSubmitWhenDirty ?? false
   const hideSubmitButton = submitConfig?.hideSubmitButton ?? false
 
@@ -368,7 +366,7 @@ export function F0FormSection<TSchema extends F0FormSchema>({
           )}
 
           {!hideSubmitButton && (!showSubmitWhenDirty || isDirty) && (
-            <div className="mt-4">
+            <div className="mt-4 flex justify-end">
               <F0Button
                 type="submit"
                 label={submitLabel}

--- a/packages/react/src/patterns/F0Form/constants.ts
+++ b/packages/react/src/patterns/F0Form/constants.ts
@@ -11,7 +11,4 @@ export const SWITCH_GROUP_PADDING = "p-4"
 /** Margin between sections (24px) */
 export const SECTION_MARGIN = "mt-6"
 
-/** Maximum width for form content (720px) */
-export const FORM_MAX_WIDTH = "max-w-[720px]"
-
 export const FORM_SIZE = "md" as const

--- a/packages/react/src/patterns/F0Form/types.ts
+++ b/packages/react/src/patterns/F0Form/types.ts
@@ -144,12 +144,10 @@ interface F0FormSubmitConfigBase {
   /** Custom label for the submit button */
   label?: string
   /**
-   * Custom icon for the submit button
-   * - undefined: uses default Save icon
-   * - null: no icon shown
-   * - IconType: custom icon
+   * Custom icon for the submit button.
+   * No icon is shown by default.
    */
-  icon?: IconType | null
+  icon?: IconType
   /** Label shown in the action bar while submitting (defaults to i18n "forms.actionBar.saving") */
   savingMessage?: string
   /**
@@ -449,12 +447,10 @@ export interface F0PerSectionSubmitConfig {
   /** Custom label for the submit button (per section) */
   label?: string
   /**
-   * Custom icon for the submit button
-   * - undefined: uses default Save icon
-   * - null: no icon shown
-   * - IconType: custom icon
+   * Custom icon for the submit button.
+   * No icon is shown by default.
    */
-  icon?: IconType | null
+  icon?: IconType
   /**
    * When true, the submit button is only visible once the section has unsaved changes.
    * @default false

--- a/packages/react/src/patterns/F0Form/types.ts
+++ b/packages/react/src/patterns/F0Form/types.ts
@@ -131,9 +131,9 @@ export type FormDefinitionItem = FieldItem | RowDefinition | SectionDefinition
 
 /**
  * When to trigger and display validation errors (does not apply with autosubmit)
- * - "on-blur": Errors appear when the user leaves a field (default)
+ * - "on-blur": Errors appear when the user leaves a field
  * - "on-change": Errors appear as the user types (real-time validation)
- * - "on-submit": Errors only appear after attempting to submit the form
+ * - "on-submit": Errors only appear after attempting to submit the form (default)
  */
 export type F0FormErrorTriggerMode = "on-blur" | "on-change" | "on-submit"
 

--- a/packages/react/src/sds/ai/F0AiChat/components/input/ChatInput.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/input/ChatInput.tsx
@@ -47,14 +47,14 @@ export const ChatInput = (props: InputProps) => {
         fullscreenWelcome && "flex-1"
       )}
     >
-      <div className="w-full max-w-[712px]">
+      <div className="max-w-content w-full">
         <ChatTextarea {...props} creditWarning={creditWarning} />
       </div>
       <AnimatePresence mode="wait" initial={false}>
         {isClarifying ? (
           <motion.div
             key="clarifying-nav-hint"
-            className="flex w-full max-w-[712px] flex-row flex-wrap items-center justify-center gap-x-3 gap-y-1 text-sm font-medium text-f1-foreground-tertiary"
+            className="max-w-content flex w-full flex-row flex-wrap items-center justify-center gap-x-3 gap-y-1 text-sm font-medium text-f1-foreground-tertiary"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -80,7 +80,7 @@ export const ChatInput = (props: InputProps) => {
           !fullscreenWelcome && (
             <motion.div
               key="chat-disclaimer"
-              className="flex w-full max-w-[712px] flex-row items-center justify-center gap-1"
+              className="max-w-content flex w-full flex-row items-center justify-center gap-1"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
@@ -109,7 +109,7 @@ export const ChatInput = (props: InputProps) => {
           <motion.div
             key="chat-footer"
             className={cn(
-              "w-full py-4 mx-auto max-w-[712px]",
+              "w-full py-4 mx-auto max-w-content",
               fullscreenWelcome && "mt-auto",
               fullscreen && "flex justify-center"
             )}

--- a/packages/react/src/sds/ai/F0AiChat/components/messages/MessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/messages/MessagesContainer.tsx
@@ -343,7 +343,7 @@ const Messages = ({
                 showWelcomeBlock && !isLoadingThread
                   ? "flex flex-1"
                   : "flex flex-col gap-6",
-                "w-full max-w-[712px]"
+                "w-full max-w-content"
               )}
             >
               {isLoadingThread && <MessagesSkeleton />}
@@ -413,7 +413,7 @@ const Messages = ({
 }
 
 const MessagesSkeleton = () => (
-  <div className="flex h-full w-full max-w-[712px] flex-col gap-6">
+  <div className="max-w-content flex h-full w-full flex-col gap-6">
     <div className="flex flex-col gap-2">
       <div className="flex justify-end">
         <Skeleton className="h-12 w-2/5 rounded-full" />

--- a/packages/react/tailwind.config.ts
+++ b/packages/react/tailwind.config.ts
@@ -1,5 +1,6 @@
-import { baseConfig } from "@factorialco/f0-core/tailwind"
 import type { Config } from "tailwindcss"
+
+import { baseConfig } from "@factorialco/f0-core/tailwind"
 
 export default {
   ...baseConfig,
@@ -15,6 +16,10 @@ export default {
     ...baseConfig.theme,
     extend: {
       ...baseConfig.theme?.extend,
+      maxWidth: {
+        ...baseConfig.theme?.extend?.maxWidth,
+        content: "712px",
+      },
       keyframes: {
         ...baseConfig.theme?.extend?.keyframes,
         "rotate-gradient": {


### PR DESCRIPTION
## Summary

This PR introduces several improvements to the F0 design system, focusing on form UX and layout consistency.

### Changes

#### Tailwind `max-w-content` utility

- Added a reusable `max-w-content` Tailwind token (712px) to the React package's Tailwind config
- Replaced all hardcoded `max-w-[712px]` and `max-w-[720px]` usages across AI Chat components, F0Form, and DataChart EmptyState

#### F0Form: validation error trigger mode

- Changed the default `errorTriggerMode` from `"on-blur"` to `"on-submit"` — validation errors now only appear after the user attempts to submit the form

#### F0Form: conditional field layout gap fix

- Fixed a bug where fields hidden via `renderIf` left an empty wrapper div in the DOM, causing unwanted gaps in the form layout
- Replaced broken CSS selectors (`empty:hidden [&>span.hidden]:hidden`) with a working `:has()` approach (`has-[>span.hidden]:hidden`)
- Added unit tests to validate the fix

#### F0Form: submit button improvements

- Submit buttons are now right-aligned by default
- Removed the default Save icon from submit buttons — no icon is shown unless the developer explicitly provides one via the `icon` prop
- Simplified the `icon` type from `IconType | null` to `IconType`