### PR TITLE
fix(inputs): preserve generic prop types for deprecated experimental re-exports

### DIFF
--- a/packages/react/src/components/F0NumberInput/index.tsx
+++ b/packages/react/src/components/F0NumberInput/index.tsx
@@ -1,6 +1,6 @@
 export * from "./F0NumberInput"
 
-import { F0NumberInput } from "./F0NumberInput"
+import { F0NumberInput, type F0NumberInputProps } from "./F0NumberInput"
 export type { F0NumberInputProps } from "./F0NumberInput"
 
 /**
@@ -21,4 +21,4 @@ export const NumberInput = F0NumberInput
  * deprecation note.
  * @removeIn 2.0.0
  */
-export type NumberInputProps = import("./F0NumberInput").F0NumberInputProps
+export type NumberInputProps = F0NumberInputProps

--- a/packages/react/src/components/F0TextAreaInput/index.tsx
+++ b/packages/react/src/components/F0TextAreaInput/index.tsx
@@ -1,6 +1,6 @@
 export * from "./F0TextAreaInput"
 
-import { F0TextAreaInput } from "./F0TextAreaInput"
+import { F0TextAreaInput, type F0TextAreaInputProps } from "./F0TextAreaInput"
 export type { F0TextAreaInputProps } from "./F0TextAreaInput"
 
 /**
@@ -21,4 +21,4 @@ export const Textarea = F0TextAreaInput
  * deprecation note.
  * @removeIn 2.0.0
  */
-export type TextareaProps = import("./F0TextAreaInput").F0TextAreaInputProps
+export type TextareaProps = F0TextAreaInputProps

--- a/packages/react/src/components/F0TextInput/index.tsx
+++ b/packages/react/src/components/F0TextInput/index.tsx
@@ -1,6 +1,6 @@
 export * from "./F0TextInput"
 
-import { F0TextInput } from "./F0TextInput"
+import { F0TextInput, type F0TextInputProps } from "./F0TextInput"
 export type { F0TextInputProps } from "./F0TextInput"
 
 /**
@@ -20,5 +20,4 @@ export const Input = F0TextInput
  * @deprecated Renamed to `F0TextInputProps`. See the `Input` deprecation note.
  * @removeIn 2.0.0
  */
-export type InputProps<T extends string> =
-  import("./F0TextInput").F0TextInputProps<T>
+export type InputProps<T extends string> = F0TextInputProps<T>


### PR DESCRIPTION
## Why

Importing the deprecated input re-exports from the experimental entry produced a typing error:

```ts
import { Input, Textarea } from '@factorialco/f0-react/dist/experimental'
// <Input onChange={(value) => ...} />
//                   ^^^^^ TS7006: Parameter 'value' implicitly has an 'any' type
```

…while the canonical imports worked fine:

```ts
import { F0TextInput, F0TextAreaInput } from '@factorialco/f0-react'
```

These deprecated aliases (`Input`, `NumberInput`, `Textarea`) were kept for backwards compatibility after #4199, but their **prop types didn't resolve in the bundled `experimental.d.ts`**, so `onChange`'s callback param lost its contextual type and fell back to implicit `any`.

## Root cause

The deprecated prop aliases used inline-import-type syntax:

```ts
export type InputProps<T extends string> = import("./F0TextInput").F0TextInputProps<T>
```

The `import("./X")` form forces api-extractor (`vite-plugin-dts` `rollupTypes`) to emit a *separate module import* (`F0TextInputProps_2`) instead of inlining the bundled type. That import landed as `from './F0TextInput'` — a path that **doesn't exist in the flat `dist/`** — so the type failed to resolve and degraded to `any`, breaking `onChange` inference. The canonical `F0TextInput` was unaffected because its prop type is inlined in the root bundle.

## Fix

In `F0TextInput`, `F0NumberInput`, and `F0TextAreaInput` `index.tsx`, replaced the `import("./X").Y` inline-import-type with a normal top-level type import, so api-extractor **inlines** the prop type. Bundled output now reads:

```ts
export declare const Input: <T extends string>(props: F0TextInputProps<T>) => JSX.Element  // local type, no _2
```

This is a minimal, source-only change — no build-tooling changes, so the rest of the package's bundled type surface is untouched.

## Verification

Rebuilt the type declarations (`BUILD_TYPES=true vite build`) and typechecked a consumer (with `skipLibCheck`, like a real app) against the bundled `experimental.d.ts`:

- No `F0*Props_2` dup imports remain; `Input`/`NumberInput`/`Textarea` reference inlined local prop types.
- `<Input onChange={(value) => …} />` infers `value` as `string` (and `number | null` for `NumberInput`) — **no `TS7006`** — identical to the canonical `F0*` exports from the root entry.

> Build-time output only — consumers pick this up after the next package build/release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)