### PR TITLE
ci(react): warn on breaking public API changes vs main

### DIFF
--- a/.github/workflows/api-surface.yaml
+++ b/.github/workflows/api-surface.yaml
@@ -72,6 +72,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -144,3 +145,28 @@ jobs:
           comment-type: api_breaking
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-body: ${{ steps.compare.outputs.body }}
+      - name: Toggle "breaking changes" label
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          HAS_BREAKING: ${{ steps.compare.outputs.has_breaking }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const label = "breaking changes";
+            const breaking = process.env.HAS_BREAKING === "true";
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            if (breaking) {
+              // addLabels creates the label automatically if it doesn't exist yet.
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+              core.info(`Added "${label}" label`);
+            } else {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label });
+                core.info(`Removed "${label}" label`);
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                core.info(`Label "${label}" not present; nothing to remove`);
+              }
+            }

--- a/.github/workflows/api-surface.yaml
+++ b/.github/workflows/api-surface.yaml
@@ -1,0 +1,146 @@
+name: Public API Surface
+on:
+  pull_request:
+    branches: [main]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  # Detect which packages changed (reused across quality workflows)
+  detect-changes:
+    uses: ./.github/workflows/_check-workspaces-changes.yaml
+
+  # Build the rolled-up type declarations on both the PR head and the base
+  # branch (main) in parallel. Each leg only needs the existing `build` script,
+  # so the base build works even though this workflow does not exist on main.
+  build-dts:
+    needs: detect-changes
+    # React source or core (whose types ripple into the React surface) changed.
+    if: |
+      (needs.detect-changes.outputs.package_react == 'true' ||
+       needs.detect-changes.outputs.package_core == 'true') &&
+      github.head_ref != 'release-please--branches--master' &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease')
+    name: "[⚛️ REACT] Build types (${{ matrix.side }})"
+    runs-on: ubuntu-22.04
+    # One side failing must not wedge the run; the diff job handles a missing
+    # artifact gracefully.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        side: [head, base]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # base: tip of the target branch (the "old version").
+          # head: the PR branch as-is, so we compare the PR's API against main.
+          ref: ${{ matrix.side == 'base' && github.event.pull_request.base.sha || github.event.pull_request.head.sha }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: "22.x"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build core package
+        run: pnpm --filter @factorialco/f0-core build
+      - name: Build React types
+        run: pnpm --filter @factorialco/f0-react build
+      - name: Upload type declarations
+        uses: actions/upload-artifact@v4
+        with:
+          name: dts-${{ matrix.side }}
+          path: |
+            packages/react/dist/f0.d.ts
+            packages/react/dist/experimental.d.ts
+            packages/react/dist/ai.d.ts
+            packages/react/dist/global.d.ts
+          if-no-files-found: error
+          retention-days: 1
+
+  api-diff:
+    needs: [detect-changes, build-dts]
+    if: |
+      (needs.detect-changes.outputs.package_react == 'true' ||
+       needs.detect-changes.outputs.package_core == 'true') &&
+      github.head_ref != 'release-please--branches--master' &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease')
+    name: "[⚛️ REACT] Public API surface check"
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: "22.x"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Download head type declarations
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: dts-head
+          path: _api/head
+      - name: Download base type declarations
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: dts-base
+          path: _api/base
+      - name: Compare public API surface
+        id: compare
+        run: |
+          cd packages/react
+
+          pnpm exec tsx .scripts/check-api-surface.ts \
+            --base "$GITHUB_WORKSPACE/_api/base" \
+            --head "$GITHUB_WORKSPACE/_api/head" \
+            --json > /tmp/api-output.txt 2>&1 || true
+
+          # Extract the last complete JSON object (the script prints pretty JSON;
+          # same extraction pattern as the cycle-dependencies check).
+          LAST_JSON_LINE=$(grep -n '^{' /tmp/api-output.txt | tail -n 1 | cut -d: -f1)
+          if [ -z "$LAST_JSON_LINE" ]; then
+            echo "ERROR: No JSON output found from API surface check"
+            cat /tmp/api-output.txt
+            exit 1
+          fi
+          sed -n "${LAST_JSON_LINE},\$p" /tmp/api-output.txt > /tmp/api-data-raw.json
+
+          if ! jq . /tmp/api-data-raw.json > /tmp/api-data.json 2>/tmp/jq-error.txt; then
+            echo "ERROR: Failed to parse JSON from API surface check"
+            cat /tmp/api-data-raw.json
+            cat /tmp/jq-error.txt
+            cat /tmp/api-output.txt
+            exit 1
+          fi
+
+          HAS_BREAKING=$(jq -r '.hasBreaking // false' /tmp/api-data.json)
+          BREAKING_TOTAL=$(jq -r '.breakingTotal // 0' /tmp/api-data.json)
+          echo "has_breaking=$HAS_BREAKING" >> "$GITHUB_OUTPUT"
+          echo "breaking_total=$BREAKING_TOTAL" >> "$GITHUB_OUTPUT"
+
+          # The script renders the ready-to-post comment body.
+          jq -r '.commentMarkdown // ""' /tmp/api-data.json > /tmp/api-comment.md
+          {
+            echo "body<<API_COMMENT_EOF"
+            cat /tmp/api-comment.md
+            echo "API_COMMENT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$HAS_BREAKING" = "true" ]; then
+            echo "::warning::$BREAKING_TOTAL breaking public API change(s) detected vs main — see the PR comment."
+          fi
+      - name: Comment on PR with API surface status
+        uses: ./.github/actions/add-or-update-pr-comment
+        with:
+          comment-type: api_breaking
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-body: ${{ steps.compare.outputs.body }}

--- a/packages/react/.scripts/__tests__/check-api-surface.test.ts
+++ b/packages/react/.scripts/__tests__/check-api-surface.test.ts
@@ -2,9 +2,13 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { analyze, type EntryDiff } from "../check-api-surface"
+
+// Each test spins up TypeScript programs (the first parses the multi-megabyte
+// default lib), which is slower than a typical unit test on CI runners.
+vi.setConfig({ testTimeout: 30000 })
 
 /**
  * Each test writes a minimal `f0.d.ts` for the "base" and "head" sides into

--- a/packages/react/.scripts/__tests__/check-api-surface.test.ts
+++ b/packages/react/.scripts/__tests__/check-api-surface.test.ts
@@ -1,0 +1,229 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import { analyze, type EntryDiff } from "../check-api-surface"
+
+/**
+ * Each test writes a minimal `f0.d.ts` for the "base" and "head" sides into
+ * separate temp dirs and runs the real analyzer end-to-end (TypeScript program
+ * + structural classification). The `experimental`/`ai` entries have no files
+ * and are reported as skipped, so we assert only on the `f0` entry.
+ */
+const createdDirs: string[] = []
+
+function dirWith(f0Dts: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "api-surface-test-"))
+  writeFileSync(path.join(dir, "f0.d.ts"), f0Dts)
+  createdDirs.push(dir)
+  return dir
+}
+
+function f0(base: string, head: string): EntryDiff {
+  const result = analyze(dirWith(base), dirWith(head))
+  return result.entries.find((e) => e.entry === "f0")!
+}
+
+function names(diff: EntryDiff): string[] {
+  return diff.breaking.map((b) => b.name).sort()
+}
+
+afterEach(() => {
+  for (const dir of createdDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// A representative base surface: an exported props type, a component that
+// consumes it, and a plain function.
+const BASE = `
+export declare type WidgetProps = { id: string; size?: "s" | "m"; onClose?: () => void };
+export declare const Widget: (props: WidgetProps) => unknown;
+export declare const compute: (x: number, y: string) => boolean;
+`
+
+describe("check-api-surface — catches breaking changes", () => {
+  it("flags a removed export", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id: string; size?: "s" | "m"; onClose?: () => void };
+      export declare const Widget: (props: WidgetProps) => unknown;
+      `
+    )
+    expect(diff.breaking).toContainEqual(
+      expect.objectContaining({ name: "compute", kind: "removed" })
+    )
+  })
+
+  it("flags a renamed export (removed old + added new)", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id: string; size?: "s" | "m"; onClose?: () => void };
+      export declare const WidgetRenamed: (props: WidgetProps) => unknown;
+      export declare const compute: (x: number, y: string) => boolean;
+      `
+    )
+    expect(diff.breaking).toContainEqual(
+      expect.objectContaining({ name: "Widget", kind: "removed" })
+    )
+    expect(diff.added).toContain("WidgetRenamed")
+  })
+
+  it("flags a removed property on an existing type", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id: string; size?: "s" | "m" };
+      export declare const Widget: (props: WidgetProps) => unknown;
+      export declare const compute: (x: number, y: string) => boolean;
+      `
+    )
+    expect(names(diff)).toContain("WidgetProps")
+    const changed = diff.breaking.find((b) => b.name === "WidgetProps")
+    expect(changed?.kind).toBe("changed")
+    expect(changed?.reasons?.some((r) => r.includes("onClose"))).toBe(true)
+  })
+
+  it("flags a retyped property", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id: number; size?: "s" | "m"; onClose?: () => void };
+      export declare const Widget: (props: WidgetProps) => unknown;
+      export declare const compute: (x: number, y: string) => boolean;
+      `
+    )
+    const changed = diff.breaking.find((b) => b.name === "WidgetProps")
+    expect(changed?.kind).toBe("changed")
+    expect(changed?.reasons?.some((r) => r.includes("id"))).toBe(true)
+  })
+
+  it("flags a newly-added required property", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id: string; title: string; size?: "s" | "m"; onClose?: () => void };
+      export declare const Widget: (props: WidgetProps) => unknown;
+      export declare const compute: (x: number, y: string) => boolean;
+      `
+    )
+    const changed = diff.breaking.find((b) => b.name === "WidgetProps")
+    expect(changed?.reasons?.some((r) => /required.*title/i.test(r))).toBe(true)
+  })
+
+  it("flags an optional property becoming required", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id: string; size: "s" | "m"; onClose?: () => void };
+      export declare const Widget: (props: WidgetProps) => unknown;
+      export declare const compute: (x: number, y: string) => boolean;
+      `
+    )
+    const changed = diff.breaking.find((b) => b.name === "WidgetProps")
+    expect(
+      changed?.reasons?.some((r) => /size.*became required/i.test(r))
+    ).toBe(true)
+  })
+
+  it("flags a changed function parameter type", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id: string; size?: "s" | "m"; onClose?: () => void };
+      export declare const Widget: (props: WidgetProps) => unknown;
+      export declare const compute: (x: string, y: string) => boolean;
+      `
+    )
+    expect(diff.breaking.find((b) => b.name === "compute")?.kind).toBe(
+      "changed"
+    )
+  })
+
+  it("flags a removed function parameter", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id: string; size?: "s" | "m"; onClose?: () => void };
+      export declare const Widget: (props: WidgetProps) => unknown;
+      export declare const compute: (x: number) => boolean;
+      `
+    )
+    expect(diff.breaking.find((b) => b.name === "compute")?.kind).toBe(
+      "changed"
+    )
+  })
+})
+
+describe("check-api-surface — does NOT flag non-breaking changes", () => {
+  it("treats an identical surface as no change", () => {
+    const diff = f0(BASE, BASE)
+    expect(diff.breaking).toHaveLength(0)
+    expect(diff.added).toHaveLength(0)
+  })
+
+  it("treats a brand-new export as additive (safe)", () => {
+    const diff = f0(
+      BASE,
+      `${BASE}
+      export declare const helper: (n: number) => number;
+      export declare type HelperOptions = { verbose?: boolean };
+      `
+    )
+    expect(diff.breaking).toHaveLength(0)
+    expect(diff.added).toEqual(
+      expect.arrayContaining(["HelperOptions", "helper"])
+    )
+  })
+
+  it("treats a new OPTIONAL property as safe", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id: string; size?: "s" | "m"; onClose?: () => void; tone?: string };
+      export declare const Widget: (props: WidgetProps) => unknown;
+      export declare const compute: (x: number, y: string) => boolean;
+      `
+    )
+    expect(diff.breaking).toHaveLength(0)
+  })
+
+  it("treats a required property becoming optional (widening) as safe", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id?: string; size?: "s" | "m"; onClose?: () => void };
+      export declare const Widget: (props: WidgetProps) => unknown;
+      export declare const compute: (x: number, y: string) => boolean;
+      `
+    )
+    expect(diff.breaking).toHaveLength(0)
+  })
+
+  it("treats a new OPTIONAL function parameter as safe", () => {
+    const diff = f0(
+      BASE,
+      `
+      export declare type WidgetProps = { id: string; size?: "s" | "m"; onClose?: () => void };
+      export declare const Widget: (props: WidgetProps) => unknown;
+      export declare const compute: (x: number, y: string, z?: boolean) => boolean;
+      `
+    )
+    expect(diff.breaking).toHaveLength(0)
+  })
+})
+
+describe("check-api-surface — determinism", () => {
+  it("reports no changes for identical surfaces in different directories", () => {
+    // Same content, different temp dirs (different absolute paths): the
+    // path/normalization must make this a no-op.
+    const result = analyze(dirWith(BASE), dirWith(BASE))
+    expect(result.hasBreaking).toBe(false)
+    expect(result.breakingTotal).toBe(0)
+    expect(result.addedTotal).toBe(0)
+  })
+})

--- a/packages/react/.scripts/check-api-surface.ts
+++ b/packages/react/.scripts/check-api-surface.ts
@@ -4,21 +4,36 @@
  * Snapshots the public TypeScript API of each shipped entry point
  * (`f0`, `experimental`, `ai`) from a set of rolled-up `.d.ts` files, then
  * compares two snapshots (a `--base` directory vs a `--head` directory) and
- * classifies every difference as either:
+ * classifies every difference.
  *
- *   - BREAKING: an export present in base is gone in head (removed / renamed),
- *     or an export present in both has a different resolved type
- *     (changed signature, prop, or type).
- *   - ADDITIVE (safe): an export present in head but not in base.
+ * Classification is **structural and member-level**, so backward-compatible
+ * changes are not flagged:
+ *
+ *   BREAKING
+ *     - an export present in base is gone in head (removed / renamed)
+ *     - a property/parameter was removed or had its type changed
+ *     - a new REQUIRED property/parameter was added
+ *     - an optional property became required
+ *     - the kind or type parameters of an export changed
+ *   SAFE (not flagged)
+ *     - a brand-new export (new component/type)
+ *     - a new OPTIONAL property/parameter
+ *     - a required property became optional (widening)
  *
  * A rename surfaces, correctly, as a BREAKING removal of the old name plus a
  * safe addition of the new name.
  *
  * Both sides are analyzed by the *same* TypeScript in a single process, so the
- * comparison is deterministic and immune to compiler-version drift. The type
- * fingerprint is built by resolving structural types through the checker, which
- * normalizes away api-extractor's rollup noise (the `F0TextInputProps_2`
- * suffixes / dangling `./types` imports) instead of diffing raw `.d.ts` text.
+ * comparison is deterministic and immune to compiler-version drift. Structural
+ * types are resolved through the checker, which normalizes away api-extractor's
+ * rollup noise (the `F0TextInputProps_2` suffixes / dangling `./types` imports)
+ * instead of diffing raw `.d.ts` text.
+ *
+ * Known simplification: leaf types (unions, primitives, external types) are
+ * compared by their normalized string, so a *widening* of a leaf type (e.g. a
+ * prop `string` → `string | number`, which is safe for an input) is reported as
+ * breaking. Object/parameter shape changes — the common case — are classified
+ * precisely.
  *
  * Usage:
  *   tsx .scripts/check-api-surface.ts --base <dir> --head <dir> [--json]
@@ -37,48 +52,72 @@ import consola from "consola"
 import ts from "typescript"
 
 /** Public entry points shipped in `dist/`. */
-const ENTRIES = ["f0", "experimental", "ai"] as const
-type Entry = (typeof ENTRIES)[number]
+export const ENTRIES = ["f0", "experimental", "ai"] as const
+export type Entry = (typeof ENTRIES)[number]
 
-/** How deep to expand F0-owned object/signature types before falling back to
- * a by-name reference. Keeps the fingerprint bounded while still catching
- * prop/signature changes one or two levels in. */
-const MAX_DEPTH = 2
+/** How deep to expand object/signature types before treating them as opaque
+ * leaves. Bounds the work while still reaching component props
+ * (export → call signature → props object → member). */
+const MAX_DEPTH = 4
 
-interface ApiSnapshot {
-  /** export name -> normalized type fingerprint */
-  items: Map<string, string>
+/**
+ * A normalized, structural representation of a type used for comparison.
+ *  - `object`: an object/props type, compared member by member.
+ *  - `callable`: a function/component, compared signature by signature.
+ *  - `opaque`: anything else (union, primitive, external type), compared by
+ *    its normalized string.
+ */
+export type ApiItem =
+  | {
+      k: "object"
+      members: Record<
+        string,
+        { optional: boolean; readonly: boolean; type: ApiItem }
+      >
+      index?: string
+    }
+  | {
+      k: "callable"
+      sigs: Array<{
+        params: Array<{ name: string; optional: boolean; type: ApiItem }>
+        ret: ApiItem
+      }>
+    }
+  | { k: "opaque"; text: string }
+
+interface ExportSnapshot {
+  kind: string
+  typeParams: string
+  /** human-readable type, for the PR comment */
+  display: string
+  /** structural representation, for classification */
+  item: ApiItem
 }
 
-interface EntryDiff {
+type EntrySnapshot = Map<string, ExportSnapshot>
+
+export interface EntryDiff {
   entry: Entry
-  /** present in base but missing/changed in head */
   breaking: Array<{
     name: string
     kind: "removed" | "changed"
+    reasons?: string[]
     before: string
     after?: string
   }>
-  /** present in head but not in base */
   added: string[]
-  /** true when the entry could not be analyzed on one side */
   skipped?: "no-base" | "no-head"
 }
 
-function parseArgs(): { base?: string; head?: string; json: boolean } {
-  const args = process.argv.slice(2)
-  const valueOf = (flag: string): string | undefined => {
-    const i = args.indexOf(flag)
-    return i !== -1 && args[i + 1] ? args[i + 1] : undefined
-  }
-  return {
-    base: valueOf("--base"),
-    head: valueOf("--head"),
-    json: args.includes("--json"),
-  }
+export interface AnalysisResult {
+  hasBreaking: boolean
+  breakingTotal: number
+  addedTotal: number
+  entries: EntryDiff[]
 }
 
-/** Resolve `<dir>/<entry>.d.ts` if it exists. */
+/* ----------------------------- snapshotting ----------------------------- */
+
 function entryDtsPath(dir: string, entry: Entry): string | undefined {
   const p = path.resolve(dir, `${entry}.d.ts`)
   return existsSync(p) ? p : undefined
@@ -86,11 +125,12 @@ function entryDtsPath(dir: string, entry: Entry): string | undefined {
 
 /**
  * Build a snapshot of the public exports of a single rolled `.d.ts` file.
- *
- * Returns `undefined` when the file does not exist (e.g. the base build did not
- * produce it), which the caller treats as "no baseline".
+ * Returns `undefined` when the file does not exist (treated as "no baseline").
  */
-function snapshotEntry(dir: string, entry: Entry): ApiSnapshot | undefined {
+export function snapshotEntry(
+  dir: string,
+  entry: Entry
+): EntrySnapshot | undefined {
   const dtsPath = entryDtsPath(dir, entry)
   if (!dtsPath) return undefined
 
@@ -113,66 +153,55 @@ function snapshotEntry(dir: string, entry: Entry): ApiSnapshot | undefined {
 
   const checker = program.getTypeChecker()
   const sourceFile = program.getSourceFile(dtsPath)
-  if (!sourceFile) return { items: new Map() }
+  if (!sourceFile) return new Map()
 
   const moduleSymbol = checker.getSymbolAtLocation(sourceFile)
-  if (!moduleSymbol) return { items: new Map() }
+  if (!moduleSymbol) return new Map()
 
-  const items = new Map<string, string>()
+  const snapshot: EntrySnapshot = new Map()
   for (const exp of checker.getExportsOfModule(moduleSymbol)) {
     const name = exp.getName()
     if (name === "default") continue
-    items.set(name, fingerprintSymbol(exp, checker, sourceFile, dirAbsolute))
+    snapshot.set(name, snapshotExport(exp, checker, sourceFile, dirAbsolute))
   }
-  return { items }
+  return snapshot
 }
 
-/** Whether a type is declared inside the analyzed dist directory (an F0-owned
- * type, worth expanding) versus an external type (React/DOM/lib, referenced by
- * name to keep the fingerprint stable and bounded). */
-function isOwned(sym: ts.Symbol | undefined, dirAbsolute: string): boolean {
-  const decls = sym?.getDeclarations()
-  if (!decls || decls.length === 0) return false
-  return decls.some((d) =>
-    d.getSourceFile().fileName.startsWith(dirAbsolute + path.sep)
-  )
-}
-
-function fingerprintSymbol(
+function snapshotExport(
   symbol: ts.Symbol,
   checker: ts.TypeChecker,
   location: ts.Node,
   dirAbsolute: string
-): string {
-  // Follow re-export aliases to the real declaration.
+): ExportSnapshot {
   let sym = symbol
   if (sym.flags & ts.SymbolFlags.Alias) {
     try {
       sym = checker.getAliasedSymbol(sym)
     } catch {
-      // keep original on failure
+      // keep original
     }
   }
 
   const kind = symbolKind(sym)
   const typeParams = typeParameterText(sym)
-
-  // Type-only symbols use the declared type; value symbols use the type of the
-  // value at the export location.
   const isTypeOnly =
     !!(sym.flags & ts.SymbolFlags.Type) && !(sym.flags & ts.SymbolFlags.Value)
 
-  let body: string
+  let item: ApiItem = { k: "opaque", text: "<unresolved>" }
+  let display = "<unresolved>"
   try {
     const type = isTypeOnly
       ? checker.getDeclaredTypeOfSymbol(sym)
       : checker.getTypeOfSymbolAtLocation(sym, location)
-    body = serializeType(type, checker, dirAbsolute, MAX_DEPTH, new Set())
+    item = buildApiItem(type, checker, dirAbsolute, MAX_DEPTH, new Set())
+    display = normalize(
+      checker.typeToString(type, undefined, TYPE_TO_STRING_FLAGS)
+    )
   } catch (err) {
-    body = `<unresolved: ${(err as Error).message}>`
+    display = `<unresolved: ${(err as Error).message}>`
   }
 
-  return normalizeFingerprint(`${kind} ${typeParams}${body}`)
+  return { kind, typeParams, display, item }
 }
 
 function symbolKind(sym: ts.Symbol): string {
@@ -200,103 +229,131 @@ function typeParameterText(sym: ts.Symbol): string {
     return ""
   }
   if (tps.length === 0) return ""
-  return `<${tps.map((t) => t.getText()).join(", ")}> `
+  return `<${tps.map((t) => t.getText()).join(", ")}>`
 }
 
 const TYPE_TO_STRING_FLAGS =
   ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.WriteArrayAsGenericType
 
 /**
- * Make a fingerprint comparable across the two analyzed directories:
+ * Normalize a type string so it is comparable across the two analyzed dirs:
  *  - strip `import("<abs path>").` qualifiers — the path is base-dir vs
  *    head-dir specific and would make every cross-referenced type look changed;
  *  - strip per-program unique-id suffixes on computed/internal names
  *    (e.g. `__@iterator@968`), which differ run-to-run.
  */
-function normalizeFingerprint(s: string): string {
+export function normalize(s: string): string {
   return s.replace(/import\("[^"]*"\)\./g, "").replace(/@\d+/g, "")
 }
 
-/**
- * Produce a normalized structural string for a type. F0-owned object/union and
- * signature types are expanded up to `depth` levels so prop/signature changes
- * are visible; external and too-deep types fall back to `typeToString` (a
- * by-name reference), which is stable.
- */
-function serializeType(
+/** A type declared only outside the analyzed dir (React/DOM/lib) — referenced
+ * by name rather than expanded, to keep snapshots stable and bounded.
+ * Anonymous types (no symbol) are treated as local and expanded. */
+function isExternal(type: ts.Type, dirAbsolute: string): boolean {
+  const sym = type.aliasSymbol ?? type.getSymbol()
+  const decls = sym?.getDeclarations()
+  if (!decls || decls.length === 0) return false
+  return decls.every((d) => {
+    const f = d.getSourceFile().fileName
+    return f.includes("node_modules") || !f.startsWith(dirAbsolute + path.sep)
+  })
+}
+
+function buildApiItem(
   type: ts.Type,
   checker: ts.TypeChecker,
   dirAbsolute: string,
   depth: number,
   visited: Set<ts.Type>
-): string {
-  const plain = () =>
-    checker.typeToString(type, undefined, TYPE_TO_STRING_FLAGS)
+): ApiItem {
+  const opaque = (): ApiItem => ({
+    k: "opaque",
+    text: normalize(
+      checker.typeToString(type, undefined, TYPE_TO_STRING_FLAGS)
+    ),
+  })
 
-  if (depth <= 0 || visited.has(type)) return plain()
-
-  // Unions / intersections: serialize each constituent (sorted for stability).
-  if (type.isUnion() || type.isIntersection()) {
-    const sep = type.isUnion() ? " | " : " & "
-    const parts = (type as ts.UnionOrIntersectionType).types
-      .map((t) => serializeType(t, checker, dirAbsolute, depth, visited))
-      .sort()
-    return parts.join(sep)
-  }
+  if (depth <= 0 || visited.has(type)) return opaque()
+  // Unions/intersections are compared as a whole (leaf), not member-expanded.
+  if (type.isUnion() || type.isIntersection()) return opaque()
 
   const callSigs = type.getCallSignatures()
   const ctorSigs = type.getConstructSignatures()
-  if (callSigs.length > 0 || ctorSigs.length > 0) {
+  const sigs = [...callSigs, ...ctorSigs]
+  if (sigs.length > 0) {
     const next = new Set(visited).add(type)
-    const sigStr = (s: ts.Signature, isCtor: boolean) =>
-      (isCtor ? "new " : "") +
-      `(${s
-        .getParameters()
-        .map((p) => {
-          const optional = !!(p.flags & ts.SymbolFlags.Optional)
-          const pt = checker.getTypeOfSymbolAtLocation(
-            p,
-            p.valueDeclaration ?? p.declarations![0]
-          )
-          return `${p.getName()}${optional ? "?" : ""}: ${serializeType(pt, checker, dirAbsolute, depth - 1, next)}`
-        })
-        .join(
-          ", "
-        )}) => ${serializeType(s.getReturnType(), checker, dirAbsolute, depth - 1, next)}`
-    return [
-      ...callSigs.map((s) => sigStr(s, false)),
-      ...ctorSigs.map((s) => sigStr(s, true)),
-    ].join(" & ")
+    return {
+      k: "callable",
+      sigs: sigs.map((s) => ({
+        params: s.getParameters().map((p) => {
+          const decl = p.valueDeclaration ?? p.declarations?.[0]
+          const pt = decl
+            ? checker.getTypeOfSymbolAtLocation(p, decl)
+            : checker.getDeclaredTypeOfSymbol(p)
+          // A parameter is optional via `?`, a default value, or rest `...`;
+          // parameter symbols do not carry SymbolFlags.Optional.
+          const pdecl = ts.isParameter(decl as ts.Node)
+            ? (decl as ts.ParameterDeclaration)
+            : undefined
+          const optional =
+            !!pdecl &&
+            (!!pdecl.questionToken ||
+              !!pdecl.initializer ||
+              !!pdecl.dotDotDotToken)
+          return {
+            name: p.getName(),
+            optional,
+            type: buildApiItem(pt, checker, dirAbsolute, depth - 1, next),
+          }
+        }),
+        ret: buildApiItem(
+          s.getReturnType(),
+          checker,
+          dirAbsolute,
+          depth - 1,
+          next
+        ),
+      })),
+    }
   }
 
-  // Only expand object types we own; external types (React/DOM) stay by-name.
-  const symbol = type.aliasSymbol ?? type.getSymbol()
+  // Only expand genuine object types (interfaces, type literals, anonymous
+  // object shapes). Primitives (string/number/…) have no Object flag, so they
+  // stay opaque instead of leaking their prototype methods (e.g. the
+  // program-specific `__@iterator@N`). Arrays/built-ins are Object types but
+  // are caught by `isExternal` (declared in lib/node_modules) and stay opaque.
+  const isObjectType = !!(type.flags & ts.TypeFlags.Object)
   const props = type.getProperties()
-  const isExpandableObject =
-    props.length > 0 || checker.getIndexInfosOfType(type).length > 0
-  if (isExpandableObject && isOwned(symbol, dirAbsolute)) {
+  const indexInfos = checker.getIndexInfosOfType(type)
+  const isObjectLike = props.length > 0 || indexInfos.length > 0
+  if (isObjectType && isObjectLike && !isExternal(type, dirAbsolute)) {
     const next = new Set(visited).add(type)
-    const members = props
-      .map((p) => {
-        const optional = !!(p.flags & ts.SymbolFlags.Optional)
-        const readonly = isReadonlySymbol(p)
-        const decl = p.valueDeclaration ?? p.declarations?.[0]
-        const pt = decl
-          ? checker.getTypeOfSymbolAtLocation(p, decl)
-          : checker.getDeclaredTypeOfSymbol(p)
-        return `${readonly ? "readonly " : ""}${p.getName()}${optional ? "?" : ""}: ${serializeType(pt, checker, dirAbsolute, depth - 1, next)}`
-      })
-      .sort()
-    const indexInfos = checker
-      .getIndexInfosOfType(type)
+    const members: Record<
+      string,
+      { optional: boolean; readonly: boolean; type: ApiItem }
+    > = {}
+    for (const p of props) {
+      const decl = p.valueDeclaration ?? p.declarations?.[0]
+      const pt = decl
+        ? checker.getTypeOfSymbolAtLocation(p, decl)
+        : checker.getDeclaredTypeOfSymbol(p)
+      members[normalize(p.getName())] = {
+        optional: !!(p.flags & ts.SymbolFlags.Optional),
+        readonly: isReadonlySymbol(p),
+        type: buildApiItem(pt, checker, dirAbsolute, depth - 1, next),
+      }
+    }
+    const index = indexInfos
       .map(
         (info) =>
-          `[index: ${checker.typeToString(info.keyType)}]: ${serializeType(info.type, checker, dirAbsolute, depth - 1, next)}`
+          `[${checker.typeToString(info.keyType)}]: ${normalize(checker.typeToString(info.type))}`
       )
-    return `{ ${[...members, ...indexInfos].join("; ")} }`
+      .sort()
+      .join("; ")
+    return { k: "object", members, index: index || undefined }
   }
 
-  return plain()
+  return opaque()
 }
 
 function isReadonlySymbol(sym: ts.Symbol): boolean {
@@ -309,47 +366,156 @@ function isReadonlySymbol(sym: ts.Symbol): boolean {
     )
 }
 
-/** Diff two snapshots for a single entry. */
-function diffEntry(
-  entry: Entry,
-  base: ApiSnapshot | undefined,
-  head: ApiSnapshot | undefined
-): EntryDiff {
-  const diff: EntryDiff = { entry, breaking: [], added: [] }
-  if (!base) {
-    diff.skipped = "no-base"
-    return diff
-  }
-  if (!head) {
-    diff.skipped = "no-head"
-    return diff
-  }
+/* ----------------------------- classification ---------------------------- */
 
-  for (const [name, beforeFp] of base.items) {
-    if (!head.items.has(name)) {
-      diff.breaking.push({ name, kind: "removed", before: beforeFp })
-    } else {
-      const afterFp = head.items.get(name)!
-      if (afterFp !== beforeFp) {
-        diff.breaking.push({
-          name,
-          kind: "changed",
-          before: beforeFp,
-          after: afterFp,
-        })
-      }
-    }
+/** Compare two exports; returns the list of breaking reasons (empty = safe). */
+export function classifyExport(
+  before: ExportSnapshot,
+  after: ExportSnapshot
+): string[] {
+  if (before.kind !== after.kind) {
+    return [`kind changed (${before.kind} → ${after.kind})`]
   }
-  for (const name of head.items.keys()) {
-    if (!base.items.has(name)) diff.added.push(name)
+  if (before.typeParams !== after.typeParams) {
+    return [
+      `type parameters changed (${before.typeParams} → ${after.typeParams})`,
+    ]
   }
-  diff.breaking.sort((a, b) => a.name.localeCompare(b.name))
-  diff.added.sort()
-  return diff
+  return classifyItem(before.item, after.item, "")
 }
 
-/** Truncate a long type fingerprint for display inside the PR comment. */
-function clip(s: string, max = 600): string {
+function at(path: string, name: string): string {
+  return path ? `${path}.${name}` : name
+}
+
+/**
+ * Structural breaking-change comparison. Variance is modelled the way a
+ * consumer experiences component props: adding an optional member or relaxing
+ * a required member to optional is safe; removing a member, retyping it, adding
+ * a required member, or tightening optional→required is breaking.
+ */
+function classifyItem(before: ApiItem, after: ApiItem, path: string): string[] {
+  if (before.k !== after.k) {
+    return [`${path || "type"} changed shape (${before.k} → ${after.k})`]
+  }
+
+  if (before.k === "opaque" && after.k === "opaque") {
+    return before.text !== after.text
+      ? [`${path || "type"} changed: \`${before.text}\` → \`${after.text}\``]
+      : []
+  }
+
+  if (before.k === "object" && after.k === "object") {
+    const reasons: string[] = []
+    for (const name of Object.keys(before.members)) {
+      const b = before.members[name]
+      const a = after.members[name]
+      if (!a) {
+        reasons.push(`\`${at(path, name)}\` was removed`)
+        continue
+      }
+      if (b.optional && !a.optional) {
+        reasons.push(`\`${at(path, name)}\` became required`)
+      }
+      reasons.push(...classifyItem(b.type, a.type, at(path, name)))
+    }
+    for (const name of Object.keys(after.members)) {
+      if (!before.members[name] && !after.members[name].optional) {
+        reasons.push(`required \`${at(path, name)}\` was added`)
+      }
+    }
+    if ((before.index ?? "") !== (after.index ?? "")) {
+      reasons.push(`${path || "type"} index signature changed`)
+    }
+    return reasons
+  }
+
+  if (before.k === "callable" && after.k === "callable") {
+    // Compare the first signature (components/most exports have one). A change
+    // in overload count is itself breaking.
+    if (before.sigs.length !== after.sigs.length) {
+      return [`${path || "type"} call signatures changed`]
+    }
+    const reasons: string[] = []
+    const bs = before.sigs[0]
+    const as = after.sigs[0]
+    const max = Math.max(bs.params.length, as.params.length)
+    for (let i = 0; i < max; i++) {
+      const bp = bs.params[i]
+      const ap = as.params[i]
+      const label = `param \`${(ap ?? bp).name}\``
+      if (bp && !ap) {
+        reasons.push(`${label} was removed`)
+      } else if (!bp && ap) {
+        if (!ap.optional) reasons.push(`required ${label} was added`)
+      } else {
+        if (bp.optional && !ap.optional)
+          reasons.push(`${label} became required`)
+        reasons.push(...classifyItem(bp.type, ap.type, at(path, ap.name)))
+      }
+    }
+    reasons.push(...classifyItem(bs.ret, as.ret, at(path, "return")))
+    return reasons
+  }
+
+  return []
+}
+
+/* -------------------------------- diffing -------------------------------- */
+
+function diffEntry(
+  entry: Entry,
+  base: EntrySnapshot | undefined,
+  head: EntrySnapshot | undefined
+): EntryDiff {
+  if (!base) return { entry, breaking: [], added: [], skipped: "no-base" }
+  if (!head) return { entry, breaking: [], added: [], skipped: "no-head" }
+
+  const breaking: EntryDiff["breaking"] = []
+  const added: string[] = []
+
+  for (const [name, b] of base) {
+    const h = head.get(name)
+    if (!h) {
+      breaking.push({ name, kind: "removed", before: b.display })
+      continue
+    }
+    const reasons = classifyExport(b, h)
+    if (reasons.length > 0) {
+      breaking.push({
+        name,
+        kind: "changed",
+        reasons,
+        before: b.display,
+        after: h.display,
+      })
+    }
+  }
+  for (const name of head.keys()) {
+    if (!base.has(name)) added.push(name)
+  }
+
+  breaking.sort((a, b) => a.name.localeCompare(b.name))
+  added.sort()
+  return { entry, breaking, added }
+}
+
+export function analyze(baseDir: string, headDir: string): AnalysisResult {
+  const entries = ENTRIES.map((entry) =>
+    diffEntry(
+      entry,
+      snapshotEntry(baseDir, entry),
+      snapshotEntry(headDir, entry)
+    )
+  )
+  const breakingTotal = entries.reduce((n, d) => n + d.breaking.length, 0)
+  const addedTotal = entries.reduce((n, d) => n + d.added.length, 0)
+  return { hasBreaking: breakingTotal > 0, breakingTotal, addedTotal, entries }
+}
+
+/* ------------------------------- reporting ------------------------------- */
+
+function clip(s: string, max = 400): string {
   return s.length > max ? `${s.slice(0, max)} …` : s
 }
 
@@ -357,32 +523,31 @@ function clip(s: string, max = 600): string {
  * Render the PR comment body. Posted whether or not breaking changes exist, so
  * a prior "⚠️ breaking" comment is cleared to "✅" once resolved.
  */
-function buildCommentMarkdown(diffs: EntryDiff[]): string {
-  const breakingTotal = diffs.reduce((n, d) => n + d.breaking.length, 0)
-  const addedTotal = diffs.reduce((n, d) => n + d.added.length, 0)
+export function buildCommentMarkdown(result: AnalysisResult): string {
+  const { hasBreaking, breakingTotal, addedTotal, entries } = result
   const lines: string[] = []
 
-  if (breakingTotal > 0) {
+  if (hasBreaking) {
     lines.push(`## ⚠️ Breaking public API changes (${breakingTotal})`)
     lines.push("")
     lines.push(
-      "These public exports were **renamed/removed or had their type changed** compared to `main`. " +
-        "Renaming components or changing existing props/types breaks consumers. " +
-        "If this is intentional, call it out in the PR description (and use a `feat!:`/`BREAKING CHANGE` commit so the release is a major bump)."
+      "These public exports were **renamed/removed, or had a property/parameter removed, retyped, or newly required** compared to `main` — that breaks consumers. " +
+        "Adding new exports or new *optional* props is always safe and is not flagged. " +
+        "If a breaking change is intentional, note it in the PR description and use a `feat!:`/`BREAKING CHANGE` commit so the release is a major bump."
     )
   } else {
     lines.push("## ✅ No breaking public API changes")
     lines.push("")
     lines.push(
-      "No public exports were renamed, removed, or retyped compared to `main`."
+      "No public exports were removed, renamed, or had existing props/types changed in a breaking way compared to `main`."
     )
   }
   lines.push("")
   lines.push(
-    "_Comparing `f0`, `experimental` and `ai` against `main`. Adding new components/types is always safe. This check is non-blocking._"
+    "_Comparing `f0`, `experimental` and `ai` against `main`. Adding components, types, or optional props is safe. This check is non-blocking._"
   )
 
-  for (const d of diffs) {
+  for (const d of entries) {
     if (d.skipped || d.breaking.length === 0) continue
     lines.push("")
     lines.push(`### \`${d.entry}\``)
@@ -390,7 +555,10 @@ function buildCommentMarkdown(diffs: EntryDiff[]): string {
       if (b.kind === "removed") {
         lines.push(`- ❌ \`${b.name}\` — **removed** (renamed or deleted)`)
       } else {
-        lines.push(`- ✏️ \`${b.name}\` — **type changed**`)
+        lines.push(`- ✏️ \`${b.name}\` — **breaking change**`)
+        for (const reason of b.reasons ?? []) {
+          lines.push(`  - ${reason}`)
+        }
         lines.push("")
         lines.push("  <details><summary>before → after</summary>")
         lines.push("")
@@ -411,7 +579,7 @@ function buildCommentMarkdown(diffs: EntryDiff[]): string {
       `<details><summary>➕ Additive changes (safe) — ${addedTotal}</summary>`
     )
     lines.push("")
-    for (const d of diffs) {
+    for (const d of entries) {
       if (d.added.length > 0) {
         lines.push(
           `- \`${d.entry}\`: ${d.added.map((n) => `\`${n}\``).join(", ")}`
@@ -421,7 +589,7 @@ function buildCommentMarkdown(diffs: EntryDiff[]): string {
     lines.push("</details>")
   }
 
-  const skipped = diffs.filter((d) => d.skipped)
+  const skipped = entries.filter((d) => d.skipped)
   if (skipped.length > 0) {
     lines.push("")
     lines.push(
@@ -430,6 +598,21 @@ function buildCommentMarkdown(diffs: EntryDiff[]): string {
   }
 
   return lines.join("\n")
+}
+
+/* --------------------------------- main ---------------------------------- */
+
+function parseArgs(): { base?: string; head?: string; json: boolean } {
+  const args = process.argv.slice(2)
+  const valueOf = (flag: string): string | undefined => {
+    const i = args.indexOf(flag)
+    return i !== -1 && args[i + 1] ? args[i + 1] : undefined
+  }
+  return {
+    base: valueOf("--base"),
+    head: valueOf("--head"),
+    json: args.includes("--json"),
+  }
 }
 
 function main(): void {
@@ -441,26 +624,13 @@ function main(): void {
     process.exit(2)
   }
 
-  const diffs = ENTRIES.map((entry) =>
-    diffEntry(entry, snapshotEntry(base, entry), snapshotEntry(head, entry))
-  )
-
-  const breakingTotal = diffs.reduce((n, d) => n + d.breaking.length, 0)
-  const addedTotal = diffs.reduce((n, d) => n + d.added.length, 0)
-  const hasBreaking = breakingTotal > 0
+  const result = analyze(base, head)
 
   if (json) {
-    // Machine-readable output must go to stdout (the CI workflow reads it);
-    // use process.stdout.write rather than console.log to satisfy oxlint.
+    // Machine-readable output to stdout (the CI workflow reads it).
     process.stdout.write(
       JSON.stringify(
-        {
-          hasBreaking,
-          breakingTotal,
-          addedTotal,
-          entries: diffs,
-          commentMarkdown: buildCommentMarkdown(diffs),
-        },
+        { ...result, commentMarkdown: buildCommentMarkdown(result) },
         null,
         2
       ) + "\n"
@@ -468,7 +638,7 @@ function main(): void {
     process.exit(0)
   }
 
-  for (const d of diffs) {
+  for (const d of result.entries) {
     if (d.skipped) {
       consola.warn(`[${d.entry}] skipped (${d.skipped})`)
       continue
@@ -485,23 +655,25 @@ function main(): void {
         consola.log(`  - removed: ${b.name}`)
       } else {
         consola.log(`  - changed: ${b.name}`)
-        consola.log(`      before: ${b.before}`)
-        consola.log(`      after:  ${b.after}`)
+        for (const reason of b.reasons ?? []) consola.log(`      • ${reason}`)
       }
     }
   }
   consola.log("")
-  if (hasBreaking) {
+  if (result.hasBreaking) {
     consola.error(
-      `${breakingTotal} breaking public API change(s) across ${ENTRIES.length} entries (${addedTotal} additive).`
+      `${result.breakingTotal} breaking public API change(s) (${result.addedTotal} additive).`
     )
   } else {
     consola.success(
-      `No breaking public API changes (${addedTotal} additive change(s)).`
+      `No breaking public API changes (${result.addedTotal} additive change(s)).`
     )
   }
   // Non-blocking: always exit 0.
   process.exit(0)
 }
 
-main()
+// Run as a CLI only when invoked directly (not when imported by tests).
+if (process.argv[1] && /check-api-surface\.(ts|js)$/.test(process.argv[1])) {
+  main()
+}

--- a/packages/react/.scripts/check-api-surface.ts
+++ b/packages/react/.scripts/check-api-surface.ts
@@ -1,0 +1,507 @@
+/**
+ * Public API surface breaking-change detector.
+ *
+ * Snapshots the public TypeScript API of each shipped entry point
+ * (`f0`, `experimental`, `ai`) from a set of rolled-up `.d.ts` files, then
+ * compares two snapshots (a `--base` directory vs a `--head` directory) and
+ * classifies every difference as either:
+ *
+ *   - BREAKING: an export present in base is gone in head (removed / renamed),
+ *     or an export present in both has a different resolved type
+ *     (changed signature, prop, or type).
+ *   - ADDITIVE (safe): an export present in head but not in base.
+ *
+ * A rename surfaces, correctly, as a BREAKING removal of the old name plus a
+ * safe addition of the new name.
+ *
+ * Both sides are analyzed by the *same* TypeScript in a single process, so the
+ * comparison is deterministic and immune to compiler-version drift. The type
+ * fingerprint is built by resolving structural types through the checker, which
+ * normalizes away api-extractor's rollup noise (the `F0TextInputProps_2`
+ * suffixes / dangling `./types` imports) instead of diffing raw `.d.ts` text.
+ *
+ * Usage:
+ *   tsx .scripts/check-api-surface.ts --base <dir> --head <dir> [--json]
+ *
+ * `<dir>` is a directory containing the entry `.d.ts` files (f0.d.ts,
+ * experimental.d.ts, ai.d.ts, plus global.d.ts so self-references resolve).
+ *
+ * The process always exits 0 (the check is non-blocking); whether breaking
+ * changes were found is reported via the `hasBreaking` field of the `--json`
+ * output and via the human-readable summary.
+ */
+import { existsSync } from "node:fs"
+import path from "node:path"
+
+import consola from "consola"
+import ts from "typescript"
+
+/** Public entry points shipped in `dist/`. */
+const ENTRIES = ["f0", "experimental", "ai"] as const
+type Entry = (typeof ENTRIES)[number]
+
+/** How deep to expand F0-owned object/signature types before falling back to
+ * a by-name reference. Keeps the fingerprint bounded while still catching
+ * prop/signature changes one or two levels in. */
+const MAX_DEPTH = 2
+
+interface ApiSnapshot {
+  /** export name -> normalized type fingerprint */
+  items: Map<string, string>
+}
+
+interface EntryDiff {
+  entry: Entry
+  /** present in base but missing/changed in head */
+  breaking: Array<{
+    name: string
+    kind: "removed" | "changed"
+    before: string
+    after?: string
+  }>
+  /** present in head but not in base */
+  added: string[]
+  /** true when the entry could not be analyzed on one side */
+  skipped?: "no-base" | "no-head"
+}
+
+function parseArgs(): { base?: string; head?: string; json: boolean } {
+  const args = process.argv.slice(2)
+  const valueOf = (flag: string): string | undefined => {
+    const i = args.indexOf(flag)
+    return i !== -1 && args[i + 1] ? args[i + 1] : undefined
+  }
+  return {
+    base: valueOf("--base"),
+    head: valueOf("--head"),
+    json: args.includes("--json"),
+  }
+}
+
+/** Resolve `<dir>/<entry>.d.ts` if it exists. */
+function entryDtsPath(dir: string, entry: Entry): string | undefined {
+  const p = path.resolve(dir, `${entry}.d.ts`)
+  return existsSync(p) ? p : undefined
+}
+
+/**
+ * Build a snapshot of the public exports of a single rolled `.d.ts` file.
+ *
+ * Returns `undefined` when the file does not exist (e.g. the base build did not
+ * produce it), which the caller treats as "no baseline".
+ */
+function snapshotEntry(dir: string, entry: Entry): ApiSnapshot | undefined {
+  const dtsPath = entryDtsPath(dir, entry)
+  if (!dtsPath) return undefined
+
+  const dirAbsolute = path.resolve(dir)
+
+  const program = ts.createProgram({
+    rootNames: [dtsPath],
+    options: {
+      noEmit: true,
+      skipLibCheck: true,
+      skipDefaultLibCheck: true,
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      jsx: ts.JsxEmit.Preserve,
+      allowJs: false,
+      strict: false,
+    },
+  })
+
+  const checker = program.getTypeChecker()
+  const sourceFile = program.getSourceFile(dtsPath)
+  if (!sourceFile) return { items: new Map() }
+
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile)
+  if (!moduleSymbol) return { items: new Map() }
+
+  const items = new Map<string, string>()
+  for (const exp of checker.getExportsOfModule(moduleSymbol)) {
+    const name = exp.getName()
+    if (name === "default") continue
+    items.set(name, fingerprintSymbol(exp, checker, sourceFile, dirAbsolute))
+  }
+  return { items }
+}
+
+/** Whether a type is declared inside the analyzed dist directory (an F0-owned
+ * type, worth expanding) versus an external type (React/DOM/lib, referenced by
+ * name to keep the fingerprint stable and bounded). */
+function isOwned(sym: ts.Symbol | undefined, dirAbsolute: string): boolean {
+  const decls = sym?.getDeclarations()
+  if (!decls || decls.length === 0) return false
+  return decls.some((d) =>
+    d.getSourceFile().fileName.startsWith(dirAbsolute + path.sep)
+  )
+}
+
+function fingerprintSymbol(
+  symbol: ts.Symbol,
+  checker: ts.TypeChecker,
+  location: ts.Node,
+  dirAbsolute: string
+): string {
+  // Follow re-export aliases to the real declaration.
+  let sym = symbol
+  if (sym.flags & ts.SymbolFlags.Alias) {
+    try {
+      sym = checker.getAliasedSymbol(sym)
+    } catch {
+      // keep original on failure
+    }
+  }
+
+  const kind = symbolKind(sym)
+  const typeParams = typeParameterText(sym)
+
+  // Type-only symbols use the declared type; value symbols use the type of the
+  // value at the export location.
+  const isTypeOnly =
+    !!(sym.flags & ts.SymbolFlags.Type) && !(sym.flags & ts.SymbolFlags.Value)
+
+  let body: string
+  try {
+    const type = isTypeOnly
+      ? checker.getDeclaredTypeOfSymbol(sym)
+      : checker.getTypeOfSymbolAtLocation(sym, location)
+    body = serializeType(type, checker, dirAbsolute, MAX_DEPTH, new Set())
+  } catch (err) {
+    body = `<unresolved: ${(err as Error).message}>`
+  }
+
+  return normalizeFingerprint(`${kind} ${typeParams}${body}`)
+}
+
+function symbolKind(sym: ts.Symbol): string {
+  const f = sym.flags
+  if (f & ts.SymbolFlags.Class) return "class"
+  if (f & ts.SymbolFlags.Interface) return "interface"
+  if (f & ts.SymbolFlags.TypeAlias) return "type"
+  if (f & ts.SymbolFlags.Enum) return "enum"
+  if (f & ts.SymbolFlags.Function) return "function"
+  if (f & ts.SymbolFlags.Variable) return "const"
+  if (f & ts.SymbolFlags.Module) return "namespace"
+  return "value"
+}
+
+/** `<T extends string, U>` from the symbol's declaration, when present. */
+function typeParameterText(sym: ts.Symbol): string {
+  const decl = sym.getDeclarations()?.[0]
+  if (!decl) return ""
+  let tps: readonly ts.TypeParameterDeclaration[] = []
+  try {
+    tps = ts.getEffectiveTypeParameterDeclarations(
+      decl as ts.DeclarationWithTypeParameters
+    )
+  } catch {
+    return ""
+  }
+  if (tps.length === 0) return ""
+  return `<${tps.map((t) => t.getText()).join(", ")}> `
+}
+
+const TYPE_TO_STRING_FLAGS =
+  ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.WriteArrayAsGenericType
+
+/**
+ * Make a fingerprint comparable across the two analyzed directories:
+ *  - strip `import("<abs path>").` qualifiers — the path is base-dir vs
+ *    head-dir specific and would make every cross-referenced type look changed;
+ *  - strip per-program unique-id suffixes on computed/internal names
+ *    (e.g. `__@iterator@968`), which differ run-to-run.
+ */
+function normalizeFingerprint(s: string): string {
+  return s.replace(/import\("[^"]*"\)\./g, "").replace(/@\d+/g, "")
+}
+
+/**
+ * Produce a normalized structural string for a type. F0-owned object/union and
+ * signature types are expanded up to `depth` levels so prop/signature changes
+ * are visible; external and too-deep types fall back to `typeToString` (a
+ * by-name reference), which is stable.
+ */
+function serializeType(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  dirAbsolute: string,
+  depth: number,
+  visited: Set<ts.Type>
+): string {
+  const plain = () =>
+    checker.typeToString(type, undefined, TYPE_TO_STRING_FLAGS)
+
+  if (depth <= 0 || visited.has(type)) return plain()
+
+  // Unions / intersections: serialize each constituent (sorted for stability).
+  if (type.isUnion() || type.isIntersection()) {
+    const sep = type.isUnion() ? " | " : " & "
+    const parts = (type as ts.UnionOrIntersectionType).types
+      .map((t) => serializeType(t, checker, dirAbsolute, depth, visited))
+      .sort()
+    return parts.join(sep)
+  }
+
+  const callSigs = type.getCallSignatures()
+  const ctorSigs = type.getConstructSignatures()
+  if (callSigs.length > 0 || ctorSigs.length > 0) {
+    const next = new Set(visited).add(type)
+    const sigStr = (s: ts.Signature, isCtor: boolean) =>
+      (isCtor ? "new " : "") +
+      `(${s
+        .getParameters()
+        .map((p) => {
+          const optional = !!(p.flags & ts.SymbolFlags.Optional)
+          const pt = checker.getTypeOfSymbolAtLocation(
+            p,
+            p.valueDeclaration ?? p.declarations![0]
+          )
+          return `${p.getName()}${optional ? "?" : ""}: ${serializeType(pt, checker, dirAbsolute, depth - 1, next)}`
+        })
+        .join(
+          ", "
+        )}) => ${serializeType(s.getReturnType(), checker, dirAbsolute, depth - 1, next)}`
+    return [
+      ...callSigs.map((s) => sigStr(s, false)),
+      ...ctorSigs.map((s) => sigStr(s, true)),
+    ].join(" & ")
+  }
+
+  // Only expand object types we own; external types (React/DOM) stay by-name.
+  const symbol = type.aliasSymbol ?? type.getSymbol()
+  const props = type.getProperties()
+  const isExpandableObject =
+    props.length > 0 || checker.getIndexInfosOfType(type).length > 0
+  if (isExpandableObject && isOwned(symbol, dirAbsolute)) {
+    const next = new Set(visited).add(type)
+    const members = props
+      .map((p) => {
+        const optional = !!(p.flags & ts.SymbolFlags.Optional)
+        const readonly = isReadonlySymbol(p)
+        const decl = p.valueDeclaration ?? p.declarations?.[0]
+        const pt = decl
+          ? checker.getTypeOfSymbolAtLocation(p, decl)
+          : checker.getDeclaredTypeOfSymbol(p)
+        return `${readonly ? "readonly " : ""}${p.getName()}${optional ? "?" : ""}: ${serializeType(pt, checker, dirAbsolute, depth - 1, next)}`
+      })
+      .sort()
+    const indexInfos = checker
+      .getIndexInfosOfType(type)
+      .map(
+        (info) =>
+          `[index: ${checker.typeToString(info.keyType)}]: ${serializeType(info.type, checker, dirAbsolute, depth - 1, next)}`
+      )
+    return `{ ${[...members, ...indexInfos].join("; ")} }`
+  }
+
+  return plain()
+}
+
+function isReadonlySymbol(sym: ts.Symbol): boolean {
+  return !!sym
+    .getDeclarations()
+    ?.some(
+      (d) =>
+        (ts.isPropertySignature(d) || ts.isPropertyDeclaration(d)) &&
+        !!d.modifiers?.some((m) => m.kind === ts.SyntaxKind.ReadonlyKeyword)
+    )
+}
+
+/** Diff two snapshots for a single entry. */
+function diffEntry(
+  entry: Entry,
+  base: ApiSnapshot | undefined,
+  head: ApiSnapshot | undefined
+): EntryDiff {
+  const diff: EntryDiff = { entry, breaking: [], added: [] }
+  if (!base) {
+    diff.skipped = "no-base"
+    return diff
+  }
+  if (!head) {
+    diff.skipped = "no-head"
+    return diff
+  }
+
+  for (const [name, beforeFp] of base.items) {
+    if (!head.items.has(name)) {
+      diff.breaking.push({ name, kind: "removed", before: beforeFp })
+    } else {
+      const afterFp = head.items.get(name)!
+      if (afterFp !== beforeFp) {
+        diff.breaking.push({
+          name,
+          kind: "changed",
+          before: beforeFp,
+          after: afterFp,
+        })
+      }
+    }
+  }
+  for (const name of head.items.keys()) {
+    if (!base.items.has(name)) diff.added.push(name)
+  }
+  diff.breaking.sort((a, b) => a.name.localeCompare(b.name))
+  diff.added.sort()
+  return diff
+}
+
+/** Truncate a long type fingerprint for display inside the PR comment. */
+function clip(s: string, max = 600): string {
+  return s.length > max ? `${s.slice(0, max)} …` : s
+}
+
+/**
+ * Render the PR comment body. Posted whether or not breaking changes exist, so
+ * a prior "⚠️ breaking" comment is cleared to "✅" once resolved.
+ */
+function buildCommentMarkdown(diffs: EntryDiff[]): string {
+  const breakingTotal = diffs.reduce((n, d) => n + d.breaking.length, 0)
+  const addedTotal = diffs.reduce((n, d) => n + d.added.length, 0)
+  const lines: string[] = []
+
+  if (breakingTotal > 0) {
+    lines.push(`## ⚠️ Breaking public API changes (${breakingTotal})`)
+    lines.push("")
+    lines.push(
+      "These public exports were **renamed/removed or had their type changed** compared to `main`. " +
+        "Renaming components or changing existing props/types breaks consumers. " +
+        "If this is intentional, call it out in the PR description (and use a `feat!:`/`BREAKING CHANGE` commit so the release is a major bump)."
+    )
+  } else {
+    lines.push("## ✅ No breaking public API changes")
+    lines.push("")
+    lines.push(
+      "No public exports were renamed, removed, or retyped compared to `main`."
+    )
+  }
+  lines.push("")
+  lines.push(
+    "_Comparing `f0`, `experimental` and `ai` against `main`. Adding new components/types is always safe. This check is non-blocking._"
+  )
+
+  for (const d of diffs) {
+    if (d.skipped || d.breaking.length === 0) continue
+    lines.push("")
+    lines.push(`### \`${d.entry}\``)
+    for (const b of d.breaking) {
+      if (b.kind === "removed") {
+        lines.push(`- ❌ \`${b.name}\` — **removed** (renamed or deleted)`)
+      } else {
+        lines.push(`- ✏️ \`${b.name}\` — **type changed**`)
+        lines.push("")
+        lines.push("  <details><summary>before → after</summary>")
+        lines.push("")
+        lines.push("  ```ts")
+        lines.push(`  // before`)
+        lines.push(`  ${clip(b.before)}`)
+        lines.push(`  // after`)
+        lines.push(`  ${clip(b.after ?? "")}`)
+        lines.push("  ```")
+        lines.push("  </details>")
+      }
+    }
+  }
+
+  if (addedTotal > 0) {
+    lines.push("")
+    lines.push(
+      `<details><summary>➕ Additive changes (safe) — ${addedTotal}</summary>`
+    )
+    lines.push("")
+    for (const d of diffs) {
+      if (d.added.length > 0) {
+        lines.push(
+          `- \`${d.entry}\`: ${d.added.map((n) => `\`${n}\``).join(", ")}`
+        )
+      }
+    }
+    lines.push("</details>")
+  }
+
+  const skipped = diffs.filter((d) => d.skipped)
+  if (skipped.length > 0) {
+    lines.push("")
+    lines.push(
+      `> ⚠️ Could not analyze ${skipped.map((d) => `\`${d.entry}\` (${d.skipped})`).join(", ")} — a build may have failed; results may be incomplete.`
+    )
+  }
+
+  return lines.join("\n")
+}
+
+function main(): void {
+  const { base, head, json } = parseArgs()
+  if (!base || !head) {
+    consola.error(
+      "Usage: tsx .scripts/check-api-surface.ts --base <dir> --head <dir> [--json]"
+    )
+    process.exit(2)
+  }
+
+  const diffs = ENTRIES.map((entry) =>
+    diffEntry(entry, snapshotEntry(base, entry), snapshotEntry(head, entry))
+  )
+
+  const breakingTotal = diffs.reduce((n, d) => n + d.breaking.length, 0)
+  const addedTotal = diffs.reduce((n, d) => n + d.added.length, 0)
+  const hasBreaking = breakingTotal > 0
+
+  if (json) {
+    // Machine-readable output must go to stdout (the CI workflow reads it);
+    // use process.stdout.write rather than console.log to satisfy oxlint.
+    process.stdout.write(
+      JSON.stringify(
+        {
+          hasBreaking,
+          breakingTotal,
+          addedTotal,
+          entries: diffs,
+          commentMarkdown: buildCommentMarkdown(diffs),
+        },
+        null,
+        2
+      ) + "\n"
+    )
+    process.exit(0)
+  }
+
+  for (const d of diffs) {
+    if (d.skipped) {
+      consola.warn(`[${d.entry}] skipped (${d.skipped})`)
+      continue
+    }
+    if (d.breaking.length === 0) {
+      consola.success(
+        `[${d.entry}] no breaking changes (${d.added.length} additive)`
+      )
+      continue
+    }
+    consola.error(`[${d.entry}] ${d.breaking.length} breaking change(s):`)
+    for (const b of d.breaking) {
+      if (b.kind === "removed") {
+        consola.log(`  - removed: ${b.name}`)
+      } else {
+        consola.log(`  - changed: ${b.name}`)
+        consola.log(`      before: ${b.before}`)
+        consola.log(`      after:  ${b.after}`)
+      }
+    }
+  }
+  consola.log("")
+  if (hasBreaking) {
+    consola.error(
+      `${breakingTotal} breaking public API change(s) across ${ENTRIES.length} entries (${addedTotal} additive).`
+    )
+  } else {
+    consola.success(
+      `No breaking public API changes (${addedTotal} additive change(s)).`
+    )
+  }
+  // Non-blocking: always exit 0.
+  process.exit(0)
+}
+
+main()

--- a/packages/react/.scripts/check-api-surface.ts
+++ b/packages/react/.scripts/check-api-surface.ts
@@ -123,6 +123,54 @@ function entryDtsPath(dir: string, entry: Entry): string | undefined {
   return existsSync(p) ? p : undefined
 }
 
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  noEmit: true,
+  skipLibCheck: true,
+  skipDefaultLibCheck: true,
+  target: ts.ScriptTarget.ESNext,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  jsx: ts.JsxEmit.Preserve,
+  allowJs: false,
+  strict: false,
+}
+
+// One `analyze()` run creates many small programs (per entry, per side). The
+// dominant cost is parsing the multi-megabyte default TypeScript lib, which is
+// identical across every program. Share a compiler host that caches parsed
+// source files by name so the lib is parsed once instead of per program — this
+// keeps each program from blowing the test timeout on slower CI runners.
+let sharedHost: ts.CompilerHost | undefined
+const sourceFileCache = new Map<string, ts.SourceFile | undefined>()
+
+function getCompilerHost(): ts.CompilerHost {
+  if (sharedHost) return sharedHost
+  const host = ts.createCompilerHost(COMPILER_OPTIONS)
+  const original = host.getSourceFile.bind(host)
+  host.getSourceFile = (
+    fileName,
+    languageVersionOrOptions,
+    onError,
+    shouldCreate
+  ) => {
+    const cached = sourceFileCache.get(fileName)
+    if (cached !== undefined) return cached
+    const sf = original(
+      fileName,
+      languageVersionOrOptions,
+      onError,
+      shouldCreate
+    )
+    // Entry `.d.ts` files live at unique paths (temp dirs / base-vs-head dirs)
+    // and are read once, so caching every file by name is safe and reuses the
+    // expensive lib/node_modules parses across programs.
+    sourceFileCache.set(fileName, sf)
+    return sf
+  }
+  sharedHost = host
+  return host
+}
+
 /**
  * Build a snapshot of the public exports of a single rolled `.d.ts` file.
  * Returns `undefined` when the file does not exist (treated as "no baseline").
@@ -138,17 +186,8 @@ export function snapshotEntry(
 
   const program = ts.createProgram({
     rootNames: [dtsPath],
-    options: {
-      noEmit: true,
-      skipLibCheck: true,
-      skipDefaultLibCheck: true,
-      target: ts.ScriptTarget.ESNext,
-      module: ts.ModuleKind.ESNext,
-      moduleResolution: ts.ModuleResolutionKind.Bundler,
-      jsx: ts.JsxEmit.Preserve,
-      allowJs: false,
-      strict: false,
-    },
+    options: COMPILER_OPTIONS,
+    host: getCompilerHost(),
   })
 
   const checker = program.getTypeChecker()

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,6 +46,7 @@
     "format": "sh -c 'oxfmt \"${@:-src/}\"' --",
     "format:check": "sh -c 'oxfmt --check \"${@:-src/}\"' --",
     "tsc": "tsc --noEmit",
+    "check:api-surface": "tsx .scripts/check-api-surface.ts",
     "vitest": "vitest --project=unit",
     "vitest:ui": "vitest --project=unit --ui",
     "vitest:watch": "vitest --project=unit dev",


### PR DESCRIPTION
## Why

It's currently too easy to ship a breaking change to the public API of `@factorialco/f0-react` without noticing — e.g. #4199 renamed components (`Input` → `F0TextInput`), and a follow-up regression silently degraded prop types to `any`. Neither was caught in CI. This PR adds a **non-blocking** safeguard that detects breaking public-API changes on every PR, comments on the PR, and labels it.

## What counts as breaking (precise, member-level)

The check compares the PR's public API surface against `main` across all three shipped entries (`f0`, `experimental`, `ai`), classifying each export **structurally**:

| Change | Result |
| --- | --- |
| Export removed / renamed | ❌ breaking |
| Property/parameter removed or retyped | ❌ breaking |
| New **required** property/parameter | ❌ breaking |
| Optional → required | ❌ breaking |
| Kind or type-parameters changed | ❌ breaking |
| New export (component/type) | ✅ safe |
| New **optional** property/parameter | ✅ safe |
| Required → optional (widening) | ✅ safe |

So adding an optional prop or a whole new component does **not** warn; only genuinely consumer-breaking changes do.

## How it works

- **`.github/workflows/api-surface.yaml`** — on PRs touching the React/core package, two parallel jobs build the rolled-up `.d.ts` on the PR head and on `main` and upload them as artifacts (the base build uses the existing `build` script, so it works even though this workflow doesn't exist on `main` yet). A diff job runs the analyzer, then:
  - posts/updates a PR comment via the existing `add-or-update-pr-comment` action,
  - emits a `::warning::` annotation, and
  - adds/removes a **`breaking changes`** label on the PR.
  - It **never blocks merge.**
- **`packages/react/.scripts/check-api-surface.ts`** — snapshots each entry's public exports via the **TypeScript compiler API** (resolving structural types, so api-extractor rollup noise like `*_2` suffixes / dangling `./types` imports and primitive prototype methods are normalized away), then compares member-by-member. Both sides are analyzed by the same TS in one process → deterministic. Run locally: `pnpm --filter @factorialco/f0-react check:api-surface --base <dir> --head <dir>`.

## Tests

`packages/react/.scripts/__tests__/check-api-surface.test.ts` — 14 cases that build real `.d.ts` fixtures and run the analyzer end-to-end, asserting **both directions**:
- **Caught:** removed export, renamed export, removed prop, retyped prop, added-required prop, optional→required, changed param type, removed param.
- **Not flagged:** identical surface, brand-new export, new optional prop, required→optional, new optional param.
- Plus a cross-directory determinism check.

All 14 pass and are discovered by the `unit` vitest project (runs in the existing `test.yaml`).
