### PR TITLE
feat(F0AiChat): typewriter welcome + fullscreen parity; new ChatSpinner

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -280,7 +280,7 @@ export const defaultTranslations = {
     stopAnswerGeneration: "Stop generating",
     responseStopped: "You stopped this response",
     sendMessage: "Send message",
-    thoughtsGroupTitle: "Reflection",
+    thoughtsGroupTitle: "Reasoning",
     resourcesGroupTitle: "Resources",
     thinking: "Thinking...",
     feedbackModal: {

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -359,7 +359,13 @@ const meta: Meta<typeof ApplicationFrame> = {
       showDevConsole: false,
       enabled: true,
       resizable: true,
-      greeting: "Hello, John",
+      initialMessage: [
+        "Operational work, automated by One",
+        "Ask anything about your company",
+        "Skip the boring part of your job",
+        "Ask anything about your people, policies, or payroll",
+        "Turn months of data into a one-line answer",
+      ],
       canvasActions: {
         dashboard: {
           save: async (id, category, config) => {
@@ -737,7 +743,13 @@ export const FullscreenWithActions: Story = {
       showDevConsole: false,
       enabled: true,
       resizable: true,
-      greeting: "Hello, John",
+      initialMessage: [
+        "Operational work, automated by One",
+        "Ask anything about your company",
+        "Skip the boring part of your job",
+        "Ask anything about your people, policies, or payroll",
+        "Turn months of data into a one-line answer",
+      ],
       defaultVisualizationMode: "fullscreen",
       lockVisualizationMode: true,
       footer: <QuickActions />,
@@ -886,7 +898,13 @@ export const WithEmployeeCredits: Story = {
       showDevConsole: false,
       enabled: true,
       resizable: true,
-      greeting: "Hello, John",
+      initialMessage: [
+        "Operational work, automated by One",
+        "Ask anything about your company",
+        "Skip the boring part of your job",
+        "Ask anything about your people, policies, or payroll",
+        "Turn months of data into a one-line answer",
+      ],
       employeeCredits: {
         fetchUsage: mockFetchEmployeeCreditsUsage,
         companyName: "Factorial",

--- a/packages/react/src/sds/Home/DaytimePage/index.stories.tsx
+++ b/packages/react/src/sds/Home/DaytimePage/index.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof DaytimePage> = {
           credentials: "include",
           showDevConsole: false,
           enabled: true,
-          greeting: "Hello, John",
+          initialMessage: "Ask anything about your company",
         }}
       >
         <Story />

--- a/packages/react/src/sds/ai/F0ActionItem/F0ActionItem.tsx
+++ b/packages/react/src/sds/ai/F0ActionItem/F0ActionItem.tsx
@@ -10,9 +10,6 @@ import { ChatSpinner } from "./components/ChatSpinner"
 import "./styles.css"
 import { F0ActionItemProps } from "./types"
 
-// Opacity-only swap. Animating `scale` on the wrapper applies a
-// `transform: scale(...)` that competes with ChatSpinner's own
-// `transform: rotate(...)` inside `motion.svg` and freezes the spin.
 const ICON_MOTION = {
   initial: { opacity: 0 },
   animate: { opacity: 1 },

--- a/packages/react/src/sds/ai/F0ActionItem/F0ActionItem.tsx
+++ b/packages/react/src/sds/ai/F0ActionItem/F0ActionItem.tsx
@@ -23,10 +23,10 @@ export const F0ActionItem = ({ title, status, inGroup }: F0ActionItemProps) => {
     ease: [0.33, 1, 0.68, 1] as const,
   }
 
-  const inProgress = !!(status == "inProgress")
-  const executing = !!(status == "executing")
-  const completed = !!(status == "completed")
-  const writing = !!(status == "writing")
+  const inProgress = status === "inProgress"
+  const executing = status === "executing"
+  const completed = status === "completed"
+  const writing = status === "writing"
 
   return (
     <div className="flex w-full items-start gap-1 text-f1-foreground-secondary">

--- a/packages/react/src/sds/ai/F0ActionItem/F0ActionItem.tsx
+++ b/packages/react/src/sds/ai/F0ActionItem/F0ActionItem.tsx
@@ -23,11 +23,16 @@ export const F0ActionItem = ({ title, status, inGroup }: F0ActionItemProps) => {
     ease: [0.33, 1, 0.68, 1] as const,
   }
 
+  const inProgress = !!(status == "inProgress")
+  const executing = !!(status == "executing")
+  const completed = !!(status == "completed")
+  const writing = !!(status == "writing")
+
   return (
     <div className="flex w-full items-start gap-1 text-f1-foreground-secondary">
       <div className="flex h-5 w-6 shrink-0 items-center justify-start">
         <AnimatePresence mode="wait">
-          {status === "inProgress" && (
+          {inProgress && (
             <motion.div
               key="inProgress"
               className="flex h-5 w-5 shrink-0 items-center justify-center"
@@ -41,12 +46,12 @@ export const F0ActionItem = ({ title, status, inGroup }: F0ActionItemProps) => {
               />
             </motion.div>
           )}
-          {status === "executing" && (
+          {(executing || writing) && (
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">
-              <ChatSpinner />
+              <ChatSpinner variant={executing ? "default" : "continuous"} />
             </div>
           )}
-          {status === "completed" && (
+          {completed && (
             <motion.div
               key="completed"
               {...ICON_MOTION}
@@ -67,7 +72,7 @@ export const F0ActionItem = ({ title, status, inGroup }: F0ActionItemProps) => {
         <p
           className={cn(
             "text-pretty leading-5",
-            status === "executing" && "shine-text"
+            (executing || writing) && "shine-text"
           )}
         >
           {title}

--- a/packages/react/src/sds/ai/F0ActionItem/__stories__/ChatSpinner.stories.tsx
+++ b/packages/react/src/sds/ai/F0ActionItem/__stories__/ChatSpinner.stories.tsx
@@ -8,10 +8,38 @@ const meta: Meta<typeof ChatSpinner> = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs", "no-sidebar"],
+  tags: ["autodocs"],
 }
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const Small: Story = {
+  args: { size: 20 },
+}
+
+export const Medium: Story = {
+  args: { size: 32 },
+}
+
+export const Large: Story = {
+  args: { size: 60 },
+}
+
+export const Hero: Story = {
+  args: { size: 120 },
+}
+
+export const AllSizes: Story = {
+  render: () => (
+    <div style={{ display: "flex", alignItems: "center", gap: 24 }}>
+      <ChatSpinner size={20} />
+      <ChatSpinner size={28} />
+      <ChatSpinner size={32} />
+      <ChatSpinner size={60} />
+      <ChatSpinner size={120} />
+    </div>
+  ),
+}

--- a/packages/react/src/sds/ai/F0ActionItem/__stories__/F0ActionItem.stories.tsx
+++ b/packages/react/src/sds/ai/F0ActionItem/__stories__/F0ActionItem.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
     },
     status: {
       control: "select",
-      options: ["inProgress", "executing", "completed"],
+      options: ["inProgress", "executing", "writing", "completed"],
       description: "Current status of the action item",
     },
   },
@@ -37,9 +37,24 @@ export const Default: Story = {
   },
 }
 
+export const Writing: Story = {
+  args: {
+    title: "Writing response",
+    status: "writing",
+  },
+  render: (args) => {
+    return <F0ActionItem {...args} />
+  },
+}
+
 export const InfiniteStatusCycling: Story = {
   render: (args) => {
-    const statuses = ["inProgress", "executing", "completed"] as const
+    const statuses = [
+      "inProgress",
+      "executing",
+      "writing",
+      "completed",
+    ] as const
     const [currentStatusIndex, setCurrentStatusIndex] = React.useState(0)
 
     useEffect(() => {

--- a/packages/react/src/sds/ai/F0ActionItem/components/ChatSpinner.tsx
+++ b/packages/react/src/sds/ai/F0ActionItem/components/ChatSpinner.tsx
@@ -1,161 +1,94 @@
-import type { SVGProps } from "react"
+import type { CSSProperties, Ref } from "react"
 
-import { motion } from "motion/react"
-import { Ref, forwardRef, useId } from "react"
+import { forwardRef, useEffect, useRef, useState } from "react"
 
-const pieces = [
-  {
-    id: "bottom",
-    delay: 2.6,
-    transformOrigin: "center 89%",
-    rotateAxis: "1, 0, 0",
-    path: "M15.9939 24.8399C19.6511 24.8399 23.2335 26.0603 26.0525 28.4219C23.2335 30.7072 19.651 32.001 15.9939 32.001C12.1849 32.0009 8.67993 30.6307 5.93728 28.4219C8.75621 26.1365 12.3369 24.84 15.9939 24.8399Z",
-  },
-  {
-    id: "right",
-    delay: 2.4,
-    transformOrigin: "88.5% center",
-    rotateAxis: "0, 1, 0",
-    path: "M28.4236 5.94142C30.7088 8.76031 32.0046 12.3412 32.0047 15.9981C32.0047 19.6551 30.7851 23.2376 28.4236 26.0567C26.1382 23.2376 24.8435 19.6552 24.8435 15.9981C24.8436 12.1889 26.2147 8.6841 28.4236 5.94142Z",
-  },
-  {
-    id: "top",
-    delay: 2,
-    transformOrigin: "center 11%",
-    rotateAxis: "1, 0, 0",
-    path: "M15.9939 1.33514e-05C19.6511 1.37386e-05 23.2335 1.22043 26.0525 3.58204C23.2335 5.86737 19.651 7.16115 15.9939 7.16115C12.1849 7.16103 8.67993 5.79089 5.93728 3.58204C8.75621 1.29671 12.3369 0.000125175 15.9939 1.33514e-05Z",
-  },
-  {
-    id: "left",
-    delay: 2.2,
-    transformOrigin: "11% center",
-    rotateAxis: "0, 1, 0",
-    path: "M3.57986 5.94142C5.86509 8.76031 7.1608 12.3412 7.16092 15.9981C7.16092 19.6551 5.94136 23.2376 3.57986 26.0567C1.29443 23.2376 -0.000215909 19.6552 -0.00021553 15.9981C-0.000100728 12.1889 1.37091 8.6841 3.57986 5.94142Z",
-  },
-]
+import { cn } from "@/lib/utils"
+
+import type { Quad } from "./globeSpinMath"
+import {
+  buildFrame,
+  easeInOutCubic,
+  PAUSE_MS,
+  PRECESSION_MS,
+  SPIN_MS,
+} from "./globeSpinMath"
+
+type ChatSpinnerProps = {
+  size?: number
+  className?: string
+  style?: CSSProperties
+}
 
 const ChatSpinnerComponent = (
-  svgProps: SVGProps<SVGSVGElement>,
-  ref: Ref<SVGSVGElement>
+  { size = 20, className, style }: ChatSpinnerProps,
+  ref: Ref<HTMLDivElement>
 ) => {
-  const clipPathId = useId()
-  const {
-    onAnimationStart: _onAnimationStart,
-    onAnimationEnd: _onAnimationEnd,
-    onDragStart: _onDragStart,
-    onDragEnd: _onDragEnd,
-    onDrag: _onDrag,
-    ...safeSvgProps
-  } = svgProps
+  const [quads, setQuads] = useState<Quad[]>(() => buildFrame(0, size, 0))
+  const rafRef = useRef<number | null>(null)
+  const startRef = useRef<number | null>(null)
+  const mountRef = useRef<number | null>(null)
+  const phaseRef = useRef<"spin" | "pause">("spin")
+  const pauseStartRef = useRef<number>(0)
+
+  useEffect(() => {
+    const tick = (now: number) => {
+      if (startRef.current === null) startRef.current = now
+      if (mountRef.current === null) mountRef.current = now
+
+      let progress = 0
+      if (phaseRef.current === "spin") {
+        progress = Math.min((now - startRef.current) / SPIN_MS, 1)
+        if (progress >= 1) {
+          progress = 0
+          phaseRef.current = "pause"
+          pauseStartRef.current = now
+        }
+      } else {
+        progress = 0
+        if (now - pauseStartRef.current >= PAUSE_MS) {
+          phaseRef.current = "spin"
+          startRef.current = now
+        }
+      }
+
+      const axisPhase = ((now - mountRef.current) / PRECESSION_MS) % 1
+      setQuads(buildFrame(easeInOutCubic(progress), size, axisPhase))
+      rafRef.current = requestAnimationFrame(tick)
+    }
+
+    rafRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current)
+    }
+  }, [size])
 
   return (
-    <div className="h-4 w-4 shrink-0">
-      <motion.svg
+    <div
+      ref={ref}
+      role="progressbar"
+      aria-label="Loading"
+      className={cn(
+        "shrink-0 globe-spin-enter globe-spin-breathe globe-spin-glow",
+        className
+      )}
+      style={{ width: size, height: size, ...style }}
+    >
+      <svg
         width="100%"
         height="100%"
-        viewBox="0 0 32 32"
+        viewBox={`0 0 ${size} ${size}`}
         xmlns="http://www.w3.org/2000/svg"
-        ref={ref}
-        initial={{
-          rotate: "0deg",
-          opacity: 0,
-          scale: 0.8,
-          filter: "blur(4px)",
-        }}
-        animate={{
-          "--gradient-angle": ["0deg", "360deg"],
-          rotate: "360deg",
-          opacity: 1,
-          scale: 1,
-          filter: "blur(0px)",
-        }}
-        transition={{
-          "--gradient-angle": {
-            duration: 3,
-            ease: "linear",
-            repeat: Infinity,
-          },
-          rotate: {
-            duration: 2,
-            ease: [0.76, 0, 0.24, 1],
-            repeat: Infinity,
-          },
-          opacity: {
-            duration: 0.5,
-            ease: [0.33, 1, 0.68, 1],
-          },
-          scale: {
-            duration: 0.5,
-            ease: [0.25, 0.46, 0.45, 1.94],
-          },
-          filter: {
-            duration: 0.5,
-            ease: [0.33, 1, 0.68, 1],
-          },
-        }}
-        style={
-          {
-            "--gradient-angle": "0deg",
-            ...safeSvgProps.style,
-          } as React.CSSProperties
-        }
-        {...(({ style: _style, ...rest }) => rest)(safeSvgProps)}
+        shapeRendering="geometricPrecision"
+        style={{ display: "block", overflow: "visible" }}
       >
-        <defs>
-          <clipPath id={`${clipPathId}-circle`}>
-            <circle cx="16" cy="16" r="16" />
-          </clipPath>
-          {pieces.map((piece) => (
-            <clipPath key={piece.id} id={`${clipPathId}-${piece.id}`}>
-              <path d={piece.path} />
-            </clipPath>
-          ))}
-        </defs>
-
-        <g clipPath={`url(#${clipPathId}-circle)`}>
-          {pieces.map((piece) => (
-            <motion.foreignObject
-              key={piece.id}
-              x="0"
-              y="0"
-              width="32"
-              height="32"
-              clipPath={`url(#${clipPathId}-${piece.id})`}
-              animate={{
-                "--scale": [1, 8, 1],
-              }}
-              transition={{
-                "--scale": {
-                  duration: 2,
-                  ease: [0.85, 0, 0.15, 1],
-                  repeat: Infinity,
-                  delay: 1,
-                },
-              }}
-              style={
-                {
-                  "--scale": 1,
-                  transform: `scale(var(--scale))`,
-                  transformOrigin: piece.transformOrigin,
-                  willChange: "transform",
-                } as React.CSSProperties
-              }
-            >
-              <div
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  background: `conic-gradient(from var(--gradient-angle) at 50% 50%, #E55619 0%, #A1ADE5 33%, #E51943 66%, #E55619 100%)`,
-                }}
-              />
-            </motion.foreignObject>
-          ))}
-        </g>
-      </motion.svg>
+        {quads.map((q, i) => (
+          <polygon key={i} points={q.points} fill={q.color} stroke="none" />
+        ))}
+      </svg>
     </div>
   )
 }
 
-export const ChatSpinner = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>(
+export const ChatSpinner = forwardRef<HTMLDivElement, ChatSpinnerProps>(
   ChatSpinnerComponent
 )

--- a/packages/react/src/sds/ai/F0ActionItem/components/ChatSpinner.tsx
+++ b/packages/react/src/sds/ai/F0ActionItem/components/ChatSpinner.tsx
@@ -15,7 +15,7 @@ import {
   SPIN_MS,
 } from "./globeSpinMath"
 
-type ChatSpinnerProps = {
+export interface ChatSpinnerProps {
   size?: number
   className?: string
   style?: CSSProperties
@@ -177,7 +177,7 @@ const ChatSpinnerComponent = (
       ref={setRefs}
       role="progressbar"
       aria-label="Loading"
-      className={cn("shrink-0 globe-spin-enter globe-spin-breathe", className)}
+      className={cn("shrink-0 globe-spin-anim", className)}
       style={{ width: size, height: size, ...style }}
     >
       <svg
@@ -200,3 +200,4 @@ const ChatSpinnerComponent = (
 export const ChatSpinner = forwardRef<HTMLDivElement, ChatSpinnerProps>(
   ChatSpinnerComponent
 )
+ChatSpinner.displayName = "ChatSpinner"

--- a/packages/react/src/sds/ai/F0ActionItem/components/ChatSpinner.tsx
+++ b/packages/react/src/sds/ai/F0ActionItem/components/ChatSpinner.tsx
@@ -1,15 +1,17 @@
 import type { CSSProperties, Ref } from "react"
 
-import { forwardRef, useEffect, useRef, useState } from "react"
+import { forwardRef, useEffect, useMemo, useRef } from "react"
 
 import { cn } from "@/lib/utils"
 
-import type { Quad } from "./globeSpinMath"
+import type { GlobeSpinState } from "./globeSpinMath"
 import {
-  buildFrame,
+  buildFrameInto,
+  createGlobeSpinState,
   easeInOutCubic,
   PAUSE_MS,
   PRECESSION_MS,
+  QUAD_POOL_SIZE,
   SPIN_MS,
 } from "./globeSpinMath"
 
@@ -17,63 +19,169 @@ type ChatSpinnerProps = {
   size?: number
   className?: string
   style?: CSSProperties
+  /**
+   * "default" → spins 2 rotations, pauses, repeats.
+   * "continuous" → 2 rotations forward, then 2 backward, no pause. Used for
+   * "writing"-style activity where the indicator should never rest.
+   */
+  variant?: "default" | "continuous"
 }
 
 const ChatSpinnerComponent = (
-  { size = 20, className, style }: ChatSpinnerProps,
+  { size = 20, className, style, variant = "default" }: ChatSpinnerProps,
   ref: Ref<HTMLDivElement>
 ) => {
-  const [quads, setQuads] = useState<Quad[]>(() => buildFrame(0, size, 0))
-  const rafRef = useRef<number | null>(null)
-  const startRef = useRef<number | null>(null)
-  const mountRef = useRef<number | null>(null)
-  const phaseRef = useRef<"spin" | "pause">("spin")
-  const pauseStartRef = useRef<number>(0)
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  // Pool — created lazily once per instance, reused across all frames.
+  const stateRef = useRef<GlobeSpinState | null>(null)
+  if (stateRef.current === null) stateRef.current = createGlobeSpinState()
+
+  // Stable placeholder array for the JSX: one <polygon> per pool slot. We pay
+  // the React mount cost ONCE; per-frame updates go straight to the DOM.
+  const placeholders = useMemo(() => new Array(QUAD_POOL_SIZE).fill(0), [])
+
+  const setRefs = (el: HTMLDivElement | null) => {
+    wrapperRef.current = el
+    if (!ref) return
+    if (typeof ref === "function") ref(el)
+    else (ref as { current: HTMLDivElement | null }).current = el
+  }
 
   useEffect(() => {
+    const svg = svgRef.current
+    const wrapper = wrapperRef.current
+    if (!svg || !wrapper) return
+
+    const polys = svg.querySelectorAll(
+      "polygon"
+    ) as NodeListOf<SVGPolygonElement>
+    const state = stateRef.current!
+
+    let rafId: number | null = null
+    let start = 0
+    let mount = 0
+    let pauseStart = 0
+    let pausedAt: number | null = null
+    let phase: "spin" | "pause" = "spin"
+    let visible = true
+    let everTicked = false
+
+    const paint = (count: number) => {
+      const quads = state.quads
+      for (let i = 0; i < polys.length; i++) {
+        const p = polys[i]
+        if (i < count) {
+          const q = quads[i]
+          p.setAttribute("points", q.points)
+          p.setAttribute("fill", q.color)
+          if (p.hasAttribute("display")) p.removeAttribute("display")
+        } else if (!p.hasAttribute("display")) {
+          p.setAttribute("display", "none")
+        }
+      }
+    }
+
     const tick = (now: number) => {
-      if (startRef.current === null) startRef.current = now
-      if (mountRef.current === null) mountRef.current = now
+      if (!everTicked) {
+        start = now
+        mount = now
+        everTicked = true
+      }
 
       let progress = 0
-      if (phaseRef.current === "spin") {
-        progress = Math.min((now - startRef.current) / SPIN_MS, 1)
+      let applyEase = true
+
+      if (variant === "continuous") {
+        const cycleMs = SPIN_MS * 2
+        const p = ((now - start) % cycleMs) / cycleMs
+        progress = p < 0.5 ? p * 2 : (1 - p) * 2
+        applyEase = false
+      } else if (phase === "spin") {
+        progress = Math.min((now - start) / SPIN_MS, 1)
         if (progress >= 1) {
           progress = 0
-          phaseRef.current = "pause"
-          pauseStartRef.current = now
+          phase = "pause"
+          pauseStart = now
         }
       } else {
         progress = 0
-        if (now - pauseStartRef.current >= PAUSE_MS) {
-          phaseRef.current = "spin"
-          startRef.current = now
+        if (now - pauseStart >= PAUSE_MS) {
+          phase = "spin"
+          start = now
         }
       }
 
-      const axisPhase = ((now - mountRef.current) / PRECESSION_MS) % 1
-      setQuads(buildFrame(easeInOutCubic(progress), size, axisPhase))
-      rafRef.current = requestAnimationFrame(tick)
+      const axisPhase = ((now - mount) / PRECESSION_MS) % 1
+      const angleProgress = applyEase ? easeInOutCubic(progress) : progress
+      const count = buildFrameInto(state, angleProgress, size, axisPhase)
+      paint(count)
+
+      rafId = requestAnimationFrame(tick)
     }
 
-    rafRef.current = requestAnimationFrame(tick)
-    return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current)
+    const startLoop = () => {
+      if (rafId !== null) return
+      rafId = requestAnimationFrame(tick)
     }
-  }, [size])
+    const stopLoop = () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
+    }
+
+    // Initial paint so the spinner shows static geometry before the first
+    // RAF tick fires (eliminates a flash of empty SVG on mount).
+    paint(buildFrameInto(state, 0, size, 0))
+
+    // Pause the animation while off-screen. On resume, shift the time origin
+    // forward by the elapsed gap so the spinner picks up where it left off
+    // instead of jumping to "current time".
+    let observer: IntersectionObserver | null = null
+    if (typeof IntersectionObserver !== "undefined") {
+      observer = new IntersectionObserver(
+        (entries) => {
+          const isVisible = entries[0]?.isIntersecting ?? true
+          if (isVisible === visible) return
+          visible = isVisible
+          if (isVisible) {
+            if (pausedAt !== null && everTicked) {
+              const gap = performance.now() - pausedAt
+              start += gap
+              mount += gap
+              pauseStart += gap
+            }
+            pausedAt = null
+            startLoop()
+          } else {
+            pausedAt = performance.now()
+            stopLoop()
+          }
+        },
+        { threshold: 0 }
+      )
+      observer.observe(wrapper)
+    }
+
+    startLoop()
+
+    return () => {
+      stopLoop()
+      observer?.disconnect()
+    }
+  }, [size, variant])
 
   return (
     <div
-      ref={ref}
+      ref={setRefs}
       role="progressbar"
       aria-label="Loading"
-      className={cn(
-        "shrink-0 globe-spin-enter globe-spin-breathe globe-spin-glow",
-        className
-      )}
+      className={cn("shrink-0 globe-spin-enter globe-spin-breathe", className)}
       style={{ width: size, height: size, ...style }}
     >
       <svg
+        ref={svgRef}
         width="100%"
         height="100%"
         viewBox={`0 0 ${size} ${size}`}
@@ -81,8 +189,8 @@ const ChatSpinnerComponent = (
         shapeRendering="geometricPrecision"
         style={{ display: "block", overflow: "visible" }}
       >
-        {quads.map((q, i) => (
-          <polygon key={i} points={q.points} fill={q.color} stroke="none" />
+        {placeholders.map((_, i) => (
+          <polygon key={i} stroke="none" display="none" />
         ))}
       </svg>
     </div>

--- a/packages/react/src/sds/ai/F0ActionItem/components/globeSpinMath.ts
+++ b/packages/react/src/sds/ai/F0ActionItem/components/globeSpinMath.ts
@@ -1,5 +1,9 @@
 // Pure JS math for the globe-spin animation. No DOM, no React, no SVG —
 // fully portable to React Native (only the render layer differs per platform).
+//
+// Performance-critical: every frame at 60fps touches this file. The shape is
+// deliberately allocation-free in the hot path — callers pass a pre-allocated
+// state object (`createGlobeSpinState()`) and `buildFrameInto` mutates it.
 
 // ─── Config ───────────────────────────────────────────────────────────────────
 export const VEL_X = 60
@@ -34,11 +38,16 @@ type V = [number, number, number]
 
 export type Quad = {
   // Canonical SVG-polygon points: "x1,y1 x2,y2 x3,y3 x4,y4".
-  // Works directly in <svg><polygon points={...} /> on web AND in
-  // react-native-svg's <Polygon points={...} /> when porting to native.
   points: string
   color: string
   avgZ: number
+}
+
+type GridPoint = { x: number; y: number; z: number; t: number }
+
+export type GlobeSpinState = {
+  quads: Quad[]
+  grid: GridPoint[]
 }
 
 // ─── Math helpers ─────────────────────────────────────────────────────────────
@@ -67,16 +76,21 @@ function qRot(ax: number, ay: number, az: number, ang: number): Q {
   return [Math.cos(ang / 2), ax * s, ay * s, az * s]
 }
 
-function rotVec(q: Q, [x, y, z]: V): V {
-  const [w, qx, qy, qz] = q
+// Module-level scratch vector — `rotVecInto` writes its result here so the
+// hot loop doesn't allocate a 3-tuple per call (~1100 allocations/frame saved).
+const _scratchV: V = [0, 0, 0]
+
+function rotVecInto(q: Q, x: number, y: number, z: number, out: V): void {
+  const w = q[0]
+  const qx = q[1]
+  const qy = q[2]
+  const qz = q[3]
   const tx = 2 * (qy * z - qz * y)
   const ty = 2 * (qz * x - qx * z)
   const tz = 2 * (qx * y - qy * x)
-  return [
-    x + w * tx + qy * tz - qz * ty,
-    y + w * ty + qz * tx - qx * tz,
-    z + w * tz + qx * ty - qy * tx,
-  ]
+  out[0] = x + w * tx + qy * tz - qz * ty
+  out[1] = y + w * ty + qz * tx - qx * tz
+  out[2] = z + w * tz + qx * ty - qy * tx
 }
 
 function eulerToQ(ex: number, ey: number, ez: number): Q {
@@ -86,18 +100,35 @@ function eulerToQ(ex: number, ey: number, ez: number): Q {
   return qNorm(qMul(qMul(qy, qx), qz))
 }
 
-function lerpColor(
-  c1: [number, number, number],
-  c2: [number, number, number],
-  t: number
-): string {
-  return `rgb(${Math.round(c1[0] + (c2[0] - c1[0]) * t)},${Math.round(c1[1] + (c2[1] - c1[1]) * t)},${Math.round(c1[2] + (c2[2] - c1[2]) * t)})`
-}
-
 // Cubic ease-in-out — smooth acceleration into the spin and gentle
 // deceleration into the pause, instead of a constant-velocity rotation.
 export function easeInOutCubic(t: number): number {
   return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2
+}
+
+// ─── Color LUT ───────────────────────────────────────────────────────────────
+// 256 pre-computed `rgb(r,g,b)` strings spanning COLOR_A → COLOR_B. Each frame
+// looks up the closest entry instead of allocating a fresh string per quad
+// (~700 string allocations/frame saved). 256 levels is well below the eye's
+// gradient discrimination, so the LUT is visually lossless.
+const COLOR_LUT_SIZE = 256
+const COLOR_LUT: string[] = (() => {
+  const out: string[] = new Array(COLOR_LUT_SIZE)
+  for (let i = 0; i < COLOR_LUT_SIZE; i++) {
+    const t = i / (COLOR_LUT_SIZE - 1)
+    const r = Math.round(COLOR_A[0] + (COLOR_B[0] - COLOR_A[0]) * t)
+    const g = Math.round(COLOR_A[1] + (COLOR_B[1] - COLOR_A[1]) * t)
+    const b = Math.round(COLOR_A[2] + (COLOR_B[2] - COLOR_A[2]) * t)
+    out[i] = `rgb(${r},${g},${b})`
+  }
+  return out
+})()
+
+function colorFor(t: number): string {
+  // Clamp + quantize to LUT index. `t` is expected in [0, 1].
+  const i =
+    t <= 0 ? 0 : t >= 1 ? COLOR_LUT_SIZE - 1 : (t * (COLOR_LUT_SIZE - 1)) | 0
+  return COLOR_LUT[i]
 }
 
 function getLatFactor(size: number): number {
@@ -125,101 +156,156 @@ const PATH_AXIS: V = [VEL_X / SPEED, VEL_Y / SPEED, 0]
 const Q_INIT_A = eulerToQ(INIT_A.x, INIT_A.y, INIT_A.z)
 const Q_INIT_B = eulerToQ(INIT_B.x, INIT_B.y, INIT_B.z)
 
+const LAT_STEPS = ROWS * 3
+const GRID_STRIDE = SEGS + 1
+const GRID_SIZE = (LAT_STEPS + 1) * GRID_STRIDE
+export const QUAD_POOL_SIZE = 4 * LAT_STEPS * SEGS // 960
+
+// Per-component scratch arrays for the cap rotations. Allocated once at module
+// load — shared across all spinners because each call to `buildFrameInto`
+// fully overwrites them before reading.
+const _capQs: Q[] = [
+  [0, 0, 0, 0],
+  [0, 0, 0, 0],
+]
+const _compareAvgZ = (a: Quad, b: Quad): number => a.avgZ - b.avgZ
+
+export function createGlobeSpinState(): GlobeSpinState {
+  const quads: Quad[] = new Array(QUAD_POOL_SIZE)
+  for (let i = 0; i < QUAD_POOL_SIZE; i++) {
+    quads[i] = { points: "", color: "", avgZ: Infinity }
+  }
+  const grid: GridPoint[] = new Array(GRID_SIZE)
+  for (let i = 0; i < GRID_SIZE; i++) {
+    grid[i] = { x: 0, y: 0, z: 0, t: 0 }
+  }
+  return { quads, grid }
+}
+
 /**
- * Build one frame of the globe-spin animation.
+ * Build one frame of the globe-spin animation into a caller-owned state pool.
+ * Returns the count of active (non-culled) quads — those occupy `state.quads[0..count)`
+ * after the call, sorted by ascending `avgZ` (back-to-front).
  *
+ * @param state        Pool created by `createGlobeSpinState()`. Reused across frames.
  * @param progress     Eased 0..1 within the current spin cycle.
  * @param size         Pixel size of the spinner.
- * @param axisPhase    Monotonic 0..1 that wraps slowly (≈12s period). Drives a
- *                     gentle precession of the rotation axis so each spin
- *                     reveals a slightly different great circle — the loop
- *                     never visually repeats.
+ * @param axisPhase    Monotonic 0..1 that wraps every PRECESSION_MS. Drives a
+ *                     gentle precession of the rotation axis so the loop never
+ *                     visually repeats.
  */
-export function buildFrame(
+export function buildFrameInto(
+  state: GlobeSpinState,
   progress: number,
   size: number,
-  axisPhase = 0
-): Quad[] {
+  axisPhase: number
+): number {
+  const { quads, grid } = state
   const R = size * 0.392
   const cx = size / 2
   const cy = size / 2
   const latEdge = LAT_BASE * getLatFactor(size)
-  const latSteps = ROWS * 3
 
   const angle = progress * TOTAL_ANGLE
 
   // Precess PATH_AXIS around Z so the axis itself slowly rotates over time.
   const precessQ = qRot(0, 0, 1, axisPhase * 2 * Math.PI)
-  const [pax, pay, paz] = rotVec(precessQ, PATH_AXIS)
-  const qDelta = qRot(pax, pay, paz, angle)
+  rotVecInto(precessQ, PATH_AXIS[0], PATH_AXIS[1], PATH_AXIS[2], _scratchV)
+  const qDelta = qRot(_scratchV[0], _scratchV[1], _scratchV[2], angle)
   const qA = qMul(qDelta, Q_INIT_A)
   const qB = qMul(qDelta, Q_INIT_B)
+  // Pack into scratch array so the per-cap loop is a plain index lookup.
+  _capQs[0] = qA
+  _capQs[1] = qB
 
-  const all: Quad[] = []
+  let count = 0
 
-  for (const [q, sign] of [
-    [qA, 1],
-    [qA, -1],
-    [qB, 1],
-    [qB, -1],
-  ] as [Q, number][]) {
-    const grid: { x: number; y: number; z: number; t: number }[][] = []
-    for (let li = 0; li <= latSteps; li++) {
-      const lat = sign * (Math.PI / 2 - (li / latSteps) * latEdge)
-      const row: { x: number; y: number; z: number; t: number }[] = []
+  // Four caps: (qA,+1), (qA,-1), (qB,+1), (qB,-1).
+  for (let capIdx = 0; capIdx < 4; capIdx++) {
+    const q = _capQs[capIdx >> 1]
+    const sign = capIdx & 1 ? -1 : 1
+
+    // Build the grid for this cap into the pool. Mutates `grid` in place.
+    for (let li = 0; li <= LAT_STEPS; li++) {
+      const lat = sign * (Math.PI / 2 - (li / LAT_STEPS) * latEdge)
+      const cl = Math.cos(lat)
+      const sl = Math.sin(lat)
+      const t = Math.sin((li / LAT_STEPS) * Math.PI)
+      const row = li * GRID_STRIDE
       for (let si = 0; si <= SEGS; si++) {
         const lon = (si / SEGS) * Math.PI * 2
-        const cl = Math.cos(lat),
-          sl = Math.sin(lat)
-        const [wx, wy, wz] = rotVec(q, [
-          cl * Math.cos(lon),
-          sl,
-          cl * Math.sin(lon),
-        ])
-        row.push({
-          x: wx,
-          y: wy,
-          z: wz,
-          t: Math.sin((li / latSteps) * Math.PI),
-        })
+        rotVecInto(q, cl * Math.cos(lon), sl, cl * Math.sin(lon), _scratchV)
+        const cell = grid[row + si]
+        cell.x = _scratchV[0]
+        cell.y = _scratchV[1]
+        cell.z = _scratchV[2]
+        cell.t = t
       }
-      grid.push(row)
     }
-    for (let li = 0; li < latSteps; li++) {
+
+    // Build quads from the grid into the pool.
+    for (let li = 0; li < LAT_STEPS; li++) {
+      const rowA = li * GRID_STRIDE
+      const rowB = (li + 1) * GRID_STRIDE
       for (let si = 0; si < SEGS; si++) {
-        const p00 = grid[li][si],
-          p01 = grid[li][si + 1]
-        const p10 = grid[li + 1][si],
-          p11 = grid[li + 1][si + 1]
-        if ((p00.t + p01.t + p10.t + p11.t) / 4 < 0.001) continue
+        const p00 = grid[rowA + si]
+        const p01 = grid[rowA + si + 1]
+        const p10 = grid[rowB + si]
+        const p11 = grid[rowB + si + 1]
 
-        const mx = (p00.x + p01.x + p10.x + p11.x) / 4
-        const avgZ = (p00.z + p01.z + p10.z + p11.z) / 4
+        const avgT = (p00.t + p01.t + p10.t + p11.t) * 0.25
+        if (avgT < 0.001) continue
+
+        const mx = (p00.x + p01.x + p10.x + p11.x) * 0.25
+        const my = (p00.y + p01.y + p10.y + p11.y) * 0.25
+        const avgZ = (p00.z + p01.z + p10.z + p11.z) * 0.25
         const cxq = mx * R
-        const cyq = ((p00.y + p01.y + p10.y + p11.y) / 4) * R
+        const cyq = my * R
 
-        const ep = (p: { x: number; y: number }): [number, number] => {
-          const dx = p.x * R - cxq,
-            dy = p.y * R - cyq
-          const d = Math.sqrt(dx * dx + dy * dy)
-          const f = d > 0 ? (d + 0.9) / d : 1
-          return [cx + cxq + dx * f, cy - cyq - dy * f]
-        }
+        // Inlined `ep` for each vertex — same math as before, no function-call
+        // overhead and no intermediate tuples in the hot path.
+        const px0 = p00.x * R - cxq
+        const py0 = p00.y * R - cyq
+        const d0 = Math.sqrt(px0 * px0 + py0 * py0)
+        const f0 = d0 > 0 ? (d0 + 0.9) / d0 : 1
+        const ax = cx + cxq + px0 * f0
+        const ay = cy - cyq - py0 * f0
 
-        const [ax, ay] = ep(p00),
-          [bx, by] = ep(p01)
-        const [dx, dy] = ep(p11),
-          [ex, ey] = ep(p10)
+        const px1 = p01.x * R - cxq
+        const py1 = p01.y * R - cyq
+        const d1 = Math.sqrt(px1 * px1 + py1 * py1)
+        const f1 = d1 > 0 ? (d1 + 0.9) / d1 : 1
+        const bx = cx + cxq + px1 * f1
+        const by = cy - cyq - py1 * f1
 
-        all.push({
-          points: `${ax},${ay} ${bx},${by} ${dx},${dy} ${ex},${ey}`,
-          color: lerpColor(COLOR_A, COLOR_B, (mx + 1) / 2),
-          avgZ,
-        })
+        const px2 = p11.x * R - cxq
+        const py2 = p11.y * R - cyq
+        const d2 = Math.sqrt(px2 * px2 + py2 * py2)
+        const f2 = d2 > 0 ? (d2 + 0.9) / d2 : 1
+        const dxv = cx + cxq + px2 * f2
+        const dyv = cy - cyq - py2 * f2
+
+        const px3 = p10.x * R - cxq
+        const py3 = p10.y * R - cyq
+        const d3 = Math.sqrt(px3 * px3 + py3 * py3)
+        const f3 = d3 > 0 ? (d3 + 0.9) / d3 : 1
+        const ex = cx + cxq + px3 * f3
+        const ey = cy - cyq - py3 * f3
+
+        const slot = quads[count]
+        slot.points = `${ax},${ay} ${bx},${by} ${dxv},${dyv} ${ex},${ey}`
+        slot.color = colorFor((mx + 1) * 0.5)
+        slot.avgZ = avgZ
+        count++
       }
     }
   }
 
-  all.sort((a, b) => a.avgZ - b.avgZ)
-  return all
+  // Mark inactive slots so they sort to the end of the pool.
+  for (let i = count; i < QUAD_POOL_SIZE; i++) {
+    quads[i].avgZ = Infinity
+  }
+  quads.sort(_compareAvgZ)
+
+  return count
 }

--- a/packages/react/src/sds/ai/F0ActionItem/components/globeSpinMath.ts
+++ b/packages/react/src/sds/ai/F0ActionItem/components/globeSpinMath.ts
@@ -1,0 +1,225 @@
+// Pure JS math for the globe-spin animation. No DOM, no React, no SVG —
+// fully portable to React Native (only the render layer differs per platform).
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+export const VEL_X = 60
+export const VEL_Y = 40
+export const SPIN_MS = 2000
+export const PAUSE_MS = 500
+// Period of the slow precession of the rotation axis. Long enough to be
+// imperceptible inside a single cycle, but breaks the visual loop over time.
+export const PRECESSION_MS = 12000
+const ROWS = 2
+const SEGS = 40
+const COLOR_A: [number, number, number] = [255, 60, 0]
+const COLOR_B: [number, number, number] = [160, 140, 220]
+
+const INIT_A = { x: -12, y: 0, z: 0 }
+const INIT_B = { x: -12, y: 12, z: 90 }
+
+// Calibrated latEdge factors per size (controls form vs gap ratio).
+// Interpolates automatically for unlisted sizes.
+const LAT_FACTORS: Record<number, number> = {
+  20: 0.72,
+  28: 0.66,
+  32: 0.72,
+  60: 0.77,
+  80: 0.8,
+  120: 0.85,
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+type Q = [number, number, number, number]
+type V = [number, number, number]
+
+export type Quad = {
+  // Canonical SVG-polygon points: "x1,y1 x2,y2 x3,y3 x4,y4".
+  // Works directly in <svg><polygon points={...} /> on web AND in
+  // react-native-svg's <Polygon points={...} /> when porting to native.
+  points: string
+  color: string
+  avgZ: number
+}
+
+// ─── Math helpers ─────────────────────────────────────────────────────────────
+const D2R = Math.PI / 180
+const LAT_BASE = (ROWS / 8) * Math.PI
+// Two full rotations per spin. Multiple of 2π → end orientation matches the
+// start, so the pause-to-spin loop has no visual jump.
+const TOTAL_ANGLE = 4 * Math.PI
+
+function qMul(a: Q, b: Q): Q {
+  return [
+    a[0] * b[0] - a[1] * b[1] - a[2] * b[2] - a[3] * b[3],
+    a[0] * b[1] + a[1] * b[0] + a[2] * b[3] - a[3] * b[2],
+    a[0] * b[2] - a[1] * b[3] + a[2] * b[0] + a[3] * b[1],
+    a[0] * b[3] + a[1] * b[2] - a[2] * b[1] + a[3] * b[0],
+  ]
+}
+
+function qNorm(q: Q): Q {
+  const n = Math.sqrt(q[0] ** 2 + q[1] ** 2 + q[2] ** 2 + q[3] ** 2)
+  return [q[0] / n, q[1] / n, q[2] / n, q[3] / n]
+}
+
+function qRot(ax: number, ay: number, az: number, ang: number): Q {
+  const s = Math.sin(ang / 2)
+  return [Math.cos(ang / 2), ax * s, ay * s, az * s]
+}
+
+function rotVec(q: Q, [x, y, z]: V): V {
+  const [w, qx, qy, qz] = q
+  const tx = 2 * (qy * z - qz * y)
+  const ty = 2 * (qz * x - qx * z)
+  const tz = 2 * (qx * y - qy * x)
+  return [
+    x + w * tx + qy * tz - qz * ty,
+    y + w * ty + qz * tx - qx * tz,
+    z + w * tz + qx * ty - qy * tx,
+  ]
+}
+
+function eulerToQ(ex: number, ey: number, ez: number): Q {
+  const qx = qRot(1, 0, 0, ex * D2R)
+  const qy = qRot(0, 1, 0, ey * D2R)
+  const qz = qRot(0, 0, 1, ez * D2R)
+  return qNorm(qMul(qMul(qy, qx), qz))
+}
+
+function lerpColor(
+  c1: [number, number, number],
+  c2: [number, number, number],
+  t: number
+): string {
+  return `rgb(${Math.round(c1[0] + (c2[0] - c1[0]) * t)},${Math.round(c1[1] + (c2[1] - c1[1]) * t)},${Math.round(c1[2] + (c2[2] - c1[2]) * t)})`
+}
+
+// Cubic ease-in-out — smooth acceleration into the spin and gentle
+// deceleration into the pause, instead of a constant-velocity rotation.
+export function easeInOutCubic(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2
+}
+
+function getLatFactor(size: number): number {
+  const sizes = Object.keys(LAT_FACTORS)
+    .map(Number)
+    .sort((a, b) => a - b)
+  if (size <= sizes[0]) return LAT_FACTORS[sizes[0]]
+  if (size >= sizes[sizes.length - 1])
+    return LAT_FACTORS[sizes[sizes.length - 1]]
+  for (let i = 0; i < sizes.length - 1; i++) {
+    if (size >= sizes[i] && size <= sizes[i + 1]) {
+      const t = (size - sizes[i]) / (sizes[i + 1] - sizes[i])
+      return (
+        LAT_FACTORS[sizes[i]] +
+        (LAT_FACTORS[sizes[i + 1]] - LAT_FACTORS[sizes[i]]) * t
+      )
+    }
+  }
+  return 0.72
+}
+
+// ─── Frame builder ────────────────────────────────────────────────────────────
+const SPEED = Math.sqrt(VEL_X ** 2 + VEL_Y ** 2)
+const PATH_AXIS: V = [VEL_X / SPEED, VEL_Y / SPEED, 0]
+const Q_INIT_A = eulerToQ(INIT_A.x, INIT_A.y, INIT_A.z)
+const Q_INIT_B = eulerToQ(INIT_B.x, INIT_B.y, INIT_B.z)
+
+/**
+ * Build one frame of the globe-spin animation.
+ *
+ * @param progress     Eased 0..1 within the current spin cycle.
+ * @param size         Pixel size of the spinner.
+ * @param axisPhase    Monotonic 0..1 that wraps slowly (≈12s period). Drives a
+ *                     gentle precession of the rotation axis so each spin
+ *                     reveals a slightly different great circle — the loop
+ *                     never visually repeats.
+ */
+export function buildFrame(
+  progress: number,
+  size: number,
+  axisPhase = 0
+): Quad[] {
+  const R = size * 0.392
+  const cx = size / 2
+  const cy = size / 2
+  const latEdge = LAT_BASE * getLatFactor(size)
+  const latSteps = ROWS * 3
+
+  const angle = progress * TOTAL_ANGLE
+
+  // Precess PATH_AXIS around Z so the axis itself slowly rotates over time.
+  const precessQ = qRot(0, 0, 1, axisPhase * 2 * Math.PI)
+  const [pax, pay, paz] = rotVec(precessQ, PATH_AXIS)
+  const qDelta = qRot(pax, pay, paz, angle)
+  const qA = qMul(qDelta, Q_INIT_A)
+  const qB = qMul(qDelta, Q_INIT_B)
+
+  const all: Quad[] = []
+
+  for (const [q, sign] of [
+    [qA, 1],
+    [qA, -1],
+    [qB, 1],
+    [qB, -1],
+  ] as [Q, number][]) {
+    const grid: { x: number; y: number; z: number; t: number }[][] = []
+    for (let li = 0; li <= latSteps; li++) {
+      const lat = sign * (Math.PI / 2 - (li / latSteps) * latEdge)
+      const row: { x: number; y: number; z: number; t: number }[] = []
+      for (let si = 0; si <= SEGS; si++) {
+        const lon = (si / SEGS) * Math.PI * 2
+        const cl = Math.cos(lat),
+          sl = Math.sin(lat)
+        const [wx, wy, wz] = rotVec(q, [
+          cl * Math.cos(lon),
+          sl,
+          cl * Math.sin(lon),
+        ])
+        row.push({
+          x: wx,
+          y: wy,
+          z: wz,
+          t: Math.sin((li / latSteps) * Math.PI),
+        })
+      }
+      grid.push(row)
+    }
+    for (let li = 0; li < latSteps; li++) {
+      for (let si = 0; si < SEGS; si++) {
+        const p00 = grid[li][si],
+          p01 = grid[li][si + 1]
+        const p10 = grid[li + 1][si],
+          p11 = grid[li + 1][si + 1]
+        if ((p00.t + p01.t + p10.t + p11.t) / 4 < 0.001) continue
+
+        const mx = (p00.x + p01.x + p10.x + p11.x) / 4
+        const avgZ = (p00.z + p01.z + p10.z + p11.z) / 4
+        const cxq = mx * R
+        const cyq = ((p00.y + p01.y + p10.y + p11.y) / 4) * R
+
+        const ep = (p: { x: number; y: number }): [number, number] => {
+          const dx = p.x * R - cxq,
+            dy = p.y * R - cyq
+          const d = Math.sqrt(dx * dx + dy * dy)
+          const f = d > 0 ? (d + 0.9) / d : 1
+          return [cx + cxq + dx * f, cy - cyq - dy * f]
+        }
+
+        const [ax, ay] = ep(p00),
+          [bx, by] = ep(p01)
+        const [dx, dy] = ep(p11),
+          [ex, ey] = ep(p10)
+
+        all.push({
+          points: `${ax},${ay} ${bx},${by} ${dx},${dy} ${ex},${ey}`,
+          color: lerpColor(COLOR_A, COLOR_B, (mx + 1) / 2),
+          avgZ,
+        })
+      }
+    }
+  }
+
+  all.sort((a, b) => a.avgZ - b.avgZ)
+  return all
+}

--- a/packages/react/src/sds/ai/F0ActionItem/components/globeSpinMath.ts
+++ b/packages/react/src/sds/ai/F0ActionItem/components/globeSpinMath.ts
@@ -131,10 +131,14 @@ function colorFor(t: number): string {
   return COLOR_LUT[i]
 }
 
+// Hoist the sorted size list out of the hot path. `getLatFactor` runs once
+// per frame; computing this on every call was a small but avoidable cost.
+const LAT_FACTOR_SIZES = Object.keys(LAT_FACTORS)
+  .map(Number)
+  .sort((a, b) => a - b)
+
 function getLatFactor(size: number): number {
-  const sizes = Object.keys(LAT_FACTORS)
-    .map(Number)
-    .sort((a, b) => a - b)
+  const sizes = LAT_FACTOR_SIZES
   if (size <= sizes[0]) return LAT_FACTORS[sizes[0]]
   if (size >= sizes[sizes.length - 1])
     return LAT_FACTORS[sizes[sizes.length - 1]]

--- a/packages/react/src/sds/ai/F0ActionItem/styles.css
+++ b/packages/react/src/sds/ai/F0ActionItem/styles.css
@@ -36,10 +36,6 @@
   }
 }
 
-.globe-spin-enter {
-  animation: globe-spin-enter 0.5s cubic-bezier(0.33, 1, 0.68, 1) both;
-}
-
 /* Subtle "thinking" breath. Plays after the entrance finishes (0.5s delay)
    and loops forever. Amplitude is small (~3.5%) so it reads as life, not noise. */
 @keyframes globe-spin-breathe {
@@ -52,12 +48,18 @@
   }
 }
 
-.globe-spin-breathe {
-  animation: globe-spin-breathe 3.6s ease-in-out 0.5s infinite;
+/* Both animations live in one class because the `animation` shorthand resets
+   all `animation-*` properties: applying `.globe-spin-enter` and
+   `.globe-spin-breathe` separately would have the second one wipe out the
+   first. Comma-separated values let both run on the same element. */
+.globe-spin-anim {
+  animation:
+    globe-spin-enter 0.5s cubic-bezier(0.33, 1, 0.68, 1) both,
+    globe-spin-breathe 3.6s ease-in-out 0.5s infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .globe-spin-breathe {
+  .globe-spin-anim {
     animation: none;
   }
 }

--- a/packages/react/src/sds/ai/F0ActionItem/styles.css
+++ b/packages/react/src/sds/ai/F0ActionItem/styles.css
@@ -2,16 +2,16 @@
   background: linear-gradient(
     90deg,
     #888 0%,
-    #888 33%,
-    #aaa 50%,
-    #888 66%,
+    #888 35%,
+    #f5f5f5 50%,
+    #888 65%,
     #888 100%
   );
   background-size: 200% 100%;
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  animation: shine 1.5s ease-in-out infinite;
+  animation: shine 3s ease-in-out infinite;
 }
 
 @keyframes shine {
@@ -56,27 +56,8 @@
   animation: globe-spin-breathe 3.6s ease-in-out 0.5s infinite;
 }
 
-/* Soft "AI thinking" halo. Cycles between the two brand colors of the globe
-   so the glow feels coherent with what's spinning inside, not stuck on. */
-@keyframes globe-spin-glow {
-  0%,
-  100% {
-    filter: drop-shadow(0 0 2px rgba(255, 90, 30, 0.35))
-      drop-shadow(0 0 6px rgba(255, 90, 30, 0.18));
-  }
-  50% {
-    filter: drop-shadow(0 0 3px rgba(180, 150, 230, 0.45))
-      drop-shadow(0 0 8px rgba(180, 150, 230, 0.22));
-  }
-}
-
-.globe-spin-glow {
-  animation: globe-spin-glow 3.6s ease-in-out 0.5s infinite;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .globe-spin-breathe,
-  .globe-spin-glow {
+  .globe-spin-breathe {
     animation: none;
   }
 }

--- a/packages/react/src/sds/ai/F0ActionItem/styles.css
+++ b/packages/react/src/sds/ai/F0ActionItem/styles.css
@@ -22,3 +22,61 @@
     background-position: -200% 0;
   }
 }
+
+@keyframes globe-spin-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+    filter: blur(4px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0);
+  }
+}
+
+.globe-spin-enter {
+  animation: globe-spin-enter 0.5s cubic-bezier(0.33, 1, 0.68, 1) both;
+}
+
+/* Subtle "thinking" breath. Plays after the entrance finishes (0.5s delay)
+   and loops forever. Amplitude is small (~3.5%) so it reads as life, not noise. */
+@keyframes globe-spin-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.035);
+  }
+}
+
+.globe-spin-breathe {
+  animation: globe-spin-breathe 3.6s ease-in-out 0.5s infinite;
+}
+
+/* Soft "AI thinking" halo. Cycles between the two brand colors of the globe
+   so the glow feels coherent with what's spinning inside, not stuck on. */
+@keyframes globe-spin-glow {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 2px rgba(255, 90, 30, 0.35))
+      drop-shadow(0 0 6px rgba(255, 90, 30, 0.18));
+  }
+  50% {
+    filter: drop-shadow(0 0 3px rgba(180, 150, 230, 0.45))
+      drop-shadow(0 0 8px rgba(180, 150, 230, 0.22));
+  }
+}
+
+.globe-spin-glow {
+  animation: globe-spin-glow 3.6s ease-in-out 0.5s infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .globe-spin-breathe,
+  .globe-spin-glow {
+    animation: none;
+  }
+}

--- a/packages/react/src/sds/ai/F0ActionItem/types.ts
+++ b/packages/react/src/sds/ai/F0ActionItem/types.ts
@@ -9,7 +9,7 @@ export interface F0ActionItemProps {
   /**
    * Current status of the action item
    */
-  status?: "inProgress" | "executing" | "completed"
+  status?: "inProgress" | "executing" | "writing" | "completed"
   /**
    * Whether the action item is part of a group
    */
@@ -19,6 +19,7 @@ export interface F0ActionItemProps {
 export const actionItemStatuses = [
   "inProgress",
   "executing",
+  "writing",
   "completed",
 ] as const
 export type ActionItemStatus = (typeof actionItemStatuses)[number]

--- a/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
@@ -20,7 +20,6 @@ import { AiChatProviderProps, type WelcomeScreenSuggestion } from "./types"
 
 const F0AiChatProviderComponent = ({
   enabled = false,
-  greeting,
   initialMessage,
   welcomeScreenSuggestions,
   disclaimer,
@@ -49,7 +48,6 @@ const F0AiChatProviderComponent = ({
   return (
     <AiChatStateProvider
       enabled={enabled}
-      greeting={greeting}
       initialMessage={initialMessage}
       onThumbsUp={onThumbsUp}
       onThumbsDown={onThumbsDown}

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiChat.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiChat.stories.tsx
@@ -116,7 +116,13 @@ const meta = {
             agent="one-workflow"
             credentials="include"
             showDevConsole={false}
-            greeting="Hello, John"
+            initialMessage={[
+              "Operational work, automated by One",
+              "Ask anything about your company",
+              "Skip the boring part of your job",
+              "Ask anything about your people, policies, or payroll",
+              "Turn months of data into a one-line answer",
+            ]}
             disclaimer={{
               text: "One works within your permissions.",
               link: "/permissions",
@@ -209,7 +215,7 @@ export const WithFooter: Story = {
             agent="one-workflow"
             credentials="include"
             showDevConsole={false}
-            greeting="Hello, John"
+            initialMessage="Ask anything about your company"
             disclaimer={{
               text: "One works within your permissions.",
               link: "/permissions",

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx
@@ -266,7 +266,7 @@ export const FormWithAiChat: Story = {
           agent="one-workflow"
           credentials="include"
           showDevConsole={false}
-          greeting="Hello! I can help you fill out the employee form. Ask me to describe it, fill fields, or submit."
+          initialMessage="Help me fill out the employee form"
         >
           <AutoOpenChat>
             <ApplicationFrame
@@ -852,7 +852,7 @@ export const AvailableForms: Story = {
           agent="one-workflow"
           credentials="include"
           showDevConsole={false}
-          greeting="Hello! I can help you with forms. I can fill, describe, and submit any of the available forms. Try asking me to fill a time-off request or the new employee form."
+          initialMessage="What form do you want to fill out?"
         >
           <AutoOpenChat>
             <ApplicationFrame
@@ -1115,7 +1115,7 @@ export const FormWithDefaultValuesParams: Story = {
           agent="one-workflow"
           credentials="include"
           showDevConsole={false}
-          greeting="Hello! I can open an aircraft edit form pre-populated with its current data. Try: 'Edit aircraft ac-1' or 'Open the edit form for the A350'."
+          initialMessage="Which aircraft do you want to edit?"
         >
           <AutoOpenChat>
             <ApplicationFrame

--- a/packages/react/src/sds/ai/F0AiChat/components/ConnectedChatInput.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/ConnectedChatInput.tsx
@@ -14,7 +14,10 @@ import {
 
 import { filterNonRenderableMessages } from "../internal-types"
 import { useAiChat } from "../providers/AiChatStateProvider"
-import type { WelcomeScreenSuggestionItem } from "../types"
+import type {
+  WelcomeScreenSuggestion,
+  WelcomeScreenSuggestionItem,
+} from "../types"
 
 /**
  * Internal wrapper that connects F0AiChatTextArea to the AiChat provider.
@@ -105,12 +108,13 @@ export const ConnectedChatInput = (props: InputProps) => {
   )
 
   const handleSuggestionClick = useCallback(
-    (item: WelcomeScreenSuggestionItem) => {
-      tracking?.onWelcomeSuggestionClick?.(item)
+    (item: WelcomeScreenSuggestionItem, group: WelcomeScreenSuggestion) => {
+      const prompt = item.prompt || item.title
+      tracking?.onWelcomeSuggestionClick?.({ item, group, prompt })
       sendMessage({
         id: randomId(),
         role: "user",
-        content: item.prompt || item.title,
+        content: prompt,
       })
     },
     [sendMessage, tracking]

--- a/packages/react/src/sds/ai/F0AiChat/components/ConnectedMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/ConnectedMessagesContainer.tsx
@@ -91,7 +91,6 @@ export const ConnectedMessagesContainer = ({
   const lazyToolRendered = useLazyToolRenderer()
 
   const {
-    greeting,
     initialMessage,
     isLoadingThread,
     setInProgress,
@@ -99,7 +98,6 @@ export const ConnectedMessagesContainer = ({
     visualizationMode,
     tracking,
     setPendingQuote,
-    openGame,
     onThumbsUp,
     onThumbsDown,
   } = useAiChat()
@@ -225,10 +223,6 @@ export const ConnectedMessagesContainer = ({
   }, [filteredMessages, inProgress])
 
   // ── Callbacks ──
-  const onWelcomeIconClick = useCallback(() => {
-    openGame("pong")
-  }, [openGame])
-
   const onReplyQuote = useCallback(
     (text: string) => {
       setPendingQuote({ text })
@@ -269,9 +263,7 @@ export const ConnectedMessagesContainer = ({
       turns={turns}
       isLoadingThread={isLoadingThread}
       interrupt={interrupt}
-      greeting={greeting}
       initialMessage={initialMessage}
-      onWelcomeIconClick={onWelcomeIconClick}
       renderToolCall={renderToolCall}
       onReplyQuote={onReplyQuote}
       onAssistantMessageRendered={onAssistantMessageRendered}

--- a/packages/react/src/sds/ai/F0AiChat/components/ConnectedMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/ConnectedMessagesContainer.tsx
@@ -98,6 +98,7 @@ export const ConnectedMessagesContainer = ({
     visualizationMode,
     tracking,
     setPendingQuote,
+    openGame,
     onThumbsUp,
     onThumbsDown,
   } = useAiChat()
@@ -223,6 +224,12 @@ export const ConnectedMessagesContainer = ({
   }, [filteredMessages, inProgress])
 
   // ── Callbacks ──
+  // Welcome phrase click → pong easter egg. Replaces the previous F0OneIcon
+  // entry point that the simplified welcome screen no longer renders.
+  const onWelcomeClick = useCallback(() => {
+    openGame("pong")
+  }, [openGame])
+
   const onReplyQuote = useCallback(
     (text: string) => {
       setPendingQuote({ text })
@@ -264,6 +271,7 @@ export const ConnectedMessagesContainer = ({
       isLoadingThread={isLoadingThread}
       interrupt={interrupt}
       initialMessage={initialMessage}
+      onWelcomeClick={onWelcomeClick}
       renderToolCall={renderToolCall}
       onReplyQuote={onReplyQuote}
       onAssistantMessageRendered={onAssistantMessageRendered}

--- a/packages/react/src/sds/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -1,4 +1,3 @@
-import { useCopilotChatInternal } from "@copilotkit/react-core"
 import { type WindowProps } from "@copilotkit/react-ui"
 import { breakpoints } from "@factorialco/f0-core"
 import { AnimatePresence, motion } from "motion/react"
@@ -7,7 +6,6 @@ import { useMediaQuery } from "usehooks-ts"
 
 import { cn } from "@/lib/utils"
 
-import { filterNonRenderableMessages } from "../../internal-types"
 import { useAiChat } from "../../providers/AiChatStateProvider"
 import { MAX_CHAT_WIDTH, MIN_CHAT_WIDTH } from "../../utils/constants"
 import { DropOverlay } from "../../../F0AiChatTextArea"
@@ -30,14 +28,7 @@ export const SidebarWindow = ({ children }: WindowProps) => {
     processDroppedFiles,
     activeGame,
     closeGame,
-    isLoadingThread,
   } = useAiChat()
-  const { messages } = useCopilotChatInternal()
-  const filteredMessages = useMemo(
-    () => filterNonRenderableMessages(messages),
-    [messages]
-  )
-  const isWelcomeScreen = filteredMessages.length === 0 && !isLoadingThread
   const isCanvasMode = visualizationMode === "canvas"
 
   const dragCounterRef = useRef(0)
@@ -155,25 +146,7 @@ export const SidebarWindow = ({ children }: WindowProps) => {
             onDrop={handleDrop}
           >
             <motion.div
-              className={cn(
-                "relative flex h-full w-full flex-col overflow-hidden",
-                // Fullscreen welcome: only the chat content (Messages + Input,
-                // wrapped by copilotkit's `.copilotKitChat`) should center —
-                // the Header is its sibling and stays pinned to the top.
-                //
-                // The trick: split the remaining height 50/50 between the
-                // messages section and the textarea section by giving both
-                // direct children `flex-1`. The welcome content uses
-                // `justify-end` inside the messages section so it hugs the
-                // bottom of its half, while the textarea sits at the top of
-                // its half by default. Result: they "stick" at the midpoint,
-                // giving the visual impression of a centered block.
-                fullscreen &&
-                  isWelcomeScreen && [
-                    "[&_.copilotKitChat]:flex-1",
-                    "[&_.copilotKitChat>div]:flex-1",
-                  ]
-              )}
+              className="relative flex h-full w-full flex-col overflow-hidden"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -26,7 +26,6 @@ import {
  * Internal state for the AiChat provider
  */
 export interface AiChatState {
-  greeting?: string
   enabled: boolean
   agent?: string
   initialMessage?: string | string[]
@@ -255,7 +254,6 @@ export type AiChatProviderReturnValue = {
   setPendingQuote: React.Dispatch<React.SetStateAction<PendingQuote | null>>
 } & Pick<
   AiChatState,
-  | "greeting"
   | "agent"
   | "disclaimer"
   | "resizable"

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -202,10 +202,22 @@ export type AiChatFileAttachmentConfig = {
   maxFiles?: number
 }
 
+/**
+ * Payload for `tracking.onWelcomeSuggestionClick`. Carries everything an
+ * analytics layer (e.g. Amplitude) needs to attribute the click: the picked
+ * sub-item, its parent group, and the resolved prompt that was actually sent.
+ */
+export type WelcomeSuggestionClickEvent = {
+  item: WelcomeScreenSuggestionItem
+  group: WelcomeScreenSuggestion
+  /** Prompt actually sent to the AI — `item.prompt` falling back to `item.title`. */
+  prompt: string
+}
+
 export type AiChatTrackingOptions = {
   onVisibility?: () => void
   onClose?: () => void
-  onWelcomeSuggestionClick?: (item: WelcomeScreenSuggestionItem) => void
+  onWelcomeSuggestionClick?: (event: WelcomeSuggestionClickEvent) => void
   onNewChat?: () => void
   onMessage?: (message: Message) => void
 }

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -215,7 +215,6 @@ export type AiChatTrackingOptions = {
  */
 export type AiChatProviderProps = {
   enabled?: boolean
-  greeting?: string
   initialMessage?: string | string[]
   welcomeScreenSuggestions?: WelcomeScreenSuggestion[]
   disclaimer?: AiChatDisclaimer

--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -89,7 +89,6 @@ export const F0AiChatTextArea = ({
   onSuggestionClick,
   ref,
 }: F0AiChatTextAreaProps) => {
-  const fullscreenWelcome = fullscreen && isWelcomeScreen
   const translation = useI18n()
   const shouldReduceMotion = useReducedMotion()
   const [inputValue, setInputValue] = useState("")
@@ -249,16 +248,7 @@ export const F0AiChatTextArea = ({
     mentions.mentions.length > 0 || mentions.inlineCompletion !== null
 
   return (
-    <div
-      ref={ref}
-      className={cn(
-        "flex flex-col items-center gap-2 px-4 pb-3 pt-2",
-        // Only grow to share space with the messages container when we're in
-        // the fullscreen welcome layout — that's where the "stick to the
-        // middle" centering trick relies on the textarea taking its half.
-        fullscreenWelcome && "flex-grow"
-      )}
-    >
+    <div ref={ref} className="flex flex-col items-center gap-2 px-4 pb-3 pt-2">
       <div className="flex w-full max-w-content flex-col gap-2">
         {isWelcomeScreen &&
           welcomeScreenSuggestions &&
@@ -446,8 +436,7 @@ export const F0AiChatTextArea = ({
             </span>
           </motion.div>
         ) : (
-          disclaimer?.text &&
-          !fullscreenWelcome && (
+          disclaimer?.text && (
             <motion.div
               key="chat-disclaimer"
               className="flex w-full max-w-content flex-row items-center justify-center gap-1"

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
@@ -67,7 +67,7 @@ describe("WelcomeScreenSuggestionsRow", () => {
     ).toBeInTheDocument()
   })
 
-  it("calls onItemClick with the item and closes the popover", async () => {
+  it("calls onItemClick with the item and its parent group, and closes the popover", async () => {
     const user = userEvent.setup()
     const onItemClick = vi.fn()
     zeroRender(
@@ -84,9 +84,10 @@ describe("WelcomeScreenSuggestionsRow", () => {
     await user.click(item)
 
     expect(onItemClick).toHaveBeenCalledTimes(1)
-    expect(onItemClick).toHaveBeenCalledWith({
-      title: "April leave and overtime summary",
-    })
+    expect(onItemClick).toHaveBeenCalledWith(
+      { title: "April leave and overtime summary" },
+      groups[0]
+    )
 
     expect(
       screen.queryByRole("button", { name: /april leave and overtime/i })

--- a/packages/react/src/sds/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -29,8 +29,15 @@ function pickRandomItems(
 
 export type WelcomeScreenSuggestionsRowProps = {
   suggestions: WelcomeScreenSuggestion[]
-  /** Fired when the user picks a sub-suggestion. */
-  onItemClick: (item: WelcomeScreenSuggestionItem) => void
+  /**
+   * Fired when the user picks a sub-suggestion. Receives the picked `item`
+   * AND its parent `group` so callers (tracking, analytics) can attribute
+   * the click to the full path the user took.
+   */
+  onItemClick: (
+    item: WelcomeScreenSuggestionItem,
+    group: WelcomeScreenSuggestion
+  ) => void
   /**
    * Fires while the user hovers an item (passes the item) and when the
    * hover ends (passes null). Used to preview the item's prompt as the
@@ -103,7 +110,7 @@ export const WelcomeScreenSuggestionsRow = ({
                 key={index}
                 type="button"
                 onClick={() => {
-                  onItemClick(item)
+                  onItemClick(item, activeGroup)
                   setActiveIdx(null)
                   onItemHover?.(null)
                 }}

--- a/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
@@ -119,8 +119,12 @@ export type F0AiChatTextAreaProps = {
    * Hovering an item previews its prompt in the textarea placeholder.
    */
   welcomeScreenSuggestions?: WelcomeScreenSuggestion[]
-  /** Called when the user clicks a sub-suggestion. */
-  onSuggestionClick?: (item: WelcomeScreenSuggestionItem) => void
+  /** Called when the user clicks a sub-suggestion. Receives the picked
+   *  `item` and its parent `group` (the outline-button entry). */
+  onSuggestionClick?: (
+    item: WelcomeScreenSuggestionItem,
+    group: WelcomeScreenSuggestion
+  ) => void
 
   /**
    * When true, the composer adopts the fullscreen layout: the welcome

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
@@ -251,9 +251,7 @@ const Messages = ({
         {turn.endIndicator === "thinking" && (
           <F0ActionItem title={translations.ai.thinking} status="executing" />
         )}
-        {turn.endIndicator === "activity" && (
-          <F0ActionItem title="" status="executing" />
-        )}
+        {turn.endIndicator === "activity" && <F0ActionItem status="writing" />}
         {turn.feedback && (
           <TurnFeedback
             content={turn.feedback.content}

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
@@ -50,12 +50,9 @@ export type F0AiMessagesContainerProps = {
   /** Optional React node rendered inline at the end of the list (e.g. CopilotKit interrupt). */
   interrupt?: ReactNode
 
-  /** Greeting shown above the initial message in the welcome screen. */
-  greeting?: string
-  /** Initial message(s) shown in the welcome screen, or a default if omitted. */
+  /** Welcome phrase shown centered when the chat is empty. Falls back to
+   *  `translations.ai.defaultInitialMessage` if omitted. */
   initialMessage?: string | string[]
-  /** Optional click on the One icon (factorial uses it for the pong easter egg). */
-  onWelcomeIconClick?: () => void
 
   /** Returns a React node for an assistant message's tool call, or null. */
   renderToolCall?: F0AssistantMessageExtraProps["renderToolCall"]
@@ -102,9 +99,7 @@ const Messages = ({
   turns,
   isLoadingThread = false,
   interrupt,
-  greeting,
   initialMessage,
-  onWelcomeIconClick,
   renderToolCall,
   onReplyQuote,
   onAssistantMessageRendered,
@@ -140,8 +135,14 @@ const Messages = ({
     [initialMessages, translations.ai.defaultInitialMessage]
   )
 
-  const showWelcomeBlock =
-    turns.length === 0 && (greeting || resolvedInitialMessages.length > 0)
+  const welcomeMessages = useMemo(
+    () =>
+      resolvedInitialMessages
+        .map((m) => (typeof m.content === "string" ? m.content : ""))
+        .filter((s) => s.length > 0),
+    [resolvedInitialMessages]
+  )
+  const showWelcomeBlock = turns.length === 0 && welcomeMessages.length > 0
 
   // Scroll state
   const viewportRef = useRef<HTMLDivElement>(null)
@@ -292,11 +293,7 @@ const Messages = ({
             >
               {isLoadingThread && <MessagesSkeleton />}
               {!isLoadingThread && showWelcomeBlock && (
-                <WelcomeScreen
-                  greeting={greeting}
-                  initialMessages={resolvedInitialMessages}
-                  onIconClick={onWelcomeIconClick}
-                />
+                <WelcomeScreen messages={welcomeMessages} />
               )}
               {!isLoadingThread &&
                 turns.map((turn, turnIndex) => renderTurn(turn, turnIndex))}

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
@@ -53,6 +53,9 @@ export type F0AiMessagesContainerProps = {
   /** Welcome phrase shown centered when the chat is empty. Falls back to
    *  `translations.ai.defaultInitialMessage` if omitted. */
   initialMessage?: string | string[]
+  /** Called when the user clicks the welcome phrase (used by F0AiChat to open
+   *  the pong easter egg). When omitted the phrase is non-interactive. */
+  onWelcomeClick?: () => void
 
   /** Returns a React node for an assistant message's tool call, or null. */
   renderToolCall?: F0AssistantMessageExtraProps["renderToolCall"]
@@ -100,6 +103,7 @@ const Messages = ({
   isLoadingThread = false,
   interrupt,
   initialMessage,
+  onWelcomeClick,
   renderToolCall,
   onReplyQuote,
   onAssistantMessageRendered,
@@ -291,7 +295,10 @@ const Messages = ({
             >
               {isLoadingThread && <MessagesSkeleton />}
               {!isLoadingThread && showWelcomeBlock && (
-                <WelcomeScreen messages={welcomeMessages} />
+                <WelcomeScreen
+                  messages={welcomeMessages}
+                  onClick={onWelcomeClick}
+                />
               )}
               {!isLoadingThread &&
                 turns.map((turn, turnIndex) => renderTurn(turn, turnIndex))}

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/__stories__/F0AiMessagesContainer.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/__stories__/F0AiMessagesContainer.stories.tsx
@@ -150,8 +150,7 @@ export const LoadingThread: Story = {
 export const EmptyWelcome: Story = {
   args: {
     turns: [],
-    greeting: "Hello, John",
-    initialMessage: "How can I help you today?",
+    initialMessage: "Ask anything about your company",
   },
 }
 

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/__tests__/WelcomeScreen.test.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/__tests__/WelcomeScreen.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, userEvent, zeroRender } from "@/testing/test-utils"
+
+import { WelcomeScreen } from "../components/WelcomeScreen"
+
+describe("WelcomeScreen", () => {
+  it("renders the message as a non-interactive paragraph when no onClick is given", () => {
+    zeroRender(<WelcomeScreen messages={["Ask anything"]} />)
+    const p = screen.getByLabelText("Ask anything")
+    expect(p).toBeInTheDocument()
+    expect(p).not.toHaveAttribute("role", "button")
+    expect(p).not.toHaveAttribute("tabIndex")
+  })
+
+  it("becomes interactive when onClick is provided", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    zeroRender(<WelcomeScreen messages={["Ask anything"]} onClick={onClick} />)
+
+    const button = screen.getByRole("button", { name: "Ask anything" })
+    expect(button).toHaveAttribute("tabIndex", "0")
+
+    await user.click(button)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("fires onClick on Enter and Space when focused", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    zeroRender(<WelcomeScreen messages={["Ask anything"]} onClick={onClick} />)
+
+    const button = screen.getByRole("button", { name: "Ask anything" })
+    button.focus()
+    await user.keyboard("{Enter}")
+    expect(onClick).toHaveBeenCalledTimes(1)
+
+    await user.keyboard(" ")
+    expect(onClick).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/Thinking.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/Thinking.tsx
@@ -30,7 +30,7 @@ export const Thinking = ({
   }, [inProgress, isOpen])
 
   const headerTitle = inProgress
-    ? "Reflection"
+    ? translations.ai.thoughtsGroupTitle
     : (title ?? translations.ai.thoughtsGroupTitle)
   const lastIndex = titles.length - 1
   const itemStatus = (index: number): "executing" | "completed" => {

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
@@ -11,9 +11,15 @@ type Phase = "starting" | "writing" | "holding" | "erasing"
 export type WelcomeScreenProps = {
   /** One or more phrases. With more than one, they rotate in an infinite loop. */
   messages: string[]
+  /**
+   * Optional click handler on the phrase itself. When set, the phrase becomes
+   * keyboard-activatable (Enter / Space) and gets a subtle hover hint. Used by
+   * `F0AiChat` to wire the pong easter egg.
+   */
+  onClick?: () => void
 }
 
-export const WelcomeScreen = ({ messages }: WelcomeScreenProps) => {
+export const WelcomeScreen = ({ messages, onClick }: WelcomeScreenProps) => {
   const [index, setIndex] = useState(0)
   const [chars, setChars] = useState(0)
   const [phase, setPhase] = useState<Phase>("starting")
@@ -52,11 +58,30 @@ export const WelcomeScreen = ({ messages }: WelcomeScreenProps) => {
   // Pulse arrives just after the full phrase becomes visible.
   const pulseDelay = (START_DELAY_MS + current.length * CHAR_IN_MS) / 1000
 
+  const interactive = !!onClick
+  const handleKeyDown = interactive
+    ? (e: React.KeyboardEvent<HTMLParagraphElement>) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          onClick?.()
+        }
+      }
+    : undefined
+
   return (
     <div className="flex w-full flex-1 items-center justify-center px-4">
       <p
         key={index}
-        className="bg-gradient-to-r from-[#E55619] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent"
+        role={interactive ? "button" : undefined}
+        tabIndex={interactive ? 0 : undefined}
+        onClick={onClick}
+        onKeyDown={handleKeyDown}
+        className={
+          "bg-gradient-to-r from-[#E55619] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent" +
+          (interactive
+            ? " cursor-pointer transition-transform duration-200 hover:scale-[1.02] focus-visible:scale-[1.02] focus-visible:outline-none motion-reduce:transition-none motion-reduce:hover:scale-100 motion-reduce:focus-visible:scale-100"
+            : "")
+        }
         style={{ animationDelay: `${pulseDelay}s`, minHeight: 28 }}
         aria-label={current}
       >

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
@@ -1,164 +1,67 @@
-import { AnimatePresence, motion } from "motion/react"
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 
-import { F0OneIcon } from "../../F0OneIcon"
+const CHAR_IN_MS = 35
+const CHAR_OUT_MS = 22
+const START_DELAY_MS = 400
+const HOLD_MS = 2500
+const END_DELAY_MS = 220
 
-import { PongBall } from "../../F0AiPong"
-import { type Message } from "../types"
-
-// Streaming text effect — reveals chars in cascade so the greeting feels typed.
-const STREAM_CHAR_DURATION = 0.025
-const GREETING_START_DELAY = 0.4
-const STREAM_GAP = 0.15
-
-const streamCharVariants = {
-  hidden: { opacity: 0 },
-  visible: { opacity: 1, transition: { duration: 0.2 } },
-}
-
-type StreamedTextProps = {
-  text: string
-  startDelay: number
-  className?: string
-}
-
-const StreamedText = ({ text, startDelay, className }: StreamedTextProps) => {
-  const containerVariants = useMemo(
-    () => ({
-      hidden: {},
-      visible: {
-        transition: {
-          staggerChildren: STREAM_CHAR_DURATION,
-          delayChildren: startDelay,
-        },
-      },
-    }),
-    [startDelay]
-  )
-
-  return (
-    <motion.p
-      className={className}
-      initial="hidden"
-      animate="visible"
-      variants={containerVariants}
-      aria-label={text}
-    >
-      {[...text].map((char, index) => (
-        <motion.span key={index} variants={streamCharVariants} aria-hidden>
-          {char}
-        </motion.span>
-      ))}
-    </motion.p>
-  )
-}
+type Phase = "starting" | "writing" | "holding" | "erasing"
 
 export type WelcomeScreenProps = {
-  greeting?: string
-  // todo make it string
-  initialMessages?: Message[]
-  /** Optional click on the One icon (factorial uses it for the pong easter egg). */
-  onIconClick?: () => void
+  /** One or more phrases. With more than one, they rotate in an infinite loop. */
+  messages: string[]
 }
 
-export const WelcomeScreen = ({
-  greeting,
-  initialMessages = [],
-  onIconClick,
-}: WelcomeScreenProps) => {
-  const [isHovered, setIsHovered] = useState(false)
-  const hoverTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+export const WelcomeScreen = ({ messages }: WelcomeScreenProps) => {
+  const [index, setIndex] = useState(0)
+  const [chars, setChars] = useState(0)
+  const [phase, setPhase] = useState<Phase>("starting")
+  const current = messages[index] ?? ""
 
-  const handleMouseEnter = useCallback(() => {
-    hoverTimeout.current = setTimeout(() => setIsHovered(true), 80)
-  }, [])
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined
 
-  const handleMouseLeave = useCallback(() => {
-    if (hoverTimeout.current) clearTimeout(hoverTimeout.current)
-    setIsHovered(false)
-  }, [])
+    if (phase === "starting") {
+      timer = setTimeout(() => setPhase("writing"), START_DELAY_MS)
+    } else if (phase === "writing") {
+      if (chars < current.length) {
+        timer = setTimeout(() => setChars((c) => c + 1), CHAR_IN_MS)
+      } else {
+        setPhase("holding")
+      }
+    } else if (phase === "holding") {
+      if (messages.length <= 1) return
+      timer = setTimeout(() => setPhase("erasing"), HOLD_MS)
+    } else if (phase === "erasing") {
+      if (chars > 0) {
+        timer = setTimeout(() => setChars((c) => c - 1), CHAR_OUT_MS)
+      } else {
+        timer = setTimeout(() => {
+          setIndex((i) => (i + 1) % messages.length)
+          setPhase("starting")
+        }, END_DELAY_MS)
+      }
+    }
+
+    return () => {
+      if (timer) clearTimeout(timer)
+    }
+  }, [phase, chars, current.length, messages.length])
+
+  // Pulse arrives just after the full phrase becomes visible.
+  const pulseDelay = (START_DELAY_MS + current.length * CHAR_IN_MS) / 1000
 
   return (
-    <AnimatePresence mode="popLayout">
-      <motion.div
-        key="welcome"
-        className="flex w-full flex-1 flex-col justify-end gap-6 sm:gap-4"
-        initial={{ opacity: 1 }}
+    <div className="flex w-full flex-1 items-center justify-center px-4">
+      <p
+        key={index}
+        className="bg-gradient-to-r from-[#E55619] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent"
+        style={{ animationDelay: `${pulseDelay}s`, minHeight: 28 }}
+        aria-label={current}
       >
-        <div className="px-1">
-          <motion.div
-            className="flex w-fit justify-center"
-            initial={{ opacity: 0, scale: 0.8, filter: "blur(6px)" }}
-            animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
-            transition={{
-              duration: 0.3,
-              ease: "easeOut",
-              delay: 0.4,
-            }}
-          >
-            <div
-              className={onIconClick ? "relative cursor-pointer" : "relative"}
-              onClick={onIconClick}
-              onMouseEnter={onIconClick ? handleMouseEnter : undefined}
-              onMouseLeave={onIconClick ? handleMouseLeave : undefined}
-            >
-              <motion.div
-                animate={{
-                  opacity: isHovered ? 0 : 1,
-                  scale: isHovered ? 0.6 : 1,
-                }}
-                transition={{ duration: 0.3, ease: "easeInOut" }}
-              >
-                <F0OneIcon spin size="lg" className="my-4" />
-              </motion.div>
-              <motion.div
-                className="absolute inset-0 flex items-center justify-center"
-                initial={{ opacity: 0, scale: 0.4 }}
-                animate={{
-                  opacity: isHovered ? 1 : 0,
-                  scale: isHovered ? 1 : 0.4,
-                }}
-                transition={{ duration: 0.3, ease: "easeOut" }}
-              >
-                <PongBall size={40} className="shadow-lg" />
-              </motion.div>
-            </div>
-          </motion.div>
-          {greeting && (
-            <StreamedText
-              text={greeting}
-              startDelay={GREETING_START_DELAY}
-              className="text-2xl font-semibold leading-[28px] text-f1-foreground-tertiary"
-            />
-          )}
-          {initialMessages.map((message, msgIdx) => {
-            const content =
-              typeof message.content === "string" ? message.content : ""
-            const priorChars =
-              (greeting?.length ?? 0) +
-              initialMessages
-                .slice(0, msgIdx)
-                .reduce(
-                  (sum, m) =>
-                    sum +
-                    (typeof m.content === "string" ? m.content.length : 0),
-                  0
-                )
-            const startDelay =
-              GREETING_START_DELAY +
-              priorChars * STREAM_CHAR_DURATION +
-              STREAM_GAP * (msgIdx + (greeting ? 1 : 0))
-            return (
-              <StreamedText
-                key={message.id}
-                text={content}
-                startDelay={startDelay}
-                className="text-2xl font-semibold leading-[28px] text-f1-foreground"
-              />
-            )
-          })}
-        </div>
-      </motion.div>
-    </AnimatePresence>
+        {current.slice(0, chars)}
+      </p>
+    </div>
   )
 }

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useState } from "react"
+import { useEffect, useState, type KeyboardEvent } from "react"
+
+import { cn } from "@/lib/utils"
 
 const CHAR_IN_MS = 35
 const CHAR_OUT_MS = 22
@@ -8,7 +10,7 @@ const END_DELAY_MS = 220
 
 type Phase = "starting" | "writing" | "holding" | "erasing"
 
-export type WelcomeScreenProps = {
+export interface WelcomeScreenProps {
   /** One or more phrases. With more than one, they rotate in an infinite loop. */
   messages: string[]
   /**
@@ -24,6 +26,17 @@ export const WelcomeScreen = ({ messages, onClick }: WelcomeScreenProps) => {
   const [chars, setChars] = useState(0)
   const [phase, setPhase] = useState<Phase>("starting")
   const current = messages[index] ?? ""
+
+  // Recover from external mutations of `messages` (e.g. host swapping in a
+  // shorter array). Without this, an out-of-range `index` would render a
+  // blank phrase for one full cycle and `(i + 1) % 0` would yield NaN.
+  useEffect(() => {
+    if (messages.length > 0 && index >= messages.length) {
+      setIndex(0)
+      setChars(0)
+      setPhase("starting")
+    }
+  }, [messages.length, index])
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | undefined
@@ -55,12 +68,9 @@ export const WelcomeScreen = ({ messages, onClick }: WelcomeScreenProps) => {
     }
   }, [phase, chars, current.length, messages.length])
 
-  // Pulse arrives just after the full phrase becomes visible.
-  const pulseDelay = (START_DELAY_MS + current.length * CHAR_IN_MS) / 1000
-
   const interactive = !!onClick
   const handleKeyDown = interactive
-    ? (e: React.KeyboardEvent<HTMLParagraphElement>) => {
+    ? (e: KeyboardEvent<HTMLParagraphElement>) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault()
           onClick?.()
@@ -76,13 +86,16 @@ export const WelcomeScreen = ({ messages, onClick }: WelcomeScreenProps) => {
         tabIndex={interactive ? 0 : undefined}
         onClick={onClick}
         onKeyDown={handleKeyDown}
-        className={
-          "bg-gradient-to-r from-[#E55619] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent" +
-          (interactive
-            ? " cursor-pointer transition-transform duration-200 hover:scale-[1.02] focus-visible:scale-[1.02] focus-visible:outline-none motion-reduce:transition-none motion-reduce:hover:scale-100 motion-reduce:focus-visible:scale-100"
-            : "")
-        }
-        style={{ animationDelay: `${pulseDelay}s`, minHeight: 28 }}
+        className={cn(
+          "bg-gradient-to-r from-[#E55619] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent",
+          interactive &&
+            cn(
+              "cursor-pointer transition-transform duration-200",
+              "hover:scale-[1.02] focus-visible:scale-[1.02]",
+              "motion-reduce:transition-none motion-reduce:hover:scale-100 motion-reduce:focus-visible:scale-100"
+            )
+        )}
+        style={{ minHeight: 28 }}
         aria-label={current}
       >
         {current.slice(0, chars)}


### PR DESCRIPTION
## Summary

- **WelcomeScreen** — replace the icon + greeting + initial-message stack with a single centered phrase that has a horizontal orange→lavender gradient. `initialMessage` (string | string[]) now drives an in-place typewriter that writes a phrase, holds it, erases it character-by-character, and rotates to the next one in an infinite loop. Single-phrase usage stays static.
- **Fullscreen layout parity** — the fullscreen welcome was forcing a 50/50 height split between messages and input, which unpinned the textarea and hid the disclaimer. Removed the three special cases that did this (`[&_.copilotKitChat]:flex-1` in `SidebarWindow`, `flex-grow` on the textarea container, and the `!fullscreenWelcome` guard on the disclaimer). Fullscreen now matches sidepanel: textarea pinned at the bottom, disclaimer always visible.
- **ChatSpinner** — redesigned. Pure-JS math (quaternions, 3D projection, color interpolation) in `globeSpinMath.ts` rendered as native `<svg><polygon>` on web. Two-rotation cubic ease-in-out spin, slow precession of the rotation axis so the loop never visually repeats, subtle breathe pulse during the pause, and a brand-color glow halo. Respects `prefers-reduced-motion`. The math file is platform-agnostic and ready for a React Native port — only the polygon renderer needs swapping.

### Breaking changes

- `AiChatProviderProps.greeting` removed.
- `F0AiMessagesContainerProps.greeting` and `onWelcomeIconClick` removed.
- The pong easter egg is no longer reachable through the welcome icon (the icon is gone). `openGame` still lives in the provider for any future entry point.

All consumers within this repo migrated to `initialMessage` (single string or array of strings).

## Test plan

- [ ] Open Storybook → `AI/F0AiChat/Default` (sidepanel): welcome phrase cycles through 5 messages with typewriter in/out, brand gradient, no icon, no greeting.
- [ ] Switch to fullscreen mode: textarea is pinned to the bottom, disclaimer ("One works within your permissions. See more") is visible, welcome cycles centered above.
- [ ] `AI/F0ActionItem/ChatSpinner` stories (`Small`/`Medium`/`Large`/`Hero`/`AllSizes`): globe spins twice per cycle with eased motion, has the breathe + glow, and no jaggies on small sizes thanks to native SVG.
- [ ] `Patterns/ApplicationFrame` stories with AI enabled: welcome typewriter is visible inside the chat panel.
- [ ] Single-phrase usage (e.g., `initialMessage="Hello"`): renders once, no rotation.
- [ ] OS-level Reduce Motion enabled: spinner breathe + glow disabled, spinner itself still rotates (it is the loading indicator).