### PR TITLE
fix: adjust horizontal paddings in data collection

### DIFF
--- a/packages/core/src/tokens/spacing.ts
+++ b/packages/core/src/tokens/spacing.ts
@@ -100,6 +100,14 @@ export const betweenSpacing: ThemeConfig["spacing"] = {
   xl: relativeSpacing[4],
 }
 
+/*
+ * Semantic page-level horizontal padding.
+ * Used by page headers, data collections, layouts, and tab navigation.
+ */
+export const pageSpacing: ThemeConfig["spacing"] = {
+  page: absoluteSpacing[6], // 24px
+}
+
 /**
  * Standard height scale for interactive components (buttons, inputs, segmented controls, etc.)
  *

--- a/packages/core/tailwind.ts
+++ b/packages/core/tailwind.ts
@@ -6,6 +6,7 @@ import { boxShadow } from "./src/tokens/shadows"
 import {
   absoluteSpacing,
   betweenSpacing,
+  pageSpacing,
   relativeSpacing,
 } from "./src/tokens/spacing"
 import { fontSize, fontWeight } from "./src/tokens/typography"
@@ -58,6 +59,7 @@ export const baseConfig: Omit<Config, "content"> = {
       width: relativeSpacing,
       gap: betweenSpacing,
       space: betweenSpacing,
+      padding: pageSpacing,
       colors: {
         f1: f1Colors,
       },

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -117,7 +117,7 @@ export function BaseHeader({
   }
 
   return (
-    <div className="resource-header flex flex-col gap-3 px-6 pb-5 pt-3">
+    <div className="resource-header px-page flex flex-col gap-3 pb-5 pt-3">
       <div
         className={cn(
           "flex flex-col items-start justify-start gap-4 md:flex-row",

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -146,7 +146,7 @@ export function PageHeader({
   return (
     <div
       className={cn(
-        "flex items-center justify-between px-5 py-4 xs:px-6",
+        "flex items-center justify-between px-page py-4",
         embedded ? "h-12" : "h-16"
       )}
     >

--- a/packages/react/src/layouts/HomeLayout/index.tsx
+++ b/packages/react/src/layouts/HomeLayout/index.tsx
@@ -50,7 +50,7 @@ export const HomeLayout = forwardRef<HTMLDivElement, Props>(function HomeLayout(
         </div>
 
         {/* Larger screen content */}
-        <div className="hidden grid-cols-3 gap-5 px-6 pb-6 pt-2 @5xl:grid">
+        <div className="px-page hidden grid-cols-3 gap-5 pb-6 pt-2 @5xl:grid">
           <div className="col-span-3 flex flex-row gap-5 *:flex-1">
             {arrayWidgets.slice(0, 3)}
           </div>

--- a/packages/react/src/layouts/StandardLayout/index.tsx
+++ b/packages/react/src/layouts/StandardLayout/index.tsx
@@ -14,7 +14,7 @@ export interface StandardLayoutProps extends VariantProps<
 }
 
 const layoutVariants = cva({
-  base: "relative flex min-h-full w-full flex-1 flex-col gap-4 place-self-center overflow-y-auto px-6 py-5",
+  base: "relative flex min-h-full w-full flex-1 flex-col gap-4 place-self-center overflow-y-auto px-page py-5",
   variants: {
     variant: {
       narrow: "max-w-screen-lg",

--- a/packages/react/src/layouts/TwoColumnLayout/index.tsx
+++ b/packages/react/src/layouts/TwoColumnLayout/index.tsx
@@ -33,7 +33,7 @@ const _TwoColumnLayout = forwardRef<HTMLDivElement, TwoColumnLayoutProps>(
         >
           <main
             className={cn(
-              "sm:min-h-xs order-2 h-fit border-0 px-4 py-5 sm:flex-1 sm:border-solid md:order-2 md:px-6",
+              "sm:min-h-xs order-2 h-fit border-0 py-5 sm:flex-1 sm:border-solid md:order-2 px-page",
               sticky
                 ? "md:h-full md:max-h-full md:overflow-y-auto"
                 : "min-h-full",
@@ -80,7 +80,7 @@ const Aside = ({
 }) => (
   <aside
     className={cn(
-      "min-w-30 py-5 pl-4 pr-4 sm:basis-1/4 sm:pb-6 md:max-w-80 md:pl-2",
+      "min-w-30 py-5 pl-page pr-page sm:basis-1/4 sm:pb-6 md:max-w-80 md:pl-2",
       className
     )}
   >

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -931,7 +931,7 @@ const OneDataCollectionComp = <
       }}
     >
       {showTopToolbar && (
-        <div className="border-f1-border-primary flex gap-4 px-6">
+        <div className="border-f1-border-primary px-page flex gap-4">
           {totalItemSummaryPosition === "top" && (
             <TotalItemsSummary
               isReady={!showTotalItemSummarySkeleton}
@@ -952,7 +952,7 @@ const OneDataCollectionComp = <
       {showBottomToolbar && (
         <div
           className={cn(
-            "flex flex-row gap-4 px-6",
+            "flex flex-row gap-4 px-page",
             fullHeight && "max-h-full",
             tmpFullWidth && "px-0"
           )}

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -931,7 +931,7 @@ const OneDataCollectionComp = <
       }}
     >
       {showTopToolbar && (
-        <div className="border-f1-border-primary flex gap-4 px-4">
+        <div className="border-f1-border-primary flex gap-4 px-6">
           {totalItemSummaryPosition === "top" && (
             <TotalItemsSummary
               isReady={!showTotalItemSummarySkeleton}
@@ -952,7 +952,7 @@ const OneDataCollectionComp = <
       {showBottomToolbar && (
         <div
           className={cn(
-            "flex flex-row gap-4 px-4",
+            "flex flex-row gap-4 px-6",
             fullHeight && "max-h-full",
             tmpFullWidth && "px-0"
           )}

--- a/packages/react/src/patterns/OneDataCollection/components/PagesPagination/PagesPagination.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/PagesPagination/PagesPagination.tsx
@@ -19,7 +19,7 @@ export const PagesPagination = ({
 
   return (
     <div
-      className={cn("flex w-full items-center justify-between px-4", className)}
+      className={cn("flex w-full items-center justify-between px-6", className)}
     >
       <span className="shrink-0 text-f1-foreground-secondary">
         {paginationInfo.total > 0 &&

--- a/packages/react/src/patterns/OneDataCollection/components/PagesPagination/PagesPagination.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/PagesPagination/PagesPagination.tsx
@@ -19,7 +19,10 @@ export const PagesPagination = ({
 
   return (
     <div
-      className={cn("flex w-full items-center justify-between px-6", className)}
+      className={cn(
+        "flex w-full items-center justify-between px-page",
+        className
+      )}
     >
       <span className="shrink-0 text-f1-foreground-secondary">
         {paginationInfo.total > 0 &&

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -68,7 +68,7 @@ const CardGrid = ({
   tmpFullWidth?: boolean
 }) => {
   return (
-    <div className={cn("@container", tmpFullWidth ? "px-0" : "px-6")}>
+    <div className={cn("@container", tmpFullWidth ? "px-0" : "px-page")}>
       <div
         className={cn(
           "grid grid-cols-1 gap-4",
@@ -467,7 +467,7 @@ export const CardCollection = <
                       onSelectChange={(checked) =>
                         handleSelectGroupChange(group, checked)
                       }
-                      className="px-6 pb-2 pt-4"
+                      className="px-page pb-2 pt-4"
                     />
                     <AnimatePresence>
                       {(!collapsible || openGroups[group.key]) && (

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -1,6 +1,8 @@
 import { AnimatePresence, motion } from "motion/react"
 import { useEffect, useMemo } from "react"
 
+import type { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
+
 import {
   F0Card,
   type CardImageAspectRatio,
@@ -11,20 +13,18 @@ import { CardAvatarVariant } from "@/components/F0Card/components/CardAvatar"
 import { cardPropertyRenderers } from "@/components/F0Card/components/CardMetadata"
 import { CardMetadata, CardMetadataProperty } from "@/components/F0Card/types"
 import { IconType } from "@/components/F0Icon"
-import { useDataCollectionData } from "@/patterns/OneDataCollection/hooks/useDataCollectionData"
-import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource"
-import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
 import { GroupingDefinition, RecordType } from "@/hooks/datasource"
 import { SortingsDefinition } from "@/hooks/datasource/types/sortings.typings"
 import { getAnimationVariants, useGroups } from "@/hooks/datasource/useGroups"
 import { useSelectable } from "@/hooks/datasource/useSelectable/useSelectable"
 import { Placeholder } from "@/icons/app"
 import { cn } from "@/lib/utils"
+import { useDataCollectionData } from "@/patterns/OneDataCollection/hooks/useDataCollectionData"
+import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource"
+import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
 import { Card, CardContent, CardHeader, CardTitle } from "@/ui/Card"
 import { GroupHeader } from "@/ui/GroupHeader/GroupHeader"
 import { Skeleton } from "@/ui/skeleton"
-
-import type { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
 
 import { PagesPagination } from "../../../components/PagesPagination"
 import { ItemActionsDefinition } from "../../../item-actions"
@@ -68,7 +68,7 @@ const CardGrid = ({
   tmpFullWidth?: boolean
 }) => {
   return (
-    <div className={cn("@container", tmpFullWidth ? "px-0" : "px-4")}>
+    <div className={cn("@container", tmpFullWidth ? "px-0" : "px-6")}>
       <div
         className={cn(
           "grid grid-cols-1 gap-4",
@@ -467,7 +467,7 @@ export const CardCollection = <
                       onSelectChange={(checked) =>
                         handleSelectGroupChange(group, checked)
                       }
-                      className="px-4 pb-2 pt-4"
+                      className="px-6 pb-2 pt-4"
                     />
                     <AnimatePresence>
                       {(!collapsible || openGroups[group.key]) && (

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/index.tsx
@@ -175,7 +175,7 @@ export const ListCollection = <
     <div
       className={cn(
         "flex max-h-full min-h-0 flex-1 flex-col gap-4 py-2",
-        !tmpFullWidth && "px-6",
+        !tmpFullWidth && "px-page",
         tmpFullWidth && "px-0"
       )}
     >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/index.tsx
@@ -1,9 +1,8 @@
 import { AnimatePresence, motion } from "motion/react"
 import { useEffect } from "react"
 
-import { useDataCollectionData } from "@/patterns/OneDataCollection/hooks/useDataCollectionData"
-import { useInfiniteScrollPagination } from "@/patterns/OneDataCollection/hooks/useInfiniteScrollPagination"
-import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
+import type { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
+
 import {
   isInfiniteScrollPagination,
   RecordType,
@@ -13,9 +12,10 @@ import {
 import { useGroups } from "@/hooks/datasource/useGroups"
 import { useDebounceBoolean } from "@/lib/useDebounceBoolean"
 import { cn } from "@/lib/utils"
+import { useDataCollectionData } from "@/patterns/OneDataCollection/hooks/useDataCollectionData"
+import { useInfiniteScrollPagination } from "@/patterns/OneDataCollection/hooks/useInfiniteScrollPagination"
+import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
 import { GroupHeader } from "@/ui/GroupHeader/GroupHeader"
-
-import type { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
 
 import { PagesPagination } from "../../../components/PagesPagination"
 import { ItemActionsDefinition } from "../../../item-actions"
@@ -175,7 +175,7 @@ export const ListCollection = <
     <div
       className={cn(
         "flex max-h-full min-h-0 flex-1 flex-col gap-4 py-2",
-        !tmpFullWidth && "px-4",
+        !tmpFullWidth && "px-6",
         tmpFullWidth && "px-0"
       )}
     >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -34,6 +34,11 @@ import { useDataCollectionSettings } from "@/patterns/OneDataCollection/Settings
 import { GroupHeader } from "@/ui/GroupHeader/index"
 import { Skeleton } from "@/ui/skeleton.tsx"
 
+import type {
+  TableCustomizationProps,
+  TableVisualizationOptions,
+} from "./types"
+
 import { PrimaryActionItemDefinition } from "../../../actions"
 import { useDataCollectionData } from "../../../hooks/useDataCollectionData"
 import { useInfiniteScrollPagination } from "../../../hooks/useInfiniteScrollPagination"
@@ -47,10 +52,6 @@ import { Row } from "./components/Row"
 import { useColumns } from "./hooks/useColums"
 import { groupBorderClass, useHeaderGroups } from "./hooks/useHeaderGroups"
 import { NestedDataProvider } from "./providers/NestedProvider"
-import type {
-  TableCustomizationProps,
-  TableVisualizationOptions,
-} from "./types"
 import { useSticky } from "./useSticky"
 export * from "./settings/SettingsRenderer"
 
@@ -408,7 +409,7 @@ export const TableCollection = <
                         "hover:after:bg-transparent"
                       )}
                     >
-                      <div className="ml-1.5 flex w-full items-center justify-start" />
+                      <div className="ml-3.5 flex w-full items-center justify-start" />
                     </TableHead>
                   )}
                   {headerGroups.map((entry, entryIndex) => {
@@ -477,7 +478,7 @@ export const TableCollection = <
                         : undefined
                     }
                   >
-                    <div className="ml-1.5 flex w-full items-center justify-start">
+                    <div className="ml-3.5 flex w-full items-center justify-start">
                       <F0Checkbox
                         checked={isAllSelected}
                         indeterminate={hasSelection && !isAllSelected}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -256,7 +256,7 @@ const RowComponentInner = <
           referenceRowType={referenceRowType}
         >
           {id !== undefined && (
-            <div className="pointer-events-auto ml-1.5 flex h-full items-center justify-start">
+            <div className="pointer-events-auto ml-3.5 flex h-full items-center justify-start">
               <Checkbox
                 checked={selectedItems.has(id)}
                 onCheckedChange={onCheckedChange}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/useSticky.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/useSticky.ts
@@ -1,8 +1,8 @@
 import { useCallback } from "react"
 
-import { SummariesDefinition } from "@/patterns/OneDataCollection/summary"
 import { RecordType } from "@/hooks/datasource"
 import { SortingsDefinition } from "@/hooks/datasource/types/sortings.typings"
+import { SummariesDefinition } from "@/patterns/OneDataCollection/summary"
 
 import { TableColumnDefinition } from "./types"
 
@@ -15,7 +15,7 @@ export const useSticky = <
   columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>,
   hasCheckColumn: boolean
 ) => {
-  const checkColumnWidth = hasCheckColumn ? 46 : 0
+  const checkColumnWidth = hasCheckColumn ? 56 : 0
   const getStickyPosition = useCallback(
     (cellIndex: number) => {
       return cellIndex < frozenColumnsLeft && columns.length > 1

--- a/packages/react/src/sds/Home/DaytimePage/index.tsx
+++ b/packages/react/src/sds/Home/DaytimePage/index.tsx
@@ -1,16 +1,16 @@
 import { cva, type VariantProps } from "cva"
 import { ComponentProps } from "react"
 
-import { F0OneSwitch } from "@/sds/ai/F0OneSwitch"
 import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
 import { F0AvatarPulse } from "@/components/avatars/F0AvatarPulse"
 import { F0Button } from "@/components/F0Button"
 import { OneSwitch as OnePromotionSwitch } from "@/experimental/AiPromotionChat/OneSwitch"
-import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
 import Menu from "@/icons/app/Menu"
 import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 import { cn } from "@/lib/utils"
+import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
+import { F0OneSwitch } from "@/sds/ai/F0OneSwitch"
 
 const daytimePageVariants = cva({
   base: "pointer-events-none absolute inset-0 h-screen max-h-[1000px] opacity-[0.08]",
@@ -62,7 +62,7 @@ function _DaytimePage({
       <div className={daytimePageVariants({ period })} />
       {header && (
         <div className="flex flex-row items-center justify-between pr-6 @container">
-          <div className="flex flex-row items-center gap-2 px-5 py-4 @5xl:px-6">
+          <div className="@5xl:px-page flex flex-row items-center gap-2 px-5 py-4">
             {(isSmallScreen || sidebarState === "hidden") && (
               <F0Button
                 variant="ghost"

--- a/packages/react/src/ui/Kanban/Kanban.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.tsx
@@ -292,7 +292,7 @@ export function Kanban<TRecord extends RecordType>(
   }
 
   return (
-    <div className={cn("relative h-full w-full px-4", className)}>
+    <div className={cn("relative h-full w-full px-6", className)}>
       <ScrollArea
         className={"relative h-full w-full [&>div>div]:h-full"}
         viewportRef={viewportRef}

--- a/packages/react/src/ui/Lane/Lane.tsx
+++ b/packages/react/src/ui/Lane/Lane.tsx
@@ -5,11 +5,11 @@ import type { RecordType } from "@/hooks/datasource"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Card } from "@/components/F0Card"
-import { Spinner } from "@/ui/Spinner"
-import { useInfiniteScrollPagination } from "@/patterns/OneDataCollection/hooks/useInfiniteScrollPagination"
 import { ScrollArea } from "@/experimental/Utilities/ScrollArea"
 import { Plus } from "@/icons/app"
 import { cn } from "@/lib/utils"
+import { useInfiniteScrollPagination } from "@/patterns/OneDataCollection/hooks/useInfiniteScrollPagination"
+import { Spinner } from "@/ui/Spinner"
 
 import { LaneHeader } from "./components/LaneHeader"
 import { LoadingSkeleton } from "./components/LoadingSkeleton"
@@ -51,7 +51,7 @@ export function Lane<Record extends RecordType>({
   const showFooterAction = Boolean(onFooterAction)
 
   return (
-    <div className="shadow-sm group relative flex h-full w-[323.2px] flex-col">
+    <div className="shadow-sm group relative flex h-full w-[322px] flex-col">
       <LaneHeader
         label={title || "Lane"}
         variant={variant}

--- a/packages/react/src/ui/tab-navigation.tsx
+++ b/packages/react/src/ui/tab-navigation.tsx
@@ -26,7 +26,7 @@ function getSubtree(
 }
 
 const tabNavigationVariants = cva({
-  base: "relative flex items-center justify-start gap-1 overflow-x-auto whitespace-nowrap px-6 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+  base: "relative flex items-center justify-start gap-1 overflow-x-auto whitespace-nowrap px-page py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
   variants: {
     secondary: {
       true: "bg-f1-foreground/[.02] dark:bg-f1-foreground/[.02]",


### PR DESCRIPTION
## Tokenize page horizontal padding (`px-6` → `px-page`)

Introduces a semantic Tailwind spacing token `page` (= 24px) for page-level horizontal padding, replacing hardcoded `px-6` across all page containers.

## Why?

We had this disalignement at the moment in production in between page headers/tabs and data collections.

<img width="750" height="476" alt="Screenshot 2026-05-26 at 14 41 26" src="https://github.com/user-attachments/assets/3811239a-03ba-42fb-9ea1-f375d8c454ec" />


### Changes

**Token definition (`packages/core`):**
- Added `pageSpacing` export in `src/tokens/spacing.ts` mapping `page` → `24px`
- Extended `padding` in `tailwind.ts` with `pageSpacing` (follows the existing `betweenSpacing` → `gap`/`space` pattern)

**Consumers updated (`packages/react`):**
- `PageHeader`
- `OneDataCollection` (toolbar, list view, card view, pagination)
- `StandardLayout`, `HomeLayout`, `TwoColumnLayout`
- `TabNavigation`
- `BaseHeader` (resource header)
- `DaytimePage`

All usages now reference `px-page` (or responsive variants like `md:px-page`, `@5xl:px-page`), making it possible to update the page padding value from a single token.