### PR TITLE
feat: one table min width

### DIFF
--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -46,6 +46,13 @@ interface TableCellProps {
   width?: number | "auto"
 
   /**
+   * Optional minimum width for the cell. When provided, overrides the
+   * minWidth derived from `width`, allowing the cell to shrink no further
+   * than this value.
+   */
+  minWidth?: number | "auto"
+
+  /**
    * When true, the header cell will stick in the specified position when scrolling horizontally
    * @default undefined
    */
@@ -99,6 +106,7 @@ export function TableCell({
   href,
   onClick,
   width = "auto",
+  minWidth,
   firstCell = false,
   sticky,
   colSpan,
@@ -118,6 +126,7 @@ export function TableCell({
   const stickyRight = sticky?.right
 
   const colWidth = getColWidth(width)
+  const colMinWidth = minWidth !== undefined ? getColWidth(minWidth) : colWidth
 
   const linkRef = useRef<HTMLAnchorElement>(null)
   const depth = nestedRowProps?.depth ?? 0
@@ -146,7 +155,7 @@ export function TableCell({
       style={{
         width: colWidth,
         maxWidth: colWidth,
-        minWidth: colWidth,
+        minWidth: colMinWidth,
         left: stickyLeft,
         right: stickyRight,
       }}

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -21,6 +21,13 @@ interface TableHeadProps {
   width?: ColumnWidth
 
   /**
+   * Optional minimum width for the header cell. When provided, overrides the
+   * minWidth derived from `width`, allowing the column to grow past `width`
+   * while never shrinking below this value.
+   */
+  minWidth?: ColumnWidth
+
+  /**
    * When true, the header cell will stick in the specified position when scrolling horizontally
    * @default undefined
    */
@@ -77,6 +84,7 @@ interface TableHeadProps {
 export function TableHead({
   children,
   width = "auto",
+  minWidth,
   sortState = "none",
   onSortClick,
   info,
@@ -187,6 +195,7 @@ export function TableHead({
   )
 
   const colWidth = getColWidth(width)
+  const colMinWidth = minWidth !== undefined ? getColWidth(minWidth) : colWidth
 
   return (
     <TableHeadRoot
@@ -206,7 +215,7 @@ export function TableHead({
       style={{
         width: colWidth,
         maxWidth: colWidth,
-        minWidth: colWidth,
+        minWidth: colMinWidth,
         left: stickyLeft,
         right: stickyRight,
       }}

--- a/packages/react/src/experimental/OneTable/index.stories.tsx
+++ b/packages/react/src/experimental/OneTable/index.stories.tsx
@@ -129,6 +129,31 @@ export const Default: Story = {
   ),
 }
 
+export const MinWidth: Story = {
+  render: () => (
+    <OneTable>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead minWidth={500}>Role (minWidth 500)</TableHead>
+          <TableHead>Manager</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {sampleData.map((row) => (
+          <TableRow key={row.id}>
+            <TableCell>{row.name}</TableCell>
+            <TableCell>{row.email}</TableCell>
+            <TableCell>{row.role}</TableCell>
+            <TableCell>{row.manager}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </OneTable>
+  ),
+}
+
 export const Check: Story = {
   render: () => {
     const [selectedRows, setSelectedRows] = useState<Record<string, boolean>>(

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -437,6 +437,7 @@ export const TableCollection = <
                         align="right"
                         className={borderClass}
                         width={columns[entry.columnIndices[0]].width}
+                        minWidth={columns[entry.columnIndices[0]].minWidth}
                         key={`header-ungrouped-${entry.columnIndices[0]}`}
                         sticky={getStickyPosition(entry.columnIndices[0])}
                       >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -112,7 +112,7 @@ window.IntersectionObserver = MockIntersectionObserver
 
 describe("TableCollection", () => {
   describe("rendering", () => {
-    it("shows loading state initially", () => {
+    it("shows loading state initially", async () => {
       render(
         <TableCollection<
           Person,
@@ -346,10 +346,20 @@ describe("TableCollection", () => {
 
       expect(fetchChildrenMock).not.toHaveBeenCalled()
     })
-  })
 
-  describe("edge cases", () => {
-    it("handles empty data gracefully", async () => {
+    it("applies minWidth to header and row cells", async () => {
+      const columnsWithMinWidth = [
+        {
+          label: "name",
+          render: (item: Person) => item.name,
+          minWidth: 220,
+        },
+        {
+          label: "email",
+          render: (item: Person) => item.email,
+        },
+      ]
+
       render(
         <TableCollection<
           Person,
@@ -360,25 +370,78 @@ describe("TableCollection", () => {
           TestNavigationFilters,
           GroupingDefinition<Person>
         >
-          columns={testColumns}
-          source={createTestSource([])}
+          columns={columnsWithMinWidth}
+          source={createTestSource()}
           onSelectItems={vi.fn()}
           onLoadData={vi.fn()}
           onLoadError={vi.fn()}
         />
       )
 
-      // Wait for loading state to finish
       await waitFor(() => {
-        const rows = screen.getAllByRole("row")
-        expect(rows).toHaveLength(1) // Just the header row
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
       })
 
-      // Headers should still be present
-      expect(screen.getAllByRole("columnheader")).toHaveLength(2)
+      const nameHeader = screen.getByRole("columnheader", { name: "name" })
+      expect(nameHeader).toHaveStyle({ minWidth: "220px" })
+
+      const firstNameCell = screen
+        .getAllByText(testData[0].name)[0]
+        .closest("td")
+      expect(firstNameCell).toHaveStyle({ minWidth: "220px" })
     })
 
-    it("handles error states appropriately", async () => {
+    it("applies minWidth in grouped header placeholders for ungrouped columns", async () => {
+      const groupedColumns = [
+        {
+          label: "name",
+          render: (item: Person) => item.name,
+          headerGroupId: "identity",
+        },
+        {
+          label: "email",
+          render: (item: Person) => item.email,
+          minWidth: 180,
+        },
+      ]
+
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={groupedColumns}
+          source={createTestSource()}
+          headerGroupLabels={{ identity: "Identity" }}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      const identityGroupHeader = screen.getByRole("columnheader", {
+        name: "Identity",
+      })
+      const groupedHeaderRow = identityGroupHeader.closest("tr")
+      const groupedHeaderCells = within(
+        groupedHeaderRow as HTMLElement
+      ).getAllByRole("columnheader")
+
+      const ungroupedPlaceholderHeader =
+        groupedHeaderCells[groupedHeaderCells.length - 1]
+      expect(ungroupedPlaceholderHeader).toHaveStyle({ minWidth: "180px" })
+    })
+
+    it("renders error state when data fetch fails", async () => {
       const errorMessage = "Failed to fetch data"
       const error = new Error(errorMessage)
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -299,6 +299,7 @@ const RowComponentInner = <
             href={itemHref}
             onClick={itemOnClick}
             width={column.width}
+            minWidth={column.minWidth}
             sticky={getStickyPosition(cellIndex)}
             loading={loading}
             nestedRowProps={{

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -35,6 +35,13 @@ export type WithOptionalSorting<
    * The width of the column. If not provided, the width will be "auto"
    */
   width?: number
+
+  /**
+   * Optional minimum width for the column in pixels. When provided, overrides
+   * the minWidth derived from `width`. Useful for columns with no fixed
+   * `width` that should not shrink below a given size.
+   */
+  minWidth?: number
 }
 
 export type ColId = string
@@ -46,7 +53,7 @@ export type TableColumnDefinition<
 > = WithOptionalSorting<R, Sortings> &
   Pick<
     ComponentProps<typeof TableHead>,
-    "hidden" | "info" | "infoIcon" | "sticky" | "width"
+    "hidden" | "info" | "infoIcon" | "sticky" | "width" | "minWidth"
   > & {
     /**
      * Optional summary configuration for this column


### PR DESCRIPTION
## Description

This PR introduces `minWidth` to `OneTable` columns

- `TableHead` and `TableCell` accept an optional `minWidth` prop that overrides the minWidth derived from `width`, letting columns grow past `width` without shrinking below a floor.
- Column `minWidth` plumbed through `TableColumnDefinition`, `Table.tsx`, and `Row.tsx`.
- New `MinWidth` story.
<img width="1918" height="1080" alt="Screenshot 2026-05-18 at 14 21 57" src="https://github.com/user-attachments/assets/ac3e5a33-21a1-4672-8f48-483e04f90d8b" />

[Link to Figma Design](https://www.figma.com/design/A4204Nlu1QulvPCR8nr6GM/Headcount-planning?node-id=10382-87109&p=f&t=B5lO21aEFsYpdR5u-0)

## Implementation details

### OneTable

- **`TableCell/index.tsx` and `TableHead/index.tsx`**: Added optional `minWidth` prop (`number | "auto"` and `ColumnWidth` respectively). When set, it overrides the `minWidth` style that previously always equaled `width`. Implemented as `colMinWidth = minWidth !== undefined ? getColWidth(minWidth) : colWidth` so existing behavior is preserved when the prop is omitted.
- **Why**: Previously `minWidth === width === maxWidth`, which prevented columns from growing past their declared width. The new prop decouples the lower bound so a column can flex upward while keeping a floor.

### Stories

- New OneTable story: `MinWidth`.
