### PR TITLE
fix: granularityDefinitions type

### DIFF
--- a/packages/react/src/components/OneCalendar/granularities/index.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/index.tsx
@@ -10,7 +10,7 @@ import { yearGranularity } from "./year"
 export * from "./consts"
 export * from "./types"
 
-export const granularityDefinitions: Record<string, GranularityDefinition> = {
+export const granularityDefinitions = {
   day: dayGranularity,
   week: weekGranularity,
   month: monthGranularity,
@@ -18,7 +18,7 @@ export const granularityDefinitions: Record<string, GranularityDefinition> = {
   halfyear: halfyearGranularity,
   year: yearGranularity,
   range: rangeGranularity,
-} as const
+} as const satisfies Record<string, GranularityDefinition>
 
 export type GranularityDefinitionKey = keyof typeof granularityDefinitions
 

--- a/packages/react/src/ui/DatePickerPopup/DatePickerPopup.tsx
+++ b/packages/react/src/ui/DatePickerPopup/DatePickerPopup.tsx
@@ -29,9 +29,8 @@ export type CompareToDef = {
     | ((value: DateRangeComplete) => DateRangeComplete | DateRangeComplete[])
 }
 
-export type DatePickerCompareTo = Record<
-  GranularityDefinitionKey,
-  CompareToDef[]
+export type DatePickerCompareTo = Partial<
+  Record<GranularityDefinitionKey, CompareToDef[]>
 >
 
 export interface DatePickerPopupProps {


### PR DESCRIPTION
## Description

While `granularityDefinitions` in Factorial there is a type error when trying to access to any of the properties since it says it can be `undefined`.

This happens because the variable is typed as `Record<string, GranularityDefinition>`, so the `as const` does nothing.

## Screenshots

Before:
<img width="772" height="301" alt="image" src="https://github.com/user-attachments/assets/2a442e91-aaf8-46f0-8932-9a40d44953fa" />

After:
<img width="598" height="514" alt="image" src="https://github.com/user-attachments/assets/d679d6bf-8d70-43a8-9389-54aedc121869" />

## Implementation details

I used `satisfies Record<string, GranularityDefinition>`, instead, which not only makes the `as const` work but also prevents users from using wrong types in the object.