### PR TITLE
docs(crud-patterns): add Right Dialog read variant for Table and List

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
@@ -351,6 +351,20 @@ to a page when the resource needs a durable destination.
         <td>
           <a
             target="_parent"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog"
+          >
+            Table Read — Right Dialog
+          </a>
+        </td>
+        <td>
+          Clicking a row opens a Right Dialog while the collection stays
+          visible.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a
+            target="_parent"
             href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog-to-page"
           >
             Table Read — Dialog to Page
@@ -372,6 +386,20 @@ to a page when the resource needs a durable destination.
         </td>
         <td>
           Clicking a table row or chevron action routes to a resource page.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a
+            target="_parent"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--list-read-right-dialog"
+          >
+            List Read — Right Dialog
+          </a>
+        </td>
+        <td>
+          Clicking a list item opens a Right Dialog while the list stays
+          visible.
         </td>
       </tr>
       <tr>

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.mdx
@@ -30,6 +30,13 @@ layout.
       },
       {
         icon: Table,
+        title: "Table — Right Dialog",
+        description:
+          "Clicking a row opens a Right Dialog so the user can read the resource while keeping the collection visible.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog",
+      },
+      {
+        icon: Table,
         title: "Table — Dialog to Page",
         description:
           "Clicking an item opens a reduced Right Dialog that can lead to a full page when the resource needs a durable destination.",
@@ -41,6 +48,13 @@ layout.
         description:
           "Clicking a table row or chevron action routes to a resource page.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page",
+      },
+      {
+        icon: List,
+        title: "List — Right Dialog",
+        description:
+          "Clicking a list item opens a Right Dialog so the user can read the resource while keeping the list visible.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--list-read-right-dialog",
       },
       {
         icon: List,
@@ -68,6 +82,8 @@ layout.
 ## When to use
 
 - Use a Default Dialog for quick inspection and lightweight details.
+- Use a Right Dialog for Table or List reads when keeping the collection visible
+  helps comparison or row-by-row scanning.
 - Use a Dialog to Page flow when the resource starts with a reduced view
   but may expand into a full destination.
 - Use a Table to Page flow when dense tabular scanning still needs a dedicated
@@ -109,6 +125,24 @@ layout.
           Quick read flows with limited content and a short decision loop.
         </td>
         <td>Less room for tabs, dense layouts, or extended workflows.</td>
+      </tr>
+      <tr>
+        <td>
+          <a
+            target="_parent"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog"
+          >
+            Right Dialog
+          </a>
+        </td>
+        <td>
+          Table or List reads where keeping the collection visible helps
+          comparison or scanning.
+        </td>
+        <td>
+          Less focused than a centered dialog; resource must fit comfortably in
+          the right rail.
+        </td>
       </tr>
       <tr>
         <td>
@@ -213,6 +247,10 @@ layout.
         <td>Default Dialog</td>
       </tr>
       <tr>
+        <td>Does reading benefit from keeping nearby rows or items visible?</td>
+        <td>Right Dialog</td>
+      </tr>
+      <tr>
         <td>
           Does the user need a quick preview before deciding to open the full
           page?
@@ -251,6 +289,12 @@ The Default Dialog is the baseline read pattern because it keeps the interaction
 close to the collection and supports fast inspection. It is the right starting
 point until the resource becomes large enough to need its own information
 architecture.
+
+Use a Right Dialog as the final read destination when the resource fits the
+right rail and the user benefits from seeing the collection alongside, for
+example to compare nearby rows in a Table or scan adjacent items in a List.
+Promote to a Dialog to Page flow only when the resource has a durable full-page
+destination.
 
 Use a Dialog to Page flow when the first step should stay anchored to the
 collection, but the resource still deserves a full page for deeper reading,

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
@@ -241,6 +241,45 @@ function OpenAsPageScenario({
   )
 }
 
+function RightDialogScenario({
+  visualization = tableVisualization,
+}: {
+  visualization?: CrudVisualization
+} = {}) {
+  const [selectedResource, setSelectedResource] = useState<Resource | null>(
+    null
+  )
+
+  const source = useDataCollectionSource({
+    dataAdapter: createResourceDataAdapter(initialResources),
+    filters: resourceFilters,
+    itemOnClick: (item) => () => setSelectedResource(item),
+    primaryActions: () => defaultCrudPrimaryAction(() => {}),
+    secondaryActions: defaultCrudSecondaryActions(),
+  })
+
+  return (
+    <CrudPatternLayout>
+      <OneDataCollection source={source} visualizations={[visualization]} />
+      <F0Dialog
+        isOpen={selectedResource !== null}
+        onClose={() => setSelectedResource(null)}
+        title="Resource details"
+        description="Open a reduced view in a Right Dialog, then continue to the full page when deeper exploration is needed."
+        position="right"
+        width="sm"
+        disableContentPadding
+        secondaryAction={{
+          label: "Close",
+          onClick: () => setSelectedResource(null),
+        }}
+      >
+        {selectedResource && <ResourceDialogPreview />}
+      </F0Dialog>
+    </CrudPatternLayout>
+  )
+}
+
 function RightDialogToPageScenario() {
   const [selectedResource, setSelectedResource] = useState<Resource | null>(
     null
@@ -296,12 +335,20 @@ export const TableReadDialog: Story = {
   render: () => <DefaultDialogScenario />,
 }
 
+export const TableReadRightDialog: Story = {
+  render: () => <RightDialogScenario />,
+}
+
 export const TableReadRightDialogToPage: Story = {
   render: () => <RightDialogToPageScenario />,
 }
 
 export const TableReadPage: Story = {
   render: () => <OpenAsPageScenario />,
+}
+
+export const ListReadRightDialog: Story = {
+  render: () => <RightDialogScenario visualization={listVisualization} />,
 }
 
 export const ListReadPage: Story = {


### PR DESCRIPTION
## What

Adds the missing stay-and-read Right Dialog variant to the Read pattern docs for Table and List. Until now the Read page only surfaced Right Dialog as the preview step of the Dialog to Page flow, even though the CRUD overview already listed Right Dialog as a valid Read option when the user benefits from keeping the collection visible.

## Why

The Read documentation was incomplete vs the agnostic CRUD principles. A user reading a row or list item often benefits from keeping the rest of the collection in view (comparison, scanning, context). The existing Default Dialog covers the focused case, and Dialog to Page covers the preview-then-promote case, but the in-between — Right Dialog as the final read destination — was missing.

## Changes

- New stories in `read.stories.tsx`:
  - `TableReadRightDialog` — Right Dialog with no `Open Details` action; dialog is the final destination.
  - `ListReadRightDialog` — same pattern with the List visualization.
  - Both backed by a standalone `RightDialogScenario` (no shared state-machine refactor with `RightDialogToPageScenario`).
- `read.mdx` updates:
  - Two new FeatureGrid cards (`Table — Right Dialog`, `List — Right Dialog`).
  - New When-to-use bullet covering keep-collection-visible reads.
  - New Pattern options row for Right Dialog, between Default Dialog and Dialog to Page.
  - New Decision criteria row ("Does reading benefit from keeping nearby rows or items visible?" → Right Dialog).
  - Guidance paragraph clarifying that Right Dialog can be a final read destination, not only a preview.
- `overview.mdx`: two new Read scenarios so the table mirrors the operation page.

## Scope

- Documentation + Storybook stories only. No production code changes.
- Card, Kanban, and Editable Table reads are unchanged.
- Follow-up to #4248.

## Verification

- `pnpm --filter @factorialco/f0-react run format` — clean.
- `pnpm --filter @factorialco/f0-react run tsc` — only pre-existing `F0Graph` errors (unrelated; missing `@xyflow/react` types).