### PR TITLE
fix(inputs): resolve InputFieldProps in bundled types at the source

### DIFF
--- a/packages/react/src/components/F0DatePicker/components/DateInput.tsx
+++ b/packages/react/src/components/F0DatePicker/components/DateInput.tsx
@@ -10,7 +10,7 @@ import { isActiveDate } from "@/components/OneCalendar/utils"
 import { Calendar } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { Input } from "@/ui/input"
-import { InputFieldProps } from "@/components/F0InputField/F0InputField"
+import { InputFieldProps } from "@/components/F0InputField"
 
 import { DatePickerValue } from "../types"
 import { InputFieldInheritedProps } from "../types.internal"

--- a/packages/react/src/components/F0DatePicker/types.ts
+++ b/packages/react/src/components/F0DatePicker/types.ts
@@ -3,10 +3,7 @@ import {
   DatePickerPopupProps,
   DatePickerValue as DatePickerPopupValue,
 } from "@/ui/DatePickerPopup"
-import {
-  INPUTFIELD_SIZES,
-  InputFieldProps,
-} from "@/components/F0InputField/F0InputField"
+import { INPUTFIELD_SIZES, InputFieldProps } from "@/components/F0InputField"
 
 import { InputFieldInheritedProps } from "./types.internal"
 

--- a/packages/react/src/components/F0SearchInput/F0SearchInput.tsx
+++ b/packages/react/src/components/F0SearchInput/F0SearchInput.tsx
@@ -9,7 +9,7 @@ import {
 import { Search } from "@/icons/app"
 import { experimentalComponent } from "@/lib/experimental"
 import { Input } from "@/ui/input"
-import { InputFieldProps } from "@/components/F0InputField/F0InputField"
+import { InputFieldProps } from "@/components/F0InputField"
 
 export type F0SearchInputProps = {
   value?: string

--- a/packages/react/src/components/F0SearchInput/index.tsx
+++ b/packages/react/src/components/F0SearchInput/index.tsx
@@ -14,4 +14,8 @@ export type { F0SearchInputProps } from "./F0SearchInput"
  *
  * @removeIn 2.0.0
  */
-export const F1SearchBox = F0SearchInput
+// Typed as `typeof F0SearchInput` (rather than inferred) so the bundled
+// declaration references F0SearchInput's type instead of re-expanding the
+// forwardRef type — which otherwise produces a circular `InputFieldProps_2`
+// self-import that resolves to `any` for consumers.
+export const F1SearchBox: typeof F0SearchInput = F0SearchInput

--- a/packages/react/src/ui/input.tsx
+++ b/packages/react/src/ui/input.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
 
+import { F0InputField, InputFieldProps } from "@/components/F0InputField"
+
 import { cn } from "../lib/utils"
-import { F0InputField, InputFieldProps } from "../components/F0InputField"
 
 export type InputProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,

--- a/packages/react/src/ui/textarea.tsx
+++ b/packages/react/src/ui/textarea.tsx
@@ -6,8 +6,9 @@ import {
   type TextareaHTMLAttributes,
 } from "react"
 
+import { F0InputField, InputFieldProps } from "@/components/F0InputField"
+
 import { cn } from "../lib/utils"
-import { F0InputField, InputFieldProps } from "../components/F0InputField"
 
 export type TextareaProps = Omit<
   TextareaHTMLAttributes<HTMLTextAreaElement>,


### PR DESCRIPTION
## Why

Consumers bumping `@factorialco/f0-react` hit a cascade of TS errors on the search/date inputs:

```
Type '{ placeholder; value; onChange; clearable; autoFocus }' is missing the following
properties from type 'Pick<InputFieldProps_2<string>, "name" | "disabled" | ...>': name,
disabled, size, loading, ...
Parameter 'value' implicitly has an 'any' type.
```

## Root cause (introduced by #4199)

The #4199 rename/relocate wired `InputFieldProps` through **inconsistent module specifiers** — `F0SearchInput`/`F0DatePicker` imported it from the deep `@/components/F0InputField/F0InputField` path while everything else used the `@/components/F0InputField` barrel. api-extractor treats the same type reached via different specifiers as two symbols → it emits a duplicate `InputFieldProps_2`, which the d.ts rollup turns into a circular self-import that resolves to **`any`**. `Pick<any, "name" | …>` then makes every prop **required** (→ "missing props") and `onChange` becomes `any` (→ `value` implicit any). The deprecated `F1SearchBox` alias compounded it by re-expanding the forwardRef type a second time.

## Fix — source only (no vite/build change)

Matches the approach from #4317:

- Import `InputFieldProps` from the `@/components/F0InputField` **barrel** everywhere (`F0SearchInput`, `F0DatePicker` `DateInput` + `types`, `ui/input`, `ui/textarea`), so api-extractor sees one canonical type.
- Type the deprecated `F1SearchBox` alias as `typeof F0SearchInput`, so the bundle references `F0SearchInput`'s type instead of re-expanding the forwardRef (the last source of the `_2`).

6 files, +12/−9. **No `vite.config.ts` change** — like #4199, this stays entirely in source.

## Verification

- `InputFieldProps_2` is **gone** from both `dist/f0.d.ts` and `dist/experimental.d.ts`.
- A consumer probe rendering `F0SearchInput`, `F1SearchBox`, and the experimental `F1SearchBox` with a subset of props and an un-annotated `onChange={(value) => …}` compiles, with `value` typed `string`. The pre-fix shape reproduced the exact `TS2740` + `TS7006` errors.

## Notes

- The same `_2`-self-import pattern still exists for other types in the rollup (e.g. cell-value types api-extractor doesn't inline) — they were already `any` before this PR and are unchanged here; they can be fixed the same way (consistent imports / `typeof` alias) as they surface.
- The i18n translation keys (voice dictation) remain an intentional breaking change, covered separately.
