### PR TITLE
fix(ci): skip alpha publish on release-please PRs

### DIFF
--- a/.github/workflows/build-and-publish-alpha.yaml
+++ b/.github/workflows/build-and-publish-alpha.yaml
@@ -15,11 +15,12 @@ jobs:
     name: "[⚛️ REACT] Build and Publish ALPHA"
     needs: detect-changes
     if: |
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       github.event.comment.body == 'build') ||
-      (github.event_name == 'pull_request' && 
-      needs.detect-changes.outputs.package_react == 'true')
+      !startsWith(github.head_ref, 'release-please--') &&
+      ((github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.body == 'build') ||
+       (github.event_name == 'pull_request' &&
+        needs.detect-changes.outputs.package_react == 'true'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -50,11 +51,12 @@ jobs:
     name: "[📱 REACT NATIVE] Build and Publish ALPHA"
     needs: detect-changes
     if: |
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       github.event.comment.body == 'build') ||
-      (github.event_name == 'pull_request' && 
-      needs.detect-changes.outputs.package_react_native == 'true')
+      !startsWith(github.head_ref, 'release-please--') &&
+      ((github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.body == 'build') ||
+       (github.event_name == 'pull_request' &&
+        needs.detect-changes.outputs.package_react_native == 'true'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -99,11 +101,12 @@ jobs:
     name: "[🎯 CORE] Build and Publish ALPHA"
     needs: detect-changes
     if: |
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       github.event.comment.body == 'build') ||
-      (github.event_name == 'pull_request' && 
-      needs.detect-changes.outputs.package_core == 'true')
+      !startsWith(github.head_ref, 'release-please--') &&
+      ((github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.body == 'build') ||
+       (github.event_name == 'pull_request' &&
+        needs.detect-changes.outputs.package_core == 'true'))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- The alpha workflow was failing on release-please PRs because `actions/checkout@v4` tried to checkout `release-please--branches--main`, which gets deleted once the PR is merged
- Added `!startsWith(github.head_ref, 'release-please--')` guard to all three publish jobs (react, react-native, core)

## Root cause

[Run 26945927751](https://github.com/factorialco/f0/actions/runs/26945927751/job/79498781070) — `github.event.pull_request.head.ref` resolves to `release-please--branches--main` on release-please PRs, and that branch no longer exists after merge.

## Test plan

- [ ] Merge a release-please PR and confirm the alpha workflow is skipped
- [ ] Open a normal feature PR with React changes and confirm the alpha workflow still runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)