### PR TITLE
fix(react): fix formatting in CrudPatterns MDX documentation files

### DIFF
--- a/packages/react/src/experimental/CrudPatterns/__stories__/action-hierarchy.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/action-hierarchy.mdx
@@ -104,7 +104,8 @@ control how they render depending on the visualization's density:
         <td>Primary</td>
         <td>The most-likely-next action (Edit, Open)</td>
         <td>
-          Persistent button on low-density surfaces; hover-revealed on dense ones
+          Persistent button on low-density surfaces; hover-revealed on dense
+          ones
         </td>
       </tr>
       <tr>

--- a/packages/react/src/experimental/CrudPatterns/__stories__/bulk-and-async.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/bulk-and-async.mdx
@@ -65,6 +65,7 @@ only affected the visible page.
 explicit through a **selection-scope banner**.
 
 Banner pattern:
+
 > "25 items on this page are selected. **Select all 1,432 items matching your filters.**"
 
 This banner appears after the user checks the "select all on page" affordance,
@@ -78,7 +79,7 @@ deliberate click.
   }}
   dont={{
     description:
-      "Do not silently select all results when the user checks the page-level \"select all\" — that's a different scope.",
+      'Do not silently select all results when the user checks the page-level "select all" — that\'s a different scope.',
   }}
 />
 
@@ -90,6 +91,7 @@ For large datasets, representing selection as "an array of IDs" breaks down. The
 correct abstraction is a **predicate**: "all items matching the current filter."
 
 Bulk action handlers must accept either:
+
 - A list of specific item identifiers, OR
 - A predicate (the active filter state + "all selected" flag)
 
@@ -103,12 +105,14 @@ enables bulk actions on millions of records without enumerating them client-side
 The floating bar that appears when items are selected:
 
 **Anatomy:**
+
 1. **Counter** — "N selected" (must reflect actual scope: page or all)
 2. **Primary actions** — up to two buttons (the most common bulk operations)
 3. **Overflow** — additional or destructive bulk actions
 4. **Cancel** — clears selection, always visible, always immediate
 
 **Behavior:**
+
 - Appears when one or more items are selected
 - Floats at the bottom (or top) of the viewport, sticky
 - Disappears when selection is cleared or action completes (unless keepSelection is desired)
@@ -216,6 +220,6 @@ Partial success is the common case for bulk operations. Design for it:
   }}
   dont={{
     description:
-      "Do not report only \"Some items failed\" — show the count and let users inspect details.",
+      'Do not report only "Some items failed" — show the count and let users inspect details.',
   }}
 />

--- a/packages/react/src/experimental/CrudPatterns/__stories__/checklist.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/checklist.mdx
@@ -12,86 +12,86 @@ principle or pattern page for context.
 ## Collection setup
 
 - [ ] There is exactly **one primary action** per collection
-  ([Principle 1](/?path=/docs/experimental-crud-patterns-principles--documentation))
+      ([Principle 1](/?path=/docs/experimental-crud-patterns-principles--documentation))
 - [ ] The primary action label is a verb-noun pair ("Add employee", not "New")
-  ([Create & Update](/?path=/docs/experimental-crud-patterns-create-update--documentation))
+      ([Create & Update](/?path=/docs/experimental-crud-patterns-create-update--documentation))
 - [ ] Create is anchored to the collection frame, not to any item
-  ([Principle 2](/?path=/docs/experimental-crud-patterns-principles--documentation))
+      ([Principle 2](/?path=/docs/experimental-crud-patterns-principles--documentation))
 - [ ] No more than 2 expanded secondary actions in the toolbar
-  ([Action hierarchy](/?path=/docs/experimental-crud-patterns-action-hierarchy--documentation))
+      ([Action hierarchy](/?path=/docs/experimental-crud-patterns-action-hierarchy--documentation))
 
 ---
 
 ## Forms (Create & Update)
 
 - [ ] The update form reuses the create form (same fields, order, validation)
-  ([Principle 3](/?path=/docs/experimental-crud-patterns-principles--documentation))
+      ([Principle 3](/?path=/docs/experimental-crud-patterns-principles--documentation))
 - [ ] The container matches operation complexity (not over- or under-weighted)
-  ([Containers](/?path=/docs/experimental-crud-patterns-containers--documentation))
+      ([Containers](/?path=/docs/experimental-crud-patterns-containers--documentation))
 - [ ] If a wizard is used, there is actual branching or validation gating
-  ([Containers](/?path=/docs/experimental-crud-patterns-containers--documentation))
+      ([Containers](/?path=/docs/experimental-crud-patterns-containers--documentation))
 - [ ] If a side panel is used, it degrades gracefully below ~900px
-  ([Containers](/?path=/docs/experimental-crud-patterns-containers--documentation))
+      ([Containers](/?path=/docs/experimental-crud-patterns-containers--documentation))
 
 ---
 
 ## Read
 
 - [ ] The read container matches the resource depth: overlay for simple, page for deep
-  ([Principle 4](/?path=/docs/experimental-crud-patterns-principles--documentation))
+      ([Principle 4](/?path=/docs/experimental-crud-patterns-principles--documentation))
 - [ ] The user does not lose scroll position when opening/closing read
-  ([Read](/?path=/docs/experimental-crud-patterns-read--documentation))
+      ([Read](/?path=/docs/experimental-crud-patterns-read--documentation))
 - [ ] If detail-then-escalate is used, "Open full view" is a clear affordance
-  ([Read](/?path=/docs/experimental-crud-patterns-read--documentation))
+      ([Read](/?path=/docs/experimental-crud-patterns-read--documentation))
 - [ ] Editable surfaces do NOT use row-click for read (conflicts with cell focus)
-  ([Read](/?path=/docs/experimental-crud-patterns-read--documentation))
+      ([Read](/?path=/docs/experimental-crud-patterns-read--documentation))
 
 ---
 
 ## Destructive actions
 
 - [ ] Destructive actions default to overflow (ellipsis); if surfaced, there is deliberate justification
-  ([Principle 6](/?path=/docs/experimental-crud-patterns-principles--documentation))
+      ([Principle 6](/?path=/docs/experimental-crud-patterns-principles--documentation))
 - [ ] Confirmation names the resource, count, and reversibility
-  ([Delete & destructive](/?path=/docs/experimental-crud-patterns-delete-destructive--documentation))
+      ([Delete & destructive](/?path=/docs/experimental-crud-patterns-delete-destructive--documentation))
 - [ ] No generic "Are you sure?" confirmations anywhere
-  ([Principle 5](/?path=/docs/experimental-crud-patterns-principles--documentation))
+      ([Principle 5](/?path=/docs/experimental-crud-patterns-principles--documentation))
 - [ ] Destructive styling appears only at the confirmation step, not in the menu
-  ([Delete & destructive](/?path=/docs/experimental-crud-patterns-delete-destructive--documentation))
+      ([Delete & destructive](/?path=/docs/experimental-crud-patterns-delete-destructive--documentation))
 
 ---
 
 ## Bulk operations
 
 - [ ] Selection scope is explicit — user knows if they selected page or all results
-  ([Principle 7](/?path=/docs/experimental-crud-patterns-principles--documentation))
+      ([Principle 7](/?path=/docs/experimental-crud-patterns-principles--documentation))
 - [ ] A scope banner appears when the dataset spans pages
-  ([Bulk & async](/?path=/docs/experimental-crud-patterns-bulk-async--documentation))
+      ([Bulk & async](/?path=/docs/experimental-crud-patterns-bulk-async--documentation))
 - [ ] Bulk bar shows the exact count of selected items
-  ([Action hierarchy](/?path=/docs/experimental-crud-patterns-action-hierarchy--documentation))
+      ([Action hierarchy](/?path=/docs/experimental-crud-patterns-action-hierarchy--documentation))
 - [ ] Bulk destructive actions always show a confirmation with count
-  ([Delete & destructive](/?path=/docs/experimental-crud-patterns-delete-destructive--documentation))
+      ([Delete & destructive](/?path=/docs/experimental-crud-patterns-delete-destructive--documentation))
 - [ ] Partial failure is handled: count shown, failed items stay selected, retry offered
-  ([Bulk & async](/?path=/docs/experimental-crud-patterns-bulk-async--documentation))
+      ([Bulk & async](/?path=/docs/experimental-crud-patterns-bulk-async--documentation))
 
 ---
 
 ## Async feedback
 
 - [ ] Feedback is co-located with the triggering affordance (button/bar/container)
-  ([Principle 8](/?path=/docs/experimental-crud-patterns-principles--documentation))
+      ([Principle 8](/?path=/docs/experimental-crud-patterns-principles--documentation))
 - [ ] Global notifications (toasts) are used ONLY for background work the user is not waiting on
-  ([Bulk & async](/?path=/docs/experimental-crud-patterns-bulk-async--documentation))
+      ([Bulk & async](/?path=/docs/experimental-crud-patterns-bulk-async--documentation))
 - [ ] The state machine covers all four states: idle, loading, success, error
-  ([Bulk & async](/?path=/docs/experimental-crud-patterns-bulk-async--documentation))
+      ([Bulk & async](/?path=/docs/experimental-crud-patterns-bulk-async--documentation))
 
 ---
 
 ## Affordances & density
 
 - [ ] Dense surfaces (tables): actions are hover-revealed or in a dedicated column
-  ([Principle 10](/?path=/docs/experimental-crud-patterns-principles--documentation))
+      ([Principle 10](/?path=/docs/experimental-crud-patterns-principles--documentation))
 - [ ] Sparse/touch surfaces (cards, mobile): actions are persistently visible
-  ([Principle 10](/?path=/docs/experimental-crud-patterns-principles--documentation))
+      ([Principle 10](/?path=/docs/experimental-crud-patterns-principles--documentation))
 - [ ] Item actions return nothing (not disabled) for items where the action is inapplicable
-  ([Action hierarchy](/?path=/docs/experimental-crud-patterns-action-hierarchy--documentation))
+      ([Action hierarchy](/?path=/docs/experimental-crud-patterns-action-hierarchy--documentation))

--- a/packages/react/src/experimental/CrudPatterns/__stories__/containers.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/containers.mdx
@@ -60,17 +60,20 @@ A modal, content-focused surface anchored in the viewport center. The **baseline
 container** for Create, Update, and Confirm.
 
 **Anatomy:**
+
 - Title bar (resource name + operation verb)
 - Body (form fields or content)
 - Footer: one primary action + one cancel
 - Optional: overflow trigger in the title bar for secondary/critical actions
 
 **Use when:**
+
 - The decision is self-contained
 - The user does not need to reference background content
 - The form has up to ~10 simple fields
 
 **Don't use when:**
+
 - The user needs to compare against the collection underneath
 - The form exceeds the viewport height comfortably
 
@@ -93,15 +96,18 @@ A persistent overlay anchored to one edge of the viewport (typically the right),
 leaving the collection visible underneath.
 
 **Anatomy:**
+
 - Title bar with close affordance
 - Scrollable body
 - Sticky footer with primary action + cancel
 
 **Use when:**
+
 - The user benefits from seeing the collection while editing (comparison, sequential editing)
 - The operation is moderate complexity but context-dependent
 
 **Don't use when:**
+
 - The viewport is narrow — below a threshold, fall back to centered overlay or full screen
 - The operation is trivially simple (use inline) or deeply complex (use a page)
 
@@ -127,17 +133,20 @@ sheet.
 A sequence of validated steps with explicit progress and back/next navigation.
 
 **Anatomy:**
+
 - Step indicator (progress bar, numbered steps, or breadcrumbs)
 - Current-step content area
 - Footer: Back / Next / Submit + persistent Cancel
 - Optional: step-level validation gating (Next disabled until valid)
 
 **Use when:**
+
 - The flow branches based on early choices (step 1 determines which step 2 appears)
 - Steps have heavy validation that must pass before proceeding
 - The cognitive load of presenting all fields at once is too high
 
 **Don't use when:**
+
 - There is no branching and no validation gates — a wizard becomes bureaucratic theatre
 - The "steps" are just visual sections of one form — use a scrollable container instead
 
@@ -160,17 +169,20 @@ A full route, deep-linkable and refreshable, hosting the full content of a singl
 item.
 
 **Anatomy:**
+
 - Page header (title + primary/secondary actions)
 - Body (often tabbed or multi-section)
 - Back-affordance to the originating collection
 - URL that can be shared and bookmarked
 
 **Use when:**
+
 - The item has multiple sub-views (activity, files, permissions, comments)
 - The item is shared via URL
 - The item supports more than ~30 fields or deep nested content
 
 **Don't use when:**
+
 - The item is simple enough to understand in an overlay
 - The user flow is "glance and return" rather than "deep dive"
 
@@ -192,17 +204,20 @@ item.
 Editing happens directly in the cell, row, or item — no container opens.
 
 **Anatomy:**
+
 - Field becomes editable on focus (click or keyboard)
 - Commits on blur, Enter, or explicit save
 - Shows per-field error state on validation failure
 - Optional: revert on Escape
 
 **Use when:**
+
 - The edit is a single field with trivial or local validation
 - Users edit in flow across many items in succession
 - The collection's primary purpose is data maintenance
 
 **Don't use when:**
+
 - Fields have cross-validation or dependencies on each other
 - The field requires a complex picker, calendar, or sub-flow
 - Accidental edits would be costly (no undo mechanism)
@@ -227,15 +242,18 @@ view, and exposes an explicit affordance — "Open full view" — that escalates
 the dedicated page.
 
 **Anatomy:**
+
 - Light surface: summary content + key actions + one prominent "Open full" affordance
 - Heavy surface: the dedicated page (reachable from the light surface)
 
 **Use when:**
+
 - Most reads are shallow (users glance and return) but a minority need the full page
 - The content has both a "preview shape" and a "deep shape"
 - You want to offer progressive disclosure without forcing a page load
 
 **Don't use when:**
+
 - The resource is always simple enough for the light surface alone
 - The resource always needs the full page (skip the light surface)
 
@@ -246,7 +264,7 @@ the dedicated page.
   }}
   dont={{
     description:
-      "Do not treat the light surface as a \"preview\" that always requires escalation — if the overlay is sufficient, stop there.",
+      'Do not treat the light surface as a "preview" that always requires escalation — if the overlay is sufficient, stop there.',
   }}
 />
 
@@ -258,17 +276,20 @@ A small, centered overlay whose only job is to make the user **reconsider** an
 action.
 
 **Anatomy:**
+
 - Title: names the resource and scope ("Delete 14 invoices?")
 - Body: one sentence on consequence and reversibility
 - Primary action: confirm, styled critically (destructive color)
 - Secondary action: cancel (the default keyboard target / focus)
 
 **Always use for:**
+
 - Anything irreversible at the system level
 - Anything with cross-user side effects
 - Bulk destructive operations regardless of undo availability
 
 **Never use for:**
+
 - Reversible actions with fast undo (toast-based undo is sufficient)
 - Read operations
 - Non-destructive state changes
@@ -276,7 +297,7 @@ action.
 <DoDonts
   do={{
     description:
-      "Name the target and count in the confirmation title: \"Delete 3 reports?\" not \"Are you sure?\"",
+      'Name the target and count in the confirmation title: "Delete 3 reports?" not "Are you sure?"',
   }}
   dont={{
     description:

--- a/packages/react/src/experimental/CrudPatterns/__stories__/create-and-update.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/create-and-update.mdx
@@ -17,6 +17,7 @@ Creation is always anchored to the **collection's frame** — its header, toolba
 or empty state. Never to a specific item.
 
 This is true even for scoped creation:
+
 - A board lane with an "Add" action is still collection-level — the lane _is_ a sub-collection.
 - An editable grid with "Add row" is collection-level — the grid _is_ the collection.
 
@@ -148,6 +149,7 @@ For surfaces whose purpose is rapid data entry, creation can be **inline**:
 - No container opens — the collection _is_ the form.
 
 This is appropriate only when:
+
 - The item has few fields (up to 5-7 visible columns)
 - Fields are simple (text, numbers, dropdowns)
 - The user is likely creating many items in sequence

--- a/packages/react/src/experimental/CrudPatterns/__stories__/decisions.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/decisions.mdx
@@ -40,7 +40,7 @@ Start
   }}
   dont={{
     description:
-      "Do not choose a side panel or wizard because they \"look nicer\" — each carries UX cost that must be justified.",
+      'Do not choose a side panel or wizard because they "look nicer" — each carries UX cost that must be justified.',
   }}
 />
 
@@ -93,7 +93,9 @@ Start
       </tr>
       <tr>
         <td>Reversible within seconds</td>
-        <td>Optimistic execution + visible undo affordance — no confirmation</td>
+        <td>
+          Optimistic execution + visible undo affordance — no confirmation
+        </td>
       </tr>
       <tr>
         <td>Irreversible AND cross-user impact</td>
@@ -145,6 +147,7 @@ Check any that apply. If **any** box is checked, treat the action as critical:
 - The action's name contains "delete", "remove", "revoke", "cancel", or "destroy"
 
 **Critical actions should:**
+
 - Default to overflow — surfacing outside overflow is acceptable when the context
   and resource justify it (e.g., deletion is a core frequent workflow)
 - Always require a confirmation overlay (regardless of placement)

--- a/packages/react/src/experimental/CrudPatterns/__stories__/delete-and-destructive.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/delete-and-destructive.mdx
@@ -58,6 +58,7 @@ justify surfacing a destructive action more prominently:
   "clean up duplicates" view)
 
 When surfacing a destructive action outside of overflow, you must still:
+
 - Keep the confirmation overlay (always)
 - Use critical/destructive styling on the affordance so it is visually distinct
 - Ensure it cannot be confused with a non-destructive action nearby
@@ -103,7 +104,7 @@ Flow: **Select items → Bulk bar appears → Delete action → Confirmation ove
   }}
   dont={{
     description:
-      "Do not say \"Delete selected items\" without naming the count — the user cannot verify scope.",
+      'Do not say "Delete selected items" without naming the count — the user cannot verify scope.',
   }}
 />
 

--- a/packages/react/src/experimental/CrudPatterns/__stories__/new-surfaces.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/new-surfaces.mdx
@@ -95,6 +95,7 @@ The container decision is independent of the surface. The same rules apply:
 - Inline edit only if the surface supports in-place focus without ambiguity
 
 **Special considerations for novel surfaces:**
+
 - If the surface is spatial (map, graph), side panels often work better than
   centered overlays because the user wants to see how their edit affects the layout.
 - If the surface is temporal (timeline, calendar), confirm that "Create" has a
@@ -162,6 +163,7 @@ Destructive patterns are surface-agnostic. Regardless of how novel the surface i
 - Bulk delete requires visible scope
 
 The only surface-specific decision: **where does the overflow menu live?**
+
 - On item hover/select: popover or context menu
 - On a detail view: header overflow
 - In bulk: the bar's overflow section
@@ -173,7 +175,7 @@ The only surface-specific decision: **where does the overflow menu live?**
   }}
   dont={{
     description:
-      "Do not surface a \"Delete\" button on map markers, graph nodes, or timeline items without deliberate justification and confirmation.",
+      'Do not surface a "Delete" button on map markers, graph nodes, or timeline items without deliberate justification and confirmation.',
   }}
 />
 

--- a/packages/react/src/experimental/CrudPatterns/__stories__/principles.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/principles.mdx
@@ -49,8 +49,7 @@ collection.
       "Anchor Create to the collection's frame (header, top bar, or empty state).",
   }}
   dont={{
-    description:
-      "Do not put a Create action on a row, card, or detail view.",
+    description: "Do not put a Create action on a row, card, or detail view.",
   }}
 />
 
@@ -113,11 +112,11 @@ _what_ is being affected, _how much_ of it, and _whether_ it can be undone.
 <DoDonts
   do={{
     description:
-      "Write confirmations that name the resource and the scope: \"Delete the 14 selected invoices? This cannot be undone.\"",
+      'Write confirmations that name the resource and the scope: "Delete the 14 selected invoices? This cannot be undone."',
   }}
   dont={{
     description:
-      "Do not rely on generic \"Are you sure?\" prompts that give the user nothing to evaluate.",
+      'Do not rely on generic "Are you sure?" prompts that give the user nothing to evaluate.',
   }}
 />
 
@@ -218,8 +217,7 @@ must show their actions persistently. Hover is not a feature on touch.
 
 <DoDonts
   do={{
-    description:
-      "Persistently show actions on low-density and touch surfaces.",
+    description: "Persistently show actions on low-density and touch surfaces.",
   }}
   dont={{
     description:

--- a/packages/react/src/experimental/CrudPatterns/__stories__/quick-reference.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/quick-reference.mdx
@@ -104,11 +104,31 @@ Otherwise?                              ► Centered overlay (default)
       </tr>
     </thead>
     <tbody>
-      <tr><td>Fields changed</td><td>1</td><td>2+</td></tr>
-      <tr><td>Cross-field validation</td><td>No</td><td>Yes</td></tr>
-      <tr><td>Complex picker needed</td><td>No</td><td>Yes</td></tr>
-      <tr><td>Sequential multi-item edits</td><td>Yes</td><td>No</td></tr>
-      <tr><td>Field dependencies</td><td>No</td><td>Yes</td></tr>
+      <tr>
+        <td>Fields changed</td>
+        <td>1</td>
+        <td>2+</td>
+      </tr>
+      <tr>
+        <td>Cross-field validation</td>
+        <td>No</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Complex picker needed</td>
+        <td>No</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Sequential multi-item edits</td>
+        <td>Yes</td>
+        <td>No</td>
+      </tr>
+      <tr>
+        <td>Field dependencies</td>
+        <td>No</td>
+        <td>Yes</td>
+      </tr>
     </tbody>
   </table>
 </Unstyled>
@@ -127,10 +147,26 @@ Otherwise?                              ► Centered overlay (default)
       </tr>
     </thead>
     <tbody>
-      <tr><td>Need background context</td><td>No</td><td>Yes</td></tr>
-      <tr><td>Sequential editing</td><td>No</td><td>Yes</td></tr>
-      <tr><td>Self-contained decision</td><td>Yes</td><td>No</td></tr>
-      <tr><td>Narrow viewport</td><td>Yes (fallback)</td><td>Not viable</td></tr>
+      <tr>
+        <td>Need background context</td>
+        <td>No</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Sequential editing</td>
+        <td>No</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Self-contained decision</td>
+        <td>Yes</td>
+        <td>No</td>
+      </tr>
+      <tr>
+        <td>Narrow viewport</td>
+        <td>Yes (fallback)</td>
+        <td>Not viable</td>
+      </tr>
     </tbody>
   </table>
 </Unstyled>

--- a/packages/react/src/experimental/CrudPatterns/__stories__/read.mdx
+++ b/packages/react/src/experimental/CrudPatterns/__stories__/read.mdx
@@ -67,7 +67,7 @@ deliberately.
 <DoDonts
   do={{
     description:
-      "Expose a clear \"Open full view\" affordance in the light surface so users can escalate when needed.",
+      'Expose a clear "Open full view" affordance in the light surface so users can escalate when needed.',
   }}
   dont={{
     description:
@@ -82,6 +82,7 @@ deliberately.
 The trigger for read and the container it opens into depend on the surface:
 
 **Dense surfaces (tabular data):**
+
 - Item click or row click opens a read overlay or navigates to a page.
 - Hover-revealed actions may include an explicit "View" action, but clicking the
   row itself is the primary read affordance.
@@ -89,18 +90,20 @@ The trigger for read and the container it opens into depend on the surface:
   with cell focus for editing.
 
 **Sparse surfaces (cards, list items):**
+
 - Item click opens a read overlay.
 - The card/item body itself is the read affordance.
 - Edit and other actions are exposed _inside_ the read view, not on the card surface.
 
 **Board/kanban surfaces:**
+
 - Card click opens a read overlay (typically centered).
 - The overlay serves as a hub: read the item, then edit, delete, or reassign from within.
 
 <DoDonts
   do={{
     description:
-      "On editable surfaces, avoid row-click for read — it conflicts with cell selection. Use an explicit \"View\" item action instead.",
+      'On editable surfaces, avoid row-click for read — it conflicts with cell selection. Use an explicit "View" item action instead.',
   }}
   dont={{
     description:


### PR DESCRIPTION
## Description

Fix formatting issues in CrudPatterns documentation MDX files that were causing CI to fail. Ran `pnpm --filter @factorialco/f0-react run format` to apply correct formatting via oxfmt.

## Screenshots (if applicable)

N/A — documentation/formatting only changes.

[Link to Figma Design](Figma URL here)

## Implementation details

Applied auto-formatting to 11 MDX story files under `packages/react/src/experimental/CrudPatterns/__stories__/` that had formatting inconsistencies flagged by the CI format check. No logic or content changes.