### PR TITLE
feat: drop dc_id from data collection url params + cleaner sort encoding

### DIFF
--- a/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionUrlParams.test.ts
+++ b/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionUrlParams.test.ts
@@ -15,8 +15,8 @@ import {
 } from "../dataCollectionUrlParams"
 import { readDataCollectionStorage } from "../readDataCollectionStorage"
 
-const ID = "organization/employees/v1"
-const KEY = getDataCollectionStorageKey(ID)
+const STORAGE_ID = "organization/employees/v1"
+const KEY = getDataCollectionStorageKey(STORAGE_ID)
 
 // Only `type` matters for decoding; the rest is filled to satisfy the type.
 const FILTERS = {
@@ -30,34 +30,33 @@ const FILTERS = {
   },
 } as unknown as FiltersDefinition
 
+const hasDcParams = (params: URLSearchParams) =>
+  [...params.keys()].some((k) => k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX))
+
 afterEach(() => {
   localStorage.clear()
   window.history.replaceState(null, "", "/")
 })
 
 describe("parseDataCollectionUrlParams", () => {
-  it("returns null when there is no dc_id", () => {
-    expect(parseDataCollectionUrlParams("dc_search=ada", FILTERS)).toBeNull()
-    expect(parseDataCollectionUrlParams("")).toBeNull()
+  it("returns an empty state when there are no dc_ params", () => {
+    expect(parseDataCollectionUrlParams("")).toEqual({})
+    expect(parseDataCollectionUrlParams("tab=overview", FILTERS)).toEqual({})
   })
 
-  it("parses the id, search and shorthand sortings", () => {
-    const parsed = parseDataCollectionUrlParams(
-      `dc_id=${ID}&dc_search=ada&dc_sort=salary:desc`
-    )
-    expect(parsed).toEqual({
-      id: ID,
-      state: { search: "ada", sortings: { field: "salary", order: "desc" } },
-    })
+  it("parses search and shorthand sortings (no dc_id)", () => {
+    expect(
+      parseDataCollectionUrlParams(`dc_search=ada&dc_sort=salary-desc`)
+    ).toEqual({ search: "ada", sortings: { field: "salary", order: "desc" } })
   })
 
   it("decodes each filter from its own dc_<key> param", () => {
-    const parsed = parseDataCollectionUrlParams(
-      `dc_id=${ID}&dc_department=Engineering&dc_department=Product&dc_query=ann&dc_salary=1000..5000`,
+    const state = parseDataCollectionUrlParams(
+      `dc_department=Engineering&dc_department=Product&dc_query=ann&dc_salary=1000..5000`,
       FILTERS
     )
 
-    expect(parsed?.state.filters).toEqual({
+    expect(state.filters).toEqual({
       // repeated params → array (multi-select)
       department: ["Engineering", "Product"],
       query: "ann",
@@ -71,22 +70,19 @@ describe("parseDataCollectionUrlParams", () => {
 
   it("decodes a single multi-select value as a one-item array", () => {
     expect(
-      parseDataCollectionUrlParams(`dc_id=${ID}&dc_department=Sales`, FILTERS)
-        ?.state.filters
+      parseDataCollectionUrlParams(`dc_department=Sales`, FILTERS).filters
     ).toEqual({ department: ["Sales"] })
   })
 
   it("decodes a single-mode number", () => {
     expect(
-      parseDataCollectionUrlParams(`dc_id=${ID}&dc_salary=4200`, FILTERS)?.state
-        .filters
+      parseDataCollectionUrlParams(`dc_salary=4200`, FILTERS).filters
     ).toEqual({ salary: { mode: "single", value: 4200 } })
   })
 
   it("distinguishes inclusive vs exclusive range bounds via the * marker", () => {
     const salaryOf = (raw: string) =>
-      parseDataCollectionUrlParams(`dc_id=${ID}&dc_salary=${raw}`, FILTERS)
-        ?.state.filters?.salary
+      parseDataCollectionUrlParams(`dc_salary=${raw}`, FILTERS).filters?.salary
 
     // no marker → both inclusive (>=, <=)
     expect(salaryOf("1000..5000")).toEqual({
@@ -115,67 +111,53 @@ describe("parseDataCollectionUrlParams", () => {
   })
 
   it("parses the visualization as a type/key string", () => {
-    expect(
-      parseDataCollectionUrlParams(`dc_id=${ID}&dc_view=kanban`)?.state
-        .visualization
-    ).toBe("kanban")
-    // Absent → not present.
-    expect(
-      parseDataCollectionUrlParams(`dc_id=${ID}`)?.state
-    ).not.toHaveProperty("visualization")
+    expect(parseDataCollectionUrlParams(`dc_view=kanban`).visualization).toBe(
+      "kanban"
+    )
+    expect(parseDataCollectionUrlParams(``)).not.toHaveProperty("visualization")
   })
 
   it("parses the page (1-indexed)", () => {
-    expect(
-      parseDataCollectionUrlParams(`dc_id=${ID}&dc_page=3`)?.state.page
-    ).toBe(3)
-    expect(
-      parseDataCollectionUrlParams(`dc_id=${ID}`)?.state
-    ).not.toHaveProperty("page")
+    expect(parseDataCollectionUrlParams(`dc_page=3`).page).toBe(3)
+    expect(parseDataCollectionUrlParams(``)).not.toHaveProperty("page")
     // page 0 / negative are ignored.
-    expect(
-      parseDataCollectionUrlParams(`dc_id=${ID}&dc_page=0`)?.state
-    ).not.toHaveProperty("page")
+    expect(parseDataCollectionUrlParams(`dc_page=0`)).not.toHaveProperty("page")
   })
 
   it("skips filters when no definition is provided", () => {
     expect(
-      parseDataCollectionUrlParams(`dc_id=${ID}&dc_department=Sales`)?.state
+      parseDataCollectionUrlParams(`dc_department=Sales`)
     ).not.toHaveProperty("filters")
   })
 
   it("keeps an empty search distinct from an absent one", () => {
-    expect(
-      parseDataCollectionUrlParams(`dc_id=${ID}&dc_search=`)?.state
-    ).toHaveProperty("search", "")
-    expect(
-      parseDataCollectionUrlParams(`dc_id=${ID}`)?.state
-    ).not.toHaveProperty("search")
+    expect(parseDataCollectionUrlParams(`dc_search=`)).toHaveProperty(
+      "search",
+      ""
+    )
+    expect(parseDataCollectionUrlParams(``)).not.toHaveProperty("search")
   })
 })
 
 describe("buildDataCollectionUrlParams", () => {
-  it("encodes each filter as its own prefixed param (no JSON)", () => {
-    const params = buildDataCollectionUrlParams(ID, {
+  it("encodes each filter as its own prefixed param (no JSON, no dc_id)", () => {
+    const params = buildDataCollectionUrlParams({
       search: "ada",
-      filters: {
-        department: ["Engineering", "Product"],
-        query: "ann",
-      },
+      filters: { department: ["Engineering", "Product"], query: "ann" },
       sortings: { field: "name", order: "asc" },
     })
 
-    expect(params.get(DATA_COLLECTION_URL_PARAMS.id)).toBe(ID)
+    expect(params.has("dc_id")).toBe(false)
     expect(params.getAll("dc_department")).toEqual(["Engineering", "Product"])
     expect(params.get("dc_query")).toBe("ann")
     expect(params.get(DATA_COLLECTION_URL_PARAMS.search)).toBe("ada")
-    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("name:asc")
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("name-asc")
     // Readable: no value is a JSON blob.
     expect(params.toString()).not.toContain("%7B")
   })
 
   it("encodes a number range as from..to", () => {
-    const params = buildDataCollectionUrlParams(ID, {
+    const params = buildDataCollectionUrlParams({
       filters: {
         salary: {
           mode: "range",
@@ -193,11 +175,11 @@ describe("buildDataCollectionUrlParams", () => {
       from: { value: 1000, closed: false },
       to: { value: 5000, closed: true },
     }
-    const params = buildDataCollectionUrlParams(ID, { filters: { salary } })
+    const params = buildDataCollectionUrlParams({ filters: { salary } })
 
     expect(params.get("dc_salary")).toBe("1000*..5000")
     expect(
-      parseDataCollectionUrlParams(params, FILTERS)?.state.filters?.salary
+      parseDataCollectionUrlParams(params, FILTERS).filters?.salary
     ).toEqual(salary)
   })
 
@@ -217,52 +199,57 @@ describe("buildDataCollectionUrlParams", () => {
       sortings: { field: "salary", order: "desc" as const },
     }
 
-    const params = buildDataCollectionUrlParams(ID, state)
-    expect(parseDataCollectionUrlParams(params, FILTERS)).toEqual({
-      id: ID,
-      state,
-    })
+    expect(
+      parseDataCollectionUrlParams(buildDataCollectionUrlParams(state), FILTERS)
+    ).toEqual(state)
   })
 
-  it("emits only dc_id for an empty state", () => {
-    const params = buildDataCollectionUrlParams(ID)
-    expect([...params.keys()]).toEqual([DATA_COLLECTION_URL_PARAMS.id])
+  it("encodes sortings with a hyphen, leaving the URL un-escaped", () => {
+    const params = buildDataCollectionUrlParams({
+      sortings: { field: "email", order: "asc" },
+    })
+    expect(params.get("dc_sort")).toBe("email-asc")
+    // No percent-encoding in the serialized query string.
+    const serialized = params.toString()
+    expect(serialized).toBe("dc_sort=email-asc")
+    expect(serialized).not.toContain("%3A")
+  })
+
+  it("round-trips sort fields that themselves contain hyphens or dots", () => {
+    for (const field of ["permissions.read", "first-name"]) {
+      const state = { sortings: { field, order: "desc" as const } }
+      expect(
+        parseDataCollectionUrlParams(buildDataCollectionUrlParams(state))
+      ).toEqual(state)
+    }
+  })
+
+  it("emits no params for an empty state", () => {
+    expect([...buildDataCollectionUrlParams().keys()]).toEqual([])
+    expect([...buildDataCollectionUrlParams({}).keys()]).toEqual([])
   })
 
   it("encodes the visualization as its type/key", () => {
     expect(
-      buildDataCollectionUrlParams(ID, { visualization: "kanban" }).get(
-        "dc_view"
-      )
+      buildDataCollectionUrlParams({ visualization: "kanban" }).get("dc_view")
     ).toBe("kanban")
-    // No view → no dc_view (the caller omits the default view).
-    expect(buildDataCollectionUrlParams(ID, {}).has("dc_view")).toBe(false)
-    expect([...buildDataCollectionUrlParams(ID, {}).keys()]).toEqual([
-      DATA_COLLECTION_URL_PARAMS.id,
-    ])
+    expect([...buildDataCollectionUrlParams({}).keys()]).toEqual([])
   })
 
   it("encodes the page, omitting the first one", () => {
-    expect(buildDataCollectionUrlParams(ID, { page: 3 }).get("dc_page")).toBe(
-      "3"
-    )
-    expect(buildDataCollectionUrlParams(ID, { page: 1 }).has("dc_page")).toBe(
-      false
-    )
-    expect([...buildDataCollectionUrlParams(ID, { page: 1 }).keys()]).toEqual([
-      DATA_COLLECTION_URL_PARAMS.id,
-    ])
+    expect(buildDataCollectionUrlParams({ page: 3 }).get("dc_page")).toBe("3")
+    expect(buildDataCollectionUrlParams({ page: 1 }).has("dc_page")).toBe(false)
   })
 
-  it("keeps page and sorting together (they don't clobber each other)", () => {
+  it("round-trips sorting + page together (no clobber)", () => {
     const state = {
       sortings: { field: "salary", order: "desc" as const },
       page: 3,
     }
-    const params = buildDataCollectionUrlParams(ID, state)
-    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("salary:desc")
+    const params = buildDataCollectionUrlParams(state)
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("salary-desc")
     expect(params.get(DATA_COLLECTION_URL_PARAMS.page)).toBe("3")
-    expect(parseDataCollectionUrlParams(params)).toEqual({ id: ID, state })
+    expect(parseDataCollectionUrlParams(params)).toEqual(state)
   })
 
   it("round-trips the visualization with other state", () => {
@@ -270,11 +257,9 @@ describe("buildDataCollectionUrlParams", () => {
       filters: { department: ["Design"] },
       visualization: "kanban",
     }
-    const params = buildDataCollectionUrlParams(ID, state)
-    expect(parseDataCollectionUrlParams(params, FILTERS)).toEqual({
-      id: ID,
-      state,
-    })
+    expect(
+      parseDataCollectionUrlParams(buildDataCollectionUrlParams(state), FILTERS)
+    ).toEqual(state)
   })
 })
 
@@ -285,37 +270,33 @@ describe("search-type filters", () => {
   } as unknown as FiltersDefinition
 
   it("reflects a plain-string search filter value", () => {
-    const params = buildDataCollectionUrlParams(ID, {
-      filters: { name: "ann" },
-    })
+    const params = buildDataCollectionUrlParams({ filters: { name: "ann" } })
     expect(params.get("dc_name")).toBe("ann")
     expect(
-      parseDataCollectionUrlParams(params, SEARCH_FILTERS)?.state.filters
+      parseDataCollectionUrlParams(params, SEARCH_FILTERS).filters
     ).toEqual({ name: "ann" })
   })
 
   it("reflects the strict-toggle object form (search term only)", () => {
-    const params = buildDataCollectionUrlParams(ID, {
+    const params = buildDataCollectionUrlParams({
       filters: { name: { value: "ann", strict: true } },
     })
     expect(params.get("dc_name")).toBe("ann")
     expect(
-      parseDataCollectionUrlParams(params, SEARCH_FILTERS)?.state.filters
+      parseDataCollectionUrlParams(params, SEARCH_FILTERS).filters
     ).toEqual({ name: "ann" })
   })
 
   it("reflects a filter keyed exactly 'search'", () => {
-    const params = buildDataCollectionUrlParams(ID, {
-      filters: { search: "ann" },
-    })
+    const params = buildDataCollectionUrlParams({ filters: { search: "ann" } })
     expect(params.get("dc_search")).toBe("ann")
     expect(
-      parseDataCollectionUrlParams(params, SEARCH_FILTERS)?.state.filters
+      parseDataCollectionUrlParams(params, SEARCH_FILTERS).filters
     ).toEqual({ search: "ann" })
   })
 
   it("lets the top-level search win over a same-named filter on clash", () => {
-    const params = buildDataCollectionUrlParams(ID, {
+    const params = buildDataCollectionUrlParams({
       search: "top",
       filters: { search: "filter" },
     })
@@ -327,19 +308,19 @@ describe("large multi-select values (e.g. select-all over a data source)", () =>
   const many = (n: number) => Array.from({ length: n }, (_, i) => `id-${i}`)
 
   it("keeps a selection at the cap but omits one over it", () => {
-    const atCap = buildDataCollectionUrlParams(ID, {
+    const atCap = buildDataCollectionUrlParams({
       filters: { department: many(MAX_URL_FILTER_VALUES) },
     })
     expect(atCap.getAll("dc_department")).toHaveLength(MAX_URL_FILTER_VALUES)
 
-    const overCap = buildDataCollectionUrlParams(ID, {
+    const overCap = buildDataCollectionUrlParams({
       filters: { department: many(MAX_URL_FILTER_VALUES + 1) },
     })
     expect(overCap.has("dc_department")).toBe(false)
   })
 
   it("drops only the oversized filter, keeping smaller filters, search and sort", () => {
-    const params = buildDataCollectionUrlParams(ID, {
+    const params = buildDataCollectionUrlParams({
       search: "ada",
       filters: { department: many(100), role: ["Manager"] },
       sortings: { field: "name", order: "asc" },
@@ -348,19 +329,15 @@ describe("large multi-select values (e.g. select-all over a data source)", () =>
     expect(params.has("dc_department")).toBe(false)
     expect(params.getAll("dc_role")).toEqual(["Manager"])
     expect(params.get(DATA_COLLECTION_URL_PARAMS.search)).toBe("ada")
-    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("name:asc")
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("name-asc")
   })
 
   it("leaves the URL free of dc_ params when only an oversized filter is active", () => {
-    const params = setDataCollectionUrlParams("keep=1", ID, {
+    const params = setDataCollectionUrlParams("keep=1", {
       filters: { department: many(100) },
     })
 
-    expect(
-      [...params.keys()].some((k) =>
-        k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX)
-      )
-    ).toBe(false)
+    expect(hasDcParams(params)).toBe(false)
     expect(params.get("keep")).toBe("1")
   })
 })
@@ -369,36 +346,32 @@ describe("setDataCollectionUrlParams", () => {
   it("preserves unrelated params and rebuilds the dc_ family", () => {
     const params = setDataCollectionUrlParams(
       `tab=overview&dc_department=Old`,
-      ID,
-      { filters: { department: ["Engineering"] } }
+      {
+        filters: { department: ["Engineering"] },
+      }
     )
 
     expect(params.get("tab")).toBe("overview")
     // The stale dc_department=Old is replaced, not appended.
     expect(params.getAll("dc_department")).toEqual(["Engineering"])
-    expect(params.get(DATA_COLLECTION_URL_PARAMS.id)).toBe(ID)
   })
 
-  it("drops the whole dc_ family (incl. dc_id) for empty state", () => {
-    const start = `${DATA_COLLECTION_URL_PARAMS.id}=${ID}&dc_department=A&dc_search=old&keep=1`
+  it("drops the whole dc_ family for empty state", () => {
+    const start = `dc_department=A&dc_search=old&keep=1`
 
-    const params = setDataCollectionUrlParams(start, ID, {
+    const params = setDataCollectionUrlParams(start, {
       search: "",
       filters: { department: [] },
       sortings: null,
     })
 
-    expect(
-      [...params.keys()].some((k) =>
-        k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX)
-      )
-    ).toBe(false)
+    expect(hasDcParams(params)).toBe(false)
     expect(params.get("keep")).toBe("1")
   })
 
   it("does not mutate a passed-in URLSearchParams", () => {
     const source = new URLSearchParams("keep=1")
-    setDataCollectionUrlParams(source, ID, { search: "ada" })
+    setDataCollectionUrlParams(source, { search: "ada" })
     expect([...source.keys()]).toEqual(["keep"])
   })
 })
@@ -407,7 +380,7 @@ describe("syncDataCollectionUrlParams", () => {
   it("writes the current state onto window.location, preserving the path + extras", () => {
     window.history.replaceState(null, "", "/people?tab=overview")
 
-    const query = syncDataCollectionUrlParams(ID, {
+    const query = syncDataCollectionUrlParams({
       filters: { department: ["Engineering", "Product"] },
       sortings: { field: "salary", order: "desc" },
     })
@@ -416,28 +389,23 @@ describe("syncDataCollectionUrlParams", () => {
     const params = new URLSearchParams(window.location.search)
     expect(params.get("tab")).toBe("overview")
     expect(params.getAll("dc_department")).toEqual(["Engineering", "Product"])
-    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("salary:desc")
+    expect(params.get(DATA_COLLECTION_URL_PARAMS.sortings)).toBe("salary-desc")
     expect(query).toBe(window.location.search.replace(/^\?/, ""))
   })
 
   it("clears all dc_ params when the state becomes empty", () => {
-    window.history.replaceState(null, "", `/?keep=1&dc_id=${ID}&dc_search=ada`)
+    window.history.replaceState(null, "", `/?keep=1&dc_search=ada`)
 
-    syncDataCollectionUrlParams(ID, { search: "", filters: {}, sortings: null })
+    syncDataCollectionUrlParams({ search: "", filters: {}, sortings: null })
 
     const params = new URLSearchParams(window.location.search)
-    expect(
-      [...params.keys()].some((k) =>
-        k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX)
-      )
-    ).toBe(false)
+    expect(hasDcParams(params)).toBe(false)
     expect(params.get("keep")).toBe("1")
   })
 
   it("leaves history untouched with history: 'none' but returns the query", () => {
     window.history.replaceState(null, "", "/")
     const query = syncDataCollectionUrlParams(
-      ID,
       { search: "ada" },
       { history: "none" }
     )
@@ -448,8 +416,8 @@ describe("syncDataCollectionUrlParams", () => {
 
 describe("writeDataCollectionStorage", () => {
   it("persists under the prefixed key so readDataCollectionStorage can read it", () => {
-    writeDataCollectionStorage(ID, { search: "ada" })
+    writeDataCollectionStorage(STORAGE_ID, { search: "ada" })
     expect(localStorage.getItem(KEY)).toBe(JSON.stringify({ search: "ada" }))
-    expect(readDataCollectionStorage(ID)?.search).toBe("ada")
+    expect(readDataCollectionStorage(STORAGE_ID)?.search).toBe("ada")
   })
 })

--- a/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
+++ b/packages/react/src/lib/providers/datacollection/dataCollectionUrlParams.ts
@@ -12,19 +12,19 @@ import { DataCollectionStorage } from "./types"
 
 /**
  * Every data collection URL param shares this prefix, so each filter is its own
- * readable param — e.g. `?dc_id=people/v1&dc_department=Sales&dc_search=ada`
- * instead of a single JSON blob.
+ * readable param — e.g. `?dc_department=Sales&dc_search=ada&dc_view=kanban`
+ * instead of a single JSON blob. Params are not scoped to a collection id, so
+ * this assumes a single URL-synced collection per page.
  */
 export const DATA_COLLECTION_URL_PARAM_PREFIX = "dc_"
 
 /**
  * The reserved (non-filter) param names. Individual filters are encoded as
- * `dc_<filterKey>`; these three names are written last (via `set`) so that on
- * the rare clash where a filter key is exactly `id`, `search` or `sort`, the
+ * `dc_<filterKey>`; these names are written last (via `set`) so that on the rare
+ * clash where a filter key is exactly `search`, `sort`, `view` or `page`, the
  * reserved param wins.
  */
 export const DATA_COLLECTION_URL_PARAMS = {
-  id: "dc_id",
   search: "dc_search",
   sortings: "dc_sort",
   /** Active visualization type/key, e.g. `table` (omitted for the default one). */
@@ -44,6 +44,13 @@ const RANGE_SEPARATOR = ".."
  */
 const EXCLUSIVE_BOUND = "*"
 const SORTINGS_NONE = "none"
+/**
+ * Separator between a sorting's field and order, e.g. `email-asc`. A hyphen is
+ * used (rather than `:`) so the URL stays free of percent-encoding (`:` → `%3A`).
+ * Decoding splits on the *last* hyphen, so field names may themselves contain
+ * one.
+ */
+const SORTINGS_SEPARATOR = "-"
 
 /**
  * Maximum number of values a single filter may contribute to the URL.
@@ -77,14 +84,6 @@ export type DataCollectionUrlState<
   visualization?: string
   /** Current page (1-indexed). Not part of persisted storage — URL only. */
   page?: number
-}
-
-export type DataCollectionUrlParams<
-  CurrentFiltersState extends FiltersState<FiltersDefinition> =
-    FiltersState<FiltersDefinition>,
-> = {
-  id: string
-  state: DataCollectionUrlState<CurrentFiltersState>
 }
 
 /** How {@link syncDataCollectionUrlParams} should update the browser history. */
@@ -121,15 +120,24 @@ const parseSortings = (raw: string): SortingsState<SortingsDefinition> => {
   if (trimmed === "" || trimmed === SORTINGS_NONE || trimmed === "null") {
     return null
   }
-  const [field, order] = trimmed.split(":")
-  if (!field) return null
-  return { field, order: order === "desc" ? "desc" : "asc" }
+  // Split on the last separator (so field names may contain one), and only
+  // treat the suffix as the order when it is a recognized one.
+  const sep = trimmed.lastIndexOf(SORTINGS_SEPARATOR)
+  const suffix = sep === -1 ? "" : trimmed.slice(sep + 1)
+  if (suffix === "asc" || suffix === "desc") {
+    const field = trimmed.slice(0, sep)
+    return field ? { field, order: suffix } : null
+  }
+  // No recognizable order suffix → default to ascending on the whole value.
+  return { field: trimmed, order: "asc" }
 }
 
 const serializeSortings = (
   sortings: SortingsState<SortingsDefinition>
 ): string =>
-  sortings ? `${String(sortings.field)}:${sortings.order}` : SORTINGS_NONE
+  sortings
+    ? `${String(sortings.field)}${SORTINGS_SEPARATOR}${sortings.order}`
+    : SORTINGS_NONE
 
 /* ------------------------------------------------------------------ */
 /* Per-filter value <-> param values                                   */
@@ -260,13 +268,15 @@ const decodeFilterValue = (type: string, values: string[]): unknown => {
 /* ------------------------------------------------------------------ */
 
 /**
- * Parses the data collection identifier and state out of URL query params.
+ * Parses a data collection's state out of URL query params.
  *
  * @param input - A query string, a `URLSearchParams`, or omitted to read from
  *                `window.location.search`.
  * @param filtersDefinition - Needed to decode the `dc_<filterKey>` params back
  *                into correctly-typed filter values. Omit to skip filters.
- * @returns `{ id, state }`, or `null` when no `dc_id` is present.
+ * @returns The state encoded in the URL (empty when no `dc_` params are present).
+ *          Params are not scoped to a collection id — one synced collection per
+ *          page is assumed.
  */
 export const parseDataCollectionUrlParams = <
   CurrentFiltersState extends FiltersState<FiltersDefinition> =
@@ -274,11 +284,8 @@ export const parseDataCollectionUrlParams = <
 >(
   input?: string | URLSearchParams,
   filtersDefinition?: FiltersDefinition
-): DataCollectionUrlParams<CurrentFiltersState> | null => {
+): DataCollectionUrlState<CurrentFiltersState> => {
   const params = toSearchParams(input)
-  const id = params.get(DATA_COLLECTION_URL_PARAMS.id)
-  if (!id) return null
-
   const state: DataCollectionUrlState<CurrentFiltersState> = {}
 
   if (params.has(DATA_COLLECTION_URL_PARAMS.search)) {
@@ -316,7 +323,7 @@ export const parseDataCollectionUrlParams = <
     if (hasFilters) state.filters = filters as CurrentFiltersState
   }
 
-  return { id, state }
+  return state
 }
 
 /* ------------------------------------------------------------------ */
@@ -346,7 +353,6 @@ const writeStateToParams = <
   CurrentFiltersState extends FiltersState<FiltersDefinition>,
 >(
   params: URLSearchParams,
-  id: string,
   state: DataCollectionUrlState<CurrentFiltersState>
 ): void => {
   // Filters first (via `append`, so multi-select keeps repeated params); the
@@ -363,8 +369,6 @@ const writeStateToParams = <
       encoded.forEach((entry) => params.append(filterParamName(key), entry))
     }
   }
-
-  params.set(DATA_COLLECTION_URL_PARAMS.id, id)
 
   if (state.search) {
     params.set(DATA_COLLECTION_URL_PARAMS.search, state.search)
@@ -398,46 +402,44 @@ const hasActiveState = <
     Object.values(state.filters).some(isUrlSerializableFilter))
 
 /**
- * Builds a fresh `URLSearchParams` encoding a data collection `id` and state,
- * symmetric with {@link parseDataCollectionUrlParams}. Always sets `dc_id`.
+ * Builds a fresh `URLSearchParams` encoding a data collection's state, symmetric
+ * with {@link parseDataCollectionUrlParams}.
  */
 export const buildDataCollectionUrlParams = <
   CurrentFiltersState extends FiltersState<FiltersDefinition> =
     FiltersState<FiltersDefinition>,
 >(
-  id: string,
   state: DataCollectionUrlState<CurrentFiltersState> = {}
 ): URLSearchParams => {
   const params = new URLSearchParams()
-  writeStateToParams(params, id, state)
+  writeStateToParams(params, state)
   return params
 }
 
 /**
- * Writes a data collection's current filters/search/sortings onto an existing
- * query string, preserving any unrelated params. Every `dc_`-prefixed param is
- * rebuilt from `state`, so cleared filters drop out and an entirely empty state
- * leaves the URL free of `dc_` params (rather than a bare `?dc_id=<id>`).
+ * Writes a data collection's current state onto an existing query string,
+ * preserving any unrelated params. Every `dc_`-prefixed param is rebuilt from
+ * `state`, so cleared values drop out and an entirely empty state leaves the URL
+ * free of `dc_` params.
  */
 export const setDataCollectionUrlParams = <
   CurrentFiltersState extends FiltersState<FiltersDefinition> =
     FiltersState<FiltersDefinition>,
 >(
   current: string | URLSearchParams | undefined,
-  id: string,
   state: DataCollectionUrlState<CurrentFiltersState>
 ): URLSearchParams => {
   // Clone so we never mutate a caller-owned URLSearchParams (e.g. the live one).
   const params = new URLSearchParams(toSearchParams(current))
   deleteDataCollectionParams(params)
   if (hasActiveState(state)) {
-    writeStateToParams(params, id, state)
+    writeStateToParams(params, state)
   }
   return params
 }
 
 /**
- * Reflects a data collection's current filters/search/sortings into the URL.
+ * Reflects a data collection's current state into the URL.
  *
  * Pairs with {@link parseDataCollectionUrlParams} (which reads the other way).
  * `OneDataCollection` wires this up by default when an `id` is set.
@@ -448,13 +450,12 @@ export const syncDataCollectionUrlParams = <
   CurrentFiltersState extends FiltersState<FiltersDefinition> =
     FiltersState<FiltersDefinition>,
 >(
-  id: string,
   state: DataCollectionUrlState<CurrentFiltersState>,
   options?: { history?: DataCollectionUrlHistoryMode }
 ): string | null => {
   if (typeof window === "undefined") return null
 
-  const params = setDataCollectionUrlParams(window.location.search, id, state)
+  const params = setDataCollectionUrlParams(window.location.search, state)
   const query = params.toString()
   const url = query
     ? `${window.location.pathname}?${query}`

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -192,10 +192,12 @@ export type OneDataCollectionProps<
       }
 
   /**
-   * By default, when an `id` is set, the data collection reads its
-   * filters/search/sortings from the URL query params on mount and reflects any
-   * later changes back into them (see `dataCollectionUrlParams`). Set this to
-   * `true` to opt out of that URL syncing.
+   * By default the data collection reads its filters/search/sortings/
+   * visualization/page from the URL query params on mount and reflects any later
+   * changes back into them (see `dataCollectionUrlParams`). This applies to any
+   * collection — no `id` is required, and params are not scoped to one, so a
+   * single URL-synced collection per page is assumed. Set this to `true` to opt
+   * out of URL syncing.
    */
   disableUrlParams?: boolean
   /**
@@ -831,9 +833,9 @@ const OneDataCollectionComp = <
   )
 
   // Two-way sync between the collection state and the URL query params. Enabled
-  // by default whenever an `id` is set; opt out with `disableUrlParams`.
+  // by default for any collection (no `id` required); opt out with
+  // `disableUrlParams`.
   useDataCollectionUrlSync({
-    id,
     disabled: !!disableUrlParams,
     storageReady,
     filtersDefinition: filters as FiltersDefinition | undefined,

--- a/packages/react/src/patterns/OneDataCollection/__stories__/url-params.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/url-params.stories.tsx
@@ -23,27 +23,29 @@ const STORAGE_ID = "examples/url-params/v1"
 /**
  * Filters, sorting and pagination for one collection, all reflected in the URL
  * together — each filter in its own readable `dc_<key>` param (`dc_department`,
- * `dc_assignee`, …), plus `dc_sort` and `dc_page`.
+ * `dc_assignee`, …), plus `dc_sort` and `dc_page`. There is no `dc_id`: a single
+ * URL-synced collection per page is assumed.
  *
  * Filter, sort and page through: the URL updates with all of them at once, and
- * reloading (or opening a shared URL) restores the same filters, sorting and
- * page. Because pagination lives inside the data hook, page + the rest are read
- * from the URL synchronously (seeding the first fetch — no race) and written
- * back by a single writer, which is what lets them coexist without clobbering.
- * Try `Assignee` → "Select all": over {@link MAX_URL_FILTER_VALUES} values it is
- * dropped from the URL (still applied). Storage is off here, so this also shows
- * URL syncing needs no storage.
+ * reloading (or opening a shared URL) restores the same state. Because
+ * pagination lives inside the data hook, everything is read from the URL
+ * synchronously (seeding the first fetch — no race) and written back by a single
+ * writer, which is what lets them coexist without clobbering. Try `Assignee` →
+ * "Select all": over {@link MAX_URL_FILTER_VALUES} values it is dropped from the
+ * URL (still applied). Storage is off here, so this also shows URL syncing needs
+ * no storage.
  */
 const UrlParamsExample = () => {
-  // Read filters + sorting + page synchronously from the URL so the data hook's
-  // first fetch already has all of them.
-  const initial = useMemo(() => {
-    const parsed = parseDataCollectionUrlParams(
-      window.location.search,
-      paginationFilters as unknown as FiltersDefinition
-    )
-    return parsed?.id === STORAGE_ID ? parsed.state : {}
-  }, [])
+  // Read everything synchronously from the URL so the first fetch/render already
+  // has filters + sorting + page.
+  const initial = useMemo(
+    () =>
+      parseDataCollectionUrlParams(
+        window.location.search,
+        paginationFilters as unknown as FiltersDefinition
+      ),
+    []
+  )
 
   const [filters, setFilters] = useState(
     (initial.filters ?? {}) as FiltersState<PaginationFiltersType>
@@ -54,7 +56,7 @@ const UrlParamsExample = () => {
 
   // A single writer for every param, so none clobbers the others.
   useEffect(() => {
-    const params = buildDataCollectionUrlParams(STORAGE_ID, {
+    const params = buildDataCollectionUrlParams({
       filters: filters as FiltersState<FiltersDefinition>,
       sortings,
       page,

--- a/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncChipClear.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncChipClear.test.tsx
@@ -109,11 +109,7 @@ describe("OneDataCollection URL sync — clearing a filter chip", () => {
   })
 
   it("removes the param when clearing a chip for a filter loaded from the URL", async () => {
-    window.history.replaceState(
-      null,
-      "",
-      "/people?dc_id=people/v1&dc_department=Engineering"
-    )
+    window.history.replaceState(null, "", "/people?dc_department=Engineering")
 
     render(<ExampleComponent id="people/v1" />)
 

--- a/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncNoStorage.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncNoStorage.test.tsx
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest"
-import { waitFor, zeroRender as render } from "@/testing/test-utils"
+
+import { screen, waitFor, zeroRender as render } from "@/testing/test-utils"
+
 import { ExampleComponent } from "../__stories__/mockData"
 
 afterEach(() => {
@@ -31,5 +33,31 @@ describe("URL sync without storage", () => {
     await waitFor(() =>
       expect(window.location.search).toContain("dc_department=Design")
     )
+  })
+})
+
+describe("URL sync without an id", () => {
+  it("reflects filters in the URL even when the collection has no id", async () => {
+    // No `id` prop — URL syncing is on by default regardless.
+    render(
+      <ExampleComponent currentFilters={{ department: ["Engineering"] }} />
+    )
+
+    await waitFor(() =>
+      expect(window.location.search).toContain("dc_department=Engineering")
+    )
+  })
+
+  it("applies URL params on mount when the collection has no id", async () => {
+    window.history.replaceState(null, "", "/people?dc_department=Design")
+
+    render(<ExampleComponent />)
+
+    // A filter chip rendered → the URL filter was applied to a collection
+    // without an id, and the param survives (re-affirmed by the write).
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument()
+    )
+    expect(window.location.search).toContain("dc_department=Design")
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncVisualization.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/urlSyncVisualization.test.tsx
@@ -12,11 +12,7 @@ afterEach(() => {
 describe("OneDataCollection URL sync — visualization", () => {
   it("keeps the visualization param (by type) from the URL on mount (wiring smoke)", async () => {
     // ExampleComponent renders [table, card, list, …], so dc_view=card → index 1.
-    window.history.replaceState(
-      null,
-      "",
-      "/people?dc_id=people/v1&dc_view=card"
-    )
+    window.history.replaceState(null, "", "/people?dc_view=card")
 
     render(<ExampleComponent id="people/v1" />)
 

--- a/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useDataCollectionUrlSync.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useDataCollectionUrlSync.test.tsx
@@ -6,8 +6,6 @@ import { zeroRenderHook as renderHook } from "@/testing/test-utils"
 
 import { useDataCollectionUrlSync } from "../useDataCollectionUrlSync"
 
-const ID = "team/people/v1"
-
 const FILTERS = {
   department: { type: "in", label: "Department", options: { options: [] } },
 } as unknown as FiltersDefinition
@@ -21,7 +19,6 @@ const setup = (overrides: Partial<Props> = {}) => {
   const setVisualization = vi.fn()
 
   let props: Props = {
-    id: ID,
     disabled: false,
     storageReady: true,
     filtersDefinition: FILTERS,
@@ -65,11 +62,11 @@ afterEach(() => {
 })
 
 describe("useDataCollectionUrlSync — URL → collection", () => {
-  it("applies matching, per-filter URL params on mount", () => {
+  it("applies per-filter URL params on mount", () => {
     window.history.replaceState(
       null,
       "",
-      `/?dc_id=${ID}&dc_department=Engineering&dc_department=Product&dc_sort=salary:desc`
+      `/?dc_department=Engineering&dc_department=Product&dc_sort=salary-desc`
     )
 
     const { setFilters, setSortings, setSearch } = setup()
@@ -82,19 +79,13 @@ describe("useDataCollectionUrlSync — URL → collection", () => {
   })
 
   it("waits for storage hydration before applying", () => {
-    window.history.replaceState(null, "", `/?dc_id=${ID}&dc_search=ada`)
+    window.history.replaceState(null, "", `/?dc_search=ada`)
 
     const { setSearch, rerender } = setup({ storageReady: false })
     expect(setSearch).not.toHaveBeenCalled()
 
     rerender({ storageReady: true })
     expect(setSearch).toHaveBeenCalledWith("ada")
-  })
-
-  it("ignores params addressed to a different collection id", () => {
-    window.history.replaceState(null, "", `/?dc_id=other/v1&dc_search=ada`)
-    const { setSearch } = setup()
-    expect(setSearch).not.toHaveBeenCalled()
   })
 })
 
@@ -106,7 +97,7 @@ describe("useDataCollectionUrlSync — collection → URL", () => {
     rerender({ filters: { department: ["Design", "Sales"] } })
 
     expect(window.location.pathname).toBe("/people")
-    expect(currentParams().get("dc_id")).toBe(ID)
+    expect(currentParams().has("dc_id")).toBe(false)
     expect(currentParams().getAll("dc_department")).toEqual(["Design", "Sales"])
   })
 
@@ -124,7 +115,7 @@ describe("useDataCollectionUrlSync — collection → URL", () => {
 
 describe("useDataCollectionUrlSync — visualization", () => {
   it("maps a view key from the URL back to its index", () => {
-    window.history.replaceState(null, "", `/?dc_id=${ID}&dc_view=list`)
+    window.history.replaceState(null, "", `/?dc_view=list`)
 
     const { setVisualization } = setup({
       visualizationKeys: ["table", "card", "list"],
@@ -133,7 +124,7 @@ describe("useDataCollectionUrlSync — visualization", () => {
   })
 
   it("ignores an unknown view key", () => {
-    window.history.replaceState(null, "", `/?dc_id=${ID}&dc_view=gallery`)
+    window.history.replaceState(null, "", `/?dc_view=gallery`)
 
     const { setVisualization } = setup({
       visualizationKeys: ["table", "card", "list"],
@@ -142,7 +133,7 @@ describe("useDataCollectionUrlSync — visualization", () => {
   })
 
   it("does not sync visualization when there is only one", () => {
-    window.history.replaceState(null, "", `/?dc_id=${ID}&dc_view=card`)
+    window.history.replaceState(null, "", `/?dc_view=card`)
 
     const { setVisualization, rerender } = setup({
       visualizationKeys: ["table"],
@@ -166,9 +157,9 @@ describe("useDataCollectionUrlSync — visualization", () => {
   })
 })
 
-describe("useDataCollectionUrlSync — disabled / no id", () => {
+describe("useDataCollectionUrlSync — enabled regardless of id", () => {
   it("neither reads nor writes when disabled", () => {
-    window.history.replaceState(null, "", `/?dc_id=${ID}&dc_search=ada`)
+    window.history.replaceState(null, "", `/?dc_search=ada`)
 
     const { setSearch, rerender } = setup({ disabled: true })
     expect(setSearch).not.toHaveBeenCalled()
@@ -177,13 +168,14 @@ describe("useDataCollectionUrlSync — disabled / no id", () => {
     expect(currentParams().get("dc_search")).toBe("ada")
   })
 
-  it("does nothing without an id", () => {
-    window.history.replaceState(null, "", "/people")
+  it("syncs both ways with no id involved (the hook takes no id)", () => {
+    // URL → collection
+    window.history.replaceState(null, "", `/?dc_search=ada`)
+    const { setSearch, rerender } = setup()
+    expect(setSearch).toHaveBeenCalledWith("ada")
 
-    const { setSearch, rerender } = setup({ id: undefined })
-    rerender({ search: "ada" })
-
-    expect(setSearch).not.toHaveBeenCalled()
-    expect(window.location.search).toBe("")
+    // collection → URL
+    rerender({ search: "bob" })
+    expect(currentParams().get("dc_search")).toBe("bob")
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionUrlSync.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionUrlSync.ts
@@ -13,9 +13,12 @@ import {
 } from "@/lib/providers/datacollection/dataCollectionUrlParams"
 
 type UseDataCollectionUrlSyncOptions = {
-  /** The OneDataCollection `id`; required to address its `?dc_id=<id>` params. */
-  id: string | undefined
-  /** When true, no reading from or writing to the URL happens. */
+  /**
+   * When true, no reading from or writing to the URL happens. URL syncing is on
+   * by default for *any* collection (an `id` is not required) — params are not
+   * scoped to a collection, so a single URL-synced collection per page is
+   * assumed.
+   */
   disabled: boolean
   /** Storage hydration gate — we apply the URL only after it resolves. */
   storageReady: boolean
@@ -44,8 +47,8 @@ type UseDataCollectionUrlSyncOptions = {
  * sync with the URL query params (see `dataCollectionUrlParams`):
  *
  * - **URL → collection:** once, after storage has hydrated (so the URL takes
- *   precedence over persisted state), any `dc`-addressed params matching this
- *   collection's `id` are applied to the current state.
+ *   precedence over persisted state), the `dc_`-prefixed params are applied to
+ *   the current state.
  * - **collection → URL:** thereafter, every change to filters/search/sortings is
  *   reflected back into the URL via `history.replaceState`.
  *
@@ -55,7 +58,6 @@ type UseDataCollectionUrlSyncOptions = {
  * state, so the first write re-affirms the URL rather than wiping it).
  */
 export const useDataCollectionUrlSync = ({
-  id,
   disabled,
   storageReady,
   filtersDefinition,
@@ -69,7 +71,7 @@ export const useDataCollectionUrlSync = ({
   setSortings,
   setVisualization,
 }: UseDataCollectionUrlSyncOptions): void => {
-  const active = !disabled && !!id
+  const active = !disabled
   // Only sync the visualization when there is a real choice to reflect.
   const syncVisualization = visualizationKeys.length > 1
   const [urlApplied, setUrlApplied] = useState(false)
@@ -78,35 +80,32 @@ export const useDataCollectionUrlSync = ({
   useEffect(() => {
     if (!active || !storageReady || urlApplied) return
 
-    const parsed = parseDataCollectionUrlParams(
+    const state = parseDataCollectionUrlParams(
       typeof window !== "undefined" ? window.location.search : "",
       filtersDefinition
     )
-    if (parsed && parsed.id === id) {
-      const { state } = parsed
-      // Only the params present in the URL override the current state.
-      if ("filters" in state) {
-        setFilters((state.filters ?? {}) as FiltersState<FiltersDefinition>)
-      }
-      if ("search" in state) setSearch(state.search)
-      if ("sortings" in state) setSortings(state.sortings ?? null)
-      // Map the readable view key back to its index; ignore unknown keys.
-      if (syncVisualization && state.visualization !== undefined) {
-        const index = visualizationKeys.indexOf(state.visualization)
-        if (index >= 0) setVisualization(index)
-      }
+    // Only the params present in the URL override the current state.
+    if ("filters" in state) {
+      setFilters((state.filters ?? {}) as FiltersState<FiltersDefinition>)
+    }
+    if ("search" in state) setSearch(state.search)
+    if ("sortings" in state) setSortings(state.sortings ?? null)
+    // Map the readable view key back to its index; ignore unknown keys.
+    if (syncVisualization && state.visualization !== undefined) {
+      const index = visualizationKeys.indexOf(state.visualization)
+      if (index >= 0) setVisualization(index)
     }
 
     // Enable writing in the same render as the applied state, so the first
     // write reflects the URL we just read rather than the prior snapshot.
     setUrlApplied(true)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- apply once when ready
-  }, [active, storageReady, id])
+  }, [active, storageReady])
 
   // collection → URL.
   useDeepCompareEffect(() => {
-    if (!active || !urlApplied || !id) return
-    syncDataCollectionUrlParams(id, {
+    if (!active || !urlApplied) return
+    syncDataCollectionUrlParams({
       filters,
       search,
       sortings,
@@ -119,7 +118,6 @@ export const useDataCollectionUrlSync = ({
   }, [
     active,
     urlApplied,
-    id,
     filters,
     search,
     sortings,


### PR DESCRIPTION
## Description

Follow-up refinements to the OneDataCollection URL syncing shipped in #4303, based on review feedback:

- **Drop `dc_id` from the URL.** The collection identifier was only used to scope params to a specific collection; since the product is single-collection-per-page, it added noise without value. URLs are now just the state, e.g. `?dc_department=Engineering&dc_sort=salary-desc&dc_page=3`.
- **URL syncing applies to any collection** — an `id` is no longer required to enable it. It's on by default and still opt-out via `disableUrlParams`. (`id` remains the storage key.)
- **Cleaner sort encoding.** `dc_sort` now uses a hyphen (`dc_sort=email-asc`) instead of a colon, so the URL stays free of percent-encoding (`:` → `%3A`).

## Implementation details

`dataCollectionUrlParams.ts`:
- Removed `id` from `DATA_COLLECTION_URL_PARAMS`; `parseDataCollectionUrlParams` now returns the `DataCollectionUrlState` directly (no `{ id, state }`, never `null`), and `build`/`set`/`sync`/`writeStateToParams` no longer take an `id`. Removed the now-unused `DataCollectionUrlParams` type. `deleteDataCollectionParams` still clears any `dc_`-prefixed key, so cleanup is unchanged.
- Sortings encode as `field-order` via a `SORTINGS_SEPARATOR = "-"`. Decoding splits on the **last** hyphen and only treats the suffix as the order when it's exactly `asc`/`desc`, so field names containing hyphens or dots (e.g. `first-name`, `permissions.read`) round-trip correctly.

`useDataCollectionUrlSync.ts` / `OneDatacollection.tsx`:
- Dropped the `id` gate (`active = !disabled`) and the `parsed.id === id` scoping check; the hook no longer takes an `id`. Updated the `disableUrlParams` prop doc.

**Notes / limitations**
- Without `dc_id`, params are no longer scoped to a collection — two URL-synced collections on the same page would share `dc_` params. This matches the intended single-collection-per-page usage; use `disableUrlParams` on secondary collections.
