### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.16.3",
+  "packages/react": "2.17.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.51.1"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.17.0](https://github.com/factorialco/f0/compare/f0-react-v2.16.3...f0-react-v2.17.0) (2026-05-22)
+
+
+### Features
+
+* add min/max constraints to editable table date cell ([#4205](https://github.com/factorialco/f0/issues/4205)) ([3271274](https://github.com/factorialco/f0/commit/32712746f54f062cb363532bd8e176ed792af49e))
+
 ## [2.16.3](https://github.com/factorialco/f0/compare/f0-react-v2.16.2...f0-react-v2.16.3) (2026-05-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.17.0</summary>

## [2.17.0](https://github.com/factorialco/f0/compare/f0-react-v2.16.3...f0-react-v2.17.0) (2026-05-22)


### Features

* add min/max constraints to editable table date cell ([#4205](https://github.com/factorialco/f0/issues/4205)) ([3271274](https://github.com/factorialco/f0/commit/32712746f54f062cb363532bd8e176ed792af49e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).