### PR TITLE
fix(F0Form): preserve cleared optional values after submit

### DIFF
--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -722,7 +722,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
     const result = await onSubmit(cleanedData)
 
     if (result.success) {
-      form.reset(data)
+      form.reset(form.getValues())
       resetErrorNavigation()
       setSuccessMessage(result.message)
       setActionBarStatus("success")

--- a/packages/react/src/patterns/F0Form/__tests__/F0Form.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0Form.test.tsx
@@ -3515,3 +3515,51 @@ describe("F0Form renderIf hidden field layout", () => {
     expect(screen.getByLabelText("Conditional Field")).toBeInTheDocument()
   })
 })
+
+describe("F0Form clearing optional values", () => {
+  it("keeps the cleared input empty after submit when the parent owns the value", async () => {
+    const user = userEvent.setup()
+
+    const formSchema = z.object({
+      budget: f0FormField.money({
+        label: "Budget",
+        currency: "EUR",
+        optional: true,
+      }),
+    })
+
+    const submissions: Array<number | undefined> = []
+
+    const Harness = () => {
+      const [budget, setBudget] = React.useState<number | undefined>(50)
+      return (
+        <F0Form
+          name="controlled-optional-money-regression"
+          schema={formSchema}
+          defaultValues={{ budget }}
+          onSubmit={async (data) => {
+            submissions.push(data.budget)
+            setBudget(data.budget)
+            return { success: true }
+          }}
+        />
+      )
+    }
+
+    render(<Harness />)
+
+    const input = screen.getByLabelText("Budget") as HTMLInputElement
+    expect(input.value).toBe("50")
+
+    await user.clear(input)
+    expect(input.value).toBe("")
+
+    await user.click(screen.getByText("Submit"))
+
+    await waitFor(() => {
+      expect(submissions).toEqual([undefined])
+    })
+
+    expect(input.value).toBe("")
+  })
+})


### PR DESCRIPTION
## Summary
- Calling `form.reset(data)` with the resolver-transformed `data` re-introduced stale values into cleared optional fields after submit.
- The conditional resolver coerces `null` → `undefined` for Zod, so `data` carries `undefined` for cleared fields. RHF's `useWatch` then falls back to the `defaultValue` it captured at initial render — bringing the old value back into the input.
- Reset with `form.getValues()` instead, which still holds the raw `null` sentinel the codebase already uses to mark fields as cleared.

## Repro (before the fix)
1. Render `F0Form` with a parent-owned optional money field starting at `50`.
2. Clear the input and submit.
3. Parent state updates to `undefined`, but the input still shows `50`.

## Screenshots
Before:
<img width="583" height="253" alt="f0form-before" src="https://github.com/user-attachments/assets/dcaf32ab-6ade-425d-8140-3d92dea399b8" />

After:
<img width="583" height="253" alt="f0form-after" src="https://github.com/user-attachments/assets/0462a745-66ea-4321-95e6-69bd7be4430d" />

## Test plan
- [x] Added regression test in `F0Form.test.tsx` (`F0Form clearing optional values`) — verified it fails on the unpatched code and passes with the fix.
- [x] `pnpm vitest run src/patterns/F0Form/__tests__/` → 334 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)