### PR TITLE
fix(WelcomeScreen): add coral red mid-stop to welcome gradient

### DIFF
--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
@@ -87,7 +87,7 @@ export const WelcomeScreen = ({ messages, onClick }: WelcomeScreenProps) => {
         onClick={onClick}
         onKeyDown={handleKeyDown}
         className={cn(
-          "bg-gradient-to-r from-[#E55619] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent",
+          "bg-gradient-to-r from-[#E55619] via-[#E51943] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent",
           interactive &&
             cn(
               "cursor-pointer transition-transform duration-200",


### PR DESCRIPTION
## Summary

- Adds `#E51943` (coral red) as a `via` step in the welcome screen gradient
- The gradient now goes `#E55619` → `#E51943` → `#A1ADE5`, consistent with the palette used across other AI components (`ChatTextarea`, `PongGame`, `F0OneIcon`)

## Test plan

- [ ] Open Storybook → AI > F0AiMessagesContainer > Empty Welcome
- [ ] Verify the gradient shows orange → coral → lavender