### PR TITLE
chore: remove foundations from some directories as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,5 +3,6 @@
 /packages/react/src/experimental/
 /packages/react/src/kits/
 /packages/react/src/ai/ @factorialco/platform-ai-building-blocks
+/packages/react/src/sds/ai/ @factorialco/platform-ai-building-blocks
 /packages/react/src/sds/UpsellingKit/ @factorialco/product-growth
 /packages/react/src/sds/UpsellingKit/ai/ @factorialco/product-growth @factorialco/platform-ai-building-blocks

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,7 @@
-/packages/react/src/ai/ @factorialco/platform-ai-building-blocks
-/packages/react/src/sds/UpsellingKit @factorialco/product-growth
 * @factorialco/foundations
+/packages/react-native/ @factorialco/mobile
+/packages/react/src/experimental/
+/packages/react/src/kits/
+/packages/react/src/ai/ @factorialco/platform-ai-building-blocks
+/packages/react/src/sds/UpsellingKit/ @factorialco/product-growth
+/packages/react/src/sds/UpsellingKit/ai/ @factorialco/product-growth @factorialco/platform-ai-building-blocks

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 * @factorialco/foundations
 /packages/react-native/ @factorialco/mobile
-/packages/react/src/experimental/
-/packages/react/src/kits/
+/packages/react/src/experimental/ @factorialco/dev
+/packages/react/src/kits/ @factorialco/dev
 /packages/react/src/ai/ @factorialco/platform-ai-building-blocks
 /packages/react/src/sds/ai/ @factorialco/platform-ai-building-blocks
 /packages/react/src/sds/UpsellingKit/ @factorialco/product-growth


### PR DESCRIPTION
### CODEOWNERS state

The CODEOWNERS file now intentionally separates ownership by subtree:

- `*` falls back to `@factorialco/foundations`
- `/packages/react-native/` is owned by `@factorialco/mobile`
- `/packages/react/src/experimental/` has no owners, so it does not request foundations
- `/packages/react/src/kits/` has no owners, so it also does not request foundations
- `/packages/react/src/sds/ai/` is owned by `@factorialco/platform-ai-building-blocks`
- `/packages/react/src/ai/` is owned by `@factorialco/platform-ai-building-blocks`
- `/packages/react/src/sds/UpsellingKit/` is owned by `@factorialco/product-growth`
- `/packages/react/src/sds/UpsellingKit/ai/` is jointly owned by `@factorialco/product-growth` and `@factorialco/platform-ai-building-blocks`

This means experimental and kits paths are excluded from foundations review, while the rest of the repository still uses the default fallback.