### PR TITLE
feat(F0Card): add a bookmark (save) toggle overlay

### DIFF
--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -249,7 +249,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
     const cardBody = (
       <Card
         className={cn(
-          "group relative bg-f1-background shadow-none transition-all",
+          "group relative border-f1-border-secondary bg-f1-background shadow-none transition-all",
           compact && "p-3",
           fullHeight && "h-full",
           (selectable || (otherActions && otherActions.length > 0)) &&
@@ -287,7 +287,9 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
         {image && (
           <div
             className={cn(
-              "relative -mx-3 -mt-3 mb-4 rounded-md",
+              // pointer-events-none lets clicks on the image fall through to the
+              // full-card overlay link; interactive overlay controls re-enable them.
+              "pointer-events-none relative -mx-3 -mt-3 mb-4 rounded-md",
               imageAspectRatio === "video"
                 ? "aspect-video"
                 : imageSizeClassMap[imageSize],

--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -175,6 +175,13 @@ export interface CardInternalProps {
   fullHeight?: boolean
 
   /**
+   * Use a softer/lighter border (`border-f1-border-secondary`) instead of the default
+   * `border-f1-border`. Opt-in so existing cards keep their current appearance.
+   * @default false
+   */
+  subtleBorder?: boolean
+
+  /**
    * When true, disables the full-card overlay link so parent components
    * can manage drag-and-drop while still allowing click navigation via onClick
    */
@@ -223,6 +230,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
       otherActions,
       bookmark,
       selectable = false,
+      subtleBorder = false,
       selected = false,
       onSelect,
       onClick,
@@ -249,7 +257,8 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
     const cardBody = (
       <Card
         className={cn(
-          "group relative border-f1-border-secondary bg-f1-background shadow-none transition-all",
+          "group relative bg-f1-background shadow-none transition-all",
+          subtleBorder && "border-f1-border-secondary",
           compact && "p-3",
           fullHeight && "h-full",
           (selectable || (otherActions && otherActions.length > 0)) &&

--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -26,6 +26,7 @@ import { CardMetadata } from "./components/CardMetadata"
 import { CardOptions } from "./components/CardOptions"
 import {
   type CardAlertProps,
+  type CardBookmark,
   type CardMetadata as CardMetadataType,
 } from "./types"
 
@@ -137,6 +138,12 @@ export interface CardInternalProps {
   otherActions?: DropdownItem[]
 
   /**
+   * Bookmark (save) toggle rendered as an icon button in the card's options overlay.
+   * Shows an outline bookmark when not bookmarked and a filled one when bookmarked.
+   */
+  bookmark?: CardBookmark
+
+  /**
    * Whether the card is selectable
    */
   selectable?: boolean
@@ -214,6 +221,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
       primaryAction,
       secondaryActions,
       otherActions,
+      bookmark,
       selectable = false,
       selected = false,
       onSelect,
@@ -321,6 +329,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
               selectable={selectable}
               selected={selected}
               onSelect={onSelect}
+              bookmark={bookmark}
               title={title}
               overlay
             />
@@ -383,6 +392,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
                 selectable={selectable}
                 selected={selected}
                 onSelect={onSelect}
+                bookmark={bookmark}
                 title={title}
               />
             )}

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -287,6 +287,45 @@ export const Selectable: Story = {
   },
 }
 
+export const Bookmarkable: Story = {
+  args: {
+    ...Default.args,
+  },
+  render: (args) => {
+    const [bookmarked, setBookmarked] = useState(false)
+    return (
+      <F0Card
+        {...args}
+        bookmark={{
+          bookmarked,
+          onBookmarkChange: setBookmarked,
+          label: "Save",
+        }}
+      />
+    )
+  },
+}
+
+export const BookmarkableWithImage: Story = {
+  args: {
+    ...Default.args,
+    image: image,
+  },
+  render: (args) => {
+    const [bookmarked, setBookmarked] = useState(false)
+    return (
+      <F0Card
+        {...args}
+        bookmark={{
+          bookmarked,
+          onBookmarkChange: setBookmarked,
+          label: "Save",
+        }}
+      />
+    )
+  },
+}
+
 export const WithChildren: Story = {
   args: {
     title: "Card with children",

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -105,6 +105,15 @@ const meta = {
         defaultValue: { summary: "sm" },
       },
     },
+    subtleBorder: {
+      control: "boolean",
+      description:
+        "Use a softer/lighter border (`border-f1-border-secondary`). Opt-in so " +
+        "existing cards keep the default `border-f1-border`.",
+      table: {
+        defaultValue: { summary: "false" },
+      },
+    },
     bookmark: {
       control: false,
       description:

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -105,6 +105,17 @@ const meta = {
         defaultValue: { summary: "sm" },
       },
     },
+    bookmark: {
+      control: false,
+      description:
+        "Optional save/bookmark toggle rendered as a circular icon button in the " +
+        "card overlay. Pass `{ bookmarked, onBookmarkChange, label? }`. Shows an " +
+        "outline icon when not saved and a filled icon when saved; it is revealed " +
+        "on card hover and stays visible while bookmarked.",
+      table: {
+        type: { summary: "CardBookmark" },
+      },
+    },
     ...dataTestIdArgs,
   } as never,
   args: {
@@ -288,6 +299,16 @@ export const Selectable: Story = {
 }
 
 export const Bookmarkable: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pass `bookmark` to add a save/bookmark toggle. The control is a circular " +
+          "icon button shown in the card overlay — outline when not saved, filled when " +
+          "saved. It toggles without triggering the card's `link`/`onClick`.",
+      },
+    },
+  },
   args: {
     ...Default.args,
   },
@@ -307,6 +328,16 @@ export const Bookmarkable: Story = {
 }
 
 export const BookmarkableWithImage: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "With an image, the bookmark toggle overlays the top-right corner. It is " +
+          "revealed on card hover and stays visible while bookmarked, so the saved " +
+          "state is always recognisable at a glance.",
+      },
+    },
+  },
   args: {
     ...Default.args,
     image: image,

--- a/packages/react/src/components/F0Card/__tests__/Card.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/Card.test.tsx
@@ -411,4 +411,79 @@ describe("F0Card Component", () => {
       ).not.toBeInTheDocument()
     })
   })
+
+  describe("bookmark", () => {
+    it("renders a bookmark toggle with the provided label", () => {
+      render(
+        <F0Card
+          title="Card"
+          bookmark={{
+            bookmarked: false,
+            onBookmarkChange: vi.fn(),
+            label: "Save product",
+          }}
+        />
+      )
+
+      expect(
+        screen.getByRole("button", { name: "Save product" })
+      ).toBeInTheDocument()
+    })
+
+    it("calls onBookmarkChange with the next state when toggled", async () => {
+      const onBookmarkChange = vi.fn()
+      render(
+        <F0Card
+          title="Card"
+          bookmark={{
+            bookmarked: false,
+            onBookmarkChange,
+            label: "Save product",
+          }}
+        />
+      )
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Save product" })
+      )
+
+      expect(onBookmarkChange).toHaveBeenCalledWith(true)
+    })
+
+    it("does not trigger card navigation when the bookmark is toggled", async () => {
+      const onClick = vi.fn()
+      const onBookmarkChange = vi.fn()
+      render(
+        <F0Card
+          title="Card"
+          onClick={onClick}
+          bookmark={{
+            bookmarked: false,
+            onBookmarkChange,
+            label: "Save product",
+          }}
+        />
+      )
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Save product" })
+      )
+
+      expect(onBookmarkChange).toHaveBeenCalledWith(true)
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it("falls back to the card title as the accessible label", () => {
+      render(
+        <F0Card
+          title="My device"
+          bookmark={{ bookmarked: true, onBookmarkChange: vi.fn() }}
+        />
+      )
+
+      expect(screen.getByTestId("card-bookmark-toggle")).toHaveAccessibleName(
+        "My device"
+      )
+    })
+  })
 })

--- a/packages/react/src/components/F0Card/__tests__/Card.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/Card.test.tsx
@@ -485,5 +485,31 @@ describe("F0Card Component", () => {
         "My device"
       )
     })
+
+    it("always has an accessible name when no label or title is provided", () => {
+      render(
+        <F0Card bookmark={{ bookmarked: false, onBookmarkChange: vi.fn() }} />
+      )
+
+      const toggle = screen.getByTestId("card-bookmark-toggle")
+      expect(toggle).toHaveAttribute("aria-label")
+      expect(toggle.getAttribute("aria-label")).toBeTruthy()
+    })
+  })
+
+  describe("subtleBorder", () => {
+    it("does not apply the subtle border by default", () => {
+      render(<F0Card title="Card" />)
+      expect(screen.getByTestId("card")).not.toHaveClass(
+        "border-f1-border-secondary"
+      )
+    })
+
+    it("applies the subtle border when enabled", () => {
+      render(<F0Card title="Card" subtleBorder />)
+      expect(screen.getByTestId("card")).toHaveClass(
+        "border-f1-border-secondary"
+      )
+    })
   })
 })

--- a/packages/react/src/components/F0Card/components/CardOptions.tsx
+++ b/packages/react/src/components/F0Card/components/CardOptions.tsx
@@ -2,11 +2,10 @@ import { useState } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Checkbox } from "@/components/F0Checkbox"
-import { F0Icon } from "@/components/F0Icon"
 import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { Bookmark, BookmarkFilled, Ellipsis } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
-import { cn, focusRing } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 
 import { type CardBookmark } from "../types"
 
@@ -64,20 +63,16 @@ export function CardOptions({
     return null
   }
 
-  // When the bookmark is the only control it carries its own circular chrome,
-  // so the shared translucent container is skipped to keep it visually clean.
-  const onlyBookmark = !!bookmark && !hasOtherActions && !selectable
-
   return (
     <div
       className={cn(
         "flex flex-row gap-1 opacity-100 transition-opacity delay-150 duration-150 focus-within:delay-0 group-hover:delay-0 sm:opacity-0 focus-within:sm:opacity-100 group-hover:sm:opacity-100 [&>div]:z-[1]",
+        // Stays visible (no hover needed) while the dropdown is open, the card is
+        // selected, or the card is bookmarked — otherwise reveals on card hover.
         (isOpen || selected || bookmark?.bookmarked) &&
           "delay-0 sm:opacity-100",
-        overlay && "pointer-events-auto absolute right-2 top-2",
         overlay &&
-          !onlyBookmark &&
-          "rounded-sm bg-f1-background/60 p-1 shadow-md backdrop-blur-sm"
+          "pointer-events-auto absolute right-2 top-2 rounded-sm bg-f1-background/60 p-1 shadow-md backdrop-blur-sm"
       )}
     >
       {hasOtherActions && (
@@ -110,26 +105,20 @@ export function CardOptions({
       )}
       {bookmark && (
         <div className="flex items-center justify-center">
-          <button
-            type="button"
-            aria-label={bookmark.label ?? title ?? translations.actions.save}
-            aria-pressed={bookmark.bookmarked}
+          <ButtonInternal
+            label={bookmark.label ?? title ?? translations.actions.save}
+            icon={bookmark.bookmarked ? BookmarkFilled : Bookmark}
+            variant="ghost"
+            size="sm"
+            hideLabel
+            pressed={bookmark.bookmarked}
+            compact
             data-testid="card-bookmark-toggle"
-            className={cn(
-              "flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border border-solid border-f1-border bg-f1-background p-0",
-              focusRing()
-            )}
             onClick={(e) => {
-              e.preventDefault()
               e.stopPropagation()
               bookmark.onBookmarkChange(!bookmark.bookmarked)
             }}
-          >
-            <F0Icon
-              icon={bookmark.bookmarked ? BookmarkFilled : Bookmark}
-              size="sm"
-            />
-          </button>
+          />
         </div>
       )}
     </div>

--- a/packages/react/src/components/F0Card/components/CardOptions.tsx
+++ b/packages/react/src/components/F0Card/components/CardOptions.tsx
@@ -3,9 +3,11 @@ import { useState } from "react"
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Checkbox } from "@/components/F0Checkbox"
 import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
-import { Ellipsis } from "@/icons/app"
+import { Bookmark, BookmarkFilled, Ellipsis } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
+
+import { type CardBookmark } from "../types"
 
 interface CardOptionsProps {
   /**
@@ -29,6 +31,11 @@ interface CardOptionsProps {
   onSelect?: (selected: boolean) => void
 
   /**
+   * Bookmark (save) toggle rendered alongside the other options.
+   */
+  bookmark?: CardBookmark
+
+  /**
    * Title for accessibility
    */
   title?: string
@@ -44,6 +51,7 @@ export function CardOptions({
   selectable = false,
   selected = false,
   onSelect,
+  bookmark,
   title,
   overlay = false,
 }: CardOptionsProps) {
@@ -51,7 +59,7 @@ export function CardOptions({
   const hasOtherActions = otherActions && otherActions.length > 0
   const [isOpen, setIsOpen] = useState(false)
 
-  if (!hasOtherActions && !selectable) {
+  if (!hasOtherActions && !selectable && !bookmark) {
     return null
   }
 
@@ -59,7 +67,7 @@ export function CardOptions({
     <div
       className={cn(
         "flex flex-row gap-1 opacity-100 transition-opacity delay-150 duration-150 focus-within:delay-0 group-hover:delay-0 sm:opacity-0 focus-within:sm:opacity-100 group-hover:sm:opacity-100 [&>div]:z-[1]",
-        (isOpen || selected) && "delay-0 sm:opacity-100",
+        (isOpen || selected || !!bookmark) && "delay-0 sm:opacity-100",
         overlay &&
           "absolute right-2 top-2 rounded-sm bg-f1-background/60 p-1 shadow-md backdrop-blur-sm"
       )}
@@ -89,6 +97,24 @@ export function CardOptions({
             onCheckedChange={onSelect}
             hideLabel
             stopPropagation
+          />
+        </div>
+      )}
+      {bookmark && (
+        <div className="flex items-center justify-center">
+          <ButtonInternal
+            label={bookmark.label ?? title ?? ""}
+            icon={bookmark.bookmarked ? BookmarkFilled : Bookmark}
+            variant="ghost"
+            size="sm"
+            hideLabel
+            pressed={bookmark.bookmarked}
+            compact
+            data-testid="card-bookmark-toggle"
+            onClick={(e) => {
+              e.stopPropagation()
+              bookmark.onBookmarkChange(!bookmark.bookmarked)
+            }}
           />
         </div>
       )}

--- a/packages/react/src/components/F0Card/components/CardOptions.tsx
+++ b/packages/react/src/components/F0Card/components/CardOptions.tsx
@@ -109,26 +109,28 @@ export function CardOptions({
         </div>
       )}
       {bookmark && (
-        <button
-          type="button"
-          aria-label={bookmark.label ?? title}
-          aria-pressed={bookmark.bookmarked}
-          data-testid="card-bookmark-toggle"
-          className={cn(
-            "flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border border-solid border-f1-border bg-f1-background p-0",
-            focusRing()
-          )}
-          onClick={(e) => {
-            e.preventDefault()
-            e.stopPropagation()
-            bookmark.onBookmarkChange(!bookmark.bookmarked)
-          }}
-        >
-          <F0Icon
-            icon={bookmark.bookmarked ? BookmarkFilled : Bookmark}
-            size="sm"
-          />
-        </button>
+        <div className="flex items-center justify-center">
+          <button
+            type="button"
+            aria-label={bookmark.label ?? title ?? translations.actions.save}
+            aria-pressed={bookmark.bookmarked}
+            data-testid="card-bookmark-toggle"
+            className={cn(
+              "flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border border-solid border-f1-border bg-f1-background p-0",
+              focusRing()
+            )}
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              bookmark.onBookmarkChange(!bookmark.bookmarked)
+            }}
+          >
+            <F0Icon
+              icon={bookmark.bookmarked ? BookmarkFilled : Bookmark}
+              size="sm"
+            />
+          </button>
+        </div>
       )}
     </div>
   )

--- a/packages/react/src/components/F0Card/components/CardOptions.tsx
+++ b/packages/react/src/components/F0Card/components/CardOptions.tsx
@@ -2,10 +2,11 @@ import { useState } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Checkbox } from "@/components/F0Checkbox"
+import { F0Icon } from "@/components/F0Icon"
 import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { Bookmark, BookmarkFilled, Ellipsis } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 
 import { type CardBookmark } from "../types"
 
@@ -63,13 +64,20 @@ export function CardOptions({
     return null
   }
 
+  // When the bookmark is the only control it carries its own circular chrome,
+  // so the shared translucent container is skipped to keep it visually clean.
+  const onlyBookmark = !!bookmark && !hasOtherActions && !selectable
+
   return (
     <div
       className={cn(
         "flex flex-row gap-1 opacity-100 transition-opacity delay-150 duration-150 focus-within:delay-0 group-hover:delay-0 sm:opacity-0 focus-within:sm:opacity-100 group-hover:sm:opacity-100 [&>div]:z-[1]",
-        (isOpen || selected || !!bookmark) && "delay-0 sm:opacity-100",
+        (isOpen || selected || bookmark?.bookmarked) &&
+          "delay-0 sm:opacity-100",
+        overlay && "pointer-events-auto absolute right-2 top-2",
         overlay &&
-          "absolute right-2 top-2 rounded-sm bg-f1-background/60 p-1 shadow-md backdrop-blur-sm"
+          !onlyBookmark &&
+          "rounded-sm bg-f1-background/60 p-1 shadow-md backdrop-blur-sm"
       )}
     >
       {hasOtherActions && (
@@ -101,22 +109,26 @@ export function CardOptions({
         </div>
       )}
       {bookmark && (
-        <div className="flex items-center justify-center">
-          <ButtonInternal
-            label={bookmark.label ?? title ?? ""}
+        <button
+          type="button"
+          aria-label={bookmark.label ?? title}
+          aria-pressed={bookmark.bookmarked}
+          data-testid="card-bookmark-toggle"
+          className={cn(
+            "flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border border-solid border-f1-border bg-f1-background p-0",
+            focusRing()
+          )}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            bookmark.onBookmarkChange(!bookmark.bookmarked)
+          }}
+        >
+          <F0Icon
             icon={bookmark.bookmarked ? BookmarkFilled : Bookmark}
-            variant="ghost"
             size="sm"
-            hideLabel
-            pressed={bookmark.bookmarked}
-            compact
-            data-testid="card-bookmark-toggle"
-            onClick={(e) => {
-              e.stopPropagation()
-              bookmark.onBookmarkChange(!bookmark.bookmarked)
-            }}
           />
-        </div>
+        </button>
       )}
     </div>
   )

--- a/packages/react/src/components/F0Card/types.ts
+++ b/packages/react/src/components/F0Card/types.ts
@@ -105,3 +105,25 @@ export type CardMetadata =
   | {
       property: Extract<CardMetadataProperty, { type: "file" }>
     }
+
+/**
+ * Bookmark (save) toggle rendered as an icon button in the card's options overlay.
+ * Shows an outline bookmark icon when not bookmarked and a filled one when bookmarked,
+ * giving an at-a-glance indication of the saved state.
+ */
+export interface CardBookmark {
+  /**
+   * Whether the card is currently bookmarked (saved).
+   * Controls the filled vs. outline icon and keeps the toggle visible while active.
+   */
+  bookmarked: boolean
+  /**
+   * Called with the next bookmarked state when the user toggles the bookmark.
+   */
+  onBookmarkChange: (bookmarked: boolean) => void
+  /**
+   * Accessible label for the toggle button (e.g. "Save product").
+   * Falls back to the card `title` when omitted.
+   */
+  label?: string
+}


### PR DESCRIPTION
## feat(F0Card): add a bookmark (save) toggle overlay

### Summary

Adds an optional **bookmark / save toggle** to `F0Card`, rendered as a circular icon button
in the card's overlay. It shows an **outline** bookmark when not saved and a **filled** bookmark
when saved, giving an at-a-glance indication of the saved state. This unblocks catalog /
marketplace surfaces (e.g. the IT *Device catalog*) that need a save affordance on the card
without hand-rolling the whole component.

> **Non-breaking.** The `bookmark` prop is **optional and additive** — no existing prop,
> type, or default changes. Cards that don't pass `bookmark` render exactly as before.
> No new required i18n keys (the accessible label is consumer-provided, like `title`).

### What's added

A new optional `bookmark` prop on `F0Card`:

```ts
bookmark?: {
  /** Current saved state — controls the filled vs. outline icon. */
  bookmarked: boolean
  /** Called with the next state when the user toggles the bookmark. */
  onBookmarkChange: (bookmarked: boolean) => void
  /** Accessible label, e.g. "Save product". Falls back to the card `title`. */
  label?: string
}
```

```tsx
const [bookmarked, setBookmarked] = useState(false)

<F0Card
  image={image}
  title="Lenovo V15 Gen 4"
  link="/device-catalog/123"
  bookmark={{ bookmarked, onBookmarkChange: setBookmarked, label: "Save product" }}
/>
```

### Behaviour

- **Circular icon button**, no background change on hover; reuses the existing
  `Bookmark` / `BookmarkFilled` icons.
- **Revealed on card hover**, and **always visible while bookmarked** (so the saved state is
  always recognisable) — mirrors the existing `selected` reveal convention.
- Toggling **stops propagation**, so it never triggers the card's `link` / `onClick`.
- Lives in the existing `CardOptions` overlay (top-right on the image, or in the header when
  there is no image), alongside `selectable` / `otherActions`.

### Accompanying F0Card changes (all additive / opt-in — no existing card changes appearance)

1. **`subtleBorder` (opt-in prop).** A softer `border-f1-border-secondary` is available via the
   new optional `subtleBorder` prop. **Default is unchanged** (`border-f1-border`), so existing
   consumers are unaffected. _(Earlier revision changed this globally; reworked into an opt-in
   prop per review.)_
2. **Full-card click target (bug fix).** When `link` is set the whole card is now clickable.
   Previously the image sat above the full-card overlay link and swallowed clicks (only the
   title navigated). The image container is `pointer-events-none` so clicks fall through to the
   link, while overlay controls re-enable pointer events to stay interactive.

### Documentation

`F0Card` uses Storybook **autodocs**, so the feature is documented via:

- JSDoc on the `bookmark` prop and the `CardBookmark` type (feeds the props table).
- An `argTypes` description for `bookmark`.
- Two example stories — `Bookmarkable` and `BookmarkableWithImage` — each with a docs
  description explaining the behaviour.

### Tests

- 4 new unit tests (renders toggle, calls `onBookmarkChange`, does not navigate on toggle,
  falls back to `title` for the label). **28/28 F0Card tests pass.**
- `oxlint` 0/0, `oxfmt` clean, `tsc` clean.

### Files changed

- `components/F0Card/types.ts` — new `CardBookmark` type.
- `components/F0Card/CardInternal.tsx` — `bookmark` prop threaded to both `CardOptions`
  placements; lighter border; image `pointer-events-none`. Auto-exposed by `F0Card`.
- `components/F0Card/components/CardOptions.tsx` — circular bookmark toggle + visibility +
  re-enabled pointer events.
- `components/F0Card/__stories__/Card.stories.tsx` — stories + autodocs.
- `components/F0Card/__tests__/Card.test.tsx` — tests.

### Accessibility

- Native `<button>` with an accessible name (`label`, falling back to `title`) and
  `aria-pressed` reflecting the saved state.
