### PR TITLE
feat(f0compose): flexible accrual rules prototype

### DIFF
--- a/packages/f0compose/checks/runStaticChecks.ts
+++ b/packages/f0compose/checks/runStaticChecks.ts
@@ -10,15 +10,15 @@
  *  - heuristic: arrays inline with > 3 elements should come from @/fixtures
  */
 
-import { parse } from "@babel/parser"
-import traverseDefault from "@babel/traverse"
-import * as t from "@babel/types"
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
-import { extname, join, relative } from "node:path"
+import { parse } from "@babel/parser";
+import traverseDefault from "@babel/traverse";
+import * as t from "@babel/types";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { extname, join, relative } from "node:path";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const traverse: typeof traverseDefault =
-  (traverseDefault as any).default ?? traverseDefault
+  (traverseDefault as any).default ?? traverseDefault;
 
 const ALLOWED_BARE = [
   "react",
@@ -29,73 +29,75 @@ const ALLOWED_BARE = [
   "react-router-dom",
   "@factorialco/f0-react",
   "@factorialco/f0-core",
-] as const
+  "@xyflow/react",
+] as const;
 
 const ALLOWED_PATH_ALIASES = [
   "@/fixtures",
   "@/lib",
   "@/prototypes",
   "@/shell",
-] as const
+  "@/copilot",
+] as const;
 
 const FORBIDDEN_COLOR_PATTERNS = [
   /\b(text|bg|border|ring|fill|stroke|from|to|via)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d+\b/,
   /#[0-9a-fA-F]{3,8}\b/,
-]
+];
 
 const BIG_LIST_COMPONENTS = new Set([
   "OneDataCollection",
   "F0DataChart",
   "F0AnalyticsDashboard",
   "OneCalendar",
-])
+]);
 
 export type Violation = {
-  file: string
-  line: number
-  column: number
-  rule: string
-  message: string
-}
+  file: string;
+  line: number;
+  column: number;
+  rule: string;
+  message: string;
+};
 
 export type CheckResult = {
-  ok: boolean
-  filesChecked: number
-  violations: Violation[]
-}
+  ok: boolean;
+  filesChecked: number;
+  violations: Violation[];
+};
 
 type RegistryShape = {
   components: Array<{
-    name: string
-    props: Array<{ name: string }>
-    propsExtractionIncomplete?: boolean
-  }>
-}
+    name: string;
+    props: Array<{ name: string }>;
+    propsExtractionIncomplete?: boolean;
+  }>;
+};
 
 export function runStaticChecks(
   target: string,
-  registryPath: string
+  registryPath: string,
 ): CheckResult {
-  const registry = loadRegistry(registryPath)
-  const componentNames = new Set(registry.components.map((c) => c.name))
-  const propsByComponent = new Map<string, Set<string>>()
-  const componentsWithIncompleteProps = new Set<string>()
+  const registry = loadRegistry(registryPath);
+  const componentNames = new Set(registry.components.map((c) => c.name));
+  const propsByComponent = new Map<string, Set<string>>();
+  const componentsWithIncompleteProps = new Set<string>();
   for (const c of registry.components) {
-    propsByComponent.set(c.name, new Set(c.props.map((p) => p.name)))
-    if (c.propsExtractionIncomplete) componentsWithIncompleteProps.add(c.name)
+    propsByComponent.set(c.name, new Set(c.props.map((p) => p.name)));
+    if (c.propsExtractionIncomplete) componentsWithIncompleteProps.add(c.name);
   }
 
-  const files = collectFiles(target)
-  const violations: Violation[] = []
+  const files = collectFiles(target);
+  const violations: Violation[] = [];
 
   for (const file of files) {
-    const content = readFileSync(file, "utf8")
-    let ast
+    const content = readFileSync(file, "utf8");
+    let ast;
     try {
       ast = parse(content, {
         sourceType: "module",
         plugins: ["typescript", "jsx", "decorators-legacy"],
-      })
+      });
     } catch (err) {
       violations.push({
         file,
@@ -103,22 +105,22 @@ export function runStaticChecks(
         column: 1,
         rule: "parse-error",
         message: `Failed to parse: ${(err as Error).message}`,
-      })
-      continue
+      });
+      continue;
     }
 
-    const f0ImportedNames = new Set<string>()
+    const f0ImportedNames = new Set<string>();
 
     traverse(ast, {
       ImportDeclaration(path) {
-        const source = path.node.source.value
-        const isRelative = source.startsWith(".") || source.startsWith("/")
+        const source = path.node.source.value;
+        const isRelative = source.startsWith(".") || source.startsWith("/");
         const isBareAllowed = ALLOWED_BARE.some(
-          (a) => source === a || source.startsWith(a + "/")
-        )
+          (a) => source === a || source.startsWith(a + "/"),
+        );
         const isAliasAllowed = ALLOWED_PATH_ALIASES.some(
-          (a) => source === a || source.startsWith(a + "/")
-        )
+          (a) => source === a || source.startsWith(a + "/"),
+        );
         if (!isRelative && !isBareAllowed && !isAliasAllowed) {
           violations.push({
             file,
@@ -128,9 +130,9 @@ export function runStaticChecks(
             message:
               `Import "${source}" is not allowed. Allowed: ` +
               [...ALLOWED_BARE, ...ALLOWED_PATH_ALIASES, "relative paths"].join(
-                ", "
+                ", ",
               ),
-          })
+          });
         }
         if (
           source === "@factorialco/f0-react" ||
@@ -139,7 +141,7 @@ export function runStaticChecks(
           for (const spec of path.node.specifiers) {
             if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported)) {
               if (componentNames.has(spec.imported.name)) {
-                f0ImportedNames.add(spec.local.name)
+                f0ImportedNames.add(spec.local.name);
               }
             }
           }
@@ -154,11 +156,11 @@ export function runStaticChecks(
           rule: "no-any",
           message:
             "Avoid `any`. f0 components are strictly typed; the code you write should be too.",
-        })
+        });
       },
 
       TSAsExpression(path) {
-        const ann = path.node.typeAnnotation
+        const ann = path.node.typeAnnotation;
         if (t.isTSAnyKeyword(ann)) {
           violations.push({
             file,
@@ -166,24 +168,24 @@ export function runStaticChecks(
             column: path.node.loc?.start.column ?? 0,
             rule: "no-as-any",
             message: "`as any` is forbidden — express the real type.",
-          })
+          });
         }
       },
 
       JSXOpeningElement(path) {
-        const nameNode = path.node.name
-        if (!t.isJSXIdentifier(nameNode)) return
-        const localName = nameNode.name
-        if (!f0ImportedNames.has(localName)) return
-        const componentName = componentNames.has(localName) ? localName : null
-        if (!componentName) return
-        if (componentsWithIncompleteProps.has(componentName)) return
-        const known = propsByComponent.get(componentName)
-        if (!known || known.size === 0) return
+        const nameNode = path.node.name;
+        if (!t.isJSXIdentifier(nameNode)) return;
+        const localName = nameNode.name;
+        if (!f0ImportedNames.has(localName)) return;
+        const componentName = componentNames.has(localName) ? localName : null;
+        if (!componentName) return;
+        if (componentsWithIncompleteProps.has(componentName)) return;
+        const known = propsByComponent.get(componentName);
+        if (!known || known.size === 0) return;
         for (const attr of path.node.attributes) {
-          if (!t.isJSXAttribute(attr)) continue
-          if (!t.isJSXIdentifier(attr.name)) continue
-          const propName = attr.name.name
+          if (!t.isJSXAttribute(attr)) continue;
+          if (!t.isJSXIdentifier(attr.name)) continue;
+          const propName = attr.name.name;
           if (
             propName === "key" ||
             propName === "ref" ||
@@ -193,7 +195,7 @@ export function runStaticChecks(
             propName === "style" ||
             propName === "id"
           )
-            continue
+            continue;
           if (!known.has(propName)) {
             violations.push({
               file,
@@ -203,33 +205,33 @@ export function runStaticChecks(
               message:
                 `Prop "${propName}" not found on ${componentName}. ` +
                 `Available: ${[...known].slice(0, 8).join(", ")}${known.size > 8 ? ", ..." : ""}.`,
-            })
+            });
           }
         }
       },
 
       JSXAttribute(path) {
-        if (!t.isJSXIdentifier(path.node.name)) return
-        if (path.node.name.name !== "className") return
-        const value = path.node.value
-        let stringValue: string | null = null
-        if (t.isStringLiteral(value)) stringValue = value.value
+        if (!t.isJSXIdentifier(path.node.name)) return;
+        if (path.node.name.name !== "className") return;
+        const value = path.node.value;
+        let stringValue: string | null = null;
+        if (t.isStringLiteral(value)) stringValue = value.value;
         else if (
           t.isJSXExpressionContainer(value) &&
           (t.isStringLiteral(value.expression) ||
             t.isTemplateLiteral(value.expression))
         ) {
           if (t.isStringLiteral(value.expression)) {
-            stringValue = value.expression.value
+            stringValue = value.expression.value;
           } else {
             stringValue = value.expression.quasis
               .map((q) => q.value.cooked || q.value.raw)
-              .join(" ")
+              .join(" ");
           }
         }
-        if (!stringValue) return
+        if (!stringValue) return;
         for (const pattern of FORBIDDEN_COLOR_PATTERNS) {
-          const m = stringValue.match(pattern)
+          const m = stringValue.match(pattern);
           if (m) {
             violations.push({
               file,
@@ -237,27 +239,27 @@ export function runStaticChecks(
               column: path.node.loc?.start.column ?? 0,
               rule: "no-raw-colors",
               message: `Raw color "${m[0]}" — use f1-* tokens (e.g., text-f1-foreground, bg-f1-background, border-f1-border).`,
-            })
+            });
           }
         }
       },
 
       JSXExpressionContainer(path) {
-        const expr = path.node.expression
-        if (!t.isArrayExpression(expr)) return
-        if (expr.elements.length <= 3) return
-        const parent = path.parent
-        if (!t.isJSXAttribute(parent)) return
+        const expr = path.node.expression;
+        if (!t.isArrayExpression(expr)) return;
+        if (expr.elements.length <= 3) return;
+        const parent = path.parent;
+        if (!t.isJSXAttribute(parent)) return;
         const propName = t.isJSXIdentifier(parent.name)
           ? parent.name.name
-          : null
-        const grandparent = path.parentPath?.parent
-        if (!grandparent || !t.isJSXOpeningElement(grandparent)) return
+          : null;
+        const grandparent = path.parentPath?.parent;
+        if (!grandparent || !t.isJSXOpeningElement(grandparent)) return;
         const compName = t.isJSXIdentifier(grandparent.name)
           ? grandparent.name.name
-          : null
-        if (!compName || !BIG_LIST_COMPONENTS.has(compName)) return
-        if (!propName) return
+          : null;
+        if (!compName || !BIG_LIST_COMPONENTS.has(compName)) return;
+        if (!propName) return;
         violations.push({
           file,
           line: path.node.loc?.start.line ?? 1,
@@ -266,36 +268,36 @@ export function runStaticChecks(
           message:
             `Inline array of ${expr.elements.length} items passed as ${compName}.${propName}. ` +
             `Move to @/fixtures and import — prototypes must use curated mocks.`,
-        })
+        });
       },
-    })
+    });
   }
 
   return {
     ok: violations.length === 0,
     filesChecked: files.length,
     violations,
-  }
+  };
 }
 
 function loadRegistry(registryPath: string): RegistryShape {
   if (!existsSync(registryPath)) {
     throw new Error(
-      `Registry not found at ${registryPath}. Run \`pnpm --filter @factorialco/f0compose generate:manifest\` first.`
-    )
+      `Registry not found at ${registryPath}. Run \`pnpm --filter @factorialco/f0compose generate:manifest\` first.`,
+    );
   }
-  return JSON.parse(readFileSync(registryPath, "utf8")) as RegistryShape
+  return JSON.parse(readFileSync(registryPath, "utf8")) as RegistryShape;
 }
 
 function collectFiles(target: string): string[] {
-  const out: string[] = []
-  const stat = statSync(target)
+  const out: string[] = [];
+  const stat = statSync(target);
   if (stat.isFile()) {
-    if (isProtoFile(target)) out.push(target)
-    return out
+    if (isProtoFile(target)) out.push(target);
+    return out;
   }
-  walk(target, out)
-  return out
+  walk(target, out);
+  return out;
 }
 
 function walk(dir: string, out: string[]): void {
@@ -305,33 +307,35 @@ function walk(dir: string, out: string[]): void {
       name === "__tests__" ||
       name === "__stories__"
     )
-      continue
-    const full = join(dir, name)
-    let s
+      continue;
+    const full = join(dir, name);
+    let s;
     try {
-      s = statSync(full)
+      s = statSync(full);
     } catch {
-      continue
+      continue;
     }
-    if (s.isDirectory()) walk(full, out)
-    else if (s.isFile() && isProtoFile(full)) out.push(full)
+    if (s.isDirectory()) walk(full, out);
+    else if (s.isFile() && isProtoFile(full)) out.push(full);
   }
 }
 
 function isProtoFile(file: string): boolean {
-  const ext = extname(file)
-  return ext === ".ts" || ext === ".tsx"
+  const ext = extname(file);
+  return ext === ".ts" || ext === ".tsx";
 }
 
 export function formatViolations(result: CheckResult, root: string): string {
-  if (result.ok) return `✓ ${result.filesChecked} file(s) checked, no issues.`
+  if (result.ok) return `✓ ${result.filesChecked} file(s) checked, no issues.`;
   const lines = [
     `✗ ${result.violations.length} violation(s) across ${result.filesChecked} file(s):`,
     "",
-  ]
+  ];
   for (const v of result.violations) {
-    lines.push(`  ${relative(root, v.file)}:${v.line}:${v.column}  [${v.rule}]`)
-    lines.push(`    ${v.message}`)
+    lines.push(
+      `  ${relative(root, v.file)}:${v.line}:${v.column}  [${v.rule}]`,
+    );
+    lines.push(`    ${v.message}`);
   }
-  return lines.join("\n")
+  return lines.join("\n");
 }

--- a/packages/f0compose/package.json
+++ b/packages/f0compose/package.json
@@ -28,6 +28,7 @@
     "@copilotkit/react-core": "^1.54.0",
     "@factorialco/f0-core": "workspace:*",
     "@factorialco/f0-react": "workspace:*",
+    "@xyflow/react": "^12.10.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "^6.30.0",

--- a/packages/f0compose/src/prototypes/flexible-accrual/FlexibleAccrual.tsx
+++ b/packages/f0compose/src/prototypes/flexible-accrual/FlexibleAccrual.tsx
@@ -1,0 +1,90 @@
+import { StandardLayout } from "@factorialco/f0-react";
+import {
+  Page,
+  PageHeader,
+  Tabs,
+} from "@factorialco/f0-react/dist/experimental";
+import { useSearchParams } from "react-router-dom";
+
+import type { PrototypeMeta } from "../types";
+import { AuthoringView } from "./authoring/AuthoringView";
+import { EmployeeView } from "./employee/EmployeeView";
+import { SimulateView } from "./simulate/SimulateView";
+
+export const meta: PrototypeMeta = {
+  slug: "flexible-accrual",
+  title: "Flexible Accrual Rules",
+  description:
+    "RFC prototype: AI-powered accrual rule authoring for HR, dry-run simulation with receipt-style breakdowns, and employee balance explainability panel.",
+  category: "Time",
+  module: "time-off",
+  audience: ["admin", "employee"],
+  tags: ["accrual", "time-off", "ai", "simulation", "leave"],
+  createdAt: "2026-05-25",
+  author: "f0compose",
+};
+
+const tabs = [
+  {
+    id: "authoring",
+    label: "Rule Authoring",
+  },
+  {
+    id: "simulate",
+    label: "Simulate",
+  },
+  {
+    id: "employee",
+    label: "Employee View",
+  },
+] as const;
+
+type TabId = (typeof tabs)[number]["id"];
+const VALID_TABS = new Set<string>(tabs.map((t) => t.id));
+
+export default function FlexibleAccrual() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawTab = searchParams.get("tab");
+  const activeTab: TabId =
+    rawTab && VALID_TABS.has(rawTab) ? (rawTab as TabId) : "authoring";
+
+  const setTab = (id: string) => {
+    const next = new URLSearchParams();
+    if (id !== "authoring") next.set("tab", id);
+    setSearchParams(next);
+  };
+
+  const goToSimulate = () => setTab("simulate");
+
+  const tabsWithNav = tabs.map((t) => ({
+    ...t,
+    onClick: () => setTab(t.id),
+  }));
+
+  return (
+    <Page
+      header={
+        <>
+          <PageHeader
+            module={{
+              id: "timeoff",
+              name: "Time Off",
+              href: "/p/flexible-accrual",
+            }}
+            breadcrumbs={[{ id: "accrual-rules", label: "Accrual Rules" }]}
+            actions={[]}
+          />
+          <Tabs key={activeTab} tabs={tabsWithNav} activeTabId={activeTab} />
+        </>
+      }
+    >
+      <StandardLayout>
+        {activeTab === "authoring" && (
+          <AuthoringView onSimulate={goToSimulate} />
+        )}
+        {activeTab === "simulate" && <SimulateView />}
+        {activeTab === "employee" && <EmployeeView />}
+      </StandardLayout>
+    </Page>
+  );
+}

--- a/packages/f0compose/src/prototypes/flexible-accrual/authoring/AuthoringView.tsx
+++ b/packages/f0compose/src/prototypes/flexible-accrual/authoring/AuthoringView.tsx
@@ -1,0 +1,466 @@
+import "@xyflow/react/dist/style.css";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  Handle,
+  Position,
+  type Node,
+  type Edge,
+  type NodeProps,
+} from "@xyflow/react";
+import { F0Box, F0Button, F0Heading, F0Text } from "@factorialco/f0-react";
+import { useAiChat } from "@factorialco/f0-react";
+import { useCopilotAction } from "@/copilot";
+import { useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Custom node components
+// ---------------------------------------------------------------------------
+function StartNode({
+  data,
+}: NodeProps & { data: { label: string; sublabel?: string } }) {
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 2,
+        background: "var(--f1-color-surface-selected)",
+        border: "2px solid var(--f1-color-border-strong)",
+        borderRadius: 24,
+        padding: "8px 24px",
+        minWidth: 220,
+        textAlign: "center",
+      }}
+    >
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+      <span
+        style={{
+          fontWeight: 600,
+          fontSize: 13,
+          color: "var(--f1-color-text-default)",
+        }}
+      >
+        {data.label}
+      </span>
+      {data.sublabel && (
+        <span style={{ fontSize: 11, color: "var(--f1-color-text-subtle)" }}>
+          {data.sublabel}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function DiamondNode({ data }: NodeProps & { data: { label: string } }) {
+  return (
+    <div
+      style={{
+        width: 120,
+        height: 120,
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          transform: "rotate(45deg)",
+          background: "var(--f1-color-surface-default)",
+          border: "2px solid var(--f1-color-border-strong)",
+          borderRadius: 6,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          position: "absolute",
+        }}
+      >
+        <span
+          style={{
+            transform: "rotate(-45deg)",
+            display: "block",
+            textAlign: "center",
+            fontWeight: 600,
+            fontSize: 12,
+            color: "var(--f1-color-text-default)",
+            padding: "0 10px",
+            lineHeight: 1.3,
+            maxWidth: 80,
+          }}
+        >
+          {data.label}
+        </span>
+      </div>
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+    </div>
+  );
+}
+
+function ResultNode({
+  data,
+}: NodeProps & { data: { label: string; sublabel?: string } }) {
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 2,
+        background: "var(--f1-color-surface-subtle)",
+        border: "1px solid var(--f1-color-border-default)",
+        borderRadius: 8,
+        padding: "8px 16px",
+        minWidth: 130,
+        textAlign: "center",
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+      <span
+        style={{
+          fontWeight: 700,
+          fontSize: 14,
+          color: "var(--f1-color-text-default)",
+        }}
+      >
+        {data.label}
+      </span>
+      {data.sublabel && (
+        <span style={{ fontSize: 11, color: "var(--f1-color-text-subtle)" }}>
+          {data.sublabel}
+        </span>
+      )}
+    </div>
+  );
+}
+
+const nodeTypes = {
+  start: StartNode,
+  diamond: DiamondNode,
+  result: ResultNode,
+};
+
+// ---------------------------------------------------------------------------
+// Node / edge definitions
+// ---------------------------------------------------------------------------
+const SEED_NODES: Node[] = [
+  {
+    id: "start",
+    type: "start",
+    position: { x: 0, y: 0 },
+    data: {
+      label: "Employee starts accrual cycle",
+      sublabel: "Hire-anniversary basis",
+    },
+  },
+  {
+    id: "result-base",
+    type: "result",
+    position: { x: 45, y: 130 },
+    data: { label: "26 days", sublabel: "Base entitlement" },
+  },
+];
+
+const SEED_EDGES: Edge[] = [
+  {
+    id: "e-start-base",
+    source: "start",
+    target: "result-base",
+    type: "smoothstep",
+  },
+];
+
+// Full tree — two branches (full-time / part-time), each with three tenure tiers
+const FULL_NODES: Node[] = [
+  {
+    id: "start",
+    type: "start",
+    position: { x: 240, y: 0 },
+    data: {
+      label: "Employee starts accrual cycle",
+      sublabel: "Hire-anniversary basis",
+    },
+  },
+  {
+    id: "contract",
+    type: "diamond",
+    position: { x: 200, y: 110 },
+    data: { label: "Contract type?" },
+  },
+  // Full-time branch
+  {
+    id: "ft-tenure",
+    type: "diamond",
+    position: { x: 20, y: 290 },
+    data: { label: "Tenure?" },
+  },
+  {
+    id: "ft-10",
+    type: "result",
+    position: { x: -120, y: 470 },
+    data: { label: "28 days", sublabel: "Base + 10 yr bonus" },
+  },
+  {
+    id: "ft-5",
+    type: "result",
+    position: { x: 20, y: 470 },
+    data: { label: "27 days", sublabel: "Base + 5 yr bonus" },
+  },
+  {
+    id: "ft-base",
+    type: "result",
+    position: { x: 160, y: 470 },
+    data: { label: "26 days", sublabel: "Base entitlement" },
+  },
+  // Part-time branch
+  {
+    id: "pt-tenure",
+    type: "diamond",
+    position: { x: 440, y: 290 },
+    data: { label: "Tenure?" },
+  },
+  {
+    id: "pt-10",
+    type: "result",
+    position: { x: 300, y: 470 },
+    data: { label: "28 × (h/40)", sublabel: "10 yr, prorated" },
+  },
+  {
+    id: "pt-5",
+    type: "result",
+    position: { x: 440, y: 470 },
+    data: { label: "27 × (h/40)", sublabel: "5 yr, prorated" },
+  },
+  {
+    id: "pt-base",
+    type: "result",
+    position: { x: 580, y: 470 },
+    data: { label: "26 × (h/40)", sublabel: "Base, prorated" },
+  },
+];
+
+const FULL_EDGES: Edge[] = [
+  {
+    id: "e-start-contract",
+    source: "start",
+    target: "contract",
+    type: "smoothstep",
+  },
+  {
+    id: "e-contract-ft",
+    source: "contract",
+    target: "ft-tenure",
+    label: "Full-time (≥ 40 h/wk)",
+    type: "smoothstep",
+  },
+  {
+    id: "e-contract-pt",
+    source: "contract",
+    target: "pt-tenure",
+    label: "Part-time (< 40 h/wk)",
+    type: "smoothstep",
+  },
+  {
+    id: "e-ft-10",
+    source: "ft-tenure",
+    target: "ft-10",
+    label: "≥ 10 years",
+    type: "smoothstep",
+  },
+  {
+    id: "e-ft-5",
+    source: "ft-tenure",
+    target: "ft-5",
+    label: "≥ 5 years",
+    type: "smoothstep",
+  },
+  {
+    id: "e-ft-base",
+    source: "ft-tenure",
+    target: "ft-base",
+    label: "< 5 years",
+    type: "smoothstep",
+  },
+  {
+    id: "e-pt-10",
+    source: "pt-tenure",
+    target: "pt-10",
+    label: "≥ 10 years",
+    type: "smoothstep",
+  },
+  {
+    id: "e-pt-5",
+    source: "pt-tenure",
+    target: "pt-5",
+    label: "≥ 5 years",
+    type: "smoothstep",
+  },
+  {
+    id: "e-pt-base",
+    source: "pt-tenure",
+    target: "pt-base",
+    label: "< 5 years",
+    type: "smoothstep",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Main view
+// ---------------------------------------------------------------------------
+type Props = {
+  onSimulate: () => void;
+};
+
+export function AuthoringView({ onSimulate }: Props) {
+  const { setOpen, setPlaceholders, sendMessage } = useAiChat();
+  const [state, setState] = useState<"empty" | "seed" | "full">("empty");
+
+  // When the real One agent is connected it can call this action to expand the
+  // tree after it has understood the rule description.
+  useCopilotAction({
+    name: "expandAccrualTree",
+    description:
+      "Expand the accrual rule decision tree canvas to show the full compiled rule. Call this after you have understood the user's accrual rule description.",
+    parameters: [],
+    handler: () => {
+      setState("full");
+    },
+  });
+
+  const handleCoCreate = () => {
+    setPlaceholders([
+      "e.g. Italian employees get 26 days/year, +1 day after 5 years tenure…",
+      "e.g. Vacation accrues monthly, hire-date cycle, prorated for part-time…",
+    ]);
+    setOpen(true);
+    setState("seed");
+  };
+
+  // Demo helper — lets reviewers see the full tree without a live agent.
+  const handleDemoExpand = () => {
+    setState("full");
+    sendMessage(
+      "Build me the accrual rule for Italy: 26 days base, +1 day at 5 years tenure, +2 days at 10 years. Part-time employees are prorated by contracted hours.",
+    );
+  };
+
+  // ── Empty state ──────────────────────────────────────────────────────────
+  if (state === "empty") {
+    return (
+      <div
+        style={{
+          border: "2px dashed var(--f1-color-border-default)",
+          borderRadius: 12,
+          padding: 48,
+          minHeight: 320,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 16,
+          textAlign: "center",
+        }}
+      >
+        <F0Heading
+          content="No accrual rule defined"
+          variant="heading"
+          as="h2"
+        />
+        <F0Text
+          content="Describe the policy in plain language and One will compile it into a structured rule."
+          variant="description"
+        />
+        <F0Button label="Co-create with One" onClick={handleCoCreate} />
+      </div>
+    );
+  }
+
+  // ── Seed / full tree canvas ──────────────────────────────────────────────
+  const nodes = state === "seed" ? SEED_NODES : FULL_NODES;
+  const edges = state === "seed" ? SEED_EDGES : FULL_EDGES;
+  const canvasHeight = state === "seed" ? 260 : 600;
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="xl">
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div>
+          <F0Heading content="Vacation · Italy" variant="heading" as="h2" />
+          <F0Text
+            content={
+              state === "seed"
+                ? "Describe the full rule in One to build the decision tree."
+                : "Decision tree compiled by One. Continue editing in the chat."
+            }
+            variant="description"
+          />
+        </div>
+        <div style={{ display: "flex", flexDirection: "row", gap: 8 }}>
+          {state === "seed" && (
+            <F0Button
+              label="Demo: expand tree"
+              variant="neutral"
+              onClick={handleDemoExpand}
+            />
+          )}
+          <F0Button
+            label="Edit with One"
+            variant="outline"
+            onClick={() => setOpen(true)}
+          />
+          {state === "full" && (
+            <>
+              <F0Button
+                label="Simulate"
+                variant="outline"
+                onClick={onSimulate}
+              />
+              <F0Button label="Publish" />
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* ReactFlow canvas */}
+      <div
+        style={{
+          border: "1px solid var(--f1-color-border-default)",
+          borderRadius: 12,
+          overflow: "hidden",
+          height: canvasHeight,
+          background: "var(--f1-color-surface-subtle)",
+          transition: "height 0.3s ease",
+        }}
+      >
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.3 }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          zoomOnScroll={false}
+          panOnDrag={true}
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background gap={16} size={1} />
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      </div>
+    </F0Box>
+  );
+}

--- a/packages/f0compose/src/prototypes/flexible-accrual/employee/EmployeeView.tsx
+++ b/packages/f0compose/src/prototypes/flexible-accrual/employee/EmployeeView.tsx
@@ -1,0 +1,574 @@
+import {
+  F0Box,
+  F0Button,
+  F0Card,
+  F0Heading,
+  F0Text,
+} from "@factorialco/f0-react";
+import { useState } from "react";
+import { timeOffRequests, timeOffBalances, timeOffPolicies } from "@/fixtures";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type LeaveTab = "vacation" | "sick" | "personal" | "parental";
+type PrimitiveTab = "calculator" | "free-text" | "tree";
+
+// ─── Static data ──────────────────────────────────────────────────────────────
+
+const LEAVE_TABS: { id: LeaveTab; label: string }[] = [
+  { id: "vacation", label: "Vacation" },
+  { id: "sick", label: "Sick leave" },
+  { id: "personal", label: "Personal" },
+  { id: "parental", label: "Parental" },
+];
+
+const PRIMITIVE_TABS: { id: PrimitiveTab; label: string }[] = [
+  { id: "calculator", label: "Calculator" },
+  { id: "free-text", label: "Free Text" },
+  { id: "tree", label: "Decision Tree" },
+];
+
+const SNAPSHOT = {
+  base: 26,
+  tenure: 1,
+  total: 27,
+  programVersion: "v3 — published 2026-01-01",
+  freeText:
+    "You accrued 27 days in 2026: 26 days base entitlement plus a 1-day tenure bonus for 6 years of service.",
+};
+
+const TREE_NODES = [
+  {
+    label: "Base entitlement",
+    condition: "All employees",
+    value: "+ 26 days",
+    fired: true,
+  },
+  {
+    label: "Tenure bonus (≥5 yrs)",
+    condition: "tenure ≥ 5 years",
+    value: "+ 1 day",
+    fired: true,
+  },
+  {
+    label: "Tenure bonus (≥10 yrs)",
+    condition: "tenure ≥ 10 years",
+    value: "+ 2 days",
+    fired: false,
+  },
+  {
+    label: "Part-time proration",
+    condition: "hours < 40/wk",
+    value: "× proration",
+    fired: false,
+  },
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const ME = "emp-001";
+
+function formatDate(iso: string) {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function statusColor(status: string): string {
+  if (status === "approved") return "var(--f1-color-text-success)";
+  if (status === "pending") return "var(--f1-color-text-warning)";
+  if (status === "rejected" || status === "cancelled")
+    return "var(--f1-color-text-danger)";
+  return "var(--f1-color-text-default)";
+}
+
+function statusLabel(status: string): string {
+  if (status === "approved") return "Approved";
+  if (status === "pending") return "Pending";
+  if (status === "rejected") return "Rejected";
+  if (status === "cancelled") return "Cancelled";
+  return status;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function ExplainabilityPanel({ onClose }: { onClose: () => void }) {
+  const [activeTab, setActiveTab] = useState<PrimitiveTab>("calculator");
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        right: 0,
+        width: 420,
+        height: "100vh",
+        background: "hsl(var(--page))",
+        borderLeft: "1px solid var(--f1-color-border-default)",
+        boxShadow: "-4px 0 24px rgba(0,0,0,0.12)",
+        display: "flex",
+        flexDirection: "column",
+        zIndex: 100,
+        overflow: "hidden",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: "20px 20px 16px",
+          borderBottom: "1px solid var(--f1-color-border-default)",
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+          }}
+        >
+          <div>
+            <F0Heading
+              content="Why 27 days accrued?"
+              variant="heading"
+              as="h3"
+            />
+            <F0Text
+              content={`Rule: ${SNAPSHOT.programVersion}`}
+              variant="description"
+            />
+          </div>
+          <F0Button label="Close" variant="neutral" onClick={onClose} />
+        </div>
+
+        {/* Tabs */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            gap: 0,
+            borderBottom: "1px solid var(--f1-color-border-default)",
+            marginTop: 8,
+          }}
+        >
+          {PRIMITIVE_TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              style={{
+                padding: "6px 16px",
+                border: "none",
+                borderBottom:
+                  activeTab === tab.id
+                    ? "2px solid var(--f1-color-border-strong)"
+                    : "2px solid transparent",
+                cursor: "pointer",
+                background: "transparent",
+                color:
+                  activeTab === tab.id
+                    ? "var(--f1-color-text-default)"
+                    : "var(--f1-color-text-subtle)",
+                fontFamily: "inherit",
+                fontSize: 13,
+                fontWeight: activeTab === tab.id ? 600 : 400,
+                marginBottom: -1,
+              }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          padding: 20,
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+        }}
+      >
+        {activeTab === "calculator" && (
+          <>
+            {[
+              {
+                label: "Base entitlement",
+                sublabel: "All employees",
+                value: `+${SNAPSHOT.base} days`,
+              },
+              {
+                label: "Tenure bonus (6 yrs service)",
+                sublabel: "≥5 years tier",
+                value: `+${SNAPSHOT.tenure} day`,
+              },
+            ].map((row, i) => (
+              <div
+                key={i}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  padding: "10px 12px",
+                  borderRadius: 8,
+                  background: "var(--f1-color-surface-subtle)",
+                }}
+              >
+                <div>
+                  <F0Text content={row.label} variant="body" />
+                  <F0Text content={row.sublabel} variant="description" />
+                </div>
+                <F0Text content={row.value} variant="label" />
+              </div>
+            ))}
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                padding: "12px 8px",
+                borderTop: "2px solid var(--f1-color-border-strong)",
+                marginTop: 4,
+              }}
+            >
+              <F0Heading content="Total accrued" variant="heading" as="h4" />
+              <F0Heading
+                content={`${SNAPSHOT.total} days`}
+                variant="heading-large"
+                as="h4"
+              />
+            </div>
+            <F0Text
+              content="This calculation is locked to the rule version and employee facts active on the calculation date. Re-running it produces the same result."
+              variant="description"
+            />
+          </>
+        )}
+
+        {activeTab === "free-text" && (
+          <div
+            style={{
+              padding: 16,
+              background: "var(--f1-color-surface-subtle)",
+              borderRadius: 8,
+              borderLeft: "4px solid var(--f1-color-border-strong)",
+            }}
+          >
+            <F0Text content={SNAPSHOT.freeText} variant="body" />
+          </div>
+        )}
+
+        {activeTab === "tree" && (
+          <>
+            <F0Text
+              content="Rules evaluated in order — highlighted rows fired for your profile."
+              variant="description"
+            />
+            {TREE_NODES.map((node, i) => (
+              <div
+                key={i}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: "10px 12px",
+                  borderRadius: 8,
+                  background: node.fired
+                    ? "var(--f1-color-surface-selected)"
+                    : "var(--f1-color-surface-subtle)",
+                  border: node.fired
+                    ? "2px solid var(--f1-color-border-strong)"
+                    : "1px solid var(--f1-color-border-default)",
+                  opacity: node.fired ? 1 : 0.45,
+                }}
+              >
+                <div style={{ flex: 1 }}>
+                  <F0Text content={node.label} variant="label" />
+                  <F0Text content={node.condition} variant="description" />
+                </div>
+                <F0Text content={node.value} variant="label" />
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function EmployeeView() {
+  const [leaveTab, setLeaveTab] = useState<LeaveTab>("vacation");
+  const [panelOpen, setPanelOpen] = useState(false);
+
+  // Derive balance for the selected leave type
+  const myBalance = timeOffBalances.find((b) => b.employeeId === ME);
+  const policyForTab = timeOffPolicies.find((p) => p.type === leaveTab);
+
+  const accrued =
+    leaveTab === "vacation" ? 27 : (policyForTab?.annualDays ?? 0);
+  const taken =
+    leaveTab === "vacation"
+      ? (myBalance?.taken ?? 0)
+      : timeOffRequests
+          .filter(
+            (r) =>
+              r.employeeId === ME &&
+              r.type === leaveTab &&
+              r.status === "approved",
+          )
+          .reduce((s, r) => s + r.workingDays, 0);
+  const pending =
+    leaveTab === "vacation"
+      ? (myBalance?.pending ?? 0)
+      : timeOffRequests
+          .filter(
+            (r) =>
+              r.employeeId === ME &&
+              r.type === leaveTab &&
+              r.status === "pending",
+          )
+          .reduce((s, r) => s + r.workingDays, 0);
+  const available = Math.max(accrued - taken - pending, 0);
+
+  // Requests for selected leave type
+  const myRequests = timeOffRequests
+    .filter((r) => r.employeeId === ME && r.type === leaveTab)
+    .sort(
+      (a, b) =>
+        new Date(b.startDate).getTime() - new Date(a.startDate).getTime(),
+    );
+
+  return (
+    <>
+      {/* ── Page shell ── */}
+      <F0Box display="flex" flexDirection="column" gap="lg">
+        {/* Page header */}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <div>
+            <F0Heading content="My Time Off" variant="heading-large" as="h1" />
+            <F0Text
+              content="Ada Lovelace · Barcelona · hired 4 Mar 2019 (6 yrs)"
+              variant="description"
+            />
+          </div>
+          <F0Button
+            label="New request"
+            variant="primary"
+            onClick={() => undefined}
+          />
+        </div>
+
+        {/* Leave type tabs */}
+        <div
+          style={{
+            display: "flex",
+            borderBottom: "1px solid var(--f1-color-border-default)",
+            gap: 0,
+          }}
+        >
+          {LEAVE_TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setLeaveTab(tab.id)}
+              style={{
+                padding: "8px 20px",
+                border: "none",
+                borderBottom:
+                  leaveTab === tab.id
+                    ? "2px solid var(--f1-color-text-default)"
+                    : "2px solid transparent",
+                cursor: "pointer",
+                background: "transparent",
+                color:
+                  leaveTab === tab.id
+                    ? "var(--f1-color-text-default)"
+                    : "var(--f1-color-text-subtle)",
+                fontFamily: "inherit",
+                fontSize: 14,
+                fontWeight: leaveTab === tab.id ? 600 : 400,
+                marginBottom: -1,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Balance tiles */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(4, 1fr)",
+            gap: 16,
+          }}
+        >
+          {[
+            {
+              id: "accrued",
+              label: "Accrued",
+              value: accrued,
+              sub: "Jan 2026 – Jan 2027",
+              explainer: leaveTab === "vacation",
+            },
+            { id: "taken", label: "Taken", value: taken, sub: "Approved" },
+            {
+              id: "pending",
+              label: "Pending",
+              value: pending,
+              sub: "Awaiting approval",
+            },
+            {
+              id: "available",
+              label: "Available",
+              value: available,
+              sub: "Accrued – taken – pending",
+            },
+          ].map((tile) => (
+            <F0Card key={tile.id}>
+              <div
+                style={{
+                  padding: 20,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 8,
+                }}
+              >
+                <F0Text content={tile.label} variant="label" />
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "baseline",
+                    gap: 6,
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: "2.25rem",
+                      fontWeight: 700,
+                      lineHeight: 1,
+                      color: "var(--f1-color-text-default)",
+                    }}
+                  >
+                    {tile.value}
+                  </span>
+                  <F0Text content="days" variant="description" />
+                </div>
+                <F0Text content={tile.sub} variant="description" />
+                {"explainer" in tile && tile.explainer && (
+                  <div style={{ marginTop: 4 }}>
+                    <F0Button
+                      label="Why this number?"
+                      variant="outline"
+                      onClick={() => setPanelOpen(true)}
+                    />
+                  </div>
+                )}
+              </div>
+            </F0Card>
+          ))}
+        </div>
+
+        {/* Requests list */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <F0Heading content="Requests" variant="heading" as="h2" />
+            <F0Text
+              content={`${myRequests.length} request${myRequests.length !== 1 ? "s" : ""}`}
+              variant="description"
+            />
+          </div>
+
+          {myRequests.length === 0 ? (
+            <F0Card>
+              <div style={{ padding: 32, textAlign: "center" }}>
+                <F0Text
+                  content="No requests for this leave type yet."
+                  variant="description"
+                />
+              </div>
+            </F0Card>
+          ) : (
+            <F0Card>
+              {/* Table header */}
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr 80px 100px",
+                  gap: 8,
+                  padding: "10px 16px",
+                  borderBottom: "1px solid var(--f1-color-border-default)",
+                }}
+              >
+                {["Date range", "Reason", "Days", "Status"].map((h) => (
+                  <F0Text key={h} content={h} variant="label" />
+                ))}
+              </div>
+
+              {/* Rows */}
+              {myRequests.map((r, i) => (
+                <div
+                  key={r.id}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1fr 1fr 80px 100px",
+                    gap: 8,
+                    padding: "12px 16px",
+                    borderBottom:
+                      i < myRequests.length - 1
+                        ? "1px solid var(--f1-color-border-default)"
+                        : "none",
+                    alignItems: "center",
+                  }}
+                >
+                  <div>
+                    <F0Text
+                      content={`${formatDate(r.startDate)} – ${formatDate(r.endDate)}`}
+                      variant="body"
+                    />
+                  </div>
+                  <F0Text content={r.reason ?? "—"} variant="description" />
+                  <F0Text content={`${r.workingDays}d`} variant="body" />
+                  <span
+                    style={{
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: statusColor(r.status),
+                      textTransform: "capitalize",
+                    }}
+                  >
+                    {statusLabel(r.status)}
+                  </span>
+                </div>
+              ))}
+            </F0Card>
+          )}
+        </div>
+      </F0Box>
+
+      {/* ── Explainability side panel ── */}
+      {panelOpen && <ExplainabilityPanel onClose={() => setPanelOpen(false)} />}
+    </>
+  );
+}

--- a/packages/f0compose/src/prototypes/flexible-accrual/simulate/SimulateView.tsx
+++ b/packages/f0compose/src/prototypes/flexible-accrual/simulate/SimulateView.tsx
@@ -1,0 +1,902 @@
+import "@xyflow/react/dist/style.css";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  Handle,
+  Position,
+  type Node,
+  type Edge,
+  type NodeProps,
+} from "@xyflow/react";
+import { F0Box, F0Heading, F0Text } from "@factorialco/f0-react";
+import { useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+type Contract = "full-time" | "part-time";
+type NodeState = "idle" | "active" | "dim";
+
+interface SimulationResult {
+  activeNodes: Set<string>;
+  activeEdges: Set<string>;
+  summary: string;
+}
+
+interface ChatMessage {
+  role: "assistant" | "user";
+  text: string;
+}
+
+// ---------------------------------------------------------------------------
+// Scripted conversation steps
+// ---------------------------------------------------------------------------
+// Step 1: One asks for inputs (shown immediately on mount)
+// Step 2: User types something
+// Step 3: One replies with the trace + tree updates
+//
+// The demo parses the user text client-side and generates step 3 dynamically.
+// ---------------------------------------------------------------------------
+
+const OPENING_MESSAGE: ChatMessage = {
+  role: "assistant",
+  text: 'To simulate this accrual rule I need two things:\n\n**Contract type** — full-time or part-time?\n**Tenure** — how many years has this employee worked?\n\nAnswer in plain text, e.g. "full-time, 7 years".',
+};
+
+// ---------------------------------------------------------------------------
+// Path computation
+// ---------------------------------------------------------------------------
+function computeSimulation(
+  contract: Contract,
+  tenure: number,
+): SimulationResult {
+  const base = 26;
+  const bonus = tenure >= 10 ? 2 : tenure >= 5 ? 1 : 0;
+  const total = base + bonus;
+  const isPartTime = contract === "part-time";
+  const prefix = isPartTime ? "pt" : "ft";
+
+  const activeNodes = new Set([
+    "start",
+    "contract",
+    `${prefix}-tenure`,
+    tenure >= 10
+      ? `${prefix}-10`
+      : tenure >= 5
+        ? `${prefix}-5`
+        : `${prefix}-base`,
+  ]);
+  const activeEdges = new Set([
+    "e-start-contract",
+    isPartTime ? "e-contract-pt" : "e-contract-ft",
+    tenure >= 10
+      ? `e-${prefix}-10`
+      : tenure >= 5
+        ? `e-${prefix}-5`
+        : `e-${prefix}-base`,
+  ]);
+
+  const prorationSuffix = isPartTime ? " × (h/40)" : "";
+  const summary = `**${contract}** · **${tenure} yr${tenure !== 1 ? "s" : ""}** tenure → **${total}${prorationSuffix} days**`;
+
+  return { activeNodes, activeEdges, summary };
+}
+
+function buildReply(
+  contract: Contract,
+  tenure: number,
+  sim: SimulationResult,
+): string {
+  const base = 26;
+  const bonus = tenure >= 10 ? 2 : tenure >= 5 ? 1 : 0;
+  const total = base + bonus;
+  const isPartTime = contract === "part-time";
+  const tierLabel =
+    tenure >= 10
+      ? "10+ years tier — +2 days bonus"
+      : tenure >= 5
+        ? "5+ years tier — +1 day bonus"
+        : "No tenure bonus (under 5 years)";
+
+  void sim; // used for side-effect only (tree update)
+
+  return (
+    `Here's the evaluation:\n\n` +
+    `**Contract:** ${contract}\n` +
+    `**Tenure:** ${tenure} year${tenure !== 1 ? "s" : ""}\n\n` +
+    `Path taken:\n` +
+    `1. Contract type → ${contract}\n` +
+    `2. Tenure check → ${tierLabel}\n\n` +
+    `**Result: ${total}${isPartTime ? " × (h/40)" : ""} days**\n\n` +
+    `The matching path is highlighted in the tree. Try another profile anytime.`
+  );
+}
+
+function parseInput(
+  text: string,
+): { contract: Contract; tenure: number } | null {
+  const lower = text.toLowerCase();
+  const contract: Contract = lower.includes("part") ? "part-time" : "full-time";
+  const match = text.match(/\d+/);
+  if (!match) return null;
+  return { contract, tenure: parseInt(match[0], 10) };
+}
+
+// ---------------------------------------------------------------------------
+// ReactFlow node / edge data
+// ---------------------------------------------------------------------------
+const BASE_NODES: Node[] = [
+  {
+    id: "start",
+    type: "simStart",
+    position: { x: 240, y: 0 },
+    data: {
+      label: "Employee starts accrual cycle",
+      sublabel: "Hire-anniversary basis",
+    },
+  },
+  {
+    id: "contract",
+    type: "simDiamond",
+    position: { x: 200, y: 110 },
+    data: { label: "Contract type?" },
+  },
+  {
+    id: "ft-tenure",
+    type: "simDiamond",
+    position: { x: 20, y: 290 },
+    data: { label: "Tenure?" },
+  },
+  {
+    id: "ft-10",
+    type: "simResult",
+    position: { x: -120, y: 470 },
+    data: { label: "28 days", sublabel: "Base + 10 yr bonus" },
+  },
+  {
+    id: "ft-5",
+    type: "simResult",
+    position: { x: 20, y: 470 },
+    data: { label: "27 days", sublabel: "Base + 5 yr bonus" },
+  },
+  {
+    id: "ft-base",
+    type: "simResult",
+    position: { x: 160, y: 470 },
+    data: { label: "26 days", sublabel: "Base entitlement" },
+  },
+  {
+    id: "pt-tenure",
+    type: "simDiamond",
+    position: { x: 440, y: 290 },
+    data: { label: "Tenure?" },
+  },
+  {
+    id: "pt-10",
+    type: "simResult",
+    position: { x: 300, y: 470 },
+    data: { label: "28 × (h/40)", sublabel: "10 yr, prorated" },
+  },
+  {
+    id: "pt-5",
+    type: "simResult",
+    position: { x: 440, y: 470 },
+    data: { label: "27 × (h/40)", sublabel: "5 yr, prorated" },
+  },
+  {
+    id: "pt-base",
+    type: "simResult",
+    position: { x: 580, y: 470 },
+    data: { label: "26 × (h/40)", sublabel: "Base, prorated" },
+  },
+];
+
+const BASE_EDGES: Edge[] = [
+  {
+    id: "e-start-contract",
+    source: "start",
+    target: "contract",
+    type: "smoothstep",
+  },
+  {
+    id: "e-contract-ft",
+    source: "contract",
+    target: "ft-tenure",
+    label: "Full-time",
+    type: "smoothstep",
+  },
+  {
+    id: "e-contract-pt",
+    source: "contract",
+    target: "pt-tenure",
+    label: "Part-time",
+    type: "smoothstep",
+  },
+  {
+    id: "e-ft-10",
+    source: "ft-tenure",
+    target: "ft-10",
+    label: ">= 10 yrs",
+    type: "smoothstep",
+  },
+  {
+    id: "e-ft-5",
+    source: "ft-tenure",
+    target: "ft-5",
+    label: ">= 5 yrs",
+    type: "smoothstep",
+  },
+  {
+    id: "e-ft-base",
+    source: "ft-tenure",
+    target: "ft-base",
+    label: "< 5 yrs",
+    type: "smoothstep",
+  },
+  {
+    id: "e-pt-10",
+    source: "pt-tenure",
+    target: "pt-10",
+    label: ">= 10 yrs",
+    type: "smoothstep",
+  },
+  {
+    id: "e-pt-5",
+    source: "pt-tenure",
+    target: "pt-5",
+    label: ">= 5 yrs",
+    type: "smoothstep",
+  },
+  {
+    id: "e-pt-base",
+    source: "pt-tenure",
+    target: "pt-base",
+    label: "< 5 yrs",
+    type: "smoothstep",
+  },
+];
+
+function applyHighlight(sim: SimulationResult | null): {
+  nodes: Node[];
+  edges: Edge[];
+} {
+  if (!sim) return { nodes: BASE_NODES, edges: BASE_EDGES };
+  return {
+    nodes: BASE_NODES.map((n) => ({
+      ...n,
+      data: {
+        ...n.data,
+        state: (sim.activeNodes.has(n.id) ? "active" : "dim") as NodeState,
+      },
+    })),
+    edges: BASE_EDGES.map((e) => ({
+      ...e,
+      animated: sim.activeEdges.has(e.id),
+      style: sim.activeEdges.has(e.id)
+        ? { strokeWidth: 3, opacity: 1 }
+        : { opacity: 0.15 },
+      labelStyle: sim.activeEdges.has(e.id)
+        ? { fontWeight: 700, fontSize: 11 }
+        : { opacity: 0.25, fontSize: 11 },
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Custom ReactFlow node components
+// ---------------------------------------------------------------------------
+const TR = "opacity 0.35s ease";
+
+function SimStartNode({
+  data,
+}: NodeProps & {
+  data: { label: string; sublabel?: string; state?: NodeState };
+}) {
+  const active = data.state === "active";
+  return (
+    <div
+      style={{
+        opacity: data.state === "dim" ? 0.25 : 1,
+        transition: TR,
+        display: "inline-flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 2,
+        background: active
+          ? "hsl(var(--positive-50) / 0.12)"
+          : "hsl(var(--selected-50) / 0.1)",
+        border: `2px solid ${active ? "hsl(var(--positive-50))" : "hsl(var(--neutral-30))"}`,
+        borderRadius: 24,
+        padding: "8px 24px",
+        minWidth: 220,
+        textAlign: "center",
+      }}
+    >
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+      <span
+        style={{
+          fontWeight: 600,
+          fontSize: 13,
+          color: "hsl(var(--neutral-100))",
+        }}
+      >
+        {data.label}
+      </span>
+      {data.sublabel && (
+        <span style={{ fontSize: 11, color: "hsl(var(--neutral-50))" }}>
+          {data.sublabel}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function SimDiamondNode({
+  data,
+}: NodeProps & { data: { label: string; state?: NodeState } }) {
+  const active = data.state === "active";
+  return (
+    <div
+      style={{
+        opacity: data.state === "dim" ? 0.25 : 1,
+        transition: TR,
+        width: 120,
+        height: 120,
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          transform: "rotate(45deg)",
+          background: active
+            ? "hsl(var(--positive-50) / 0.12)"
+            : "hsl(var(--neutral-0))",
+          border: `2px solid ${active ? "hsl(var(--positive-50))" : "hsl(var(--neutral-30))"}`,
+          borderRadius: 6,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          position: "absolute",
+        }}
+      >
+        <span
+          style={{
+            transform: "rotate(-45deg)",
+            display: "block",
+            textAlign: "center",
+            fontWeight: 600,
+            fontSize: 12,
+            color: "hsl(var(--neutral-100))",
+            padding: "0 10px",
+            lineHeight: 1.3,
+            maxWidth: 80,
+          }}
+        >
+          {data.label}
+        </span>
+      </div>
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+    </div>
+  );
+}
+
+function SimResultNode({
+  data,
+}: NodeProps & {
+  data: { label: string; sublabel?: string; state?: NodeState };
+}) {
+  const active = data.state === "active";
+  return (
+    <div
+      style={{
+        opacity: data.state === "dim" ? 0.25 : 1,
+        transition: TR,
+        display: "inline-flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 2,
+        background: active
+          ? "hsl(var(--positive-50) / 0.12)"
+          : "hsl(var(--neutral-5))",
+        border: `${active ? 2 : 1}px solid ${active ? "hsl(var(--positive-50))" : "hsl(var(--neutral-10))"}`,
+        borderRadius: 8,
+        padding: "8px 16px",
+        minWidth: 130,
+        textAlign: "center",
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+      <span
+        style={{
+          fontWeight: 700,
+          fontSize: 14,
+          color: "hsl(var(--neutral-100))",
+        }}
+      >
+        {data.label}
+      </span>
+      {data.sublabel && (
+        <span style={{ fontSize: 11, color: "hsl(var(--neutral-50))" }}>
+          {data.sublabel}
+        </span>
+      )}
+    </div>
+  );
+}
+
+const nodeTypes = {
+  simStart: SimStartNode,
+  simDiamond: SimDiamondNode,
+  simResult: SimResultNode,
+};
+
+// ---------------------------------------------------------------------------
+// One chat mock — pixel-faithful replica of F0AiChat
+// ---------------------------------------------------------------------------
+
+// Render **bold** markdown inline
+function Md({ text }: { text: string }) {
+  const parts = text.split(/(\*\*[^*]+\*\*)/);
+  return (
+    <>
+      {parts.map((p, i) =>
+        p.startsWith("**") ? (
+          <strong key={i}>{p.slice(2, -2)}</strong>
+        ) : (
+          <span key={i}>{p}</span>
+        ),
+      )}
+    </>
+  );
+}
+
+// One logo SVG (gradient circle matching the real logo)
+function OneLogo({ size = 24 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+      <circle cx="16" cy="16" r="16" fill="url(#oneGrad)" />
+      <defs>
+        <radialGradient id="oneGrad" cx="30%" cy="30%" r="80%">
+          <stop offset="0%" stopColor="#E57373" />
+          <stop offset="50%" stopColor="#9575CD" />
+          <stop offset="100%" stopColor="#E51943" />
+        </radialGradient>
+      </defs>
+      <circle cx="16" cy="16" r="6" fill="white" fillOpacity="0.9" />
+      <circle cx="16" cy="16" r="3" fill="url(#oneGrad)" />
+    </svg>
+  );
+}
+
+function ThinkingDots() {
+  return (
+    <div style={{ display: "flex", gap: 4, padding: "4px 0" }}>
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: "50%",
+            background: "hsl(var(--neutral-40))",
+            animation: `oneDot 1.2s ease-in-out ${i * 0.2}s infinite`,
+          }}
+        />
+      ))}
+      <style>{`
+        @keyframes oneDot {
+          0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+          40% { opacity: 1; transform: scale(1); }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function OneChat({
+  messages,
+  thinking,
+  input,
+  onInput,
+  onSend,
+}: {
+  messages: ChatMessage[];
+  thinking: boolean;
+  input: string;
+  onInput: (v: string) => void;
+  onSend: () => void;
+}) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, thinking]);
+
+  const canSend = input.trim().length > 0 && !thinking;
+
+  return (
+    <div
+      style={{
+        width: 360,
+        flexShrink: 0,
+        display: "flex",
+        flexDirection: "column",
+        height: 620,
+        // Panel: bg-f1-special-page = hsl(var(--page))
+        background: "hsl(var(--page))",
+        border: "1px solid hsl(var(--neutral-10))",
+        borderRadius: 12,
+        overflow: "hidden",
+        boxShadow: "0 4px 24px rgba(0,0,0,0.08)",
+      }}
+    >
+      {/* ── Header ── */}
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          padding: "10px 12px 10px 14px",
+          borderBottom: "1px solid hsl(var(--neutral-10))",
+          background: "hsl(var(--page))",
+        }}
+      >
+        {/* Thread title (mimics "New conversation" with chevron) */}
+        <div
+          style={{ display: "flex", alignItems: "center", gap: 4, minWidth: 0 }}
+        >
+          <span
+            style={{
+              fontSize: 14,
+              fontWeight: 500,
+              color: "hsl(var(--neutral-100))",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            New conversation
+          </span>
+          <span style={{ fontSize: 10, color: "hsl(var(--neutral-40))" }}>
+            ▾
+          </span>
+        </div>
+        {/* Right icons */}
+        <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
+          {/* Expand icon */}
+          <button
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              padding: 6,
+              borderRadius: 6,
+              color: "hsl(var(--neutral-50))",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M10 2h4v4M6 14H2v-4M14 2l-5 5M2 14l5-5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+          {/* Close icon */}
+          <button
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              padding: 6,
+              borderRadius: 6,
+              color: "hsl(var(--neutral-50))",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M2 2l12 12M14 2L2 14"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </header>
+
+      {/* ── Messages ── */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          padding: "16px 16px 8px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 24,
+          scrollbarWidth: "thin",
+          scrollbarColor: "transparent transparent",
+        }}
+      >
+        {messages.map((msg, i) => (
+          <div key={i}>
+            {msg.role === "assistant" ? (
+              // Assistant: no bubble, left-aligned, preceded by logo
+              <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <OneLogo size={20} />
+                  <span
+                    style={{
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: "hsl(var(--neutral-50))",
+                    }}
+                  >
+                    One
+                  </span>
+                </div>
+                <div
+                  style={{
+                    fontSize: 14,
+                    lineHeight: 1.6,
+                    color: "hsl(var(--neutral-100))",
+                    whiteSpace: "pre-wrap",
+                    paddingLeft: 28,
+                  }}
+                >
+                  <Md text={msg.text} />
+                </div>
+              </div>
+            ) : (
+              // User: right-aligned bubble — bg-f1-background-tertiary
+              <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                <div
+                  style={{
+                    maxWidth: "90%",
+                    background: "hsl(var(--neutral-5))",
+                    border: "1px solid hsl(var(--neutral-10))",
+                    borderRadius: 16,
+                    padding: "10px 14px",
+                    fontSize: 14,
+                    lineHeight: 1.5,
+                    color: "hsl(var(--neutral-100))",
+                    whiteSpace: "pre-wrap",
+                  }}
+                >
+                  <Md text={msg.text} />
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+
+        {/* Thinking indicator */}
+        {thinking && (
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <OneLogo size={20} />
+              <span
+                style={{
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: "hsl(var(--neutral-50))",
+                }}
+              >
+                One
+              </span>
+            </div>
+            <div style={{ paddingLeft: 28 }}>
+              <ThinkingDots />
+            </div>
+          </div>
+        )}
+
+        <div ref={bottomRef} />
+      </div>
+
+      {/* ── Input ── */}
+      <div style={{ padding: "8px 16px 16px" }}>
+        {/* Textarea form — mimics the conic-gradient focus border */}
+        <div
+          style={{
+            border: "1px solid hsl(var(--neutral-30))",
+            borderRadius: 8,
+            background: "hsl(var(--neutral-0))",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <textarea
+            ref={textareaRef}
+            rows={2}
+            value={input}
+            onChange={(e) => onInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                onSend();
+              }
+            }}
+            placeholder={thinking ? "One is thinking…" : "Message One"}
+            style={{
+              resize: "none",
+              border: "none",
+              outline: "none",
+              background: "transparent",
+              padding: "12px 12px 4px",
+              fontFamily: "inherit",
+              fontSize: 14,
+              lineHeight: "20px",
+              color: "hsl(var(--neutral-100))",
+              width: "100%",
+              boxSizing: "border-box",
+            }}
+          />
+          {/* Action bar */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              alignItems: "center",
+              padding: "4px 8px 8px",
+            }}
+          >
+            <button
+              onClick={onSend}
+              disabled={!canSend}
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: 6,
+                border: "none",
+                cursor: canSend ? "pointer" : "default",
+                background: canSend
+                  ? "hsl(var(--neutral-100))"
+                  : "hsl(var(--neutral-10))",
+                color: canSend
+                  ? "hsl(var(--neutral-0))"
+                  : "hsl(var(--neutral-40))",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                transition: "background 0.15s, color 0.15s",
+              }}
+            >
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                <path
+                  d="M8 13V3M3 8l5-5 5 5"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main view
+// ---------------------------------------------------------------------------
+export function SimulateView() {
+  const [sim, setSim] = useState<SimulationResult | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([OPENING_MESSAGE]);
+  const [input, setInput] = useState("");
+  const [thinking, setThinking] = useState(false);
+
+  const handleSend = () => {
+    const text = input.trim();
+    if (!text || thinking) return;
+    setInput("");
+    setMessages((prev) => [...prev, { role: "user", text }]);
+    setThinking(true);
+
+    setTimeout(() => {
+      const parsed = parseInput(text);
+      if (!parsed) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: "assistant",
+            text: 'I need a tenure number too. Try something like "full-time, 7 years" or "part-time, 3 years".',
+          },
+        ]);
+      } else {
+        const result = computeSimulation(parsed.contract, parsed.tenure);
+        setSim(result);
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: "assistant",
+            text: buildReply(parsed.contract, parsed.tenure, result),
+          },
+        ]);
+      }
+      setThinking(false);
+    }, 900);
+  };
+
+  const { nodes, edges } = applyHighlight(sim);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        gap: 20,
+        alignItems: "flex-start",
+      }}
+    >
+      {/* Decision tree */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <F0Box display="flex" flexDirection="column" gap="sm">
+          <F0Heading
+            content="Vacation · Italy — decision tree"
+            variant="heading"
+            as="h2"
+          />
+          <F0Text
+            content={
+              sim
+                ? sim.summary
+                : "Answer One on the right — the matching path will light up."
+            }
+            variant="description"
+          />
+          <div
+            style={{
+              border: "1px solid hsl(var(--neutral-10))",
+              borderRadius: 12,
+              overflow: "hidden",
+              height: 560,
+              background: "hsl(var(--neutral-5))",
+            }}
+          >
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              nodeTypes={nodeTypes}
+              fitView
+              fitViewOptions={{ padding: 0.3 }}
+              nodesDraggable={false}
+              nodesConnectable={false}
+              elementsSelectable={false}
+              zoomOnScroll={false}
+              panOnDrag={true}
+              proOptions={{ hideAttribution: true }}
+            >
+              <Background gap={16} size={1} />
+              <Controls showInteractive={false} />
+            </ReactFlow>
+          </div>
+        </F0Box>
+      </div>
+
+      {/* One chat mock */}
+      <OneChat
+        messages={messages}
+        thinking={thinking}
+        input={input}
+        onInput={setInput}
+        onSend={handleSend}
+      />
+    </div>
+  );
+}

--- a/packages/f0compose/vite-plugins/allowlist.ts
+++ b/packages/f0compose/vite-plugins/allowlist.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "vite"
+import type { Plugin } from "vite";
 
 /**
  * Allowlist resolver for prototype files. Hard-constrains imports under
@@ -24,28 +24,30 @@ const ALLOWED_BARE = new Set([
   // Zod is the schema language used by F0Form (`f0FormField` wraps a Zod
   // schema). Prototypes that build co-created forms need it directly.
   "zod",
-])
+  // ReactFlow for interactive node/edge diagrams (decision trees, workflows).
+  "@xyflow/react",
+]);
 
 export function allowlistPlugin(): Plugin {
   return {
     name: "f0compose:allowlist",
     enforce: "pre",
     resolveId(source, importer) {
-      if (!importer) return null
+      if (!importer) return null;
       // Only police prototype files.
-      if (!importer.includes("/src/prototypes/")) return null
+      if (!importer.includes("/src/prototypes/")) return null;
       // Vite/HMR internals.
-      if (source.startsWith("/@") || source.startsWith("\0")) return null
+      if (source.startsWith("/@") || source.startsWith("\0")) return null;
       // Relative + absolute paths within the project.
-      if (source.startsWith(".") || source.startsWith("/")) return null
+      if (source.startsWith(".") || source.startsWith("/")) return null;
       // The @/ alias is allowed (e.g., @/fixtures, @/lib, @/shell).
       // We allow ALL @/ subpaths because Vite's alias is internal to the
       // app; the static check is more granular.
-      if (source.startsWith("@/")) return null
+      if (source.startsWith("@/")) return null;
       // Anything in the bare allowlist or its sub-paths (e.g., f0-react/icons/app).
-      if (ALLOWED_BARE.has(source)) return null
+      if (ALLOWED_BARE.has(source)) return null;
       for (const allowed of ALLOWED_BARE) {
-        if (source.startsWith(allowed + "/")) return null
+        if (source.startsWith(allowed + "/")) return null;
       }
       throw new Error(
         `[f0compose] Blocked import: "${source}" in ${importer}.\n` +
@@ -54,8 +56,8 @@ export function allowlistPlugin(): Plugin {
           `    - @/fixtures, @/lib, @/prototypes (path alias)\n` +
           `    - relative paths\n` +
           `  Use the equivalent f0 component instead. ` +
-          `Read packages/f0compose/generated/registry.json for what's available.`
-      )
+          `Read packages/f0compose/generated/registry.json for what's available.`,
+      );
     },
-  }
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@factorialco/f0-react':
         specifier: workspace:*
         version: link:../react
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -5977,6 +5980,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -6278,12 +6282,22 @@ packages:
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -6722,7 +6736,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -7006,6 +7020,9 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -11923,6 +11940,7 @@ packages:
   recharts@2.15.0:
     resolution: {integrity: sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
@@ -13809,6 +13827,21 @@ packages:
 
   zrender@6.0.0:
     resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': 18.3.18
+      immer: '>=9.0.6'
+      react: 18.3.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -20894,6 +20927,29 @@ snapshots:
   '@xtuc/long@4.2.2':
     optional: true
 
+  '@xyflow/react@12.10.2(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.7(@types/react@18.3.18)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   JSONStream@1.3.5:
     dependencies:
       jsonparse: 1.3.1
@@ -21717,6 +21773,8 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  classcat@5.0.5: {}
 
   clean-stack@2.2.0: {}
 
@@ -30109,5 +30167,12 @@ snapshots:
   zrender@6.0.0:
     dependencies:
       tslib: 2.3.0
+
+  zustand@4.5.7(@types/react@18.3.18)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      react: 18.3.1
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Interactive prototype for the RFC Flexible Accrual Rules covering three user flows:
- Rule Authoring: ReactFlow decision tree canvas with 3 build states (empty → seed → full), custom node types with handles, Co-create with One opens native AI chat panel, demo expand-tree mode
- Simulate: fully mocked One chat panel (pixel-faithful) on the right + ReactFlow path highlighting on the left — zero backend calls
- Employee View: mocked Factorial Time Off page with leave type tabs, 4 balance tiles, request history table, and Why this number? panel Also adds @xyflow/react dependency and allowlist entries.

## Description

<!-- Provide a brief summary of the changes (e.g., "Add new Button component to experimental" or "Promote Card component to stable"). Describe what this PR does and why it's needed -->

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
