### PR TITLE
style(F0AiChat): simplify user message bubble (rounded-xl, no border)

### DIFF
--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/UserMessage.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/UserMessage.tsx
@@ -180,7 +180,7 @@ export const UserMessage = ({
       {hasVisibleText && (
         <div
           ref={bubbleRef}
-          className="w-fit max-w-[90%] self-end whitespace-pre-wrap rounded-2xl border border-solid border-f1-border-secondary bg-f1-background-tertiary px-4 py-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-1"
+          className="w-fit max-w-[90%] self-end whitespace-pre-wrap rounded-xl bg-f1-background-tertiary px-4 py-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-1"
         >
           {(renderMarkdown ?? defaultMarkdownFallback)(content)}
         </div>


### PR DESCRIPTION
## Summary
- Simplify the F0 AI chat user message bubble styling: use `rounded-xl` instead of `rounded-2xl` and remove the border (`border border-solid border-f1-border-secondary`).

## Test plan
- [ ] Storybook: verify the user message bubble appearance (smaller corner radius, no border)