### PR TITLE
feat(changelog-summarizer): product-focused weekly F0 summary from merged PRs

### DIFF
--- a/.github/workflows/changelog-summary.yaml
+++ b/.github/workflows/changelog-summary.yaml
@@ -1,8 +1,12 @@
-name: "Weekly F0 Changelog Summary"
+name: "Weekly F0 Changelog Summary (legacy — auto-run disabled)"
 
+# NOTE: superseded by `zerito-product-summary.yaml`. This legacy engineering
+# summarizer shares `src/index.ts`, which now produces the PRODUCT summary, so
+# the per-package publish step below would post a malformed message. The weekly
+# schedule is therefore removed to avoid a broken/duplicate Friday post; the
+# workflow is kept as manual-only until we decide to retire it or give the
+# engineering summary its own code path.
 on:
-  schedule:
-    - cron: "0 10 * * 5" # Every Friday at 10:00 UTC
   workflow_dispatch:
     inputs:
       from:

--- a/.github/workflows/changelog-summary.yaml
+++ b/.github/workflows/changelog-summary.yaml
@@ -96,13 +96,9 @@ jobs:
             --output /tmp/summary.md
 
           echo "summary_file=/tmp/summary.md" >> "$GITHUB_OUTPUT"
-
-          # The CLI writes the thread file as <output>-thread.txt and already
-          # appends `thread_file=` to $GITHUB_OUTPUT, but we guard here too in
-          # case the env var wasn't set.
-          if [ -f /tmp/summary-thread.txt ]; then
-            echo "thread_file=/tmp/summary-thread.txt" >> "$GITHUB_OUTPUT"
-          fi
+          # index.ts pre-renders the Block Kit payload (sections already split
+          # under Slack's 3000-char limit) next to the summary.
+          echo "blocks_file=/tmp/summary.blocks.json" >> "$GITHUB_OUTPUT"
         working-directory: ${{ github.workspace }}/packages/changelog-summarizer
 
       - name: Save last-run cache
@@ -121,134 +117,25 @@ jobs:
           SUMMARY_FILE: ${{ steps.summarize.outputs.summary_file }}
         run: cat "$SUMMARY_FILE"
 
-      - name: Publish summary to Slack
+      - name: Publish to Slack
         if: ${{ inputs.dry_run != 'true' }}
         env:
-          SUMMARY_FILE: ${{ steps.summarize.outputs.summary_file }}
-          THREAD_FILE: ${{ steps.summarize.outputs.thread_file }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_F0_SUMMARIZER }}
+          BLOCKS_FILE: ${{ steps.summarize.outputs.blocks_file }}
+          # Incoming webhook for #f0-design-system. Use a webhook created in the
+          # "Zero Updater" Slack app so the message posts as that bot (zerito).
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_F0_SUMMARIZER }}
         run: |
-          # The summary file has the structure:
-          #   Line 1: plain-text title (e.g. "F0 Weekly Summary (2026-02-23 – 2026-03-01)")
-          #   ---
-          #   <section title line>   (e.g. "🚀 What's new")
-          #   <body lines...>
-          #   ---
-          #   <next section title>
-          #   ...
-          #
-          # We build a Block Kit payload:
-          #   • One top-level "header" block for the title
-          #   • For each section: "divider" + "header" (title) + "section" (body)
-
-          CONTENT=$(cat "$SUMMARY_FILE")
-
-          # Extract the top-level title (first line before the first ---)
-          TITLE=$(printf '%s' "$CONTENT" | head -n1)
-
-          # Start the blocks array with the top-level header
-          BLOCKS=$(jq -n --arg t "$TITLE" \
-            '[{ type: "header", text: { type: "plain_text", text: $t, emoji: true } }]')
-
-          # Split the file into sections on lines that are exactly "---"
-          # Skip the first segment (it's the title line we already handled).
-          # Each subsequent segment's first line is the section title; the rest is the body.
-          SEGMENT=""
-          FIRST_SEGMENT=true
-
-          while IFS= read -r line; do
-            if [ "$line" = "---" ]; then
-              if $FIRST_SEGMENT; then
-                # Discard the title segment — already captured above
-                FIRST_SEGMENT=false
-                SEGMENT=""
-                continue
-              fi
-              # Flush the accumulated segment as a section
-              if [ -n "$SEGMENT" ]; then
-                SECTION_TITLE=$(printf '%s' "$SEGMENT" | head -n1)
-                SECTION_BODY=$(printf '%s' "$SEGMENT" | tail -n +2)
-                BLOCKS=$(printf '%s' "$BLOCKS" | jq \
-                  --arg h "$SECTION_TITLE" \
-                  --arg b "$SECTION_BODY" \
-                  '. + [
-                    { type: "divider" },
-                    { type: "header", text: { type: "plain_text", text: $h, emoji: true } },
-                    { type: "section", text: { type: "mrkdwn", text: $b } }
-                  ]')
-              fi
-              SEGMENT=""
-            else
-              if [ -z "$SEGMENT" ]; then
-                SEGMENT="$line"
-              else
-                SEGMENT="${SEGMENT}"$'\n'"${line}"
-              fi
-            fi
-          done <<< "$CONTENT"
-
-          # Flush the last segment (no trailing --- in the file)
-          if [ -n "$SEGMENT" ] && ! $FIRST_SEGMENT; then
-            SECTION_TITLE=$(printf '%s' "$SEGMENT" | head -n1)
-            SECTION_BODY=$(printf '%s' "$SEGMENT" | tail -n +2)
-            BLOCKS=$(printf '%s' "$BLOCKS" | jq \
-              --arg h "$SECTION_TITLE" \
-              --arg b "$SECTION_BODY" \
-              '. + [
-                { type: "divider" },
-                { type: "header", text: { type: "plain_text", text: $h, emoji: true } },
-                { type: "section", text: { type: "mrkdwn", text: $b } }
-              ]')
-          fi
-
-          # Build the chat.postMessage payload. `text` is required as a fallback
-          # for notifications and accessibility (mobile, screen readers).
-          jq -n \
-            --arg channel "$SLACK_CHANNEL_ID" \
-            --arg fallback "$TITLE" \
-            --argjson blocks "$BLOCKS" \
-            '{ channel: $channel, text: $fallback, blocks: $blocks }' > /tmp/payload.json
-
-          RESPONSE=$(curl --silent --show-error \
-            -X POST \
-            -H "Content-Type: application/json; charset=utf-8" \
-            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-            --data @/tmp/payload.json \
-            "https://slack.com/api/chat.postMessage")
-
-          echo "$RESPONSE" | jq -c '{ ok, error, ts }' || true
-
-          OK=$(printf '%s' "$RESPONSE" | jq -r '.ok')
-          if [ "$OK" != "true" ]; then
-            ERR=$(printf '%s' "$RESPONSE" | jq -r '.error // "unknown"')
-            echo "::error::Slack chat.postMessage failed: $ERR"
+          if [ -z "$SLACK_WEBHOOK" ]; then
+            echo "::error::SLACK_WEBHOOK_F0_SUMMARIZER is not set"
             exit 1
           fi
-
-          TS=$(printf '%s' "$RESPONSE" | jq -r '.ts')
-
-          # Post the threaded reply with technical details (best-effort).
-          if [ -n "$THREAD_FILE" ] && [ -f "$THREAD_FILE" ]; then
-            THREAD_TEXT=$(cat "$THREAD_FILE")
-            if [ -n "$THREAD_TEXT" ]; then
-              jq -n \
-                --arg channel "$SLACK_CHANNEL_ID" \
-                --arg thread_ts "$TS" \
-                --arg text "$THREAD_TEXT" \
-                '{ channel: $channel, thread_ts: $thread_ts, text: $text }' > /tmp/thread-payload.json
-
-              THREAD_RESPONSE=$(curl --silent --show-error \
-                -X POST \
-                -H "Content-Type: application/json; charset=utf-8" \
-                -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-                --data @/tmp/thread-payload.json \
-                "https://slack.com/api/chat.postMessage")
-
-              THREAD_OK=$(printf '%s' "$THREAD_RESPONSE" | jq -r '.ok')
-              if [ "$THREAD_OK" != "true" ]; then
-                THREAD_ERR=$(printf '%s' "$THREAD_RESPONSE" | jq -r '.error // "unknown"')
-                echo "::warning::Threaded reply failed ($THREAD_ERR) — main message already published"
-              fi
-            fi
+          # index.ts already produced the Block Kit payload ({ "blocks": [...] })
+          # with long sections split under Slack's 3000-char limit — just post it.
+          RESPONSE=$(curl --silent --show-error --fail \
+            -X POST -H "Content-Type: application/json; charset=utf-8" \
+            --data @"$BLOCKS_FILE" "$SLACK_WEBHOOK")
+          echo "Slack response: $RESPONSE"
+          if [ "$RESPONSE" != "ok" ]; then
+            echo "::error::Slack webhook post failed: $RESPONSE"
+            exit 1
           fi

--- a/.github/workflows/changelog-summary.yaml
+++ b/.github/workflows/changelog-summary.yaml
@@ -90,7 +90,7 @@ jobs:
 
           pnpm tsx src/index.ts \
             "${ARGS[@]}" \
-            --prompt src/prompts/product-v2.md \
+            --prompt src/prompts/product-v3.md \
             --github-token "$GITHUB_TOKEN" \
             --repo-root "${{ github.workspace }}" \
             --output /tmp/summary.md

--- a/.github/workflows/changelog-summary.yaml
+++ b/.github/workflows/changelog-summary.yaml
@@ -72,7 +72,6 @@ jobs:
           FROM_DATE: ${{ inputs.from || '' }}
           TO_DATE: ${{ inputs.to || '' }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ARGS=(--provider "$PROVIDER")
 
@@ -90,15 +89,10 @@ jobs:
 
           pnpm tsx src/index.ts \
             "${ARGS[@]}" \
-            --prompt src/prompts/product-v3.md \
-            --github-token "$GITHUB_TOKEN" \
             --repo-root "${{ github.workspace }}" \
             --output /tmp/summary.md
 
           echo "summary_file=/tmp/summary.md" >> "$GITHUB_OUTPUT"
-          # index.ts pre-renders the Block Kit payload (sections already split
-          # under Slack's 3000-char limit) next to the summary.
-          echo "blocks_file=/tmp/summary.blocks.json" >> "$GITHUB_OUTPUT"
         working-directory: ${{ github.workspace }}/packages/changelog-summarizer
 
       - name: Save last-run cache
@@ -117,25 +111,87 @@ jobs:
           SUMMARY_FILE: ${{ steps.summarize.outputs.summary_file }}
         run: cat "$SUMMARY_FILE"
 
-      - name: Publish to Slack
+      - name: Publish summary to Slack
         if: ${{ inputs.dry_run != 'true' }}
         env:
-          BLOCKS_FILE: ${{ steps.summarize.outputs.blocks_file }}
-          # Incoming webhook for #f0-design-system. Use a webhook created in the
-          # "Zero Updater" Slack app so the message posts as that bot (zerito).
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_F0_SUMMARIZER }}
+          SUMMARY_FILE: ${{ steps.summarize.outputs.summary_file }}
         run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then
-            echo "::error::SLACK_WEBHOOK_F0_SUMMARIZER is not set"
-            exit 1
+          # The summary file has the structure:
+          #   Line 1: plain-text title (e.g. "F0 Weekly Summary (2026-02-23 – 2026-03-01)")
+          #   ---
+          #   <package title line>   (e.g. "⚛️ F0 React — v1.380.0 → v1.384.0")
+          #   <body lines...>
+          #   ---
+          #   <next package title>
+          #   ...
+          #
+          # We build a Block Kit payload:
+          #   • One top-level "header" block for the title
+          #   • For each package section: "divider" + "header" (title) + "section" (body)
+
+          CONTENT=$(cat "$SUMMARY_FILE")
+
+          # Extract the top-level title (first line before the first ---)
+          TITLE=$(printf '%s' "$CONTENT" | head -n1)
+
+          # Start the blocks array with the top-level header
+          BLOCKS=$(jq -n --arg t "$TITLE" \
+            '[{ type: "header", text: { type: "plain_text", text: $t, emoji: true } }]')
+
+          # Split the file into sections on lines that are exactly "---"
+          # Skip the first segment (it's the title line we already handled).
+          # Each subsequent segment's first line is the package title; the rest is the body.
+          SEGMENT=""
+          FIRST_SEGMENT=true
+
+          while IFS= read -r line; do
+            if [ "$line" = "---" ]; then
+              if $FIRST_SEGMENT; then
+                # Discard the title segment — already captured above
+                FIRST_SEGMENT=false
+                SEGMENT=""
+                continue
+              fi
+              # Flush the accumulated segment as a package section
+              if [ -n "$SEGMENT" ]; then
+                PKG_TITLE=$(printf '%s' "$SEGMENT" | head -n1)
+                PKG_BODY=$(printf '%s' "$SEGMENT" | tail -n +2)
+                BLOCKS=$(printf '%s' "$BLOCKS" | jq \
+                  --arg h "$PKG_TITLE" \
+                  --arg b "$PKG_BODY" \
+                  '. + [
+                    { type: "divider" },
+                    { type: "header", text: { type: "plain_text", text: $h, emoji: true } },
+                    { type: "section", text: { type: "mrkdwn", text: $b } }
+                  ]')
+              fi
+              SEGMENT=""
+            else
+              if [ -z "$SEGMENT" ]; then
+                SEGMENT="$line"
+              else
+                SEGMENT="${SEGMENT}"$'\n'"${line}"
+              fi
+            fi
+          done <<< "$CONTENT"
+
+          # Flush the last segment (no trailing --- in the file)
+          if [ -n "$SEGMENT" ] && ! $FIRST_SEGMENT; then
+            PKG_TITLE=$(printf '%s' "$SEGMENT" | head -n1)
+            PKG_BODY=$(printf '%s' "$SEGMENT" | tail -n +2)
+            BLOCKS=$(printf '%s' "$BLOCKS" | jq \
+              --arg h "$PKG_TITLE" \
+              --arg b "$PKG_BODY" \
+              '. + [
+                { type: "divider" },
+                { type: "header", text: { type: "plain_text", text: $h, emoji: true } },
+                { type: "section", text: { type: "mrkdwn", text: $b } }
+              ]')
           fi
-          # index.ts already produced the Block Kit payload ({ "blocks": [...] })
-          # with long sections split under Slack's 3000-char limit — just post it.
-          RESPONSE=$(curl --silent --show-error --fail \
-            -X POST -H "Content-Type: application/json; charset=utf-8" \
-            --data @"$BLOCKS_FILE" "$SLACK_WEBHOOK")
-          echo "Slack response: $RESPONSE"
-          if [ "$RESPONSE" != "ok" ]; then
-            echo "::error::Slack webhook post failed: $RESPONSE"
-            exit 1
-          fi
+
+          # Build and send the final payload
+          jq -n --argjson blocks "$BLOCKS" '{ blocks: $blocks }' > /tmp/payload.json
+
+          curl -X POST -H "Content-Type: application/json" \
+            --data @/tmp/payload.json \
+            "${{ secrets.SLACK_WEBHOOK_F0_SUMMARIZER }}"

--- a/.github/workflows/changelog-summary.yaml
+++ b/.github/workflows/changelog-summary.yaml
@@ -1,12 +1,8 @@
-name: "Weekly F0 Changelog Summary (legacy — auto-run disabled)"
+name: "Weekly F0 Changelog Summary"
 
-# NOTE: superseded by `zerito-product-summary.yaml`. This legacy engineering
-# summarizer shares `src/index.ts`, which now produces the PRODUCT summary, so
-# the per-package publish step below would post a malformed message. The weekly
-# schedule is therefore removed to avoid a broken/duplicate Friday post; the
-# workflow is kept as manual-only until we decide to retire it or give the
-# engineering summary its own code path.
 on:
+  schedule:
+    - cron: "0 10 * * 5" # Every Friday at 10:00 UTC
   workflow_dispatch:
     inputs:
       from:

--- a/.github/workflows/changelog-summary.yaml
+++ b/.github/workflows/changelog-summary.yaml
@@ -72,6 +72,7 @@ jobs:
           FROM_DATE: ${{ inputs.from || '' }}
           TO_DATE: ${{ inputs.to || '' }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ARGS=(--provider "$PROVIDER")
 
@@ -89,10 +90,19 @@ jobs:
 
           pnpm tsx src/index.ts \
             "${ARGS[@]}" \
+            --prompt src/prompts/product-v2.md \
+            --github-token "$GITHUB_TOKEN" \
             --repo-root "${{ github.workspace }}" \
             --output /tmp/summary.md
 
           echo "summary_file=/tmp/summary.md" >> "$GITHUB_OUTPUT"
+
+          # The CLI writes the thread file as <output>-thread.txt and already
+          # appends `thread_file=` to $GITHUB_OUTPUT, but we guard here too in
+          # case the env var wasn't set.
+          if [ -f /tmp/summary-thread.txt ]; then
+            echo "thread_file=/tmp/summary-thread.txt" >> "$GITHUB_OUTPUT"
+          fi
         working-directory: ${{ github.workspace }}/packages/changelog-summarizer
 
       - name: Save last-run cache
@@ -115,19 +125,22 @@ jobs:
         if: ${{ inputs.dry_run != 'true' }}
         env:
           SUMMARY_FILE: ${{ steps.summarize.outputs.summary_file }}
+          THREAD_FILE: ${{ steps.summarize.outputs.thread_file }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_F0_SUMMARIZER }}
         run: |
           # The summary file has the structure:
           #   Line 1: plain-text title (e.g. "F0 Weekly Summary (2026-02-23 – 2026-03-01)")
           #   ---
-          #   <package title line>   (e.g. "⚛️ F0 React — v1.380.0 → v1.384.0")
+          #   <section title line>   (e.g. "🚀 What's new")
           #   <body lines...>
           #   ---
-          #   <next package title>
+          #   <next section title>
           #   ...
           #
           # We build a Block Kit payload:
           #   • One top-level "header" block for the title
-          #   • For each package section: "divider" + "header" (title) + "section" (body)
+          #   • For each section: "divider" + "header" (title) + "section" (body)
 
           CONTENT=$(cat "$SUMMARY_FILE")
 
@@ -140,7 +153,7 @@ jobs:
 
           # Split the file into sections on lines that are exactly "---"
           # Skip the first segment (it's the title line we already handled).
-          # Each subsequent segment's first line is the package title; the rest is the body.
+          # Each subsequent segment's first line is the section title; the rest is the body.
           SEGMENT=""
           FIRST_SEGMENT=true
 
@@ -152,13 +165,13 @@ jobs:
                 SEGMENT=""
                 continue
               fi
-              # Flush the accumulated segment as a package section
+              # Flush the accumulated segment as a section
               if [ -n "$SEGMENT" ]; then
-                PKG_TITLE=$(printf '%s' "$SEGMENT" | head -n1)
-                PKG_BODY=$(printf '%s' "$SEGMENT" | tail -n +2)
+                SECTION_TITLE=$(printf '%s' "$SEGMENT" | head -n1)
+                SECTION_BODY=$(printf '%s' "$SEGMENT" | tail -n +2)
                 BLOCKS=$(printf '%s' "$BLOCKS" | jq \
-                  --arg h "$PKG_TITLE" \
-                  --arg b "$PKG_BODY" \
+                  --arg h "$SECTION_TITLE" \
+                  --arg b "$SECTION_BODY" \
                   '. + [
                     { type: "divider" },
                     { type: "header", text: { type: "plain_text", text: $h, emoji: true } },
@@ -177,11 +190,11 @@ jobs:
 
           # Flush the last segment (no trailing --- in the file)
           if [ -n "$SEGMENT" ] && ! $FIRST_SEGMENT; then
-            PKG_TITLE=$(printf '%s' "$SEGMENT" | head -n1)
-            PKG_BODY=$(printf '%s' "$SEGMENT" | tail -n +2)
+            SECTION_TITLE=$(printf '%s' "$SEGMENT" | head -n1)
+            SECTION_BODY=$(printf '%s' "$SEGMENT" | tail -n +2)
             BLOCKS=$(printf '%s' "$BLOCKS" | jq \
-              --arg h "$PKG_TITLE" \
-              --arg b "$PKG_BODY" \
+              --arg h "$SECTION_TITLE" \
+              --arg b "$SECTION_BODY" \
               '. + [
                 { type: "divider" },
                 { type: "header", text: { type: "plain_text", text: $h, emoji: true } },
@@ -189,9 +202,53 @@ jobs:
               ]')
           fi
 
-          # Build and send the final payload
-          jq -n --argjson blocks "$BLOCKS" '{ blocks: $blocks }' > /tmp/payload.json
+          # Build the chat.postMessage payload. `text` is required as a fallback
+          # for notifications and accessibility (mobile, screen readers).
+          jq -n \
+            --arg channel "$SLACK_CHANNEL_ID" \
+            --arg fallback "$TITLE" \
+            --argjson blocks "$BLOCKS" \
+            '{ channel: $channel, text: $fallback, blocks: $blocks }' > /tmp/payload.json
 
-          curl -X POST -H "Content-Type: application/json" \
+          RESPONSE=$(curl --silent --show-error \
+            -X POST \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             --data @/tmp/payload.json \
-            "${{ secrets.SLACK_WEBHOOK_F0_SUMMARIZER }}"
+            "https://slack.com/api/chat.postMessage")
+
+          echo "$RESPONSE" | jq -c '{ ok, error, ts }' || true
+
+          OK=$(printf '%s' "$RESPONSE" | jq -r '.ok')
+          if [ "$OK" != "true" ]; then
+            ERR=$(printf '%s' "$RESPONSE" | jq -r '.error // "unknown"')
+            echo "::error::Slack chat.postMessage failed: $ERR"
+            exit 1
+          fi
+
+          TS=$(printf '%s' "$RESPONSE" | jq -r '.ts')
+
+          # Post the threaded reply with technical details (best-effort).
+          if [ -n "$THREAD_FILE" ] && [ -f "$THREAD_FILE" ]; then
+            THREAD_TEXT=$(cat "$THREAD_FILE")
+            if [ -n "$THREAD_TEXT" ]; then
+              jq -n \
+                --arg channel "$SLACK_CHANNEL_ID" \
+                --arg thread_ts "$TS" \
+                --arg text "$THREAD_TEXT" \
+                '{ channel: $channel, thread_ts: $thread_ts, text: $text }' > /tmp/thread-payload.json
+
+              THREAD_RESPONSE=$(curl --silent --show-error \
+                -X POST \
+                -H "Content-Type: application/json; charset=utf-8" \
+                -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+                --data @/tmp/thread-payload.json \
+                "https://slack.com/api/chat.postMessage")
+
+              THREAD_OK=$(printf '%s' "$THREAD_RESPONSE" | jq -r '.ok')
+              if [ "$THREAD_OK" != "true" ]; then
+                THREAD_ERR=$(printf '%s' "$THREAD_RESPONSE" | jq -r '.error // "unknown"')
+                echo "::warning::Threaded reply failed ($THREAD_ERR) — main message already published"
+              fi
+            fi
+          fi

--- a/.github/workflows/zerito-product-summary.yaml
+++ b/.github/workflows/zerito-product-summary.yaml
@@ -1,0 +1,139 @@
+name: "Zerito — Weekly F0 Product Summary"
+
+on:
+  schedule:
+    - cron: "0 10 * * 5" # Every Friday at 10:00 UTC
+  workflow_dispatch:
+    inputs:
+      from:
+        description: "Start date (YYYY-MM-DD). Defaults to 7 days ago or last run."
+        required: false
+      to:
+        description: "End date (YYYY-MM-DD). Defaults to today."
+        required: false
+      dry_run:
+        description: "Skip publishing to Slack (summary is printed to the workflow log instead)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      ignore_last_run:
+        description: "Ignore the cached last-run date and always use the last 7 days"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+env:
+  PROVIDER: groq
+  SLACK_CHANNEL: "#testing-zerito"
+
+jobs:
+  summarize:
+    name: "Generate and publish product summary"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: pnpm
+
+      - name: Install changelog-summarizer dependencies
+        run: pnpm install --filter @factorialco/f0-changelog-summarizer
+        working-directory: ${{ github.workspace }}
+
+      - name: Restore last-run cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .cache/zerito-product-last-run
+          key: zerito-product-last-run
+
+      - name: Generate summary
+        id: summarize
+        env:
+          FROM_DATE: ${{ inputs.from || '' }}
+          TO_DATE: ${{ inputs.to || '' }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARGS=(--provider "$PROVIDER")
+
+          if [ -n "$FROM_DATE" ]; then
+            ARGS+=(--from "$FROM_DATE")
+          fi
+
+          if [ -n "$TO_DATE" ]; then
+            ARGS+=(--to "$TO_DATE")
+          fi
+
+          if [ "${{ inputs.ignore_last_run }}" = "true" ]; then
+            ARGS+=(--ignore-last-run)
+          fi
+
+          pnpm tsx src/index.ts \
+            "${ARGS[@]}" \
+            --prompt src/prompts/product-v3.md \
+            --github-token "$GITHUB_TOKEN" \
+            --repo-root "${{ github.workspace }}" \
+            --output /tmp/summary.md
+
+          echo "summary_file=/tmp/summary.md" >> "$GITHUB_OUTPUT"
+          # index.ts pre-renders the Block Kit payload (sections already split
+          # under Slack's 3000-char limit) next to the summary.
+          echo "blocks_file=/tmp/summary.blocks.json" >> "$GITHUB_OUTPUT"
+        working-directory: ${{ github.workspace }}/packages/changelog-summarizer
+
+      - name: Save last-run cache
+        if: ${{ inputs.dry_run != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: .cache/zerito-product-last-run
+          key: zerito-product-last-run
+
+      - name: Print summary (dry run)
+        if: ${{ inputs.dry_run == 'true' }}
+        env:
+          SUMMARY_FILE: ${{ steps.summarize.outputs.summary_file }}
+        run: cat "$SUMMARY_FILE"
+
+      - name: Publish to Slack via Zerito
+        if: ${{ inputs.dry_run != 'true' }}
+        env:
+          BLOCKS_FILE: ${{ steps.summarize.outputs.blocks_file }}
+          SLACK_BOT_TOKEN: ${{ secrets.ZERITO_SLACK_BOT_TOKEN }}
+        run: |
+          if [ -z "$SLACK_BOT_TOKEN" ]; then
+            echo "::error::ZERITO_SLACK_BOT_TOKEN is not set"
+            exit 1
+          fi
+          # index.ts already produced the Block Kit payload ({ "blocks": [...] })
+          # with long sections split under Slack's 3000-char limit.
+          # We inject the target channel and post via chat.postMessage.
+          jq --arg channel "$SLACK_CHANNEL" '. + {channel: $channel}' "$BLOCKS_FILE" > /tmp/payload.json
+          RESPONSE=$(curl --silent --show-error --fail \
+            -X POST \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data @/tmp/payload.json \
+            https://slack.com/api/chat.postMessage)
+          echo "Slack response: $RESPONSE"
+          if ! echo "$RESPONSE" | jq -e '.ok' > /dev/null; then
+            echo "::error::chat.postMessage failed: $(echo "$RESPONSE" | jq -r '.error')"
+            exit 1
+          fi

--- a/packages/changelog-summarizer/scripts/preview-prs.ts
+++ b/packages/changelog-summarizer/scripts/preview-prs.ts
@@ -101,10 +101,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  let summaryFile = `:f0-dev: F0 Weekly Summary (${from} – ${to})\n---\n${slackText}`;
-  if (summaryJson.thread_details?.trim()) {
-    summaryFile += `\n---\n🛠️ For engineers\n\n${summaryJson.thread_details.trim()}`;
-  }
+  const summaryFile = `:f0-dev: F0 Weekly Summary (${from} – ${to})\n---\n${slackText}`;
   writeFileSync("/tmp/zerito-prs.md", summaryFile);
   writeFileSync(
     "/tmp/zerito-prs-blocks.json",

--- a/packages/changelog-summarizer/scripts/preview-prs.ts
+++ b/packages/changelog-summarizer/scripts/preview-prs.ts
@@ -29,6 +29,7 @@ import {
   jsonToSlackText,
   parseSummaryJson,
 } from "../src/formatters/json-formatter.js";
+import { buildBlocks } from "../src/formatters/blockkit.js";
 import type { SummaryJson } from "../src/types.js";
 
 function arg(name: string): string | undefined {
@@ -100,9 +101,11 @@ async function main(): Promise<void> {
     return;
   }
 
-  const summaryFile = `:f0-dev: F0 Weekly Summary (${from} – ${to})\n---\n${slackText}`;
+  let summaryFile = `:f0-dev: F0 Weekly Summary (${from} – ${to})\n---\n${slackText}`;
+  if (summaryJson.thread_details?.trim()) {
+    summaryFile += `\n---\n🛠️ For engineers\n\n${summaryJson.thread_details.trim()}`;
+  }
   writeFileSync("/tmp/zerito-prs.md", summaryFile);
-  writeFileSync("/tmp/zerito-prs-thread.txt", summaryJson.thread_details ?? "");
   writeFileSync(
     "/tmp/zerito-prs-blocks.json",
     JSON.stringify({ blocks: buildBlocks(summaryFile) }, null, 2),
@@ -111,7 +114,7 @@ async function main(): Promise<void> {
   // Report
   const s = json.sections;
   console.error("\n✅ PR-driven preview ready (deterministic, no LLM):");
-  console.error("   /tmp/zerito-prs.md / -thread.txt / -blocks.json");
+  console.error("   /tmp/zerito-prs.md / -blocks.json");
   console.error(
     `\n   ${prs.length} merged PRs → new:${s.new?.length ?? 0} stabilized:${s.stabilized?.length ?? 0} enhancements:${s.enhancements?.length ?? 0} breaking:${s.breaking_changes?.length ?? 0} | fixes:${facts.fixes.length} infra:${facts.infra.length}`,
   );
@@ -129,66 +132,6 @@ async function main(): Promise<void> {
   if (facts.unclassified.length) {
     console.error(`\n   ⚠️ Unclassified (non-conventional titles): ${facts.unclassified.length}`);
   }
-}
-
-interface BlockKitBlock {
-  type: string;
-  text?: { type: string; text: string; emoji?: boolean };
-}
-
-/** Split a section body into <3000-char chunks at bullet boundaries. */
-function chunkMrkdwn(body: string, limit = 2900): string[] {
-  if (body.length <= limit) return [body];
-  const bullets = body.split("\n\n");
-  const chunks: string[] = [];
-  let current = "";
-  for (const bullet of bullets) {
-    const candidate = current ? `${current}\n\n${bullet}` : bullet;
-    if (candidate.length > limit && current) {
-      chunks.push(current);
-      current = bullet;
-    } else {
-      current = candidate;
-    }
-  }
-  if (current) chunks.push(current);
-  return chunks;
-}
-
-function buildBlocks(content: string): BlockKitBlock[] {
-  const lines = content.split("\n");
-  const blocks: BlockKitBlock[] = [
-    { type: "header", text: { type: "plain_text", text: lines[0], emoji: true } },
-  ];
-  let firstSeen = false;
-  let segment: string[] = [];
-  const flush = () => {
-    if (segment.length === 0) return;
-    blocks.push({ type: "divider" });
-    blocks.push({
-      type: "header",
-      text: { type: "plain_text", text: segment[0], emoji: true },
-    });
-    for (const chunk of chunkMrkdwn(segment.slice(1).join("\n"))) {
-      blocks.push({ type: "section", text: { type: "mrkdwn", text: chunk } });
-    }
-    segment = [];
-  };
-  for (let i = 1; i < lines.length; i++) {
-    const line = lines[i];
-    if (line === "---") {
-      if (!firstSeen) {
-        firstSeen = true;
-        segment = [];
-        continue;
-      }
-      flush();
-      continue;
-    }
-    segment.push(line);
-  }
-  if (firstSeen) flush();
-  return blocks;
 }
 
 main().catch((err) => {

--- a/packages/changelog-summarizer/scripts/preview-prs.ts
+++ b/packages/changelog-summarizer/scripts/preview-prs.ts
@@ -30,6 +30,7 @@ import {
   parseSummaryJson,
 } from "../src/formatters/json-formatter.js";
 import { buildBlocks } from "../src/formatters/blockkit.js";
+import { FOUNDATIONS_AUTHORS } from "../src/foundations.js";
 import type { SummaryJson } from "../src/types.js";
 
 function arg(name: string): string | undefined {
@@ -72,7 +73,11 @@ async function main(): Promise<void> {
 
   const storyIndex = await collectStoryIndex();
   const storyUrls = storyIndex.urlByKey;
-  const facts = classifyMergedPrs(withFiles, storyIndex);
+  const facts = classifyMergedPrs(
+    withFiles,
+    storyIndex,
+    new Set(FOUNDATIONS_AUTHORS),
+  );
 
   // Compose the technical thread reply deterministically from fixes + infra.
   const threadParts: string[] = [];

--- a/packages/changelog-summarizer/scripts/preview-prs.ts
+++ b/packages/changelog-summarizer/scripts/preview-prs.ts
@@ -1,0 +1,197 @@
+/**
+ * End-to-end preview from REAL merged PRs — the deterministic, no-hallucination
+ * path. Lists PRs merged into main in a date range, classifies them from their
+ * title + changed files (NO LLM), renders the Slack message, and writes a Block
+ * Kit payload you can paste into https://app.slack.com/block-kit-builder.
+ *
+ * Run from `packages/changelog-summarizer/`:
+ *   GITHUB_TOKEN=$(gh auth token) pnpm tsx scripts/preview-prs.ts --from 2026-04-27 --to 2026-05-26
+ */
+
+import { writeFileSync } from "fs";
+import {
+  fetchPrBodies,
+  fetchPrFiles,
+  listMergedPRs,
+  type PrFile,
+} from "../src/collectors/github.js";
+import {
+  classifyMergedPrs,
+  TYPES_NEEDING_FILES,
+  parseConventionalTitle,
+  type PrWithFiles,
+} from "../src/collectors/prs.js";
+import {
+  collectStoryIndex,
+  resolveStoryUrl,
+} from "../src/collectors/stories.js";
+import {
+  jsonToSlackText,
+  parseSummaryJson,
+} from "../src/formatters/json-formatter.js";
+import type { SummaryJson } from "../src/types.js";
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+async function main(): Promise<void> {
+  const from = arg("from") ?? "2026-04-27";
+  const to = arg("to") ?? "2026-05-26";
+  const token = process.env["GITHUB_TOKEN"];
+  if (!token) {
+    console.error(
+      "⚠️  No GITHUB_TOKEN — run with `GITHUB_TOKEN=$(gh auth token) ...` (unauthenticated calls hit low rate limits).",
+    );
+  }
+
+  console.error(`[preview-prs] Listing merged PRs ${from} → ${to}…`);
+  const prs = await listMergedPRs(from, to, token);
+
+  // Only inspect files for PR types that can introduce a new component or a
+  // stabilization (or breaking changes). fix/chore/ci/etc. are bucketed by
+  // title alone — no need for an extra API call per PR.
+  console.error("[preview-prs] Fetching changed files for relevant PRs…");
+  const withFiles: PrWithFiles[] = [];
+  for (const pr of prs) {
+    const { type, breaking } = parseConventionalTitle(pr.title);
+    let files: PrFile[] = [];
+    if (breaking || TYPES_NEEDING_FILES.has(type)) {
+      files = await fetchPrFiles(pr.number, token);
+    }
+    // Breaking changes need the PR description to explain the migration.
+    let body: string | undefined;
+    if (breaking) {
+      const bodies = await fetchPrBodies([pr.number], token);
+      body = bodies.get(pr.number)?.body;
+    }
+    withFiles.push({ ...pr, files, body });
+  }
+
+  const storyIndex = await collectStoryIndex();
+  const storyUrls = storyIndex.urlByKey;
+  const facts = classifyMergedPrs(withFiles, storyIndex);
+
+  // Compose the technical thread reply deterministically from fixes + infra.
+  const threadParts: string[] = [];
+  if (facts.fixes.length > 0) {
+    threadParts.push(`Fixes this week: ${facts.fixes.join("; ")}.`);
+  }
+  if (facts.infra.length > 0) {
+    threadParts.push(`Infra & tooling: ${facts.infra.join("; ")}.`);
+  }
+  if (facts.contributors.length > 0) {
+    threadParts.push(
+      `Thanks to ${facts.contributors.map((c) => `@${c}`).join(", ")}.`,
+    );
+  }
+
+  const summaryJson: SummaryJson = {
+    ...facts.skeleton,
+    thread_details: threadParts.join(" "),
+  };
+
+  // Round-trip through the parser to exercise the same path as production.
+  const json = parseSummaryJson(JSON.stringify(summaryJson));
+  const slackText = jsonToSlackText(json, storyUrls);
+  if (!slackText) {
+    console.error("[preview-prs] No product-visible changes in this window.");
+    return;
+  }
+
+  const summaryFile = `:f0-dev: F0 Weekly Summary (${from} – ${to})\n---\n${slackText}`;
+  writeFileSync("/tmp/zerito-prs.md", summaryFile);
+  writeFileSync("/tmp/zerito-prs-thread.txt", summaryJson.thread_details ?? "");
+  writeFileSync(
+    "/tmp/zerito-prs-blocks.json",
+    JSON.stringify({ blocks: buildBlocks(summaryFile) }, null, 2),
+  );
+
+  // Report
+  const s = json.sections;
+  console.error("\n✅ PR-driven preview ready (deterministic, no LLM):");
+  console.error("   /tmp/zerito-prs.md / -thread.txt / -blocks.json");
+  console.error(
+    `\n   ${prs.length} merged PRs → new:${s.new?.length ?? 0} stabilized:${s.stabilized?.length ?? 0} enhancements:${s.enhancements?.length ?? 0} breaking:${s.breaking_changes?.length ?? 0} | fixes:${facts.fixes.length} infra:${facts.infra.length}`,
+  );
+  if (s.stabilized?.length) {
+    console.error("\n   ✅ Now stable (from newly-added MDX docs = DoD complete):");
+    for (const e of s.stabilized) console.error(`      ${e.component} (by ${e.author})`);
+  }
+  console.error("\n   Links resolved (★ = deep-link to a specific story):");
+  for (const e of [...(s.new ?? []), ...(s.stabilized ?? []), ...(s.enhancements ?? [])]) {
+    const deep = e.url;
+    const url = deep ?? resolveStoryUrl(e.component, storyUrls);
+    const tag = deep ? "★ story deep-link" : url ? "docs page" : "(no link)";
+    console.error(`      ${e.component.padEnd(24)} ${tag}`);
+  }
+  if (facts.unclassified.length) {
+    console.error(`\n   ⚠️ Unclassified (non-conventional titles): ${facts.unclassified.length}`);
+  }
+}
+
+interface BlockKitBlock {
+  type: string;
+  text?: { type: string; text: string; emoji?: boolean };
+}
+
+/** Split a section body into <3000-char chunks at bullet boundaries. */
+function chunkMrkdwn(body: string, limit = 2900): string[] {
+  if (body.length <= limit) return [body];
+  const bullets = body.split("\n\n");
+  const chunks: string[] = [];
+  let current = "";
+  for (const bullet of bullets) {
+    const candidate = current ? `${current}\n\n${bullet}` : bullet;
+    if (candidate.length > limit && current) {
+      chunks.push(current);
+      current = bullet;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+function buildBlocks(content: string): BlockKitBlock[] {
+  const lines = content.split("\n");
+  const blocks: BlockKitBlock[] = [
+    { type: "header", text: { type: "plain_text", text: lines[0], emoji: true } },
+  ];
+  let firstSeen = false;
+  let segment: string[] = [];
+  const flush = () => {
+    if (segment.length === 0) return;
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "header",
+      text: { type: "plain_text", text: segment[0], emoji: true },
+    });
+    for (const chunk of chunkMrkdwn(segment.slice(1).join("\n"))) {
+      blocks.push({ type: "section", text: { type: "mrkdwn", text: chunk } });
+    }
+    segment = [];
+  };
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === "---") {
+      if (!firstSeen) {
+        firstSeen = true;
+        segment = [];
+        continue;
+      }
+      flush();
+      continue;
+    }
+    segment.push(line);
+  }
+  if (firstSeen) flush();
+  return blocks;
+}
+
+main().catch((err) => {
+  console.error("Error:", err instanceof Error ? err.stack : String(err));
+  process.exit(1);
+});

--- a/packages/changelog-summarizer/scripts/preview-real.ts
+++ b/packages/changelog-summarizer/scripts/preview-real.ts
@@ -1,0 +1,281 @@
+/**
+ * Real-data preview — builds a Block Kit payload from actual commits between
+ * 2026-04-27 and today, classified by hand (since the LLM is unavailable).
+ *
+ * Run from `packages/changelog-summarizer/`:
+ *   pnpm tsx scripts/preview-real.ts
+ */
+
+import { writeFileSync } from "fs"
+import { collectStoryUrls, resolveStoryUrl } from "../src/collectors/stories.js"
+import {
+  jsonToSlackText,
+  parseSummaryJson,
+} from "../src/formatters/json-formatter.js"
+
+// Classification based on the actual git log between 2026-04-27 and 2026-05-26.
+// Followed the same rules as the product-v2 prompt:
+// - "new" = brand-new component (didn't exist before)
+// - "enhancements" = additions/improvements to existing components
+// - "fixes" = single sentence grouping all fixes
+// - "infrastructure" = build, tests, tooling, docs infra
+const realJson = {
+  sections: {
+    new: [
+      {
+        component: "F0Graph",
+        summary:
+          "New chart pattern for building runtime graph visualizations",
+        detail: "Lives under Patterns/Graph in Storybook",
+        storybook: true,
+        author: "Ángel Saavedra",
+      },
+      {
+        component: "F0SegmentedControl",
+        summary:
+          "New experimental segmented control for switching between a few related options",
+        storybook: true,
+        author: "Desirée Navarro",
+      },
+      {
+        component: "UpsellingAlert",
+        summary:
+          "New alert component for the upselling kit to prompt plan upgrades inline",
+        storybook: true,
+        author: "daviz-fct",
+      },
+    ],
+    // NOTE: illustrative — these two were actually promoted to stable in early
+    // April (#3849/#3850), just before this preview's window, but there were no
+    // stabilizations in 2026-04-27 → 2026-05-26. Kept here to show the section.
+    stabilized: [
+      {
+        component: "F0DatePicker",
+        summary: "Promoted out of experimental — now stable and safe to use",
+        storybook: true,
+        author: "Eliseo Juan Quintanilla",
+      },
+      {
+        component: "OneEmptyState",
+        summary: "Promoted out of experimental — now stable and safe to use",
+        storybook: true,
+        author: "Eliseo Juan Quintanilla",
+      },
+    ],
+    enhancements: [
+      {
+        component: "F0AiChat",
+        summary:
+          "Big push this week — added the ability to ask clarifying questions mid-conversation, employee credits popover, before-send hook, file attachment limits, dashboard header redesign and a pluggable canvas",
+        detail:
+          "Per-column tooltips, requisition entity ref enrichment and chat-wide drop zone also shipped",
+        storybook: true,
+        author: "Raúl Sigüenza & contributors",
+      },
+      {
+        component: "PageHeader",
+        summary: "Page title area now supports AI-kind actions",
+        storybook: true,
+        author: "Igor Safonov",
+      },
+      {
+        component: "F0Card",
+        summary:
+          "Added a controlled alert option and an optional action button on the alert area",
+        storybook: true,
+        author: "Idowu Arifayan",
+      },
+      {
+        component: "F0Form",
+        summary:
+          "New autosubmit submit type that keeps focus on the active field while saving",
+        storybook: true,
+        author: "Rubén Moya",
+      },
+      {
+        component: "F0Link",
+        summary:
+          "Added a mention variant with a shared mention recipe so the same look works across surfaces",
+        storybook: true,
+        author: "Desirée Navarro",
+      },
+      {
+        component: "F0DataChart",
+        summary: "Data charts now show a proper empty state",
+        storybook: true,
+        author: "Raúl Sigüenza Sánchez",
+      },
+      {
+        component: "F0Box",
+        summary: "New inset options for finer control over internal spacing",
+        storybook: true,
+        author: "David Matos",
+      },
+      {
+        component: "F0Tabs",
+        summary:
+          "Tab id type is now generic so consumers can use their own union types",
+        storybook: true,
+        author: "oscarbyte",
+      },
+      {
+        component: "EditableTable",
+        summary:
+          "Several improvements: per-row dynamic units, min/max constraints on date cells, formulas and hints on cells, null handling on number cells, and fixes to focus loss and action column width",
+        storybook: true,
+        author: "Vinicius Meneses & contributors",
+      },
+      {
+        component: "ResourceHeader",
+        summary: "Added a secondary dropdown option for additional actions",
+        storybook: true,
+        author: "Pau Hernando",
+      },
+      {
+        component: "RadarChart",
+        summary:
+          "Interactive legend with the ability to hide individual series",
+        storybook: true,
+        author: "Vinicius Meneses",
+      },
+      {
+        component: "Selectable and bulk actions",
+        summary:
+          "Data collection bulk actions now report loading, success and error status as they run",
+        storybook: true,
+        author: "Jan Chruszcz",
+      },
+      {
+        component: "SurveyFormBuilder",
+        summary:
+          "Hide individual question actions in surveys; also new option creation for select-from-dataset questions",
+        storybook: true,
+        author: "Santi Guillén & Maria",
+      },
+      {
+        component: "Filters",
+        summary:
+          "Filters can now be cancelled and the apply action runs independently; tags also expose onApply and support icons",
+        storybook: true,
+        author: "David Matos",
+      },
+    ],
+  },
+  thread_details:
+    "Technical notes for consumers: F0AiChat received a breaking change (#4106) — built-in actions were dropped and the canvas is now pluggable; please review your composition before upgrading. A new ExpenseEntityRef hover card was added alongside the existing Candidate/Requisition/Vacancy ones — registered automatically via entityRefRegistry. F0Graph is a new pattern, see Patterns/Graph in Storybook. F0SegmentedControl is experimental — API may still change. UpsellingAlert lives in the upselling-kit (SDS). F0DatePicker and OneEmptyState were promoted from experimental to stable. EditableTable gained per-row dynamic units (`unitsByRow`), formulas/hints (`hint`, `formula`), and number cells now accept null. F0Card now exposes a controlled `alert` prop on top of the new `CardAlert.action`. F0Form's `autosubmit` submit type preserves focus on the active input. F0Box gained `insetX`/`insetY` props. F0Tabs id type is now generic — `<F0Tabs<\"foo\" | \"bar\">>`. PageHeader actions can now be tagged as AI-kind. Fixes this week: F0Select double-emit on async datasources and external value resets, RichTextEditor fullscreen inside dialogs, F0Button docs sidebar visibility, ApplicationFrame stories, MultitaskHeader icon consistency, SurveyAnsweringForm centering, and MDX formatting in CrudPatterns. Infra: Storybook MDX sidebar visibility improved, CRUD patterns docs landed, the release workflow can now be triggered manually, and the F0Button/F0ButtonDropdown docs pages are now discoverable.",
+}
+
+async function main(): Promise<void> {
+  console.error("[preview-real] Fetching Storybook index for real URLs…")
+  const storyUrls = await collectStoryUrls()
+
+  const json = parseSummaryJson(JSON.stringify(realJson))
+  const slackText = jsonToSlackText(json, storyUrls)
+  if (!slackText) throw new Error("Formatter returned null")
+
+  const fromStr = "2026-04-27"
+  const toStr = "2026-05-26"
+  const summaryFile = `:f0-dev: F0 Weekly Summary (${fromStr} – ${toStr})\n---\n${slackText}`
+  const threadFile = json.thread_details ?? ""
+
+  writeFileSync("/tmp/zerito-real.md", summaryFile)
+  writeFileSync("/tmp/zerito-real-thread.txt", threadFile)
+
+  const blocks = buildBlocks(summaryFile)
+  writeFileSync(
+    "/tmp/zerito-real-blocks.json",
+    JSON.stringify({ blocks }, null, 2),
+  )
+
+  console.error("")
+  console.error("✅ Real-data preview ready:")
+  console.error("   /tmp/zerito-real.md          (raw summary file)")
+  console.error("   /tmp/zerito-real-thread.txt  (threaded reply)")
+  console.error("   /tmp/zerito-real-blocks.json (paste in Block Kit Builder)")
+  console.error("")
+  console.error("Resolved Storybook links:")
+  for (const entry of [
+    ...(json.sections.new ?? []),
+    ...(json.sections.enhancements ?? []),
+  ]) {
+    if (!entry.storybook) continue
+    const url = resolveStoryUrl(entry.component, storyUrls)
+    const status = url
+      ? `→ ${url}`
+      : "→ (no docs page — bullet shown without link)"
+    console.error(`   ${entry.component.padEnd(24)} ${status}`)
+  }
+}
+
+interface BlockKitBlock {
+  type: string
+  text?: { type: string; text: string; emoji?: boolean }
+}
+
+/**
+ * Split a section body into chunks that each stay under Slack's 3000-char
+ * mrkdwn limit, breaking only at bullet boundaries (blank lines) so no single
+ * bullet is ever cut in half.
+ */
+function chunkMrkdwn(body: string, limit = 2900): string[] {
+  if (body.length <= limit) return [body]
+  const bullets = body.split("\n\n")
+  const chunks: string[] = []
+  let current = ""
+  for (const bullet of bullets) {
+    const candidate = current ? `${current}\n\n${bullet}` : bullet
+    if (candidate.length > limit && current) {
+      chunks.push(current)
+      current = bullet
+    } else {
+      current = candidate
+    }
+  }
+  if (current) chunks.push(current)
+  return chunks
+}
+
+function buildBlocks(content: string): BlockKitBlock[] {
+  const lines = content.split("\n")
+  const title = lines[0]
+  const blocks: BlockKitBlock[] = [
+    { type: "header", text: { type: "plain_text", text: title, emoji: true } },
+  ]
+  let firstSeen = false
+  let segment: string[] = []
+  const flush = () => {
+    if (segment.length === 0) return
+    blocks.push({ type: "divider" })
+    blocks.push({
+      type: "header",
+      text: { type: "plain_text", text: segment[0], emoji: true },
+    })
+    // Slack caps a section's mrkdwn text at 3000 chars. A category with many
+    // bullets can blow past that, so split the body into multiple section
+    // blocks at bullet boundaries (blank lines) instead of one oversized block.
+    for (const chunk of chunkMrkdwn(segment.slice(1).join("\n"))) {
+      blocks.push({ type: "section", text: { type: "mrkdwn", text: chunk } })
+    }
+    segment = []
+  }
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line === "---") {
+      if (!firstSeen) {
+        firstSeen = true
+        segment = []
+        continue
+      }
+      flush()
+      continue
+    }
+    segment.push(line)
+  }
+  if (firstSeen) flush()
+  return blocks
+}
+
+main().catch((err) => {
+  console.error("Error:", err instanceof Error ? err.stack : String(err))
+  process.exit(1)
+})

--- a/packages/changelog-summarizer/scripts/preview.ts
+++ b/packages/changelog-summarizer/scripts/preview.ts
@@ -1,0 +1,198 @@
+/**
+ * Visual preview tool — generates an example summary file + Block Kit payload
+ * without calling the LLM, so you can paste it into
+ * https://app.slack.com/block-kit-builder to see exactly how the message
+ * renders in Slack.
+ *
+ * Run from `packages/changelog-summarizer/`:
+ *   pnpm tsx scripts/preview.ts
+ *
+ * Outputs:
+ *   /tmp/zerito-preview.md          ← summary file (what the workflow parses)
+ *   /tmp/zerito-preview-thread.txt  ← threaded technical reply
+ *   /tmp/zerito-preview-blocks.json ← Block Kit payload, paste this in the Builder
+ */
+
+import { writeFileSync } from "fs"
+import { collectStoryUrls } from "../src/collectors/stories.js"
+import {
+  jsonToSlackText,
+  parseSummaryJson,
+} from "../src/formatters/json-formatter.js"
+
+// A realistic-looking JSON, matching what the product-v2 prompt would emit
+// for a typical F0 week. Mix of: components with Storybook pages, internal
+// product components (no link), enhancements, fixes summary, infrastructure.
+const sampleJson = {
+  sections: {
+    new: [
+      {
+        component: "VacancyEntityRef",
+        summary:
+          "New component for displaying vacancy information — no more custom solutions needed",
+        storybook: false,
+      },
+      {
+        component: "RequisitionEntityRef",
+        summary:
+          "New component for displaying requisition information — speeds up development",
+        storybook: false,
+      },
+      {
+        component: "EditableTable",
+        summary:
+          "New table component with inline editing support straight out of the box",
+        storybook: true,
+      },
+    ],
+    enhancements: [
+      {
+        component: "CandidateEntityRef",
+        summary:
+          "Now shows source and applied date, making candidate tracking easier",
+        storybook: false,
+      },
+      {
+        component: "F0AiChat",
+        summary:
+          "UX improved with clarifying questions, persistence between sessions, smoother animations, and reply support",
+        storybook: true,
+      },
+      {
+        component: "FileUpload",
+        summary:
+          "Document upload experience improved — drag, preview, and submit in one flow",
+        storybook: true,
+      },
+      {
+        component: "F0Form",
+        summary: "Field shortcuts added — speeds up form completion",
+        storybook: true,
+      },
+      {
+        component: "PageHeader",
+        summary:
+          "Now supports custom actions on click — more flexible page interactions",
+        storybook: true,
+      },
+      {
+        component: "F0Button",
+        summary: "New icons and visual changes — updated look and feel",
+        storybook: true,
+      },
+    ],
+    fixes: {
+      summary:
+        "Fixed issues with form submission in edit mode, rich text field updates, and various visual glitches",
+    },
+    infrastructure: {
+      summary:
+        "Build pipeline optimized, Storybook updated, and new tests added — improves development efficiency",
+    },
+  },
+  thread_details:
+    "Technical notes for consumers: VacancyEntityRef and RequisitionEntityRef live in the product app, not in @factorialco/f0-react. EditableTable is new in packages/react under Patterns/Data Collection. F0AiChat gained `onClarify`, `persistSession`, and `onReply` options — no breaking changes. PageHeader actions now accept a custom `onClick` handler in addition to `href`. Storybook upgraded to v10.2.10, drop your local cache before re-running stories.",
+}
+
+async function main(): Promise<void> {
+  console.error("[preview] Fetching Storybook index for real URLs…")
+  const storyUrls = await collectStoryUrls()
+
+  // Round-trip through the parser so we exercise the same path as production.
+  const json = parseSummaryJson(JSON.stringify(sampleJson))
+  const slackText = jsonToSlackText(json, storyUrls)
+  if (!slackText) {
+    throw new Error("Formatter returned null — sample JSON was empty?")
+  }
+
+  const fromStr = "2026-04-17"
+  const toStr = "2026-04-23"
+  const summaryFile = `:f0-dev: F0 Weekly Summary (${fromStr} – ${toStr})\n---\n${slackText}`
+  const threadFile = json.thread_details ?? ""
+
+  writeFileSync("/tmp/zerito-preview.md", summaryFile)
+  writeFileSync("/tmp/zerito-preview-thread.txt", threadFile)
+
+  // Build the exact Block Kit payload the workflow produces, so you can paste
+  // it into https://app.slack.com/block-kit-builder
+  const blocks = buildBlocks(summaryFile)
+  const payload = { blocks }
+  writeFileSync(
+    "/tmp/zerito-preview-blocks.json",
+    JSON.stringify(payload, null, 2),
+  )
+
+  console.error("")
+  console.error("✅ Preview ready:")
+  console.error("   /tmp/zerito-preview.md          (raw summary file)")
+  console.error("   /tmp/zerito-preview-thread.txt  (threaded reply)")
+  console.error("   /tmp/zerito-preview-blocks.json (paste in Block Kit Builder)")
+  console.error("")
+  console.error("Resolved Storybook links:")
+  for (const entry of [
+    ...(json.sections.new ?? []),
+    ...(json.sections.enhancements ?? []),
+  ]) {
+    if (!entry.storybook) continue
+    const url = storyUrls.get(entry.component.toLowerCase()) ??
+      storyUrls.get(`f0${entry.component.toLowerCase()}`) ??
+      storyUrls.get(entry.component.toLowerCase().replace(/^f0/, "")) ?? null
+    const status = url ? `→ ${url}` : "→ (no docs page — bullet shown without link)"
+    console.error(`   ${entry.component.padEnd(22)} ${status}`)
+  }
+}
+
+interface BlockKitBlock {
+  type: string
+  text?: { type: string; text: string; emoji?: boolean }
+}
+
+function buildBlocks(content: string): BlockKitBlock[] {
+  const lines = content.split("\n")
+  const title = lines[0]
+  const blocks: BlockKitBlock[] = [
+    { type: "header", text: { type: "plain_text", text: title, emoji: true } },
+  ]
+
+  // Mirror the bash logic in changelog-summary.yaml
+  let firstSeen = false
+  let segment: string[] = []
+
+  const flush = () => {
+    if (segment.length === 0) return
+    const segTitle = segment[0]
+    const segBody = segment.slice(1).join("\n")
+    blocks.push({ type: "divider" })
+    blocks.push({
+      type: "header",
+      text: { type: "plain_text", text: segTitle, emoji: true },
+    })
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: segBody },
+    })
+    segment = []
+  }
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line === "---") {
+      if (!firstSeen) {
+        firstSeen = true
+        segment = []
+        continue
+      }
+      flush()
+      continue
+    }
+    segment.push(line)
+  }
+  if (firstSeen) flush()
+
+  return blocks
+}
+
+main().catch((err) => {
+  console.error("Error:", err instanceof Error ? err.stack : String(err))
+  process.exit(1)
+})

--- a/packages/changelog-summarizer/src/collectors/github.ts
+++ b/packages/changelog-summarizer/src/collectors/github.ts
@@ -1,0 +1,295 @@
+/**
+ * Fetch pull request bodies from the GitHub REST API to give the LLM richer
+ * context about what each PR actually did. Only feature PRs are fetched —
+ * bug fixes are noisy and the CHANGELOG one-liner is usually enough.
+ */
+
+const REPO = "factorialco/f0";
+const API_BASE = `https://api.github.com/repos/${REPO}`;
+const SEARCH_BASE = "https://api.github.com/search/issues";
+const MAX_BODY_CHARS = 600;
+const REQUEST_DELAY_MS = 150;
+
+export interface PrInfo {
+  number: number;
+  body: string;
+}
+
+/** A merged pull request, as returned by the search API. */
+export interface MergedPr {
+  number: number;
+  title: string;
+  author: string;
+  labels: string[];
+}
+
+/** A single file changed by a pull request. */
+export interface PrFile {
+  filename: string;
+  /** "added" | "modified" | "removed" | "renamed" | "copied" | "changed" */
+  status: string;
+  /** Unified diff for the file. Omitted by GitHub for very large/binary files. */
+  patch?: string;
+}
+
+function ghHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "factorial-one-changelog-summarizer",
+  };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return headers;
+}
+
+const PR_NUMBER_REGEX = /(?:#|\/pull\/)(\d{2,})/g;
+
+/**
+ * Extract PR numbers from arbitrary text. Recognises `#1234` and `/pull/1234`
+ * patterns. Returns a deduplicated list sorted in descending order so the most
+ * recent PRs are fetched first.
+ */
+export function extractPrNumbers(text: string): number[] {
+  if (!text) return [];
+
+  const seen = new Set<number>();
+  for (const match of text.matchAll(PR_NUMBER_REGEX)) {
+    const n = Number.parseInt(match[1], 10);
+    if (Number.isFinite(n) && n > 0) seen.add(n);
+  }
+
+  return [...seen].sort((a, b) => b - a);
+}
+
+function cleanBoilerplate(body: string): string {
+  // Strip common Factorial PR template sections that add no signal.
+  const lines = body.replace(/\r\n/g, "\n").split("\n");
+  const cleaned: string[] = [];
+
+  // Headings (markdown) that mark template noise we want to drop along with
+  // everything below them until the next heading of equal or higher level.
+  const NOISE_HEADINGS =
+    /^#{1,6}\s+(checklist|how to test|how to qa|qa|screenshots?|videos?|notes for reviewers?|related (issues|tickets|prs)|references?)\s*$/i;
+
+  let skip = false;
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+/);
+    if (headingMatch) {
+      skip = NOISE_HEADINGS.test(line);
+      if (skip) continue;
+    }
+    if (skip) continue;
+
+    // Strip HTML comments often left over from templates.
+    if (/^<!--/.test(line) || /-->$/.test(line)) continue;
+
+    cleaned.push(line);
+  }
+
+  return cleaned.join("\n").trim();
+}
+
+function truncateAtSentence(text: string, max: number): string {
+  if (text.length <= max) return text;
+
+  const slice = text.slice(0, max);
+  // Prefer breaking at the last sentence boundary.
+  const lastStop = Math.max(
+    slice.lastIndexOf(". "),
+    slice.lastIndexOf("! "),
+    slice.lastIndexOf("? "),
+    slice.lastIndexOf(".\n"),
+    slice.lastIndexOf("!\n"),
+    slice.lastIndexOf("?\n"),
+  );
+
+  if (lastStop > max * 0.5) {
+    return `${slice.slice(0, lastStop + 1).trim()}…`;
+  }
+
+  return `${slice.trim()}…`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetch PR bodies sequentially with a small delay between calls to stay well
+ * below GitHub's secondary rate limits.
+ *
+ * - 403/404 are treated as "skip" (they happen when the workflow token lacks
+ *   permission for a PR, or the PR was deleted). They don't break the run.
+ * - Network errors log a warning and are skipped.
+ * - When no `token` is provided we still try unauthenticated; this is the
+ *   developer-machine path with low traffic.
+ */
+export async function fetchPrBodies(
+  prNumbers: number[],
+  token?: string,
+): Promise<Map<number, PrInfo>> {
+  const map = new Map<number, PrInfo>();
+  if (prNumbers.length === 0) return map;
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "factorial-one-changelog-summarizer",
+  };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  for (const num of prNumbers) {
+    try {
+      const res = await fetch(`${API_BASE}/pulls/${num}`, { headers });
+
+      if (res.status === 403 || res.status === 404) {
+        console.error(
+          `[github] PR #${num}: HTTP ${res.status} — skipping`,
+        );
+        await sleep(REQUEST_DELAY_MS);
+        continue;
+      }
+
+      if (!res.ok) {
+        console.error(
+          `[github] PR #${num}: HTTP ${res.status} — skipping`,
+        );
+        await sleep(REQUEST_DELAY_MS);
+        continue;
+      }
+
+      const json = (await res.json()) as { body?: string | null };
+      const rawBody = typeof json.body === "string" ? json.body : "";
+      const cleaned = cleanBoilerplate(rawBody);
+      const truncated = truncateAtSentence(cleaned, MAX_BODY_CHARS);
+
+      if (truncated.length > 0) {
+        map.set(num, { number: num, body: truncated });
+        console.error(
+          `[github] PR #${num}: fetched (${truncated.length} chars)`,
+        );
+      } else {
+        console.error(`[github] PR #${num}: empty body — skipping`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[github] PR #${num}: error (${msg}) — skipping`);
+    }
+
+    await sleep(REQUEST_DELAY_MS);
+  }
+
+  return map;
+}
+
+/**
+ * List pull requests merged into `main` within [from, to] (inclusive,
+ * YYYY-MM-DD). Uses the Search API and paginates. This is the backbone of the
+ * summary: a merged PR is "what actually shipped", with a real author and a
+ * conventional-commit title we can classify deterministically.
+ */
+export async function listMergedPRs(
+  from: string,
+  to: string,
+  token?: string,
+): Promise<MergedPr[]> {
+  const headers = ghHeaders(token);
+  const q = `repo:${REPO} is:pr is:merged base:main merged:${from}..${to}`;
+  const all: MergedPr[] = [];
+
+  for (let page = 1; page <= 10; page++) {
+    const url = `${SEARCH_BASE}?q=${encodeURIComponent(q)}&per_page=100&page=${page}&sort=created&order=asc`;
+    let res: Response;
+    try {
+      res = await fetch(url, { headers });
+    } catch (err) {
+      console.error(
+        `[github] search PRs page ${page}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      break;
+    }
+
+    if (!res.ok) {
+      console.error(`[github] search PRs page ${page}: HTTP ${res.status}`);
+      break;
+    }
+
+    const json = (await res.json()) as {
+      items?: Array<{
+        number: number;
+        title: string;
+        user?: { login?: string };
+        labels?: Array<{ name?: string }>;
+      }>;
+    };
+
+    const items = json.items ?? [];
+    for (const it of items) {
+      all.push({
+        number: it.number,
+        title: it.title,
+        author: it.user?.login ?? "",
+        labels: (it.labels ?? [])
+          .map((l) => l.name ?? "")
+          .filter((n) => n.length > 0),
+      });
+    }
+
+    if (items.length < 100) break;
+    await sleep(REQUEST_DELAY_MS);
+  }
+
+  console.error(`[github] Found ${all.length} merged PRs in ${from}..${to}`);
+  return all;
+}
+
+/**
+ * Fetch the list of files changed by a PR, including the per-file unified diff
+ * (`patch`). We read the diff to detect deterministic signals — e.g. a story's
+ * `tags` gaining `"stable"` (a stabilization) or a new `*.stories.tsx` (a new
+ * component/pattern) — instead of trusting the PR title or the LLM.
+ */
+export async function fetchPrFiles(
+  prNumber: number,
+  token?: string,
+): Promise<PrFile[]> {
+  const headers = ghHeaders(token);
+  const files: PrFile[] = [];
+
+  for (let page = 1; page <= 10; page++) {
+    let res: Response;
+    try {
+      res = await fetch(
+        `${API_BASE}/pulls/${prNumber}/files?per_page=100&page=${page}`,
+        { headers },
+      );
+    } catch (err) {
+      console.error(
+        `[github] PR #${prNumber} files: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      break;
+    }
+
+    if (!res.ok) {
+      if (res.status !== 404) {
+        console.error(`[github] PR #${prNumber} files: HTTP ${res.status}`);
+      }
+      break;
+    }
+
+    const json = (await res.json()) as Array<{
+      filename: string;
+      status: string;
+      patch?: string;
+    }>;
+
+    for (const f of json) {
+      files.push({ filename: f.filename, status: f.status, patch: f.patch });
+    }
+
+    if (json.length < 100) break;
+    await sleep(REQUEST_DELAY_MS);
+  }
+
+  return files;
+}

--- a/packages/changelog-summarizer/src/collectors/prs.ts
+++ b/packages/changelog-summarizer/src/collectors/prs.ts
@@ -206,6 +206,7 @@ export interface PrFacts {
 export function classifyMergedPrs(
   prs: PrWithFiles[],
   storyIndex?: StoryIndex,
+  foundationsAuthors?: Set<string>,
 ): PrFacts {
   const newEntries: SummaryNewEntry[] = [];
   const stabilized: SummaryStabilizedEntry[] = [];
@@ -248,18 +249,27 @@ export function classifyMergedPrs(
 
     // 2. Stabilization — the component's manual MDX docs were added (the final
     //    Definition-of-Done step). NOT inferred from the `stable` tag alone.
+    //    AND only counts if the author is on the F0/Foundations team: only
+    //    Foundations promotes to stable; other teams can ship new components
+    //    but can't mark something stable.
     const stabilizedComps = stabilizedComponents(pr.files);
     if (stabilizedComps.length > 0) {
-      for (const component of stabilizedComps) {
-        stabilized.push({
-          component,
-          summary: "Now documented and stable — safe to use in production",
-          storybook: true,
-          author: pr.author,
-        });
+      const byFoundations =
+        !foundationsAuthors || foundationsAuthors.has(pr.author);
+      if (byFoundations) {
+        for (const component of stabilizedComps) {
+          stabilized.push({
+            component,
+            summary: "Now documented and stable — safe to use in production",
+            storybook: true,
+            author: pr.author,
+          });
+        }
+        contributors.add(pr.author);
+        continue;
       }
-      contributors.add(pr.author);
-      continue;
+      // MDX docs added by a non-Foundations author → NOT a stable promotion.
+      // Fall through and let it be classified as an enhancement/other instead.
     }
 
     // 3. Breaking change

--- a/packages/changelog-summarizer/src/collectors/prs.ts
+++ b/packages/changelog-summarizer/src/collectors/prs.ts
@@ -1,0 +1,363 @@
+/**
+ * Turn merged pull requests into a deterministic, factual summary skeleton.
+ *
+ * The whole point of this module is veracity: every entry is derived from a
+ * real merged PR — its conventional-commit title (type + scope) and its changed
+ * files (the diff) — NOT from the LLM. The LLM only rewrites the wording
+ * afterwards, fact-checked against this skeleton.
+ *
+ * Signals (per PR, in priority order):
+ *   1. New component/pattern  → a `*.stories.tsx` file was ADDED.
+ *   2. Stabilization          → an existing story diff NEWLY adds a
+ *                               `tags: [… "stable" …]` line (promoted to stable).
+ *   3. Breaking change        → conventional `!` in the title.
+ *   4. Enhancement            → `feat`/`perf` on a resolvable component, with a
+ *                               deep-link to the specific story the PR added.
+ *   5. Fix                    → `fix` (folded into the technical thread reply).
+ *   6. Infrastructure / other → everything else (folded into the thread reply).
+ */
+
+import type {
+  SummaryBreakingChangeEntry,
+  SummaryEnhancementEntry,
+  SummaryJson,
+  SummaryNewEntry,
+  SummaryStabilizedEntry,
+} from "../types.js";
+import type { MergedPr, PrFile } from "./github.js";
+import {
+  resolveStoryDeepLink,
+  resolveStoryUrl,
+  type StoryIndex,
+} from "./stories.js";
+
+export interface PrWithFiles extends MergedPr {
+  files: PrFile[];
+  /** PR description, fetched for breaking-change PRs to explain the migration. */
+  body?: string;
+}
+
+/** Conventional-commit types whose diff we must inspect to find new/stable. */
+export const TYPES_NEEDING_FILES = new Set(["feat", "perf", "refactor", "docs"]);
+
+interface ParsedTitle {
+  type: string;
+  scope?: string;
+  breaking: boolean;
+  subject: string;
+}
+
+const TITLE_RE = /^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/;
+
+export function parseConventionalTitle(title: string): ParsedTitle {
+  const m = title.trim().match(TITLE_RE);
+  if (!m) return { type: "", breaking: false, subject: title.trim() };
+  return {
+    type: m[1].toLowerCase(),
+    scope: m[2]?.trim() || undefined,
+    breaking: m[3] === "!",
+    subject: m[4].trim(),
+  };
+}
+
+const STORY_RE = /\.stories\.tsx$/;
+const REACT_SRC = "packages/react/src/";
+
+// Folder/segment words that are never a component name.
+const GENERIC = new Set([
+  "components", "patterns", "kits", "sds", "lib", "hooks", "experimental",
+  "utilities", "ui", "react", "core", "docs", "ai", "examples", "playground",
+  "internal", "dashboard", "deps", "repo", "ci", "build",
+]);
+
+/** A real F0 component name: PascalCase, or F0/One-prefixed. No slashes. */
+function isComponentName(name: string | null | undefined): name is string {
+  if (!name || name.includes("/")) return false;
+  if (GENERIC.has(name.toLowerCase())) return false;
+  return /^(F0|One)/.test(name) || /^[A-Z][A-Za-z0-9]+$/.test(name);
+}
+
+function isReactStory(path: string): boolean {
+  return path.startsWith(REACT_SRC) && STORY_RE.test(path);
+}
+
+/** Extract a (validated) component name from a story file path, else null. */
+function componentFromStoryPath(path: string): string | null {
+  const parts = path.split("/");
+  const storiesIdx = parts.findIndex((p) => p === "__stories__");
+  let candidate: string | null = null;
+  if (storiesIdx > 0) {
+    candidate = parts[storiesIdx - 1];
+  } else {
+    const fileIdx = parts.findIndex((p) => STORY_RE.test(p));
+    if (fileIdx > 0) {
+      const base = parts[fileIdx].replace(STORY_RE, "");
+      candidate = base.toLowerCase() === "index" ? parts[fileIdx - 1] : base;
+    }
+  }
+  return isComponentName(candidate) ? candidate : null;
+}
+
+/**
+ * Detect a brand-new component/pattern from the PR title: "add/introduce
+ * <Component>", where <Component> is the OBJECT of the verb and looks like a
+ * component name (PascalCase / F0·One). This distinguishes "add F0Graph
+ * pattern" (new) from "add alert option" (an enhancement of an existing
+ * component — "alert" isn't a component). New-vs-enhancement is ultimately a
+ * judgement call the LLM finalises; this just gets the common cases right.
+ */
+function newComponentFromTitle(
+  subject: string,
+): { component: string; kind: "pattern" | "component" } | null {
+  // "add <Component> [experimental] component|pattern" — the trailing
+  // "component"/"pattern" keyword is what separates a genuinely new component
+  // from a docs PR ("add <Component> Storybook documentation") or a feature
+  // ("add alert option").
+  const m = subject.match(
+    /\b(?:[Aa]dd(?:s|ed)?|[Ii]ntroduces?|[Nn]ew)\s+(?:the\s+|an?\s+)?((?:F0|One)[A-Za-z0-9]+|[A-Z][A-Za-z0-9]{2,})\s+(?:\w+\s+){0,2}(component|pattern)s?\b/,
+  );
+  if (!m || !isComponentName(m[1])) return null;
+  return {
+    component: m[1],
+    kind: m[2].toLowerCase() === "pattern" ? "pattern" : "component",
+  };
+}
+
+/**
+ * Resolve a component name from the PR title — the last PascalCase / F0·One
+ * token that actually exists in Storybook. Used when the conventional scope is
+ * generic (e.g. `feat(react): … in SurveyFormBuilder`) so we name the real
+ * component instead of a folder picked off a story path.
+ */
+function componentFromTitle(
+  subject: string,
+  storyIndex?: StoryIndex,
+): string | null {
+  if (!storyIndex) return null;
+  const tokens = subject.match(/\b(?:F0|One)?[A-Z][A-Za-z0-9]+\b/g) ?? [];
+  let best: string | null = null;
+  for (const t of tokens) {
+    if (isComponentName(t) && resolveStoryUrl(t, storyIndex.urlByKey)) best = t;
+  }
+  return best;
+}
+
+const MDX_RE = /\.mdx$/;
+
+/**
+ * Extract the component a `.mdx` doc file belongs to. In F0, writing a
+ * component's manual MDX documentation is the final Definition-of-Done step —
+ * so a newly ADDED `<Component>.mdx` is the reliable signal that the component
+ * is now genuinely stable (vs. just carrying a `stable` tag set prematurely).
+ */
+function componentFromMdxPath(path: string): string | null {
+  if (!path.startsWith(REACT_SRC) || !MDX_RE.test(path)) return null;
+  const parts = path.split("/");
+  const storiesIdx = parts.findIndex((p) => p === "__stories__");
+  const candidate = storiesIdx > 0 ? parts[storiesIdx - 1] : parts[parts.length - 2];
+  return isComponentName(candidate) ? candidate : null;
+}
+
+/**
+ * Components stabilized by a PR = those whose manual MDX docs were ADDED in it
+ * (DoD complete). Detected purely from the PR's changed files, so a `stable`
+ * tag set without the accompanying docs does NOT count.
+ */
+function stabilizedComponents(files: PrFile[]): string[] {
+  return [
+    ...new Set(
+      files
+        .filter((f) => f.status === "added")
+        .map((f) => componentFromMdxPath(f.filename))
+        .filter((c): c is string => c !== null),
+    ),
+  ];
+}
+
+/** Story exports added by this diff (e.g. `+export const WithAlertAction = …`). */
+function addedStoryExports(patch?: string): string[] {
+  if (!patch) return [];
+  const out: string[] = [];
+  for (const l of patch.split("\n")) {
+    if (!l.startsWith("+") || l.startsWith("+++")) continue;
+    const m = l.match(/^\+\s*export const (\w+)\s*[:=]/);
+    if (m && !/^(meta|default)$/i.test(m[1])) out.push(m[1]);
+  }
+  return out;
+}
+
+function scopeIsComponent(scope?: string): scope is string {
+  return isComponentName(scope);
+}
+
+function cleanSubject(subject: string): string {
+  const s = subject.replace(/\s+#\d+\s*$/, "").replace(/[.\s]+$/, "").trim();
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export interface PrFacts {
+  skeleton: SummaryJson;
+  fixes: string[];
+  infra: string[];
+  contributors: string[];
+  unclassified: string[];
+}
+
+export function classifyMergedPrs(
+  prs: PrWithFiles[],
+  storyIndex?: StoryIndex,
+): PrFacts {
+  const newEntries: SummaryNewEntry[] = [];
+  const stabilized: SummaryStabilizedEntry[] = [];
+  const enhancements: SummaryEnhancementEntry[] = [];
+  // Raw per-PR enhancements, grouped by component after the loop so a component
+  // with several PRs this period becomes ONE bullet (less noise).
+  const rawEnhancements: Array<{
+    component: string;
+    summary: string;
+    author: string;
+    url?: string;
+  }> = [];
+  const breaking: SummaryBreakingChangeEntry[] = [];
+  const fixes: string[] = [];
+  const infra: string[] = [];
+  const contributors = new Set<string>();
+  const unclassified: string[] = [];
+
+  for (const pr of prs) {
+    const { type, scope, breaking: isBreaking, subject } =
+      parseConventionalTitle(pr.title);
+    const summary = cleanSubject(subject);
+    const reactStories = pr.files.filter((f) => isReactStory(f.filename));
+
+    // 1. New component/pattern — the PR title introduces it ("add <Component>").
+    //    Adding a feature to an existing component is NOT new — it's an
+    //    enhancement.
+    const newComp = newComponentFromTitle(subject);
+    if (newComp) {
+      newEntries.push({
+        component: newComp.component,
+        summary,
+        detail: newComp.kind === "pattern" ? "New pattern" : undefined,
+        storybook: true,
+        author: pr.author,
+      });
+      contributors.add(pr.author);
+      continue;
+    }
+
+    // 2. Stabilization — the component's manual MDX docs were added (the final
+    //    Definition-of-Done step). NOT inferred from the `stable` tag alone.
+    const stabilizedComps = stabilizedComponents(pr.files);
+    if (stabilizedComps.length > 0) {
+      for (const component of stabilizedComps) {
+        stabilized.push({
+          component,
+          summary: "Now documented and stable — safe to use in production",
+          storybook: true,
+          author: pr.author,
+        });
+      }
+      contributors.add(pr.author);
+      continue;
+    }
+
+    // 3. Breaking change
+    if (isBreaking) {
+      breaking.push({
+        component: isComponentName(scope) ? scope : "F0",
+        summary,
+        // The PR description carries the migration; the LLM polishes it later.
+        migration: pr.body?.trim() ?? "",
+      });
+      contributors.add(pr.author);
+      continue;
+    }
+
+    // 4. Enhancement (feat/perf on a resolvable component, with story deep-link)
+    if (type === "feat" || type === "perf") {
+      const component = scopeIsComponent(scope)
+        ? scope
+        : componentFromTitle(subject, storyIndex) ??
+          reactStories
+            .map((f) => componentFromStoryPath(f.filename))
+            .find((c): c is string => c !== null) ??
+          null;
+
+      if (component) {
+        let url: string | undefined;
+        if (storyIndex) {
+          const exports = reactStories.flatMap((f) =>
+            addedStoryExports(f.patch),
+          );
+          for (const ex of exports) {
+            const link = resolveStoryDeepLink(component, ex, storyIndex);
+            if (link) {
+              url = link;
+              break;
+            }
+          }
+        }
+        rawEnhancements.push({ component, summary, author: pr.author, url });
+        contributors.add(pr.author);
+      } else {
+        // A feature with no resolvable component → keep it out of the clean
+        // product sections; let it live in the technical thread instead.
+        infra.push(summary);
+      }
+      continue;
+    }
+
+    // 5. Fix
+    if (type === "fix") {
+      fixes.push(summary);
+      continue;
+    }
+
+    // 6. Infra / other
+    infra.push(summary);
+    if (type === "") unclassified.push(`#${pr.number} ${pr.title}`);
+  }
+
+  // Group enhancements by component: one bullet per component, with the extra
+  // changes folded into `detail`. A deep-link is only kept when the component
+  // had a single enhancement (otherwise it's ambiguous → docs page).
+  const byComponent = new Map<string, typeof rawEnhancements>();
+  for (const e of rawEnhancements) {
+    const list = byComponent.get(e.component) ?? [];
+    list.push(e);
+    byComponent.set(e.component, list);
+  }
+  for (const [component, group] of byComponent) {
+    const summaries = [...new Set(group.map((g) => g.summary))];
+    const authors = [...new Set(group.map((g) => g.author))].filter(Boolean);
+    enhancements.push({
+      component,
+      summary: summaries[0],
+      detail:
+        summaries.length > 1
+          ? `Also: ${summaries.slice(1).join("; ")}`
+          : undefined,
+      storybook: true,
+      author: authors.join(", "),
+      url: group.length === 1 ? group[0].url : undefined,
+    });
+  }
+
+  const skeleton: SummaryJson = {
+    sections: {
+      ...(newEntries.length > 0 ? { new: newEntries } : {}),
+      ...(stabilized.length > 0 ? { stabilized } : {}),
+      ...(enhancements.length > 0 ? { enhancements } : {}),
+      ...(breaking.length > 0 ? { breaking_changes: breaking } : {}),
+    },
+  };
+
+  return {
+    skeleton,
+    fixes,
+    infra,
+    contributors: [...contributors].filter(Boolean),
+    unclassified,
+  };
+}

--- a/packages/changelog-summarizer/src/collectors/stories.ts
+++ b/packages/changelog-summarizer/src/collectors/stories.ts
@@ -1,0 +1,254 @@
+/**
+ * Build a map from component name to its precise Storybook docs URL by
+ * fetching the published Storybook's `index.json`, and (optionally) resolve
+ * deep-links to individual stories.
+ *
+ * IMPORTANT: we never scan local story files. Local titles (e.g.
+ * `Button/Button`) often differ from the published titles (e.g.
+ * `Components/Button/Button`), so the only reliable source of truth is the
+ * deployed Storybook.
+ */
+
+const STORYBOOK_BASE = "https://ds.factorial.dev";
+const STORYBOOK_INDEX_URL = `${STORYBOOK_BASE}/index.json`;
+
+interface StorybookIndexEntry {
+  id: string;
+  title: string;
+  name?: string;
+  type?: string;
+}
+
+interface StorybookIndex {
+  entries: Record<string, StorybookIndexEntry>;
+}
+
+/**
+ * Resolved Storybook index:
+ * - `docsUrlByKey`: component lookup-key → docs page URL
+ * - `docsIdByKey`:  component lookup-key → docs id prefix (e.g. `components-card`)
+ * - `storyIds`:     every individual story id (type `"story"`), used to verify
+ *                   a deep-link actually exists before we emit it
+ */
+export interface StoryIndex {
+  docsUrlByKey: Map<string, string>;
+  docsIdByKey: Map<string, string>;
+  storyIds: Set<string>;
+  /** Component key → a representative story URL (fallback when there's no docs page). */
+  storyUrlByKey: Map<string, string>;
+  /** Component key → best URL: the docs page if it exists, else a story. */
+  urlByKey: Map<string, string>;
+}
+
+/**
+ * Derive lookup keys for a Storybook docs entry from its title. Only the last
+ * segment of the title path is meaningful for matching component names — the
+ * leading folders (e.g. `Components/`, `SDS/AI/`) are organisational noise.
+ *
+ * Examples:
+ *   "Components/Button/Button"     → ["button", "f0button"]
+ *   "Patterns/Forms/F0Form"        → ["f0form", "form"]
+ *   "SDS/AI/F0AiChat"              → ["f0aichat", "aichat"]
+ */
+const GENERIC_SEGMENTS =
+  /^(components?|patterns?|kits?|sds|lib|library|hooks?|utilities|charts?|experimental|forms?|navigation|information|actions?|home|communities|data|datacollection|visualizations?|inputs?|layouts?|surveys?|ai)$/i;
+
+export function keysForTitle(title: string): string[] {
+  const segments = title.split("/").map((s) => s.trim()).filter(Boolean);
+  if (segments.length === 0) return [];
+
+  const keys = new Set<string>();
+  const addVariants = (name: string) => {
+    const lower = name.toLowerCase().replace(/\s+/g, "");
+    if (lower.length === 0) return;
+    keys.add(lower);
+    if (lower.startsWith("f0")) {
+      const stripped = lower.slice(2);
+      if (stripped.length > 0) keys.add(stripped);
+    } else {
+      keys.add(`f0${lower}`);
+    }
+  };
+
+  // The leaf segment is the primary key (e.g. "Components/Card" → card/f0card).
+  addVariants(segments[segments.length - 1]);
+
+  // Also index component-like ancestor folders, so docs split into sub-pages
+  // (e.g. "Kits/F0DataChart/Bar") still resolve by the component name
+  // ("f0datachart"), not only the leaf ("bar").
+  for (const seg of segments.slice(0, -1)) {
+    if (GENERIC_SEGMENTS.test(seg)) continue;
+    if (/^(F0|One)/.test(seg) || /^[A-Z][A-Za-z0-9]+$/.test(seg)) {
+      addVariants(seg);
+    }
+  }
+
+  return [...keys];
+}
+
+/**
+ * Fetch the published Storybook `index.json` and build the resolved index.
+ * Returns empty maps/sets (never throws) if the network call fails — callers
+ * should treat a missing URL as "no precise link available".
+ */
+export async function collectStoryIndex(): Promise<StoryIndex> {
+  const docsUrlByKey = new Map<string, string>();
+  const docsIdByKey = new Map<string, string>();
+  const storyIds = new Set<string>();
+  const storyUrlByKey = new Map<string, string>();
+
+  const build = (): StoryIndex => {
+    // Best URL per component: prefer the docs page, fall back to a story so a
+    // component that's visible in Storybook always gets a link.
+    const urlByKey = new Map(storyUrlByKey);
+    for (const [key, url] of docsUrlByKey) urlByKey.set(key, url);
+    return { docsUrlByKey, docsIdByKey, storyIds, storyUrlByKey, urlByKey };
+  };
+
+  try {
+    const res = await fetch(STORYBOOK_INDEX_URL);
+    if (!res.ok) {
+      console.error(
+        `[stories] Failed to fetch index.json: HTTP ${res.status} — continuing without Storybook links`,
+      );
+      return build();
+    }
+
+    const index = (await res.json()) as StorybookIndex;
+    if (!index?.entries || typeof index.entries !== "object") {
+      console.error(
+        "[stories] index.json missing 'entries' object — continuing without Storybook links",
+      );
+      return build();
+    }
+
+    let docsCount = 0;
+    for (const entry of Object.values(index.entries)) {
+      if (typeof entry.id !== "string" || typeof entry.title !== "string") {
+        continue;
+      }
+
+      if (entry.type === "story") {
+        storyIds.add(entry.id);
+        const storyUrl = `${STORYBOOK_BASE}/?path=/story/${entry.id}`;
+        for (const key of keysForTitle(entry.title)) {
+          // First story per component wins (usually the primary/default).
+          if (!storyUrlByKey.has(key)) storyUrlByKey.set(key, storyUrl);
+        }
+        continue;
+      }
+
+      if (entry.type !== "docs") continue;
+
+      const url = `${STORYBOOK_BASE}/?path=/docs/${entry.id}`;
+      const prefix = entry.id.replace(/--documentation$/, "");
+      for (const key of keysForTitle(entry.title)) {
+        // First docs entry wins.
+        if (!docsUrlByKey.has(key)) {
+          docsUrlByKey.set(key, url);
+          docsIdByKey.set(key, prefix);
+        }
+      }
+      docsCount += 1;
+    }
+
+    console.error(
+      `[stories] Indexed ${docsCount} docs pages, ${storyIds.size} stories, ${docsUrlByKey.size}+${storyUrlByKey.size} keys`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[stories] Could not fetch Storybook index (${msg}) — continuing without Storybook links`,
+    );
+  }
+
+  return build();
+}
+
+/**
+ * Backwards-compatible helper returning just the component → docs URL map.
+ */
+export async function collectStoryUrls(): Promise<Map<string, string>> {
+  return (await collectStoryIndex()).urlByKey;
+}
+
+function lookupKeys(componentName: string): string[] {
+  const raw = componentName.trim();
+  if (raw.length === 0) return [];
+  const lower = raw.toLowerCase();
+  const compact = lower.replace(/\s+/g, "");
+
+  const variants = new Set<string>();
+  variants.add(lower);
+  variants.add(compact);
+  if (compact.startsWith("f0")) {
+    const stripped = compact.slice(2);
+    if (stripped.length > 0) variants.add(stripped);
+  } else {
+    variants.add(`f0${compact}`);
+  }
+  // Components are often coded with a `One` prefix but published without it
+  // (e.g. `OneEmptyState` → `Components/EmptyState`, `OneDataCollection` →
+  // `Patterns/Data collection`). Try the de-prefixed form too.
+  if (compact.startsWith("one")) {
+    const stripped = compact.slice(3);
+    if (stripped.length > 0) variants.add(stripped);
+  }
+  return [...variants];
+}
+
+/**
+ * Resolve a Storybook docs URL for a component name. Returns `null` when no
+ * precise match exists — callers MUST NOT fall back to a generic search URL.
+ */
+export function resolveStoryUrl(
+  componentName: string,
+  storyUrls: Map<string, string>,
+): string | null {
+  for (const variant of lookupKeys(componentName)) {
+    const url = storyUrls.get(variant);
+    if (url) return url;
+  }
+  return null;
+}
+
+/**
+ * Convert a story's exported name (e.g. `WithAlertAction`) to the kebab id
+ * segment Storybook uses (`with-alert-action`). Approximate — we always verify
+ * the resulting id against the real index before using it, so a mismatch just
+ * means we fall back to the component docs page (never a broken link).
+ */
+export function kebabFromExport(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/([A-Za-z])([0-9])/g, "$1-$2")
+    .replace(/([0-9])([A-Za-z])/g, "$1-$2")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .toLowerCase()
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Resolve a deep-link to a SPECIFIC story for `componentName` given an exported
+ * story name from the PR diff. Returns `null` unless the computed story id
+ * actually exists in the published index — that verification is what keeps the
+ * link veracious.
+ */
+export function resolveStoryDeepLink(
+  componentName: string,
+  exportName: string,
+  index: StoryIndex,
+): string | null {
+  let prefix: string | undefined;
+  for (const variant of lookupKeys(componentName)) {
+    prefix = index.docsIdByKey.get(variant);
+    if (prefix) break;
+  }
+  if (!prefix) return null;
+
+  const id = `${prefix}--${kebabFromExport(exportName)}`;
+  if (index.storyIds.has(id)) {
+    return `${STORYBOOK_BASE}/?path=/story/${id}`;
+  }
+  return null;
+}

--- a/packages/changelog-summarizer/src/formatters/blockkit.ts
+++ b/packages/changelog-summarizer/src/formatters/blockkit.ts
@@ -1,0 +1,101 @@
+/**
+ * Convert the `---`-separated summary text into a Slack Block Kit payload.
+ *
+ * The summary text has the shape:
+ *   <title>
+ *   ---
+ *   <section header>
+ *   <section body...>
+ *   ---
+ *   <next section header>
+ *   ...
+ *
+ * Produces: one top-level `header` for the title, then per section a
+ * `divider` + `header` + one or more `section` blocks. Long section bodies are
+ * split at bullet boundaries so no block exceeds Slack's 3000-char mrkdwn limit.
+ */
+
+export interface BlockKitBlock {
+  type: string;
+  text?: { type: string; text: string; emoji?: boolean };
+}
+
+const SECTION_LIMIT = 2900;
+
+/** Hard-split a single chunk that has no blank lines (e.g. one long paragraph),
+ *  breaking at a sentence or space boundary near the limit. */
+function hardSplit(s: string, limit: number): string[] {
+  if (s.length <= limit) return [s];
+  const out: string[] = [];
+  let rest = s;
+  while (rest.length > limit) {
+    let cut = rest.lastIndexOf(". ", limit);
+    if (cut < limit * 0.5) cut = rest.lastIndexOf(" ", limit);
+    if (cut < limit * 0.5) cut = limit;
+    out.push(rest.slice(0, cut + 1).trim());
+    rest = rest.slice(cut + 1).trim();
+  }
+  if (rest) out.push(rest);
+  return out;
+}
+
+/** Split a section body into <3000-char chunks: first at blank-line (bullet)
+ *  boundaries, then hard-splitting any single chunk that still exceeds the limit. */
+export function chunkMrkdwn(body: string, limit = SECTION_LIMIT): string[] {
+  if (body.length <= limit) return [body];
+  const bullets = body.split("\n\n");
+  const chunks: string[] = [];
+  let current = "";
+  for (const bullet of bullets) {
+    const candidate = current ? `${current}\n\n${bullet}` : bullet;
+    if (candidate.length > limit && current) {
+      chunks.push(current);
+      current = bullet;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks.flatMap((c) => hardSplit(c, limit));
+}
+
+export function buildBlocks(content: string): BlockKitBlock[] {
+  const lines = content.split("\n");
+  const blocks: BlockKitBlock[] = [
+    { type: "header", text: { type: "plain_text", text: lines[0], emoji: true } },
+  ];
+
+  let firstSeen = false;
+  let segment: string[] = [];
+
+  const flush = () => {
+    if (segment.length === 0) return;
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "header",
+      text: { type: "plain_text", text: segment[0], emoji: true },
+    });
+    for (const chunk of chunkMrkdwn(segment.slice(1).join("\n"))) {
+      blocks.push({ type: "section", text: { type: "mrkdwn", text: chunk } });
+    }
+    segment = [];
+  };
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === "---") {
+      if (!firstSeen) {
+        // The first `---` closes the title line we already captured.
+        firstSeen = true;
+        segment = [];
+        continue;
+      }
+      flush();
+      continue;
+    }
+    segment.push(line);
+  }
+  if (firstSeen) flush();
+
+  return blocks;
+}

--- a/packages/changelog-summarizer/src/formatters/json-formatter.ts
+++ b/packages/changelog-summarizer/src/formatters/json-formatter.ts
@@ -1,0 +1,252 @@
+import { resolveStoryUrl } from "../collectors/stories.js";
+import type {
+  SummaryEnhancementEntry,
+  SummaryJson,
+  SummaryNewEntry,
+  SummaryStabilizedEntry,
+} from "../types.js";
+
+/**
+ * Deterministic plain-English replacements applied to every product-facing
+ * string emitted by the LLM. The model is told to avoid jargon in the prompt
+ * but we enforce a final pass so the published message is predictable.
+ */
+const JARGON_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/\bprops\b/gi, "options"],
+  [/\bprop\b/gi, "option"],
+  [/\bcanvas mode\b/gi, "edit mode"],
+  [/\bi18n\b/gi, "translations"],
+  [/\bPageHeader\b/g, "page title area"],
+  [/\bPageAction\b/g, "page title button"],
+  [/\bblast radius\b/gi, ""],
+  [
+    /\bclarifying question UX\b/gi,
+    "ability to ask clarifying questions mid-conversation",
+  ],
+  [/\bmotion polish\b/gi, "smoother animations"],
+  [/\bpersistence\b/gi, "remembers your state between sessions"],
+];
+
+/** Normalize raw PR-body markdown into Slack-friendly inline text. */
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/^#{1,6}\s+/gm, "") // drop heading markers (## Summary → Summary)
+    .replace(/\*\*([^*]+)\*\*/g, "*$1*") // **bold** → *bold*
+    .replace(/`{1,3}([^`]+)`{1,3}/g, "`$1`") // collapse code fences to inline
+    .replace(/\s*\n+\s*/g, " ") // flatten line breaks
+    .replace(/\s{2,}/g, " ")
+    .replace(/^Summary\s+/i, "") // the leading "Summary" label adds nothing
+    .trim();
+}
+
+function dejargon(text: string): string {
+  let out = text;
+  for (const [regex, replacement] of JARGON_REPLACEMENTS) {
+    out = out.replace(regex, replacement);
+  }
+  // Collapse the double spaces / dangling " — " that omissions can leave behind.
+  out = out.replace(/\s{2,}/g, " ").replace(/\s+—\s+\./g, ".").trim();
+  return out;
+}
+
+function storybookLink(
+  componentName: string,
+  storyUrls: Map<string, string>,
+): string | null {
+  return resolveStoryUrl(componentName, storyUrls);
+}
+
+function joinSummaryAndDetail(summary: string, detail?: string): string {
+  const s = dejargon(summary).replace(/\s+$/, "");
+  if (!detail) return s;
+  const d = dejargon(detail).replace(/^\s+/, "");
+  if (d.length === 0) return s;
+  // Ensure a clean separator without doubling punctuation.
+  const trimmedSummary = s.replace(/[.\s]+$/, "");
+  return `${trimmedSummary} — ${d}`;
+}
+
+function bulletNew(
+  entry: SummaryNewEntry,
+  storyUrls: Map<string, string>,
+): string {
+  const component = entry.component.trim();
+  const text = joinSummaryAndDetail(entry.summary, entry.detail);
+  let head = `• *${component}* — ${text}`;
+  if (entry.author && entry.author.trim().length > 0) {
+    head += ` _— by ${entry.author.trim()}_`;
+  }
+
+  // Prefer a pre-resolved deep-link to a specific story; otherwise fall back to
+  // the component's docs page.
+  const deepLink = entry.url;
+  const docsLink = entry.storybook ? storybookLink(component, storyUrls) : null;
+  const url = deepLink ?? docsLink;
+  if (url) {
+    const label = deepLink ? "View story" : "View in Storybook";
+    return `${head}\n_<${url}|${label}>_`;
+  }
+  return head;
+}
+
+function bulletEnhancement(
+  entry: SummaryEnhancementEntry,
+  storyUrls: Map<string, string>,
+): string {
+  // Same shape as `new` entries for now; kept separate so we can diverge later.
+  return bulletNew(entry as SummaryNewEntry, storyUrls);
+}
+
+function bulletStabilized(
+  entry: SummaryStabilizedEntry,
+  storyUrls: Map<string, string>,
+): string {
+  // Same shape as `new` entries; kept separate so we can diverge later.
+  return bulletNew(entry as SummaryNewEntry, storyUrls);
+}
+
+/**
+ * Strip markdown code fences and try to recover from the most common JSON
+ * formatting mistake made by LLMs (Groq especially): literal newlines inside
+ * a JSON string value, which would otherwise make `JSON.parse` fail.
+ */
+function stripFences(raw: string): string {
+  let s = raw.trim();
+  if (s.startsWith("```")) {
+    s = s.replace(/^```(?:json)?\s*\n?/i, "");
+    s = s.replace(/```\s*$/i, "");
+  }
+  return s.trim();
+}
+
+function sanitizeJsonNewlines(raw: string): string {
+  // Walk the string; while inside a "double-quoted" region replace literal \n
+  // and \r with their escaped forms. Respect backslash escapes so we don't
+  // double-escape already-escaped quotes.
+  let out = "";
+  let inString = false;
+  let escape = false;
+
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+
+    if (escape) {
+      out += ch;
+      escape = false;
+      continue;
+    }
+
+    if (ch === "\\") {
+      out += ch;
+      escape = true;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = !inString;
+      out += ch;
+      continue;
+    }
+
+    if (inString && ch === "\n") {
+      out += "\\n";
+      continue;
+    }
+    if (inString && ch === "\r") {
+      out += "\\r";
+      continue;
+    }
+    if (inString && ch === "\t") {
+      out += "\\t";
+      continue;
+    }
+
+    out += ch;
+  }
+
+  return out;
+}
+
+export function parseSummaryJson(raw: string): SummaryJson {
+  const stripped = stripFences(raw);
+  const sanitized = sanitizeJsonNewlines(stripped);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(sanitized);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to parse LLM output as JSON (${msg}). First 200 chars: ${sanitized.slice(0, 200)}`,
+    );
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("sections" in parsed)
+  ) {
+    throw new Error("LLM output JSON is missing a top-level `sections` object");
+  }
+
+  return parsed as SummaryJson;
+}
+
+function isNonEmpty<T>(arr: T[] | undefined): arr is T[] {
+  return Array.isArray(arr) && arr.length > 0;
+}
+
+function hasText(s: string | undefined): s is string {
+  return typeof s === "string" && s.trim().length > 0;
+}
+
+/**
+ * Convert the parsed JSON into the `---`-separated plain text expected by the
+ * Slack publishing step in `changelog-summary.yaml`.
+ *
+ * Returns `null` when every section is empty so the caller can fall back to
+ * an "_No changes this week._" placeholder.
+ */
+export function jsonToSlackText(
+  json: SummaryJson,
+  storyUrls: Map<string, string>,
+): string | null {
+  const sections = json.sections ?? {};
+  const parts: string[] = [];
+
+  if (isNonEmpty(sections.new)) {
+    const bullets = sections.new.map((e) => bulletNew(e, storyUrls)).join("\n\n");
+    parts.push(`🚀 What's new\n\n${bullets}`);
+  }
+
+  if (isNonEmpty(sections.stabilized)) {
+    const bullets = sections.stabilized
+      .map((e) => bulletStabilized(e, storyUrls))
+      .join("\n\n");
+    parts.push(`✅ Now stable — safe to use\n\n${bullets}`);
+  }
+
+  if (isNonEmpty(sections.enhancements)) {
+    const bullets = sections.enhancements
+      .map((e) => bulletEnhancement(e, storyUrls))
+      .join("\n\n");
+    parts.push(`✨ Enhancements\n\n${bullets}`);
+  }
+
+  if (isNonEmpty(sections.breaking_changes)) {
+    const bullets = sections.breaking_changes
+      .map((e) => {
+        const head = `• *${e.component.trim()}* — ${dejargon(e.summary)}`;
+        const migration = hasText(e.migration)
+          ? `\n_What to do: ${dejargon(stripMarkdown(e.migration))}_`
+          : "";
+        return `${head}${migration}`;
+      })
+      .join("\n\n");
+    parts.push(`⚠️ Breaking changes — you may need to update your code\n\n${bullets}`);
+  }
+
+  if (parts.length === 0) return null;
+
+  return parts.join("\n---\n");
+}

--- a/packages/changelog-summarizer/src/formatters/markdown.ts
+++ b/packages/changelog-summarizer/src/formatters/markdown.ts
@@ -1,3 +1,4 @@
+import type { PrInfo } from "../collectors/github.js";
 import type { ChangelogEntry, CommitEntry } from "../types.js";
 
 const PACKAGE_PATH_MAP: Record<string, string> = {
@@ -68,6 +69,7 @@ export function buildContextMessage(
   commits: CommitEntry[],
   from: string,
   to: string,
+  prBodies?: Map<number, PrInfo>,
 ): string {
   const sections: string[] = [`Weekly summary period: ${from} to ${to}`, ""];
 
@@ -107,6 +109,18 @@ export function buildContextMessage(
 
   sections.push("## Additional commits not in changelog");
   sections.push(formatCommits(extraCommits));
+
+  if (prBodies && prBodies.size > 0) {
+    sections.push("");
+    sections.push("## PR descriptions");
+    // Sort by PR number desc so the most recent context appears first.
+    const ordered = [...prBodies.values()].sort((a, b) => b.number - a.number);
+    for (const pr of ordered) {
+      sections.push("");
+      sections.push(`PR #${pr.number}:`);
+      sections.push(pr.body);
+    }
+  }
 
   return sections.join("\n");
 }

--- a/packages/changelog-summarizer/src/formatters/postprocess.ts
+++ b/packages/changelog-summarizer/src/formatters/postprocess.ts
@@ -1,0 +1,35 @@
+/**
+ * Deterministic cleanup for the legacy non-JSON prompt path
+ * (`src/prompts/default.md`). Models occasionally emit markdown headings or
+ * inconsistent bullet characters; Slack ignores `#` headings entirely so we
+ * normalise the output before publishing.
+ */
+
+export function postprocess(raw: string): string {
+  if (!raw) return "";
+
+  const lines = raw.replace(/\r\n/g, "\n").split("\n");
+  const out: string[] = [];
+
+  for (const original of lines) {
+    let line = original;
+
+    // Drop markdown ATX headings — Slack doesn't render them.
+    if (/^#{1,6}\s+/.test(line)) {
+      line = line.replace(/^#{1,6}\s+/, "");
+    }
+
+    // Normalise bullets: `- ` or `* ` → `• `.
+    line = line.replace(/^(\s*)[-*]\s+/, "$1• ");
+
+    // Collapse runs of spaces inside the line (not at the start).
+    const leading = line.match(/^\s*/)?.[0] ?? "";
+    const body = line.slice(leading.length).replace(/[ \t]{2,}/g, " ");
+    line = leading + body;
+
+    out.push(line.trimEnd());
+  }
+
+  // Collapse 3+ blank lines down to 2.
+  return out.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}

--- a/packages/changelog-summarizer/src/foundations.ts
+++ b/packages/changelog-summarizer/src/foundations.ts
@@ -1,0 +1,27 @@
+/**
+ * GitHub logins authorized to promote F0 components to **stable**.
+ *
+ * Only stabilizations authored by these people are reported under "Now stable".
+ * Other teams can still ship NEW (experimental) components — they just can't
+ * mark something stable. (Per the F0 lifecycle: only Foundations promotes.)
+ *
+ * Seeded from the `@factorialco/foundations` GitHub team + the F0 designer/PM.
+ * The GitHub teams are not fully maintained (e.g. `f0-designers` is incomplete
+ * and the F0 designer isn't in the team yet), so this list is the source of
+ * truth — keep it in sync as the team changes.
+ */
+export const FOUNDATIONS_AUTHORS: readonly string[] = [
+  // @factorialco/foundations
+  "arnaub",
+  "fleveque",
+  "rubenmoya",
+  "eliseo-juan",
+  "sauldom102",
+  "dmaza81",
+  "albertpmz",
+  "developerdanx",
+  "siguenzaraul",
+  "davidsalgado-fct",
+  // F0 design / PM (not in the GH team yet)
+  "desiree-np",
+];

--- a/packages/changelog-summarizer/src/index.ts
+++ b/packages/changelog-summarizer/src/index.ts
@@ -4,20 +4,23 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { resolve, join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { execSync } from "child_process";
-import { collectChangelogs } from "./collectors/changelog.js";
-import { collectCommits } from "./collectors/commits.js";
-import { extractPrNumbers, fetchPrBodies } from "./collectors/github.js";
-import type { PrInfo } from "./collectors/github.js";
-import { collectStoryUrls } from "./collectors/stories.js";
-import { resolveApiKey, resolveModel } from "./providers.js";
-import { generateSummary } from "./summarizer.js";
-import { buildContextMessage } from "./formatters/markdown.js";
 import {
-  jsonToSlackText,
-  parseSummaryJson,
-} from "./formatters/json-formatter.js";
-import { postprocess } from "./formatters/postprocess.js";
-import type { Provider } from "./types.js";
+  listMergedPRs,
+  fetchPrFiles,
+  fetchPrBodies,
+  type PrFile,
+} from "./collectors/github.js";
+import {
+  classifyMergedPrs,
+  parseConventionalTitle,
+  TYPES_NEEDING_FILES,
+  type PrWithFiles,
+} from "./collectors/prs.js";
+import { collectStoryIndex } from "./collectors/stories.js";
+import { resolveApiKey, resolveModel } from "./providers.js";
+import { polishSummary, reconcileSummary } from "./summarizer.js";
+import { jsonToSlackText } from "./formatters/json-formatter.js";
+import type { Provider, SummaryJson } from "./types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -110,54 +113,6 @@ function saveLastRunDate(repoRoot: string): void {
   } catch {
     console.warn("[cache] Could not save last-run date");
   }
-}
-
-function saveDebugFiles(
-  debugDir: string,
-  data: {
-    fromStr: string;
-    toStr: string;
-    changelogs: ReturnType<typeof collectChangelogs>;
-    commits: ReturnType<typeof collectCommits>;
-    systemPrompt: string;
-    contextMessage: string;
-  },
-): void {
-  mkdirSync(debugDir, { recursive: true });
-
-  writeFileSync(
-    join(debugDir, "changelogs.json"),
-    JSON.stringify(data.changelogs, null, 2),
-  );
-
-  writeFileSync(
-    join(debugDir, "commits.json"),
-    JSON.stringify(data.commits, null, 2),
-  );
-
-  writeFileSync(join(debugDir, "system-prompt.md"), data.systemPrompt);
-
-  writeFileSync(join(debugDir, "context-message.md"), data.contextMessage);
-
-  const meta = {
-    from: data.fromStr,
-    to: data.toStr,
-    changelogEntries: data.changelogs.length,
-    commits: data.commits.length,
-    generatedAt: new Date().toISOString(),
-  };
-  writeFileSync(join(debugDir, "meta.json"), JSON.stringify(meta, null, 2));
-
-  console.error(`[debug] Context saved to ${debugDir}/`);
-  console.error(
-    `[debug]   changelogs.json    — ${data.changelogs.length} entries`,
-  );
-  console.error(
-    `[debug]   commits.json       — ${data.commits.length} commits`,
-  );
-  console.error(`[debug]   system-prompt.md   — system prompt`);
-  console.error(`[debug]   context-message.md — full LLM user message`);
-  console.error(`[debug]   meta.json          — run metadata`);
 }
 
 async function main(): Promise<void> {
@@ -266,118 +221,99 @@ async function main(): Promise<void> {
     }
     systemPrompt = readFileSync(promptPath, "utf-8");
   } else {
-    const defaultPromptPath = join(__dirname, "prompts", "default.md");
+    const defaultPromptPath = join(__dirname, "prompts", "product-v3.md");
     systemPrompt = readFileSync(defaultPromptPath, "utf-8");
   }
 
-  // Collect data
-  console.error("[collect] Reading changelogs…");
-  const changelogs = collectChangelogs(repoRoot, from, to);
-  console.error(`[collect] Found ${changelogs.length} changelog entries`);
-
-  console.error("[collect] Reading commits…");
-  const commits = collectCommits(repoRoot, from, to);
-  console.error(`[collect] Found ${commits.length} commits`);
-
-  // Build precise Storybook URL map from the published index.json.
-  console.error("[collect] Fetching Storybook index…");
-  const storyUrls = await collectStoryUrls();
-  console.error(`[collect] Built story URL map (${storyUrls.size} entries)`);
-
-  // Fetch PR bodies only for *features* — bug fix one-liners from the
-  // CHANGELOG are usually enough and fetching every PR explodes the token.
-  const featureText = [
-    ...changelogs.flatMap((e) => e.features),
-    ...commits
-      .filter((c) => /^feat(\(|:|!)/.test(c.message))
-      .map((c) => c.message),
-  ].join(" ");
-  const prNumbers = extractPrNumbers(featureText);
+  // ---- Collect: merged PRs are the source of truth for what shipped ----
   const githubToken = opts.githubToken ?? process.env["GITHUB_TOKEN"];
-  let prBodies: Map<number, PrInfo> = new Map();
-  if (prNumbers.length > 0) {
-    console.error(
-      `[collect] Fetching ${prNumbers.length} PR description(s)…`,
-    );
-    prBodies = await fetchPrBodies(prNumbers, githubToken);
-    console.error(`[collect] Got ${prBodies.size} PR description(s)`);
-  }
 
-  // Save debug files if requested
-  if (opts.debug) {
-    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const debugDir =
-      opts.debugDir ?? `/tmp/changelog-summarizer-debug-${timestamp}`;
+  console.error("[collect] Fetching Storybook index…");
+  const storyIndex = await collectStoryIndex();
 
-    const contextMessage = buildContextMessage(
-      changelogs,
-      commits,
-      fromStr,
-      toStr,
-      prBodies,
-    );
+  console.error("[collect] Listing merged PRs…");
+  const prs = await listMergedPRs(fromStr, toStr, githubToken);
 
-    saveDebugFiles(debugDir, {
-      fromStr,
-      toStr,
-      changelogs,
-      commits,
-      systemPrompt,
-      contextMessage,
-    });
-  }
-
-  // Check for empty context
-  if (changelogs.length === 0 && commits.length === 0) {
-    console.error("[warn] No changes found for the given date range");
-    const emptyMessage = `:f0-dev: F0 Weekly Summary (${fromStr} – ${toStr})\n---\n_No changes this week._`;
-    if (opts.output) {
-      writeFileSync(resolve(opts.output), emptyMessage);
-    } else {
-      process.stdout.write(emptyMessage + "\n");
+  console.error("[collect] Fetching changed files / PR bodies…");
+  const withFiles: PrWithFiles[] = [];
+  for (const pr of prs) {
+    const { type, breaking } = parseConventionalTitle(pr.title);
+    let files: PrFile[] = [];
+    if (breaking || TYPES_NEEDING_FILES.has(type)) {
+      files = await fetchPrFiles(pr.number, githubToken);
     }
+    let body: string | undefined;
+    if (breaking) {
+      body = (await fetchPrBodies([pr.number], githubToken)).get(pr.number)
+        ?.body;
+    }
+    withFiles.push({ ...pr, files, body });
+  }
+
+  const facts = classifyMergedPrs(withFiles, storyIndex);
+
+  // Technical thread reply (for engineers): bug fixes + infra + thanks.
+  const threadParts: string[] = [];
+  if (facts.fixes.length > 0)
+    threadParts.push(`Fixes this week: ${facts.fixes.join("; ")}.`);
+  if (facts.infra.length > 0)
+    threadParts.push(`Infra & tooling: ${facts.infra.join("; ")}.`);
+  if (facts.contributors.length > 0)
+    threadParts.push(
+      `Thanks to ${facts.contributors.map((c) => `@${c}`).join(", ")}.`,
+    );
+
+  const skeleton: SummaryJson = {
+    ...facts.skeleton,
+    thread_details: threadParts.join(" "),
+  };
+
+  // Empty week → short placeholder.
+  const hasContent = Object.values(skeleton.sections).some((v) =>
+    Array.isArray(v) ? v.length > 0 : Boolean(v),
+  );
+  if (!hasContent) {
+    console.error("[warn] No product-visible changes for the given date range");
+    const emptyMessage = `:f0-dev: F0 Weekly Summary (${fromStr} – ${toStr})\n---\n_No changes this week._`;
+    if (opts.output) writeFileSync(resolve(opts.output), emptyMessage);
+    else process.stdout.write(emptyMessage + "\n");
+    saveLastRunDate(repoRoot);
     return;
   }
 
-  // Generate summary
-  console.error(`[llm] Generating summary with ${provider}…`);
-  const rawSummary = await generateSummary(model, systemPrompt, {
-    from: fromStr,
-    to: toStr,
-    changelogs,
-    commits,
-    prBodies,
-  });
-
-  // Decide post-processing path based on what the model returned. The
-  // product-v2 prompt asks for strict JSON; the legacy prompt asks for
-  // free-form mrkdwn that just needs cleanup.
-  let summary: string;
-  let threadDetails: string | undefined;
-
-  const trimmedRaw = rawSummary.trim();
-  const looksLikeJson =
-    trimmedRaw.startsWith("{") || trimmedRaw.startsWith("```");
-
-  if (looksLikeJson) {
-    console.error("[post] Detected JSON output — using product-v2 path");
-    const json = parseSummaryJson(rawSummary);
-    const slackText = jsonToSlackText(json, storyUrls);
-    if (slackText === null) {
-      summary = "_No changes this week._";
-    } else {
-      summary = slackText;
-    }
-    if (typeof json.thread_details === "string" && json.thread_details.trim()) {
-      threadDetails = json.thread_details.trim();
-    }
-  } else {
-    console.error("[post] Plain text output — using legacy postprocess path");
-    summary = postprocess(rawSummary);
+  // ---- Polish: the LLM rewrites each summary into product language with the
+  //      "why", bounded to the facts above (it may drop/merge, never invent).
+  //      If it fails, we publish the factual summary as-is.
+  let finalJson: SummaryJson = skeleton;
+  try {
+    console.error(`[llm] Polishing summary with ${provider}…`);
+    const polished = await polishSummary(model, systemPrompt, skeleton);
+    finalJson = reconcileSummary(skeleton, polished);
+  } catch (err) {
+    console.error(
+      `[llm] Polish failed (${err instanceof Error ? err.message : String(err)}) — using the factual summary`,
+    );
   }
 
-  // Prepend a plain-text title line (used as the top-level Slack header block)
-  // followed by --- so the workflow parser treats it as the first section delimiter.
+  if (opts.debug) {
+    const debugDir = opts.debugDir ?? "/tmp/changelog-summarizer-debug";
+    mkdirSync(debugDir, { recursive: true });
+    writeFileSync(
+      join(debugDir, "skeleton.json"),
+      JSON.stringify(skeleton, null, 2),
+    );
+    writeFileSync(
+      join(debugDir, "final.json"),
+      JSON.stringify(finalJson, null, 2),
+    );
+    console.error(`[debug] Wrote skeleton.json + final.json to ${debugDir}/`);
+  }
+
+  const summary =
+    jsonToSlackText(finalJson, storyIndex.urlByKey) ?? "_No changes this week._";
+  const threadDetails = finalJson.thread_details?.trim() || undefined;
+
+  // Prepend a plain-text title line (the top-level Slack header block) + ---.
   const output = `:f0-dev: F0 Weekly Summary (${fromStr} – ${toStr})\n---\n${summary}`;
 
   // Output

--- a/packages/changelog-summarizer/src/index.ts
+++ b/packages/changelog-summarizer/src/index.ts
@@ -20,6 +20,7 @@ import { collectStoryIndex } from "./collectors/stories.js";
 import { resolveApiKey, resolveModel } from "./providers.js";
 import { polishSummary, reconcileSummary } from "./summarizer.js";
 import { jsonToSlackText } from "./formatters/json-formatter.js";
+import { buildBlocks } from "./formatters/blockkit.js";
 import type { Provider, SummaryJson } from "./types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -313,40 +314,38 @@ async function main(): Promise<void> {
     jsonToSlackText(finalJson, storyIndex.urlByKey) ?? "_No changes this week._";
   const threadDetails = finalJson.thread_details?.trim() || undefined;
 
-  // Prepend a plain-text title line (the top-level Slack header block) + ---.
-  const output = `:f0-dev: F0 Weekly Summary (${fromStr} – ${toStr})\n---\n${summary}`;
+  // Title line (top-level Slack header) + the product sections. The technical
+  // notes go in a final "For engineers" section (webhook publishing can't post
+  // a threaded reply, so we keep the detail at the bottom of the same message).
+  let publishText = `:f0-dev: F0 Weekly Summary (${fromStr} – ${toStr})\n---\n${summary}`;
+  if (threadDetails) {
+    publishText += `\n---\n🛠️ For engineers\n\n${threadDetails}`;
+  }
 
-  // Output
+  // Pre-render the Block Kit payload so the workflow just posts it (no fragile
+  // bash parsing, and long sections are split under Slack's 3000-char limit).
+  const payload = JSON.stringify({ blocks: buildBlocks(publishText) }, null, 2);
+
   if (opts.output) {
-    writeFileSync(resolve(opts.output), output);
-    console.error(`[done] Summary written to ${opts.output}`);
+    const outputPath = resolve(opts.output);
+    writeFileSync(outputPath, publishText);
+    const blocksPath = outputPath.replace(/(\.[^./]+)?$/, ".blocks.json");
+    writeFileSync(blocksPath, payload);
+    console.error(`[done] Summary written to ${outputPath}`);
+    console.error(`[done] Block Kit payload written to ${blocksPath}`);
 
-    if (threadDetails) {
-      const outputPath = resolve(opts.output);
-      const threadPath = outputPath.replace(/(\.[^./]+)?$/, "-thread.txt");
-      writeFileSync(threadPath, threadDetails);
-      console.error(`[done] Thread details written to ${threadPath}`);
-
-      const githubOutput = process.env["GITHUB_OUTPUT"];
-      if (githubOutput) {
-        try {
-          writeFileSync(
-            githubOutput,
-            `thread_file=${threadPath}\n`,
-            { flag: "a" },
-          );
-        } catch (err) {
-          console.warn(
-            `[done] Could not append thread_file to GITHUB_OUTPUT: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
+    const githubOutput = process.env["GITHUB_OUTPUT"];
+    if (githubOutput) {
+      try {
+        writeFileSync(githubOutput, `blocks_file=${blocksPath}\n`, { flag: "a" });
+      } catch (err) {
+        console.warn(
+          `[done] Could not append blocks_file to GITHUB_OUTPUT: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
   } else {
-    process.stdout.write(output + "\n");
-    if (threadDetails) {
-      process.stdout.write(`\n--- THREAD ---\n${threadDetails}\n`);
-    }
+    process.stdout.write(publishText + "\n");
   }
 
   // Save last run date for next invocation

--- a/packages/changelog-summarizer/src/index.ts
+++ b/packages/changelog-summarizer/src/index.ts
@@ -6,9 +6,17 @@ import { fileURLToPath } from "url";
 import { execSync } from "child_process";
 import { collectChangelogs } from "./collectors/changelog.js";
 import { collectCommits } from "./collectors/commits.js";
+import { extractPrNumbers, fetchPrBodies } from "./collectors/github.js";
+import type { PrInfo } from "./collectors/github.js";
+import { collectStoryUrls } from "./collectors/stories.js";
 import { resolveApiKey, resolveModel } from "./providers.js";
 import { generateSummary } from "./summarizer.js";
 import { buildContextMessage } from "./formatters/markdown.js";
+import {
+  jsonToSlackText,
+  parseSummaryJson,
+} from "./formatters/json-formatter.js";
+import { postprocess } from "./formatters/postprocess.js";
 import type { Provider } from "./types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -195,6 +203,10 @@ async function main(): Promise<void> {
       "--debug-dir <path>",
       "Directory to save debug files (default: /tmp/changelog-summarizer-debug-{timestamp})",
     )
+    .option(
+      "--github-token <token>",
+      "GitHub token used to fetch PR descriptions (falls back to $GITHUB_TOKEN)",
+    )
     .parse(process.argv);
 
   const opts = program.opts<{
@@ -209,6 +221,7 @@ async function main(): Promise<void> {
     ignoreLastRun?: boolean;
     debug?: boolean;
     debugDir?: string;
+    githubToken?: string;
   }>();
 
   // Validate provider
@@ -266,6 +279,30 @@ async function main(): Promise<void> {
   const commits = collectCommits(repoRoot, from, to);
   console.error(`[collect] Found ${commits.length} commits`);
 
+  // Build precise Storybook URL map from the published index.json.
+  console.error("[collect] Fetching Storybook index…");
+  const storyUrls = await collectStoryUrls();
+  console.error(`[collect] Built story URL map (${storyUrls.size} entries)`);
+
+  // Fetch PR bodies only for *features* — bug fix one-liners from the
+  // CHANGELOG are usually enough and fetching every PR explodes the token.
+  const featureText = [
+    ...changelogs.flatMap((e) => e.features),
+    ...commits
+      .filter((c) => /^feat(\(|:|!)/.test(c.message))
+      .map((c) => c.message),
+  ].join(" ");
+  const prNumbers = extractPrNumbers(featureText);
+  const githubToken = opts.githubToken ?? process.env["GITHUB_TOKEN"];
+  let prBodies: Map<number, PrInfo> = new Map();
+  if (prNumbers.length > 0) {
+    console.error(
+      `[collect] Fetching ${prNumbers.length} PR description(s)…`,
+    );
+    prBodies = await fetchPrBodies(prNumbers, githubToken);
+    console.error(`[collect] Got ${prBodies.size} PR description(s)`);
+  }
+
   // Save debug files if requested
   if (opts.debug) {
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
@@ -277,6 +314,7 @@ async function main(): Promise<void> {
       commits,
       fromStr,
       toStr,
+      prBodies,
     );
 
     saveDebugFiles(debugDir, {
@@ -303,12 +341,40 @@ async function main(): Promise<void> {
 
   // Generate summary
   console.error(`[llm] Generating summary with ${provider}…`);
-  const summary = await generateSummary(model, systemPrompt, {
+  const rawSummary = await generateSummary(model, systemPrompt, {
     from: fromStr,
     to: toStr,
     changelogs,
     commits,
+    prBodies,
   });
+
+  // Decide post-processing path based on what the model returned. The
+  // product-v2 prompt asks for strict JSON; the legacy prompt asks for
+  // free-form mrkdwn that just needs cleanup.
+  let summary: string;
+  let threadDetails: string | undefined;
+
+  const trimmedRaw = rawSummary.trim();
+  const looksLikeJson =
+    trimmedRaw.startsWith("{") || trimmedRaw.startsWith("```");
+
+  if (looksLikeJson) {
+    console.error("[post] Detected JSON output — using product-v2 path");
+    const json = parseSummaryJson(rawSummary);
+    const slackText = jsonToSlackText(json, storyUrls);
+    if (slackText === null) {
+      summary = "_No changes this week._";
+    } else {
+      summary = slackText;
+    }
+    if (typeof json.thread_details === "string" && json.thread_details.trim()) {
+      threadDetails = json.thread_details.trim();
+    }
+  } else {
+    console.error("[post] Plain text output — using legacy postprocess path");
+    summary = postprocess(rawSummary);
+  }
 
   // Prepend a plain-text title line (used as the top-level Slack header block)
   // followed by --- so the workflow parser treats it as the first section delimiter.
@@ -318,8 +384,33 @@ async function main(): Promise<void> {
   if (opts.output) {
     writeFileSync(resolve(opts.output), output);
     console.error(`[done] Summary written to ${opts.output}`);
+
+    if (threadDetails) {
+      const outputPath = resolve(opts.output);
+      const threadPath = outputPath.replace(/(\.[^./]+)?$/, "-thread.txt");
+      writeFileSync(threadPath, threadDetails);
+      console.error(`[done] Thread details written to ${threadPath}`);
+
+      const githubOutput = process.env["GITHUB_OUTPUT"];
+      if (githubOutput) {
+        try {
+          writeFileSync(
+            githubOutput,
+            `thread_file=${threadPath}\n`,
+            { flag: "a" },
+          );
+        } catch (err) {
+          console.warn(
+            `[done] Could not append thread_file to GITHUB_OUTPUT: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
   } else {
     process.stdout.write(output + "\n");
+    if (threadDetails) {
+      process.stdout.write(`\n--- THREAD ---\n${threadDetails}\n`);
+    }
   }
 
   // Save last run date for next invocation

--- a/packages/changelog-summarizer/src/index.ts
+++ b/packages/changelog-summarizer/src/index.ts
@@ -17,6 +17,7 @@ import {
   type PrWithFiles,
 } from "./collectors/prs.js";
 import { collectStoryIndex } from "./collectors/stories.js";
+import { FOUNDATIONS_AUTHORS } from "./foundations.js";
 import { resolveApiKey, resolveModel } from "./providers.js";
 import { polishSummary, reconcileSummary } from "./summarizer.js";
 import { jsonToSlackText } from "./formatters/json-formatter.js";
@@ -251,7 +252,11 @@ async function main(): Promise<void> {
     withFiles.push({ ...pr, files, body });
   }
 
-  const facts = classifyMergedPrs(withFiles, storyIndex);
+  const facts = classifyMergedPrs(
+    withFiles,
+    storyIndex,
+    new Set(FOUNDATIONS_AUTHORS),
+  );
 
   // Technical thread reply (for engineers): bug fixes + infra + thanks.
   const threadParts: string[] = [];

--- a/packages/changelog-summarizer/src/index.ts
+++ b/packages/changelog-summarizer/src/index.ts
@@ -312,15 +312,10 @@ async function main(): Promise<void> {
 
   const summary =
     jsonToSlackText(finalJson, storyIndex.urlByKey) ?? "_No changes this week._";
-  const threadDetails = finalJson.thread_details?.trim() || undefined;
 
-  // Title line (top-level Slack header) + the product sections. The technical
-  // notes go in a final "For engineers" section (webhook publishing can't post
-  // a threaded reply, so we keep the detail at the bottom of the same message).
-  let publishText = `:f0-dev: F0 Weekly Summary (${fromStr} – ${toStr})\n---\n${summary}`;
-  if (threadDetails) {
-    publishText += `\n---\n🛠️ For engineers\n\n${threadDetails}`;
-  }
+  // Product-focused message only: title + the product sections. Bug fixes and
+  // infra are intentionally NOT published (too technical for this audience).
+  const publishText = `:f0-dev: F0 Weekly Summary (${fromStr} – ${toStr})\n---\n${summary}`;
 
   // Pre-render the Block Kit payload so the workflow just posts it (no fragile
   // bash parsing, and long sections are split under Slack's 3000-char limit).

--- a/packages/changelog-summarizer/src/prompts/product-v2.md
+++ b/packages/changelog-summarizer/src/prompts/product-v2.md
@@ -1,0 +1,129 @@
+You are the F0 design system's weekly product writer at Factorial. Your job is
+to turn this week's CHANGELOG entries, commit log and pull request descriptions
+into a Slack update that anyone at the company can read — designers, PMs,
+ops, support, sales, executives, not just engineers.
+
+F0 is Factorial's internal design system. It provides modular, reusable UI
+components for web (`@factorialco/f0-react`), mobile
+(`@factorialco/f0-react-native`), and shared utilities
+(`@factorialco/f0-core`).
+
+## Audience
+
+The whole company reads this message. Write for a non-technical reader:
+
+- Lead with user-visible impact, not implementation details.
+- No jargon. Replace technical terms with their plain-English equivalent:
+  - "prop" / "props" → "option" / "options"
+  - "canvas mode" → "edit mode"
+  - "i18n" → "translations"
+  - "PageHeader" → "page title area"
+  - "PageAction" → "page title button"
+  - "blast radius" → omit entirely
+  - "clarifying question UX" → "ability to ask clarifying questions mid-conversation"
+  - "motion polish" → "smoother animations"
+  - "persistence" → "remembers your state between sessions"
+- Never say "refactor", "internal", "DX", "tech debt" without rephrasing the
+  user-visible consequence.
+- Engineers get their own technical paragraph in `thread_details`.
+
+## Output format — strict JSON
+
+Output **only** a single JSON object. No markdown fences. No prose before or
+after. Schema:
+
+```
+{
+  "sections": {
+    "new": [
+      {
+        "component": "ComponentName or PatternName",
+        "summary": "One short product-oriented sentence.",
+        "detail": "Optional second sentence with more context.",
+        "storybook": true
+      }
+    ],
+    "stabilized": [
+      {
+        "component": "ComponentName",
+        "summary": "Now stable and safe to use in production.",
+        "detail": "Optional.",
+        "storybook": true
+      }
+    ],
+    "enhancements": [
+      {
+        "component": "ComponentName",
+        "summary": "What improved for the user.",
+        "detail": "Optional.",
+        "storybook": true
+      }
+    ],
+    "breaking_changes": [
+      {
+        "component": "ComponentName",
+        "summary": "What broke.",
+        "migration": "How to migrate."
+      }
+    ]
+  },
+  "thread_details": "Technical paragraph for developers consuming the design system. ALSO summarize this week's bug fixes and any build / tooling / test / infrastructure changes here — these do NOT get their own section in the main message."
+}
+```
+
+## Classification rules
+
+- **`new`**: components OR patterns that did **not** exist before this week.
+  New patterns (anything published under `Patterns/` in Storybook) go here too —
+  treat them like any other new entry. If something already existed and was
+  improved, it is an **enhancement**, not new. When in doubt, classify as
+  enhancement.
+- **`stabilized`**: components that were **promoted from experimental to
+  stable** this week, i.e. now safe to use in production. Signals: commit/PR
+  messages like "promote from experimental to stable", "stabilize", "stability
+  audit", or a lifecycle status change to stable. Only include components with a
+  clear stabilization signal — do NOT guess. This is high-value adoption news.
+- **`enhancements`**: improvements to components that already existed.
+- **`breaking_changes`**: only renames, removals, or signature changes that
+  require consumers to update their code. Always include a `migration` field.
+- **Bug fixes and infrastructure** (build, tests, tooling, dependencies, docs
+  infra) do NOT get a main-message section. Fold a one-line summary of each into
+  `thread_details` instead — they're for the engineers reading the thread, not
+  the company-wide message.
+
+## `storybook` field
+
+Set `storybook: true` **only** for components that are part of the F0 React
+library (`packages/react`) — these are the ones documented in Storybook at
+ds.factorial.dev. Set `false` (or omit) for:
+
+- Internal product components (anything that lives outside `packages/react`,
+  for example `EntityRef` variants used only inside the product).
+- Tokens, utilities, build changes, tests.
+
+The formatter will append the Storybook link on your behalf. **Do not** write
+"View in Storybook" or any link in `summary` or `detail`.
+
+## Section rules
+
+- Omit any section that has no entries. If `new` is empty, leave it out of the
+  JSON entirely (do not emit an empty array).
+- Same for `stabilized`, `enhancements` and `breaking_changes`.
+- If the whole week has no user-visible changes, return `{ "sections": {} }`.
+
+## Content rules
+
+- Never invent information. Use only what is present in the CHANGELOG, commits
+  and PR descriptions provided in the context.
+- Do not include commit hashes, PR numbers, package versions, or author names
+  in the JSON output.
+- Keep each `summary` to one sentence. Keep each `detail` to one sentence.
+- `thread_details` is a single paragraph (no bullets, no headings) aimed at
+  developers consuming F0 — mention migration notes, new options, behavioural
+  changes, this week's notable bug fixes, and any build/tooling/test/infra
+  changes; anything they'd want to know before upgrading.
+
+## Reminder
+
+Output the JSON object and **nothing else**. No ``` fences. No
+"Here is the summary:". No trailing newline commentary.

--- a/packages/changelog-summarizer/src/prompts/product-v3.md
+++ b/packages/changelog-summarizer/src/prompts/product-v3.md
@@ -1,0 +1,57 @@
+You are the F0 design system's weekly product writer at Factorial. You are given
+a FACTUAL JSON summary of what shipped this week (derived deterministically from
+merged pull requests). Your only job is to rewrite the wording so the whole
+company — designers, PMs, ops, support, sales, execs, not just engineers — can
+understand what's new, what improved, and **why it matters to the product**.
+
+F0 is Factorial's internal design system: reusable UI components for web
+(`@factorialco/f0-react`), mobile (`@factorialco/f0-react-native`) and shared
+utilities (`@factorialco/f0-core`).
+
+## The input
+
+A JSON object with this shape (sections may be missing):
+
+```
+{
+  "sections": {
+    "new": [{ "component", "summary", "detail?", "storybook?", "author?", "url?" }],
+    "stabilized": [{ "component", "summary", ... }],
+    "enhancements": [{ "component", "summary", ... }],
+    "breaking_changes": [{ "component", "summary", "migration" }]
+  },
+  "thread_details": "..."
+}
+```
+
+## What you may and may NOT change
+
+- **Rewrite** every `summary` (and `detail`) into ONE short, plain-English,
+  product-oriented sentence: what changed and why it helps the teams using F0.
+- You **MAY drop** an entry under `new` or `enhancements` if it has no
+  product-visible relevance (pure internal/technical churn). You **MAY** also
+  leave wording terse if the change is genuinely small.
+- You **MUST NOT** add any `component` that is not already in the input.
+- You **MUST NOT** change `component`, `author`, `url`, `storybook`, or which
+  section an entry belongs to. Do not drop anything under `stabilized` or
+  `breaking_changes`.
+- For `breaking_changes`, rewrite `summary` into the user-visible impact and
+  `migration` into a short, concrete "what to do".
+- Rewrite `thread_details` into one concise technical paragraph for engineers
+  consuming F0 (migration notes, new options, behavioural changes, notable bug
+  fixes, infra). No bullets, no headings.
+
+## Language / tone
+
+- Lead with impact, not implementation. No jargon. Replace technical terms with
+  plain equivalents: "prop"→"option", "i18n"→"translations", "canvas mode"→
+  "edit mode", "PageHeader"→"page title area". Drop "refactor/DX/tech debt".
+- Warm and clear. Do NOT write "View in Storybook" or any link in `summary`/
+  `detail` — links are added automatically from `url`.
+- Do NOT include PR numbers, commit hashes, versions, or (in summaries) author
+  names — those are handled separately.
+
+## Output
+
+Return ONLY the JSON object, same shape as the input. No markdown fences, no
+prose before or after.

--- a/packages/changelog-summarizer/src/summarizer.ts
+++ b/packages/changelog-summarizer/src/summarizer.ts
@@ -1,20 +1,26 @@
-import { generateText } from "ai";
-import type { LanguageModel } from "ai";
-import type { CollectedContext } from "./types.js";
-import { buildContextMessage } from "./formatters/markdown.js";
+import { generateText, type LanguageModel } from "ai";
+import { parseSummaryJson } from "./formatters/json-formatter.js";
+import type {
+  SummaryBreakingChangeEntry,
+  SummaryJson,
+  SummaryStabilizedEntry,
+} from "./types.js";
 
-export async function generateSummary(
+/**
+ * Ask the LLM to rewrite the factual skeleton into product language with the
+ * "why". The model receives the deterministic facts and returns the same JSON
+ * shape — see `prompts/product-v3.md`.
+ */
+export async function polishSummary(
   model: LanguageModel,
   systemPrompt: string,
-  context: CollectedContext,
-): Promise<string> {
-  const userMessage = buildContextMessage(
-    context.changelogs,
-    context.commits,
-    context.from,
-    context.to,
-    context.prBodies,
-  );
+  skeleton: SummaryJson,
+): Promise<SummaryJson> {
+  const userMessage =
+    "Here is this week's factual F0 summary as JSON. Rewrite it following " +
+    "your instructions and return ONLY the JSON object.\n\n```json\n" +
+    JSON.stringify(skeleton, null, 2) +
+    "\n```";
 
   const { text } = await generateText({
     model,
@@ -22,5 +28,108 @@ export async function generateSummary(
     prompt: userMessage,
   });
 
-  return text;
+  return parseSummaryJson(text);
+}
+
+const keyOf = (c: string | undefined): string => (c ?? "").trim().toLowerCase();
+
+/**
+ * Merge the LLM's polished wording back onto the factual skeleton.
+ *
+ * Guardrail: the LLM may rewrite text and, for `new`/`enhancements`, DROP an
+ * entry it judged not product-relevant — but it can NEVER introduce a component
+ * that wasn't in the skeleton, and `component`/`author`/`url`/`storybook` and
+ * the section a component lives in always come from the facts, not the model.
+ */
+export function reconcileSummary(
+  skeleton: SummaryJson,
+  polished: SummaryJson,
+): SummaryJson {
+  const pol = polished.sections ?? {};
+
+  // Curatable: keep only polished entries that match a factual entry (drop
+  // invented ones); the LLM may omit entries to curate. Never drop everything.
+  const curate = <T extends { component: string; summary: string; detail?: string }>(
+    skel: T[] | undefined,
+    polArr:
+      | Array<{ component?: string; summary?: string; detail?: string }>
+      | undefined,
+  ): T[] | undefined => {
+    if (!skel || skel.length === 0) return skel;
+    const byComp = new Map(skel.map((e) => [keyOf(e.component), e]));
+    const seen = new Set<string>();
+    const out: T[] = [];
+    for (const p of polArr ?? []) {
+      const k = keyOf(p.component);
+      const s = byComp.get(k);
+      if (!s || seen.has(k)) continue;
+      seen.add(k);
+      out.push({
+        ...s,
+        summary: p.summary?.trim() || s.summary,
+        detail: p.detail?.trim() || s.detail,
+      });
+    }
+    return out.length > 0 ? out : skel;
+  };
+
+  // Keep-all: high-value sections keep every factual entry; text only.
+  const rewriteStable = (
+    skel: SummaryStabilizedEntry[] | undefined,
+    polArr:
+      | Array<{ component?: string; summary?: string; detail?: string }>
+      | undefined,
+  ): SummaryStabilizedEntry[] | undefined => {
+    if (!skel) return skel;
+    const byComp = new Map((polArr ?? []).map((p) => [keyOf(p.component), p]));
+    return skel.map((s) => {
+      const p = byComp.get(keyOf(s.component));
+      return {
+        ...s,
+        summary: p?.summary?.trim() || s.summary,
+        detail: p?.detail?.trim() || s.detail,
+      };
+    });
+  };
+
+  const rewriteBreaking = (
+    skel: SummaryBreakingChangeEntry[] | undefined,
+    polArr:
+      | Array<{ component?: string; summary?: string; migration?: string }>
+      | undefined,
+  ): SummaryBreakingChangeEntry[] | undefined => {
+    if (!skel) return skel;
+    const byComp = new Map((polArr ?? []).map((p) => [keyOf(p.component), p]));
+    return skel.map((s) => {
+      const p = byComp.get(keyOf(s.component));
+      return {
+        ...s,
+        summary: p?.summary?.trim() || s.summary,
+        migration: p?.migration?.trim() || s.migration,
+      };
+    });
+  };
+
+  return {
+    sections: {
+      ...(skeleton.sections.new
+        ? { new: curate(skeleton.sections.new, pol.new) }
+        : {}),
+      ...(skeleton.sections.stabilized
+        ? { stabilized: rewriteStable(skeleton.sections.stabilized, pol.stabilized) }
+        : {}),
+      ...(skeleton.sections.enhancements
+        ? { enhancements: curate(skeleton.sections.enhancements, pol.enhancements) }
+        : {}),
+      ...(skeleton.sections.breaking_changes
+        ? {
+            breaking_changes: rewriteBreaking(
+              skeleton.sections.breaking_changes,
+              pol.breaking_changes,
+            ),
+          }
+        : {}),
+    },
+    thread_details: polished.thread_details?.trim() || skeleton.thread_details,
+  };
 }

--- a/packages/changelog-summarizer/src/summarizer.ts
+++ b/packages/changelog-summarizer/src/summarizer.ts
@@ -13,6 +13,7 @@ export async function generateSummary(
     context.commits,
     context.from,
     context.to,
+    context.prBodies,
   );
 
   const { text } = await generateText({

--- a/packages/changelog-summarizer/src/types.ts
+++ b/packages/changelog-summarizer/src/types.ts
@@ -1,3 +1,5 @@
+import type { PrInfo } from "./collectors/github.js";
+
 export interface ChangelogEntry {
   package: string;
   version: string;
@@ -20,6 +22,7 @@ export interface CollectedContext {
   to: string;
   changelogs: ChangelogEntry[];
   commits: CommitEntry[];
+  prBodies?: Map<number, PrInfo>;
 }
 
 export type Provider = "openai" | "anthropic" | "google" | "groq";
@@ -33,4 +36,54 @@ export interface CliOptions {
   prompt?: string;
   output?: string;
   repoRoot?: string;
+  githubToken?: string;
+}
+
+// ---- Product-v2 JSON output schema ----
+
+export interface SummaryNewEntry {
+  component: string;
+  summary: string;
+  detail?: string;
+  storybook?: boolean;
+  author?: string;
+  /** Pre-resolved Storybook link (e.g. a specific story deep-link). When set,
+   * the formatter uses it instead of resolving the component docs page. */
+  url?: string;
+}
+
+export interface SummaryEnhancementEntry {
+  component: string;
+  summary: string;
+  detail?: string;
+  storybook?: boolean;
+  author?: string;
+  url?: string;
+}
+
+export interface SummaryStabilizedEntry {
+  component: string;
+  summary: string;
+  detail?: string;
+  storybook?: boolean;
+  author?: string;
+  url?: string;
+}
+
+export interface SummaryBreakingChangeEntry {
+  component: string;
+  summary: string;
+  migration: string;
+}
+
+export interface SummarySections {
+  new?: SummaryNewEntry[];
+  stabilized?: SummaryStabilizedEntry[];
+  enhancements?: SummaryEnhancementEntry[];
+  breaking_changes?: SummaryBreakingChangeEntry[];
+}
+
+export interface SummaryJson {
+  sections: SummarySections;
+  thread_details?: string;
 }


### PR DESCRIPTION
## What

A **product-focused weekly F0 summary**, readable by the whole company, built
from **merged PRs** (what actually shipped). Posts as the **Zerito** bot to
**#testing-zerito** for now (switch to #f0-design-system once validated).

## How it works

- **Deterministic facts** from each merged PR (title + diff — the model decides
  nothing):
  - 🚀 **What's new** — "add `<Component>` component/pattern"
  - ✅ **Now stable** — the component's manual MDX docs were added (DoD complete)
    **and the author is on the F0/Foundations allowlist** (`src/foundations.ts`).
    Only Foundations promotes to stable; other teams' stable markings are ignored.
  - ✨ **Enhancements** — `feat`/`perf` on an existing component, grouped
  - ⚠️ **Breaking changes** — conventional `!`, migration from the PR body
- **LLM polish** (bounded): rewrites summaries into product language + the "why";
  can reword/drop but never invent a component (`reconcileSummary`). Falls back
  to the factual summary if the LLM call fails.
- **Storybook links**: per-story deep-link when the PR added a story, else the
  component docs page, else any story.
- `index.ts` pre-renders the Block Kit payload (sections split under Slack's
  3000-char limit); the workflow posts it via `chat.postMessage`.

## Workflows

- **`zerito-product-summary.yaml`** (NEW, by @eliseo-juan): this summary →
  `#testing-zerito` via `ZERITO_SLACK_BOT_TOKEN`. Cron Fri 10:00 UTC + manual.
- **`changelog-summary.yaml`** (legacy engineering): auto-run **disabled** (it
  shares `src/index.ts`, now product-focused). Decide later: retire or give it
  its own code path.

## Secrets (already set)
`GROQ_API_KEY` ✅ · `ZERITO_SLACK_BOT_TOKEN` ✅

## Rollout after merge
1. Manually run **"Zerito — Weekly F0 Product Summary"** with `from=2026-04-27`,
   `to=` (today), `dry_run=true` → check the log.
2. Same with `dry_run=false` → posts the quarter-to-date message to
   #testing-zerito and sets the weekly watermark.
3. Friday cron then posts the weekly increment. Switch `SLACK_CHANNEL` to
   #f0-design-system when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)