### PR TITLE
feat(F0Sidepanel): add experimental side-anchored panel component

### DIFF
--- a/packages/react/src/experimental/Overlays/F0Sidepanel/F0Sidepanel.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/F0Sidepanel.tsx
@@ -1,0 +1,8 @@
+import { F0SidepanelInternal } from "./F0SidepanelInternal"
+import { F0SidepanelProps } from "./types"
+
+export const F0Sidepanel = (props: F0SidepanelProps) => (
+  <F0SidepanelInternal {...props} />
+)
+
+F0Sidepanel.displayName = "F0Sidepanel"

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/F0SidepanelInternal.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/F0SidepanelInternal.tsx
@@ -31,6 +31,7 @@ export const F0SidepanelInternal = ({
   locked = false,
   allowBackgroundInteraction = false,
   headerBorder = false,
+  loading = false,
   options,
   navigation,
   children,
@@ -96,6 +97,7 @@ export const F0SidepanelInternal = ({
           navigation={navigation}
           options={options}
           headerBorder={headerBorder}
+          loading={loading}
         />
 
         <div

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/F0SidepanelInternal.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/F0SidepanelInternal.tsx
@@ -39,6 +39,12 @@ export const F0SidepanelInternal = ({
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
+    // If the parent re-opens us before the exit-animation timeout has fired,
+    // cancel the pending onClose so it doesn't run while the panel is visible.
+    if (open && closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current)
+      closeTimeoutRef.current = null
+    }
     setIsOpen(open)
   }, [open])
 

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/F0SidepanelInternal.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/F0SidepanelInternal.tsx
@@ -31,7 +31,6 @@ export const F0SidepanelInternal = ({
   locked = false,
   allowBackgroundInteraction = false,
   headerBorder = false,
-  shadow = true,
   options,
   navigation,
   children,
@@ -75,7 +74,6 @@ export const F0SidepanelInternal = ({
       <SheetContent
         side={side}
         withOverlay={overlay && !allowBackgroundInteraction}
-        withShadow={shadow}
         className={cn(widthClasses[width], "rounded-none")}
         onOpenAutoFocus={(event) => event.preventDefault()}
         onInteractOutside={(event) => {

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/F0SidepanelInternal.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/F0SidepanelInternal.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { cn } from "@/lib/utils"
+import { Sheet, SheetContent } from "@/ui/Sheet/sheet"
+
+import { F0SidepanelFooter } from "./components/F0SidepanelFooter"
+import { F0SidepanelHeader } from "./components/F0SidepanelHeader"
+import { F0SidepanelProps, SidepanelWidth } from "./types"
+
+const EXIT_DURATION_MS = 200
+
+const widthClasses: Record<SidepanelWidth, string> = {
+  narrow: "w-full max-w-[360px]",
+  wide: "w-full max-w-[600px]",
+  wideXL: "w-full max-w-[800px]",
+  extended: "w-[95vw] max-w-[95vw]",
+  full: "w-screen max-w-full",
+}
+
+export const F0SidepanelInternal = ({
+  open,
+  onClose,
+  onCloseClicked,
+  title,
+  closeLabel = "Close",
+  side = "right",
+  width = "narrow",
+  boxPadding = true,
+  footer,
+  overlay = true,
+  locked = false,
+  allowBackgroundInteraction = false,
+  headerBorder = false,
+  shadow = true,
+  options,
+  navigation,
+  children,
+}: F0SidepanelProps) => {
+  const [isOpen, setIsOpen] = useState(open)
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    setIsOpen(open)
+  }, [open])
+
+  useEffect(
+    () => () => {
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current)
+    },
+    []
+  )
+
+  const requestClose = useCallback(() => {
+    setIsOpen(false)
+    onCloseClicked?.()
+    if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current)
+    closeTimeoutRef.current = setTimeout(() => {
+      onClose()
+    }, EXIT_DURATION_MS)
+  }, [onClose, onCloseClicked])
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      if (locked) return
+      requestClose()
+    }
+  }
+
+  return (
+    <Sheet
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      modal={!allowBackgroundInteraction}
+    >
+      <SheetContent
+        side={side}
+        withOverlay={overlay && !allowBackgroundInteraction}
+        withShadow={shadow}
+        className={cn(widthClasses[width], "rounded-none")}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onInteractOutside={(event) => {
+          if (locked || allowBackgroundInteraction) event.preventDefault()
+        }}
+        onEscapeKeyDown={(event) => {
+          if (locked) event.preventDefault()
+        }}
+      >
+        <F0SidepanelHeader
+          title={title}
+          closeLabel={closeLabel}
+          onCloseClick={requestClose}
+          navigation={navigation}
+          options={options}
+          headerBorder={headerBorder}
+        />
+
+        <div
+          className={cn(
+            "flex-1 overflow-y-auto",
+            boxPadding ? "px-6 py-6" : "p-0"
+          )}
+        >
+          {children}
+        </div>
+
+        {footer && <F0SidepanelFooter>{footer}</F0SidepanelFooter>}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/F0SidepanelInternal.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/F0SidepanelInternal.tsx
@@ -22,7 +22,7 @@ export const F0SidepanelInternal = ({
   onClose,
   onCloseClicked,
   title,
-  closeLabel = "Close",
+  closeLabel,
   side = "right",
   width = "narrow",
   boxPadding = true,

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/__stories__/F0Sidepanel.stories.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/__stories__/F0Sidepanel.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { Delete, Pencil, Save } from "@/icons/app"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0Sidepanel } from "../index"
 import { sidepanelSides, sidepanelWidths } from "../types"
@@ -381,4 +382,45 @@ export const NoBoxPadding: Story = {
       </div>
     ),
   },
+}
+
+const SnapshotDemo = () => {
+  // Open by default so Chromatic captures the panel; the trigger button is
+  // still wired up so the story is interactable after closing.
+  const [open, setOpen] = useState(true)
+
+  return (
+    <div className="flex h-[600px] items-center justify-center">
+      <F0Button label="Open sidepanel" onClick={() => setOpen(true)} />
+      <F0Sidepanel
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Ainhoa López"
+        width="wide"
+        headerBorder
+        navigation={{
+          counter: { current: 1, total: 4 },
+          previous: { onClick: () => {}, title: "Previous employee" },
+          next: { onClick: () => {}, title: "Next employee" },
+        }}
+        options={[
+          { label: "Edit", icon: Pencil, onClick: () => {} },
+          { label: "Delete", icon: Delete, critical: true, onClick: () => {} },
+        ]}
+        footer={
+          <>
+            <F0Button variant="outline" label="Cancel" />
+            <F0Button label="Save" icon={Save} />
+          </>
+        }
+      >
+        <ExampleBody />
+      </F0Sidepanel>
+    </div>
+  )
+}
+
+export const Snapshot: StoryObj = {
+  parameters: withSnapshot({}),
+  render: () => <SnapshotDemo />,
 }

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/__stories__/F0Sidepanel.stories.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/__stories__/F0Sidepanel.stories.tsx
@@ -67,11 +67,6 @@ const meta: Meta<typeof Demo> = {
       description: "Show a bottom border on the header.",
       control: { type: "boolean" },
     },
-    shadow: {
-      description: "Render with the elevation shadow.",
-      control: { type: "boolean" },
-      table: { defaultValue: { summary: "true" } },
-    },
     title: {
       description:
         "Header title. Renders centered as a bold label when a string, or as-is when a ReactNode. Omit (or pass null) to use the title-less Figma layout.",
@@ -308,11 +303,11 @@ export const Extended: Story = {
   },
 }
 
-export const NoShadow: Story = {
+export const NoOverlay: Story = {
   args: {
     width: "wide",
-    title: "Flush variant",
-    shadow: false,
+    title: "No backdrop",
+    overlay: false,
     headerBorder: true,
     children: <ExampleBody />,
   },
@@ -320,7 +315,25 @@ export const NoShadow: Story = {
     docs: {
       description: {
         story:
-          "Use `shadow={false}` for embedded or flush placements where the surrounding chrome already provides separation.",
+          "Use `overlay={false}` to hide the dimmed backdrop while keeping the panel modal. The user still can't reach the page underneath — outside-click and Escape still close the panel.",
+      },
+    },
+  },
+}
+
+export const Floating: Story = {
+  args: {
+    width: "wide",
+    title: "Floating panel",
+    allowBackgroundInteraction: true,
+    headerBorder: true,
+    children: <ExampleBody />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use `allowBackgroundInteraction` for an inspector/utility panel that coexists with the page. No overlay, no modal focus trap — the user can scroll, click, and type behind the panel.",
       },
     },
   },

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/__stories__/F0Sidepanel.stories.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/__stories__/F0Sidepanel.stories.tsx
@@ -67,6 +67,12 @@ const meta: Meta<typeof Demo> = {
       description: "Show a bottom border on the header.",
       control: { type: "boolean" },
     },
+    loading: {
+      description:
+        "Replace the header title and navigation controls with skeleton placeholders while data is loading. Close button and options menu stay functional.",
+      control: { type: "boolean" },
+      table: { defaultValue: { summary: "false" } },
+    },
     title: {
       description:
         "Header title. Renders centered as a bold label when a string, or as-is when a ReactNode. Omit (or pass null) to use the title-less Figma layout.",
@@ -300,6 +306,29 @@ export const Extended: Story = {
     width: "extended",
     title: "Extended (95% viewport)",
     children: <ExampleBody />,
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    width: "wide",
+    loading: true,
+    headerBorder: true,
+    children: (
+      <p className="text-sm text-f1-foreground-secondary">
+        `loading={"{true}"}` only affects the header (title + navigation
+        skeletons). Render your own body content here — or your own body-level
+        skeleton — while data is loading.
+      </p>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use `loading={true}` to swap the header title and navigation chevrons with skeleton placeholders while data is loading. The close button and options menu stay functional. Body and footer are unchanged — manage their loading state yourself.",
+      },
+    },
   },
 }
 

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/__stories__/F0Sidepanel.stories.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/__stories__/F0Sidepanel.stories.tsx
@@ -1,0 +1,342 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useState } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { Delete, Pencil, Save } from "@/icons/app"
+
+import { F0Sidepanel } from "../index"
+import { sidepanelSides, sidepanelWidths } from "../types"
+
+const Demo = (
+  props: Omit<React.ComponentProps<typeof F0Sidepanel>, "open" | "onClose">
+) => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex h-[600px] items-center justify-center">
+      <F0Button label="Open sidepanel" onClick={() => setOpen(true)} />
+      <F0Sidepanel {...props} open={open} onClose={() => setOpen(false)} />
+    </div>
+  )
+}
+
+const meta: Meta<typeof Demo> = {
+  title: "Components/F0Sidepanel",
+  component: Demo,
+  tags: ["autodocs", "experimental"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      story: { inline: false, height: "640px" },
+    },
+  },
+  argTypes: {
+    side: {
+      description: "Which edge the sidepanel slides in from.",
+      control: { type: "select" },
+      options: sidepanelSides,
+      table: { defaultValue: { summary: "right" } },
+    },
+    width: {
+      description: "Width preset for the sidepanel.",
+      control: { type: "select" },
+      options: sidepanelWidths,
+      table: { defaultValue: { summary: "narrow" } },
+    },
+    boxPadding: {
+      description: "Apply default 24px padding around children.",
+      control: { type: "boolean" },
+      table: { defaultValue: { summary: "true" } },
+    },
+    overlay: {
+      description: "Show the dimmed background overlay.",
+      control: { type: "boolean" },
+      table: { defaultValue: { summary: "true" } },
+    },
+    locked: {
+      description: "Prevent closing via outside click / Esc.",
+      control: { type: "boolean" },
+    },
+    allowBackgroundInteraction: {
+      description:
+        "Skip the overlay entirely so background remains interactive.",
+      control: { type: "boolean" },
+    },
+    headerBorder: {
+      description: "Show a bottom border on the header.",
+      control: { type: "boolean" },
+    },
+    shadow: {
+      description: "Render with the elevation shadow.",
+      control: { type: "boolean" },
+      table: { defaultValue: { summary: "true" } },
+    },
+    title: {
+      description:
+        "Header title. Renders centered as a bold label when a string, or as-is when a ReactNode. Omit (or pass null) to use the title-less Figma layout.",
+      control: { type: "text" },
+      table: { type: { summary: "ReactNode" } },
+    },
+    closeLabel: {
+      description:
+        "Accessible label for the X button (used as aria-label and title).",
+      control: { type: "text" },
+      table: { defaultValue: { summary: '"Close"' } },
+    },
+    navigation: {
+      description:
+        "Page-stepping navigation rendered in the header (counter + previous/next chevrons). See `WithLiveNavigation` for a working example. Omit `previous` or `next` at boundaries to auto-disable the buttons.",
+      control: { type: "object" },
+      table: {
+        type: {
+          summary: "SidepanelNavigation",
+          detail:
+            "{ counter?: { current; total }, previous?: { onClick | url, title? }, next?: { onClick | url, title? } }",
+        },
+      },
+    },
+    options: {
+      description:
+        "Legacy actions menu rendered as a kebab dropdown on the right of the header.",
+      control: { type: "object" },
+      table: { type: { summary: "SidepanelOption[]" } },
+    },
+    footer: {
+      description:
+        "Footer slot, right-aligned with a top border. Typically used for primary/secondary action buttons.",
+      control: false,
+      table: { type: { summary: "ReactNode" } },
+    },
+    onCloseClicked: {
+      description:
+        "Fires immediately when the user requests close (X, outside click, Esc). `onClose` fires after the 200ms exit animation.",
+      action: "closeClicked",
+      table: { type: { summary: "() => void" } },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Demo>
+
+const ExampleBody = () => (
+  <div className="flex flex-col gap-3">
+    {Array.from({ length: 12 }, (_, i) => (
+      <div
+        key={i}
+        className="rounded-md border border-solid border-f1-border-secondary p-3"
+      >
+        Row {i + 1}
+      </div>
+    ))}
+  </div>
+)
+
+export const Default: Story = {
+  args: {
+    width: "wide",
+    children: <ExampleBody />,
+  },
+}
+
+export const LeftSide: Story = {
+  args: {
+    side: "left",
+    width: "wide",
+    title: "Filters",
+    headerBorder: true,
+    children: <ExampleBody />,
+  },
+}
+
+export const WithTitle: Story = {
+  args: {
+    width: "wide",
+    title: "Ainhoa López",
+    headerBorder: true,
+    children: <ExampleBody />,
+  },
+}
+
+export const WithFooter: Story = {
+  args: {
+    width: "wide",
+    title: "Edit compensation",
+    footer: (
+      <>
+        <F0Button variant="outline" label="Cancel" />
+        <F0Button label="Save" icon={Save} />
+      </>
+    ),
+    children: <ExampleBody />,
+  },
+}
+
+export const WithNavigation: Story = {
+  args: {
+    width: "wide",
+    headerBorder: true,
+    navigation: {
+      counter: { current: 1, total: 4 },
+      previous: { onClick: () => {}, title: "Previous resource" },
+      next: { onClick: () => {}, title: "Next resource" },
+    },
+    children: <ExampleBody />,
+  },
+}
+
+const SAMPLE_EMPLOYEES = [
+  { id: "1", name: "Ainhoa López", role: "Product Designer" },
+  { id: "2", name: "Vincent Tang", role: "Engineering Manager" },
+  { id: "3", name: "Sarah Mehta", role: "Senior Product Manager" },
+  { id: "4", name: "Michael Roberts", role: "Staff Engineer" },
+  { id: "5", name: "Charles Okafor", role: "Data Scientist" },
+] as const
+
+const LiveNavigationDemo = () => {
+  const [currentIndex, setCurrentIndex] = useState<number | null>(null)
+  const isOpen = currentIndex !== null
+  const current = isOpen ? SAMPLE_EMPLOYEES[currentIndex] : null
+  const total = SAMPLE_EMPLOYEES.length
+
+  return (
+    <div className="flex h-[600px] items-center justify-center">
+      <F0Button
+        label="Open first employee"
+        onClick={() => setCurrentIndex(0)}
+      />
+      <F0Sidepanel
+        open={isOpen}
+        onClose={() => setCurrentIndex(null)}
+        title={current?.name}
+        width="wide"
+        headerBorder
+        navigation={{
+          counter:
+            currentIndex !== null
+              ? { current: currentIndex + 1, total }
+              : undefined,
+          previous:
+            currentIndex !== null && currentIndex > 0
+              ? {
+                  onClick: () => setCurrentIndex(currentIndex - 1),
+                  title: "Previous employee",
+                }
+              : undefined,
+          next:
+            currentIndex !== null && currentIndex < total - 1
+              ? {
+                  onClick: () => setCurrentIndex(currentIndex + 1),
+                  title: "Next employee",
+                }
+              : undefined,
+        }}
+      >
+        {current && (
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-f1-foreground-secondary">
+              Step through employees using the chevrons in the header. Buttons
+              auto-disable at the start and end of the list.
+            </p>
+            <div className="rounded-md border border-solid border-f1-border-secondary p-4">
+              <p className="text-base font-semibold text-f1-foreground">
+                {current.name}
+              </p>
+              <p className="text-sm text-f1-foreground-secondary">
+                {current.role}
+              </p>
+            </div>
+          </div>
+        )}
+      </F0Sidepanel>
+    </div>
+  )
+}
+
+export const WithLiveNavigation: StoryObj = {
+  render: () => <LiveNavigationDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Working example: open the sidepanel and step through a list of employees with the chevron buttons. Previous/next are omitted at the boundaries so the buttons disable automatically.",
+      },
+    },
+  },
+}
+
+export const WithOptions: Story = {
+  args: {
+    width: "wide",
+    title: "Resource",
+    options: [
+      { label: "Edit", icon: Pencil, onClick: () => {} },
+      { label: "Delete", icon: Delete, critical: true, onClick: () => {} },
+    ],
+    children: <ExampleBody />,
+  },
+}
+
+export const Locked: Story = {
+  args: {
+    width: "wide",
+    title: "Locked",
+    locked: true,
+    children: (
+      <p className="text-sm text-f1-foreground-secondary">
+        Outside clicks and Escape are disabled — close via the X button.
+      </p>
+    ),
+  },
+}
+
+export const WideXL: Story = {
+  args: {
+    width: "wideXL",
+    title: "wideXL (800px)",
+    children: <ExampleBody />,
+  },
+}
+
+export const Extended: Story = {
+  args: {
+    width: "extended",
+    title: "Extended (95% viewport)",
+    children: <ExampleBody />,
+  },
+}
+
+export const NoShadow: Story = {
+  args: {
+    width: "wide",
+    title: "Flush variant",
+    shadow: false,
+    headerBorder: true,
+    children: <ExampleBody />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use `shadow={false}` for embedded or flush placements where the surrounding chrome already provides separation.",
+      },
+    },
+  },
+}
+
+export const NoBoxPadding: Story = {
+  args: {
+    width: "wide",
+    title: "Form owns its padding",
+    boxPadding: false,
+    children: (
+      <div className="bg-f1-background-secondary p-6">
+        <p className="text-sm text-f1-foreground-secondary">
+          With boxPadding=false, the form below renders edge-to-edge.
+        </p>
+      </div>
+    ),
+  },
+}

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/__tests__/F0Sidepanel.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/__tests__/F0Sidepanel.test.tsx
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { Delete, Pencil } from "@/icons/app"
+import {
+  screen,
+  userEvent,
+  waitFor,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import { F0Sidepanel } from "../index"
+
+describe("F0Sidepanel", () => {
+  describe("mounting", () => {
+    it("renders content when open", () => {
+      render(
+        <F0Sidepanel open onClose={() => {}}>
+          <p>Inside body</p>
+        </F0Sidepanel>
+      )
+      expect(screen.getByText("Inside body")).toBeInTheDocument()
+    })
+
+    it("does not render content when closed", () => {
+      render(
+        <F0Sidepanel open={false} onClose={() => {}}>
+          <p>Inside body</p>
+        </F0Sidepanel>
+      )
+      expect(screen.queryByText("Inside body")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("close timing", () => {
+    it("fires onCloseClicked immediately and onClose after the exit animation", async () => {
+      const onCloseClicked = vi.fn()
+      const onClose = vi.fn()
+
+      render(
+        <F0Sidepanel
+          open
+          onClose={onClose}
+          onCloseClicked={onCloseClicked}
+          title="Resource"
+        >
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: /close/i }))
+
+      expect(onCloseClicked).toHaveBeenCalledTimes(1)
+      expect(onClose).not.toHaveBeenCalled()
+
+      await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1), {
+        timeout: 500,
+      })
+    })
+
+    it("fires onClose on Escape (not locked)", async () => {
+      const onClose = vi.fn()
+
+      render(
+        <F0Sidepanel open onClose={onClose} title="Resource">
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      await userEvent.keyboard("{Escape}")
+
+      await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1), {
+        timeout: 500,
+      })
+    })
+  })
+
+  describe("locked", () => {
+    it("does not call onClose on Escape when locked", async () => {
+      const onClose = vi.fn()
+      const onCloseClicked = vi.fn()
+
+      render(
+        <F0Sidepanel
+          open
+          locked
+          onClose={onClose}
+          onCloseClicked={onCloseClicked}
+          title="Resource"
+        >
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      await userEvent.keyboard("{Escape}")
+      // Wait past the exit animation window to be sure nothing fires later.
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      expect(onCloseClicked).not.toHaveBeenCalled()
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it("still allows close via the X button when locked", async () => {
+      const onClose = vi.fn()
+
+      render(
+        <F0Sidepanel open locked onClose={onClose} title="Resource">
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: /close/i }))
+
+      await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1), {
+        timeout: 500,
+      })
+    })
+  })
+
+  describe("navigation", () => {
+    it("fires previous and next onClick callbacks", async () => {
+      const onPrev = vi.fn()
+      const onNext = vi.fn()
+
+      render(
+        <F0Sidepanel
+          open
+          onClose={() => {}}
+          title="Resource"
+          navigation={{
+            counter: { current: 2, total: 5 },
+            previous: { onClick: onPrev, title: "Previous resource" },
+            next: { onClick: onNext, title: "Next resource" },
+          }}
+        >
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /previous resource/i })
+      )
+      expect(onPrev).toHaveBeenCalledTimes(1)
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /next resource/i })
+      )
+      expect(onNext).toHaveBeenCalledTimes(1)
+    })
+
+    it("disables the previous chevron when previous is omitted", () => {
+      render(
+        <F0Sidepanel
+          open
+          onClose={() => {}}
+          title="Resource"
+          navigation={{
+            next: { onClick: () => {}, title: "Next resource" },
+          }}
+        >
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled()
+      expect(
+        screen.getByRole("button", { name: /next resource/i })
+      ).not.toBeDisabled()
+    })
+
+    it("renders the counter when provided", () => {
+      render(
+        <F0Sidepanel
+          open
+          onClose={() => {}}
+          title="Resource"
+          navigation={{ counter: { current: 2, total: 5 } }}
+        >
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      expect(screen.getByText("2/5")).toBeInTheDocument()
+    })
+  })
+
+  describe("options menu", () => {
+    it("opens the kebab dropdown and invokes the selected item's onClick", async () => {
+      const onEdit = vi.fn()
+
+      render(
+        <F0Sidepanel
+          open
+          onClose={() => {}}
+          title="Resource"
+          options={[
+            { label: "Edit", icon: Pencil, onClick: onEdit },
+            {
+              label: "Delete",
+              icon: Delete,
+              critical: true,
+              onClick: () => {},
+            },
+          ]}
+        >
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /more actions/i })
+      )
+
+      const editItem = await screen.findByRole("menuitem", { name: /edit/i })
+      await userEvent.click(editItem)
+
+      // f0 Dropdown delays onClick by ~200ms (Radix dialog animation workaround).
+      await waitFor(() => expect(onEdit).toHaveBeenCalledTimes(1), {
+        timeout: 500,
+      })
+    })
+  })
+
+  describe("title", () => {
+    it("renders a string title", () => {
+      render(
+        <F0Sidepanel open onClose={() => {}} title="Ainhoa López">
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      expect(screen.getByText("Ainhoa López")).toBeInTheDocument()
+    })
+
+    it("does not render the title slot when null", () => {
+      render(
+        <F0Sidepanel open onClose={() => {}} title={null}>
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      // No title text rendered; close button still present.
+      expect(screen.queryByText("Ainhoa López")).not.toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/__tests__/F0Sidepanel.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/__tests__/F0Sidepanel.test.tsx
@@ -57,6 +57,36 @@ describe("F0Sidepanel", () => {
       })
     })
 
+    it("cancels the pending onClose if the parent re-opens the panel before the exit animation fires", async () => {
+      const onClose = vi.fn()
+
+      const { rerender } = render(
+        <F0Sidepanel open onClose={onClose} title="Resource">
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: /close/i }))
+
+      // Parent closes (e.g. from onCloseClicked) and immediately re-opens,
+      // simulating a quick toggle within the 200ms exit-animation window.
+      rerender(
+        <F0Sidepanel open={false} onClose={onClose} title="Resource">
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+      rerender(
+        <F0Sidepanel open onClose={onClose} title="Resource">
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      // Wait past the original exit window — onClose must not fire because the
+      // pending timeout was cleared on re-open.
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
     it("fires onClose on Escape (not locked)", async () => {
       const onClose = vi.fn()
 

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/__tests__/F0Sidepanel.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/__tests__/F0Sidepanel.test.tsx
@@ -250,6 +250,40 @@ describe("F0Sidepanel", () => {
     })
   })
 
+  describe("loading", () => {
+    it("renders skeleton placeholders for the title and navigation when loading", () => {
+      render(
+        <F0Sidepanel open onClose={() => {}} title="Resource" loading>
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      expect(screen.getByTestId("sidepanel-title-skeleton")).toBeInTheDocument()
+      expect(
+        screen.getByTestId("sidepanel-navigation-skeleton")
+      ).toBeInTheDocument()
+
+      // Real title text should not render while loading.
+      expect(screen.queryByText("Resource")).not.toBeInTheDocument()
+    })
+
+    it("keeps the close button functional while loading", async () => {
+      const onClose = vi.fn()
+
+      render(
+        <F0Sidepanel open onClose={onClose} title="Resource" loading>
+          <p>Inside</p>
+        </F0Sidepanel>
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: /close/i }))
+
+      await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1), {
+        timeout: 500,
+      })
+    })
+  })
+
   describe("title", () => {
     it("renders a string title", () => {
       render(

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelFooter.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelFooter.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from "react"
+
+interface Props {
+  children: ReactNode
+}
+
+export const F0SidepanelFooter = ({ children }: Props) => (
+  <div className="mt-auto flex shrink-0 items-center justify-end gap-2 border-0 border-t border-solid border-f1-border-secondary p-4">
+    {children}
+  </div>
+)

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelHeader.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelHeader.tsx
@@ -4,8 +4,10 @@ import { ReactNode } from "react"
 import { F0Button } from "@/components/F0Button"
 import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { Cross, EllipsisHorizontal } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { SheetTitle } from "@/ui/Sheet/sheet"
+import { Skeleton } from "@/ui/skeleton"
 
 import { SidepanelNavigation, SidepanelOption } from "../types"
 import { F0SidepanelNavigation } from "./F0SidepanelNavigation"
@@ -17,6 +19,7 @@ interface Props {
   navigation?: SidepanelNavigation
   options?: SidepanelOption[]
   headerBorder?: boolean
+  loading?: boolean
 }
 
 const toDropdownItems = (options: SidepanelOption[]): DropdownItem[] =>
@@ -30,6 +33,19 @@ const toDropdownItems = (options: SidepanelOption[]): DropdownItem[] =>
     critical: option.critical,
   }))
 
+const NavigationSkeleton = () => (
+  <div
+    className="flex items-center gap-3"
+    data-testid="sidepanel-navigation-skeleton"
+  >
+    <Skeleton className="h-4 w-8" />
+    <div className="flex items-center gap-2">
+      <Skeleton className="h-8 w-8 rounded-[8px]" />
+      <Skeleton className="h-8 w-8 rounded-[8px]" />
+    </div>
+  </div>
+)
+
 export const F0SidepanelHeader = ({
   title,
   closeLabel = "Close",
@@ -37,7 +53,9 @@ export const F0SidepanelHeader = ({
   navigation,
   options,
   headerBorder = false,
+  loading = false,
 }: Props) => {
+  const i18n = useI18n()
   const hasOptions = options && options.length > 0
   const hasRight = !!navigation || hasOptions
   const hasVisibleTitle = title !== undefined && title !== null
@@ -59,7 +77,17 @@ export const F0SidepanelHeader = ({
         onClick={onCloseClick}
       />
 
-      {hasVisibleTitle ? (
+      {loading ? (
+        <div
+          className="flex flex-1 items-center justify-center px-2"
+          data-testid="sidepanel-title-skeleton"
+        >
+          <VisuallyHidden.Root>
+            <SheetTitle>{i18n.actions.loading}</SheetTitle>
+          </VisuallyHidden.Root>
+          <Skeleton className="h-5 w-32" />
+        </div>
+      ) : hasVisibleTitle ? (
         <div className="flex flex-1 items-center justify-center px-2">
           {typeof title === "string" ? (
             <SheetTitle className="truncate text-base font-semibold text-f1-foreground">
@@ -79,9 +107,13 @@ export const F0SidepanelHeader = ({
         </VisuallyHidden.Root>
       )}
 
-      {hasRight ? (
+      {loading || hasRight ? (
         <div className="flex items-center gap-3">
-          {navigation && <F0SidepanelNavigation navigation={navigation} />}
+          {loading ? (
+            <NavigationSkeleton />
+          ) : (
+            navigation && <F0SidepanelNavigation navigation={navigation} />
+          )}
           {hasOptions && (
             <Dropdown items={toDropdownItems(options)}>
               <F0Button

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelHeader.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelHeader.tsx
@@ -121,7 +121,7 @@ export const F0SidepanelHeader = ({
                 size="sm"
                 variant="outline"
                 icon={EllipsisHorizontal}
-                label="More actions"
+                label={i18n.graph.detailPanel.moreActions}
                 hideLabel
               />
             </Dropdown>

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelHeader.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelHeader.tsx
@@ -1,0 +1,103 @@
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden"
+import { ReactNode } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
+import { Cross, EllipsisHorizontal } from "@/icons/app"
+import { cn } from "@/lib/utils"
+import { SheetTitle } from "@/ui/Sheet/sheet"
+
+import { SidepanelNavigation, SidepanelOption } from "../types"
+import { F0SidepanelNavigation } from "./F0SidepanelNavigation"
+
+interface Props {
+  title?: ReactNode
+  closeLabel?: string
+  onCloseClick: () => void
+  navigation?: SidepanelNavigation
+  options?: SidepanelOption[]
+  headerBorder?: boolean
+}
+
+const toDropdownItems = (options: SidepanelOption[]): DropdownItem[] =>
+  options.map((option) => ({
+    type: "item",
+    label: option.label,
+    description: option.description,
+    icon: option.icon,
+    onClick: option.onClick,
+    href: option.href,
+    critical: option.critical,
+  }))
+
+export const F0SidepanelHeader = ({
+  title,
+  closeLabel = "Close",
+  onCloseClick,
+  navigation,
+  options,
+  headerBorder = false,
+}: Props) => {
+  const hasOptions = options && options.length > 0
+  const hasRight = !!navigation || hasOptions
+  const hasVisibleTitle = title !== undefined && title !== null
+
+  return (
+    <div
+      className={cn(
+        "flex h-14 shrink-0 items-center justify-between gap-3 px-4 py-3",
+        headerBorder &&
+          "border-0 border-b border-solid border-f1-border-secondary"
+      )}
+    >
+      <F0Button
+        size="md"
+        variant="outline"
+        icon={Cross}
+        label={closeLabel}
+        hideLabel
+        onClick={onCloseClick}
+      />
+
+      {hasVisibleTitle ? (
+        <div className="flex flex-1 items-center justify-center px-2">
+          {typeof title === "string" ? (
+            <SheetTitle className="truncate text-base font-semibold text-f1-foreground">
+              {title}
+            </SheetTitle>
+          ) : (
+            <SheetTitle asChild>
+              <div>{title}</div>
+            </SheetTitle>
+          )}
+        </div>
+      ) : (
+        // Radix Dialog requires a Title for screen readers; keep one hidden when
+        // the visual title slot is empty.
+        <VisuallyHidden.Root>
+          <SheetTitle>{closeLabel}</SheetTitle>
+        </VisuallyHidden.Root>
+      )}
+
+      {hasRight ? (
+        <div className="flex items-center gap-3">
+          {navigation && <F0SidepanelNavigation navigation={navigation} />}
+          {hasOptions && (
+            <Dropdown items={toDropdownItems(options)}>
+              <F0Button
+                size="sm"
+                variant="outline"
+                icon={EllipsisHorizontal}
+                label="More actions"
+                hideLabel
+              />
+            </Dropdown>
+          )}
+        </div>
+      ) : (
+        // Keep header layout balanced when there's no right cluster but a title is present.
+        hasVisibleTitle && <div aria-hidden className="invisible h-8 w-8" />
+      )}
+    </div>
+  )
+}

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelHeader.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelHeader.tsx
@@ -48,7 +48,7 @@ const NavigationSkeleton = () => (
 
 export const F0SidepanelHeader = ({
   title,
-  closeLabel = "Close",
+  closeLabel,
   onCloseClick,
   navigation,
   options,
@@ -56,6 +56,7 @@ export const F0SidepanelHeader = ({
   loading = false,
 }: Props) => {
   const i18n = useI18n()
+  const effectiveCloseLabel = closeLabel || i18n.actions.close
   const hasOptions = options && options.length > 0
   const hasRight = !!navigation || hasOptions
   const hasVisibleTitle = title !== undefined && title !== null
@@ -72,7 +73,7 @@ export const F0SidepanelHeader = ({
         size="md"
         variant="outline"
         icon={Cross}
-        label={closeLabel}
+        label={effectiveCloseLabel}
         hideLabel
         onClick={onCloseClick}
       />
@@ -103,7 +104,7 @@ export const F0SidepanelHeader = ({
         // Radix Dialog requires a Title for screen readers; keep one hidden when
         // the visual title slot is empty.
         <VisuallyHidden.Root>
-          <SheetTitle>{closeLabel}</SheetTitle>
+          <SheetTitle>{effectiveCloseLabel}</SheetTitle>
         </VisuallyHidden.Root>
       )}
 

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelNavigation.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelNavigation.tsx
@@ -1,0 +1,50 @@
+import { F0Button } from "@/components/F0Button"
+import { ChevronDown, ChevronUp } from "@/icons/app"
+
+import { NavigationStep, SidepanelNavigation } from "../types"
+
+interface Props {
+  navigation: SidepanelNavigation
+}
+
+const hasUrl = (
+  step: NavigationStep
+): step is NavigationStep & { url: string } => "url" in step
+
+export const F0SidepanelNavigation = ({ navigation }: Props) => {
+  const { previous, next, counter } = navigation
+
+  return (
+    <div className="flex items-center gap-3">
+      {counter && (
+        <span className="text-sm text-f1-foreground-secondary">
+          {counter.current}/{counter.total}
+        </span>
+      )}
+      <div className="flex items-center gap-2">
+        <F0Button
+          size="sm"
+          variant="outline"
+          icon={ChevronUp}
+          label={previous?.title ?? "Previous"}
+          hideLabel
+          disabled={!previous}
+          {...(previous && hasUrl(previous)
+            ? { href: previous.url }
+            : { onClick: previous?.onClick })}
+        />
+        <F0Button
+          size="sm"
+          variant="outline"
+          icon={ChevronDown}
+          label={next?.title ?? "Next"}
+          hideLabel
+          disabled={!next}
+          {...(next && hasUrl(next)
+            ? { href: next.url }
+            : { onClick: next?.onClick })}
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelNavigation.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/components/F0SidepanelNavigation.tsx
@@ -1,5 +1,6 @@
 import { F0Button } from "@/components/F0Button"
 import { ChevronDown, ChevronUp } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
 
 import { NavigationStep, SidepanelNavigation } from "../types"
 
@@ -12,6 +13,7 @@ const hasUrl = (
 ): step is NavigationStep & { url: string } => "url" in step
 
 export const F0SidepanelNavigation = ({ navigation }: Props) => {
+  const i18n = useI18n()
   const { previous, next, counter } = navigation
 
   return (
@@ -26,7 +28,7 @@ export const F0SidepanelNavigation = ({ navigation }: Props) => {
           size="sm"
           variant="outline"
           icon={ChevronUp}
-          label={previous?.title ?? "Previous"}
+          label={previous?.title || i18n.navigation.previous}
           hideLabel
           disabled={!previous}
           {...(previous && hasUrl(previous)
@@ -37,7 +39,7 @@ export const F0SidepanelNavigation = ({ navigation }: Props) => {
           size="sm"
           variant="outline"
           icon={ChevronDown}
-          label={next?.title ?? "Next"}
+          label={next?.title || i18n.navigation.next}
           hideLabel
           disabled={!next}
           {...(next && hasUrl(next)

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/index.tsx
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/index.tsx
@@ -1,0 +1,21 @@
+import { withDataTestId } from "@/lib/data-testid"
+import { experimentalComponent } from "@/lib/experimental"
+
+import { F0Sidepanel as F0SidepanelBase } from "./F0Sidepanel"
+
+export type {
+  F0SidepanelProps,
+  NavigationStep,
+  SidepanelNavigation,
+  SidepanelOption,
+  SidepanelSide,
+  SidepanelWidth,
+} from "./types"
+export { sidepanelSides, sidepanelWidths } from "./types"
+
+/**
+ * @experimental This is an experimental component use it at your own risk.
+ */
+export const F0Sidepanel = withDataTestId(
+  experimentalComponent("F0Sidepanel", F0SidepanelBase)
+)

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/types.ts
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/types.ts
@@ -1,0 +1,70 @@
+import { ReactNode } from "react"
+
+import { IconType } from "@/components/F0Icon"
+
+export const sidepanelWidths = [
+  "narrow",
+  "wide",
+  "wideXL",
+  "extended",
+  "full",
+] as const
+
+export type SidepanelWidth = (typeof sidepanelWidths)[number]
+
+export const sidepanelSides = ["left", "right"] as const
+
+export type SidepanelSide = (typeof sidepanelSides)[number]
+
+export type NavigationStep = { title?: string } & (
+  | { url: string }
+  | { onClick: () => void }
+)
+
+export interface SidepanelNavigation {
+  previous?: NavigationStep
+  next?: NavigationStep
+  counter?: { current: number; total: number }
+}
+
+export interface SidepanelOption {
+  label: string
+  description?: string
+  icon?: IconType
+  onClick?: () => void
+  href?: string
+  critical?: boolean
+}
+
+export interface F0SidepanelProps {
+  open: boolean
+  onClose: () => void
+  /**
+   * Fires immediately when the user requests to close (click outside, X, Esc).
+   * `onClose` fires after the exit animation completes.
+   */
+  onCloseClicked?: () => void
+  title?: ReactNode
+  closeLabel?: string
+  /** Which edge the sidepanel slides in from. Default "right". */
+  side?: SidepanelSide
+  width?: SidepanelWidth
+  /** Apply default 24px padding around children. Default true. */
+  boxPadding?: boolean
+  footer?: ReactNode
+  /** Show the dimmed background overlay. Default true. */
+  overlay?: boolean
+  /** Prevent closing via outside click / Esc. Default false. */
+  locked?: boolean
+  /** Skip the overlay entirely so background remains interactive. Default false. */
+  allowBackgroundInteraction?: boolean
+  /** Show a bottom border on the header. Default false. */
+  headerBorder?: boolean
+  /** Render with the elevation shadow. Default true. */
+  shadow?: boolean
+  /** Legacy actions menu rendered as a kebab dropdown on the right of the header. */
+  options?: SidepanelOption[]
+  /** Page-stepping navigation (previous/next + counter). */
+  navigation?: SidepanelNavigation
+  children?: ReactNode
+}

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/types.ts
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/types.ts
@@ -60,6 +60,12 @@ export interface F0SidepanelProps {
   allowBackgroundInteraction?: boolean
   /** Show a bottom border on the header. Default false. */
   headerBorder?: boolean
+  /**
+   * When true, replaces the header title and navigation controls with skeleton
+   * placeholders. The close button and options menu stay functional. Body and
+   * footer are unchanged — manage their loading state yourself. Default false.
+   */
+  loading?: boolean
   /** Legacy actions menu rendered as a kebab dropdown on the right of the header. */
   options?: SidepanelOption[]
   /** Page-stepping navigation (previous/next + counter). */

--- a/packages/react/src/experimental/Overlays/F0Sidepanel/types.ts
+++ b/packages/react/src/experimental/Overlays/F0Sidepanel/types.ts
@@ -60,8 +60,6 @@ export interface F0SidepanelProps {
   allowBackgroundInteraction?: boolean
   /** Show a bottom border on the header. Default false. */
   headerBorder?: boolean
-  /** Render with the elevation shadow. Default true. */
-  shadow?: boolean
   /** Legacy actions menu rendered as a kebab dropdown on the right of the header. */
   options?: SidepanelOption[]
   /** Page-stepping navigation (previous/next + counter). */

--- a/packages/react/src/experimental/Overlays/exports.tsx
+++ b/packages/react/src/experimental/Overlays/exports.tsx
@@ -1,3 +1,14 @@
 /** @deprecated Dialog has moved to @/deprecated/Dialog. Import from there instead. */
 export { Dialog } from "../../deprecated/Dialog"
+export {
+  F0Sidepanel,
+  type F0SidepanelProps,
+  type NavigationStep,
+  type SidepanelNavigation,
+  type SidepanelOption,
+  type SidepanelSide,
+  type SidepanelWidth,
+  sidepanelSides,
+  sidepanelWidths,
+} from "./F0Sidepanel"
 export { Tooltip, type TooltipProps } from "./Tooltip"

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -68,6 +68,7 @@ export const defaultTranslations = {
     selectAll: "Select all",
     selectAllItems: "Select all {{total}} items",
     apply: "Apply",
+    loading: "Loading",
   },
   status: {
     selected: {

--- a/packages/react/src/ui/Sheet/__stories__/Sheet.stories.tsx
+++ b/packages/react/src/ui/Sheet/__stories__/Sheet.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useState } from "react"
+
+import { F0Button } from "@/components/F0Button"
+
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+  sheetSides,
+} from "../sheet"
+
+type DemoProps = {
+  side?: (typeof sheetSides)[number]
+  withOverlay?: boolean
+}
+
+const Demo = ({ side = "right", withOverlay = true }: DemoProps) => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex h-[500px] items-center justify-center">
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger asChild>
+          <F0Button label={`Open ${side} sheet`} />
+        </SheetTrigger>
+        <SheetContent
+          side={side}
+          withOverlay={withOverlay}
+          className={
+            side === "left" || side === "right" ? "w-full max-w-[400px]" : ""
+          }
+        >
+          <SheetHeader>
+            <SheetTitle>Sheet title</SheetTitle>
+            <SheetDescription>
+              The sheet primitive renders Radix Dialog content with side-aware
+              slide animations.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="flex-1 overflow-y-auto px-4 pb-4">
+            <p className="text-sm text-f1-foreground-secondary">
+              Compose the sheet however you need: this story shows the default
+              header, body, and footer slots.
+            </p>
+          </div>
+          <SheetFooter>
+            <SheetClose asChild>
+              <F0Button variant="outline" label="Cancel" />
+            </SheetClose>
+            <SheetClose asChild>
+              <F0Button label="Confirm" />
+            </SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}
+
+const meta: Meta<typeof Demo> = {
+  title: "Components/Sheet",
+  component: Demo,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: [
+          "Sheet is a low-level primitive built on Radix Dialog with slide-from-edge animations.",
+          "It powers `F0Sidepanel` and any other sheet/drawer pattern that needs to slide in from a side.",
+          "Internal use only — exposed via `@/ui/Sheet/sheet`, not part of the public f0 surface.",
+        ]
+          .map((line) => `<p>${line}</p>`)
+          .join(""),
+      },
+    },
+  },
+  tags: ["autodocs", "internal"],
+  argTypes: {
+    side: {
+      description: "Which edge the sheet slides in from.",
+      control: { type: "select" },
+      options: sheetSides,
+      table: { defaultValue: { summary: "right" } },
+    },
+    withOverlay: {
+      description: "Render the dimmed background overlay.",
+      control: { type: "boolean" },
+      table: { defaultValue: { summary: "true" } },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Demo>
+
+export const Right: Story = { args: { side: "right" } }
+export const Left: Story = { args: { side: "left" } }
+export const Top: Story = { args: { side: "top" } }
+export const Bottom: Story = { args: { side: "bottom" } }
+export const NoOverlay: Story = { args: { side: "right", withOverlay: false } }

--- a/packages/react/src/ui/Sheet/components/SheetClose.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetClose.tsx
@@ -1,0 +1,3 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+export const SheetClose = DialogPrimitive.Close

--- a/packages/react/src/ui/Sheet/components/SheetContent.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetContent.tsx
@@ -24,7 +24,6 @@ export interface SheetContentProps extends React.ComponentPropsWithoutRef<
 > {
   side?: SheetSide
   withOverlay?: boolean
-  withShadow?: boolean
   container?: HTMLElement | null
 }
 
@@ -36,7 +35,6 @@ export const SheetContent = forwardRef<
     {
       side = "right",
       withOverlay = true,
-      withShadow = true,
       container,
       className,
       children,
@@ -49,8 +47,7 @@ export const SheetContent = forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          "fixed z-50 flex flex-col gap-0 border-solid border-f1-border bg-f1-background text-f1-foreground transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
-          withShadow && "shadow-lg",
+          "fixed z-50 flex flex-col gap-0 border-solid border-f1-border bg-f1-background text-f1-foreground shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
           sideClasses[side],
           className
         )}

--- a/packages/react/src/ui/Sheet/components/SheetContent.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetContent.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { forwardRef } from "react"
+
+import { cn } from "../../../lib/utils"
+import { SheetOverlay } from "./SheetOverlay"
+import { SheetPortal } from "./SheetPortal"
+
+export const sheetSides = ["top", "right", "bottom", "left"] as const
+export type SheetSide = (typeof sheetSides)[number]
+
+const sideClasses: Record<SheetSide, string> = {
+  top: "inset-x-0 top-0 h-auto border-b data-[state=open]:slide-in-from-top data-[state=closed]:slide-out-to-top",
+  right:
+    "inset-y-0 right-0 h-full border-l data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right",
+  bottom:
+    "inset-x-0 bottom-0 h-auto border-t data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom",
+  left: "inset-y-0 left-0 h-full border-r data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left",
+}
+
+export interface SheetContentProps extends React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Content
+> {
+  side?: SheetSide
+  withOverlay?: boolean
+  withShadow?: boolean
+  container?: HTMLElement | null
+}
+
+export const SheetContent = forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(
+  (
+    {
+      side = "right",
+      withOverlay = true,
+      withShadow = true,
+      container,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => (
+    <SheetPortal container={container ?? undefined}>
+      {withOverlay && <SheetOverlay />}
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed z-50 flex flex-col gap-0 border-solid border-f1-border bg-f1-background text-f1-foreground transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
+          withShadow && "shadow-lg",
+          sideClasses[side],
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </SheetPortal>
+  )
+)
+SheetContent.displayName = DialogPrimitive.Content.displayName

--- a/packages/react/src/ui/Sheet/components/SheetContent.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetContent.tsx
@@ -11,12 +11,12 @@ export const sheetSides = ["top", "right", "bottom", "left"] as const
 export type SheetSide = (typeof sheetSides)[number]
 
 const sideClasses: Record<SheetSide, string> = {
-  top: "inset-x-0 top-0 h-auto border-b data-[state=open]:slide-in-from-top data-[state=closed]:slide-out-to-top",
+  top: "inset-x-0 top-0 h-auto data-[state=open]:slide-in-from-top data-[state=closed]:slide-out-to-top",
   right:
-    "inset-y-0 right-0 h-full border-l data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right",
+    "inset-y-0 right-0 h-full data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right",
   bottom:
-    "inset-x-0 bottom-0 h-auto border-t data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom",
-  left: "inset-y-0 left-0 h-full border-r data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left",
+    "inset-x-0 bottom-0 h-auto data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom",
+  left: "inset-y-0 left-0 h-full data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left",
 }
 
 export interface SheetContentProps extends React.ComponentPropsWithoutRef<
@@ -47,7 +47,7 @@ export const SheetContent = forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          "fixed z-50 flex flex-col gap-0 border-solid border-f1-border bg-f1-background text-f1-foreground shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
+          "fixed z-50 flex flex-col gap-0 bg-f1-background text-f1-foreground shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
           sideClasses[side],
           className
         )}

--- a/packages/react/src/ui/Sheet/components/SheetDescription.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetDescription.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { forwardRef } from "react"
+
+import { cn } from "../../../lib/utils"
+
+export const SheetDescription = forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-f1-foreground-secondary", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = DialogPrimitive.Description.displayName

--- a/packages/react/src/ui/Sheet/components/SheetFooter.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetFooter.tsx
@@ -1,0 +1,14 @@
+import { HTMLAttributes } from "react"
+
+import { cn } from "../../../lib/utils"
+
+export const SheetFooter = ({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"

--- a/packages/react/src/ui/Sheet/components/SheetHeader.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetHeader.tsx
@@ -1,0 +1,11 @@
+import { HTMLAttributes } from "react"
+
+import { cn } from "../../../lib/utils"
+
+export const SheetHeader = ({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col gap-1 p-4", className)} {...props} />
+)
+SheetHeader.displayName = "SheetHeader"

--- a/packages/react/src/ui/Sheet/components/SheetOverlay.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetOverlay.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { forwardRef } from "react"
+
+import { cn } from "../../../lib/utils"
+
+export const SheetOverlay = forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-f1-background-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+SheetOverlay.displayName = DialogPrimitive.Overlay.displayName

--- a/packages/react/src/ui/Sheet/components/SheetPortal.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetPortal.tsx
@@ -1,0 +1,3 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+export const SheetPortal = DialogPrimitive.Portal

--- a/packages/react/src/ui/Sheet/components/SheetTitle.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetTitle.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { forwardRef } from "react"
+
+import { cn } from "../../../lib/utils"
+
+export const SheetTitle = forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-base font-semibold text-f1-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = DialogPrimitive.Title.displayName

--- a/packages/react/src/ui/Sheet/components/SheetTrigger.tsx
+++ b/packages/react/src/ui/Sheet/components/SheetTrigger.tsx
@@ -1,0 +1,3 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+export const SheetTrigger = DialogPrimitive.Trigger

--- a/packages/react/src/ui/Sheet/sheet.tsx
+++ b/packages/react/src/ui/Sheet/sheet.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+import { SheetClose } from "./components/SheetClose"
+import {
+  SheetContent,
+  type SheetContentProps,
+  type SheetSide,
+  sheetSides,
+} from "./components/SheetContent"
+import { SheetDescription } from "./components/SheetDescription"
+import { SheetFooter } from "./components/SheetFooter"
+import { SheetHeader } from "./components/SheetHeader"
+import { SheetOverlay } from "./components/SheetOverlay"
+import { SheetPortal } from "./components/SheetPortal"
+import { SheetTitle } from "./components/SheetTitle"
+import { SheetTrigger } from "./components/SheetTrigger"
+
+const Sheet = DialogPrimitive.Root
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  type SheetContentProps,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  type SheetSide,
+  sheetSides,
+  SheetTitle,
+  SheetTrigger,
+}


### PR DESCRIPTION
## Description

Introduce **F0Sidepanel** in `experimental/Overlays/`, backed by a new internal **Sheet** primitive in `ui/Sheet/`. This is the f0 port of the existing Factorial monorepo `Sidepanel` component (`modules/core/components/Sidepanel`) plus the new affordances from the Sidepanel revamp Figma spec.

**Why this component exists:**

- The current `Sidepanel` lives in the Factorial monorepo, depends on `@factorialco/deprecated-design-system`, and uses `framer-motion` for slide animations. As consumers move to f0 there is no equivalent — they have to either keep the legacy import (blocks the design-system migration) or fall back to `F0Dialog` with `position="right"`, which renders as a centered-modal-pinned-to-the-edge and doesn't match the Sidepanel UX.
- The Sidepanel revamp design adds a new header pattern (close on the left, page-stepping navigation on the right) that no existing f0 component supports. Wrapping it as a Radix-based primitive lets the AppHeader's `navigation` shape be reused directly.
- Building on the `ui/Sheet/` primitive (modelled on `ui/Dialog/`) keeps animations Tailwind-only — no `framer-motion` dependency in the f0 surface — and unblocks any future "slide-from-edge" need without bespoke code.

**API parity + extensions:**

| Legacy `Sidepanel` prop | F0Sidepanel | Notes |
|---|---|---|
| `open`, `onClose`, `onCloseClicked` | ✓ | Preserves the 200ms exit-animation delay before `onClose` fires (legacy callers depend on this for post-close cleanup) |
| `title`, `closeLabel` | ✓ | `title` accepts string or ReactNode; `null` skips the title slot per the Figma layout |
| `width` (narrow / wide / wideXL / extended / full) | ✓ | Same names; `wide = 600px` matches Figma spec |
| `overlay`, `locked`, `allowBackgroundInteraction`, `headerBorder` | ✓ | |
| `footer`, `boxPadding` | ✓ | |
| `options` (kebab actions menu) | ✓ | Backed by `experimental/Navigation/Dropdown` |
| — | `navigation` *(new)* | Page-stepping: `{ counter, previous, next }` with `url \| onClick` step variants. Same shape as `experimental/Navigation/Header/PageHeader.navigation` for consistency |
| — | `side` *(new)* | `"left" \| "right"`, default `"right"`. Constrained to side-anchored placements |

**A11y:**

- Always renders a Radix `DialogTitle` (wrapped in `VisuallyHidden` from `@radix-ui/react-visually-hidden` when the visual title slot is empty), to satisfy Radix's screen-reader contract.
- Sets `onOpenAutoFocus={(e) => e.preventDefault()}` (same pattern `F0Dialog` uses) — avoids jarring focus shifts on open and sidesteps a jsdom focus-recursion issue when testing with Radix's `FocusScope`.

## Screenshots
<img width="1215" height="529" alt="Screenshot 2026-06-01 at 23 17 51" src="https://github.com/user-attachments/assets/a125a8dc-004c-4009-844e-58d7da4627b3" />

https://github.com/user-attachments/assets/c0aa697e-0718-4964-81d9-90aabd3a4730



[Link to Figma Design](https://www.figma.com/design/SqIAXKMbJVUbwRYBvTILqW/Sidepanel-revamp?node-id=6216-44093&t=8g7MQoNDlNnx9Idl-4)

Storybook coverage: `Default`, `LeftSide`, `WithTitle`, `WithFooter`, `WithNavigation`, **`WithLiveNavigation`** (steps through a 5-employee in-memory list — buttons auto-disable at boundaries), `WithOptions`, `Locked`, `WideXL`, `Extended`, `NoOverlay`, `Floating`, `NoBoxPadding`.

## Implementation details

**New files** (under `packages/react/src/`):

- `ui/Sheet/` — shadcn-style Radix Dialog wrapper with `top|right|bottom|left` side variants, toggleable overlay, Tailwind data-state slide animations. Mirrors the per-file structure of `ui/Dialog/`. Internal-only per AGENTS.md (`ui/*` is not part of the public f0 surface).
- `experimental/Overlays/F0Sidepanel/` — pattern component:
  - `F0Sidepanel.tsx` + `F0SidepanelInternal.tsx` — public wrapper + implementation
  - `types.ts` — `F0SidepanelProps`, `SidepanelSide`, `SidepanelWidth`, `SidepanelNavigation`, `NavigationStep`, `SidepanelOption` with `as const` arrays
  - `components/F0SidepanelHeader.tsx` — header (close, optional title, navigation, options menu)
  - `components/F0SidepanelNavigation.tsx` — counter + chevrons using `F0Button` with `ChevronUp`/`ChevronDown` (mirrors `PageHeader` layout)
  - `components/F0SidepanelFooter.tsx` — right-aligned footer with top border
  - `__stories__/F0Sidepanel.stories.tsx` — 13 stories including the live-navigation walkthrough
  - `__tests__/F0Sidepanel.test.tsx` — 12 Vitest tests covering mount/unmount, close timing (sync `onCloseClicked` + delayed `onClose`), `locked` behavior on Esc / outside-click / X, navigation callbacks + boundary disable, options menu open + invoke, title rendering

**Export wiring:**

- `experimental/Overlays/F0Sidepanel/index.tsx` wraps with `experimentalComponent("F0Sidepanel", …)` + `withDataTestId(…)`, matching the `Tooltip` pattern.
- Re-exported from `experimental/Overlays/exports.tsx`.

**Width mapping:**

| Variant | Width |
|---|---|
| `narrow` | `max-w-[360px]` |
| `wide` | `max-w-[600px]` (Figma spec) |
| `wideXL` | `max-w-[800px]` |
| `extended` | `max-w-[95vw]` |
| `full` | `max-w-full` |

**Validation:**

- `pnpm format` — clean
- `pnpm tsc` — no errors
- `oxlint` on changed files — 0 warnings / 0 errors
- `pnpm vitest run` against the new spec — 12/12 pass

**Follow-ups (out of scope for this PR):**

- A future `useResourceNavigation<T>` hook could absorb the prev/next/counter wiring in callers — proposed in the integration notes for the compensations team once the cursor-pagination question is settled.
- Foundations team may want to revisit the elevation token: f0's `shadow-lg` is intentionally subtle compared to Figma's `s400` (3-layer drop shadow). Not blocking the experimental ship.