### PR TITLE
feat(f0compose): add training permissions prototypes

### DIFF
--- a/packages/f0compose/src/prototypes/training-access-admin/TrainingAccessAdmin.tsx
+++ b/packages/f0compose/src/prototypes/training-access-admin/TrainingAccessAdmin.tsx
@@ -1,0 +1,1207 @@
+import {
+  F0Avatar,
+  F0Box,
+  F0Button,
+  F0ButtonDropdown,
+  F0Dialog,
+  F0Select,
+  F0Heading,
+  F0Text,
+  TwoColumnLayout,
+} from "@factorialco/f0-react"
+import {
+  OneDataCollection,
+  Page,
+  PageHeader,
+  ResourceHeader,
+  Tabs,
+  Tooltip,
+  useDataCollectionSource,
+} from "@factorialco/f0-react/dist/experimental"
+import {
+  Check,
+  Delete,
+  Link,
+  PersonPlus,
+  Reset,
+  Settings,
+} from "@factorialco/f0-react/icons/app"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+
+import { competencies, employees, findTraining, trainings } from "@/fixtures"
+import type { Employee } from "@/fixtures/types"
+import type { Training } from "@/fixtures"
+import { applySort } from "@/lib/applySort"
+
+import { AttachmentsTab } from "../trainings/detail/AttachmentsTab"
+import { AdminCourseModals, type AdminAction } from "../training-access-shared/AdminCourseModals"
+import { EditableClassDetail } from "../training-access-shared/EditableClassDetail"
+import { EditableClassesTab } from "../training-access-shared/EditableClassesTab"
+import { ContentTab } from "../trainings/detail/ContentTab"
+import { DocumentsTab } from "../trainings/detail/DocumentsTab"
+import { FormsTab } from "../trainings/detail/FormsTab"
+import { FundaeTab } from "../trainings/detail/FundaeTab"
+import { ParticipantsTab } from "../trainings/detail/ParticipantsTab"
+import { PageContent } from "../trainings/_shared/PageContent"
+import { type DetailTabId, detailTabs } from "../trainings/tabs"
+import type { PrototypeMeta } from "../types"
+
+export const meta: PrototypeMeta = {
+  slug: "training-access-admin",
+  title: "Training access admin",
+  description:
+    "Admin prototype for sharing one training with editors, viewers and derived instructors.",
+  category: "Talent",
+  module: "trainings",
+  audience: ["admin"],
+  tags: ["trainings", "permissions", "sharing", "admin"],
+  createdAt: "2026-05-22",
+}
+
+type DirectAccessRole = "author" | "editor" | "viewer"
+type EditableRole = Exclude<DirectAccessRole, "author">
+
+type DirectAccess = {
+  employeeId: string
+  role: DirectAccessRole
+}
+
+type AccessSource = "direct" | "instructor" | "direct-and-instructor"
+
+type AccessRowModel = DirectAccess & {
+  source: AccessSource
+}
+
+type PersonOption = {
+  value: string
+  label: string
+  description: string
+  avatar: {
+    type: "person"
+    firstName: string
+    lastName: string
+    src: string
+  }
+  disabled?: boolean
+}
+
+type Notice = {
+  tone: "positive" | "warning"
+  message: string
+}
+
+type CandidateOption = PersonOption & {
+  employee: Employee
+}
+
+const BASE_HREF = "/p/training-access-admin"
+const VALID_TABS = new Set<string>(detailTabs.map((tab) => tab.id))
+
+const initialAccess: DirectAccess[] = [
+  { employeeId: "emp-002", role: "author" },
+  { employeeId: "emp-011", role: "editor" },
+  { employeeId: "emp-009", role: "viewer" },
+  { employeeId: "emp-003", role: "viewer" },
+]
+
+const derivedInstructorIds = ["emp-003", "emp-012"]
+
+const roleOptions: { value: EditableRole; label: string }[] = [
+  { value: "editor", label: "Can edit" },
+  { value: "viewer", label: "Can view" },
+]
+
+const personOptions: PersonOption[] = employees
+  .filter((employee) => employee.status === "active")
+  .map((employee) => ({
+    value: employee.id,
+    label: employee.fullName,
+    description: employee.role,
+    avatar: employeeAvatar(employee),
+  }))
+
+function employeeAvatar(employee: Employee) {
+  const [firstName = employee.fullName, ...lastNameParts] = employee.fullName.split(" ")
+  return {
+    type: "person" as const,
+    firstName,
+    lastName: lastNameParts.join(" "),
+    src: employee.avatarUrl,
+  }
+}
+
+function findEmployee(employeeId: string) {
+  const employee = employees.find((item) => item.id === employeeId)
+  if (!employee) {
+    throw new Error(`Missing employee fixture for ${employeeId}`)
+  }
+  return employee
+}
+
+function roleLabel(role: DirectAccessRole) {
+  if (role === "author") return "Owner"
+  if (role === "editor") return "Can edit"
+  return "Can view"
+}
+
+function formatMoney(amount: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(amount)
+}
+
+function formatScore(value: number | null | undefined): string {
+  if (value == null) return "-"
+  return value.toFixed(1)
+}
+
+function OverviewSection({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <F0Box display="flex" flexDirection="column" gap="sm">
+      <F0Text content={label} variant="label" />
+      {children}
+    </F0Box>
+  )
+}
+
+function OverviewTag({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center rounded-md bg-f1-background-secondary px-2 py-0.5 text-sm text-f1-foreground-secondary">
+      {label}
+    </span>
+  )
+}
+
+function CostWithTooltip({
+  label,
+  amount,
+  tooltip,
+}: {
+  label: string
+  amount: number
+  tooltip: string
+}) {
+  return (
+    <F0Box display="flex" flexDirection="column" gap="sm">
+      <F0Box display="flex" flexDirection="row" alignItems="center" gap="sm">
+        <F0Text content={label} variant="label" />
+        <Tooltip label={tooltip}>
+          <span
+            className="inline-flex h-4 w-4 items-center justify-center rounded-full text-xs text-f1-foreground-secondary"
+            aria-label={tooltip}
+          >
+            i
+          </span>
+        </Tooltip>
+      </F0Box>
+      <F0Text content={formatMoney(amount)} variant="body" />
+    </F0Box>
+  )
+}
+
+function AdminTrainingOverview({ training }: { training: Training }) {
+  const trainingCompetencies = training.competencyIds?.length
+    ? competencies.filter((competency) => training.competencyIds?.includes(competency.id))
+    : []
+  const isSpanishCompany = training.countryHint === "es"
+  const isFrenchCompany = training.countryHint === "fr"
+  const subsidyText = training.fundaeSubsidized && isSpanishCompany
+    ? "Subsidized by FUNDAE"
+    : training.subsidized && !isSpanishCompany
+      ? "Subsidized"
+      : "Non-subsidized"
+
+  const mainContent = (
+    <F0Box display="flex" flexDirection="column" gap="xl">
+      <F0Box display="flex" flexDirection="row" gap="xl" flexWrap="wrap">
+        <F0Box display="flex" flexDirection="column" gap="sm">
+          <F0Text content="Course satisfaction" variant="label" />
+          <F0Heading
+            content={formatScore(training.scoreSatisfaction)}
+            as="h3"
+            variant="heading"
+          />
+        </F0Box>
+        <F0Box display="flex" flexDirection="column" gap="sm">
+          <F0Text content="Course effectiveness" variant="label" />
+          <F0Heading
+            content={formatScore(training.scoreEffectiveness)}
+            as="h3"
+            variant="heading"
+          />
+        </F0Box>
+        <F0Box display="flex" flexDirection="column" gap="sm">
+          <F0Text content="Knowledge test" variant="label" />
+          <F0Heading
+            content={formatScore(training.scoreKnowledge)}
+            as="h3"
+            variant="heading"
+          />
+        </F0Box>
+      </F0Box>
+
+      <OverviewSection label="Competencies">
+        {trainingCompetencies.length > 0 ? (
+          <F0Box display="flex" flexDirection="row" flexWrap="wrap" gap="sm">
+            {trainingCompetencies.map((competency) => (
+              <OverviewTag key={competency.id} label={competency.name} />
+            ))}
+          </F0Box>
+        ) : null}
+      </OverviewSection>
+
+      <OverviewSection label="Objectives">
+        <F0Text content={training.objectives || ""} variant="body" />
+      </OverviewSection>
+
+      <OverviewSection label="Description">
+        <F0Text content={training.description || ""} variant="body" />
+      </OverviewSection>
+
+      {training.validFor && (
+        <OverviewSection label="Course validity">
+          <F0Text
+            content={training.validFor === 1 ? "1 year" : `${training.validFor} years`}
+            variant="body"
+          />
+        </OverviewSection>
+      )}
+
+      {training.learningPlatformLink && (
+        <OverviewSection label="Learning platform">
+          <a
+            href={training.learningPlatformLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-f1-foreground-info underline"
+          >
+            {training.learningPlatformLink}
+          </a>
+        </OverviewSection>
+      )}
+    </F0Box>
+  )
+
+  const sideContent = (
+    <F0Box display="flex" flexDirection="column" gap="xl" paddingLeft="xl">
+      {training.thumbnail && (
+        <div className="flex max-h-[140px] max-w-[360px] items-center justify-center overflow-hidden rounded-md">
+          <img
+            src={training.thumbnail}
+            alt={training.name}
+            className="h-auto max-h-full w-auto max-w-full object-contain"
+          />
+        </div>
+      )}
+
+      <OverviewSection label="Subsidy">
+        <F0Text content={subsidyText} variant="body" />
+      </OverviewSection>
+
+      <OverviewSection label="Workflow">
+        <F0Text
+          content={training.processId ? training.workflowName || "" : "Not linked to Workflows"}
+          variant="body"
+        />
+      </OverviewSection>
+
+      <OverviewSection label="Internal code">
+        <F0Text content={training.code ?? "-"} variant="body" />
+      </OverviewSection>
+
+      {training.type === "external" && training.externalProvider && (
+        <OverviewSection label="Provider">
+          <F0Text content={training.externalProvider} variant="body" />
+        </OverviewSection>
+      )}
+
+      <OverviewSection label="Tags">
+        {training.categories.length > 0 ? (
+          <F0Box display="flex" flexDirection="row" flexWrap="wrap" gap="sm">
+            {training.categories.map((category) => (
+              <OverviewTag key={category.id} label={category.name} />
+            ))}
+          </F0Box>
+        ) : (
+          <F0Text content="-" variant="body" />
+        )}
+      </OverviewSection>
+
+      {isFrenchCompany && training.axes && training.axes.length > 0 && (
+        <OverviewSection label="Axes">
+          <F0Box display="flex" flexDirection="row" flexWrap="wrap" gap="sm">
+            {training.axes.map((axis) => (
+              <OverviewTag key={axis.id} label={axis.name} />
+            ))}
+          </F0Box>
+        </OverviewSection>
+      )}
+
+      <CostWithTooltip
+        label="Total cost"
+        amount={training.totalCost}
+        tooltip="Sum of direct and indirect cost of all the groups"
+      />
+
+      <CostWithTooltip
+        label="Total salary cost"
+        amount={training.totalSalaryCost}
+        tooltip="Sum of the salary cost of all the groups"
+      />
+
+      <CostWithTooltip
+        label="Subsidiary cost"
+        amount={training.totalSubsidizedCost}
+        tooltip="Sum of the subsidized cost of all the groups"
+      />
+
+      <OverviewSection label="Creation year">
+        <F0Text content={String(training.year)} variant="body" />
+      </OverviewSection>
+    </F0Box>
+  )
+
+  return (
+    <F0Box padding="xl">
+      <TwoColumnLayout sideContent={sideContent}>{mainContent}</TwoColumnLayout>
+    </F0Box>
+  )
+}
+
+export default function TrainingAccessAdmin() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [isShareOpen, setIsShareOpen] = useState(false)
+  const [adminAction, setAdminAction] = useState<AdminAction>(null)
+  const [directAccess, setDirectAccess] = useState<DirectAccess[]>(initialAccess)
+  const [selectedEmployeeIds, setSelectedEmployeeIds] = useState<string[]>([])
+  const [selectedRole, setSelectedRole] = useState<EditableRole>("editor")
+  const [personSearch, setPersonSearch] = useState("")
+  const [isPeopleListOpen, setIsPeopleListOpen] = useState(false)
+  const [notice, setNotice] = useState<Notice | null>(null)
+  const [isCopyLinkCopied, setIsCopyLinkCopied] = useState(false)
+
+  const trainingId = searchParams.get("training")
+  const requestedTraining = trainingId ? findTraining(trainingId) : undefined
+  const rawTab = searchParams.get("dtab")
+  const classId = searchParams.get("class")
+  const selectedTraining = requestedTraining
+    ? trainings.find((item) => item.id === requestedTraining.id)
+    : classId
+      ? trainings.find((item) => item.classes.some((klass) => klass.id === classId))
+      : undefined
+  const activeTab: DetailTabId =
+    rawTab && VALID_TABS.has(rawTab) ? (rawTab as DetailTabId) : "overview"
+
+  const training = selectedTraining ?? trainings[0]
+  const trainingHref = `${BASE_HREF}?training=${training.id}`
+  const isDraft = training.status === "draft"
+
+  const getTotalDuration = () => {
+    const totalMinutes = training.totalDuration * 60
+    const hours = Math.floor(totalMinutes / 60)
+    const minutes = Math.round(totalMinutes % 60)
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+  }
+
+  const handleCopyLink = () => {
+    setIsCopyLinkCopied(true)
+    void navigator.clipboard?.writeText(window.location.href).catch(() => {})
+    window.setTimeout(() => setIsCopyLinkCopied(false), 4000)
+  }
+
+  const secondaryActions = [
+    {
+      label: "Course settings",
+      icon: Settings,
+      onClick: () => setAdminAction("settings"),
+      tooltip: "Course settings",
+      hideLabel: true as const,
+    },
+    ...(!isDraft
+      ? [
+          {
+            label: "Copy link",
+            icon: Link,
+            onClick: handleCopyLink,
+            tooltip: "Copy link",
+            hideLabel: true as const,
+          },
+        ]
+      : []),
+  ]
+
+  const otherActions = [
+    ...(!isDraft
+      ? [
+          {
+            label: "Revert to draft",
+            onClick: () => setAdminAction("revert-draft"),
+            variant: "critical" as const,
+            icon: Reset,
+          },
+        ]
+      : []),
+  ]
+
+  const tabsWithNav = detailTabs.map((tab) => ({
+    ...tab,
+    onClick: () => {
+      const next = new URLSearchParams(searchParams)
+      next.set("dtab", tab.id)
+      setSearchParams(next)
+    },
+  }))
+
+  const directEmployeeIds = useMemo(
+    () => new Set(directAccess.map((access) => access.employeeId)),
+    [directAccess]
+  )
+
+  const availablePersonOptions = personOptions.map((option) => ({
+    ...option,
+    disabled: directEmployeeIds.has(option.value),
+  }))
+
+  const candidateOptions: CandidateOption[] = availablePersonOptions
+    .filter((option) => !option.disabled && !selectedEmployeeIds.includes(option.value))
+    .map((option) => ({
+      ...option,
+      employee: findEmployee(option.value),
+    }))
+    .filter((option) => {
+      const term = personSearch.toLowerCase().trim()
+      if (term === "") return true
+      return `${option.employee.fullName} ${option.employee.email}`
+        .toLowerCase()
+        .includes(term)
+    })
+    .slice(0, 12)
+
+  const handlePersonSearchChange = (value: string | undefined) => {
+    const nextSearch = value ?? ""
+    setPersonSearch(nextSearch)
+    setIsPeopleListOpen(true)
+
+  }
+
+  const handleSelectedEmployeeChange = (employeeId: string) => {
+    setSelectedEmployeeIds((current) =>
+      current.includes(employeeId)
+        ? current.filter((id) => id !== employeeId)
+        : [...current, employeeId]
+    )
+    setPersonSearch("")
+    setIsPeopleListOpen(false)
+  }
+
+  const handleSelectedEmployeeRemove = (employeeId: string) => {
+    setSelectedEmployeeIds((current) => current.filter((id) => id !== employeeId))
+  }
+
+  const instructorIdSet = useMemo(() => new Set(derivedInstructorIds), [])
+  const peopleWithAccess: AccessRowModel[] = [
+    ...directAccess.map((access) => ({
+      ...access,
+      source: instructorIdSet.has(access.employeeId)
+        ? ("direct-and-instructor" as const)
+        : ("direct" as const),
+    })),
+    ...derivedInstructorIds
+      .filter((employeeId) => !directEmployeeIds.has(employeeId))
+      .map((employeeId) => ({
+        employeeId,
+        role: "viewer" as const,
+        source: "instructor" as const,
+      })),
+  ]
+
+  if (!selectedTraining) {
+    return <AdminCoursesList baseHref={BASE_HREF} />
+  }
+
+  if (classId) {
+    return (
+      <EditableClassDetail
+        training={training}
+        classId={classId}
+        baseHref={BASE_HREF}
+        trainingHref={trainingHref}
+      />
+    )
+  }
+
+  const handleAddAccess = () => {
+    const newAccess = selectedEmployeeIds.filter(
+      (employeeId) => !directAccess.some((access) => access.employeeId === employeeId)
+    )
+
+    if (newAccess.length === 0) {
+      setNotice({
+        tone: "warning",
+        message: "Select at least one person to add.",
+      })
+      return
+    }
+
+    setDirectAccess((current) => [
+      ...current,
+      ...newAccess.map((employeeId) => ({ employeeId, role: selectedRole })),
+    ])
+    setSelectedEmployeeIds([])
+    setPersonSearch("")
+    setIsPeopleListOpen(false)
+    setNotice({
+      tone: "positive",
+      message:
+        newAccess.length === 1
+          ? `${findEmployee(newAccess[0]).fullName} was added with ${roleLabel(selectedRole)} access.`
+          : `${newAccess.length} people were added with ${roleLabel(selectedRole)} access.`,
+    })
+  }
+
+  const handleChangeAccess = (employeeId: string, role: EditableRole) => {
+    const employee = findEmployee(employeeId)
+    setDirectAccess((current) =>
+      current.map((access) =>
+        access.employeeId === employeeId ? { ...access, role } : access
+      )
+    )
+    setNotice({
+      tone: "positive",
+      message: `${employee.fullName} now has ${roleLabel(role)} access.`,
+    })
+  }
+
+  const handleRemoveAccess = (employeeId: string) => {
+    const employee = findEmployee(employeeId)
+    const access = directAccess.find((item) => item.employeeId === employeeId)
+
+    if (access?.role === "author") return
+
+    setDirectAccess((current) => current.filter((item) => item.employeeId !== employeeId))
+    setNotice({
+      tone: "positive",
+      message: `${employee.fullName} was removed from this access list.`,
+    })
+  }
+
+  return (
+    <>
+      <Page
+        header={
+          <>
+            <PageHeader
+              module={{ id: "company_trainings", name: "Trainings", href: BASE_HREF }}
+              breadcrumbs={[
+                { id: "courses", label: "Courses", href: BASE_HREF },
+                { id: training.id, label: training.name },
+              ]}
+            />
+            <ResourceHeader
+              title={training.name}
+              metadata={[
+                {
+                  label: "Type",
+                  value: {
+                    type: "text",
+                    content: training.type === "internal" ? "Internal" : "External",
+                  },
+                },
+                ...(training.totalDuration
+                  ? [
+                      {
+                        label: "Total duration",
+                        value: {
+                          type: "text" as const,
+                          content: getTotalDuration(),
+                        },
+                      },
+                    ]
+                  : []),
+                ...(training.groupNames.length > 0
+                  ? [
+                      {
+                        label: "Training groups",
+                        value: {
+                          type: "data-list" as const,
+                          data: training.groupNames,
+                        },
+                      },
+                    ]
+                  : []),
+                ...(training.participantAvatars.length > 0
+                  ? [
+                      {
+                        label: "",
+                        value: {
+                          type: "list" as const,
+                          variant: "person" as const,
+                          avatars: training.participantAvatars.map((avatar) => ({
+                            ...avatar,
+                            type: "person" as const,
+                          })),
+                        },
+                      },
+                    ]
+                  : []),
+                ...(training.instructorAvatars.length > 0
+                  ? [
+                      {
+                        label: "Instructor(s)",
+                        value: {
+                          type: "list" as const,
+                          variant: "person" as const,
+                          avatars: training.instructorAvatars.map((avatar) => ({
+                            ...avatar,
+                            type: "person" as const,
+                          })),
+                        },
+                      },
+                    ]
+                  : []),
+                ...(training.publishedAsFreeCourse
+                  ? [
+                      {
+                        label: "",
+                        value: {
+                          type: "status" as const,
+                          label: "Published as free course",
+                          variant: "positive" as const,
+                        },
+                      },
+                    ]
+                  : []),
+              ]}
+              status={{ label: "", text: "Published", variant: "positive" }}
+              primaryAction={
+                isDraft
+                  ? { label: "Publish", onClick: () => setAdminAction("publish") }
+                  : {
+                      label: "Share",
+                      icon: PersonPlus,
+                      onClick: () => setIsShareOpen(true),
+                    }
+              }
+              secondaryActions={secondaryActions}
+              otherActions={otherActions}
+            />
+            <Tabs key={activeTab} tabs={tabsWithNav} activeTabId={activeTab} />
+          </>
+        }
+      >
+        <PageContent>
+          {activeTab === "overview" && <AdminTrainingOverview training={training} />}
+          {activeTab === "content" && <ContentTab training={training} />}
+          {activeTab === "groups" && <EditableClassesTab training={training} />}
+          {activeTab === "participants" && <ParticipantsTab training={training} />}
+          {activeTab === "attachments" && <AttachmentsTab training={training} />}
+          {activeTab === "documents" && <DocumentsTab training={training} />}
+          {activeTab === "surveys" && <FormsTab training={training} />}
+          {activeTab === "fundae" && <FundaeTab training={training} />}
+        </PageContent>
+      </Page>
+
+      <ShareTrainingDialog
+        isOpen={isShareOpen}
+        training={training}
+        peopleWithAccess={peopleWithAccess}
+        notice={notice}
+        candidateOptions={candidateOptions}
+        isPeopleListOpen={isPeopleListOpen}
+        personSearch={personSearch}
+        selectedEmployeeIds={selectedEmployeeIds}
+        selectedRole={selectedRole}
+        onClose={() => setIsShareOpen(false)}
+        onAddAccess={handleAddAccess}
+        onChangeAccess={handleChangeAccess}
+        onRemoveAccess={handleRemoveAccess}
+        onPersonSearchChange={handlePersonSearchChange}
+        onPeopleListOpenChange={setIsPeopleListOpen}
+        onSelectedEmployeeRemove={handleSelectedEmployeeRemove}
+        onSelectedEmployeeChange={handleSelectedEmployeeChange}
+        onSelectedRoleChange={setSelectedRole}
+      />
+
+      <AdminCourseModals
+        action={adminAction}
+        training={training}
+        onClose={() => setAdminAction(null)}
+      />
+
+      {isCopyLinkCopied && <LinkCopiedTooltip />}
+    </>
+  )
+}
+
+function LinkCopiedTooltip() {
+  return (
+    <div
+      role="status"
+      className="fixed right-6 top-28 z-[9999] rounded-md bg-f1-background-inverse px-3 py-2 shadow-lg"
+      style={{ position: "fixed", right: 24, top: 112, zIndex: 9999 }}
+    >
+      <F0Text content="Link copied" variant="inverse" />
+    </div>
+  )
+}
+
+function AdminCoursesList({ baseHref }: { baseHref: string }) {
+  const source = useDataCollectionSource<Training>(
+    {
+      search: { enabled: true, sync: true },
+      presets: [{ label: "All courses", filter: {} }],
+      filters: {
+        status: {
+          type: "in",
+          label: "Status",
+          options: {
+            options: [
+              { value: "active", label: "Published" },
+              { value: "draft", label: "Draft" },
+            ],
+          },
+        },
+      },
+      sortings: {
+        name: { label: "Name" },
+        year: { label: "Year" },
+      },
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 20,
+        fetchData: ({ filters, search, sortings, pagination }) => {
+          const statusFilter = Array.isArray(filters?.status)
+            ? (filters.status as string[])
+            : []
+          const term = (search ?? "").toLowerCase().trim()
+          const filtered = trainings
+            .filter((training) =>
+              statusFilter.length === 0
+                ? true
+                : statusFilter.includes(training.status)
+            )
+            .filter((training) =>
+              term === "" ? true : training.name.toLowerCase().includes(term)
+            )
+          const sorted = applySort(filtered, sortings, (training, field) => {
+            if (field === "name") return training.name.toLowerCase()
+            if (field === "year") return training.year
+            return null
+          })
+          const perPage = pagination?.perPage ?? 20
+          const currentPage =
+            pagination && "currentPage" in pagination && pagination.currentPage
+              ? pagination.currentPage
+              : 1
+          const total = sorted.length
+          const pagesCount = Math.max(1, Math.ceil(total / perPage))
+          const start = (currentPage - 1) * perPage
+
+          return {
+            type: "pages" as const,
+            records: sorted.slice(start, start + perPage),
+            total,
+            perPage,
+            currentPage,
+            pagesCount,
+          }
+        },
+      },
+      itemUrl: (training) => `${baseHref}?training=${training.id}`,
+    },
+    [baseHref]
+  )
+
+  return (
+    <Page
+      header={
+        <>
+          <PageHeader
+            module={{ id: "company_trainings", name: "Trainings", href: baseHref }}
+            breadcrumbs={[{ id: "courses", label: "Courses" }]}
+          />
+          <ResourceHeader
+            title="Courses"
+            description="All courses you can manage as a training admin."
+            metadata={[
+              {
+                label: "Access",
+                value: { type: "status", label: "Admin", variant: "positive" },
+              },
+            ]}
+          />
+        </>
+      }
+    >
+      <PageContent>
+        <OneDataCollection
+          id="training-access-admin/courses/v1"
+          source={source}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                frozenColumns: 1,
+                columns: [
+                  {
+                    label: "Name",
+                    sorting: "name",
+                    render: (training) => ({
+                      type: "text" as const,
+                      value: training.name,
+                    }),
+                  },
+                  {
+                    label: "Status",
+                    render: (training) => ({
+                      type: "status" as const,
+                      value: {
+                        status: training.status === "active" ? "positive" : "neutral",
+                        label: training.status === "active" ? "Published" : "Draft",
+                      },
+                    }),
+                  },
+                  {
+                    label: "Participants",
+                    render: (training) => ({
+                      type: "number" as const,
+                      value: training.participantCount,
+                    }),
+                  },
+                  {
+                    label: "Groups",
+                    render: (training) => ({
+                      type: "text" as const,
+                      value: String(training.classes.length),
+                    }),
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      </PageContent>
+    </Page>
+  )
+}
+
+function ShareTrainingDialog({
+  isOpen,
+  training,
+  peopleWithAccess,
+  notice,
+  candidateOptions,
+  isPeopleListOpen,
+  personSearch,
+  selectedEmployeeIds,
+  selectedRole,
+  onClose,
+  onAddAccess,
+  onChangeAccess,
+  onRemoveAccess,
+  onPersonSearchChange,
+  onPeopleListOpenChange,
+  onSelectedEmployeeRemove,
+  onSelectedEmployeeChange,
+  onSelectedRoleChange,
+}: {
+  isOpen: boolean
+  training: Training
+  peopleWithAccess: AccessRowModel[]
+  notice: Notice | null
+  candidateOptions: CandidateOption[]
+  isPeopleListOpen: boolean
+  personSearch: string
+  selectedEmployeeIds: string[]
+  selectedRole: EditableRole
+  onClose: () => void
+  onAddAccess: () => void
+  onChangeAccess: (employeeId: string, role: EditableRole) => void
+  onRemoveAccess: (employeeId: string) => void
+  onPersonSearchChange: (value: string | undefined) => void
+  onPeopleListOpenChange: (isOpen: boolean) => void
+  onSelectedEmployeeRemove: (employeeId: string) => void
+  onSelectedEmployeeChange: (employeeId: string) => void
+  onSelectedRoleChange: (role: EditableRole) => void
+}) {
+  const searchAreaRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!isPeopleListOpen) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (target instanceof Node && searchAreaRef.current?.contains(target)) return
+      onPeopleListOpenChange(false)
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown)
+    return () => document.removeEventListener("pointerdown", handlePointerDown)
+  }, [isPeopleListOpen, onPeopleListOpenChange])
+
+  return (
+    <F0Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      width="md"
+      title="Share training"
+      description={training.name}
+      primaryAction={{ label: "Done", icon: Check, onClick: onClose }}
+    >
+      <F0Box display="flex" flexDirection="column" gap="lg">
+        <F0Box display="flex" flexDirection="column" gap="xs">
+          <F0Box display="flex" alignItems="start" gap="sm">
+            <F0Box grow position="relative" ref={searchAreaRef}>
+              <F0Box onClick={() => onPeopleListOpenChange(true)}>
+                <PeopleSearchInput
+                  selectedEmployeeIds={selectedEmployeeIds}
+                  searchValue={personSearch}
+                  onSearchChange={onPersonSearchChange}
+                  onRemove={onSelectedEmployeeRemove}
+                />
+              </F0Box>
+              {isPeopleListOpen && (
+                <PeopleSearchResults
+                  candidates={candidateOptions}
+                  selectedEmployeeIds={selectedEmployeeIds}
+                  onSelect={(employeeId) => {
+                    onSelectedEmployeeChange(employeeId)
+                  }}
+                />
+              )}
+            </F0Box>
+            <F0Box width="1/4" paddingTop="xl">
+              <F0Select
+                label="Access"
+                hideLabel
+                value={selectedRole}
+                onChange={onSelectedRoleChange}
+                options={roleOptions}
+              />
+            </F0Box>
+            <F0Box paddingTop="xl">
+              <F0Button
+                label="Add"
+                icon={PersonPlus}
+                variant={selectedEmployeeIds.length > 0 ? "default" : "neutral"}
+                disabled={selectedEmployeeIds.length === 0}
+                onClick={onAddAccess}
+              />
+            </F0Box>
+          </F0Box>
+        </F0Box>
+
+        {notice && <NoticeText notice={notice} />}
+
+        <F0Box display="flex" flexDirection="column" gap="sm">
+          <F0Text content="People with access" variant="label" />
+          <F0Box display="flex" flexDirection="column" borderTop="default" borderColor="secondary">
+            {peopleWithAccess.map((access) => (
+              <AccessRow
+                key={access.employeeId}
+                access={access}
+                onChangeAccess={onChangeAccess}
+                onRemoveAccess={onRemoveAccess}
+              />
+            ))}
+          </F0Box>
+        </F0Box>
+      </F0Box>
+    </F0Dialog>
+  )
+}
+
+function PeopleSearchInput({
+  selectedEmployeeIds,
+  searchValue,
+  onSearchChange,
+  onRemove,
+}: {
+  selectedEmployeeIds: string[]
+  searchValue: string
+  onSearchChange: (value: string | undefined) => void
+  onRemove: (employeeId: string) => void
+}) {
+  return (
+    <F0Box display="flex" flexDirection="column" gap="xs">
+      <F0Text content="Add people" variant="label" />
+      <div className="flex min-h-8 w-full flex-wrap items-center gap-1 rounded-md border border-solid border-f1-border-secondary bg-f1-background px-2 py-1 focus-within:border-f1-border-selected">
+        {selectedEmployeeIds.length > 0 && (
+          <div className="flex max-h-24 flex-wrap gap-1 overflow-y-auto">
+            {selectedEmployeeIds.map((employeeId) => {
+              const employee = findEmployee(employeeId)
+              return (
+                <div
+                  key={employeeId}
+                  className="flex w-fit items-center gap-1 rounded-md border border-solid border-f1-border-secondary bg-f1-background-secondary px-2 py-1 text-sm text-f1-foreground"
+                >
+                  <span>{employee.email}</span>
+                  <button
+                    type="button"
+                    className="border-0 bg-transparent p-0 text-f1-foreground-secondary"
+                    aria-label={`Remove ${employee.fullName}`}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      onRemove(employeeId)
+                    }}
+                  >
+                    x
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        )}
+        <input
+          aria-label="Add people"
+          className="min-w-28 flex-1 border-0 bg-transparent p-1 text-sm text-f1-foreground outline-none placeholder:text-f1-foreground-secondary"
+          value={searchValue}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder={selectedEmployeeIds.length === 0 ? "Search by name or email" : ""}
+        />
+      </div>
+    </F0Box>
+  )
+}
+
+function PeopleSearchResults({
+  candidates,
+  selectedEmployeeIds,
+  onSelect,
+}: {
+  candidates: CandidateOption[]
+  selectedEmployeeIds: string[]
+  onSelect: (employeeId: string) => void
+}) {
+  return (
+    <div
+      className="absolute left-0 right-0 top-full z-10 mt-1 flex max-h-72 flex-col gap-0 overflow-y-auto rounded-md border border-solid border-f1-border-secondary bg-f1-background p-1 shadow-lg"
+    >
+      {candidates.length > 0 ? (
+        candidates.map((candidate) => {
+          const selected = selectedEmployeeIds.includes(candidate.value)
+          return (
+            <div
+              key={candidate.value}
+              role="button"
+              tabIndex={0}
+              className={`flex w-full items-center justify-between rounded-md border-0 bg-transparent p-2 text-left hover:bg-f1-background-hover ${
+                selected ? "bg-f1-background-selected" : ""
+              }`}
+              onClick={() => onSelect(candidate.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault()
+                  onSelect(candidate.value)
+                }
+              }}
+            >
+              <PersonCell employee={candidate.employee} supportingText={candidate.employee.email} />
+              {selected && <F0Text content="Selected" variant="description" />}
+            </div>
+          )
+        })
+      ) : (
+        <F0Box padding="sm">
+          <F0Text content="No people found" variant="description" />
+        </F0Box>
+      )}
+    </div>
+  )
+}
+
+function NoticeText({ notice }: { notice: Notice }) {
+  return (
+    <F0Box padding="sm" borderRadius="md" background={notice.tone}>
+      <F0Text content={notice.message} variant="small" />
+    </F0Box>
+  )
+}
+
+function AccessRow({
+  access,
+  onChangeAccess,
+  onRemoveAccess,
+}: {
+  access: AccessRowModel
+  onChangeAccess: (employeeId: string, role: EditableRole) => void
+  onRemoveAccess: (employeeId: string) => void
+}) {
+  const employee = findEmployee(access.employeeId)
+  const isMutable = access.role !== "author" && access.source !== "instructor"
+  const supportingText =
+    access.role === "author"
+      ? "Created this course"
+      : access.source === "direct-and-instructor" || access.source === "instructor"
+        ? `${employee.email} · Instructor in class`
+        : employee.email
+
+  return (
+    <F0Box
+      display="flex"
+      alignItems="center"
+      justifyContent="between"
+      gap="md"
+      paddingY="sm"
+      borderBottom="default"
+      borderColor="secondary"
+    >
+      <PersonCell employee={employee} supportingText={supportingText} />
+      <F0Box display="flex" alignItems="center" gap="sm" shrink={false}>
+        {isMutable ? (
+          <F0ButtonDropdown
+            mode="dropdown"
+            trigger={roleLabel(access.role)}
+            variant="neutral"
+            size="sm"
+            items={[
+              { value: "editor", label: "Can edit" },
+              { value: "viewer", label: "Can view" },
+              { value: "remove", label: "Remove access", icon: Delete, critical: true },
+            ]}
+            onClick={(value) => {
+              if (value === "remove") {
+                onRemoveAccess(access.employeeId)
+                return
+              }
+              onChangeAccess(access.employeeId, value as EditableRole)
+            }}
+          />
+        ) : (
+          <F0Text
+            content={access.source === "instructor" ? "Instructor" : roleLabel(access.role)}
+            variant="small"
+          />
+        )}
+      </F0Box>
+    </F0Box>
+  )
+}
+
+function PersonCell({
+  employee,
+  supportingText,
+}: {
+  employee: Employee
+  supportingText: string
+}) {
+  return (
+    <F0Box display="flex" alignItems="center" gap="sm" grow>
+      <F0Avatar avatar={employeeAvatar(employee)} size="sm" />
+      <F0Box display="flex" flexDirection="column" gap="none">
+        <F0Text content={employee.fullName} variant="body" />
+        <F0Text content={supportingText} variant="description" />
+      </F0Box>
+    </F0Box>
+  )
+}

--- a/packages/f0compose/src/prototypes/training-access-editor/TrainingAccessEditor.tsx
+++ b/packages/f0compose/src/prototypes/training-access-editor/TrainingAccessEditor.tsx
@@ -1,0 +1,421 @@
+import { F0Text } from "@factorialco/f0-react"
+import {
+  OneDataCollection,
+  Page,
+  PageHeader,
+  ResourceHeader,
+  Tabs,
+  useDataCollectionSource,
+} from "@factorialco/f0-react/dist/experimental"
+import { Link } from "@factorialco/f0-react/icons/app"
+import { useState } from "react"
+import { useSearchParams } from "react-router-dom"
+
+import { type Training, findTraining, trainings } from "@/fixtures"
+import { applySort } from "@/lib/applySort"
+
+import { AttachmentsTab } from "../trainings/detail/AttachmentsTab"
+import { EditableClassDetail } from "../training-access-shared/EditableClassDetail"
+import { EditableClassesTab } from "../training-access-shared/EditableClassesTab"
+import { ContentTab } from "../trainings/detail/ContentTab"
+import { DocumentsTab } from "../trainings/detail/DocumentsTab"
+import { FormsTab } from "../trainings/detail/FormsTab"
+import { FundaeTab } from "../trainings/detail/FundaeTab"
+import { OverviewTab } from "../trainings/detail/OverviewTab"
+import { ParticipantsTab } from "../trainings/detail/ParticipantsTab"
+import { PageContent } from "../trainings/_shared/PageContent"
+import { type DetailTabId, detailTabs } from "../trainings/tabs"
+import type { PrototypeMeta } from "../types"
+
+export const meta: PrototypeMeta = {
+  slug: "training-access-editor",
+  title: "Training access editor",
+  description: "Editor experience for a course shared with Can edit access.",
+  category: "Talent",
+  module: "trainings",
+  audience: ["employee", "manager"],
+  tags: ["trainings", "permissions", "sharing", "editor"],
+  createdAt: "2026-05-25",
+}
+
+const BASE_HREF = "/p/training-access-editor"
+const EDITOR_TRAINING_IDS = new Set(["trn-001", "trn-003"])
+const ROLE_TRAINING_IDS = {
+  editor: EDITOR_TRAINING_IDS,
+  viewer: new Set(["trn-002", "trn-004"]),
+}
+const editorTrainings = trainings.filter((item) => EDITOR_TRAINING_IDS.has(item.id))
+const VALID_TABS = new Set<string>(detailTabs.map((tab) => tab.id))
+
+function getTotalDuration(training: Training) {
+  const totalMinutes = training.totalDuration * 60
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = Math.round(totalMinutes % 60)
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+}
+
+export default function TrainingAccessEditor() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [isCopyLinkCopied, setIsCopyLinkCopied] = useState(false)
+  const trainingId = searchParams.get("training")
+  const rawTab = searchParams.get("dtab")
+  const classId = searchParams.get("class")
+  const requestedTraining = trainingId ? findTraining(trainingId) : undefined
+  const selectedTraining = requestedTraining
+    ? editorTrainings.find((item) => item.id === requestedTraining.id)
+    : classId
+      ? editorTrainings.find((item) =>
+          item.classes.some((klass) => klass.id === classId)
+        )
+      : undefined
+  const activeTab: DetailTabId =
+    rawTab && VALID_TABS.has(rawTab) ? (rawTab as DetailTabId) : "overview"
+
+  if (!selectedTraining) {
+    return <RoleCoursesList accessRole="editor" baseHref={BASE_HREF} />
+  }
+
+  const training = selectedTraining
+  const trainingHref = `${BASE_HREF}?training=${training.id}`
+
+  const tabsWithNav = detailTabs.map((tab) => ({
+    ...tab,
+    onClick: () => {
+      const next = new URLSearchParams(searchParams)
+      next.set("dtab", tab.id)
+      setSearchParams(next)
+    },
+  }))
+
+  const handleCopyLink = () => {
+    setIsCopyLinkCopied(true)
+    void navigator.clipboard?.writeText(window.location.href).catch(() => {})
+    window.setTimeout(() => setIsCopyLinkCopied(false), 4000)
+  }
+
+  if (classId) {
+    return (
+      <EditableClassDetail
+        training={training}
+        classId={classId}
+        baseHref={BASE_HREF}
+        trainingHref={trainingHref}
+      />
+    )
+  }
+
+  return (
+    <>
+      <Page
+        header={
+          <>
+            <PageHeader
+              module={{ id: "company_trainings", name: "Trainings", href: BASE_HREF }}
+              breadcrumbs={[
+                { id: "courses", label: "Courses", href: BASE_HREF },
+                { id: training.id, label: training.name },
+              ]}
+            />
+            <ResourceHeader
+              title={training.name}
+              metadata={[
+                {
+                  label: "Access",
+                  value: {
+                    type: "status",
+                    label: "Can edit",
+                    variant: "warning",
+                  },
+                },
+                {
+                  label: "Type",
+                  value: {
+                    type: "text",
+                    content: training.type === "internal" ? "Internal" : "External",
+                  },
+                },
+                ...(training.totalDuration
+                  ? [
+                      {
+                        label: "Total duration",
+                        value: {
+                          type: "text" as const,
+                          content: getTotalDuration(training),
+                        },
+                      },
+                    ]
+                  : []),
+                ...(training.groupNames.length > 0
+                  ? [
+                      {
+                        label: "Training groups",
+                        value: {
+                          type: "data-list" as const,
+                          data: training.groupNames,
+                        },
+                      },
+                    ]
+                  : []),
+                ...(training.participantAvatars.length > 0
+                  ? [
+                      {
+                        label: "",
+                        value: {
+                          type: "list" as const,
+                          variant: "person" as const,
+                          avatars: training.participantAvatars.map((avatar) => ({
+                            ...avatar,
+                            type: "person" as const,
+                          })),
+                        },
+                      },
+                    ]
+                  : []),
+                ...(training.instructorAvatars.length > 0
+                  ? [
+                      {
+                        label: "Instructor(s)",
+                        value: {
+                          type: "list" as const,
+                          variant: "person" as const,
+                          avatars: training.instructorAvatars.map((avatar) => ({
+                            ...avatar,
+                            type: "person" as const,
+                          })),
+                        },
+                      },
+                    ]
+                  : []),
+                ...(training.publishedAsFreeCourse
+                  ? [
+                      {
+                        label: "",
+                        value: {
+                          type: "status" as const,
+                          label: "Published as free course",
+                          variant: "positive" as const,
+                        },
+                      },
+                    ]
+                  : []),
+              ]}
+              status={{ label: "", text: "Published", variant: "positive" }}
+              secondaryActions={[
+                {
+                  label: "Copy link",
+                  icon: Link,
+                  onClick: handleCopyLink,
+                  tooltip: "Copy link",
+                  hideLabel: true,
+                },
+              ]}
+            />
+            <Tabs key={activeTab} tabs={tabsWithNav} activeTabId={activeTab} />
+          </>
+        }
+      >
+        <PageContent>
+          {activeTab === "overview" && <OverviewTab training={training} />}
+          {activeTab === "content" && <ContentTab training={training} />}
+          {activeTab === "groups" && <EditableClassesTab training={training} />}
+          {activeTab === "participants" && <ParticipantsTab training={training} />}
+          {activeTab === "attachments" && <AttachmentsTab training={training} />}
+          {activeTab === "documents" && <DocumentsTab training={training} />}
+          {activeTab === "surveys" && <FormsTab training={training} />}
+          {activeTab === "fundae" && <FundaeTab training={training} />}
+        </PageContent>
+      </Page>
+      {isCopyLinkCopied && <LinkCopiedTooltip />}
+    </>
+  )
+}
+
+function LinkCopiedTooltip() {
+  return (
+    <div
+      role="status"
+      className="fixed right-6 top-28 z-[9999] rounded-md bg-f1-background-inverse px-3 py-2 shadow-lg"
+      style={{ position: "fixed", right: 24, top: 112, zIndex: 9999 }}
+    >
+      <F0Text content="Link copied" variant="inverse" />
+    </div>
+  )
+}
+
+type AccessRole = "editor" | "viewer"
+
+function RoleCoursesList({
+  accessRole,
+  baseHref,
+}: {
+  accessRole: AccessRole
+  baseHref: string
+}) {
+  const rows = trainings.filter((training) => ROLE_TRAINING_IDS[accessRole].has(training.id))
+  const source = useDataCollectionSource<Training>(
+    {
+      search: { enabled: true, sync: true },
+      presets: [
+        {
+          label:
+            accessRole === "editor"
+              ? "Trainings I can edit"
+              : "Trainings I can view",
+          filter: {},
+        },
+      ],
+      filters: {
+        status: {
+          type: "in",
+          label: "Status",
+          options: {
+            options: [
+              { value: "active", label: "Published" },
+              { value: "draft", label: "Draft" },
+            ],
+          },
+        },
+      },
+      sortings: {
+        name: { label: "Name" },
+        year: { label: "Year" },
+      },
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 20,
+        fetchData: ({ filters, search, sortings, pagination }) => {
+          const statusFilter = Array.isArray(filters?.status)
+            ? (filters.status as string[])
+            : []
+          const term = (search ?? "").toLowerCase().trim()
+          const filtered = rows
+            .filter((training) =>
+              statusFilter.length === 0
+                ? true
+                : statusFilter.includes(training.status)
+            )
+            .filter((training) =>
+              term === "" ? true : training.name.toLowerCase().includes(term)
+            )
+          const sorted = applySort(filtered, sortings, (training, field) => {
+            if (field === "name") return training.name.toLowerCase()
+            if (field === "year") return training.year
+            return null
+          })
+          const perPage = pagination?.perPage ?? 20
+          const currentPage =
+            pagination && "currentPage" in pagination && pagination.currentPage
+              ? pagination.currentPage
+              : 1
+          const total = sorted.length
+          const pagesCount = Math.max(1, Math.ceil(total / perPage))
+          const start = (currentPage - 1) * perPage
+
+          return {
+            type: "pages" as const,
+            records: sorted.slice(start, start + perPage),
+            total,
+            perPage,
+            currentPage,
+            pagesCount,
+          }
+        },
+      },
+      itemUrl: (training) => `${baseHref}?training=${training.id}`,
+    },
+    [accessRole, baseHref]
+  )
+
+  const accessLabel = accessRole === "editor" ? "Can edit" : "Can view"
+  const accessStatus = accessRole === "editor" ? "warning" : "info"
+
+  return (
+    <Page
+      header={
+        <>
+          <PageHeader
+            module={{ id: "company_trainings", name: "Trainings", href: baseHref }}
+            breadcrumbs={[{ id: "courses", label: "Courses" }]}
+          />
+          <ResourceHeader
+            title="Courses"
+            description={
+              accessRole === "editor"
+                ? "Courses shared with you as Can edit."
+                : "Courses shared with you as Can view."
+            }
+            metadata={[
+              {
+                label: "Access",
+                value: {
+                  type: "status",
+                  label: accessLabel,
+                  variant: accessStatus,
+                },
+              },
+            ]}
+          />
+        </>
+      }
+    >
+      <PageContent>
+        <OneDataCollection
+          id={`training-access-${accessRole}/courses/v1`}
+          source={source}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                frozenColumns: 1,
+                columns: [
+                  {
+                    label: "Name",
+                    sorting: "name",
+                    render: (training) => ({
+                      type: "text" as const,
+                      value: training.name,
+                    }),
+                  },
+                  {
+                    label: "Access",
+                    render: () => ({
+                      type: "status" as const,
+                      value: {
+                        status: accessStatus,
+                        label: accessLabel,
+                      },
+                    }),
+                  },
+                  {
+                    label: "Status",
+                    render: (training) => ({
+                      type: "status" as const,
+                      value: {
+                        status: training.status === "active" ? "positive" : "neutral",
+                        label: training.status === "active" ? "Published" : "Draft",
+                      },
+                    }),
+                  },
+                  {
+                    label: "Participants",
+                    render: (training) => ({
+                      type: "number" as const,
+                      value: training.participantCount,
+                    }),
+                  },
+                  {
+                    label: "Groups",
+                    render: (training) => ({
+                      type: "text" as const,
+                      value: String(training.classes.length),
+                    }),
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      </PageContent>
+    </Page>
+  )
+}

--- a/packages/f0compose/src/prototypes/training-access-shared/AdminCourseModals.tsx
+++ b/packages/f0compose/src/prototypes/training-access-shared/AdminCourseModals.tsx
@@ -1,0 +1,146 @@
+import {
+  F0Box,
+  F0Checkbox,
+  F0Dialog,
+  F0Select,
+  F0Text,
+} from "@factorialco/f0-react"
+import { Input, Textarea } from "@factorialco/f0-react/dist/experimental"
+import { useEffect, useState } from "react"
+
+import type { Training } from "@/fixtures"
+
+export type AdminAction = "publish" | "revert-draft" | "settings" | null
+
+type Props = {
+  action: AdminAction
+  training: Training
+  onClose: () => void
+}
+
+const TYPE_OPTIONS = [
+  { value: "internal", label: "Internal" },
+  { value: "external", label: "External" },
+]
+
+const VISIBILITY_OPTIONS = [
+  { value: "private", label: "Private - invitation only" },
+  { value: "catalog", label: "Catalog - discoverable" },
+  { value: "free", label: "Free course - public" },
+]
+
+const TITLES: Record<Exclude<AdminAction, null>, string> = {
+  publish: "Publish training",
+  "revert-draft": "Revert to draft",
+  settings: "Training settings",
+}
+
+const PRIMARY_LABELS: Record<Exclude<AdminAction, null>, string> = {
+  publish: "Publish",
+  "revert-draft": "Revert to draft",
+  settings: "Save settings",
+}
+
+export function AdminCourseModals({ action, training, onClose }: Props) {
+  const [name, setName] = useState(training.name)
+  const [description, setDescription] = useState(training.description ?? "")
+  const [type, setType] = useState<string>(training.type)
+  const [visibility, setVisibility] = useState<string>("private")
+  const [notify, setNotify] = useState(true)
+  const [autoArchive, setAutoArchive] = useState(false)
+  const [reason, setReason] = useState("")
+
+  useEffect(() => {
+    if (!action) return
+
+    setName(training.name)
+    setDescription(training.description ?? "")
+    setType(training.type)
+    setVisibility("private")
+    setNotify(true)
+    setAutoArchive(false)
+    setReason("")
+  }, [action, training])
+
+  if (!action) return null
+
+  const isCritical = action === "revert-draft"
+
+  return (
+    <F0Dialog
+      isOpen={action !== null}
+      onClose={onClose}
+      width={action === "settings" ? "lg" : "md"}
+      title={TITLES[action]}
+      description={training.name}
+      primaryAction={{
+        label: PRIMARY_LABELS[action],
+        onClick: onClose,
+        variant: isCritical ? "critical" : "default",
+      }}
+      secondaryAction={{ label: "Cancel", onClick: onClose }}
+    >
+      <F0Box display="flex" flexDirection="column" gap="md">
+        {action === "publish" && (
+          <F0Text
+            content="Publishing makes the training visible to its participants. They will receive an email and an in-app notification. You can still edit content, schedule groups and update participants after publishing."
+            variant="body"
+          />
+        )}
+
+        {action === "revert-draft" && (
+          <>
+            <F0Text
+              content="Reverting hides the training from participants and stops all reminders. Existing progress is preserved."
+              variant="body"
+            />
+            <Textarea
+              label="Reason (optional)"
+              value={reason}
+              onChange={(value) => setReason(value ?? "")}
+              rows={3}
+            />
+          </>
+        )}
+
+        {action === "settings" && (
+          <>
+            <Input
+              label="Name"
+              value={name}
+              onChange={(value) => setName(value ?? "")}
+            />
+            <Textarea
+              label="Description"
+              value={description}
+              onChange={(value) => setDescription(value ?? "")}
+              rows={4}
+            />
+            <F0Select
+              label="Type"
+              value={type}
+              onChange={(value: string) => setType(value)}
+              options={TYPE_OPTIONS}
+            />
+            <F0Select
+              label="Visibility"
+              value={visibility}
+              onChange={(value: string) => setVisibility(value)}
+              options={VISIBILITY_OPTIONS}
+            />
+            <F0Checkbox
+              checked={notify}
+              onCheckedChange={(checked) => setNotify(checked === true)}
+              title="Notify participants when content is updated"
+            />
+            <F0Checkbox
+              checked={autoArchive}
+              onCheckedChange={(checked) => setAutoArchive(checked === true)}
+              title="Auto-archive 30 days after completion"
+            />
+          </>
+        )}
+      </F0Box>
+    </F0Dialog>
+  )
+}

--- a/packages/f0compose/src/prototypes/training-access-shared/EditableClassDetail.tsx
+++ b/packages/f0compose/src/prototypes/training-access-shared/EditableClassDetail.tsx
@@ -1,0 +1,416 @@
+import { F0Alert } from "@factorialco/f0-react"
+import {
+  OneDataCollection,
+  Page,
+  PageHeader,
+  ResourceHeader,
+  Tabs,
+  useDataCollectionSource,
+} from "@factorialco/f0-react/dist/experimental"
+import {
+  Add,
+  Delete,
+  DottedCircle,
+  Laptop,
+  LayersFront,
+  Office,
+  Pencil,
+} from "@factorialco/f0-react/icons/app"
+import { useState } from "react"
+import { useSearchParams } from "react-router-dom"
+
+import {
+  findEmployee,
+  sessionsForClass,
+  type Training,
+  type TrainingClass,
+  type TrainingSession,
+} from "@/fixtures"
+import { applySort } from "@/lib/applySort"
+
+import { ClassModals, type ClassAction } from "../trainings/detail/ClassModals"
+import { CostsTab } from "../trainings/detail/CostsTab"
+import { DocumentsTab as ClassDocumentsTab } from "../trainings/detail/class/DocumentsTab"
+import { MaterialsTab as ClassMaterialsTab } from "../trainings/detail/class/MaterialsTab"
+import { ParticipantsTab as ClassParticipantsTab } from "../trainings/detail/class/ParticipantsTab"
+import { PageContent } from "../trainings/_shared/PageContent"
+
+type Props = {
+  training: Training
+  classId: string
+  baseHref: string
+  trainingHref: string
+}
+
+type ClassTabId = "sessions" | "participants" | "materials" | "documents" | "costs"
+type Modality = "onsite" | "virtual" | "hybrid"
+
+const CLASS_TABS: Array<{ id: ClassTabId; label: string }> = [
+  { id: "sessions", label: "Sessions" },
+  { id: "participants", label: "Participants" },
+  { id: "materials", label: "Materials" },
+  { id: "documents", label: "Documents" },
+  { id: "costs", label: "Costs" },
+]
+
+const VALID_CTABS = new Set<string>(CLASS_TABS.map((tab) => tab.id))
+
+const currencyFmt = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 0,
+})
+
+const MODE_TO_MODALITY: Record<TrainingSession["mode"], Modality> = {
+  in_person: "onsite",
+  online: "virtual",
+  hybrid: "hybrid",
+}
+
+const MODALITY_LABEL: Record<Modality, string> = {
+  onsite: "Onsite",
+  virtual: "Virtual",
+  hybrid: "Hybrid",
+}
+
+const MODALITY_ICON: Record<Modality, typeof Office> = {
+  onsite: Office,
+  virtual: Laptop,
+  hybrid: DottedCircle,
+}
+
+function formatLongDate(iso: string | null): string {
+  if (!iso) return "-"
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return date.toLocaleDateString("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  })
+}
+
+function formatSessionDate(session: TrainingSession): string {
+  const start = new Date(session.startsAt)
+  const end = new Date(session.endsAt)
+  const day = start.getDate()
+  const suffix =
+    day % 10 === 1 && day !== 11
+      ? "st"
+      : day % 10 === 2 && day !== 12
+        ? "nd"
+        : day % 10 === 3 && day !== 13
+          ? "rd"
+          : "th"
+  const month = start.toLocaleString("en-GB", { month: "short" })
+  const startTime = start.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })
+  const endTime = end.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })
+  const hours = Math.floor(session.durationMinutes / 60)
+  const minutes = session.durationMinutes % 60
+  return `${day}${suffix} ${month}, ${startTime} - ${endTime} (${hours}h ${minutes}m)`
+}
+
+export function EditableClassDetail({
+  training,
+  classId,
+  baseHref,
+  trainingHref,
+}: Props) {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [classAction, setClassAction] = useState<ClassAction>(null)
+  const [actionSession, setActionSession] = useState<TrainingSession | null>(null)
+  const klass = training.classes.find((item) => item.id === classId)
+  const rawTab = searchParams.get("ctab")
+  const activeTab: ClassTabId =
+    rawTab && VALID_CTABS.has(rawTab) ? (rawTab as ClassTabId) : "sessions"
+
+  const setTab = (id: string) => {
+    const next = new URLSearchParams(searchParams)
+    next.set("ctab", id)
+    setSearchParams(next)
+  }
+
+  const tabsWithNav = CLASS_TABS.map((tab) => ({
+    ...tab,
+    onClick: () => setTab(tab.id),
+  }))
+
+  const openClassAction = (
+    action: ClassAction,
+    session: TrainingSession | null = null
+  ) => {
+    setActionSession(session)
+    setClassAction(action)
+  }
+
+  const closeClassAction = () => {
+    setClassAction(null)
+    setActionSession(null)
+  }
+
+  if (!klass) {
+    return (
+      <Page
+        header={
+          <PageHeader
+            module={{ id: "company_trainings", name: "Training", href: baseHref }}
+            breadcrumbs={[
+              { id: "courses", label: "Courses", href: baseHref },
+              { id: training.id, label: training.name, href: trainingHref },
+              { id: "missing", label: "Group not found" },
+            ]}
+          />
+        }
+      >
+        <PageContent>
+          <F0Alert
+            variant="warning"
+            title="Group not found"
+            description="This shared training does not contain the selected group."
+          />
+        </PageContent>
+      </Page>
+    )
+  }
+
+  const participantAvatars = klass.participants.map((participant) => ({
+    firstName: participant.firstName,
+    lastName: participant.lastName,
+    src: participant.src,
+    type: "person" as const,
+  }))
+
+  const seenInstructorIds = new Set<string>()
+  const instructorAvatars = sessionsForClass(klass.id)
+    .flatMap((session) => session.instructorIds)
+    .filter((id) => {
+      if (seenInstructorIds.has(id)) return false
+      seenInstructorIds.add(id)
+      return true
+    })
+    .map((id) => findEmployee(id))
+    .filter((employee): employee is NonNullable<typeof employee> => Boolean(employee))
+    .map((employee) => {
+      const [firstName, ...lastNameParts] = employee.fullName.split(" ")
+      return {
+        firstName: firstName ?? "",
+        lastName: lastNameParts.join(" "),
+        src: employee.avatarUrl,
+        type: "person" as const,
+      }
+    })
+
+  const trainingBudget = training.totalCost > 0 ? currencyFmt.format(training.totalCost) : null
+
+  return (
+    <>
+      <Page
+        header={
+          <>
+            <PageHeader
+              module={{ id: "company_trainings", name: "Training", href: baseHref }}
+              breadcrumbs={[
+                { id: "courses", label: "Courses", href: baseHref },
+                { id: training.id, label: training.name, href: trainingHref },
+                { id: klass.id, label: klass.name },
+              ]}
+            />
+            <ResourceHeader
+              title={klass.name}
+              description={training.description}
+              metadata={[
+                {
+                  label: "Start date",
+                  value: { type: "text", content: formatLongDate(klass.startDate) },
+                },
+                {
+                  label: "End date",
+                  value: { type: "text", content: formatLongDate(klass.endDate) },
+                },
+                {
+                  label: "Participants",
+                  value: {
+                    type: "list",
+                    variant: "person",
+                    avatars: participantAvatars,
+                  },
+                },
+                {
+                  label: "Instructors",
+                  value: {
+                    type: "list",
+                    variant: "person",
+                    avatars: instructorAvatars,
+                  },
+                },
+                ...(trainingBudget
+                  ? [
+                      {
+                        label: "Training budget",
+                        value: { type: "text" as const, content: trainingBudget },
+                      },
+                    ]
+                  : []),
+              ]}
+            />
+            <Tabs key={activeTab} tabs={tabsWithNav} activeTabId={activeTab} />
+          </>
+        }
+      >
+        <PageContent>
+          {activeTab === "sessions" && (
+            <EditableSessionsTab klass={klass} onAction={openClassAction} />
+          )}
+          {activeTab === "participants" && (
+            <ClassParticipantsTab training={training} klass={klass} />
+          )}
+          {activeTab === "materials" && (
+            <ClassMaterialsTab training={training} klass={klass} />
+          )}
+          {activeTab === "documents" && (
+            <ClassDocumentsTab training={training} klass={klass} />
+          )}
+          {activeTab === "costs" && <CostsTab training={training} klass={klass} />}
+        </PageContent>
+      </Page>
+      <ClassModals
+        action={classAction}
+        trainingId={training.id}
+        klass={klass}
+        session={actionSession}
+        onClose={closeClassAction}
+      />
+    </>
+  )
+}
+
+function EditableSessionsTab({
+  klass,
+  onAction,
+}: {
+  klass: TrainingClass
+  onAction: (action: ClassAction, session?: TrainingSession | null) => void
+}) {
+  const source = useDataCollectionSource<TrainingSession>(
+    {
+      search: { enabled: true, sync: false },
+      sortings: {
+        name: { label: "Session" },
+        startsAt: { label: "Date" },
+      },
+      filters: {
+        modality: {
+          type: "in",
+          label: "Modality",
+          options: {
+            options: [
+              { value: "onsite", label: "Onsite" },
+              { value: "virtual", label: "Virtual" },
+              { value: "hybrid", label: "Hybrid" },
+            ],
+          },
+        },
+      },
+      dataAdapter: {
+        fetchData: ({ filters, search, sortings }) => {
+          const modalityFilter = Array.isArray(filters?.modality)
+            ? (filters.modality as string[])
+            : []
+          const term = (search ?? "").toLowerCase().trim()
+
+          const filtered = sessionsForClass(klass.id)
+            .filter((session) => {
+              if (modalityFilter.length === 0) return true
+              return modalityFilter.includes(MODE_TO_MODALITY[session.mode])
+            })
+            .filter((session) =>
+              term === "" ? true : session.title.toLowerCase().includes(term)
+            )
+
+          const sorted = applySort(filtered, sortings, (session, field) => {
+            if (field === "name") return session.title.toLowerCase()
+            if (field === "startsAt") return session.startsAt
+            return null
+          })
+
+          return { records: sorted, totalCount: sorted.length }
+        },
+      },
+      primaryActions: () => ({
+        label: "New session",
+        icon: Add,
+        onClick: () => onAction("new-session"),
+      }),
+      itemActions: (item) => [
+        { label: "Edit", icon: Pencil, onClick: () => onAction("edit-session", item) },
+        {
+          label: "Duplicate",
+          icon: LayersFront,
+          onClick: () => onAction("new-session", item),
+        },
+        {
+          label: "Delete",
+          icon: Delete,
+          critical: true,
+          onClick: () => onAction("cancel-session", item),
+        },
+      ],
+    },
+    [klass.id, onAction]
+  )
+
+  return (
+    <OneDataCollection
+      id={`training-access/sessions/${klass.id}/v1`}
+      source={source}
+      visualizations={[
+        {
+          type: "table",
+          options: {
+            frozenColumns: 1,
+            columns: [
+              {
+                label: "Session",
+                sorting: "name",
+                render: (item) => ({ type: "text", value: item.title }),
+              },
+              {
+                label: "Date",
+                sorting: "startsAt",
+                render: (item) => ({ type: "text", value: formatSessionDate(item) }),
+              },
+              {
+                label: "Type",
+                render: () => ({
+                  type: "dotTag",
+                  value: { label: "Scheduled", color: "barbie" },
+                }),
+              },
+              {
+                label: "Modality",
+                render: (item) => {
+                  const modality = MODE_TO_MODALITY[item.mode]
+                  return {
+                    type: "tag",
+                    value: {
+                      label: MODALITY_LABEL[modality],
+                      icon: MODALITY_ICON[modality],
+                    },
+                  }
+                },
+              },
+            ],
+          },
+        },
+      ]}
+    />
+  )
+}

--- a/packages/f0compose/src/prototypes/training-access-shared/EditableClassesTab.tsx
+++ b/packages/f0compose/src/prototypes/training-access-shared/EditableClassesTab.tsx
@@ -1,0 +1,253 @@
+import { F0Dialog } from "@factorialco/f0-react"
+import {
+  OneDataCollection,
+  useDataCollectionSource,
+} from "@factorialco/f0-react/dist/experimental"
+import { Add, Delete, LayersFront, Pencil } from "@factorialco/f0-react/icons/app"
+import { useState } from "react"
+import { useSearchParams } from "react-router-dom"
+
+import type { Training, TrainingClass } from "@/fixtures"
+import { applySort } from "@/lib/applySort"
+
+import { NewClassWizard } from "../trainings/detail/NewClassWizard"
+
+type Props = { training: Training }
+
+type ConfirmKind = "duplicate" | "delete"
+
+export function EditableClassesTab({ training }: Props) {
+  const [showNewClass, setShowNewClass] = useState(false)
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [confirm, setConfirm] = useState<{
+    kind: ConfirmKind
+    klass: TrainingClass
+  } | null>(null)
+
+  const openClass = (klass: TrainingClass) => {
+    const next = new URLSearchParams(searchParams)
+    next.set("training", training.id)
+    next.set("dtab", "groups")
+    next.set("class", klass.id)
+    setSearchParams(next)
+  }
+
+  const startDateOptions = Array.from(
+    new Set(training.classes.map((klass) => klass.startDate).filter(Boolean))
+  ).map((date) => ({ label: String(date), value: String(date) }))
+  const endDateOptions = Array.from(
+    new Set(training.classes.map((klass) => klass.endDate).filter(Boolean))
+  ).map((date) => ({ label: String(date), value: String(date) }))
+
+  const source = useDataCollectionSource<TrainingClass>(
+    {
+      search: { enabled: true, sync: true },
+      sortings: {
+        startDate: { label: "Start date" },
+        endDate: { label: "End date" },
+      },
+      defaultSortings: { field: "startDate", order: "asc" },
+      filters: {
+        startDate: {
+          type: "in",
+          label: "Start date",
+          options: { options: startDateOptions },
+        },
+        endDate: {
+          type: "in",
+          label: "End date",
+          options: { options: endDateOptions },
+        },
+      },
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 20,
+        fetchData: ({ search, sortings, filters, pagination }) => {
+          const term = (search ?? "").toLowerCase().trim()
+          const wantedStart = Array.isArray(filters?.startDate)
+            ? (filters.startDate as string[])
+            : []
+          const wantedEnd = Array.isArray(filters?.endDate)
+            ? (filters.endDate as string[])
+            : []
+
+          const filtered = training.classes.filter((klass) => {
+            if (term !== "" && !klass.name.toLowerCase().includes(term)) return false
+            if (wantedStart.length > 0 && !wantedStart.includes(klass.startDate ?? "")) {
+              return false
+            }
+            if (wantedEnd.length > 0 && !wantedEnd.includes(klass.endDate ?? "")) {
+              return false
+            }
+            return true
+          })
+
+          const sorted = applySort(filtered, sortings, (klass, field) => {
+            if (field === "startDate") return klass.startDate ?? ""
+            if (field === "endDate") return klass.endDate ?? ""
+            return null
+          })
+
+          const perPage = pagination?.perPage ?? 20
+          const currentPage =
+            pagination && "currentPage" in pagination && pagination.currentPage
+              ? pagination.currentPage
+              : 1
+          const total = sorted.length
+          const pagesCount = Math.max(1, Math.ceil(total / perPage))
+          const start = (currentPage - 1) * perPage
+
+          return {
+            type: "pages" as const,
+            records: sorted.slice(start, start + perPage),
+            total,
+            perPage,
+            currentPage,
+            pagesCount,
+          }
+        },
+      },
+      primaryActions: () => ({
+        label: "New group",
+        icon: Add,
+        onClick: () => setShowNewClass(true),
+      }),
+      itemOnClick: (klass) => () => openClass(klass),
+      itemActions: (klass) => [
+        { label: "Edit", icon: Pencil, onClick: () => openClass(klass) },
+        {
+          label: "Duplicate group",
+          icon: LayersFront,
+          onClick: () => setConfirm({ kind: "duplicate", klass }),
+        },
+        {
+          label: "Delete group",
+          icon: Delete,
+          onClick: () => setConfirm({ kind: "delete", klass }),
+          critical: true,
+        },
+      ],
+    },
+    [training.id, refreshKey]
+  )
+
+  return (
+    <>
+      <OneDataCollection
+        id={`training-access/groups-${training.id}/v1`}
+        source={source}
+        emptyStates={{
+          "no-data": {
+            emoji: "👥",
+            title: "No groups yet",
+            description:
+              "Groups will appear here once this training has assigned employees, sessions or costs.",
+            actions: [
+              {
+                label: "New group",
+                icon: Add,
+                onClick: () => setShowNewClass(true),
+                variant: "outline",
+              },
+            ],
+          },
+        }}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              columns: [
+                {
+                  label: "Group",
+                  render: (klass) => ({ type: "text", value: klass.name }),
+                },
+                {
+                  label: "Start date",
+                  sorting: "startDate",
+                  render: (klass) => ({ type: "text", value: klass.startDate ?? "-" }),
+                },
+                {
+                  label: "End date",
+                  sorting: "endDate",
+                  render: (klass) => ({ type: "text", value: klass.endDate ?? "-" }),
+                },
+                {
+                  label: "Sessions",
+                  render: (klass) => ({ type: "text", value: String(klass.sessionCount) }),
+                },
+                {
+                  label: "Participants",
+                  render: (klass) => ({
+                    type: "avatarList",
+                    value: {
+                      avatarList: klass.participants.map((participant) => ({
+                        firstName: participant.firstName,
+                        lastName: participant.lastName,
+                        type: "person" as const,
+                        src: participant.src,
+                      })),
+                      max: 5,
+                    },
+                  }),
+                },
+                {
+                  label: "Participation rate",
+                  render: (klass) => {
+                    const completed = klass.completedAttendancesCount
+                    const total = klass.totalAttendancesCount
+                    const percentage =
+                      total > 0 ? Number(((completed / total) * 100).toFixed(1)) : 0
+                    return {
+                      type: "percentage",
+                      value: { label: `${percentage}%`, percentage },
+                    }
+                  },
+                },
+              ],
+            },
+          },
+        ]}
+      />
+
+      <NewClassWizard
+        trainingId={training.id}
+        isOpen={showNewClass}
+        onClose={() => setShowNewClass(false)}
+        onCreated={(klass) => {
+          setShowNewClass(false)
+          setRefreshKey((current) => current + 1)
+          openClass(klass)
+        }}
+      />
+
+      {confirm && (
+        <F0Dialog
+          isOpen
+          onClose={() => setConfirm(null)}
+          position="center"
+          width="md"
+          title={
+            confirm.kind === "duplicate"
+              ? `Duplicate "${confirm.klass.name}"?`
+              : `Delete "${confirm.klass.name}"?`
+          }
+          description={
+            confirm.kind === "duplicate"
+              ? "A copy of this group will be created with the same sessions and participants."
+              : "This will permanently delete the group along with its sessions, participants and attendance records."
+          }
+          primaryAction={{
+            label: confirm.kind === "duplicate" ? "Duplicate" : "Delete",
+            variant: confirm.kind === "delete" ? "critical" : "default",
+            onClick: () => {
+              setConfirm(null)
+              setRefreshKey((current) => current + 1)
+            },
+          }}
+          secondaryAction={{ label: "Cancel", onClick: () => setConfirm(null) }}
+        />
+      )}
+    </>
+  )
+}

--- a/packages/f0compose/src/prototypes/training-access-viewer/ReadOnlyClassDetail.tsx
+++ b/packages/f0compose/src/prototypes/training-access-viewer/ReadOnlyClassDetail.tsx
@@ -1,0 +1,812 @@
+import { F0Alert, F0Box, F0Card, F0Heading, F0Text } from "@factorialco/f0-react"
+import {
+  OneDataCollection,
+  Page,
+  PageHeader,
+  ResourceHeader,
+  Tabs,
+  useDataCollectionSource,
+} from "@factorialco/f0-react/dist/experimental"
+import { DottedCircle, Laptop, Office } from "@factorialco/f0-react/icons/app"
+import { useMemo, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+
+import {
+  certificatesForTraining,
+  filesForTraining,
+  findEmployee,
+  sessionsForClass,
+  type ParticipantStatus,
+  type Training,
+  type TrainingClass,
+  type TrainingFile,
+  type TrainingSession,
+} from "@/fixtures"
+import { applySort } from "@/lib/applySort"
+
+import { PageContent } from "../trainings/_shared/PageContent"
+
+type Props = {
+  training: Training
+  classId: string
+  baseHref: string
+  trainingHref: string
+}
+
+type ClassTabId = "sessions" | "participants" | "materials" | "documents" | "costs"
+
+type Modality = "onsite" | "virtual" | "hybrid"
+
+const CLASS_TABS: Array<{ id: ClassTabId; label: string }> = [
+  { id: "sessions", label: "Sessions" },
+  { id: "participants", label: "Participants" },
+  { id: "materials", label: "Materials" },
+  { id: "documents", label: "Documents" },
+  { id: "costs", label: "Costs" },
+]
+
+const VALID_CTABS = new Set<string>(CLASS_TABS.map((tab) => tab.id))
+
+const currencyFmt = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 0,
+})
+
+const MODE_TO_MODALITY: Record<TrainingSession["mode"], Modality> = {
+  in_person: "onsite",
+  online: "virtual",
+  hybrid: "hybrid",
+}
+
+const MODALITY_LABEL: Record<Modality, string> = {
+  onsite: "Onsite",
+  virtual: "Virtual",
+  hybrid: "Hybrid",
+}
+
+const MODALITY_ICON: Record<Modality, typeof Office> = {
+  onsite: Office,
+  virtual: Laptop,
+  hybrid: DottedCircle,
+}
+
+const PARTICIPANT_STATUS_LABEL: Record<ParticipantStatus, string> = {
+  completed: "Completed",
+  in_progress: "In progress",
+  not_started: "Enrolled",
+  expired: "Expired",
+}
+
+const PARTICIPANT_STATUS_VARIANT: Record<
+  ParticipantStatus,
+  "neutral" | "positive" | "warning" | "critical"
+> = {
+  completed: "positive",
+  in_progress: "warning",
+  not_started: "neutral",
+  expired: "critical",
+}
+
+const FILE_ICON_BY_TYPE: Record<TrainingFile["type"], string> = {
+  pdf: "📄",
+  video: "🎬",
+  doc: "📝",
+  link: "🔗",
+  image: "🖼️",
+  scorm: "📦",
+}
+
+function formatLongDate(iso: string | null): string {
+  if (!iso) return "-"
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return date.toLocaleDateString("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  })
+}
+
+function formatSessionDate(session: TrainingSession): string {
+  const start = new Date(session.startsAt)
+  const end = new Date(session.endsAt)
+  const day = start.getDate()
+  const suffix =
+    day % 10 === 1 && day !== 11
+      ? "st"
+      : day % 10 === 2 && day !== 12
+        ? "nd"
+        : day % 10 === 3 && day !== 13
+          ? "rd"
+          : "th"
+  const month = start.toLocaleString("en-GB", { month: "short" })
+  const startTime = start.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })
+  const endTime = end.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })
+  const hours = Math.floor(session.durationMinutes / 60)
+  const minutes = session.durationMinutes % 60
+  return `${day}${suffix} ${month}, ${startTime} - ${endTime} (${hours}h ${minutes}m)`
+}
+
+export function ReadOnlyClassDetail({
+  training,
+  classId,
+  baseHref,
+  trainingHref,
+}: Props) {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const klass = training.classes.find((item) => item.id === classId)
+  const rawTab = searchParams.get("ctab")
+  const activeTab: ClassTabId =
+    rawTab && VALID_CTABS.has(rawTab) ? (rawTab as ClassTabId) : "sessions"
+
+  const setTab = (id: string) => {
+    const next = new URLSearchParams(searchParams)
+    next.set("ctab", id)
+    setSearchParams(next)
+  }
+
+  const tabsWithNav = CLASS_TABS.map((tab) => ({
+    ...tab,
+    onClick: () => setTab(tab.id),
+  }))
+
+  if (!klass) {
+    return (
+      <Page
+        header={
+          <PageHeader
+            module={{ id: "company_trainings", name: "Training", href: baseHref }}
+            breadcrumbs={[
+              { id: "courses", label: "Courses", href: baseHref },
+              { id: training.id, label: training.name, href: trainingHref },
+              { id: "missing", label: "Group not found" },
+            ]}
+          />
+        }
+      >
+        <PageContent>
+          <F0Alert
+            variant="warning"
+            title="Group not found"
+            description="This shared training does not contain the selected group."
+          />
+        </PageContent>
+      </Page>
+    )
+  }
+
+  const participantAvatars = klass.participants.map((participant) => ({
+    firstName: participant.firstName,
+    lastName: participant.lastName,
+    src: participant.src,
+    type: "person" as const,
+  }))
+
+  const seenInstructorIds = new Set<string>()
+  const instructorAvatars = sessionsForClass(klass.id)
+    .flatMap((session) => session.instructorIds)
+    .filter((id) => {
+      if (seenInstructorIds.has(id)) return false
+      seenInstructorIds.add(id)
+      return true
+    })
+    .map((id) => findEmployee(id))
+    .filter((employee): employee is NonNullable<typeof employee> => Boolean(employee))
+    .map((employee) => {
+      const [firstName, ...lastNameParts] = employee.fullName.split(" ")
+      return {
+        firstName: firstName ?? "",
+        lastName: lastNameParts.join(" "),
+        src: employee.avatarUrl,
+        type: "person" as const,
+      }
+    })
+
+  const trainingBudget =
+    training.totalCost > 0 ? currencyFmt.format(training.totalCost) : null
+
+  return (
+    <Page
+      header={
+        <>
+          <PageHeader
+            module={{ id: "company_trainings", name: "Training", href: baseHref }}
+            breadcrumbs={[
+              { id: "courses", label: "Courses", href: baseHref },
+              { id: training.id, label: training.name, href: trainingHref },
+              { id: klass.id, label: klass.name },
+            ]}
+          />
+          <ResourceHeader
+            title={klass.name}
+            description={training.description}
+            metadata={[
+              {
+                label: "Access",
+                value: { type: "status", label: "Can view", variant: "info" },
+              },
+              {
+                label: "Start date",
+                value: { type: "text", content: formatLongDate(klass.startDate) },
+              },
+              {
+                label: "End date",
+                value: { type: "text", content: formatLongDate(klass.endDate) },
+              },
+              {
+                label: "Participants",
+                value: {
+                  type: "list",
+                  variant: "person",
+                  avatars: participantAvatars,
+                },
+              },
+              {
+                label: "Instructors",
+                value: {
+                  type: "list",
+                  variant: "person",
+                  avatars: instructorAvatars,
+                },
+              },
+              ...(trainingBudget
+                ? [
+                    {
+                      label: "Training budget",
+                      value: { type: "text" as const, content: trainingBudget },
+                    },
+                  ]
+                : []),
+            ]}
+          />
+          <Tabs key={activeTab} tabs={tabsWithNav} activeTabId={activeTab} />
+        </>
+      }
+    >
+      <PageContent>
+        {activeTab === "sessions" && <ReadOnlySessionsTab klass={klass} />}
+        {activeTab === "participants" && <ReadOnlyClassParticipantsTab klass={klass} />}
+        {activeTab === "materials" && <ReadOnlyClassMaterialsTab training={training} />}
+        {activeTab === "documents" && (
+          <ReadOnlyClassDocumentsTab training={training} klass={klass} />
+        )}
+        {activeTab === "costs" && <ReadOnlyClassCostsTab training={training} klass={klass} />}
+      </PageContent>
+    </Page>
+  )
+}
+
+function ReadOnlySessionsTab({ klass }: { klass: TrainingClass }) {
+  const source = useDataCollectionSource<TrainingSession>(
+    {
+      search: { enabled: true, sync: false },
+      sortings: {
+        name: { label: "Session" },
+        startsAt: { label: "Date" },
+      },
+      filters: {
+        modality: {
+          type: "in",
+          label: "Modality",
+          options: {
+            options: [
+              { value: "onsite", label: "Onsite" },
+              { value: "virtual", label: "Virtual" },
+              { value: "hybrid", label: "Hybrid" },
+            ],
+          },
+        },
+      },
+      dataAdapter: {
+        fetchData: ({ filters, search, sortings }) => {
+          const modalityFilter = Array.isArray(filters?.modality)
+            ? (filters.modality as string[])
+            : []
+          const term = (search ?? "").toLowerCase().trim()
+          const filtered = sessionsForClass(klass.id)
+            .filter((session) => {
+              if (modalityFilter.length === 0) return true
+              return modalityFilter.includes(MODE_TO_MODALITY[session.mode])
+            })
+            .filter((session) =>
+              term === "" ? true : session.title.toLowerCase().includes(term)
+            )
+          const sorted = applySort(filtered, sortings, (session, field) => {
+            if (field === "name") return session.title.toLowerCase()
+            if (field === "startsAt") return session.startsAt
+            return null
+          })
+
+          return { records: sorted, totalCount: sorted.length }
+        },
+      },
+    },
+    [klass.id]
+  )
+
+  return (
+    <OneDataCollection
+      id={`training-access-viewer/sessions/${klass.id}/v1`}
+      source={source}
+      visualizations={[
+        {
+          type: "table",
+          options: {
+            frozenColumns: 1,
+            columns: [
+              {
+                id: "session",
+                label: "Session",
+                sorting: "name",
+                render: (item: TrainingSession) => ({
+                  type: "text" as const,
+                  value: item.title,
+                }),
+              },
+              {
+                id: "date",
+                label: "Date",
+                sorting: "startsAt",
+                render: (item: TrainingSession) => ({
+                  type: "text" as const,
+                  value: formatSessionDate(item),
+                }),
+              },
+              {
+                id: "type",
+                label: "Type",
+                render: () => ({
+                  type: "dotTag" as const,
+                  value: { label: "Scheduled", color: "barbie" as const },
+                }),
+              },
+              {
+                id: "modality",
+                label: "Modality",
+                render: (item: TrainingSession) => {
+                  const modality = MODE_TO_MODALITY[item.mode]
+                  return {
+                    type: "tag" as const,
+                    value: {
+                      label: MODALITY_LABEL[modality],
+                      icon: MODALITY_ICON[modality],
+                    },
+                  }
+                },
+              },
+            ],
+          },
+        },
+      ]}
+    />
+  )
+}
+
+type ParticipantRow = {
+  id: string
+  firstName: string
+  lastName: string
+  fullName: string
+  src?: string
+  status: ParticipantStatus
+  certificate: string
+  completionDate: string
+  courseValidity: string
+  attendedSessions: number
+  totalSessions: number
+  knowledgeTestPassed: boolean | null
+  completedModules: number
+  totalModules: number
+}
+
+function ReadOnlyClassParticipantsTab({ klass }: { klass: TrainingClass }) {
+  const rows = useClassParticipantRows(klass)
+  const source = useDataCollectionSource<ParticipantRow>(
+    {
+      search: { enabled: true, sync: false },
+      presets: [
+        {
+          label: "Pending group assignment",
+          filter: { status: ["not_started", "in_progress"] },
+        },
+        { label: "Expired", filter: { status: ["expired"] } },
+      ],
+      filters: {
+        status: {
+          type: "in",
+          label: "Status",
+          options: {
+            options: [
+              { label: "Enrolled", value: "not_started" },
+              { label: "In progress", value: "in_progress" },
+              { label: "Completed", value: "completed" },
+              { label: "Expired", value: "expired" },
+            ],
+          },
+        },
+      },
+      dataAdapter: {
+        fetchData: ({ filters, search }) => {
+          const statusFilter = Array.isArray(filters?.status)
+            ? (filters.status as string[])
+            : []
+          const term = (search ?? "").toLowerCase().trim()
+          const filtered = rows
+            .filter((row) =>
+              statusFilter.length === 0 ? true : statusFilter.includes(row.status)
+            )
+            .filter((row) =>
+              term === "" ? true : row.fullName.toLowerCase().includes(term)
+            )
+
+          return { records: filtered, totalCount: filtered.length }
+        },
+      },
+    },
+    [rows]
+  )
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="lg">
+      <F0Box display="flex" flexDirection="column" gap="xs">
+        <F0Heading
+          as="h3"
+          variant="heading-large"
+          content={`Participants (${rows.length})`}
+        />
+        <F0Text
+          variant="description"
+          content="People enrolled in this group. Can view access is read-only."
+        />
+      </F0Box>
+      <OneDataCollection
+        id={`training-access-viewer/group-participants/${klass.id}/v1`}
+        source={source}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              columns: getParticipantColumns(),
+            },
+          },
+        ]}
+      />
+    </F0Box>
+  )
+}
+
+function useClassParticipantRows(klass: TrainingClass): ParticipantRow[] {
+  const total = klass.totalAttendancesCount || klass.participants.length || 0
+  const completed = klass.completedAttendancesCount
+  const inProgress = Math.min(
+    Math.max(total - completed, 0),
+    Math.round((total - completed) * 0.6)
+  )
+  const notStarted = Math.max(total - completed - inProgress, 0)
+  const statuses: ParticipantStatus[] = [
+    ...Array(completed).fill("completed" as ParticipantStatus),
+    ...Array(inProgress).fill("in_progress" as ParticipantStatus),
+    ...Array(notStarted).fill("not_started" as ParticipantStatus),
+  ]
+
+  return useMemo(
+    () =>
+      klass.participants.map((participant, index) => ({
+        id: `${participant.firstName}-${participant.lastName}-${index}`,
+        firstName: participant.firstName,
+        lastName: participant.lastName,
+        fullName: `${participant.firstName} ${participant.lastName}`.trim(),
+        src: participant.src,
+        status: statuses[index] ?? "not_started",
+        certificate: index === 0 && completed > 0 ? "1 file" : "-",
+        completionDate: statuses[index] === "completed" ? "Not set" : "Not set",
+        courseValidity: "No date",
+        attendedSessions: 0,
+        totalSessions: 0,
+        knowledgeTestPassed: null,
+        completedModules: 0,
+        totalModules: 0,
+      })),
+    [completed, klass.participants, statuses]
+  )
+}
+
+function getParticipantColumns() {
+  return [
+    {
+      id: "participant",
+      label: "Participant",
+      sorting: "fullName" as const,
+      render: (row: ParticipantRow) => ({
+        type: "person" as const,
+        value: {
+          firstName: row.firstName,
+          lastName: row.lastName,
+          src: row.src,
+        },
+      }),
+    },
+    {
+      id: "status",
+      label: "Status",
+      sorting: "status" as const,
+      render: (row: ParticipantRow) => ({
+        type: "status" as const,
+        value: {
+          status: PARTICIPANT_STATUS_VARIANT[row.status],
+          label: PARTICIPANT_STATUS_LABEL[row.status],
+        },
+      }),
+    },
+    {
+      id: "certificate",
+      label: "Certificate",
+      render: (row: ParticipantRow) => ({ type: "text" as const, value: row.certificate }),
+    },
+    {
+      id: "completion-date",
+      label: "Completion date",
+      render: (row: ParticipantRow) => ({
+        type: "text" as const,
+        value: row.completionDate,
+      }),
+    },
+    {
+      id: "course-validity",
+      label: "Course validity",
+      render: (row: ParticipantRow) => ({
+        type: "text" as const,
+        value: row.courseValidity,
+      }),
+    },
+    {
+      id: "session-attendance",
+      label: "Session attendance",
+      render: (row: ParticipantRow) => ({
+        type: "percentage" as const,
+        value: {
+          percentage:
+            row.totalSessions > 0
+              ? (row.attendedSessions / row.totalSessions) * 100
+              : 0,
+          label: `${row.attendedSessions}/${row.totalSessions}`,
+        },
+      }),
+    },
+    {
+      id: "knowledge-test-results",
+      label: "Knowledge test results",
+      render: (row: ParticipantRow) => ({
+        type: "status" as const,
+        value:
+          row.knowledgeTestPassed === null
+            ? { status: "warning" as const, label: "Pending" }
+            : row.knowledgeTestPassed
+              ? { status: "positive" as const, label: "Passed" }
+              : { status: "critical" as const, label: "Failed" },
+      }),
+    },
+    {
+      id: "module-progress",
+      label: "Module progress",
+      render: (row: ParticipantRow) => ({
+        type: "percentage" as const,
+        value: {
+          percentage:
+            row.totalModules > 0
+              ? (row.completedModules / row.totalModules) * 100
+              : 0,
+          label: `${row.completedModules}/${row.totalModules}`,
+        },
+      }),
+    },
+  ]
+}
+
+function ReadOnlyClassMaterialsTab({ training }: { training: Training }) {
+  const [filter, setFilter] = useState<"all" | "file" | "link">("all")
+  const materials = filesForTraining(training.id).map((file) => ({
+    ...file,
+    kind: file.type === "link" ? "link" : "file",
+  }))
+  const filtered =
+    filter === "all" ? materials : materials.filter((material) => material.kind === filter)
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="lg">
+      <F0Box display="flex" flexDirection="column" gap="xs">
+        <F0Heading
+          as="h3"
+          variant="heading-large"
+          content={`Materials (${materials.length})`}
+        />
+        <F0Text
+          variant="description"
+          content="Files and links shared with this group's participants."
+        />
+      </F0Box>
+      <F0Box display="flex" gap="sm">
+        <FilterButton active={filter === "all"} label="All" onClick={() => setFilter("all")} />
+        <FilterButton active={filter === "file"} label="Files" onClick={() => setFilter("file")} />
+        <FilterButton active={filter === "link"} label="Links" onClick={() => setFilter("link")} />
+      </F0Box>
+      {filtered.length === 0 ? (
+        <F0Alert
+          variant="info"
+          title="No materials yet"
+          description="Materials accessible to this group will appear here."
+        />
+      ) : (
+        <F0Box display="grid" columns="3" gap="md">
+          {filtered.map((material) => (
+            <F0Card
+              key={material.id}
+              title={material.name}
+              description={`${material.type.toUpperCase()} · ${material.size ?? "Link"} · ${material.uploadedAt}`}
+              avatar={{
+                type: "emoji",
+                emoji: FILE_ICON_BY_TYPE[material.type] ?? "📎",
+                "aria-label": material.type,
+              }}
+            />
+          ))}
+        </F0Box>
+      )}
+    </F0Box>
+  )
+}
+
+function FilterButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-md border border-solid px-3 py-1.5 text-sm font-medium transition-colors ${
+        active
+          ? "border-f1-border-bold bg-f1-background-bold text-f1-foreground-bold"
+          : "border-f1-border-secondary bg-f1-background text-f1-foreground"
+      }`}
+    >
+      {label}
+    </button>
+  )
+}
+
+function ReadOnlyClassDocumentsTab({
+  training,
+  klass,
+}: {
+  training: Training
+  klass: TrainingClass
+}) {
+  const participantNames = new Set(
+    klass.participants.map((participant) =>
+      `${participant.firstName} ${participant.lastName}`.trim()
+    )
+  )
+  const certificates = certificatesForTraining(training.id).filter((certificate) =>
+    participantNames.has(certificate.employeeName)
+  )
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="lg">
+      <F0Box display="flex" flexDirection="column" gap="xs">
+        <F0Heading
+          content={`Documents (${certificates.length})`}
+          variant="heading-large"
+          as="h2"
+        />
+        <F0Text
+          content="Certificates issued for this group only."
+          variant="description"
+        />
+      </F0Box>
+      {certificates.length === 0 ? (
+        <F0Alert
+          variant="info"
+          title="No documents yet"
+          description="Certificates and supporting paperwork will appear here."
+        />
+      ) : (
+        <F0Card title={`Certificates (${certificates.length})`}>
+          <F0Box display="flex" flexDirection="column" gap="sm" padding="lg">
+            {certificates.map((certificate) => (
+              <F0Box
+                key={certificate.id}
+                display="grid"
+                columns="4"
+                gap="md"
+                paddingY="sm"
+                borderTop="default"
+                borderColor="secondary"
+              >
+                <F0Text content={certificate.employeeName} variant="label" />
+                <F0Text content={certificate.fileName} variant="small" />
+                <F0Text content={certificate.uploadedAt.slice(0, 10)} variant="small" />
+                <F0Text content={certificate.status.replace("_", " ")} variant="small" />
+              </F0Box>
+            ))}
+          </F0Box>
+        </F0Card>
+      )}
+    </F0Box>
+  )
+}
+
+function ReadOnlyClassCostsTab({
+  training,
+  klass,
+}: {
+  training: Training
+  klass: TrainingClass
+}) {
+  const splitCount = Math.max(training.classes.length, 1)
+  const directCost = klass.cost ?? currencyFmt.format(Math.round(training.totalCost / splitCount))
+  const salaryCost =
+    klass.salaryCost ?? currencyFmt.format(Math.round(training.totalSalaryCost / splitCount))
+  const indirectCost = klass.indirectCost ?? currencyFmt.format(Math.round(training.totalCost * 0.15))
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="lg">
+      <F0Box display="flex" flexDirection="column" gap="xs">
+        <F0Heading as="h3" variant="heading-large" content="Costs" />
+        <F0Text
+          variant="description"
+          content="Can view access can inspect costs but cannot edit budget values."
+        />
+      </F0Box>
+      <F0Box display="grid" columns="3" gap="md">
+        <ReadOnlyCostCard
+          title="Direct costs"
+          description="Provider, venue and material costs assigned to this group."
+          value={directCost}
+        />
+        <ReadOnlyCostCard
+          title="Indirect costs"
+          description="Administrative costs allocated to this group."
+          value={indirectCost}
+        />
+        <ReadOnlyCostCard
+          title="Salary costs"
+          description="Estimated salary cost of participants attending the group."
+          value={salaryCost}
+        />
+      </F0Box>
+    </F0Box>
+  )
+}
+
+function ReadOnlyCostCard({
+  title,
+  description,
+  value,
+}: {
+  title: string
+  description: string
+  value: string
+}) {
+  return (
+    <F0Card title={title} description={description}>
+      <F0Box padding="lg">
+        <F0Text content={value} variant="body" />
+      </F0Box>
+    </F0Card>
+  )
+}

--- a/packages/f0compose/src/prototypes/training-access-viewer/ReadOnlyTabs.tsx
+++ b/packages/f0compose/src/prototypes/training-access-viewer/ReadOnlyTabs.tsx
@@ -1,0 +1,1255 @@
+import { F0Alert, F0Box, F0Card, F0Heading, F0Select, F0Text } from "@factorialco/f0-react"
+import {
+  OneDataCollection,
+  SectionHeader,
+  useDataCollectionSource,
+  type GroupingDefinition,
+} from "@factorialco/f0-react/dist/experimental"
+import { File as FileIcon, Link as LinkIcon } from "@factorialco/f0-react/icons/app"
+import { useMemo, useState } from "react"
+
+import {
+  answersForTraining,
+  contentModulesForTraining,
+  filesForTraining,
+  participantsForTraining,
+  surveyTemplates,
+  type ContentBlock,
+  type ContentBlockType,
+  type SurveyTemplate,
+  type Training,
+  type TrainingClass,
+  type TrainingFile,
+  type TrainingParticipant,
+} from "@/fixtures"
+import { applySort } from "@/lib/applySort"
+
+import { FormsModals } from "../trainings/detail/FormsModals"
+
+type TrainingTabProps = { training: Training }
+type ReadOnlyClassesTabProps = TrainingTabProps & { baseHref?: string }
+
+type SyllabusItem = {
+  id: string
+  moduleId: string
+  moduleTitle: string
+  blockTitle: string
+  blockType: ContentBlockType
+  estimatedMinutes: number
+  block: ContentBlock
+}
+
+const CONTENT_TYPE_LABEL: Record<ContentBlockType, string> = {
+  page: "Page",
+  video: "Video",
+  quiz: "Quiz",
+  scorm: "SCORM",
+}
+
+const CONTENT_TYPE_ICON: Record<ContentBlockType, string> = {
+  page: "📄",
+  video: "🎬",
+  quiz: "❓",
+  scorm: "📦",
+}
+
+const PARTICIPANT_STATUS_LABEL: Record<string, string> = {
+  completed: "Completed",
+  in_progress: "In progress",
+  not_started: "Not started",
+  expired: "Expired",
+}
+
+const PARTICIPANT_STATUS_VARIANT: Record<
+  string,
+  "positive" | "warning" | "neutral" | "critical"
+> = {
+  completed: "positive",
+  in_progress: "warning",
+  not_started: "neutral",
+  expired: "critical",
+}
+
+const FILE_ICON_BY_TYPE: Record<TrainingFile["type"], string> = {
+  pdf: "📄",
+  video: "🎬",
+  doc: "📝",
+  link: "🔗",
+  image: "🖼️",
+  scorm: "📦",
+}
+
+type FormItem = {
+  id: string
+  title: string
+  status: "draft" | "active"
+  formType: "satisfaction" | "knowledge" | "feedback"
+  answeredCount: number
+  sentCount: number
+  template: SurveyTemplate
+}
+
+const FORM_TYPE_LABEL: Record<FormItem["formType"], string> = {
+  satisfaction: "Satisfaction",
+  knowledge: "Knowledge check",
+  feedback: "Feedback",
+}
+
+function buildForms(training: Training): FormItem[] {
+  const linkedTemplates = surveyTemplates.slice(0, 3)
+  const answers = answersForTraining(training.id)
+
+  return linkedTemplates.map((template, index) => {
+    const templateAnswers = answers.filter(
+      (answer) => answer.templateId === template.id
+    )
+
+    return {
+      id: `form-${template.id}`,
+      title: template.name,
+      status: index === 0 ? "draft" : "active",
+      formType: template.category,
+      answeredCount: templateAnswers.filter(
+        (answer) => answer.status === "submitted"
+      ).length,
+      sentCount: templateAnswers.length,
+      template,
+    }
+  })
+}
+
+type FundaeRow = {
+  id: string
+  fullName: string
+  avatar: string
+  identifier: string
+  email: string
+  phone: string
+  professionalCategory: string
+  educationLevel: string
+  certificate: boolean
+  hasMissingData: boolean
+}
+
+const PROFESSIONAL_CATEGORIES: Record<string, string> = {
+  "emp-001": "Engineering Manager",
+  "emp-002": "Senior Engineer",
+  "emp-003": "Lead Designer",
+  "emp-004": "Engineer",
+  "emp-005": "HR Specialist",
+}
+
+const EDUCATION_LEVELS: Record<string, string> = {
+  "emp-001": "Master",
+  "emp-002": "Bachelor",
+  "emp-003": "Bachelor",
+  "emp-004": "",
+  "emp-005": "Bachelor",
+}
+
+export function ReadOnlyContentTab({ training }: TrainingTabProps) {
+  const modules = contentModulesForTraining(training.id)
+
+  const moduleInfo = useMemo(
+    () =>
+      Object.fromEntries(
+        modules.map((module) => [
+          module.id,
+          { title: module.title, blockCount: module.blocks.length },
+        ])
+      ),
+    [modules]
+  )
+
+  const items: SyllabusItem[] = useMemo(
+    () =>
+      modules.flatMap((module) =>
+        module.blocks.map((block) => ({
+          id: block.id,
+          moduleId: module.id,
+          moduleTitle: module.title,
+          blockTitle: block.title,
+          blockType: block.type,
+          estimatedMinutes: block.estimatedMinutes,
+          block,
+        }))
+      ),
+    [modules]
+  )
+
+  const grouping: GroupingDefinition<SyllabusItem> = {
+    hideSelector: true,
+    collapsible: true,
+    mandatory: true,
+    defaultOpenGroups: true,
+    groupBy: {
+      moduleId: {
+        name: "Module",
+        label: (groupId) => moduleInfo[String(groupId)]?.title ?? String(groupId),
+        itemCount: (groupId) => moduleInfo[String(groupId)]?.blockCount ?? 0,
+      },
+    },
+  }
+
+  const source = useDataCollectionSource<SyllabusItem>(
+    {
+      currentGrouping: { field: "moduleId", order: "asc" },
+      grouping,
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 500,
+        fetchData: () => ({
+          type: "pages" as const,
+          records: items,
+          total: items.length,
+          perPage: 500,
+          currentPage: 1,
+          pagesCount: 1,
+        }),
+      },
+    },
+    [training.id, items]
+  )
+
+  if (modules.length === 0) {
+    return (
+      <F0Alert
+        variant="info"
+        title="No content yet"
+        description="This training has no published content to view."
+      />
+    )
+  }
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="lg">
+      <F0Heading content="Course content" variant="heading" as="h2" />
+      <OneDataCollection
+        id={`training-access-viewer/content-${training.id}/v1`}
+        source={source}
+        visualizations={[
+          {
+            type: "list",
+            options: {
+              itemDefinition: (item: SyllabusItem) => ({
+                title: item.blockTitle,
+                description: [
+                  `${CONTENT_TYPE_LABEL[item.blockType]} • ${item.estimatedMinutes} min`,
+                ],
+                avatar: {
+                  type: "emoji" as const,
+                  emoji: CONTENT_TYPE_ICON[item.blockType],
+                  "aria-label": CONTENT_TYPE_LABEL[item.blockType],
+                },
+              }),
+              fields: [],
+            },
+          },
+        ]}
+      />
+    </F0Box>
+  )
+}
+
+export function ReadOnlyClassesTab({
+  training,
+  baseHref = "/p/training-access-viewer",
+}: ReadOnlyClassesTabProps) {
+  const startDateOptions = Array.from(
+    new Set(
+      training.classes
+        .map((group) => group.startDate)
+        .filter((date): date is string => Boolean(date))
+    )
+  ).map((date) => ({ label: date, value: date }))
+  const endDateOptions = Array.from(
+    new Set(
+      training.classes
+        .map((group) => group.endDate)
+        .filter((date): date is string => Boolean(date))
+    )
+  ).map((date) => ({ label: date, value: date }))
+
+  const source = useDataCollectionSource<TrainingClass>(
+    {
+      search: { enabled: true, sync: true },
+      sortings: {
+        startDate: { label: "Start date" },
+        endDate: { label: "End date" },
+      },
+      itemUrl: (group) => `${baseHref}?training=${training.id}&dtab=groups&class=${group.id}`,
+      defaultSortings: { field: "startDate", order: "asc" },
+      filters: {
+        startDate: {
+          type: "in",
+          label: "Start date",
+          options: { options: startDateOptions },
+        },
+        endDate: {
+          type: "in",
+          label: "End date",
+          options: { options: endDateOptions },
+        },
+      },
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 20,
+        fetchData: ({ search, sortings, filters, pagination }) => {
+          const term = (search ?? "").toLowerCase().trim()
+          const wantedStart = Array.isArray(filters?.startDate)
+            ? (filters.startDate as string[])
+            : []
+          const wantedEnd = Array.isArray(filters?.endDate)
+            ? (filters.endDate as string[])
+            : []
+
+          const filtered = training.classes.filter((group) => {
+            if (term !== "" && !group.name.toLowerCase().includes(term)) return false
+            if (
+              wantedStart.length > 0 &&
+              !wantedStart.includes(group.startDate ?? "")
+            ) {
+              return false
+            }
+            if (wantedEnd.length > 0 && !wantedEnd.includes(group.endDate ?? "")) {
+              return false
+            }
+            return true
+          })
+
+          const sorted = applySort(filtered, sortings, (group, field) => {
+            if (field === "startDate") return group.startDate ?? ""
+            if (field === "endDate") return group.endDate ?? ""
+            return null
+          })
+
+          const perPage = pagination?.perPage ?? 20
+          const currentPage =
+            pagination && "currentPage" in pagination && pagination.currentPage
+              ? pagination.currentPage
+              : 1
+          const total = sorted.length
+          const pagesCount = Math.max(1, Math.ceil(total / perPage))
+          const start = (currentPage - 1) * perPage
+
+          return {
+            type: "pages" as const,
+            records: sorted.slice(start, start + perPage),
+            total,
+            perPage,
+            currentPage,
+            pagesCount,
+          }
+        },
+      },
+    },
+    [training.id]
+  )
+
+  return (
+    <OneDataCollection
+      id={`training-access-viewer/groups-${training.id}/v1`}
+      source={source}
+      emptyStates={{
+        "no-data": {
+          emoji: "👥",
+          title: "No groups yet",
+          description:
+            "Groups will appear here once this training has assigned employees, sessions or costs.",
+        },
+      }}
+      visualizations={[
+        {
+          type: "table",
+          options: {
+            columns: [
+              {
+                label: "Group",
+                render: (group: TrainingClass) => ({
+                  type: "text" as const,
+                  value: group.name,
+                }),
+              },
+              {
+                label: "Start date",
+                sorting: "startDate",
+                render: (group: TrainingClass) => ({
+                  type: "text" as const,
+                  value: group.startDate ?? "-",
+                }),
+              },
+              {
+                label: "End date",
+                sorting: "endDate",
+                render: (group: TrainingClass) => ({
+                  type: "text" as const,
+                  value: group.endDate ?? "-",
+                }),
+              },
+              {
+                label: "Sessions",
+                render: (group: TrainingClass) => ({
+                  type: "text" as const,
+                  value: String(group.sessionCount),
+                }),
+              },
+              {
+                label: "Participants",
+                render: (group: TrainingClass) => ({
+                  type: "avatarList" as const,
+                  value: {
+                    avatarList: group.participants.map((participant) => ({
+                      firstName: participant.firstName,
+                      lastName: participant.lastName,
+                      type: "person" as const,
+                      src: participant.src,
+                    })),
+                    max: 5,
+                  },
+                }),
+              },
+              {
+                label: "Participation rate",
+                render: (group: TrainingClass) => {
+                  const completed = group.completedAttendancesCount
+                  const total = group.totalAttendancesCount
+                  const percentage =
+                    total > 0 ? Number(((completed / total) * 100).toFixed(1)) : 0
+
+                  return {
+                    type: "percentage" as const,
+                    value: { label: `${percentage}%`, percentage },
+                  }
+                },
+              },
+            ],
+          },
+        },
+      ]}
+    />
+  )
+}
+
+export function ReadOnlyParticipantsTab({ training }: TrainingTabProps) {
+  const rows = participantsForTraining(training.id)
+  const source = useParticipantsSource(training, rows)
+
+  return (
+    <OneDataCollection
+      id={`training-access-viewer/participants-${training.id}/v1`}
+      source={source}
+      visualizations={[
+        {
+          type: "table",
+          options: {
+            frozenColumns: 1,
+            allowColumnHiding: true,
+            columns: getParticipantColumns(training),
+          },
+        },
+      ]}
+    />
+  )
+}
+
+function useParticipantsSource(
+  training: Training,
+  rows: TrainingParticipant[]
+) {
+  return useDataCollectionSource<TrainingParticipant>(
+    {
+      search: { enabled: true, sync: true },
+      filters: {
+        status: {
+          type: "in",
+          label: "Status",
+          options: {
+            options: [
+              { value: "completed", label: "Completed" },
+              { value: "in_progress", label: "In progress" },
+              { value: "not_started", label: "Not started" },
+              { value: "expired", label: "Expired" },
+            ],
+          },
+        },
+      },
+      sortings: {
+        fullName: { label: "Employee" },
+        status: { label: "Status" },
+        trainingCompletedAt: { label: "Completion date" },
+        trainingDueDate: { label: "Due date" },
+      },
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 20,
+        fetchData: ({ filters, search, sortings, pagination }) => {
+          const statusFilter = Array.isArray(filters?.status)
+            ? (filters.status as string[])
+            : []
+          const term = (search ?? "").toLowerCase().trim()
+
+          const filtered = rows
+            .filter((row) =>
+              statusFilter.length === 0 ? true : statusFilter.includes(row.status)
+            )
+            .filter((row) =>
+              term === "" ? true : row.employeeName.toLowerCase().includes(term)
+            )
+
+          const sorted = applySort(filtered, sortings, (row, field) => {
+            if (field === "fullName") return row.employeeName.toLowerCase()
+            if (field === "status") return PARTICIPANT_STATUS_LABEL[row.status]
+            if (field === "trainingCompletedAt") return row.completionDate ?? ""
+            if (field === "trainingDueDate") return row.dueDate ?? ""
+            return null
+          })
+
+          const perPage = pagination?.perPage ?? 20
+          const currentPage =
+            pagination && "currentPage" in pagination && pagination.currentPage
+              ? pagination.currentPage
+              : 1
+          const total = sorted.length
+          const pagesCount = Math.max(1, Math.ceil(total / perPage))
+          const start = (currentPage - 1) * perPage
+
+          return {
+            type: "pages" as const,
+            records: sorted.slice(start, start + perPage),
+            total,
+            perPage,
+            currentPage,
+            pagesCount,
+          }
+        },
+      },
+    },
+    [training.id, rows]
+  )
+}
+
+function getParticipantColumns(training: Training) {
+  return [
+    {
+      label: "Employee",
+      sorting: "fullName" as const,
+      render: (row: TrainingParticipant) => ({
+        type: "person" as const,
+        value: {
+          firstName: row.employeeName.split(" ")[0] ?? "",
+          lastName: row.employeeName.split(" ").slice(1).join(" "),
+          src: row.employeeAvatar,
+        },
+      }),
+    },
+    {
+      label: "Status",
+      sorting: "status" as const,
+      render: (row: TrainingParticipant) => ({
+        type: "status" as const,
+        value: {
+          status: PARTICIPANT_STATUS_VARIANT[row.status] ?? "neutral",
+          label: PARTICIPANT_STATUS_LABEL[row.status] ?? row.status,
+        },
+      }),
+    },
+    {
+      label: "Certificate",
+      render: (row: TrainingParticipant) => ({
+        type: "text" as const,
+        value:
+          row.certificateCount === 0
+            ? "-"
+            : row.certificateCount === 1
+              ? "1 file"
+              : `${row.certificateCount} files`,
+      }),
+    },
+    {
+      label: "Completion date",
+      sorting: "trainingCompletedAt" as const,
+      render: (row: TrainingParticipant) => ({
+        type: "text" as const,
+        value: row.completionDate ?? "-",
+      }),
+    },
+    ...(training.courseValidityEnabled
+      ? [
+          {
+            label: "Course validity date",
+            sorting: "trainingDueDate" as const,
+            render: (row: TrainingParticipant) => getDueDateCell(row),
+          },
+        ]
+      : []),
+    ...(training.isSessionsRequired
+      ? [
+          {
+            label: "Session attendance",
+            render: (row: TrainingParticipant) => ({
+              type: "percentage" as const,
+              value: {
+                percentage: row.attendancePercentage,
+                label: `${row.sessionsAttended}/${row.sessionsTotal}`,
+              },
+            }),
+          },
+        ]
+      : []),
+    ...(training.knowledgeTestRequired
+      ? [
+          {
+            label: "Knowledge test",
+            render: (row: TrainingParticipant) => getKnowledgeTestCell(row),
+          },
+        ]
+      : []),
+    ...(training.isModulesRequired
+      ? [
+          {
+            label: "Module progress",
+            render: (row: TrainingParticipant) => {
+              const completed = row.completedModules ?? 0
+              const total = row.totalModules ?? 0
+              const percentage =
+                total > 0 ? Number(((completed / total) * 100).toFixed(1)) : 0
+
+              return {
+                type: "percentage" as const,
+                value: {
+                  percentage,
+                  label: `${completed}/${total}`,
+                },
+              }
+            },
+          },
+        ]
+      : []),
+  ]
+}
+
+function getDueDateCell(row: TrainingParticipant) {
+  if (!row.dueDate) return { type: "text" as const, value: "-" }
+
+  const today = new Date("2026-05-05")
+  const dueDate = new Date(row.dueDate)
+  const isExpired = dueDate < today
+  const isSoon =
+    !isExpired &&
+    (dueDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24) <= 30
+
+  if (isExpired) {
+    return {
+      type: "status" as const,
+      value: { status: "critical" as const, label: row.dueDate },
+    }
+  }
+  if (isSoon) {
+    return {
+      type: "status" as const,
+      value: { status: "warning" as const, label: row.dueDate },
+    }
+  }
+
+  return { type: "text" as const, value: row.dueDate }
+}
+
+function getKnowledgeTestCell(row: TrainingParticipant) {
+  if (row.knowledgeTestPassed === null || row.knowledgeTestPassed === undefined) {
+    return {
+      type: "status" as const,
+      value: { status: "warning" as const, label: "Pending" },
+    }
+  }
+
+  if (row.knowledgeTestPassed) {
+    return {
+      type: "status" as const,
+      value: { status: "positive" as const, label: "Passed" },
+    }
+  }
+
+  return {
+    type: "status" as const,
+    value: { status: "critical" as const, label: "Failed" },
+  }
+}
+
+export function ReadOnlyAttachmentsTab({ training }: TrainingTabProps) {
+  const allFiles = filesForTraining(training.id)
+    .slice()
+    .sort((first, second) => (first.name > second.name ? 1 : -1))
+
+  const source = useFilesSource(training, allFiles)
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="lg">
+      <SectionHeader
+        title="Materials"
+        description="Files and links shared with participants — handbooks, slides, videos, external resources."
+        separator="bottom"
+      />
+      <OneDataCollection
+        id={`training-access-viewer/materials-${training.id}/v1`}
+        source={source}
+        emptyStates={{
+          "no-data": {
+            title: "No materials yet",
+            description: "Materials shared with participants will appear here.",
+          },
+        }}
+        visualizations={[
+          {
+            type: "card",
+            options: {
+              title: (item: TrainingFile) => item.name,
+              description: (item: TrainingFile) =>
+                item.type === "link" ? "" : item.size ?? "",
+              cardProperties: [
+                {
+                  label: "",
+                  icon: LinkIcon,
+                  render: (item: TrainingFile) => {
+                    if (item.type !== "link") return
+                    return { type: "text" as const, value: item.url }
+                  },
+                },
+                {
+                  label: "",
+                  icon: FileIcon,
+                  render: (item: TrainingFile) => {
+                    if (item.type === "link") return
+                    return {
+                      type: "file" as const,
+                      value: { name: item.name, type: item.type },
+                    }
+                  },
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    </F0Box>
+  )
+}
+
+function useFilesSource(training: Training, allFiles: TrainingFile[]) {
+  return useDataCollectionSource<TrainingFile>(
+    {
+      search: { enabled: true, sync: true },
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 20,
+        fetchData: ({ search, pagination }) => {
+          const term = (search ?? "").toLowerCase().trim()
+          const filtered = allFiles.filter((file) =>
+            term === "" ? true : file.name.toLowerCase().includes(term)
+          )
+          const perPage = pagination?.perPage ?? 20
+          const currentPage =
+            pagination && "currentPage" in pagination && pagination.currentPage
+              ? pagination.currentPage
+              : 1
+          const total = filtered.length
+          const pagesCount = Math.max(1, Math.ceil(total / perPage))
+          const start = (currentPage - 1) * perPage
+
+          return {
+            type: "pages" as const,
+            records: filtered.slice(start, start + perPage),
+            total,
+            perPage,
+            currentPage,
+            pagesCount,
+          }
+        },
+      },
+    },
+    [training.id, allFiles]
+  )
+}
+
+export function ReadOnlyDocumentsTab({ training }: TrainingTabProps) {
+  const allFiles = filesForTraining(training.id)
+  const source = useFilesSource(training, allFiles)
+
+  if (allFiles.length === 0) {
+    return (
+      <F0Box display="flex" flexDirection="column" gap="lg">
+        <SectionHeader
+          title="Documents"
+          description="Files visible to admins and HR — internal paperwork, attendance sheets, signed agreements."
+          separator="bottom"
+        />
+        <F0Alert
+          variant="info"
+          title="No documents yet"
+          description="Training-related paperwork will appear here."
+        />
+      </F0Box>
+    )
+  }
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="lg">
+      <SectionHeader
+        title="Documents"
+        description="Files visible to admins and HR — internal paperwork, attendance sheets, signed agreements."
+        separator="bottom"
+      />
+      <OneDataCollection
+        id={`training-access-viewer/documents-${training.id}/v1`}
+        source={source}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              frozenColumns: 1,
+              allowColumnHiding: true,
+              columns: [
+                {
+                  label: "Name",
+                  render: (file: TrainingFile) => ({
+                    type: "text" as const,
+                    value: `${FILE_ICON_BY_TYPE[file.type] ?? "📄"}  ${file.name}`,
+                  }),
+                },
+                {
+                  label: "Size",
+                  render: (file: TrainingFile) => ({
+                    type: "text" as const,
+                    value: file.size ?? "-",
+                  }),
+                },
+                {
+                  label: "Uploaded",
+                  render: (file: TrainingFile) => ({
+                    type: "text" as const,
+                    value: file.uploadedAt.slice(0, 10),
+                  }),
+                },
+                {
+                  label: "Uploaded by",
+                  render: (file: TrainingFile) => ({
+                    type: "text" as const,
+                    value: file.uploadedBy,
+                  }),
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    </F0Box>
+  )
+}
+
+export function ReadOnlyFormsTab({ training }: TrainingTabProps) {
+  const allForms = buildForms(training)
+  const [selectedTemplate, setSelectedTemplate] = useState<SurveyTemplate | null>(null)
+  const source = useFormsSource(training, allForms, setSelectedTemplate)
+
+  return (
+    <>
+      <OneDataCollection
+        id={`training-access-viewer/all_forms-${training.id}/v1`}
+        source={source}
+        emptyStates={{
+          "no-data": {
+            emoji: "📋",
+            title: "No surveys yet",
+            description: "Surveys linked to this training will appear here.",
+          },
+        }}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              frozenColumns: 1,
+              columns: [
+                {
+                  label: "Name",
+                  render: (item: FormItem) => ({
+                    type: "text" as const,
+                    value: item.title,
+                  }),
+                },
+                {
+                  label: "Status",
+                  render: (item: FormItem) => ({
+                    type: "status" as const,
+                    value: {
+                      label: item.status === "draft" ? "Draft" : "Published",
+                      status: item.status === "draft" ? "neutral" : "positive",
+                    },
+                  }),
+                },
+                {
+                  label: "Type",
+                  render: (item: FormItem) => ({
+                    type: "text" as const,
+                    value: FORM_TYPE_LABEL[item.formType],
+                  }),
+                },
+                {
+                  label: "Participation rate",
+                  render: (item: FormItem) => {
+                    const percentage =
+                      item.sentCount > 0
+                        ? Number(((item.answeredCount / item.sentCount) * 100).toFixed(1))
+                        : 0
+
+                    return {
+                      type: "percentage" as const,
+                      value: { label: `${percentage}%`, percentage },
+                    }
+                  },
+                },
+              ],
+            },
+          },
+        ]}
+      />
+      <FormsModals
+        action={selectedTemplate ? "preview-template" : null}
+        training={training}
+        template={selectedTemplate}
+        answer={null}
+        onClose={() => setSelectedTemplate(null)}
+      />
+    </>
+  )
+}
+
+function useFormsSource(
+  training: Training,
+  allForms: FormItem[],
+  setSelectedTemplate: (template: SurveyTemplate) => void
+) {
+  return useDataCollectionSource<FormItem>(
+    {
+      search: { enabled: true, sync: true },
+      filters: {
+        status: {
+          type: "in",
+          label: "Status",
+          options: {
+            options: [
+              { label: "Draft", value: "draft" },
+              { label: "Active", value: "active" },
+            ],
+          },
+        },
+      },
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 20,
+        fetchData: ({ search, filters, pagination }) => {
+          const term = (search ?? "").toLowerCase().trim()
+          const wantedStatus = Array.isArray(filters?.status)
+            ? (filters.status as FormItem["status"][])
+            : []
+
+          const filtered = allForms.filter((form) => {
+            if (term !== "" && !form.title.toLowerCase().includes(term)) return false
+            if (wantedStatus.length > 0 && !wantedStatus.includes(form.status)) {
+              return false
+            }
+            return true
+          })
+
+          const perPage = pagination?.perPage ?? 20
+          const currentPage =
+            pagination && "currentPage" in pagination && pagination.currentPage
+              ? pagination.currentPage
+              : 1
+          const total = filtered.length
+          const pagesCount = Math.max(1, Math.ceil(total / perPage))
+          const start = (currentPage - 1) * perPage
+
+          return {
+            type: "pages" as const,
+            records: filtered.slice(start, start + perPage),
+            total,
+            perPage,
+            currentPage,
+            pagesCount,
+          }
+        },
+      },
+      itemOnClick: (item) => () => setSelectedTemplate(item.template),
+    },
+    [training.id, allForms, setSelectedTemplate]
+  )
+}
+
+export function ReadOnlyFundaeTab({ training }: TrainingTabProps) {
+  if (!training.fundaeSubsidized) {
+    return (
+      <F0Box display="flex" flexDirection="column" gap="lg" padding="xl">
+        <F0Alert
+          variant="warning"
+          title="This training is not marked as Fundae-bonifiable"
+          description="Fundae information will appear here when it is enabled for this training."
+        />
+      </F0Box>
+    )
+  }
+
+  if (training.classes.length === 0) {
+    return (
+      <F0Alert
+        variant="info"
+        title="No groups yet for this training"
+        description="Fundae details will appear once a group exists for this training."
+      />
+    )
+  }
+
+  return <ReadOnlyFundaeDashboard training={training} />
+}
+
+function ReadOnlyFundaeDashboard({ training }: TrainingTabProps) {
+  const classes = training.classes
+  const [selectedClassId, setSelectedClassId] = useState(classes[0]?.id ?? "")
+  const selectedClass = classes.find((group) => group.id === selectedClassId)
+
+  if (!selectedClass) return null
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="xl">
+      <SectionHeader
+        separator="bottom"
+        title="Finalise training group (Fundae)"
+        description="Review the Fundae data prepared for the selected training group."
+        link={{
+          href: "https://empresas.fundae.es/Lanzadera",
+          label: "Open Fundae portal",
+        }}
+      />
+      <F0Box display="flex" flexDirection="column" gap="2xl">
+        <F0Box maxWidth="md">
+          <F0Select
+            label="Training group"
+            placeholder="Select a group"
+            value={selectedClassId}
+            onChange={(value: string) => setSelectedClassId(value)}
+            options={classes.map((group) => ({ value: group.id, label: group.name }))}
+          />
+        </F0Box>
+        <F0Alert
+          variant="info"
+          title="Can view access is read-only"
+          description="You can inspect Fundae setup and participant data, but exporting XML or editing costs requires edit access."
+        />
+        <F0Card title="Group details">
+          <F0Box display="grid" columns="2" gap="lg" padding="lg">
+            <ReadOnlyField
+              label="Group code"
+              value={selectedClass.fundaeConfig?.codigoGrupo ?? "-"}
+            />
+            <ReadOnlyField label="Course code" value={training.codigoCurso ?? "-"} />
+            <ReadOnlyField label="Direct costs (€)" value={selectedClass.cost ?? "-"} />
+            <ReadOnlyField
+              label="Indirect costs (€)"
+              value={selectedClass.indirectCost ?? "-"}
+            />
+            <ReadOnlyField
+              label="Salary costs (€)"
+              value={selectedClass.salaryCost ?? "-"}
+            />
+          </F0Box>
+        </F0Card>
+        <ReadOnlyFundaeParticipantsTable
+          trainingClass={selectedClass}
+          trainingId={training.id}
+        />
+      </F0Box>
+    </F0Box>
+  )
+}
+
+function ReadOnlyField({ label, value }: { label: string; value: string }) {
+  return (
+    <F0Box
+      display="flex"
+      flexDirection="column"
+      gap="xs"
+      padding="md"
+      border="default"
+      borderColor="secondary"
+      borderRadius="md"
+    >
+      <F0Text content={label} variant="label" />
+      <F0Text content={value} variant="body" />
+    </F0Box>
+  )
+}
+
+function ReadOnlyFundaeParticipantsTable({
+  trainingClass,
+  trainingId,
+}: {
+  trainingClass: TrainingClass
+  trainingId: string
+}) {
+  const rows = useMemo(
+    () => buildRowsForClass(trainingId, trainingClass),
+    [trainingClass.id, trainingId]
+  )
+
+  const source = useDataCollectionSource<FundaeRow>(
+    {
+      search: { enabled: true, sync: true },
+      filters: {
+        missingData: {
+          type: "in",
+          label: "Missing data",
+          options: {
+            options: [
+              { value: "missing", label: "Missing data" },
+              { value: "complete", label: "Complete" },
+            ],
+          },
+        },
+      },
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 20,
+        fetchData: ({ search, filters, pagination }) => {
+          const term = (search ?? "").toLowerCase().trim()
+          const missingFilter = (filters?.missingData ?? []) as string[]
+          const filtered = rows.filter((row) => {
+            const matchesSearch =
+              term === "" ||
+              row.fullName.toLowerCase().includes(term) ||
+              row.identifier.toLowerCase().includes(term)
+            const matchesMissing =
+              missingFilter.length === 0 ||
+              (missingFilter.includes("missing") && row.hasMissingData) ||
+              (missingFilter.includes("complete") && !row.hasMissingData)
+            return matchesSearch && matchesMissing
+          })
+          const perPage = pagination?.perPage ?? 20
+          const currentPage =
+            pagination && "currentPage" in pagination && pagination.currentPage
+              ? pagination.currentPage
+              : 1
+          const total = filtered.length
+          const pagesCount = Math.max(1, Math.ceil(total / perPage))
+          const start = (currentPage - 1) * perPage
+
+          return {
+            type: "pages" as const,
+            records: filtered.slice(start, start + perPage),
+            total,
+            perPage,
+            currentPage,
+            pagesCount,
+          }
+        },
+      },
+    },
+    [trainingClass.id, trainingId, rows]
+  )
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="md">
+      <F0Heading as="h3" variant="heading" content="Participants" />
+      <OneDataCollection
+        id={`training-access-viewer/fundae-${trainingId}-${trainingClass.id}/v1`}
+        source={source}
+        emptyStates={{
+          "no-data": {
+            title: "No participants in this group",
+            description: "Participants assigned to this group will appear here.",
+          },
+        }}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              columns: [
+                {
+                  label: "Participant",
+                  render: (row: FundaeRow) => ({
+                    type: "person" as const,
+                    value: {
+                      firstName: row.fullName.split(" ")[0] ?? row.fullName,
+                      lastName: row.fullName.split(" ").slice(1).join(" "),
+                      src: row.avatar,
+                    },
+                  }),
+                },
+                {
+                  label: "NIF / NIE",
+                  render: (row: FundaeRow) => row.identifier || "-",
+                },
+                {
+                  label: "Phone",
+                  render: (row: FundaeRow) => row.phone || "Missing",
+                },
+                {
+                  label: "Professional category",
+                  render: (row: FundaeRow) => row.professionalCategory || "Missing",
+                },
+                {
+                  label: "Education level",
+                  render: (row: FundaeRow) => row.educationLevel || "Missing",
+                },
+                {
+                  label: "Diploma",
+                  render: (row: FundaeRow) => (row.certificate ? "Yes" : "No"),
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    </F0Box>
+  )
+}
+
+function buildRowsForClass(
+  trainingId: string,
+  trainingClass: TrainingClass
+): FundaeRow[] {
+  const allParticipants = participantsForTraining(trainingId)
+  const participantsInClass = allParticipants.filter(
+    (participant) =>
+      participant.classId === trainingClass.id || participant.classId === null
+  )
+
+  return participantsInClass.map((participant, index) =>
+    mapParticipantToFundaeRow(participant, index)
+  )
+}
+
+function mapParticipantToFundaeRow(
+  participant: TrainingParticipant,
+  index: number
+): FundaeRow {
+  const nifNumber = String(10000000 + index * 1234567).slice(0, 8)
+  const nifLetter = "TRWAGMYFPDXBNJZSQVHLCKE"[
+    Number(nifNumber) % 23
+  ] as string
+  const missingPhone = index % 3 === 0
+  const missingCategory = index % 4 === 1
+  const missingEducation = (EDUCATION_LEVELS[participant.employeeId] ?? "") === ""
+
+  return {
+    id: participant.id,
+    fullName: participant.employeeName,
+    avatar: participant.employeeAvatar,
+    identifier: `${nifNumber}${nifLetter}`,
+    email: `${participant.employeeName.toLowerCase().replace(/\s+/g, ".")}@example.com`,
+    phone: missingPhone ? "" : `+34 6${String(10000000 + index * 31).slice(-8)}`,
+    professionalCategory: missingCategory
+      ? ""
+      : PROFESSIONAL_CATEGORIES[participant.employeeId] ?? "Specialist",
+    educationLevel: EDUCATION_LEVELS[participant.employeeId] ?? "",
+    certificate: participant.certificateCount > 0,
+    hasMissingData: missingPhone || missingCategory || missingEducation,
+  }
+}

--- a/packages/f0compose/src/prototypes/training-access-viewer/TrainingAccessViewer.tsx
+++ b/packages/f0compose/src/prototypes/training-access-viewer/TrainingAccessViewer.tsx
@@ -1,0 +1,429 @@
+import { F0Text } from "@factorialco/f0-react"
+import {
+  OneDataCollection,
+  Page,
+  PageHeader,
+  ResourceHeader,
+  Tabs,
+  useDataCollectionSource,
+} from "@factorialco/f0-react/dist/experimental"
+import { Link } from "@factorialco/f0-react/icons/app"
+import { useState } from "react"
+import { useSearchParams } from "react-router-dom"
+
+import { type Training, findTraining, trainings } from "@/fixtures"
+import { applySort } from "@/lib/applySort"
+
+import { OverviewTab } from "../trainings/detail/OverviewTab"
+import { PageContent } from "../trainings/_shared/PageContent"
+import { type DetailTabId, detailTabs } from "../trainings/tabs"
+import type { PrototypeMeta } from "../types"
+import {
+  ReadOnlyAttachmentsTab,
+  ReadOnlyClassesTab,
+  ReadOnlyContentTab,
+  ReadOnlyDocumentsTab,
+  ReadOnlyFormsTab,
+  ReadOnlyFundaeTab,
+  ReadOnlyParticipantsTab,
+} from "./ReadOnlyTabs"
+import { ReadOnlyClassDetail } from "./ReadOnlyClassDetail"
+
+export const meta: PrototypeMeta = {
+  slug: "training-access-viewer",
+  title: "Training access viewer",
+  description: "Viewer experience for a course shared with Can view access.",
+  category: "Talent",
+  module: "trainings",
+  audience: ["employee", "manager"],
+  tags: ["trainings", "permissions", "sharing", "viewer"],
+  createdAt: "2026-05-25",
+}
+
+const BASE_HREF = "/p/training-access-viewer"
+const VIEWER_TRAINING_IDS = new Set(["trn-002", "trn-004"])
+const ROLE_TRAINING_IDS = {
+  editor: new Set(["trn-001", "trn-003"]),
+  viewer: VIEWER_TRAINING_IDS,
+}
+const viewerTrainings = trainings.filter((item) => VIEWER_TRAINING_IDS.has(item.id))
+const VALID_TABS = new Set<string>(detailTabs.map((tab) => tab.id))
+
+function getTotalDuration(training: Training) {
+  const totalMinutes = training.totalDuration * 60
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = Math.round(totalMinutes % 60)
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+}
+
+export default function TrainingAccessViewer() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [isCopyLinkCopied, setIsCopyLinkCopied] = useState(false)
+  const trainingId = searchParams.get("training")
+  const rawTab = searchParams.get("dtab")
+  const classId = searchParams.get("class")
+  const requestedTraining = trainingId ? findTraining(trainingId) : undefined
+  const selectedTraining = requestedTraining
+    ? viewerTrainings.find((item) => item.id === requestedTraining.id)
+    : classId
+      ? viewerTrainings.find((item) =>
+          item.classes.some((klass) => klass.id === classId)
+        )
+      : undefined
+  const activeTab: DetailTabId =
+    rawTab && VALID_TABS.has(rawTab) ? (rawTab as DetailTabId) : "overview"
+
+  if (!selectedTraining) {
+    return <RoleCoursesList accessRole="viewer" baseHref={BASE_HREF} />
+  }
+
+  const training = selectedTraining
+  const trainingHref = `${BASE_HREF}?training=${training.id}`
+
+  const tabsWithNav = detailTabs.map((tab) => ({
+    ...tab,
+    onClick: () => {
+      const next = new URLSearchParams(searchParams)
+      next.set("dtab", tab.id)
+      setSearchParams(next)
+    },
+  }))
+
+  const handleCopyLink = () => {
+    setIsCopyLinkCopied(true)
+    void navigator.clipboard?.writeText(window.location.href).catch(() => {})
+    window.setTimeout(() => setIsCopyLinkCopied(false), 4000)
+  }
+
+  if (classId) {
+    return (
+      <ReadOnlyClassDetail
+        training={training}
+        classId={classId}
+        baseHref={BASE_HREF}
+        trainingHref={trainingHref}
+      />
+    )
+  }
+
+  return (
+    <>
+      <Page
+        header={
+          <>
+            <PageHeader
+              module={{ id: "company_trainings", name: "Trainings", href: BASE_HREF }}
+              breadcrumbs={[
+                { id: "courses", label: "Courses", href: BASE_HREF },
+                { id: training.id, label: training.name },
+              ]}
+            />
+            <ResourceHeader
+            title={training.name}
+            metadata={[
+              {
+                label: "Access",
+                value: {
+                  type: "status",
+                  label: "Can view",
+                  variant: "info",
+                },
+              },
+              {
+                label: "Type",
+                value: {
+                  type: "text",
+                  content: training.type === "internal" ? "Internal" : "External",
+                },
+              },
+              ...(training.totalDuration
+                ? [
+                    {
+                      label: "Total duration",
+                      value: {
+                        type: "text" as const,
+                        content: getTotalDuration(training),
+                      },
+                    },
+                  ]
+                : []),
+              ...(training.groupNames.length > 0
+                ? [
+                    {
+                      label: "Training groups",
+                      value: {
+                        type: "data-list" as const,
+                        data: training.groupNames,
+                      },
+                    },
+                  ]
+                : []),
+              ...(training.participantAvatars.length > 0
+                ? [
+                    {
+                      label: "",
+                      value: {
+                        type: "list" as const,
+                        variant: "person" as const,
+                        avatars: training.participantAvatars.map((avatar) => ({
+                          ...avatar,
+                          type: "person" as const,
+                        })),
+                      },
+                    },
+                  ]
+                : []),
+              ...(training.instructorAvatars.length > 0
+                ? [
+                    {
+                      label: "Instructor(s)",
+                      value: {
+                        type: "list" as const,
+                        variant: "person" as const,
+                        avatars: training.instructorAvatars.map((avatar) => ({
+                          ...avatar,
+                          type: "person" as const,
+                        })),
+                      },
+                    },
+                  ]
+                : []),
+              ...(training.publishedAsFreeCourse
+                ? [
+                    {
+                      label: "",
+                      value: {
+                        type: "status" as const,
+                        label: "Published as free course",
+                        variant: "positive" as const,
+                      },
+                    },
+                  ]
+                : []),
+              ]}
+              status={{ label: "", text: "Published", variant: "positive" }}
+              secondaryActions={[
+                {
+                  label: "Copy link",
+                  icon: Link,
+                  onClick: handleCopyLink,
+                  tooltip: "Copy link",
+                  hideLabel: true,
+                },
+              ]}
+            />
+            <Tabs key={activeTab} tabs={tabsWithNav} activeTabId={activeTab} />
+          </>
+        }
+      >
+        <PageContent>
+          {activeTab === "overview" && <OverviewTab training={training} />}
+          {activeTab === "content" && <ReadOnlyContentTab training={training} />}
+          {activeTab === "groups" && (
+            <ReadOnlyClassesTab training={training} baseHref={BASE_HREF} />
+          )}
+          {activeTab === "participants" && (
+            <ReadOnlyParticipantsTab training={training} />
+          )}
+          {activeTab === "attachments" && (
+            <ReadOnlyAttachmentsTab training={training} />
+          )}
+          {activeTab === "documents" && <ReadOnlyDocumentsTab training={training} />}
+          {activeTab === "surveys" && <ReadOnlyFormsTab training={training} />}
+          {activeTab === "fundae" && <ReadOnlyFundaeTab training={training} />}
+        </PageContent>
+      </Page>
+      {isCopyLinkCopied && <LinkCopiedTooltip />}
+    </>
+  )
+}
+
+function LinkCopiedTooltip() {
+  return (
+    <div
+      role="status"
+      className="fixed right-6 top-28 z-[9999] rounded-md bg-f1-background-inverse px-3 py-2 shadow-lg"
+      style={{ position: "fixed", right: 24, top: 112, zIndex: 9999 }}
+    >
+      <F0Text content="Link copied" variant="inverse" />
+    </div>
+  )
+}
+
+type AccessRole = "editor" | "viewer"
+
+function RoleCoursesList({
+  accessRole,
+  baseHref,
+}: {
+  accessRole: AccessRole
+  baseHref: string
+}) {
+  const rows = trainings.filter((training) => ROLE_TRAINING_IDS[accessRole].has(training.id))
+  const source = useDataCollectionSource<Training>(
+    {
+      search: { enabled: true, sync: true },
+      presets: [
+        {
+          label:
+            accessRole === "editor"
+              ? "Trainings I can edit"
+              : "Trainings I can view",
+          filter: {},
+        },
+      ],
+      filters: {
+        status: {
+          type: "in",
+          label: "Status",
+          options: {
+            options: [
+              { value: "active", label: "Published" },
+              { value: "draft", label: "Draft" },
+            ],
+          },
+        },
+      },
+      sortings: {
+        name: { label: "Name" },
+        year: { label: "Year" },
+      },
+      dataAdapter: {
+        paginationType: "pages",
+        perPage: 20,
+        fetchData: ({ filters, search, sortings, pagination }) => {
+          const statusFilter = Array.isArray(filters?.status)
+            ? (filters.status as string[])
+            : []
+          const term = (search ?? "").toLowerCase().trim()
+          const filtered = rows
+            .filter((training) =>
+              statusFilter.length === 0
+                ? true
+                : statusFilter.includes(training.status)
+            )
+            .filter((training) =>
+              term === "" ? true : training.name.toLowerCase().includes(term)
+            )
+          const sorted = applySort(filtered, sortings, (training, field) => {
+            if (field === "name") return training.name.toLowerCase()
+            if (field === "year") return training.year
+            return null
+          })
+          const perPage = pagination?.perPage ?? 20
+          const currentPage =
+            pagination && "currentPage" in pagination && pagination.currentPage
+              ? pagination.currentPage
+              : 1
+          const total = sorted.length
+          const pagesCount = Math.max(1, Math.ceil(total / perPage))
+          const start = (currentPage - 1) * perPage
+
+          return {
+            type: "pages" as const,
+            records: sorted.slice(start, start + perPage),
+            total,
+            perPage,
+            currentPage,
+            pagesCount,
+          }
+        },
+      },
+      itemUrl: (training) => `${baseHref}?training=${training.id}`,
+    },
+    [accessRole, baseHref]
+  )
+
+  const accessLabel = accessRole === "editor" ? "Can edit" : "Can view"
+  const accessStatus = accessRole === "editor" ? "warning" : "info"
+
+  return (
+    <Page
+      header={
+        <>
+          <PageHeader
+            module={{ id: "company_trainings", name: "Trainings", href: baseHref }}
+            breadcrumbs={[{ id: "courses", label: "Courses" }]}
+          />
+          <ResourceHeader
+            title="Courses"
+            description={
+              accessRole === "editor"
+                ? "Courses shared with you as Can edit."
+                : "Courses shared with you as Can view."
+            }
+            metadata={[
+              {
+                label: "Access",
+                value: {
+                  type: "status",
+                  label: accessLabel,
+                  variant: accessStatus,
+                },
+              },
+            ]}
+          />
+        </>
+      }
+    >
+      <PageContent>
+        <OneDataCollection
+          id={`training-access-${accessRole}/courses/v1`}
+          source={source}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                frozenColumns: 1,
+                columns: [
+                  {
+                    label: "Name",
+                    sorting: "name",
+                    render: (training) => ({
+                      type: "text" as const,
+                      value: training.name,
+                    }),
+                  },
+                  {
+                    label: "Access",
+                    render: () => ({
+                      type: "status" as const,
+                      value: {
+                        status: accessStatus,
+                        label: accessLabel,
+                      },
+                    }),
+                  },
+                  {
+                    label: "Status",
+                    render: (training) => ({
+                      type: "status" as const,
+                      value: {
+                        status: training.status === "active" ? "positive" : "neutral",
+                        label: training.status === "active" ? "Published" : "Draft",
+                      },
+                    }),
+                  },
+                  {
+                    label: "Participants",
+                    render: (training) => ({
+                      type: "number" as const,
+                      value: training.participantCount,
+                    }),
+                  },
+                  {
+                    label: "Groups",
+                    render: (training) => ({
+                      type: "text" as const,
+                      value: String(training.classes.length),
+                    }),
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      </PageContent>
+    </Page>
+  )
+}


### PR DESCRIPTION
## Description

Add Training permissions prototypes for the three review roles:

- Admin / Owner: `/p/training-access-admin`
- Can edit: `/p/training-access-editor`
- Can view: `/p/training-access-viewer`

This is intentionally scoped to new `training-access-*` prototype files so the PR does not modify shared Trainings prototype modules.

## Screenshots (if applicable)

Vercel preview will be attached by the PR checks.

## Implementation details

- Added standalone Admin, Editor, and Viewer prototype entries.
- Added local shared editable/read-only training detail pieces used only by these role prototypes.
- Kept Instructor and advanced permission matrix questions out of this V1 prototype scope.

## Review map

- Admin / Owner: full course and group management surface.
- Can edit: editable learning flow without owner/admin-only actions.
- Can view: read-only learning flow with utility actions only.

## Verification

- `pnpm check "src/prototypes/training-access-admin"`
- `pnpm check "src/prototypes/training-access-editor"`
- `pnpm check "src/prototypes/training-access-viewer"`
- `pnpm --filter @factorialco/f0compose exec tsc --noEmit`

## Skills

- f0-prototype
- f0-design
- factorial-pr
- factorial-skill-tracking