### PR TITLE
feat(F0Checkbox): promote to stable

### DIFF
--- a/packages/react/src/components/F0Checkbox/F0Checkbox.tsx
+++ b/packages/react/src/components/F0Checkbox/F0Checkbox.tsx
@@ -1,6 +1,5 @@
 import { DataAttributes } from "@/global.types"
 import { withDataTestId } from "@/lib/data-testid"
-import { experimentalComponent } from "@/lib/experimental"
 import { Checkbox as CheckboxRoot } from "@/ui/checkbox"
 
 interface CheckboxProps extends DataAttributes {
@@ -106,9 +105,4 @@ function _F0Checkbox({
   )
 }
 
-/**
- * @experimental This is an experimental component use it at your own risk
- */
-export const F0Checkbox = withDataTestId(
-  experimentalComponent<typeof _F0Checkbox>("F0Checkbox", _F0Checkbox)
-)
+export const F0Checkbox = withDataTestId(_F0Checkbox)

--- a/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.mdx
+++ b/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.mdx
@@ -1,28 +1,75 @@
-import { Canvas, Meta, Unstyled, Controls } from "@storybook/addon-docs/blocks"
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
 import * as CheckboxStories from "./F0Checkbox.stories"
 
 <Meta of={CheckboxStories} />
 
 # Checkbox
 
-Allows users to select one or more options from a list.
+## Introduction
+
+### Definition
+
+The Checkbox component lets users select one or more options from a set, or
+confirm a single choice within a form. It renders an accessible, labelled
+control that reflects three possible states: unchecked, checked, and
+indeterminate.
+
+### Purpose
+
+- Let users select multiple independent options from a list
+- Capture a single opt-in or agreement as part of a form (e.g. accepting terms)
+- Represent a partially-selected group through the indeterminate state
 
 ## Anatomy
+
+A checkbox is composed of the selection control itself plus a `title` label.
+Always provide a meaningful `title` so the control is clearly labelled, both
+visually and for assistive technology. The component is controlled — provide
+`checked` and update it from the `onCheckedChange` callback.
 
 <Canvas of={CheckboxStories.Default} />
 <Controls of={CheckboxStories.Default} />
 
-## Examples
+## States
 
-## Indeterminate
+### Checked
+
+Set the `checked` prop to reflect the current selection. Because the checkbox is
+controlled, you are responsible for storing the value and updating it whenever
+the `onCheckedChange` callback fires.
+
+<Canvas of={CheckboxStories.Checked} />
+
+### Indeterminate
 
 A checkbox can be in an indeterminate state, which is useful for indicating that
-a group of options are selected. It's controlled using the `indeterminate` prop.
+only some options within a group are selected. It is controlled through the
+`indeterminate` prop and is purely visual — the underlying checked value stays
+whatever `checked` reports.
 
 <Canvas of={CheckboxStories.Indeterminate} />
 
-## Disabled
+### Disabled
 
-Disable a checkbox by setting the `disabled` prop.
+Disable interaction by setting the `disabled` prop. A disabled checkbox keeps
+its current visual state but cannot be toggled by the user, and is skipped by
+keyboard navigation.
 
 <Canvas of={CheckboxStories.Disabled} />
+
+## Guidelines
+
+### When to use
+
+- **Multiple selection**: Choosing several independent options from a list
+- **Opt-in / agreement**: A single checkbox to accept terms or confirm a choice
+  as part of a form submission
+- **Select-all patterns**: Pair a parent indeterminate checkbox with a group of
+  child checkboxes
+
+### When not to use
+
+- **Single on/off setting**: Use a switch/toggle when turning a single setting
+  on or off takes effect immediately, rather than being captured as a form value
+- **Mutually exclusive options**: Use a radio button when only one option can be
+  selected at a time

--- a/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.stories.tsx
+++ b/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.stories.tsx
@@ -4,12 +4,13 @@ import { useState } from "react"
 import { expect, within } from "storybook/test"
 
 import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0Checkbox } from "../F0Checkbox"
 
 const meta = {
   component: F0Checkbox,
-  tags: ["experimental", "!autodocs"],
+  tags: ["stable", "!autodocs"],
   title: "Checkbox",
   parameters: {
     layout: "centered",
@@ -131,4 +132,17 @@ export const Checked: Story = {
       <F0Checkbox {...args} checked={checked} onCheckedChange={setChecked} />
     )
   },
+}
+
+export const Snapshot: Story = {
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <F0Checkbox title="Unchecked" checked={false} />
+      <F0Checkbox title="Checked" checked={true} />
+      <F0Checkbox title="Indeterminate" indeterminate />
+      <F0Checkbox title="Disabled" disabled />
+      <F0Checkbox title="Disabled checked" disabled checked={true} />
+    </div>
+  ),
 }


### PR DESCRIPTION
## What

Promotes **F0Checkbox** from `experimental` to `stable`, closing its Definition of Done gaps.

## Changes

- **Remove experimental markers** — drop the `experimentalComponent()` wrapper and the `@experimental` JSDoc; export directly via `withDataTestId`.
- **Maturity tag** — story tag `experimental` → `stable`.
- **Snapshot story** — add a `Snapshot` story (`withSnapshot`) covering unchecked / checked / indeterminate / disabled states for Chromatic.
- **Docs** — flesh out the MDX (Introduction, Anatomy, States, Guidelines: when to use / when not to use) so it meets the documentation content bar. Clarifies that a checkbox **captures a form value** (not an immediate on/off setting — that's a switch/toggle) and points mutually-exclusive choices to a radio button.

## Verification

- `pnpm test` — F0Checkbox unit tests 13/13 ✅
- `oxlint` — 0 warnings / 0 errors ✅
- `tsc` — no type errors ✅
- Storybook — single Docs page + 6 stories (incl. new Snapshot) render ✅
- Lifecycle dashboard scan — `stable`, content bar met, snapshot present, `satisfies Meta`, `!autodocs` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)