### PR TITLE
feat(F0Form): mark field as error when its alert resolves to "critical"

### DIFF
--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -111,6 +111,52 @@ export const Default: Story = {
 }
 
 /**
+ * A field whose `alert` resolves to `variant: "critical"` is treated as an
+ * error: the input shows error styling and the form cannot be submitted while
+ * the alert is active.
+ *
+ * Here, ordering more than the available stock (10) surfaces a critical alert
+ * and disables the submit button. Lower the quantity to 10 or below and the
+ * alert clears, re-enabling submission.
+ */
+export const CriticalAlertBlocksSubmit: Story = {
+  render() {
+    const formSchema = z.object({
+      quantity: f0FormField.number({
+        label: "Quantity",
+        placeholder: "How many units?",
+        helpText: "Only 10 units are in stock",
+        min: 0,
+        alert: ({ fieldValue }) =>
+          typeof fieldValue === "number" && fieldValue > 10
+            ? {
+                title: "Not enough stock",
+                description:
+                  "Only 10 units are available. Reduce the quantity to continue.",
+                variant: "critical" as const,
+              }
+            : null,
+      }),
+    })
+
+    const formDefinition = useF0FormDefinition({
+      name: "critical-alert-blocks-submit",
+      schema: formSchema,
+      defaultValues: {
+        quantity: 25,
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
+  },
+}
+
+/**
  * Form with fields arranged in rows using the `row` property.
  * Fields with the same `row` value are grouped horizontally.
  */

--- a/packages/react/src/patterns/F0Form/__tests__/F0Form.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0Form.test.tsx
@@ -1538,6 +1538,108 @@ describe("createConditionalResolver - null to undefined conversion", () => {
   })
 })
 
+describe("createConditionalResolver - critical alert errors", () => {
+  const resolverOptions = {
+    fields: {},
+    shouldUseNativeValidation: false,
+  }
+
+  it("marks a field as errored when its alert resolves to variant 'critical'", async () => {
+    const schema = z.object({
+      amount: f0FormField(z.number(), {
+        label: "Amount",
+        alert: ({ fieldValue }) =>
+          typeof fieldValue === "number" && fieldValue > 100
+            ? {
+                title: "Too high",
+                description: "Exceeds the allowed limit",
+                variant: "critical" as const,
+              }
+            : null,
+      }),
+    })
+
+    const resolver = createConditionalResolver(schema)
+    const result = await resolver({ amount: 150 }, undefined, resolverOptions)
+
+    const amountError =
+      "amount" in result.errors ? result.errors.amount : undefined
+    expect(amountError).toBeDefined()
+    expect(amountError?.type).toBe("alertCritical")
+    expect(amountError?.message).toBe("Too high")
+  })
+
+  it("marks a field as errored for a static 'critical' alert", async () => {
+    const schema = z.object({
+      amount: f0FormField(z.number(), {
+        label: "Amount",
+        alert: { title: "Always critical", variant: "critical" as const },
+      }),
+    })
+
+    const resolver = createConditionalResolver(schema)
+    const result = await resolver({ amount: 1 }, undefined, resolverOptions)
+
+    const amountError =
+      "amount" in result.errors ? result.errors.amount : undefined
+    expect(amountError?.type).toBe("alertCritical")
+    expect(amountError?.message).toBe("Always critical")
+  })
+
+  it("does not mark a field as errored for non-critical alert variants", async () => {
+    const schema = z.object({
+      amount: f0FormField(z.number(), {
+        label: "Amount",
+        alert: { title: "Heads up", variant: "warning" as const },
+      }),
+    })
+
+    const resolver = createConditionalResolver(schema)
+    const result = await resolver({ amount: 1 }, undefined, resolverOptions)
+
+    expect(result.errors).toEqual({})
+  })
+
+  it("does not mark a hidden field (renderIf false) as errored", async () => {
+    const schema = z.object({
+      toggle: f0FormField(z.boolean(), {
+        label: "Toggle",
+        fieldType: "switch",
+      }),
+      amount: f0FormField(z.number(), {
+        label: "Amount",
+        renderIf: { fieldId: "toggle", equalsTo: true },
+        alert: { title: "Critical", variant: "critical" as const },
+      }),
+    })
+
+    const resolver = createConditionalResolver(schema)
+    const result = await resolver(
+      { toggle: false, amount: 1 },
+      undefined,
+      resolverOptions
+    )
+
+    expect(result.errors).toEqual({})
+  })
+
+  it("does not overwrite an existing validation error with the critical alert", async () => {
+    const schema = z.object({
+      name: f0FormField(z.string().min(3, "Too short"), {
+        label: "Name",
+        alert: { title: "Critical alert", variant: "critical" as const },
+      }),
+    })
+
+    const resolver = createConditionalResolver(schema)
+    const result = await resolver({ name: "ab" }, undefined, resolverOptions)
+
+    const nameError = "name" in result.errors ? result.errors.name : undefined
+    expect(nameError?.message).toBe("Too short")
+    expect(nameError?.type).not.toBe("alertCritical")
+  })
+})
+
 describe("F0Form clearing optional fields with default values", () => {
   it("clears optional text field to empty instead of default value", async () => {
     const user = userEvent.setup()
@@ -2633,6 +2735,119 @@ describe("F0Form alert feature", () => {
 
     expect(screen.getByText("Group alert title")).toBeInTheDocument()
     expect(screen.getByText("Group alert description")).toBeInTheDocument()
+  })
+
+  it("marks the field as errored and blocks submit when the alert resolves to 'critical'", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    const formSchema = z.object({
+      code: f0FormField(z.string(), {
+        label: "Code",
+        alert: ({ fieldValue }) =>
+          fieldValue === "bad"
+            ? {
+                title: "Invalid code",
+                description: "This code is not allowed",
+                variant: "critical" as const,
+              }
+            : null,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="alert-critical-error"
+        schema={formSchema}
+        defaultValues={{ code: "bad" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    // The critical alert is rendered below the field
+    expect(screen.getByText("Invalid code")).toBeInTheDocument()
+
+    const submitButton = screen.getByText("Submit").closest("button")!
+    await user.click(submitButton)
+
+    // The field is marked as errored, so submission is blocked
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled()
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("clears the error and allows submit once the alert is no longer 'critical'", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    const formSchema = z.object({
+      code: f0FormField(z.string(), {
+        label: "Code",
+        alert: ({ fieldValue }) =>
+          fieldValue === "bad"
+            ? { title: "Invalid code", variant: "critical" as const }
+            : null,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="alert-critical-recover"
+        schema={formSchema}
+        defaultValues={{ code: "bad" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    const submitButton = screen.getByText("Submit").closest("button")!
+    await user.click(submitButton)
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled()
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    // Fix the value so the alert no longer resolves to critical
+    const input = screen.getByRole("textbox")
+    await user.clear(input)
+    await user.type(input, "good")
+
+    // The critical alert clears, re-enabling submission
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled()
+    })
+    await user.click(submitButton)
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ code: "good" })
+    })
+  })
+
+  it("does not block submit for non-critical alert variants", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    const formSchema = z.object({
+      code: f0FormField(z.string(), {
+        label: "Code",
+        alert: { title: "Just a warning", variant: "warning" as const },
+      }),
+    })
+
+    render(
+      <F0Form
+        name="alert-warning-no-block"
+        schema={formSchema}
+        defaultValues={{ code: "anything" }}
+        onSubmit={onSubmit}
+      />
+    )
+
+    expect(screen.getByText("Just a warning")).toBeInTheDocument()
+
+    await user.click(screen.getByText("Submit"))
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ code: "anything" })
+    })
   })
 })
 

--- a/packages/react/src/patterns/F0Form/components/SwitchGroupRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/components/SwitchGroupRenderer.tsx
@@ -23,7 +23,11 @@ import { generateAnchorId, useF0FormContext } from "../context"
 import { isZodType, unwrapZodSchema } from "../f0Schema"
 import { CardSelectDepsContext } from "../fields/cardSelect/CardSelectDepsContext"
 import { FieldRenderer } from "../fields/FieldRenderer"
-import { evaluateDisabled, evaluateRenderIf } from "../fields/utils"
+import {
+  evaluateDisabled,
+  evaluateRenderIf,
+  resolveFieldAlert,
+} from "../fields/utils"
 import { RowRenderer } from "./RowRenderer"
 
 /**
@@ -216,11 +220,11 @@ export function SwitchGroupRenderer({
   const alerts = useMemo(() => {
     const result: { fieldId: string; props: F0FieldAlertProps }[] = []
     for (const field of visibleFields) {
-      if (!field.alert) continue
-      const alertProps =
-        typeof field.alert === "function"
-          ? field.alert({ fieldValue: values[field.id], values })
-          : field.alert
+      const alertProps = resolveFieldAlert(
+        field.alert,
+        values[field.id],
+        values
+      )
       if (alertProps) {
         result.push({ fieldId: field.id, props: alertProps })
       }

--- a/packages/react/src/patterns/F0Form/conditionalResolver.ts
+++ b/packages/react/src/patterns/F0Form/conditionalResolver.ts
@@ -1,4 +1,9 @@
-import type { Resolver, FieldValues, ResolverOptions } from "react-hook-form"
+import type {
+  Resolver,
+  FieldValues,
+  ResolverOptions,
+  FieldError,
+} from "react-hook-form"
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z, ZodTypeAny, ZodRawShape, ZodObject, ZodEffects } from "zod"
@@ -6,7 +11,7 @@ import { z, ZodTypeAny, ZodRawShape, ZodObject, ZodEffects } from "zod"
 import type { F0FormSchema } from "./types"
 
 import { getF0Config, isZodType, unwrapToZodObject } from "./f0Schema"
-import { evaluateRenderIf } from "./fields/utils"
+import { evaluateRenderIf, resolveFieldAlert } from "./fields/utils"
 
 /**
  * Creates a conditional Zod resolver that only validates visible fields.
@@ -45,7 +50,56 @@ export function createConditionalResolver<TSchema extends F0FormSchema>(
 
     // Use the standard zodResolver with the dynamic schema
     const resolver = zodResolver(dynamicSchema, schemaOptions)
-    return resolver(processedValues, context, options)
+    const result = await resolver(processedValues, context, options)
+
+    // Mark fields as errored when their `alert` resolves to `variant: "critical"`.
+    // This both surfaces error styling on the input and blocks submission, on top
+    // of the alert that already renders below the field.
+    applyCriticalAlertErrors(
+      schema,
+      values,
+      result.errors as Record<string, FieldError>
+    )
+
+    return result
+  }
+}
+
+/**
+ * Augments a resolver's `errors` with a synthetic error for every visible field
+ * whose `alert` resolves to `variant: "critical"`. Existing errors are never
+ * overwritten, and hidden fields (via `renderIf`) are skipped.
+ */
+function applyCriticalAlertErrors<TSchema extends F0FormSchema>(
+  schema: TSchema,
+  values: Record<string, unknown>,
+  errors: Record<string, FieldError>
+): void {
+  const objectSchema = unwrapToZodObject(schema)
+
+  for (const [fieldId, fieldSchema] of Object.entries(objectSchema.shape)) {
+    // Don't clobber an existing validation error for this field.
+    if (errors[fieldId]) {
+      continue
+    }
+
+    const config = getF0Config(fieldSchema as ZodTypeAny)
+    if (!config?.alert) {
+      continue
+    }
+
+    // Skip hidden fields — they can't be acted on, so they must not block submit.
+    if (config.renderIf && !evaluateRenderIf(config.renderIf, values)) {
+      continue
+    }
+
+    const alertProps = resolveFieldAlert(config.alert, values[fieldId], values)
+    if (alertProps?.variant === "critical") {
+      errors[fieldId] = {
+        type: "alertCritical",
+        message: alertProps.title,
+      }
+    }
   }
 }
 

--- a/packages/react/src/patterns/F0Form/fields/FieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/FieldRenderer.tsx
@@ -19,7 +19,7 @@ import type { F0Field } from "./types"
 import { generateAnchorId, useF0FormContext } from "../context"
 import { renderFieldInput } from "./renderFieldInput"
 import { isFieldRequired } from "./schema"
-import { evaluateDisabled, evaluateRenderIf } from "./utils"
+import { evaluateDisabled, evaluateRenderIf, resolveFieldAlert } from "./utils"
 
 function isSelectConfig(
   result: unknown
@@ -247,11 +247,11 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
             </F0Link>
           )}
           {(() => {
-            if (!field.alert) return null
-            const alertProps =
-              typeof field.alert === "function"
-                ? field.alert({ fieldValue: formField.value, values })
-                : field.alert
+            const alertProps = resolveFieldAlert(
+              field.alert,
+              formField.value,
+              values
+            )
             if (!alertProps) return null
             return (
               <F0Alert {...alertProps} variant={alertProps.variant ?? "info"} />
@@ -260,7 +260,10 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
           {showFormMessage && !fieldState.error && (
             <InputMessages status={field.status} />
           )}
-          {showFormMessage && (
+          {/* A critical alert already conveys the message via the F0Alert above,
+              so suppress the redundant FormMessage text (the input still shows
+              error styling because fieldState.error is set). */}
+          {showFormMessage && fieldState.error?.type !== "alertCritical" && (
             <FormMessage
               fallback={
                 isRequired

--- a/packages/react/src/patterns/F0Form/fields/utils.ts
+++ b/packages/react/src/patterns/F0Form/fields/utils.ts
@@ -4,6 +4,7 @@ import type {
   RenderIfCondition,
 } from "./types"
 import type { F0DateConstraintProp } from "./date/types"
+import type { F0FieldAlert, F0FieldAlertProps } from "../f0Schema"
 
 /**
  * Evaluate a renderIf condition object against the current form values
@@ -120,6 +121,26 @@ export function evaluateRenderIf(
     return renderIf({ values })
   }
   return evaluateRenderIfCondition(renderIf, values)
+}
+
+/**
+ * Resolve a field's `alert` config against the current values.
+ *
+ * The alert can be static props (always shown) or a callback evaluated against
+ * the field value and all form values. Returns the resolved alert props, or
+ * `null` when no alert should be shown.
+ */
+export function resolveFieldAlert(
+  alert: F0FieldAlert | undefined,
+  fieldValue: unknown,
+  values: Record<string, unknown>
+): F0FieldAlertProps | null {
+  if (!alert) {
+    return null
+  }
+  const alertProps =
+    typeof alert === "function" ? alert({ fieldValue, values }) : alert
+  return alertProps ?? null
 }
 
 /**


### PR DESCRIPTION
## Description

When an `f0FormField`'s `alert` resolves to `variant: "critical"`, the field is now treated as an **error**: the input shows error styling **and** the field counts as invalid, so the form cannot be submitted while the alert is active.

Previously, a field's `alert` was purely cosmetic — it rendered an `F0Alert` below the field but had no effect on the field's error state or on submission. This makes a critical alert actionable: it surfaces the field as errored and blocks submit until the condition clears.

> Note: the supported alert variants are `info | warning | critical | neutral | positive` — there is no `"error"` variant, so `"critical"` is the error signal. Non-critical variants keep their existing cosmetic-only behavior.

## Implementation details

The cleanest way to get **both** error styling and submit-blocking is to inject a validation error during resolution — the existing pipelines then do the rest:

- `fieldState.error` becomes truthy → input renders with error styling (`visualStatus = { type: "error" }`).
- `formState.errors` populates → submit button is `disabled={hasErrors}` and `form.handleSubmit` won't invoke `onSubmit`.

Changes:

- **`conditionalResolver.ts`** — after the zod resolver runs, `applyCriticalAlertErrors` walks the schema's fields and, for any **visible** field whose `alert` resolves to `"critical"`, adds `{ type: "alertCritical", message: <alert title> }` to `errors`. It never overwrites an existing zod validation error and skips hidden fields (`renderIf` false), so they can't block submit.
- **`fields/utils.ts`** — new shared `resolveFieldAlert(alert, fieldValue, values)` helper centralizing the static-vs-callback alert evaluation that was duplicated across renderers.
- **`fields/FieldRenderer.tsx`** — uses the helper, and suppresses the redundant `FormMessage` when the error is `alertCritical` (the `F0Alert` box already conveys the message; input error styling is unaffected).
- **`components/SwitchGroupRenderer.tsx`** — refactored to use the shared helper.

Behavior note: error styling / submit-blocking engage according to the form's `errorTriggerMode` (default on-submit) — consistent with every other validation error — while the alert box itself still renders immediately.

## Tests

`F0Form.test.tsx`:

- **Resolver-level** (`createConditionalResolver - critical alert errors`): critical callback → `alertCritical` error with the alert title as message; static critical alert; non-critical variant → no error; hidden (`renderIf` false) field → no error; doesn't overwrite an existing zod error.
- **Integration** (`F0Form alert feature`): critical alert blocks submit (button disabled, `onSubmit` not called); clearing the critical condition re-enables submit; non-critical variant doesn't block.

## Storybook

Added a `CriticalAlertBlocksSubmit` story under **Forms/F0Form**: a Quantity field with a `critical` alert when the value exceeds available stock (10). It opens at `25` so the alert shows and submit is disabled; lowering to ≤10 clears the alert and re-enables submission.
