### PR TITLE
fix(kanban): isolate per-lane loading state in DataCollection lanes

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/useDataCollectionLanesData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionData/useDataCollectionLanesData.tsx
@@ -68,6 +68,16 @@ const LaneProvider = <
   NavigationFilters,
   Grouping
 >) => {
+  const [laneIsLoading, setLaneIsLoading] = useState(false)
+  const laneSource = useMemo(
+    () => ({
+      ...source,
+      isLoading: laneIsLoading,
+      setIsLoading: setLaneIsLoading,
+    }),
+    [source, laneIsLoading]
+  )
+
   const mergedFilters = useMemo(
     () => mergeFiltersWithIntersection(source.currentFilters, lane.filters),
     [source.currentFilters, lane.filters]
@@ -80,7 +90,7 @@ const LaneProvider = <
     Summaries,
     NavigationFilters,
     Grouping
-  >(source, {
+  >(laneSource, {
     filters: mergedFilters,
     onError,
   })


### PR DESCRIPTION
## Problem

Kanban lanes get stuck on loading spinners forever on a cold load, even though
every lane's data has already arrived. It reproduces whenever a Kanban view is
the initial/restored visualization (e.g. ATS job applications at
`/recruitment/jobs/:id`). Switching to another view and back "fixes" it.

## Root cause

`useDataSource` keeps `isLoading`/`setIsLoading` as a single state on the
`source` object. A Kanban renders one `LaneProvider` per lane, each calling
`useData(source, …)` and reading `isLoading` from that one shared source. With
multiple lanes the flag is written concurrently; the lanes resolve sequentially
on a cold load and the shared `isLoading` is left stuck `true`. Per-lane
`isInitialLoading`, data, pagination and error are already local to each hook —
`isLoading` was the only entangled field. Switching views and back masks it
because the cached queries resolve in one synchronous batch (single writer).

## Change

`LaneProvider` now owns its own `isLoading`/`setIsLoading` and overrides just
those two fields on the source it passes to `useDataCollectionData`. No change
to single-visualization views (table/list), which keep using the source-level
loading state.