### PR TITLE
fix(F0Select): reflect external value resets in single-selection mode

### DIFF
--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -908,4 +908,53 @@ describe("Select", () => {
       })
     })
   })
+
+  describe("controlled value sync", () => {
+    // Regression test for https://github.com/factorialco/f0/pull/4134
+    // After PR #4134 refactored F0Select to use `useSelectable`'s `localValue` /
+    // `committedSelectionRef`, programmatic resets of the `value` prop from the
+    // parent stopped being reflected in the displayed selection: the previous
+    // value remained "stuck" in the trigger because the internal
+    // `updateLocalSelectedState` merge in useSelectable was additive and never
+    // unchecked items that disappeared from the external state.
+    it("reflects an externally reset `value` prop after the user has clicked another option", async () => {
+      const user = userEvent.setup()
+
+      const { rerender } = render(
+        <F0Select
+          {...defaultSelectProps}
+          options={mockOptions}
+          value="option1"
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Option 1")).toBeInTheDocument()
+      })
+
+      // User picks Option 2 (simulates a transient selection inside a form).
+      await openSelect(user)
+      await user.click(screen.getByText("Option 2"))
+
+      await waitFor(() => {
+        expect(screen.getByText("Option 2")).toBeInTheDocument()
+      })
+
+      // Parent programmatically resets the value (e.g. cross-field rule
+      // forcing recurrence back to a default option). The trigger must
+      // reflect the new value, not stay stuck on the user's previous pick.
+      rerender(
+        <F0Select
+          {...defaultSelectProps}
+          options={mockOptions}
+          value="option3"
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Option 3")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Option 2")).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -345,7 +345,18 @@ export function useSelectable<
   )
 
   /**
-   * Merges external selected state with local state, preserving user selections
+   * Merges external selected state with local state, preserving user selections.
+   *
+   * In multi-selection mode, the merge is additive: items already checked locally
+   * are preserved when the external `selectedState` arrives (needed for
+   * paginated/infinite-scroll selections that span pages not yet known to the
+   * controlling parent).
+   *
+   * In single-selection mode, the external `selectedState` is treated as the full
+   * source of truth: items that were checked locally but are no longer present in
+   * the new external state are unchecked. This guarantees that programmatic
+   * updates from the controlling selection source are reflected in the displayed
+   * selection.
    */
   const updateLocalSelectedState = useCallback(
     (selectedState: SelectedItemsState<R> | undefined) => {
@@ -357,8 +368,17 @@ export function useSelectable<
           SelectedItemState<R>
         >()
 
+        const newItemIds = new Set(newSelectedState.items?.keys() || [])
+
         for (const [id, itemState] of current.items?.entries() || []) {
-          mergedItems.set(id, itemState)
+          if (!isMultiSelection && !newItemIds.has(id) && itemState.checked) {
+            // Single-select: external state is source of truth.
+            // Item is no longer checked externally, so uncheck it locally.
+            // Only clone when actually flipping to avoid unnecessary refs.
+            mergedItems.set(id, { ...itemState, checked: false })
+          } else {
+            mergedItems.set(id, itemState)
+          }
         }
 
         for (const [
@@ -378,6 +398,14 @@ export function useSelectable<
             mergedItems.set(itemStateId, {
               ...existingItem,
               item,
+              // Single-select: external `checked` wins over stale local state.
+              ...(isMultiSelection ? {} : { checked: itemState.checked }),
+            })
+          } else if (!isMultiSelection) {
+            // Single-select: external `checked` wins over stale local state.
+            mergedItems.set(itemStateId, {
+              ...existingItem,
+              checked: itemState.checked,
             })
           }
         }
@@ -411,7 +439,13 @@ export function useSelectable<
         }
       })
     },
-    [data.records, getSelectable, allSelectedCheck, getItemById]
+    [
+      data.records,
+      getSelectable,
+      allSelectedCheck,
+      getItemById,
+      isMultiSelection,
+    ]
   )
 
   // Selection Handlers (Internal)


### PR DESCRIPTION
## Problem

When the parent programmatically resets the `value` prop of a single-select `F0Select` after the user has clicked a different option, the trigger stays stuck on the user's previous pick instead of displaying the new value.

### Repro

```tsx
const { rerender } = render(<F0Select value="option1" options={...} onChange={noop} />)
// User picks Option 2 in the UI
await user.click(screen.getByText("Option 2"))
// Parent programmatically resets the value
rerender(<F0Select value="option3" options={...} onChange={noop} />)
// 🐞 Trigger still shows "Option 2" instead of "Option 3"
```

This was found in the `AdditionalCompensationWizard` of the Factorial monolith, where a cross-field rule forces `recurrence` back to `monthly` when the strategy switches to `per_worked_day`. After bumping `@factorialco/f0-react` from `2.8.2` to `2.14.0`, the recurrence trigger stayed on the user's previous pick.

## Root cause

PR #4134 refactored `F0Select` to consume `useSelectable`'s `localValue` / `committedSelectionRef` machinery.

The internal `updateLocalSelectedState` in `useSelectable` performs an **additive merge**:

- Items already checked locally are preserved when the new external state arrives.
- Items that disappeared from the external state are **never** unchecked.

For multi-select with infinite-scroll this is intentional (selections from pages not yet loaded by the parent must survive). For single-select it is a bug: the external `selectedState` is the full source of truth and stale checks must be cleared.

The trigger keeps rendering the first `checked: true` item by insertion order, which is the stale one, so the new `value` never surfaces.

## Fix

Make the merge mode-aware in `updateLocalSelectedState`:

- **`selectionMode === "multi"`**: additive merge (unchanged).
- **`selectionMode === "single"`**: replace strategy
  - items in `current` but not in `newSelectedState` are unchecked
  - items present in both have their `checked` taken from the external state

Multi-select behaviour is unchanged; the existing tests for multi/staged/apply scenarios all still pass.

## Test

`F0Select.test.tsx` gets a new `controlled value sync` suite with the regression case described above. Verified that the test:

- ❌ **fails** on `main` (reproduces the bug)
- ✅ **passes** with this fix

## Validation in the consumer

Patched build verified via `yalc` in the Factorial monolith on branch `chore/bump-f0-react-2.14.0`:

- `CreateAdditionalCompensationWizardModal.spec.tsx` — 9/9 tests pass with the original consumer code (no `key` workaround, no spec changes).

## Refs

- Regression introduced by #4134
- Related (touches `F0Select` neighbouring areas): #4100, #4194