### PR TITLE
fix(docs): correct dead Data Collection Storybook doc links

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.mdx
@@ -58,13 +58,13 @@ primarily through table, card, and list formats.
         title: "View Modes",
         description:
           "Data Collection offers multiple visualization modes, each optimized for different contexts and needs.",
-        href: "/?path=/docs/components-data-collection-visualizations--documentation",
+        href: "/?path=/docs/patterns-data-collection-visualizations--documentation",
       },
       {
         icon: Rocket,
         title: "Actions",
         description: "Data Collection offers global and item level actions.",
-        href: "/?path=/docs/components-data-collection-actions--documentation",
+        href: "/?path=/docs/patterns-data-collection-actions--documentation",
       },
       {
         icon: Pencil,
@@ -78,94 +78,94 @@ primarily through table, card, and list formats.
         title: "Value display",
         description:
           "The data items render is abstracted for semantic display.",
-        href: "/?path=/docs/components-data-collection-value-display--documentation",
+        href: "/?path=/docs/patterns-data-collection-value-display--documentation",
       },
       {
         icon: Filter,
         title: "Filters",
         description: "Data Collection offers filtering capabilities.",
-        href: "/?path=/docs/components-data-collection-filters--documentation",
+        href: "/?path=/docs/patterns-data-collection-filters--documentation",
       },
       {
         icon: Filter,
         title: "Navigation Filters",
         description: "Filtering specialized for navigation though the data",
-        href: "/?path=/docs/components-data-collection-navigation-filters--documentation",
+        href: "/?path=/docs/patterns-data-collection-navigation-filters--documentation",
       },
       {
         icon: CheckCircle,
         title: "Selectable and bulk actions",
         description: "How to allow users to selectable and run bulk actions",
-        href: "/?path=/docs/components-data-collection-selectable-and-bulk-actions--documentation",
+        href: "/?path=/docs/patterns-data-collection-selectable-and-bulk-actions--documentation",
       },
       {
         icon: Save,
         title: "Persistence",
         description:
           "Store the state of the data collection for the next visit",
-        href: "/?path=/docs/components-data-collection-status-persistence--documentation",
+        href: "/?path=/docs/patterns-data-collection-status-persistence--documentation",
       },
       {
         icon: Save,
         title: "Callbacks",
         description:
           "Callback functions to handle the state of the data collection",
-        href: "/?path=/docs/components-data-collection-callbacks--documentation",
+        href: "/?path=/docs/patterns-data-collection-callbacks--documentation",
       },
       {
         icon: Receipt,
         title: "Summary",
         description: "Renders summary data for the data collection",
-        href: "/?path=/docs/components-data-collection-summary--documentation",
+        href: "/?path=/docs/patterns-data-collection-summary--documentation",
       },
       {
         icon: Numbers,
         title: "Total items summary",
         description:
           "Renders a summary of the total number of items in the data collection",
-        href: "/?path=/docs/components-data-collection-total-items-summary--documentation",
+        href: "/?path=/docs/patterns-data-collection-total-items-summary--documentation",
       },
       {
         icon: Cross,
         title: "Empty State",
         description:
           "Renders a customizable empty state when no data is available.",
-        href: "/?path=/docs/components-data-collection-empty-state--documentation",
+        href: "/?path=/docs/patterns-data-collection-empty-state--documentation",
       },
       {
         icon: Spinner,
         title: "Loading",
         description:
           "Learn how data collection can display a loading state while data is being retrieved or processed.",
-        href: "/?path=/docs/components-data-collection-loading--documentation",
+        href: "/?path=/docs/patterns-data-collection-loading--documentation",
       },
       {
         icon: Sort,
         title: "Sorting",
         description:
           "Learn how data collection can display a sorting state while data is being retrieved or processed.",
-        href: "/?path=/docs/components-data-collection-sorting--documentation",
+        href: "/?path=/docs/patterns-data-collection-sorting--documentation",
       },
       {
         icon: BookOpen,
         title: "Pagination",
         description:
           "Learn how data collection can display a pagination state while data is being retrieved or processed.",
-        href: "/?path=/docs/data-collection-pagination--documentation",
+        href: "/?path=/docs/patterns-data-collection-pagination--documentation",
       },
       {
         icon: Desktop,
         title: "FullHeight Mode",
         description:
           "Learn how data collection can use the full height mode to scroll only the main content.",
-        href: "/?path=/docs/components-data-collection-full-height--documentation",
+        href: "/?path=/docs/patterns-data-collection-full-height--documentation",
       },
       {
         icon: Warning,
         title: "Temporary or Deprecated features",
         description:
           "Features that are deprecated or temporary and will be removed in the next major version.",
-        href: "/?path=/docs/components-data-collection-temporary-or-deprecated-features--documentation",
+        href: "/?path=/docs/patterns-data-collection-temporary-or-deprecated-features--documentation",
       },
     ]}
   />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations.mdx
@@ -23,35 +23,35 @@ etc.) and the visualization, of the data at item level (visualization) and
         title: "Table",
         description:
           "Table visualization is the default visualization for data collection. It displays the data in a table format.",
-        href: "/?path=/docs/components-data-collection-visualizations-table--documentation",
+        href: "/?path=/docs/patterns-data-collection-visualizations-table--documentation",
       },
       {
         icon: Pencil,
         title: "Editable Table 🚧",
         description:
           "Under construction. Same layout as Table but with inline cell editing.",
-        href: "/?path=/docs/components-data-collection-visualizations-editable-table--documentation",
+        href: "/?path=/docs/patterns-data-collection-visualizations-editable-table--documentation",
       },
       {
         icon: Kanban,
         title: "Card",
         description:
           "Card visualization is a visualization that displays the data in a card format.",
-        href: "/?path=/docs/components-data-collection-visualizations-card--documentation",
+        href: "/?path=/docs/patterns-data-collection-visualizations-card--documentation",
       },
       {
         icon: List,
         title: "List",
         description:
           "List visualization is a visualization that displays the data in a list format.",
-        href: "/?path=/docs/components-data-collection-visualizations-list--documentation",
+        href: "/?path=/docs/patterns-data-collection-visualizations-list--documentation",
       },
       {
         icon: Kanban,
         title: "Kanban",
         description:
           "Kanban visualization is a visualization that displays the data in a kanban format.",
-        href: "/?path=/docs/components-data-collection-visualizations-kanban--documentation",
+        href: "/?path=/docs/patterns-data-collection-visualizations-kanban--documentation",
       },
     ]}
   />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.mdx
@@ -11,7 +11,7 @@ import * as EditableTableStories from "./editable-table.stories"
 ## Introduction
 
 The Editable Table visualization is a tabular view that uses the same layout and
-features as the [Table](/?path=/docs/components-data-collection-visualizations-table--documentation)
+features as the [Table](/?path=/docs/patterns-data-collection-visualizations-table--documentation)
 visualization (columns, sorting, selection, grouping, pagination, summaries).
 Its main differences are:
 
@@ -93,7 +93,7 @@ Use `type: "editableTable"` in the `visualizations` prop:
 The Editable Table accepts the same base options as the Table visualization,
 plus editable-specific ones:
 
-- **columns** – Column definitions (extends the [Table column definition](/?path=/docs/components-data-collection-visualizations-table--documentation) with `editType` and `editable`; see [Editable Table Column Definition](#editable-table-column-definition) below).
+- **columns** – Column definitions (extends the [Table column definition](/?path=/docs/patterns-data-collection-visualizations-table--documentation) with `editType` and `editable`; see [Editable Table Column Definition](#editable-table-column-definition) below).
 - **onCellChange** – `(updatedItem: R) => Promise<void | Record<string, string>>`. Called whenever a user changes a cell value. `updatedItem` is the full row object with the edited field already updated. Resolve with nothing for success, or with `{ columnId: "message" }` to set errors on specific columns. If the promise rejects, the edited cell displays an error state. See [Error handling](#error-handling) below.
 - **frozenColumns** – Number of columns to freeze on the left (`0`, `1`, or `2`). Frozen columns stay visible when the user scrolls horizontally.
 - **allowColumnReordering** – Let users reorder columns via settings.


### PR DESCRIPTION
## Description

Fixes dead links in the **Data Collection** Storybook documentation. The Feature cards on the Documentation page (and a couple of inline links) navigated to non-existent pages — e.g. `https://f0.factorial.dev/?path=/docs/components-data-collection-visualizations--documentation` returned "Story not found".

The hrefs were hardcoded with a `components-data-collection-*` prefix (plus one bare `data-collection-pagination`), but these stories live under `src/patterns`, which `.storybook/main.ts` gives `titlePrefix: "Patterns"`. The correct IDs are therefore `patterns-data-collection-*`. Every corrected slug was cross-checked against the deployed Storybook manifest (`/index.json`).

## Implementation details

Corrected 23 hrefs across 3 files (all under `packages/react/src/patterns/OneDataCollection/__stories__/`):

- **`index.mdx`** — 16 Feature-card hrefs (the one already-correct `crud-patterns-overview` link was left as-is).
- **`visualizations.mdx`** — 5 Feature-card hrefs.
- **`visualizations/editable-table/editable-table.mdx`** — 2 inline links to the Table page.

### Known remaining issue (intentionally left untouched)

`visualizations.mdx:16` — the inline "cell level" link points to `data-collection-cell-types--docs`, which has **no corresponding page** in the deployed Storybook (it's not just a wrong prefix — the target doesn't exist). Closest existing page is `patterns-data-collection-value-display--documentation`. Left unchanged pending a decision on where it should point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
