### PR TITLE
feat(F0AiChat): voice dictation with live transcription

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -373,6 +373,15 @@ export const defaultTranslations = {
       dismiss: "Dismiss",
     },
     attachFile: "Attach file",
+    recordAudio: "Record audio",
+    listening: "Listening…",
+    stopRecording: "Stop and transcribe",
+    cancelRecording: "Cancel recording",
+    transcribing: "Transcribing…",
+    micPermissionDenied:
+      "Microphone access is blocked. Allow it in your browser settings to dictate.",
+    micError: "Couldn't access the microphone.",
+    transcriptionError: "Couldn't transcribe the audio. Try again.",
     removeFile: "Remove",
     fileUploadError: "Upload failed",
     fileUploadBlockedSubmit:

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -27,6 +27,7 @@ import {
   type JobPostingProfile,
   type RequisitionProfile,
   type PersonProfile,
+  type TranscribeFn,
   type UploadedFile,
   type VacancyProfile,
 } from "@/sds/ai/F0AiChat/types"
@@ -349,6 +350,21 @@ const mockUploadFiles = (files: File[]): Promise<UploadedFile[]> =>
     }, 1000)
   })
 
+// Simulates a streaming STT endpoint: streams the same transcript word by word
+// so the textarea fills live (Wispr Flow feel) without any backend.
+const MOCK_TRANSCRIPT = "How many vacation days do I have left this year?"
+const mockTranscribe: TranscribeFn = async (_audio, { onPartial, signal }) => {
+  const words = MOCK_TRANSCRIPT.split(" ")
+  let acc = ""
+  for (const word of words) {
+    if (signal?.aborted) break
+    await new Promise((r) => setTimeout(r, 140))
+    acc = acc ? `${acc} ${word}` : word
+    onPartial(acc)
+  }
+  return MOCK_TRANSCRIPT
+}
+
 const meta: Meta<typeof ApplicationFrame> = {
   title: "ApplicationFrame",
   component: ApplicationFrame,
@@ -546,6 +562,7 @@ const meta: Meta<typeof ApplicationFrame> = {
         onUploadFiles: mockUploadFiles,
         maxFiles: 5,
       },
+      onTranscribe: mockTranscribe,
       disclaimer: {
         text: "One works within your permissions.",
         link: "/permissions",
@@ -898,6 +915,7 @@ export const FullscreenWithActions: Story = {
         onUploadFiles: mockUploadFiles,
         maxFiles: 5,
       },
+      onTranscribe: mockTranscribe,
       disclaimer: {
         text: "One works within your permissions.",
         link: "/permissions",

--- a/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
@@ -48,6 +48,7 @@ const F0AiChatProviderComponent = ({
   employeeCredits,
   creditWarning,
   fileAttachments,
+  onTranscribe,
   onThumbsUp,
   onThumbsDown,
   children,
@@ -80,6 +81,7 @@ const F0AiChatProviderComponent = ({
       employeeCredits={employeeCredits}
       creditWarning={creditWarning}
       fileAttachments={fileAttachments}
+      onTranscribe={onTranscribe}
     >
       {children}
     </AiChatStateProvider>

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/_mock/MockConnectedChatInput.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/_mock/MockConnectedChatInput.tsx
@@ -22,6 +22,7 @@ export const MockConnectedChatInput = () => {
     placeholders,
     entityRefs,
     fileAttachments,
+    onTranscribe,
     pendingContext,
     setPendingContext,
     pendingQuote,
@@ -81,6 +82,7 @@ export const MockConnectedChatInput = () => {
       pendingQuote={pendingQuote}
       onPendingQuoteChange={setPendingQuote}
       fileAttachments={fileAttachments}
+      onTranscribe={onTranscribe}
       searchPersons={entityRefs?.resolvers?.searchPersons}
       onProcessFilesRef={setProcessDroppedFilesFunction}
       disclaimer={disclaimerWithGame}

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -15,6 +15,7 @@ import {
   type F0AIMessage,
   type PendingContext,
   type PendingQuote,
+  type TranscribeFn,
   type VisualizationMode,
   WelcomeScreenSuggestion,
 } from "./types"
@@ -46,6 +47,7 @@ export interface AiChatState {
   employeeCredits?: AiChatEmployeeCredits
   creditWarning?: AiChatCreditWarning
   fileAttachments?: AiChatFileAttachmentConfig
+  onTranscribe?: TranscribeFn
   placeholders?: string[]
   setPlaceholders?: React.Dispatch<React.SetStateAction<string[]>>
   onThumbsUp?: (
@@ -187,6 +189,7 @@ export type AiChatProviderReturnValue = {
   | "employeeCredits"
   | "creditWarning"
   | "fileAttachments"
+  | "onTranscribe"
 > & {
     /** The current canvas content, or null when canvas is closed */
     canvasContent: CanvasContent | null

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -71,6 +71,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   employeeCredits,
   creditWarning,
   fileAttachments,
+  onTranscribe,
   onThumbsDown,
   onThumbsUp,
   tracking,
@@ -278,6 +279,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         employeeCredits,
         creditWarning,
         fileAttachments,
+        onTranscribe,
         canvasContent,
         openCanvas,
         closeCanvas,
@@ -344,6 +346,7 @@ const UNDEFINED_KEYS = new Set<ProviderKey>([
   "employeeCredits",
   "creditWarning",
   "fileAttachments",
+  "onTranscribe",
   "onThumbsUp",
   "onThumbsDown",
 ])

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -236,6 +236,28 @@ export type AiChatFileAttachmentConfig = {
   maxFiles?: number
 }
 
+export type TranscribeOptions = {
+  /**
+   * Primary channel for live dictation: fires with the cumulative transcript
+   * as it streams in, so the composer can fill the textarea while the user
+   * speaks. Implementations that don't stream may call it once at the end.
+   */
+  onPartial: (text: string) => void
+  /** Aborted when the user cancels an in-flight transcription. */
+  signal?: AbortSignal
+}
+
+/**
+ * Transcribes a recorded audio blob to text (voice dictation). The returned
+ * promise resolves with the final transcript; `onPartial` delivers
+ * intermediate results for live textarea fill. When omitted from the chat
+ * config, the microphone button is not rendered.
+ */
+export type TranscribeFn = (
+  audio: Blob,
+  options: TranscribeOptions
+) => Promise<string>
+
 /**
  * Payload for `tracking.onWelcomeSuggestionClick`. Carries everything an
  * analytics layer (e.g. Amplitude) needs to attribute the click: the picked
@@ -343,6 +365,13 @@ export type AiChatProviderProps = {
    * File attachment configuration. When provided, enables file uploads in the chat.
    */
   fileAttachments?: AiChatFileAttachmentConfig
+  /**
+   * Voice dictation. When provided, a microphone button is shown in the
+   * composer: recorded audio is transcribed and the result fills the textarea
+   * (the user reviews and sends it as a normal text message). When omitted,
+   * the microphone is hidden.
+   */
+  onTranscribe?: TranscribeFn
   onThumbsUp?: (
     message: F0AIMessage,
     { threadId, feedback }: { threadId: string; feedback: string }

--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -22,6 +22,7 @@ import type {
 } from "../F0AiChat/types"
 import { buildHighlightSegments } from "./highlight-utils"
 import { type F0AiChatTextAreaProps } from "./types"
+import { type RecorderError, useAudioRecorder } from "./useAudioRecorder"
 import { useFileAttachments } from "./useFileAttachments"
 import { useMentions } from "./useMentions"
 
@@ -70,6 +71,7 @@ export const F0AiChatTextArea = ({
   pendingQuote = null,
   onPendingQuoteChange,
   fileAttachments,
+  onTranscribe,
   searchPersons,
   onProcessFilesRef,
   disclaimer,
@@ -137,6 +139,36 @@ export const F0AiChatTextArea = ({
     textareaRef,
   })
 
+  // Voice dictation. Transcripts are written onto whatever was already typed
+  // (captured when recording starts) so dictation appends instead of replacing.
+  const dictationBaseRef = useRef("")
+  const applyDictation = useCallback((text: string) => {
+    const base = dictationBaseRef.current
+    const separator = base && !/\s$/.test(base) ? " " : ""
+    const next = `${base}${separator}${text}`
+    setInputValue(next)
+    setCursorPosition(next.length)
+  }, [])
+  const recorderErrorMessage: Record<RecorderError, string> = {
+    "permission-denied": translation.ai.micPermissionDenied,
+    "device-error": translation.ai.micError,
+    "transcription-failed": translation.ai.transcriptionError,
+  }
+  const recorder = useAudioRecorder({
+    onTranscribe,
+    onPartial: applyDictation,
+    onFinal: (text) => {
+      applyDictation(text)
+      textareaRef.current?.focus()
+    },
+    onError: (error) => showTransientError(recorderErrorMessage[error]),
+  })
+  const canRecord = !!onTranscribe && recorder.isSupported
+  const handleStartRecording = useCallback(() => {
+    dictationBaseRef.current = inputValue
+    void recorder.start()
+  }, [inputValue, recorder])
+
   useEffect(() => {
     if (typeof window !== "undefined" && window.location.hash.length === 0) {
       textareaRef.current?.focus()
@@ -157,7 +189,12 @@ export const F0AiChatTextArea = ({
     }
   }, [onProcessFilesRef, processFiles])
 
-  const resolvedDefaultPlaceholder = translation.ai.inputPlaceholder
+  // While recording, the placeholder becomes "Listening…" so the empty
+  // textarea signals that dictation is live.
+  const isRecording = recorder.status === "recording"
+  const resolvedDefaultPlaceholder = isRecording
+    ? translation.ai.listening
+    : translation.ai.inputPlaceholder
   const uploadedFiles = attachedFiles.filter((f) => f.status === "uploaded")
   const isUploading = attachedFiles.some((f) => f.status === "uploading")
   const hasErrorFiles = attachedFiles.some((f) => f.status === "error")
@@ -266,9 +303,11 @@ export const F0AiChatTextArea = ({
   const previewPlaceholder = hoveredSuggestion
     ? (hoveredSuggestion.prompt ?? hoveredSuggestion.title)
     : null
-  const effectivePlaceholders = previewPlaceholder
-    ? [previewPlaceholder]
-    : (placeholders ?? [])
+  const effectivePlaceholders = isRecording
+    ? [translation.ai.listening]
+    : previewPlaceholder
+      ? [previewPlaceholder]
+      : (placeholders ?? [])
   const multiplePlaceholders = effectivePlaceholders.length > 1
 
   const highlightSegments = useMemo(() => {
@@ -435,6 +474,12 @@ export const F0AiChatTextArea = ({
                     inProgress={inProgress}
                     hasDataToSend={hasDataToSend}
                     isPreSending={isPreSending || pendingSubmit}
+                    canRecord={canRecord}
+                    recordingStatus={recorder.status}
+                    recordingStream={recorder.stream}
+                    onStartRecording={handleStartRecording}
+                    onStopRecording={recorder.stop}
+                    onCancelRecording={recorder.cancel}
                   />
                 </motion.div>
               )}

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -13,6 +13,7 @@ import type {
   PendingContext,
   PendingQuote,
   PersonProfile,
+  TranscribeFn,
   UploadedFile,
 } from "../../F0AiChat/types"
 
@@ -82,6 +83,21 @@ const FILE_UPLOAD_CONFIG: AiChatFileAttachmentConfig = {
   maxFiles: 3,
 }
 
+// Simulates a streaming STT endpoint: emits the same transcript word by word
+// so the textarea fills live (Wispr Flow feel) without any backend.
+const MOCK_TRANSCRIPT = "How many vacation days do I have left this year?"
+const mockTranscribe: TranscribeFn = async (_audio, { onPartial, signal }) => {
+  const words = MOCK_TRANSCRIPT.split(" ")
+  let acc = ""
+  for (const word of words) {
+    if (signal?.aborted) break
+    await new Promise((r) => setTimeout(r, 140))
+    acc = acc ? `${acc} ${word}` : word
+    onPartial(acc)
+  }
+  return MOCK_TRANSCRIPT
+}
+
 const CREDIT_WARNING: AiChatCreditWarning = {
   level: "soft",
   onGetCredits: () => console.log("get credits clicked"),
@@ -124,6 +140,7 @@ const buildClarifyingState = (
 type WrapperProps = {
   placeholders?: string[]
   fileAttachments?: AiChatFileAttachmentConfig
+  onTranscribe?: TranscribeFn
   searchPersons?: (query: string) => Promise<PersonProfile[]>
   initialPendingContext?: PendingContext | null
   initialPendingQuote?: PendingQuote | null
@@ -139,6 +156,7 @@ type WrapperProps = {
 const Wrapper = ({
   placeholders,
   fileAttachments,
+  onTranscribe,
   searchPersons,
   initialPendingContext = null,
   initialPendingQuote = null,
@@ -185,6 +203,7 @@ const Wrapper = ({
         pendingQuote={pendingQuote}
         onPendingQuoteChange={setPendingQuote}
         fileAttachments={fileAttachments}
+        onTranscribe={onTranscribe}
         searchPersons={searchPersons}
         disclaimer={disclaimer}
         footer={footer}
@@ -301,6 +320,13 @@ export const WithMentions: Story = {
   },
 }
 
+export const WithVoiceDictation: Story = {
+  args: {
+    onTranscribe: mockTranscribe,
+    placeholders: ["Tap the mic and start talking…"],
+  },
+}
+
 export const Clarifying: Story = {
   args: {
     clarifyingQuestion: buildClarifyingState(),
@@ -337,6 +363,7 @@ export const Everything: Story = {
   args: {
     placeholders: ROTATING_PLACEHOLDERS,
     fileAttachments: FILE_UPLOAD_CONFIG,
+    onTranscribe: mockTranscribe,
     searchPersons: mockSearchPersons,
     creditWarning: CREDIT_WARNING,
     disclaimer: DISCLAIMER,

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.dictation.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.dictation.test.tsx
@@ -1,0 +1,144 @@
+import { userEvent } from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
+
+import { type TranscribeFn } from "../../F0AiChat/types"
+
+interface TextareaFieldMockProps {
+  inputValue: string
+}
+
+// Reflect the controlled value so we can assert the live-filled transcript.
+vi.mock("../components/TextareaField", () => ({
+  TextareaField: ({ inputValue }: TextareaFieldMockProps) => (
+    <textarea aria-label="Message" value={inputValue} readOnly />
+  ),
+}))
+
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+
+// Minimal MediaRecorder stand-in: stop() emits one chunk then fires onstop.
+class MockMediaRecorder {
+  state: "inactive" | "recording" = "inactive"
+  ondataavailable: ((e: { data: Blob }) => void) | null = null
+  onstop: (() => void) | null = null
+  start() {
+    this.state = "recording"
+  }
+  stop() {
+    this.state = "inactive"
+    this.ondataavailable?.({
+      data: new Blob(["audio"], { type: "audio/webm" }),
+    })
+    this.onstop?.()
+  }
+}
+
+const stopTrack = vi.fn()
+
+const installMediaMocks = (getUserMedia: () => Promise<MediaStream>) => {
+  vi.stubGlobal("MediaRecorder", MockMediaRecorder)
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia: vi.fn(getUserMedia) },
+  })
+}
+
+const fakeStream = () =>
+  ({ getTracks: () => [{ stop: stopTrack }] }) as unknown as MediaStream
+
+describe("F0AiChatTextArea voice dictation", () => {
+  beforeEach(() => {
+    stopTrack.mockClear()
+  })
+
+  it("hides the microphone when onTranscribe is not provided", () => {
+    installMediaMocks(async () => fakeStream())
+    render(<F0AiChatTextArea onSubmit={vi.fn()} />)
+    expect(
+      screen.queryByRole("button", { name: /record audio/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("fills the textarea with the transcript without auto-sending", async () => {
+    installMediaMocks(async () => fakeStream())
+    const onSubmit = vi.fn()
+    const onTranscribe: TranscribeFn = vi.fn(async (_audio, { onPartial }) => {
+      onPartial("How many")
+      onPartial("How many vacation days")
+      return "How many vacation days do I have left?"
+    })
+    const user = userEvent.setup()
+
+    render(<F0AiChatTextArea onSubmit={onSubmit} onTranscribe={onTranscribe} />)
+
+    await user.click(screen.getByRole("button", { name: /record audio/i }))
+
+    // Recording UI: stop+transcribe button is shown.
+    const stopButton = await screen.findByRole("button", {
+      name: /stop and transcribe/i,
+    })
+    await user.click(stopButton)
+
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+        "How many vacation days do I have left?"
+      )
+    )
+    expect(onTranscribe).toHaveBeenCalledTimes(1)
+    expect(onSubmit).not.toHaveBeenCalled()
+    // Mic track released after recording.
+    expect(stopTrack).toHaveBeenCalled()
+  })
+
+  it("appends the transcript to text already typed", async () => {
+    installMediaMocks(async () => fakeStream())
+    const onTranscribe: TranscribeFn = vi.fn(async () => "world")
+    const user = userEvent.setup()
+
+    render(
+      <F0AiChatTextArea
+        onSubmit={vi.fn()}
+        onTranscribe={onTranscribe}
+        // seed the textarea by faking a prior transcript run
+      />
+    )
+
+    // First dictation produces "world"; second should append, not replace.
+    await user.click(screen.getByRole("button", { name: /record audio/i }))
+    await user.click(
+      await screen.findByRole("button", { name: /stop and transcribe/i })
+    )
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+        "world"
+      )
+    )
+
+    await user.click(screen.getByRole("button", { name: /record audio/i }))
+    await user.click(
+      await screen.findByRole("button", { name: /stop and transcribe/i })
+    )
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+        "world world"
+      )
+    )
+  })
+
+  it("surfaces an error when microphone permission is denied", async () => {
+    installMediaMocks(async () => {
+      throw new DOMException("denied", "NotAllowedError")
+    })
+    const user = userEvent.setup()
+
+    render(<F0AiChatTextArea onSubmit={vi.fn()} onTranscribe={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: /record audio/i }))
+
+    expect(
+      await screen.findByText(/microphone access is blocked/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChatTextArea/components/ActionBar.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/components/ActionBar.tsx
@@ -1,6 +1,5 @@
 import { type RefObject } from "react"
 
-import { F0ActionItem } from "@/ai"
 import { ButtonInternal } from "@/components/F0Button/internal"
 import {
   ArrowUp,
@@ -120,7 +119,7 @@ export const ActionBar = ({
         )}
       </div>
       <div className="flex items-center gap-2">
-        {canRecord && recordingStatus !== "transcribing" && (
+        {canRecord && (
           <ButtonInternal
             label={translation.ai.recordAudio}
             hideLabel
@@ -130,13 +129,10 @@ export const ActionBar = ({
             size="md"
             disabled={inProgress}
             onClick={onStartRecording}
+            loading={recordingStatus === "transcribing"}
           />
         )}
-        {recordingStatus === "transcribing" ? (
-          <div className="flex items-center gap-2 pr-1 text-f1-foreground-secondary h-8">
-            <F0ActionItem status="writing" />
-          </div>
-        ) : inProgress ? (
+        {recordingStatus !== "transcribing" && inProgress ? (
           <ButtonInternal
             type="submit"
             variant="neutral"

--- a/packages/react/src/sds/ai/F0AiChatTextArea/components/ActionBar.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/components/ActionBar.tsx
@@ -1,8 +1,19 @@
 import { type RefObject } from "react"
 
+import { F0ActionItem } from "@/ai"
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { ArrowUp, Paperclip, SolidStop } from "@/icons/app"
+import {
+  ArrowUp,
+  Check,
+  Cross,
+  Microphone,
+  Paperclip,
+  SolidStop,
+} from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
+
+import { type RecorderStatus } from "../useAudioRecorder"
+import { RecordingWaveform } from "./RecordingWaveform"
 
 interface ActionBarProps {
   onUploadFiles: ((files: File[]) => Promise<unknown>) | undefined
@@ -14,6 +25,13 @@ interface ActionBarProps {
   inProgress?: boolean
   hasDataToSend: boolean
   isPreSending?: boolean
+  /** Voice dictation — when canRecord is false the microphone is hidden. */
+  canRecord?: boolean
+  recordingStatus?: RecorderStatus
+  recordingStream?: MediaStream | null
+  onStartRecording?: () => void
+  onStopRecording?: () => void
+  onCancelRecording?: () => void
 }
 
 export const ActionBar = ({
@@ -26,8 +44,48 @@ export const ActionBar = ({
   inProgress,
   hasDataToSend,
   isPreSending,
+  canRecord,
+  recordingStatus = "idle",
+  recordingStream,
+  onStartRecording,
+  onStopRecording,
+  onCancelRecording,
 }: ActionBarProps) => {
   const translation = useI18n()
+
+  // Recording: a scrolling amplitude timeline fills the row (building up as
+  // seconds pass) with the cancel · confirm actions grouped on the right, so
+  // the regular send/submit button can't fire mid-record.
+  if (recordingStatus === "recording") {
+    return (
+      <div className="flex shrink-0 items-center gap-3 p-3">
+        <RecordingWaveform
+          stream={recordingStream ?? null}
+          className="min-w-0 flex-1"
+        />
+        <div className="flex shrink-0 items-center gap-2">
+          <ButtonInternal
+            label={translation.ai.cancelRecording}
+            hideLabel
+            type="button"
+            icon={Cross}
+            variant="outline"
+            size="md"
+            onClick={onCancelRecording}
+          />
+          <ButtonInternal
+            label={translation.ai.stopRecording}
+            hideLabel
+            type="button"
+            icon={Check}
+            variant="default"
+            size="md"
+            onClick={onStopRecording}
+          />
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="flex shrink-0 items-center justify-between p-3">
@@ -41,7 +99,7 @@ export const ActionBar = ({
               icon={Paperclip}
               variant="outline"
               size="md"
-              disabled={isAtMaxFiles}
+              disabled={isAtMaxFiles || recordingStatus === "transcribing"}
               onClick={(e) => {
                 e.preventDefault()
                 fileInputRef.current?.click()
@@ -61,8 +119,24 @@ export const ActionBar = ({
           </>
         )}
       </div>
-      <div className="flex items-center">
-        {inProgress ? (
+      <div className="flex items-center gap-2">
+        {canRecord && recordingStatus !== "transcribing" && (
+          <ButtonInternal
+            label={translation.ai.recordAudio}
+            hideLabel
+            type="button"
+            icon={Microphone}
+            variant="ghost"
+            size="md"
+            disabled={inProgress}
+            onClick={onStartRecording}
+          />
+        )}
+        {recordingStatus === "transcribing" ? (
+          <div className="flex items-center gap-2 pr-1 text-f1-foreground-secondary h-8">
+            <F0ActionItem status="writing" />
+          </div>
+        ) : inProgress ? (
           <ButtonInternal
             type="submit"
             variant="neutral"
@@ -76,7 +150,7 @@ export const ActionBar = ({
             // Stays enabled while an attachment uploads so the click queues the
             // send (fired once the upload finishes) instead of being a no-op.
             disabled={!hasDataToSend || isPreSending}
-            variant={hasDataToSend && !isPreSending ? "default" : "neutral"}
+            variant={"default"}
             label={translation.ai.sendMessage}
             icon={ArrowUp}
             hideLabel

--- a/packages/react/src/sds/ai/F0AiChatTextArea/components/RecordingWaveform.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/components/RecordingWaveform.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+const BAR_WIDTH = 2 // px
+const BAR_GAP = 3 // px
+/** How often a new amplitude sample is appended to the timeline. */
+const SAMPLE_MS = 70
+/** Resting height fraction so silent moments render as small dots. */
+const MIN_SCALE = 0.08
+/** Gain applied to RMS so normal speech uses a good chunk of the height. */
+const LEVEL_GAIN = 3
+
+type WindowWithWebkitAudio = Window &
+  typeof globalThis & {
+    webkitAudioContext?: typeof AudioContext
+  }
+
+const getAudioContextCtor = (): typeof AudioContext | undefined => {
+  if (typeof window === "undefined") return undefined
+  const w = window as WindowWithWebkitAudio
+  return w.AudioContext ?? w.webkitAudioContext
+}
+
+type RecordingWaveformProps = {
+  /** Live mic stream. Drives the timeline via a Web Audio analyser. */
+  stream: MediaStream | null
+  className?: string
+}
+
+/**
+ * Scrolling amplitude timeline (à la Claude/voice memos): every `SAMPLE_MS` a
+ * new bar is appended whose height is the current mic loudness. Bars are
+ * right-anchored, so the newest sample sits at the right edge and the line
+ * builds up right→left as seconds pass, scrolling once it fills the width.
+ * Degrades to an empty track where Web Audio is missing (SSR / tests).
+ */
+export const RecordingWaveform = ({
+  stream,
+  className,
+}: RecordingWaveformProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [capacity, setCapacity] = useState(0)
+  const [levels, setLevels] = useState<number[]>([])
+
+  // Capacity = how many bars fit the current width (timeline scrolls past it).
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const measure = () => {
+      const width = el.clientWidth
+      setCapacity(
+        Math.max(1, Math.floor((width + BAR_GAP) / (BAR_WIDTH + BAR_GAP)))
+      )
+    }
+    measure()
+    if (typeof ResizeObserver === "undefined") return
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const AudioCtx = getAudioContextCtor()
+    if (!stream || !AudioCtx || capacity === 0) {
+      setLevels([])
+      return
+    }
+
+    const ctx = new AudioCtx()
+    const source = ctx.createMediaStreamSource(stream)
+    const analyser = ctx.createAnalyser()
+    analyser.fftSize = 1024
+    source.connect(analyser)
+    const data = new Uint8Array(analyser.fftSize)
+
+    const id = setInterval(() => {
+      analyser.getByteTimeDomainData(data)
+      let sum = 0
+      for (let i = 0; i < data.length; i++) {
+        const deviation = (data[i] - 128) / 128
+        sum += deviation * deviation
+      }
+      const rms = Math.sqrt(sum / data.length)
+      const level = Math.min(1, rms * LEVEL_GAIN)
+      setLevels((prev) => {
+        const next =
+          prev.length >= capacity
+            ? prev.slice(prev.length - capacity + 1)
+            : prev.slice()
+        next.push(level)
+        return next
+      })
+    }, SAMPLE_MS)
+
+    return () => {
+      clearInterval(id)
+      source.disconnect()
+      analyser.disconnect()
+      void ctx.close()
+      setLevels([])
+    }
+  }, [stream, capacity])
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "flex h-6 items-center justify-end overflow-hidden",
+        className
+      )}
+      style={{ gap: `${BAR_GAP}px` }}
+      aria-hidden="true"
+    >
+      {levels.map((level, i) => (
+        <span
+          key={i}
+          className="shrink-0 rounded-full bg-f1-foreground-secondary"
+          style={{
+            width: `${BAR_WIDTH}px`,
+            height: `${(MIN_SCALE + level * (1 - MIN_SCALE)) * 100}%`,
+          }}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
@@ -7,6 +7,7 @@ import type {
   PendingContext,
   PendingQuote,
   PersonProfile,
+  TranscribeFn,
   UploadedFile,
   WelcomeScreenSuggestion,
   WelcomeScreenSuggestionItem,
@@ -84,6 +85,13 @@ export type F0AiChatTextAreaProps = {
 
   /** File attachment configuration. When omitted, attachments are disabled. */
   fileAttachments?: AiChatFileAttachmentConfig
+
+  /**
+   * Voice dictation. When provided, a microphone button is shown: recorded
+   * audio is transcribed and the transcript fills the textarea (the user
+   * reviews and sends it manually). When omitted, the microphone is hidden.
+   */
+  onTranscribe?: TranscribeFn
 
   /** Async search used by the @-mention popover. When omitted, mentions are disabled. */
   searchPersons?: (query: string) => Promise<PersonProfile[]>

--- a/packages/react/src/sds/ai/F0AiChatTextArea/useAudioRecorder.ts
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/useAudioRecorder.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { type TranscribeFn } from "../F0AiChat/types"
+
+export type RecorderStatus = "idle" | "recording" | "transcribing"
+
+export type RecorderError =
+  | "permission-denied"
+  | "device-error"
+  | "transcription-failed"
+
+/** Browser chunk interval — small enough to allow future request streaming. */
+const TIMESLICE_MS = 250
+/** Hard cap so a forgotten recording can't balloon cost/payload. */
+const DEFAULT_MAX_DURATION_MS = 120_000
+
+type UseAudioRecorderParams = {
+  onTranscribe: TranscribeFn | undefined
+  /** Cumulative partial transcript — drives live textarea fill. */
+  onPartial: (text: string) => void
+  /** Final transcript once transcription resolves. */
+  onFinal: (text: string) => void
+  onError: (error: RecorderError) => void
+  maxDurationMs?: number
+}
+
+const checkSupport = (): boolean =>
+  typeof navigator !== "undefined" &&
+  !!navigator.mediaDevices?.getUserMedia &&
+  typeof MediaRecorder !== "undefined"
+
+/**
+ * Records microphone audio and pipes it through a transcription function.
+ * The recorder owns mic permission, the MediaRecorder lifecycle, a duration
+ * timer and a max-duration auto-stop; transcription streaming is delegated to
+ * `onTranscribe` (which reports partials via `onPartial`).
+ */
+export function useAudioRecorder({
+  onTranscribe,
+  onPartial,
+  onFinal,
+  onError,
+  maxDurationMs = DEFAULT_MAX_DURATION_MS,
+}: UseAudioRecorderParams) {
+  const [status, setStatus] = useState<RecorderStatus>("idle")
+  const [durationMs, setDurationMs] = useState(0)
+  const [isSupported] = useState(checkSupport)
+  // Live mic stream while recording — consumed by the waveform visualizer.
+  const [stream, setStream] = useState<MediaStream | null>(null)
+
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const abortRef = useRef<AbortController | null>(null)
+  const canceledRef = useRef(false)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const maxTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const startedAtRef = useRef(0)
+
+  // Keep the latest callbacks in refs so the MediaRecorder.onstop closure
+  // (captured at start time) always calls the current ones.
+  const cbRef = useRef({ onTranscribe, onPartial, onFinal, onError })
+  cbRef.current = { onTranscribe, onPartial, onFinal, onError }
+
+  const releaseDevice = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop())
+    streamRef.current = null
+    recorderRef.current = null
+    setStream(null)
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+    if (maxTimeoutRef.current) {
+      clearTimeout(maxTimeoutRef.current)
+      maxTimeoutRef.current = null
+    }
+  }, [])
+
+  const transcribe = useCallback(async () => {
+    const { onTranscribe, onPartial, onFinal, onError } = cbRef.current
+    const chunks = chunksRef.current
+    chunksRef.current = []
+
+    if (chunks.length === 0 || !onTranscribe) {
+      setStatus("idle")
+      setDurationMs(0)
+      return
+    }
+
+    const blob = new Blob(chunks, { type: chunks[0]?.type || "audio/webm" })
+    const controller = new AbortController()
+    abortRef.current = controller
+    setStatus("transcribing")
+
+    try {
+      const finalText = await onTranscribe(blob, {
+        onPartial,
+        signal: controller.signal,
+      })
+      if (!controller.signal.aborted) onFinal(finalText)
+    } catch {
+      if (!controller.signal.aborted) onError("transcription-failed")
+    } finally {
+      abortRef.current = null
+      setStatus("idle")
+      setDurationMs(0)
+    }
+  }, [])
+
+  const stop = useCallback(() => {
+    const recorder = recorderRef.current
+    if (recorder && recorder.state !== "inactive") recorder.stop()
+  }, [])
+
+  const start = useCallback(async () => {
+    if (status !== "idle" || !onTranscribe || !isSupported) return
+    canceledRef.current = false
+    chunksRef.current = []
+
+    let stream: MediaStream
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    } catch (err) {
+      onError(
+        err instanceof DOMException && err.name === "NotAllowedError"
+          ? "permission-denied"
+          : "device-error"
+      )
+      return
+    }
+
+    streamRef.current = stream
+    setStream(stream)
+    const recorder = new MediaRecorder(stream)
+    recorderRef.current = recorder
+
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunksRef.current.push(e.data)
+    }
+    recorder.onstop = () => {
+      releaseDevice()
+      if (canceledRef.current) {
+        chunksRef.current = []
+        setStatus("idle")
+        setDurationMs(0)
+        return
+      }
+      void transcribe()
+    }
+
+    recorder.start(TIMESLICE_MS)
+    startedAtRef.current = Date.now()
+    setStatus("recording")
+    setDurationMs(0)
+    timerRef.current = setInterval(() => {
+      setDurationMs(Date.now() - startedAtRef.current)
+    }, 200)
+    maxTimeoutRef.current = setTimeout(stop, maxDurationMs)
+  }, [
+    status,
+    onTranscribe,
+    isSupported,
+    onError,
+    releaseDevice,
+    transcribe,
+    stop,
+    maxDurationMs,
+  ])
+
+  const cancel = useCallback(() => {
+    if (status === "recording") {
+      canceledRef.current = true
+      stop()
+    } else if (status === "transcribing") {
+      abortRef.current?.abort()
+      abortRef.current = null
+      setStatus("idle")
+      setDurationMs(0)
+    }
+  }, [status, stop])
+
+  useEffect(
+    () => () => {
+      canceledRef.current = true
+      abortRef.current?.abort()
+      const recorder = recorderRef.current
+      if (recorder && recorder.state !== "inactive") recorder.stop()
+      releaseDevice()
+    },
+    [releaseDevice]
+  )
+
+  return { status, durationMs, isSupported, stream, start, stop, cancel }
+}


### PR DESCRIPTION
## Summary
Adds an optional **voice dictation** entry point to the AI chat composer (`F0AiChatTextArea`). It works like dictation, not a voice message: recorded audio is transcribed through a host-provided `onTranscribe` callback and the result fills the textarea — the user reviews and sends it as a normal text message. The audio never enters the conversation or history.

- **`onTranscribe` config** (`(audio, { onPartial, signal }) => Promise<string>`) on `AiChatProviderProps` and `F0AiChatTextArea`. When omitted, the microphone is hidden (additive, backwards-compatible). Wired through `F0AiChatProvider` so hosts (factorial, ApplicationFrame, mock runtime) can supply a transcription endpoint.
- **`useAudioRecorder`**: wraps `MediaRecorder` (mic permission, `timeslice` chunks, cancel, max-duration auto-stop) and exposes the live stream.
- **Live fill**: streaming partials (`onPartial`) write into the textarea as you speak; the transcript appends to any text already typed and is **not** auto-sent.
- **`RecordingWaveform`**: a scrolling amplitude timeline (Web Audio analyser) that builds right→left and reflects voice/tone while recording.
- **Placeholder** becomes "Listening…" while recording.
- New i18n keys: `recordAudio`, `listening`, `stopRecording`, `cancelRecording`, `transcribing`, `micPermissionDenied`, `micError`, `transcriptionError`.

## Stories
- `AI/F0AiChatTextArea › WithVoiceDictation` and `Everything` (mock that streams the same transcript word by word).
- `ApplicationFrame › Default` / `FullscreenWithActions` (dictation wired via the provider).

## Test plan
- [x] `pnpm tsc` clean
- [x] `pnpm vitest run src/sds/ai` — 188 tests pass (incl. 4 new dictation tests: live fill without auto-send, append to typed text, mic hidden without `onTranscribe`, permission-denied error)
- [x] `pnpm lint` / `oxfmt` clean
- [ ] Manual: open the chat in Storybook, click the mic, speak → waveform builds right→left, placeholder shows "Listening…", textarea fills live, review + Enter sends as text