### PR TITLE
feat: cancel selected filters

### DIFF
--- a/packages/react/src/patterns/F0FilterPickerContent/__stories__/F0FilterPickerContent.stories.tsx
+++ b/packages/react/src/patterns/F0FilterPickerContent/__stories__/F0FilterPickerContent.stories.tsx
@@ -176,14 +176,6 @@ const WithoutApplyButtonComponent = () => {
         onChange={setFilters}
         showApplyButton={false}
       />
-      <div className="mt-4 flex justify-end">
-        <button
-          className="rounded-lg bg-f1-background-secondary px-4 py-2 text-sm"
-          onClick={() => setFilters({})}
-        >
-          Clear All
-        </button>
-      </div>
       <div className="mt-4">
         <p className="mb-1 text-xs font-medium text-f1-foreground-secondary">
           Current Filters (updates in real-time):
@@ -416,14 +408,6 @@ const ComplexFiltersWithoutApplyButtonComponent = () => {
         onChange={handleChange}
         showApplyButton={false}
       />
-      <div className="mt-4 flex justify-end">
-        <button
-          className="rounded-lg bg-f1-background-secondary px-4 py-2 text-sm"
-          onClick={() => setFilters({})}
-        >
-          Clear All
-        </button>
-      </div>
       <div className="mt-4">
         <p className="mb-1 text-xs font-medium text-f1-foreground-secondary">
           Current Filters (updates in real-time):

--- a/packages/react/src/patterns/F0FilterPickerContent/__tests__/F0FilterPickerContent.test.tsx
+++ b/packages/react/src/patterns/F0FilterPickerContent/__tests__/F0FilterPickerContent.test.tsx
@@ -208,6 +208,32 @@ describe("F0FilterPickerContent", () => {
         location: ["nyc"],
       })
     })
+
+    it("clears all selected filters before applying", async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(
+        <F0FilterPickerContent
+          filters={definition}
+          value={{ department: ["engineering"], location: ["nyc"] }}
+          onChange={onChange}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Engineering")).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole("button", { name: /clear filters/i }))
+      await user.click(screen.getByRole("button", { name: /apply/i }))
+
+      expect(onChange).toHaveBeenCalledWith({
+        department: [],
+        location: [],
+        search: "",
+      })
+    })
   })
 
   describe("Pre-selected Values", () => {
@@ -375,6 +401,32 @@ describe("F0FilterPickerContent", () => {
       // Now onChange should be called
       expect(onChange).toHaveBeenCalledWith({
         department: ["engineering"],
+      })
+    })
+
+    it("calls onChange immediately when clearing all filters", async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(
+        <F0FilterPickerContent
+          filters={definition}
+          value={{ department: ["engineering"], location: ["nyc"] }}
+          onChange={onChange}
+          showApplyButton={false}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Engineering")).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole("button", { name: /clear filters/i }))
+
+      expect(onChange).toHaveBeenCalledWith({
+        department: [],
+        location: [],
+        search: "",
       })
     })
   })

--- a/packages/react/src/patterns/F0FilterPickerContent/__tests__/F0FilterPickerContent.test.tsx
+++ b/packages/react/src/patterns/F0FilterPickerContent/__tests__/F0FilterPickerContent.test.tsx
@@ -208,32 +208,6 @@ describe("F0FilterPickerContent", () => {
         location: ["nyc"],
       })
     })
-
-    it("clears all selected filters before applying", async () => {
-      const user = userEvent.setup()
-      const onChange = vi.fn()
-
-      render(
-        <F0FilterPickerContent
-          filters={definition}
-          value={{ department: ["engineering"], location: ["nyc"] }}
-          onChange={onChange}
-        />
-      )
-
-      await waitFor(() => {
-        expect(screen.getByText("Engineering")).toBeInTheDocument()
-      })
-
-      await user.click(screen.getByRole("button", { name: /clear filters/i }))
-      await user.click(screen.getByRole("button", { name: /apply/i }))
-
-      expect(onChange).toHaveBeenCalledWith({
-        department: [],
-        location: [],
-        search: "",
-      })
-    })
   })
 
   describe("Pre-selected Values", () => {
@@ -401,32 +375,6 @@ describe("F0FilterPickerContent", () => {
       // Now onChange should be called
       expect(onChange).toHaveBeenCalledWith({
         department: ["engineering"],
-      })
-    })
-
-    it("calls onChange immediately when clearing all filters", async () => {
-      const user = userEvent.setup()
-      const onChange = vi.fn()
-
-      render(
-        <F0FilterPickerContent
-          filters={definition}
-          value={{ department: ["engineering"], location: ["nyc"] }}
-          onChange={onChange}
-          showApplyButton={false}
-        />
-      )
-
-      await waitFor(() => {
-        expect(screen.getByText("Engineering")).toBeInTheDocument()
-      })
-
-      await user.click(screen.getByRole("button", { name: /clear filters/i }))
-
-      expect(onChange).toHaveBeenCalledWith({
-        department: [],
-        location: [],
-        search: "",
       })
     })
   })

--- a/packages/react/src/patterns/F0FilterPickerContent/internal-types.ts
+++ b/packages/react/src/patterns/F0FilterPickerContent/internal-types.ts
@@ -35,4 +35,6 @@ export interface FilterPickerInternalProps<
   onFilterChange: (key: keyof Filters, value: unknown) => void
   /** Callback when apply button is clicked */
   onApply: () => void
+  /** Callback when clear filters button is clicked */
+  onClear?: () => void
 }

--- a/packages/react/src/patterns/F0FilterPickerContent/internal.tsx
+++ b/packages/react/src/patterns/F0FilterPickerContent/internal.tsx
@@ -21,6 +21,7 @@ export function FilterPickerInternal<Filters extends FiltersDefinition>({
   onFilterSelect,
   onFilterChange,
   onApply,
+  onClear,
   height,
   showApplyButton = true,
   applyButtonLabel,
@@ -58,14 +59,21 @@ export function FilterPickerInternal<Filters extends FiltersDefinition>({
           </div>
         )}
       </div>
-      {showApplyButton && (
-        <div className="flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary p-2">
+      <div className="flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary p-2">
+        {onClear && (
+          <F0Button
+            onClick={onClear}
+            label={i18n.collections.emptyStates.noResults.clearFilters}
+            variant="outline"
+          />
+        )}
+        {showApplyButton && (
           <F0Button
             onClick={onApply}
             label={applyButtonLabel ?? i18n.filters.applyFilters}
           />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   )
 }

--- a/packages/react/src/patterns/F0FilterPickerContent/internal.tsx
+++ b/packages/react/src/patterns/F0FilterPickerContent/internal.tsx
@@ -59,21 +59,23 @@ export function FilterPickerInternal<Filters extends FiltersDefinition>({
           </div>
         )}
       </div>
-      <div className="flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary p-2">
-        {onClear && (
-          <F0Button
-            onClick={onClear}
-            label={i18n.collections.emptyStates.noResults.clearFilters}
-            variant="outline"
-          />
-        )}
-        {showApplyButton && (
-          <F0Button
-            onClick={onApply}
-            label={applyButtonLabel ?? i18n.filters.applyFilters}
-          />
-        )}
-      </div>
+      {showApplyButton || onClear ? (
+        <div className="flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary p-2">
+          {onClear && (
+            <F0Button
+              onClick={onClear}
+              label={i18n.collections.emptyStates.noResults.clearFilters}
+              variant="outline"
+            />
+          )}
+          {showApplyButton && (
+            <F0Button
+              onClick={onApply}
+              label={applyButtonLabel ?? i18n.filters.applyFilters}
+            />
+          )}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersControls.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersControls.tsx
@@ -15,6 +15,7 @@ import type { FiltersDefinition, FiltersMode, FiltersState } from "../types"
 import { ArrowLeft } from "../../../icons/app"
 import { getFilterType } from "../filterTypes"
 import { FilterTypeContext, FilterTypeSchema } from "../filterTypes/types"
+import { getClearedFiltersValue } from "../internal/getClearedFiltersValue"
 import { getActiveFilterKeys } from "../internal/getActiveFilterKeys"
 import { FilterContent } from "./FilterContent"
 import { FilterList } from "./FilterList"
@@ -108,6 +109,10 @@ export function FiltersControls<Filters extends FiltersDefinition>({
   const handleApplyFilters = () => {
     onChange(localFiltersValue)
     onOpenChange(false)
+  }
+
+  const handleClearFilters = () => {
+    setLocalFiltersValue(getClearedFiltersValue(filters))
   }
 
   const handleGoBack = () => {
@@ -415,6 +420,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
             onFilterSelect={setSelectedFilterKey}
             onFilterChange={updateFilterValue}
             onApply={handleApplyFilters}
+            onClear={handleClearFilters}
             height={formHeight || DEFAULT_FORM_HEIGHT}
           />
         </PopoverContent>

--- a/packages/react/src/patterns/OneFilterPicker/internal/getClearedFiltersValue.ts
+++ b/packages/react/src/patterns/OneFilterPicker/internal/getClearedFiltersValue.ts
@@ -1,0 +1,28 @@
+import { collectNestedFilterKeys } from "../filterTypes/InFilter/components/option-utils"
+import { getFilterType } from "../filterTypes"
+import type { FiltersDefinition, FiltersState } from "../types"
+
+export function getClearedFiltersValue<Filters extends FiltersDefinition>(
+  filters: Filters
+): FiltersState<Filters> {
+  const clearedFilters = {} as FiltersState<Filters>
+
+  for (const [key, filter] of Object.entries(filters)) {
+    const typedKey = key as keyof Filters
+    const filterType = getFilterType(filter.type)
+
+    clearedFilters[typedKey] =
+      filterType.emptyValue as FiltersState<Filters>[keyof Filters]
+
+    if (filter.type !== "in" || !("options" in filter)) {
+      continue
+    }
+
+    for (const nestedKey of collectNestedFilterKeys(filter.options)) {
+      clearedFilters[nestedKey as keyof Filters] =
+        [] as unknown as FiltersState<Filters>[keyof Filters]
+    }
+  }
+
+  return clearedFilters
+}


### PR DESCRIPTION
## Description

Add a built-in Clear filters action to F0FilterPickerContent, shared with OneFilterPicker, so users can reset all selected values across all filters at once.

## Screenshots (if applicable)

<img width="622" height="528" alt="image" src="https://github.com/user-attachments/assets/4723db1a-1a74-46d8-9f5e-bb9cd1b72bf3" />

## Implementation details

The current UI only supports applying selections and per-filter clearing. Users need a faster way to remove all active filters in one action, especially when multiple filters like location and employees are selected together.

[PR](https://factorialmakers.atlassian.net/browse/FCT-54815)
