### PR TITLE
docs(crud-patterns): make page-first the default for Read on Table and List

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
@@ -79,6 +79,11 @@ Table mode for field-level updates; most Table rules still apply.
 The Pattern decision table below is the canonical reference. Later sections
 expand on individual operations, views, and edge cases.
 
+For Read on Table and List, routing to a page is the default — it is the most
+common Read interaction observed across the product. Dialog-based reads are
+reserved for cases where the resource is small enough to be fully understood
+in a dialog and no durable page destination exists.
+
 <Unstyled>
   <table className="mb-4 w-full dark:text-f1-foreground-inverse/80">
     <thead>
@@ -110,7 +115,16 @@ expand on individual operations, views, and edge cases.
       </tr>
       <tr>
         <td>
-          User benefits from a preview of a complex resource that can lead to a
+          <strong>Default Read destination</strong> — resource has, or warrants,
+          a durable page with persistent navigation, tabs, or page-level actions
+        </td>
+        <td>Table, List</td>
+        <td>Read</td>
+        <td>Table to Page / List to Page</td>
+      </tr>
+      <tr>
+        <td>
+          User benefits from a reduced preview before committing to the full
           page
         </td>
         <td>Table, List</td>
@@ -118,10 +132,13 @@ expand on individual operations, views, and edge cases.
         <td>Dialog to Page</td>
       </tr>
       <tr>
-        <td>Resource needs persistent navigation, tabs, or deeper structure</td>
+        <td>
+          Lightweight inspection only — resource is small, fits a centered
+          dialog, and has no durable page destination
+        </td>
         <td>Table, List</td>
         <td>Read</td>
-        <td>Table to Page / List to Page</td>
+        <td>Default Dialog (Read fallback)</td>
       </tr>
       <tr>
         <td>
@@ -330,9 +347,10 @@ multi-step flows.
 
 ### Read
 
-Triggered by clicking a row, list item, or card. Opens a dialog for contained
-resources, a Right Dialog when collection context helps scanning, or navigates
-to a page when the resource needs a durable destination.
+Triggered by clicking a row, list item, or card. By default, Table and List
+reads route to a page; dialog-based reads are reserved for lightweight
+inspection when the resource has no durable page destination. Card and Kanban
+reads open a focused dialog because the card surface is already object-level.
 
 <Unstyled>
   <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
@@ -347,25 +365,28 @@ to a page when the resource needs a durable destination.
         <td>
           <a
             target="_parent"
-            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-dialog"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page"
           >
-            Table Read — Default
+            Table to Page
           </a>
         </td>
-        <td>Clicking an item opens the Default Dialog.</td>
+        <td>
+          Clicking a table row or chevron action routes to a resource page.
+          Default Read pattern for Table.
+        </td>
       </tr>
       <tr>
         <td>
           <a
             target="_parent"
-            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--list-read-page"
           >
-            Table Read — Right Dialog
+            List to Page
           </a>
         </td>
         <td>
-          Clicking a row opens a Right Dialog while the collection stays
-          visible.
+          Clicking a list item or chevron action routes to a resource page.
+          Default Read pattern for List.
         </td>
       </tr>
       <tr>
@@ -386,13 +407,14 @@ to a page when the resource needs a durable destination.
         <td>
           <a
             target="_parent"
-            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog"
           >
-            Table to Page
+            Table Read — Right Dialog
           </a>
         </td>
         <td>
-          Clicking a table row or chevron action routes to a resource page.
+          Clicking a row opens a Right Dialog while the collection stays
+          visible. Use when row comparison helps the task.
         </td>
       </tr>
       <tr>
@@ -406,20 +428,21 @@ to a page when the resource needs a durable destination.
         </td>
         <td>
           Clicking a list item opens a Right Dialog while the list stays
-          visible.
+          visible. Use when list context helps scanning.
         </td>
       </tr>
       <tr>
         <td>
           <a
             target="_parent"
-            href="/?path=/story/patterns-data-collection-crud-patterns-read--list-read-page"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-dialog"
           >
-            List to Page
+            Table Read — Default
           </a>
         </td>
         <td>
-          Clicking a list item or chevron action routes to a resource page.
+          Clicking an item opens the Default Dialog. Reserved for lightweight
+          inspection when no page destination exists.
         </td>
       </tr>
       <tr>
@@ -661,10 +684,12 @@ update instead.
 
 How each view applies the Pattern decision table by default.
 
-- **Table:** Right Dialog for read or update when row comparison helps the
-  task.
-- **List:** Right Dialog for read or update when list context remains useful
-  while reading or editing.
+- **Table:** route to a page by default for read. Right Dialog only when row
+  comparison materially helps the task. Default Dialog only when the resource
+  is small and no page destination exists.
+- **List:** route to a page by default for read. Right Dialog only when list
+  context remains useful while reading. Default Dialog only when the resource
+  is small and no page destination exists.
 - **Card:** click opens read first; edit is an explicit action inside the read
   dialog or from a card item action (ellipsis menu).
 - **Kanban:** lane create for state-scoped resources; drag for state updates;
@@ -680,10 +705,21 @@ How each view applies the Pattern decision table by default.
 <DoDonts
   do={{
     description:
-      "Use the Default Dialog as the baseline for create, read, and update flows.",
+      "Use the Default Dialog as the baseline for create and update flows.",
   }}
   dont={{
     description: "Do not make Right Dialogs the default container.",
+  }}
+/>
+
+<DoDonts
+  do={{
+    description:
+      "Use a page as the default Read destination on Table and List, especially when the resource has its own URL, tabs, or page-level actions.",
+  }}
+  dont={{
+    description:
+      "Do not default to a Default Dialog for Read when a page destination exists or could reasonably be built.",
   }}
 />
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.mdx
@@ -13,6 +13,12 @@ Read patterns define how a user reads and inspects a resource from a Data
 Collection. The selected container should balance speed, context, and depth.
 Use the lightest pattern that still gives the resource enough room.
 
+For Table and List, the default Read destination is a page. Pages support
+deep linking, persistent navigation, and page-level actions, and they are the
+most common Read interaction observed across the product. Reach for
+dialog-based reads only when the resource is small enough to be fully
+understood in a dialog or a page destination does not yet exist.
+
 The stories use a neutral grey content placeholder on purpose, so the example
 focuses on the container pattern rather than implying a specific internal page
 layout.
@@ -24,16 +30,10 @@ layout.
     features={[
       {
         icon: Table,
-        title: "Table — Default",
-        description: "Clicking an item opens the Default Dialog.",
-        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-dialog",
-      },
-      {
-        icon: Table,
-        title: "Table — Right Dialog",
+        title: "Table to Page",
         description:
-          "Clicking a row opens a Right Dialog so the user can read the resource while keeping the collection visible.",
-        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog",
+          "Default for Table reads. Clicking a row or chevron action routes to a resource page with persistent navigation and page-level actions.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page",
       },
       {
         icon: Table,
@@ -44,10 +44,24 @@ layout.
       },
       {
         icon: Table,
-        title: "Table to Page",
+        title: "Table — Right Dialog",
         description:
-          "Clicking a table row or chevron action routes to a resource page.",
-        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page",
+          "Clicking a row opens a Right Dialog so the user can read the resource while keeping the collection visible. Use when row comparison helps the task.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog",
+      },
+      {
+        icon: Table,
+        title: "Table — Default",
+        description:
+          "Centered dialog read. Reserved for lightweight inspection — small resources with no durable page destination.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--table-read-dialog",
+      },
+      {
+        icon: List,
+        title: "List to Page",
+        description:
+          "Default for List reads. Clicking a list item or chevron action routes to a resource page.",
+        href: "/?path=/story/patterns-data-collection-crud-patterns-read--list-read-page",
       },
       {
         icon: List,
@@ -55,13 +69,6 @@ layout.
         description:
           "Clicking a list item opens a Right Dialog so the user can read the resource while keeping the list visible.",
         href: "/?path=/story/patterns-data-collection-crud-patterns-read--list-read-right-dialog",
-      },
-      {
-        icon: List,
-        title: "List to Page",
-        description:
-          "Clicking a list item or chevron action routes to a resource page.",
-        href: "/?path=/story/patterns-data-collection-crud-patterns-read--list-read-page",
       },
       {
         icon: CardPin,
@@ -81,15 +88,16 @@ layout.
 
 ## When to use
 
-- Use a Default Dialog for quick inspection and lightweight details.
-- Use a Right Dialog for Table or List reads when keeping the collection visible
-  helps comparison or row-by-row scanning.
-- Use a Dialog to Page flow when the resource starts with a reduced view
-  but may expand into a full destination.
-- Use a Table to Page flow when dense tabular scanning still needs a dedicated
-  destination for deeper reading.
-- Use a List to Page flow when list-style browsing should open a dedicated
-  destination with more structure and actions.
+- Use a Table to Page flow as the **default** for Table reads, and a List to
+  Page flow as the **default** for List reads — pages give the resource a
+  durable destination for follow-up actions, deep linking, and page-level
+  navigation.
+- Use a Dialog to Page flow when a reduced preview anchored to the collection
+  helps the user decide whether to commit to the full page.
+- Use a Right Dialog when keeping the collection visible materially helps
+  comparison or row-by-row scanning, and the resource fits the right rail.
+- Use a Default Dialog only for lightweight inspection — small resources with
+  a short decision loop and no durable page destination.
 - Use card click to dialog/page for Card views. **Recommended** because the card
   is already an object-level surface.
 - Use Kanban card click to dialog/page for Kanban views. **Recommended** because
@@ -97,8 +105,6 @@ layout.
 - In Editable Table, avoid row-click read behavior when it competes with inline
   editing. Use an explicit action when read needs to coexist with editable cells.
 - Keep item click behavior consistent within the same collection.
-- Reserve page navigation for resources that are meaningful enough to justify
-  their own destination.
 
 ## Pattern options
 
@@ -116,15 +122,49 @@ layout.
         <td>
           <a
             target="_parent"
-            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-dialog"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page"
           >
-            Default Dialog
+            Table to Page
           </a>
         </td>
         <td>
-          Quick read flows with limited content and a short decision loop.
+          <strong>Default for Table reads.</strong> Detailed resources with
+          hierarchy, navigation, or page-level actions.
         </td>
-        <td>Less room for tabs, dense layouts, or extended workflows.</td>
+        <td>Higher navigation cost for very quick lookups.</td>
+      </tr>
+      <tr>
+        <td>
+          <a
+            target="_parent"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--list-read-page"
+          >
+            List to Page
+          </a>
+        </td>
+        <td>
+          <strong>Default for List reads.</strong> Detailed resources discovered
+          through a list view, where the teaser structure helps users browse
+          before opening the full page.
+        </td>
+        <td>Adds navigation cost vs. a stay-and-read flow.</td>
+      </tr>
+      <tr>
+        <td>
+          <a
+            target="_parent"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog-to-page"
+          >
+            Dialog to Page
+          </a>
+        </td>
+        <td>
+          Preview the resource without leaving the collection, while preserving
+          a clear transition into a full page.
+        </td>
+        <td>
+          Introduces a two-step read flow instead of a single destination.
+        </td>
       </tr>
       <tr>
         <td>
@@ -148,51 +188,16 @@ layout.
         <td>
           <a
             target="_parent"
-            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-right-dialog-to-page"
+            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-dialog"
           >
-            Dialog to Page
+            Default Dialog
           </a>
         </td>
         <td>
-          Preview the resource without leaving the collection, while preserving
-          a clear transition into a full page.
+          Lightweight inspection only — small resources with no durable page
+          destination and a short decision loop.
         </td>
-        <td>
-          Introduces a two-step read flow instead of a single destination.
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <a
-            target="_parent"
-            href="/?path=/story/patterns-data-collection-crud-patterns-read--table-read-page"
-          >
-            Table to Page
-          </a>
-        </td>
-        <td>
-          Detailed resources with hierarchy, navigation, or page-level actions
-          that start from a table row.
-        </td>
-        <td>Higher navigation cost for quick lookups.</td>
-      </tr>
-      <tr>
-        <td>
-          <a
-            target="_parent"
-            href="/?path=/story/patterns-data-collection-crud-patterns-read--list-read-page"
-          >
-            List to Page
-          </a>
-        </td>
-        <td>
-          Detailed resources discovered through a list view, where the teaser
-          structure helps users browse before opening the full page.
-        </td>
-        <td>
-          Adds navigation cost and is less efficient than staying in the list
-          for lightweight inspection.
-        </td>
+        <td>Less room for tabs, dense layouts, or extended workflows.</td>
       </tr>
       <tr>
         <td>
@@ -243,23 +248,11 @@ layout.
     </thead>
     <tbody>
       <tr>
-        <td>Does the user only need a fast inspection flow?</td>
-        <td>Default Dialog</td>
-      </tr>
-      <tr>
-        <td>Does reading benefit from keeping nearby rows or items visible?</td>
-        <td>Right Dialog</td>
-      </tr>
-      <tr>
         <td>
-          Does the user need a quick preview before deciding to open the full
-          page?
+          Does the resource have (or warrant) a durable page destination — its
+          own URL, tabs, page header, or page-level actions?
         </td>
-        <td>Dialog to Page</td>
-      </tr>
-      <tr>
-        <td>Does the resource need breadcrumbs, tabs, or a page header?</td>
-        <td>Table to Page or List to Page</td>
+        <td>Table to Page or List to Page (default)</td>
       </tr>
       <tr>
         <td>Will the user likely continue into editing or configuration?</td>
@@ -267,9 +260,21 @@ layout.
       </tr>
       <tr>
         <td>
-          Should the user remain anchored to the collection while reading?
+          Does the user need a reduced preview before deciding to open the full
+          page?
         </td>
-        <td>Default Dialog</td>
+        <td>Dialog to Page</td>
+      </tr>
+      <tr>
+        <td>Does reading benefit from keeping nearby rows or items visible?</td>
+        <td>Right Dialog</td>
+      </tr>
+      <tr>
+        <td>
+          Is the resource small, with a short decision loop, and no page
+          destination available?
+        </td>
+        <td>Default Dialog (fallback)</td>
       </tr>
       <tr>
         <td>Is the current visualization Card or Kanban?</td>
@@ -285,21 +290,29 @@ layout.
 
 ## Guidance
 
-The Default Dialog is the baseline read pattern because it keeps the interaction
-close to the collection and supports fast inspection. It is the right starting
-point until the resource becomes large enough to need its own information
-architecture.
+On Table and List, routing to a page is the default Read pattern. Pages provide
+a durable destination, support deep linking, and have room for tabs,
+page-level actions, and persistent navigation. They are the most common Read
+interaction observed across the product, so prefer a page whenever the
+resource has — or could reasonably have — its own destination.
+
+Choose Table to Page when people start from dense, comparison-oriented rows and
+need a direct chevron action that routes into a full destination. Choose List
+to Page when the collection already uses list teasers and the browsing model is
+closer to scanning summaries than comparing columns.
+
+Use a Dialog to Page flow when a reduced preview anchored to the collection
+helps the user decide whether to commit to the full page. The Right Dialog
+should be a reduced view, not a compressed version of the full page.
 
 Use a Right Dialog as the final read destination when the resource fits the
-right rail and the user benefits from seeing the collection alongside, for
-example to compare nearby rows in a Table or scan adjacent items in a List.
-Promote to a Dialog to Page flow only when the resource has a durable full-page
-destination.
+right rail and the user benefits from seeing the collection alongside — for
+example, to compare nearby rows in a Table or scan adjacent items in a List.
 
-Use a Dialog to Page flow when the first step should stay anchored to the
-collection, but the resource still deserves a full page for deeper reading,
-follow-up actions, or page-level navigation. The Right Dialog should be a
-reduced view, not a compressed version of the full page.
+Reserve the Default Dialog for lightweight inspection — small resources with a
+short decision loop and no durable page destination. Do not stretch a dialog
+beyond its intended scope: promote to a page when content competes for
+vertical space, sub-navigation, or multiple action groups.
 
 This dialog-to-page behavior is portable. Any compatible Default Dialog or
 right-position read dialog can expose **Open Details** as the primary action when
@@ -307,16 +320,6 @@ the dialog is intentionally a reduced preview and the resource has a durable
 full-page destination. Do not duplicate this copy in every story; use it as the
 decision logic for Table, List, Card, or Kanban when the resource needs deeper
 page structure.
-
-Move to a Table to Page or List to Page pattern when the resource is no longer
-just a quick read target. If the resource has sub-navigation, multiple action
-groups, or content that competes for vertical space, a page is more predictable
-than stretching a dialog beyond its intended scope.
-
-Choose Table to Page when people start from dense, comparison-oriented rows and
-need a direct chevron action that routes into a full destination. Choose list
-to page when the collection already uses list teasers and the browsing model is
-closer to scanning summaries than comparing columns.
 
 For Card and Kanban, the item surface itself is a strong read affordance, so
 card click to dialog is **Recommended** for quick inspection. Keep update and
@@ -334,11 +337,11 @@ action for read when both behaviors must coexist.
 <DoDonts
   do={{
     description:
-      "Use a Default Dialog as the first option for straightforward read flows that keep the user near the collection.",
+      "Use a page as the default Read destination on Table and List — especially when the resource has its own URL, tabs, or page-level actions.",
   }}
   dont={{
     description:
-      "Do not force complex resources into a dialog when the content needs page-level structure.",
+      "Do not default to a Default Dialog for Read when a page destination exists or could reasonably be built.",
   }}
 />
 


### PR DESCRIPTION
> Originally planned as a stacked PR on #4260. That PR merged in the meantime, so this PR now targets \`main\` directly.

## Summary

The team has observed that **Table to Page** and **List to Page** are the most common Read interactions across the product. The CRUD pattern docs previously presented **Default Dialog** as the baseline for Read, which contradicts the observed reality. This PR reframes Read on Table and List to be **page-first by default**, keeps **Dialog to Page** and **Right Dialog** as the alternatives when collection context helps, and demotes **Default Dialog** to a fallback for lightweight inspection only.

Card and Kanban Read recommendations are intentionally unchanged: the card surface is already object-level, and Kanban must coexist with drag. Their wording is preserved.

## Changes

### \`overview.mdx\`
- New intro paragraph above the Pattern decision table establishing page-first as the default for Read on Table/List.
- Pattern decision table: reordered Read rows — Table/List to Page first, Dialog to Page second, Default Dialog last as a fallback with reworded intent (\"lightweight inspection only\").
- Read operation scenarios table: reordered so page scenarios lead, dialog variants follow. Section lead-in rewritten.
- View behaviors: Table and List bullets recommend page by default; Right Dialog only when comparison materially helps; Default Dialog only when no page destination exists.
- Guidelines DoDonts: split the original \"Default Dialog as baseline\" DoDont — Create/Update keep that message, and a new Read-specific DoDont pushes page-first.

### \`read.mdx\`
- New lead-in paragraph stating page is the default Read destination for Table and List.
- Examples FeatureGrid reordered: Table to Page → Table — Dialog to Page → Table — Right Dialog → Table — Default (last, reworded), then List to Page → List — Right Dialog, then Card/Kanban unchanged.
- When-to-use bullets rewritten to lead with page-first guidance.
- Pattern options table reordered to match, with Table/List to Page marked **Default** for their view and Default Dialog reworded as \"lightweight inspection only\".
- Decision criteria table rewritten: first question is whether the resource has (or warrants) a durable page destination; Default Dialog answer is explicitly a fallback.
- Guidance prose rewritten to lead with page-first reasoning and demote Default Dialog. Open Details portability guidance and Card/Kanban/Editable Table paragraphs preserved.
- First DoDont replaced with a page-first Read recommendation.

## Out of scope
- No story file changes (the underlying stories already exist).
- No changes to Create, Update, or Delete docs.
- No changes to Card/Kanban Read recommendations beyond layout.
- No changes to \`experimental/CrudPatterns/\`.

## Validation
- \`pnpm --filter @factorialco/f0-react run format\` ✓
- \`pnpm --filter @factorialco/f0-react run tsc\` ✓ (only pre-existing F0Graph errors, unrelated)

## Review tips
The reordering is best reviewed alongside the Storybook render. Key pages:
- \`patterns-data-collection-crud-patterns-overview\` — decision table and Read scenarios.
- \`patterns-data-collection-crud-patterns-read--documentation\` — FeatureGrid, Pattern options, Decision criteria, Guidance.