### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.20.0",
+  "packages/react": "2.20.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.20.1](https://github.com/factorialco/f0/compare/f0-react-v2.20.0...f0-react-v2.20.1) (2026-05-27)
+
+
+### Bug Fixes
+
+* preserve default values fn in available form definition conversion ([#4179](https://github.com/factorialco/f0/issues/4179)) ([0f1f69b](https://github.com/factorialco/f0/commit/0f1f69b5b5ff5b216ccb1a5dd0eb1963a7f78479))
+
 ## [2.20.0](https://github.com/factorialco/f0/compare/f0-react-v2.19.1...f0-react-v2.20.0) (2026-05-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.20.1</summary>

## [2.20.1](https://github.com/factorialco/f0/compare/f0-react-v2.20.0...f0-react-v2.20.1) (2026-05-27)


### Bug Fixes

* preserve default values fn in available form definition conversion ([#4179](https://github.com/factorialco/f0/issues/4179)) ([0f1f69b](https://github.com/factorialco/f0/commit/0f1f69b5b5ff5b216ccb1a5dd0eb1963a7f78479))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).