### PR TITLE
feat: add support to persist data collection filters/sorting/search with url params

### DIFF
--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -7,7 +7,7 @@ import {
 } from "@/patterns/OneFilterPicker/types"
 import { PromiseState } from "@/lib/promise-to-observable"
 
-import { DataAdapter } from "./fetch.typings"
+import { DataAdapter, PaginationInfo } from "./fetch.typings"
 import { GroupingDefinition, GroupingState } from "./grouping.typings"
 import { ChildrenPaginationInfo, ChildrenResponse } from "./nested.typings"
 import { RecordType } from "./records.typings"
@@ -59,6 +59,21 @@ export type DataSourceDefinition<
   defaultSortings?: SortingsState<Sortings>
   /** Current state of applied sortings */
   currentSortings?: SortingsState<Sortings>
+  /*******************************************************/
+
+  /***** PAGINATION ***************************************************/
+  /**
+   * Initial page to fetch (1-indexed) for page-based pagination. Applied on the
+   * first load only; the page resets to 1 whenever filters/search/sortings
+   * change (as it always has). Useful for restoring a page from the URL.
+   */
+  currentPage?: number
+  /**
+   * Called whenever the pagination info changes — e.g. the user navigates to a
+   * different page. Lets a consumer observe the current page (to persist it in
+   * the URL, analytics, etc.) without owning the pagination state.
+   */
+  onPaginationChange?: (paginationInfo: PaginationInfo | null) => void
   /*******************************************************/
 
   /** Data adapter responsible for fetching and managing data */

--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -254,6 +254,8 @@ export function useData<
     grouping,
     idProvider = defaultIdProvider,
     itemPreFilter,
+    currentPage,
+    onPaginationChange,
   } = source
 
   const cleanup = useRef<(() => void) | undefined>()
@@ -305,6 +307,16 @@ export function useData<
   const [isLoadingMore, setIsLoadingMore] = useState(false)
 
   const isLoadingMoreRef = useRef(false)
+
+  // The provided `currentPage` only seeds the very first page-based fetch
+  // (e.g. restoring a page from the URL); later fetches reset to page 1 as
+  // before — notably when filters/search/sortings change.
+  const initialPageRef = useRef(currentPage)
+
+  // Surface pagination changes (page navigation, etc.) to the consumer.
+  useEffect(() => {
+    onPaginationChange?.(paginationInfo)
+  }, [paginationInfo, onPaginationChange])
 
   const mergedFilters = useMemo(() => {
     return { ...currentFilters, ...filters }
@@ -737,9 +749,15 @@ export function useData<
     () => {
       if (!isLoadingMoreRef.current) {
         setIsLoading(true)
-        // Explicitly pass 0 as the initial position for infinite scroll
+        // Seed the first page-based fetch from `currentPage` (if provided), then
+        // fall back to page 1 for every subsequent fetch (filter/search/sorting
+        // changes still reset to the first page).
+        const seededPage = initialPageRef.current
+        initialPageRef.current = undefined
         const initialPosition =
-          dataAdapter.paginationType === "infinite-scroll" ? 0 : 1
+          dataAdapter.paginationType === "infinite-scroll"
+            ? 0
+            : (seededPage ?? 1)
         fetchDataAndUpdate({
           filters: mergedFilters,
           currentPage: initialPosition,

--- a/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionUrlParams.test.ts
+++ b/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionUrlParams.test.ts
@@ -123,9 +123,9 @@ describe("parseDataCollectionUrlParams", () => {
     expect(
       parseDataCollectionUrlParams(`dc_id=${ID}&dc_search=`)?.state
     ).toHaveProperty("search", "")
-    expect(parseDataCollectionUrlParams(`dc_id=${ID}`)?.state).not.toHaveProperty(
-      "search"
-    )
+    expect(
+      parseDataCollectionUrlParams(`dc_id=${ID}`)?.state
+    ).not.toHaveProperty("search")
   })
 })
 
@@ -273,7 +273,11 @@ describe("setDataCollectionUrlParams", () => {
       sortings: null,
     })
 
-    expect([...params.keys()].some((k) => k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX))).toBe(false)
+    expect(
+      [...params.keys()].some((k) =>
+        k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX)
+      )
+    ).toBe(false)
     expect(params.get("keep")).toBe("1")
   })
 
@@ -302,16 +306,16 @@ describe("syncDataCollectionUrlParams", () => {
   })
 
   it("clears all dc_ params when the state becomes empty", () => {
-    window.history.replaceState(
-      null,
-      "",
-      `/?keep=1&dc_id=${ID}&dc_search=ada`
-    )
+    window.history.replaceState(null, "", `/?keep=1&dc_id=${ID}&dc_search=ada`)
 
     syncDataCollectionUrlParams(ID, { search: "", filters: {}, sortings: null })
 
     const params = new URLSearchParams(window.location.search)
-    expect([...params.keys()].some((k) => k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX))).toBe(false)
+    expect(
+      [...params.keys()].some((k) =>
+        k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX)
+      )
+    ).toBe(false)
     expect(params.get("keep")).toBe("1")
   })
 

--- a/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionUrlParams.test.ts
+++ b/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionUrlParams.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
+
+import { getDataCollectionStorageKey } from "../dataCollectionStorageKey"
+import {
+  buildDataCollectionUrlParams,
+  DATA_COLLECTION_URL_PARAM_PREFIX,
+  DATA_COLLECTION_URL_PARAMS,
+  parseDataCollectionUrlParams,
+  setDataCollectionUrlParams,
+  syncDataCollectionUrlParams,
+  writeDataCollectionStorage,
+} from "../dataCollectionUrlParams"
+import { readDataCollectionStorage } from "../readDataCollectionStorage"
+
+const ID = "organization/employees/v1"
+const KEY = getDataCollectionStorageKey(ID)
+
+// Only `type` matters for decoding; the rest is filled to satisfy the type.
+const FILTERS = {
+  department: { type: "in", label: "Department", options: { options: [] } },
+  role: { type: "in", label: "Role", options: { options: [] } },
+  query: { type: "search", label: "Query" },
+  salary: {
+    type: "number",
+    label: "Salary",
+    options: { modes: ["range", "single"], min: 0 },
+  },
+} as unknown as FiltersDefinition
+
+afterEach(() => {
+  localStorage.clear()
+  window.history.replaceState(null, "", "/")
+})
+
+describe("parseDataCollectionUrlParams", () => {
+  it("returns null when there is no dc_id", () => {
+    expect(parseDataCollectionUrlParams("dc_search=ada", FILTERS)).toBeNull()
+    expect(parseDataCollectionUrlParams("")).toBeNull()
+  })
+
+  it("parses the id, search and shorthand sortings", () => {
+    const parsed = parseDataCollectionUrlParams(
+      `dc_id=${ID}&dc_search=ada&dc_sort=salary:desc`
+    )
+    expect(parsed).toEqual({
+      id: ID,
+      state: { search: "ada", sortings: { field: "salary", order: "desc" } },
+    })
+  })
+
+  it("decodes each filter from its own dc_<key> param", () => {
+    const parsed = parseDataCollectionUrlParams(
+      `dc_id=${ID}&dc_department=Engineering&dc_department=Product&dc_query=ann&dc_salary=1000..5000`,
+      FILTERS
+    )
+
+    expect(parsed?.state.filters).toEqual({
+      // repeated params → array (multi-select)
+      department: ["Engineering", "Product"],
+      query: "ann",
+      salary: {
+        mode: "range",
+        from: { value: 1000, closed: true },
+        to: { value: 5000, closed: true },
+      },
+    })
+  })
+
+  it("decodes a single multi-select value as a one-item array", () => {
+    expect(
+      parseDataCollectionUrlParams(`dc_id=${ID}&dc_department=Sales`, FILTERS)
+        ?.state.filters
+    ).toEqual({ department: ["Sales"] })
+  })
+
+  it("decodes a single-mode number", () => {
+    expect(
+      parseDataCollectionUrlParams(`dc_id=${ID}&dc_salary=4200`, FILTERS)?.state
+        .filters
+    ).toEqual({ salary: { mode: "single", value: 4200 } })
+  })
+
+  it("distinguishes inclusive vs exclusive range bounds via the * marker", () => {
+    const salaryOf = (raw: string) =>
+      parseDataCollectionUrlParams(`dc_id=${ID}&dc_salary=${raw}`, FILTERS)
+        ?.state.filters?.salary
+
+    // no marker → both inclusive (>=, <=)
+    expect(salaryOf("1000..5000")).toEqual({
+      mode: "range",
+      from: { value: 1000, closed: true },
+      to: { value: 5000, closed: true },
+    })
+    // lower exclusive (>), upper inclusive (<=)
+    expect(salaryOf("1000*..5000")).toEqual({
+      mode: "range",
+      from: { value: 1000, closed: false },
+      to: { value: 5000, closed: true },
+    })
+    // lower inclusive (>=), upper exclusive (<)
+    expect(salaryOf("1000..5000*")).toEqual({
+      mode: "range",
+      from: { value: 1000, closed: true },
+      to: { value: 5000, closed: false },
+    })
+    // both exclusive (>, <), with an open upper end
+    expect(salaryOf("1000*..*")).toEqual({
+      mode: "range",
+      from: { value: 1000, closed: false },
+      to: { value: undefined, closed: false },
+    })
+  })
+
+  it("skips filters when no definition is provided", () => {
+    expect(
+      parseDataCollectionUrlParams(`dc_id=${ID}&dc_department=Sales`)?.state
+    ).not.toHaveProperty("filters")
+  })
+
+  it("keeps an empty search distinct from an absent one", () => {
+    expect(
+      parseDataCollectionUrlParams(`dc_id=${ID}&dc_search=`)?.state
+    ).toHaveProperty("search", "")
+    expect(parseDataCollectionUrlParams(`dc_id=${ID}`)?.state).not.toHaveProperty(
+      "search"
+    )
+  })
+})
+
+describe("buildDataCollectionUrlParams", () => {
+  it("encodes each filter as its own prefixed param (no JSON)", () => {
+    const params = buildDataCollectionUrlParams(ID, {
+      search: "ada",
+      filters: {
+        department: ["Engineering", "Product"],
+        query: "ann",
+      },
+      sortings: { field: "name", order: "asc" },
+    })
+
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.id)).toBe(ID)
+    expect(params.getAll("dc_department")).toEqual(["Engineering", "Product"])
+    expect(params.get("dc_query")).toBe("ann")
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.search)).toBe("ada")
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("name:asc")
+    // Readable: no value is a JSON blob.
+    expect(params.toString()).not.toContain("%7B")
+  })
+
+  it("encodes a number range as from..to", () => {
+    const params = buildDataCollectionUrlParams(ID, {
+      filters: {
+        salary: {
+          mode: "range",
+          from: { value: 1000, closed: true },
+          to: { value: 5000, closed: true },
+        },
+      },
+    })
+    expect(params.get("dc_salary")).toBe("1000..5000")
+  })
+
+  it("marks exclusive range bounds with * and round-trips them", () => {
+    const salary = {
+      mode: "range" as const,
+      from: { value: 1000, closed: false },
+      to: { value: 5000, closed: true },
+    }
+    const params = buildDataCollectionUrlParams(ID, { filters: { salary } })
+
+    expect(params.get("dc_salary")).toBe("1000*..5000")
+    expect(
+      parseDataCollectionUrlParams(params, FILTERS)?.state.filters?.salary
+    ).toEqual(salary)
+  })
+
+  it("round-trips multiple filters + search + sortings", () => {
+    const state = {
+      search: "ada",
+      filters: {
+        department: ["Engineering", "Product"],
+        role: ["Manager"],
+        query: "ann",
+        salary: {
+          mode: "range" as const,
+          from: { value: 1000, closed: true },
+          to: { value: 5000, closed: true },
+        },
+      },
+      sortings: { field: "salary", order: "desc" as const },
+    }
+
+    const params = buildDataCollectionUrlParams(ID, state)
+    expect(parseDataCollectionUrlParams(params, FILTERS)).toEqual({
+      id: ID,
+      state,
+    })
+  })
+
+  it("emits only dc_id for an empty state", () => {
+    const params = buildDataCollectionUrlParams(ID)
+    expect([...params.keys()]).toEqual([DATA_COLLECTION_URL_PARAMS.id])
+  })
+})
+
+describe("search-type filters", () => {
+  const SEARCH_FILTERS = {
+    name: { type: "search", label: "Name" },
+    search: { type: "search", label: "Search" },
+  } as unknown as FiltersDefinition
+
+  it("reflects a plain-string search filter value", () => {
+    const params = buildDataCollectionUrlParams(ID, {
+      filters: { name: "ann" },
+    })
+    expect(params.get("dc_name")).toBe("ann")
+    expect(
+      parseDataCollectionUrlParams(params, SEARCH_FILTERS)?.state.filters
+    ).toEqual({ name: "ann" })
+  })
+
+  it("reflects the strict-toggle object form (search term only)", () => {
+    const params = buildDataCollectionUrlParams(ID, {
+      filters: { name: { value: "ann", strict: true } },
+    })
+    expect(params.get("dc_name")).toBe("ann")
+    expect(
+      parseDataCollectionUrlParams(params, SEARCH_FILTERS)?.state.filters
+    ).toEqual({ name: "ann" })
+  })
+
+  it("reflects a filter keyed exactly 'search'", () => {
+    const params = buildDataCollectionUrlParams(ID, {
+      filters: { search: "ann" },
+    })
+    expect(params.get("dc_search")).toBe("ann")
+    expect(
+      parseDataCollectionUrlParams(params, SEARCH_FILTERS)?.state.filters
+    ).toEqual({ search: "ann" })
+  })
+
+  it("lets the top-level search win over a same-named filter on clash", () => {
+    const params = buildDataCollectionUrlParams(ID, {
+      search: "top",
+      filters: { search: "filter" },
+    })
+    expect(params.getAll("dc_search")).toEqual(["top"])
+  })
+})
+
+describe("setDataCollectionUrlParams", () => {
+  it("preserves unrelated params and rebuilds the dc_ family", () => {
+    const params = setDataCollectionUrlParams(
+      `tab=overview&dc_department=Old`,
+      ID,
+      { filters: { department: ["Engineering"] } }
+    )
+
+    expect(params.get("tab")).toBe("overview")
+    // The stale dc_department=Old is replaced, not appended.
+    expect(params.getAll("dc_department")).toEqual(["Engineering"])
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.id)).toBe(ID)
+  })
+
+  it("drops the whole dc_ family (incl. dc_id) for empty state", () => {
+    const start = `${DATA_COLLECTION_URL_PARAMS.id}=${ID}&dc_department=A&dc_search=old&keep=1`
+
+    const params = setDataCollectionUrlParams(start, ID, {
+      search: "",
+      filters: { department: [] },
+      sortings: null,
+    })
+
+    expect([...params.keys()].some((k) => k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX))).toBe(false)
+    expect(params.get("keep")).toBe("1")
+  })
+
+  it("does not mutate a passed-in URLSearchParams", () => {
+    const source = new URLSearchParams("keep=1")
+    setDataCollectionUrlParams(source, ID, { search: "ada" })
+    expect([...source.keys()]).toEqual(["keep"])
+  })
+})
+
+describe("syncDataCollectionUrlParams", () => {
+  it("writes the current state onto window.location, preserving the path + extras", () => {
+    window.history.replaceState(null, "", "/people?tab=overview")
+
+    const query = syncDataCollectionUrlParams(ID, {
+      filters: { department: ["Engineering", "Product"] },
+      sortings: { field: "salary", order: "desc" },
+    })
+
+    expect(window.location.pathname).toBe("/people")
+    const params = new URLSearchParams(window.location.search)
+    expect(params.get("tab")).toBe("overview")
+    expect(params.getAll("dc_department")).toEqual(["Engineering", "Product"])
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("salary:desc")
+    expect(query).toBe(window.location.search.replace(/^\?/, ""))
+  })
+
+  it("clears all dc_ params when the state becomes empty", () => {
+    window.history.replaceState(
+      null,
+      "",
+      `/?keep=1&dc_id=${ID}&dc_search=ada`
+    )
+
+    syncDataCollectionUrlParams(ID, { search: "", filters: {}, sortings: null })
+
+    const params = new URLSearchParams(window.location.search)
+    expect([...params.keys()].some((k) => k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX))).toBe(false)
+    expect(params.get("keep")).toBe("1")
+  })
+
+  it("leaves history untouched with history: 'none' but returns the query", () => {
+    window.history.replaceState(null, "", "/")
+    const query = syncDataCollectionUrlParams(
+      ID,
+      { search: "ada" },
+      { history: "none" }
+    )
+    expect(window.location.search).toBe("")
+    expect(query).toContain("dc_search=ada")
+  })
+})
+
+describe("writeDataCollectionStorage", () => {
+  it("persists under the prefixed key so readDataCollectionStorage can read it", () => {
+    writeDataCollectionStorage(ID, { search: "ada" })
+    expect(localStorage.getItem(KEY)).toBe(JSON.stringify({ search: "ada" }))
+    expect(readDataCollectionStorage(ID)?.search).toBe("ada")
+  })
+})

--- a/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionUrlParams.test.ts
+++ b/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionUrlParams.test.ts
@@ -7,6 +7,7 @@ import {
   buildDataCollectionUrlParams,
   DATA_COLLECTION_URL_PARAM_PREFIX,
   DATA_COLLECTION_URL_PARAMS,
+  MAX_URL_FILTER_VALUES,
   parseDataCollectionUrlParams,
   setDataCollectionUrlParams,
   syncDataCollectionUrlParams,
@@ -247,6 +248,48 @@ describe("search-type filters", () => {
       filters: { search: "filter" },
     })
     expect(params.getAll("dc_search")).toEqual(["top"])
+  })
+})
+
+describe("large multi-select values (e.g. select-all over a data source)", () => {
+  const many = (n: number) => Array.from({ length: n }, (_, i) => `id-${i}`)
+
+  it("keeps a selection at the cap but omits one over it", () => {
+    const atCap = buildDataCollectionUrlParams(ID, {
+      filters: { department: many(MAX_URL_FILTER_VALUES) },
+    })
+    expect(atCap.getAll("dc_department")).toHaveLength(MAX_URL_FILTER_VALUES)
+
+    const overCap = buildDataCollectionUrlParams(ID, {
+      filters: { department: many(MAX_URL_FILTER_VALUES + 1) },
+    })
+    expect(overCap.has("dc_department")).toBe(false)
+  })
+
+  it("drops only the oversized filter, keeping smaller filters, search and sort", () => {
+    const params = buildDataCollectionUrlParams(ID, {
+      search: "ada",
+      filters: { department: many(100), role: ["Manager"] },
+      sortings: { field: "name", order: "asc" },
+    })
+
+    expect(params.has("dc_department")).toBe(false)
+    expect(params.getAll("dc_role")).toEqual(["Manager"])
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.search)).toBe("ada")
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("name:asc")
+  })
+
+  it("leaves the URL free of dc_ params when only an oversized filter is active", () => {
+    const params = setDataCollectionUrlParams("keep=1", ID, {
+      filters: { department: many(100) },
+    })
+
+    expect(
+      [...params.keys()].some((k) =>
+        k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX)
+      )
+    ).toBe(false)
+    expect(params.get("keep")).toBe("1")
   })
 })
 

--- a/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionUrlParams.test.ts
+++ b/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionUrlParams.test.ts
@@ -114,6 +114,30 @@ describe("parseDataCollectionUrlParams", () => {
     })
   })
 
+  it("parses the visualization as a type/key string", () => {
+    expect(
+      parseDataCollectionUrlParams(`dc_id=${ID}&dc_view=kanban`)?.state
+        .visualization
+    ).toBe("kanban")
+    // Absent → not present.
+    expect(
+      parseDataCollectionUrlParams(`dc_id=${ID}`)?.state
+    ).not.toHaveProperty("visualization")
+  })
+
+  it("parses the page (1-indexed)", () => {
+    expect(
+      parseDataCollectionUrlParams(`dc_id=${ID}&dc_page=3`)?.state.page
+    ).toBe(3)
+    expect(
+      parseDataCollectionUrlParams(`dc_id=${ID}`)?.state
+    ).not.toHaveProperty("page")
+    // page 0 / negative are ignored.
+    expect(
+      parseDataCollectionUrlParams(`dc_id=${ID}&dc_page=0`)?.state
+    ).not.toHaveProperty("page")
+  })
+
   it("skips filters when no definition is provided", () => {
     expect(
       parseDataCollectionUrlParams(`dc_id=${ID}&dc_department=Sales`)?.state
@@ -203,6 +227,54 @@ describe("buildDataCollectionUrlParams", () => {
   it("emits only dc_id for an empty state", () => {
     const params = buildDataCollectionUrlParams(ID)
     expect([...params.keys()]).toEqual([DATA_COLLECTION_URL_PARAMS.id])
+  })
+
+  it("encodes the visualization as its type/key", () => {
+    expect(
+      buildDataCollectionUrlParams(ID, { visualization: "kanban" }).get(
+        "dc_view"
+      )
+    ).toBe("kanban")
+    // No view → no dc_view (the caller omits the default view).
+    expect(buildDataCollectionUrlParams(ID, {}).has("dc_view")).toBe(false)
+    expect([...buildDataCollectionUrlParams(ID, {}).keys()]).toEqual([
+      DATA_COLLECTION_URL_PARAMS.id,
+    ])
+  })
+
+  it("encodes the page, omitting the first one", () => {
+    expect(buildDataCollectionUrlParams(ID, { page: 3 }).get("dc_page")).toBe(
+      "3"
+    )
+    expect(buildDataCollectionUrlParams(ID, { page: 1 }).has("dc_page")).toBe(
+      false
+    )
+    expect([...buildDataCollectionUrlParams(ID, { page: 1 }).keys()]).toEqual([
+      DATA_COLLECTION_URL_PARAMS.id,
+    ])
+  })
+
+  it("keeps page and sorting together (they don't clobber each other)", () => {
+    const state = {
+      sortings: { field: "salary", order: "desc" as const },
+      page: 3,
+    }
+    const params = buildDataCollectionUrlParams(ID, state)
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("salary:desc")
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.page)).toBe("3")
+    expect(parseDataCollectionUrlParams(params)).toEqual({ id: ID, state })
+  })
+
+  it("round-trips the visualization with other state", () => {
+    const state = {
+      filters: { department: ["Design"] },
+      visualization: "kanban",
+    }
+    const params = buildDataCollectionUrlParams(ID, state)
+    expect(parseDataCollectionUrlParams(params, FILTERS)).toEqual({
+      id: ID,
+      state,
+    })
   })
 })
 

--- a/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
+++ b/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
@@ -1,0 +1,430 @@
+import { DateRange } from "@/components/OneCalendar/types"
+import {
+  SortingsDefinition,
+  SortingsState,
+} from "@/hooks/datasource"
+import { NumberFilterValue } from "@/patterns/OneFilterPicker/filterTypes/NumberFilter/NumberFilter"
+import {
+  FilterDefinition,
+  FiltersDefinition,
+  FiltersState,
+} from "@/patterns/OneFilterPicker/types"
+
+import { getDataCollectionStorageKey } from "./dataCollectionStorageKey"
+import { DataCollectionStorage } from "./types"
+
+/**
+ * Every data collection URL param shares this prefix, so each filter is its own
+ * readable param — e.g. `?dc_id=people/v1&dc_department=Sales&dc_search=ada`
+ * instead of a single JSON blob.
+ */
+export const DATA_COLLECTION_URL_PARAM_PREFIX = "dc_"
+
+/**
+ * The reserved (non-filter) param names. Individual filters are encoded as
+ * `dc_<filterKey>`; these three names are written last (via `set`) so that on
+ * the rare clash where a filter key is exactly `id`, `search` or `sort`, the
+ * reserved param wins.
+ */
+export const DATA_COLLECTION_URL_PARAMS = {
+  id: "dc_id",
+  search: "dc_search",
+  sortings: "dc_sort",
+} as const
+
+/** Separator for range-style values (number / date ranges): `from..to`. */
+const RANGE_SEPARATOR = ".."
+/**
+ * Suffix marking a range bound as *exclusive* (strict). No marker means the
+ * bound is inclusive, so `1000..5000` is `≥1000 and ≤5000` while
+ * `1000*..5000*` is `>1000 and <5000` — keeping the URL clean (`*` is one of the
+ * few punctuation chars URLSearchParams leaves unescaped) while still
+ * distinguishing the open/closed bounds.
+ */
+const EXCLUSIVE_BOUND = "*"
+const SORTINGS_NONE = "none"
+
+const filterParamName = (key: string): string =>
+  `${DATA_COLLECTION_URL_PARAM_PREFIX}${key}`
+
+/** The subset of a data collection's state we read from / write to the URL. */
+export type DataCollectionUrlState<
+  CurrentFiltersState extends FiltersState<FiltersDefinition> =
+    FiltersState<FiltersDefinition>,
+> = Pick<
+  DataCollectionStorage<CurrentFiltersState>,
+  "filters" | "search" | "sortings"
+>
+
+export type DataCollectionUrlParams<
+  CurrentFiltersState extends FiltersState<FiltersDefinition> =
+    FiltersState<FiltersDefinition>,
+> = {
+  id: string
+  state: DataCollectionUrlState<CurrentFiltersState>
+}
+
+/** How {@link syncDataCollectionUrlParams} should update the browser history. */
+export type DataCollectionUrlHistoryMode = "replace" | "push" | "none"
+
+/* ------------------------------------------------------------------ */
+/* Search params helpers                                               */
+/* ------------------------------------------------------------------ */
+
+const toSearchParams = (input?: string | URLSearchParams): URLSearchParams => {
+  if (input instanceof URLSearchParams) return input
+  if (typeof input === "string") return new URLSearchParams(input)
+  if (typeof window !== "undefined") {
+    return new URLSearchParams(window.location.search)
+  }
+  return new URLSearchParams()
+}
+
+const deleteDataCollectionParams = (params: URLSearchParams): void => {
+  const keys = new Set(
+    [...params.keys()].filter((key) =>
+      key.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX)
+    )
+  )
+  keys.forEach((key) => params.delete(key))
+}
+
+/* ------------------------------------------------------------------ */
+/* Sortings (`field:order`)                                            */
+/* ------------------------------------------------------------------ */
+
+const parseSortings = (raw: string): SortingsState<SortingsDefinition> => {
+  const trimmed = raw.trim()
+  if (trimmed === "" || trimmed === SORTINGS_NONE || trimmed === "null") {
+    return null
+  }
+  const [field, order] = trimmed.split(":")
+  if (!field) return null
+  return { field, order: order === "desc" ? "desc" : "asc" }
+}
+
+const serializeSortings = (
+  sortings: SortingsState<SortingsDefinition>
+): string =>
+  sortings ? `${String(sortings.field)}:${sortings.order}` : SORTINGS_NONE
+
+/* ------------------------------------------------------------------ */
+/* Per-filter value <-> param values                                   */
+/* ------------------------------------------------------------------ */
+
+const isoDate = (date: Date): string => date.toISOString().slice(0, 10)
+
+/**
+ * Encodes a single filter value into the list of param values to emit for its
+ * `dc_<key>` param. Multi-select (`in`) values become repeated params; ranges
+ * become `from..to`. Returns `[]` when there is nothing to emit.
+ *
+ * Driven by the value shape, so encoding needs no filter definition — only
+ * {@link decodeFilterValue} does, to restore the right type.
+ */
+const encodeFilterValue = (value: unknown): string[] => {
+  if (value === undefined || value === null) return []
+
+  // `in` filter → repeated params, e.g. dc_department=A&dc_department=B
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry) => entry !== undefined && entry !== null)
+      .map(String)
+  }
+
+  if (typeof value === "string") return value === "" ? [] : [value]
+  if (typeof value === "number") return [String(value)]
+  if (value instanceof Date) return [isoDate(value)]
+
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>
+
+    // search filter with the strict toggle → { value: string; strict: boolean }.
+    // Only the search term is reflected (the strict flag is not round-tripped).
+    if (typeof record.value === "string" && "strict" in record) {
+      return record.value === "" ? [] : [record.value]
+    }
+
+    // number filter
+    if (record.mode === "single") {
+      const single = record.value
+      return single === undefined || single === null ? [] : [String(single)]
+    }
+    if (record.mode === "range") {
+      const from = record.from as { value?: number; closed?: boolean } | undefined
+      const to = record.to as { value?: number; closed?: boolean } | undefined
+      if (from?.value == null && to?.value == null) return []
+      const bound = (
+        b: { value?: number; closed?: boolean } | undefined
+      ): string =>
+        b?.value == null
+          ? ""
+          : `${b.value}${b.closed === false ? EXCLUSIVE_BOUND : ""}`
+      return [`${bound(from)}${RANGE_SEPARATOR}${bound(to)}`]
+    }
+
+    // date range { from: Date, to?: Date }
+    if (record.from instanceof Date || record.to instanceof Date) {
+      const from = record.from instanceof Date ? isoDate(record.from) : ""
+      const to = record.to instanceof Date ? isoDate(record.to) : ""
+      return [`${from}${RANGE_SEPARATOR}${to}`]
+    }
+  }
+
+  return []
+}
+
+const decodeBound = (
+  part: string
+): { value: number | undefined; closed: boolean } => {
+  const exclusive = part.endsWith(EXCLUSIVE_BOUND)
+  const raw = exclusive ? part.slice(0, -EXCLUSIVE_BOUND.length) : part
+  return {
+    value: raw === "" ? undefined : Number(raw),
+    // No marker → inclusive (closed). `*` marker → exclusive (open).
+    closed: !exclusive,
+  }
+}
+
+const decodeNumber = (raw: string): NumberFilterValue => {
+  if (raw.includes(RANGE_SEPARATOR)) {
+    const [from, to] = raw.split(RANGE_SEPARATOR)
+    return {
+      mode: "range",
+      from: decodeBound(from ?? ""),
+      to: decodeBound(to ?? ""),
+    }
+  }
+  const parsed = Number(raw)
+  return { mode: "single", value: Number.isNaN(parsed) ? undefined : parsed }
+}
+
+const decodeDate = (raw: string): Date | DateRange | undefined => {
+  if (raw.includes(RANGE_SEPARATOR)) {
+    const [from, to] = raw.split(RANGE_SEPARATOR)
+    if (!from) return undefined
+    return to ? { from: new Date(from), to: new Date(to) } : { from: new Date(from) }
+  }
+  return raw ? new Date(raw) : undefined
+}
+
+/**
+ * Restores a filter value from its param value(s), using the filter's declared
+ * `type` so each filter ends up with the right shape (array / string / number /
+ * date).
+ */
+const decodeFilterValue = (type: string, values: string[]): unknown => {
+  switch (type) {
+    case "in":
+      return values
+    case "search":
+      return values[0]
+    case "number":
+      return decodeNumber(values[0] ?? "")
+    case "date":
+      return decodeDate(values[0] ?? "")
+    default:
+      return values.length > 1 ? values : values[0]
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Read: URL -> state                                                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Parses the data collection identifier and state out of URL query params.
+ *
+ * @param input - A query string, a `URLSearchParams`, or omitted to read from
+ *                `window.location.search`.
+ * @param filtersDefinition - Needed to decode the `dc_<filterKey>` params back
+ *                into correctly-typed filter values. Omit to skip filters.
+ * @returns `{ id, state }`, or `null` when no `dc_id` is present.
+ */
+export const parseDataCollectionUrlParams = <
+  CurrentFiltersState extends FiltersState<FiltersDefinition> =
+    FiltersState<FiltersDefinition>,
+>(
+  input?: string | URLSearchParams,
+  filtersDefinition?: FiltersDefinition
+): DataCollectionUrlParams<CurrentFiltersState> | null => {
+  const params = toSearchParams(input)
+  const id = params.get(DATA_COLLECTION_URL_PARAMS.id)
+  if (!id) return null
+
+  const state: DataCollectionUrlState<CurrentFiltersState> = {}
+
+  if (params.has(DATA_COLLECTION_URL_PARAMS.search)) {
+    state.search = params.get(DATA_COLLECTION_URL_PARAMS.search) ?? undefined
+  }
+
+  if (params.has(DATA_COLLECTION_URL_PARAMS.sortings)) {
+    state.sortings = parseSortings(
+      params.get(DATA_COLLECTION_URL_PARAMS.sortings) ?? ""
+    )
+  }
+
+  if (filtersDefinition) {
+    const filters: Record<string, unknown> = {}
+    let hasFilters = false
+    for (const [key, definition] of Object.entries(filtersDefinition)) {
+      const name = filterParamName(key)
+      if (!params.has(name)) continue
+      filters[key] = decodeFilterValue(
+        (definition as FilterDefinition).type,
+        params.getAll(name)
+      )
+      hasFilters = true
+    }
+    if (hasFilters) state.filters = filters as CurrentFiltersState
+  }
+
+  return { id, state }
+}
+
+/* ------------------------------------------------------------------ */
+/* Write: state -> URL                                                 */
+/* ------------------------------------------------------------------ */
+
+const writeStateToParams = <
+  CurrentFiltersState extends FiltersState<FiltersDefinition>,
+>(
+  params: URLSearchParams,
+  id: string,
+  state: DataCollectionUrlState<CurrentFiltersState>
+): void => {
+  // Filters first (via `append`, so multi-select keeps repeated params); the
+  // reserved params below are written with `set` and therefore win on a clash.
+  if (state.filters) {
+    for (const [key, value] of Object.entries(state.filters)) {
+      encodeFilterValue(value).forEach((entry) =>
+        params.append(filterParamName(key), entry)
+      )
+    }
+  }
+
+  params.set(DATA_COLLECTION_URL_PARAMS.id, id)
+
+  if (state.search) {
+    params.set(DATA_COLLECTION_URL_PARAMS.search, state.search)
+  }
+  if (state.sortings) {
+    params.set(
+      DATA_COLLECTION_URL_PARAMS.sortings,
+      serializeSortings(state.sortings)
+    )
+  }
+}
+
+const hasActiveState = <
+  CurrentFiltersState extends FiltersState<FiltersDefinition>,
+>(
+  state: DataCollectionUrlState<CurrentFiltersState>
+): boolean =>
+  !!state.search ||
+  !!state.sortings ||
+  (!!state.filters &&
+    Object.values(state.filters).some(
+      (value) => encodeFilterValue(value).length > 0
+    ))
+
+/**
+ * Builds a fresh `URLSearchParams` encoding a data collection `id` and state,
+ * symmetric with {@link parseDataCollectionUrlParams}. Always sets `dc_id`.
+ */
+export const buildDataCollectionUrlParams = <
+  CurrentFiltersState extends FiltersState<FiltersDefinition> =
+    FiltersState<FiltersDefinition>,
+>(
+  id: string,
+  state: DataCollectionUrlState<CurrentFiltersState> = {}
+): URLSearchParams => {
+  const params = new URLSearchParams()
+  writeStateToParams(params, id, state)
+  return params
+}
+
+/**
+ * Writes a data collection's current filters/search/sortings onto an existing
+ * query string, preserving any unrelated params. Every `dc_`-prefixed param is
+ * rebuilt from `state`, so cleared filters drop out and an entirely empty state
+ * leaves the URL free of `dc_` params (rather than a bare `?dc_id=<id>`).
+ */
+export const setDataCollectionUrlParams = <
+  CurrentFiltersState extends FiltersState<FiltersDefinition> =
+    FiltersState<FiltersDefinition>,
+>(
+  current: string | URLSearchParams | undefined,
+  id: string,
+  state: DataCollectionUrlState<CurrentFiltersState>
+): URLSearchParams => {
+  // Clone so we never mutate a caller-owned URLSearchParams (e.g. the live one).
+  const params = new URLSearchParams(toSearchParams(current))
+  deleteDataCollectionParams(params)
+  if (hasActiveState(state)) {
+    writeStateToParams(params, id, state)
+  }
+  return params
+}
+
+/**
+ * Reflects a data collection's current filters/search/sortings into the URL.
+ *
+ * Pairs with {@link parseDataCollectionUrlParams} (which reads the other way).
+ * `OneDataCollection` wires this up by default when an `id` is set.
+ *
+ * @returns The resulting query string (no leading `?`), or `null` under SSR.
+ */
+export const syncDataCollectionUrlParams = <
+  CurrentFiltersState extends FiltersState<FiltersDefinition> =
+    FiltersState<FiltersDefinition>,
+>(
+  id: string,
+  state: DataCollectionUrlState<CurrentFiltersState>,
+  options?: { history?: DataCollectionUrlHistoryMode }
+): string | null => {
+  if (typeof window === "undefined") return null
+
+  const params = setDataCollectionUrlParams(window.location.search, id, state)
+  const query = params.toString()
+  const url = query
+    ? `${window.location.pathname}?${query}`
+    : window.location.pathname
+
+  const mode = options?.history ?? "replace"
+  if (mode === "push") {
+    window.history.pushState(null, "", url)
+  } else if (mode === "replace") {
+    window.history.replaceState(null, "", url)
+  }
+
+  return query
+}
+
+/* ------------------------------------------------------------------ */
+/* Storage writer (mirrors readDataCollectionStorage)                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Synchronously persists a OneDataCollection's state to localStorage, mirroring
+ * `readDataCollectionStorage`. Uses the same `datacollection-` prefixed key as
+ * `dataCollectionLocalStorageHandler` so the component hydrates from it.
+ *
+ * @param id - The OneDataCollection `id`, WITHOUT the `datacollection-` prefix.
+ */
+export const writeDataCollectionStorage = <
+  CurrentFiltersState extends FiltersState<FiltersDefinition> =
+    FiltersState<FiltersDefinition>,
+>(
+  id: string,
+  storage: DataCollectionStorage<CurrentFiltersState>
+): void => {
+  try {
+    localStorage.setItem(
+      getDataCollectionStorageKey(id),
+      JSON.stringify(storage)
+    )
+  } catch {
+    // Best-effort: storage may be unavailable (private mode, quota, SSR).
+  }
+}

--- a/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
+++ b/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
@@ -1,8 +1,5 @@
 import { DateRange } from "@/components/OneCalendar/types"
-import {
-  SortingsDefinition,
-  SortingsState,
-} from "@/hooks/datasource"
+import { SortingsDefinition, SortingsState } from "@/hooks/datasource"
 import { NumberFilterValue } from "@/patterns/OneFilterPicker/filterTypes/NumberFilter/NumberFilter"
 import {
   FilterDefinition,
@@ -151,7 +148,9 @@ const encodeFilterValue = (value: unknown): string[] => {
       return single === undefined || single === null ? [] : [String(single)]
     }
     if (record.mode === "range") {
-      const from = record.from as { value?: number; closed?: boolean } | undefined
+      const from = record.from as
+        | { value?: number; closed?: boolean }
+        | undefined
       const to = record.to as { value?: number; closed?: boolean } | undefined
       if (from?.value == null && to?.value == null) return []
       const bound = (
@@ -203,7 +202,9 @@ const decodeDate = (raw: string): Date | DateRange | undefined => {
   if (raw.includes(RANGE_SEPARATOR)) {
     const [from, to] = raw.split(RANGE_SEPARATOR)
     if (!from) return undefined
-    return to ? { from: new Date(from), to: new Date(to) } : { from: new Date(from) }
+    return to
+      ? { from: new Date(from), to: new Date(to) }
+      : { from: new Date(from) }
   }
   return raw ? new Date(raw) : undefined
 }

--- a/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
+++ b/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
@@ -27,6 +27,10 @@ export const DATA_COLLECTION_URL_PARAMS = {
   id: "dc_id",
   search: "dc_search",
   sortings: "dc_sort",
+  /** Active visualization type/key, e.g. `table` (omitted for the default one). */
+  visualization: "dc_view",
+  /** Current page (1-indexed; omitted for the first page). */
+  page: "dc_page",
 } as const
 
 /** Separator for range-style values (number / date ranges): `from..to`. */
@@ -63,7 +67,17 @@ export type DataCollectionUrlState<
 > = Pick<
   DataCollectionStorage<CurrentFiltersState>,
   "filters" | "search" | "sortings"
->
+> & {
+  /**
+   * Active visualization, addressed by its **type/key** (e.g. `"table"`,
+   * `"kanban"`) rather than a positional index — readable and stable across
+   * reordering. Mapping to/from the index is the caller's job (the data
+   * collection knows the visualization list).
+   */
+  visualization?: string
+  /** Current page (1-indexed). Not part of persisted storage — URL only. */
+  page?: number
+}
 
 export type DataCollectionUrlParams<
   CurrentFiltersState extends FiltersState<FiltersDefinition> =
@@ -277,6 +291,16 @@ export const parseDataCollectionUrlParams = <
     )
   }
 
+  if (params.has(DATA_COLLECTION_URL_PARAMS.visualization)) {
+    const view = params.get(DATA_COLLECTION_URL_PARAMS.visualization)
+    if (view) state.visualization = view
+  }
+
+  if (params.has(DATA_COLLECTION_URL_PARAMS.page)) {
+    const page = Number(params.get(DATA_COLLECTION_URL_PARAMS.page))
+    if (Number.isInteger(page) && page >= 1) state.page = page
+  }
+
   if (filtersDefinition) {
     const filters: Record<string, unknown> = {}
     let hasFilters = false
@@ -351,6 +375,14 @@ const writeStateToParams = <
       serializeSortings(state.sortings)
     )
   }
+  // The caller omits the default view, so any value here should be reflected.
+  if (state.visualization) {
+    params.set(DATA_COLLECTION_URL_PARAMS.visualization, state.visualization)
+  }
+  // Omit the first page (1) to keep the URL clean.
+  if (state.page && state.page > 1) {
+    params.set(DATA_COLLECTION_URL_PARAMS.page, String(state.page))
+  }
 }
 
 const hasActiveState = <
@@ -360,6 +392,8 @@ const hasActiveState = <
 ): boolean =>
   !!state.search ||
   !!state.sortings ||
+  !!state.visualization ||
+  (state.page !== undefined && state.page > 1) ||
   (!!state.filters &&
     Object.values(state.filters).some(isUrlSerializableFilter))
 

--- a/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
+++ b/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
@@ -41,6 +41,18 @@ const RANGE_SEPARATOR = ".."
 const EXCLUSIVE_BOUND = "*"
 const SORTINGS_NONE = "none"
 
+/**
+ * Maximum number of values a single filter may contribute to the URL.
+ *
+ * A multi-select (`in`) filter materializes one URL param per selected value,
+ * so "select all" over a large or paginated data source would otherwise dump
+ * hundreds of ids into the query string (bloated, and beyond browser/server URL
+ * length limits). Past this cap the filter is left out of the URL — it is still
+ * applied in-memory and persisted via storage, just not shareable through the
+ * URL. Deliberately conservative; tune if a use case needs more.
+ */
+export const MAX_URL_FILTER_VALUES = 25
+
 const filterParamName = (key: string): string =>
   `${DATA_COLLECTION_URL_PARAM_PREFIX}${key}`
 
@@ -287,6 +299,25 @@ export const parseDataCollectionUrlParams = <
 /* Write: state -> URL                                                 */
 /* ------------------------------------------------------------------ */
 
+/** Dev warning, emitted once per filter key, when a filter is too big for the URL. */
+const oversizedFilterWarned = new Set<string>()
+const warnOversizedFilter = (key: string, count: number): void => {
+  if (oversizedFilterWarned.has(key)) return
+  oversizedFilterWarned.add(key)
+  // eslint-disable-next-line no-console -- intentional dev guidance
+  console.warn(
+    `[OneDataCollection] Filter "${key}" has ${count} selected values, ` +
+      `over the URL limit of ${MAX_URL_FILTER_VALUES}; it will not be reflected ` +
+      `in the URL (still applied in-memory and persisted via storage).`
+  )
+}
+
+/** Whether a filter value is non-empty and small enough to put in the URL. */
+const isUrlSerializableFilter = (value: unknown): boolean => {
+  const length = encodeFilterValue(value).length
+  return length > 0 && length <= MAX_URL_FILTER_VALUES
+}
+
 const writeStateToParams = <
   CurrentFiltersState extends FiltersState<FiltersDefinition>,
 >(
@@ -298,9 +329,14 @@ const writeStateToParams = <
   // reserved params below are written with `set` and therefore win on a clash.
   if (state.filters) {
     for (const [key, value] of Object.entries(state.filters)) {
-      encodeFilterValue(value).forEach((entry) =>
-        params.append(filterParamName(key), entry)
-      )
+      const encoded = encodeFilterValue(value)
+      // Skip filters that would dump an unbounded number of values (e.g.
+      // "select all" over a large/paginated source) into the URL.
+      if (encoded.length > MAX_URL_FILTER_VALUES) {
+        warnOversizedFilter(key, encoded.length)
+        continue
+      }
+      encoded.forEach((entry) => params.append(filterParamName(key), entry))
     }
   }
 
@@ -324,10 +360,7 @@ const hasActiveState = <
 ): boolean =>
   !!state.search ||
   !!state.sortings ||
-  (!!state.filters &&
-    Object.values(state.filters).some(
-      (value) => encodeFilterValue(value).length > 0
-    ))
+  (!!state.filters && Object.values(state.filters).some(isUrlSerializableFilter))
 
 /**
  * Builds a fresh `URLSearchParams` encoding a data collection `id` and state,

--- a/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
+++ b/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
@@ -360,7 +360,8 @@ const hasActiveState = <
 ): boolean =>
   !!state.search ||
   !!state.sortings ||
-  (!!state.filters && Object.values(state.filters).some(isUrlSerializableFilter))
+  (!!state.filters &&
+    Object.values(state.filters).some(isUrlSerializableFilter))
 
 /**
  * Builds a fresh `URLSearchParams` encoding a data collection `id` and state,

--- a/packages/react/src/lib/providers/datacollection/exports.ts
+++ b/packages/react/src/lib/providers/datacollection/exports.ts
@@ -1,4 +1,5 @@
 export * from "./dataCollectionLocalStorageHandler"
 export * from "./dataCollectionStorageKey"
+export * from "./dataCollectionUrlParams"
 export * from "./readDataCollectionStorage"
 export * from "./types"

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -55,6 +55,7 @@ import { useDataCollectionStorage } from "./hooks/useDataColectionStorage/useDat
 import { DataCollectionSource } from "./hooks/useDataCollectionSource"
 import { CustomEmptyStates, useEmptyState } from "./hooks/useEmptyState"
 import { useExportAction } from "./hooks/useExportAction"
+import { useDataCollectionUrlSync } from "./hooks/useDataCollectionUrlSync"
 import { usePerVisualizationFilters } from "./hooks/usePerVisualizationFilters"
 import { ItemActionsDefinition } from "./item-actions"
 import { NavigationFiltersDefinition } from "./navigationFilters/types"
@@ -189,6 +190,14 @@ export type OneDataCollectionProps<
          */
         features?: DataCollectionStorageFeaturesDefinition
       }
+
+  /**
+   * By default, when an `id` is set, the data collection reads its
+   * filters/search/sortings from the URL query params on mount and reflects any
+   * later changes back into them (see `dataCollectionUrlParams`). Set this to
+   * `true` to opt out of that URL syncing.
+   */
+  disableUrlParams?: boolean
   /**
    * @deprecated removes the horizontal padding from the data collection
    */
@@ -222,6 +231,7 @@ const OneDataCollectionComp = <
   fullHeight,
   storage,
   id,
+  disableUrlParams,
   tmpFullWidth,
   csvExport,
 }: OneDataCollectionProps<
@@ -819,6 +829,25 @@ const OneDataCollectionComp = <
     },
     storage === false
   )
+
+  // Two-way sync between the collection state and the URL query params. Enabled
+  // by default whenever an `id` is set; opt out with `disableUrlParams`.
+  useDataCollectionUrlSync({
+    id,
+    disabled: !!disableUrlParams,
+    storageReady,
+    filtersDefinition: filters as FiltersDefinition | undefined,
+    filters: activeCurrentFilters as FiltersState<FiltersDefinition>,
+    search: currentSearch,
+    sortings: currentSortings as SortingsState<SortingsDefinition>,
+    setFilters: activeSetCurrentFilters as (
+      value: FiltersState<FiltersDefinition>
+    ) => void,
+    setSearch: setCurrentSearch,
+    setSortings: setCurrentSortings as (
+      value: SortingsState<SortingsDefinition>
+    ) => void,
+  })
 
   const showTotalItemSummarySkeleton = useDebounceBoolean({
     value: isInitialLoading && storageReady,

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -840,6 +840,8 @@ const OneDataCollectionComp = <
     filters: activeCurrentFilters as FiltersState<FiltersDefinition>,
     search: currentSearch,
     sortings: currentSortings as SortingsState<SortingsDefinition>,
+    visualization: currentVisualization,
+    visualizationKeys: visualizations.map((v) => v.type),
     setFilters: activeSetCurrentFilters as (
       value: FiltersState<FiltersDefinition>
     ) => void,
@@ -847,6 +849,7 @@ const OneDataCollectionComp = <
     setSortings: setCurrentSortings as (
       value: SortingsState<SortingsDefinition>
     ) => void,
+    setVisualization: setCurrentVisualization,
   })
 
   const showTotalItemSummarySkeleton = useDebounceBoolean({

--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -25,9 +25,11 @@ import {
   InfiniteScrollPaginatedResponse,
   OnSelectItemsCallback,
   PaginatedResponse,
+  PaginationInfo,
   PaginationType,
   RecordType,
   SelectedItemsState,
+  SortingsDefinition,
   SortingsState,
 } from "@/hooks/datasource/types"
 import { SearchOptions } from "@/hooks/datasource/types/search.typings"
@@ -1647,76 +1649,6 @@ export const manyOptionFilters = {
   },
 } as const
 
-export type ManyOptionFiltersType = typeof manyOptionFilters
-
-/**
- * A collection whose only filter (`assignee`) has 60 options. Use it to exercise
- * "select all" → the selection applies and persists, but is dropped from the URL
- * once it exceeds the value cap (see `MAX_URL_FILTER_VALUES`).
- */
-export const ManyOptionsFilterExampleComponent = ({ id }: { id?: string }) => {
-  const dataAdapterMemoized = useMemo(
-    () => ({
-      fetchData: (
-        options: DataCollectionBaseFetchOptions<
-          ManyOptionFiltersType,
-          NavigationFiltersDefinition
-        >
-      ) => {
-        const { sortings: s, search } = options
-        return new Promise<BaseResponse<MockUser>>((resolve) => {
-          setTimeout(() => {
-            // The assignee selection is irrelevant to the mock data; we only
-            // honor search so the list still reacts to something.
-            const filtered = filterUsers(
-              mockUsers,
-              {} as FiltersState<FiltersType>,
-              s,
-              undefined,
-              search
-            )
-            resolve({ records: filtered })
-          }, 100)
-        })
-      },
-    }),
-    []
-  )
-
-  const dataSource = useDataCollectionSource(
-    {
-      filters: manyOptionFilters,
-      sortings,
-      itemOnClick: (item) => () => console.log(`Clicking ${item.name}`),
-      dataAdapter: dataAdapterMemoized,
-    },
-    []
-  )
-
-  const mockVisualizations = getMockVisualizations({}) as unknown as Record<
-    string,
-    Visualization<
-      MockUser,
-      ManyOptionFiltersType,
-      typeof sortings,
-      SummariesDefinition,
-      ItemActionsDefinition<MockUser>,
-      NavigationFiltersDefinition,
-      GroupingDefinition<MockUser>
-    >
-  >
-
-  return (
-    <OneDataCollection
-      dataTestId={`one-data-collection-${id ?? "many-options"}`}
-      id={id}
-      storage={{ features: ["filters", "search", "sortings"] }}
-      source={dataSource}
-      visualizations={[mockVisualizations.table, mockVisualizations.list]}
-    />
-  )
-}
-
 interface DataAdapterOptions<TRecord> {
   data: TRecord[]
   delay?: number
@@ -2107,6 +2039,105 @@ export function createDataAdapter<
   }
 
   return adapter
+}
+
+/**
+ * Filters used by the combined URL-params story: the standard set plus an
+ * `assignee` filter with 60 options (to exercise the "select all" URL value
+ * cap).
+ */
+export const paginationFilters = {
+  ...filters,
+  assignee: manyOptionFilters.assignee,
+} as const
+
+export type PaginationFiltersType = typeof paginationFilters
+
+/**
+ * A page-paginated collection (8 per page over 48 records → 6 pages) with
+ * filters (including a 60-option multi-select) and sorting. It exposes the
+ * current page via `onPaginationChange` and the rest of the state via
+ * `onStateChange`, and seeds `currentFilters` / `currentSortings` /
+ * `currentPage` synchronously. The built-in URL sync is disabled and storage is
+ * off, so the consumer (the story) owns reflecting *all* of them in the URL —
+ * which is what lets page + sorting + filters coexist without clobbering.
+ *
+ * Seeding synchronously means the very first fetch already has filters + sorting
+ * + page, so loading a `?dc_page=3&dc_sort=…&dc_department=…` URL lands on the
+ * right page with the right filters/sorting and no reset race.
+ */
+export const PaginationExampleComponent = ({
+  id,
+  currentFilters,
+  currentPage,
+  currentSortings,
+  onPaginationChange,
+  onStateChange,
+}: {
+  id?: string
+  currentFilters?: FiltersState<PaginationFiltersType>
+  currentPage?: number
+  currentSortings?: SortingsState<SortingsDefinition>
+  onPaginationChange?: (paginationInfo: PaginationInfo | null) => void
+  onStateChange?: (
+    state: DataCollectionStatusComplete<FiltersState<PaginationFiltersType>>
+  ) => void
+}) => {
+  const dataAdapter = useMemo(
+    () =>
+      createDataAdapter<
+        MockUser,
+        PaginationFiltersType,
+        NavigationFiltersDefinition
+      >({
+        data: generateMockUsers(48),
+        paginationType: "pages",
+        perPage: 8,
+        delay: 100,
+      }),
+    []
+  )
+
+  const dataSource = useDataCollectionSource(
+    {
+      filters: paginationFilters,
+      currentFilters,
+      sortings,
+      currentSortings: currentSortings as SortingsState<typeof sortings>,
+      currentPage,
+      onPaginationChange,
+      dataAdapter,
+      itemOnClick: (item) => () => console.log(`Clicking ${item.name}`),
+    },
+    []
+  )
+
+  const mockVisualizations = getMockVisualizations({}) as unknown as Record<
+    string,
+    Visualization<
+      MockUser,
+      PaginationFiltersType,
+      typeof sortings,
+      SummariesDefinition,
+      ItemActionsDefinition<MockUser>,
+      NavigationFiltersDefinition,
+      GroupingDefinition<MockUser>
+    >
+  >
+
+  return (
+    <OneDataCollection
+      dataTestId={`one-data-collection-${id ?? "pagination"}`}
+      id={id}
+      // The story manages the params itself; keep the built-in sync and
+      // storage out of the way.
+      disableUrlParams
+      storage={false}
+      source={dataSource}
+      onStateChange={onStateChange}
+      visualizations={[mockVisualizations.table]}
+    />
+  )
 }
 
 // Example of a comprehensive actions definition with various types of actions

--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -1629,6 +1629,94 @@ export const SubfiltersExampleComponent = () => {
   )
 }
 
+/**
+ * An `in` filter with many options — stands in for a filter backed by a large /
+ * paginated data source. Selecting all of them produces a big value array, which
+ * is exactly the case the URL-params value cap guards against.
+ */
+export const manyOptionFilters = {
+  assignee: {
+    type: "in" as const,
+    label: "Assignee (60 options)",
+    options: {
+      options: Array.from({ length: 60 }, (_, i) => ({
+        value: `user-${i + 1}`,
+        label: `Teammate ${i + 1}`,
+      })),
+    },
+  },
+} as const
+
+export type ManyOptionFiltersType = typeof manyOptionFilters
+
+/**
+ * A collection whose only filter (`assignee`) has 60 options. Use it to exercise
+ * "select all" → the selection applies and persists, but is dropped from the URL
+ * once it exceeds the value cap (see `MAX_URL_FILTER_VALUES`).
+ */
+export const ManyOptionsFilterExampleComponent = ({ id }: { id?: string }) => {
+  const dataAdapterMemoized = useMemo(
+    () => ({
+      fetchData: (
+        options: DataCollectionBaseFetchOptions<
+          ManyOptionFiltersType,
+          NavigationFiltersDefinition
+        >
+      ) => {
+        const { sortings: s, search } = options
+        return new Promise<BaseResponse<MockUser>>((resolve) => {
+          setTimeout(() => {
+            // The assignee selection is irrelevant to the mock data; we only
+            // honor search so the list still reacts to something.
+            const filtered = filterUsers(
+              mockUsers,
+              {} as FiltersState<FiltersType>,
+              s,
+              undefined,
+              search
+            )
+            resolve({ records: filtered })
+          }, 100)
+        })
+      },
+    }),
+    []
+  )
+
+  const dataSource = useDataCollectionSource(
+    {
+      filters: manyOptionFilters,
+      sortings,
+      itemOnClick: (item) => () => console.log(`Clicking ${item.name}`),
+      dataAdapter: dataAdapterMemoized,
+    },
+    []
+  )
+
+  const mockVisualizations = getMockVisualizations({}) as unknown as Record<
+    string,
+    Visualization<
+      MockUser,
+      ManyOptionFiltersType,
+      typeof sortings,
+      SummariesDefinition,
+      ItemActionsDefinition<MockUser>,
+      NavigationFiltersDefinition,
+      GroupingDefinition<MockUser>
+    >
+  >
+
+  return (
+    <OneDataCollection
+      dataTestId={`one-data-collection-${id ?? "many-options"}`}
+      id={id}
+      storage={{ features: ["filters", "search", "sortings"] }}
+      source={dataSource}
+      visualizations={[mockVisualizations.table, mockVisualizations.list]}
+    />
+  )
+}
+
 interface DataAdapterOptions<TRecord> {
   data: TRecord[]
   delay?: number

--- a/packages/react/src/patterns/OneDataCollection/__stories__/url-params.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/url-params.stories.tsx
@@ -1,163 +1,101 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
-import { useCallback, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
-import { F0Button } from "@/components/F0Button"
+import type { PaginationInfo } from "@/hooks/datasource/types"
 import {
   buildDataCollectionUrlParams,
-  type DataCollectionUrlState,
   MAX_URL_FILTER_VALUES,
-  writeDataCollectionStorage,
+  parseDataCollectionUrlParams,
 } from "@/lib/providers/datacollection/dataCollectionUrlParams"
-import { FiltersState } from "@/patterns/OneFilterPicker/types"
+import {
+  FiltersDefinition,
+  FiltersState,
+} from "@/patterns/OneFilterPicker/types"
 
 import {
-  ExampleComponent,
-  type FiltersType,
-  ManyOptionsFilterExampleComponent,
+  paginationFilters,
+  type PaginationFiltersType,
+  PaginationExampleComponent,
 } from "./mockData"
 
-/**
- * Identifier persisted to (and read from) the URL + localStorage cache. The URL
- * uses `?dc=<id>` to address this exact data collection.
- */
 const STORAGE_ID = "examples/url-params/v1"
 
-type CurrentFilters = FiltersState<FiltersType>
-type UrlState = DataCollectionUrlState<CurrentFilters>
-
-/** A salary range filter value (`{ mode: "range", from, to }`). */
-const salaryRange = (from: number, to: number): UrlState["filters"] => ({
-  salary: {
-    mode: "range",
-    from: { value: from, closed: true },
-    to: { value: to, closed: true },
-  },
-})
-
 /**
- * Button presets that map to a URL query string the data collection reacts to.
- * Each filter rides in its own `dc_<key>` param, so the URLs stay readable —
- * e.g. `?dc_id=…&dc_department=Engineering&dc_department=Product&dc_search=a`.
- */
-const PRESETS: { label: string; state: UrlState }[] = [
-  {
-    label: "Eng + Product (multi)",
-    state: { filters: { department: ["Engineering", "Product"] } },
-  },
-  {
-    label: "Eng + salary 1k–9k",
-    state: {
-      filters: { department: ["Engineering"], ...salaryRange(1000, 9000) },
-    },
-  },
-  {
-    label: "Salary >1k, <9k (exclusive)",
-    state: {
-      filters: {
-        salary: {
-          mode: "range",
-          from: { value: 1000, closed: false },
-          to: { value: 9000, closed: false },
-        },
-      },
-    },
-  },
-  {
-    label: "Search “a”",
-    state: { search: "a" },
-  },
-  {
-    label: "Search filter “ann” (type: search)",
-    state: { filters: { searchStrict: "ann" } },
-  },
-  {
-    label: "Design + search + sort",
-    state: {
-      filters: { department: ["Design"] },
-      search: "a",
-      sortings: { field: "salary", order: "desc" },
-    },
-  },
-  {
-    label: "Sort name ↑",
-    state: { sortings: { field: "name", order: "asc" } },
-  },
-]
-
-/**
- * Demonstrates the built-in two-way URL sync of OneDataCollection. Note that the
- * collection only receives an `id` — no extra props are needed for the syncing;
- * it is on by default (and could be turned off with `disableUrlParams`).
+ * Filters, sorting and pagination for one collection, all reflected in the URL
+ * together — each filter in its own readable `dc_<key>` param (`dc_department`,
+ * `dc_assignee`, …), plus `dc_sort` and `dc_page`.
  *
- * - **collection → URL:** change the filters, sorting or search directly in the
- *   UI and watch the query string update automatically.
- * - **URL → collection:** the preset buttons rewrite the URL and remount the
- *   collection, which reads the params on mount and applies them — the same path
- *   a fresh navigation to a shared URL would take.
+ * Filter, sort and page through: the URL updates with all of them at once, and
+ * reloading (or opening a shared URL) restores the same filters, sorting and
+ * page. Because pagination lives inside the data hook, page + the rest are read
+ * from the URL synchronously (seeding the first fetch — no race) and written
+ * back by a single writer, which is what lets them coexist without clobbering.
+ * Try `Assignee` → "Select all": over {@link MAX_URL_FILTER_VALUES} values it is
+ * dropped from the URL (still applied). Storage is off here, so this also shows
+ * URL syncing needs no storage.
  */
 const UrlParamsExample = () => {
-  // Remounting re-runs OneDataCollection's read-from-URL on mount.
-  const [hydrationKey, setHydrationKey] = useState(0)
-  const [query, setQuery] = useState("")
-
-  // The collection writes the URL itself (via replaceState, which fires no
-  // event), so poll it to keep this demo's read-out in sync.
-  useEffect(() => {
-    const update = () => setQuery(window.location.search.replace(/^\?/, ""))
-    update()
-    const interval = setInterval(update, 300)
-    return () => clearInterval(interval)
+  // Read filters + sorting + page synchronously from the URL so the data hook's
+  // first fetch already has all of them.
+  const initial = useMemo(() => {
+    const parsed = parseDataCollectionUrlParams(
+      window.location.search,
+      paginationFilters as unknown as FiltersDefinition
+    )
+    return parsed?.id === STORAGE_ID ? parsed.state : {}
   }, [])
 
-  const goToUrl = useCallback((search: URLSearchParams) => {
-    const next = search.toString()
+  const [filters, setFilters] = useState(
+    (initial.filters ?? {}) as FiltersState<PaginationFiltersType>
+  )
+  const [sortings, setSortings] = useState(initial.sortings ?? null)
+  const [page, setPage] = useState<number>(initial.page ?? 1)
+  const [query, setQuery] = useState("")
+
+  // A single writer for every param, so none clobbers the others.
+  useEffect(() => {
+    const params = buildDataCollectionUrlParams(STORAGE_ID, {
+      filters: filters as FiltersState<FiltersDefinition>,
+      sortings,
+      page,
+    })
+    const next = params.toString()
     window.history.replaceState(
       null,
       "",
       next ? `${window.location.pathname}?${next}` : window.location.pathname
     )
     setQuery(next)
-    setHydrationKey((key) => key + 1)
-  }, [])
-
-  const applyPreset = useCallback(
-    (state: UrlState) => {
-      goToUrl(buildDataCollectionUrlParams<CurrentFilters>(STORAGE_ID, state))
-    },
-    [goToUrl]
-  )
-
-  const reset = useCallback(() => {
-    // Clear the persisted state too, otherwise the collection would re-hydrate
-    // the previous filters from storage on remount.
-    writeDataCollectionStorage(STORAGE_ID, {})
-    goToUrl(new URLSearchParams())
-  }, [goToUrl])
+  }, [filters, sortings, page])
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center gap-2">
-        {PRESETS.map((preset) => (
-          <F0Button
-            key={preset.label}
-            label={preset.label}
-            variant="outline"
-            size="sm"
-            onClick={() => applyPreset(preset.state)}
-          />
-        ))}
-        <F0Button label="Reset" variant="critical" size="sm" onClick={reset} />
-      </div>
+      <p className="max-w-prose text-sm text-f1-foreground-secondary">
+        Filters, sorting and the current page all ride in the URL together —
+        filter, sort and page through, then reload to restore them. The{" "}
+        <strong>Assignee</strong> filter has 60 options; “Select all” exceeds
+        the {MAX_URL_FILTER_VALUES}-value cap and is left out of the URL (still
+        applied).
+      </p>
 
       <div className="font-mono text-sm text-f1-foreground-secondary">
         URL query: <span data-testid="url-params-query">{query || "—"}</span>
       </div>
 
-      <ExampleComponent
-        key={hydrationKey}
+      <PaginationExampleComponent
         id={STORAGE_ID}
-        storage={{ features: ["filters", "search", "sortings"] }}
-        searchBar
+        currentFilters={initial.filters as FiltersState<PaginationFiltersType>}
+        currentSortings={initial.sortings ?? null}
+        currentPage={initial.page ?? 1}
+        onPaginationChange={(info: PaginationInfo | null) =>
+          setPage(info?.type === "pages" ? info.currentPage : 1)
+        }
+        onStateChange={(state) => {
+          setFilters(
+            (state.filters ?? {}) as FiltersState<PaginationFiltersType>
+          )
+          setSortings(state.sortings ?? null)
+        }}
       />
     </div>
   )
@@ -176,60 +114,8 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 /**
- * Change filters/sorting/search to see them reflected in the URL, or click a
- * preset to load that state from the URL into the collection.
+ * Filters + sorting + pagination all persisted in the URL at once.
  */
 export const Default: Story = {
   render: () => <UrlParamsExample />,
-}
-
-const LARGE_FILTER_STORAGE_ID = "examples/url-params-large/v1"
-
-/**
- * A collection whose only filter (`Assignee`) has 60 options — a stand-in for a
- * filter backed by a large / paginated data source.
- *
- * Open the filter and hit **Select all**: the selection applies (and persists
- * via storage), but it is deliberately left out of the URL because it exceeds
- * the {@link MAX_URL_FILTER_VALUES}-value cap — otherwise "select all" would dump
- * 60 ids into the query string. Selecting just a few keeps them in the URL.
- */
-const LargeFilterExample = () => {
-  const [query, setQuery] = useState("")
-
-  useEffect(() => {
-    const update = () => setQuery(window.location.search.replace(/^\?/, ""))
-    update()
-    const interval = setInterval(update, 300)
-    return () => clearInterval(interval)
-  }, [])
-
-  return (
-    <div className="space-y-4">
-      <p className="max-w-prose text-sm text-f1-foreground-secondary">
-        The <strong>Assignee</strong> filter has 60 options. Selecting a handful
-        reflects them as <code>dc_assignee=…</code> params; “Select all” exceeds
-        the {MAX_URL_FILTER_VALUES}-value cap, so it is applied and persisted
-        but kept out of the URL (no 60-id query string).
-      </p>
-
-      <div className="font-mono text-sm text-f1-foreground-secondary">
-        URL query: <span data-testid="url-params-query">{query || "—"}</span>
-      </div>
-
-      <ManyOptionsFilterExampleComponent id={LARGE_FILTER_STORAGE_ID} />
-    </div>
-  )
-}
-
-/**
- * Exercises the URL value cap for large multi-select filters (e.g. select-all
- * over a data source).
- */
-export const LargeMultiSelectFilter: Story = {
-  render: () => <LargeFilterExample />,
-  tags: ["experimental"],
-  parameters: {
-    layout: "padded",
-  },
 }

--- a/packages/react/src/patterns/OneDataCollection/__stories__/url-params.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/url-params.stories.tsx
@@ -1,15 +1,20 @@
-import { useCallback, useEffect, useState } from "react"
 import { Meta, StoryObj } from "@storybook/react-vite"
+import { useCallback, useEffect, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import {
   buildDataCollectionUrlParams,
   type DataCollectionUrlState,
+  MAX_URL_FILTER_VALUES,
   writeDataCollectionStorage,
 } from "@/lib/providers/datacollection/dataCollectionUrlParams"
 import { FiltersState } from "@/patterns/OneFilterPicker/types"
 
-import { ExampleComponent, type FiltersType } from "./mockData"
+import {
+  ExampleComponent,
+  type FiltersType,
+  ManyOptionsFilterExampleComponent,
+} from "./mockData"
 
 /**
  * Identifier persisted to (and read from) the URL + localStorage cache. The URL
@@ -144,7 +149,7 @@ const UrlParamsExample = () => {
         <F0Button label="Reset" variant="critical" size="sm" onClick={reset} />
       </div>
 
-      <div className="text-f1-foreground-secondary font-mono text-sm">
+      <div className="font-mono text-sm text-f1-foreground-secondary">
         URL query: <span data-testid="url-params-query">{query || "—"}</span>
       </div>
 
@@ -175,5 +180,56 @@ type Story = StoryObj<typeof meta>
  * preset to load that state from the URL into the collection.
  */
 export const Default: Story = {
-  render: () => <UrlParamsExample />,
+  render: () => <LargeFilterExample />,
+}
+
+const LARGE_FILTER_STORAGE_ID = "examples/url-params-large/v1"
+
+/**
+ * A collection whose only filter (`Assignee`) has 60 options — a stand-in for a
+ * filter backed by a large / paginated data source.
+ *
+ * Open the filter and hit **Select all**: the selection applies (and persists
+ * via storage), but it is deliberately left out of the URL because it exceeds
+ * the {@link MAX_URL_FILTER_VALUES}-value cap — otherwise "select all" would dump
+ * 60 ids into the query string. Selecting just a few keeps them in the URL.
+ */
+const LargeFilterExample = () => {
+  const [query, setQuery] = useState("")
+
+  useEffect(() => {
+    const update = () => setQuery(window.location.search.replace(/^\?/, ""))
+    update()
+    const interval = setInterval(update, 300)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      <p className="max-w-prose text-sm text-f1-foreground-secondary">
+        The <strong>Assignee</strong> filter has 60 options. Selecting a handful
+        reflects them as <code>dc_assignee=…</code> params; “Select all” exceeds
+        the {MAX_URL_FILTER_VALUES}-value cap, so it is applied and persisted
+        but kept out of the URL (no 60-id query string).
+      </p>
+
+      <div className="font-mono text-sm text-f1-foreground-secondary">
+        URL query: <span data-testid="url-params-query">{query || "—"}</span>
+      </div>
+
+      <ManyOptionsFilterExampleComponent id={LARGE_FILTER_STORAGE_ID} />
+    </div>
+  )
+}
+
+/**
+ * Exercises the URL value cap for large multi-select filters (e.g. select-all
+ * over a data source).
+ */
+export const LargeMultiSelectFilter: Story = {
+  render: () => <LargeFilterExample />,
+  tags: ["experimental"],
+  parameters: {
+    layout: "padded",
+  },
 }

--- a/packages/react/src/patterns/OneDataCollection/__stories__/url-params.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/url-params.stories.tsx
@@ -180,7 +180,7 @@ type Story = StoryObj<typeof meta>
  * preset to load that state from the URL into the collection.
  */
 export const Default: Story = {
-  render: () => <LargeFilterExample />,
+  render: () => <UrlParamsExample />,
 }
 
 const LARGE_FILTER_STORAGE_ID = "examples/url-params-large/v1"

--- a/packages/react/src/patterns/OneDataCollection/__stories__/url-params.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/url-params.stories.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useState } from "react"
+import { Meta, StoryObj } from "@storybook/react-vite"
+
+import { F0Button } from "@/components/F0Button"
+import {
+  buildDataCollectionUrlParams,
+  type DataCollectionUrlState,
+  writeDataCollectionStorage,
+} from "@/lib/providers/datacollection/dataCollectionUrlParams"
+import { FiltersState } from "@/patterns/OneFilterPicker/types"
+
+import { ExampleComponent, type FiltersType } from "./mockData"
+
+/**
+ * Identifier persisted to (and read from) the URL + localStorage cache. The URL
+ * uses `?dc=<id>` to address this exact data collection.
+ */
+const STORAGE_ID = "examples/url-params/v1"
+
+type CurrentFilters = FiltersState<FiltersType>
+type UrlState = DataCollectionUrlState<CurrentFilters>
+
+/** A salary range filter value (`{ mode: "range", from, to }`). */
+const salaryRange = (from: number, to: number): UrlState["filters"] => ({
+  salary: {
+    mode: "range",
+    from: { value: from, closed: true },
+    to: { value: to, closed: true },
+  },
+})
+
+/**
+ * Button presets that map to a URL query string the data collection reacts to.
+ * Each filter rides in its own `dc_<key>` param, so the URLs stay readable —
+ * e.g. `?dc_id=…&dc_department=Engineering&dc_department=Product&dc_search=a`.
+ */
+const PRESETS: { label: string; state: UrlState }[] = [
+  {
+    label: "Eng + Product (multi)",
+    state: { filters: { department: ["Engineering", "Product"] } },
+  },
+  {
+    label: "Eng + salary 1k–9k",
+    state: {
+      filters: { department: ["Engineering"], ...salaryRange(1000, 9000) },
+    },
+  },
+  {
+    label: "Salary >1k, <9k (exclusive)",
+    state: {
+      filters: {
+        salary: {
+          mode: "range",
+          from: { value: 1000, closed: false },
+          to: { value: 9000, closed: false },
+        },
+      },
+    },
+  },
+  {
+    label: "Search “a”",
+    state: { search: "a" },
+  },
+  {
+    label: "Search filter “ann” (type: search)",
+    state: { filters: { searchStrict: "ann" } },
+  },
+  {
+    label: "Design + search + sort",
+    state: {
+      filters: { department: ["Design"] },
+      search: "a",
+      sortings: { field: "salary", order: "desc" },
+    },
+  },
+  {
+    label: "Sort name ↑",
+    state: { sortings: { field: "name", order: "asc" } },
+  },
+]
+
+/**
+ * Demonstrates the built-in two-way URL sync of OneDataCollection. Note that the
+ * collection only receives an `id` — no extra props are needed for the syncing;
+ * it is on by default (and could be turned off with `disableUrlParams`).
+ *
+ * - **collection → URL:** change the filters, sorting or search directly in the
+ *   UI and watch the query string update automatically.
+ * - **URL → collection:** the preset buttons rewrite the URL and remount the
+ *   collection, which reads the params on mount and applies them — the same path
+ *   a fresh navigation to a shared URL would take.
+ */
+const UrlParamsExample = () => {
+  // Remounting re-runs OneDataCollection's read-from-URL on mount.
+  const [hydrationKey, setHydrationKey] = useState(0)
+  const [query, setQuery] = useState("")
+
+  // The collection writes the URL itself (via replaceState, which fires no
+  // event), so poll it to keep this demo's read-out in sync.
+  useEffect(() => {
+    const update = () => setQuery(window.location.search.replace(/^\?/, ""))
+    update()
+    const interval = setInterval(update, 300)
+    return () => clearInterval(interval)
+  }, [])
+
+  const goToUrl = useCallback((search: URLSearchParams) => {
+    const next = search.toString()
+    window.history.replaceState(
+      null,
+      "",
+      next ? `${window.location.pathname}?${next}` : window.location.pathname
+    )
+    setQuery(next)
+    setHydrationKey((key) => key + 1)
+  }, [])
+
+  const applyPreset = useCallback(
+    (state: UrlState) => {
+      goToUrl(buildDataCollectionUrlParams<CurrentFilters>(STORAGE_ID, state))
+    },
+    [goToUrl]
+  )
+
+  const reset = useCallback(() => {
+    // Clear the persisted state too, otherwise the collection would re-hydrate
+    // the previous filters from storage on remount.
+    writeDataCollectionStorage(STORAGE_ID, {})
+    goToUrl(new URLSearchParams())
+  }, [goToUrl])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        {PRESETS.map((preset) => (
+          <F0Button
+            key={preset.label}
+            label={preset.label}
+            variant="outline"
+            size="sm"
+            onClick={() => applyPreset(preset.state)}
+          />
+        ))}
+        <F0Button label="Reset" variant="critical" size="sm" onClick={reset} />
+      </div>
+
+      <div className="text-f1-foreground-secondary font-mono text-sm">
+        URL query: <span data-testid="url-params-query">{query || "—"}</span>
+      </div>
+
+      <ExampleComponent
+        key={hydrationKey}
+        id={STORAGE_ID}
+        storage={{ features: ["filters", "search", "sortings"] }}
+        searchBar
+      />
+    </div>
+  )
+}
+
+const meta = {
+  title: "Data Collection/URL params",
+  component: UrlParamsExample,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["experimental"],
+} satisfies Meta<typeof UrlParamsExample>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Change filters/sorting/search to see them reflected in the URL, or click a
+ * preset to load that state from the URL into the collection.
+ */
+export const Default: Story = {
+  render: () => <UrlParamsExample />,
+}

--- a/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncChipClear.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncChipClear.test.tsx
@@ -108,6 +108,28 @@ describe("OneDataCollection URL sync — clearing a filter chip", () => {
     )
   })
 
+  it("syncs and then clears the search bar value in the URL", async () => {
+    render(<ExampleComponent id="people/v1" searchBar />)
+
+    const toggle = await screen.findByRole("button", { name: /search/i })
+    await userEvent.click(toggle)
+
+    const input = await screen.findByPlaceholderText(/search/i)
+    await userEvent.type(input, "ada")
+
+    await waitFor(
+      () => expect(window.location.search).toContain("dc_search=ada"),
+      { timeout: 2000 }
+    )
+
+    await userEvent.clear(input)
+
+    await waitFor(
+      () => expect(window.location.search).not.toContain("dc_search"),
+      { timeout: 2000 }
+    )
+  })
+
   it("removes the param when clearing a chip for a filter loaded from the URL", async () => {
     window.history.replaceState(
       null,

--- a/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncChipClear.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncChipClear.test.tsx
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  screen,
+  userEvent,
+  waitFor,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import { ExampleComponent } from "../__stories__/mockData"
+
+afterEach(() => {
+  window.history.replaceState(null, "", "/")
+  localStorage.clear()
+})
+
+describe("OneDataCollection URL sync — clearing a filter chip", () => {
+  it("removes the param when clearing a chip for a filter set via props", async () => {
+    render(
+      <ExampleComponent
+        id="people/v1"
+        currentFilters={{ department: ["Engineering"] }}
+      />
+    )
+
+    await waitFor(() =>
+      expect(window.location.search).toContain("dc_department=Engineering")
+    )
+
+    const close = await screen.findByRole("button", { name: "Close" })
+    await userEvent.click(close)
+
+    await waitFor(() =>
+      expect(window.location.search).not.toContain("dc_department")
+    )
+  })
+
+  it("removes only the cleared filter's param when several are applied", async () => {
+    render(
+      <ExampleComponent
+        id="people/v1"
+        currentFilters={{
+          department: ["Engineering"],
+          salary: {
+            mode: "range",
+            from: { value: 1000, closed: true },
+            to: { value: 5000, closed: true },
+          },
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(window.location.search).toContain("dc_department=Engineering")
+      expect(window.location.search).toContain("dc_salary=1000..5000")
+    })
+
+    // Clear the *first* chip (department).
+    const closeButtons = await screen.findAllByRole("button", { name: "Close" })
+    await userEvent.click(closeButtons[0])
+
+    await waitFor(() => {
+      expect(window.location.search).not.toContain("dc_department")
+      // The other filter survives.
+      expect(window.location.search).toContain("dc_salary=1000..5000")
+    })
+  })
+
+  it("removes the param when clearing a search-type filter chip", async () => {
+    render(
+      <ExampleComponent
+        id="people/v1"
+        currentFilters={{ searchStrict: "ann" }}
+      />
+    )
+
+    await waitFor(() =>
+      expect(window.location.search).toContain("dc_searchStrict=ann")
+    )
+
+    const close = await screen.findByRole("button", { name: "Close" })
+    await userEvent.click(close)
+
+    await waitFor(() =>
+      expect(window.location.search).not.toContain("dc_searchStrict")
+    )
+  })
+
+  it("clears the chip param with the story's exact storage/searchBar props", async () => {
+    render(
+      <ExampleComponent
+        id="people/v1"
+        storage={{ features: ["filters", "search", "sortings"] }}
+        searchBar
+        currentFilters={{ department: ["Engineering"] }}
+      />
+    )
+
+    await waitFor(() =>
+      expect(window.location.search).toContain("dc_department=Engineering")
+    )
+
+    const close = await screen.findByRole("button", { name: "Close" })
+    await userEvent.click(close)
+
+    await waitFor(() =>
+      expect(window.location.search).not.toContain("dc_department")
+    )
+  })
+
+  it("removes the param when clearing a chip for a filter loaded from the URL", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/people?dc_id=people/v1&dc_department=Engineering"
+    )
+
+    render(<ExampleComponent id="people/v1" />)
+
+    // Chip rendered from the URL-loaded filter.
+    const close = await screen.findByRole("button", { name: "Close" })
+    expect(window.location.search).toContain("dc_department=Engineering")
+
+    await userEvent.click(close)
+
+    await waitFor(() =>
+      expect(window.location.search).not.toContain("dc_department")
+    )
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncChipClear.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncChipClear.test.tsx
@@ -108,28 +108,6 @@ describe("OneDataCollection URL sync — clearing a filter chip", () => {
     )
   })
 
-  it("syncs and then clears the search bar value in the URL", async () => {
-    render(<ExampleComponent id="people/v1" searchBar />)
-
-    const toggle = await screen.findByRole("button", { name: /search/i })
-    await userEvent.click(toggle)
-
-    const input = await screen.findByPlaceholderText(/search/i)
-    await userEvent.type(input, "ada")
-
-    await waitFor(
-      () => expect(window.location.search).toContain("dc_search=ada"),
-      { timeout: 2000 }
-    )
-
-    await userEvent.clear(input)
-
-    await waitFor(
-      () => expect(window.location.search).not.toContain("dc_search"),
-      { timeout: 2000 }
-    )
-  })
-
   it("removes the param when clearing a chip for a filter loaded from the URL", async () => {
     window.history.replaceState(
       null,

--- a/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncNoStorage.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncNoStorage.test.tsx
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { waitFor, zeroRender as render } from "@/testing/test-utils"
+import { ExampleComponent } from "../__stories__/mockData"
+
+afterEach(() => {
+  window.history.replaceState(null, "", "/")
+  localStorage.clear()
+})
+
+describe("URL sync without storage", () => {
+  it("reflects filters in the URL with storage disabled (storage={false})", async () => {
+    render(
+      <ExampleComponent
+        id="people/v1"
+        storage={false}
+        currentFilters={{ department: ["Engineering"] }}
+      />
+    )
+    await waitFor(() =>
+      expect(window.location.search).toContain("dc_department=Engineering")
+    )
+  })
+
+  it("reflects filters with no storage prop at all", async () => {
+    render(
+      <ExampleComponent
+        id="people/v1"
+        currentFilters={{ department: ["Design"] }}
+      />
+    )
+    await waitFor(() =>
+      expect(window.location.search).toContain("dc_department=Design")
+    )
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncPagination.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncPagination.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { waitFor, zeroRender as render } from "@/testing/test-utils"
+
+import { PaginationExampleComponent } from "../__stories__/mockData"
+
+afterEach(() => {
+  window.history.replaceState(null, "", "/")
+  localStorage.clear()
+})
+
+describe("OneDataCollection — pagination page persistence", () => {
+  it("seeds the first fetch from currentPage and reports it back", async () => {
+    const onPaginationChange = vi.fn()
+
+    render(
+      <PaginationExampleComponent
+        id="people/v1"
+        currentPage={3}
+        onPaginationChange={onPaginationChange}
+      />
+    )
+
+    await waitFor(() => {
+      const last = onPaginationChange.mock.calls.at(-1)?.[0]
+      expect(last?.type).toBe("pages")
+      expect(last?.currentPage).toBe(3)
+    })
+  })
+
+  it("defaults to page 1 when no currentPage is provided", async () => {
+    const onPaginationChange = vi.fn()
+
+    render(
+      <PaginationExampleComponent
+        id="people/v1"
+        onPaginationChange={onPaginationChange}
+      />
+    )
+
+    await waitFor(() => {
+      const last = onPaginationChange.mock.calls.at(-1)?.[0]
+      expect(last?.type).toBe("pages")
+      expect(last?.currentPage).toBe(1)
+    })
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncVisualization.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncVisualization.test.tsx
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { waitFor, zeroRender as render } from "@/testing/test-utils"
+
+import { ExampleComponent } from "../__stories__/mockData"
+
+afterEach(() => {
+  window.history.replaceState(null, "", "/")
+  localStorage.clear()
+})
+
+describe("OneDataCollection URL sync — visualization", () => {
+  it("keeps the visualization param (by type) from the URL on mount (wiring smoke)", async () => {
+    // ExampleComponent renders [table, card, list, …], so dc_view=card → index 1.
+    window.history.replaceState(
+      null,
+      "",
+      "/people?dc_id=people/v1&dc_view=card"
+    )
+
+    render(<ExampleComponent id="people/v1" />)
+
+    // The view is applied and re-affirmed, so dc_view=card survives (it would be
+    // dropped if visualization weren't wired into the URL sync).
+    await waitFor(() =>
+      expect(window.location.search).toContain("dc_view=card")
+    )
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useDataCollectionUrlSync.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useDataCollectionUrlSync.test.tsx
@@ -18,6 +18,7 @@ const setup = (overrides: Partial<Props> = {}) => {
   const setFilters = vi.fn()
   const setSearch = vi.fn()
   const setSortings = vi.fn()
+  const setVisualization = vi.fn()
 
   let props: Props = {
     id: ID,
@@ -27,9 +28,12 @@ const setup = (overrides: Partial<Props> = {}) => {
     filters: {},
     search: undefined,
     sortings: null,
+    visualization: 0,
+    visualizationKeys: ["table", "card", "list"],
     setFilters,
     setSearch,
     setSortings,
+    setVisualization,
     ...overrides,
   }
 
@@ -42,6 +46,7 @@ const setup = (overrides: Partial<Props> = {}) => {
     setFilters,
     setSearch,
     setSortings,
+    setVisualization,
     rerender: (next: Partial<Props> = {}) => {
       props = { ...props, ...next }
       view.rerender(props)
@@ -114,6 +119,50 @@ describe("useDataCollectionUrlSync — collection → URL", () => {
 
     rerender({ search: "" })
     expect(hasDcParams()).toBe(false)
+  })
+})
+
+describe("useDataCollectionUrlSync — visualization", () => {
+  it("maps a view key from the URL back to its index", () => {
+    window.history.replaceState(null, "", `/?dc_id=${ID}&dc_view=list`)
+
+    const { setVisualization } = setup({
+      visualizationKeys: ["table", "card", "list"],
+    })
+    expect(setVisualization).toHaveBeenCalledWith(2)
+  })
+
+  it("ignores an unknown view key", () => {
+    window.history.replaceState(null, "", `/?dc_id=${ID}&dc_view=gallery`)
+
+    const { setVisualization } = setup({
+      visualizationKeys: ["table", "card", "list"],
+    })
+    expect(setVisualization).not.toHaveBeenCalled()
+  })
+
+  it("does not sync visualization when there is only one", () => {
+    window.history.replaceState(null, "", `/?dc_id=${ID}&dc_view=card`)
+
+    const { setVisualization, rerender } = setup({
+      visualizationKeys: ["table"],
+    })
+    expect(setVisualization).not.toHaveBeenCalled()
+
+    rerender({ visualization: 0 })
+    expect(currentParams().has("dc_view")).toBe(false)
+  })
+
+  it("reflects a visualization change into the URL by type (omitting the first)", () => {
+    window.history.replaceState(null, "", "/people")
+
+    const { rerender } = setup({ visualizationKeys: ["table", "card", "list"] })
+
+    rerender({ visualization: 2 })
+    expect(currentParams().get("dc_view")).toBe("list")
+
+    rerender({ visualization: 0 })
+    expect(currentParams().has("dc_view")).toBe(false)
   })
 })
 

--- a/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useDataCollectionUrlSync.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useDataCollectionUrlSync.test.tsx
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { DATA_COLLECTION_URL_PARAM_PREFIX } from "@/lib/providers/datacollection/dataCollectionUrlParams"
+import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
+import { zeroRenderHook as renderHook } from "@/testing/test-utils"
+
+import { useDataCollectionUrlSync } from "../useDataCollectionUrlSync"
+
+const ID = "team/people/v1"
+
+const FILTERS = {
+  department: { type: "in", label: "Department", options: { options: [] } },
+} as unknown as FiltersDefinition
+
+type Props = Parameters<typeof useDataCollectionUrlSync>[0]
+
+const setup = (overrides: Partial<Props> = {}) => {
+  const setFilters = vi.fn()
+  const setSearch = vi.fn()
+  const setSortings = vi.fn()
+
+  let props: Props = {
+    id: ID,
+    disabled: false,
+    storageReady: true,
+    filtersDefinition: FILTERS,
+    filters: {},
+    search: undefined,
+    sortings: null,
+    setFilters,
+    setSearch,
+    setSortings,
+    ...overrides,
+  }
+
+  const view = renderHook((p: Props) => useDataCollectionUrlSync(p), {
+    initialProps: props,
+  })
+
+  return {
+    ...view,
+    setFilters,
+    setSearch,
+    setSortings,
+    rerender: (next: Partial<Props> = {}) => {
+      props = { ...props, ...next }
+      view.rerender(props)
+    },
+  }
+}
+
+const currentParams = () => new URLSearchParams(window.location.search)
+const hasDcParams = () =>
+  [...currentParams().keys()].some((k) =>
+    k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX)
+  )
+
+afterEach(() => {
+  window.history.replaceState(null, "", "/")
+})
+
+describe("useDataCollectionUrlSync — URL → collection", () => {
+  it("applies matching, per-filter URL params on mount", () => {
+    window.history.replaceState(
+      null,
+      "",
+      `/?dc_id=${ID}&dc_department=Engineering&dc_department=Product&dc_sort=salary:desc`
+    )
+
+    const { setFilters, setSortings, setSearch } = setup()
+
+    expect(setFilters).toHaveBeenCalledWith({
+      department: ["Engineering", "Product"],
+    })
+    expect(setSortings).toHaveBeenCalledWith({ field: "salary", order: "desc" })
+    expect(setSearch).not.toHaveBeenCalled()
+  })
+
+  it("waits for storage hydration before applying", () => {
+    window.history.replaceState(null, "", `/?dc_id=${ID}&dc_search=ada`)
+
+    const { setSearch, rerender } = setup({ storageReady: false })
+    expect(setSearch).not.toHaveBeenCalled()
+
+    rerender({ storageReady: true })
+    expect(setSearch).toHaveBeenCalledWith("ada")
+  })
+
+  it("ignores params addressed to a different collection id", () => {
+    window.history.replaceState(null, "", `/?dc_id=other/v1&dc_search=ada`)
+    const { setSearch } = setup()
+    expect(setSearch).not.toHaveBeenCalled()
+  })
+})
+
+describe("useDataCollectionUrlSync — collection → URL", () => {
+  it("reflects later state changes as readable per-filter params", () => {
+    window.history.replaceState(null, "", "/people")
+
+    const { rerender } = setup()
+    rerender({ filters: { department: ["Design", "Sales"] } })
+
+    expect(window.location.pathname).toBe("/people")
+    expect(currentParams().get("dc_id")).toBe(ID)
+    expect(currentParams().getAll("dc_department")).toEqual(["Design", "Sales"])
+  })
+
+  it("clears the dc_ params when the state goes back to empty", () => {
+    window.history.replaceState(null, "", "/people")
+
+    const { rerender } = setup()
+    rerender({ search: "ada" })
+    expect(currentParams().get("dc_search")).toBe("ada")
+
+    rerender({ search: "" })
+    expect(hasDcParams()).toBe(false)
+  })
+})
+
+describe("useDataCollectionUrlSync — disabled / no id", () => {
+  it("neither reads nor writes when disabled", () => {
+    window.history.replaceState(null, "", `/?dc_id=${ID}&dc_search=ada`)
+
+    const { setSearch, rerender } = setup({ disabled: true })
+    expect(setSearch).not.toHaveBeenCalled()
+
+    rerender({ search: "changed" })
+    expect(currentParams().get("dc_search")).toBe("ada")
+  })
+
+  it("does nothing without an id", () => {
+    window.history.replaceState(null, "", "/people")
+
+    const { setSearch, rerender } = setup({ id: undefined })
+    rerender({ search: "ada" })
+
+    expect(setSearch).not.toHaveBeenCalled()
+    expect(window.location.search).toBe("")
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionUrlSync.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionUrlSync.ts
@@ -24,14 +24,24 @@ type UseDataCollectionUrlSyncOptions = {
   filters: FiltersState<FiltersDefinition>
   search: string | undefined
   sortings: SortingsState<SortingsDefinition>
+  /** Index of the active visualization. */
+  visualization: number
+  /**
+   * Ordered visualization type/keys (e.g. `["table", "kanban"]`), used to map
+   * the index to/from the readable `dc_view` value. URL `dc_view` is only synced
+   * when there is more than one visualization. Duplicate types resolve to the
+   * first matching index on read.
+   */
+  visualizationKeys: readonly string[]
   setFilters: (value: FiltersState<FiltersDefinition>) => void
   setSearch: (value: string | undefined) => void
   setSortings: (value: SortingsState<SortingsDefinition>) => void
+  setVisualization: (value: number) => void
 }
 
 /**
- * Keeps a OneDataCollection's filters/search/sortings in two-way sync with the
- * URL query params (see `dataCollectionUrlParams`):
+ * Keeps a OneDataCollection's filters/search/sortings/visualization in two-way
+ * sync with the URL query params (see `dataCollectionUrlParams`):
  *
  * - **URL → collection:** once, after storage has hydrated (so the URL takes
  *   precedence over persisted state), any `dc`-addressed params matching this
@@ -52,11 +62,16 @@ export const useDataCollectionUrlSync = ({
   filters,
   search,
   sortings,
+  visualization,
+  visualizationKeys,
   setFilters,
   setSearch,
   setSortings,
+  setVisualization,
 }: UseDataCollectionUrlSyncOptions): void => {
   const active = !disabled && !!id
+  // Only sync the visualization when there is a real choice to reflect.
+  const syncVisualization = visualizationKeys.length > 1
   const [urlApplied, setUrlApplied] = useState(false)
 
   // URL → collection (run once, after hydration so the URL wins over storage).
@@ -75,6 +90,11 @@ export const useDataCollectionUrlSync = ({
       }
       if ("search" in state) setSearch(state.search)
       if ("sortings" in state) setSortings(state.sortings ?? null)
+      // Map the readable view key back to its index; ignore unknown keys.
+      if (syncVisualization && state.visualization !== undefined) {
+        const index = visualizationKeys.indexOf(state.visualization)
+        if (index >= 0) setVisualization(index)
+      }
     }
 
     // Enable writing in the same render as the applied state, so the first
@@ -86,6 +106,25 @@ export const useDataCollectionUrlSync = ({
   // collection → URL.
   useDeepCompareEffect(() => {
     if (!active || !urlApplied || !id) return
-    syncDataCollectionUrlParams(id, { filters, search, sortings })
-  }, [active, urlApplied, id, filters, search, sortings])
+    syncDataCollectionUrlParams(id, {
+      filters,
+      search,
+      sortings,
+      // Omit the default (first) view; reflect others by their type/key.
+      visualization:
+        syncVisualization && visualization > 0
+          ? visualizationKeys[visualization]
+          : undefined,
+    })
+  }, [
+    active,
+    urlApplied,
+    id,
+    filters,
+    search,
+    sortings,
+    visualization,
+    visualizationKeys,
+    syncVisualization,
+  ])
 }

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionUrlSync.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionUrlSync.ts
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react"
+import { useDeepCompareEffect } from "@reactuses/core"
+
+import {
+  FiltersDefinition,
+  FiltersState,
+  SortingsDefinition,
+  SortingsState,
+} from "@/hooks/datasource"
+import {
+  parseDataCollectionUrlParams,
+  syncDataCollectionUrlParams,
+} from "@/lib/providers/datacollection/dataCollectionUrlParams"
+
+type UseDataCollectionUrlSyncOptions = {
+  /** The OneDataCollection `id`; required to address its `?dc_id=<id>` params. */
+  id: string | undefined
+  /** When true, no reading from or writing to the URL happens. */
+  disabled: boolean
+  /** Storage hydration gate — we apply the URL only after it resolves. */
+  storageReady: boolean
+  /** Needed to decode `dc_<filterKey>` params back into typed filter values. */
+  filtersDefinition: FiltersDefinition | undefined
+  filters: FiltersState<FiltersDefinition>
+  search: string | undefined
+  sortings: SortingsState<SortingsDefinition>
+  setFilters: (value: FiltersState<FiltersDefinition>) => void
+  setSearch: (value: string | undefined) => void
+  setSortings: (value: SortingsState<SortingsDefinition>) => void
+}
+
+/**
+ * Keeps a OneDataCollection's filters/search/sortings in two-way sync with the
+ * URL query params (see `dataCollectionUrlParams`):
+ *
+ * - **URL → collection:** once, after storage has hydrated (so the URL takes
+ *   precedence over persisted state), any `dc`-addressed params matching this
+ *   collection's `id` are applied to the current state.
+ * - **collection → URL:** thereafter, every change to filters/search/sortings is
+ *   reflected back into the URL via `history.replaceState`.
+ *
+ * The "apply once, then write" ordering avoids the pre-hydration empty snapshot
+ * clobbering freshly-loaded params: writing only starts after the URL has been
+ * read and applied (which flips `urlApplied` in the same render as the applied
+ * state, so the first write re-affirms the URL rather than wiping it).
+ */
+export const useDataCollectionUrlSync = ({
+  id,
+  disabled,
+  storageReady,
+  filtersDefinition,
+  filters,
+  search,
+  sortings,
+  setFilters,
+  setSearch,
+  setSortings,
+}: UseDataCollectionUrlSyncOptions): void => {
+  const active = !disabled && !!id
+  const [urlApplied, setUrlApplied] = useState(false)
+
+  // URL → collection (run once, after hydration so the URL wins over storage).
+  useEffect(() => {
+    if (!active || !storageReady || urlApplied) return
+
+    const parsed = parseDataCollectionUrlParams(
+      typeof window !== "undefined" ? window.location.search : "",
+      filtersDefinition
+    )
+    if (parsed && parsed.id === id) {
+      const { state } = parsed
+      // Only the params present in the URL override the current state.
+      if ("filters" in state) {
+        setFilters((state.filters ?? {}) as FiltersState<FiltersDefinition>)
+      }
+      if ("search" in state) setSearch(state.search)
+      if ("sortings" in state) setSortings(state.sortings ?? null)
+    }
+
+    // Enable writing in the same render as the applied state, so the first
+    // write reflects the URL we just read rather than the prior snapshot.
+    setUrlApplied(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- apply once when ready
+  }, [active, storageReady, id])
+
+  // collection → URL.
+  useDeepCompareEffect(() => {
+    if (!active || !urlApplied || !id) return
+    syncDataCollectionUrlParams(id, { filters, search, sortings })
+  }, [active, urlApplied, id, filters, search, sortings])
+}


### PR DESCRIPTION
## Description

Adds **two-way syncing between a `OneDataCollection`'s state and the URL query params** — filters, search, sorting, the active **visualization**, and the current **page**. With an `id` set, the collection reads its state from the URL on mount and reflects later changes back into it. Filters/search/sorting/visualization sync automatically (opt out with `disableUrlParams`); pagination is wired through additive data-source hooks (see below).

### Value

- **Shareable & bookmarkable views** — copy the URL and the recipient lands on the same filtered/sorted/searched list, in the same view and on the same page.
- **Back/forward & refresh friendly** — the active view is encoded in the address bar, so a reload or navigation restores it.
- **Deep-linkable** — other parts of the product (or external links) can point users straight to a pre-filtered collection.
- **Readable URLs** — each filter is its own param rather than an opaque JSON blob, and the visualization is its type (not an index), e.g.
  `?dc_id=organization/employees/v1&dc_department=Engineering&dc_department=Product&dc_salary=1000..5000&dc_search=ada&dc_sort=salary:desc&dc_view=kanban&dc_page=3`

## Screenshots (if applicable)

See the **Data Collection / URL params** story: filter, sort, switch view and page through, and watch the query string update; reload to restore the same state.

## Implementation details

**URL encoding** (`dataCollectionUrlParams.ts`) — a small, readable, symmetric codec:
- `dc_id` carries the collection identifier; `dc_search` / `dc_sort` carry the search text and `field:order` sorting.
- Each filter is encoded under its own `dc_<filterKey>` param (no `JSON.stringify`):
  - **multi-select (`in`)** → repeated params (`dc_department=A&dc_department=B`)
  - **search** → the term (the niche strict-toggle flag isn't round-tripped)
  - **number ranges** → `from..to`, with a `*` suffix marking an *exclusive* bound (`1000*..5000` = `>1000 and ≤5000`) so open/closed bounds survive while keeping the URL clean (only `* . - _` survive URLSearchParams un-escaped).
- **`dc_view`** — the active visualization by its **type/key** (`table`, `kanban`, …), not a positional index. The codec keeps it opaque; the URL-sync hook maps index ↔ type from the visualization list, omits the default view, and ignores unknown/duplicate keys.
- **`dc_page`** — the current page (1-indexed, omitted on page 1).
- Empty/cleared state drops the whole `dc_` family so the URL stays clean; unrelated query params are always preserved.
- **Value cap (`MAX_URL_FILTER_VALUES`)** — a multi-select filter past the cap (e.g. "select all" over a large/paginated source) is left out of the URL to avoid unbounded query strings; it is still applied in-memory and persisted via storage.

**Component integration** (`useDataCollectionUrlSync` + `OneDatacollection.tsx`):
- Applies the URL **once, after storage hydration** (so the URL wins over persisted state), then reflects every later change back. The "apply-then-write" ordering avoids the pre-hydration empty snapshot clobbering freshly-loaded params.
- Filters/search/sorting/visualization are collection-level controlled state, so they're synced automatically. Optional `disableUrlParams` opts out; behavior is a no-op without an `id`, and URL syncing does **not** depend on storage being configured.

**Pagination** (additive, no behavior change when unused): the current page lives inside the per-visualization `useData` hook, so it's exposed via optional `currentPage` (initial/seed) + `onPaginationChange` on the data source. This lets a consumer seed the page from the URL synchronously (so the first fetch is correct — no reset race) and observe page changes, without `useData` owning pagination as collection-level state.

**Story** — a single **URL params** story exercising filters (including a 60-option multi-select that hits the value cap), sorting and pagination together, reflecting all of them in the URL at once. It seeds everything from the URL synchronously and writes it back with a single writer, and runs with storage disabled to show URL syncing needs no storage.

**Notes / limitations**
- Single-collection-per-page assumption (one `dc_id`); use `disableUrlParams` on secondary collections on the same route.
- `id`, `search`, `sort`, `view`, `page` are reserved param names — on the rare clash with a filter of that exact key, the reserved param wins.
- Pagination is consumer-wired (via the data-source hooks) rather than fully built-in, because the page is per-visualization internal state; a fully built-in version would require lifting it to source-controlled state.

**Tests**
- `dataCollectionUrlParams.test.ts` — encode/parse round-trips for every filter type, repeated multi-select params, number-range inclusivity (`*`), `dc_view` (by type) and `dc_page`, reserved-key precedence, value cap, clean-up on empty.
- `useDataCollectionUrlSync.test.tsx` — URL→collection apply (waits for hydration, ignores mismatched id), collection→URL writes/clears, visualization type↔index mapping, disabled / no-id no-ops.
- Component-level integration — clearing a filter chip removes its param; URL syncing works with storage disabled; visualization (`dc_view=card`) survives mount; pagination seeds the first fetch from `currentPage` and reports it back.
