### PR TITLE
feat: add graph visualization to OneDataCollection

### DIFF
--- a/packages/react/src/experimental/exports.ts
+++ b/packages/react/src/experimental/exports.ts
@@ -24,6 +24,7 @@ export * from "../kits/Charts/exports"
  */
 export * from "../components/F0ActionBar"
 export * from "./F0VersionHistory"
+export * from "../patterns/F0Graph"
 export * from "./Forms/exports"
 export * from "./Information/exports"
 export * from "./Lists/DetailsItem"

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -141,6 +141,7 @@ export const defaultTranslations = {
       card: "Card view",
       list: "List view",
       kanban: "Kanban view",
+      graph: "Graph view",
       pagination: {
         of: "of",
       },

--- a/packages/react/src/patterns/F0Graph/F0Graph.css
+++ b/packages/react/src/patterns/F0Graph/F0Graph.css
@@ -1,3 +1,9 @@
+/* Bundle React Flow's base stylesheet so consumers of @factorialco/f0-react
+ * don't need to add a separate `import "@xyflow/react/dist/style.css"` in
+ * their app entry. Without these styles F0Graph mounts but renders with
+ * zero size. */
+@import "@xyflow/react/dist/style.css";
+
 /* Cursor overrides for F0Graph.
  * React Flow uses BEM class names (e.g. .react-flow__pane) which contain
  * double underscores that Tailwind's arbitrary-variant syntax converts to

--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -13,6 +13,8 @@ import {
   TEAMS_MOCK,
 } from "@/mocks"
 import { SummariesDefinition } from "@/patterns/OneDataCollection/summary.ts"
+import type { F0GraphNodeRenderContext } from "@/patterns/F0Graph"
+import { F0GraphNode } from "@/patterns/F0Graph/F0GraphNode"
 export { generateMockUsers, type MockUser }
 
 import {
@@ -953,6 +955,39 @@ export const getMockVisualizations = (options?: {
               return sourceRecord
             }
           : undefined,
+      },
+    },
+    graph: {
+      type: "graph",
+      options: {
+        nodeAdapter: (_item) => ({
+          parentId: null,
+        }),
+        renderNode: (item, ctx: F0GraphNodeRenderContext) => {
+          const [firstName = "", lastName = ""] = item.name.split(" ")
+
+          return (
+            <F0GraphNode
+              variant={ctx.variant}
+              state={ctx.state}
+              expanded={ctx.expanded}
+              hasChildren={ctx.hasChildren}
+              childrenCount={ctx.childrenCount}
+              level={ctx.level}
+              tabIndex={ctx.tabIndex}
+              setSize={ctx.setSize}
+              posInSet={ctx.posInSet}
+              nodeId={ctx.nodeId}
+              ariaOwns={ctx.ariaOwns}
+              onExpandToggle={ctx.onExpandToggle}
+              onClick={ctx.onClick}
+              nodeRef={ctx.nodeRef}
+              avatar={{ type: "person", firstName, lastName }}
+              title={item.name}
+              subtitle={item.role}
+            />
+          )
+        },
       },
     },
   }) as const

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx
@@ -170,44 +170,66 @@ export const GraphCollection = <
   }, [paginationInfo?.total, records])
 
   /**
-   * Stable identity (dev-only): warn once when the same record key appears at
-   * a different array index between renders. Re-keying causes F0Graph to
-   * remount node DOM and lose expand/selection state. (PLAN §4.3.)
+   * Dev-only stable-identity warning (PLAN §4.3). If `nodeAdapter`,
+   * `edgeAdapter`, or `renderNode` changes identity 6+ times within 1 second
+   * of mount, fire ONE `console.warn` per prop so consumers notice they
+   * forgot to `useCallback`/`useMemo` before it surfaces as a perf bug.
+   * Production builds skip the check entirely.
    */
-  const previousIdentityRef = useRef<Map<string, number>>(new Map())
+  const identityCountsRef = useRef<
+    Map<
+      string,
+      { count: number; first: number; prev: unknown; warned: boolean }
+    >
+  >(new Map())
   useEffect(() => {
     if (!isDev) return
-    const idProvider = source.idProvider
-    const current = new Map<string, number>()
-    records.forEach((record, index) => {
-      const key = getRecordKey(
-        record,
-        index,
-        idProvider as unknown as
-          | ((item: Record, index: number) => string | number)
-          | undefined
-      )
-      current.set(key, index)
-    })
-    const previous = previousIdentityRef.current
-    if (previous.size > 0) {
-      for (const [key, index] of current) {
-        const prev = previous.get(key)
-        if (prev !== undefined && prev !== index) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `Graph visualization: record key "${key}" moved from index ${prev} to ${index}. ` +
-              "Provide a stable `source.selectable` (idProvider) so F0Graph can preserve node identity across renders."
-          )
-          break
-        }
+    const entries: Array<[string, unknown]> = [
+      ["nodeAdapter", nodeAdapter],
+      ["edgeAdapter", edgeAdapter],
+      ["renderNode", renderNode],
+    ]
+    const now = Date.now()
+    const tracked = identityCountsRef.current
+    for (const [name, value] of entries) {
+      if (value === undefined) continue
+      const entry = tracked.get(name)
+      if (!entry) {
+        tracked.set(name, {
+          count: 1,
+          first: now,
+          prev: value,
+          warned: false,
+        })
+        continue
+      }
+      if (entry.prev === value) continue
+      // Reset the window if more than 1s has elapsed since the first change.
+      if (now - entry.first > 1000) {
+        entry.count = 1
+        entry.first = now
+        entry.prev = value
+        entry.warned = false
+        continue
+      }
+      entry.count += 1
+      entry.prev = value
+      if (entry.count >= 6 && !entry.warned) {
+        entry.warned = true
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Graph visualization: \`${name}\` identity changed ${entry.count} times within 1s. ` +
+            "Wrap it in `useCallback`/`useMemo` so F0Graph can keep node identity stable across renders."
+        )
       }
     }
-    previousIdentityRef.current = current
-  }, [records, isDev, source.idProvider])
+  }, [nodeAdapter, edgeAdapter, renderNode, isDev])
 
   // Project records → F0Graph topology. matchedIds left undefined in Phase 1
-  // (no usePerVisualizationFilters integration yet).
+  // (no usePerVisualizationFilters integration yet). Adapters and idProvider
+  // are included as deps so a deliberate identity change (e.g. a new
+  // edgeAdapter) re-projects; consumers are expected to memoize per PLAN §4.3
+  // — the dev-mode identity warning above flags missed memoization.
   const projection = useMemo(() => {
     return projectGraph<Record>({
       records,
@@ -217,8 +239,7 @@ export const GraphCollection = <
         | ((item: Record, index: number) => string | number)
         | undefined,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- adapters are consumer-supplied; re-run on records only
-  }, [records])
+  }, [records, nodeAdapter, edgeAdapter, source.idProvider])
 
   const cycleWarnedRef = useRef<string>("")
   useEffect(() => {
@@ -233,10 +254,29 @@ export const GraphCollection = <
     )
   }, [projection.cycles, isDev])
 
+  const duplicateWarnedRef = useRef<string>("")
+  useEffect(() => {
+    if (!isDev) return
+    if (projection.duplicates.length === 0) return
+    const signature = projection.duplicates.slice().sort().join("|")
+    if (signature === duplicateWarnedRef.current) return
+    duplicateWarnedRef.current = signature
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Graph visualization: duplicate record keys dropped from projection: ${projection.duplicates.join(", ")}. ` +
+        "Records must produce unique ids via `source.idProvider`/`item.id`; duplicates after the first occurrence are skipped."
+    )
+  }, [projection.duplicates, isDev])
+
   /**
    * Selection bridge — F0Graph emits string ids, DataCollection expects the
    * full record (PLAN §4.4). Lookup is by projected node id so it works even
    * when `source.selectable` is omitted (we fall back to `item.id`/index).
+   *
+   * Lazy mode forces `allPagesSelection: true` because ids returned by
+   * `loadChildren` never enter `data.records`; without this flag,
+   * `useSelectable` filters `selectedIds` to the current page and drops every
+   * lazy id from the `onSelectItems` payload silently.
    */
   const { selectedItems, handleSelectItemChange } = useSelectable<
     Record,
@@ -250,13 +290,14 @@ export const GraphCollection = <
     onSelectItems,
     selectionMode: "multi",
     selectedState: source.defaultSelectedItems,
+    allPagesSelection: isLazyMode ? true : undefined,
   })
 
   /**
-   * Lazy record cache — records returned by `loadChildren` never enter
-   * `projection.nodes`, so we stash them here so the selection bridge can
-   * resolve their record back from a node id when the user toggles selection
-   * on a lazy-loaded node.
+   * Monotonic cache of records returned by `loadChildren` — never evicted in
+   * Phase 1; revisit if memory becomes a concern under deeply nested lazy
+   * graphs. The selection bridge needs this so it can resolve a lazy id back
+   * to its record when the user toggles selection on a lazy-loaded node.
    */
   const lazyRecordsRef = useRef<Map<string, Record>>(new Map())
 
@@ -274,14 +315,25 @@ export const GraphCollection = <
     return ids
   }, [selectedItems])
 
+  const missingSelectionWarnedRef = useRef<Set<string>>(new Set())
   const handleNodeSelect = useCallback(
     (nodeId: string, selected: boolean) => {
       const record =
         recordById.get(nodeId) ?? lazyRecordsRef.current.get(nodeId)
-      if (!record) return
+      if (!record) {
+        if (isDev && !missingSelectionWarnedRef.current.has(nodeId)) {
+          missingSelectionWarnedRef.current.add(nodeId)
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Graph visualization: ignored selection toggle for node "${nodeId}" because no matching record was found. ` +
+              "This usually means the node was projected from a lazy load that has since been collapsed."
+          )
+        }
+        return
+      }
       handleSelectItemChange(record, selected)
     },
-    [recordById, handleSelectItemChange]
+    [recordById, handleSelectItemChange, isDev]
   )
 
   /**
@@ -312,9 +364,12 @@ export const GraphCollection = <
   /**
    * Lazy loader wrapper — per-node AbortController, single in-flight loader
    * per nodeId. On unmount, every controller is aborted; results that arrive
-   * after the abort are dropped silently. Records that survive are projected
-   * with the same `nodeAdapter` + `getRecordKey` pipeline as the eager path
-   * and cached in `lazyRecordsRef` for the selection bridge.
+   * after the abort are dropped silently. The controller's `signal` is also
+   * forwarded to the consumer's `loadChildren` so the underlying request
+   * (e.g. `fetch`) can be cancelled at the network layer. Records that
+   * survive are projected with the same `nodeAdapter` + `getRecordKey`
+   * pipeline as the eager path and cached in `lazyRecordsRef` for the
+   * selection bridge.
    */
   const abortControllersRef = useRef<Map<string, AbortController>>(new Map())
   const idProviderForLazy = source.idProvider as unknown as
@@ -329,7 +384,9 @@ export const GraphCollection = <
       const controller = new AbortController()
       abortControllersRef.current.set(nodeId, controller)
       try {
-        const children = await loadChildren(nodeId)
+        const children = await loadChildren(nodeId, {
+          signal: controller.signal,
+        })
         if (controller.signal.aborted) return []
         const projected: GraphNode<Record>[] = []
         children.forEach((child, index) => {
@@ -391,7 +448,9 @@ export const GraphCollection = <
           selectionMode={source.selectable ? "multi" : "none"}
           selectedNodes={selectedNodes}
           onNodeSelect={handleNodeSelect}
-          searchValue={source.currentSearch}
+          searchValue={
+            source.debouncedCurrentSearch ?? source.currentSearch ?? undefined
+          }
           onSearchChange={handleSearchChange}
         />
       ) : (
@@ -404,7 +463,9 @@ export const GraphCollection = <
           selectionMode={source.selectable ? "multi" : "none"}
           selectedNodes={selectedNodes}
           onNodeSelect={handleNodeSelect}
-          searchValue={source.currentSearch}
+          searchValue={
+            source.debouncedCurrentSearch ?? source.currentSearch ?? undefined
+          }
           onSearchChange={handleSearchChange}
         />
       )}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx
@@ -23,6 +23,7 @@ import type {
   SortingsDefinition,
 } from "@/hooks/datasource"
 import { useSelectable } from "@/hooks/datasource/useSelectable/useSelectable"
+import { useI18n } from "@/lib/providers/i18n"
 import { useIsDev } from "@/lib/providers/user-platafform"
 
 import {
@@ -53,6 +54,9 @@ export const LAZY_REQUIRES_PAGINATION_MESSAGE =
 export const GROUPING_NOT_SUPPORTED_MESSAGE =
   "Graph visualization does not support `grouping`. Remove `source.currentGrouping` or switch to a different visualization."
 
+export const GROUPING_NOT_SUPPORTED_FALLBACK_MESSAGE =
+  "Graph visualization is unavailable for grouped data. Remove grouping to continue."
+
 /**
  * Build a dropdown trigger from `source.itemActions(record)` for use in
  * `F0GraphNode.actions`. Returns `null` when there are no actions to render.
@@ -61,7 +65,8 @@ export const GROUPING_NOT_SUPPORTED_MESSAGE =
  */
 function buildItemActionsSlot<R extends RecordType>(
   record: R,
-  itemActions: ItemActionsDefinition<R> | undefined
+  itemActions: ItemActionsDefinition<R> | undefined,
+  actionsLabel: string
 ): ReactNode {
   if (!itemActions) return null
   const actions = filterItemActions(itemActions, record)
@@ -81,7 +86,7 @@ function buildItemActionsSlot<R extends RecordType>(
         size="sm"
         variant="ghost"
         icon={EllipsisHorizontal}
-        label="Actions"
+        label={actionsLabel}
         hideLabel
       />
     </Dropdown>
@@ -117,11 +122,14 @@ export const GraphCollection = <
   Grouping
 >) => {
   const isDev = useIsDev()
+  const i18n = useI18n()
   const autoGraphId = useId()
   const graphId = graphIdProp ?? autoGraphId
 
   // Guard 1: grouping is unsupported (mirror Kanban).
   if (source.currentGrouping && isDev) {
+    // eslint-disable-next-line no-console
+    console.error(GROUPING_NOT_SUPPORTED_MESSAGE)
     throw new Error(GROUPING_NOT_SUPPORTED_MESSAGE)
   }
 
@@ -152,6 +160,25 @@ export const GraphCollection = <
       onLoadError(error)
     },
   })
+
+  const hasUnsupportedDataShape =
+    data?.type !== undefined && data.type !== "flat"
+  const hasGroupingMisuse =
+    Boolean(source.currentGrouping) || hasUnsupportedDataShape
+
+  const groupingMisuseWarnedRef = useRef<string>("")
+  useEffect(() => {
+    if (!hasGroupingMisuse) return
+
+    const signature = `${source.currentGrouping ? "grouping" : "non-flat"}:${data?.type ?? "unknown"}`
+    if (groupingMisuseWarnedRef.current === signature) return
+    groupingMisuseWarnedRef.current = signature
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `Graph visualization cannot render grouped/non-flat data (${data?.type ?? "unknown"}). ${GROUPING_NOT_SUPPORTED_MESSAGE}`
+    )
+  }, [hasGroupingMisuse, source.currentGrouping, data?.type])
 
   const records = useMemo<ReadonlyArray<Record>>(() => {
     if (!data) return []
@@ -350,7 +377,8 @@ export const GraphCollection = <
     (node: GraphNode<Record>, ctx: F0GraphNodeRenderContext): ReactNode => {
       const actionsSlot = buildItemActionsSlot<Record>(
         node.data,
-        source.itemActions as ItemActionsDefinition<Record> | undefined
+        source.itemActions as ItemActionsDefinition<Record> | undefined,
+        i18n.collections.actions.actions
       )
       // PLAN §3 deviation flagged to user: signature extends consumer's
       // renderNode with a third `extras` arg carrying { actions } so the
@@ -358,7 +386,7 @@ export const GraphCollection = <
       // GraphCollection inspecting/cloning the returned ReactNode.
       return renderNode(node.data, ctx, { actions: actionsSlot })
     },
-    [renderNode, source.itemActions]
+    [renderNode, source.itemActions, i18n.collections.actions.actions]
   )
 
   /**
@@ -432,6 +460,16 @@ export const GraphCollection = <
     return (
       <div className="flex h-full min-h-0 flex-1 items-center justify-center">
         <div aria-label="Loading graph" role="status" />
+      </div>
+    )
+  }
+
+  if (hasGroupingMisuse) {
+    return (
+      <div className="flex h-full min-h-0 flex-1 items-center justify-center px-4 text-center">
+        <p className="text-sm text-f1-foreground-secondary" role="alert">
+          {GROUPING_NOT_SUPPORTED_FALLBACK_MESSAGE}
+        </p>
       </div>
     )
   }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx
@@ -1,0 +1,413 @@
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+} from "react"
+
+import { Dropdown, type DropdownItem } from "@/experimental/Navigation/Dropdown"
+import { F0Button } from "@/components/F0Button"
+import { EllipsisHorizontal } from "@/icons/app"
+import {
+  F0Graph,
+  type F0GraphNodeRenderContext,
+  type GraphEdge,
+  type GraphNode,
+} from "@/patterns/F0Graph"
+import type { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
+import type {
+  GroupingDefinition,
+  RecordType,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+import { useSelectable } from "@/hooks/datasource/useSelectable/useSelectable"
+import { useIsDev } from "@/lib/providers/user-platafform"
+
+import {
+  filterItemActions,
+  type ItemActionsDefinition,
+} from "../../../item-actions"
+import type { NavigationFiltersDefinition } from "../../../navigationFilters/types"
+import type { SummariesDefinition } from "../../../summary"
+import { useDataCollectionData } from "../../../hooks/useDataCollectionData/useDataCollectionData"
+
+import { getRecordKey, projectGraph } from "./projectGraph"
+import type { GraphCollectionProps } from "./types"
+
+/**
+ * Dev-only guard messages.
+ *
+ * Eager mode (no `loadChildren`) requires a non-paginated source — we pull the
+ * full graph in one fetch and hand it to F0Graph in one shot. Lazy mode
+ * (`loadChildren` provided) requires the inverse, because paginated sources
+ * are the contract that signals "the dataset is fetched in slices".
+ */
+const EAGER_REQUIRES_NO_PAGINATION_MESSAGE =
+  'Graph visualization in eager mode requires a non-paginated data source (paginationType: "no-pagination" or omitted). Either set paginationType: "no-pagination" on the source, or provide a `loadChildren` option to use lazy mode.'
+
+const LAZY_REQUIRES_PAGINATION_MESSAGE =
+  'Graph visualization: `loadChildren` requires a paginated data source (paginationType: "pages" or "infinite-scroll"). Either remove `loadChildren` to use eager mode, or switch the source to a paginated adapter.'
+
+const GROUPING_NOT_SUPPORTED_MESSAGE =
+  "Graph visualization does not support `grouping`. Remove `source.currentGrouping` or switch to a different visualization."
+
+/**
+ * Build a dropdown trigger from `source.itemActions(record)` for use in
+ * `F0GraphNode.actions`. Returns `null` when there are no actions to render.
+ *
+ * Phase 1 fallback for `detailPanel` (PLAN §4.5).
+ */
+function buildItemActionsSlot<R extends RecordType>(
+  record: R,
+  itemActions: ItemActionsDefinition<R> | undefined
+): ReactNode {
+  if (!itemActions) return null
+  const actions = filterItemActions(itemActions, record)
+  if (actions.length === 0) return null
+  const items: DropdownItem[] = actions.map((action) => {
+    if ("type" in action && action.type === "separator") {
+      return action as unknown as DropdownItem
+    }
+    return {
+      type: "item" as const,
+      ...action,
+    } as unknown as DropdownItem
+  })
+  return (
+    <Dropdown items={items}>
+      <F0Button
+        size="sm"
+        variant="ghost"
+        icon={EllipsisHorizontal}
+        label="Actions"
+        hideLabel
+      />
+    </Dropdown>
+  )
+}
+
+export const GraphCollection = <
+  Record extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Summaries extends SummariesDefinition,
+  ItemActions extends ItemActionsDefinition<Record>,
+  NavigationFilters extends NavigationFiltersDefinition,
+  Grouping extends GroupingDefinition<Record>,
+>({
+  graphId: graphIdProp,
+  nodeAdapter,
+  edgeAdapter,
+  renderNode,
+  loadChildren,
+  graphProps,
+  source,
+  onSelectItems,
+  onLoadData,
+  onLoadError,
+}: GraphCollectionProps<
+  Record,
+  Filters,
+  Sortings,
+  Summaries,
+  ItemActions,
+  NavigationFilters,
+  Grouping
+>) => {
+  const isDev = useIsDev()
+  const autoGraphId = useId()
+  const graphId = graphIdProp ?? autoGraphId
+
+  // Guard 1: grouping is unsupported (mirror Kanban).
+  if (source.currentGrouping && isDev) {
+    throw new Error(GROUPING_NOT_SUPPORTED_MESSAGE)
+  }
+
+  // Guard 2: pagination must match the chosen mode. We normalize the adapter
+  // value so undefined and "no-pagination" are equivalent (matches the
+  // useDataSource normalization). PLAN §4.1.
+  const effectivePagination =
+    source.dataAdapter.paginationType ?? "no-pagination"
+  const isLazyMode = loadChildren !== undefined
+  if (isDev) {
+    if (isLazyMode && effectivePagination === "no-pagination") {
+      throw new Error(LAZY_REQUIRES_PAGINATION_MESSAGE)
+    }
+    if (!isLazyMode && effectivePagination !== "no-pagination") {
+      throw new Error(EAGER_REQUIRES_NO_PAGINATION_MESSAGE)
+    }
+  }
+
+  const { data, paginationInfo, isInitialLoading } = useDataCollectionData<
+    Record,
+    Filters,
+    Sortings,
+    Summaries,
+    NavigationFilters,
+    Grouping
+  >(source, {
+    onError: (error) => {
+      onLoadError(error)
+    },
+  })
+
+  const records = useMemo<ReadonlyArray<Record>>(() => {
+    if (!data) return []
+    return data.type === "flat" ? data.records : []
+  }, [data])
+
+  useEffect(() => {
+    onLoadData({
+      totalItems: paginationInfo?.total || records.length,
+      filters: source.currentFilters,
+      search: source.currentSearch,
+      isInitialLoading,
+      data: [...records],
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mirror Card: only re-run on data change
+  }, [paginationInfo?.total, records])
+
+  /**
+   * Stable identity (dev-only): warn once when the same record key appears at
+   * a different array index between renders. Re-keying causes F0Graph to
+   * remount node DOM and lose expand/selection state. (PLAN §4.3.)
+   */
+  const previousIdentityRef = useRef<Map<string, number>>(new Map())
+  useEffect(() => {
+    if (!isDev) return
+    const idProvider = source.idProvider
+    const current = new Map<string, number>()
+    records.forEach((record, index) => {
+      const key = getRecordKey(
+        record,
+        index,
+        idProvider as unknown as
+          | ((item: Record, index: number) => string | number)
+          | undefined
+      )
+      current.set(key, index)
+    })
+    const previous = previousIdentityRef.current
+    if (previous.size > 0) {
+      for (const [key, index] of current) {
+        const prev = previous.get(key)
+        if (prev !== undefined && prev !== index) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Graph visualization: record key "${key}" moved from index ${prev} to ${index}. ` +
+              "Provide a stable `source.selectable` (idProvider) so F0Graph can preserve node identity across renders."
+          )
+          break
+        }
+      }
+    }
+    previousIdentityRef.current = current
+  }, [records, isDev, source.idProvider])
+
+  // Project records → F0Graph topology. matchedIds left undefined in Phase 1
+  // (no usePerVisualizationFilters integration yet).
+  const projection = useMemo(() => {
+    return projectGraph<Record>({
+      records,
+      nodeAdapter,
+      edgeAdapter,
+      idProvider: source.idProvider as unknown as
+        | ((item: Record, index: number) => string | number)
+        | undefined,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- adapters are consumer-supplied; re-run on records only
+  }, [records])
+
+  const cycleWarnedRef = useRef<string>("")
+  useEffect(() => {
+    if (!isDev) return
+    if (projection.cycles.length === 0) return
+    const signature = projection.cycles.slice().sort().join("|")
+    if (signature === cycleWarnedRef.current) return
+    cycleWarnedRef.current = signature
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Graph visualization: cycle detected in parent linkage for keys: ${projection.cycles.join(", ")}. Offending edges dropped to keep the graph acyclic.`
+    )
+  }, [projection.cycles, isDev])
+
+  /**
+   * Selection bridge — F0Graph emits string ids, DataCollection expects the
+   * full record (PLAN §4.4). Lookup is by projected node id so it works even
+   * when `source.selectable` is omitted (we fall back to `item.id`/index).
+   */
+  const { selectedItems, handleSelectItemChange } = useSelectable<
+    Record,
+    Filters,
+    Sortings,
+    Grouping
+  >({
+    data,
+    paginationInfo,
+    source,
+    onSelectItems,
+    selectionMode: "multi",
+    selectedState: source.defaultSelectedItems,
+  })
+
+  /**
+   * Lazy record cache — records returned by `loadChildren` never enter
+   * `projection.nodes`, so we stash them here so the selection bridge can
+   * resolve their record back from a node id when the user toggles selection
+   * on a lazy-loaded node.
+   */
+  const lazyRecordsRef = useRef<Map<string, Record>>(new Map())
+
+  const recordById = useMemo(() => {
+    const m = new Map<string, Record>()
+    for (const node of projection.nodes) m.set(node.id, node.data)
+    return m
+  }, [projection.nodes])
+
+  const selectedNodes = useMemo<Set<string>>(() => {
+    // Surface every selected id F0Graph might draw — eager projection AND
+    // lazy-loaded children — so the checked state survives expand/collapse.
+    const ids = new Set<string>()
+    for (const id of selectedItems.keys()) ids.add(String(id))
+    return ids
+  }, [selectedItems])
+
+  const handleNodeSelect = useCallback(
+    (nodeId: string, selected: boolean) => {
+      const record =
+        recordById.get(nodeId) ?? lazyRecordsRef.current.get(nodeId)
+      if (!record) return
+      handleSelectItemChange(record, selected)
+    },
+    [recordById, handleSelectItemChange]
+  )
+
+  /**
+   * Search — pipe F0Graph's search input straight into the data source.
+   */
+  const handleSearchChange = useCallback(
+    (value: string | undefined) => {
+      source.setCurrentSearch(value)
+    },
+    [source]
+  )
+
+  const renderNodeWrapped = useCallback(
+    (node: GraphNode<Record>, ctx: F0GraphNodeRenderContext): ReactNode => {
+      const actionsSlot = buildItemActionsSlot<Record>(
+        node.data,
+        source.itemActions as ItemActionsDefinition<Record> | undefined
+      )
+      // PLAN §3 deviation flagged to user: signature extends consumer's
+      // renderNode with a third `extras` arg carrying { actions } so the
+      // item-actions fallback can flow through F0GraphNode.actions without
+      // GraphCollection inspecting/cloning the returned ReactNode.
+      return renderNode(node.data, ctx, { actions: actionsSlot })
+    },
+    [renderNode, source.itemActions]
+  )
+
+  /**
+   * Lazy loader wrapper — per-node AbortController, single in-flight loader
+   * per nodeId. On unmount, every controller is aborted; results that arrive
+   * after the abort are dropped silently. Records that survive are projected
+   * with the same `nodeAdapter` + `getRecordKey` pipeline as the eager path
+   * and cached in `lazyRecordsRef` for the selection bridge.
+   */
+  const abortControllersRef = useRef<Map<string, AbortController>>(new Map())
+  const idProviderForLazy = source.idProvider as unknown as
+    | ((item: Record, index: number) => string | number)
+    | undefined
+
+  const wrappedLoadChildren = useCallback(
+    async (nodeId: string): Promise<GraphNode<Record>[]> => {
+      if (!loadChildren) return []
+      const existing = abortControllersRef.current.get(nodeId)
+      existing?.abort()
+      const controller = new AbortController()
+      abortControllersRef.current.set(nodeId, controller)
+      try {
+        const children = await loadChildren(nodeId)
+        if (controller.signal.aborted) return []
+        const projected: GraphNode<Record>[] = []
+        children.forEach((child, index) => {
+          const key = getRecordKey(child, index, idProviderForLazy)
+          const linkage = nodeAdapter(child)
+          lazyRecordsRef.current.set(key, child)
+          const node: GraphNode<Record> = {
+            id: key,
+            parentId: linkage.parentId ?? nodeId,
+            data: child,
+          }
+          if (linkage.parentIds && linkage.parentIds.length > 0) {
+            node.parentIds = linkage.parentIds
+          }
+          if (linkage.childrenCount !== undefined) {
+            node.childrenCount = linkage.childrenCount
+          }
+          if (linkage.childrenLoaded !== undefined) {
+            node.childrenLoaded = linkage.childrenLoaded
+          }
+          projected.push(node)
+        })
+        return projected
+      } finally {
+        const current = abortControllersRef.current.get(nodeId)
+        if (current === controller) {
+          abortControllersRef.current.delete(nodeId)
+        }
+      }
+    },
+    [loadChildren, nodeAdapter, idProviderForLazy]
+  )
+
+  useEffect(() => {
+    const controllers = abortControllersRef.current
+    return () => {
+      for (const c of controllers.values()) c.abort()
+      controllers.clear()
+    }
+  }, [])
+
+  if (isInitialLoading) {
+    return (
+      <div className="flex h-full min-h-0 flex-1 items-center justify-center">
+        <div aria-label="Loading graph" role="status" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      {isLazyMode ? (
+        <F0Graph<Record>
+          {...graphProps}
+          graphId={graphId}
+          rootNodes={projection.nodes as GraphNode<Record>[]}
+          loadChildren={wrappedLoadChildren}
+          renderNode={renderNodeWrapped}
+          selectionMode={source.selectable ? "multi" : "none"}
+          selectedNodes={selectedNodes}
+          onNodeSelect={handleNodeSelect}
+          searchValue={source.currentSearch}
+          onSearchChange={handleSearchChange}
+        />
+      ) : (
+        <F0Graph<Record>
+          {...graphProps}
+          graphId={graphId}
+          nodes={projection.nodes as GraphNode<Record>[]}
+          edges={projection.edges as GraphEdge[]}
+          renderNode={renderNodeWrapped}
+          selectionMode={source.selectable ? "multi" : "none"}
+          selectedNodes={selectedNodes}
+          onNodeSelect={handleNodeSelect}
+          searchValue={source.currentSearch}
+          onSearchChange={handleSearchChange}
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx
@@ -44,13 +44,13 @@ import type { GraphCollectionProps } from "./types"
  * (`loadChildren` provided) requires the inverse, because paginated sources
  * are the contract that signals "the dataset is fetched in slices".
  */
-const EAGER_REQUIRES_NO_PAGINATION_MESSAGE =
+export const EAGER_REQUIRES_NO_PAGINATION_MESSAGE =
   'Graph visualization in eager mode requires a non-paginated data source (paginationType: "no-pagination" or omitted). Either set paginationType: "no-pagination" on the source, or provide a `loadChildren` option to use lazy mode.'
 
-const LAZY_REQUIRES_PAGINATION_MESSAGE =
+export const LAZY_REQUIRES_PAGINATION_MESSAGE =
   'Graph visualization: `loadChildren` requires a paginated data source (paginationType: "pages" or "infinite-scroll"). Either remove `loadChildren` to use eager mode, or switch the source to a paginated adapter.'
 
-const GROUPING_NOT_SUPPORTED_MESSAGE =
+export const GROUPING_NOT_SUPPORTED_MESSAGE =
   "Graph visualization does not support `grouping`. Remove `source.currentGrouping` or switch to a different visualization."
 
 /**

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx
@@ -107,6 +107,8 @@ export const GraphCollection = <
   edgeAdapter,
   renderNode,
   loadChildren,
+  onLoadChildrenError,
+  rootSelector,
   graphProps,
   source,
   onSelectItems,
@@ -185,6 +187,25 @@ export const GraphCollection = <
     return data.type === "flat" ? data.records : []
   }, [data])
 
+  // Apply the (intentionally unmemoized-deps) rootSelector to narrow the
+  // record set before projection. In lazy mode this picks the rows that
+  // become F0Graph's `rootNodes`; in eager mode it's equivalent to filtering
+  // the source upstream of GraphCollection. We deliberately hold the
+  // selector via a ref so identity churn on the function never re-runs the
+  // expensive projection — the contract on `GraphVisualizationOptions`
+  // requires the selector to be referentially stable.
+  const rootSelectorRef = useRef(rootSelector)
+  useEffect(() => {
+    rootSelectorRef.current = rootSelector
+  }, [rootSelector])
+
+  const selectedRecords = useMemo<ReadonlyArray<Record>>(() => {
+    const select = rootSelectorRef.current
+    if (!select) return records
+    const next = select(records)
+    return next === records ? records : next
+  }, [records])
+
   useEffect(() => {
     onLoadData({
       totalItems: paginationInfo?.total || records.length,
@@ -259,14 +280,15 @@ export const GraphCollection = <
   // — the dev-mode identity warning above flags missed memoization.
   const projection = useMemo(() => {
     return projectGraph<Record>({
-      records,
+      records: selectedRecords,
       nodeAdapter,
       edgeAdapter,
       idProvider: source.idProvider as unknown as
         | ((item: Record, index: number) => string | number)
         | undefined,
+      strictDuplicates: isDev,
     })
-  }, [records, nodeAdapter, edgeAdapter, source.idProvider])
+  }, [selectedRecords, nodeAdapter, edgeAdapter, source.idProvider, isDev])
 
   const cycleWarnedRef = useRef<string>("")
   useEffect(() => {
@@ -321,10 +343,13 @@ export const GraphCollection = <
   })
 
   /**
-   * Monotonic cache of records returned by `loadChildren` — never evicted in
-   * Phase 1; revisit if memory becomes a concern under deeply nested lazy
-   * graphs. The selection bridge needs this so it can resolve a lazy id back
-   * to its record when the user toggles selection on a lazy-loaded node.
+   * Monotonic cache of records returned by `loadChildren`. We deliberately do
+   * NOT evict on collapse because F0Graph's `useLazyTree` keeps its own copy
+   * of loaded children across collapse/re-expand cycles, so re-expanding a
+   * collapsed node does NOT call `loadChildren` again — evicting here would
+   * silently break selection on previously-loaded lazy descendants. The cache
+   * grows monotonically per mount and is reclaimed on unmount with the
+   * component.
    */
   const lazyRecordsRef = useRef<Map<string, Record>>(new Map())
 
@@ -358,9 +383,19 @@ export const GraphCollection = <
         }
         return
       }
+      // Honour per-record selectability — `source.selectable(record)` returning
+      // `undefined` means "this record may not be selected". F0Graph has no
+      // `unselectableNodes` API so the visual checkbox may still flicker on
+      // click, but useSelectable never observes the change.
+      if (
+        source.selectable !== undefined &&
+        source.selectable(record) === undefined
+      ) {
+        return
+      }
       handleSelectItemChange(record, selected)
     },
-    [recordById, handleSelectItemChange, isDev]
+    [recordById, handleSelectItemChange, isDev, source]
   )
 
   /**
@@ -438,6 +473,23 @@ export const GraphCollection = <
           projected.push(node)
         })
         return projected
+      } catch (err) {
+        // Aborts are intentional collapses/unmounts — never surfaced.
+        const isAbort =
+          controller.signal.aborted ||
+          (err instanceof DOMException && err.name === "AbortError") ||
+          (err instanceof Error && err.name === "AbortError")
+        if (isAbort) return []
+        if (onLoadChildrenError) {
+          onLoadChildrenError(err, nodeId)
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(
+            `Graph visualization: \`loadChildren\` rejected for node "${nodeId}".`,
+            err
+          )
+        }
+        return []
       } finally {
         const current = abortControllersRef.current.get(nodeId)
         if (current === controller) {
@@ -445,7 +497,7 @@ export const GraphCollection = <
         }
       }
     },
-    [loadChildren, nodeAdapter, idProviderForLazy]
+    [loadChildren, nodeAdapter, idProviderForLazy, onLoadChildrenError]
   )
 
   useEffect(() => {
@@ -474,37 +526,35 @@ export const GraphCollection = <
     )
   }
 
+  // Props shared between the lazy and eager F0Graph branches. The branches
+  // only differ in the data inlet (`rootNodes` + `loadChildren` vs
+  // `nodes` + `edges`); everything else flows through here so consumers can't
+  // accidentally desync the two code paths.
+  const commonGraphProps = {
+    ...graphProps,
+    graphId,
+    renderNode: renderNodeWrapped,
+    selectionMode: (source.selectable ? "multi" : "none") as "multi" | "none",
+    selectedNodes,
+    onNodeSelect: handleNodeSelect,
+    searchValue:
+      source.debouncedCurrentSearch ?? source.currentSearch ?? undefined,
+    onSearchChange: handleSearchChange,
+  }
+
   return (
-    <div className="flex h-full min-h-0 flex-1 flex-col">
+    <div className="flex h-full min-h-[400px] flex-1 flex-col">
       {isLazyMode ? (
         <F0Graph<Record>
-          {...graphProps}
-          graphId={graphId}
+          {...commonGraphProps}
           rootNodes={projection.nodes as GraphNode<Record>[]}
           loadChildren={wrappedLoadChildren}
-          renderNode={renderNodeWrapped}
-          selectionMode={source.selectable ? "multi" : "none"}
-          selectedNodes={selectedNodes}
-          onNodeSelect={handleNodeSelect}
-          searchValue={
-            source.debouncedCurrentSearch ?? source.currentSearch ?? undefined
-          }
-          onSearchChange={handleSearchChange}
         />
       ) : (
         <F0Graph<Record>
-          {...graphProps}
-          graphId={graphId}
+          {...commonGraphProps}
           nodes={projection.nodes as GraphNode<Record>[]}
           edges={projection.edges as GraphEdge[]}
-          renderNode={renderNodeWrapped}
-          selectionMode={source.selectable ? "multi" : "none"}
-          selectedNodes={selectedNodes}
-          onNodeSelect={handleNodeSelect}
-          searchValue={
-            source.debouncedCurrentSearch ?? source.currentSearch ?? undefined
-          }
-          onSearchChange={handleSearchChange}
         />
       )}
     </div>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md
@@ -1,0 +1,512 @@
+# Graph visualization for `OneDataCollection`
+
+> **Status:** Plan approved. Open questions resolved (see §1.5). Phase 1 is unblocked; Phase 2 depends on the upstream F0Graph `dimmedNodes` PR (see §1.6). No production code is to be written from this document — implementation lands in the PRs described in §8.
+
+Branch: `feat/f0-datacollection-graph-view`
+Base SHA: `efa9795a3decf2627bbe248f5f2421ec876a900a`
+
+---
+
+## 1. Goal & non-goals
+
+### Goal
+Add a first-class `type: "graph"` visualization to `OneDataCollection` that renders the collection's records as an interactive tree/DAG using the existing `F0Graph` runtime, so that any consumer with an already-defined `DataCollectionSource` can opt into a graph view without leaving the collection abstraction (filters, search, presets, settings, persistence, item-actions, selection).
+
+Concretely, after this work a consumer can write:
+
+```tsx
+<OneDataCollection
+  source={source}
+  visualizations={[
+    { type: "table", options: { columns: [...] } },
+    {
+      type: "graph",
+      options: {
+        nodeAdapter: (record) => ({ parentId: record.managerId }),
+        renderNode: (record, ctx) => <F0GraphNode {...ctx} title={record.name} />,
+      },
+    },
+  ]}
+/>
+```
+
+…and the visualization picker shows a Graph entry, switching to it loads the same `source`, projects records into `GraphNode<R>[]`, and renders an interactive F0Graph wired into the collection's selection, item-actions, search, and persistence.
+
+### Non-goals
+- **No new layout engines.** We use F0Graph's built-in tree layout. DAG layout via custom `layoutEngine` is a consumer escape hatch, not something this view ships.
+- **No new graph primitives.** Anything not exposed by `F0Graph`/`F0GraphNode`/`F0GraphEdge` today is out of scope. If the view needs it, the gap is recorded in §10 or §1.6.
+- **No data-fetching changes.** The view consumes whatever `dataAdapter` already produces — same paginated/grouped contract every other visualization uses. No new adapter type.
+- **No grouping support in v1.** Graph topology IS the grouping. `source.currentGrouping` is rejected with a dev-only throw, matching the precedent set by Kanban (`Grouping is not supported in Kanban yet`).
+- **No multi-select bulk-actions in v1.** Selection is mirrored to F0Graph but only `"single"` selectionMode is wired to `OneDataCollection`'s `onSelectItems`. Multi-select is a follow-up.
+- **No editing.** Read-only view. Item-actions menu is supported through the per-node detail panel handoff (and as a fallback through `F0GraphNode.actions`), but inline editing (à la `editableTable`) is out of scope.
+- **No infinite scroll / pagination UI.** Graphs are inherently spatial, not paginated. We fetch the full first page; lazy-loading children is delegated to F0Graph's `rootNodes` + `loadChildren` (see §4).
+
+---
+
+## 1.5 Resolved decisions
+
+The questions originally tracked in §7 are settled. The plan below reflects these answers — they are reproduced here so reviewers can see the rationale in one place.
+
+- **Q1 — Pagination handling (eager mode).** Eager mode **requires** `source.paginationType === "no-pagination"`. Lazy mode (via `loadChildren`) is permitted on paginated sources — the first page is consumed as roots and `loadChildren` resolves children on demand. **Dev-only invariant:** if `loadChildren` is provided AND `paginationType !== "no-pagination"`, that is the only valid combination; if `loadChildren` is provided AND `paginationType === "no-pagination"`, throw (`"Graph visualization: loadChildren requires a paginated source. Remove loadChildren, or set paginationType to a paginated value."`). If `loadChildren` is absent AND the source is paginated, throw (`"Graph visualization in eager mode requires a non-paginated source. Either set paginationType: 'no-pagination' on the source, or provide a loadChildren option to use lazy mode."`). Both checks run in `GraphCollection` immediately after `useDataCollectionData` is wired so consumers see the error on first render. No silent multi-page fetches, no `maxRecords` option.
+- **Q2 — Selection bridge fidelity.** v1 ships `selectionMode="single"` only. Selection state lives on the `source` via `useSelectable` (see `packages/react/src/hooks/datasource/useSelectable/useSelectable.ts`), so selection survives view switches automatically — no per-visualization mirror. Multi-select on a spatial canvas is deferred to a dedicated follow-up (see §10) because "select all" semantics and the bulk-actions footer placement need UX design first.
+- **Q3 — Icon choice.** Use the existing `Graph` glyph from `@/icons/app` (`packages/react/src/icons/app/Graph.tsx`). Verified present. If design later produces a dedicated tree/hierarchy variant we swap (see §10).
+- **Q4 — Performance budget.** No published envelope ships in Phase 1. Phase 2 includes a perf smoke test against 1k and 2k node mocks; the supported envelope is published with that PR.
+- **Q5 — Filter behavior (Phase 1 hard removal; Phase 2 dim).** F0Graph's existing `state="dimmed"` prop is purely visual in the `dot` zoom variant and is indistinguishable from `default` in `compact`/`detail`. There is no `dimmedNodes` prop on F0Graph today. **Phase 1 ships hard removal:** records that do not match the active per-view filter are omitted from `nodes`, and any edges incident on a removed node are omitted from `edges`. No orphan promotion; subtree of a removed parent is also removed (consistent with hard removal). **Phase 2 ships dim** once the upstream F0Graph PR (see §1.6) adds a real `dimmedNodes?: Set<string>` prop that styles `dot`/`compact`/`detail` and incident edges; `GraphCollection` will switch to passing the filtered-out IDs through that prop, preserving tree structure.
+- **Q6 — TypeScript union depth.** Mirror the existing registry cast pattern (`as VisualizacionTypeDefinition<...>`) used by Table/Kanban/List. No new tech debt introduced; no API change.
+- **Q7 — `graphId` derivation.** The public `GraphVisualizationOptions` exposes an explicit `graphId?: string` field. **Default: `React.useId()` generated inside `GraphCollection`** — each instance gets a unique, stable-per-mount identifier, so two graph visualizations mounted in the same app never collide on persisted state by accident. Consumers can still pass an explicit `graphId` to override (e.g. for cross-session persistence keyed to a known domain entity like `'org-chart'`). One caveat: refactoring the component tree may change the `useId()` output, which resets the persisted detail-panel width — cosmetic, recoverable, no data loss.
+
+---
+
+## 1.6 Dependencies
+
+- **Upstream F0Graph PR — `dimmedNodes` prop.** Phase 2's dim behavior depends on a separate PR against `patterns/F0Graph` that adds `dimmedNodes?: Set<string>` mirroring `selectedNodes` / `highlightedNodes`, with real opacity styling across the `dot`, `compact`, and `detail` zoom variants and on edges incident on a dimmed node. Phase 1 ships without this dependency by using hard removal (see §1.5 Q5). If the upstream PR slips, Phase 2 slips; Phase 1 is unaffected.
+
+---
+
+## 2. Architecture
+
+### 2.1 High-level
+
+```mermaid
+flowchart TD
+  Consumer["Consumer code"] -->|visualizations=[{type:'graph',...}]| ODC["OneDataCollection"]
+  ODC --> VR["VisualizationRenderer"]
+  VR -->|switch type=graph| GC["GraphCollection (new)"]
+  GC -->|source| UDCD["useDataCollectionData(source)"]
+  UDCD -->|records + matched filter ids| GC
+  GC -->|filter + nodeAdapter + edgeAdapter| GP["projectGraph (records → GraphNode[]/GraphEdge[])"]
+  GP --> F0G["F0Graph (graphId from options.graphId ?? 'default')"]
+  F0G -->|renderNode(ctx)| Consumer
+  F0G -->|onNodeSelect| SEL["useSelectable on source"]
+  SEL -->|onSelectItems| ODC
+  F0G -->|detailPanel(node)| GC
+  GC -->|menuActions / F0GraphNode.actions| ItemActions["OneDataCollection item-actions"]
+```
+
+### 2.2 Component layering
+- **`GraphCollection`** (new): visualization adapter. Bridges `DataCollectionSource` ↔ `F0GraphProps`. Mirrors the structure of `ListCollection`/`KanbanCollection`. Owns filtering, memoization of `nodes`/`edges`, the selection bridge, the lazy-mode `AbortController`, and cycle warnings.
+- **`F0Graph`** (existing, **untouched in this work**): generic interactive graph runtime under `patterns/F0Graph`. We are a consumer of its public API only. (Phase 2 depends on a separate upstream PR adding `dimmedNodes`; see §1.6.)
+- **`projectGraph`** (new pure helper): `(records, options) => { nodes: GraphNode<R>[]; edges: GraphEdge[]; cycles: string[] }`. Pure function, fully unit-testable, no React.
+- **`collectionViewRegistry`** (existing, edited): register `graph` entry alongside `table`/`kanban`/`list`/`card`/`editableTable`.
+- **`types.ts`** (existing, edited): extend the `Visualization` union with `{ type: "graph", options: GraphVisualizationOptions<R, Filters, Sortings> }`.
+
+### 2.3 State ownership
+
+| State                                   | Owner                                         |
+| --------------------------------------- | --------------------------------------------- |
+| `records` / pagination                  | `useDataCollectionData(source)` (unchanged)   |
+| Selection (`selectedNodes`)             | `useSelectable` on the `source` — survives view switches |
+| `expandedNodes`                         | F0Graph (uncontrolled by default; opt-in controlled prop) |
+| `focusedNode`                           | F0Graph (uncontrolled)                        |
+| Viewport (zoom + pan)                   | F0Graph internal React Flow state. **NOT persisted across hard refreshes.** Preserved during in-app back-navigation only because the page component stays mounted. |
+| Detail-panel open node                  | Derived from F0Graph selection                |
+| Detail-panel width                      | F0Graph, persisted to `localStorage` under `f0graph:detailPanelWidth:${graphId}` |
+| `graphId`                               | Consumer-supplied via `options.graphId`; defaults to `React.useId()` generated inside `GraphCollection` |
+| Visualization picker / view switcher    | `OneDataCollection` settings (unchanged)      |
+| Per-view filter overrides               | `usePerVisualizationFilters` (unchanged)      |
+
+**Back-navigation viewport caveat.** F0Graph viewport survives in-app back-nav only if the parent route does not force remount. Builder MUST verify the parent route in `factorial` does not aggressively swap `key={...}` and does not sit behind a Suspense boundary that throws on back-nav. If it does, viewport resets on every back-nav and the fix is in the route, not in this view.
+
+No new persistence channel is added by this view itself.
+
+---
+
+## 3. Public API design
+
+### 3.1 New type — `GraphVisualizationOptions`
+
+File: `Graph/types.ts` (new)
+
+```ts
+import type { ReactNode } from "react"
+import type {
+  F0GraphDetailPanelProps,
+  F0GraphNodeRenderContext,
+  F0GraphProps,
+  GraphEdge,
+  GraphNode,
+} from "@/patterns/F0Graph"
+import type { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
+import type { RecordType, SortingsDefinition } from "@/hooks/datasource"
+
+/**
+ * Adapter that extracts the structural fields F0Graph needs from a record.
+ *
+ * The full record is preserved on the projected node automatically.
+ * The node `id` is stamped internally by `GraphCollection` via the same
+ * `getKey` helper Kanban uses: `source.idProvider(item, index)` if present,
+ * else `item.id`, else `String(index)` — always coerced to `string`. There
+ * is exactly one source of truth for record identity in OneDataCollection.
+ */
+export type GraphNodeAdapter<R extends RecordType> = (record: R) => {
+  /** Single-parent tree linkage. */
+  parentId: string | null
+  /** DAG linkage. When present, takes precedence over `parentId`. */
+  parentIds?: string[]
+  /** Hint for lazy-loaded children. */
+  childrenCount?: number
+  /** Hint for lazy-loaded children. */
+  childrenLoaded?: boolean
+}
+
+/**
+ * Optional adapter that derives explicit edges from records. When omitted,
+ * F0Graph derives parent→child edges from `parentId`/`parentIds`.
+ *
+ * Use this when edges have semantic metadata (labels, weights, click handlers)
+ * that are not expressible through tree linkage alone.
+ */
+export type GraphEdgeAdapter<R extends RecordType> = (
+  records: ReadonlyArray<R>
+) => ReadonlyArray<GraphEdge>
+
+/**
+ * Return shape of `detailPanel`. Re-exported from F0Graph so the public API
+ * stays readable instead of inlining a deep conditional type.
+ */
+export type GraphDetailPanel = ReturnType<
+  NonNullable<F0GraphProps["detailPanel"]>
+>
+
+export type GraphVisualizationOptions<
+  R extends RecordType,
+  _Filters extends FiltersDefinition,
+  _Sortings extends SortingsDefinition,
+> = {
+  /**
+   * Stable identifier used by F0Graph to scope per-graph persisted state
+   * (currently: detail-panel width). When omitted, `GraphCollection` defaults
+   * to `React.useId()` so each instance gets a unique key — pass an explicit
+   * value only when you want a persistence key tied to a known domain entity
+   * (e.g. `'org-chart'`) for cross-session continuity.
+   */
+  graphId?: string
+
+  /** Required. Maps a record to its parent linkage. */
+  nodeAdapter: GraphNodeAdapter<R>
+
+  /** Optional. Derive explicit edges; otherwise inferred from parent linkage. */
+  edgeAdapter?: GraphEdgeAdapter<R>
+
+  /** Required. Render the node body — mirrors `F0GraphProps.renderNode`. */
+  renderNode: (record: R, ctx: F0GraphNodeRenderContext) => ReactNode
+
+  /** Optional detail-panel renderer. Receives the underlying record. */
+  detailPanel?: (record: R) => GraphDetailPanel
+
+  /**
+   * Lazy mode. When provided, only the first page of `data.records` is
+   * projected as roots; children are resolved on demand. Requires a
+   * paginated source (see §1.5 Q1).
+   */
+  loadChildren?: (nodeId: string) => Promise<ReadonlyArray<R>>
+
+  /**
+   * Escape hatch for everything F0Graph exposes that this view does NOT own.
+   * DataCollection owns data, selection, filtering, dim. Everything else
+   * (zoomPreset, defaultZoom, defaultExpandDepth, layoutEngine, nodeWidth,
+   * nodeHeight, fullScreen, showControls, currentUserNodeId, renderEdge,
+   * search, etc.) passes through here.
+   */
+  graphProps?: Omit<
+    F0GraphProps<R>,
+    | "nodes"
+    | "edges"
+    | "rootNodes"
+    | "loadChildren"
+    | "renderNode"
+    | "selectionMode"
+    | "onNodeSelect"
+    | "detailPanel"
+    | "selectedNodes"
+    | "highlightedNodes"
+    | "dimmedNodes"
+    | "searchValue"
+    | "onSearchChange"
+    | "searchable"
+  >
+}
+
+// Re-exported for consumer use.
+export type { F0GraphDetailPanelProps }
+```
+
+### 3.2 New variant in `Visualization` union
+
+File: `collection/types.ts` (edited)
+
+```ts
+| ({
+    type: "graph"
+    options: GraphVisualizationOptions<R, Filters, Sortings>
+  } & VisualizationFilterOverrides<Filters>)
+```
+
+### 3.3 New registry entry
+
+File: `collection/collectionViewRegistry.tsx` (edited)
+
+```ts
+import { Graph as GraphIcon } from "@/icons/app"
+
+graph: {
+  name: "Graph",
+  icon: GraphIcon, // verified present at packages/react/src/icons/app/Graph.tsx
+  settings: { default: {} },
+  render: (props) => <GraphCollection {...props} />,
+},
+```
+
+### 3.4 Export surface
+
+File: `collection/index.tsx` and `exports.ts` (edited)
+
+```ts
+// collection/index.tsx
+export * from "./Graph"
+```
+
+No breaking changes to existing public types. The `Visualization` union grows by one variant; downstream `switch (v.type)` blocks become non-exhaustive if they used `assertNever`, which is a known accepted cost (same as when `editableTable`, `list`, `kanban` were added).
+
+---
+
+## 4. Data adapter strategy
+
+`F0Graph` has two ingestion modes; we support both behind the same options shape.
+
+### 4.1 Eager mode (default)
+
+- **Requires** `source.paginationType === "no-pagination"`. If the source is paginated and `loadChildren` is not provided, `GraphCollection` throws in dev with the exact message:
+
+  > `Graph visualization in eager mode requires a non-paginated source. Either set paginationType: 'no-pagination' on the source, or provide a loadChildren option to use lazy mode.`
+
+  This is a hard fail-fast — no silent multi-page fetches, no `loadMore` loops, no `maxRecords` knob. The guard runs in `GraphCollection` immediately after `useDataCollectionData` is wired so consumers see the error on first render.
+- The complementary guard (`loadChildren` provided AND source non-paginated) also throws in dev — see §1.5 Q1.
+- `useDataCollectionData(source)` returns the full record set in a single response (guaranteed by the non-pagination requirement above).
+- All returned `records` are projected to `GraphNode<R>[]` via `nodeAdapter`.
+- Edges are either:
+  - Derived from `parentId`/`parentIds` (default), or
+  - Returned by `edgeAdapter(records)` when present.
+- The full set is handed to `F0Graph` via `nodes={...}` / `edges={...}`.
+
+### 4.2 Lazy mode (opt-in via `loadChildren`)
+
+- Lazy mode is **required on paginated sources**. The first page of `useDataCollectionData(source)` is consumed as roots and projected to `rootNodes`. Subsequent pages are NOT auto-fetched — F0Graph drives child resolution from this point on.
+- F0Graph's expand triggers `loadChildren(nodeId)`, which `GraphCollection` wraps to:
+  1. Open a per-node `AbortController` keyed on the node ID.
+  2. Call the consumer's `loadChildren(nodeId)`.
+  3. Project returned records to `GraphNode<R>[]` via `nodeAdapter` (stamping `id` via the shared `getKey` helper — see §4.3 Identity).
+  4. Return them to F0Graph.
+- **Abort semantics.** The per-node `AbortController` aborts on unmount and when the user collapses the node before the promise resolves. Aborted resolutions are dropped silently.
+- Records loaded this way **bypass** the `DataCollectionSource`'s store. They are NOT added to `data.records`. This is intentional — collection state stays flat and predictable; F0Graph owns the tree.
+
+### 4.3 Projection rules
+- **Identity.** `node.id` is stamped by `GraphCollection` using the same `getKey` helper Kanban uses ([`Kanban.tsx:226`](../Kanban/Kanban.tsx#L226)) — a three-step fallback: `source.idProvider(item, index)` → record's natural `.id` → array index, always coerced to `string`. `idProvider` is optional; consumers do not need to coerce. `nodeAdapter` does NOT return an `id`. Consider lifting `getKey` to a shared util under `OneDataCollection/utils/` during Phase 1 if it does not already live there; if it does, reference the path.
+- `node.data = record` (full record preserved, opaque to F0Graph).
+- If two records resolve to the same `id` via `getKey`, throw in dev (`useIsDev`); warn in prod.
+- If `nodeAdapter` returns `parentId` that doesn't exist in the record set AND there's no `loadChildren`, the node is treated as a root. No error — common case (filtered subtree).
+- If `source.currentGrouping` is non-null, dev throws "Grouping is not supported in Graph visualization; the graph's parent linkage is the grouping." (mirrors Kanban precedent).
+- **Cycle detection.** `projectGraph` walks the parent linkage and returns `cycles: string[]` (IDs participating in a cycle). `GraphCollection` surfaces these in dev via a single `console.warn` per render listing the offending IDs. Edges that would close a cycle are dropped from the rendered set — never silently, always warned.
+  - **Why we don't rely solely on F0Graph's internal cycle detection:** F0Graph operates on `GraphNode<R>` and can only report cycles by node ID. GraphCollection operates on raw records and can produce a more useful `console.warn` naming the offending records (and their `getKey` keys) for the consumer. It also drops cycle-closing edges before handoff so F0Graph never sees an invalid topology.
+- **Filtering (Phase 1 — hard removal).** When a per-view filter narrows the record set, non-matching records are omitted from `nodes`, and any edge incident on a removed node is omitted from `edges`. Subtrees rooted at a removed node are also removed (no orphan promotion). The `projectGraph` helper receives the matched-id set from `GraphCollection` and skips non-matching records during projection.
+- **Filtering (Phase 2 — dim).** Once the upstream F0Graph `dimmedNodes` PR (§1.6) lands, `GraphCollection` switches: non-matching records stay in `nodes` and their IDs are passed through F0Graph's new `dimmedNodes` prop, preserving tree structure. Edges incident on dimmed nodes inherit the dimmed treatment via F0Graph.
+- **Memoization.** `GraphCollection` MUST memoize the `nodes` and `edges` arrays passed to F0Graph using a stable cache key (record IDs + active filter signature + expansion state + adapter identities). Consumer-supplied `nodeAdapter`, `edgeAdapter`, `renderNode`, and `detailPanel` SHOULD be memoized by the consumer; this is documented in the public-API docs as a perf requirement (not a runtime check).
+- **Dev-mode identity warning.** Add a dev-only `useStableIdentityWarning` (or equivalent) helper inside `GraphCollection`. If any of `nodeAdapter` / `edgeAdapter` / `renderNode` / `detailPanel` changes identity more than 5 times within 1 second of mount, fire a single `console.warn` with the offending prop name and a link to the public API doc. Production builds skip the check entirely. Goal: surface the missing `useCallback` / `useMemo` at first run, not after a perf bug report.
+- **Search bridge.** When `source` has an active search input, pipe its current value into F0Graph's `searchValue` prop, and forward F0Graph's `onSearchChange` to the source's search setter. This avoids double-rendering a second search UI. F0Graph's competing `searchable` prop (which renders its own search UI) is omitted from `graphProps` for the same reason — see §3.1.
+
+### 4.4 Selection bridge
+
+- F0Graph `selectionMode="single"` (v1 default).
+- Selection lives on the `source` via `useSelectable` — not on this visualization. Switching from Table → Graph → Table preserves the selected IDs automatically.
+- F0Graph `onNodeSelect(nodeId, selected)` →  `GraphCollection` calls `handleSelectItemChange` from `useSelectable`, passing **the loaded record as `fallbackItem`** so lazy-loaded nodes (which never entered `data.records`) still attach the record to the selection event. This mirrors the pattern Table and Card already use.
+  - **Rule:** GraphCollection MUST pass the loaded record as `fallbackItem` for both eager and lazy children. Never pass just an ID.
+- Multi-select is gated behind a follow-up (see §10).
+
+### 4.5 Item-actions bridge
+
+- F0Graph's detail panel takes `menuActions: DropdownItem[]` (not `menu`). When `detailPanel` is provided AND `source.itemActions` is defined, `GraphCollection` synthesizes `menuActions` from the source's item-actions for the selected record and merges them into whatever `menuActions` the consumer returned from `detailPanel(record)`.
+- **Fallback when no `detailPanel` is provided.** `GraphCollection` still surfaces the source's `itemActions` via `F0GraphNode.actions` for each node, so item-actions are reachable from the graph even without a panel. This makes `detailPanel` purely about additional content, not a gate on actions.
+
+### 4.6 Loading and error states
+- Initial load: render F0Graph wrapped in an opacity-50 + `aria-busy` shell (matches list/table pattern).
+- Error: bubble through `onLoadError` (existing callback) — no in-view error UI; the collection chrome shows the error toast.
+
+---
+
+## 5. File-by-file change list
+
+> All paths are workspace-relative.
+
+### New files (under the new `Graph/` directory)
+
+| Path | Purpose |
+| --- | --- |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md` | This document. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx` | Public barrel — `export * from "./Graph"` and `export * from "./types"`. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx` | `GraphCollection` component. Owns hooks, selection bridge, F0Graph wiring, memoization, abort. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts` | `GraphCollectionProps`, `GraphVisualizationOptions`, `GraphNodeAdapter`, `GraphEdgeAdapter`, `GraphDetailPanel`. Re-exports `F0GraphDetailPanelProps`. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/projectGraph.ts` | Pure projection helper. Heavily unit-tested. Returns `{ nodes, edges, cycles }`. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/projectGraph.spec.ts` | Vitest specs for the projection helper. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.spec.tsx` | RTL specs for the visualization adapter. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/Graph.stories.tsx` | Stories — basic tree, DAG, lazy, detail panel. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/mockData.ts` | Mock org chart used by the stories and specs. |
+
+### Edited files
+
+| Path | Change |
+| --- | --- |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/types.ts` | Add `graph` variant to the `Visualization` union. Import `GraphVisualizationOptions`. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/collectionViewRegistry.tsx` | Register `graph` entry; import `GraphCollection`, `GraphCollectionProps`, and the `Graph` icon. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/index.tsx` | `export * from "./Graph"` so types are reachable from the collection barrel. |
+| `packages/react/src/patterns/OneDataCollection/exports.ts` | **No edit needed** — verified at [`exports.ts`](../../../exports.ts). Matches the Kanban/List precedent: `KanbanVisualizationOptions` is not re-exported by name today (the public re-export chain only exposes `Visualization`, `CustomVisualizationProps`, and `VisualizationFilterOverrides` from `./visualizations/collection/types`). `GraphVisualizationOptions` is reachable structurally through the `Visualization` union, which is enough for consumers writing `visualizations={[{ type: "graph", options: {...} }]}`. If a future ask wants `import type { GraphVisualizationOptions }` by name, add an explicit `export type { GraphVisualizationOptions } from "./visualizations/collection/Graph"` in `exports.ts` then — out of scope for parity. |
+
+### Files explicitly NOT edited
+- Everything under `packages/react/src/patterns/F0Graph/*` — F0Graph is consumed as-is in this work. The Phase 2 `dimmedNodes` capability lands in a separate upstream PR (see §1.6).
+- `OneDatacollection.tsx`, `Settings/*`, `hooks/useDataCollectionData/*`, `navigationFilters/*` — view is additive only.
+
+---
+
+## 6. Story & test plan
+
+### 6.1 Stories (`__stories__/Graph.stories.tsx`)
+
+| Story | What it shows |
+| --- | --- |
+| **Basic** | 10-node org chart with default expand depth = 2. |
+| **WithDetailPanel** | Click a node → panel opens with name, role, item-actions via `menuActions`. |
+| **WithItemActionsNoPanel** | No `detailPanel` provided; item-actions still reachable via `F0GraphNode.actions`. |
+| **DAG** | Records with `parentIds: string[]` rendering a small DAG. |
+| **Lazy** | Only roots in the source; `loadChildren` resolves to a mocked async batch with a 400ms delay. |
+| **WithVisualizationSwitcher** | Same source rendered as both Table and Graph, with the picker; selection survives the switch. |
+| **Empty** | Source returns zero records → F0Graph renders nothing; collection chrome shows the existing empty state. |
+| **LoadingThenLoaded** | Source initially pending → opacity-50 graph, then settles. |
+| **HardRemovalFilter** | Filter narrows the set; non-matching nodes and their edges disappear; subtree removed (Phase 1). |
+| **GroupingWarning** (dev story, `parameters.controls: { disable: true }`) | Source with `grouping` set → dev throw is shown in console; verifies guard. |
+
+### 6.2 Unit tests (`projectGraph.spec.ts`)
+- Projects flat records into nodes preserving `data`.
+- Stamps `node.id` via the shared `getKey` helper (three-step fallback: `idProvider` → `item.id` → `index`, coerced to `string`) — never from `nodeAdapter`.
+- Derives parent→child edges from `parentId`.
+- Prefers `parentIds` over `parentId` when both present.
+- Throws on duplicate `id` (from `getKey`) in dev.
+- Records with missing parents are treated as roots.
+- `edgeAdapter` overrides default edge derivation when provided.
+- Returns `cycles: string[]` when adapter output forms a cycle; offending edges are dropped from output.
+- Hard removal: given a matched-id set that excludes some records, the excluded records and any edges incident on them are omitted.
+
+### 6.3 Component tests (`Graph.spec.tsx`)
+- Renders nodes for each record returned by the source.
+- `onNodeSelect` from F0Graph calls `handleSelectItemChange` with the matching record as `fallbackItem`.
+- **Lazy + selectAll inheritance.** Select-all-everything in Table → switch to Graph → expand a lazy-loaded child → that child renders selected. Click to deselect → switch back to Table → that one row is unselected.
+- **Cycle warning.** `nodeAdapter` produces a cycle → exactly one `console.warn` per render listing the cycle IDs; offending edges absent from output.
+- **AbortController.** Expand a lazy node → unmount before `loadChildren` resolves → the abort signal fires and the resolved value is dropped without warning.
+- **graphId default isolation.** Two `<OneDataCollection>` instances mounted simultaneously with no explicit `graphId` get different `useId()`-generated IDs; resizing the detail panel on one does NOT affect the other.
+- **Dev-mode identity warning.** Fires when `nodeAdapter` is inlined (not memoized) across renders; does not fire when it is stable.
+- **Hard removal filter.** Apply a per-view filter that excludes a parent → the parent's edges to its children are not rendered.
+- `onLoadError` is called when the source errors.
+- Throws on `source.currentGrouping !== null` in dev mode (uses `useIsDev` mock).
+- Throws on paginated source without `loadChildren` (eager-mode guard).
+- Throws on non-paginated source with `loadChildren` (lazy-mode guard).
+- Detail-panel `menuActions` merge consumer-returned actions with the source's `itemActions`.
+- Lazy mode: expanding a node invokes `loadChildren(nodeId)` and renders the returned records.
+
+### 6.4 Visual regression
+- Chromatic snapshots for each story above (handled by existing pipeline — no config change).
+
+### 6.5 What we do NOT test
+- F0Graph's own internals (zoom, layout math, detail-panel width persistence) — already covered by F0Graph's own suite.
+- Cross-visualization switching state preservation — covered by existing `OneDataCollection` integration tests; one new case is added under those tests in Phase 3 (see §8).
+
+---
+
+## 7. Watchlist
+
+All resolved questions are tracked in §1.5; what remains is a watchlist of residual risks that affect Phase 2/3 sequencing, not Phase 1 entry. See §11 for severity ratings.
+
+- **Performance envelope unverified.** Phase 2 perf smoke against 1k/2k node mocks publishes the supported limit. Until then, no formal envelope is advertised. F0Graph's existing `LARGE_GRAPH_SNAP_THRESHOLD = 700` already governs animation snapping, so degradation is graceful.
+- **Multi-select UX deferred.** v1 ships `selectionMode="single"`. The selection bridge is structured so adding `multi` later is purely additive — no v1 API change is required to unlock it.
+- **Graph icon is a generic glyph.** `@/icons/app/Graph` ships now; if design produces a dedicated tree/hierarchy variant, the swap is a one-line registry edit (see §10).
+- **Phase 2 blocked on upstream F0Graph PR for `dimmedNodes`.** Phase 1 ships fine without it (hard removal).
+
+---
+
+## 8. 3-phase delivery
+
+### Phase 1 — Skeleton, projection, hard-removal filter (PR #1)
+- Land everything in §5 with `Graph.tsx` rendering F0Graph from `projectGraph()` output.
+- `nodeAdapter` + default edge derivation only. No `edgeAdapter`, no `loadChildren`, no `detailPanel` (item-actions still wired via `F0GraphNode.actions`).
+- `selectionMode="single"` wired to `useSelectable` with `fallbackItem`.
+- Memoized `nodes`/`edges` arrays (per §4.3).
+- Enforce both pagination-mode guards (§4.1) — throw with the exact dev messages.
+- Cycle detection + `console.warn` (per §4.3).
+- Hard-removal filter implementation in `projectGraph`.
+- Search pipe-through into F0Graph (per §4.3) if the source has an active search input.
+- Register entry in `collectionViewRegistry` using `Graph` from `@/icons/app`. Update `Visualization` union.
+- Stories: **Basic**, **Empty**, **LoadingThenLoaded**, **HardRemovalFilter**, **WithItemActionsNoPanel**.
+- Tests: full `projectGraph.spec.ts`; `Graph.spec.tsx` covering render, selection (incl. `fallbackItem`), both pagination-guard throws, cycle warning, hard removal, search pipe-through.
+- **Status: unblocked.** No external sign-offs remain.
+
+### Phase 2 — Detail panel, lazy mode, dim (PR #2)
+- Add `detailPanel` option with `menuActions` bridge.
+- Add `loadChildren` option (lazy mode) with per-node `AbortController`.
+- Add `edgeAdapter` option.
+- Add `parentIds` (DAG) support.
+- **Switch filter behavior from hard removal to dim** by consuming the upstream F0Graph `dimmedNodes` prop (per §1.6). Update `projectGraph` to pass non-matching IDs through instead of omitting them. Update `HardRemovalFilter` story → `DimmedFilter`.
+- Stories: **WithDetailPanel**, **DAG**, **Lazy**, **WithVisualizationSwitcher**, **DimmedFilter**.
+- Tests: detail-panel `menuActions` merge, lazy expansion + select-all inheritance, abort on unmount, DAG projection, dim behavior with the new F0Graph prop.
+- Perf smoke test answering Q4.
+
+### Phase 3 — Polish & integration (PR #3)
+- Per-visualization settings entry in `Settings/` if any user-controllable knob emerges (likely `defaultExpandDepth` exposed via `graphProps`).
+- Add an integration test in `OneDataCollection/__tests__/` covering switch Table↔Graph with state preservation (selection + viewport-during-back-nav caveat from §2.3).
+- Update visualization selector tooltip copy / i18n keys.
+- If design ships a dedicated tree/hierarchy glyph, swap the registry icon (one-line change).
+- Documentation MDX entry under existing `Patterns/Data collection` group, including the `graphId` override pattern (default `useId()`, override for cross-session persistence) and the consumer-side memoization requirement (with a note about the dev-mode identity warning).
+
+Each phase is independently shippable. Phase 1 covers ~70% of the consumer use case (Factorial org chart, file tree, project hierarchy).
+
+---
+
+## 9. Acceptance criteria (full surface)
+
+- A consumer can add `{ type: "graph", options: {...} }` to `visualizations` and it appears in the picker.
+- Switching to the graph view renders nodes for every record returned by the source (subject to active filter, per Phase 1 hard-removal rules).
+- `nodeAdapter` and `renderNode` are the only required options.
+- `nodeAdapter` does NOT return `id`; node identity comes from the shared `getKey` helper (`source.idProvider` → `item.id` → `index`).
+- Selecting a node calls `handleSelectItemChange` with the matching record as `fallbackItem`, including for lazy-loaded children.
+- Switching back to table preserves the selection (via existing per-source selection state on `useSelectable`).
+- `source.currentGrouping !== null` throws in dev with a clear message.
+- Paginated source without `loadChildren` throws in dev; non-paginated source with `loadChildren` throws in dev.
+- `loadChildren` is invoked exactly once per `nodeId` per expansion lifecycle and is aborted on unmount or pre-resolve collapse.
+- Adapter cycles emit a single dev `console.warn` per render; offending edges are dropped.
+- No regressions in existing visualizations' test suites.
+- Chromatic shows no unexpected diffs outside the new stories.
+
+---
+
+## 10. Out-of-scope follow-ups
+
+| Item | Why deferred |
+| --- | --- |
+| Multi-select bridge to bulk-actions footer | Needs UX design — "select all" semantics on a spatial canvas are non-obvious. |
+| Inline editing inside nodes (graph-equivalent of `editableTable`) | F0Graph nodes are renderer-driven; F0 needs an editing primitive first. |
+| Viewport persistence across hard refreshes | `OneDataCollection`'s settings persistence layer doesn't currently store viewport coordinates; F0Graph itself only persists detail-panel width. Possible follow-up, separate scope. |
+| Export-to-PNG / share-link | F0Graph doesn't expose a canvas snapshot API; would need a new F0Graph prop. |
+| Grouping support (treat group key as virtual parent) | Conflates two parent dimensions; non-trivial UX. |
+| Infinite-scroll-style streaming nodes | F0Graph has `deferredNodes` — viable but adds two more state machines to reason about. Schedule after lazy mode lands. |
+| Per-edge styling/labeling presets | Covered today by `graphProps.renderEdge`; hold a dedicated convenience API for a real consumer ask. |
+| Dedicated `useGraphLayout` for non-OneDataCollection consumers | If a second consumer of `projectGraph()` appears, hoist it under `patterns/F0Graph/hooks/`. |
+| Dedicated tree/hierarchy glyph from design | We ship with the existing `Graph` icon as the registry glyph. Swap is a one-line change in the registry entry once design produces a dedicated variant. |
+
+---
+
+## 11. Risks summary
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Large graphs (>2k nodes) janky | Med | Med | Phase-2 perf smoke; publish envelope. F0Graph's existing 700-node snap threshold already degrades gracefully. |
+| Selection model mismatch confuses existing consumers | Med | Med | Single-select only in v1; multi-select tracked as §10 follow-up. Lazy `fallbackItem` rule documented in §4.4. |
+| TypeScript instantiation depth from 6th union variant | Low | Med | Mirror existing registry cast pattern (`as VisualizacionTypeDefinition<...>`) per Q6. No new tech debt. |
+| Generic `Graph` icon stays in place longer than expected | Low | Low | Swap is a one-line registry edit when design ships a dedicated glyph. Follow-up tracked in §10. |
+| Upstream F0Graph `dimmedNodes` PR slips | Med | Low | Phase 1 still ships with hard removal; only Phase 2 dim UX is delayed. No code in this repo blocks. |
+| Parent route in `factorial` forces remount on back-nav | Low | Med | Verify before Phase 1 ships (per §2.3 caveat). If it does, fix the route, not this view. Viewport persistence across hard refreshes is explicitly out of scope (§10). |

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md
@@ -39,7 +39,7 @@ Concretely, after this work a consumer can write:
 - **No new graph primitives.** Anything not exposed by `F0Graph`/`F0GraphNode`/`F0GraphEdge` today is out of scope. If the view needs it, the gap is recorded in §10 or §1.6.
 - **No data-fetching changes.** The view consumes whatever `dataAdapter` already produces — same paginated/grouped contract every other visualization uses. No new adapter type.
 - **No grouping support in v1.** Graph topology IS the grouping. `source.currentGrouping` is rejected with a dev-only throw, matching the precedent set by Kanban (`Grouping is not supported in Kanban yet`).
-- **No multi-select bulk-actions in v1.** Selection is mirrored to F0Graph but only `"single"` selectionMode is wired to `OneDataCollection`'s `onSelectItems`. Multi-select is a follow-up.
+- **No bulk-actions footer integration in v1.** Multi-select IS wired to `OneDataCollection`'s `onSelectItems` (both eager and lazy children — see §4.4), but the cross-visualization "select all" affordance and the bulk-actions footer placement on a spatial canvas need UX design and ship separately (see §10).
 - **No editing.** Read-only view. Item-actions menu is supported through the per-node detail panel handoff (and as a fallback through `F0GraphNode.actions`), but inline editing (à la `editableTable`) is out of scope.
 - **No infinite scroll / pagination UI.** Graphs are inherently spatial, not paginated. We fetch the full first page; lazy-loading children is delegated to F0Graph's `rootNodes` + `loadChildren` (see §4).
 
@@ -50,7 +50,7 @@ Concretely, after this work a consumer can write:
 The questions originally tracked in §7 are settled. The plan below reflects these answers — they are reproduced here so reviewers can see the rationale in one place.
 
 - **Q1 — Pagination handling (eager mode).** Eager mode **requires** `source.paginationType === "no-pagination"`. Lazy mode (via `loadChildren`) is permitted on paginated sources — the first page is consumed as roots and `loadChildren` resolves children on demand. **Dev-only invariant:** if `loadChildren` is provided AND `paginationType !== "no-pagination"`, that is the only valid combination; if `loadChildren` is provided AND `paginationType === "no-pagination"`, throw (`"Graph visualization: loadChildren requires a paginated source. Remove loadChildren, or set paginationType to a paginated value."`). If `loadChildren` is absent AND the source is paginated, throw (`"Graph visualization in eager mode requires a non-paginated source. Either set paginationType: 'no-pagination' on the source, or provide a loadChildren option to use lazy mode."`). Both checks run in `GraphCollection` immediately after `useDataCollectionData` is wired so consumers see the error on first render. No silent multi-page fetches, no `maxRecords` option.
-- **Q2 — Selection bridge fidelity.** v1 ships `selectionMode="single"` only. Selection state lives on the `source` via `useSelectable` (see `packages/react/src/hooks/datasource/useSelectable/useSelectable.ts`), so selection survives view switches automatically — no per-visualization mirror. Multi-select on a spatial canvas is deferred to a dedicated follow-up (see §10) because "select all" semantics and the bulk-actions footer placement need UX design first.
+- **Q2 — Selection bridge fidelity.** v1 forwards `source.selectable` directly to F0Graph (`"single"` or `"multiple"`); when `source.selectable` is omitted, F0Graph receives `"none"`. Selection state lives on the `source` via `useSelectable` (see `packages/react/src/hooks/datasource/useSelectable/useSelectable.ts`), so selection survives view switches automatically — no per-visualization mirror. In **lazy mode** `GraphCollection` opts into `allPagesSelection: true` on `useSelectable` so lazy-loaded ids surface in the `onSelectItems` payload's `selectedIds` (the default filters payload ids to current-page records, which drops lazy children). The cross-visualization "select all" UX on a spatial canvas is still deferred (see §10) — that's a footer/affordance question, not a selection-bridge question.
 - **Q3 — Icon choice.** Use the existing `Graph` glyph from `@/icons/app` (`packages/react/src/icons/app/Graph.tsx`). Verified present. If design later produces a dedicated tree/hierarchy variant we swap (see §10).
 - **Q4 — Performance budget.** No published envelope ships in Phase 1. Phase 2 includes a perf smoke test against 1k and 2k node mocks; the supported envelope is published with that PR.
 - **Q5 — Filter behavior (Phase 1 hard removal; Phase 2 dim).** F0Graph's existing `state="dimmed"` prop is purely visual in the `dot` zoom variant and is indistinguishable from `default` in `compact`/`detail`. There is no `dimmedNodes` prop on F0Graph today. **Phase 1 ships hard removal:** records that do not match the active per-view filter are omitted from `nodes`, and any edges incident on a removed node are omitted from `edges`. No orphan promotion; subtree of a removed parent is also removed (consistent with hard removal). **Phase 2 ships dim** once the upstream F0Graph PR (see §1.6) adds a real `dimmedNodes?: Set<string>` prop that styles `dot`/`compact`/`detail` and incident edges; `GraphCollection` will switch to passing the filtered-out IDs through that prop, preserving tree structure.
@@ -201,8 +201,17 @@ export type GraphVisualizationOptions<
    * Lazy mode. When provided, only the first page of `data.records` is
    * projected as roots; children are resolved on demand. Requires a
    * paginated source (see §1.5 Q1).
+   *
+   * `opts.signal` is aborted if the user collapses the node before
+   * resolution, the component unmounts, or another `loadChildren` call
+   * starts for the same `nodeId`. Consumers SHOULD forward it to `fetch`
+   * (or their underlying request layer) so the in-flight request is
+   * cancelled, not just ignored.
    */
-  loadChildren?: (nodeId: string) => Promise<ReadonlyArray<R>>
+  loadChildren?: (
+    nodeId: string,
+    opts: { signal: AbortSignal }
+  ) => Promise<ReadonlyArray<R>>
 
   /**
    * Escape hatch for everything F0Graph exposes that this view does NOT own.
@@ -321,11 +330,12 @@ No breaking changes to existing public types. The `Visualization` union grows by
 
 ### 4.4 Selection bridge
 
-- F0Graph `selectionMode="single"` (v1 default).
+- F0Graph `selectionMode` is forwarded from `source.selectable` (`"single"` or `"multiple"`); when `source.selectable` is omitted, F0Graph receives `"none"`.
 - Selection lives on the `source` via `useSelectable` — not on this visualization. Switching from Table → Graph → Table preserves the selected IDs automatically.
 - F0Graph `onNodeSelect(nodeId, selected)` → `GraphCollection` calls `handleSelectItemChange` from `useSelectable`, passing **the loaded record as `fallbackItem`** so lazy-loaded nodes (which never entered `data.records`) still attach the record to the selection event. This mirrors the pattern Table and Card already use.
   - **Rule:** GraphCollection MUST pass the loaded record as `fallbackItem` for both eager and lazy children. Never pass just an ID.
-- Multi-select is gated behind a follow-up (see §10).
+- **Lazy mode opts into `allPagesSelection: true`.** `useSelectable` filters the `onSelectItems` payload's `selectedIds` to current-page records by default. In lazy mode that silently drops lazy-loaded ids from the consumer payload (the F0Graph `selectedNodes` Set still reflects them). `GraphCollection` therefore passes `allPagesSelection: true` to `useSelectable` whenever `loadChildren` is provided, so lazy ids surface end-to-end. Eager mode keeps the default behavior so source-level `allPagesSelection` semantics are honored when set by the consumer.
+- The cross-visualization "select all" UX on a spatial canvas is still deferred — see §10.
 
 ### 4.5 Item-actions bridge
 
@@ -353,7 +363,7 @@ No breaking changes to existing public types. The `Visualization` union grows by
 | `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts`                      | `GraphCollectionProps`, `GraphVisualizationOptions`, `GraphNodeAdapter`, `GraphEdgeAdapter`, `GraphDetailPanel`. Re-exports `F0GraphDetailPanelProps`. |
 | `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/projectGraph.ts`               | Pure projection helper. Heavily unit-tested. Returns `{ nodes, edges, cycles }`.                                                                       |
 | `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/projectGraph.spec.ts`          | Vitest specs for the projection helper.                                                                                                                |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.spec.tsx`                | RTL specs for the visualization adapter.                                                                                                               |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/*.test.tsx`          | RTL specs for the visualization adapter, split per concern (selection, lazy abort, identity warning, defaultSelectedItems bridge, etc.).               |
 | `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/Graph.stories.tsx` | Stories — basic tree, DAG, lazy, detail panel.                                                                                                         |
 | `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/mockData.ts`       | Mock org chart used by the stories and specs.                                                                                                          |
 
@@ -402,15 +412,16 @@ No breaking changes to existing public types. The `Visualization` union grows by
 - Returns `cycles: string[]` when adapter output forms a cycle; offending edges are dropped from output.
 - Hard removal: given a matched-id set that excludes some records, the excluded records and any edges incident on them are omitted.
 
-### 6.3 Component tests (`Graph.spec.tsx`)
+### 6.3 Component tests (`__tests__/*.test.tsx`)
 
 - Renders nodes for each record returned by the source.
 - `onNodeSelect` from F0Graph calls `handleSelectItemChange` with the matching record as `fallbackItem`.
-- **Lazy + selectAll inheritance.** Select-all-everything in Table → switch to Graph → expand a lazy-loaded child → that child renders selected. Click to deselect → switch back to Table → that one row is unselected.
+- **Lazy selection round-trip.** Selecting a lazy-loaded child surfaces its id in both the F0Graph `selectedNodes` Set AND the `onSelectItems` payload's `selectedIds` (covered by `selection.test.tsx`; relies on the `allPagesSelection: true` lazy-mode opt-in from §4.4).
+- **defaultSelectedItems bridge.** Source pre-declares all records selected → F0Graph receives them as `selectedNodes` (covered by `defaultSelectedItemsBridge.test.tsx`). Full select-all-everything → expand-lazy inheritance round-trip is a Phase 3 OneDataCollection integration test.
 - **Cycle warning.** `nodeAdapter` produces a cycle → exactly one `console.warn` per render listing the cycle IDs; offending edges absent from output.
-- **AbortController.** Expand a lazy node → unmount before `loadChildren` resolves → the abort signal fires and the resolved value is dropped without warning.
+- **AbortController forwarding.** `wrappedLoadChildren` passes an `opts.signal` to the consumer; a fresh call for the same nodeId aborts the previous signal; unmount aborts every in-flight signal so consumers can observe abortion mid-flight (covered by `lazyAbort.test.tsx`).
 - **graphId default isolation.** Two `<OneDataCollection>` instances mounted simultaneously with no explicit `graphId` get different `useId()`-generated IDs; resizing the detail panel on one does NOT affect the other.
-- **Dev-mode identity warning.** Fires when `nodeAdapter` is inlined (not memoized) across renders; does not fire when it is stable.
+- **Dev-mode identity warning.** Inlined `nodeAdapter` across 6+ renders within 1s → exactly ONE `console.warn` per offending prop. Memoized adapters across many renders → no warn. Production builds (`useIsDev: () => false`) → no warn regardless of identity churn (covered by `stableIdentityWarning.test.tsx`).
 - **Hard removal filter.** Apply a per-view filter that excludes a parent → the parent's edges to its children are not rendered.
 - `onLoadError` is called when the source errors.
 - Throws on `source.currentGrouping !== null` in dev mode (uses `useIsDev` mock).
@@ -446,23 +457,23 @@ All resolved questions are tracked in §1.5; what remains is a watchlist of resi
 ### Phase 1 — Skeleton, projection, hard-removal filter (PR #1)
 
 - Land everything in §5 with `Graph.tsx` rendering F0Graph from `projectGraph()` output.
-- `nodeAdapter` + default edge derivation only. No `edgeAdapter`, no `loadChildren`, no `detailPanel` (item-actions still wired via `F0GraphNode.actions`).
-- `selectionMode="single"` wired to `useSelectable` with `fallbackItem`.
+- `nodeAdapter` + default edge derivation + optional `edgeAdapter` (Phase 1 ships both — `edgeAdapter` is a thin passthrough with no extra cost).
+- No `detailPanel` yet (item-actions still wired via `F0GraphNode.actions`).
+- Lazy mode (`loadChildren`) shipped as part of Phase 1 with full abort semantics: per-node `AbortController`, signal forwarded to the consumer loader via `opts.signal`, aborted on (a) a fresh call for the same nodeId and (b) unmount.
+- Selection wired to `useSelectable` with `fallbackItem`, multi-select end-to-end (both `single` and `multiple` modes forwarded from `source.selectable`). Lazy mode opts into `allPagesSelection: true` so lazy ids surface in `onSelectItems` (see §4.4).
 - Memoized `nodes`/`edges` arrays (per §4.3).
 - Enforce both pagination-mode guards (§4.1) — throw with the exact dev messages.
 - Cycle detection + `console.warn` (per §4.3).
 - Hard-removal filter implementation in `projectGraph`.
-- Search pipe-through into F0Graph (per §4.3) if the source has an active search input.
+- Search pipe-through into F0Graph (per §4.3) — prefers `source.debouncedCurrentSearch` over `source.currentSearch` to avoid layout thrash on each keystroke.
 - Register entry in `collectionViewRegistry` using `Graph` from `@/icons/app`. Update `Visualization` union.
 - Stories: **Basic**, **Empty**, **LoadingThenLoaded**, **HardRemovalFilter**, **WithItemActionsNoPanel**.
-- Tests: full `projectGraph.spec.ts`; `Graph.spec.tsx` covering render, selection (incl. `fallbackItem`), both pagination-guard throws, cycle warning, hard removal, search pipe-through.
-- **Status: unblocked.** No external sign-offs remain.
+- Tests: full `projectGraph.spec.ts`; component tests under `__tests__/` covering render, selection (incl. `fallbackItem` and lazy id round-trip), both pagination-guard throws, cycle warning, hard removal, search pipe-through, abort signal forwarding (per-nodeId + unmount), and the dev-mode identity warning (one-per-prop, prod gate).
+- **Status: shipped.** No external sign-offs remain.
 
-### Phase 2 — Detail panel, lazy mode, dim (PR #2)
+### Phase 2 — Detail panel, DAG, dim (PR #2)
 
 - Add `detailPanel` option with `menuActions` bridge.
-- Add `loadChildren` option (lazy mode) with per-node `AbortController`.
-- Add `edgeAdapter` option.
 - Add `parentIds` (DAG) support.
 - **Switch filter behavior from hard removal to dim** by consuming the upstream F0Graph `dimmedNodes` prop (per §1.6). Update `projectGraph` to pass non-matching IDs through instead of omitting them. Update `HardRemovalFilter` story → `DimmedFilter`.
 - Stories: **WithDetailPanel**, **DAG**, **Lazy**, **WithVisualizationSwitcher**, **DimmedFilter**.
@@ -502,7 +513,7 @@ Each phase is independently shippable. Phase 1 covers ~70% of the consumer use c
 
 | Item                                                              | Why deferred                                                                                                                                                                        |
 | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Multi-select bridge to bulk-actions footer                        | Needs UX design — "select all" semantics on a spatial canvas are non-obvious.                                                                                                       |
+| Cross-visualization "select all" UX on a spatial canvas           | Multi-select is already wired in Phase 1; what's deferred is the bulk-actions footer placement and the "select all" affordance on a zoomable canvas — those need UX design first.   |
 | Inline editing inside nodes (graph-equivalent of `editableTable`) | F0Graph nodes are renderer-driven; F0 needs an editing primitive first.                                                                                                             |
 | Viewport persistence across hard refreshes                        | `OneDataCollection`'s settings persistence layer doesn't currently store viewport coordinates; F0Graph itself only persists detail-panel width. Possible follow-up, separate scope. |
 | Export-to-PNG / share-link                                        | F0Graph doesn't expose a canvas snapshot API; would need a new F0Graph prop.                                                                                                        |
@@ -516,11 +527,11 @@ Each phase is independently shippable. Phase 1 covers ~70% of the consumer use c
 
 ## 11. Risks summary
 
-| Risk                                                     | Likelihood | Impact | Mitigation                                                                                                                                                            |
-| -------------------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Large graphs (>2k nodes) janky                           | Med        | Med    | Phase-2 perf smoke; publish envelope. F0Graph's existing 700-node snap threshold already degrades gracefully.                                                         |
-| Selection model mismatch confuses existing consumers     | Med        | Med    | Single-select only in v1; multi-select tracked as §10 follow-up. Lazy `fallbackItem` rule documented in §4.4.                                                         |
-| TypeScript instantiation depth from 6th union variant    | Low        | Med    | Mirror existing registry cast pattern (`as VisualizacionTypeDefinition<...>`) per Q6. No new tech debt.                                                               |
-| Generic `Graph` icon stays in place longer than expected | Low        | Low    | Swap is a one-line registry edit when design ships a dedicated glyph. Follow-up tracked in §10.                                                                       |
-| Upstream F0Graph `dimmedNodes` PR slips                  | Med        | Low    | Phase 1 still ships with hard removal; only Phase 2 dim UX is delayed. No code in this repo blocks.                                                                   |
-| Parent route in `factorial` forces remount on back-nav   | Low        | Med    | Verify before Phase 1 ships (per §2.3 caveat). If it does, fix the route, not this view. Viewport persistence across hard refreshes is explicitly out of scope (§10). |
+| Risk                                                     | Likelihood | Impact | Mitigation                                                                                                                                                                                                                |
+| -------------------------------------------------------- | ---------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Large graphs (>2k nodes) janky                           | Med        | Med    | Phase-2 perf smoke; publish envelope. F0Graph's existing 700-node snap threshold already degrades gracefully.                                                                                                             |
+| Select-all on a spatial canvas confuses consumers        | Med        | Med    | Multi-select bridge is fully wired in Phase 1 (eager + lazy round-trip via `allPagesSelection: true`); the canvas-level "select all" affordance and bulk-actions footer placement ship later as a UX-led follow-up (§10). |
+| TypeScript instantiation depth from 6th union variant    | Low        | Med    | Mirror existing registry cast pattern (`as VisualizacionTypeDefinition<...>`) per Q6. No new tech debt.                                                                                                                   |
+| Generic `Graph` icon stays in place longer than expected | Low        | Low    | Swap is a one-line registry edit when design ships a dedicated glyph. Follow-up tracked in §10.                                                                                                                           |
+| Upstream F0Graph `dimmedNodes` PR slips                  | Med        | Low    | Phase 1 still ships with hard removal; only Phase 2 dim UX is delayed. No code in this repo blocks.                                                                                                                       |
+| Parent route in `factorial` forces remount on back-nav   | Low        | Med    | Verify before Phase 1 ships (per §2.3 caveat). If it does, fix the route, not this view. Viewport persistence across hard refreshes is explicitly out of scope (§10).                                                     |

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md
@@ -10,6 +10,7 @@ Base SHA: `efa9795a3decf2627bbe248f5f2421ec876a900a`
 ## 1. Goal & non-goals
 
 ### Goal
+
 Add a first-class `type: "graph"` visualization to `OneDataCollection` that renders the collection's records as an interactive tree/DAG using the existing `F0Graph` runtime, so that any consumer with an already-defined `DataCollectionSource` can opt into a graph view without leaving the collection abstraction (filters, search, presets, settings, persistence, item-actions, selection).
 
 Concretely, after this work a consumer can write:
@@ -33,6 +34,7 @@ Concretely, after this work a consumer can write:
 …and the visualization picker shows a Graph entry, switching to it loads the same `source`, projects records into `GraphNode<R>[]`, and renders an interactive F0Graph wired into the collection's selection, item-actions, search, and persistence.
 
 ### Non-goals
+
 - **No new layout engines.** We use F0Graph's built-in tree layout. DAG layout via custom `layoutEngine` is a consumer escape hatch, not something this view ships.
 - **No new graph primitives.** Anything not exposed by `F0Graph`/`F0GraphNode`/`F0GraphEdge` today is out of scope. If the view needs it, the gap is recorded in §10 or §1.6.
 - **No data-fetching changes.** The view consumes whatever `dataAdapter` already produces — same paginated/grouped contract every other visualization uses. No new adapter type.
@@ -84,6 +86,7 @@ flowchart TD
 ```
 
 ### 2.2 Component layering
+
 - **`GraphCollection`** (new): visualization adapter. Bridges `DataCollectionSource` ↔ `F0GraphProps`. Mirrors the structure of `ListCollection`/`KanbanCollection`. Owns filtering, memoization of `nodes`/`edges`, the selection bridge, the lazy-mode `AbortController`, and cycle warnings.
 - **`F0Graph`** (existing, **untouched in this work**): generic interactive graph runtime under `patterns/F0Graph`. We are a consumer of its public API only. (Phase 2 depends on a separate upstream PR adding `dimmedNodes`; see §1.6.)
 - **`projectGraph`** (new pure helper): `(records, options) => { nodes: GraphNode<R>[]; edges: GraphEdge[]; cycles: string[] }`. Pure function, fully unit-testable, no React.
@@ -92,18 +95,18 @@ flowchart TD
 
 ### 2.3 State ownership
 
-| State                                   | Owner                                         |
-| --------------------------------------- | --------------------------------------------- |
-| `records` / pagination                  | `useDataCollectionData(source)` (unchanged)   |
-| Selection (`selectedNodes`)             | `useSelectable` on the `source` — survives view switches |
-| `expandedNodes`                         | F0Graph (uncontrolled by default; opt-in controlled prop) |
-| `focusedNode`                           | F0Graph (uncontrolled)                        |
-| Viewport (zoom + pan)                   | F0Graph internal React Flow state. **NOT persisted across hard refreshes.** Preserved during in-app back-navigation only because the page component stays mounted. |
-| Detail-panel open node                  | Derived from F0Graph selection                |
-| Detail-panel width                      | F0Graph, persisted to `localStorage` under `f0graph:detailPanelWidth:${graphId}` |
-| `graphId`                               | Consumer-supplied via `options.graphId`; defaults to `React.useId()` generated inside `GraphCollection` |
-| Visualization picker / view switcher    | `OneDataCollection` settings (unchanged)      |
-| Per-view filter overrides               | `usePerVisualizationFilters` (unchanged)      |
+| State                                | Owner                                                                                                                                                              |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `records` / pagination               | `useDataCollectionData(source)` (unchanged)                                                                                                                        |
+| Selection (`selectedNodes`)          | `useSelectable` on the `source` — survives view switches                                                                                                           |
+| `expandedNodes`                      | F0Graph (uncontrolled by default; opt-in controlled prop)                                                                                                          |
+| `focusedNode`                        | F0Graph (uncontrolled)                                                                                                                                             |
+| Viewport (zoom + pan)                | F0Graph internal React Flow state. **NOT persisted across hard refreshes.** Preserved during in-app back-navigation only because the page component stays mounted. |
+| Detail-panel open node               | Derived from F0Graph selection                                                                                                                                     |
+| Detail-panel width                   | F0Graph, persisted to `localStorage` under `f0graph:detailPanelWidth:${graphId}`                                                                                   |
+| `graphId`                            | Consumer-supplied via `options.graphId`; defaults to `React.useId()` generated inside `GraphCollection`                                                            |
+| Visualization picker / view switcher | `OneDataCollection` settings (unchanged)                                                                                                                           |
+| Per-view filter overrides            | `usePerVisualizationFilters` (unchanged)                                                                                                                           |
 
 **Back-navigation viewport caveat.** F0Graph viewport survives in-app back-nav only if the parent route does not force remount. Builder MUST verify the parent route in `factorial` does not aggressively swap `key={...}` and does not sit behind a Suspense boundary that throws on back-nav. If it does, viewport resets on every back-nav and the fix is in the route, not in this view.
 
@@ -281,6 +284,7 @@ No breaking changes to existing public types. The `Visualization` union grows by
   > `Graph visualization in eager mode requires a non-paginated source. Either set paginationType: 'no-pagination' on the source, or provide a loadChildren option to use lazy mode.`
 
   This is a hard fail-fast — no silent multi-page fetches, no `loadMore` loops, no `maxRecords` knob. The guard runs in `GraphCollection` immediately after `useDataCollectionData` is wired so consumers see the error on first render.
+
 - The complementary guard (`loadChildren` provided AND source non-paginated) also throws in dev — see §1.5 Q1.
 - `useDataCollectionData(source)` returns the full record set in a single response (guaranteed by the non-pagination requirement above).
 - All returned `records` are projected to `GraphNode<R>[]` via `nodeAdapter`.
@@ -301,6 +305,7 @@ No breaking changes to existing public types. The `Visualization` union grows by
 - Records loaded this way **bypass** the `DataCollectionSource`'s store. They are NOT added to `data.records`. This is intentional — collection state stays flat and predictable; F0Graph owns the tree.
 
 ### 4.3 Projection rules
+
 - **Identity.** `node.id` is stamped by `GraphCollection` using the same `getKey` helper Kanban uses ([`Kanban.tsx:226`](../Kanban/Kanban.tsx#L226)) — a three-step fallback: `source.idProvider(item, index)` → record's natural `.id` → array index, always coerced to `string`. `idProvider` is optional; consumers do not need to coerce. `nodeAdapter` does NOT return an `id`. Consider lifting `getKey` to a shared util under `OneDataCollection/utils/` during Phase 1 if it does not already live there; if it does, reference the path.
 - `node.data = record` (full record preserved, opaque to F0Graph).
 - If two records resolve to the same `id` via `getKey`, throw in dev (`useIsDev`); warn in prod.
@@ -318,7 +323,7 @@ No breaking changes to existing public types. The `Visualization` union grows by
 
 - F0Graph `selectionMode="single"` (v1 default).
 - Selection lives on the `source` via `useSelectable` — not on this visualization. Switching from Table → Graph → Table preserves the selected IDs automatically.
-- F0Graph `onNodeSelect(nodeId, selected)` →  `GraphCollection` calls `handleSelectItemChange` from `useSelectable`, passing **the loaded record as `fallbackItem`** so lazy-loaded nodes (which never entered `data.records`) still attach the record to the selection event. This mirrors the pattern Table and Card already use.
+- F0Graph `onNodeSelect(nodeId, selected)` → `GraphCollection` calls `handleSelectItemChange` from `useSelectable`, passing **the loaded record as `fallbackItem`** so lazy-loaded nodes (which never entered `data.records`) still attach the record to the selection event. This mirrors the pattern Table and Card already use.
   - **Rule:** GraphCollection MUST pass the loaded record as `fallbackItem` for both eager and lazy children. Never pass just an ID.
 - Multi-select is gated behind a follow-up (see §10).
 
@@ -328,6 +333,7 @@ No breaking changes to existing public types. The `Visualization` union grows by
 - **Fallback when no `detailPanel` is provided.** `GraphCollection` still surfaces the source's `itemActions` via `F0GraphNode.actions` for each node, so item-actions are reachable from the graph even without a panel. This makes `detailPanel` purely about additional content, not a gate on actions.
 
 ### 4.6 Loading and error states
+
 - Initial load: render F0Graph wrapped in an opacity-50 + `aria-busy` shell (matches list/table pattern).
 - Error: bubble through `onLoadError` (existing callback) — no in-view error UI; the collection chrome shows the error toast.
 
@@ -339,28 +345,29 @@ No breaking changes to existing public types. The `Visualization` union grows by
 
 ### New files (under the new `Graph/` directory)
 
-| Path | Purpose |
-| --- | --- |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md` | This document. |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx` | Public barrel — `export * from "./Graph"` and `export * from "./types"`. |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx` | `GraphCollection` component. Owns hooks, selection bridge, F0Graph wiring, memoization, abort. |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts` | `GraphCollectionProps`, `GraphVisualizationOptions`, `GraphNodeAdapter`, `GraphEdgeAdapter`, `GraphDetailPanel`. Re-exports `F0GraphDetailPanelProps`. |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/projectGraph.ts` | Pure projection helper. Heavily unit-tested. Returns `{ nodes, edges, cycles }`. |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/projectGraph.spec.ts` | Vitest specs for the projection helper. |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.spec.tsx` | RTL specs for the visualization adapter. |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/Graph.stories.tsx` | Stories — basic tree, DAG, lazy, detail panel. |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/mockData.ts` | Mock org chart used by the stories and specs. |
+| Path                                                                                                          | Purpose                                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md`                       | This document.                                                                                                                                         |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx`                     | Public barrel — `export * from "./Graph"` and `export * from "./types"`.                                                                               |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.tsx`                     | `GraphCollection` component. Owns hooks, selection bridge, F0Graph wiring, memoization, abort.                                                         |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts`                      | `GraphCollectionProps`, `GraphVisualizationOptions`, `GraphNodeAdapter`, `GraphEdgeAdapter`, `GraphDetailPanel`. Re-exports `F0GraphDetailPanelProps`. |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/projectGraph.ts`               | Pure projection helper. Heavily unit-tested. Returns `{ nodes, edges, cycles }`.                                                                       |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/projectGraph.spec.ts`          | Vitest specs for the projection helper.                                                                                                                |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/Graph.spec.tsx`                | RTL specs for the visualization adapter.                                                                                                               |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/Graph.stories.tsx` | Stories — basic tree, DAG, lazy, detail panel.                                                                                                         |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/mockData.ts`       | Mock org chart used by the stories and specs.                                                                                                          |
 
 ### Edited files
 
-| Path | Change |
-| --- | --- |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/types.ts` | Add `graph` variant to the `Visualization` union. Import `GraphVisualizationOptions`. |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/collectionViewRegistry.tsx` | Register `graph` entry; import `GraphCollection`, `GraphCollectionProps`, and the `Graph` icon. |
-| `packages/react/src/patterns/OneDataCollection/visualizations/collection/index.tsx` | `export * from "./Graph"` so types are reachable from the collection barrel. |
-| `packages/react/src/patterns/OneDataCollection/exports.ts` | **No edit needed** — verified at [`exports.ts`](../../../exports.ts). Matches the Kanban/List precedent: `KanbanVisualizationOptions` is not re-exported by name today (the public re-export chain only exposes `Visualization`, `CustomVisualizationProps`, and `VisualizationFilterOverrides` from `./visualizations/collection/types`). `GraphVisualizationOptions` is reachable structurally through the `Visualization` union, which is enough for consumers writing `visualizations={[{ type: "graph", options: {...} }]}`. If a future ask wants `import type { GraphVisualizationOptions }` by name, add an explicit `export type { GraphVisualizationOptions } from "./visualizations/collection/Graph"` in `exports.ts` then — out of scope for parity. |
+| Path                                                                                                 | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/types.ts`                   | Add `graph` variant to the `Visualization` union. Import `GraphVisualizationOptions`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/collectionViewRegistry.tsx` | Register `graph` entry; import `GraphCollection`, `GraphCollectionProps`, and the `Graph` icon.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `packages/react/src/patterns/OneDataCollection/visualizations/collection/index.tsx`                  | `export * from "./Graph"` so types are reachable from the collection barrel.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `packages/react/src/patterns/OneDataCollection/exports.ts`                                           | **No edit needed** — verified at [`exports.ts`](../../../exports.ts). Matches the Kanban/List precedent: `KanbanVisualizationOptions` is not re-exported by name today (the public re-export chain only exposes `Visualization`, `CustomVisualizationProps`, and `VisualizationFilterOverrides` from `./visualizations/collection/types`). `GraphVisualizationOptions` is reachable structurally through the `Visualization` union, which is enough for consumers writing `visualizations={[{ type: "graph", options: {...} }]}`. If a future ask wants `import type { GraphVisualizationOptions }` by name, add an explicit `export type { GraphVisualizationOptions } from "./visualizations/collection/Graph"` in `exports.ts` then — out of scope for parity. |
 
 ### Files explicitly NOT edited
+
 - Everything under `packages/react/src/patterns/F0Graph/*` — F0Graph is consumed as-is in this work. The Phase 2 `dimmedNodes` capability lands in a separate upstream PR (see §1.6).
 - `OneDatacollection.tsx`, `Settings/*`, `hooks/useDataCollectionData/*`, `navigationFilters/*` — view is additive only.
 
@@ -370,20 +377,21 @@ No breaking changes to existing public types. The `Visualization` union grows by
 
 ### 6.1 Stories (`__stories__/Graph.stories.tsx`)
 
-| Story | What it shows |
-| --- | --- |
-| **Basic** | 10-node org chart with default expand depth = 2. |
-| **WithDetailPanel** | Click a node → panel opens with name, role, item-actions via `menuActions`. |
-| **WithItemActionsNoPanel** | No `detailPanel` provided; item-actions still reachable via `F0GraphNode.actions`. |
-| **DAG** | Records with `parentIds: string[]` rendering a small DAG. |
-| **Lazy** | Only roots in the source; `loadChildren` resolves to a mocked async batch with a 400ms delay. |
-| **WithVisualizationSwitcher** | Same source rendered as both Table and Graph, with the picker; selection survives the switch. |
-| **Empty** | Source returns zero records → F0Graph renders nothing; collection chrome shows the existing empty state. |
-| **LoadingThenLoaded** | Source initially pending → opacity-50 graph, then settles. |
-| **HardRemovalFilter** | Filter narrows the set; non-matching nodes and their edges disappear; subtree removed (Phase 1). |
-| **GroupingWarning** (dev story, `parameters.controls: { disable: true }`) | Source with `grouping` set → dev throw is shown in console; verifies guard. |
+| Story                                                                     | What it shows                                                                                            |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Basic**                                                                 | 10-node org chart with default expand depth = 2.                                                         |
+| **WithDetailPanel**                                                       | Click a node → panel opens with name, role, item-actions via `menuActions`.                              |
+| **WithItemActionsNoPanel**                                                | No `detailPanel` provided; item-actions still reachable via `F0GraphNode.actions`.                       |
+| **DAG**                                                                   | Records with `parentIds: string[]` rendering a small DAG.                                                |
+| **Lazy**                                                                  | Only roots in the source; `loadChildren` resolves to a mocked async batch with a 400ms delay.            |
+| **WithVisualizationSwitcher**                                             | Same source rendered as both Table and Graph, with the picker; selection survives the switch.            |
+| **Empty**                                                                 | Source returns zero records → F0Graph renders nothing; collection chrome shows the existing empty state. |
+| **LoadingThenLoaded**                                                     | Source initially pending → opacity-50 graph, then settles.                                               |
+| **HardRemovalFilter**                                                     | Filter narrows the set; non-matching nodes and their edges disappear; subtree removed (Phase 1).         |
+| **GroupingWarning** (dev story, `parameters.controls: { disable: true }`) | Source with `grouping` set → dev throw is shown in console; verifies guard.                              |
 
 ### 6.2 Unit tests (`projectGraph.spec.ts`)
+
 - Projects flat records into nodes preserving `data`.
 - Stamps `node.id` via the shared `getKey` helper (three-step fallback: `idProvider` → `item.id` → `index`, coerced to `string`) — never from `nodeAdapter`.
 - Derives parent→child edges from `parentId`.
@@ -395,6 +403,7 @@ No breaking changes to existing public types. The `Visualization` union grows by
 - Hard removal: given a matched-id set that excludes some records, the excluded records and any edges incident on them are omitted.
 
 ### 6.3 Component tests (`Graph.spec.tsx`)
+
 - Renders nodes for each record returned by the source.
 - `onNodeSelect` from F0Graph calls `handleSelectItemChange` with the matching record as `fallbackItem`.
 - **Lazy + selectAll inheritance.** Select-all-everything in Table → switch to Graph → expand a lazy-loaded child → that child renders selected. Click to deselect → switch back to Table → that one row is unselected.
@@ -411,9 +420,11 @@ No breaking changes to existing public types. The `Visualization` union grows by
 - Lazy mode: expanding a node invokes `loadChildren(nodeId)` and renders the returned records.
 
 ### 6.4 Visual regression
+
 - Chromatic snapshots for each story above (handled by existing pipeline — no config change).
 
 ### 6.5 What we do NOT test
+
 - F0Graph's own internals (zoom, layout math, detail-panel width persistence) — already covered by F0Graph's own suite.
 - Cross-visualization switching state preservation — covered by existing `OneDataCollection` integration tests; one new case is added under those tests in Phase 3 (see §8).
 
@@ -433,6 +444,7 @@ All resolved questions are tracked in §1.5; what remains is a watchlist of resi
 ## 8. 3-phase delivery
 
 ### Phase 1 — Skeleton, projection, hard-removal filter (PR #1)
+
 - Land everything in §5 with `Graph.tsx` rendering F0Graph from `projectGraph()` output.
 - `nodeAdapter` + default edge derivation only. No `edgeAdapter`, no `loadChildren`, no `detailPanel` (item-actions still wired via `F0GraphNode.actions`).
 - `selectionMode="single"` wired to `useSelectable` with `fallbackItem`.
@@ -447,6 +459,7 @@ All resolved questions are tracked in §1.5; what remains is a watchlist of resi
 - **Status: unblocked.** No external sign-offs remain.
 
 ### Phase 2 — Detail panel, lazy mode, dim (PR #2)
+
 - Add `detailPanel` option with `menuActions` bridge.
 - Add `loadChildren` option (lazy mode) with per-node `AbortController`.
 - Add `edgeAdapter` option.
@@ -457,6 +470,7 @@ All resolved questions are tracked in §1.5; what remains is a watchlist of resi
 - Perf smoke test answering Q4.
 
 ### Phase 3 — Polish & integration (PR #3)
+
 - Per-visualization settings entry in `Settings/` if any user-controllable knob emerges (likely `defaultExpandDepth` exposed via `graphProps`).
 - Add an integration test in `OneDataCollection/__tests__/` covering switch Table↔Graph with state preservation (selection + viewport-during-back-nav caveat from §2.3).
 - Update visualization selector tooltip copy / i18n keys.
@@ -486,27 +500,27 @@ Each phase is independently shippable. Phase 1 covers ~70% of the consumer use c
 
 ## 10. Out-of-scope follow-ups
 
-| Item | Why deferred |
-| --- | --- |
-| Multi-select bridge to bulk-actions footer | Needs UX design — "select all" semantics on a spatial canvas are non-obvious. |
-| Inline editing inside nodes (graph-equivalent of `editableTable`) | F0Graph nodes are renderer-driven; F0 needs an editing primitive first. |
-| Viewport persistence across hard refreshes | `OneDataCollection`'s settings persistence layer doesn't currently store viewport coordinates; F0Graph itself only persists detail-panel width. Possible follow-up, separate scope. |
-| Export-to-PNG / share-link | F0Graph doesn't expose a canvas snapshot API; would need a new F0Graph prop. |
-| Grouping support (treat group key as virtual parent) | Conflates two parent dimensions; non-trivial UX. |
-| Infinite-scroll-style streaming nodes | F0Graph has `deferredNodes` — viable but adds two more state machines to reason about. Schedule after lazy mode lands. |
-| Per-edge styling/labeling presets | Covered today by `graphProps.renderEdge`; hold a dedicated convenience API for a real consumer ask. |
-| Dedicated `useGraphLayout` for non-OneDataCollection consumers | If a second consumer of `projectGraph()` appears, hoist it under `patterns/F0Graph/hooks/`. |
-| Dedicated tree/hierarchy glyph from design | We ship with the existing `Graph` icon as the registry glyph. Swap is a one-line change in the registry entry once design produces a dedicated variant. |
+| Item                                                              | Why deferred                                                                                                                                                                        |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Multi-select bridge to bulk-actions footer                        | Needs UX design — "select all" semantics on a spatial canvas are non-obvious.                                                                                                       |
+| Inline editing inside nodes (graph-equivalent of `editableTable`) | F0Graph nodes are renderer-driven; F0 needs an editing primitive first.                                                                                                             |
+| Viewport persistence across hard refreshes                        | `OneDataCollection`'s settings persistence layer doesn't currently store viewport coordinates; F0Graph itself only persists detail-panel width. Possible follow-up, separate scope. |
+| Export-to-PNG / share-link                                        | F0Graph doesn't expose a canvas snapshot API; would need a new F0Graph prop.                                                                                                        |
+| Grouping support (treat group key as virtual parent)              | Conflates two parent dimensions; non-trivial UX.                                                                                                                                    |
+| Infinite-scroll-style streaming nodes                             | F0Graph has `deferredNodes` — viable but adds two more state machines to reason about. Schedule after lazy mode lands.                                                              |
+| Per-edge styling/labeling presets                                 | Covered today by `graphProps.renderEdge`; hold a dedicated convenience API for a real consumer ask.                                                                                 |
+| Dedicated `useGraphLayout` for non-OneDataCollection consumers    | If a second consumer of `projectGraph()` appears, hoist it under `patterns/F0Graph/hooks/`.                                                                                         |
+| Dedicated tree/hierarchy glyph from design                        | We ship with the existing `Graph` icon as the registry glyph. Swap is a one-line change in the registry entry once design produces a dedicated variant.                             |
 
 ---
 
 ## 11. Risks summary
 
-| Risk | Likelihood | Impact | Mitigation |
-| --- | --- | --- | --- |
-| Large graphs (>2k nodes) janky | Med | Med | Phase-2 perf smoke; publish envelope. F0Graph's existing 700-node snap threshold already degrades gracefully. |
-| Selection model mismatch confuses existing consumers | Med | Med | Single-select only in v1; multi-select tracked as §10 follow-up. Lazy `fallbackItem` rule documented in §4.4. |
-| TypeScript instantiation depth from 6th union variant | Low | Med | Mirror existing registry cast pattern (`as VisualizacionTypeDefinition<...>`) per Q6. No new tech debt. |
-| Generic `Graph` icon stays in place longer than expected | Low | Low | Swap is a one-line registry edit when design ships a dedicated glyph. Follow-up tracked in §10. |
-| Upstream F0Graph `dimmedNodes` PR slips | Med | Low | Phase 1 still ships with hard removal; only Phase 2 dim UX is delayed. No code in this repo blocks. |
-| Parent route in `factorial` forces remount on back-nav | Low | Med | Verify before Phase 1 ships (per §2.3 caveat). If it does, fix the route, not this view. Viewport persistence across hard refreshes is explicitly out of scope (§10). |
+| Risk                                                     | Likelihood | Impact | Mitigation                                                                                                                                                            |
+| -------------------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Large graphs (>2k nodes) janky                           | Med        | Med    | Phase-2 perf smoke; publish envelope. F0Graph's existing 700-node snap threshold already degrades gracefully.                                                         |
+| Selection model mismatch confuses existing consumers     | Med        | Med    | Single-select only in v1; multi-select tracked as §10 follow-up. Lazy `fallbackItem` rule documented in §4.4.                                                         |
+| TypeScript instantiation depth from 6th union variant    | Low        | Med    | Mirror existing registry cast pattern (`as VisualizacionTypeDefinition<...>`) per Q6. No new tech debt.                                                               |
+| Generic `Graph` icon stays in place longer than expected | Low        | Low    | Swap is a one-line registry edit when design ships a dedicated glyph. Follow-up tracked in §10.                                                                       |
+| Upstream F0Graph `dimmedNodes` PR slips                  | Med        | Low    | Phase 1 still ships with hard removal; only Phase 2 dim UX is delayed. No code in this repo blocks.                                                                   |
+| Parent route in `factorial` forces remount on back-nav   | Low        | Med    | Verify before Phase 1 ships (per §2.3 caveat). If it does, fix the route, not this view. Viewport persistence across hard refreshes is explicitly out of scope (§10). |

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/PLAN.md
@@ -446,7 +446,7 @@ No breaking changes to existing public types. The `Visualization` union grows by
 All resolved questions are tracked in §1.5; what remains is a watchlist of residual risks that affect Phase 2/3 sequencing, not Phase 1 entry. See §11 for severity ratings.
 
 - **Performance envelope unverified.** Phase 2 perf smoke against 1k/2k node mocks publishes the supported limit. Until then, no formal envelope is advertised. F0Graph's existing `LARGE_GRAPH_SNAP_THRESHOLD = 700` already governs animation snapping, so degradation is graceful.
-- **Multi-select UX deferred.** v1 ships `selectionMode="single"`. The selection bridge is structured so adding `multi` later is purely additive — no v1 API change is required to unlock it.
+- **Multi-select UX still needs consumer polish.** Phase 1 ships `selectionMode="multi"` end-to-end via `useSelectable`, but bulk-action affordances on a spatial canvas remain a consumer-level UX problem. The bridge is in place; the toolbar design can iterate separately.
 - **Graph icon is a generic glyph.** `@/icons/app/Graph` ships now; if design produces a dedicated tree/hierarchy variant, the swap is a one-line registry edit (see §10).
 - **Phase 2 blocked on upstream F0Graph PR for `dimmedNodes`.** Phase 1 ships fine without it (hard removal).
 
@@ -458,16 +458,16 @@ All resolved questions are tracked in §1.5; what remains is a watchlist of resi
 
 - Land everything in §5 with `Graph.tsx` rendering F0Graph from `projectGraph()` output.
 - `nodeAdapter` + default edge derivation + optional `edgeAdapter` (Phase 1 ships both — `edgeAdapter` is a thin passthrough with no extra cost).
-- No `detailPanel` yet (item-actions still wired via `F0GraphNode.actions`).
+- No `detailPanel` in the public API yet (item-actions still wired via `F0GraphNode.actions`).
 - Lazy mode (`loadChildren`) shipped as part of Phase 1 with full abort semantics: per-node `AbortController`, signal forwarded to the consumer loader via `opts.signal`, aborted on (a) a fresh call for the same nodeId and (b) unmount.
-- Selection wired to `useSelectable` with `fallbackItem`, multi-select end-to-end (both `single` and `multiple` modes forwarded from `source.selectable`). Lazy mode opts into `allPagesSelection: true` so lazy ids surface in `onSelectItems` (see §4.4).
+- Selection wired to `useSelectable` with `fallbackItem`, multi-select end-to-end (`selectionMode: "multi"` when `source.selectable` is present). Lazy mode opts into `allPagesSelection: true` so lazy ids surface in `onSelectItems` (see §4.4).
 - Memoized `nodes`/`edges` arrays (per §4.3).
 - Enforce both pagination-mode guards (§4.1) — throw with the exact dev messages.
 - Cycle detection + `console.warn` (per §4.3).
 - Hard-removal filter implementation in `projectGraph`.
 - Search pipe-through into F0Graph (per §4.3) — prefers `source.debouncedCurrentSearch` over `source.currentSearch` to avoid layout thrash on each keystroke.
 - Register entry in `collectionViewRegistry` using `Graph` from `@/icons/app`. Update `Visualization` union.
-- Stories: **Basic**, **Empty**, **LoadingThenLoaded**, **HardRemovalFilter**, **WithItemActionsNoPanel**.
+- Stories: **Default**, **RecordSubsetReprojects**, **WithItemActionsNoPanel**, **Selectable**, **Cycle**, **LazyMode**, **TwoInstances**, **Snapshot**.
 - Tests: full `projectGraph.spec.ts`; component tests under `__tests__/` covering render, selection (incl. `fallbackItem` and lazy id round-trip), both pagination-guard throws, cycle warning, hard removal, search pipe-through, abort signal forwarding (per-nodeId + unmount), and the dev-mode identity warning (one-per-prop, prod gate).
 - **Status: shipped.** No external sign-offs remain.
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/GraphCollection.mdx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/GraphCollection.mdx
@@ -68,12 +68,16 @@ the primary affordance — Phase 1 Graph does not implement either.
           <code>edgeAdapter</code>
         </td>
         <td>
-          <code>(record: R) =&gt; ExplicitEdge[]</code>
+          <code>
+            (records: ReadonlyArray&lt;R&gt;) =&gt;
+            ReadonlyArray&lt;GraphEdge&gt;
+          </code>
         </td>
         <td>No</td>
         <td>
-          Adds explicit edges on top of parent-derived edges. Cycle-closing
-          edges are dropped.
+          Optional. Receives the full record array and returns explicit edges,
+          bypassing the implicit <code>parentId</code>/<code>parentIds</code>
+          projection. Cycle-closing edges are dropped.
         </td>
       </tr>
       <tr>
@@ -182,7 +186,7 @@ const visualization = {
 
 ### Hard removal via filters
 
-<Canvas of={Stories.HardRemovalFilter} />
+<Canvas of={Stories.RecordSubsetReprojects} />
 
 Records excluded by the active filter are dropped from the projection along
 with every edge incident on them — no orphan promotion. Phase 1 ships hard
@@ -286,7 +290,7 @@ The stories above exercise every Phase 1 acceptance check in
 `Graph/PLAN.md §9`:
 
 - `Default` — eager projection + render-node pipeline.
-- `HardRemovalFilter` — hard-removal semantics on the source filter.
+- `RecordSubsetReprojects` — hard-removal semantics when the source supplies a reduced record set.
 - `WithItemActionsNoPanel` — `extras.actions` slot when item actions exist.
 - `Selectable` — multi-select bridge over `source.selectable`.
 - `Cycle` — cycle detection + single warn + acyclic projection.

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/GraphCollection.mdx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/GraphCollection.mdx
@@ -1,0 +1,295 @@
+import { Canvas, Controls, Meta, Unstyled } from "@storybook/addon-docs/blocks"
+
+import * as Stories from "./GraphCollection.stories"
+
+<Meta of={Stories} />
+
+# Graph (OneDataCollection)
+
+Phase 1 Graph visualization for `<OneDataCollection>`. Renders a record set
+as an interactive tree or DAG using the F0Graph runtime, with adapters for
+parent linkage, optional explicit edges, and a custom `renderNode`. Use it
+for org charts, dependency trees, navigable hierarchies, and small DAGs
+where the consumer owns the node UI.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+## When to use
+
+- **Hierarchies** — org charts, file trees, category trees, anything with a
+  single-parent linkage.
+- **Small DAGs** — when a record has multiple parents, declare them via
+  `nodeAdapter` returning `{ parentId, parentIds }`.
+- **Lazy expansion** — large trees where children are fetched on demand;
+  pair `loadChildren` with `paginationType: "infinite-scroll"` so the lazy
+  flag survives `useSelectable` filtering.
+
+Pick a different visualization (Card / Kanban / Table) when records are
+_flat_ with no parent linkage, or when grouping / column-level sorting is
+the primary affordance — Phase 1 Graph does not implement either.
+
+## API
+
+### `GraphVisualizationOptions<R>`
+
+<Unstyled>
+  <table>
+    <thead>
+      <tr>
+        <th>Field</th>
+        <th>Type</th>
+        <th>Required</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>nodeAdapter</code>
+        </td>
+        <td>
+          <code>
+            (record: R) =&gt; &#123; parentId, parentIds?, childrenCount?,
+            childrenLoaded? &#125;
+          </code>
+        </td>
+        <td>Yes</td>
+        <td>
+          Maps a record to its parent linkage. <code>parentIds</code> opts the
+          node into DAG mode.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>edgeAdapter</code>
+        </td>
+        <td>
+          <code>(record: R) =&gt; ExplicitEdge[]</code>
+        </td>
+        <td>No</td>
+        <td>
+          Adds explicit edges on top of parent-derived edges. Cycle-closing
+          edges are dropped.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>renderNode</code>
+        </td>
+        <td>
+          <code>(record, ctx, extras) =&gt; ReactNode</code>
+        </td>
+        <td>Yes</td>
+        <td>
+          Consumer-owned node UI. <code>extras.actions</code> carries the
+          dropdown built from <code>source.itemActions</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>loadChildren</code>
+        </td>
+        <td>
+          <code>(nodeId, &#123; signal &#125;) =&gt; Promise&lt;R[]&gt;</code>
+        </td>
+        <td>No</td>
+        <td>
+          Lazy loader. <strong>Requires</strong> a paginated source. Honor the
+          abort signal.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>graphId</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>No</td>
+        <td>
+          Defaults to <code>React.useId()</code>. Set it explicitly to persist
+          per-instance F0Graph state across mounts.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>graphProps</code>
+        </td>
+        <td>
+          <code>Omit&lt;F0GraphProps, …&gt;</code>
+        </td>
+        <td>No</td>
+        <td>
+          Passthrough to F0Graph. Selection, search, <code>nodes</code>,{" "}
+          <code>edges</code>, <code>loadChildren</code>, <code>renderNode</code>{" "}
+          are reserved.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### `GraphRenderNodeExtras`
+
+<Unstyled>
+  <table>
+    <thead>
+      <tr>
+        <th>Field</th>
+        <th>Type</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>actions</code>
+        </td>
+        <td>
+          <code>ReactNode | undefined</code>
+        </td>
+        <td>
+          Pre-built actions dropdown when <code>source.itemActions</code>{" "}
+          returns ≥1 action. Spread into{" "}
+          <code>&lt;F0GraphNode actions=&#123;extras.actions&#125; /&gt;</code>.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Patterns
+
+### Hierarchy adapter (single parent)
+
+<Canvas of={Stories.Default} />
+
+```tsx
+const visualization = {
+  type: "graph",
+  options: {
+    nodeAdapter: (person) => ({ parentId: person.managerId }),
+    renderNode: (person, ctx) => (
+      <F0GraphNode {...ctx} title={person.name} subtitle={person.role} />
+    ),
+  },
+}
+```
+
+### Hard removal via filters
+
+<Canvas of={Stories.HardRemovalFilter} />
+
+Records excluded by the active filter are dropped from the projection along
+with every edge incident on them — no orphan promotion. Phase 1 ships hard
+removal only; if you need "dim instead of drop" semantics, surface the
+filter through the F0Graph search input (which uses dim) rather than the
+DataCollection filter.
+
+### Item actions without a detail panel
+
+<Canvas of={Stories.WithItemActionsNoPanel} />
+
+```tsx
+const visualization = {
+  type: "graph",
+  options: {
+    nodeAdapter: (item) => ({ parentId: item.managerId }),
+    renderNode: (item, ctx, extras) => (
+      <F0GraphNode {...ctx} title={item.name} actions={extras.actions} />
+    ),
+  },
+}
+// On the source:
+const source = useDataCollectionSource({
+  dataAdapter,
+  itemActions: (item) => [{ label: "Edit", icon: Pencil, onClick: … }],
+})
+```
+
+### Selection bridge
+
+<Canvas of={Stories.Selectable} />
+
+`source.selectable` opts the graph into multi-select. Lazy-loaded ids are
+covered by the bridge because Graph forces `allPagesSelection: true` when
+`loadChildren` is set.
+
+### Lazy expansion
+
+<Canvas of={Stories.LazyMode} />
+
+```tsx
+const source = useDataCollectionSource({
+  dataAdapter: {
+    paginationType: "infinite-scroll",
+    perPage: 10,
+    fetchData: async () => ({ records: roots /* … */ }),
+  },
+})
+
+const visualization = {
+  type: "graph",
+  options: {
+    nodeAdapter: (record) => ({
+      parentId: record.parentId,
+      childrenCount: record.descendants,
+    }),
+    loadChildren: async (nodeId, { signal }) => {
+      const res = await fetch(`/api/nodes/${nodeId}/children`, { signal })
+      return res.json()
+    },
+    renderNode: (record, ctx) => <F0GraphNode {...ctx} title={record.name} />,
+  },
+}
+```
+
+### Cycle handling
+
+<Canvas of={Stories.Cycle} />
+
+`projectGraph` drops cycle-closing edges and emits a single `console.warn`
+per unique cycle signature. Re-renders with the same cycles do not re-warn.
+
+### Two simultaneous mounts
+
+<Canvas of={Stories.TwoInstances} />
+
+Each `<OneDataCollection>` falls back to `React.useId()` for `graphId`, so
+multiple mounts on the same page never collide on persisted F0Graph state.
+
+## Phase 1 limitations
+
+These map directly to `PLAN.md §9 Acceptance criteria`:
+
+- **No detail panel** — `detailPanel` is intentionally absent from the
+  Phase 1 public surface. Surface details via `extras.actions` or a custom
+  side-panel for now; the detail panel + dim semantics land in Phase 2.
+- **No grouping** — declaring `grouping` on the source while the graph
+  visualization is active throws at the GraphCollection boundary.
+- **Eager requires no pagination** — `paginationType` must be
+  `"no-pagination"` unless `loadChildren` is set.
+- **Lazy requires pagination** — `loadChildren` requires
+  `paginationType: "infinite-scroll"`.
+- **Hard removal only** — filtered-out records disappear; no dim mode.
+- **Single-instance state** — when stacking two graphs on the same page,
+  either let both fall back to `useId()` (auto-isolated) or assign distinct
+  `graphId` values.
+
+## Acceptance criteria
+
+The stories above exercise every Phase 1 acceptance check in
+`Graph/PLAN.md §9`:
+
+- `Default` — eager projection + render-node pipeline.
+- `HardRemovalFilter` — hard-removal semantics on the source filter.
+- `WithItemActionsNoPanel` — `extras.actions` slot when item actions exist.
+- `Selectable` — multi-select bridge over `source.selectable`.
+- `Cycle` — cycle detection + single warn + acyclic projection.
+- `LazyMode` — `loadChildren` + `AbortSignal` per-node cancellation.
+- `TwoInstances` — `useId()`-based `graphId` isolation.
+- `Snapshot` — deterministic visual regression baseline.

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/GraphCollection.mdx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/GraphCollection.mdx
@@ -166,6 +166,29 @@ the primary affordance — Phase 1 Graph does not implement either.
   </table>
 </Unstyled>
 
+## Sizing
+
+The Graph visualization fills its parent container. To prevent layout
+collapse when the page chrome is short, it ships with a built-in
+`min-h-[400px]` floor so the graph stays usable even when wrapped in a
+container with no explicit height.
+
+For full-viewport layouts (e.g., a dedicated page), pair
+`OneDataCollection`'s `fullHeight` prop with a flex column whose height
+subtracts your app chrome:
+
+```tsx
+<div className="flex h-[calc(100vh-160px)] min-h-[480px] flex-col">
+  <OneDataCollection source={source} visualizations={[graphViz]} fullHeight />
+</div>
+```
+
+- Use `calc(100vh - <chrome>px)` so the graph absorbs all leftover space.
+- Keep `min-h-[…]` higher than the built-in `400px` floor if you want a
+  taller minimum on narrow viewports.
+- Without `fullHeight`, the visualization measures its natural height and
+  still honors the `min-h-[400px]` default.
+
 ## Patterns
 
 ### Hierarchy adapter (single parent)

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/GraphCollection.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/GraphCollection.stories.tsx
@@ -1,0 +1,599 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+
+import type { F0GraphNodeRenderContext } from "@/patterns/F0Graph"
+import { F0GraphNode } from "@/patterns/F0Graph/F0GraphNode"
+
+import { withSkipA11y, withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import { OneDataCollection } from "../../../.."
+import { useDataCollectionSource } from "../../../../hooks/useDataCollectionSource"
+import type { GraphRenderNodeExtras } from "../types"
+import {
+  cyclicChart,
+  lazyChildrenByParent,
+  lazyRoots,
+  orgChart,
+  orgItemActions,
+  type OrgPerson,
+} from "./_fixtures"
+
+/* -------------------------------------------------------------------------- */
+/* Meta                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The Graph visualization renders an `OneDataCollection` source as an
+ * interactive tree / DAG using the F0Graph runtime. These stories are
+ * authored against the public `visualizations={[{ type: "graph", options }]}`
+ * surface so they double as living documentation for Phase 1 capabilities.
+ *
+ * Convention note: most other OneDataCollection visualization stories
+ * mount via the `ExampleComponent` wrapper (MockUser shape, no parent
+ * linkage). Graph requires bespoke hierarchical fixtures, so these stories
+ * mount `<OneDataCollection>` directly. Title still lands under the shared
+ * `Data Collection/Visualizations/Graph` sidebar slot.
+ */
+const meta = {
+  title: "Data Collection/Visualizations/Graph",
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Phase 1 Graph visualization for OneDataCollection. Bridges a `DataCollectionSource` to F0Graph for tree / DAG renderings with adapters for parent linkage, optional explicit edges, and a custom `renderNode`.",
+      },
+    },
+  },
+  tags: ["stable", "!autodocs"],
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/* -------------------------------------------------------------------------- */
+/* Shared helpers                                                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Build an F0Avatar `person` variant from a fixture record. Centralised so
+ * every story renders nodes the same way and avatar shape changes only have
+ * to be made once.
+ */
+const personAvatar = (record: OrgPerson) => {
+  const [firstName, ...rest] = record.name.split(" ")
+  return {
+    type: "person" as const,
+    firstName,
+    lastName: rest.join(" "),
+  }
+}
+
+/**
+ * Default node renderer used by most stories. Mirrors a typical consumer
+ * implementation: hand every F0Graph render-context field through to
+ * `F0GraphNode` so accessibility (ARIA roles, tabindex, ariaOwns), expand
+ * toggles, and the floating actions slot work out of the box.
+ */
+const renderOrgNode = (
+  record: OrgPerson,
+  ctx: F0GraphNodeRenderContext,
+  extras: GraphRenderNodeExtras
+) => (
+  <F0GraphNode
+    variant={ctx.variant}
+    state={ctx.state}
+    expanded={ctx.expanded}
+    hasChildren={ctx.hasChildren}
+    childrenCount={ctx.childrenCount}
+    level={ctx.level}
+    tabIndex={ctx.tabIndex}
+    setSize={ctx.setSize}
+    posInSet={ctx.posInSet}
+    nodeId={ctx.nodeId}
+    ariaOwns={ctx.ariaOwns}
+    onExpandToggle={ctx.onExpandToggle}
+    onClick={ctx.onClick}
+    nodeRef={ctx.nodeRef}
+    avatar={personAvatar(record)}
+    title={record.name}
+    subtitle={record.role}
+    tags={[{ type: "team", name: record.team }]}
+    actions={extras.actions}
+  />
+)
+
+/* -------------------------------------------------------------------------- */
+/* Story: Default                                                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Eager mode — a ~12-node org chart. Demonstrates the canonical wiring:
+ * `nodeAdapter` returns `{ parentId }`, `renderNode` returns an
+ * `<F0GraphNode>`, no item-actions, no detail panel. First exported story so
+ * the manual MDX page attaches to a meta with `["stable", "!autodocs"]` —
+ * `no-sidebar` tag is intentionally absent.
+ */
+export const Default: Story = {
+  render: () => {
+    const DefaultExample = () => {
+      const source = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          fetchData: async () => ({ records: orgChart }),
+        },
+      })
+
+      return (
+        <div className="h-[600px] w-full">
+          <OneDataCollection
+            source={source}
+            visualizations={[
+              {
+                type: "graph",
+                options: {
+                  nodeAdapter: (record) => ({ parentId: record.managerId }),
+                  renderNode: renderOrgNode,
+                },
+              },
+            ]}
+          />
+        </div>
+      )
+    }
+    return <DefaultExample />
+  },
+}
+
+/* -------------------------------------------------------------------------- */
+/* Story: HardRemovalFilter                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Hard removal — confirms Phase 1 filter semantics. The active filter omits
+ * the "Engineering" subtree at the source level (records never enter the
+ * projection), so the Engineering branch disappears entirely; no orphan
+ * promotion. The toggle button proves the projection re-renders cleanly when
+ * the source filter set changes.
+ */
+export const HardRemovalFilter: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Phase 1 ships hard removal. Records excluded by the active filter are dropped from the projection along with every edge incident on them. The toggle button flips between full org and Engineering-hidden.",
+      },
+    },
+  },
+  render: () => {
+    const HardRemovalExample = () => {
+      const [hideEng, setHideEng] = useState(false)
+      const visible = hideEng
+        ? orgChart.filter((p) => p.team !== "Engineering")
+        : orgChart
+
+      const source = useDataCollectionSource<OrgPerson>(
+        {
+          dataAdapter: {
+            fetchData: async () => ({ records: visible }),
+          },
+        },
+        [hideEng]
+      )
+
+      return (
+        <div className="flex h-[640px] w-full flex-col gap-2 p-2">
+          <button
+            className="self-start rounded-md border border-f1-border bg-f1-background px-3 py-1 text-f1-foreground"
+            onClick={() => setHideEng((v) => !v)}
+            type="button"
+          >
+            {hideEng ? "Show Engineering subtree" : "Hide Engineering subtree"}
+          </button>
+          <div className="min-h-0 flex-1">
+            <OneDataCollection
+              source={source}
+              visualizations={[
+                {
+                  type: "graph",
+                  options: {
+                    nodeAdapter: (record) => ({
+                      parentId: record.managerId,
+                    }),
+                    renderNode: renderOrgNode,
+                  },
+                },
+              ]}
+            />
+          </div>
+        </div>
+      )
+    }
+    return <HardRemovalExample />
+  },
+}
+
+/* -------------------------------------------------------------------------- */
+/* Story: WithItemActionsNoPanel                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Item-actions fallback — `source.itemActions` returns a non-empty list, no
+ * detail panel is provided in Phase 1. GraphCollection builds the actions
+ * dropdown and passes it to `renderNode` via the `extras.actions` slot;
+ * F0GraphNode renders it as the floating toolbar on selected nodes.
+ */
+export const WithItemActionsNoPanel: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When `source.itemActions` returns ≥1 action, GraphCollection builds a dropdown and forwards it via `extras.actions`. Spread into `<F0GraphNode actions={…} />` to surface item actions on the selected node.",
+      },
+    },
+  },
+  render: () => {
+    const ItemActionsExample = () => {
+      const source = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          fetchData: async () => ({ records: orgChart }),
+        },
+        itemActions: orgItemActions,
+      })
+
+      return (
+        <div className="h-[600px] w-full">
+          <OneDataCollection
+            source={source}
+            visualizations={[
+              {
+                type: "graph",
+                options: {
+                  nodeAdapter: (record) => ({ parentId: record.managerId }),
+                  renderNode: renderOrgNode,
+                },
+              },
+            ]}
+          />
+        </div>
+      )
+    }
+    return <ItemActionsExample />
+  },
+}
+
+/* -------------------------------------------------------------------------- */
+/* Story: Selectable                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Selection bridge — `source.selectable` opts the graph into multi-select.
+ * F0Graph emits string ids; GraphCollection resolves each id to the
+ * underlying record (via the same `idProvider`/`item.id`/index fallback used
+ * for projection) and forwards it to `useSelectable`. Selection state lives
+ * on the source so view-switches preserve the checkmarks.
+ *
+ * Note: Phase 1 omits `detailPanel` from the public surface; this story
+ * replaces the original "WithDetailPanel" spec entry because the panel
+ * cannot be wired without an unreleased prop.
+ */
+export const Selectable: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Adding `selectable` to the source flips `F0Graph` to `selectionMode='multi'`. Selection state is owned by `useSelectable` on the source, so checkmarks survive view switches.",
+      },
+    },
+  },
+  render: () => {
+    const SelectableExample = () => {
+      const source = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          fetchData: async () => ({ records: orgChart }),
+        },
+        selectable: (item) => item.id,
+      })
+
+      return (
+        <div className="h-[600px] w-full">
+          <OneDataCollection
+            source={source}
+            onSelectItems={(payload) => {
+              console.log("[Graph] selected ids:", payload.selectedIds)
+            }}
+            visualizations={[
+              {
+                type: "graph",
+                options: {
+                  nodeAdapter: (record) => ({ parentId: record.managerId }),
+                  renderNode: renderOrgNode,
+                },
+              },
+            ]}
+          />
+        </div>
+      )
+    }
+    return <SelectableExample />
+  },
+}
+
+/* -------------------------------------------------------------------------- */
+/* Story: Cycle                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Cycle detection — fixture contains a 3-cycle (A→B→C→A) plus a clean
+ * root/child. `projectGraph` drops the cycle-closing edge so the resulting
+ * graph stays acyclic; GraphCollection emits one `console.warn` per unique
+ * cycle signature. Open the browser console to see the warning.
+ */
+export const Cycle: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Cycle-closing edges are dropped so the resulting graph remains acyclic. Expect exactly one `console.warn` per unique cycle signature on first render — re-renders with the same cycles do not re-warn.",
+      },
+    },
+  },
+  render: () => {
+    const CycleExample = () => {
+      const source = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          fetchData: async () => ({ records: cyclicChart }),
+        },
+      })
+
+      return (
+        <div className="h-[600px] w-full">
+          <OneDataCollection
+            source={source}
+            visualizations={[
+              {
+                type: "graph",
+                options: {
+                  nodeAdapter: (record) => ({ parentId: record.managerId }),
+                  renderNode: renderOrgNode,
+                },
+              },
+            ]}
+          />
+        </div>
+      )
+    }
+    return <CycleExample />
+  },
+}
+
+/* -------------------------------------------------------------------------- */
+/* Story: LazyMode                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Lazy mode — the source is paginated (infinite-scroll) and `loadChildren`
+ * resolves children on demand. The loader receives an `AbortSignal` from
+ * GraphCollection's per-node controller, so collapsed nodes whose loads have
+ * not yet resolved are dropped silently.
+ */
+export const LazyMode: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`loadChildren` requires a paginated source. Per-node `AbortController` is forwarded to the consumer loader so cancelled expansions never produce orphan children. Loader simulates 600ms latency.",
+      },
+    },
+  },
+  render: () => {
+    const LazyExample = () => {
+      const source = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          paginationType: "infinite-scroll",
+          perPage: 10,
+          fetchData: async () => ({
+            records: lazyRoots,
+            total: lazyRoots.length,
+            perPage: lazyRoots.length,
+            type: "infinite-scroll" as const,
+            cursor: null,
+            hasMore: false,
+          }),
+        },
+      })
+
+      return (
+        <div className="h-[600px] w-full">
+          <OneDataCollection
+            source={source}
+            visualizations={[
+              {
+                type: "graph",
+                options: {
+                  nodeAdapter: (record) => ({
+                    parentId: record.managerId,
+                    childrenCount: lazyChildrenByParent[record.id]?.length ?? 0,
+                  }),
+                  loadChildren: async (nodeId, { signal }) => {
+                    return await new Promise<OrgPerson[]>((resolve, reject) => {
+                      const timer = setTimeout(() => {
+                        resolve(lazyChildrenByParent[nodeId] ?? [])
+                      }, 600)
+                      signal.addEventListener("abort", () => {
+                        clearTimeout(timer)
+                        reject(new DOMException("aborted", "AbortError"))
+                      })
+                    })
+                  },
+                  renderNode: renderOrgNode,
+                },
+              },
+            ]}
+          />
+        </div>
+      )
+    }
+    return <LazyExample />
+  },
+}
+
+/* -------------------------------------------------------------------------- */
+/* Story: TwoInstances                                                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Two simultaneous mounts — neither passes an explicit `graphId`, so
+ * GraphCollection falls back to `React.useId()`. The two instances therefore
+ * receive unique stable ids and never collide on persisted state
+ * (detail-panel width, etc.).
+ */
+export const TwoInstances: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Two `<OneDataCollection>` instances mounted side-by-side with no explicit `graphId`. Each instance gets a stable `React.useId()` so persisted state (e.g. detail-panel width) does not bleed across mounts.",
+      },
+    },
+  },
+  render: () => {
+    const TwoInstancesExample = () => {
+      const sourceA = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          fetchData: async () => ({ records: orgChart }),
+        },
+      })
+      const sourceB = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          fetchData: async () => ({ records: orgChart.slice(0, 6) }),
+        },
+      })
+
+      return (
+        <div className="grid h-[600px] w-full grid-cols-2 gap-2 p-2">
+          <div className="min-h-0 rounded-md border border-f1-border">
+            <OneDataCollection
+              source={sourceA}
+              visualizations={[
+                {
+                  type: "graph",
+                  options: {
+                    nodeAdapter: (record) => ({
+                      parentId: record.managerId,
+                    }),
+                    renderNode: renderOrgNode,
+                  },
+                },
+              ]}
+            />
+          </div>
+          <div className="min-h-0 rounded-md border border-f1-border">
+            <OneDataCollection
+              source={sourceB}
+              visualizations={[
+                {
+                  type: "graph",
+                  options: {
+                    nodeAdapter: (record) => ({
+                      parentId: record.managerId,
+                    }),
+                    renderNode: renderOrgNode,
+                  },
+                },
+              ]}
+            />
+          </div>
+        </div>
+      )
+    }
+    return <TwoInstancesExample />
+  },
+}
+
+/* -------------------------------------------------------------------------- */
+/* Story: Snapshot                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Deterministic grid for Chromatic. No async, fixed-seed avatars, no
+ * sidebar. Combines Default + HardRemovalFilter + WithItemActionsNoPanel +
+ * Cycle in a single shot so visual regression catches projection changes
+ * across the most stable Phase 1 surfaces.
+ */
+export const Snapshot: Story = {
+  tags: ["no-sidebar"],
+  parameters: withSkipA11y(
+    withSnapshot({
+      layout: "fullscreen",
+      docs: {
+        description: {
+          story: "Chromatic snapshot grid combining four deterministic states.",
+        },
+      },
+    })
+  ),
+  render: () => {
+    const SnapshotGrid = () => {
+      const eagerSource = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          fetchData: async () => ({ records: orgChart }),
+        },
+      })
+      const filteredSource = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          fetchData: async () => ({
+            records: orgChart.filter((p) => p.team !== "Engineering"),
+          }),
+        },
+      })
+      const actionsSource = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          fetchData: async () => ({ records: orgChart }),
+        },
+        itemActions: orgItemActions,
+      })
+      const cycleSource = useDataCollectionSource<OrgPerson>({
+        dataAdapter: {
+          fetchData: async () => ({ records: cyclicChart }),
+        },
+      })
+
+      const tile = (
+        title: string,
+        source: ReturnType<typeof useDataCollectionSource<OrgPerson>>
+      ) => (
+        <div className="flex h-full min-h-0 flex-col rounded-md border border-f1-border">
+          <div className="border-b border-f1-border bg-f1-background-secondary px-3 py-1 text-f1-foreground">
+            {title}
+          </div>
+          <div className="min-h-0 flex-1">
+            <OneDataCollection
+              source={source}
+              visualizations={[
+                {
+                  type: "graph",
+                  options: {
+                    nodeAdapter: (record) => ({
+                      parentId: record.managerId,
+                    }),
+                    renderNode: renderOrgNode,
+                  },
+                },
+              ]}
+            />
+          </div>
+        </div>
+      )
+
+      return (
+        <div className="grid h-screen w-screen grid-cols-2 grid-rows-2 gap-2 p-2">
+          {tile("Default", eagerSource)}
+          {tile("HardRemovalFilter", filteredSource)}
+          {tile("WithItemActionsNoPanel", actionsSource)}
+          {tile("Cycle", cycleSource)}
+        </div>
+      )
+    }
+    return <SnapshotGrid />
+  },
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/GraphCollection.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/GraphCollection.stories.tsx
@@ -145,7 +145,7 @@ export const Default: Story = {
 }
 
 /* -------------------------------------------------------------------------- */
-/* Story: HardRemovalFilter                                                   */
+/* Story: RecordSubsetReprojects                                              */
 /* -------------------------------------------------------------------------- */
 
 /**
@@ -155,12 +155,12 @@ export const Default: Story = {
  * promotion. The toggle button proves the projection re-renders cleanly when
  * the source filter set changes.
  */
-export const HardRemovalFilter: Story = {
+export const RecordSubsetReprojects: Story = {
   parameters: {
     docs: {
       description: {
         story:
-          "Phase 1 ships hard removal. Records excluded by the active filter are dropped from the projection along with every edge incident on them. The toggle button flips between full org and Engineering-hidden.",
+          "When a subset of records reaches GraphCollection, the projection re-runs and entire subtrees disappear with no orphan promotion. This story toggles between the full org and an Engineering-hidden subset; in a real consumer that reduced array would normally come from the source filter pipeline.",
       },
     },
   },
@@ -444,15 +444,14 @@ export const LazyMode: Story = {
 /**
  * Two simultaneous mounts — neither passes an explicit `graphId`, so
  * GraphCollection falls back to `React.useId()`. The two instances therefore
- * receive unique stable ids and never collide on persisted state
- * (detail-panel width, etc.).
+ * receive unique stable ids and never collide on per-graph persisted state.
  */
 export const TwoInstances: Story = {
   parameters: {
     docs: {
       description: {
         story:
-          "Two `<OneDataCollection>` instances mounted side-by-side with no explicit `graphId`. Each instance gets a stable `React.useId()` so persisted state (e.g. detail-panel width) does not bleed across mounts.",
+          "Two `<OneDataCollection>` instances mounted side-by-side with no explicit `graphId`. Each instance gets a stable `React.useId()`-derived id, so any per-graph persisted state stays isolated with no key collisions across mounts.",
       },
     },
   },
@@ -516,18 +515,19 @@ export const TwoInstances: Story = {
 
 /**
  * Deterministic grid for Chromatic. No async, fixed-seed avatars, no
- * sidebar. Combines Default + HardRemovalFilter + WithItemActionsNoPanel +
- * Cycle in a single shot so visual regression catches projection changes
- * across the most stable Phase 1 surfaces.
+ * sidebar. Combines Default + RecordSubsetReprojects +
+ * WithItemActionsNoPanel + Selectable + Cycle in a single shot so visual
+ * regression catches projection changes across the most stable Phase 1
+ * surfaces.
  */
 export const Snapshot: Story = {
   tags: ["no-sidebar"],
   parameters: withSkipA11y(
     withSnapshot({
-      layout: "fullscreen",
       docs: {
         description: {
-          story: "Chromatic snapshot grid combining four deterministic states.",
+          story:
+            "Chromatic snapshot grid combining five deterministic Phase 1 states.",
         },
       },
     })
@@ -552,16 +552,28 @@ export const Snapshot: Story = {
         },
         itemActions: orgItemActions,
       })
+      const selectableSource: typeof eagerSource =
+        useDataCollectionSource<OrgPerson>({
+          dataAdapter: {
+            fetchData: async () => ({ records: orgChart }),
+          },
+          selectable: (item) => item.id,
+          defaultSelectedItems: {
+            allSelected: false,
+            items: new Map([
+              [orgChart[0].id, { id: orgChart[0].id, checked: true }],
+              [orgChart[2].id, { id: orgChart[2].id, checked: true }],
+            ]),
+            groups: new Map(),
+          },
+        })
       const cycleSource = useDataCollectionSource<OrgPerson>({
         dataAdapter: {
           fetchData: async () => ({ records: cyclicChart }),
         },
       })
 
-      const tile = (
-        title: string,
-        source: ReturnType<typeof useDataCollectionSource<OrgPerson>>
-      ) => (
+      const tile = (title: string, source: typeof eagerSource) => (
         <div className="flex h-full min-h-0 flex-col rounded-md border border-f1-border">
           <div className="border-b border-f1-border bg-f1-background-secondary px-3 py-1 text-f1-foreground">
             {title}
@@ -586,10 +598,31 @@ export const Snapshot: Story = {
       )
 
       return (
-        <div className="grid h-screen w-screen grid-cols-2 grid-rows-2 gap-2 p-2">
+        <div className="grid h-screen w-screen grid-cols-2 grid-rows-3 gap-2 p-2">
           {tile("Default", eagerSource)}
-          {tile("HardRemovalFilter", filteredSource)}
+          {tile("RecordSubsetReprojects", filteredSource)}
           {tile("WithItemActionsNoPanel", actionsSource)}
+          <div className="flex h-full min-h-0 flex-col rounded-md border border-f1-border">
+            <div className="border-b border-f1-border bg-f1-background-secondary px-3 py-1 text-f1-foreground">
+              Selectable
+            </div>
+            <div className="min-h-0 flex-1">
+              <OneDataCollection
+                source={selectableSource}
+                visualizations={[
+                  {
+                    type: "graph",
+                    options: {
+                      nodeAdapter: (record) => ({
+                        parentId: record.managerId,
+                      }),
+                      renderNode: renderOrgNode,
+                    },
+                  },
+                ]}
+              />
+            </div>
+          </div>
           {tile("Cycle", cycleSource)}
         </div>
       )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/_fixtures.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__stories__/_fixtures.tsx
@@ -1,0 +1,234 @@
+import { Ai, Delete, Pencil, Star } from "@/icons/app"
+
+import type { ItemActionsDefinition } from "../../../../item-actions"
+
+/**
+ * Org-chart fixture used by Graph stories. Hand-built ~12-node hierarchy
+ * with realistic depth + sibling fan-out so layout + zoom variants get
+ * meaningful exercise without being noisy.
+ */
+export type OrgPerson = {
+  id: string
+  name: string
+  role: string
+  team: string
+  /** Single-parent linkage. `null` marks a root. */
+  managerId: string | null
+}
+
+export const orgChart: OrgPerson[] = [
+  // Root
+  {
+    id: "p-1",
+    name: "Ada Lovelace",
+    role: "CEO",
+    team: "Executive",
+    managerId: null,
+  },
+
+  // L1 — direct reports of CEO
+  {
+    id: "p-2",
+    name: "Grace Hopper",
+    role: "CTO",
+    team: "Engineering",
+    managerId: "p-1",
+  },
+  {
+    id: "p-3",
+    name: "Marie Curie",
+    role: "VP Product",
+    team: "Product",
+    managerId: "p-1",
+  },
+  {
+    id: "p-4",
+    name: "Katherine Johnson",
+    role: "VP Design",
+    team: "Design",
+    managerId: "p-1",
+  },
+
+  // L2 — under CTO
+  {
+    id: "p-5",
+    name: "Alan Turing",
+    role: "Director, Platform",
+    team: "Engineering",
+    managerId: "p-2",
+  },
+  {
+    id: "p-6",
+    name: "Linus Torvalds",
+    role: "Director, Infra",
+    team: "Engineering",
+    managerId: "p-2",
+  },
+
+  // L2 — under VP Product
+  {
+    id: "p-7",
+    name: "Tim Berners-Lee",
+    role: "Group PM, Web",
+    team: "Product",
+    managerId: "p-3",
+  },
+
+  // L2 — under VP Design
+  {
+    id: "p-8",
+    name: "Susan Kare",
+    role: "Design Manager",
+    team: "Design",
+    managerId: "p-4",
+  },
+
+  // L3 — under Platform director
+  {
+    id: "p-9",
+    name: "Margaret Hamilton",
+    role: "Senior Engineer",
+    team: "Engineering",
+    managerId: "p-5",
+  },
+  {
+    id: "p-10",
+    name: "Donald Knuth",
+    role: "Staff Engineer",
+    team: "Engineering",
+    managerId: "p-5",
+  },
+
+  // L3 — under Infra director
+  {
+    id: "p-11",
+    name: "Brian Kernighan",
+    role: "Senior Engineer",
+    team: "Engineering",
+    managerId: "p-6",
+  },
+
+  // L3 — under Group PM
+  {
+    id: "p-12",
+    name: "Radia Perlman",
+    role: "Senior PM",
+    team: "Product",
+    managerId: "p-7",
+  },
+]
+
+/**
+ * Fixture that contains a 3-cycle (A → B → C → A) plus a clean subtree, so
+ * the `Cycle` story can verify the dev-mode warning + cycle-closing-edge
+ * drop without losing all visible nodes.
+ */
+export const cyclicChart: OrgPerson[] = [
+  // 3-cycle
+  { id: "c-a", name: "Cycle A", role: "Eng", team: "Loop", managerId: "c-c" },
+  { id: "c-b", name: "Cycle B", role: "Eng", team: "Loop", managerId: "c-a" },
+  { id: "c-c", name: "Cycle C", role: "Eng", team: "Loop", managerId: "c-b" },
+  // Clean root + child so the canvas isn't empty when the cycle edges are
+  // dropped from the projection.
+  { id: "root", name: "Root", role: "CEO", team: "Executive", managerId: null },
+  {
+    id: "child",
+    name: "Child",
+    role: "VP",
+    team: "Executive",
+    managerId: "root",
+  },
+]
+
+/**
+ * Roots for the lazy-mode story. Children are resolved on demand by the
+ * loader in the story file.
+ */
+export const lazyRoots: OrgPerson[] = [
+  {
+    id: "lazy-1",
+    name: "Ada Lovelace",
+    role: "CEO",
+    team: "Executive",
+    managerId: null,
+  },
+  {
+    id: "lazy-2",
+    name: "Hedy Lamarr",
+    role: "COO",
+    team: "Executive",
+    managerId: null,
+  },
+]
+
+/**
+ * Lazy-loaded children keyed by parent id. Used by the `LazyMode` story so
+ * the loader is deterministic.
+ */
+export const lazyChildrenByParent: Record<string, OrgPerson[]> = {
+  "lazy-1": [
+    {
+      id: "lazy-1-a",
+      name: "Grace Hopper",
+      role: "CTO",
+      team: "Engineering",
+      managerId: "lazy-1",
+    },
+    {
+      id: "lazy-1-b",
+      name: "Marie Curie",
+      role: "VP Product",
+      team: "Product",
+      managerId: "lazy-1",
+    },
+  ],
+  "lazy-2": [
+    {
+      id: "lazy-2-a",
+      name: "Margaret Hamilton",
+      role: "VP Eng",
+      team: "Engineering",
+      managerId: "lazy-2",
+    },
+  ],
+}
+
+/**
+ * Shared item-actions definition reused by stories that exercise the
+ * actions slot (both in-node fallback and detail-panel handoff path).
+ */
+export const orgItemActions: ItemActionsDefinition<OrgPerson> = (item) => [
+  {
+    label: "Edit",
+    icon: Pencil,
+    onClick: () => {
+      console.log(`Editing ${item.name}`)
+    },
+    description: "Modify person details",
+    type: "primary",
+  },
+  {
+    label: "View profile",
+    icon: Ai,
+    onClick: () => {
+      console.log(`Viewing ${item.name}'s profile`)
+    },
+  },
+  { type: "separator" },
+  {
+    label: "Star",
+    icon: Star,
+    onClick: () => {
+      console.log(`Star ${item.name}`)
+    },
+  },
+  {
+    label: "Remove",
+    icon: Delete,
+    onClick: () => {
+      console.log(`Remove ${item.name}`)
+    },
+    critical: true,
+    description: "Permanently remove",
+  },
+]

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/_helpers.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/_helpers.tsx
@@ -1,0 +1,105 @@
+import { vi } from "vitest"
+
+import type {
+  FiltersDefinition,
+  GroupingDefinition,
+  PaginatedFetchOptions,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+
+import type { DataCollectionSource } from "../../../../hooks/useDataCollectionSource"
+import type { ItemActionsDefinition } from "../../../../item-actions"
+import type { NavigationFiltersDefinition } from "../../../../navigationFilters/types"
+import type { SummariesDefinition } from "../../../../summary"
+
+export type TestPerson = {
+  id: string
+  name: string
+  parentId: string | null
+}
+
+type TestSource = DataCollectionSource<
+  TestPerson,
+  FiltersDefinition,
+  SortingsDefinition,
+  SummariesDefinition,
+  ItemActionsDefinition<TestPerson>,
+  NavigationFiltersDefinition,
+  GroupingDefinition<TestPerson>
+>
+
+/**
+ * No-pagination source for eager-mode Graph tests (mirrors Card test pattern).
+ */
+export const createEagerSource = (
+  records: TestPerson[],
+  overrides: Partial<TestSource> = {}
+): TestSource => ({
+  currentFilters: {},
+  setCurrentFilters: vi.fn(),
+  currentSortings: null,
+  setCurrentSortings: vi.fn(),
+  currentSearch: undefined,
+  debouncedCurrentSearch: undefined,
+  setCurrentSearch: vi.fn(),
+  isLoading: false,
+  setIsLoading: vi.fn(),
+  dataAdapter: {
+    fetchData: async () => ({ records }),
+  },
+  currentNavigationFilters: {},
+  setCurrentNavigationFilters: vi.fn(),
+  navigationFilters: undefined,
+  currentGrouping: undefined,
+  setCurrentGrouping: vi.fn(),
+  idProvider: (item: TestPerson) => item.id,
+  selectable: (item: TestPerson) => item.id,
+  ...overrides,
+})
+
+/**
+ * Infinite-scroll paginated source for lazy-mode Graph tests (mirrors Kanban
+ * test pattern). Required whenever the test passes `loadChildren`.
+ */
+export const createPaginatedSource = (
+  records: TestPerson[],
+  overrides: Partial<TestSource> = {}
+): TestSource => ({
+  currentFilters: {},
+  setCurrentFilters: vi.fn(),
+  currentSortings: null,
+  setCurrentSortings: vi.fn(),
+  currentSearch: undefined,
+  debouncedCurrentSearch: undefined,
+  setCurrentSearch: vi.fn(),
+  isLoading: false,
+  setIsLoading: vi.fn(),
+  dataAdapter: {
+    fetchData: async (_options: PaginatedFetchOptions<FiltersDefinition>) => ({
+      records,
+      total: records.length,
+      perPage: records.length,
+      type: "infinite-scroll" as const,
+      cursor: null,
+      hasMore: false,
+    }),
+    paginationType: "infinite-scroll",
+    perPage: records.length || 10,
+  },
+  currentNavigationFilters: {},
+  setCurrentNavigationFilters: vi.fn(),
+  navigationFilters: undefined,
+  currentGrouping: undefined,
+  setCurrentGrouping: vi.fn(),
+  idProvider: (item: TestPerson) => item.id,
+  selectable: (item: TestPerson) => item.id,
+  ...overrides,
+})
+
+/**
+ * Render-stub renderer that just prints the record id so tests can assert on
+ * presence without depending on F0GraphNode internals.
+ */
+export const stubRenderNode = (record: TestPerson) => (
+  <span data-testid={`node-${record.id}`}>{record.name}</span>
+)

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/defaultSelectedItemsBridge.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/defaultSelectedItemsBridge.test.tsx
@@ -28,7 +28,7 @@ const records: TestPerson[] = [
   { id: "3", name: "Child B", parentId: "1" },
 ]
 
-describe("GraphCollection select-all inheritance", () => {
+describe("GraphCollection defaultSelectedItems bridge", () => {
   beforeEach(() => {
     f0GraphMock.mockClear()
   })
@@ -39,11 +39,10 @@ describe("GraphCollection select-all inheritance", () => {
   // the source already declares everything as selected via `defaultSelectedItems`,
   // GraphCollection surfaces those ids to F0Graph as `selectedNodes`.
   //
-  // TODO(Phase 1 follow-up): cover the full select-all → lazy-child inheritance
-  // flow by mounting OneDataCollection with both a Table and a Graph
-  // visualization, clicking select-all in the toolbar, expanding a graph
-  // node, and asserting the newly loaded children render as checked. That
-  // test belongs at the OneDataCollection integration level.
+  // TODO(Phase 3): integration test at OneDataCollection level for
+  // cross-visualization select-all — mount OneDataCollection with both a
+  // Table and a Graph visualization, click select-all in the toolbar, expand
+  // a graph node, and assert the newly loaded children render as checked.
 
   it("surfaces source.defaultSelectedItems as F0Graph selectedNodes", async () => {
     const items = new Map<

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/graphIdIsolation.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/graphIdIsolation.test.tsx
@@ -1,0 +1,98 @@
+import { waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { F0Graph } from "@/patterns/F0Graph"
+import { zeroRender } from "@/testing/test-utils"
+
+import { GraphCollection } from "../Graph"
+
+import { createEagerSource, stubRenderNode, type TestPerson } from "./_helpers"
+
+vi.mock("@/patterns/F0Graph", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/patterns/F0Graph")>(
+      "@/patterns/F0Graph"
+    )
+  return {
+    ...actual,
+    F0Graph: vi.fn(() => <div data-testid="f0graph-mock" />),
+  }
+})
+
+const f0GraphMock = vi.mocked(F0Graph)
+const nodeAdapter = (r: TestPerson) => ({ parentId: r.parentId })
+
+const records: TestPerson[] = [
+  { id: "1", name: "Root", parentId: null },
+  { id: "2", name: "Child", parentId: "1" },
+]
+
+describe("GraphCollection graphId isolation", () => {
+  beforeEach(() => {
+    f0GraphMock.mockClear()
+  })
+
+  it("auto-generates a unique graphId per instance when none is provided", async () => {
+    zeroRender(
+      <div>
+        <GraphCollection
+          source={createEagerSource(records)}
+          nodeAdapter={nodeAdapter}
+          renderNode={stubRenderNode}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+        <GraphCollection
+          source={createEagerSource(records)}
+          nodeAdapter={nodeAdapter}
+          renderNode={stubRenderNode}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      </div>
+    )
+
+    await waitFor(() => {
+      // Each instance must have rendered F0Graph at least once with nodes.
+      const calls = f0GraphMock.mock.calls
+      const withNodes = calls.filter((c) => {
+        const props = c[0] as unknown as { nodes?: unknown[] }
+        return Array.isArray(props.nodes) && props.nodes.length > 0
+      })
+      expect(withNodes.length).toBeGreaterThanOrEqual(2)
+    })
+
+    const graphIds = new Set<string>()
+    for (const call of f0GraphMock.mock.calls) {
+      const props = call[0] as unknown as { graphId?: string }
+      if (typeof props.graphId === "string") graphIds.add(props.graphId)
+    }
+    // Two instances → at least two distinct auto-generated graphIds.
+    expect(graphIds.size).toBeGreaterThanOrEqual(2)
+  })
+
+  it("uses the caller-provided graphId verbatim when supplied", async () => {
+    zeroRender(
+      <GraphCollection
+        graphId="custom-graph"
+        source={createEagerSource(records)}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const calls = f0GraphMock.mock.calls
+      expect(calls.length).toBeGreaterThan(0)
+    })
+    const allIds = f0GraphMock.mock.calls.map(
+      (c) => (c[0] as unknown as { graphId?: string }).graphId
+    )
+    expect(allIds.every((id) => id === "custom-graph")).toBe(true)
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/groupingFallback.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/groupingFallback.test.tsx
@@ -1,0 +1,100 @@
+import { screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { F0Graph } from "@/patterns/F0Graph"
+import type { GroupingDefinition } from "@/hooks/datasource"
+import { zeroRender } from "@/testing/test-utils"
+
+import {
+  GraphCollection,
+  GROUPING_NOT_SUPPORTED_FALLBACK_MESSAGE,
+  GROUPING_NOT_SUPPORTED_MESSAGE,
+} from "../Graph"
+
+import { createEagerSource, stubRenderNode, type TestPerson } from "./_helpers"
+
+vi.mock("@/lib/providers/user-platafform", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/providers/user-platafform")
+  >("@/lib/providers/user-platafform")
+  return {
+    ...actual,
+    useIsDev: () => false,
+  }
+})
+
+vi.mock("@/patterns/F0Graph", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/patterns/F0Graph")>(
+      "@/patterns/F0Graph"
+    )
+  return {
+    ...actual,
+    F0Graph: vi.fn(() => <div data-testid="f0graph-mock" />),
+  }
+})
+
+const f0GraphMock = vi.mocked(F0Graph)
+
+const records: TestPerson[] = [
+  { id: "1", name: "Root", parentId: null },
+  { id: "2", name: "Child", parentId: "1" },
+]
+
+const nodeAdapter = (r: TestPerson) => ({ parentId: r.parentId })
+
+const grouping: GroupingDefinition<TestPerson> = {
+  collapsible: false,
+  groupBy: {
+    parentId: {
+      name: "Parent",
+      label: (groupId) => String(groupId ?? "none"),
+    },
+  },
+}
+
+describe("GraphCollection grouped-data fallback (non-dev)", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    f0GraphMock.mockClear()
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    f0GraphMock.mockClear()
+  })
+
+  it("renders a fallback message and logs an error when grouping is present", async () => {
+    const source = createEagerSource(records, {
+      grouping,
+      currentGrouping: { field: "parentId" },
+    })
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        GROUPING_NOT_SUPPORTED_FALLBACK_MESSAGE
+      )
+    })
+
+    expect(f0GraphMock).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(GROUPING_NOT_SUPPORTED_MESSAGE)
+      )
+    })
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/lazyAbort.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/lazyAbort.test.tsx
@@ -1,0 +1,172 @@
+import { waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { F0Graph } from "@/patterns/F0Graph"
+import { zeroRender } from "@/testing/test-utils"
+
+import { GraphCollection } from "../Graph"
+
+import {
+  createPaginatedSource,
+  stubRenderNode,
+  type TestPerson,
+} from "./_helpers"
+
+vi.mock("@/patterns/F0Graph", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/patterns/F0Graph")>(
+      "@/patterns/F0Graph"
+    )
+  return {
+    ...actual,
+    F0Graph: vi.fn(() => <div data-testid="f0graph-mock" />),
+  }
+})
+
+const f0GraphMock = vi.mocked(F0Graph)
+
+const nodeAdapter = (r: TestPerson) => ({ parentId: r.parentId })
+const rootRecords: TestPerson[] = [{ id: "root", name: "Root", parentId: null }]
+
+const getWrappedLoadChildren = (): ((
+  id: string
+) => Promise<{ id: string }[]>) => {
+  const calls = f0GraphMock.mock.calls
+  const last = calls[calls.length - 1][0] as unknown as {
+    loadChildren?: (id: string) => Promise<{ id: string }[]>
+  }
+  if (!last.loadChildren)
+    throw new Error("F0Graph did not receive loadChildren")
+  return last.loadChildren
+}
+
+describe("GraphCollection lazy loader abort behavior", () => {
+  beforeEach(() => {
+    f0GraphMock.mockClear()
+  })
+
+  it("aborts the prior in-flight loader when called again for the same nodeId", async () => {
+    let firstSignal: AbortSignal | undefined
+    let secondSignal: AbortSignal | undefined
+    let resolveFirst!: (v: TestPerson[]) => void
+    let resolveSecond!: (v: TestPerson[]) => void
+
+    const loadChildren = vi.fn(
+      async (
+        _nodeId: string,
+        opts?: { signal?: AbortSignal }
+      ): Promise<TestPerson[]> => {
+        if (loadChildren.mock.calls.length === 1) {
+          firstSignal = opts?.signal
+          return new Promise((r) => {
+            resolveFirst = r
+          })
+        }
+        secondSignal = opts?.signal
+        return new Promise((r) => {
+          resolveSecond = r
+        })
+      }
+    )
+
+    zeroRender(
+      <GraphCollection
+        source={createPaginatedSource(rootRecords)}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        loadChildren={loadChildren as never}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = f0GraphMock.mock.calls[
+        f0GraphMock.mock.calls.length - 1
+      ][0] as unknown as { rootNodes?: unknown[] }
+      expect(Array.isArray(props.rootNodes)).toBe(true)
+    })
+
+    const wrapped = getWrappedLoadChildren()
+    // First call starts; do NOT await — we need to launch the second while
+    // the first is still in-flight.
+    void wrapped("root")
+    void wrapped("root")
+
+    // Each user call into the wrapper produces exactly one consumer-loadChildren
+    // call; the wrapper's own AbortController is internal — the consumer's
+    // `loadChildren` may or may not receive a signal depending on signature,
+    // but the wrapper must abort the prior controller before issuing the
+    // second underlying call.
+    expect(loadChildren).toHaveBeenCalledTimes(2)
+
+    // Settle the pending promises so vitest doesn't complain about
+    // unhandled work after the test exits.
+    resolveFirst([])
+    resolveSecond([])
+
+    // Either the consumer received the wrapper's signal (loadChildren
+    // signature: (nodeId, { signal })) and it must be aborted, or the
+    // wrapper opted to drop results internally — both behaviors satisfy
+    // the contract. We assert at least the second underlying call ran.
+    // If signals were forwarded, the first must now be aborted.
+    if (firstSignal) {
+      expect(firstSignal.aborted).toBe(true)
+    }
+    expect(secondSignal?.aborted ?? false).toBe(false)
+  })
+
+  it("aborts every in-flight loader on unmount", async () => {
+    let capturedSignal: AbortSignal | undefined
+    const loadChildren = vi.fn(
+      async (
+        _nodeId: string,
+        opts?: { signal?: AbortSignal }
+      ): Promise<TestPerson[]> => {
+        capturedSignal = opts?.signal
+        return new Promise(() => {
+          /* never resolves */
+        })
+      }
+    )
+
+    const { unmount } = zeroRender(
+      <GraphCollection
+        source={createPaginatedSource(rootRecords)}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        loadChildren={loadChildren as never}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = f0GraphMock.mock.calls[
+        f0GraphMock.mock.calls.length - 1
+      ][0] as unknown as { rootNodes?: unknown[] }
+      expect(Array.isArray(props.rootNodes)).toBe(true)
+    })
+
+    const wrapped = getWrappedLoadChildren()
+    void wrapped("root")
+    expect(loadChildren).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    // The wrapper aborts its internal controller on unmount. If it forwards
+    // the signal to the consumer, that signal is now aborted.
+    if (capturedSignal) {
+      expect(capturedSignal.aborted).toBe(true)
+    }
+    // Either way, the wrapper guards against late results — covered by the
+    // `if (controller.signal.aborted) return []` check in `wrappedLoadChildren`.
+  })
+
+  // TODO(Phase 1 follow-up): F0Graph collapsing a node should also abort any
+  // in-flight loader for that nodeId. The current GraphCollection only aborts
+  // on (a) a fresh call for the same nodeId and (b) unmount. Test once the
+  // collapse-side abort hook is wired into F0Graph's public API.
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/lazyAbort.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/lazyAbort.test.tsx
@@ -45,7 +45,7 @@ describe("GraphCollection lazy loader abort behavior", () => {
     f0GraphMock.mockClear()
   })
 
-  it("aborts the prior in-flight loader when called again for the same nodeId", async () => {
+  it("forwards an AbortSignal to the consumer loader and aborts the prior in-flight loader for the same nodeId", async () => {
     let firstSignal: AbortSignal | undefined
     let secondSignal: AbortSignal | undefined
     let resolveFirst!: (v: TestPerson[]) => void
@@ -54,15 +54,15 @@ describe("GraphCollection lazy loader abort behavior", () => {
     const loadChildren = vi.fn(
       async (
         _nodeId: string,
-        opts?: { signal?: AbortSignal }
+        opts: { signal: AbortSignal }
       ): Promise<TestPerson[]> => {
         if (loadChildren.mock.calls.length === 1) {
-          firstSignal = opts?.signal
+          firstSignal = opts.signal
           return new Promise((r) => {
             resolveFirst = r
           })
         }
-        secondSignal = opts?.signal
+        secondSignal = opts.signal
         return new Promise((r) => {
           resolveSecond = r
         })
@@ -74,7 +74,7 @@ describe("GraphCollection lazy loader abort behavior", () => {
         source={createPaginatedSource(rootRecords)}
         nodeAdapter={nodeAdapter}
         renderNode={stubRenderNode}
-        loadChildren={loadChildren as never}
+        loadChildren={loadChildren}
         onSelectItems={vi.fn()}
         onLoadData={vi.fn()}
         onLoadError={vi.fn()}
@@ -89,16 +89,10 @@ describe("GraphCollection lazy loader abort behavior", () => {
     })
 
     const wrapped = getWrappedLoadChildren()
-    // First call starts; do NOT await — we need to launch the second while
-    // the first is still in-flight.
+    // Launch first load and second load while the first is still in-flight.
     void wrapped("root")
     void wrapped("root")
 
-    // Each user call into the wrapper produces exactly one consumer-loadChildren
-    // call; the wrapper's own AbortController is internal — the consumer's
-    // `loadChildren` may or may not receive a signal depending on signature,
-    // but the wrapper must abort the prior controller before issuing the
-    // second underlying call.
     expect(loadChildren).toHaveBeenCalledTimes(2)
 
     // Settle the pending promises so vitest doesn't complain about
@@ -106,15 +100,13 @@ describe("GraphCollection lazy loader abort behavior", () => {
     resolveFirst([])
     resolveSecond([])
 
-    // Either the consumer received the wrapper's signal (loadChildren
-    // signature: (nodeId, { signal })) and it must be aborted, or the
-    // wrapper opted to drop results internally — both behaviors satisfy
-    // the contract. We assert at least the second underlying call ran.
-    // If signals were forwarded, the first must now be aborted.
-    if (firstSignal) {
-      expect(firstSignal.aborted).toBe(true)
-    }
-    expect(secondSignal?.aborted ?? false).toBe(false)
+    // The wrapper forwards its internal AbortController's signal as
+    // `opts.signal`. When a second load starts for the same nodeId, the
+    // first signal must be aborted.
+    expect(firstSignal).toBeDefined()
+    expect(firstSignal!.aborted).toBe(true)
+    expect(secondSignal).toBeDefined()
+    expect(secondSignal!.aborted).toBe(false)
   })
 
   it("aborts every in-flight loader on unmount", async () => {
@@ -122,9 +114,9 @@ describe("GraphCollection lazy loader abort behavior", () => {
     const loadChildren = vi.fn(
       async (
         _nodeId: string,
-        opts?: { signal?: AbortSignal }
+        opts: { signal: AbortSignal }
       ): Promise<TestPerson[]> => {
-        capturedSignal = opts?.signal
+        capturedSignal = opts.signal
         return new Promise(() => {
           /* never resolves */
         })
@@ -136,7 +128,7 @@ describe("GraphCollection lazy loader abort behavior", () => {
         source={createPaginatedSource(rootRecords)}
         nodeAdapter={nodeAdapter}
         renderNode={stubRenderNode}
-        loadChildren={loadChildren as never}
+        loadChildren={loadChildren}
         onSelectItems={vi.fn()}
         onLoadData={vi.fn()}
         onLoadError={vi.fn()}
@@ -156,13 +148,60 @@ describe("GraphCollection lazy loader abort behavior", () => {
 
     unmount()
 
-    // The wrapper aborts its internal controller on unmount. If it forwards
-    // the signal to the consumer, that signal is now aborted.
-    if (capturedSignal) {
-      expect(capturedSignal.aborted).toBe(true)
-    }
-    // Either way, the wrapper guards against late results — covered by the
-    // `if (controller.signal.aborted) return []` check in `wrappedLoadChildren`.
+    // The wrapper aborts its internal controller on unmount and forwards the
+    // signal to the consumer, so the consumer can cancel its underlying
+    // request (e.g. via fetch's `signal` option).
+    expect(capturedSignal).toBeDefined()
+    expect(capturedSignal!.aborted).toBe(true)
+  })
+
+  it("lets the consumer loader observe abortion mid-flight via the forwarded signal", async () => {
+    let observed: { abortedBeforeResolve: boolean } | undefined
+    const loadChildren = vi.fn(
+      async (
+        _nodeId: string,
+        opts: { signal: AbortSignal }
+      ): Promise<TestPerson[]> => {
+        // Simulate a consumer awaiting a network request that observes
+        // cancellation via the signal.
+        await new Promise<void>((resolve) => {
+          opts.signal.addEventListener("abort", () => {
+            observed = { abortedBeforeResolve: true }
+            resolve()
+          })
+        })
+        return []
+      }
+    )
+
+    const { unmount } = zeroRender(
+      <GraphCollection
+        source={createPaginatedSource(rootRecords)}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        loadChildren={loadChildren}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = f0GraphMock.mock.calls[
+        f0GraphMock.mock.calls.length - 1
+      ][0] as unknown as { rootNodes?: unknown[] }
+      expect(Array.isArray(props.rootNodes)).toBe(true)
+    })
+
+    const wrapped = getWrappedLoadChildren()
+    void wrapped("root")
+    expect(loadChildren).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    await waitFor(() => {
+      expect(observed?.abortedBeforeResolve).toBe(true)
+    })
   })
 
   // TODO(Phase 1 follow-up): F0Graph collapsing a node should also abort any

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/paginationGuards.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/paginationGuards.test.tsx
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import {
+  EAGER_REQUIRES_NO_PAGINATION_MESSAGE,
+  GraphCollection,
+  LAZY_REQUIRES_PAGINATION_MESSAGE,
+} from "../Graph"
+
+import {
+  createEagerSource,
+  createPaginatedSource,
+  stubRenderNode,
+  type TestPerson,
+} from "./_helpers"
+
+// Force `useIsDev` to return true so the guards in Graph.tsx fire. Without
+// this the default test provider returns `false` and the guards are skipped.
+vi.mock("@/lib/providers/user-platafform", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/providers/user-platafform")
+  >("@/lib/providers/user-platafform")
+  return {
+    ...actual,
+    useIsDev: () => true,
+  }
+})
+
+// Mock F0Graph so a successful render does not pull in React Flow runtime.
+vi.mock("@/patterns/F0Graph", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/patterns/F0Graph")>(
+      "@/patterns/F0Graph"
+    )
+  return {
+    ...actual,
+    F0Graph: vi.fn(() => <div data-testid="f0graph-mock" />),
+  }
+})
+
+const records: TestPerson[] = [
+  { id: "1", name: "Root", parentId: null },
+  { id: "2", name: "Child", parentId: "1" },
+]
+
+const nodeAdapter = (r: TestPerson) => ({ parentId: r.parentId })
+
+const renderEager = (
+  source: ReturnType<typeof createEagerSource>,
+  loadChildren?: () => Promise<unknown[]>
+) =>
+  zeroRender(
+    <GraphCollection
+      source={source}
+      nodeAdapter={nodeAdapter}
+      renderNode={stubRenderNode}
+      loadChildren={loadChildren as never}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+    />
+  )
+
+const renderLazy = (
+  source: ReturnType<typeof createPaginatedSource>,
+  loadChildren?: () => Promise<unknown[]>
+) =>
+  zeroRender(
+    <GraphCollection
+      source={source}
+      nodeAdapter={nodeAdapter}
+      renderNode={stubRenderNode}
+      loadChildren={loadChildren as never}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+    />
+  )
+
+describe("GraphCollection dev guards", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // React logs caught render errors via console.error; silence to keep test
+    // output clean. The guard error itself is asserted via `toThrow`.
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it("throws in eager mode when the source is paginated", () => {
+    const source = createPaginatedSource(records)
+    expect(() => renderEager(source)).toThrow(
+      EAGER_REQUIRES_NO_PAGINATION_MESSAGE
+    )
+  })
+
+  it("throws in lazy mode when the source is not paginated", () => {
+    const source = createEagerSource(records)
+    expect(() => renderLazy(source, async () => [])).toThrow(
+      LAZY_REQUIRES_PAGINATION_MESSAGE
+    )
+  })
+
+  it("renders without throwing in valid eager mode (no-pagination, no loadChildren)", () => {
+    const source = createEagerSource(records)
+    expect(() => renderEager(source)).not.toThrow()
+  })
+
+  it("renders without throwing in valid lazy mode (paginated + loadChildren)", () => {
+    const source = createPaginatedSource(records)
+    expect(() => renderLazy(source, async () => [])).not.toThrow()
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/phase2.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/phase2.test.tsx
@@ -1,0 +1,345 @@
+import { waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { F0Graph } from "@/patterns/F0Graph"
+import { zeroRender } from "@/testing/test-utils"
+
+import { GraphCollection } from "../Graph"
+
+import {
+  createEagerSource,
+  createPaginatedSource,
+  stubRenderNode,
+  type TestPerson,
+} from "./_helpers"
+
+vi.mock("@/patterns/F0Graph", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/patterns/F0Graph")>(
+      "@/patterns/F0Graph"
+    )
+  return {
+    ...actual,
+    F0Graph: vi.fn(() => <div data-testid="f0graph-mock" />),
+  }
+})
+
+const f0GraphMock = vi.mocked(F0Graph)
+type CapturedProps = Parameters<typeof F0Graph>[0]
+
+const lastF0GraphProps = (): CapturedProps => {
+  const calls = f0GraphMock.mock.calls
+  if (calls.length === 0) throw new Error("F0Graph was never rendered")
+  return calls[calls.length - 1][0] as CapturedProps
+}
+
+const nodeAdapter = (r: TestPerson) => ({ parentId: r.parentId })
+
+describe("GraphCollection Phase 2 — rootSelector", () => {
+  beforeEach(() => f0GraphMock.mockClear())
+  afterEach(() => f0GraphMock.mockClear())
+
+  it("filters records before projection in eager mode", async () => {
+    const records: TestPerson[] = [
+      { id: "a", name: "A", parentId: null },
+      { id: "b", name: "B", parentId: null },
+      { id: "c", name: "C", parentId: "a" },
+    ]
+    const source = createEagerSource(records)
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        rootSelector={(rs) => rs.filter((r) => r.id !== "b")}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = lastF0GraphProps()
+      // @ts-expect-error eager mode passes nodes
+      expect(props.nodes).toBeDefined()
+    })
+
+    const props = lastF0GraphProps()
+    // @ts-expect-error eager mode passes nodes
+    const ids = (props.nodes as Array<{ id: string }>).map((n) => n.id).sort()
+    expect(ids).toEqual(["a", "c"])
+  })
+
+  it("narrows rootNodes in lazy mode while leaving loadChildren intact", async () => {
+    const records: TestPerson[] = [
+      { id: "r1", name: "Root1", parentId: null },
+      { id: "r2", name: "Root2", parentId: null },
+    ]
+    const source = createPaginatedSource(records)
+    const loadChildren = vi.fn(async () => [])
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        loadChildren={loadChildren}
+        rootSelector={(rs) => rs.filter((r) => r.id === "r1")}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = lastF0GraphProps()
+      // @ts-expect-error lazy mode passes rootNodes
+      expect(props.rootNodes).toBeDefined()
+    })
+
+    const props = lastF0GraphProps()
+    // @ts-expect-error lazy mode passes rootNodes
+    const ids = (props.rootNodes as Array<{ id: string }>).map((n) => n.id)
+    expect(ids).toEqual(["r1"])
+    // @ts-expect-error loadChildren is forwarded as the wrapped function
+    expect(typeof props.loadChildren).toBe("function")
+  })
+})
+
+describe("GraphCollection Phase 2 — onLoadError for loadChildren", () => {
+  beforeEach(() => f0GraphMock.mockClear())
+  afterEach(() => {
+    f0GraphMock.mockClear()
+    vi.restoreAllMocks()
+  })
+
+  it("invokes onLoadError when consumer loader rejects with a non-abort error", async () => {
+    const records: TestPerson[] = [{ id: "r", name: "Root", parentId: null }]
+    const source = createPaginatedSource(records)
+    const failure = new Error("network down")
+    const loadChildren = vi.fn(async () => {
+      throw failure
+    })
+    const onLoadChildrenError = vi.fn()
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        loadChildren={loadChildren}
+        onLoadChildrenError={(err, nodeId) => onLoadChildrenError(err, nodeId)}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = lastF0GraphProps()
+      // @ts-expect-error lazy mode
+      expect(props.loadChildren).toBeDefined()
+    })
+
+    const props = lastF0GraphProps()
+    // @ts-expect-error wrapped loader is forwarded by GraphCollection
+    const wrapped = props.loadChildren as (id: string) => Promise<unknown[]>
+    const out = await wrapped("r")
+
+    expect(out).toEqual([])
+    expect(onLoadChildrenError).toHaveBeenCalledTimes(1)
+    expect(onLoadChildrenError).toHaveBeenCalledWith(failure, "r")
+  })
+
+  it("swallows AbortError without invoking onLoadError", async () => {
+    const records: TestPerson[] = [{ id: "r", name: "Root", parentId: null }]
+    const source = createPaginatedSource(records)
+    const abort = new DOMException("Aborted", "AbortError")
+    const loadChildren = vi.fn(async () => {
+      throw abort
+    })
+    const onLoadChildrenError = vi.fn()
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        loadChildren={loadChildren}
+        onLoadChildrenError={(err, nodeId) => onLoadChildrenError(err, nodeId)}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = lastF0GraphProps()
+      // @ts-expect-error lazy mode
+      expect(props.loadChildren).toBeDefined()
+    })
+
+    const props = lastF0GraphProps()
+    // @ts-expect-error wrapped loader
+    const wrapped = props.loadChildren as (id: string) => Promise<unknown[]>
+    const out = await wrapped("r")
+
+    expect(out).toEqual([])
+    expect(onLoadChildrenError).not.toHaveBeenCalled()
+  })
+
+  it("defaults to console.error when no onLoadError is provided", async () => {
+    const records: TestPerson[] = [{ id: "r", name: "Root", parentId: null }]
+    const source = createPaginatedSource(records)
+    const failure = new Error("boom")
+    const loadChildren = vi.fn(async () => {
+      throw failure
+    })
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        loadChildren={loadChildren}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = lastF0GraphProps()
+      // @ts-expect-error lazy mode
+      expect(props.loadChildren).toBeDefined()
+    })
+
+    const props = lastF0GraphProps()
+    // @ts-expect-error wrapped loader
+    const wrapped = props.loadChildren as (id: string) => Promise<unknown[]>
+    await wrapped("r")
+
+    const calls = errorSpy.mock.calls.filter((c) =>
+      String(c[0] ?? "").includes("`loadChildren` rejected for node")
+    )
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe("GraphCollection Phase 2 — per-record selectable parity", () => {
+  beforeEach(() => f0GraphMock.mockClear())
+  afterEach(() => f0GraphMock.mockClear())
+
+  it("ignores selection toggle when source.selectable(record) returns undefined", async () => {
+    const records: TestPerson[] = [
+      { id: "yes", name: "Selectable", parentId: null },
+      { id: "no", name: "Locked", parentId: null },
+    ]
+    const onSelectItems = vi.fn()
+    const source = createEagerSource(records, {
+      // Lock "no" — return undefined to opt out per-record.
+      selectable: (item: TestPerson) =>
+        item.id === "no" ? undefined : item.id,
+    })
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={onSelectItems}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = lastF0GraphProps()
+      // @ts-expect-error eager
+      expect(props.nodes).toBeDefined()
+    })
+
+    const props = lastF0GraphProps()
+    const onNodeSelect = props.onNodeSelect as (
+      id: string,
+      selected: boolean
+    ) => void
+
+    // onSelectItems fires once on mount with empty state — record that baseline.
+    const baseline = onSelectItems.mock.calls.length
+
+    onNodeSelect("no", true)
+
+    // Allow any pending microtasks to settle.
+    await Promise.resolve()
+    expect(onSelectItems.mock.calls.length).toBe(baseline)
+
+    // Allowed record still flows through.
+    onNodeSelect("yes", true)
+    await waitFor(() => {
+      expect(onSelectItems.mock.calls.length).toBeGreaterThan(baseline)
+    })
+  })
+})
+
+describe("GraphCollection Phase 2 — lazyRecordsRef survives collapse", () => {
+  beforeEach(() => f0GraphMock.mockClear())
+  afterEach(() => f0GraphMock.mockClear())
+
+  it("keeps lazy-loaded records resolvable for selection after collapse/re-expand", async () => {
+    const roots: TestPerson[] = [{ id: "r", name: "Root", parentId: null }]
+    const child: TestPerson = { id: "c", name: "Child", parentId: "r" }
+    const source = createPaginatedSource(roots)
+    const loadChildren = vi.fn(async () => [child])
+    const onSelectItems = vi.fn()
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        loadChildren={loadChildren}
+        onSelectItems={onSelectItems}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = lastF0GraphProps()
+      // @ts-expect-error lazy mode
+      expect(props.loadChildren).toBeDefined()
+    })
+
+    const props = lastF0GraphProps()
+    // @ts-expect-error wrapped loader
+    const wrapped = props.loadChildren as (id: string) => Promise<unknown[]>
+
+    // 1. Expand → child is loaded and cached.
+    const childNodes = (await wrapped("r")) as Array<{ id: string }>
+    expect(childNodes.map((n) => n.id)).toEqual(["c"])
+
+    // 2. Simulate a collapse by NOT calling loadChildren again. The cache
+    //    must still hold "c" so the next selection toggle resolves the
+    //    record. (F0Graph's useLazyTree owns expand state; GraphCollection
+    //    only owns the record cache, which is what this test guards.)
+    const onNodeSelect = props.onNodeSelect as (
+      id: string,
+      selected: boolean
+    ) => void
+    onNodeSelect("c", true)
+
+    await waitFor(() => {
+      expect(onSelectItems).toHaveBeenCalled()
+    })
+
+    const lastCall =
+      onSelectItems.mock.calls[onSelectItems.mock.calls.length - 1]
+    const status = lastCall[0] as {
+      selectedIds: ReadonlyArray<string | number>
+    }
+    expect(status.selectedIds.map(String)).toContain("c")
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/projectGraph.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/projectGraph.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { GraphEdge } from "@/patterns/F0Graph"
+
+import type { GraphNodeAdapter } from "../types"
+
+import { getRecordKey, projectGraph } from "../projectGraph"
+
+type Node = {
+  id: string
+  parentId: string | null
+  parentIds?: string[]
+  label?: string
+}
+
+const nodeAdapter: GraphNodeAdapter<Node> = (n) => ({
+  parentId: n.parentId,
+  parentIds: n.parentIds,
+})
+
+describe("getRecordKey", () => {
+  it("uses idProvider when provided", () => {
+    expect(getRecordKey({ id: "a" }, 0, (item) => item.id ?? "")).toBe("a")
+    expect(getRecordKey({ id: 7 }, 3, (item) => item.id ?? 0)).toBe("7")
+  })
+
+  it("falls back to item.id when no idProvider", () => {
+    expect(getRecordKey({ id: "x" }, 2, undefined)).toBe("x")
+    expect(getRecordKey({ id: 42 }, 2, undefined)).toBe("42")
+  })
+
+  it("falls back to index when item.id is missing", () => {
+    expect(getRecordKey({} as { id?: string }, 5, undefined)).toBe("5")
+    expect(
+      getRecordKey({ id: null } as unknown as { id: null }, 0, undefined)
+    ).toBe("0")
+  })
+})
+
+describe("projectGraph", () => {
+  it("projects records into nodes and parent-derived edges", () => {
+    const records: Node[] = [
+      { id: "root", parentId: null },
+      { id: "a", parentId: "root" },
+      { id: "b", parentId: "root" },
+      { id: "c", parentId: "a" },
+    ]
+    const result = projectGraph<Node>({
+      records,
+      nodeAdapter,
+      idProvider: (n) => n.id,
+    })
+    expect(result.nodes.map((n) => n.id)).toEqual(["root", "a", "b", "c"])
+    expect(result.edges.map((e) => `${e.source}->${e.target}`).sort()).toEqual([
+      "a->c",
+      "root->a",
+      "root->b",
+    ])
+    expect(result.cycles).toEqual([])
+    expect(result.duplicates).toEqual([])
+  })
+
+  it("treats records whose parent is missing as roots (no orphan dropping)", () => {
+    const records: Node[] = [
+      { id: "a", parentId: "missing" },
+      { id: "b", parentId: "a" },
+    ]
+    const result = projectGraph<Node>({
+      records,
+      nodeAdapter,
+      idProvider: (n) => n.id,
+    })
+    expect(result.nodes.map((n) => n.id)).toEqual(["a", "b"])
+    // Edge to missing parent is skipped; edge between known records survives.
+    expect(result.edges.map((e) => `${e.source}->${e.target}`)).toEqual([
+      "a->b",
+    ])
+  })
+
+  it("hard-removes records not in matchedIds and their descendants", () => {
+    const records: Node[] = [
+      { id: "root", parentId: null },
+      { id: "kept", parentId: "root" },
+      { id: "removed", parentId: "root" },
+      { id: "descendant", parentId: "removed" },
+    ]
+    const result = projectGraph<Node>({
+      records,
+      nodeAdapter,
+      idProvider: (n) => n.id,
+      matchedIds: new Set(["root", "kept", "descendant"]),
+    })
+    const ids = result.nodes.map((n) => n.id).sort()
+    // "removed" is dropped (not in matchedIds); "descendant" is dropped because
+    // walking ancestors crosses a removed parent that exists in records.
+    expect(ids).toEqual(["kept", "root"])
+    expect(
+      result.edges.some((e) => e.source === "removed" || e.target === "removed")
+    ).toBe(false)
+  })
+
+  it("drops the cycle-closing edge and reports cycle participants", () => {
+    const records: Node[] = [
+      { id: "a", parentId: "c" },
+      { id: "b", parentId: "a" },
+      { id: "c", parentId: "b" },
+    ]
+    const result = projectGraph<Node>({
+      records,
+      nodeAdapter,
+      idProvider: (n) => n.id,
+    })
+    expect(result.nodes.map((n) => n.id).sort()).toEqual(["a", "b", "c"])
+    // Three potential edges; the cycle detector drops exactly one.
+    expect(result.edges).toHaveLength(2)
+    expect(new Set(result.cycles)).toEqual(new Set(["a", "b", "c"]))
+  })
+
+  it("reports duplicate keys and drops the duplicate occurrence", () => {
+    const records: Node[] = [
+      { id: "a", parentId: null },
+      { id: "a", parentId: null, label: "dup" },
+      { id: "b", parentId: "a" },
+    ]
+    const result = projectGraph<Node>({
+      records,
+      nodeAdapter,
+      idProvider: (n) => n.id,
+    })
+    expect(result.duplicates).toEqual(["a"])
+    expect(result.nodes).toHaveLength(2)
+    expect(result.nodes.map((n) => n.id).sort()).toEqual(["a", "b"])
+  })
+
+  it("throws on duplicates when strictDuplicates is true", () => {
+    const records: Node[] = [
+      { id: "a", parentId: null },
+      { id: "a", parentId: null },
+    ]
+    expect(() =>
+      projectGraph<Node>({
+        records,
+        nodeAdapter,
+        idProvider: (n) => n.id,
+        strictDuplicates: true,
+      })
+    ).toThrow(/duplicate record key "a"/)
+  })
+
+  it("uses edgeAdapter when provided and filters edges referencing dropped nodes", () => {
+    const records: Node[] = [
+      { id: "a", parentId: null },
+      { id: "b", parentId: null },
+    ]
+    const edges: GraphEdge[] = [
+      { id: "e1", source: "a", target: "b" },
+      { id: "e2", source: "a", target: "ghost" },
+    ]
+    const edgeAdapter = vi.fn(() => edges)
+    const result = projectGraph<Node>({
+      records,
+      nodeAdapter,
+      edgeAdapter,
+      idProvider: (n) => n.id,
+    })
+    expect(edgeAdapter).toHaveBeenCalledTimes(1)
+    expect(result.edges.map((e) => e.id)).toEqual(["e1"])
+  })
+
+  it("supports DAG topology via parentIds", () => {
+    const records: Node[] = [
+      { id: "p1", parentId: null },
+      { id: "p2", parentId: null },
+      { id: "c", parentId: "p1", parentIds: ["p1", "p2"] },
+    ]
+    const result = projectGraph<Node>({
+      records,
+      nodeAdapter,
+      idProvider: (n) => n.id,
+    })
+    const child = result.nodes.find((n) => n.id === "c")
+    expect(child?.parentIds).toEqual(["p1", "p2"])
+    expect(result.edges.map((e) => `${e.source}->${e.target}`).sort()).toEqual([
+      "p1->c",
+      "p2->c",
+    ])
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/selectAllLazyInheritance.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/selectAllLazyInheritance.test.tsx
@@ -1,0 +1,117 @@
+import { waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { F0Graph } from "@/patterns/F0Graph"
+import { zeroRender } from "@/testing/test-utils"
+
+import { GraphCollection } from "../Graph"
+
+import { createEagerSource, stubRenderNode, type TestPerson } from "./_helpers"
+
+vi.mock("@/patterns/F0Graph", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/patterns/F0Graph")>(
+      "@/patterns/F0Graph"
+    )
+  return {
+    ...actual,
+    F0Graph: vi.fn(() => <div data-testid="f0graph-mock" />),
+  }
+})
+
+const f0GraphMock = vi.mocked(F0Graph)
+const nodeAdapter = (r: TestPerson) => ({ parentId: r.parentId })
+
+const records: TestPerson[] = [
+  { id: "1", name: "Root", parentId: null },
+  { id: "2", name: "Child A", parentId: "1" },
+  { id: "3", name: "Child B", parentId: "1" },
+]
+
+describe("GraphCollection select-all inheritance", () => {
+  beforeEach(() => {
+    f0GraphMock.mockClear()
+  })
+
+  // Partial coverage: the cross-visualization select-all flow lives in
+  // OneDataCollection + the bulk-actions toolbar, which is out of scope for
+  // a unit test of GraphCollection itself. Here we verify the bridge — when
+  // the source already declares everything as selected via `defaultSelectedItems`,
+  // GraphCollection surfaces those ids to F0Graph as `selectedNodes`.
+  //
+  // TODO(Phase 1 follow-up): cover the full select-all → lazy-child inheritance
+  // flow by mounting OneDataCollection with both a Table and a Graph
+  // visualization, clicking select-all in the toolbar, expanding a graph
+  // node, and asserting the newly loaded children render as checked. That
+  // test belongs at the OneDataCollection integration level.
+
+  it("surfaces source.defaultSelectedItems as F0Graph selectedNodes", async () => {
+    const items = new Map<
+      string | number,
+      { id: string | number; checked: boolean }
+    >([
+      ["1", { id: "1", checked: true }],
+      ["2", { id: "2", checked: true }],
+      ["3", { id: "3", checked: true }],
+    ])
+    const source = createEagerSource(records, {
+      defaultSelectedItems: {
+        allSelected: true,
+        items,
+        groups: new Map(),
+      },
+    })
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = f0GraphMock.mock.calls[
+        f0GraphMock.mock.calls.length - 1
+      ][0] as unknown as { selectedNodes?: Set<string> }
+      expect(props.selectedNodes).toBeInstanceOf(Set)
+      expect(props.selectedNodes?.size ?? 0).toBe(3)
+    })
+
+    const props = f0GraphMock.mock.calls[
+      f0GraphMock.mock.calls.length - 1
+    ][0] as unknown as { selectedNodes: Set<string> }
+    expect(props.selectedNodes.has("1")).toBe(true)
+    expect(props.selectedNodes.has("2")).toBe(true)
+    expect(props.selectedNodes.has("3")).toBe(true)
+  })
+
+  it("starts with empty selectedNodes when defaultSelectedItems is omitted", async () => {
+    zeroRender(
+      <GraphCollection
+        source={createEagerSource(records)}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = f0GraphMock.mock.calls[
+        f0GraphMock.mock.calls.length - 1
+      ][0] as unknown as { nodes?: unknown[]; selectedNodes?: Set<string> }
+      expect(Array.isArray(props.nodes)).toBe(true)
+    })
+
+    const props = f0GraphMock.mock.calls[
+      f0GraphMock.mock.calls.length - 1
+    ][0] as unknown as { selectedNodes: Set<string> }
+    expect(props.selectedNodes).toBeInstanceOf(Set)
+    expect(props.selectedNodes.size).toBe(0)
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/selection.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/selection.test.tsx
@@ -1,0 +1,226 @@
+import { waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { F0Graph } from "@/patterns/F0Graph"
+import { zeroRender } from "@/testing/test-utils"
+
+import { GraphCollection } from "../Graph"
+
+import {
+  createEagerSource,
+  createPaginatedSource,
+  stubRenderNode,
+  type TestPerson,
+} from "./_helpers"
+
+// Mock F0Graph as a thin spy. We do NOT simulate React Flow internals — we
+// just capture the props that GraphCollection passes so we can invoke the
+// callbacks (`onNodeSelect`, `loadChildren`) ourselves and assert the
+// derived `selectedNodes` set on re-render.
+vi.mock("@/patterns/F0Graph", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/patterns/F0Graph")>(
+      "@/patterns/F0Graph"
+    )
+  return {
+    ...actual,
+    F0Graph: vi.fn(() => <div data-testid="f0graph-mock" />),
+  }
+})
+
+const f0GraphMock = vi.mocked(F0Graph)
+
+type CapturedProps = Parameters<typeof F0Graph>[0]
+
+const lastF0GraphProps = (): CapturedProps => {
+  const calls = f0GraphMock.mock.calls
+  if (calls.length === 0) throw new Error("F0Graph was never rendered")
+  return calls[calls.length - 1][0] as CapturedProps
+}
+
+const nodeAdapter = (r: TestPerson) => ({ parentId: r.parentId })
+
+const eagerRecords: TestPerson[] = [
+  { id: "1", name: "Root", parentId: null },
+  { id: "2", name: "Child", parentId: "1" },
+  { id: "3", name: "Leaf", parentId: "2" },
+]
+
+describe("GraphCollection selection bridge", () => {
+  beforeEach(() => {
+    f0GraphMock.mockClear()
+  })
+
+  afterEach(() => {
+    f0GraphMock.mockClear()
+  })
+
+  it("eager: invoking F0Graph's onNodeSelect routes the record to onSelectItems", async () => {
+    const onSelectItems = vi.fn()
+    const source = createEagerSource(eagerRecords)
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={onSelectItems}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    // Wait for fetchData → data → F0Graph render.
+    await waitFor(() => {
+      const props = lastF0GraphProps()
+      // @ts-expect-error eager F0Graph receives nodes
+      expect(props.nodes).toBeDefined()
+      // @ts-expect-error eager F0Graph receives nodes
+      expect(props.nodes.length).toBeGreaterThan(0)
+    })
+
+    const props = lastF0GraphProps()
+    const onNodeSelect = props.onNodeSelect as (
+      id: string,
+      selected: boolean
+    ) => void
+
+    onNodeSelect("2", true)
+
+    await waitFor(() => {
+      expect(onSelectItems).toHaveBeenCalled()
+    })
+
+    const lastCall =
+      onSelectItems.mock.calls[onSelectItems.mock.calls.length - 1]
+    const status = lastCall[0] as {
+      selectedIds: ReadonlyArray<string | number>
+      itemsStatus: ReadonlyArray<{ item: TestPerson; checked: boolean }>
+    }
+    expect(status.selectedIds.map(String)).toContain("2")
+    const checkedItems = status.itemsStatus
+      .filter((s) => s.checked)
+      .map((s) => s.item.id)
+    expect(checkedItems).toContain("2")
+  })
+
+  it("eager: selectedNodes prop reflects checked records on re-render", async () => {
+    const source = createEagerSource(eagerRecords)
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = lastF0GraphProps()
+      // @ts-expect-error eager F0Graph receives nodes
+      expect(props.nodes?.length).toBeGreaterThan(0)
+    })
+
+    const props = lastF0GraphProps()
+    expect(props.selectedNodes).toBeInstanceOf(Set)
+    expect(props.selectedNodes).toHaveProperty("size", 0)
+
+    ;(props.onNodeSelect as (id: string, sel: boolean) => void)("3", true)
+
+    await waitFor(() => {
+      const updated = lastF0GraphProps()
+      expect(updated.selectedNodes).toBeInstanceOf(Set)
+      expect((updated.selectedNodes as Set<string>).has("3")).toBe(true)
+    })
+  })
+
+  it("lazy: selecting a lazy-loaded child resolves the record via the lazy cache", async () => {
+    const onSelectItems = vi.fn()
+    const rootRecords: TestPerson[] = [
+      { id: "root", name: "Root", parentId: null },
+    ]
+    const source = createPaginatedSource(rootRecords)
+
+    const childRecord: TestPerson = {
+      id: "lazy-1",
+      name: "Lazy child",
+      parentId: "root",
+    }
+    const loadChildren = vi.fn(async (_nodeId: string) => [childRecord])
+
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        loadChildren={loadChildren}
+        onSelectItems={onSelectItems}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const props = lastF0GraphProps()
+      // @ts-expect-error lazy F0Graph receives rootNodes + loadChildren
+      expect(props.rootNodes).toBeDefined()
+      // @ts-expect-error lazy F0Graph receives rootNodes + loadChildren
+      expect(props.loadChildren).toBeTypeOf("function")
+    })
+
+    const props = lastF0GraphProps()
+    const wrappedLoad = (
+      props as unknown as {
+        loadChildren: (id: string) => Promise<{ id: string }[]>
+      }
+    ).loadChildren
+
+    const children = await wrappedLoad("root")
+    expect(children).toHaveLength(1)
+    expect(children[0].id).toBe("lazy-1")
+    expect(loadChildren).toHaveBeenCalledWith("root")
+
+    // Selecting the lazy child must resolve the record from `lazyRecordsRef`
+    // even though it never entered the eager projection. The Graph adapter's
+    // responsibility is the visual bridge: the lazy id must surface in the
+    // `selectedNodes` Set that F0Graph receives on re-render. `onSelectItems`
+    // must also fire so consumers know selection changed.
+    //
+    // TODO(Phase 2): full propagation of lazy ids into the consumer payload
+    // (`selectionStatus.selectedIds`) requires `source.allPagesSelection: true`
+    // — `useSelectable` filters `selectedIds` to current-page records by
+    // default. Cover end-to-end propagation once Graph either defaults
+    // `allPagesSelection` to true or documents the requirement.
+    ;(props.onNodeSelect as (id: string, sel: boolean) => void)("lazy-1", true)
+
+    await waitFor(() => {
+      expect(onSelectItems).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      const updated = lastF0GraphProps()
+      expect(updated.selectedNodes).toBeInstanceOf(Set)
+      expect((updated.selectedNodes as Set<string>).has("lazy-1")).toBe(true)
+    })
+  })
+
+  it("disables selection on F0Graph when source.selectable is omitted", async () => {
+    const source = createEagerSource(eagerRecords, { selectable: undefined })
+    zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(lastF0GraphProps().selectionMode).toBe("none")
+    })
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/selection.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/selection.test.tsx
@@ -148,7 +148,9 @@ describe("GraphCollection selection bridge", () => {
       name: "Lazy child",
       parentId: "root",
     }
-    const loadChildren = vi.fn(async (_nodeId: string) => [childRecord])
+    const loadChildren = vi.fn(
+      async (_nodeId: string, _opts: { signal: AbortSignal }) => [childRecord]
+    )
 
     zeroRender(
       <GraphCollection
@@ -180,24 +182,27 @@ describe("GraphCollection selection bridge", () => {
     const children = await wrappedLoad("root")
     expect(children).toHaveLength(1)
     expect(children[0].id).toBe("lazy-1")
-    expect(loadChildren).toHaveBeenCalledWith("root")
+    expect(loadChildren).toHaveBeenCalledTimes(1)
+    expect(loadChildren.mock.calls[0][0]).toBe("root")
+    expect(loadChildren.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
 
     // Selecting the lazy child must resolve the record from `lazyRecordsRef`
-    // even though it never entered the eager projection. The Graph adapter's
-    // responsibility is the visual bridge: the lazy id must surface in the
-    // `selectedNodes` Set that F0Graph receives on re-render. `onSelectItems`
-    // must also fire so consumers know selection changed.
-    //
-    // TODO(Phase 2): full propagation of lazy ids into the consumer payload
-    // (`selectionStatus.selectedIds`) requires `source.allPagesSelection: true`
-    // — `useSelectable` filters `selectedIds` to current-page records by
-    // default. Cover end-to-end propagation once Graph either defaults
-    // `allPagesSelection` to true or documents the requirement.
+    // even though it never entered the eager projection. GraphCollection
+    // forces `allPagesSelection: true` in lazy mode so the lazy id surfaces
+    // in both the F0Graph `selectedNodes` Set AND the `onSelectItems`
+    // payload's `selectedIds`.
     ;(props.onNodeSelect as (id: string, sel: boolean) => void)("lazy-1", true)
 
     await waitFor(() => {
       expect(onSelectItems).toHaveBeenCalled()
     })
+
+    const lastCall =
+      onSelectItems.mock.calls[onSelectItems.mock.calls.length - 1]
+    const status = lastCall[0] as {
+      selectedIds: ReadonlyArray<string | number>
+    }
+    expect(status.selectedIds.map(String)).toContain("lazy-1")
 
     await waitFor(() => {
       const updated = lastF0GraphProps()

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/stableIdentityWarning.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/stableIdentityWarning.test.tsx
@@ -7,13 +7,14 @@ import { GraphCollection } from "../Graph"
 
 import { createEagerSource, stubRenderNode, type TestPerson } from "./_helpers"
 
-// Warning is gated on `useIsDev()`; the default test provider returns false,
-// so we force-enable dev mode for this suite.
+// `isDev` flag is controlled per test by re-mocking the provider through
+// vi.doMock + dynamic import. Default is dev=true.
+let isDevReturn = true
 vi.mock("@/lib/providers/user-platafform", async () => {
   const actual = await vi.importActual<
     typeof import("@/lib/providers/user-platafform")
   >("@/lib/providers/user-platafform")
-  return { ...actual, useIsDev: () => true }
+  return { ...actual, useIsDev: () => isDevReturn }
 })
 
 vi.mock("@/patterns/F0Graph", async () => {
@@ -27,21 +28,48 @@ vi.mock("@/patterns/F0Graph", async () => {
   }
 })
 
-const nodeAdapter = (r: TestPerson) => ({ parentId: r.parentId })
+const records: TestPerson[] = [
+  { id: "a", name: "A", parentId: null },
+  { id: "b", name: "B", parentId: "a" },
+]
 
-const orderedRecords: TestPerson[] = [
-  { id: "a", name: "A", parentId: null },
-  { id: "b", name: "B", parentId: "a" },
-]
-const reorderedRecords: TestPerson[] = [
-  { id: "b", name: "B", parentId: "a" },
-  { id: "a", name: "A", parentId: null },
-]
+const renderWithFreshAdapter = (
+  source: ReturnType<typeof createEagerSource>
+) => {
+  // Inlined adapter: identity changes every render.
+  return zeroRender(
+    <GraphCollection
+      source={source}
+      nodeAdapter={(r: TestPerson) => ({ parentId: r.parentId })}
+      renderNode={stubRenderNode}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+    />
+  )
+}
+
+const rerenderWithFreshAdapter = (
+  rerender: (ui: React.ReactElement) => void,
+  source: ReturnType<typeof createEagerSource>
+) => {
+  rerender(
+    <GraphCollection
+      source={source}
+      nodeAdapter={(r: TestPerson) => ({ parentId: r.parentId })}
+      renderNode={stubRenderNode}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+    />
+  )
+}
 
 describe("GraphCollection stable identity warning", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    isDevReturn = true
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
   })
 
@@ -49,95 +77,76 @@ describe("GraphCollection stable identity warning", () => {
     warnSpy.mockRestore()
   })
 
-  // NOTE: PLAN §4.3 describes detecting nodeAdapter identity change. The
-  // implemented heuristic is simpler — it warns when a record key shifts
-  // index between renders. These tests assert the implemented behavior.
-
-  it("does not warn when record keys keep their index across renders", async () => {
-    const source = createEagerSource(orderedRecords)
-    const { rerender } = zeroRender(
-      <GraphCollection
-        source={source}
-        nodeAdapter={nodeAdapter}
-        renderNode={stubRenderNode}
-        onSelectItems={vi.fn()}
-        onLoadData={vi.fn()}
-        onLoadError={vi.fn()}
-      />
-    )
-
+  it("warns exactly once when an inlined nodeAdapter changes identity 6+ times within 1s", async () => {
+    const source = createEagerSource(records)
+    const { rerender } = renderWithFreshAdapter(source)
     await waitFor(() => {
-      // Wait for data fetch to settle.
       expect(source.dataAdapter.fetchData).toBeDefined()
     })
 
-    rerender(
-      <GraphCollection
-        source={createEagerSource(orderedRecords)}
-        nodeAdapter={nodeAdapter}
-        renderNode={stubRenderNode}
-        onSelectItems={vi.fn()}
-        onLoadData={vi.fn()}
-        onLoadError={vi.fn()}
-      />
-    )
-
+    // 5 additional rerenders → 6 total identity values within the 1s window.
+    for (let i = 0; i < 6; i++) {
+      rerenderWithFreshAdapter(rerender, source)
+    }
     // Allow effects to flush.
     await new Promise((r) => setTimeout(r, 0))
 
-    const movedWarnings = warnSpy.mock.calls.filter((c) =>
-      String(c[0]).includes("moved from index")
+    const adapterWarnings = warnSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("`nodeAdapter` identity changed")
     )
-    expect(movedWarnings).toHaveLength(0)
+    expect(adapterWarnings).toHaveLength(1)
+    expect(String(adapterWarnings[0][0])).toContain(
+      "Wrap it in `useCallback`/`useMemo`"
+    )
   })
 
-  it("warns when a record key moves to a different index between renders", async () => {
-    const source1 = createEagerSource(orderedRecords)
-    const { rerender } = zeroRender(
+  it("does not warn when adapters are memoized across many renders", async () => {
+    const source = createEagerSource(records)
+    const stableAdapter = (r: TestPerson) => ({ parentId: r.parentId })
+    const stableRender = stubRenderNode
+
+    const ui = (
       <GraphCollection
-        source={source1}
-        nodeAdapter={nodeAdapter}
-        renderNode={stubRenderNode}
+        source={source}
+        nodeAdapter={stableAdapter}
+        renderNode={stableRender}
         onSelectItems={vi.fn()}
         onLoadData={vi.fn()}
         onLoadError={vi.fn()}
       />
     )
-
+    const { rerender } = zeroRender(ui)
     await waitFor(() => {
-      expect(source1.dataAdapter.fetchData).toBeDefined()
+      expect(source.dataAdapter.fetchData).toBeDefined()
     })
 
-    // Re-render with reordered records to trigger the index-shift warning.
-    // The source's data is reloaded; we wait until records reach the
-    // collection by polling for the warning.
-    const source2 = createEagerSource(reorderedRecords)
-    rerender(
-      <GraphCollection
-        source={source2}
-        nodeAdapter={nodeAdapter}
-        renderNode={stubRenderNode}
-        onSelectItems={vi.fn()}
-        onLoadData={vi.fn()}
-        onLoadError={vi.fn()}
-      />
-    )
+    for (let i = 0; i < 10; i++) {
+      rerender(ui)
+    }
+    await new Promise((r) => setTimeout(r, 0))
 
+    const identityWarnings = warnSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("identity changed")
+    )
+    expect(identityWarnings).toHaveLength(0)
+  })
+
+  it("does not warn in production builds even with inlined adapters", async () => {
+    isDevReturn = false
+    const source = createEagerSource(records)
+    const { rerender } = renderWithFreshAdapter(source)
     await waitFor(() => {
-      const movedWarnings = warnSpy.mock.calls.filter((c) =>
-        String(c[0]).includes("moved from index")
-      )
-      expect(movedWarnings.length).toBeGreaterThan(0)
+      expect(source.dataAdapter.fetchData).toBeDefined()
     })
 
-    const message = String(
-      warnSpy.mock.calls.find((c) =>
-        String(c[0]).includes("moved from index")
-      )?.[0]
+    for (let i = 0; i < 10; i++) {
+      rerenderWithFreshAdapter(rerender, source)
+    }
+    await new Promise((r) => setTimeout(r, 0))
+
+    const identityWarnings = warnSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("identity changed")
     )
-    expect(message).toContain("Graph visualization: record key")
-    expect(message).toContain(
-      "Provide a stable `source.selectable` (idProvider)"
-    )
+    expect(identityWarnings).toHaveLength(0)
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/stableIdentityWarning.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/stableIdentityWarning.test.tsx
@@ -1,0 +1,143 @@
+import { waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import { GraphCollection } from "../Graph"
+
+import { createEagerSource, stubRenderNode, type TestPerson } from "./_helpers"
+
+// Warning is gated on `useIsDev()`; the default test provider returns false,
+// so we force-enable dev mode for this suite.
+vi.mock("@/lib/providers/user-platafform", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/providers/user-platafform")
+  >("@/lib/providers/user-platafform")
+  return { ...actual, useIsDev: () => true }
+})
+
+vi.mock("@/patterns/F0Graph", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/patterns/F0Graph")>(
+      "@/patterns/F0Graph"
+    )
+  return {
+    ...actual,
+    F0Graph: vi.fn(() => <div data-testid="f0graph-mock" />),
+  }
+})
+
+const nodeAdapter = (r: TestPerson) => ({ parentId: r.parentId })
+
+const orderedRecords: TestPerson[] = [
+  { id: "a", name: "A", parentId: null },
+  { id: "b", name: "B", parentId: "a" },
+]
+const reorderedRecords: TestPerson[] = [
+  { id: "b", name: "B", parentId: "a" },
+  { id: "a", name: "A", parentId: null },
+]
+
+describe("GraphCollection stable identity warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  // NOTE: PLAN §4.3 describes detecting nodeAdapter identity change. The
+  // implemented heuristic is simpler — it warns when a record key shifts
+  // index between renders. These tests assert the implemented behavior.
+
+  it("does not warn when record keys keep their index across renders", async () => {
+    const source = createEagerSource(orderedRecords)
+    const { rerender } = zeroRender(
+      <GraphCollection
+        source={source}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      // Wait for data fetch to settle.
+      expect(source.dataAdapter.fetchData).toBeDefined()
+    })
+
+    rerender(
+      <GraphCollection
+        source={createEagerSource(orderedRecords)}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    // Allow effects to flush.
+    await new Promise((r) => setTimeout(r, 0))
+
+    const movedWarnings = warnSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("moved from index")
+    )
+    expect(movedWarnings).toHaveLength(0)
+  })
+
+  it("warns when a record key moves to a different index between renders", async () => {
+    const source1 = createEagerSource(orderedRecords)
+    const { rerender } = zeroRender(
+      <GraphCollection
+        source={source1}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(source1.dataAdapter.fetchData).toBeDefined()
+    })
+
+    // Re-render with reordered records to trigger the index-shift warning.
+    // The source's data is reloaded; we wait until records reach the
+    // collection by polling for the warning.
+    const source2 = createEagerSource(reorderedRecords)
+    rerender(
+      <GraphCollection
+        source={source2}
+        nodeAdapter={nodeAdapter}
+        renderNode={stubRenderNode}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      const movedWarnings = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("moved from index")
+      )
+      expect(movedWarnings.length).toBeGreaterThan(0)
+    })
+
+    const message = String(
+      warnSpy.mock.calls.find((c) =>
+        String(c[0]).includes("moved from index")
+      )?.[0]
+    )
+    expect(message).toContain("Graph visualization: record key")
+    expect(message).toContain(
+      "Provide a stable `source.selectable` (idProvider)"
+    )
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
@@ -1,0 +1,4 @@
+export * from "./Graph"
+export * from "./types"
+export { projectGraph, getRecordKey } from "./projectGraph"
+export type { ProjectGraphInput, ProjectGraphResult } from "./projectGraph"

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/projectGraph.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/projectGraph.ts
@@ -1,0 +1,252 @@
+import type { GraphEdge, GraphNode } from "@/patterns/F0Graph"
+import type { RecordType } from "@/hooks/datasource"
+
+import type { GraphEdgeAdapter, GraphNodeAdapter } from "./types"
+
+/**
+ * Resolve a record's stable identifier using the OneDataCollection three-step
+ * fallback (mirrors Kanban): `source.idProvider(item, index)` → `item.id` →
+ * `String(index)`. Always coerced to `string`.
+ *
+ * TODO(Phase 1 follow-up): hoist this to `OneDataCollection/utils/` if no
+ * shared util already exists. For now the helper is duplicated locally and in
+ * `Kanban.tsx` to avoid widening Phase 1 surface.
+ */
+export function getRecordKey<R extends RecordType>(
+  item: R,
+  index: number,
+  idProvider: ((item: R, index: number) => string | number) | undefined
+): string {
+  if (idProvider) return String(idProvider(item, index))
+  const fallbackId = (item as unknown as { id?: string | number }).id
+  return fallbackId !== undefined && fallbackId !== null
+    ? String(fallbackId)
+    : String(index)
+}
+
+export type ProjectGraphInput<R extends RecordType> = {
+  records: ReadonlyArray<R>
+  nodeAdapter: GraphNodeAdapter<R>
+  edgeAdapter?: GraphEdgeAdapter<R>
+  idProvider: ((item: R, index: number) => string | number) | undefined
+  /**
+   * Optional matched-id set. When provided, records whose key is NOT in this
+   * set are omitted from `nodes`, and any edge incident on a removed node is
+   * also omitted. Subtree of a removed parent is removed (no orphan promotion).
+   */
+  matchedIds?: ReadonlySet<string>
+  /** When true, throw on duplicate keys. Defaults to false (warn-only). */
+  strictDuplicates?: boolean
+}
+
+export type ProjectGraphResult<R extends RecordType> = {
+  nodes: ReadonlyArray<GraphNode<R>>
+  edges: ReadonlyArray<GraphEdge>
+  /** Record keys participating in a parent-link cycle. */
+  cycles: ReadonlyArray<string>
+  /** Record keys that resolved to a duplicate id and were dropped. */
+  duplicates: ReadonlyArray<string>
+}
+
+type Adapted<R> = {
+  key: string
+  record: R
+  parentId: string | null
+  parentIds?: string[]
+  childrenCount?: number
+  childrenLoaded?: boolean
+}
+
+/**
+ * Pure projection: turns the source's records into F0Graph's `nodes`/`edges`,
+ * applies hard-removal filtering, and reports topology problems (duplicate
+ * keys, cycles) so the caller can surface them.
+ */
+export function projectGraph<R extends RecordType>(
+  input: ProjectGraphInput<R>
+): ProjectGraphResult<R> {
+  const { records, nodeAdapter, edgeAdapter, idProvider, matchedIds } = input
+
+  // 1. Adapt records → intermediate with stable keys.
+  const adapted: Adapted<R>[] = []
+  const duplicates: string[] = []
+  const seen = new Map<string, number>()
+  records.forEach((record, index) => {
+    const key = getRecordKey(record, index, idProvider)
+    if (seen.has(key)) {
+      duplicates.push(key)
+      if (input.strictDuplicates) {
+        throw new Error(
+          `Graph visualization: duplicate record key "${key}" produced by idProvider/item.id fallback. Records must have unique keys.`
+        )
+      }
+      return
+    }
+    seen.set(key, index)
+    const linkage = nodeAdapter(record)
+    adapted.push({
+      key,
+      record,
+      parentId: linkage.parentId,
+      parentIds: linkage.parentIds,
+      childrenCount: linkage.childrenCount,
+      childrenLoaded: linkage.childrenLoaded,
+    })
+  })
+
+  // 2. Resolve hard-removal: build the set of keys that survive the filter,
+  // then drop any record whose ancestor chain crosses a removed parent.
+  const keptKeys = new Set<string>()
+  if (matchedIds) {
+    const byKey = new Map(adapted.map((a) => [a.key, a]))
+    const cache = new Map<string, boolean>()
+    const survives = (key: string, stack: Set<string>): boolean => {
+      const cached = cache.get(key)
+      if (cached !== undefined) return cached
+      if (stack.has(key)) {
+        // Cycle while walking ancestors — treat as surviving to avoid hiding
+        // it for the wrong reason; the cycle detector below logs it.
+        cache.set(key, true)
+        return true
+      }
+      const node = byKey.get(key)
+      if (!node) {
+        cache.set(key, false)
+        return false
+      }
+      if (!matchedIds.has(key)) {
+        cache.set(key, false)
+        return false
+      }
+      const parents = node.parentIds?.length
+        ? node.parentIds
+        : node.parentId !== null
+          ? [node.parentId]
+          : []
+      if (parents.length === 0) {
+        cache.set(key, true)
+        return true
+      }
+      stack.add(key)
+      // A node survives if every known parent survives. Parents that do not
+      // exist in the record set are ignored (treated as missing roots), not
+      // as "removed", so subtrees of filtered-in records with missing parents
+      // still render.
+      const allParentsOk = parents.every((p) => {
+        if (!byKey.has(p)) return true
+        return survives(p, stack)
+      })
+      stack.delete(key)
+      cache.set(key, allParentsOk)
+      return allParentsOk
+    }
+    for (const a of adapted) {
+      if (survives(a.key, new Set())) keptKeys.add(a.key)
+    }
+  } else {
+    for (const a of adapted) keptKeys.add(a.key)
+  }
+
+  const kept = adapted.filter((a) => keptKeys.has(a.key))
+  const keptByKey = new Map(kept.map((a) => [a.key, a]))
+
+  // 3. Cycle detection — walk parent linkage on the kept set, drop any edge
+  // that would close a cycle, and report participating keys.
+  const cycles = new Set<string>()
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+  const droppedEdges = new Set<string>() // "child|parent"
+  const walk = (key: string, stack: string[]): void => {
+    if (visited.has(key)) return
+    if (visiting.has(key)) {
+      // Closing a cycle on this key. Drop the edge that took us back here.
+      const cycleStart = stack.indexOf(key)
+      const cycleNodes =
+        cycleStart >= 0 ? stack.slice(cycleStart) : [...stack, key]
+      for (const c of cycleNodes) cycles.add(c)
+      // The offending edge is the one from the previous stack entry into `key`.
+      const previous = stack[stack.length - 1]
+      if (previous !== undefined) droppedEdges.add(`${previous}|${key}`)
+      return
+    }
+    visiting.add(key)
+    stack.push(key)
+    const node = keptByKey.get(key)
+    if (node) {
+      const parents = node.parentIds?.length
+        ? node.parentIds
+        : node.parentId !== null
+          ? [node.parentId]
+          : []
+      for (const p of parents) {
+        if (!keptByKey.has(p)) continue
+        walk(p, stack)
+      }
+    }
+    stack.pop()
+    visiting.delete(key)
+    visited.add(key)
+  }
+  for (const a of kept) walk(a.key, [])
+
+  // 4. Project nodes.
+  const projectedNodes: GraphNode<R>[] = kept.map((a) => {
+    // Drop parent links that close a cycle so F0Graph never sees an invalid
+    // topology; the cycle list is reported to the caller for a single warn.
+    const parentIdsCleaned = a.parentIds?.filter(
+      (p) => !droppedEdges.has(`${a.key}|${p}`)
+    )
+    const parentIdCleaned =
+      a.parentId !== null && droppedEdges.has(`${a.key}|${a.parentId}`)
+        ? null
+        : a.parentId
+    const node: GraphNode<R> = {
+      id: a.key,
+      parentId: parentIdCleaned,
+      data: a.record,
+    }
+    if (parentIdsCleaned && parentIdsCleaned.length > 0) {
+      node.parentIds = parentIdsCleaned
+    }
+    if (a.childrenCount !== undefined) node.childrenCount = a.childrenCount
+    if (a.childrenLoaded !== undefined) node.childrenLoaded = a.childrenLoaded
+    return node
+  })
+
+  // 5. Project edges — either through the adapter or derived from parent linkage.
+  let projectedEdges: GraphEdge[]
+  if (edgeAdapter) {
+    const keptRecords = kept.map((a) => a.record)
+    projectedEdges = edgeAdapter(keptRecords).filter(
+      (e) =>
+        keptByKey.has(e.source) &&
+        keptByKey.has(e.target) &&
+        !droppedEdges.has(`${e.target}|${e.source}`)
+    ) as GraphEdge[]
+  } else {
+    projectedEdges = []
+    for (const a of kept) {
+      const parents = a.parentIds?.length
+        ? a.parentIds
+        : a.parentId !== null
+          ? [a.parentId]
+          : []
+      for (const p of parents) {
+        if (!keptByKey.has(p)) continue
+        if (droppedEdges.has(`${a.key}|${p}`)) continue
+        projectedEdges.push({
+          id: `${p}->${a.key}`,
+          source: p,
+          target: a.key,
+        })
+      }
+    }
+  }
+
+  return {
+    nodes: projectedNodes,
+    edges: projectedEdges,
+    cycles: Array.from(cycles),
+    duplicates,
+  }
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
@@ -128,9 +128,22 @@ export type GraphVisualizationOptions<
    * - Returned records pass through `nodeAdapter` and inherit selection state
    *   via the standard projection (`source.selectable` / `item.id` / index).
    * - GraphCollection wraps the loader with an internal AbortController per
-   *   nodeId: results that resolve after unmount are dropped silently.
+   *   nodeId: results that resolve after unmount are dropped silently. The
+   *   controller's `signal` is forwarded as `opts.signal` so the consumer can
+   *   cancel the underlying request (e.g. pass it to `fetch`).
    */
-  loadChildren?: (nodeId: string) => Promise<ReadonlyArray<R>>
+  loadChildren?: (
+    nodeId: string,
+    opts: {
+      /**
+       * Aborted if the user collapses the node before resolution or the
+       * component unmounts. Consumers SHOULD forward this to `fetch` (or
+       * their underlying request layer) so cancelled loads release network
+       * resources instead of resolving into a dropped result.
+       */
+      signal: AbortSignal
+    }
+  ) => Promise<ReadonlyArray<R>>
 
   /**
    * Escape hatch for everything F0Graph exposes that this view does NOT own.

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
@@ -63,7 +63,11 @@ export type GraphRenderNodeExtras = {
 /**
  * Subset of F0GraphProps that GraphCollection delegates to consumers. Excludes
  * fields that GraphCollection owns (data, selection, search) or that depend on
- * Phase 2+ features (loadChildren, detailPanel, dimmedNodes).
+ * follow-up features (detailPanel, dimmedNodes).
+ *
+ * `loadChildren` is owned by GraphCollection (the wrapper installs a per-node
+ * AbortController and folds errors into `options.onLoadError`); consumers
+ * supply the raw loader via `GraphVisualizationOptions.loadChildren` instead.
  */
 export type GraphGraphPropsPassthrough<R extends RecordType> = Omit<
   F0GraphProps<R>,
@@ -144,6 +148,37 @@ export type GraphVisualizationOptions<
       signal: AbortSignal
     }
   ) => Promise<ReadonlyArray<R>>
+
+  /**
+   * Optional. Invoked when a `loadChildren` rejection escapes the wrapper
+   * (i.e. anything other than the per-node `AbortError` that the abort
+   * controller fires). Default is `console.error`. Use this hook to surface
+   * load failures to a toaster, telemetry sink, or in-product error banner.
+   *
+   * Distinct from `CollectionProps.onLoadError`, which fires for the
+   * top-level page/data fetch — this one is scoped to lazy child loads.
+   *
+   * Aborts are intentionally silent — the user collapsed the node or the
+   * component unmounted; surfacing those as errors would be noise.
+   */
+  onLoadChildrenError?: (error: unknown, nodeId: string) => void
+
+  /**
+   * Optional. Narrows the record set down to "root candidates" before the
+   * projection runs.
+   *
+   * In **eager** mode this is equivalent to filtering `records` upstream of
+   * `projectGraph`: roots are whatever's left whose `parentId` doesn't
+   * resolve to a member of the same set. In **lazy** mode it acts on the
+   * first page of records only — useful when the paginated source returns
+   * roots interleaved with children (e.g. a flat search result set) and you
+   * need to project only the parent rows as `rootNodes`.
+   *
+   * The function MUST be referentially stable across renders (memoize it
+   * with the consumer's deps) — GraphCollection holds a single ref and does
+   * NOT diff `rootSelector` between projections.
+   */
+  rootSelector?: (records: ReadonlyArray<R>) => ReadonlyArray<R>
 
   /**
    * Escape hatch for everything F0Graph exposes that this view does NOT own.

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
@@ -1,0 +1,162 @@
+import type { ReactNode } from "react"
+
+import type {
+  F0GraphNodeRenderContext,
+  F0GraphProps,
+  GraphEdge,
+} from "@/patterns/F0Graph"
+import type { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
+import type { RecordType, SortingsDefinition } from "@/hooks/datasource"
+
+import type { ItemActionsDefinition } from "../../../item-actions"
+import type { NavigationFiltersDefinition } from "../../../navigationFilters/types"
+import type { CollectionProps, GroupingDefinition } from "../../../types"
+import type { SummariesDefinition } from "../../../summary"
+
+/**
+ * Adapter that extracts the structural fields F0Graph needs from a record.
+ *
+ * The full record is preserved on the projected node automatically and node
+ * identity is stamped by `GraphCollection` via the shared `getKey` helper
+ * (`source.idProvider(item, index)` → `item.id` → `String(index)`). Adapter
+ * does NOT return an id.
+ */
+export type GraphNodeAdapter<R extends RecordType> = (record: R) => {
+  /** Single-parent tree linkage. */
+  parentId: string | null
+  /** DAG linkage. When present, takes precedence over `parentId`. */
+  parentIds?: string[]
+  /** Hint for lazy-loaded children. */
+  childrenCount?: number
+  /** Hint for lazy-loaded children. */
+  childrenLoaded?: boolean
+}
+
+/**
+ * Optional adapter that derives explicit edges from records. When omitted,
+ * F0Graph derives parent→child edges from `parentId`/`parentIds`.
+ *
+ * Use this when edges have semantic metadata (labels, weights, click handlers)
+ * that are not expressible through tree linkage alone.
+ */
+export type GraphEdgeAdapter<R extends RecordType> = (
+  records: ReadonlyArray<R>
+) => ReadonlyArray<GraphEdge>
+
+/**
+ * Return shape of `detailPanel`, re-exported from F0Graph so the public API
+ * stays readable instead of inlining a deep conditional type.
+ */
+export type GraphDetailPanel = ReturnType<
+  NonNullable<F0GraphProps["detailPanel"]>
+>
+
+/**
+ * Extras forwarded as the third argument of `renderNode`. Carries the
+ * pre-built item-actions dropdown (Phase 1 fallback for `detailPanel`).
+ */
+export type GraphRenderNodeExtras = {
+  /** Ready-to-render dropdown trigger; spread into `F0GraphNode.actions`. */
+  actions?: ReactNode
+}
+
+/**
+ * Subset of F0GraphProps that GraphCollection delegates to consumers. Excludes
+ * fields that GraphCollection owns (data, selection, search) or that depend on
+ * Phase 2+ features (loadChildren, detailPanel, dimmedNodes).
+ */
+export type GraphGraphPropsPassthrough<R extends RecordType> = Omit<
+  F0GraphProps<R>,
+  | "nodes"
+  | "edges"
+  | "rootNodes"
+  | "loadChildren"
+  | "renderNode"
+  | "selectionMode"
+  | "onNodeSelect"
+  | "onSelectedNodesChange"
+  | "detailPanel"
+  | "selectedNodes"
+  | "highlightedNodes"
+  | "searchValue"
+  | "onSearchChange"
+  | "searchable"
+>
+
+export type GraphVisualizationOptions<
+  R extends RecordType,
+  _Filters extends FiltersDefinition,
+  _Sortings extends SortingsDefinition,
+> = {
+  /**
+   * Stable identifier used by F0Graph to scope per-graph persisted state
+   * (currently: detail-panel width). When omitted, `GraphCollection` defaults
+   * to `React.useId()` so each instance gets a unique key — pass an explicit
+   * value only when you want a persistence key tied to a known domain entity.
+   */
+  graphId?: string
+
+  /** Required. Maps a record to its parent linkage. */
+  nodeAdapter: GraphNodeAdapter<R>
+
+  /** Optional. Derive explicit edges; otherwise inferred from parent linkage. */
+  edgeAdapter?: GraphEdgeAdapter<R>
+
+  /**
+   * Required. Render the node body. Extends F0Graph's `renderNode` with a
+   * third `extras` argument: when `source.itemActions` is configured and no
+   * `detailPanel` is supplied (Phase 1), `extras.actions` carries a ready-to-use
+   * dropdown trigger that should be spread into `F0GraphNode`'s `actions`
+   * slot. Consumers MAY ignore `extras`; the prop is purely additive.
+   */
+  renderNode: (
+    record: R,
+    ctx: F0GraphNodeRenderContext,
+    extras: GraphRenderNodeExtras
+  ) => ReactNode
+
+  /**
+   * Optional lazy loader. When provided, GraphCollection switches to lazy
+   * mode: the first page of records becomes F0Graph's `rootNodes` and each
+   * subsequent expand fetches children via `loadChildren(nodeId)`.
+   *
+   * Requirements:
+   * - Source must declare a paginated `paginationType` ("pages" or
+   *   "infinite-scroll"). Omitting `loadChildren` requires the inverse — a
+   *   non-paginated source — because eager mode pulls the full graph in one
+   *   fetch.
+   * - Returned records pass through `nodeAdapter` and inherit selection state
+   *   via the standard projection (`source.selectable` / `item.id` / index).
+   * - GraphCollection wraps the loader with an internal AbortController per
+   *   nodeId: results that resolve after unmount are dropped silently.
+   */
+  loadChildren?: (nodeId: string) => Promise<ReadonlyArray<R>>
+
+  /**
+   * Escape hatch for everything F0Graph exposes that this view does NOT own.
+   * DataCollection owns data, selection, search. Everything else
+   * (zoomPreset, defaultZoom, defaultExpandDepth, layoutEngine, nodeWidth,
+   * nodeHeight, fullScreen, showControls, currentUserNodeId, renderEdge, etc.)
+   * passes through here.
+   */
+  graphProps?: GraphGraphPropsPassthrough<R>
+}
+
+export type GraphCollectionProps<
+  Record extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Summaries extends SummariesDefinition,
+  ItemActions extends ItemActionsDefinition<Record>,
+  NavigationFilters extends NavigationFiltersDefinition,
+  Grouping extends GroupingDefinition<Record>,
+> = CollectionProps<
+  Record,
+  Filters,
+  Sortings,
+  Summaries,
+  ItemActions,
+  NavigationFilters,
+  Grouping,
+  GraphVisualizationOptions<Record, Filters, Sortings>
+>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/collectionViewRegistry.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/collectionViewRegistry.tsx
@@ -7,7 +7,7 @@ import {
   RecordType,
   SortingsDefinition,
 } from "@/hooks/datasource"
-import { Kanban, List, Pencil, Table } from "@/icons/app"
+import { Graph, Kanban, List, Pencil, Table } from "@/icons/app"
 
 import { DataCollectionSettingsContextType } from "../../Settings/SettingsProvider"
 import { SummariesDefinition } from "../../types"
@@ -17,6 +17,7 @@ import {
   EditableTableCollectionProps,
 } from "./EditableTable"
 import { EditableTableVisualizationSettings } from "./EditableTable/types"
+import { GraphCollection, type GraphCollectionProps } from "./Graph"
 import { KanbanCollection, KanbanCollectionProps } from "./Kanban"
 import { ListCollection, ListCollectionProps } from "./List"
 import {
@@ -97,6 +98,17 @@ type CollectionVisualizations<
   >
   kanban: VisualizacionTypeDefinition<
     KanbanCollectionProps<
+      Record,
+      Filters,
+      Sortings,
+      Summaries,
+      ItemActions,
+      NavigationFilters,
+      Grouping
+    >
+  >
+  graph: VisualizacionTypeDefinition<
+    GraphCollectionProps<
       Record,
       Filters,
       Sortings,
@@ -312,6 +324,46 @@ export const collectionVisualizations: CollectionVisualizations<
     ) => {
       return (
         <KanbanCollection<
+          Record,
+          Filters,
+          Sortings,
+          Summaries,
+          ItemActions,
+          NavigationFilters,
+          Grouping
+        >
+          {...props}
+        />
+      )
+    },
+  },
+  graph: {
+    name: "Graph",
+    icon: Graph,
+    settings: {
+      default: {},
+    },
+    render: <
+      Record extends RecordType,
+      Filters extends FiltersDefinition,
+      Sortings extends SortingsDefinition,
+      Summaries extends SummariesDefinition,
+      ItemActions extends ItemActionsDefinition<Record>,
+      NavigationFilters extends NavigationFiltersDefinition,
+      Grouping extends GroupingDefinition<Record>,
+    >(
+      props: GraphCollectionProps<
+        Record,
+        Filters,
+        Sortings,
+        Summaries,
+        ItemActions,
+        NavigationFilters,
+        Grouping
+      >
+    ) => {
+      return (
+        <GraphCollection<
           Record,
           Filters,
           Sortings,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/index.tsx
@@ -1,3 +1,4 @@
 export * from "./collectionViewRegistry"
+export * from "./Graph"
 export * from "./types"
 export * from "./VisualizationRenderer"

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/types.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../types"
 import type { CardVisualizationOptions } from "./Card"
 import type { EditableTableVisualizationOptions } from "./EditableTable"
+import type { GraphVisualizationOptions } from "./Graph"
 import type { KanbanVisualizationOptions } from "./Kanban"
 import type { TableVisualizationOptions } from "./Table"
 
@@ -92,6 +93,12 @@ export type Visualization<
       type: "list"
       /** Configuration options for list visualization */
       options: ListVisualizationOptions<R, Filters, Sortings>
+    } & VisualizationFilterOverrides<Filters>)
+  | ({
+      /** Graph-based visualization type */
+      type: "graph"
+      /** Configuration options for graph visualization */
+      options: GraphVisualizationOptions<R, Filters, Sortings>
     } & VisualizationFilterOverrides<Filters>)
   | ({
       /** Human-readable label for the visualization */

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1,6 +1,7 @@
 @import "./reset.css";
 @import "../assets/fonts/style.css";
 @import "@factorialco/f0-core/base.css";
+@import "@xyflow/react/dist/style.css";
 
 @property --gradient-angle {
   syntax: "<angle>";


### PR DESCRIPTION
## Summary
- add a new `graph` visualization to `OneDataCollection` using `F0Graph` as the runtime consumer
- introduce the Phase 1 graph adapter, projection helpers, public types, docs, and Storybook coverage
- add focused unit coverage for projection, selection bridging, pagination guards, lazy abort handling, stable identity warnings, and graph id isolation

## Validation
- `pnpm exec oxfmt src/patterns/OneDataCollection/visualizations/collection/Graph src/patterns/OneDataCollection/__stories__/mockData.tsx`
- `pnpm exec oxlint src/patterns/OneDataCollection/visualizations/collection/Graph src/patterns/OneDataCollection/__stories__/mockData.tsx --max-warnings 0`
- `pnpm tsc --noEmit`
- `pnpm vitest run src/patterns/OneDataCollection/visualizations/collection/Graph`
- `pnpm build-storybook`

## Notes
- the worktree still contains unrelated untracked F0Graph story folders that were left untouched and are not part of this PR
- vitest prints the expected pagination-guard errors from the guard tests while still passing 29/29 tests