### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.14.0",
+  "packages/react": "2.14.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.51.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.14.1](https://github.com/factorialco/f0/compare/f0-react-v2.14.0...f0-react-v2.14.1) (2026-05-21)
+
+
+### Bug Fixes
+
+* some adjustments to F0 forms ([#4194](https://github.com/factorialco/f0/issues/4194)) ([801cb2c](https://github.com/factorialco/f0/commit/801cb2ceba25b9d9129127eebd1a00acfb6abb2b))
+
 ## [2.14.0](https://github.com/factorialco/f0/compare/f0-react-v2.13.1...f0-react-v2.14.0) (2026-05-21)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.14.1</summary>

## [2.14.1](https://github.com/factorialco/f0/compare/f0-react-v2.14.0...f0-react-v2.14.1) (2026-05-21)


### Bug Fixes

* some adjustments to F0 forms ([#4194](https://github.com/factorialco/f0/issues/4194)) ([801cb2c](https://github.com/factorialco/f0/commit/801cb2ceba25b9d9129127eebd1a00acfb6abb2b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).