### PR TITLE
feat(F0ClarifyingPanel): add isSubmitDisabled prop

### DIFF
--- a/packages/react/src/sds/ai/F0ClarifyingPanel/F0ClarifyingPanel.tsx
+++ b/packages/react/src/sds/ai/F0ClarifyingPanel/F0ClarifyingPanel.tsx
@@ -16,6 +16,12 @@ const DURATION = 0.3
 
 interface F0ClarifyingPanelProps {
   clarifyingQuestion: ClarifyingQuestionState
+  /**
+   * Disables submitting the final step (confirm button, Enter on the custom
+   * answer input, and Skip) — e.g. while the assistant is still streaming a
+   * response. Step navigation and option selection stay interactive.
+   */
+  isSubmitDisabled?: boolean
 }
 
 /**
@@ -32,6 +38,7 @@ interface F0ClarifyingPanelProps {
  */
 export const F0ClarifyingPanel = ({
   clarifyingQuestion,
+  isSubmitDisabled,
 }: F0ClarifyingPanelProps) => {
   const shouldReduceMotion = useReducedMotion()
   const duration = shouldReduceMotion ? 0 : DURATION
@@ -44,13 +51,17 @@ export const F0ClarifyingPanel = ({
       transition={{ duration, ease: EASE }}
       className="overflow-hidden"
     >
-      <F0ClarifyingPanelContent clarifyingQuestion={clarifyingQuestion} />
+      <F0ClarifyingPanelContent
+        clarifyingQuestion={clarifyingQuestion}
+        isSubmitDisabled={isSubmitDisabled}
+      />
     </motion.div>
   )
 }
 
 const F0ClarifyingPanelContent = ({
   clarifyingQuestion,
+  isSubmitDisabled,
 }: F0ClarifyingPanelProps) => {
   const translation = useI18n()
   const shouldReduceMotion = useReducedMotion()
@@ -96,6 +107,20 @@ const F0ClarifyingPanelContent = ({
   const hasCustomText = (customAnswerText ?? "").trim().length > 0
   const canProceed =
     hasSelection || (isCustomAnswerActive && hasCustomText) || optional === true
+
+  // Only the final step submits (sends a message back to the assistant) —
+  // navigating between steps stays allowed while submission is disabled.
+  const isSubmitBlocked = isSubmitDisabled === true && isFinalStep
+
+  const handleConfirm = () => {
+    if (isSubmitBlocked) return
+    confirm()
+  }
+
+  const handleSkip = () => {
+    if (isSubmitBlocked) return
+    skip()
+  }
 
   // In single-select mode, auto-advance on selection when this is not the
   // last step — avoids requiring an explicit "Next" click. Only advance when
@@ -179,7 +204,7 @@ const F0ClarifyingPanelContent = ({
               onActivateCustom={handleActivateCustom}
               onChangeCustomText={setCustomAnswerText}
               onToggleCustomActive={setCustomAnswerActive}
-              onConfirm={confirm}
+              onConfirm={handleConfirm}
             />
           </motion.div>
         </AnimatePresence>
@@ -187,9 +212,10 @@ const F0ClarifyingPanelContent = ({
 
       <ConfirmFooter
         canProceed={canProceed}
+        submitDisabled={isSubmitBlocked}
         label={confirmButtonLabel}
-        onConfirm={confirm}
-        onSkip={skip}
+        onConfirm={handleConfirm}
+        onSkip={handleSkip}
         showSkip={showSkip}
       />
     </div>

--- a/packages/react/src/sds/ai/F0ClarifyingPanel/__stories__/F0ClarifyingPanel.stories.tsx
+++ b/packages/react/src/sds/ai/F0ClarifyingPanel/__stories__/F0ClarifyingPanel.stories.tsx
@@ -229,14 +229,23 @@ function useLocalClarifyingState(steps: StoryStep[]) {
 // Story shell — renders the panel plus a "resolved" log. No F0AiChat anywhere.
 // ---------------------------------------------------------------------------
 
-const StoryShell = ({ steps }: { steps: StoryStep[] }) => {
+const StoryShell = ({
+  steps,
+  isSubmitDisabled,
+}: {
+  steps: StoryStep[]
+  isSubmitDisabled?: boolean
+}) => {
   const { state, resolved, reset } = useLocalClarifyingState(steps)
 
   return (
     <div className="w-[360px] space-y-3">
       <div className="rounded-lg border border-solid border-f1-border-secondary bg-f1-background">
         {state ? (
-          <F0ClarifyingPanel clarifyingQuestion={state} />
+          <F0ClarifyingPanel
+            clarifyingQuestion={state}
+            isSubmitDisabled={isSubmitDisabled}
+          />
         ) : (
           <div className="flex flex-col gap-2 p-4">
             <div className="text-sm font-medium text-f1-foreground">
@@ -367,6 +376,42 @@ export const CustomAnswerMultiple: Story = {
       []
     )
     return <StoryShell steps={steps} />
+  },
+}
+
+/**
+ * Simulates the assistant still streaming a response: submission (final-step
+ * confirm, Enter on the custom answer, and Skip) is disabled until the toggle
+ * is turned off, while option selection and step navigation stay interactive.
+ */
+export const SubmitDisabled: Story = {
+  render: () => {
+    const [isResponding, setIsResponding] = useState(true)
+    const steps = useMemo<StoryStep[]>(
+      () => [
+        {
+          question: "What time period should the report cover?",
+          options: SINGLE_OPTIONS,
+          selectionMode: "single",
+          optional: true,
+          allowCustomAnswer: true,
+        },
+      ],
+      []
+    )
+    return (
+      <div className="space-y-3">
+        <label className="flex items-center gap-2 text-sm text-f1-foreground">
+          <input
+            type="checkbox"
+            checked={isResponding}
+            onChange={(e) => setIsResponding(e.target.checked)}
+          />
+          Assistant is responding (submit disabled)
+        </label>
+        <StoryShell steps={steps} isSubmitDisabled={isResponding} />
+      </div>
+    )
   },
 }
 

--- a/packages/react/src/sds/ai/F0ClarifyingPanel/__tests__/F0ClarifyingPanel.test.tsx
+++ b/packages/react/src/sds/ai/F0ClarifyingPanel/__tests__/F0ClarifyingPanel.test.tsx
@@ -115,6 +115,60 @@ describe("F0ClarifyingPanel", () => {
     expect(screen.getAllByRole("radio")).toHaveLength(3)
   })
 
+  describe("isSubmitDisabled", () => {
+    it("disables the submit button on the final step", () => {
+      const state = buildState({}, { selectedOptionIds: ["this-month"] })
+      render(<F0ClarifyingPanel clarifyingQuestion={state} isSubmitDisabled />)
+      expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled()
+    })
+
+    it("does not call confirm() when Enter is pressed in the custom answer input on the final step", async () => {
+      const state = buildState(
+        {},
+        { allowCustomAnswer: true, isCustomAnswerActive: true }
+      )
+      render(<F0ClarifyingPanel clarifyingQuestion={state} isSubmitDisabled />)
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "my answer{Enter}")
+      expect(state.confirm).not.toHaveBeenCalled()
+    })
+
+    it("disables the Skip button on a final optional step", () => {
+      const state = buildState({}, { optional: true })
+      render(<F0ClarifyingPanel clarifyingQuestion={state} isSubmitDisabled />)
+      expect(screen.getByRole("button", { name: "Skip" })).toBeDisabled()
+    })
+
+    it("keeps the Next button enabled on non-final steps", () => {
+      const state = buildState(
+        { currentStepIndex: 0, totalSteps: 2 },
+        { selectedOptionIds: ["this-month"] }
+      )
+      render(<F0ClarifyingPanel clarifyingQuestion={state} isSubmitDisabled />)
+      // Both the step-header arrow and the footer button are named "Next"
+      const nextButtons = screen.getAllByRole("button", { name: "Next" })
+      nextButtons.forEach((button) => expect(button).toBeEnabled())
+    })
+
+    it("keeps option selection interactive on the final step", async () => {
+      const state = buildState()
+      render(<F0ClarifyingPanel clarifyingQuestion={state} isSubmitDisabled />)
+      await userEvent.click(screen.getByRole("radio", { name: "This month" }))
+      expect(state.toggleOption).toHaveBeenCalledWith("this-month")
+    })
+
+    it("enables the submit button when isSubmitDisabled is false", () => {
+      const state = buildState({}, { selectedOptionIds: ["this-month"] })
+      render(
+        <F0ClarifyingPanel
+          clarifyingQuestion={state}
+          isSubmitDisabled={false}
+        />
+      )
+      expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled()
+    })
+  })
+
   describe("auto-advance in single-select mode", () => {
     it("calls confirm() after selecting an option on a non-final step", async () => {
       const state = buildState({ currentStepIndex: 0, totalSteps: 2 })

--- a/packages/react/src/sds/ai/F0ClarifyingPanel/components/ConfirmFooter.tsx
+++ b/packages/react/src/sds/ai/F0ClarifyingPanel/components/ConfirmFooter.tsx
@@ -3,6 +3,8 @@ import { useI18n } from "@/lib/providers/i18n"
 
 interface ConfirmFooterProps {
   canProceed: boolean
+  /** Disables both submit actions (confirm and skip), e.g. while the assistant is still responding */
+  submitDisabled?: boolean
   label: string
   onConfirm: () => void
   onSkip?: () => void
@@ -12,6 +14,7 @@ interface ConfirmFooterProps {
 
 export const ConfirmFooter = ({
   canProceed,
+  submitDisabled,
   label,
   onConfirm,
   onSkip,
@@ -27,11 +30,12 @@ export const ConfirmFooter = ({
             variant="outline"
             label={translation.ai.clarifyingQuestion.skip}
             onClick={onSkip}
+            disabled={submitDisabled}
           />
         )}
       </div>
       <F0Button
-        disabled={!canProceed}
+        disabled={!canProceed || submitDisabled}
         variant={"default"}
         label={label}
         onClick={onConfirm}


### PR DESCRIPTION
## Description

Adds an optional `isSubmitDisabled` prop to `F0ClarifyingPanel` so hosts can block submission while the assistant is still streaming a response.

Today the panel's submit button is only gated on having a selection (`canProceed`), so users can submit their answer mid-stream — in the Factorial One chat this fires `sendMessage` while the previous run is still active. This prop lets the host (e.g. `ConnectedChatInput` in the monolith) pass its `inProgress` flag and re-enable submission automatically when the stream ends.

## Implementation details

- `F0ClarifyingPanel` accepts `isSubmitDisabled?: boolean`. Only **submission** is blocked (`isSubmitDisabled && isFinalStep`): the final-step confirm button, Enter on the custom-answer input, and final-step Skip. Option selection, Back/Next navigation, and Escape-to-cancel stay interactive, so users can fill out the form while the assistant finishes.
- `confirm`/`skip` are wrapped with a guard (not just visually disabled) because Enter in `CustomAnswerRow` and the `StepHeader` arrow also invoke them.
- `ConfirmFooter` gets a `submitDisabled` prop that disables both the Submit and Skip buttons.
- 6 new unit tests covering disabled submit/skip/Enter on the final step, Next staying enabled on non-final steps, selection staying interactive, and re-enabling when the flag is false.

## Demo
### Before

https://github.com/user-attachments/assets/01e6da68-8527-4e0a-9c7c-f910c5d7e953

### After

https://github.com/user-attachments/assets/b5f4044c-4474-4525-b3eb-2f1d5f033efd

