### PR TITLE
fix: reset to default button behavior in data collection

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -997,6 +997,7 @@ const OneDataCollectionComp = <
                   onGroupingChange={setCurrentGrouping}
                   sortings={sortings}
                   currentSortings={currentSortings}
+                  defaultSortings={defaultSortings.current}
                   onSortingsChange={setCurrentSortings}
                 />
               )}

--- a/packages/react/src/patterns/OneDataCollection/Settings/Settings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/Settings.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
 import {
   GroupingDefinition,
   GroupingState,
@@ -12,6 +11,7 @@ import {
 } from "@/hooks/datasource"
 import { Reset, Sliders } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
+import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
 import { ItemActionsDefinition } from "../item-actions"
@@ -58,6 +58,7 @@ type SettingsProps<
   sortings?: SortingsDefinition
   summaries?: SummariesDefinition
   currentSortings: SortingsState<Sortings>
+  defaultSortings: SortingsState<Sortings>
   onSortingsChange: (sortings: SortingsState<Sortings>) => void
 }
 
@@ -79,6 +80,7 @@ export const Settings = <
   onGroupingChange,
   sortings,
   currentSortings,
+  defaultSortings,
   onSortingsChange,
 }: SettingsProps<
   R,
@@ -153,11 +155,33 @@ export const Settings = <
 
   const settingsContext = useDataCollectionSettings()
 
+  const hasModifiedSettings = useMemo(() => {
+    if (JSON.stringify(currentSortings) !== JSON.stringify(defaultSortings))
+      return true
+
+    const visualizationType = visualizations[currentVisualization]?.type
+    if (!visualizationType || !(visualizationType in collectionVisualizations))
+      return false
+
+    const key = visualizationType as keyof typeof collectionVisualizations
+    const currentSettings = settingsContext.settings.visualization[key]
+    const defaultSettings = collectionVisualizations[key]?.settings.default
+
+    return JSON.stringify(currentSettings) !== JSON.stringify(defaultSettings)
+  }, [
+    settingsContext.settings.visualization,
+    visualizations,
+    currentVisualization,
+    currentSortings,
+    defaultSortings,
+  ])
+
   const onResetSettings = () => {
     // Call to the all visualizations reset handler
     Object.values(collectionVisualizations).forEach((visualization) => {
       visualization.settings.resetHandler?.(settingsContext)
     })
+    onSortingsChange(defaultSortings)
   }
 
   return (
@@ -222,18 +246,20 @@ export const Settings = <
                 {visualizacionSettings}
               </section>
             ),
-            <section
-              key="reset"
-              className="border-0 border-t border-solid border-t-f1-border p-3"
-            >
-              <F0Button
-                size="sm"
-                variant="ghost"
-                icon={Reset}
-                label={i18n.collections.visualizations.reset}
-                onClick={onResetSettings}
-              />
-            </section>,
+            hasModifiedSettings && (
+              <section
+                key="reset"
+                className="border-0 border-t border-solid border-t-f1-border p-3"
+              >
+                <F0Button
+                  size="sm"
+                  variant="ghost"
+                  icon={Reset}
+                  label={i18n.collections.visualizations.reset}
+                  onClick={onResetSettings}
+                />
+              </section>
+            ),
           ].filter(Boolean)}
         </PopoverContent>
       </Popover>

--- a/packages/react/src/patterns/OneDataCollection/Settings/components/SortingSelector.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/components/SortingSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useMemo } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { F0Select } from "@/components/F0Select"
@@ -33,20 +33,14 @@ export const SortingSelector = <Sortings extends SortingsDefinition>({
     })),
   ]
 
-  const [localSortings, setLocalSortings] =
-    useState<SortingsState<Sortings>>(currentSortings)
-
-  useEffect(() => {
-    if (!currentSortings) {
-      setLocalSortings({
-        field: EmptySortingValue,
-        order: "asc",
-      })
-    } else {
-      setLocalSortings(currentSortings)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- we are deep comparing the currentSortings
-  }, [JSON.stringify(currentSortings)])
+  const displaySortings = useMemo(
+    () =>
+      currentSortings ?? {
+        field: EmptySortingValue as SortingKey<Sortings>,
+        order: "asc" as const,
+      },
+    [currentSortings]
+  )
 
   const handleChange = (sorting: SortingsState<Sortings>) => {
     if (!sorting || sorting.field === EmptySortingValue) {
@@ -61,29 +55,30 @@ export const SortingSelector = <Sortings extends SortingsDefinition>({
       <div className="flex items-end gap-2">
         <div className="shrink grow [&_button]:h-8 [&_button]:rounded">
           <F0Select
+            key={displaySortings.field as string}
             label={i18n.collections.sorting.sortBy}
             options={sortingOptions}
-            value={localSortings?.field as string}
+            value={displaySortings.field as string}
             onChange={(value) => {
               handleChange({
                 field: value as SortingKey<Sortings>,
-                order: localSortings?.order ?? "asc",
+                order: displaySortings.order ?? "asc",
               })
             }}
           />
         </div>
 
-        {localSortings?.field !== EmptySortingValue && (
+        {displaySortings.field !== EmptySortingValue && (
           <div>
             <F0Button
               hideLabel
               label={i18n.collections.sorting.toggleDirection}
               variant="outline"
-              icon={localSortings?.order === "asc" ? Ascending : Descending}
+              icon={displaySortings.order === "asc" ? Ascending : Descending}
               onClick={() =>
                 handleChange({
-                  field: localSortings?.field as SortingKey<Sortings>,
-                  order: localSortings?.order === "asc" ? "desc" : "asc",
+                  field: displaySortings.field as SortingKey<Sortings>,
+                  order: displaySortings.order === "asc" ? "desc" : "asc",
                 })
               }
             />

--- a/packages/react/src/patterns/OneDataCollection/Settings/components/__tests__/SortingSelector.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/components/__tests__/SortingSelector.test.tsx
@@ -1,0 +1,279 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SortingsDefinition } from "@/hooks/datasource/types/sortings.typings"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { EmptySortingValue, SortingSelector } from "../SortingSelector"
+
+const sortings: SortingsDefinition = {
+  name: { label: "Name" },
+  date: { label: "Date" },
+  amount: { label: "Amount" },
+}
+
+global.ResizeObserver = class MockResizeObserver {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+} as typeof ResizeObserver
+
+const openSelect = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole("combobox"))
+  await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+  fireEvent.animationStart(screen.getByRole("listbox"))
+}
+
+describe("SortingSelector", () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      value: 800,
+      configurable: true,
+    })
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      value: 800,
+      configurable: true,
+    })
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      () => ({
+        width: 200,
+        height: 40,
+        top: 0,
+        left: 0,
+        bottom: 40,
+        right: 200,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      })
+    )
+  })
+
+  it("should render with no sorting selected when currentSortings is null", () => {
+    const onChange = vi.fn()
+
+    render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={null}
+        onChange={onChange}
+      />
+    )
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+  })
+
+  it("should render with a sorting field selected", () => {
+    const onChange = vi.fn()
+
+    render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={{ field: "name", order: "asc" }}
+        onChange={onChange}
+      />
+    )
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+  })
+
+  it("should call onChange with null when selecting no-sorting option", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={{ field: "name", order: "asc" }}
+        onChange={onChange}
+      />
+    )
+
+    await openSelect(user)
+    const listbox = screen.getByRole("listbox")
+    const noSortingOption = within(listbox).getByRole("option", {
+      name: /no sorting/i,
+    })
+    await user.click(noSortingOption)
+
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it("should call onChange with the selected sorting field", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={null}
+        onChange={onChange}
+      />
+    )
+
+    await openSelect(user)
+    const listbox = screen.getByRole("listbox")
+    const dateOption = within(listbox).getByRole("option", { name: "Date" })
+    await user.click(dateOption)
+
+    expect(onChange).toHaveBeenCalledWith({ field: "date", order: "asc" })
+  })
+
+  it("should preserve order direction when changing sorting field", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={{ field: "name", order: "desc" }}
+        onChange={onChange}
+      />
+    )
+
+    await openSelect(user)
+    const listbox = screen.getByRole("listbox")
+    const amountOption = within(listbox).getByRole("option", {
+      name: "Amount",
+    })
+    await user.click(amountOption)
+
+    expect(onChange).toHaveBeenCalledWith({ field: "amount", order: "desc" })
+  })
+
+  it("should not fire onChange when value echoes back the current sorting (echo guard)", async () => {
+    const onChange = vi.fn()
+
+    const { rerender } = render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={{ field: "name", order: "asc" }}
+        onChange={onChange}
+      />
+    )
+
+    // Rerender with a different sorting (simulating reset)
+    rerender(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={{ field: "date", order: "asc" }}
+        onChange={onChange}
+      />
+    )
+
+    // The echo guard should prevent onChange from being called with the old value
+    // when F0Select internally fires onChange during value prop transition
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("should update displayed value when currentSortings prop changes (controlled)", () => {
+    const onChange = vi.fn()
+
+    const { rerender } = render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={{ field: "name", order: "asc" }}
+        onChange={onChange}
+      />
+    )
+
+    // Simulate reset: change from "name" to null
+    rerender(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={null}
+        onChange={onChange}
+      />
+    )
+
+    // Should not call onChange during programmatic update
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("should update displayed value when sorting changes from one field to another", () => {
+    const onChange = vi.fn()
+
+    const { rerender } = render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={{ field: "name", order: "asc" }}
+        onChange={onChange}
+      />
+    )
+
+    // Simulate external change (e.g., reset to default sorting)
+    rerender(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={{ field: "date", order: "desc" }}
+        onChange={onChange}
+      />
+    )
+
+    // Should not trigger onChange when props change programmatically
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("should toggle sort direction when direction button is clicked", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={{ field: "name", order: "asc" }}
+        onChange={onChange}
+      />
+    )
+
+    // The toggle direction button should be visible when a sorting is selected
+    const toggleButton = screen.getByLabelText(/toggle sorting direction/i)
+    await user.click(toggleButton)
+
+    expect(onChange).toHaveBeenCalledWith({ field: "name", order: "desc" })
+  })
+
+  it("should not show direction button when no sorting is selected", () => {
+    const onChange = vi.fn()
+
+    render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={null}
+        onChange={onChange}
+      />
+    )
+
+    expect(
+      screen.queryByLabelText(/toggle sorting direction/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it("should treat EmptySortingValue field as no sorting", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(
+      <SortingSelector
+        sortings={sortings}
+        currentSortings={{ field: "name", order: "asc" }}
+        onChange={onChange}
+      />
+    )
+
+    await openSelect(user)
+    const listbox = screen.getByRole("listbox")
+    // Select "No sorting" option
+    const noSortingOption = within(listbox).getByRole("option", {
+      name: /no sorting/i,
+    })
+    await user.click(noSortingOption)
+
+    // Should call onChange with null (not with EmptySortingValue)
+    expect(onChange).toHaveBeenCalledWith(null)
+    expect(onChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ field: EmptySortingValue })
+    )
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumns.settings.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumns.settings.test.ts
@@ -272,4 +272,69 @@ describe("useColumns with settings", () => {
     // column3 should still be hidden (from user preferences)
     expect(result.current.colsHidden).toContain("column3")
   })
+
+  it("should restore default hidden columns when settings are reset (hidden becomes undefined)", () => {
+    const settings: TableVisualizationSettings = {
+      hidden: [], // User showed all columns
+    }
+    const frozenColumns = 0
+    const allowSorting = true
+    const allowHiding = true
+
+    const { result, rerender } = renderHook(
+      ({ settings }) =>
+        useColumns(
+          mockColumns,
+          frozenColumns,
+          settings,
+          allowSorting,
+          allowHiding
+        ),
+      { initialProps: { settings } }
+    )
+
+    // All columns visible because user explicitly set hidden to []
+    expect(result.current.colsHidden).toEqual([])
+
+    // Simulate "Reset to default" — settings become empty object (hidden: undefined)
+    rerender({ settings: {} })
+
+    // Should restore developer defaults: column2 and column3 hidden
+    expect(result.current.colsHidden).toEqual(["column2", "column3"])
+  })
+
+  it("should restore default column order when settings are reset (order becomes undefined)", () => {
+    const columnsWithOrder: TableColumnDefinition<unknown, never, never>[] = [
+      { id: "column1", label: "Column 1", order: 3 },
+      { id: "column2", label: "Column 2", order: 1 },
+      { id: "column3", label: "Column 3", order: 2 },
+    ]
+    const settings: TableVisualizationSettings = {
+      order: ["column3", "column1", "column2"], // User reordered
+    }
+    const frozenColumns = 0
+    const allowSorting = true
+    const allowHiding = true
+
+    const { result, rerender } = renderHook(
+      ({ settings }) =>
+        useColumns(
+          columnsWithOrder,
+          frozenColumns,
+          settings,
+          allowSorting,
+          allowHiding
+        ),
+      { initialProps: { settings } }
+    )
+
+    // User's custom order
+    expect(result.current.colsOrder).toEqual(["column3", "column1", "column2"])
+
+    // Simulate "Reset to default" — settings become empty object (order: undefined)
+    rerender({ settings: {} })
+
+    // Should restore developer-defined order
+    expect(result.current.colsOrder).toEqual(["column2", "column3", "column1"])
+  })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
@@ -112,15 +112,19 @@ export const useColumns = <
   )
 
   useEffect(() => {
-    if (allowHiding && settings?.hidden !== undefined) {
+    if (allowHiding) {
       setColsHidden(getMergedHidden())
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to re-run this effect when the settings change
   }, [JSON.stringify(settings?.hidden), allowHiding])
 
   useEffect(() => {
-    if (allowSorting && settings?.order !== undefined) {
-      setColsOrder(settings.order)
+    if (allowSorting) {
+      setColsOrder(
+        settings?.order !== undefined
+          ? settings.order
+          : getColsOrderFromDefinition(originalColumns)
+      )
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to re-run this effect when the settings change
   }, [JSON.stringify(settings?.order), allowSorting])


### PR DESCRIPTION
## Fix "Reset to default" button in OneDataCollection settings

### Problem

The "Reset to default" button in the OneDataCollection settings popover had several issues:

1. **Hidden columns not resetting** — Clicking reset did not restore developer-defined hidden columns
2. **Button always visible** — The reset button showed even when settings were already at defaults
3. **Column order not resetting** — Custom column ordering was not reverted to definition defaults
4. **Sorting not resetting** — The active sorting field/direction was not included in the reset

### Changes

- **`useColums.ts`** — Removed overly strict guards (`settings?.hidden !== undefined`, `settings?.order !== undefined`) in the useEffects that sync column state. When settings are reset to `{}`, the effects now correctly fall back to developer-defined defaults.

- **`Settings.tsx`** — Added `hasModifiedSettings` check that compares current sorting + visualization settings against defaults. The reset button only renders when there are actual modifications. Added `defaultSortings` prop and sorting reset to `onResetSettings`.

- **`SortingSelector.tsx`** — Refactored from useState+useEffect sync pattern to a fully controlled component using `useMemo`. Added `key={displaySortings.field}` on F0Select to force remount on field changes, which eliminates internal state echoes that caused the snap-back behavior.

- **`OneDatacollection.tsx`** — Passes `defaultSortings` (captured at mount via useRef) to the Settings component.
