### PR TITLE
fix: preserve f0 react modules for tree shaking

### DIFF
--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -166,6 +166,8 @@ export default defineConfig({
         globals: {
           react: "React",
         },
+        preserveModules: true,
+        preserveModulesRoot: "src",
       },
     },
   },

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -159,6 +159,7 @@ export default defineConfig({
         /@copilotkit\/.*/,
         /@livekit\/.*/,
         "livekit-client",
+        /^recharts(\/.*)?$/,
       ],
       maxParallelFileOps: 100,
       // Workaround to fix rebuild https://github.com/vitejs/vite/issues/19410#issuecomment-2661835482


### PR DESCRIPTION
TL;DR: huge bundle size from F0 was preventing Factorial ID from upgrading since version ~1.266. This is an attempt at repackaging so we can ship a smaller bundle and upgrade to the latest version.

## Description

This is a draft/proof-of-concept to improve tree-shaking for `@factorialco/f0-react` consumers.

The current library build emits a few large shared chunks from the public barrel entries. In small consumers, importing a handful of components can pull in unrelated heavy modules (AI canvas, data collection, rich text/chart dependencies, etc.). This PR enables Rollup `preserveModules` for the React package build so consumers can tree-shake at module granularity.



## Screenshots (if applicable)

N/A — packaging-only change.

[Link to Figma Design](N/A)

## Implementation details

Changed `packages/react/vite.config.ts` to preserve the source module graph in `dist`:

```ts
preserveModules: true,
preserveModulesRoot: "src",
```

### Bundle-size experiment

Tested by packing this local F0 build and using it in `factorial-id` and the monolith frontend.

In `factorial-id`, upgrading from F0 `1.266.0` to the monolith's published `2.32.0` significantly increased the main bundle:

| Case | main JS | gzip |
| --- | ---: | ---: |
| current factorial-id F0 `1.266.0` | 5,224.64 kB | 1,458.68 kB |
| published F0 `2.32.0` | 8,801.26 kB | 2,619.24 kB |
| local F0 `2.39.1` with `preserveModules` | 4,040.58 kB | 1,119.63 kB |

The local `preserveModules` build removed unused heavy code from the factorial-id bundle, including `echarts`, `prosemirror`, `yjs`, `gridstack`, and `F0CanvasPanel`.

### Main frontend test

Also temporarily installed the packed local F0 package in `../frontend`, the primary F0 consumer.

Findings:

- Vite build got through module transformation (`41606 modules transformed`), so the packaging/import layout itself did not fail in the main frontend path.
- The build then failed on an unrelated generated GraphQL export: `EmployeeReferenceContractDocument` missing from `src/generated/resources/graphql.ts`.
- `pnpm tsc` showed existing/unrelated generated GraphQL errors, plus expected F0 upgrade API/type issues from testing local `2.39.1` over the monolith's current `2.32.0`:
  - Missing newer AI translation keys in `src/modules/core/lib/f0-provider.tsx` (`recordAudio`, `listening`, `stopRecording`, `cancelRecording`, etc.).
  - Stricter/broken `F1SearchBox` props typings in several monolith call sites where TS now expects `name`, `disabled`, `size`, `loading`, `onBlur`, `clearable`, etc.

### Validation run

- `pnpm --filter @factorialco/f0-react run format vite.config.ts`
- `pnpm --filter @factorialco/f0-react run tsc`
- `pnpm --filter @factorialco/f0-react run build`
- `pnpm --dir factorial-id/frontend build` with packed local F0
- `pnpm --dir ../frontend build` with packed local F0 (failed on unrelated generated GraphQL export after module transformation)

### Caveat

The F0 package build currently prints a Rollup warning about a Recharts circular chunk relationship when `preserveModules` is enabled. That should be reviewed before moving this from draft to ready-for-review.
