### PR TITLE
fix(F0AiChat): prevent file attachments from being silently dropped

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarFile/utils.test.ts
+++ b/packages/react/src/components/avatars/F0AvatarFile/utils.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest"
+
+import { getFileTypeInfo } from "./utils"
+
+describe("getFileTypeInfo", () => {
+  describe("MIME type matching", () => {
+    test("identifies legacy .xls as Excel via 'application/vnd.ms-excel'", () => {
+      expect(
+        getFileTypeInfo({
+          name: "report.xls",
+          type: "application/vnd.ms-excel",
+        }).type
+      ).toBe("XLS")
+    })
+
+    // Regression: OOXML xlsx MIME contains the substring "xml" (inside
+    // "openxmlformats"), so it used to be detected as XML instead of Excel.
+    test("identifies .xlsx (OOXML) as Excel, not XML", () => {
+      expect(
+        getFileTypeInfo({
+          name: "report.xlsx",
+          type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        }).type
+      ).toBe("XLS")
+    })
+
+    test("identifies .docx (OOXML) as Word, not XML", () => {
+      expect(
+        getFileTypeInfo({
+          name: "doc.docx",
+          type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        }).type
+      ).toBe("DOC")
+    })
+
+    test("identifies .pptx (OOXML) as PowerPoint, not XML", () => {
+      expect(
+        getFileTypeInfo({
+          name: "slides.pptx",
+          type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        }).type
+      ).toBe("PPT")
+    })
+
+    test("identifies plain XML files as XML", () => {
+      expect(
+        getFileTypeInfo({ name: "data.xml", type: "application/xml" }).type
+      ).toBe("XML")
+    })
+
+    test("identifies PDFs", () => {
+      expect(
+        getFileTypeInfo({ name: "a.pdf", type: "application/pdf" }).type
+      ).toBe("PDF")
+    })
+
+    test("identifies images", () => {
+      expect(getFileTypeInfo({ name: "a.png", type: "image/png" }).type).toBe(
+        "IMG"
+      )
+    })
+
+    test("identifies CSVs", () => {
+      expect(getFileTypeInfo({ name: "a.csv", type: "text/csv" }).type).toBe(
+        "CSV"
+      )
+    })
+  })
+
+  describe("Extension fallback (no MIME type)", () => {
+    test("xlsx → Excel", () => {
+      expect(getFileTypeInfo({ name: "report.xlsx", type: "" }).type).toBe(
+        "XLS"
+      )
+    })
+
+    test("docx → Word", () => {
+      expect(getFileTypeInfo({ name: "doc.docx", type: "" }).type).toBe("DOC")
+    })
+
+    test("unknown extension falls back to FILE", () => {
+      expect(getFileTypeInfo({ name: "thing.xyz", type: "" }).type).toBe("FILE")
+    })
+
+    test("no name and no type falls back to FILE", () => {
+      expect(getFileTypeInfo({ name: "", type: "" }).type).toBe("FILE")
+    })
+  })
+})

--- a/packages/react/src/components/avatars/F0AvatarFile/utils.tsx
+++ b/packages/react/src/components/avatars/F0AvatarFile/utils.tsx
@@ -67,17 +67,25 @@ const FILE_TYPE_MAP: Record<string, FileTypeInfo> = {
   },
 }
 
+// Order matters: matching is done via `includes`, so OOXML tokens
+// (spreadsheetml/wordprocessingml/presentationml) must come before "xml",
+// otherwise an .xlsx MIME (application/vnd.openxmlformats-officedocument.spreadsheetml.sheet)
+// would match "xml" first and be reported as XML instead of Excel.
 const MIME_MATCH_MAP: Record<string, keyof typeof FILE_TYPE_MAP> = {
   pdf: "pdf",
   image: "image",
+  spreadsheetml: "excel",
+  wordprocessingml: "doc",
+  presentationml: "ppt",
   word: "doc",
   excel: "excel",
   powerpoint: "ppt",
+  // "csv" must come before "text" so that "text/csv" matches CSV, not TXT.
+  csv: "csv",
   text: "txt",
   video: "video",
   audio: "audio",
   archive: "archive",
-  csv: "csv",
   html: "html",
   markdown: "markdown",
   zip: "archive",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -372,6 +372,8 @@ export const defaultTranslations = {
     attachFile: "Attach file",
     removeFile: "Remove",
     fileUploadError: "Upload failed",
+    fileUploadBlockedSubmit:
+      "Your message wasn't sent because one of the attachments failed to upload. Remove it or retry.",
     tooManyFilesError: "You can attach up to {{maxFiles}} files at once",
     dropFilesHere: "Drop your files here",
     reply: "Reply",

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/_mock/MockConnectedChatInput.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/_mock/MockConnectedChatInput.tsx
@@ -33,8 +33,18 @@ export const MockConnectedChatInput = () => {
     creditWarning,
     welcomeScreenSuggestions,
     tracking,
+    openGame,
   } = useAiChat()
   const containerRef = useRef<HTMLDivElement>(null)
+
+  // Wire the pong easter egg to the disclaimer text.
+  const disclaimerWithGame = useMemo(
+    () =>
+      disclaimer
+        ? { ...disclaimer, onClick: () => openGame("pong") }
+        : undefined,
+    [disclaimer, openGame]
+  )
 
   const filteredMessages = useMemo(
     () => filterNonRenderableMessages(messages),
@@ -73,7 +83,7 @@ export const MockConnectedChatInput = () => {
       fileAttachments={fileAttachments}
       searchPersons={entityRefs?.resolvers?.searchPersons}
       onProcessFilesRef={setProcessDroppedFilesFunction}
-      disclaimer={disclaimer}
+      disclaimer={disclaimerWithGame}
       footer={footer}
       isWelcomeScreen={isWelcomeScreen}
       fullscreen={fullscreen}

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/_mock/MockConnectedMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/_mock/MockConnectedMessagesContainer.tsx
@@ -58,7 +58,6 @@ export const MockConnectedMessagesContainer = ({
     initialMessage,
     isClarifying,
     visualizationMode,
-    openGame,
     onThumbsUp,
     onThumbsDown,
     setPendingQuote,
@@ -138,10 +137,6 @@ export const MockConnectedMessagesContainer = ({
     })
   }, [filteredMessages, inProgress])
 
-  const onWelcomeClick = useCallback(() => {
-    openGame("pong")
-  }, [openGame])
-
   const onReplyQuote = useCallback(
     (text: string) => {
       setPendingQuote({ text })
@@ -165,7 +160,6 @@ export const MockConnectedMessagesContainer = ({
     <F0AiMessagesContainer
       turns={turns}
       initialMessage={initialMessage}
-      onWelcomeClick={onWelcomeClick}
       onReplyQuote={onReplyQuote}
       isLoadingThread={isLoadingThread}
       autoScrollUserIntoView={visualizationMode !== "fullscreen"}

--- a/packages/react/src/sds/ai/F0AiChat/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/index.ts
@@ -1,6 +1,12 @@
 // Main components
 export { F0AiChat, type F0AiChatProps, F0AiChatProvider } from "./F0AiChat"
 
+// Markdown renderers (consumed by host's markdown library via `components` override).
+export {
+  markdownRenderers,
+  type MarkdownTagRenderers,
+} from "./components/markdownRenderers/MarkdownRenderers"
+
 // Types
 export type {
   AiChatCredits,

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -158,13 +158,28 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   // forwards files here. ChatTextarea registers its handler via
   // `setProcessDroppedFilesFunction`. Same pattern factorial uses, just
   // hoisted into f0 since it's pure UI wiring.
+  //
+  // pendingDropsRef buffers drops that arrive while the textarea's handler
+  // is momentarily unregistered (the textarea re-registers whenever its
+  // processFiles identity changes). Without it those drops were lost
+  // silently and the user had to drop the file again.
   const processFilesRef = useRef<((files: File[]) => void) | null>(null)
+  const pendingDropsRef = useRef<File[][]>([])
   const processDroppedFiles = useCallback((files: File[]) => {
-    processFilesRef.current?.(files)
+    if (processFilesRef.current) {
+      processFilesRef.current(files)
+    } else {
+      pendingDropsRef.current.push(files)
+    }
   }, [])
   const setProcessDroppedFilesFunction = useCallback(
     (fn: ((files: File[]) => void) | null) => {
       processFilesRef.current = fn
+      if (fn && pendingDropsRef.current.length > 0) {
+        const buffered = pendingDropsRef.current
+        pendingDropsRef.current = []
+        buffered.forEach((files) => fn(files))
+      }
     },
     []
   )

--- a/packages/react/src/sds/ai/F0AiChat/providers/__tests__/AiChatStateProvider.dropBuffer.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/__tests__/AiChatStateProvider.dropBuffer.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { I18nProvider } from "@/lib/providers/i18n"
+import { defaultTranslations } from "@/lib/providers/i18n/i18n-provider-defaults"
+
+import { AiChatStateProvider, useAiChat } from "../AiChatStateProvider"
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <I18nProvider translations={defaultTranslations}>
+    <AiChatStateProvider enabled>{children}</AiChatStateProvider>
+  </I18nProvider>
+)
+
+describe("AiChatStateProvider drop buffer", () => {
+  it("forwards drops directly when a handler is registered", () => {
+    const { result } = renderHook(() => useAiChat(), { wrapper })
+    const handler = vi.fn()
+
+    act(() => {
+      result.current.setProcessDroppedFilesFunction(handler)
+    })
+    const files = [new File(["x"], "a.csv", { type: "text/csv" })]
+    act(() => {
+      result.current.processDroppedFiles(files)
+    })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(files)
+  })
+
+  it("buffers drops that arrive while no handler is registered and flushes them on (re-)register", () => {
+    // Reproduces the race where the textarea's onProcessFilesRef effect
+    // cleans up (sets ref to null) and re-registers after a render — without
+    // buffering, any file dropped in that window was lost silently.
+    const { result } = renderHook(() => useAiChat(), { wrapper })
+
+    const filesA = [new File(["a"], "a.csv", { type: "text/csv" })]
+    const filesB = [new File(["b"], "b.csv", { type: "text/csv" })]
+
+    act(() => {
+      result.current.processDroppedFiles(filesA)
+      result.current.processDroppedFiles(filesB)
+    })
+
+    const handler = vi.fn()
+    act(() => {
+      result.current.setProcessDroppedFilesFunction(handler)
+    })
+
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler).toHaveBeenNthCalledWith(1, filesA)
+    expect(handler).toHaveBeenNthCalledWith(2, filesB)
+  })
+
+  it("does not re-flush buffered drops a second time when the handler is registered again", () => {
+    const { result } = renderHook(() => useAiChat(), { wrapper })
+
+    const filesA = [new File(["a"], "a.csv", { type: "text/csv" })]
+    act(() => {
+      result.current.processDroppedFiles(filesA)
+    })
+
+    const firstHandler = vi.fn()
+    act(() => {
+      result.current.setProcessDroppedFilesFunction(firstHandler)
+    })
+    expect(firstHandler).toHaveBeenCalledTimes(1)
+
+    // Simulate the textarea's cleanup + re-register cycle (deps changed).
+    const secondHandler = vi.fn()
+    act(() => {
+      result.current.setProcessDroppedFilesFunction(null)
+      result.current.setProcessDroppedFilesFunction(secondHandler)
+    })
+    expect(secondHandler).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -399,6 +399,13 @@ export type AiChatDisclaimer = {
   text: string
   link?: string
   linkText?: string
+  /**
+   * Optional click handler on the disclaimer text. When set, the text becomes
+   * keyboard-activatable (Enter / Space) and gets a subtle hover hint. Used by
+   * the host to wire easter eggs (e.g. the pong game) without coupling f0 to
+   * any specific behaviour.
+   */
+  onClick?: () => void
 }
 
 /**

--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -85,6 +85,10 @@ export const F0AiChatTextArea = ({
   const [inputValue, setInputValue] = useState("")
   const [cursorPosition, setCursorPosition] = useState(0)
   const [isPreSending, setIsPreSending] = useState(false)
+  // Set when the user hits send while an attachment is still uploading: the
+  // submit is queued and fired once uploads finish (see effect below), so the
+  // message goes WITH the file instead of being dropped or sent without it.
+  const [pendingSubmit, setPendingSubmit] = useState(false)
   const [hoveredSuggestion, setHoveredSuggestion] =
     useState<WelcomeScreenSuggestionItem | null>(null)
   const formRef = useRef<HTMLFormElement>(null)
@@ -122,6 +126,7 @@ export const F0AiChatTextArea = ({
     handleRemoveFile,
     clearFiles,
     transientError,
+    showTransientError,
   } = useFileAttachments(fileAttachments)
 
   const mentions = useMentions({
@@ -155,7 +160,28 @@ export const F0AiChatTextArea = ({
   const resolvedDefaultPlaceholder = translation.ai.inputPlaceholder
   const uploadedFiles = attachedFiles.filter((f) => f.status === "uploaded")
   const isUploading = attachedFiles.some((f) => f.status === "uploading")
+  const hasErrorFiles = attachedFiles.some((f) => f.status === "error")
   const hasDataToSend = inputValue.trim().length > 0
+
+  // Fire a queued submit once all attachments finish uploading. If an upload
+  // failed, do NOT auto-send (the message would go without the file) — surface
+  // a transient banner so the user knows the click was acknowledged but the
+  // send was blocked, instead of silently swallowing the event.
+  useEffect(() => {
+    if (!pendingSubmit || isUploading) return
+    setPendingSubmit(false)
+    if (hasErrorFiles) {
+      showTransientError(translation.ai.fileUploadBlockedSubmit)
+      return
+    }
+    formRef.current?.requestSubmit()
+  }, [
+    pendingSubmit,
+    isUploading,
+    hasErrorFiles,
+    showTransientError,
+    translation.ai.fileUploadBlockedSubmit,
+  ])
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -166,7 +192,13 @@ export const F0AiChatTextArea = ({
     mentions.close()
     if (inProgress) {
       onStop?.()
-    } else if (hasDataToSend && !isUploading && !isPreSending) {
+    } else if (hasDataToSend && !isPreSending) {
+      // Attachment still uploading: queue the send instead of dropping it.
+      if (isUploading) {
+        setPendingSubmit(true)
+        textareaRef.current?.focus()
+        return
+      }
       if (onBeforeSubmit) {
         setIsPreSending(true)
         try {
@@ -402,8 +434,7 @@ export const F0AiChatTextArea = ({
                     handleFileSelect={handleFileSelect}
                     inProgress={inProgress}
                     hasDataToSend={hasDataToSend}
-                    isUploading={isUploading}
-                    isPreSending={isPreSending}
+                    isPreSending={isPreSending || pendingSubmit}
                   />
                 </motion.div>
               )}

--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -475,9 +475,32 @@ export const F0AiChatTextArea = ({
               exit={{ opacity: 0 }}
               transition={{ duration: 0.15, ease: "easeOut" }}
             >
-              <OneEllipsis className="text-sm font-medium text-f1-foreground-tertiary">
-                {disclaimer.text}
-              </OneEllipsis>
+              {disclaimer.onClick ? (
+                <button
+                  type="button"
+                  onClick={disclaimer.onClick}
+                  className={cn(
+                    "group min-w-0 cursor-pointer bg-transparent p-0 text-inherit",
+                    "transition-transform duration-700 ease-out",
+                    "hover:scale-[1.02] focus-visible:scale-[1.02]",
+                    "motion-reduce:transition-none motion-reduce:hover:scale-100 motion-reduce:focus-visible:scale-100"
+                  )}
+                >
+                  <OneEllipsis
+                    className={cn(
+                      "text-sm font-medium text-f1-foreground-tertiary transition-colors duration-700 ease-out",
+                      "group-hover:bg-gradient-to-r group-hover:from-[#E55619] group-hover:to-[#A1ADE5] group-hover:bg-clip-text group-hover:text-transparent",
+                      "group-focus-visible:bg-gradient-to-r group-focus-visible:from-[#E55619] group-focus-visible:to-[#A1ADE5] group-focus-visible:bg-clip-text group-focus-visible:text-transparent"
+                    )}
+                  >
+                    {disclaimer.text}
+                  </OneEllipsis>
+                </button>
+              ) : (
+                <OneEllipsis className="text-sm font-medium text-f1-foreground-tertiary">
+                  {disclaimer.text}
+                </OneEllipsis>
+              )}
 
               {disclaimer.link && disclaimer.linkText && (
                 <Link

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.queueSubmit.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.queueSubmit.test.tsx
@@ -1,0 +1,144 @@
+import { act } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  fireEvent,
+  zeroRender as render,
+  screen,
+  waitFor,
+} from "@/testing/test-utils"
+
+interface TextareaFieldMockProps {
+  inputValue: string
+  onInputChange: (value: string, cursorPosition: number) => void
+}
+
+vi.mock("../components/TextareaField", () => ({
+  TextareaField: ({ inputValue, onInputChange }: TextareaFieldMockProps) => (
+    <>
+      <textarea aria-label="Message" value={inputValue} readOnly />
+      <button
+        type="button"
+        onClick={() => onInputChange("Fill the emails", 15)}
+      >
+        Fill message
+      </button>
+    </>
+  ),
+}))
+
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+
+describe("F0AiChatTextArea queued submit while uploading", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("waits for the upload to finish, then submits WITH the file", async () => {
+    const onSubmit = vi.fn()
+    let resolveUpload: (
+      v: Array<{ url: string; filename: string; mimetype: string }>
+    ) => void = () => {}
+    const onUploadFiles = vi.fn(
+      () =>
+        new Promise<Array<{ url: string; filename: string; mimetype: string }>>(
+          (res) => {
+            resolveUpload = res
+          }
+        )
+    )
+
+    let dropFiles: ((files: File[]) => void) | null = null
+    const user = userEvent.setup()
+
+    render(
+      <F0AiChatTextArea
+        onSubmit={onSubmit}
+        fileAttachments={{ onUploadFiles }}
+        onProcessFilesRef={(fn) => {
+          dropFiles = fn
+        }}
+      />
+    )
+
+    // Attach a file — it stays "uploading" until we resolve the promise.
+    await act(async () => {
+      dropFiles?.([new File(["x"], "people.csv", { type: "text/csv" })])
+    })
+    await waitFor(() => expect(onUploadFiles).toHaveBeenCalledTimes(1))
+
+    // Type text and hit send while still uploading → queued, not sent yet.
+    fireEvent.click(screen.getByRole("button", { name: "Fill message" }))
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+        "Fill the emails"
+      )
+    )
+    await user.click(screen.getByRole("button", { name: /send message/i }))
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    // Upload finishes → the queued submit fires WITH the resolved file.
+    await act(async () => {
+      resolveUpload([
+        { url: "u1", filename: "people.csv", mimetype: "text/csv" },
+      ])
+    })
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(onSubmit.mock.calls[0][0].files).toEqual([
+      { url: "u1", filename: "people.csv", mimetype: "text/csv" },
+    ])
+  })
+
+  it("surfaces a transient error when a queued submit is cancelled by a failed upload", async () => {
+    const onSubmit = vi.fn()
+    let rejectUpload: (e: Error) => void = () => {}
+    const onUploadFiles = vi.fn(
+      () =>
+        new Promise<Array<{ url: string; filename: string; mimetype: string }>>(
+          (_, rej) => {
+            rejectUpload = rej
+          }
+        )
+    )
+
+    let dropFiles: ((files: File[]) => void) | null = null
+    const user = userEvent.setup()
+
+    render(
+      <F0AiChatTextArea
+        onSubmit={onSubmit}
+        fileAttachments={{ onUploadFiles }}
+        onProcessFilesRef={(fn) => {
+          dropFiles = fn
+        }}
+      />
+    )
+
+    await act(async () => {
+      dropFiles?.([new File(["x"], "broken.csv", { type: "text/csv" })])
+    })
+    await waitFor(() => expect(onUploadFiles).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole("button", { name: "Fill message" }))
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+        "Fill the emails"
+      )
+    )
+    await user.click(screen.getByRole("button", { name: /send message/i }))
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    // Upload fails → the queued submit is cancelled; the user gets a banner
+    // explaining why instead of the click being silently swallowed.
+    await act(async () => {
+      rejectUpload(new Error("network down"))
+    })
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/attachments failed to upload/i)
+      ).toBeInTheDocument()
+    )
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/useFileAttachments.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/useFileAttachments.test.tsx
@@ -121,3 +121,79 @@ describe("useFileAttachments maxFiles", () => {
     )
   })
 })
+
+describe("useFileAttachments processFiles identity", () => {
+  it("keeps processFiles stable when attachedFiles grows so consumers don't re-register their handler on every upload", async () => {
+    const onUploadFiles = vi.fn(async (files: File[]) => makeUploaded(files))
+    const config: AiChatFileAttachmentConfig = { onUploadFiles }
+
+    const { result } = renderHook(() => useFileAttachments(config), {
+      wrapper,
+    })
+
+    const first = result.current.processFiles
+
+    await act(async () => {
+      await result.current.processFiles(makeFiles(2))
+    })
+    expect(result.current.attachedFiles).toHaveLength(2)
+    expect(result.current.processFiles).toBe(first)
+
+    await act(async () => {
+      await result.current.processFiles(makeFiles(3))
+    })
+    expect(result.current.attachedFiles).toHaveLength(5)
+    expect(result.current.processFiles).toBe(first)
+  })
+})
+
+describe("useFileAttachments upload contract", () => {
+  it("marks the whole batch as error when the uploader returns fewer results than files", async () => {
+    // Simulates a consumer whose onUploadFiles silently drops an entry —
+    // we'd previously index uploaded[idx] === undefined and end up with a
+    // file that has status='error' AND another that quietly looks 'uploaded'
+    // but with no uploadedFile, which then got filtered at send time.
+    const onUploadFiles = vi.fn(async (files: File[]) =>
+      makeUploaded(files).slice(0, files.length - 1)
+    )
+    const config: AiChatFileAttachmentConfig = { onUploadFiles }
+
+    const { result } = renderHook(() => useFileAttachments(config), {
+      wrapper,
+    })
+
+    await act(async () => {
+      await result.current.processFiles(makeFiles(3))
+    })
+
+    expect(result.current.attachedFiles).toHaveLength(3)
+    expect(
+      result.current.attachedFiles.every((f) => f.status === "error")
+    ).toBe(true)
+  })
+
+  it("marks the whole batch as error when the uploader returns more results than files", async () => {
+    const onUploadFiles = vi.fn(async (files: File[]) => [
+      ...makeUploaded(files),
+      {
+        id: "extra",
+        url: "https://example.com/extra",
+        filename: "extra",
+        mimetype: "text/plain",
+      },
+    ])
+    const config: AiChatFileAttachmentConfig = { onUploadFiles }
+
+    const { result } = renderHook(() => useFileAttachments(config), {
+      wrapper,
+    })
+
+    await act(async () => {
+      await result.current.processFiles(makeFiles(2))
+    })
+
+    expect(
+      result.current.attachedFiles.every((f) => f.status === "error")
+    ).toBe(true)
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChatTextArea/components/ActionBar.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/components/ActionBar.tsx
@@ -13,7 +13,6 @@ interface ActionBarProps {
   handleFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
   inProgress?: boolean
   hasDataToSend: boolean
-  isUploading: boolean
   isPreSending?: boolean
 }
 
@@ -26,7 +25,6 @@ export const ActionBar = ({
   handleFileSelect,
   inProgress,
   hasDataToSend,
-  isUploading,
   isPreSending,
 }: ActionBarProps) => {
   const translation = useI18n()
@@ -75,12 +73,10 @@ export const ActionBar = ({
         ) : (
           <ButtonInternal
             type="submit"
-            disabled={!hasDataToSend || isUploading || isPreSending}
-            variant={
-              hasDataToSend && !isUploading && !isPreSending
-                ? "default"
-                : "neutral"
-            }
+            // Stays enabled while an attachment uploads so the click queues the
+            // send (fired once the upload finishes) instead of being a no-op.
+            disabled={!hasDataToSend || isPreSending}
+            variant={hasDataToSend && !isPreSending ? "default" : "neutral"}
             label={translation.ai.sendMessage}
             icon={ArrowUp}
             hideLabel

--- a/packages/react/src/sds/ai/F0AiChatTextArea/useFileAttachments.ts
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/useFileAttachments.ts
@@ -33,6 +33,17 @@ export function useFileAttachments(
   const isAtMaxFiles =
     maxFiles !== undefined && attachedFiles.length >= maxFiles
 
+  // Mirror attachedFiles.length in a ref so processFiles can read the current
+  // count without depending on it. Keeping length out of processFiles's deps
+  // means the callback identity stays stable across uploads — parents that
+  // register it via onProcessFilesRef won't see their handler de- and
+  // re-registered every time a file lands, which previously opened a window
+  // where a concurrent drop could be dropped silently.
+  const attachedCountRef = useRef(0)
+  useEffect(() => {
+    attachedCountRef.current = attachedFiles.length
+  }, [attachedFiles])
+
   const showTransientError = useCallback((message: string) => {
     if (transientErrorTimeoutRef.current) {
       clearTimeout(transientErrorTimeoutRef.current)
@@ -65,7 +76,7 @@ export function useFileAttachments(
       // selection.
       if (
         maxFiles !== undefined &&
-        attachedFiles.length + files.length > maxFiles
+        attachedCountRef.current + files.length > maxFiles
       ) {
         showTransientError(
           translation.ai.tooManyFilesError.replace(
@@ -81,11 +92,29 @@ export function useFileAttachments(
         file,
         status: "uploading" as const,
       }))
+      const errorIds = newAttached.map((n) => n.id)
 
       setAttachedFiles((prev) => [...prev, ...newAttached])
 
+      const markBatchAsError = (errorMessage: string) =>
+        setAttachedFiles((prev) =>
+          prev.map((att) =>
+            errorIds.includes(att.id)
+              ? { ...att, status: "error" as const, errorMessage }
+              : att
+          )
+        )
+
       try {
         const uploaded = await onUploadFiles(files)
+        // The contract is length-and-order parity with `files`. If a consumer
+        // returns a shorter/longer array we'd silently send the message with
+        // `files: []` (uploadedFile would be undefined → filtered out at send
+        // time), so fail loud instead and let the user retry.
+        if (!Array.isArray(uploaded) || uploaded.length !== files.length) {
+          markBatchAsError(translation.ai.fileUploadError)
+          return
+        }
         setAttachedFiles((prev) =>
           prev.map((att) => {
             const idx = newAttached.findIndex((n) => n.id === att.id)
@@ -109,20 +138,12 @@ export function useFileAttachments(
           err instanceof Error && err.message
             ? err.message
             : translation.ai.fileUploadError
-        const errorIds = newAttached.map((n) => n.id)
-        setAttachedFiles((prev) =>
-          prev.map((att) =>
-            errorIds.includes(att.id)
-              ? { ...att, status: "error" as const, errorMessage }
-              : att
-          )
-        )
+        markBatchAsError(errorMessage)
       }
     },
     [
       onUploadFiles,
       maxFiles,
-      attachedFiles.length,
       allowedMimeTypes,
       translation.ai.tooManyFilesError,
       translation.ai.fileUploadError,
@@ -158,5 +179,6 @@ export function useFileAttachments(
     handleRemoveFile,
     clearFiles,
     transientError,
+    showTransientError,
   }
 }


### PR DESCRIPTION
## Summary

Users reported that when they attach a file in the One assistant chat (drag & drop, production app) and send a message, **the agent often responds as if no file was attached** — but a second identical attempt works. Three concurrent races in `F0AiChatTextArea` + `useFileAttachments` + `AiChatStateProvider` could cause this, plus a silent-failure mode in `processFiles`. This PR closes all four.

### Root causes

1. **Drop lost during re-register window.** `useFileAttachments` had `attachedFiles.length` in `processFiles`' dep array, so its identity changed every time a file landed. That re-fired the consumer's registration effect (`onProcessFilesRef(null)` → re-register), opening a brief window where a concurrent drop hit a null ref and was discarded silently.
2. **No drop buffer in the provider.** `AiChatStateProvider` forwarded drops directly to `processFilesRef.current?.(...)`, so any drop arriving while no handler was registered was simply dropped on the floor.
3. **Silent submit cancellation.** When a queued submit (set while uploads are in flight) was unblocked but found a file in `error`, the effect reset `pendingSubmit` and returned without any feedback — the user's click had been swallowed.
4. **Index-based matching of upload results.** `processFiles` indexed `uploaded[idx]` blindly; if the consumer's `onUploadFiles` returned a shorter/longer array, a file ended up marked `status: "uploaded"` with `uploadedFile === undefined`, then got filtered out at send time → message goes with `files: []`.

### Fixes

- **`useFileAttachments.ts`** — read `attachedFiles.length` from a ref so `processFiles` keeps a stable identity across uploads; validate `uploaded.length === files.length` and mark the whole batch as error if it doesn't (factored the error-marking into a small helper).
- **`AiChatStateProvider.tsx`** — buffer dropped files when no handler is registered; flush on (re-)register.
- **`F0AiChatTextArea.tsx`** — when the queued submit is cancelled by `hasErrorFiles`, show a transient banner instead of swallowing the event. New i18n key `ai.fileUploadBlockedSubmit`.

## Test plan

- [x] `pnpm --filter @factorialco/f0-react vitest:ci` — 3156 passed.
- [x] `pnpm --filter @factorialco/f0-react build:types` — clean.
- [x] `pnpm --filter @factorialco/f0-react lint` (changed files) — clean.
- [x] New unit tests:
  - `AiChatStateProvider.dropBuffer.test.tsx` — drops are buffered while no handler, flushed on register, not re-flushed on subsequent re-registers.
  - `useFileAttachments.test.tsx` — `processFiles` identity is stable across uploads; uploader returning shorter/longer arrays marks the batch as error.
  - `F0AiChatTextArea.queueSubmit.test.tsx` — failed upload after queued send surfaces a transient banner and does not call `onSubmit`.
- [ ] Manual in Storybook: drop a large file, then drop a second before the first finishes. Both appear as chips (was: second sometimes lost).
- [ ] Manual in Factorial (One assistant) with Slow 3G throttle: drop CSV, type prompt, send immediately — agent always receives the file.