### PR TITLE
feat(ResourceHeader): leading icon on metadata items + showBottomBorder

### DIFF
--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react"
+import { Fragment, ReactNode } from "react"
 
 import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Button } from "@/components/F0Button"
@@ -57,6 +57,13 @@ interface BaseHeaderProps {
     actions?: MetadataAction[]
   }
   metadata?: MetadataProps["items"]
+  /**
+   * Custom content rendered inside the header, directly below the title and metadata.
+   * Shares the header's vertical rhythm so it reads as part of the header.
+   */
+  belowTitle?: ReactNode
+  /** Renders a 1px bottom border at the very bottom of the header. */
+  showBottomBorder?: boolean
 }
 
 const isVisible = (action: { isVisible?: boolean }) =>
@@ -72,6 +79,8 @@ export function BaseHeader({
   otherActions = [],
   status,
   metadata = [],
+  belowTitle,
+  showBottomBorder = false,
 }: BaseHeaderProps) {
   const allMetadata: BaseHeaderProps["metadata"] = [
     status && {
@@ -117,7 +126,12 @@ export function BaseHeader({
   }
 
   return (
-    <div className="resource-header px-page flex flex-col gap-3 pb-5 pt-3">
+    <div
+      className={cn(
+        "resource-header px-page flex flex-col gap-3 pb-5 pt-3",
+        showBottomBorder && "border-b border-solid border-f1-border"
+      )}
+    >
       <div
         className={cn(
           "flex flex-col items-start justify-start gap-4 md:flex-row",
@@ -302,6 +316,7 @@ export function BaseHeader({
           <Metadata items={allMetadata} />
         </div>
       )}
+      {belowTitle != null && <div>{belowTitle}</div>}
     </div>
   )
 }

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode } from "react"
+import { Fragment } from "react"
 
 import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Button } from "@/components/F0Button"
@@ -57,11 +57,6 @@ interface BaseHeaderProps {
     actions?: MetadataAction[]
   }
   metadata?: MetadataProps["items"]
-  /**
-   * Custom content rendered inside the header, directly below the title and metadata.
-   * Shares the header's vertical rhythm so it reads as part of the header.
-   */
-  belowTitle?: ReactNode
   /** Renders a 1px bottom border at the very bottom of the header. */
   showBottomBorder?: boolean
 }
@@ -79,7 +74,6 @@ export function BaseHeader({
   otherActions = [],
   status,
   metadata = [],
-  belowTitle,
   showBottomBorder = false,
 }: BaseHeaderProps) {
   const allMetadata: BaseHeaderProps["metadata"] = [
@@ -316,7 +310,6 @@ export function BaseHeader({
           <Metadata items={allMetadata} />
         </div>
       )}
-      {belowTitle != null && <div>{belowTitle}</div>}
     </div>
   )
 }

--- a/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
@@ -92,6 +92,12 @@ interface MetadataItem {
   hideLabel?: boolean
 
   /**
+   * Optional leading icon shown before the label/value. Useful when the icon itself
+   * conveys the field (e.g. with `hideLabel`), so the item reads as "icon + value".
+   */
+  icon?: IconType
+
+  /**
    * Optional info text. When provided, displays an info icon next to the label
    * that shows this text in a tooltip when hovered.
    */
@@ -159,6 +165,11 @@ function MetadataItem({ item }: { item: MetadataItem }) {
 
   return (
     <div className="flex h-8 items-center gap-2">
+      {item.icon && (
+        <span className="flex shrink-0 items-center text-f1-foreground-secondary">
+          <F0Icon icon={item.icon} size="md" />
+        </span>
+      )}
       <div
         className={cn(
           "flex w-28 items-center gap-1 truncate text-f1-foreground-secondary md:w-fit",

--- a/packages/react/src/patterns/ResourceHeader/index.stories.tsx
+++ b/packages/react/src/patterns/ResourceHeader/index.stories.tsx
@@ -529,6 +529,26 @@ export const TeamHeader: Story = {
   },
 }
 
+export const WithContentBelowTitle: Story = {
+  tags: ["!dev"],
+  args: {
+    title: 'MacBook Pro 14" M5',
+    showBottomBorder: true,
+    belowTitle: (
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-f1-foreground-secondary">
+        <span>Laptops</span>
+        <span>
+          Brand <span className="font-semibold text-f1-foreground">Apple</span>
+        </span>
+        <span>24h delivery</span>
+        <span>
+          SKU <span className="font-semibold text-f1-foreground">000017</span>
+        </span>
+      </div>
+    ),
+  },
+}
+
 export const WithLongDescription: Story = {
   tags: ["!dev"],
   args: {

--- a/packages/react/src/patterns/ResourceHeader/index.stories.tsx
+++ b/packages/react/src/patterns/ResourceHeader/index.stories.tsx
@@ -529,23 +529,33 @@ export const TeamHeader: Story = {
   },
 }
 
-export const WithContentBelowTitle: Story = {
+export const WithIconMetadataAndBorder: Story = {
   tags: ["!dev"],
   args: {
     title: 'MacBook Pro 14" M5',
     showBottomBorder: true,
-    belowTitle: (
-      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-f1-foreground-secondary">
-        <span>Laptops</span>
-        <span>
-          Brand <span className="font-semibold text-f1-foreground">Apple</span>
-        </span>
-        <span>24h delivery</span>
-        <span>
-          SKU <span className="font-semibold text-f1-foreground">000017</span>
-        </span>
-      </div>
-    ),
+    metadata: [
+      {
+        icon: Icon.Laptop,
+        label: "Category",
+        hideLabel: true,
+        value: { type: "text", content: "Laptops" },
+      },
+      {
+        label: "Brand",
+        value: { type: "text", content: "Apple" },
+      },
+      {
+        icon: Icon.Calendar,
+        label: "Delivery",
+        hideLabel: true,
+        value: { type: "text", content: "24h delivery" },
+      },
+      {
+        label: "SKU",
+        value: { type: "text", content: "000017" },
+      },
+    ],
   },
 }
 

--- a/packages/react/src/patterns/ResourceHeader/index.tsx
+++ b/packages/react/src/patterns/ResourceHeader/index.tsx
@@ -17,7 +17,6 @@ type Props = {} & Pick<
   | "metadata"
   | "status"
   | "deactivated"
-  | "belowTitle"
   | "showBottomBorder"
 >
 
@@ -31,7 +30,6 @@ const _ResourceHeader = ({
   status,
   metadata,
   deactivated,
-  belowTitle,
   showBottomBorder,
 }: Props) => {
   return (
@@ -45,7 +43,6 @@ const _ResourceHeader = ({
       status={status}
       metadata={metadata}
       deactivated={deactivated}
-      belowTitle={belowTitle}
       showBottomBorder={showBottomBorder}
     />
   )

--- a/packages/react/src/patterns/ResourceHeader/index.tsx
+++ b/packages/react/src/patterns/ResourceHeader/index.tsx
@@ -17,6 +17,8 @@ type Props = {} & Pick<
   | "metadata"
   | "status"
   | "deactivated"
+  | "belowTitle"
+  | "showBottomBorder"
 >
 
 const _ResourceHeader = ({
@@ -29,6 +31,8 @@ const _ResourceHeader = ({
   status,
   metadata,
   deactivated,
+  belowTitle,
+  showBottomBorder,
 }: Props) => {
   return (
     <BaseHeader
@@ -41,6 +45,8 @@ const _ResourceHeader = ({
       status={status}
       metadata={metadata}
       deactivated={deactivated}
+      belowTitle={belowTitle}
+      showBottomBorder={showBottomBorder}
     />
   )
 }


### PR DESCRIPTION
## Description

Two small, additive, backward-compatible capabilities so pages can show an icon-prefixed
key/value row in the resource header **through the structured `metadata` API** (no custom-content
props):

- **`MetadataItem.icon?: IconType`** — an optional leading icon rendered before the label/value.
  Combined with `hideLabel`, an item reads as **"icon + value"** (e.g. a category or delivery
  icon). It's always visible (independent of `hideLabel`) and inherits the secondary label tone.
- **`ResourceHeader.showBottomBorder?: boolean`** — a 1px bottom border at the very bottom of the
  header, as a separator from the page content.

## Context — what changed since the first revision

The first revision added a `belowTitle?: ReactNode` slot. Per @sauldom102's review ("avoid props
accepting custom content, use metadata"), that's been **dropped** in favour of the structured
`icon` field above — the actual gap was that `metadata` items couldn't render a leading icon, not
that we needed arbitrary content. Everything our consumer needs (icon+value, label+value) is now
expressible via typed `metadata`.

## Implementation details

- `Metadata` (`MetadataItem`): added optional `icon`; rendered as the first child of the item row
  inside a secondary-toned wrapper so `F0Icon`'s `currentColor` picks up the label tone. No change
  to existing items (icon is opt-in) or to `hideLabel` behaviour.
- `ResourceHeader` / `BaseHeader`: `showBottomBorder` applies `border-b border-solid border-f1-border`
  via `cn(...)`; `belowTitle` removed.
- Story: `WithIconMetadataAndBorder` (icon metadata + bottom border).
- `tsc`, `oxlint`, and the Metadata/ResourceHeader unit tests pass; `oxfmt` applied.

## Consumer

factorialco/factorial#100343 (IT device-catalog detail page). It currently renders the params row
at the monorepo wrapper level; once this lands and `@factorialco/f0-react` is bumped, it will pass
icon-bearing `metadata` items straight to `ResourceHeader`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)