### PR TITLE
fix(F0AnalyticsDashboard): auto-grow rows for loaded content

### DIFF
--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -4,6 +4,23 @@ import { zeroRender as render, waitFor } from "@/testing/test-utils"
 import { DashboardGrid } from "../components/DashboardGrid/DashboardGrid"
 import type { DashboardItem } from "../types"
 
+type ExpenseRecord = {
+  employee: string
+  category: string
+  amount: number
+}
+
+const expenseTableVisualization = {
+  type: "table",
+  options: {
+    columns: [
+      { label: "Employee", render: (item: ExpenseRecord) => item.employee },
+      { label: "Category", render: (item: ExpenseRecord) => item.category },
+      { label: "Amount", render: (item: ExpenseRecord) => item.amount },
+    ],
+  },
+}
+
 function makeMetricItems(itemHeight: number): DashboardItem[] {
   return [
     {
@@ -18,6 +35,35 @@ function makeMetricItems(itemHeight: number): DashboardItem[] {
       type: "metric",
       title: "Turnover",
       fetchData: async () => ({ value: 7 }),
+    },
+  ]
+}
+
+function makeCollectionItems(itemHeight: number): DashboardItem[] {
+  return [
+    {
+      id: "expenses",
+      type: "collection",
+      title: "Expenses",
+      itemHeight,
+      visualizations: [expenseTableVisualization],
+      createSource: () => ({
+        dataAdapter: {
+          fetchData: async () => ({ records: [], total: 0 }),
+        },
+      }),
+    },
+    {
+      id: "category-totals",
+      type: "collection",
+      title: "Category totals",
+      itemHeight: 480,
+      visualizations: [expenseTableVisualization],
+      createSource: () => ({
+        dataAdapter: {
+          fetchData: async () => ({ records: [], total: 0 }),
+        },
+      }),
     },
   ]
 }
@@ -48,6 +94,30 @@ describe("DashboardGrid", () => {
 
     await waitFor(() => {
       expect(getDashboardRowHeight(container)).toBe("288px")
+    })
+  })
+
+  it("recomputes collection row height when itemHeight changes after data loads", async () => {
+    const { container, rerender } = render(
+      <DashboardGrid items={makeCollectionItems(480)} filters={{}} />
+    )
+
+    const collectionCard = container.querySelector('[data-card-id="expenses"]')
+    if (!(collectionCard instanceof HTMLElement)) {
+      throw new Error("Expected collection item to be rendered")
+    }
+
+    const collectionRow = collectionCard.parentElement
+    if (!(collectionRow instanceof HTMLElement)) {
+      throw new Error("Expected collection row to be rendered")
+    }
+
+    expect(collectionRow.style.height).toBe("480px")
+
+    rerender(<DashboardGrid items={makeCollectionItems(960)} filters={{}} />)
+
+    await waitFor(() => {
+      expect(collectionRow.style.height).toBe("960px")
     })
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { zeroRender as render, waitFor } from "@/testing/test-utils"
 
 import { DashboardGrid } from "../components/DashboardGrid/DashboardGrid"
@@ -83,6 +83,10 @@ function getDashboardRowHeight(container: HTMLElement): string {
 }
 
 describe("DashboardGrid", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("recomputes row height when itemHeight changes for existing items", async () => {
     const { container, rerender } = render(
       <DashboardGrid items={makeMetricItems(144)} filters={{}} />
@@ -115,6 +119,33 @@ describe("DashboardGrid", () => {
     expect(collectionRow.style.height).toBe("480px")
 
     rerender(<DashboardGrid items={makeCollectionItems(960)} filters={{}} />)
+
+    await waitFor(() => {
+      expect(collectionRow.style.height).toBe("960px")
+    })
+  })
+
+  it("grows a row when loaded content is taller than the configured itemHeight", async () => {
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(
+      function getScrollHeight(this: HTMLElement) {
+        if (this.dataset.cardId === "expenses") return 960
+        return 0
+      }
+    )
+
+    const { container } = render(
+      <DashboardGrid items={makeCollectionItems(480)} filters={{}} />
+    )
+
+    const collectionCard = container.querySelector('[data-card-id="expenses"]')
+    if (!(collectionCard instanceof HTMLElement)) {
+      throw new Error("Expected collection item to be rendered")
+    }
+
+    const collectionRow = collectionCard.parentElement
+    if (!(collectionRow instanceof HTMLElement)) {
+      throw new Error("Expected collection row to be rendered")
+    }
 
     await waitFor(() => {
       expect(collectionRow.style.height).toBe("960px")

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { zeroRender as render, waitFor } from "@/testing/test-utils"
+
+import { DashboardGrid } from "../components/DashboardGrid/DashboardGrid"
+import type { DashboardItem } from "../types"
+
+function makeMetricItems(itemHeight: number): DashboardItem[] {
+  return [
+    {
+      id: "headcount",
+      type: "metric",
+      title: "Headcount",
+      itemHeight,
+      fetchData: async () => ({ value: 42 }),
+    },
+    {
+      id: "turnover",
+      type: "metric",
+      title: "Turnover",
+      fetchData: async () => ({ value: 7 }),
+    },
+  ]
+}
+
+function getDashboardRowHeight(container: HTMLElement): string {
+  const card = container.querySelector('[data-card-id="headcount"]')
+  if (!(card instanceof HTMLElement)) {
+    throw new Error("Expected dashboard item to be rendered")
+  }
+
+  const row = card.parentElement
+  if (!(row instanceof HTMLElement)) {
+    throw new Error("Expected dashboard row to be rendered")
+  }
+
+  return row.style.height
+}
+
+describe("DashboardGrid", () => {
+  it("recomputes row height when itemHeight changes for existing items", async () => {
+    const { container, rerender } = render(
+      <DashboardGrid items={makeMetricItems(144)} filters={{}} />
+    )
+
+    expect(getDashboardRowHeight(container)).toBe("144px")
+
+    rerender(<DashboardGrid items={makeMetricItems(288)} filters={{}} />)
+
+    await waitFor(() => {
+      expect(getDashboardRowHeight(container)).toBe("288px")
+    })
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -114,6 +114,9 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
 
   // ─── Rows state ─────────────────────────────────────────────
   const [rows, setRows] = useState<Row[]>(() => buildInitialRows(items))
+  const [measuredItemHeights, setMeasuredItemHeights] = useState<
+    Map<string, number>
+  >(new Map())
 
   // Sync rows when externally-owned item layout changes.
   const prevItemLayoutSignatureRef = useRef(buildItemLayoutSignature(items))
@@ -133,6 +136,24 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       setRows(buildInitialRows(items))
     }
   }, [resetKey, items])
+
+  useEffect(() => {
+    const itemIds = new Set(items.map((item) => item.id))
+    setMeasuredItemHeights((prev) => {
+      let changed = false
+      const next = new Map<string, number>()
+
+      for (const [id, height] of prev) {
+        if (itemIds.has(id)) {
+          next.set(id, height)
+        } else {
+          changed = true
+        }
+      }
+
+      return changed ? next : prev
+    })
+  }, [items])
 
   // ─── Narrow detection ───────────────────────────────────────
   useEffect(() => {
@@ -177,6 +198,31 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       onLayoutChange(layout)
     },
     [onLayoutChange]
+  )
+
+  const handleItemContentHeightChange = useCallback(
+    (itemId: string, contentHeight: number) => {
+      const item = itemMap.get(itemId)
+      const minHeight = item
+        ? (MIN_ROW_HEIGHTS[item.type] ?? DEFAULT_MIN_ROW_HEIGHT)
+        : DEFAULT_MIN_ROW_HEIGHT
+      const nextHeight = Math.max(minHeight, Math.ceil(contentHeight))
+
+      setMeasuredItemHeights((prev) => {
+        const currentHeight = prev.get(itemId)
+        if (
+          currentHeight !== undefined &&
+          Math.abs(currentHeight - nextHeight) < 1
+        ) {
+          return prev
+        }
+
+        const next = new Map(prev)
+        next.set(itemId, nextHeight)
+        return next
+      })
+    },
+    [itemMap]
   )
 
   // ─── Delete ─────────────────────────────────────────────────
@@ -306,9 +352,11 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
 
   // ─── Row resize ─────────────────────────────────────────────
   const startResize = useCallback(
-    (rowIdx: number, startY: number) => {
-      const startHeight = rows[rowIdx].height
-      const minHeight = getMinRowHeight(rows[rowIdx], itemMap)
+    (rowIdx: number, startY: number, startHeight: number) => {
+      const minHeight = Math.max(
+        getMinRowHeight(rows[rowIdx], itemMap),
+        getMeasuredRowHeight(rows[rowIdx], measuredItemHeights)
+      )
       const onMove = (e: MouseEvent) => {
         const newHeight = Math.max(minHeight, startHeight + e.clientY - startY)
         setRows((prev) =>
@@ -328,7 +376,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       document.addEventListener("mousemove", onMove)
       document.addEventListener("mouseup", onUp)
     },
-    [rows, emitLayout]
+    [rows, emitLayout, itemMap, measuredItemHeights]
   )
 
   // ─── Render ─────────────────────────────────────────────────
@@ -421,7 +469,10 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
                 "flex rounded-lg transition-colors duration-200",
                 isDropRow && "bg-f1-background-hover"
               )}
-              style={{ gap: GAP, height: row.height }}
+              style={{
+                gap: GAP,
+                height: getRenderableRowHeight(row, measuredItemHeights),
+              }}
               onDragOver={canDrag ? (e) => handleRowDragOver(e, ri) : undefined}
               onDrop={canDrag ? () => {} : undefined}
             >
@@ -449,6 +500,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
                     draggable={canDrag}
                     onDragStart={handleDragStart}
                     onDragEnd={handleDragEnd}
+                    onContentHeightChange={handleItemContentHeightChange}
                   >
                     <DashboardGridItem
                       item={item}
@@ -470,7 +522,11 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
                 className="group/resize absolute -bottom-3.5 mx-auto flex h-3 w-full items-center justify-center hover:cursor-ns-resize"
                 onMouseDown={(e) => {
                   e.preventDefault()
-                  startResize(ri, e.clientY)
+                  startResize(
+                    ri,
+                    e.clientY,
+                    getRenderableRowHeight(row, measuredItemHeights)
+                  )
                 }}
               >
                 <div className="h-1 w-16 rounded-full bg-transparent transition-colors group-hover/resize:bg-f1-foreground-tertiary" />
@@ -502,6 +558,7 @@ function RowItem({
   draggable: canDrag,
   onDragStart,
   onDragEnd,
+  onContentHeightChange,
   children,
 }: {
   id: string
@@ -511,15 +568,68 @@ function RowItem({
   draggable: boolean
   onDragStart: (id: string) => void
   onDragEnd: () => void
+  onContentHeightChange: (id: string, height: number) => void
   children: React.ReactNode
 }) {
   // Track whether the drag started from the handle. If not, cancel it.
   const fromHandleRef = useRef(false)
+  const itemRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = itemRef.current
+    if (!el) return
+
+    let frame: number | undefined
+    const requestFrame =
+      typeof requestAnimationFrame === "function"
+        ? requestAnimationFrame
+        : (callback: FrameRequestCallback) => window.setTimeout(callback, 0)
+    const cancelFrame =
+      typeof cancelAnimationFrame === "function"
+        ? cancelAnimationFrame
+        : window.clearTimeout
+
+    const scheduleMeasure = () => {
+      if (frame !== undefined) {
+        cancelFrame(frame)
+      }
+
+      frame = requestFrame(() => {
+        frame = undefined
+        const height = Math.max(
+          el.scrollHeight,
+          el.getBoundingClientRect().height
+        )
+        onContentHeightChange(id, height)
+      })
+    }
+
+    scheduleMeasure()
+
+    const resizeObserver = new ResizeObserver(scheduleMeasure)
+    resizeObserver.observe(el)
+
+    const mutationObserver = new MutationObserver(scheduleMeasure)
+    mutationObserver.observe(el, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    })
+
+    return () => {
+      if (frame !== undefined) {
+        cancelFrame(frame)
+      }
+      resizeObserver.disconnect()
+      mutationObserver.disconnect()
+    }
+  }, [id, onContentHeightChange])
 
   return (
     <>
       {showIndicatorBefore && <DropIndicator />}
       <div
+        ref={itemRef}
         data-card-id={id}
         draggable={canDrag}
         onDragStart={
@@ -720,6 +830,25 @@ function getMinRowHeight<Filters extends FiltersDefinition>(
     if (h > min) min = h
   }
   return min
+}
+
+function getMeasuredRowHeight(
+  row: Row,
+  measuredItemHeights: Map<string, number>
+): number {
+  let measuredHeight = 0
+  for (const id of row.ids) {
+    const itemHeight = measuredItemHeights.get(id) ?? 0
+    if (itemHeight > measuredHeight) measuredHeight = itemHeight
+  }
+  return measuredHeight
+}
+
+function getRenderableRowHeight(
+  row: Row,
+  measuredItemHeights: Map<string, number>
+): number {
+  return Math.max(row.height, getMeasuredRowHeight(row, measuredItemHeights))
 }
 
 function getSlotWeight<Filters extends FiltersDefinition>(

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -115,12 +115,12 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   // ─── Rows state ─────────────────────────────────────────────
   const [rows, setRows] = useState<Row[]>(() => buildInitialRows(items))
 
-  // Sync rows when items change from outside
-  const prevItemIdsRef = useRef(items.map((i) => i.id).join(","))
+  // Sync rows when externally-owned item layout changes.
+  const prevItemLayoutSignatureRef = useRef(buildItemLayoutSignature(items))
   useEffect(() => {
-    const newIds = items.map((i) => i.id).join(",")
-    if (newIds !== prevItemIdsRef.current) {
-      prevItemIdsRef.current = newIds
+    const newLayoutSignature = buildItemLayoutSignature(items)
+    if (newLayoutSignature !== prevItemLayoutSignatureRef.current) {
+      prevItemLayoutSignatureRef.current = newLayoutSignature
       setRows(buildInitialRows(items))
     }
   }, [items])
@@ -628,6 +628,24 @@ function buildInitialRows<Filters extends FiltersDefinition>(
   }
 
   return buildRowsGreedy(items)
+}
+
+function buildItemLayoutSignature<Filters extends FiltersDefinition>(
+  items: DashboardItemType<Filters>[]
+): string {
+  return items
+    .map((item) =>
+      [
+        item.id,
+        item.type,
+        item.itemHeight ?? "",
+        item.rowSpan ?? "",
+        item.x ?? "",
+        item.y ?? "",
+        item.colSpan ?? "",
+      ].join(":")
+    )
+    .join("|")
 }
 
 /** Group items by saved `y` coordinate to reconstruct saved rows. */

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -633,19 +633,17 @@ function buildInitialRows<Filters extends FiltersDefinition>(
 function buildItemLayoutSignature<Filters extends FiltersDefinition>(
   items: DashboardItemType<Filters>[]
 ): string {
-  return items
-    .map((item) =>
-      [
-        item.id,
-        item.type,
-        item.itemHeight ?? "",
-        item.rowSpan ?? "",
-        item.x ?? "",
-        item.y ?? "",
-        item.colSpan ?? "",
-      ].join(":")
-    )
-    .join("|")
+  return JSON.stringify(
+    items.map((item) => [
+      item.id,
+      item.type,
+      item.itemHeight ?? null,
+      item.rowSpan ?? null,
+      item.x ?? null,
+      item.y ?? null,
+      item.colSpan ?? null,
+    ])
+  )
 }
 
 /** Group items by saved `y` coordinate to reconstruct saved rows. */


### PR DESCRIPTION
## Description

`F0AnalyticsDashboard` could keep a stale row height after dashboard item content loaded asynchronously. In AI report dashboards this made collection/table widgets render beyond their card slot and overlap the following dashboard items. This was observed in AI-generated expense dashboards where multiple stacked collection/table widgets loaded async data: the first table's rows could overflow its fixed grid slot and visually overlap the next table below.

Example of the overflow issue seen:
<img width="2668" height="1658" alt="image" src="https://github.com/user-attachments/assets/6fb56713-aca0-41c9-a8b5-bbd5852fe970" />


After the solution:
<img width="1619" height="902" alt="Screenshot 2026-06-05 at 12 31 19" src="https://github.com/user-attachments/assets/3293187f-00cb-45df-885e-4e1ff27c1370" />



There were two related gaps:

- F0 only rebuilt its row model when item IDs changed, not when a consumer updated the same item with a new `itemHeight`.
- F0 did not measure rendered item content, so a collection whose loaded table was taller than its configured slot could overflow even when the app could not know the final content height ahead of time.

## Implementation details

- Rebuild dashboard rows when the externally-owned layout signature changes: `id`, `type`, `itemHeight`, legacy `rowSpan`, and saved `x`/`y`/`colSpan`.
- Measure each rendered grid item from inside F0 using `scrollHeight`, scheduled via `requestAnimationFrame` and refreshed with `ResizeObserver` + `MutationObserver`.
- Render each row at `max(configuredRowHeight, measuredContentHeight)` so async-loaded tables can grow the parent row without app-level DOM measurement, magic constants, or remount hacks.
- Preserve manual larger resizes by keeping configured row height as the authored/persisted floor.
- Add regression coverage for both externally updated `itemHeight` and content that becomes taller than the configured collection height.

## Verification

- `pnpm --filter @factorialco/f0-react vitest:ci src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx`
- `pnpm --filter @factorialco/f0-react run format`
- `pnpm --filter @factorialco/f0-react run tsc`
- `pnpm --filter @factorialco/f0-react build`
- Pre-commit hooks: cycle-dependencies, format-react, lint-react
- Local Factorial app smoke test with rebuilt F0 dist and prompt: `Build an report for 2026 grouped by employee and category, including totals per category and the top spenders`
  - Generated 7-card dashboard.
  - Large employee/category collection row auto-grew to `981px`.
  - All measured dashboard cards returned `overflows: false`.

## Notes

The local Factorial app was only wired to the rebuilt F0 package for smoke testing. The source fix lives in this F0 PR.

