### PR TITLE
fix(react): animation polish — easing, scale, tooltip origin, dropdown zoom

### DIFF
--- a/packages/react/src/sds/ai/F0ActionItem/styles.css
+++ b/packages/react/src/sds/ai/F0ActionItem/styles.css
@@ -11,7 +11,7 @@
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  animation: shine 3s ease-in-out infinite;
+  animation: shine 3s linear infinite;
 }
 
 @keyframes shine {
@@ -20,6 +20,14 @@
   }
   100% {
     background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shine-text {
+    animation: none;
+    -webkit-text-fill-color: #888;
+    background: none;
   }
 }
 

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -178,7 +178,7 @@ div[role="dialog"] {
 }
 
 .f0-chat-cursor-blink {
-  animation: f0-chat-cursor-blink 0.8s ease-in-out infinite;
+  animation: f0-chat-cursor-blink 0.6s steps(2) infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/react/src/ui/Action/variants.ts
+++ b/packages/react/src/ui/Action/variants.ts
@@ -4,7 +4,7 @@ import { mentionClasses } from "@/lib/recipes"
 import { cn } from "@/lib/utils"
 
 const baseButton =
-  "group relative inline-flex items-center justify-center gap-1 whitespace-nowrap rounded border-none p-0 text-base font-medium shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(13,22,37,.04)] transition-colors [&_.main]:transform-gpu [&_.main]:transition-transform [&_.main]:duration-100 active:[&_.main]:translate-y-px [&_.main]:flex [&_.main]:items-center [&_.main]:justify-center disabled:opacity-30 disabled:cursor-not-allowed no-underline [&_.main]:z-20"
+  "group relative inline-flex items-center justify-center gap-1 whitespace-nowrap rounded border-none p-0 text-base font-medium shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_-2px_4px_rgba(13,22,37,.04)] transition-colors [&_.main]:transform-gpu [&_.main]:transition-transform [&_.main]:duration-100 active:[&_.main]:translate-y-px active:[&_.main]:scale-[0.97] [&_.main]:flex [&_.main]:items-center [&_.main]:justify-center disabled:opacity-30 disabled:cursor-not-allowed no-underline [&_.main]:z-20"
 
 const baseLink =
   "relative flex-row font-medium [&[aria-disabled=true]]:pointer-events-none [&[aria-disabled=true]]:cursor-not-allowed [&[aria-disabled=true]]:opacity-30 transition-colors"
@@ -69,7 +69,7 @@ export const actionVariants = cva({
       ),
       ai: cn(
         baseButton,
-        "bg-f1-border text-f1-foreground transition-all duration-200",
+        "bg-f1-border text-f1-foreground transition-colors duration-200",
         "[--gradient-angle:0deg]",
         "hover:bg-[conic-gradient(from_var(--gradient-angle),hsla(229,57%,76%,0.7),hsla(348,80%,50%,0.7),hsla(348,80%,50%,0.7),hsla(18,80%,50%,0.7),hsla(229,57%,76%,0.7),hsla(229,57%,76%,0.7))] hover:before:opacity-100",
         "hover:animate-rotate-gradient",

--- a/packages/react/src/ui/ButtonCopy/ButtonCopy.tsx
+++ b/packages/react/src/ui/ButtonCopy/ButtonCopy.tsx
@@ -25,9 +25,9 @@ export type ButtonCopyProps = Omit<
 }
 
 const copyIconMotionVariants = {
-  initial: { scale: 0.5, opacity: 0 },
+  initial: { scale: 0.9, opacity: 0 },
   animate: { scale: 1, opacity: 1 },
-  exit: { scale: 0.5, opacity: 0 },
+  exit: { scale: 0.9, opacity: 0 },
 }
 const copyIconTransition = { duration: 0.15, ease: "easeOut" }
 

--- a/packages/react/src/ui/ChevronToggle/ChevronToggle.tsx
+++ b/packages/react/src/ui/ChevronToggle/ChevronToggle.tsx
@@ -1,5 +1,3 @@
-import { motion } from "motion/react"
-
 import { F0Icon } from "@/components/F0Icon"
 import { ChevronDown } from "@/icons/app"
 import { useReducedMotion } from "@/lib/a11y"
@@ -27,19 +25,19 @@ export const ChevronToggle = ({
   const shouldReduceMotion = useReducedMotion()
   const rotation = open ? openRotation : closedRotation
   return (
-    <motion.div
-      initial={{ rotate: rotation }}
-      animate={{ rotate: rotation }}
-      transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
+    <div
+      style={{
+        transform: `rotate(${rotation}deg)`,
+        transition: shouldReduceMotion ? "none" : "transform 200ms ease-out",
+      }}
       className={cn(
         "flex h-3 w-3 shrink-0 items-center justify-center",
         disabled && "cursor-not-allowed opacity-50",
-
         className
       )}
       onClick={onClick}
     >
       <F0Icon icon={ChevronDown} size={size} role="button" />
-    </motion.div>
+    </div>
   )
 }

--- a/packages/react/src/ui/dropdown-menu.tsx
+++ b/packages/react/src/ui/dropdown-menu.tsx
@@ -49,7 +49,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -67,7 +67,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border border-solid border-f1-border-secondary bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border border-solid border-f1-border-secondary bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         "origin-[var(--radix-dropdown-menu-content-transform-origin)]",
         className
       )}

--- a/packages/react/src/ui/tooltip.tsx
+++ b/packages/react/src/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded bg-f1-background border border-solid border-f1-border-secondary dark px-2 py-1.5 leading-tight text-f1-foreground-inverse animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 overflow-hidden rounded bg-f1-background border border-solid border-f1-border-secondary dark px-2 py-1.5 leading-tight text-f1-foreground-inverse animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:origin-top data-[side=top]:origin-bottom data-[side=left]:origin-right data-[side=right]:origin-left",
         "break-words",
         className
       )}


### PR DESCRIPTION
## Summary

Animation improvements across `@factorialco/f0-react` based on an Emil Kowalski design engineering review:

- **F0ActionItem shimmer**: `ease-in-out` → `linear` — eliminates the invisible stutter at each loop boundary
- **F0ActionItem shimmer**: adds `@media (prefers-reduced-motion)` fallback — was the only animated component in the system without one
- **ButtonCopy icon swap**: initial/exit scale `0.5` → `0.9` — nothing in the real world disappears completely to reappear; subtle scale reads as natural
- **Cursor blink**: `0.8s ease-in-out` → `0.6s steps(2)` — cursors blink (on/off), not fade; `steps(2)` matches OS behaviour, 0.6s matches VS Code/terminal defaults
- **DropdownMenu** Content + SubContent: adds `zoom-in-95 zoom-out-95` — was inconsistent with Popover and Tooltip which already had zoom; the `transform-origin` was already set correctly but unused
- **Tooltip**: adds `data-[side=*]:origin-*` classes — zoom now scales from the trigger direction instead of the element center
- **Action baseButton**: adds `active:scale-[0.97]` — press feedback on all button variants; combines with existing `translate-y-px` for a more tactile feel
- **Action AI variant**: `transition-all` → `transition-colors` — avoids triggering paint on shadow/border during transitions
- **ChevronToggle**: replaces Framer Motion `rotate` shorthand with a plain CSS `transition` — Framer shorthand runs on the main thread via rAF; CSS transform runs on the compositor, keeping accordion/nav animations smooth under load

## Performance notes

Two changes have measurable perf impact beyond visual polish:
- `transition-all → transition-colors` reduces style recalc scope on hover
- `ChevronToggle` CSS transition runs off the main thread — matters in tables and navigation with many chevrons

No regressions: all changes are additive (new classes) or narrowing (fewer animated properties).