### PR TITLE
fix(TableOfContent): use background-hover for active item and reduce padding without icon

### DIFF
--- a/packages/react/src/experimental/Navigation/F0TableOfContent/Item/PrimitiveItem.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/Item/PrimitiveItem.tsx
@@ -77,7 +77,7 @@ export function PrimitiveItem({
         className={cn(
           focusRing("focus:border-f1-border-focus"),
           "relative flex h-[36px] min-w-0 flex-grow items-center gap-1 rounded border border-solid border-transparent px-1.5 text-sm transition-colors",
-          isActive && "bg-f1-background-selected",
+          isActive && "bg-f1-background-hover",
           onClick && !disabled && "cursor-pointer hover:bg-f1-background-hover",
           disabled && "cursor-not-allowed opacity-30"
         )}
@@ -132,7 +132,7 @@ export function PrimitiveItem({
           lines={1}
           className={cn(
             "flex-grow text-[14px] font-medium text-f1-foreground transition-all",
-            showHandleIcon || icon ? "pl-7" : "pl-0"
+            showHandleIcon || icon ? "pl-7" : "pl-0.5"
           )}
         >
           {label}


### PR DESCRIPTION
## Summary

- Active item now uses `bg-f1-background-hover` instead of `bg-f1-background-selected` for a more subtle selection indicator
- Left padding when no icon is present changed from `pl-0` to `pl-0.5` (2px) for better text alignment

## Test plan

- [ ] Open Storybook → Experimental > Navigation > TableOfContent
- [ ] Verify active item shows `background-hover` color
- [ ] Verify items without icons have 2px left padding
- [ ] Verify items with icons still have `pl-7` left padding