### PR TITLE
fix(Metadata): add key to Fragment wrapper in metadata items map

### DIFF
--- a/packages/react/src/experimental/Information/Headers/Metadata/index.test.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/index.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { Metadata } from "./index"
+
+describe("Metadata", () => {
+  it("renders multiple items without React key warnings", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+
+    try {
+      render(
+        <Metadata
+          items={[
+            { label: "Status", value: { type: "text", content: "Active" } },
+            { label: "Owner", value: { type: "text", content: "Alice" } },
+            { label: "Team", value: { type: "text", content: "Engineering" } },
+          ]}
+        />
+      )
+
+      expect(consoleError).not.toHaveBeenCalled()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+})

--- a/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "motion/react"
-import { memo, useState } from "react"
+import { Fragment, memo, useState } from "react"
 
 import {
   AvatarVariant,
@@ -281,15 +281,12 @@ const _Metadata = memo(function Metadata({ items }: MetadataProps) {
   return (
     <div className="flex flex-col items-start gap-x-3 gap-y-0 md:flex-row md:flex-wrap md:items-center">
       {cleanedItems.map((item, index) => (
-        <>
-          <MetadataItem key={`item-${index}`} item={item} />
+        <Fragment key={`metadata-item-${index}`}>
+          <MetadataItem item={item} />
           {index < cleanedItems.length - 1 && (
-            <div
-              key={`separator-${index}`}
-              className="hidden h-4 w-[1px] bg-f1-border md:block"
-            />
+            <div className="hidden h-4 w-[1px] bg-f1-border md:block" />
           )}
-        </>
+        </Fragment>
       ))}
     </div>
   )


### PR DESCRIPTION
## What

- Replace the shorthand Fragment returned from `Metadata` item mapping with an explicit keyed `Fragment`
- Remove redundant child keys now that the mapped Fragment owns the key
- Add a regression test that renders multiple metadata items without React unique-key warnings

## Why

React requires the key on the top-level element returned by a `.map()` callback. The previous code keyed children inside an unkeyed Fragment, which still produced a missing-key warning.

Fixes #4208

## Validation

```bash
cd packages/react
mise exec -- pnpm format src/experimental/Information/Headers/Metadata/index.tsx src/experimental/Information/Headers/Metadata/index.test.tsx
mise exec -- pnpm lint src/experimental/Information/Headers/Metadata/index.tsx src/experimental/Information/Headers/Metadata/index.test.tsx
mise exec -- pnpm vitest run --reporter=verbose src/experimental/Information/Headers/Metadata/index.test.tsx
```