### PR TITLE
feat(F0Dialog): resource-aware header variant + opt-in metadata row gap

### DIFF
--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -57,6 +57,7 @@ interface BaseHeaderProps {
     actions?: MetadataAction[]
   }
   metadata?: MetadataProps["items"]
+  metadataRowGap?: MetadataProps["rowGap"]
   /** Renders a 1px bottom border at the very bottom of the header. */
   showBottomBorder?: boolean
 }
@@ -74,6 +75,7 @@ export function BaseHeader({
   otherActions = [],
   status,
   metadata = [],
+  metadataRowGap = "none",
   showBottomBorder = false,
 }: BaseHeaderProps) {
   const allMetadata: BaseHeaderProps["metadata"] = [
@@ -165,7 +167,7 @@ export function BaseHeader({
 
         {allMetadata.length > 0 && (
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
-            <Metadata items={allMetadata} />
+            <Metadata items={allMetadata} rowGap={metadataRowGap} />
           </div>
         )}
 
@@ -307,7 +309,7 @@ export function BaseHeader({
       </div>
       {allMetadata.length > 0 && (
         <div className="hidden flex-wrap items-center gap-x-3 gap-y-1 md:block">
-          <Metadata items={allMetadata} />
+          <Metadata items={allMetadata} rowGap={metadataRowGap} />
         </div>
       )}
     </div>

--- a/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
@@ -107,6 +107,15 @@ interface MetadataItem {
   }
 }
 
+export type MetadataRowGap = "none" | "xs" | "sm" | "md"
+
+const metadataRowGapClass: Record<MetadataRowGap, string> = {
+  none: "gap-y-0",
+  xs: "gap-y-1",
+  sm: "gap-y-2",
+  md: "gap-y-3",
+}
+
 export interface MetadataProps {
   /**
    * Everything is not a MetadataItem is ignored.
@@ -118,6 +127,8 @@ export interface MetadataProps {
    * If true and the metadata type is a list, it will be collapsed to the first item
    */
   collapse?: boolean
+
+  rowGap?: MetadataRowGap
 }
 
 function MetadataItem({ item }: { item: MetadataItem }) {
@@ -287,10 +298,18 @@ function MetadataItem({ item }: { item: MetadataItem }) {
   )
 }
 
-const _Metadata = memo(function Metadata({ items }: MetadataProps) {
+const _Metadata = memo(function Metadata({
+  items,
+  rowGap = "none",
+}: MetadataProps) {
   const cleanedItems = items.filter((item) => typeof item === "object")
   return (
-    <div className="flex flex-col items-start gap-x-3 gap-y-0 md:flex-row md:flex-wrap md:items-center">
+    <div
+      className={cn(
+        "flex flex-col items-start gap-x-3 md:flex-row md:flex-wrap md:items-center",
+        metadataRowGapClass[rowGap]
+      )}
+    >
       {cleanedItems.map((item, index) => (
         <Fragment key={`metadata-item-${index}`}>
           <MetadataItem item={item} />

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -11,7 +11,7 @@ import { F0TagStatus } from "@/components/tags/F0TagStatus"
 import { OneSwitch as OnePromotionSwitch } from "@/experimental/AiPromotionChat/OneSwitch"
 import { Dropdown } from "@/experimental/Navigation/Dropdown"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
-import { ChevronDown, ChevronLeft, ChevronUp, Menu } from "@/icons/app"
+import { ChevronLeft, Menu } from "@/icons/app"
 import { Link } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
 import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
@@ -21,6 +21,7 @@ import { Skeleton } from "@/ui/skeleton"
 
 import { Breadcrumbs, BreadcrumbsProps } from "../Breadcrumbs"
 import { FavoriteButton } from "../Favorites"
+import { NavigationProps, PageNavigation } from "../PageNavigation"
 import { ProductUpdates, ProductUpdatesProp } from "../ProductUpdates"
 
 export type PageAction = {
@@ -38,21 +39,6 @@ export type PageAction = {
       actions: Array<{ label: string; href: string }>
     }
 )
-
-type NavigationProps = {
-  previous?: {
-    url: string
-    title: string
-  }
-  next?: {
-    url: string
-    title: string
-  }
-  counter?: {
-    current: number
-    total: number
-  }
-}
 
 type HeaderProps = {
   module: {
@@ -82,34 +68,6 @@ type HeaderProps = {
     whenEnabled?: string
   }
   oneSwitchAutoOpen?: boolean
-}
-
-function PageNavigationLink({
-  icon,
-  href,
-  label,
-  disabled,
-}: {
-  icon: IconType
-  href: string
-  label: string
-  disabled?: boolean
-}) {
-  const ref = useRef<HTMLAnchorElement>(null)
-  return (
-    <F0Button
-      href={href}
-      title={label}
-      aria-label={label}
-      disabled={disabled}
-      ref={ref}
-      size="sm"
-      variant="outline"
-      label={label}
-      icon={icon}
-      hideLabel
-    />
-  )
 }
 
 export function PageHeader({
@@ -237,29 +195,7 @@ export function PageHeader({
           (navigation || hasActions || hasProductUpdates) && (
             <div className="h-4 w-px bg-f1-border-secondary" />
           )}
-        {navigation && (
-          <div className="flex items-center gap-3">
-            {navigation.counter && (
-              <span className="text-sm text-f1-foreground-secondary">
-                {navigation.counter.current}/{navigation.counter.total}
-              </span>
-            )}
-            <div className="flex items-center gap-2">
-              <PageNavigationLink
-                icon={ChevronUp}
-                label={navigation.previous?.title || "Previous"}
-                href={navigation.previous?.url || ""}
-                disabled={!navigation.previous}
-              />
-              <PageNavigationLink
-                icon={ChevronDown}
-                label={navigation.next?.title || "Next"}
-                href={navigation.next?.url || ""}
-                disabled={!navigation.next}
-              />
-            </div>
-          </div>
-        )}
+        {navigation && <PageNavigation {...navigation} />}
         {navigation && hasActions && (
           <div className="h-4 w-px bg-f1-border-secondary" />
         )}

--- a/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
@@ -1,0 +1,70 @@
+import { F0Button } from "@/components/F0Button"
+import { IconType } from "@/components/F0Icon"
+import { ChevronDown, ChevronUp } from "@/icons/app"
+
+export type NavigationProps = {
+  previous?: {
+    url: string
+    title: string
+  }
+  next?: {
+    url: string
+    title: string
+  }
+  counter?: {
+    current: number
+    total: number
+  }
+}
+
+function PageNavigationLink({
+  icon,
+  href,
+  label,
+  disabled,
+}: {
+  icon: IconType
+  href: string
+  label: string
+  disabled?: boolean
+}) {
+  return (
+    <F0Button
+      href={href}
+      title={label}
+      aria-label={label}
+      disabled={disabled}
+      size="sm"
+      variant="outline"
+      label={label}
+      icon={icon}
+      hideLabel
+    />
+  )
+}
+
+export function PageNavigation({ previous, next, counter }: NavigationProps) {
+  return (
+    <div className="flex items-center gap-3">
+      {counter && (
+        <span className="text-sm text-f1-foreground-secondary">
+          {counter.current}/{counter.total}
+        </span>
+      )}
+      <div className="flex items-center gap-2">
+        <PageNavigationLink
+          icon={ChevronUp}
+          label={previous?.title || "Previous"}
+          href={previous?.url || ""}
+          disabled={!previous}
+        />
+        <PageNavigationLink
+          icon={ChevronDown}
+          label={next?.title || "Next"}
+          href={next?.url || ""}
+          disabled={!next}
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/experimental/Navigation/Header/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/index.tsx
@@ -1,3 +1,4 @@
 export * from "./Breadcrumbs"
 export * from "./Breadcrumbs/internal/BreadcrumbSelect"
 export * from "./PageHeader"
+export * from "./PageNavigation"

--- a/packages/react/src/patterns/F0Dialog/F0DialogInternal.tsx
+++ b/packages/react/src/patterns/F0Dialog/F0DialogInternal.tsx
@@ -78,6 +78,9 @@ export const F0DialogInternal: FC<F0DialogInternalProps> = ({
   description,
   module,
   otherActions,
+  navigation,
+  resourceHeader,
+  controls,
   tabs,
   activeTabId,
   setActiveTabId,
@@ -138,11 +141,20 @@ export const F0DialogInternal: FC<F0DialogInternalProps> = ({
     })
   }, [variant, position, localWidth])
 
+  if (resourceHeader && !isSidePosition) {
+    console.warn(
+      "F0Dialog: `resourceHeader` is only applicable to side panel positions (left/right)"
+    )
+  }
+
   const headerProps = {
     title,
     description,
     module,
     otherActions,
+    navigation,
+    resourceHeader,
+    controls,
     tabs,
     activeTabId,
     setActiveTabId,

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
@@ -3,10 +3,12 @@ import {
   DropdownInternal,
   DropdownItemObject,
 } from "@/experimental/Navigation/Dropdown/internal"
+import { BaseHeader } from "@/experimental/Information/Headers/BaseHeader"
 import { BreadcrumbItem } from "@/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem"
+import { PageNavigation } from "@/experimental/Navigation/Header/PageNavigation"
 import { Tabs } from "@/patterns/Navigation/Tabs"
 import CrossIcon from "@/icons/app/Cross"
-import { Ellipsis } from "@/icons/app"
+import { ChevronLeft, Ellipsis, Maximize } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { BreadcrumbList } from "@/ui/breadcrumb"
@@ -21,6 +23,9 @@ export const F0DialogHeader = ({
   description,
   module,
   otherActions,
+  navigation,
+  resourceHeader,
+  controls,
   tabs,
   activeTabId,
   setActiveTabId,
@@ -84,6 +89,86 @@ export const F0DialogHeader = ({
     )
   }
 
+  const CloseButton = () => (
+    <ButtonInternal
+      variant="outline"
+      icon={CrossIcon}
+      onClick={onClose}
+      label={translations.actions.close}
+      hideLabel
+    />
+  )
+
+  const TabsStrip = () =>
+    tabs ? (
+      <div className="-mx-2">
+        <Tabs
+          tabs={tabs}
+          activeTabId={activeTabId}
+          setActiveTabId={setActiveTabId}
+        />
+      </div>
+    ) : null
+
+  const Controls = () => {
+    if (!controls) return null
+
+    if (controls.kind === "back") {
+      return (
+        <ButtonInternal
+          variant="outline"
+          icon={ChevronLeft}
+          onClick={controls.onClick}
+          label={controls.label}
+        />
+      )
+    }
+
+    return (
+      <>
+        {controls.expand && (
+          <ButtonInternal
+            variant="outline"
+            icon={Maximize}
+            onClick={controls.expand.onClick}
+            label={controls.expand.label}
+          />
+        )}
+        {controls.expand && controls.navigation && <Divider />}
+        {controls.navigation && <PageNavigation {...controls.navigation} />}
+      </>
+    )
+  }
+
+  // `navigation` alone is intentionally excluded so legacy title/module dialogs stay on the branch below.
+  if (resourceHeader || controls) {
+    return (
+      <>
+        <div className="flex flex-row items-center justify-between gap-3 px-4 py-3">
+          <div className="flex flex-row items-center gap-2">
+            <Controls />
+          </div>
+          <div className="flex flex-row items-center gap-2">
+            <Actions />
+            <CloseButton />
+          </div>
+        </div>
+        {/* BaseHeader shows the title as a styled span, so emit a visually-hidden DialogTitle for the accessible name. */}
+        {resourceHeader ? (
+          <>
+            <DialogTitle className="sr-only">
+              {resourceHeader.title}
+            </DialogTitle>
+            <BaseHeader {...resourceHeader} />
+          </>
+        ) : (
+          title && <DialogTitle className="sr-only">{title}</DialogTitle>
+        )}
+        <TabsStrip />
+      </>
+    )
+  }
+
   return (
     <>
       <div
@@ -93,43 +178,34 @@ export const F0DialogHeader = ({
             "border border-x-0 border-b border-t-0 border-solid border-f1-border-secondary"
         )}
       >
-        <div className="flex flex-col gap-1">
-          {module ? (
-            <Module />
-          ) : (
-            title && (
-              <DialogTitle className="py-1 text-lg font-semibold text-f1-foreground">
-                {title}
-              </DialogTitle>
-            )
-          )}
-          {!!description && (
-            <DrawerDescription className="text-base text-f1-foreground-secondary">
-              {description}
-            </DrawerDescription>
+        <div className="flex flex-row items-center gap-3">
+          {(module || title || !!description) && (
+            <div className="flex flex-col gap-1">
+              {module ? (
+                <Module />
+              ) : (
+                title && (
+                  <DialogTitle className="py-1 text-lg font-semibold text-f1-foreground">
+                    {title}
+                  </DialogTitle>
+                )
+              )}
+              {!!description && (
+                <DrawerDescription className="text-base text-f1-foreground-secondary">
+                  {description}
+                </DrawerDescription>
+              )}
+            </div>
           )}
         </div>
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-row items-center gap-2">
+          {navigation && <PageNavigation {...navigation} />}
           <Actions />
-          {otherActions && <Divider />}
-          <ButtonInternal
-            variant="outline"
-            icon={CrossIcon}
-            onClick={onClose}
-            label={translations.actions.close}
-            hideLabel
-          />
+          {(navigation || otherActions) && <Divider />}
+          <CloseButton />
         </div>
       </div>
-      {tabs && (
-        <div className="-mx-2">
-          <Tabs
-            tabs={tabs}
-            activeTabId={activeTabId}
-            setActiveTabId={setActiveTabId}
-          />
-        </div>
-      )}
+      <TabsStrip />
     </>
   )
 }

--- a/packages/react/src/patterns/F0Dialog/index.tsx
+++ b/packages/react/src/patterns/F0Dialog/index.tsx
@@ -9,6 +9,7 @@ export {
   useF0Dialog,
 } from "./components/F0DialogProvider"
 export type {
+  DialogControls,
   DialogPosition,
   DialogWidth,
   F0DialogActionsProps,

--- a/packages/react/src/patterns/F0Dialog/internal-types.ts
+++ b/packages/react/src/patterns/F0Dialog/internal-types.ts
@@ -2,9 +2,12 @@ import { ReactNode } from "react"
 
 import { ModuleId } from "@/components/avatars/F0AvatarModule"
 import { DropdownInternalProps } from "@/experimental/Navigation/Dropdown/internal"
+import { NavigationProps } from "@/experimental/Navigation/Header/PageNavigation"
 import { TabsProps } from "@/patterns/Navigation/Tabs"
+import { ResourceHeaderProps } from "@/patterns/ResourceHeader"
 
 import {
+  DialogControls,
   DialogPosition,
   DialogWidth,
   F0DialogPrimaryAction,
@@ -22,6 +25,9 @@ export type F0DialogHeaderProps = {
     href: string
   }
   otherActions?: DropdownInternalProps["items"]
+  navigation?: NavigationProps
+  resourceHeader?: ResourceHeaderProps
+  controls?: DialogControls
 } & Partial<Pick<TabsProps, "tabs" | "activeTabId" | "setActiveTabId">>
 
 export type F0DialogContextType = {
@@ -68,6 +74,9 @@ export type F0DialogInternalProps = {
   module?: F0DialogHeaderProps["module"]
   // Other actions to display in the header
   otherActions?: F0DialogHeaderProps["otherActions"]
+  navigation?: F0DialogHeaderProps["navigation"]
+  resourceHeader?: F0DialogHeaderProps["resourceHeader"]
+  controls?: F0DialogHeaderProps["controls"]
   // Custom content to render in the dialog
   children: ReactNode
   // Disable the default padding from the dialog content area

--- a/packages/react/src/patterns/F0Dialog/types.ts
+++ b/packages/react/src/patterns/F0Dialog/types.ts
@@ -1,4 +1,5 @@
 import { IconType } from "@/components/F0Icon"
+import { NavigationProps } from "@/experimental/Navigation/Header/PageNavigation"
 
 export const dialogPositions = [
   "center",
@@ -48,3 +49,15 @@ export type F0DialogActionsProps = {
   primaryAction?: F0DialogPrimaryAction | F0DialogPrimaryActionItem[]
   secondaryAction?: F0DialogSecondaryAction | F0DialogSecondaryActionItem[]
 }
+
+export type DialogControls =
+  | {
+      kind: "resource"
+      expand?: { label: string; onClick: () => void }
+      navigation?: NavigationProps
+    }
+  | {
+      kind: "back"
+      label: string
+      onClick: () => void
+    }

--- a/packages/react/src/patterns/ResourceHeader/index.tsx
+++ b/packages/react/src/patterns/ResourceHeader/index.tsx
@@ -17,6 +17,7 @@ type Props = {} & Pick<
   | "metadata"
   | "status"
   | "deactivated"
+  | "metadataRowGap"
   | "showBottomBorder"
 >
 
@@ -30,6 +31,7 @@ const _ResourceHeader = ({
   status,
   metadata,
   deactivated,
+  metadataRowGap,
   showBottomBorder,
 }: Props) => {
   return (
@@ -43,6 +45,7 @@ const _ResourceHeader = ({
       status={status}
       metadata={metadata}
       deactivated={deactivated}
+      metadataRowGap={metadataRowGap}
       showBottomBorder={showBottomBorder}
     />
   )


### PR DESCRIPTION
## Description

Adds an opt-in, resource-aware variant to `F0Dialog` so side panels (e.g. an ATS
application preview) can show a resource identity band — avatar, title, description,
status, metadata — with the dialog owning its top chrome (expand / back / prev-next /
kebab / close), instead of composing that chrome inside the dialog body.

The header is modeled as **independent layers** rather than one coupled flag —
controls row ⟂ identity band ⟂ tabs ⟂ footer. Every addition is **optional and
defaults to current behavior**: existing `F0Dialog`, `ResourceHeader`, `BaseHeader`,
`Metadata`, and `PageHeader` consumers render unchanged.

## Implementation details

**F0Dialog — controls + resource-aware header (`patterns/F0Dialog`)**
- `DialogControls` discriminated union for the left control slot:
  - `{ kind: "resource", expand?, navigation? }` — top-level: "Open detail" + prev/next
  - `{ kind: "back", label, onClick }` — drilled-in sub-page: a single back affordance

  The two navigation modes are mutually exclusive, so illegal combinations (e.g. back
  *and* prev/next at once) are unrepresentable rather than something the component has
  to defensively reconcile.
- Decoupled the identity band from the controls: the resource layout is entered on
  `resourceHeader || controls`, and `BaseHeader` renders **only** when `resourceHeader`
  is set. A visually-hidden `DialogTitle` (from `resourceHeader.title`, falling back to
  `title`) keeps an accessible name. Identity band, controls, `tabs`, and footer
  (`primaryAction` / `secondaryAction`) each compose independently.
- `otherActions` (kebab) stays a **separate, orthogonal** prop. It answers a different
  question than `controls` ("what can I do to this resource?" vs. "what navigation mode
  am I in?"), is resource-scoped, and remains available in *any* control mode — main
  view and drilled-in sub-page alike — so it isn't folded into the union.

**Metadata row gap (`Metadata`, `BaseHeader`, `ResourceHeader`)**
- Opt-in `rowGap` / `metadataRowGap`: `none` (default, == prior `gap-y-0`) | `xs` |
  `sm` | `md` (12px). Threaded ResourceHeader → BaseHeader → Metadata.

**PageNavigation extraction (`Navigation/Header`)**
- Moved the inline prev/next/counter UI + `NavigationProps` type out of `PageHeader`
  into a shared `PageNavigation` component (exported from `Navigation/Header`, reused by
  `PageHeader` and the dialog header). Behavior identical.

## Why this shape (the flexibility it buys)

1. **Any combination is expressible** — identity band with or without controls, controls
   with or without an identity band, tabs with neither. The main view and a sub-page are
   just different selections over the same orthogonal slots.
2. **The drill-down "back" pattern is a first-class dialog affordance** — any `F0Dialog`
   consumer gets it for free, instead of hand-rolling a back button inside body content.
3. **"Open detail" survives as a persistent escape hatch** at the top level without
   entangling it with back.
4. **Adding a new navigation mode is additive** — a union arm + a switch case, with no
   change to consumers of other modes.
5. **The contract documents intent** — the prop shape says "resource mode, these tabs,
   this identity, these actions," instead of a pile of optionals a reader must mentally
   reconcile.

## Note on the API surface check

The `ResourceHeader` / `ResourceHeaderProps` "breaking change" flags are **false
positives**. The only change there is the new **optional** `metadataRowGap` prop
(default `"none"`). Existing consumers compile unchanged — nobody is forced to pass it.

The check trips because `ResourceHeaderProps` is a `Pick<ComponentProps<typeof
BaseHeader>, …>`, and `"metadataRowGap"` added to that key list; the structural
differ can't see inside the `Pick` to tell the added member is optional, so it
conservatively reports the parameter type as "changed." This is an **additive, minor**
change — not a major bump.

<img width="883" height="759" alt="Screenshot 2026-06-03 at 22 06 22" src="https://github.com/user-attachments/assets/3203d4f6-7fc1-43ee-9986-5bdeffe612f3" />

https://github.com/user-attachments/assets/6fafee52-0b5b-40d8-8130-0c73887a05f6


