### PR TITLE
fix(EditableTable): forward cellHint in display-only and disabled cells

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DisabledCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DisabledCell.test.tsx
@@ -1,0 +1,73 @@
+import "@testing-library/jest-dom/vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import InfoCircleLine from "@/icons/app/InfoCircleLine"
+
+import { zeroRender as render } from "../../../../../../testing/test-utils"
+import { EditableCellProps } from "../components/cells"
+import { DisabledCell } from "../components/cells/status/DisabledCell"
+
+type TestRecord = { id: string; name: string }
+
+function makeEditableColumn(
+  overrides: Partial<EditableCellProps<TestRecord>["editableColumn"]> = {}
+) {
+  return {
+    label: "Name",
+    render: (item: TestRecord) => item.name,
+    ...overrides,
+  } as EditableCellProps<TestRecord>["editableColumn"]
+}
+
+describe("DisabledCell", () => {
+  const defaultProps: EditableCellProps<TestRecord> = {
+    editableColumn: makeEditableColumn(),
+    value: "John Doe",
+    onChange: vi.fn(),
+    item: { id: "1", name: "John Doe" },
+  }
+
+  it("renders the cell value", () => {
+    render(<DisabledCell {...defaultProps} />)
+
+    expect(screen.getByText("John Doe")).toBeInTheDocument()
+  })
+
+  it("renders a hint icon when hint is provided", () => {
+    render(
+      <DisabledCell
+        {...defaultProps}
+        hint={{ icon: InfoCircleLine, message: "Locked by policy" }}
+      />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Locked by policy" })
+    ).toBeInTheDocument()
+  })
+
+  it("does not render a hint icon when hint is omitted", () => {
+    render(<DisabledCell {...defaultProps} />)
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("shows the hint tooltip on hover", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DisabledCell
+        {...defaultProps}
+        hint={{ icon: InfoCircleLine, message: "Locked by policy" }}
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: "Locked by policy" })
+    await user.hover(trigger)
+
+    const tooltip = await screen.findByRole("tooltip", {}, { timeout: 1000 })
+    expect(tooltip).toHaveTextContent("Locked by policy")
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NonEditableCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NonEditableCell.test.tsx
@@ -1,0 +1,75 @@
+import "@testing-library/jest-dom/vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import InfoCircleLine from "@/icons/app/InfoCircleLine"
+
+import { zeroRender as render } from "../../../../../../testing/test-utils"
+import { EditableCellProps } from "../components/cells"
+import { NonEditableCell } from "../components/cells/status/NonEditableCell"
+
+type TestRecord = { id: string; name: string }
+
+function makeEditableColumn(
+  overrides: Partial<EditableCellProps<TestRecord>["editableColumn"]> = {}
+) {
+  return {
+    label: "Name",
+    render: (item: TestRecord) => item.name,
+    ...overrides,
+  } as EditableCellProps<TestRecord>["editableColumn"]
+}
+
+describe("NonEditableCell", () => {
+  const defaultProps: EditableCellProps<TestRecord> = {
+    editableColumn: makeEditableColumn(),
+    value: "John Doe",
+    onChange: vi.fn(),
+    item: { id: "1", name: "John Doe" },
+  }
+
+  it("renders the cell value", () => {
+    render(<NonEditableCell {...defaultProps} />)
+
+    expect(screen.getByText("John Doe")).toBeInTheDocument()
+  })
+
+  it("renders a hint icon when hint is provided", () => {
+    render(
+      <NonEditableCell
+        {...defaultProps}
+        hint={{ icon: InfoCircleLine, message: "Backfilling Jane's position" }}
+      />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Backfilling Jane's position" })
+    ).toBeInTheDocument()
+  })
+
+  it("does not render a hint icon when hint is omitted", () => {
+    render(<NonEditableCell {...defaultProps} />)
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("shows the hint tooltip on hover", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <NonEditableCell
+        {...defaultProps}
+        hint={{ icon: InfoCircleLine, message: "Backfilling Jane's position" }}
+      />
+    )
+
+    const trigger = screen.getByRole("button", {
+      name: "Backfilling Jane's position",
+    })
+    await user.hover(trigger)
+
+    const tooltip = await screen.findByRole("tooltip", {}, { timeout: 1000 })
+    expect(tooltip).toHaveTextContent("Backfilling Jane's position")
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
@@ -9,11 +9,12 @@ import { BaseCell } from "../BaseCell"
 export function DisabledCell<R extends RecordType>({
   editableColumn,
   item,
+  hint,
 }: EditableCellProps<R>) {
   const i18n = useI18n()
 
   return (
-    <BaseCell borderOnHover={false}>
+    <BaseCell borderOnHover={false} hint={hint}>
       <div
         className={cn(
           editableColumn.align === "right" ? "justify-end" : "",

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
@@ -10,11 +10,12 @@ export function NonEditableCell<R extends RecordType>({
   editableColumn,
   item,
   isLastColumn,
+  hint,
 }: EditableCellProps<R>) {
   const i18n = useI18n()
 
   return (
-    <BaseCell showRightBorder={!isLastColumn} borderOnHover={false}>
+    <BaseCell showRightBorder={!isLastColumn} borderOnHover={false} hint={hint}>
       <div
         className={cn(
           "flex w-full min-w-0",

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -164,7 +164,11 @@ export type EditableTableColumnDefinition<
 
   /**
    * Returns a hint to display as an icon with tooltip inside the cell.
-   * Use to warn the user when a value diverges from its formula-inferred value.
+   * Use to warn the user when a value diverges from its formula-inferred value,
+   * or to provide extra context for non-editable / disabled cells (e.g. why a
+   * value was inferred, who a row is backfilling, why editing is locked).
+   *
+   * Supported by all `editType` values, including `display-only` and `disabled`.
    *
    * Return `undefined` to hide the hint.
    *


### PR DESCRIPTION
## Description

`cellHint` was documented as a column-level affordance for any editable-table column, but `NonEditableCell` (`editType: 'display-only'`) and `DisabledCell` (`editType: 'disabled'`) did not destructure the `hint` prop and so never forwarded it to `BaseCell`. As a result, consumers using `cellHint` on a non-editable or disabled column saw no tooltip icon. This PR forwards `hint` from both cells to `BaseCell` so the hint icon and tooltip render for every `editType`.

## Implementation details

- fix: forward `hint` from `NonEditableCell` to `BaseCell` so `cellHint` renders on `display-only` columns
- fix: forward `hint` from `DisabledCell` to `BaseCell` so `cellHint` renders on `disabled` columns
- docs: clarify in the `cellHint` JSDoc that the hint is supported by every `editType`, including `display-only` and `disabled`
- test: add unit tests covering hint rendering, omission, and tooltip behavior for `NonEditableCell` and `DisabledCell`

## Downstream consumer

This unblocks the FCT-55235 tooltip in the Factorial monorepo: [factorialco/factorial#100221](https://github.com/factorialco/factorial/pull/100221) — *Headcount Planning "Backfill" rows need to show whose position is being backfilled*. That PR sets `cellHint` on a `display-only` column; without this upstream fix the tooltip icon never renders.
