### PR TITLE
feat(F0Box): add boxShadow prop with token-based elevation

### DIFF
--- a/packages/react/src/lib/F0Box/F0Box.tsx
+++ b/packages/react/src/lib/F0Box/F0Box.tsx
@@ -20,6 +20,7 @@ import {
   overflowVariants,
   paddingDefaults,
   paddingVariants,
+  shadowVariants,
   zIndexVariants,
 } from "./utils"
 import {
@@ -42,6 +43,7 @@ const boxVariants = cva({
     ...borderVariants,
     ...overflowVariants,
     ...dividerVariants,
+    ...shadowVariants,
     ...zIndexVariants,
   },
   defaultVariants: {
@@ -138,6 +140,7 @@ export const F0Box = forwardRef<HTMLDivElement, F0BoxProps>(
       // Divider
       divider,
       dividerColor,
+      boxShadow,
       // Flex
       alignItems,
       justifyContent,
@@ -234,6 +237,7 @@ export const F0Box = forwardRef<HTMLDivElement, F0BoxProps>(
             flexWrap,
             grow,
             shrink,
+            boxShadow,
           }),
           responsiveClasses,
           hasBorder && !borderColor && "border-f1-border",

--- a/packages/react/src/lib/F0Box/__stories__/F0Box.stories.tsx
+++ b/packages/react/src/lib/F0Box/__stories__/F0Box.stories.tsx
@@ -286,6 +286,11 @@ const meta = {
     overflow: { control: "select", options: overflowOptions },
     overflowX: { control: "select", options: overflowOptions },
     overflowY: { control: "select", options: overflowOptions },
+    // Shadow
+    boxShadow: {
+      control: "select",
+      options: [undefined, "none", "md", "lg", "xl"],
+    },
     // Divider
     divider: { control: "select", options: [undefined, "x", "y"] },
     dividerColor: { control: "select", options: borderColorOptions },
@@ -2744,6 +2749,36 @@ export const TokenReference: Story = {
                 {b.px}
               </span>
             </F0Box>
+          </F0Box>
+        ))}
+      </F0Box>
+    </F0Box>
+  ),
+}
+
+// ─── Shadow ──────────────────────────────────────────────────────
+
+export const Shadow: Story = {
+  render: () => (
+    <F0Box display="flex" flexDirection="column" gap="xl">
+      <Label subtitle="boxShadow applies elevation using core shadow tokens">
+        Shadow tokens
+      </Label>
+
+      <F0Box display="flex" gap="xl" flexWrap="wrap" alignItems="end">
+        {(["none", "md", "lg", "xl"] as const).map((s) => (
+          <F0Box
+            key={s}
+            width="32"
+            height="24"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            background="primary"
+            borderRadius="md"
+            boxShadow={s}
+          >
+            <span className="text-sm font-semibold">{s}</span>
           </F0Box>
         ))}
       </F0Box>

--- a/packages/react/src/lib/F0Box/index.tsx
+++ b/packages/react/src/lib/F0Box/index.tsx
@@ -12,6 +12,7 @@ export const F0Box = Component(
 export type { F0BoxProps }
 export type {
   AlignItemsToken,
+  BoxShadowToken,
   BackgroundToken,
   BorderColorToken,
   BorderRadiusToken,

--- a/packages/react/src/lib/F0Box/types.ts
+++ b/packages/react/src/lib/F0Box/types.ts
@@ -303,3 +303,5 @@ export type ZIndexToken = "auto" | "0" | "10" | "20" | "30" | "40" | "50"
 
 /** Border style */
 export type BorderStyleToken = "solid" | "dashed" | "dotted" | "double" | "none"
+
+export type BoxShadowToken = "none" | "md" | "lg" | "xl"

--- a/packages/react/src/lib/F0Box/utils/index.ts
+++ b/packages/react/src/lib/F0Box/utils/index.ts
@@ -9,6 +9,7 @@ export { insetVariants } from "./inset"
 export { marginDefaults, marginVariants } from "./margin"
 export { overflowDefaults, overflowVariants } from "./overflow"
 export { paddingDefaults, paddingVariants } from "./padding"
+export { shadowVariants } from "./shadow"
 export { zIndexVariants } from "./zIndex"
 export {
   resolveResponsiveClasses,

--- a/packages/react/src/lib/F0Box/utils/shadow.ts
+++ b/packages/react/src/lib/F0Box/utils/shadow.ts
@@ -1,0 +1,10 @@
+import type { BoxShadowToken } from "../types"
+
+export const shadowVariants = {
+  boxShadow: {
+    none: "shadow-none",
+    md: "shadow-md",
+    lg: "shadow-lg",
+    xl: "shadow-xl",
+  } satisfies Record<BoxShadowToken, string>,
+}


### PR DESCRIPTION
## Summary

- Adds a `boxShadow` prop to F0Box accepting token values `"none" | "md" | "lg" | "xl"` mapped to core shadow tokens
- Non-responsive (static value only); responsive support can be added later if needed
- Includes Storybook story and argType control