### PR TITLE
feat(F0CanvasCard): support file avatars, custom action button, optional description

### DIFF
--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/FormCard.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/FormCard.tsx
@@ -242,7 +242,7 @@ export function FormCard({
 
   return (
     <F0CanvasCard
-      avatar={{ type: "module", module: formModule }}
+      avatar={formModule ? { type: "module", module: formModule } : undefined}
       title={title}
       description={description}
       isActive={isActive}

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/FormCard.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/FormCard.tsx
@@ -242,13 +242,16 @@ export function FormCard({
 
   return (
     <F0CanvasCard
-      module={formModule}
+      avatar={{ type: "module", module: formModule }}
       title={title}
       description={description}
-      onClose={closeCanvas}
       isActive={isActive}
-      onOpen={handleOpen}
-      showOpenButton={isActive}
+      action={{
+        type: "open",
+        onOpen: handleOpen,
+        onClose: closeCanvas,
+        showButton: isActive,
+      }}
     >
       {visibleFields.length > 0 && !isActive && (
         <div className="-mx-3 flex w-full flex-col overflow-hidden pb-1">

--- a/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
+++ b/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
@@ -71,9 +71,7 @@ export function F0CanvasCard({
       className={cn(
         "flex flex-col items-center justify-between gap-3 rounded-lg border border-solid px-3 py-2",
         isOpenAction && "cursor-pointer",
-        isActive
-          ? "border-f1-border-hover"
-          : "border-f1-border-secondary hover:border-f1-border-hover"
+        isActive ? "border-f1-border-hover" : "border-f1-border-secondary"
       )}
       onClick={handleCardClick}
     >
@@ -96,7 +94,7 @@ export function F0CanvasCard({
         </div>
         {action.type === "open" && action.showButton !== false && (
           <F0Button
-            variant="neutral"
+            variant="outline"
             size="md"
             label={
               isActive

--- a/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
+++ b/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
@@ -108,7 +108,7 @@ export function F0CanvasCard({
         )}
         {action.type === "custom" && (
           <F0Button
-            variant="neutral"
+            variant="outline"
             size="md"
             icon={action.icon}
             label={action.label}

--- a/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
+++ b/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
@@ -2,68 +2,99 @@ import {
   F0AvatarModule,
   type ModuleId,
 } from "@/components/avatars/F0AvatarModule"
+import { F0AvatarFile } from "@/components/avatars/F0AvatarFile"
+import type { FileDef } from "@/components/avatars/F0AvatarFile/types"
 import { F0Button } from "@/components/F0Button"
+import type { IconType } from "@/components/F0Icon"
 import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
+type CanvasCardAvatar =
+  | { type: "module"; module: ModuleId }
+  | { type: "file"; file: FileDef }
+
+type CanvasCardAction =
+  | {
+      type: "open"
+      onOpen: () => void
+      onClose: () => void
+      /** When false, hides the Open/Close button but the card stays clickable. Default true. */
+      showButton?: boolean
+    }
+  | {
+      type: "custom"
+      icon: IconType
+      label: string
+      onClick: () => void
+      hideLabel?: boolean
+    }
+
 export type F0CanvasCardProps = {
-  /** Module avatar to display (e.g. "analytics", "surveys", "goals") */
-  module?: ModuleId
+  /** Avatar to display: a module icon or a file-type badge */
+  avatar?: CanvasCardAvatar
   /** Primary title */
   title: string
-  /** Secondary description line */
-  description: string
-  /** Called when the user clicks the "Open" button */
-  onOpen: () => void
-  /** Whether to show the "Open" button */
-  showOpenButton?: boolean
-  /** Called when the user clicks the "Close" button (active state) */
-  onClose: () => void
-  /** Whether this card's content is currently shown in the canvas */
-  isActive: boolean
+  /** Optional secondary description line */
+  description?: string
+  /** Whether this card's content is currently shown in the canvas (only meaningful for action.type === "open") */
+  isActive?: boolean
+  /** Action exposed by the card: either an Open/Close toggle or a custom icon button */
+  action: CanvasCardAction
   /** Optional content rendered below the card header (e.g. a data preview) */
   children?: React.ReactNode
 }
 
 /**
  * Shared inline card rendered in the AI chat for any canvas entity.
- * Shows a module avatar, title, description, and an Open/Close toggle button.
- * When active, displays a focus ring and the button switches to "Close".
+ * Shows an avatar, title, optional description, and a configurable action button.
  */
 export function F0CanvasCard({
-  module: cardModule,
+  avatar,
   title,
   description,
-  onOpen,
-  showOpenButton = true,
-  onClose,
-  isActive,
+  isActive = false,
+  action,
   children,
 }: F0CanvasCardProps) {
   const translations = useI18n()
 
+  const isOpenAction = action.type === "open"
+  const handleCardClick = isOpenAction
+    ? isActive
+      ? action.onClose
+      : action.onOpen
+    : undefined
+
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-between gap-3 rounded-lg border border-solid px-3 py-2 cursor-pointer",
+        "flex flex-col items-center justify-between gap-3 rounded-lg border border-solid px-3 py-2",
+        isOpenAction && "cursor-pointer",
         isActive
           ? "border-f1-border-hover"
           : "border-f1-border-secondary hover:border-f1-border-hover"
       )}
-      onClick={isActive ? onClose : onOpen}
+      onClick={handleCardClick}
     >
       <div className="flex w-full min-w-0 flex-row items-center gap-3">
-        {!!cardModule && <F0AvatarModule module={cardModule} size="lg" />}
+        {avatar?.type === "module" && (
+          <F0AvatarModule module={avatar.module} size="lg" />
+        )}
+        {avatar?.type === "file" && (
+          <F0AvatarFile file={avatar.file} size="lg" />
+        )}
         <div className="flex min-w-0 flex-1 flex-col">
           <OneEllipsis className="text-lg font-semibold text-f1-foreground">
             {title}
           </OneEllipsis>
-          <OneEllipsis className="text-base text-f1-foreground-secondary">
-            {description}
-          </OneEllipsis>
+          {description && (
+            <OneEllipsis className="text-base text-f1-foreground-secondary">
+              {description}
+            </OneEllipsis>
+          )}
         </div>
-        {showOpenButton && (
+        {action.type === "open" && action.showButton !== false && (
           <F0Button
             variant="neutral"
             size="md"
@@ -72,7 +103,17 @@ export function F0CanvasCard({
                 ? translations.actions.close
                 : translations.ai.reportCard.openButton
             }
-            onClick={isActive ? onClose : onOpen}
+            onClick={isActive ? action.onClose : action.onOpen}
+          />
+        )}
+        {action.type === "custom" && (
+          <F0Button
+            variant="neutral"
+            size="md"
+            icon={action.icon}
+            label={action.label}
+            hideLabel={action.hideLabel}
+            onClick={action.onClick}
           />
         )}
       </div>

--- a/packages/react/src/sds/ai/canvas/F0CanvasCard/__stories__/F0CanvasCard.stories.tsx
+++ b/packages/react/src/sds/ai/canvas/F0CanvasCard/__stories__/F0CanvasCard.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { fn } from "storybook/test"
 
+import { Download } from "@/icons/app"
+
 import { F0CanvasCard } from "../F0CanvasCard"
 
 const meta = {
@@ -22,48 +24,98 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+const openAction = {
+  type: "open" as const,
+  onOpen: fn(),
+  onClose: fn(),
+}
+
 export const Default: Story = {
   args: {
-    module: "analytics",
+    avatar: { type: "module", module: "analytics" },
     title: "Headcount Overview",
     description: "Employee distribution by department",
-    onOpen: fn(),
-    onClose: fn(),
     isActive: false,
+    action: openAction,
   },
 }
 
 export const Active: Story = {
   args: {
-    module: "analytics",
+    avatar: { type: "module", module: "analytics" },
     title: "Headcount Overview",
     description: "Employee distribution by department",
-    onOpen: fn(),
-    onClose: fn(),
     isActive: true,
+    action: openAction,
   },
 }
 
 export const LongTitle: Story = {
   args: {
-    module: "analytics",
+    avatar: { type: "module", module: "analytics" },
     title:
       "Quarterly Performance Review Dashboard with Detailed Metrics and Historical Trends",
     description:
       "A comprehensive view of team performance across all departments for Q1 2026",
-    onOpen: fn(),
-    onClose: fn(),
     isActive: false,
+    action: openAction,
   },
 }
 
 export const DifferentModule: Story = {
   args: {
-    module: "my_surveys",
+    avatar: { type: "module", module: "my_surveys" },
     title: "Employee Satisfaction Survey",
     description: "Results from the latest pulse survey",
-    onOpen: fn(),
-    onClose: fn(),
     isActive: false,
+    action: openAction,
+  },
+}
+
+export const FileAvatar: Story = {
+  args: {
+    avatar: { type: "file", file: { name: "headcount_q1.pdf", type: "pdf" } },
+    title: "Headcount report Q1",
+    description: "Generated 2026-04-01",
+    isActive: false,
+    action: openAction,
+  },
+}
+
+export const FileAvatarNoDescription: Story = {
+  args: {
+    avatar: { type: "file", file: { name: "headcount_q1.pdf", type: "pdf" } },
+    title: "Headcount report Q1",
+    isActive: false,
+    action: openAction,
+  },
+}
+
+export const CustomAction: Story = {
+  args: {
+    avatar: {
+      type: "file",
+      file: { name: "payroll_2026_q1.csv", type: "csv" },
+    },
+    title: "payroll_2026_q1.csv",
+    description: "2.4 MB · ready to download",
+    isActive: false,
+    action: {
+      type: "custom",
+      icon: Download,
+      label: "Download",
+      hideLabel: true,
+      onClick: fn(),
+    },
+  },
+}
+
+export const OpenButtonHidden: Story = {
+  args: {
+    avatar: { type: "module", module: "analytics" },
+    title: "Headcount Overview",
+    description: "Employee distribution by department",
+    isActive: false,
+    action: { type: "open", onOpen: fn(), onClose: fn(), showButton: false },
   },
 }

--- a/packages/react/src/sds/ai/canvas/F0CanvasCard/__tests__/F0CanvasCard.test.tsx
+++ b/packages/react/src/sds/ai/canvas/F0CanvasCard/__tests__/F0CanvasCard.test.tsx
@@ -2,16 +2,23 @@ import { describe, expect, it, vi } from "vitest"
 import "@testing-library/jest-dom/vitest"
 import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
 
+import { Download } from "@/icons/app"
+
 import { F0CanvasCard } from "../F0CanvasCard"
 
 describe("F0CanvasCard", () => {
-  const defaultProps = {
-    module: "analytics" as const,
-    title: "Test Dashboard",
-    description: "A test description",
+  const openAction = {
+    type: "open" as const,
     onOpen: vi.fn(),
     onClose: vi.fn(),
+  }
+
+  const defaultProps = {
+    avatar: { type: "module" as const, module: "analytics" as const },
+    title: "Test Dashboard",
+    description: "A test description",
     isActive: false,
+    action: openAction,
   }
 
   it("renders title and description", () => {
@@ -37,7 +44,13 @@ describe("F0CanvasCard", () => {
     const user = userEvent.setup()
     const onOpen = vi.fn()
 
-    render(<F0CanvasCard {...defaultProps} onOpen={onOpen} isActive={false} />)
+    render(
+      <F0CanvasCard
+        {...defaultProps}
+        isActive={false}
+        action={{ type: "open", onOpen, onClose: vi.fn() }}
+      />
+    )
 
     await user.click(screen.getByRole("button", { name: "Open" }))
     expect(onOpen).toHaveBeenCalled()
@@ -47,7 +60,13 @@ describe("F0CanvasCard", () => {
     const user = userEvent.setup()
     const onClose = vi.fn()
 
-    render(<F0CanvasCard {...defaultProps} onClose={onClose} isActive={true} />)
+    render(
+      <F0CanvasCard
+        {...defaultProps}
+        isActive={true}
+        action={{ type: "open", onOpen: vi.fn(), onClose }}
+      />
+    )
 
     await user.click(screen.getByRole("button", { name: "Close" }))
     expect(onClose).toHaveBeenCalled()
@@ -69,5 +88,101 @@ describe("F0CanvasCard", () => {
 
     const card = container.firstElementChild as HTMLElement
     expect(card.className).not.toContain("ring-2")
+  })
+
+  it("renders file avatar with the file type label", () => {
+    render(
+      <F0CanvasCard
+        {...defaultProps}
+        avatar={{ type: "file", file: { name: "report.pdf", type: "pdf" } }}
+      />
+    )
+
+    expect(screen.getByText("PDF")).toBeInTheDocument()
+  })
+
+  it("does not render description line when description is omitted", () => {
+    render(
+      <F0CanvasCard
+        {...defaultProps}
+        description={undefined}
+        title="Only title"
+      />
+    )
+
+    expect(screen.getByText("Only title")).toBeInTheDocument()
+    expect(screen.queryByText("A test description")).not.toBeInTheDocument()
+  })
+
+  it("renders the custom action button with icon and label and calls onClick", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    render(
+      <F0CanvasCard
+        {...defaultProps}
+        action={{
+          type: "custom",
+          icon: Download,
+          label: "Download",
+          onClick,
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Download" }))
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it("does not make the card clickable when action is custom", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    const { container } = render(
+      <F0CanvasCard
+        {...defaultProps}
+        action={{
+          type: "custom",
+          icon: Download,
+          label: "Download",
+          hideLabel: true,
+          onClick,
+        }}
+      />
+    )
+
+    const card = container.firstElementChild as HTMLElement
+    expect(card.className).not.toContain("cursor-pointer")
+
+    await user.click(screen.getByText("Test Dashboard"))
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it("hides the open button when action.showButton is false but keeps the card clickable", async () => {
+    const user = userEvent.setup()
+    const onOpen = vi.fn()
+
+    const { container } = render(
+      <F0CanvasCard
+        {...defaultProps}
+        isActive={false}
+        action={{
+          type: "open",
+          onOpen,
+          onClose: vi.fn(),
+          showButton: false,
+        }}
+      />
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "Open" })
+    ).not.toBeInTheDocument()
+
+    const card = container.firstElementChild as HTMLElement
+    expect(card.className).toContain("cursor-pointer")
+
+    await user.click(card)
+    expect(onOpen).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Generalize `F0CanvasCard` so the same component covers both the existing "open canvas" pattern (module avatar + Open/Close button) and new patterns like "download a file" (file-type badge avatar + icon-only action button + title-only).

The 3 existing call sites (`FormCard` in this repo, `DashboardCard` and `DataDownloadCard` consumed downstream) are migrated in the same change.

## API changes

```ts
type CanvasCardAvatar =
  | { type: "module"; module: ModuleId }
  | { type: "file"; file: FileDef }

type CanvasCardAction =
  | { type: "open"; onOpen; onClose; showButton? }
  | { type: "custom"; icon; label; onClick; hideLabel? }

type F0CanvasCardProps = {
  avatar?: CanvasCardAvatar           // was: module?: ModuleId
  title: string
  description?: string                // was: required
  isActive?: boolean                  // was: required
  action: CanvasCardAction            // was: top-level onOpen/onClose/showOpenButton
  children?: React.ReactNode
}
```

- **Avatar** is a discriminated union so a third type (employee, …) can be added later without a breaking change.
- **Action** is a discriminated union so `onOpen/onClose` only exist on the open variant and `icon/label/onClick` only on the custom variant.
- When `action.type === "custom"` the **card body is no longer clickable**; only the button triggers the handler. This avoids accidental side-effects (e.g. a click anywhere on a download card triggering a download).
- `showButton` lives inside the `open` variant to preserve the existing `FormCard` pattern (button only visible while active).

## Breaking change

This is a breaking change for any other consumer of `F0CanvasCard`. Downstream repos must migrate from the old top-level props to `avatar` + `action`.

## Test plan

- [x] `pnpm tsc` in `packages/react`
- [x] `pnpm vitest src/sds/ai/canvas/F0CanvasCard` — 12/12 tests pass (7 updated + 5 new: file avatar renders type label, description omission, custom action click-handling, card not clickable for custom, `showButton: false` hides button while keeping card clickable)
- [x] `pnpm tsc` in the consumer repo on the migrated call sites
- [ ] Visual review of the new Storybook stories: `FileAvatar`, `FileAvatarNoDescription`, `CustomAction` (download icon-only), `OpenButtonHidden`