### PR TITLE
fix(CompanySelector): remove asymmetric avatar rounding

### DIFF
--- a/packages/react/src/patterns/Navigation/Sidebar/CompanySelector/index.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/CompanySelector/index.tsx
@@ -171,7 +171,7 @@ const SelectedCompanyLabel = ({
   return (
     <div
       className={cn(
-        "flex min-w-0 max-w-full flex-1 items-center gap-2 overflow-hidden rounded text-lg font-semibold text-f1-foreground transition-colors"
+        "flex min-w-0 max-w-full flex-1 items-center gap-2 overflow-hidden text-lg font-semibold text-f1-foreground transition-colors"
       )}
     >
       <F0AvatarCompany


### PR DESCRIPTION
## What

Removes the `rounded` class from the `SelectedCompanyLabel` wrapper in `CompanySelector`, which was causing the company avatar to render with a larger radius on its **left** corners than its right.

## Why

The wrapper combines `rounded` with `overflow-hidden`. Because the avatar is the left-most child flush against the container's left edge, the container's radius clipped the avatar's left corners — overriding the avatar's own `rounded-sm` and producing visibly asymmetric rounding (left more rounded than right).

The wrapper has no background or border, so `rounded` had no legitimate purpose; its only effect was this unwanted clipping. `overflow-hidden` is kept since it's still needed for text truncation.

## Verification

Confirmed in Storybook (`Sidebar/CompanySelector` → Default):
- Avatar corner radii are now uniform on all four corners.
- The label wrapper no longer applies any border radius / clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)