### PR TITLE
feat(avatar): add color variant to F0Avatar

### DIFF
--- a/packages/react/src/components/avatars/F0Avatar/F0Avatar.tsx
+++ b/packages/react/src/components/avatars/F0Avatar/F0Avatar.tsx
@@ -1,5 +1,8 @@
 import { ComponentProps, ReactNode } from "react"
 
+import { DistributiveOmit } from "@/lib/typescript-utils/distributive-omit"
+
+import { F0AvatarColor, F0AvatarColorProps } from "../F0AvatarColor"
 import { F0AvatarCompany, F0AvatarCompanyProps } from "../F0AvatarCompany"
 import { F0AvatarEmoji, F0AvatarEmojiProps } from "../F0AvatarEmoji"
 import { F0AvatarFile, F0AvatarFileProps } from "../F0AvatarFile"
@@ -23,6 +26,7 @@ export type AvatarVariant =
   | ({ type: "flag" } & Omit<F0AvatarFlagProps, "size">)
   | ({ type: "emoji" } & Omit<F0AvatarEmojiProps, "size">)
   | ({ type: "icon" } & Omit<F0AvatarIconProps, "size">)
+  | ({ type: "color" } & DistributiveOmit<F0AvatarColorProps, "size">)
 
 export const F0Avatar = ({
   avatar,
@@ -106,6 +110,18 @@ export const F0Avatar = ({
           icon={avatar.icon}
           size={size as ComponentProps<typeof F0AvatarIcon>["size"]}
           state={avatar.state}
+          aria-label={avatar["aria-label"]}
+          aria-labelledby={avatar["aria-labelledby"]}
+          dataTestId={dataTestId}
+        />
+      )
+    case "color":
+      return (
+        <F0AvatarColor
+          {...("color" in avatar
+            ? { color: avatar.color }
+            : { customColor: avatar.customColor })}
+          size={size as ComponentProps<typeof F0AvatarColor>["size"]}
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}
           dataTestId={dataTestId}

--- a/packages/react/src/components/avatars/F0Avatar/types.ts
+++ b/packages/react/src/components/avatars/F0Avatar/types.ts
@@ -1,7 +1,8 @@
 import { ModuleId } from "@/components/avatars/F0AvatarModule"
-import { BadgeProps } from "@/ui/IconBadge"
 import { DistributiveOmit } from "@/lib/typescript-utils/distributive-omit"
+import { BadgeProps } from "@/ui/IconBadge"
 
+import { F0AvatarColorProps } from "../F0AvatarColor"
 import { F0AvatarCompanyProps } from "../F0AvatarCompany"
 import { F0AvatarEmojiProps } from "../F0AvatarEmoji"
 import { F0AvatarFileProps } from "../F0AvatarFile"
@@ -40,7 +41,8 @@ export type AvatarVariant = DistributiveOmit<
   | ({ type: "company" } & F0AvatarCompanyProps)
   | ({ type: "file" } & F0AvatarFileProps)
   | ({ type: "flag" } & F0AvatarFlagProps)
-  | ({ type: "icon" } & F0AvatarIconProps),
+  | ({ type: "icon" } & F0AvatarIconProps)
+  | ({ type: "color" } & F0AvatarColorProps),
   "size"
 >
 
@@ -51,3 +53,4 @@ export type CompanyAvatarVariant = Extract<AvatarVariant, { type: "company" }>
 export type FileAvatarVariant = Extract<AvatarVariant, { type: "file" }>
 export type FlagAvatarVariant = Extract<AvatarVariant, { type: "flag" }>
 export type IconAvatarVariant = Extract<AvatarVariant, { type: "icon" }>
+export type ColorAvatarVariant = Extract<AvatarVariant, { type: "color" }>

--- a/packages/react/src/components/avatars/F0AvatarColor/F0AvatarColor.tsx
+++ b/packages/react/src/components/avatars/F0AvatarColor/F0AvatarColor.tsx
@@ -1,0 +1,55 @@
+import { baseColors } from "@factorialco/f0-core"
+
+import { NewColor } from "@/components/tags/F0TagDot/types"
+import { cn } from "@/lib/utils"
+
+import { AvatarSize, BaseAvatarProps } from "../internal/BaseAvatar"
+
+/**
+ * A color-swatch avatar: a solid circle filled with an entity's color. Used to represent entities
+ * whose identity is a color (e.g. a leave type). Mirrors `F0TagDot`'s color API — pass a named
+ * design token via `color`, or an arbitrary CSS color (e.g. a hex) via `customColor`.
+ */
+export type F0AvatarColorProps = {
+  size?: AvatarSize
+} & ({ color: NewColor } | { customColor: string }) &
+  Partial<Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">>
+
+// Dimensions mirror the underlying `@/ui/Avatar` size scale (size-5 … size-18).
+const sizes: Record<AvatarSize, string> = {
+  xs: "size-5",
+  sm: "size-6",
+  md: "size-8",
+  lg: "size-10",
+  xl: "size-14",
+  "2xl": "size-18",
+}
+
+export const F0AvatarColor = (props: F0AvatarColorProps) => {
+  const {
+    size = "md",
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledby,
+  } = props
+
+  // Named tokens resolve to their shade-50 (as HSL), matching F0TagDot; custom colors pass through.
+  const backgroundColor =
+    "color" in props ? `hsl(${baseColors[props.color][50]})` : props.customColor
+
+  const hasAria = Boolean(ariaLabel || ariaLabelledby)
+
+  return (
+    <div
+      className={cn("aspect-square rounded-full", sizes[size])}
+      style={{ backgroundColor }}
+      role="img"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
+      aria-hidden={!hasAria}
+      // The color is the content; its contrast is intentional and not subject to a11y contrast rules.
+      data-a11y-color-contrast-ignore
+    />
+  )
+}
+
+F0AvatarColor.displayName = "ColorAvatar"

--- a/packages/react/src/components/avatars/F0AvatarColor/__storybook__/F0AvatarColor.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarColor/__storybook__/F0AvatarColor.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { tagDotColors } from "@/components/tags/F0TagDot/types"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import { avatarSizes } from "../../internal/BaseAvatar"
+import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
+import { F0AvatarColor } from "../F0AvatarColor"
+
+const meta: Meta<typeof F0AvatarColor> = {
+  component: F0AvatarColor,
+  title: "Avatars/AvatarColor",
+  tags: ["autodocs"],
+  argTypes: {
+    ...getBaseAvatarArgTypes(["size", "aria-label", "aria-labelledby"]),
+    size: {
+      control: "select",
+      options: avatarSizes,
+      description: "The size of the avatar",
+    },
+    color: {
+      control: "select",
+      options: tagDotColors,
+      description: "A named design-token color",
+    },
+    customColor: {
+      control: "color",
+      description:
+        "An arbitrary CSS color (e.g. a hex). Use instead of `color`.",
+    },
+  },
+  args: {
+    customColor: "#FF5733",
+    size: "md",
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: [
+          "An avatar that displays a solid color swatch, for entities whose identity is a color (e.g. a leave type).",
+          "Pass a named design token via `color`, or an arbitrary CSS color via `customColor`.",
+        ]
+          .map((line) => `<p>${line}</p>`)
+          .join(""),
+      },
+    },
+    a11y: {
+      config: {
+        rules: [
+          {
+            id: "color-contrast",
+            enabled: false,
+          },
+        ],
+      },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof F0AvatarColor>
+
+export const Default: Story = {}
+
+export const Snapshot: Story = {
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex w-fit flex-col gap-2">
+      <div className="flex flex-row items-center gap-2">
+        <h4 className="text-lg font-semibold">Custom color (hex)</h4>
+        {avatarSizes.map((size) => (
+          <F0AvatarColor key={size} size={size} customColor="#FF5733" />
+        ))}
+      </div>
+      <div className="flex flex-row items-center gap-2">
+        <h4 className="text-lg font-semibold">Named token</h4>
+        {avatarSizes.map((size) => (
+          <F0AvatarColor key={size} size={size} color="viridian" />
+        ))}
+      </div>
+    </div>
+  ),
+}

--- a/packages/react/src/components/avatars/F0AvatarColor/index.tsx
+++ b/packages/react/src/components/avatars/F0AvatarColor/index.tsx
@@ -1,0 +1,6 @@
+import { withDataTestId } from "@/lib/data-testid"
+
+import { F0AvatarColor as _F0AvatarColor } from "./F0AvatarColor"
+
+export type { F0AvatarColorProps } from "./F0AvatarColor"
+export const F0AvatarColor = withDataTestId(_F0AvatarColor)

--- a/packages/react/src/components/avatars/exports.ts
+++ b/packages/react/src/components/avatars/exports.ts
@@ -1,5 +1,6 @@
 export * from "./F0Avatar"
 export * from "./F0AvatarAlert"
+export * from "./F0AvatarColor"
 export * from "./F0AvatarCompany"
 export * from "./F0AvatarDate"
 export * from "./F0AvatarEmoji"


### PR DESCRIPTION
## What

Adds a new `color` variant to `F0Avatar` — a solid color-swatch avatar for entities whose identity
is a color (e.g. a Time Off leave type).

```tsx
<F0Avatar avatar={{ type: "color", color: "viridian" }} />        // named design token
<F0Avatar avatar={{ type: "color", customColor: "#FF5733" }} />   // arbitrary CSS color
```

## Why

The OneDataCollection list/card identity slot only accepts `title: string` + `avatar: AvatarVariant`,
and `AvatarVariant` had no color member — so there was no way to show an entity's color next to its
name. The only arbitrary-hex primitive (`F0TagDot`'s `customColor`) is a right-side tag cell. This adds
a first-class color avatar so consumers (List, Card, Chip, …) can represent color-identified entities
in the avatar slot. First consumer will be the Time Off "Absence Types" list —
factorialco/factorial#100304 (it'll render each leave type's color next to its name once this lands
and `@factorialco/f0-react` is bumped).

## How

- New `F0AvatarColor/` (mirrors the `F0AvatarEmoji` anatomy): a `rounded-full` swatch across the full
  `AvatarSize` scale (`size-5`…`size-18`), `role="img"`, `aria-hidden` when unlabeled, and
  `data-a11y-color-contrast-ignore` (the color is decorative content).
- API mirrors `F0TagDot`: `({ color: NewColor } | { customColor: string })`. Named tokens resolve via
  `hsl(baseColors[color][50])` (same as `F0TagDot`); `customColor` is applied verbatim as the
  background. `F0TagDot` is intentionally left untouched (no shared-helper refactor).
- Wired into the `F0Avatar` dispatcher (new `color` union arm + `case`) and the public `AvatarVariant`
  (+ `ColorAvatarVariant` extract); exported from `avatars/exports.ts`. No consumer changes — adding the
  arm to `AvatarVariant` makes the List/Card/Chip avatar slots accept it automatically.
- Storybook story under `Avatars/AvatarColor` (sizes × named/custom color).

## Verification

`pnpm tsc` ✅ · `pnpm lint` (oxlint, `--max-warnings 0`) ✅ · `oxfmt` ✅ ·
`pnpm vitest --project=unit` (avatars) 33/33 ✅ · `pnpm build-storybook` ✅.

## Related

- Consumer: factorialco/factorial#100304 — Time Off "Absence Types" → F0 migration (will use
  `{ type: "color", customColor: leaveType.color }` once this is published).
