### PR TITLE
docs(crud-patterns): Right Dialog read variant + Delete-in-ellipsis rule

### DIFF
--- a/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
+++ b/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
@@ -117,6 +117,7 @@ const OTHER_ACTIONS = [
   {
     label: "Delete",
     icon: DeleteIcon,
+    critical: true,
     onClick: () => {},
   },
 ]

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
@@ -43,7 +43,9 @@ export const F0DialogHeader = ({
   const Actions = () => {
     if (!otherActionItems.length || !otherActions) return null
 
-    if (otherActionItems.length <= 2) {
+    const hasCriticalAction = otherActionItems.some((action) => action.critical)
+
+    if (otherActionItems.length <= 2 && !hasCriticalAction) {
       return (
         <div className="flex flex-row gap-2">
           {otherActionItems.map((action) => (

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/delete/delete.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/delete/delete.stories.tsx
@@ -47,6 +47,7 @@ function TableSingleDeleteScenario() {
         label: "Delete",
         icon: Delete,
         critical: true,
+        type: "other",
         onClick: () => setSelectedResource(item),
       },
     ],
@@ -346,7 +347,7 @@ export const CardDelete: Story = {
 }
 
 export const EditableTableDeleteRowAction: Story = {
-  render: () => <EditableTableDeleteScenario actionType="secondary" />,
+  render: () => <EditableTableDeleteScenario actionType="other" />,
 }
 
 export const KanbanDeleteBulk: Story = {

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
@@ -351,6 +351,20 @@ to a page when the resource needs a durable destination.
         <td>
           <a
             target="_parent"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog"
+          >
+            Table Read — Right Dialog
+          </a>
+        </td>
+        <td>
+          Clicking a row opens a Right Dialog while the collection stays
+          visible.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a
+            target="_parent"
             href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog-to-page"
           >
             Table Read — Dialog to Page
@@ -372,6 +386,20 @@ to a page when the resource needs a durable destination.
         </td>
         <td>
           Clicking a table row or chevron action routes to a resource page.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a
+            target="_parent"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--list-read-right-dialog"
+          >
+            List Read — Right Dialog
+          </a>
+        </td>
+        <td>
+          Clicking a list item opens a Right Dialog while the list stays
+          visible.
         </td>
       </tr>
       <tr>

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
@@ -63,6 +63,13 @@ Table mode for field-level updates; most Table rules still apply.
           "Field-level updates that should happen in place. Best for spreadsheet-like flows where opening a form for every edit would slow users down.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-by-view--editable-table",
       },
+      {
+        icon: Table,
+        title: "Page",
+        description:
+          "Clicking a row or item routes directly to the resource page — no dialog preview. Best when the resource is always read on its own page because of persistent navigation, tabs, deeper structure, or page-level actions.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page",
+      },
     ]}
   />
 </Unstyled>

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.mdx
@@ -30,6 +30,13 @@ layout.
       },
       {
         icon: Table,
+        title: "Table — Right Dialog",
+        description:
+          "Clicking a row opens a Right Dialog so the user can read the resource while keeping the collection visible.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog",
+      },
+      {
+        icon: Table,
         title: "Table — Dialog to Page",
         description:
           "Clicking an item opens a reduced Right Dialog that can lead to a full page when the resource needs a durable destination.",
@@ -41,6 +48,13 @@ layout.
         description:
           "Clicking a table row or chevron action routes to a resource page.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page",
+      },
+      {
+        icon: List,
+        title: "List — Right Dialog",
+        description:
+          "Clicking a list item opens a Right Dialog so the user can read the resource while keeping the list visible.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--list-read-right-dialog",
       },
       {
         icon: List,
@@ -68,6 +82,8 @@ layout.
 ## When to use
 
 - Use a Default Dialog for quick inspection and lightweight details.
+- Use a Right Dialog for Table or List reads when keeping the collection visible
+  helps comparison or row-by-row scanning.
 - Use a Dialog to Page flow when the resource starts with a reduced view
   but may expand into a full destination.
 - Use a Table to Page flow when dense tabular scanning still needs a dedicated
@@ -109,6 +125,24 @@ layout.
           Quick read flows with limited content and a short decision loop.
         </td>
         <td>Less room for tabs, dense layouts, or extended workflows.</td>
+      </tr>
+      <tr>
+        <td>
+          <a
+            target="_parent"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog"
+          >
+            Right Dialog
+          </a>
+        </td>
+        <td>
+          Table or List reads where keeping the collection visible helps
+          comparison or scanning.
+        </td>
+        <td>
+          Less focused than a centered dialog; resource must fit comfortably in
+          the right rail.
+        </td>
       </tr>
       <tr>
         <td>
@@ -213,6 +247,10 @@ layout.
         <td>Default Dialog</td>
       </tr>
       <tr>
+        <td>Does reading benefit from keeping nearby rows or items visible?</td>
+        <td>Right Dialog</td>
+      </tr>
+      <tr>
         <td>
           Does the user need a quick preview before deciding to open the full
           page?
@@ -251,6 +289,12 @@ The Default Dialog is the baseline read pattern because it keeps the interaction
 close to the collection and supports fast inspection. It is the right starting
 point until the resource becomes large enough to need its own information
 architecture.
+
+Use a Right Dialog as the final read destination when the resource fits the
+right rail and the user benefits from seeing the collection alongside, for
+example to compare nearby rows in a Table or scan adjacent items in a List.
+Promote to a Dialog to Page flow only when the resource has a durable full-page
+destination.
 
 Use a Dialog to Page flow when the first step should stay anchored to the
 collection, but the resource still deserves a full page for deeper reading,

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
@@ -264,7 +264,9 @@ function RightDialogScenario({
       <F0Dialog
         isOpen={selectedResource !== null}
         onClose={() => setSelectedResource(null)}
+        title="Resource details"
         description="Open details in a Right Dialog so the user can read the resource while keeping the collection visible."
+        position="right"
         width="sm"
         disableContentPadding
         secondaryAction={{

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
@@ -264,9 +264,7 @@ function RightDialogScenario({
       <F0Dialog
         isOpen={selectedResource !== null}
         onClose={() => setSelectedResource(null)}
-        title="Resource details"
-        description="Open a reduced view in a Right Dialog, then continue to the full page when deeper exploration is needed."
-        position="right"
+        description="Open details in a Right Dialog so the user can read the resource while keeping the collection visible."
         width="sm"
         disableContentPadding
         secondaryAction={{

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
@@ -241,6 +241,45 @@ function OpenAsPageScenario({
   )
 }
 
+function RightDialogScenario({
+  visualization = tableVisualization,
+}: {
+  visualization?: CrudVisualization
+} = {}) {
+  const [selectedResource, setSelectedResource] = useState<Resource | null>(
+    null
+  )
+
+  const source = useDataCollectionSource({
+    dataAdapter: createResourceDataAdapter(initialResources),
+    filters: resourceFilters,
+    itemOnClick: (item) => () => setSelectedResource(item),
+    primaryActions: () => defaultCrudPrimaryAction(() => {}),
+    secondaryActions: defaultCrudSecondaryActions(),
+  })
+
+  return (
+    <CrudPatternLayout>
+      <OneDataCollection source={source} visualizations={[visualization]} />
+      <F0Dialog
+        isOpen={selectedResource !== null}
+        onClose={() => setSelectedResource(null)}
+        title="Resource details"
+        description="Open a reduced view in a Right Dialog, then continue to the full page when deeper exploration is needed."
+        position="right"
+        width="sm"
+        disableContentPadding
+        secondaryAction={{
+          label: "Close",
+          onClick: () => setSelectedResource(null),
+        }}
+      >
+        {selectedResource && <ResourceDialogPreview />}
+      </F0Dialog>
+    </CrudPatternLayout>
+  )
+}
+
 function RightDialogToPageScenario() {
   const [selectedResource, setSelectedResource] = useState<Resource | null>(
     null
@@ -296,12 +335,20 @@ export const TableReadDialog: Story = {
   render: () => <DefaultDialogScenario />,
 }
 
+export const TableReadRightDialog: Story = {
+  render: () => <RightDialogScenario />,
+}
+
 export const TableReadRightDialogToPage: Story = {
   render: () => <RightDialogToPageScenario />,
 }
 
 export const TableReadPage: Story = {
   render: () => <OpenAsPageScenario />,
+}
+
+export const ListReadRightDialog: Story = {
+  render: () => <RightDialogScenario visualization={listVisualization} />,
 }
 
 export const ListReadPage: Story = {


### PR DESCRIPTION
## Summary

Three related changes to the CRUD patterns docs and the F0Dialog component, ensuring docs and behaviour line up with the destructive-action rule (\"Delete always sits behind an ellipsis by default\") and giving Read a documented Right Dialog stay-and-read variant.

### 1. Read — Right Dialog variant (`68e89f40e`)

Adds a stay-and-read Right Dialog scenario for Table and List reads. Useful when the user benefits from keeping the collection visible (comparison, row-by-row scanning) and the resource fits comfortably in the right rail.

- `read.stories.tsx`: new \`RightDialogScenario\` (no \`primaryAction\`, reuses existing \"Resource details\" copy); new exports \`TableReadRightDialog\`, \`ListReadRightDialog\`.
- `read.mdx`: 2 new FeatureGrid cards, When-to-use bullet, Pattern options row (between Default Dialog and Dialog to Page), Decision criteria row, clarifying Guidance paragraph.
- `overview.mdx`: 2 new Read scenario rows linking to the new stories.

### 2. CRUD Delete — row Delete always in ellipsis (`08f33ec56`)

Aligns the docs with the destructive-action rule by moving row-level Delete into the ellipsis menu in delete scenarios.

- `delete.stories.tsx`: \`TableSingleDeleteScenario\` row Delete → \`type: \"other\"\`; \`EditableTableDeleteRowAction\` export → \`actionType=\"other\"\`.
- Bulk Delete actions and Delete-confirmation primary CTAs are intentionally out of scope.

### 3. F0Dialog — force ellipsis when otherActions include a critical item (`364dc5b5f`)

\`F0DialogHeader\` previously rendered \`otherActions\` as visible icon buttons whenever there were 1–2 of them, only falling back to an ellipsis dropdown at 3+. This made destructive actions (e.g., Delete with \`critical: true\`) appear as a first-class header affordance — the opposite of the destructive-action rule.

**Behaviour now:**
- 1–2 non-critical actions → visible icon buttons (unchanged).
- Any critical action present → ellipsis dropdown (new), keeping the destructive action intentional rather than visible.

Also:
- \`F0Modal.stories.tsx\`: mark Delete in \`OTHER_ACTIONS\` as \`critical: true\` to reflect the correct semantic and the new rendering.
- \`overview.mdx\`: rename the by-view \"Table to Page\" feature card to \"Page\" for consistency with the other view-named cards (Table, List, Card, Kanban, Editable Table).

## Visual verification (Storybook)

**Delete now behind ellipsis (dialog header):**
- by-view read dialogs: \`patterns-data-collection-crud-patterns-by-view--table|list|card|kanban|editable-table\` → click a row, Edit visible, Delete inside ellipsis.
- Card Delete scenario: \`patterns-data-collection-crud-patterns-delete--card-delete\` → Duplicate visible, Delete inside ellipsis.
- Any F0Dialog story passing a critical otherAction: e.g. \`patterns-f0dialog-f0modal\`.

**New Right Dialog read variant:**
- \`patterns-data-collection-crud-patterns-read--table-read-right-dialog\`
- \`patterns-data-collection-crud-patterns-read--list-read-right-dialog\`

**Card rename:**
- CRUD overview by-view grid: \"Page\" card (previously \"Table to Page\").

## Notes

- The F0DialogHeader change applies to **all** F0Dialog consumers, not just CRUD stories. Any dialog elsewhere passing a \`critical: true\` action in \`otherActions\` will now correctly show it inside an ellipsis. No app-side dialog audit was done as part of this PR.
- No unit tests exist for \`src/patterns/F0Dialog/\`; no new tests were added.
- Pre-existing tsc errors in \`src/patterns/F0Graph/\` are unrelated.

## Validation
- \`pnpm --filter @factorialco/f0-react run format:check\` ✓
- \`pnpm --filter @factorialco/f0-react run lint\` ✓
- \`pnpm --filter @factorialco/f0-react run tsc\` ✓ (only pre-existing F0Graph errors)