### PR TITLE
feat(F0Button): right-positioned icon + ArrowRight on CRUD Read open actions

### DIFF
--- a/packages/react/src/components/F0Button/__tests__/F0Button.test.tsx
+++ b/packages/react/src/components/F0Button/__tests__/F0Button.test.tsx
@@ -41,6 +41,18 @@ describe("F0Button", () => {
     expect(screen.getByText("Add Item")).toBeInTheDocument()
   })
 
+  it("should render the icon after the label when iconPosition is right", () => {
+    render(<F0Button label="Open Details" icon={Add} iconPosition="right" />)
+    const button = screen.getByRole("button")
+    const svg = button.querySelector("svg")
+    const label = screen.getByText("Open Details")
+    expect(svg).toBeInTheDocument()
+    // The icon node should follow the label in DOM order.
+    expect(
+      label.compareDocumentPosition(svg!) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
   it("should render as icon-only when hideLabel is true", () => {
     render(<F0Button label="Add Item" icon={Add} hideLabel round />)
     const button = screen.getByRole("button")

--- a/packages/react/src/components/F0Button/internal-types.ts
+++ b/packages/react/src/components/F0Button/internal-types.ts
@@ -56,6 +56,10 @@ export type ButtonInternalProps = Pick<
      */
     icon?: IconType
     /**
+     * Sets the side of the label the icon is placed on. Defaults to "left".
+     */
+    iconPosition?: "left" | "right"
+    /**
      * Adds an emoji to the button, can be used as a special case of icon-only button.
      */
     emoji?: string

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -29,6 +29,7 @@ const ButtonInternal = forwardRef<
     withoutDisabledAppearance,
     loading: forceLoading,
     icon,
+    iconPosition = "left",
     emoji,
     variant = "default",
     size = "md",
@@ -75,6 +76,38 @@ const ButtonInternal = forwardRef<
 
   const buttonLabel = (label ?? "").toString()
   const buttonFontSize = fontSize ?? size
+
+  const iconNode = icon ? (
+    iconRotate ? (
+      <IconMotion
+        size={size === "sm" ? "sm" : "md"}
+        icon={icon}
+        animate={{
+          rotate: isHovered ? 90 : 0,
+          scale: isHovered ? [1, 0.8, 1] : 1,
+          filter: isHovered
+            ? ["blur(0px)", "blur(1px)", "blur(0px)"]
+            : "blur(0px)",
+        }}
+        transition={{
+          rotate: {
+            duration: 0.5,
+            ease: [0.77, 0, 0.13, 1.52],
+          },
+          scale: {
+            duration: 0.4,
+            ease: [0.65, 0, 0.35, 1],
+          },
+          filter: {
+            duration: 0.4,
+            ease: [0.65, 0, 0.35, 1],
+          },
+        }}
+      />
+    ) : (
+      <F0Icon size={size === "sm" ? "sm" : "md"} icon={icon} />
+    )
+  ) : null
 
   return (
     <>
@@ -129,39 +162,12 @@ const ButtonInternal = forwardRef<
           className={cn(
             isLoading && "invisible",
             "flex min-w-0 flex-1 items-center justify-center gap-1",
-            icon && !hideLabel && "-ml-[3px]"
+            icon &&
+              !hideLabel &&
+              (iconPosition === "right" ? "-mr-[3px]" : "-ml-[3px]")
           )}
         >
-          {icon &&
-            (iconRotate ? (
-              <IconMotion
-                size={size === "sm" ? "sm" : "md"}
-                icon={icon}
-                animate={{
-                  rotate: isHovered ? 90 : 0,
-                  scale: isHovered ? [1, 0.8, 1] : 1,
-                  filter: isHovered
-                    ? ["blur(0px)", "blur(1px)", "blur(0px)"]
-                    : "blur(0px)",
-                }}
-                transition={{
-                  rotate: {
-                    duration: 0.5,
-                    ease: [0.77, 0, 0.13, 1.52],
-                  },
-                  scale: {
-                    duration: 0.4,
-                    ease: [0.65, 0, 0.35, 1],
-                  },
-                  filter: {
-                    duration: 0.4,
-                    ease: [0.65, 0, 0.35, 1],
-                  },
-                }}
-              />
-            ) : (
-              <F0Icon size={size === "sm" ? "sm" : "md"} icon={icon} />
-            ))}
+          {iconPosition === "left" && iconNode}
           {emoji && (
             <EmojiImage
               emoji={emoji}
@@ -182,6 +188,7 @@ const ButtonInternal = forwardRef<
           ) : (
             <span className="sr-only">{buttonLabel}</span>
           )}
+          {iconPosition === "right" && iconNode}
           {append}{" "}
           {counterValue && (
             <Counter value={counterValue} size="sm" type="selected" />

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogFooter.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogFooter.tsx
@@ -58,6 +58,7 @@ export const F0DialogFooter = ({
         onClick={primaryAction.onClick}
         variant="default"
         icon={primaryAction.icon}
+        iconPosition={primaryAction.iconPosition}
         disabled={primaryAction.disabled}
         loading={primaryAction.loading}
       />
@@ -90,6 +91,7 @@ export const F0DialogFooter = ({
         onClick={secondaryAction.onClick}
         variant="outline"
         icon={secondaryAction.icon}
+        iconPosition={secondaryAction.iconPosition}
         disabled={secondaryAction.disabled}
         loading={secondaryAction.loading}
       />

--- a/packages/react/src/patterns/F0Dialog/types.ts
+++ b/packages/react/src/patterns/F0Dialog/types.ts
@@ -14,6 +14,7 @@ export type DialogWidth = (typeof dialogWidths)[number]
 export type F0DialogPrimaryAction = {
   label: string
   icon?: IconType
+  iconPosition?: "left" | "right"
   onClick: () => void
   disabled?: boolean
   loading?: boolean
@@ -22,6 +23,7 @@ export type F0DialogPrimaryAction = {
 export type F0DialogSecondaryAction = {
   label: string
   icon?: IconType
+  iconPosition?: "left" | "right"
   onClick: () => void
   disabled?: boolean
   loading?: boolean

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentProps, useState } from "react"
 
 import { StandardLayout } from "@/layouts/StandardLayout"
 import { PageHeader } from "@/experimental/Navigation/Header/PageHeader"
-import { ChevronRight, Download, Files, Pencil } from "@/icons/app"
+import { ArrowRight, Download, Files, Pencil } from "@/icons/app"
 import { ApplicationFrame } from "@/patterns/ApplicationFrame"
 import ApplicationFrameStoryMeta from "@/patterns/ApplicationFrame/index.stories"
 import { F0Dialog } from "@/patterns/F0Dialog"
@@ -219,7 +219,7 @@ function OpenAsPageScenario({
       },
       {
         label: "Open",
-        icon: ChevronRight,
+        icon: ArrowRight,
         type: "primary",
         hideLabel: true,
         hideInMobileDropdown: true,
@@ -322,7 +322,7 @@ function RightDialogToPageScenario() {
         disableContentPadding
         primaryAction={{
           label: "Open Details",
-          icon: ChevronRight,
+          icon: ArrowRight,
           iconPosition: "right",
           onClick: () => setSurface("page"),
         }}

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
@@ -322,6 +322,8 @@ function RightDialogToPageScenario() {
         disableContentPadding
         primaryAction={{
           label: "Open Details",
+          icon: ChevronRight,
+          iconPosition: "right",
           onClick: () => setSurface("page"),
         }}
       >


### PR DESCRIPTION
## What

In the Data Collection / CRUD **Read** pattern, the open/go-to-detail affordances now show a right-pointing arrow:

- The icon-only **"Open"** row action uses `ArrowRight`.
- The right-dialog → page **"Open Details"** primary action shows `ArrowRight` to the **right** of the label, signalling the forward transition into the full page.

To support an icon on the trailing side, this adds a small, reusable **`iconPosition?: "left" | "right"`** prop to `F0Button` (default `"left"`, non-breaking) and threads it through `F0Dialog`'s primary/secondary action types.

## Scope

These are the only "open item / go to detail page" affordances across all CRUD patterns:
- **Data collection / CRUD patterns** — Create/Update/Delete/By-view have no open-detail affordance (their actions are Create/Edit/Save/Delete); the other Read dialogs are terminal, so their primary actions aren't page transitions.
- **Experimental / CRUD patterns** — documentation-only MDX, no interactive buttons to restyle.

## Changes

- `F0Button`: add `iconPosition` prop; render the icon before or after the label accordingly (flipping the optical `-ml`/`-mr` nudge). Extracted the icon into a shared node.
- `F0Dialog`: thread `iconPosition` through primary/secondary action types and the footer.
- `read.stories.tsx`: both Read open affordances now use `ArrowRight` (`iconPosition: "right"` on the dialog button).
- Added a unit test asserting the icon follows the label in DOM order when `iconPosition="right"`.

## Verification

- `tsc` clean, lint/format clean.
- F0Button + F0Dialog unit tests pass (incl. the new ordering test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)