### PR TITLE
feat(avatars): promote F0Avatar + entity types to stable

### DIFF
--- a/packages/react/src/components/avatars/F0Avatar/F0Avatar.tsx
+++ b/packages/react/src/components/avatars/F0Avatar/F0Avatar.tsx
@@ -83,7 +83,7 @@ export const F0Avatar = ({
       return (
         <F0AvatarFlag
           flag={avatar.flag}
-          size={size as ComponentProps<typeof F0AvatarFile>["size"]}
+          size={size}
           badge={avatar.badge}
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}

--- a/packages/react/src/components/avatars/F0Avatar/__stories__/F0Avatar.mdx
+++ b/packages/react/src/components/avatars/F0Avatar/__stories__/F0Avatar.mdx
@@ -1,0 +1,300 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as AvatarStories from "./F0Avatar.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+import { F0Avatar } from "../F0Avatar"
+
+<Meta of={AvatarStories} />
+
+# Avatar
+
+Avatar gives any entity — a person, team, company, file and more — a compact,
+recognizable visual identity. It lets people identify and tell entities apart at
+a glance, providing visual feedback so they don't have to read a name or label
+to know what something is.
+
+---
+
+## Overview
+
+### Purpose
+
+- **Visual recognition**: Identify an entity instantly from an image, initials
+  or icon instead of reading text
+- **Scannability**: Help users tell items apart at a glance in lists, tables,
+  comments and assignments
+- **Consistent identity**: Give any entity the same visual representation
+  wherever it appears across the product
+- **Context and hierarchy**: Convey relative importance and optional status
+  through a shared sizing and badge system
+
+### Anatomy
+
+`F0Avatar` is polymorphic: a single `avatar` prop carries a `type` discriminator
+plus the data for that type, and the component renders the matching avatar.
+Person avatars are fully circular; every other type uses a square with rounded
+corners. When no image is provided, the avatar falls back to initials or a type
+icon, so it is never empty.
+
+<Canvas of={AvatarStories.Default} />
+
+<Controls of={AvatarStories.Default} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Element</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Required</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>Container</code>
+        </td>
+        <td>
+          Base container carrying the size, shape and color styling, built on
+          the Radix Avatar root
+        </td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Content</code>
+        </td>
+        <td>
+          Image, initials, icon, emoji or other specialized content representing
+          the entity
+        </td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Badge</code>
+        </td>
+        <td>Optional status or contextual indicator layered on the corner</td>
+        <td>No</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Variants
+
+#### Type
+
+Choose the `type` that matches the entity you are representing.
+
+<Canvas of={AvatarStories.AllTypes} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Type</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">When to use</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>person</code>
+        </td>
+        <td>An individual — employee, user or contact</td>
+        <td>Representing a person; circular, shows photo or initials</td>
+      </tr>
+      <tr>
+        <td>
+          <code>team</code>
+        </td>
+        <td>A team or group of people</td>
+        <td>Representing a team or group</td>
+      </tr>
+      <tr>
+        <td>
+          <code>company</code>
+        </td>
+        <td>A company or legal entity</td>
+        <td>Representing an organization</td>
+      </tr>
+      <tr>
+        <td>
+          <code>file</code>
+        </td>
+        <td>A file or document</td>
+        <td>Representing a file, with an icon derived from its type</td>
+      </tr>
+      <tr>
+        <td>
+          <code>flag</code>
+        </td>
+        <td>A country or locale</td>
+        <td>Representing a country or region by its flag</td>
+      </tr>
+      <tr>
+        <td>
+          <code>emoji</code>
+        </td>
+        <td>An emoji</td>
+        <td>Representing a concept or reaction with an emoji</td>
+      </tr>
+      <tr>
+        <td>
+          <code>icon</code>
+        </td>
+        <td>A generic icon</td>
+        <td>Representing an entity that has no photo, with an icon</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+#### Sizes
+
+All avatar types share a single sizing system, so they stay aligned wherever
+they appear. Pick the size from the surrounding density rather than the entity
+type.
+
+<Canvas of={AvatarStories.PersonAvatar} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Size</th>
+        <th className="text-left">Dimensions</th>
+        <th className="text-left">Usage context</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>2xl</code>
+        </td>
+        <td>72px</td>
+        <td>Hero sections, large displays</td>
+      </tr>
+      <tr>
+        <td>
+          <code>xl</code>
+        </td>
+        <td>56px</td>
+        <td>Headers, profile sections</td>
+      </tr>
+      <tr>
+        <td>
+          <code>lg</code>
+        </td>
+        <td>40px</td>
+        <td>Prominent display, cards</td>
+      </tr>
+      <tr>
+        <td>
+          <code>md</code>
+        </td>
+        <td>32px</td>
+        <td>Standard interface use</td>
+      </tr>
+      <tr>
+        <td>
+          <code>sm</code>
+        </td>
+        <td>24px</td>
+        <td>Secondary information</td>
+      </tr>
+      <tr>
+        <td>
+          <code>xs</code>
+        </td>
+        <td>20px</td>
+        <td>Compact lists, tags</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+## Guidelines
+
+### Design best practices
+
+Reach for `F0Avatar` when the **entity type is dynamic** — driven by data rather
+than known at build time.
+
+#### When to use
+
+- The type comes from data and can vary per item — a row, dropdown entry or
+  collection item that could be a person, team, company, file, etc. Pass
+  `avatar={item.avatar}` and `F0Avatar` renders the right type without a `switch`.
+- You want one component to render heterogeneous entities consistently across
+  lists, tables, dropdowns, data collections and graph nodes.
+
+#### When NOT to use
+
+- **The type is fixed and known** (e.g. always a person): use the specific
+  component directly — `F0AvatarPerson`, `F0AvatarTeam`, `F0AvatarCompany`… —
+  with its own props, instead of wrapping the data in `{ type, … }`.
+- **Specialized avatars**: a date, an alert/status, a module, or a stack of
+  several avatars are not entity types and don't follow the shared size system
+  (a date chip, for instance, is fixed-size and shows month + day). They live as
+  dedicated components — `F0AvatarDate`, `F0AvatarAlert`, `F0AvatarModule`,
+  `F0AvatarList` — rather than `F0Avatar` types, so use those directly.
+- **Decoration**: when the graphic does not stand for a real entity, use an icon
+  instead of an avatar.
+
+#### How to use
+
+- Use a badge only to surface meaningful status or context
+- Match the avatar size to the surrounding density
+
+<DoDonts
+  do={{
+    description:
+      "Use the type that matches the entity — a person avatar for a person",
+    children: (
+      <F0Avatar
+        size="lg"
+        avatar={{
+          type: "person",
+          firstName: "Jane",
+          lastName: "Smith",
+          src: "/avatars/person02.jpg",
+          "aria-label": "Jane Smith",
+        }}
+      />
+    ),
+  }}
+  dont={{
+    description:
+      "Don't stand in for a real entity with an emoji or generic icon",
+    children: (
+      <F0Avatar
+        size="lg"
+        avatar={{ type: "emoji", emoji: "🙂", "aria-label": "Jane Smith" }}
+      />
+    ),
+  }}
+/>
+
+---
+
+## Behavior
+
+### Polymorphic rendering
+
+`F0Avatar` renders a different underlying avatar depending on `avatar.type`. The
+`avatar` object is a discriminated union, so TypeScript only allows the props
+that belong to the selected type — `firstName`/`lastName` for `person`, `name`
+for `team` and `company`, `flag` for `flag`, and so on.
+
+### Accessible name
+
+An avatar carries no inherent text, so it is hidden from assistive technology
+(`aria-hidden`) unless you give it a name. Pass `aria-label` (or
+`aria-labelledby`) only when the avatar stands on its own; when it sits next to
+the entity's visible name, leave it unlabeled so screen readers don't announce
+it twice.

--- a/packages/react/src/components/avatars/F0Avatar/__stories__/F0Avatar.stories.tsx
+++ b/packages/react/src/components/avatars/F0Avatar/__stories__/F0Avatar.stories.tsx
@@ -3,7 +3,7 @@ import type { ComponentProps } from "react"
 
 import { expect, within } from "storybook/test"
 
-import { Check, Warning } from "@/icons/app"
+import { Calendar, Check, Warning } from "@/icons/app"
 import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { internalAvatarSizes } from "@/ui/Avatar"
@@ -12,22 +12,10 @@ import { avatarSizes } from "../../internal/BaseAvatar"
 import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
 import { F0Avatar } from "../F0Avatar"
 
-const meta: Meta<typeof F0Avatar> = {
+const meta = {
   component: F0Avatar,
   title: "Avatars/Avatar",
-  tags: ["autodocs"],
-  parameters: {
-    docs: {
-      description: {
-        component: [
-          "A polymorphic avatar component that can display person, team, or company avatars.",
-          "The component automatically renders the appropriate avatar type based on the avatar prop configuration.",
-        ]
-          .map((line) => `<p>${line}</p>`)
-          .join(""),
-      },
-    },
-  },
+  tags: ["stable", "!autodocs"],
   argTypes: {
     ...getBaseAvatarArgTypes(["size"]),
     size: {
@@ -51,7 +39,7 @@ const meta: Meta<typeof F0Avatar> = {
     },
     ...dataTestIdArgs,
   },
-}
+} satisfies Meta<typeof F0Avatar>
 
 export default meta
 type Story = StoryObj<typeof F0Avatar>
@@ -60,7 +48,7 @@ const SIZES = avatarSizes
 
 export const WithDataTestId: Story = {
   args: {
-    size: "md",
+    size: "lg",
     avatar: {
       type: "person",
       firstName: "John",
@@ -98,7 +86,7 @@ export const PersonAvatar: Story = {
               type: "person",
               firstName: "Jane",
               lastName: "Smith",
-              src: "/storybook-assets/avatar.jpeg",
+              src: "/avatars/person02.jpg",
             }}
           />
           <F0Avatar
@@ -137,7 +125,7 @@ export const TeamAvatar: Story = {
             avatar={{
               type: "team",
               name: "Design Team",
-              src: "/storybook-assets/avatar.jpeg",
+              src: "/avatars/team02.jpg",
             }}
           />
           <F0Avatar
@@ -175,7 +163,7 @@ export const CompanyAvatar: Story = {
             avatar={{
               type: "company",
               name: "Acme Corp",
-              src: "/storybook-assets/avatar.jpeg",
+              src: "/avatars/company01.jpg",
             }}
           />
           <F0Avatar
@@ -195,49 +183,76 @@ export const CompanyAvatar: Story = {
   ),
 }
 
-export const AllTypes: Story = {
-  render: () => (
-    <div className="flex w-fit flex-col gap-4">
-      <h3 className="text-lg font-semibold">All Avatar Types</h3>
-      <div className="flex flex-row gap-4">
-        <div className="flex flex-col items-center gap-2">
-          <span className="text-sm font-medium">Person</span>
-          <F0Avatar
-            size="lg"
-            avatar={{
-              type: "person",
-              firstName: "John",
-              lastName: "Doe",
-              src: "/storybook-assets/avatar.jpeg",
-            }}
-          />
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <span className="text-sm font-medium">Team</span>
-          <F0Avatar
-            size="lg"
-            avatar={{
-              type: "team",
-              name: "Engineering Team",
-            }}
-          />
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <span className="text-sm font-medium">Company</span>
-          <F0Avatar
-            size="lg"
-            avatar={{
-              type: "company",
-              name: "Factorial HR",
-            }}
-          />
-        </div>
-      </div>
-    </div>
-  ),
+export const Default: Story = {
+  args: {
+    size: "lg",
+    avatar: {
+      type: "person",
+      firstName: "John",
+      lastName: "Doe",
+      "aria-label": "John Doe",
+    },
+  } as ComponentProps<typeof F0Avatar>,
+  render: (args) => <F0Avatar {...args} />,
 }
 
-export const WithBadges: Story = {
+export const AllTypes: Story = {
+  render: () => {
+    const types = [
+      {
+        label: "Person",
+        avatar: {
+          type: "person",
+          firstName: "John",
+          lastName: "Doe",
+          src: "/avatars/person04.jpg",
+        },
+      },
+      {
+        label: "Team",
+        avatar: {
+          type: "team",
+          name: "Engineering Team",
+          src: "/avatars/team01.jpg",
+        },
+      },
+      {
+        label: "Company",
+        avatar: {
+          type: "company",
+          name: "Factorial HR",
+          src: "/avatars/company02.jpg",
+        },
+      },
+      {
+        label: "File",
+        avatar: {
+          type: "file",
+          file: { name: "report.pdf", type: "application/pdf" },
+        },
+      },
+      { label: "Flag", avatar: { type: "flag", flag: "es" } },
+      { label: "Emoji", avatar: { type: "emoji", emoji: "🎉" } },
+      { label: "Icon", avatar: { type: "icon", icon: Calendar } },
+    ] as const
+
+    return (
+      <div className="flex w-fit flex-col gap-4">
+        <h3 className="text-lg font-semibold">All Avatar Types</h3>
+        <div className="flex flex-row flex-wrap gap-4">
+          {types.map(({ label, avatar }) => (
+            <div key={label} className="flex flex-col items-center gap-2">
+              <span className="text-sm font-medium">{label}</span>
+              <F0Avatar size="lg" avatar={avatar} />
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  },
+}
+
+export const Snapshot: Story = {
   parameters: withSnapshot({}),
   render: () => (
     <div className="flex w-fit flex-col gap-4">

--- a/packages/react/src/components/avatars/F0Avatar/__tests__/F0Avatar.test.tsx
+++ b/packages/react/src/components/avatars/F0Avatar/__tests__/F0Avatar.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { F0Avatar } from "../F0Avatar"
+
+describe("F0Avatar", () => {
+  it("renders the person variant with its accessible label", () => {
+    zeroRender(
+      <F0Avatar
+        avatar={{
+          type: "person",
+          firstName: "John",
+          lastName: "Doe",
+          "aria-label": "John Doe",
+        }}
+      />
+    )
+
+    expect(screen.getByRole("img", { name: "John Doe" })).toBeInTheDocument()
+  })
+
+  it("dispatches to the avatar matching the type discriminator", () => {
+    zeroRender(
+      <F0Avatar
+        avatar={{
+          type: "company",
+          name: "Factorial HR",
+          "aria-label": "Factorial HR",
+        }}
+      />
+    )
+
+    expect(
+      screen.getByRole("img", { name: "Factorial HR" })
+    ).toBeInTheDocument()
+  })
+
+  it("forwards dataTestId to the rendered avatar", () => {
+    zeroRender(
+      <F0Avatar
+        dataTestId="my-test-avatar"
+        avatar={{
+          type: "team",
+          name: "Engineering Team",
+          "aria-label": "Engineering Team",
+        }}
+      />
+    )
+
+    expect(screen.getByTestId("my-test-avatar")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/avatars/F0AvatarCompany/__stories__/F0AvatarCompany.mdx
+++ b/packages/react/src/components/avatars/F0AvatarCompany/__stories__/F0AvatarCompany.mdx
@@ -1,0 +1,52 @@
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
+import * as CompanyStories from "./F0AvatarCompany.stories"
+
+<Meta of={CompanyStories} />
+
+# AvatarCompany
+
+The avatar for a company or legal entity.
+
+---
+
+## Overview
+
+### Purpose
+
+- Represent a company or organization consistently across the interface
+- Help distinguish companies at a glance in lists, headers and pickers
+
+### Anatomy
+
+A company avatar uses a square shape with rounded corners — the default shape
+shared by every avatar type except person.
+
+<Canvas of={CompanyStories.Default} />
+
+<Controls of={CompanyStories.Default} />
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- The entity is always a company and known at build time
+- Company pickers, organization headers, billing and account rows
+
+#### When NOT to use
+
+- The entity type is dynamic (could be a person or team): use `F0Avatar`
+- The entity is not a company: use the matching `F0Avatar*` component
+
+---
+
+## Behavior
+
+### Image fallback
+
+With no `src` — or if the image fails to load — the avatar shows the company's
+initials. Unlike person and team avatars, the fallback uses a single fixed
+background color rather than one derived from the name.

--- a/packages/react/src/components/avatars/F0AvatarCompany/__stories__/F0AvatarCompany.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarCompany/__stories__/F0AvatarCompany.stories.tsx
@@ -1,18 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { Check } from "@/icons/app"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { mockImage } from "@/testing/mocks/images"
-import { mockModuleId } from "@/testing/mocks/modules"
 
 import { avatarSizes } from "../../internal/BaseAvatar"
 import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
-import { F0AvatarTeam } from "../F0AvatarTeam"
+import { F0AvatarCompany } from "../F0AvatarCompany"
 
-const meta: Meta<typeof F0AvatarTeam> = {
-  component: F0AvatarTeam,
-  title: "Avatars/AvatarTeam",
-  tags: ["autodocs"],
+const meta = {
+  component: F0AvatarCompany,
+  title: "Avatars/AvatarCompany",
+  tags: ["stable", "!autodocs"],
   argTypes: {
     ...getBaseAvatarArgTypes([
       "size",
@@ -20,30 +18,51 @@ const meta: Meta<typeof F0AvatarTeam> = {
       "aria-labelledby",
       "badge",
     ]),
+    name: {
+      control: "text",
+      description:
+        "The company name to display (used for initials if no image provided)",
+    },
+    src: {
+      control: "text",
+      description:
+        "URL of the company logo/image. If no logo is provided, it will display the company name initials with a fixed background color.",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: ["A company avatar component."]
+          .map((line) => `<p>${line}</p>`)
+          .join(""),
+      },
+    },
   },
   args: {
-    name: "Design",
-    size: "md",
+    name: "Factorial",
+    size: "lg",
+    "aria-label": "Factorial avatar",
   },
-}
+} satisfies Meta<typeof F0AvatarCompany>
 
 export default meta
 
-type Story = StoryObj<typeof F0AvatarTeam>
+type Story = StoryObj<typeof F0AvatarCompany>
 
 export const Default: Story = {}
 
 export const WithImage: Story = {
   args: {
-    src: "/avatars/team01.jpg",
+    src: "/avatars/factorial.png",
   },
 }
 
-export const WithBadge: Story = {
+export const WithModuleBadge: Story = {
   args: {
+    src: "/avatars/factorial.png",
     badge: {
-      type: "positive",
-      icon: Check,
+      type: "module",
+      module: "inbox",
     },
   },
 }
@@ -58,7 +77,7 @@ export const Snapshot: Story = {
         <h4 className="text-lg font-semibold">Without Image</h4>
         <div className="flex flex-row gap-2">
           {avatarSizes.map((size) => (
-            <F0AvatarTeam key={size} size={size} name="Engineering" />
+            <F0AvatarCompany key={size} size={size} name="Factorial" />
           ))}
         </div>
       </section>
@@ -66,11 +85,11 @@ export const Snapshot: Story = {
         <h4 className="text-lg font-semibold">With Image</h4>
         <div className="flex flex-row gap-2">
           {avatarSizes.map((size, index) => (
-            <F0AvatarTeam
+            <F0AvatarCompany
               key={size}
               size={size}
-              name="Engineering"
-              src={mockImage("team", index)}
+              name="Factorial"
+              src={mockImage("company", index)}
             />
           ))}
         </div>
@@ -79,12 +98,12 @@ export const Snapshot: Story = {
         <h4 className="text-lg font-semibold">With Module Badge</h4>
         <div className="flex flex-row gap-2">
           {avatarSizes.map((size, index) => (
-            <F0AvatarTeam
+            <F0AvatarCompany
               key={size}
               size={size}
-              name="Engineering"
-              src={mockImage("team", index)}
-              badge={{ type: "module", module: mockModuleId(index) }}
+              name="Factorial"
+              src={mockImage("company", index)}
+              badge={{ type: "module", module: "inbox" }}
             />
           ))}
         </div>

--- a/packages/react/src/components/avatars/F0AvatarCompany/__tests__/F0AvatarCompany.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarCompany/__tests__/F0AvatarCompany.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { F0AvatarCompany } from "../F0AvatarCompany"
+
+describe("F0AvatarCompany", () => {
+  it("exposes the accessible name when labelled", () => {
+    zeroRender(<F0AvatarCompany name="Acme Corp" aria-label="Acme Corp" />)
+
+    expect(screen.getByRole("img", { name: "Acme Corp" })).toBeInTheDocument()
+  })
+
+  it("falls back to the name initials when no image is provided", () => {
+    zeroRender(<F0AvatarCompany name="Acme" size="md" aria-label="Acme" />)
+
+    expect(screen.getByText("AC")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/avatars/F0AvatarEmoji/F0AvatarEmoji.tsx
+++ b/packages/react/src/components/avatars/F0AvatarEmoji/F0AvatarEmoji.tsx
@@ -11,7 +11,7 @@ export type F0AvatarEmojiProps = {
 
 const sizes = {
   sm: "w-6 h-6 rounded-sm",
-  md: "w-9 h-9 rounded",
+  md: "w-8 h-8 rounded",
   lg: "w-10 h-10 rounded-md",
   xl: "w-14 h-14 rounded-lg",
 }

--- a/packages/react/src/components/avatars/F0AvatarEmoji/__stories__/F0AvatarEmoji.mdx
+++ b/packages/react/src/components/avatars/F0AvatarEmoji/__stories__/F0AvatarEmoji.mdx
@@ -1,0 +1,43 @@
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
+import * as EmojiStories from "./F0AvatarEmoji.stories"
+
+<Meta of={EmojiStories} />
+
+# AvatarEmoji
+
+The avatar for a concept or reaction shown as an emoji.
+
+---
+
+## Overview
+
+### Purpose
+
+- Represent a concept, mood or reaction with a single emoji
+- Add a lightweight, recognizable marker to items in lists and headers
+- Offer an expressive alternative when an entity has no photo or icon
+
+### Anatomy
+
+An emoji avatar is square and renders a single emoji. It is available in sizes
+`sm`–`xl`.
+
+<Canvas of={EmojiStories.Default} />
+
+<Controls of={EmojiStories.Default} />
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- The content is always a single emoji
+- Reactions, lightweight category markers, expressive placeholders
+
+#### When NOT to use
+
+- The entity type is dynamic: use `F0Avatar`
+- You need a system icon rather than an emoji: use `F0AvatarIcon`

--- a/packages/react/src/components/avatars/F0AvatarEmoji/__stories__/F0AvatarEmoji.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarEmoji/__stories__/F0AvatarEmoji.stories.tsx
@@ -5,10 +5,10 @@ import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
 import { avatarEmojiSizes, F0AvatarEmoji } from "../F0AvatarEmoji"
 
-const meta: Meta<typeof F0AvatarEmoji> = {
+const meta = {
   component: F0AvatarEmoji,
   title: "Avatars/AvatarEmoji",
-  tags: ["autodocs"],
+  tags: ["stable", "!autodocs"],
   argTypes: {
     ...getBaseAvatarArgTypes(["size", "aria-label", "aria-labelledby"]),
     size: {
@@ -19,7 +19,7 @@ const meta: Meta<typeof F0AvatarEmoji> = {
   },
   args: {
     emoji: "🍑",
-    size: "sm",
+    size: "lg",
   },
   parameters: {
     docs: {
@@ -40,7 +40,7 @@ const meta: Meta<typeof F0AvatarEmoji> = {
       },
     },
   },
-}
+} satisfies Meta<typeof F0AvatarEmoji>
 
 export default meta
 

--- a/packages/react/src/components/avatars/F0AvatarEmoji/__tests__/F0AvatarEmoji.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarEmoji/__tests__/F0AvatarEmoji.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import { F0AvatarEmoji } from "../F0AvatarEmoji"
+
+describe("F0AvatarEmoji", () => {
+  it("renders with the provided accessible label", () => {
+    const { container } = zeroRender(
+      <F0AvatarEmoji emoji="🍑" aria-label="Peach" />
+    )
+
+    expect(container.querySelector('[aria-label="Peach"]')).toBeInTheDocument()
+  })
+
+  it("falls back to a neutral emoji for an invalid value", () => {
+    const { container } = zeroRender(
+      <F0AvatarEmoji emoji="not-an-emoji" aria-label="Invalid" />
+    )
+
+    expect(
+      container.querySelector('[aria-label="Invalid"]')
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/avatars/F0AvatarFile/__stories__/F0AvatarFile.mdx
+++ b/packages/react/src/components/avatars/F0AvatarFile/__stories__/F0AvatarFile.mdx
@@ -1,0 +1,51 @@
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
+import * as FileStories from "./F0AvatarFile.stories"
+
+<Meta of={FileStories} />
+
+# AvatarFile
+
+The avatar for a file or document.
+
+---
+
+## Overview
+
+### Purpose
+
+- Represent a file or document at a glance
+- Communicate the kind of file through an icon derived from its type
+
+### Anatomy
+
+A file avatar is square and shows an icon derived from the file's name and MIME
+type, so the file kind is recognizable without opening it. It is available in
+sizes `xs`–`lg`.
+
+<Canvas of={FileStories.Default} />
+
+<Controls of={FileStories.Default} />
+
+### Variants
+
+#### File types
+
+The icon adapts to the file type — documents, images, spreadsheets, and so on.
+
+<Canvas of={FileStories.AllFileTypes} />
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- The entity is always a file or document
+- File lists, attachments, upload previews
+
+#### When NOT to use
+
+- The entity type is dynamic: use `F0Avatar`
+- The item is not a file: use the matching `F0Avatar*` component

--- a/packages/react/src/components/avatars/F0AvatarFile/__stories__/F0AvatarFile.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarFile/__stories__/F0AvatarFile.stories.tsx
@@ -9,9 +9,8 @@ import { avatarFileSizes } from "../types"
 const meta = {
   component: F0AvatarFile,
   title: "Avatars/AvatarFile",
-  tags: ["autodocs"],
+  tags: ["stable", "!autodocs"],
   parameters: {
-    layout: "centered",
     docs: {
       description: {
         component: ["An avatar component that displays a file type icon."]
@@ -40,14 +39,14 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     file: { name: "document.pdf", type: "application/pdf" },
-    size: "md",
+    size: "lg",
   },
 }
 
 export const WithBadge: Story = {
   args: {
     file: { name: "document.pdf", type: "application/pdf" },
-    size: "md",
+    size: "lg",
     badge: {
       type: "module",
       module: "inbox",
@@ -83,7 +82,7 @@ const fileTypes = [
 export const AllFileTypes: Story = {
   args: {
     file: { name: "document.pdf", type: "application/pdf" },
-    size: "md",
+    size: "lg",
   },
   render: (args: F0AvatarFileProps) => {
     return (
@@ -103,7 +102,7 @@ export const AllFileTypes: Story = {
 export const Snapshot: Story = {
   parameters: withSnapshot({}),
   args: {
-    size: "md",
+    size: "lg",
     file: { name: "document.pdf", type: "application/pdf" },
   },
   render: () => (

--- a/packages/react/src/components/avatars/F0AvatarFlag/__stories__/F0AvatarFlag.mdx
+++ b/packages/react/src/components/avatars/F0AvatarFlag/__stories__/F0AvatarFlag.mdx
@@ -1,0 +1,42 @@
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
+import * as FlagStories from "./F0AvatarFlag.stories"
+
+<Meta of={FlagStories} />
+
+# AvatarFlag
+
+The avatar for a country or locale.
+
+---
+
+## Overview
+
+### Purpose
+
+- Represent a country, region or locale by its flag
+- Make locale-specific items recognizable at a glance
+
+### Anatomy
+
+A flag avatar is square and displays the flag image for the given country or
+region code.
+
+<Canvas of={FlagStories.Default} />
+
+<Controls of={FlagStories.Default} />
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- The entity is always a country, region or locale
+- Language and region pickers, localized content, nationality fields
+
+#### When NOT to use
+
+- The entity type is dynamic: use `F0Avatar`
+- The entity is not a country/locale: use the matching `F0Avatar*` component

--- a/packages/react/src/components/avatars/F0AvatarFlag/__stories__/F0AvatarFlag.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarFlag/__stories__/F0AvatarFlag.stories.tsx
@@ -8,10 +8,10 @@ import { avatarSizes } from "../../internal/BaseAvatar"
 import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
 import { F0AvatarFlag } from "../F0AvatarFlag.tsx"
 
-const meta: Meta<typeof F0AvatarFlag> = {
+const meta = {
   component: F0AvatarFlag,
   title: "Avatars/AvatarFlag",
-  tags: ["autodocs"],
+  tags: ["stable", "!autodocs"],
   argTypes: {
     ...getBaseAvatarArgTypes([
       "size",
@@ -34,10 +34,10 @@ const meta: Meta<typeof F0AvatarFlag> = {
     },
   },
   args: {
-    size: "md",
+    size: "lg",
     "aria-label": "Factorial avatar",
   },
-}
+} satisfies Meta<typeof F0AvatarFlag>
 
 export default meta
 

--- a/packages/react/src/components/avatars/F0AvatarFlag/__tests__/F0AvatarFlag.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarFlag/__tests__/F0AvatarFlag.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { F0AvatarFlag } from "../F0AvatarFlag"
+
+describe("F0AvatarFlag", () => {
+  it("exposes the accessible name when labelled", () => {
+    zeroRender(<F0AvatarFlag flag="es" aria-label="Spain" />)
+
+    expect(screen.getByRole("img", { name: "Spain" })).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
@@ -33,7 +33,7 @@ export const F0AvatarIcon = ({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
     >
-      <F0Icon icon={icon} size={size} state={state} color="bold" />
+      <F0Icon icon={icon} size={size} state={state} color="default" />
     </div>
   )
 }

--- a/packages/react/src/components/avatars/F0AvatarIcon/__stories__/F0AvatarIcon.mdx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/__stories__/F0AvatarIcon.mdx
@@ -1,0 +1,43 @@
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
+import * as IconStories from "./F0AvatarIcon.stories"
+
+<Meta of={IconStories} />
+
+# AvatarIcon
+
+The avatar for a generic entity represented by an icon.
+
+---
+
+## Overview
+
+### Purpose
+
+- Represent an entity that has no photo, using a system icon
+- Provide a consistent, recognizable marker across the interface
+- Stand in for categories, object types or placeholders
+
+### Anatomy
+
+An icon avatar is square and renders a system icon in the default icon color. It
+is available in sizes `sm`–`lg`.
+
+<Canvas of={IconStories.Default} />
+
+<Controls of={IconStories.Default} />
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- The entity is best represented by a system icon
+- Object types, categories, generic placeholders
+
+#### When NOT to use
+
+- The entity type is dynamic: use `F0Avatar`
+- The marker is an emoji rather than a system icon: use `F0AvatarEmoji`

--- a/packages/react/src/components/avatars/F0AvatarIcon/__stories__/F0AvatarIcon.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/__stories__/F0AvatarIcon.stories.tsx
@@ -6,10 +6,10 @@ import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
 import { avatarIconSizes, F0AvatarIcon } from "../F0AvatarIcon"
 
-const meta: Meta<typeof F0AvatarIcon> = {
+const meta = {
   component: F0AvatarIcon,
   title: "Avatars/AvatarIcon",
-  tags: ["autodocs"],
+  tags: ["stable", "!autodocs"],
   argTypes: {
     size: {
       control: "select",
@@ -26,7 +26,7 @@ const meta: Meta<typeof F0AvatarIcon> = {
   },
   args: {
     icon: Icons.Placeholder,
-    size: "md",
+    size: "lg",
   },
   parameters: {
     docs: {
@@ -47,7 +47,7 @@ const meta: Meta<typeof F0AvatarIcon> = {
       },
     },
   },
-}
+} satisfies Meta<typeof F0AvatarIcon>
 
 export default meta
 

--- a/packages/react/src/components/avatars/F0AvatarIcon/__tests__/F0AvatarIcon.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/__tests__/F0AvatarIcon.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { Placeholder } from "@/icons/app"
+import { zeroRender } from "@/testing/test-utils"
+
+import { F0AvatarIcon } from "../F0AvatarIcon"
+
+describe("F0AvatarIcon", () => {
+  it("renders the icon with the provided accessible label", () => {
+    const { container } = zeroRender(
+      <F0AvatarIcon icon={Placeholder} aria-label="Placeholder" />
+    )
+
+    expect(
+      container.querySelector('[aria-label="Placeholder"]')
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/avatars/F0AvatarPerson/__stories__/F0AvatarPerson.mdx
+++ b/packages/react/src/components/avatars/F0AvatarPerson/__stories__/F0AvatarPerson.mdx
@@ -1,0 +1,62 @@
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
+import * as PersonStories from "./F0AvatarPerson.stories"
+
+<Meta of={PersonStories} />
+
+# AvatarPerson
+
+The avatar for an individual — an employee, user or contact.
+
+---
+
+## Overview
+
+### Purpose
+
+- Represent a specific person consistently across the interface
+- Help distinguish people at a glance in lists, headers and assignments
+- Convey a person's state, such as deactivated
+
+### Anatomy
+
+Person avatars are always circular — the only avatar type that is, setting
+people apart from the square shape used by every other type.
+
+<Canvas of={PersonStories.Default} />
+
+<Controls of={PersonStories.Default} />
+
+### Variants
+
+#### States
+
+A person can be shown as deactivated, which replaces the content with a muted
+person icon to signal that the account is no longer active.
+
+<Canvas of={PersonStories.Deactivated} />
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- The entity is always a person and known at build time
+- Profile headers, employee rows, comment authors, assignees
+
+#### When NOT to use
+
+- The entity type is dynamic (could be a team or company): use `F0Avatar`
+- The entity is not a person: use the matching `F0Avatar*` component
+
+---
+
+## Behavior
+
+### Image fallback
+
+With no `src` — or if the image fails to load — the avatar shows the initials
+from the name over a color derived deterministically from it, so the same person
+always keeps the same color.

--- a/packages/react/src/components/avatars/F0AvatarPerson/__stories__/F0AvatarPerson.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarPerson/__stories__/F0AvatarPerson.stories.tsx
@@ -8,10 +8,10 @@ import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/uti
 import { avatarSizes } from "../../internal/BaseAvatar/types"
 import { F0AvatarPerson } from "../F0AvatarPerson"
 
-const meta: Meta<typeof F0AvatarPerson> = {
+const meta = {
   component: F0AvatarPerson,
   title: "Avatars/AvatarPerson",
-  tags: ["autodocs"],
+  tags: ["stable", "!autodocs"],
   argTypes: {
     ...getBaseAvatarArgTypes([
       "size",
@@ -30,7 +30,7 @@ export const Default: Story = {
   args: {
     firstName: "Dani",
     lastName: "Moreno",
-    size: "md",
+    size: "lg",
   },
 }
 

--- a/packages/react/src/components/avatars/F0AvatarPerson/__tests__/F0AvatarPerson.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarPerson/__tests__/F0AvatarPerson.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { F0AvatarPerson } from "../F0AvatarPerson"
+
+describe("F0AvatarPerson", () => {
+  it("exposes the accessible name when labelled", () => {
+    zeroRender(
+      <F0AvatarPerson
+        firstName="Jane"
+        lastName="Smith"
+        aria-label="Jane Smith"
+      />
+    )
+
+    expect(screen.getByRole("img", { name: "Jane Smith" })).toBeInTheDocument()
+  })
+
+  it("falls back to the name initials when no image is provided", () => {
+    zeroRender(
+      <F0AvatarPerson
+        firstName="Jane"
+        lastName="Smith"
+        size="md"
+        aria-label="Jane Smith"
+      />
+    )
+
+    expect(screen.getByText("JS")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/avatars/F0AvatarTeam/__stories__/F0AvatarTeam.mdx
+++ b/packages/react/src/components/avatars/F0AvatarTeam/__stories__/F0AvatarTeam.mdx
@@ -1,0 +1,52 @@
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
+import * as TeamStories from "./F0AvatarTeam.stories"
+
+<Meta of={TeamStories} />
+
+# AvatarTeam
+
+The avatar for a team or group of people.
+
+---
+
+## Overview
+
+### Purpose
+
+- Represent a team or group consistently across the interface
+- Help distinguish teams at a glance in lists, headers and assignments
+
+### Anatomy
+
+A team avatar uses a square shape with rounded corners — the default shape
+shared by every avatar type except person.
+
+<Canvas of={TeamStories.Default} />
+
+<Controls of={TeamStories.Default} />
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- The entity is always a team and known at build time
+- Team pickers, group headers, ownership and assignment rows
+
+#### When NOT to use
+
+- The entity type is dynamic (could be a person or company): use `F0Avatar`
+- The entity is not a team: use the matching `F0Avatar*` component
+
+---
+
+## Behavior
+
+### Image fallback
+
+With no `src` — or if the image fails to load — the avatar shows the team's
+initials over a color derived deterministically from its name, so the same team
+always keeps the same color.

--- a/packages/react/src/components/avatars/F0AvatarTeam/__stories__/F0AvatarTeam.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarTeam/__stories__/F0AvatarTeam.stories.tsx
@@ -1,16 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { Check } from "@/icons/app"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { mockImage } from "@/testing/mocks/images"
+import { mockModuleId } from "@/testing/mocks/modules"
 
 import { avatarSizes } from "../../internal/BaseAvatar"
 import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
-import { F0AvatarCompany } from "../F0AvatarCompany"
+import { F0AvatarTeam } from "../F0AvatarTeam"
 
-const meta: Meta<typeof F0AvatarCompany> = {
-  component: F0AvatarCompany,
-  title: "Avatars/AvatarCompany",
-  tags: ["autodocs"],
+const meta = {
+  component: F0AvatarTeam,
+  title: "Avatars/AvatarTeam",
+  tags: ["stable", "!autodocs"],
   argTypes: {
     ...getBaseAvatarArgTypes([
       "size",
@@ -18,51 +20,30 @@ const meta: Meta<typeof F0AvatarCompany> = {
       "aria-labelledby",
       "badge",
     ]),
-    name: {
-      control: "text",
-      description:
-        "The company name to display (used for initials if no image provided)",
-    },
-    src: {
-      control: "text",
-      description:
-        "URL of the company logo/image. If no logo is provided, it will display the company name initials with a fixed background color.",
-    },
-  },
-  parameters: {
-    docs: {
-      description: {
-        component: ["A company avatar component."]
-          .map((line) => `<p>${line}</p>`)
-          .join(""),
-      },
-    },
   },
   args: {
-    name: "Factorial",
-    size: "md",
-    "aria-label": "Factorial avatar",
+    name: "Design",
+    size: "lg",
   },
-}
+} satisfies Meta<typeof F0AvatarTeam>
 
 export default meta
 
-type Story = StoryObj<typeof F0AvatarCompany>
+type Story = StoryObj<typeof F0AvatarTeam>
 
 export const Default: Story = {}
 
 export const WithImage: Story = {
   args: {
-    src: "/avatars/factorial.png",
+    src: "/avatars/team01.jpg",
   },
 }
 
-export const WithModuleBadge: Story = {
+export const WithBadge: Story = {
   args: {
-    src: "/avatars/factorial.png",
     badge: {
-      type: "module",
-      module: "inbox",
+      type: "positive",
+      icon: Check,
     },
   },
 }
@@ -77,7 +58,7 @@ export const Snapshot: Story = {
         <h4 className="text-lg font-semibold">Without Image</h4>
         <div className="flex flex-row gap-2">
           {avatarSizes.map((size) => (
-            <F0AvatarCompany key={size} size={size} name="Factorial" />
+            <F0AvatarTeam key={size} size={size} name="Engineering" />
           ))}
         </div>
       </section>
@@ -85,11 +66,11 @@ export const Snapshot: Story = {
         <h4 className="text-lg font-semibold">With Image</h4>
         <div className="flex flex-row gap-2">
           {avatarSizes.map((size, index) => (
-            <F0AvatarCompany
+            <F0AvatarTeam
               key={size}
               size={size}
-              name="Factorial"
-              src={mockImage("company", index)}
+              name="Engineering"
+              src={mockImage("team", index)}
             />
           ))}
         </div>
@@ -98,12 +79,12 @@ export const Snapshot: Story = {
         <h4 className="text-lg font-semibold">With Module Badge</h4>
         <div className="flex flex-row gap-2">
           {avatarSizes.map((size, index) => (
-            <F0AvatarCompany
+            <F0AvatarTeam
               key={size}
               size={size}
-              name="Factorial"
-              src={mockImage("company", index)}
-              badge={{ type: "module", module: "inbox" }}
+              name="Engineering"
+              src={mockImage("team", index)}
+              badge={{ type: "module", module: mockModuleId(index) }}
             />
           ))}
         </div>

--- a/packages/react/src/components/avatars/F0AvatarTeam/__tests__/F0AvatarTeam.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarTeam/__tests__/F0AvatarTeam.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { F0AvatarTeam } from "../F0AvatarTeam"
+
+describe("F0AvatarTeam", () => {
+  it("exposes the accessible name when labelled", () => {
+    zeroRender(
+      <F0AvatarTeam name="Engineering Team" aria-label="Engineering Team" />
+    )
+
+    expect(
+      screen.getByRole("img", { name: "Engineering Team" })
+    ).toBeInTheDocument()
+  })
+
+  it("falls back to the name initials when no image is provided", () => {
+    zeroRender(
+      <F0AvatarTeam name="Engineering" size="md" aria-label="Engineering" />
+    )
+
+    expect(screen.getByText("EN")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What

Promotes the polymorphic **F0Avatar** and its **seven entity types** to `stable`:

`F0Avatar` · `F0AvatarPerson` · `F0AvatarTeam` · `F0AvatarCompany` · `F0AvatarFile` · `F0AvatarFlag` · `F0AvatarEmoji` · `F0AvatarIcon`

> ⚠️ **Scope:** this is the *entity* avatar group only. The **specialized** avatars (`F0AvatarDate`, `F0AvatarAlert`, `F0AvatarModule`, `F0AvatarList`, `F0AvatarPulse`) are intentionally **left for a follow-up** — they aren't entity types and carry separate systemic work (see below).

## Changes per component

- Maturity tag `["stable", "!autodocs"]`, `satisfies Meta`, a `Snapshot` story
- Focused MDX docs — shared concepts (badges, the size system, the accessible-name behavior) live in the **F0Avatar umbrella** to avoid repetition; each type doc covers only what's specific to it (shape, fallback, when to use vs `F0Avatar`)
- Unit tests
- `__storybook__` → `__stories__` folder rename (convention)

## Consistency fixes surfaced during the audit

- **F0AvatarEmoji**: `md` container aligned to 32px (was 36px)
- **F0Avatar**: fixed the `flag` case casting `size` to `F0AvatarFile`'s size type
- **F0AvatarIcon**: icon rendered in the default icon color token (was `bold`)
- Default stories render at `lg` (40px), left-aligned, across the family

## Verification

- Lifecycle DoD (`check-one`): **0 issues** on all 8
- Unit tests: **46/46**
- `oxlint` 0/0 · `tsc` clean

## Follow-ups (tracked separately)

- Unify the avatar size scale across the family
- Route `F0AvatarIcon` through `BaseAvatar`
- Reconsider `F0AvatarList` as an AvatarGroup/Stack primitive
- Stabilize the specialized avatars (Date, Alert, Module, List, Pulse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Implemented-with: factorial-f0