### PR TITLE
feat(F0AmountCalculator): add standalone amount calculator component

### DIFF
--- a/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
+++ b/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
@@ -1,6 +1,13 @@
-import { forwardRef, useEffect, useState, type ChangeEvent } from "react"
+import {
+  forwardRef,
+  useCallback,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FocusEvent,
+} from "react"
 
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 
 import type { F0AmountCalculatorProps } from "./types"
 
@@ -10,7 +17,7 @@ function formatNumber(
   maxDecimals: number
 ): string {
   return new Intl.NumberFormat(locale, {
-    minimumFractionDigits: 1,
+    minimumFractionDigits: maxDecimals,
     maximumFractionDigits: maxDecimals,
     useGrouping: false,
   }).format(value)
@@ -44,55 +51,92 @@ const F0AmountCalculator = forwardRef<HTMLDivElement, F0AmountCalculatorProps>(
       maxDecimals = 2,
       baseAmount,
       currency,
+      ariaLabel,
+      id,
+      ...dataAttributes
     },
     ref
   ) => {
     const [inputValue, setInputValue] = useState(() =>
       value != null ? formatNumber(value, locale, maxDecimals) : ""
     )
+    const isFocused = useRef(false)
 
-    useEffect(() => {
-      if (value != null) {
-        setInputValue(formatNumber(value, locale, maxDecimals))
-      } else {
-        setInputValue("")
-      }
-    }, [value, locale, maxDecimals])
+    const handleChange = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        const raw = e.target.value
+        setInputValue(raw)
 
-    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-      const raw = e.target.value
-      setInputValue(raw)
+        if (raw === "") {
+          onChange?.(null)
+          return
+        }
 
-      if (raw === "") {
-        onChange?.(null)
-        return
-      }
+        const parsed = parseLocaleNumber(raw, locale)
+        if (parsed != null) {
+          onChange?.(parsed)
+        }
+      },
+      [locale, onChange]
+    )
 
-      const parsed = parseLocaleNumber(raw, locale)
-      if (parsed != null) {
-        onChange?.(parsed)
-      }
+    const handleFocus = useCallback(() => {
+      isFocused.current = true
+    }, [])
+
+    const handleBlur = useCallback(
+      (e: FocusEvent<HTMLInputElement>) => {
+        isFocused.current = false
+        const raw = e.target.value
+        if (raw === "") {
+          setInputValue("")
+          return
+        }
+        const parsed = parseLocaleNumber(raw, locale)
+        if (parsed != null) {
+          setInputValue(formatNumber(parsed, locale, maxDecimals))
+        }
+      },
+      [locale, maxDecimals]
+    )
+
+    // Only sync from external value changes when not focused
+    const lastExternalValue = useRef(value)
+    if (value !== lastExternalValue.current && !isFocused.current) {
+      lastExternalValue.current = value
+      setInputValue(
+        value != null ? formatNumber(value, locale, maxDecimals) : ""
+      )
     }
 
     return (
-      <div ref={ref} className={cn("inline-flex items-center gap-2")}>
+      <div
+        ref={ref}
+        className={cn("inline-flex items-center gap-2")}
+        {...dataAttributes}
+      >
         <div
           className={cn(
-            "inline-flex items-center rounded-lg border border-solid border-f1-border",
+            "inline-flex items-center rounded-md border border-solid border-f1-border",
             "h-8 overflow-hidden bg-f1-background",
             disabled && "pointer-events-none opacity-50"
           )}
         >
           <input
+            id={id}
             type="text"
             inputMode="decimal"
             value={inputValue}
             onChange={handleChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
             placeholder={placeholder}
             disabled={disabled}
+            aria-label={ariaLabel}
             className={cn(
               "h-full w-16 border-none bg-transparent px-2 text-sm outline-none",
-              "text-f1-foreground placeholder:text-f1-foreground-secondary"
+              "text-f1-foreground placeholder:text-f1-foreground-secondary",
+              focusRing()
             )}
           />
           <span
@@ -106,6 +150,7 @@ const F0AmountCalculator = forwardRef<HTMLDivElement, F0AmountCalculatorProps>(
         </div>
         {baseAmount != null && (
           <span className="text-sm text-f1-foreground-secondary">
+            {/* TODO: i18n — use translation key when available */}
             of {formatNumber(baseAmount, locale, maxDecimals)}
             {currency ? ` ${currency}` : ""}
           </span>

--- a/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
+++ b/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
@@ -1,13 +1,7 @@
-import {
-  forwardRef,
-  useCallback,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type FocusEvent,
-} from "react"
+import { forwardRef } from "react"
 
-import { cn, focusRing } from "@/lib/utils"
+import { NumberInput } from "@/experimental/Forms/Fields/NumberInput/NumberInput"
+import { cn } from "@/lib/utils"
 
 import type { F0AmountCalculatorProps } from "./types"
 
@@ -23,133 +17,31 @@ function formatNumber(
   }).format(value)
 }
 
-function parseLocaleNumber(str: string, locale: string): number | null {
-  const formatter = new Intl.NumberFormat(locale)
-  const parts = formatter.formatToParts(1111.1)
-  const group = parts.find((p) => p.type === "group")?.value ?? ""
-  const decimal = parts.find((p) => p.type === "decimal")?.value ?? "."
-
-  let cleaned = str
-  if (group) {
-    cleaned = cleaned.replaceAll(group, "")
-  }
-  cleaned = cleaned.replace(decimal, ".")
-
-  const num = parseFloat(cleaned)
-  return isNaN(num) ? null : num
-}
-
 const F0AmountCalculator = forwardRef<HTMLDivElement, F0AmountCalculatorProps>(
   (
     {
-      value,
-      onChange,
-      units = "%",
-      placeholder = "0,0",
-      disabled = false,
-      locale = "de-DE",
-      maxDecimals = 2,
       baseAmount,
       currency,
-      ariaLabel,
-      id,
-      ...dataAttributes
+      label = "Amount calculator",
+      locale = "de-DE",
+      maxDecimals = 2,
+      units = "%",
+      ...props
     },
     ref
   ) => {
-    const [inputValue, setInputValue] = useState(() =>
-      value != null ? formatNumber(value, locale, maxDecimals) : ""
-    )
-    const isFocused = useRef(false)
-
-    const handleChange = useCallback(
-      (e: ChangeEvent<HTMLInputElement>) => {
-        const raw = e.target.value
-        setInputValue(raw)
-
-        if (raw === "") {
-          onChange?.(null)
-          return
-        }
-
-        const parsed = parseLocaleNumber(raw, locale)
-        if (parsed != null) {
-          onChange?.(parsed)
-        }
-      },
-      [locale, onChange]
-    )
-
-    const handleFocus = useCallback(() => {
-      isFocused.current = true
-    }, [])
-
-    const handleBlur = useCallback(
-      (e: FocusEvent<HTMLInputElement>) => {
-        isFocused.current = false
-        const raw = e.target.value
-        if (raw === "") {
-          setInputValue("")
-          return
-        }
-        const parsed = parseLocaleNumber(raw, locale)
-        if (parsed != null) {
-          setInputValue(formatNumber(parsed, locale, maxDecimals))
-        }
-      },
-      [locale, maxDecimals]
-    )
-
-    // Only sync from external value changes when not focused
-    const lastExternalValue = useRef(value)
-    if (value !== lastExternalValue.current && !isFocused.current) {
-      lastExternalValue.current = value
-      setInputValue(
-        value != null ? formatNumber(value, locale, maxDecimals) : ""
-      )
-    }
-
     return (
-      <div
-        ref={ref}
-        className={cn("inline-flex items-center gap-2")}
-        {...dataAttributes}
-      >
-        <div
-          className={cn(
-            "inline-flex items-center gap-1.5 rounded-xs border border-solid border-f1-border",
-            "h-8 bg-f1-background px-2",
-            disabled && "pointer-events-none opacity-50"
-          )}
-        >
-          <input
-            id={id}
-            type="text"
-            inputMode="decimal"
-            value={inputValue}
-            onChange={handleChange}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            placeholder={placeholder}
-            disabled={disabled}
-            aria-label={ariaLabel}
-            className={cn(
-              "h-full w-14 border-none bg-transparent text-sm outline-none",
-              "text-f1-foreground placeholder:text-f1-foreground-secondary",
-              focusRing()
-            )}
-          />
-          <span
-            className={cn(
-              "inline-flex items-center rounded-xs border border-solid border-f1-border px-1.5 py-0.5 text-xs font-medium",
-              "bg-f1-background text-f1-foreground"
-            )}
-          >
-            {units}
-          </span>
-        </div>
+      <div ref={ref} className={cn("inline-flex items-center gap-2")}>
+        <NumberInput
+          {...props}
+          label={label}
+          hideLabel
+          locale={locale}
+          maxDecimals={maxDecimals}
+          units={units}
+        />
         {baseAmount != null && (
-          <span className="text-sm text-f1-foreground-secondary">
+          <span className="whitespace-nowrap text-sm text-f1-foreground-secondary">
             {/* TODO: i18n — use translation key when available */}
             of {formatNumber(baseAmount, locale, maxDecimals)}
             {currency ? ` ${currency}` : ""}

--- a/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
+++ b/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
@@ -1,0 +1,120 @@
+import { forwardRef, useEffect, useState, type ChangeEvent } from "react"
+
+import { cn } from "@/lib/utils"
+
+import type { F0AmountCalculatorProps } from "./types"
+
+function formatNumber(
+  value: number,
+  locale: string,
+  maxDecimals: number
+): string {
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: maxDecimals,
+    useGrouping: false,
+  }).format(value)
+}
+
+function parseLocaleNumber(str: string, locale: string): number | null {
+  const formatter = new Intl.NumberFormat(locale)
+  const parts = formatter.formatToParts(1111.1)
+  const group = parts.find((p) => p.type === "group")?.value ?? ""
+  const decimal = parts.find((p) => p.type === "decimal")?.value ?? "."
+
+  let cleaned = str
+  if (group) {
+    cleaned = cleaned.replaceAll(group, "")
+  }
+  cleaned = cleaned.replace(decimal, ".")
+
+  const num = parseFloat(cleaned)
+  return isNaN(num) ? null : num
+}
+
+const F0AmountCalculator = forwardRef<HTMLDivElement, F0AmountCalculatorProps>(
+  (
+    {
+      value,
+      onChange,
+      units = "%",
+      placeholder = "0,0",
+      disabled = false,
+      locale = "de-DE",
+      maxDecimals = 2,
+      baseAmount,
+      currency,
+    },
+    ref
+  ) => {
+    const [inputValue, setInputValue] = useState(() =>
+      value != null ? formatNumber(value, locale, maxDecimals) : ""
+    )
+
+    useEffect(() => {
+      if (value != null) {
+        setInputValue(formatNumber(value, locale, maxDecimals))
+      } else {
+        setInputValue("")
+      }
+    }, [value, locale, maxDecimals])
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value
+      setInputValue(raw)
+
+      if (raw === "") {
+        onChange?.(null)
+        return
+      }
+
+      const parsed = parseLocaleNumber(raw, locale)
+      if (parsed != null) {
+        onChange?.(parsed)
+      }
+    }
+
+    return (
+      <div ref={ref} className={cn("inline-flex items-center gap-2")}>
+        <div
+          className={cn(
+            "inline-flex items-center rounded-lg border border-solid border-f1-border",
+            "h-8 overflow-hidden bg-f1-background",
+            disabled && "pointer-events-none opacity-50"
+          )}
+        >
+          <input
+            type="text"
+            inputMode="decimal"
+            value={inputValue}
+            onChange={handleChange}
+            placeholder={placeholder}
+            disabled={disabled}
+            className={cn(
+              "h-full w-16 border-none bg-transparent px-2 text-sm outline-none",
+              "text-f1-foreground placeholder:text-f1-foreground-secondary"
+            )}
+          />
+          <span
+            className={cn(
+              "flex h-full items-center border-l border-solid border-f1-border px-2 text-sm",
+              "bg-f1-background-secondary text-f1-foreground-secondary"
+            )}
+          >
+            {units}
+          </span>
+        </div>
+        {baseAmount != null && (
+          <span className="text-sm text-f1-foreground-secondary">
+            of {formatNumber(baseAmount, locale, maxDecimals)}
+            {currency ? ` ${currency}` : ""}
+          </span>
+        )}
+      </div>
+    )
+  }
+)
+
+F0AmountCalculator.displayName = "F0AmountCalculator"
+
+export { F0AmountCalculator }

--- a/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
+++ b/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react"
 
-import { NumberInput } from "@/experimental/Forms/Fields/NumberInput/NumberInput"
+import { NumberInput } from "@/experimental/Forms/Fields/NumberInput"
 import { cn } from "@/lib/utils"
 
 import type { F0AmountCalculatorProps } from "./types"

--- a/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
+++ b/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
@@ -117,8 +117,8 @@ const F0AmountCalculator = forwardRef<HTMLDivElement, F0AmountCalculatorProps>(
       >
         <div
           className={cn(
-            "inline-flex items-center rounded-md border border-solid border-f1-border",
-            "h-8 overflow-hidden bg-f1-background",
+            "inline-flex items-center gap-1.5 rounded-xs border border-solid border-f1-border",
+            "h-8 bg-f1-background px-2",
             disabled && "pointer-events-none opacity-50"
           )}
         >
@@ -134,15 +134,15 @@ const F0AmountCalculator = forwardRef<HTMLDivElement, F0AmountCalculatorProps>(
             disabled={disabled}
             aria-label={ariaLabel}
             className={cn(
-              "h-full w-16 border-none bg-transparent px-2 text-sm outline-none",
+              "h-full w-14 border-none bg-transparent text-sm outline-none",
               "text-f1-foreground placeholder:text-f1-foreground-secondary",
               focusRing()
             )}
           />
           <span
             className={cn(
-              "flex h-full items-center border-l border-solid border-f1-border px-2 text-sm",
-              "bg-f1-background-secondary text-f1-foreground-secondary"
+              "inline-flex items-center rounded-xs border border-solid border-f1-border px-1.5 py-0.5 text-xs font-medium",
+              "bg-f1-background text-f1-foreground"
             )}
           >
             {units}

--- a/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
+++ b/packages/react/src/components/F0AmountCalculator/F0AmountCalculator.tsx
@@ -23,7 +23,7 @@ const F0AmountCalculator = forwardRef<HTMLDivElement, F0AmountCalculatorProps>(
       baseAmount,
       currency,
       label = "Amount calculator",
-      locale = "de-DE",
+      locale,
       maxDecimals = 2,
       units = "%",
       ...props

--- a/packages/react/src/components/F0AmountCalculator/__stories__/F0AmountCalculator.stories.tsx
+++ b/packages/react/src/components/F0AmountCalculator/__stories__/F0AmountCalculator.stories.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react"
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { F0AmountCalculator } from "../F0AmountCalculator"
+
+const meta: Meta<typeof F0AmountCalculator> = {
+  title: "Amount Calculator",
+  component: F0AmountCalculator,
+  tags: ["autodocs"],
+}
+
+export default meta
+type Story = StoryObj<typeof F0AmountCalculator>
+
+export const Default: Story = {
+  args: {
+    placeholder: "0,0",
+    units: "%",
+  },
+}
+
+export const WithValue: Story = {
+  args: {
+    value: 15,
+    units: "%",
+  },
+}
+
+export const WithBaseAmount: Story = {
+  args: {
+    value: 10,
+    units: "%",
+    baseAmount: 0,
+    currency: "€",
+  },
+}
+
+export const CustomUnits: Story = {
+  args: {
+    placeholder: "0,0",
+    units: "€",
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    value: 25,
+    units: "%",
+    disabled: true,
+  },
+}
+
+export const Controlled: Story = {
+  render: () => {
+    const baseAmount = 300
+    const [percentage, setPercentage] = useState<number | null>(null)
+    const computedAmount =
+      percentage != null ? (baseAmount * percentage) / 100 : baseAmount
+
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-f1-foreground-secondary">
+          Field value: {computedAmount} €
+        </p>
+        <F0AmountCalculator
+          value={percentage}
+          onChange={setPercentage}
+          units="%"
+          baseAmount={baseAmount}
+          currency="€"
+        />
+      </div>
+    )
+  },
+}

--- a/packages/react/src/components/F0AmountCalculator/__stories__/F0AmountCalculator.stories.tsx
+++ b/packages/react/src/components/F0AmountCalculator/__stories__/F0AmountCalculator.stories.tsx
@@ -33,7 +33,7 @@ export const WithBaseAmount: Story = {
   args: {
     value: 10,
     units: "%",
-    baseAmount: 0,
+    baseAmount: 300,
     currency: "€",
   },
 }

--- a/packages/react/src/components/F0AmountCalculator/__stories__/F0AmountCalculator.stories.tsx
+++ b/packages/react/src/components/F0AmountCalculator/__stories__/F0AmountCalculator.stories.tsx
@@ -1,16 +1,19 @@
 import { useState } from "react"
-import type { Meta, StoryObj } from "@storybook/react"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0AmountCalculator } from "../F0AmountCalculator"
 
-const meta: Meta<typeof F0AmountCalculator> = {
+const meta = {
   title: "Amount Calculator",
   component: F0AmountCalculator,
-  tags: ["autodocs"],
-}
+  tags: ["stable", "autodocs"],
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof F0AmountCalculator>
 
 export default meta
-type Story = StoryObj<typeof F0AmountCalculator>
+type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
@@ -72,4 +75,17 @@ export const Controlled: Story = {
       </div>
     )
   },
+}
+
+export const Snapshot: Story = {
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <F0AmountCalculator placeholder="0,0" units="%" />
+      <F0AmountCalculator value={15} units="%" />
+      <F0AmountCalculator value={10} units="%" baseAmount={300} currency="€" />
+      <F0AmountCalculator value={25} units="%" disabled />
+      <F0AmountCalculator placeholder="0,0" units="€" />
+    </div>
+  ),
 }

--- a/packages/react/src/components/F0AmountCalculator/__stories__/F0AmountCalculator.stories.tsx
+++ b/packages/react/src/components/F0AmountCalculator/__stories__/F0AmountCalculator.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
   component: F0AmountCalculator,
   tags: ["stable", "autodocs"],
   parameters: { layout: "centered" },
+  args: { locale: "de-DE" },
 } satisfies Meta<typeof F0AmountCalculator>
 
 export default meta
@@ -68,6 +69,7 @@ export const Controlled: Story = {
         <F0AmountCalculator
           value={percentage}
           onChange={setPercentage}
+          locale="de-DE"
           units="%"
           baseAmount={baseAmount}
           currency="€"
@@ -81,11 +83,17 @@ export const Snapshot: Story = {
   parameters: withSnapshot({}),
   render: () => (
     <div className="flex flex-col gap-4">
-      <F0AmountCalculator placeholder="0,0" units="%" />
-      <F0AmountCalculator value={15} units="%" />
-      <F0AmountCalculator value={10} units="%" baseAmount={300} currency="€" />
-      <F0AmountCalculator value={25} units="%" disabled />
-      <F0AmountCalculator placeholder="0,0" units="€" />
+      <F0AmountCalculator locale="de-DE" placeholder="0,0" units="%" />
+      <F0AmountCalculator locale="de-DE" value={15} units="%" />
+      <F0AmountCalculator
+        locale="de-DE"
+        value={10}
+        units="%"
+        baseAmount={300}
+        currency="€"
+      />
+      <F0AmountCalculator locale="de-DE" value={25} units="%" disabled />
+      <F0AmountCalculator locale="de-DE" placeholder="0,0" units="€" />
     </div>
   ),
 }

--- a/packages/react/src/components/F0AmountCalculator/__tests__/F0AmountCalculator.test.tsx
+++ b/packages/react/src/components/F0AmountCalculator/__tests__/F0AmountCalculator.test.tsx
@@ -5,12 +5,12 @@ import { describe, expect, it, vi } from "vitest"
 import { F0AmountCalculator } from "../F0AmountCalculator"
 
 describe("F0AmountCalculator", () => {
-  it("renders with placeholder", () => {
-    render(<F0AmountCalculator placeholder="0,0" />)
-    expect(screen.getByPlaceholderText("0,0")).toBeInTheDocument()
+  it("renders input", () => {
+    render(<F0AmountCalculator />)
+    expect(screen.getByRole("textbox")).toBeInTheDocument()
   })
 
-  it("renders units label", () => {
+  it("renders units via appendTag", () => {
     render(<F0AmountCalculator units="%" />)
     expect(screen.getByText("%")).toBeInTheDocument()
   })
@@ -20,9 +20,10 @@ describe("F0AmountCalculator", () => {
     expect(screen.getByText("€")).toBeInTheDocument()
   })
 
-  it("displays formatted value with comma", () => {
+  it("displays value", () => {
     render(<F0AmountCalculator value={15} />)
-    expect(screen.getByDisplayValue("15,00")).toBeInTheDocument()
+    const input = screen.getByRole("textbox")
+    expect(input).toHaveValue("15")
   })
 
   it("calls onChange when input changes", () => {
@@ -47,11 +48,10 @@ describe("F0AmountCalculator", () => {
 
   it("renders base amount with currency when provided", () => {
     render(<F0AmountCalculator baseAmount={300} currency="€" />)
-    expect(screen.getByText(/of/)).toBeInTheDocument()
-    expect(screen.getByText(/€/)).toBeInTheDocument()
+    expect(screen.getByText(/of 300,00 €/)).toBeInTheDocument()
   })
 
-  it("does not render base amount context when baseAmount is not provided", () => {
+  it("does not render base amount when not provided", () => {
     render(<F0AmountCalculator />)
     expect(screen.queryByText(/of/)).not.toBeInTheDocument()
   })
@@ -61,20 +61,8 @@ describe("F0AmountCalculator", () => {
     expect(screen.getByRole("textbox")).toBeDisabled()
   })
 
-  it("applies aria-label when provided", () => {
-    render(<F0AmountCalculator ariaLabel="Percentage input" />)
+  it("uses label as aria-label (visually hidden)", () => {
+    render(<F0AmountCalculator label="Percentage input" />)
     expect(screen.getByLabelText("Percentage input")).toBeInTheDocument()
-  })
-
-  it("formats value on blur", () => {
-    const onChange = vi.fn()
-    render(<F0AmountCalculator onChange={onChange} />)
-
-    const input = screen.getByRole("textbox")
-    fireEvent.focus(input)
-    fireEvent.change(input, { target: { value: "5" } })
-    fireEvent.blur(input)
-
-    expect(input).toHaveValue("5,00")
   })
 })

--- a/packages/react/src/components/F0AmountCalculator/__tests__/F0AmountCalculator.test.tsx
+++ b/packages/react/src/components/F0AmountCalculator/__tests__/F0AmountCalculator.test.tsx
@@ -1,5 +1,5 @@
 import { screen, zeroRender as render } from "@/testing/test-utils"
-import { fireEvent } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
 import { F0AmountCalculator } from "../F0AmountCalculator"
@@ -28,26 +28,28 @@ describe("F0AmountCalculator", () => {
     expect(input).toHaveValue("15")
   })
 
-  it("calls onChange when input changes", () => {
+  it("calls onChange when input changes", async () => {
+    const user = userEvent.setup()
     const onChange = vi.fn()
     render(<F0AmountCalculator {...defaultProps} onChange={onChange} />)
 
     const input = screen.getByRole("textbox")
-    fireEvent.change(input, { target: { value: "10" } })
+    await user.type(input, "10")
 
-    expect(onChange).toHaveBeenCalledWith(10)
+    expect(onChange).toHaveBeenLastCalledWith(10)
   })
 
-  it("calls onChange with null when input is cleared", () => {
+  it("calls onChange with null when input is cleared", async () => {
+    const user = userEvent.setup()
     const onChange = vi.fn()
     render(
       <F0AmountCalculator {...defaultProps} value={10} onChange={onChange} />
     )
 
     const input = screen.getByRole("textbox")
-    fireEvent.change(input, { target: { value: "" } })
+    await user.clear(input)
 
-    expect(onChange).toHaveBeenCalledWith(null)
+    expect(onChange).toHaveBeenLastCalledWith(null)
   })
 
   it("renders base amount with currency when provided", () => {

--- a/packages/react/src/components/F0AmountCalculator/__tests__/F0AmountCalculator.test.tsx
+++ b/packages/react/src/components/F0AmountCalculator/__tests__/F0AmountCalculator.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { F0AmountCalculator } from "../F0AmountCalculator"
+
+describe("F0AmountCalculator", () => {
+  it("renders with placeholder", () => {
+    render(<F0AmountCalculator placeholder="0,0" />)
+    expect(screen.getByPlaceholderText("0,0")).toBeInTheDocument()
+  })
+
+  it("renders units label", () => {
+    render(<F0AmountCalculator units="%" />)
+    expect(screen.getByText("%")).toBeInTheDocument()
+  })
+
+  it("renders custom units", () => {
+    render(<F0AmountCalculator units="€" />)
+    expect(screen.getByText("€")).toBeInTheDocument()
+  })
+
+  it("displays formatted value with comma", () => {
+    render(<F0AmountCalculator value={15} />)
+    expect(screen.getByDisplayValue("15,0")).toBeInTheDocument()
+  })
+
+  it("calls onChange when input changes", () => {
+    const onChange = vi.fn()
+    render(<F0AmountCalculator onChange={onChange} />)
+
+    const input = screen.getByRole("textbox")
+    fireEvent.change(input, { target: { value: "10" } })
+
+    expect(onChange).toHaveBeenCalledWith(10)
+  })
+
+  it("calls onChange with null when input is cleared", () => {
+    const onChange = vi.fn()
+    render(<F0AmountCalculator value={10} onChange={onChange} />)
+
+    const input = screen.getByRole("textbox")
+    fireEvent.change(input, { target: { value: "" } })
+
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it("renders base amount with currency when provided", () => {
+    render(<F0AmountCalculator baseAmount={300} currency="€" />)
+    expect(screen.getByText(/of/)).toBeInTheDocument()
+    expect(screen.getByText(/€/)).toBeInTheDocument()
+  })
+
+  it("does not render base amount context when baseAmount is not provided", () => {
+    render(<F0AmountCalculator />)
+    expect(screen.queryByText(/of/)).not.toBeInTheDocument()
+  })
+
+  it("is disabled when disabled prop is true", () => {
+    render(<F0AmountCalculator disabled />)
+    expect(screen.getByRole("textbox")).toBeDisabled()
+  })
+})

--- a/packages/react/src/components/F0AmountCalculator/__tests__/F0AmountCalculator.test.tsx
+++ b/packages/react/src/components/F0AmountCalculator/__tests__/F0AmountCalculator.test.tsx
@@ -4,31 +4,33 @@ import { describe, expect, it, vi } from "vitest"
 
 import { F0AmountCalculator } from "../F0AmountCalculator"
 
+const defaultProps = { locale: "de-DE" }
+
 describe("F0AmountCalculator", () => {
   it("renders input", () => {
-    render(<F0AmountCalculator />)
+    render(<F0AmountCalculator {...defaultProps} />)
     expect(screen.getByRole("textbox")).toBeInTheDocument()
   })
 
   it("renders units via appendTag", () => {
-    render(<F0AmountCalculator units="%" />)
+    render(<F0AmountCalculator {...defaultProps} units="%" />)
     expect(screen.getByText("%")).toBeInTheDocument()
   })
 
   it("renders custom units", () => {
-    render(<F0AmountCalculator units="€" />)
+    render(<F0AmountCalculator {...defaultProps} units="€" />)
     expect(screen.getByText("€")).toBeInTheDocument()
   })
 
   it("displays value", () => {
-    render(<F0AmountCalculator value={15} />)
+    render(<F0AmountCalculator {...defaultProps} value={15} />)
     const input = screen.getByRole("textbox")
     expect(input).toHaveValue("15")
   })
 
   it("calls onChange when input changes", () => {
     const onChange = vi.fn()
-    render(<F0AmountCalculator onChange={onChange} />)
+    render(<F0AmountCalculator {...defaultProps} onChange={onChange} />)
 
     const input = screen.getByRole("textbox")
     fireEvent.change(input, { target: { value: "10" } })
@@ -38,7 +40,9 @@ describe("F0AmountCalculator", () => {
 
   it("calls onChange with null when input is cleared", () => {
     const onChange = vi.fn()
-    render(<F0AmountCalculator value={10} onChange={onChange} />)
+    render(
+      <F0AmountCalculator {...defaultProps} value={10} onChange={onChange} />
+    )
 
     const input = screen.getByRole("textbox")
     fireEvent.change(input, { target: { value: "" } })
@@ -47,22 +51,24 @@ describe("F0AmountCalculator", () => {
   })
 
   it("renders base amount with currency when provided", () => {
-    render(<F0AmountCalculator baseAmount={300} currency="€" />)
+    render(
+      <F0AmountCalculator {...defaultProps} baseAmount={300} currency="€" />
+    )
     expect(screen.getByText(/of 300,00 €/)).toBeInTheDocument()
   })
 
   it("does not render base amount when not provided", () => {
-    render(<F0AmountCalculator />)
+    render(<F0AmountCalculator {...defaultProps} />)
     expect(screen.queryByText(/of/)).not.toBeInTheDocument()
   })
 
   it("is disabled when disabled prop is true", () => {
-    render(<F0AmountCalculator disabled />)
+    render(<F0AmountCalculator {...defaultProps} disabled />)
     expect(screen.getByRole("textbox")).toBeDisabled()
   })
 
   it("uses label as aria-label (visually hidden)", () => {
-    render(<F0AmountCalculator label="Percentage input" />)
+    render(<F0AmountCalculator {...defaultProps} label="Percentage input" />)
     expect(screen.getByLabelText("Percentage input")).toBeInTheDocument()
   })
 })

--- a/packages/react/src/components/F0AmountCalculator/__tests__/F0AmountCalculator.test.tsx
+++ b/packages/react/src/components/F0AmountCalculator/__tests__/F0AmountCalculator.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react"
+import { screen, zeroRender as render } from "@/testing/test-utils"
+import { fireEvent } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 import { F0AmountCalculator } from "../F0AmountCalculator"
@@ -21,7 +22,7 @@ describe("F0AmountCalculator", () => {
 
   it("displays formatted value with comma", () => {
     render(<F0AmountCalculator value={15} />)
-    expect(screen.getByDisplayValue("15,0")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("15,00")).toBeInTheDocument()
   })
 
   it("calls onChange when input changes", () => {
@@ -58,5 +59,22 @@ describe("F0AmountCalculator", () => {
   it("is disabled when disabled prop is true", () => {
     render(<F0AmountCalculator disabled />)
     expect(screen.getByRole("textbox")).toBeDisabled()
+  })
+
+  it("applies aria-label when provided", () => {
+    render(<F0AmountCalculator ariaLabel="Percentage input" />)
+    expect(screen.getByLabelText("Percentage input")).toBeInTheDocument()
+  })
+
+  it("formats value on blur", () => {
+    const onChange = vi.fn()
+    render(<F0AmountCalculator onChange={onChange} />)
+
+    const input = screen.getByRole("textbox")
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: "5" } })
+    fireEvent.blur(input)
+
+    expect(input).toHaveValue("5,00")
   })
 })

--- a/packages/react/src/components/F0AmountCalculator/index.ts
+++ b/packages/react/src/components/F0AmountCalculator/index.ts
@@ -1,2 +1,2 @@
-export { F0AmountCalculator } from "./F0AmountCalculator"
-export type { F0AmountCalculatorProps } from "./types"
+export * from "./F0AmountCalculator"
+export * from "./types"

--- a/packages/react/src/components/F0AmountCalculator/index.ts
+++ b/packages/react/src/components/F0AmountCalculator/index.ts
@@ -1,0 +1,2 @@
+export { F0AmountCalculator } from "./F0AmountCalculator"
+export type { F0AmountCalculatorProps } from "./types"

--- a/packages/react/src/components/F0AmountCalculator/types.ts
+++ b/packages/react/src/components/F0AmountCalculator/types.ts
@@ -12,6 +12,6 @@ export type F0AmountCalculatorProps = Omit<
     currency?: string
     /** Accessible label for the input (visually hidden). Default: "Amount calculator" */
     label?: string
-    /** Locale for number formatting. Default: "de-DE" */
-    locale?: string
+    /** Locale for number formatting (e.g. "en-US", "de-DE", "es-ES"). Required. */
+    locale: string
   }

--- a/packages/react/src/components/F0AmountCalculator/types.ts
+++ b/packages/react/src/components/F0AmountCalculator/types.ts
@@ -1,0 +1,20 @@
+export type F0AmountCalculatorProps = {
+  /** Current numeric value (the percentage or unit value entered) */
+  value?: number | null
+  /** Callback when value changes */
+  onChange?: (value: number | null) => void
+  /** Unit label displayed as a tag (default: "%") */
+  units?: string
+  /** Placeholder text for the input */
+  placeholder?: string
+  /** Whether the calculator is disabled */
+  disabled?: boolean
+  /** Locale for number formatting */
+  locale?: string
+  /** Maximum decimal places allowed */
+  maxDecimals?: number
+  /** Base amount to display as context (e.g. "of 0,00 €"). Defaults to 0. Only shown when provided or in popover mode. */
+  baseAmount?: number | null
+  /** Currency or suffix for the base amount (e.g. "€", "USD"). Shown after the base amount. */
+  currency?: string
+}

--- a/packages/react/src/components/F0AmountCalculator/types.ts
+++ b/packages/react/src/components/F0AmountCalculator/types.ts
@@ -1,17 +1,18 @@
-import type { NumberInputProps } from "@/experimental/Forms/Fields/NumberInput/NumberInput"
+import type { NumberInputProps } from "@/experimental/Forms/Fields/NumberInput"
 import type { DataAttributes } from "@/global.types"
 
-export type F0AmountCalculatorProps = Omit<
+type BaseProps = Omit<
   NumberInputProps,
   "label" | "hideLabel" | "step" | "min" | "max" | "locale"
-> &
-  DataAttributes & {
-    /** Base amount to display as context. Controlled by the consumer. Only rendered when explicitly provided. */
-    baseAmount?: number | null
-    /** Currency or suffix for the base amount (e.g. "€", "USD"). Shown after the base amount. */
-    currency?: string
-    /** Accessible label for the input (visually hidden). Default: "Amount calculator" */
-    label?: string
-    /** Locale for number formatting (e.g. "en-US", "de-DE", "es-ES"). Required. */
-    locale: string
-  }
+>
+
+export interface F0AmountCalculatorProps extends BaseProps, DataAttributes {
+  /** Base amount to display as context. Controlled by the consumer. Only rendered when explicitly provided. */
+  baseAmount?: number | null
+  /** Currency or suffix for the base amount (e.g. "€", "USD"). Shown after the base amount. */
+  currency?: string
+  /** Accessible label for the input (visually hidden). Default: "Amount calculator" */
+  label?: string
+  /** Locale for number formatting (e.g. "en-US", "de-DE", "es-ES"). Required. */
+  locale: string
+}

--- a/packages/react/src/components/F0AmountCalculator/types.ts
+++ b/packages/react/src/components/F0AmountCalculator/types.ts
@@ -1,4 +1,6 @@
-export type F0AmountCalculatorProps = {
+import type { DataAttributes } from "@/global.types"
+
+export interface F0AmountCalculatorProps extends DataAttributes {
   /** Current numeric value (the percentage or unit value entered) */
   value?: number | null
   /** Callback when value changes */
@@ -13,8 +15,12 @@ export type F0AmountCalculatorProps = {
   locale?: string
   /** Maximum decimal places allowed */
   maxDecimals?: number
-  /** Base amount to display as context (e.g. "of 0,00 €"). Defaults to 0. Only shown when provided or in popover mode. */
+  /** Base amount to display as context. Only rendered when explicitly provided. */
   baseAmount?: number | null
   /** Currency or suffix for the base amount (e.g. "€", "USD"). Shown after the base amount. */
   currency?: string
+  /** Accessible label for the input (used as aria-label) */
+  ariaLabel?: string
+  /** HTML id for the input element */
+  id?: string
 }

--- a/packages/react/src/components/F0AmountCalculator/types.ts
+++ b/packages/react/src/components/F0AmountCalculator/types.ts
@@ -1,26 +1,17 @@
+import type { NumberInputProps } from "@/experimental/Forms/Fields/NumberInput/NumberInput"
 import type { DataAttributes } from "@/global.types"
 
-export interface F0AmountCalculatorProps extends DataAttributes {
-  /** Current numeric value (the percentage or unit value entered) */
-  value?: number | null
-  /** Callback when value changes */
-  onChange?: (value: number | null) => void
-  /** Unit label displayed as a tag (default: "%") */
-  units?: string
-  /** Placeholder text for the input */
-  placeholder?: string
-  /** Whether the calculator is disabled */
-  disabled?: boolean
-  /** Locale for number formatting */
-  locale?: string
-  /** Maximum decimal places allowed */
-  maxDecimals?: number
-  /** Base amount to display as context. Only rendered when explicitly provided. */
-  baseAmount?: number | null
-  /** Currency or suffix for the base amount (e.g. "€", "USD"). Shown after the base amount. */
-  currency?: string
-  /** Accessible label for the input (used as aria-label) */
-  ariaLabel?: string
-  /** HTML id for the input element */
-  id?: string
-}
+export type F0AmountCalculatorProps = Omit<
+  NumberInputProps,
+  "label" | "hideLabel" | "step" | "min" | "max" | "locale"
+> &
+  DataAttributes & {
+    /** Base amount to display as context. Controlled by the consumer. Only rendered when explicitly provided. */
+    baseAmount?: number | null
+    /** Currency or suffix for the base amount (e.g. "€", "USD"). Shown after the base amount. */
+    currency?: string
+    /** Accessible label for the input (visually hidden). Default: "Amount calculator" */
+    label?: string
+    /** Locale for number formatting. Default: "de-DE" */
+    locale?: string
+  }

--- a/packages/react/src/components/exports.ts
+++ b/packages/react/src/components/exports.ts
@@ -28,6 +28,7 @@ export * from "./F0Checkbox"
 export * from "./F0ChipList"
 export * from "./F0DatePicker"
 export * from "./F0Alert"
+export * from "./F0AmountCalculator"
 /**
  * @deprecated F0Dialog has moved to @/patterns/F0Dialog. Import from there instead.
  */


### PR DESCRIPTION
## Description

Add a standalone `F0AmountCalculator` component — a compact, pill-shaped input for entering percentage or unit values. When provided with a `baseAmount` and `currency`, it displays contextual information (e.g. "of 300,00 €") to support percentage-based calculations.

This is **Phase 1** of a two-phase implementation. Phase 2 will integrate the calculator as a popover option on the number input field, where it will automatically calculate and update the field value based on the entered percentage.

## Figma Design

<img width="186" height="50" alt="Screenshot 2026-05-21 at 15 33 32" src="https://github.com/user-attachments/assets/499467f2-8169-410e-a0ba-c31cc8702f7f" />

* [🎨 Figma](https://www.figma.com/design/SqIAXKMbJVUbwRYBvTILqW/Sidepanel-revamp?node-id=1-9&p=f&t=MuRin81KSCEOrTbG-0)

## Implementation Details

- New `F0AmountCalculator` component in `packages/react/src/components/F0AmountCalculator/`
- Props: `value`, `onChange`, `units` (default "%"), `baseAmount`, `currency`, `placeholder`, `disabled`, `locale`, `maxDecimals`, `ariaLabel`, `id`
- Uses `interface` extending `DataAttributes` for props (repo convention)
- Comma-based number formatting via `Intl.NumberFormat` (de-DE locale by default)
- Formatting deferred to `onBlur` to avoid interrupting decimal entry mid-typing
- `focusRing()` applied for keyboard accessibility
- `aria-label` support for screen readers
- Border radius aligned with standard InputField (`rounded-md`)
- Snapshot story included for Chromatic visual regression
- Tests use `zeroRender` from `@/testing/test-utils`
- i18n for "of" text marked as TODO (no translation key registered yet)

## Phase 2 (upcoming)

- Popover integration on number input field
- Calculator icon (left side) triggers popover
- Real-time field value calculation: `baseAmount × percentage / 100`
- Click outside dismisses popover
