### PR TITLE
docs: add example FeatureGrid to CRUD pattern operation pages

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/create/create.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/create/create.mdx
@@ -54,14 +54,14 @@ the task.
       },
       {
         icon: Kanban,
-        title: "Kanban Lane",
+        title: "Kanban — Lane",
         description:
           "Lane create action creates a resource already scoped to the selected workflow state.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-create--kanban-create-lane",
       },
       {
         icon: Pencil,
-        title: "Editable Table Add Row",
+        title: "Editable Table — Add Row",
         description:
           "Inline add-row action creates a lightweight row directly in the table.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-create--editable-table-create-row",

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/create/create.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/create/create.mdx
@@ -1,5 +1,7 @@
 import { Meta, Unstyled } from "@storybook/addon-docs/blocks"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import { FeatureGrid } from "~/docs/components/FeatureGrid"
+import { Table, List, Kanban, Pencil, Add } from "@/icons/app"
 
 import * as Stories from "./create.stories"
 
@@ -11,6 +13,62 @@ Create is the entry point for adding a new resource from a Data Collection. The
 collection toolbar should expose the action, and the chosen container should
 match the amount of guidance, structure, and time the user needs to complete
 the task.
+
+## Examples
+
+<Unstyled>
+  <FeatureGrid
+    features={[
+      {
+        icon: Table,
+        title: "Table — Default",
+        description:
+          "Collection primary action triggers a default create dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-create--table-create-dialog",
+      },
+      {
+        icon: Table,
+        title: "Table — Right Dialog",
+        description:
+          "Collection primary action opens a Right Dialog to keep the collection visible while creating.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-create--table-create-right-dialog",
+      },
+      {
+        icon: List,
+        title: "List — Default",
+        description: "List primary action triggers a default create dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-create--list-create-dialog",
+      },
+      {
+        icon: List,
+        title: "List — Right Dialog",
+        description:
+          "List primary action opens a Right Dialog to keep the list visible while creating.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-create--list-create-right-dialog",
+      },
+      {
+        icon: Add,
+        title: "Wizard Dialog",
+        description: "Collection primary action triggers a Wizard Dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-create--create-wizard-dialog",
+      },
+      {
+        icon: Kanban,
+        title: "Kanban Lane",
+        description:
+          "Lane create action creates a resource already scoped to the selected workflow state.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-create--kanban-create-lane",
+      },
+      {
+        icon: Pencil,
+        title: "Editable Table Add Row",
+        description:
+          "Inline add-row action creates a lightweight row directly in the table.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-create--editable-table-create-row",
+      },
+    ]}
+  />
+</Unstyled>
 
 ## When to use
 
@@ -203,38 +261,8 @@ can be created with defaults and refined inline.
   }}
 />
 
-## Related stories
+## Related documentation
 
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-create--table-create-dialog"
-  >
-    Default Dialog
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-create--table-create-right-dialog"
-  >
-    Right Dialog
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-create--create-wizard-dialog"
-  >
-    Wizard Dialog
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-create--kanban-create-lane"
-  >
-    Kanban Lane Create
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-create--editable-table-create-row"
-  >
-    Editable Table Add Row
-  </a>
 - <a
     target="_parent"
     href="/?path=/docs/patterns-data-collection-crud-patterns-overview--documentation"

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/delete/delete.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/delete/delete.mdx
@@ -19,13 +19,13 @@ step must make the scope and consequence explicit before the user commits.
     features={[
       {
         icon: Table,
-        title: "Table Single",
+        title: "Table — Single",
         description: "Item delete action triggers a Confirmation Dialog.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-delete--table-delete-single",
       },
       {
         icon: Table,
-        title: "Table Bulk",
+        title: "Table — Bulk",
         description:
           "Selection and bulk action trigger a scoped Confirmation Dialog.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-delete--table-delete-bulk",
@@ -38,7 +38,7 @@ step must make the scope and consequence explicit before the user commits.
       },
       {
         icon: Kanban,
-        title: "Kanban Bulk",
+        title: "Kanban — Bulk",
         description:
           "Selected Kanban cards use a scoped destructive Confirmation Dialog.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-delete--kanban-delete-bulk",

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/delete/delete.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/delete/delete.mdx
@@ -1,5 +1,7 @@
 import { Meta, Unstyled } from "@storybook/addon-docs/blocks"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import { FeatureGrid } from "~/docs/components/FeatureGrid"
+import { Table, CardPin, Kanban, Pencil } from "@/icons/app"
 
 import * as Stories from "./delete.stories"
 
@@ -9,6 +11,48 @@ import * as Stories from "./delete.stories"
 
 Delete patterns cover destructive actions in a Data Collection. The confirmation
 step must make the scope and consequence explicit before the user commits.
+
+## Examples
+
+<Unstyled>
+  <FeatureGrid
+    features={[
+      {
+        icon: Table,
+        title: "Table Single",
+        description: "Item delete action triggers a Confirmation Dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-delete--table-delete-single",
+      },
+      {
+        icon: Table,
+        title: "Table Bulk",
+        description:
+          "Selection and bulk action trigger a scoped Confirmation Dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-delete--table-delete-bulk",
+      },
+      {
+        icon: CardPin,
+        title: "Card",
+        description: "Card item action triggers a Confirmation Dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-delete--card-delete",
+      },
+      {
+        icon: Kanban,
+        title: "Kanban Bulk",
+        description:
+          "Selected Kanban cards use a scoped destructive Confirmation Dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-delete--kanban-delete-bulk",
+      },
+      {
+        icon: Pencil,
+        title: "Editable Table",
+        description:
+          "Editable Table row dropdown action triggers a Confirmation Dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-delete--editable-table-delete-row-action",
+      },
+    ]}
+  />
+</Unstyled>
 
 ## When to use
 
@@ -194,38 +238,8 @@ delete separate from editable cell interactions.
   }}
 />
 
-## Related stories
+## Related documentation
 
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-delete--table-delete-single"
-  >
-    Table Single Delete
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-delete--table-delete-bulk"
-  >
-    Table Bulk Delete
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-delete--card-delete"
-  >
-    Card Delete
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-delete--editable-table-delete-row-action"
-  >
-    Editable Table Delete
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-delete--kanban-delete-bulk"
-  >
-    Kanban Bulk Delete
-  </a>
 - <a
     target="_parent"
     href="/?path=/docs/patterns-data-collection-crud-patterns-overview--documentation"

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.mdx
@@ -1,5 +1,7 @@
 import { Meta, Unstyled } from "@storybook/addon-docs/blocks"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import { FeatureGrid } from "~/docs/components/FeatureGrid"
+import { Table, List, CardPin, Kanban } from "@/icons/app"
 
 import * as Stories from "./read.stories"
 
@@ -14,6 +16,54 @@ Use the lightest pattern that still gives the resource enough room.
 The stories use a neutral grey content placeholder on purpose, so the example
 focuses on the container pattern rather than implying a specific internal page
 layout.
+
+## Examples
+
+<Unstyled>
+  <FeatureGrid
+    features={[
+      {
+        icon: Table,
+        title: "Table — Default",
+        description: "Clicking an item opens the Default Dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-dialog",
+      },
+      {
+        icon: Table,
+        title: "Table — Dialog to Page",
+        description:
+          "Clicking an item opens a reduced Right Dialog that can lead to a full page when the resource needs a durable destination.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog-to-page",
+      },
+      {
+        icon: Table,
+        title: "Table to Page",
+        description:
+          "Clicking a table row or chevron action routes to a resource page.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page",
+      },
+      {
+        icon: List,
+        title: "List to Page",
+        description:
+          "Clicking a list item or chevron action routes to a resource page.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--list-read-page",
+      },
+      {
+        icon: CardPin,
+        title: "Card to Dialog",
+        description: "Clicking the card opens a focused read dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--card-read-dialog",
+      },
+      {
+        icon: Kanban,
+        title: "Kanban Card to Dialog",
+        description: "Clicking a Kanban card opens a focused read dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--kanban-read-dialog",
+      },
+    ]}
+  />
+</Unstyled>
 
 ## When to use
 
@@ -270,44 +320,8 @@ action for read when both behaviors must coexist.
   }}
 />
 
-## Related stories
+## Related documentation
 
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-dialog"
-  >
-    Default Dialog
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog-to-page"
-  >
-    Dialog to Page
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page"
-  >
-    Table to Page
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-read--list-read-page"
-  >
-    List to Page
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-read--card-read-dialog"
-  >
-    Card to Dialog
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-read--kanban-read-dialog"
-  >
-    Kanban Card to Dialog
-  </a>
 - <a
     target="_parent"
     href="/?path=/docs/patterns-data-collection-crud-patterns-overview--documentation"

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/update/update.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/update/update.mdx
@@ -1,5 +1,7 @@
 import { Meta, Unstyled } from "@storybook/addon-docs/blocks"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import { FeatureGrid } from "~/docs/components/FeatureGrid"
+import { Table, List, CardPin, Kanban, Pencil } from "@/icons/app"
 
 import * as Stories from "./update.stories"
 
@@ -10,6 +12,63 @@ import * as Stories from "./update.stories"
 Update patterns define how a user updates an existing resource from a Data
 Collection. The update flow should usually mirror create so users do not need to
 relearn the form, field order, or terminology when updating the same data.
+
+## Examples
+
+<Unstyled>
+  <FeatureGrid
+    features={[
+      {
+        icon: Table,
+        title: "Table — Default",
+        description:
+          "Reuse the same form structure as create whenever possible.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-update--table-update-dialog",
+      },
+      {
+        icon: Table,
+        title: "Table — Right Dialog",
+        description: "Table variation uses a Right Dialog for editing.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-update--table-update-right-dialog",
+      },
+      {
+        icon: List,
+        title: "List — Right Dialog",
+        description:
+          "List variation keeps the collection visible while editing from the current selection.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-update--list-update-right-dialog",
+      },
+      {
+        icon: Table,
+        title: "Table Bulk",
+        description:
+          "Multi-selection plus a bulk action apply one update flow to the current selection.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-update--table-bulk-update",
+      },
+      {
+        icon: CardPin,
+        title: "Card Actions",
+        description:
+          "Card edit is available from a card item action (ellipsis menu) and from inside the read dialog.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-update--card-update-from-read-dialog",
+      },
+      {
+        icon: Kanban,
+        title: "Kanban Bulk",
+        description:
+          "Selected Kanban cards use the bulk action bar when scope is explicit.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-update--kanban-bulk-update",
+      },
+      {
+        icon: Pencil,
+        title: "Editable Table Inline",
+        description:
+          "Editable cells update fields directly without opening a form.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-update--editable-table-update-inline",
+      },
+    ]}
+  />
+</Unstyled>
 
 ## When to use
 
@@ -238,50 +297,8 @@ reserve dialogs for full-resource updates.
   }}
 />
 
-## Related stories
+## Related documentation
 
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-update--table-update-dialog"
-  >
-    Default Dialog
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-update--table-bulk-update"
-  >
-    Bulk Update
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-update--table-update-right-dialog"
-  >
-    Right Dialog for Table
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-update--list-update-right-dialog"
-  >
-    Right Dialog for List
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-update--card-update-from-read-dialog"
-  >
-    Card Actions Update
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-update--kanban-bulk-update"
-  >
-    Kanban Bulk Update
-  </a>
-- <a
-    target="_parent"
-    href="/?path=/story/patterns-data-collection-crud-patterns-update--editable-table-update-inline"
-  >
-    Editable Table Inline Update
-  </a>
 - <a
     target="_parent"
     href="/?path=/docs/patterns-data-collection-crud-patterns-overview--documentation"

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/update/update.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/update/update.mdx
@@ -40,28 +40,28 @@ relearn the form, field order, or terminology when updating the same data.
       },
       {
         icon: Table,
-        title: "Table Bulk",
+        title: "Table — Bulk",
         description:
           "Multi-selection plus a bulk action apply one update flow to the current selection.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-update--table-bulk-update",
       },
       {
         icon: CardPin,
-        title: "Card Actions",
+        title: "Card — Actions",
         description:
           "Card edit is available from a card item action (ellipsis menu) and from inside the read dialog.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-update--card-update-from-read-dialog",
       },
       {
         icon: Kanban,
-        title: "Kanban Bulk",
+        title: "Kanban — Bulk",
         description:
           "Selected Kanban cards use the bulk action bar when scope is explicit.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-update--kanban-bulk-update",
       },
       {
         icon: Pencil,
-        title: "Editable Table Inline",
+        title: "Editable Table — Inline",
         description:
           "Editable cells update fields directly without opening a form.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-update--editable-table-update-inline",


### PR DESCRIPTION
## Why

In the public Storybook build, `docsMode` collapses each story file into a single Documentation page and hides individual story entries from the sidebar. That means the per-operation CRUD pattern pages (Create, Read, Update, Delete) no longer expose their individual scenario stories — users land on a single Documentation page with no visual entry point into each example.

## What

Adds an `## Examples` section near the top of each per-operation page with a `FeatureGrid` linking to every scenario story, mirroring the pattern already used in `overview.mdx`.

### Per-operation grids

- **Create** — 7 cards (Table / List default + right dialog, Wizard, Kanban Lane, Editable Table Add Row)
- **Read** — 6 cards (Table default / dialog-to-page / page, List to page, Card / Kanban to dialog)
- **Update** — 7 cards (Table / List default + right dialog, Bulk variants, Card actions, Editable Table inline)
- **Delete** — 5 cards (Table single / bulk, Card, Kanban Bulk, Editable Table)

### Other tweaks

- Wrap each `FeatureGrid` in `<Unstyled>` so the inherited docs-theme link underline doesn't bleed into card text (matches the overview page).
- Trim the operation verb from card titles (e.g. `Table Create — Default` → `Table — Default`) since the page heading already scopes them.
- Replace the trailing `Related stories` list with a slim `Related documentation` section containing only cross-doc links (CRUD overview + agnostic principles).

### Out of scope

- `overview.mdx` already uses `FeatureGrid` correctly — untouched.
- `by-view.stories.tsx` keeps `tags: ["!autodocs"]`; overview already covers it.
- No changes to `src/experimental/CrudPatterns/`.