### PR TITLE
fix(F0Select): prevent double onChange emit on async datasources

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -637,9 +637,11 @@ const F0SelectComponent = forwardRef(function Select<
       if (lastEmittedMultiRef.current === valuesKey) {
         return
       }
-      lastEmittedMultiRef.current = valuesKey
 
       if (!hasDeferredApply) {
+        // Only commit to the ref what we actually emit, so a later transition
+        // from deferred-apply back to immediate-emit isn't suppressed.
+        lastEmittedMultiRef.current = valuesKey
         onChange?.(values, originalItems, options)
       }
     } else {
@@ -674,9 +676,11 @@ const F0SelectComponent = forwardRef(function Select<
       ) {
         return
       }
-      lastEmittedSingleRef.current = { value: valueKey }
 
       if (!hasDeferredApply) {
+        // Only commit to the ref what we actually emit, so a later transition
+        // from deferred-apply back to immediate-emit isn't suppressed.
+        lastEmittedSingleRef.current = { value: valueKey }
         onChange?.(value as T, originalItem, option)
       }
     }

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -473,6 +473,16 @@ const F0SelectComponent = forwardRef(function Select<
   const hasUserInteracted = useRef(false)
   const isFirstRender = useRef(true)
 
+  // Track the last value emitted via onChange to avoid spurious re-emits when
+  // the effect deps change but the selected value did not. Without this guard,
+  // async datasources (records resolving after the click), or downstream
+  // clones of `selectedState` items, can re-fire the emit effect with the
+  // same logical selection.
+  const lastEmittedSingleRef = useRef<{ value: string | undefined } | null>(
+    null
+  )
+  const lastEmittedMultiRef = useRef<string | null>(null)
+
   const onItemCheckChange = useCallback(
     (value: string, checked: boolean) => {
       // Prevent deselection in single select mode when not clearable
@@ -621,6 +631,14 @@ const F0SelectComponent = forwardRef(function Select<
       // Use Set to ensure unique values and prevent duplicates
       setLocalValue(Array.from(new Set(values.map(String))))
 
+      // Guard: only emit when the set of selected values actually changes.
+      // Sort + join to compare order-independently with a stable key.
+      const valuesKey = values.map(String).sort().join("\u0000")
+      if (lastEmittedMultiRef.current === valuesKey) {
+        return
+      }
+      lastEmittedMultiRef.current = valuesKey
+
       if (!hasDeferredApply) {
         onChange?.(values, originalItems, options)
       }
@@ -644,6 +662,19 @@ const F0SelectComponent = forwardRef(function Select<
 
       // Sync localValue with actual selection state (as string for internal comparison)
       setLocalValue(value !== undefined ? [String(value)] : [])
+
+      // Guard: only emit when the selected value identity actually changes.
+      // Without this, async datasources (record resolving after a click) or
+      // unrelated `source`/`selectedState` content changes can re-fire the
+      // effect with the same selection and produce duplicate onChange calls.
+      const valueKey = value === undefined ? undefined : String(value)
+      if (
+        lastEmittedSingleRef.current !== null &&
+        lastEmittedSingleRef.current.value === valueKey
+      ) {
+        return
+      }
+      lastEmittedSingleRef.current = { value: valueKey }
 
       if (!hasDeferredApply) {
         onChange?.(value as T, originalItem, option)

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -988,4 +988,91 @@ describe("Select", () => {
       expect(screen.queryByText("Option 2")).not.toBeInTheDocument()
     })
   })
+
+  describe("onChange emit is debounced against spurious re-fires", () => {
+    // Regression for the F0Select double-emit observed in the
+    // BankAccountTypeSelectorWizardStepF0 flow:
+    //
+    // With an async datasource (`useGraphqlDataSource`-style), clicking a
+    // single-select option fired `onChange` once on the click, and then a
+    // second time once the async `records` finished resolving / the
+    // `selectedState` items were re-cloned by `updateLocalSelectedState`.
+    // Consumers that toggle state on every onChange call ended up flipping
+    // back to a stale value.
+    //
+    // The contract we enforce here: a single user click on a single-select
+    // F0Select with an async datasource must call `onChange` exactly once
+    // with that value, even after async data resolution settles.
+    it("single-select async datasource: a single click emits onChange exactly once", async () => {
+      const handleChange = vi.fn()
+      const user = userEvent.setup()
+
+      let resolveFetch: (() => void) | undefined
+      const source = createDataSourceDefinition<RecordType>({
+        dataAdapter: {
+          paginationType: "infinite-scroll",
+          fetchData: async () => {
+            // Defer the first resolution to simulate an async backend
+            // (GraphQL roundtrip). The click below should NOT wait for this.
+            await new Promise<void>((resolve) => {
+              resolveFetch = resolve
+            })
+            return {
+              type: "infinite-scroll" as const,
+              cursor: "100",
+              perPage: 100,
+              hasMore: false,
+              records: [
+                { id: "1", name: "Alice" },
+                { id: "2", name: "Bob" },
+              ],
+              total: 2,
+            }
+          },
+        },
+      })
+
+      render(
+        <F0Select
+          {...defaultSelectProps}
+          source={source}
+          mapOptions={(item: RecordType) => ({
+            value: item.id as string,
+            label: item.name as string,
+          })}
+          onChange={handleChange}
+          asList
+          showSearchBox
+        />
+      )
+
+      // Resolve the initial fetch so the options render.
+      resolveFetch?.()
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Alice").length).toBeGreaterThanOrEqual(1)
+      })
+
+      // Pick "Alice".
+      await user.click(screen.getAllByText("Alice")[0])
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith(
+          "1",
+          expect.objectContaining({ id: "1", name: "Alice" }),
+          expect.objectContaining({ value: "1", label: "Alice" })
+        )
+      })
+
+      // Give async effects (record resolution, deep-compare effects, item
+      // reference population) time to settle. The selection has not changed,
+      // so onChange must not fire again.
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const callsForOne = handleChange.mock.calls.filter(
+        (call: unknown[]) => call[0] === "1"
+      )
+      expect(callsForOne).toHaveLength(1)
+    })
+  })
 })

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -1046,8 +1046,13 @@ describe("Select", () => {
         />
       )
 
-      // Resolve the initial fetch so the options render.
-      resolveFetch?.()
+      // Wait until the datasource's fetchData effect has run and exposed the
+      // resolver, then resolve so the options render. Calling resolveFetch
+      // synchronously after render races with the useEffect that triggers it.
+      await waitFor(() => {
+        expect(resolveFetch).toBeDefined()
+      })
+      resolveFetch!()
 
       await waitFor(() => {
         expect(screen.getAllByText("Alice").length).toBeGreaterThanOrEqual(1)
@@ -1065,9 +1070,14 @@ describe("Select", () => {
       })
 
       // Give async effects (record resolution, deep-compare effects, item
-      // reference population) time to settle. The selection has not changed,
-      // so onChange must not fire again.
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      // reference population) time to settle, then assert the emit count
+      // stays at exactly one. Note: a `waitFor`-based check is not suitable
+      // here because `waitFor` returns on the first passing assertion and
+      // therefore cannot prove "stays stable over a window" — a regression
+      // that produces a second emit a few ms later would slip through. We
+      // wait an explicit window (100ms is generous w.r.t. the < ~16ms render
+      // cycle that would carry the duplicate emit) and then assert.
+      await new Promise((resolve) => setTimeout(resolve, 100))
 
       const callsForOne = handleChange.mock.calls.filter(
         (call: unknown[]) => call[0] === "1"

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -401,8 +401,15 @@ export function useSelectable<
               // Single-select: external `checked` wins over stale local state.
               ...(isMultiSelection ? {} : { checked: itemState.checked }),
             })
-          } else if (!isMultiSelection) {
+          } else if (
+            !isMultiSelection &&
+            existingItem.checked !== itemState.checked
+          ) {
             // Single-select: external `checked` wins over stale local state.
+            // Only clone when actually flipping; otherwise the entry stored
+            // in loop 1 already has the right shape and keeping the same
+            // reference avoids spurious re-renders / re-emits in consumers
+            // that compare `selectedState` deeply.
             mergedItems.set(itemStateId, {
               ...existingItem,
               checked: itemState.checked,


### PR DESCRIPTION
## Summary

`F0Select` used with async data sources (e.g. `useGraphqlDataSource`) was emitting `onChange` **twice per user action**:

1. First synchronously on click with the clicked value.
2. Again once the async records finished resolving and the deep-compare effect re-fired with a freshly cloned `selectedState` entry.

In monorepo consumers that derive form state from each `onChange` call, the redundant second emit caused state flicker and, in some flows, persisted an intermediate value that did not match the user's actual selection. In the worst case (consumers that toggle state on every emit, e.g. `BankAccountTypeSelectorWizardStepF0` and the Procurement vendor selector that triggered the FCT-54721 incident), the chain became an **infinite re-emit loop**.

## Repro (before fix)

Wire `F0Select` to an async datasource (any `useGraphqlDataSource` wrapper such as `LegalEntitySelectorF0` in the monorepo, or the new test in this PR). Click a single option. Observe two `onChange` calls in a row with the same selected `value` but different `originalItem` (`undefined` first, resolved second). In consumers with a feedback loop, observe an infinite emit loop.

## Fix

Two layers:

### 1. `useSelectable.ts` — guard the redundant clone

In the single-select branch, only clone state when `existingItem.checked !== itemState.checked`. Without this, every `updateLocalSelectedState` produced a brand-new reference for an entry whose logical state had not changed, which propagated to downstream `useDeepCompareEffect` consumers as a "changed" dependency.

### 2. `F0Select.tsx` — last-emit refs

Track the last emitted value with refs (single + multi) and skip emitting when the new value identity matches the last one. Multi-select uses a sorted-and-joined key (`\u0000` separator) to compare order-independently.

This second layer is defensive: even if a future regression reintroduces a redundant `selectedState` re-clone, the `onChange` contract toward consumers stays at "1 emit per real value change".

## Test

Adds a regression test in `F0Select.test.tsx` (`onChange emit is debounced against spurious re-fires`) that:

- Renders `F0Select` with a deferred async `dataAdapter` (simulates a GraphQL roundtrip).
- Resolves the fetch, picks an option.
- Waits 50ms for any pending async effects to settle.
- Asserts `onChange` was called **exactly once** for that value.

## Validation

Verified locally against the monorepo `LegalEntitySelectorF0` wizard step (banking → add manual account → legal entity selector), which is the same `F0Select` + `useGraphqlDataSource` pattern as the failed Procurement flow:

| Version | Behavior |
|---|---|
| 2.14.2 (released, no fix) | Infinite emit loop on click. |
| 2.14.5 (this PR, tarball) | Exactly 1 emit per user action across select / clear / change-selection / multi-click scenarios. |

A/B video attached below (Before / After).

## Related

- Detonator: #4210
- Enablers: #4134, #3041
- Customer-side incident: FCT-54721 (Procurement Purchase Request `malformed_request` on Italian customer template).
- Downstream bump PR in monorepo: factorialco/factorial#99525 (blocked on this release).

## Out of scope

- The `BankAccountTypeSelectorWizardStepF0` consumer has an unrelated feedback-loop bug that this fix incidentally tames. That consumer should still be revisited, but it is not the root cause of the double emit and is intentionally not touched in this PR.

## Before 
https://github.com/user-attachments/assets/a0ab6ecc-7d74-41fc-a639-4e8376fca5f9

## After
https://github.com/user-attachments/assets/7be24f5d-76a6-4c34-8f6a-df3d3797e1c8




