### PR TITLE
feat(ui): add F0CardRow component

### DIFF
--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -1,7 +1,6 @@
 import { forwardRef } from "react"
 
 import { F0Link } from "@/components/F0Link"
-import { type TagStatusProps } from "@/components/tags/F0TagStatus"
 import { DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { withDataTestId } from "@/lib/data-testid"
 import { withSkeleton } from "@/lib/skeleton"
@@ -21,6 +20,7 @@ import {
   CardRowActions,
   type CardRowConfirmAction,
   type CardRowStackAt,
+  type CardRowStatus,
   cardRowClassName,
 } from "./components/CardRowActions"
 import { type CardAlertProps } from "./types"
@@ -72,12 +72,13 @@ export interface F0CardRowProps {
   rejectAction?: CardRowConfirmAction
 
   /**
-   * Resolved-state status tag shown at the trailing edge in place of any
-   * actions — e.g. the `{ text: "Accepted", variant: "positive" }` /
-   * `{ text: "Rejected", variant: "critical" }` outcome of a confirm/reject row.
+   * Resolved-state indicator shown at the trailing edge in place of any actions
+   * — the outcome of a confirm/reject row. Either a status tag
+   * (`{ text: "Accepted", variant: "positive" }`) or a coloured icon
+   * (`{ icon: Check, variant: "positive", label: "Accepted" }`).
    * Takes precedence over the action props.
    */
-  status?: TagStatusProps
+  status?: CardRowStatus
 
   /**
    * Strikes through and dims the title/description, marking the row's subject as

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from "react"
 
 import { F0Link } from "@/components/F0Link"
+import { type TagStatusProps } from "@/components/tags/F0TagStatus"
 import { DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { withDataTestId } from "@/lib/data-testid"
 import { withSkeleton } from "@/lib/skeleton"
@@ -71,6 +72,14 @@ export interface F0CardRowProps {
   rejectAction?: CardRowConfirmAction
 
   /**
+   * Resolved-state status tag shown at the trailing edge in place of any
+   * actions — e.g. the `{ text: "Accepted", variant: "positive" }` /
+   * `{ text: "Rejected", variant: "critical" }` outcome of a confirm/reject row.
+   * Takes precedence over the action props.
+   */
+  status?: TagStatusProps
+
+  /**
    * Compact layout: tighter padding and smaller controls.
    */
   compact?: boolean
@@ -129,6 +138,7 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
       otherActions,
       confirmAction,
       rejectAction,
+      status,
       compact = false,
       link,
       fullHeight = false,
@@ -192,6 +202,7 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
             otherActions={otherActions}
             confirmAction={confirmAction}
             rejectAction={rejectAction}
+            status={status}
             compact={compact}
             stackAt={stackAt}
           />

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -72,10 +72,9 @@ export interface F0CardRowProps {
   rejectAction?: CardRowConfirmAction
 
   /**
-   * Resolved-state indicator shown at the trailing edge in place of any actions
-   * — the outcome of a confirm/reject row. Either a status tag
-   * (`{ text: "Accepted", variant: "positive" }`) or a coloured icon
-   * (`{ icon: Check, variant: "positive", label: "Accepted" }`).
+   * Resolved-state icon shown at the trailing edge in place of any actions — the
+   * outcome of a confirm/reject row, e.g.
+   * `{ icon: Check, variant: "positive", label: "Accepted" }`.
    * Takes precedence over the action props.
    */
   status?: CardRowStatus

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -80,6 +80,13 @@ export interface F0CardRowProps {
   status?: TagStatusProps
 
   /**
+   * Strikes through and dims the title/description, marking the row's subject as
+   * void or closed (e.g. a rejected request). Purely presentational — pair it
+   * with the matching `status` tag at the call site.
+   */
+  inactive?: boolean
+
+  /**
    * Compact layout: tighter padding and smaller controls.
    */
   compact?: boolean
@@ -139,6 +146,7 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
       confirmAction,
       rejectAction,
       status,
+      inactive = false,
       compact = false,
       link,
       fullHeight = false,
@@ -188,10 +196,21 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
             {avatar && <CardAvatar avatar={avatar} size="lg" />}
             <div className="flex min-w-0 flex-col gap-0">
               {title && (
-                <Text variant="body" content={title} className="font-medium" />
+                <Text
+                  variant="body"
+                  content={title}
+                  className={cn(
+                    "font-medium",
+                    inactive && "text-f1-foreground-secondary line-through"
+                  )}
+                />
               )}
               {description && (
-                <Text variant="description" content={description} />
+                <Text
+                  variant="description"
+                  content={description}
+                  className={cn(inactive && "line-through")}
+                />
               )}
             </div>
           </div>

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -195,16 +195,14 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
           <div className="flex min-w-0 flex-row items-center gap-3">
             {avatar && <CardAvatar avatar={avatar} size="lg" />}
             <div className="flex min-w-0 flex-col gap-0">
-              {title && (
-                <Text
-                  variant="body"
-                  content={title}
-                  className={cn(
-                    "font-medium",
-                    inactive && "text-f1-foreground-secondary line-through"
-                  )}
-                />
-              )}
+              <Text
+                variant="body"
+                content={title}
+                className={cn(
+                  "font-medium",
+                  inactive && "text-f1-foreground-secondary line-through"
+                )}
+              />
               {description && (
                 <Text
                   variant="description"

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -177,15 +177,10 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
             {avatar && <CardAvatar avatar={avatar} size="lg" />}
             <div className="flex min-w-0 flex-col gap-0">
               {title && (
-                <Text
-                  variant="body"
-                  content={title}
-                  className="font-medium"
-                  ellipsis
-                />
+                <Text variant="body" content={title} className="font-medium" />
               )}
               {description && (
-                <Text variant="description" content={description} ellipsis />
+                <Text variant="description" content={description} />
               )}
             </div>
           </div>

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -1,0 +1,248 @@
+import { forwardRef } from "react"
+
+import { F0Link } from "@/components/F0Link"
+import { DropdownItem } from "@/experimental/Navigation/Dropdown"
+import { withDataTestId } from "@/lib/data-testid"
+import { withSkeleton } from "@/lib/skeleton"
+import { cn, focusRing } from "@/lib/utils"
+import { Card } from "@/ui/Card"
+import { Skeleton } from "@/ui/skeleton"
+import { Text } from "@/ui/Text"
+
+import {
+  type CardPrimaryAction,
+  type CardSecondaryAction,
+  type CardSecondaryLink,
+} from "./components/CardActions"
+import { CardAlertWrapper, alertBorderColor } from "./components/CardAlert"
+import { CardAvatar, type CardAvatarVariant } from "./components/CardAvatar"
+import {
+  CardRowActions,
+  type CardRowConfirmAction,
+  type CardRowStackAt,
+  cardRowClassName,
+} from "./components/CardRowActions"
+import { type CardAlertProps } from "./types"
+
+export interface F0CardRowProps {
+  /**
+   * The primary line of text.
+   */
+  title: string
+
+  /**
+   * Optional secondary line shown beneath the title (single line, truncated).
+   */
+  description?: string
+
+  /**
+   * Optional avatar rendered at a fixed `lg` size on the left (the size is not
+   * configurable). Accepts any avatar type in the system: person, company, team,
+   * file, flag, icon, emoji, module, alert, date, pulse. Types without a `lg`
+   * variant (date, pulse) render at their intrinsic size.
+   */
+  avatar?: CardAvatarVariant
+
+  /**
+   * The primary action button, shown at the trailing edge of the row.
+   */
+  primaryAction?: CardPrimaryAction
+
+  /**
+   * Secondary actions (buttons) or a single link, shown before the primary action.
+   */
+  secondaryActions?: CardSecondaryAction[] | CardSecondaryLink
+
+  /**
+   * Overflow (⋯) menu actions, rendered as the trailing control of the row.
+   */
+  otherActions?: DropdownItem[]
+
+  /**
+   * Confirm/reject variant: renders an icon-only ✗ (reject) + ✓ (confirm) pair
+   * instead of the standard actions. Provide either or both.
+   */
+  confirmAction?: CardRowConfirmAction
+
+  /**
+   * Reject (✗) action of the confirm/reject variant. See {@link confirmAction}.
+   */
+  rejectAction?: CardRowConfirmAction
+
+  /**
+   * Compact layout: tighter padding and smaller controls.
+   */
+  compact?: boolean
+
+  /**
+   * Container width at which the actions drop to their own line (below it) vs.
+   * sit inline (at/above it). `never` keeps them inline at every width.
+   * @default "never"
+   */
+  stackAt?: CardRowStackAt
+
+  /**
+   * When set, the whole row becomes a link to this href.
+   */
+  link?: string
+
+  /**
+   * Stretch to fill the height of its container.
+   */
+  fullHeight?: boolean
+
+  /**
+   * Alert banner displayed above the row with a coloured header strip and matching
+   * border. Supports info, warning, critical and positive variants.
+   * Use `visible` + `onDismiss` for controlled dismiss behaviour.
+   */
+  alert?: CardAlertProps
+
+  /**
+   * Called when the row is clicked.
+   */
+  onClick?: () => void
+
+  /**
+   * Disables the full-row overlay link so a parent can manage drag-and-drop while
+   * still allowing click navigation via `onClick`.
+   */
+  disableOverlayLink?: boolean
+}
+
+/**
+ * A single-row card: optional avatar on the left, stacked title + description,
+ * and actions on the right. By default the actions stay inline at every width;
+ * set `stackAt` to drop them onto their own line below a container breakpoint
+ * (a container query on the card's width, not the viewport), so it reacts
+ * correctly inside grids and columns.
+ */
+const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
+  function F0CardRow(
+    {
+      title,
+      description,
+      avatar,
+      primaryAction,
+      secondaryActions,
+      otherActions,
+      confirmAction,
+      rejectAction,
+      compact = false,
+      link,
+      fullHeight = false,
+      alert,
+      onClick,
+      disableOverlayLink = false,
+      stackAt = "never",
+    },
+    ref
+  ) {
+    const hasAlert = !!alert && alert.visible !== false
+
+    const body = (
+      <Card
+        ref={hasAlert ? undefined : ref}
+        className={cn(
+          "group relative @container bg-f1-background shadow-none transition-all",
+          compact && "p-3",
+          fullHeight && "h-full",
+          link &&
+            "focus-within:border-f1-border-hover focus-within:shadow-md hover:border-f1-border-hover hover:shadow-md"
+        )}
+        style={
+          hasAlert
+            ? {
+                borderColor: alertBorderColor[alert.variant],
+                borderWidth: "2px",
+              }
+            : undefined
+        }
+        onClick={onClick}
+        data-testid="card"
+      >
+        {link && !disableOverlayLink && (
+          <F0Link
+            href={link}
+            variant="unstyled"
+            className={cn("z-1 absolute inset-0 block rounded-xl", focusRing())}
+            aria-label={title}
+          >
+            &nbsp;
+          </F0Link>
+        )}
+
+        <div className={cardRowClassName[stackAt]}>
+          <div className="flex min-w-0 flex-row items-center gap-3">
+            {avatar && <CardAvatar avatar={avatar} size="lg" />}
+            <div className="flex min-w-0 flex-col gap-0">
+              {title && (
+                <Text
+                  variant="body"
+                  content={title}
+                  className="font-medium"
+                  ellipsis
+                />
+              )}
+              {description && (
+                <Text variant="description" content={description} ellipsis />
+              )}
+            </div>
+          </div>
+
+          <CardRowActions
+            primaryAction={primaryAction}
+            secondaryActions={secondaryActions}
+            otherActions={otherActions}
+            confirmAction={confirmAction}
+            rejectAction={rejectAction}
+            compact={compact}
+            stackAt={stackAt}
+          />
+        </div>
+      </Card>
+    )
+
+    if (hasAlert) {
+      return (
+        <CardAlertWrapper ref={ref} alert={alert} fullHeight={fullHeight}>
+          {body}
+        </CardAlertWrapper>
+      )
+    }
+
+    return body
+  }
+)
+
+F0CardRowBase.displayName = "F0CardRow"
+
+const F0CardRowSkeleton = ({ compact = false }: { compact?: boolean }) => {
+  return (
+    <Card
+      className={cn(
+        "group relative bg-f1-background shadow-none",
+        compact && "p-3"
+      )}
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="flex flex-row items-center justify-between gap-4">
+        <div className="flex min-w-0 flex-row items-center gap-3">
+          <Skeleton
+            className={cn("h-10 w-10 rounded-full", compact && "h-8 w-8")}
+          />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-3 w-32 rounded-md" />
+            <Skeleton className="h-3 w-20 rounded-md" />
+          </div>
+        </div>
+        <Skeleton className="h-9 w-24 rounded-md" />
+      </div>
+    </Card>
+  )
+}
+
+export const F0CardRow = withDataTestId(
+  withSkeleton(F0CardRowBase, F0CardRowSkeleton)
+)

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -31,7 +31,8 @@ export interface F0CardRowProps {
   title: string
 
   /**
-   * Optional secondary line shown beneath the title (single line, truncated).
+   * Optional secondary line shown beneath the title (wraps across multiple
+   * lines when long).
    */
   description?: string
 

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -9,7 +9,7 @@ import { F0CardRow } from "../F0CardRow"
 
 const meta: Meta<typeof F0CardRow> = {
   component: F0CardRow,
-  title: "Card/Row",
+  title: "Card Row",
   parameters: {
     docs: {
       description: {

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -146,43 +146,11 @@ export const ConfirmReject: Story = {
 
 /**
  * Resolved state of a confirm/reject row: once a decision is made, pass `status`
- * to swap the buttons for a status tag. The accepted/rejected → positive/critical
+ * a coloured icon (`{ icon, variant, label }`, the `label` keeps it accessible)
+ * to swap the buttons for the outcome. The accepted/rejected → positive/critical
  * mapping lives with the caller (here in the story).
  */
 export const Accepted: Story = {
-  args: {
-    avatar: {
-      type: "person",
-      firstName: "Jane",
-      lastName: "Cooper",
-      src: image,
-    },
-    title: "Jane Cooper",
-    description: "Requested 3 days off",
-    status: { text: "Accepted", variant: "positive" },
-  },
-}
-
-export const Rejected: Story = {
-  args: {
-    avatar: {
-      type: "person",
-      firstName: "Jane",
-      lastName: "Cooper",
-      src: image,
-    },
-    title: "Jane Cooper",
-    description: "Requested 3 days off",
-    status: { text: "Rejected", variant: "critical" },
-    inactive: true,
-  },
-}
-
-/**
- * The resolved state can also be shown as a coloured icon instead of a tag —
- * pass `status` an `{ icon, variant, label }` (the `label` keeps it accessible).
- */
-export const AcceptedIcon: Story = {
   args: {
     avatar: {
       type: "person",
@@ -196,7 +164,7 @@ export const AcceptedIcon: Story = {
   },
 }
 
-export const RejectedIcon: Story = {
+export const Rejected: Story = {
   args: {
     avatar: {
       type: "person",

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import image from "@storybook-static/avatars/person04.jpg"
 import { fn } from "storybook/test"
 
-import { Briefcase, Delete, Envelope } from "@/icons/app"
+import { Briefcase, Check, Cross, Delete, Envelope } from "@/icons/app"
 
 import { F0CardRow } from "../F0CardRow"
 
@@ -174,6 +174,39 @@ export const Rejected: Story = {
     title: "Jane Cooper",
     description: "Requested 3 days off",
     status: { text: "Rejected", variant: "critical" },
+    inactive: true,
+  },
+}
+
+/**
+ * The resolved state can also be shown as a coloured icon instead of a tag —
+ * pass `status` an `{ icon, variant, label }` (the `label` keeps it accessible).
+ */
+export const AcceptedIcon: Story = {
+  args: {
+    avatar: {
+      type: "person",
+      firstName: "Jane",
+      lastName: "Cooper",
+      src: image,
+    },
+    title: "Jane Cooper",
+    description: "Requested 3 days off",
+    status: { icon: Check, variant: "positive", label: "Accepted" },
+  },
+}
+
+export const RejectedIcon: Story = {
+  args: {
+    avatar: {
+      type: "person",
+      firstName: "Jane",
+      lastName: "Cooper",
+      src: image,
+    },
+    title: "Jane Cooper",
+    description: "Requested 3 days off",
+    status: { icon: Cross, variant: "critical", label: "Rejected" },
     inactive: true,
   },
 }

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -174,6 +174,7 @@ export const Rejected: Story = {
     title: "Jane Cooper",
     description: "Requested 3 days off",
     status: { text: "Rejected", variant: "critical" },
+    inactive: true,
   },
 }
 

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -138,6 +138,7 @@ export const ConfirmReject: Story = {
     },
     title: "Jane Cooper",
     description: "Requested 3 days off",
+    stackAt: "md",
     rejectAction: { label: "Reject", onClick: fn() },
     confirmAction: { label: "Approve", onClick: fn() },
   },

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -145,6 +145,39 @@ export const ConfirmReject: Story = {
 }
 
 /**
+ * Resolved state of a confirm/reject row: once a decision is made, pass `status`
+ * to swap the buttons for a status tag. The accepted/rejected → positive/critical
+ * mapping lives with the caller (here in the story).
+ */
+export const Accepted: Story = {
+  args: {
+    avatar: {
+      type: "person",
+      firstName: "Jane",
+      lastName: "Cooper",
+      src: image,
+    },
+    title: "Jane Cooper",
+    description: "Requested 3 days off",
+    status: { text: "Accepted", variant: "positive" },
+  },
+}
+
+export const Rejected: Story = {
+  args: {
+    avatar: {
+      type: "person",
+      firstName: "Jane",
+      lastName: "Cooper",
+      src: image,
+    },
+    title: "Jane Cooper",
+    description: "Requested 3 days off",
+    status: { text: "Rejected", variant: "critical" },
+  },
+}
+
+/**
  * Actions stay inline at every width by default (`stackAt: "never"`). Opt into a
  * responsive collapse with `stackAt` (e.g. `"md"`): below that container width the
  * actions drop onto their own line with a separator, and secondary buttons fold

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -31,7 +31,7 @@ const meta: Meta<typeof F0CardRow> = {
     title: { control: "text", description: "The primary line of text." },
     description: {
       control: "text",
-      description: "Optional secondary line (single line, truncated).",
+      description: "Optional secondary line (wraps when long).",
     },
     avatar: {
       control: "object",

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -1,0 +1,341 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import image from "@storybook-static/avatars/person04.jpg"
+import { fn } from "storybook/test"
+
+import { Briefcase, Delete, Envelope } from "@/icons/app"
+
+import { F0CardRow } from "../F0CardRow"
+
+const meta: Meta<typeof F0CardRow> = {
+  component: F0CardRow,
+  title: "Card/Row",
+  parameters: {
+    docs: {
+      description: {
+        component: [
+          "`F0CardRow` is a compact, single-row card: an optional avatar on the left, a title with an optional description, and trailing actions on the right.",
+          "Use it for list rows, inline confirmations and dense layouts where a full `F0Card` is too heavy — e.g. a settings toggle row, a pending-approval item, or a selectable entity.",
+          "Actions stay inline at every width by default. Set <code>stackAt</code> to collapse them onto their own line below a container breakpoint — secondary buttons fold into a left ⋯ menu while the primary stays pinned. For an approve/reject row, use the icon-only <code>confirmAction</code> / <code>rejectAction</code> variant. The avatar renders at a fixed size and accepts any avatar type in the system.",
+        ]
+          .map((line) => `<p>${line}</p>`)
+          .join("\n"),
+      },
+      story: { inline: false, height: "160px" },
+    },
+  },
+  tags: ["autodocs", "stable"],
+  // Explicit argTypes: docgen can't infer props through the
+  // withDataTestId(withSkeleton(...)) wrapper, so we declare the controls here.
+  argTypes: {
+    title: { control: "text", description: "The primary line of text." },
+    description: {
+      control: "text",
+      description: "Optional secondary line (single line, truncated).",
+    },
+    avatar: {
+      control: "object",
+      description:
+        "Optional avatar rendered at md on the left. Any avatar type: person, team, company, file, flag, emoji, icon, module.",
+    },
+    stackAt: {
+      control: "select",
+      options: ["sm", "md", "lg", "never"],
+      description:
+        "Container width at which the actions drop to their own line. `never` keeps them inline at every width.",
+      table: { defaultValue: { summary: "never" } },
+    },
+    compact: {
+      control: "boolean",
+      description: "Tighter padding and smaller controls.",
+    },
+    fullHeight: {
+      control: "boolean",
+      description: "Stretch to fill the height of the container.",
+    },
+    link: {
+      control: "text",
+      description: "When set, the whole row becomes a link to this href.",
+    },
+    // Function-bearing props: disable the control so it doesn't dump the
+    // serialized mock fn() source. They still appear in the args table.
+    primaryAction: {
+      control: false,
+      description: "Primary action button, pinned at the trailing edge.",
+    },
+    secondaryActions: {
+      control: false,
+      description: "Secondary actions (buttons) or a single link.",
+    },
+    otherActions: {
+      control: false,
+      description: "Overflow (⋯) menu actions, kept in the left more-menu.",
+    },
+    confirmAction: {
+      control: false,
+      description:
+        "Confirm (✓) icon-only action of the confirm/reject variant.",
+    },
+    rejectAction: {
+      control: false,
+      description: "Reject (✗) icon-only action of the confirm/reject variant.",
+    },
+    alert: {
+      control: false,
+      description: "Alert banner displayed above the row.",
+    },
+    onClick: {
+      action: "clicked",
+      description: "Called when the row is clicked.",
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      if (context.parameters?.noMetaLayout) {
+        return <Story />
+      }
+      return (
+        <div className="flex h-[calc(100vh-32px)] w-full items-center justify-center">
+          <div className="w-[640px]">
+            <Story />
+          </div>
+        </div>
+      )
+    },
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    title: "Do you want to proceed?",
+    primaryAction: {
+      label: "Confirm",
+      onClick: fn(),
+    },
+    secondaryActions: [
+      {
+        label: "Cancel",
+        onClick: fn(),
+      },
+    ],
+  },
+}
+
+/**
+ * Confirm/reject variant: icon-only ✗ (reject) + ✓ (confirm) buttons instead of
+ * the standard actions. Useful for inline approve/reject rows.
+ */
+export const ConfirmReject: Story = {
+  args: {
+    avatar: {
+      type: "person",
+      firstName: "Jane",
+      lastName: "Cooper",
+      src: image,
+    },
+    title: "Jane Cooper",
+    description: "Requested 3 days off",
+    rejectAction: { label: "Reject", onClick: fn() },
+    confirmAction: { label: "Approve", onClick: fn() },
+  },
+}
+
+/**
+ * Actions stay inline at every width by default (`stackAt: "never"`). Opt into a
+ * responsive collapse with `stackAt` (e.g. `"md"`): below that container width the
+ * actions drop onto their own line with a separator, and secondary buttons fold
+ * into the left ⋯. Resize the card narrower than ~448px to see it.
+ */
+export const Stacking: Story = {
+  args: {
+    avatar: {
+      type: "person",
+      firstName: "Jane",
+      lastName: "Cooper",
+      src: image,
+    },
+    title: "Jane Cooper",
+    description: "Drops to its own line below @md",
+    stackAt: "md",
+    secondaryActions: [{ label: "Edit", onClick: fn() }],
+    otherActions: [
+      { label: "Mail", icon: Envelope, onClick: fn() },
+      { type: "separator" },
+      { label: "Delete", icon: Delete, onClick: fn(), critical: true },
+    ],
+    primaryAction: { label: "Open", onClick: fn() },
+  },
+}
+
+export const WithAvatar: Story = {
+  args: {
+    avatar: {
+      type: "person",
+      firstName: "Jane",
+      lastName: "Cooper",
+      src: image,
+    },
+    title: "Jane Cooper",
+    description: "Product designer",
+    primaryAction: {
+      label: "Open",
+      onClick: fn(),
+    },
+    secondaryActions: [
+      {
+        label: "Edit",
+        onClick: fn(),
+      },
+    ],
+    otherActions: [
+      {
+        label: "Mail",
+        icon: Envelope,
+        onClick: fn(),
+      },
+      { type: "separator" },
+      {
+        label: "Delete",
+        icon: Delete,
+        onClick: fn(),
+        critical: true,
+      },
+    ],
+  },
+}
+
+export const WithAlert: Story = {
+  args: {
+    avatar: {
+      type: "person",
+      firstName: "Jane",
+      lastName: "Cooper",
+      src: image,
+    },
+    title: "Jane Cooper",
+    description: "Contract ends in 3 days",
+    alert: {
+      variant: "warning",
+      title: "Action required",
+    },
+    primaryAction: {
+      label: "Renew",
+      onClick: fn(),
+    },
+    secondaryActions: [
+      {
+        label: "Dismiss",
+        onClick: fn(),
+      },
+    ],
+  },
+  parameters: {
+    docs: { story: { inline: false, height: "200px" } },
+  },
+}
+
+/**
+ * The `avatar` prop accepts every single-avatar type in the system — person,
+ * company, team, file, flag, icon, emoji, module, alert, date and pulse — each
+ * rendered at a single, fixed size on the left (the size is not configurable).
+ */
+export const AvatarTypes: Story = {
+  parameters: {
+    noMetaLayout: true,
+    docs: { story: { inline: false, height: "840px" } },
+  },
+  render: () => (
+    <div className="flex w-[640px] flex-col gap-3">
+      <F0CardRow
+        avatar={{
+          type: "person",
+          firstName: "Jane",
+          lastName: "Cooper",
+          src: image,
+        }}
+        title="Jane Cooper"
+        description="Person avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+      <F0CardRow
+        avatar={{ type: "company", name: "Acme Inc" }}
+        title="Acme Inc"
+        description="Company avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+      <F0CardRow
+        avatar={{ type: "team", name: "Design" }}
+        title="Design Team"
+        description="Team avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+      <F0CardRow
+        avatar={{
+          type: "file",
+          file: { name: "contract.pdf", type: "application/pdf" },
+        }}
+        title="contract.pdf"
+        description="File avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+      <F0CardRow
+        avatar={{ type: "flag", flag: "es" }}
+        title="Spain"
+        description="Flag avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+      <F0CardRow
+        avatar={{ type: "icon", icon: Briefcase }}
+        title="Engineering"
+        description="Icon avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+      <F0CardRow
+        avatar={{ type: "emoji", emoji: "🚀" }}
+        title="Launch"
+        description="Emoji avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+      <F0CardRow
+        avatar={{ type: "module", module: "goals" }}
+        title="Goals"
+        description="Module avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+      <F0CardRow
+        avatar={{ type: "alert", variant: "warning" }}
+        title="Action required"
+        description="Alert avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+      <F0CardRow
+        avatar={{ type: "date", date: new Date(2026, 5, 5) }}
+        title="Team offsite"
+        description="Date avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+      <F0CardRow
+        avatar={{
+          type: "pulse",
+          firstName: "Jane",
+          lastName: "Cooper",
+          pulse: "positive",
+          onPulseClick: fn(),
+        }}
+        title="Jane Cooper"
+        description="Pulse avatar"
+        primaryAction={{ label: "Open", onClick: fn() }}
+      />
+    </div>
+  ),
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-[calc(100vh-32px)] w-full items-center justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { Briefcase } from "@/icons/app"
+import {
+  zeroRender as render,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/testing/test-utils"
+
+import type { CardSecondaryLink } from "../components/CardActions"
+import type { CardAvatarVariant } from "../components/CardAvatar"
+
+import { F0CardRow } from "../F0CardRow"
+
+describe("F0CardRow", () => {
+  it("renders title and description", () => {
+    render(<F0CardRow title="Jane Cooper" description="Product designer" />)
+
+    expect(screen.getByText("Jane Cooper")).toBeInTheDocument()
+    expect(screen.getByText("Product designer")).toBeInTheDocument()
+  })
+
+  it("renders an avatar when provided", () => {
+    render(
+      <F0CardRow
+        title="Jane Cooper"
+        avatar={{ type: "person", firstName: "Jane", lastName: "Cooper" }}
+      />
+    )
+
+    expect(screen.getByTestId("card-avatar")).toBeInTheDocument()
+  })
+
+  it("renders every supported avatar type", () => {
+    const avatars: CardAvatarVariant[] = [
+      { type: "person", firstName: "Jane", lastName: "Cooper" },
+      { type: "company", name: "Acme Inc" },
+      { type: "team", name: "Design" },
+      { type: "file", file: { name: "contract.pdf", type: "application/pdf" } },
+      { type: "flag", flag: "es" },
+      { type: "icon", icon: Briefcase },
+      { type: "emoji", emoji: "🚀" },
+      { type: "module", module: "goals" },
+      { type: "alert", variant: "warning" },
+      { type: "date", date: new Date(2026, 5, 5) },
+      {
+        type: "pulse",
+        firstName: "Jane",
+        lastName: "Cooper",
+        onPulseClick: vi.fn(),
+      },
+    ]
+
+    avatars.forEach((avatar) => {
+      const { unmount } = render(<F0CardRow title="Title" avatar={avatar} />)
+      expect(screen.getByTestId("card-avatar")).toBeInTheDocument()
+      unmount()
+    })
+  })
+
+  it("renders as a clickable link when link is provided", () => {
+    render(<F0CardRow title="Linked row" link="/test-link" />)
+
+    const link = screen.getByRole("link", { name: "Linked row" })
+    expect(link).toHaveAttribute("href", "/test-link")
+  })
+
+  it("calls onClick when the row is clicked", async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+
+    render(<F0CardRow title="Clickable" onClick={handleClick} />)
+
+    await user.click(screen.getByText("Clickable"))
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls primaryAction.onClick", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    render(<F0CardRow title="Row" primaryAction={{ label: "Open", onClick }} />)
+
+    await user.click(screen.getByTestId("primary-button"))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls a secondary action's onClick", async () => {
+    const user = userEvent.setup()
+    const onEdit = vi.fn()
+
+    render(
+      <F0CardRow
+        title="Row"
+        secondaryActions={[{ label: "Edit", onClick: onEdit }]}
+        primaryAction={{ label: "Open", onClick: vi.fn() }}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Edit" }))
+    expect(onEdit).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders a secondary action link", () => {
+    const secondaryLink: CardSecondaryLink = {
+      label: "View more",
+      href: "/test-page",
+      target: "_blank",
+    }
+
+    render(<F0CardRow title="Row" secondaryActions={secondaryLink} />)
+
+    const link = screen.getByTestId("secondary-link")
+    expect(link).toHaveAttribute("href", "/test-page")
+    expect(link).toHaveAttribute("target", "_blank")
+  })
+
+  it("opens the overflow menu and triggers otherActions", async () => {
+    const user = userEvent.setup()
+    const onArchive = vi.fn()
+
+    render(
+      <F0CardRow
+        title="Row"
+        otherActions={[{ label: "Archive", onClick: onArchive }]}
+      />
+    )
+
+    // With only otherActions and the default stackAt="never", the sole button is
+    // the overflow (⋯) trigger.
+    await user.click(screen.getByRole("button"))
+    await user.click(screen.getByRole("menuitem", { name: "Archive" }))
+    await waitFor(() => expect(onArchive).toHaveBeenCalledTimes(1))
+  })
+
+  describe("confirm/reject variant", () => {
+    it("calls confirmAction.onClick", async () => {
+      const user = userEvent.setup()
+      const onConfirm = vi.fn()
+
+      render(<F0CardRow title="Row" confirmAction={{ onClick: onConfirm }} />)
+
+      await user.click(screen.getByTestId("confirm-button"))
+      expect(onConfirm).toHaveBeenCalledTimes(1)
+    })
+
+    it("calls rejectAction.onClick", async () => {
+      const user = userEvent.setup()
+      const onReject = vi.fn()
+
+      render(<F0CardRow title="Row" rejectAction={{ onClick: onReject }} />)
+
+      await user.click(screen.getByTestId("reject-button"))
+      expect(onReject).toHaveBeenCalledTimes(1)
+    })
+
+    it("replaces the standard actions", () => {
+      render(
+        <F0CardRow
+          title="Row"
+          confirmAction={{ onClick: vi.fn() }}
+          rejectAction={{ onClick: vi.fn() }}
+          primaryAction={{ label: "Open", onClick: vi.fn() }}
+        />
+      )
+
+      expect(screen.getByTestId("confirm-button")).toBeInTheDocument()
+      expect(screen.getByTestId("reject-button")).toBeInTheDocument()
+      expect(screen.queryByTestId("primary-button")).not.toBeInTheDocument()
+    })
+  })
+
+  it("renders the alert banner when alert is provided", () => {
+    render(
+      <F0CardRow
+        title="Row"
+        alert={{ variant: "warning", title: "Action required" }}
+      />
+    )
+
+    expect(screen.getByText("Action required")).toBeInTheDocument()
+  })
+
+  it("renders for every stackAt value", () => {
+    const values = ["sm", "md", "lg", "never"] as const
+
+    values.forEach((stackAt) => {
+      const { unmount } = render(
+        <F0CardRow
+          title="Row"
+          stackAt={stackAt}
+          primaryAction={{ label: "Open", onClick: vi.fn() }}
+        />
+      )
+
+      expect(screen.getByTestId("card")).toBeInTheDocument()
+      // The primary stays visible at every breakpoint (rendered in the inline
+      // cluster and, for non-"never", the stacked cluster too).
+      expect(screen.getAllByTestId("primary-button").length).toBeGreaterThan(0)
+      unmount()
+    })
+  })
+})

--- a/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
@@ -166,7 +166,7 @@ describe("F0CardRow", () => {
 
       render(<F0CardRow title="Row" rejectAction={{ onClick: onReject }} />)
 
-      await user.click(screen.getByRole("button", { name: "Reject" }))
+      await user.click(screen.getByRole("button", { name: "Cancel" }))
       expect(onReject).toHaveBeenCalledTimes(1)
     })
 
@@ -183,7 +183,7 @@ describe("F0CardRow", () => {
       expect(
         screen.getByRole("button", { name: "Confirm" })
       ).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
       expect(
         screen.queryByRole("button", { name: "Open" })
       ).not.toBeInTheDocument()

--- a/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
@@ -190,6 +190,38 @@ describe("F0CardRow", () => {
     })
   })
 
+  describe("status (resolved state)", () => {
+    it("renders the status tag", () => {
+      render(
+        <F0CardRow
+          title="Row"
+          status={{ text: "Accepted", variant: "positive" }}
+        />
+      )
+
+      expect(screen.getByText("Accepted")).toBeInTheDocument()
+    })
+
+    it("takes precedence over the action props", () => {
+      render(
+        <F0CardRow
+          title="Row"
+          status={{ text: "Rejected", variant: "critical" }}
+          primaryAction={{ label: "Open", onClick: vi.fn() }}
+          secondaryActions={[{ label: "Edit", onClick: vi.fn() }]}
+        />
+      )
+
+      expect(screen.getByText("Rejected")).toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: "Open" })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: "Edit" })
+      ).not.toBeInTheDocument()
+    })
+  })
+
   it("renders the alert banner when alert is provided", () => {
     render(
       <F0CardRow

--- a/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 import "@testing-library/jest-dom/vitest"
-import { Briefcase, Check } from "@/icons/app"
+import { Briefcase, Check, Cross } from "@/icons/app"
 import {
   zeroRender as render,
   screen,
@@ -191,37 +191,7 @@ describe("F0CardRow", () => {
   })
 
   describe("status (resolved state)", () => {
-    it("renders the status tag", () => {
-      render(
-        <F0CardRow
-          title="Row"
-          status={{ text: "Accepted", variant: "positive" }}
-        />
-      )
-
-      expect(screen.getByText("Accepted")).toBeInTheDocument()
-    })
-
-    it("takes precedence over the action props", () => {
-      render(
-        <F0CardRow
-          title="Row"
-          status={{ text: "Rejected", variant: "critical" }}
-          primaryAction={{ label: "Open", onClick: vi.fn() }}
-          secondaryActions={[{ label: "Edit", onClick: vi.fn() }]}
-        />
-      )
-
-      expect(screen.getByText("Rejected")).toBeInTheDocument()
-      expect(
-        screen.queryByRole("button", { name: "Open" })
-      ).not.toBeInTheDocument()
-      expect(
-        screen.queryByRole("button", { name: "Edit" })
-      ).not.toBeInTheDocument()
-    })
-
-    it("renders an icon status by its accessible label", () => {
+    it("renders the status icon by its accessible label", () => {
       render(
         <F0CardRow
           title="Row"
@@ -230,6 +200,25 @@ describe("F0CardRow", () => {
       )
 
       expect(screen.getByRole("img", { name: "Accepted" })).toBeInTheDocument()
+    })
+
+    it("takes precedence over the action props", () => {
+      render(
+        <F0CardRow
+          title="Row"
+          status={{ icon: Cross, variant: "critical", label: "Rejected" }}
+          primaryAction={{ label: "Open", onClick: vi.fn() }}
+          secondaryActions={[{ label: "Edit", onClick: vi.fn() }]}
+        />
+      )
+
+      expect(screen.getByRole("img", { name: "Rejected" })).toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: "Open" })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: "Edit" })
+      ).not.toBeInTheDocument()
     })
 
     it("strikes through and dims the title when inactive", () => {

--- a/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 import "@testing-library/jest-dom/vitest"
-import { Briefcase } from "@/icons/app"
+import { Briefcase, Check } from "@/icons/app"
 import {
   zeroRender as render,
   screen,
@@ -219,6 +219,17 @@ describe("F0CardRow", () => {
       expect(
         screen.queryByRole("button", { name: "Edit" })
       ).not.toBeInTheDocument()
+    })
+
+    it("renders an icon status by its accessible label", () => {
+      render(
+        <F0CardRow
+          title="Row"
+          status={{ icon: Check, variant: "positive", label: "Accepted" }}
+        />
+      )
+
+      expect(screen.getByRole("img", { name: "Accepted" })).toBeInTheDocument()
     })
 
     it("strikes through and dims the title when inactive", () => {

--- a/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
@@ -166,7 +166,7 @@ describe("F0CardRow", () => {
 
       render(<F0CardRow title="Row" rejectAction={{ onClick: onReject }} />)
 
-      await user.click(screen.getByRole("button", { name: "Cancel" }))
+      await user.click(screen.getByRole("button", { name: "Reject" }))
       expect(onReject).toHaveBeenCalledTimes(1)
     })
 
@@ -183,7 +183,7 @@ describe("F0CardRow", () => {
       expect(
         screen.getByRole("button", { name: "Confirm" })
       ).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument()
       expect(
         screen.queryByRole("button", { name: "Open" })
       ).not.toBeInTheDocument()

--- a/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
@@ -220,6 +220,15 @@ describe("F0CardRow", () => {
         screen.queryByRole("button", { name: "Edit" })
       ).not.toBeInTheDocument()
     })
+
+    it("strikes through and dims the title when inactive", () => {
+      render(<F0CardRow title="Void request" description="Details" inactive />)
+
+      const title = screen.getByText("Void request")
+      expect(title).toHaveClass("line-through")
+      expect(title).toHaveClass("text-f1-foreground-secondary")
+      expect(screen.getByText("Details")).toHaveClass("line-through")
+    })
   })
 
   it("renders the alert banner when alert is provided", () => {

--- a/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
@@ -8,6 +8,21 @@ import {
   waitFor,
 } from "@/testing/test-utils"
 
+// The actions delegate to ButtonGroup, whose width-driven overflow measures DOM
+// it can't in jsdom (zero layout) — so it would shove every action into the "⋯"
+// menu. Stub the measurement to keep everything visible, as a real browser would.
+vi.mock("@/ui/OverflowList/useOverflowCalculation", () => ({
+  useOverflowCalculation: <T,>(items: T[]) => ({
+    containerRef: { current: null },
+    overflowButtonRef: { current: null },
+    customOverflowIndicatorRef: { current: null },
+    measurementContainerRef: { current: null },
+    visibleItems: items,
+    overflowItems: [],
+    isInitialized: true,
+  }),
+}))
+
 import type { CardSecondaryLink } from "../components/CardActions"
 import type { CardAvatarVariant } from "../components/CardAvatar"
 
@@ -82,7 +97,7 @@ describe("F0CardRow", () => {
 
     render(<F0CardRow title="Row" primaryAction={{ label: "Open", onClick }} />)
 
-    await user.click(screen.getByTestId("primary-button"))
+    await user.click(screen.getByRole("button", { name: "Open" }))
     expect(onClick).toHaveBeenCalledTimes(1)
   })
 
@@ -111,7 +126,7 @@ describe("F0CardRow", () => {
 
     render(<F0CardRow title="Row" secondaryActions={secondaryLink} />)
 
-    const link = screen.getByTestId("secondary-link")
+    const link = screen.getByRole("link", { name: "View more" })
     expect(link).toHaveAttribute("href", "/test-page")
     expect(link).toHaveAttribute("target", "_blank")
   })
@@ -141,7 +156,7 @@ describe("F0CardRow", () => {
 
       render(<F0CardRow title="Row" confirmAction={{ onClick: onConfirm }} />)
 
-      await user.click(screen.getByTestId("confirm-button"))
+      await user.click(screen.getByRole("button", { name: "Confirm" }))
       expect(onConfirm).toHaveBeenCalledTimes(1)
     })
 
@@ -151,7 +166,7 @@ describe("F0CardRow", () => {
 
       render(<F0CardRow title="Row" rejectAction={{ onClick: onReject }} />)
 
-      await user.click(screen.getByTestId("reject-button"))
+      await user.click(screen.getByRole("button", { name: "Reject" }))
       expect(onReject).toHaveBeenCalledTimes(1)
     })
 
@@ -165,9 +180,13 @@ describe("F0CardRow", () => {
         />
       )
 
-      expect(screen.getByTestId("confirm-button")).toBeInTheDocument()
-      expect(screen.getByTestId("reject-button")).toBeInTheDocument()
-      expect(screen.queryByTestId("primary-button")).not.toBeInTheDocument()
+      expect(
+        screen.getByRole("button", { name: "Confirm" })
+      ).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: "Open" })
+      ).not.toBeInTheDocument()
     })
   })
 
@@ -195,9 +214,8 @@ describe("F0CardRow", () => {
       )
 
       expect(screen.getByTestId("card")).toBeInTheDocument()
-      // The primary stays visible at every breakpoint (rendered in the inline
-      // cluster and, for non-"never", the stacked cluster too).
-      expect(screen.getAllByTestId("primary-button").length).toBeGreaterThan(0)
+      // The primary stays visible (pinned at the trailing edge) at every breakpoint.
+      expect(screen.getByRole("button", { name: "Open" })).toBeInTheDocument()
       unmount()
     })
   })

--- a/packages/react/src/components/F0Card/components/CardAvatar.tsx
+++ b/packages/react/src/components/F0Card/components/CardAvatar.tsx
@@ -1,7 +1,17 @@
 import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
+import {
+  type AlertAvatarProps,
+  F0AvatarAlert,
+} from "@/components/avatars/F0AvatarAlert"
+import { F0AvatarDate } from "@/components/avatars/F0AvatarDate"
 import { F0AvatarEmoji } from "@/components/avatars/F0AvatarEmoji"
 import { F0AvatarFile } from "@/components/avatars/F0AvatarFile"
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
+import {
+  F0AvatarModule,
+  type ModuleId,
+} from "@/components/avatars/F0AvatarModule"
+import { F0AvatarPulse, type Pulse } from "@/components/avatars/F0AvatarPulse"
 import { IconType } from "@/components/F0Icon"
 import { cn } from "@/lib/utils"
 
@@ -10,6 +20,19 @@ type CardAvatarVariant =
   | { type: "emoji"; emoji: string }
   | { type: "file"; file: File }
   | { type: "icon"; icon: IconType }
+  | { type: "module"; module: ModuleId }
+  | { type: "alert"; variant: AlertAvatarProps["type"] }
+  | { type: "date"; date: Date }
+  | {
+      type: "pulse"
+      firstName: string
+      lastName: string
+      src?: string
+      pulse?: Pulse
+      onPulseClick: () => void
+    }
+
+type CardAvatarSize = "sm" | "md" | "lg"
 
 interface CardAvatarProps {
   /**
@@ -26,33 +49,64 @@ interface CardAvatarProps {
    * Whether the avatar is displayed in a compact layout
    */
   compact?: boolean
+
+  /**
+   * Explicit size override. When omitted, the size derives from `compact`
+   * (sm) or the default vertical layout (lg). Passing a size also signals
+   * inline usage (e.g. the card row) and drops the vertical margin.
+   */
+  size?: CardAvatarSize
 }
 
 const AvatarRender = ({
   avatar,
-  compact = false,
+  size,
 }: {
   avatar: CardAvatarVariant
-  compact?: boolean
+  size: CardAvatarSize
 }) => {
   if (avatar.type === "emoji") {
-    return <F0AvatarEmoji emoji={avatar.emoji} size={compact ? "sm" : "lg"} />
+    return <F0AvatarEmoji emoji={avatar.emoji} size={size} />
   }
   if (avatar.type === "file") {
-    return <F0AvatarFile file={avatar.file} size={compact ? "sm" : "lg"} />
+    return <F0AvatarFile file={avatar.file} size={size} />
   }
   if (avatar.type === "icon") {
-    return <F0AvatarIcon icon={avatar.icon} size={compact ? "sm" : "lg"} />
+    return <F0AvatarIcon icon={avatar.icon} size={size} />
   }
-  return <F0Avatar avatar={avatar} size={compact ? "sm" : "lg"} />
+  if (avatar.type === "module") {
+    return <F0AvatarModule module={avatar.module} size={size} />
+  }
+  if (avatar.type === "alert") {
+    return <F0AvatarAlert type={avatar.variant} size={size} />
+  }
+  if (avatar.type === "date") {
+    // F0AvatarDate has a fixed intrinsic size (no size prop).
+    return <F0AvatarDate date={avatar.date} />
+  }
+  if (avatar.type === "pulse") {
+    // F0AvatarPulse has a fixed intrinsic size (no size prop).
+    return (
+      <F0AvatarPulse
+        firstName={avatar.firstName}
+        lastName={avatar.lastName}
+        src={avatar.src}
+        pulse={avatar.pulse}
+        onPulseClick={avatar.onPulseClick}
+      />
+    )
+  }
+  return <F0Avatar avatar={avatar} size={size} />
 }
 
 export function CardAvatar({
   avatar,
   overlay = false,
   compact = false,
+  size,
 }: CardAvatarProps) {
   const isRounded = avatar.type === "person"
+  const resolvedSize: CardAvatarSize = size ?? (compact ? "sm" : "lg")
 
   return (
     <div
@@ -62,11 +116,11 @@ export function CardAvatar({
           !compact &&
           "absolute -top-9 left-0 rounded-md ring-[3px] ring-f1-background",
         overlay && isRounded && "rounded-full",
-        compact && "mb-0"
+        (compact || size) && "mb-0"
       )}
       data-testid="card-avatar"
     >
-      <AvatarRender avatar={avatar} compact={compact} />
+      <AvatarRender avatar={avatar} size={resolvedSize} />
     </div>
   )
 }

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -1,4 +1,9 @@
-import { F0TagStatus, type TagStatusProps } from "@/components/tags/F0TagStatus"
+import { F0Icon, type IconType } from "@/components/F0Icon"
+import {
+  F0TagStatus,
+  type StatusVariant,
+  type TagStatusProps,
+} from "@/components/tags/F0TagStatus"
 import { type DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { Check, Cross } from "@/icons/app"
 import { cn } from "@/lib/utils"
@@ -95,6 +100,37 @@ export interface CardRowConfirmAction {
   disabled?: boolean
 }
 
+/** Resolved-state indicator at the trailing edge: a coloured icon. */
+export interface CardRowStatusIcon {
+  /** The icon to render (e.g. `Check` for accepted, `Cross` for rejected). */
+  icon: IconType
+  /** Colour family — same variants as the status tag. */
+  variant: StatusVariant
+  /** Accessible label; the icon carries meaning, so this is required. */
+  label: string
+}
+
+/**
+ * Resolved state shown in place of the actions: either a {@link F0TagStatus}
+ * pill ({@link TagStatusProps}) or a {@link CardRowStatusIcon} coloured icon.
+ */
+export type CardRowStatus = TagStatusProps | CardRowStatusIcon
+
+// Status variant → F0Icon colour token (no "neutral" icon colour; map to secondary).
+const statusIconColor: Record<
+  StatusVariant,
+  "secondary" | "info" | "positive" | "warning" | "critical"
+> = {
+  neutral: "secondary",
+  info: "info",
+  positive: "positive",
+  warning: "warning",
+  critical: "critical",
+}
+
+const isStatusIcon = (status: CardRowStatus): status is CardRowStatusIcon =>
+  "icon" in status
+
 interface CardRowActionsProps {
   primaryAction?: CardPrimaryAction
   secondaryActions?: CardSecondaryAction[] | CardSecondaryLink
@@ -105,11 +141,11 @@ interface CardRowActionsProps {
   /** Reject (✗) icon-only action — enables the confirm/reject variant. */
   rejectAction?: CardRowConfirmAction
   /**
-   * Resolved-state status tag shown at the trailing edge in place of any
-   * actions (e.g. the "Accepted" / "Rejected" outcome of a confirm/reject row).
-   * Takes precedence over every action prop.
+   * Resolved-state indicator shown at the trailing edge in place of any actions
+   * (e.g. the "Accepted" / "Rejected" outcome of a confirm/reject row) — a
+   * status tag or a coloured icon. Takes precedence over every action prop.
    */
-  status?: TagStatusProps
+  status?: CardRowStatus
   compact?: boolean
   /** Container breakpoint at which the actions drop to their own line. */
   stackAt?: CardRowStackAt
@@ -157,7 +193,17 @@ export function CardRowActions({
           stackAt !== "never" && compact && "mt-3 pt-3"
         )}
       >
-        <F0TagStatus {...status} />
+        {isStatusIcon(status) ? (
+          <F0Icon
+            icon={status.icon}
+            color={statusIconColor[status.variant]}
+            size="lg"
+            role="img"
+            aria-label={status.label}
+          />
+        ) : (
+          <F0TagStatus {...status} />
+        )}
       </div>
     )
   }

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -1,3 +1,4 @@
+import { F0TagStatus, type TagStatusProps } from "@/components/tags/F0TagStatus"
 import { type DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { Check, Cross } from "@/icons/app"
 import { cn } from "@/lib/utils"
@@ -103,6 +104,12 @@ interface CardRowActionsProps {
   confirmAction?: CardRowConfirmAction
   /** Reject (✗) icon-only action — enables the confirm/reject variant. */
   rejectAction?: CardRowConfirmAction
+  /**
+   * Resolved-state status tag shown at the trailing edge in place of any
+   * actions (e.g. the "Accepted" / "Rejected" outcome of a confirm/reject row).
+   * Takes precedence over every action prop.
+   */
+  status?: TagStatusProps
   compact?: boolean
   /** Container breakpoint at which the actions drop to their own line. */
   stackAt?: CardRowStackAt
@@ -132,10 +139,28 @@ export function CardRowActions({
   otherActions,
   confirmAction,
   rejectAction,
+  status,
   compact = false,
   stackAt = "never",
 }: CardRowActionsProps) {
   const size = compact ? "sm" : "md"
+
+  // Resolved state: a status tag replaces the actions. It's informational, so
+  // no click-stop / z-index — a row-level overlay link stays clickable through
+  // it. The outer flex drops it to its own line when stacked, with the footer.
+  if (status) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-end",
+          stackedChrome[stackAt],
+          stackAt !== "never" && compact && "mt-3 pt-3"
+        )}
+      >
+        <F0TagStatus {...status} />
+      </div>
+    )
+  }
 
   const wrapperClassName = cn(
     "relative z-[1]",

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -1,0 +1,307 @@
+import { type Ref } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { F0Link } from "@/components/F0Link"
+import { Dropdown, type DropdownItem } from "@/experimental/Navigation/Dropdown"
+import { Check, Cross } from "@/icons/app"
+import { cn } from "@/lib/utils"
+import { useOverflowCalculation } from "@/ui/OverflowList/useOverflowCalculation"
+
+import {
+  type CardPrimaryAction,
+  type CardSecondaryAction,
+  type CardSecondaryLink,
+} from "./CardActions"
+
+// Pixel gap between the trailing controls — mirrors the `gap-2` used elsewhere.
+const GAP = 8
+
+/**
+ * Container breakpoint at which the card row switches between its inline and its
+ * stacked (actions-on-their-own-line) layout. `never` keeps it inline at every
+ * width.
+ */
+export type CardRowStackAt = "sm" | "md" | "lg" | "never"
+
+/**
+ * Outer row layout: a stacked column that becomes an inline row at the chosen
+ * container breakpoint. Exported so the card root and the actions share one source
+ * of truth (the breakpoint must match for the layout to stay coherent).
+ * Each value is a full static string so Tailwind's JIT can see the classes.
+ *
+ * Breakpoint mapping (ascending): the `"sm"` option uses Tailwind's `@xs`
+ * (24rem / 384px). f0-core overrides `@sm` to 40rem (640px) — larger than
+ * `@md` (28rem / 448px) — so using `@sm` here would (wrongly) stack *before*
+ * `md`. `@xs < @md < @lg` keeps sm < md < lg as expected.
+ */
+export const cardRowClassName: Record<CardRowStackAt, string> = {
+  sm: "flex flex-col @xs:flex-row @xs:items-center @xs:justify-between @xs:gap-4",
+  md: "flex flex-col @md:flex-row @md:items-center @md:justify-between @md:gap-4",
+  lg: "flex flex-col @lg:flex-row @lg:items-center @lg:justify-between @lg:gap-4",
+  never: "flex flex-row items-center justify-between gap-4",
+}
+
+// Inline ("wide") cluster — shown only at/above the breakpoint.
+const wideClusterVisibility: Record<CardRowStackAt, string> = {
+  sm: "hidden @xs:flex",
+  md: "hidden @md:flex",
+  lg: "hidden @lg:flex",
+  never: "flex",
+}
+
+// Stacked ("narrow") cluster — shown only below the breakpoint.
+const narrowClusterVisibility: Record<CardRowStackAt, string> = {
+  sm: "flex @xs:hidden",
+  md: "flex @md:hidden",
+  lg: "flex @lg:hidden",
+  never: "hidden",
+}
+
+// Footer-style separator shown while the actions sit on their own stacked line;
+// removed once they go inline at the breakpoint.
+const stackedChrome: Record<CardRowStackAt, string> = {
+  sm: "-mx-4 mt-4 border-0 border-t border-solid border-t-f1-border-secondary px-4 pt-4 @xs:mx-0 @xs:mt-0 @xs:border-t-0 @xs:px-0 @xs:pt-0",
+  md: "-mx-4 mt-4 border-0 border-t border-solid border-t-f1-border-secondary px-4 pt-4 @md:mx-0 @md:mt-0 @md:border-t-0 @md:px-0 @md:pt-0",
+  lg: "-mx-4 mt-4 border-0 border-t border-solid border-t-f1-border-secondary px-4 pt-4 @lg:mx-0 @lg:mt-0 @lg:border-t-0 @lg:px-0 @lg:pt-0",
+  never: "",
+}
+
+export interface CardRowConfirmAction {
+  onClick: () => void
+  /** Accessible label and tooltip. Defaults to "Confirm" / "Reject". */
+  label?: string
+  disabled?: boolean
+}
+
+interface CardRowActionsProps {
+  primaryAction?: CardPrimaryAction
+  secondaryActions?: CardSecondaryAction[] | CardSecondaryLink
+  /** Overflow (⋯) menu actions — always live in the left "more" menu. */
+  otherActions?: DropdownItem[]
+  /** Confirm (✓) icon-only action — enables the confirm/reject variant. */
+  confirmAction?: CardRowConfirmAction
+  /** Reject (✗) icon-only action — enables the confirm/reject variant. */
+  rejectAction?: CardRowConfirmAction
+  compact?: boolean
+  /** Container breakpoint at which the actions drop to their own line. */
+  stackAt?: CardRowStackAt
+}
+
+/**
+ * Trailing actions for the card row. The "more" (⋯) menu sits on the LEFT and
+ * the primary stays pinned at the trailing edge.
+ *
+ * Two layouts, toggled by the card's container width at `stackAt`:
+ * - Wide (inline): all secondary buttons shown; the ⋯ holds only `otherActions`.
+ * - Narrow: the row drops onto its own full-width line; there the cluster IS
+ *   width-bounded, so we measure it (same engine as `OverflowList`) and shed
+ *   secondary buttons right→left into the left ⋯ as it tightens.
+ *
+ * Pass `confirmAction` / `rejectAction` for the icon-only confirm/reject variant
+ * (✗ then ✓), which replaces the standard actions.
+ */
+export function CardRowActions({
+  primaryAction,
+  secondaryActions,
+  otherActions,
+  confirmAction,
+  rejectAction,
+  compact = false,
+  stackAt = "never",
+}: CardRowActionsProps) {
+  const size = compact ? "sm" : "md"
+
+  // Hook must run unconditionally, before any early return.
+  const secondaryArray = Array.isArray(secondaryActions) ? secondaryActions : []
+  const {
+    containerRef,
+    measurementContainerRef,
+    customOverflowIndicatorRef,
+    visibleItems,
+    overflowItems,
+    isInitialized,
+  } = useOverflowCalculation(secondaryArray, GAP)
+
+  const chrome = cn(
+    stackedChrome[stackAt],
+    stackAt !== "never" && compact && "mt-3 pt-3"
+  )
+
+  // Confirm/reject variant: icon-only outline buttons, reject (✗) then confirm (✓).
+  if (confirmAction || rejectAction) {
+    return (
+      <div
+        className={cn(
+          "relative z-[1] flex flex-row items-center justify-end gap-2",
+          chrome
+        )}
+      >
+        {rejectAction && (
+          <F0Button
+            icon={Cross}
+            label={rejectAction.label ?? "Reject"}
+            hideLabel
+            variant="outline"
+            size={size}
+            disabled={rejectAction.disabled}
+            onClick={(e) => {
+              e.stopPropagation()
+              rejectAction.onClick()
+            }}
+            data-testid="reject-button"
+          />
+        )}
+        {confirmAction && (
+          <F0Button
+            icon={Check}
+            label={confirmAction.label ?? "Confirm"}
+            hideLabel
+            variant="outline"
+            size={size}
+            disabled={confirmAction.disabled}
+            onClick={(e) => {
+              e.stopPropagation()
+              confirmAction.onClick()
+            }}
+            data-testid="confirm-button"
+          />
+        )}
+      </div>
+    )
+  }
+
+  const secondaryLink =
+    secondaryActions && !Array.isArray(secondaryActions)
+      ? secondaryActions
+      : undefined
+  const other = otherActions ?? []
+
+  // Before the first measurement, optimistically show everything so the row
+  // doesn't flash empty; the measured split takes over once initialized.
+  const shown = isInitialized ? visibleItems : secondaryArray
+  const overflowed = isInitialized ? overflowItems : []
+
+  const toDropdownItem = (action: CardSecondaryAction): DropdownItem => ({
+    label: action.label,
+    icon: action.icon,
+    onClick: action.onClick,
+  })
+
+  // Narrow ⋯ menu = collapsed secondaries, then the always-present otherActions,
+  // divided by a separator when both are present.
+  const narrowMenu: DropdownItem[] = [
+    ...overflowed.map(toDropdownItem),
+    ...(overflowed.length > 0 && other.length > 0
+      ? [{ type: "separator" } as DropdownItem]
+      : []),
+    ...other,
+  ]
+
+  const hasAnyAction =
+    primaryAction ||
+    secondaryArray.length > 0 ||
+    !!secondaryLink ||
+    other.length > 0
+
+  if (!hasAnyAction) {
+    return null
+  }
+
+  const renderSecondary = (action: CardSecondaryAction, index: number) => (
+    <F0Button
+      key={index}
+      label={action.label}
+      icon={action.icon}
+      variant="outline"
+      size={size}
+      onClick={(e) => {
+        e.stopPropagation()
+        action.onClick()
+      }}
+    />
+  )
+
+  const more = (items: DropdownItem[], ref?: Ref<HTMLDivElement>) =>
+    items.length > 0 ? (
+      <div ref={ref} onClick={(e) => e.stopPropagation()}>
+        <Dropdown items={items} size={size} />
+      </div>
+    ) : null
+
+  const link = secondaryLink ? (
+    <F0Link
+      href={secondaryLink.href}
+      target={secondaryLink.target}
+      disabled={secondaryLink.disabled}
+      onClick={(e) => e.stopPropagation()}
+      data-testid="secondary-link"
+    >
+      {secondaryLink.label}
+    </F0Link>
+  ) : null
+
+  const primary = primaryAction ? (
+    <F0Button
+      label={primaryAction.label}
+      icon={primaryAction.icon}
+      size={size}
+      onClick={(e) => {
+        e.stopPropagation()
+        primaryAction.onClick()
+      }}
+      data-testid="primary-button"
+    />
+  ) : null
+
+  return (
+    <>
+      {/* Wide (inline): all secondary buttons shown, ⋯ = otherActions. */}
+      <div
+        className={cn(
+          "relative z-[1] flex-row items-center justify-end gap-2",
+          wideClusterVisibility[stackAt]
+        )}
+      >
+        {more(other)}
+        {secondaryArray.map(renderSecondary)}
+        {link}
+        {primary}
+      </div>
+
+      {/* Narrow: own full-width line; measured left-overflow. Only rendered when
+          a breakpoint is set — with `never` the inline cluster above is enough,
+          and we avoid a hidden measurement subtree + its ResizeObserver. */}
+      {stackAt !== "never" && (
+        <div
+          className={cn(
+            "relative z-[1] flex-row items-center justify-end gap-2",
+            narrowClusterVisibility[stackAt],
+            chrome
+          )}
+        >
+          <div
+            ref={containerRef}
+            className="relative flex min-w-0 flex-1 items-center justify-end"
+            style={{ gap: GAP }}
+          >
+            {/* Hidden measurement copy of every secondary button. */}
+            <div
+              ref={measurementContainerRef}
+              aria-hidden="true"
+              className="pointer-events-none invisible absolute left-0 top-0 flex items-center whitespace-nowrap"
+              style={{ gap: GAP }}
+            >
+              {secondaryArray.map(renderSecondary)}
+            </div>
+
+            {more(narrowMenu, customOverflowIndicatorRef)}
+            {shown.map(renderSecondary)}
+          </div>
+
+          {link}
+          {primary}
+        </div>
+      )}
+    </>
+  )
+}

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -1,11 +1,12 @@
-import { type Ref } from "react"
-
-import { F0Button } from "@/components/F0Button"
-import { F0Link } from "@/components/F0Link"
-import { Dropdown, type DropdownItem } from "@/experimental/Navigation/Dropdown"
+import { type DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { Check, Cross } from "@/icons/app"
 import { cn } from "@/lib/utils"
-import { useOverflowCalculation } from "@/ui/OverflowList/useOverflowCalculation"
+import {
+  ButtonGroup,
+  type ButtonGroupButton,
+  type ButtonGroupSecondaryItem,
+  type ButtonGroupSecondaryLink,
+} from "@/ui/ButtonGroup"
 
 import {
   type CardPrimaryAction,
@@ -41,20 +42,20 @@ export const cardRowClassName: Record<CardRowStackAt, string> = {
   never: "flex flex-row items-center justify-between gap-4",
 }
 
-// Inline ("wide") cluster — shown only at/above the breakpoint.
-const wideClusterVisibility: Record<CardRowStackAt, string> = {
-  sm: "hidden @xs:flex",
-  md: "hidden @md:flex",
-  lg: "hidden @lg:flex",
-  never: "flex",
-}
-
-// Stacked ("narrow") cluster — shown only below the breakpoint.
-const narrowClusterVisibility: Record<CardRowStackAt, string> = {
-  sm: "flex @xs:hidden",
-  md: "flex @md:hidden",
-  lg: "flex @lg:hidden",
-  never: "hidden",
+/**
+ * Width of the actions wrapper. `ButtonGroup` reserves the "⋯"-button width on
+ * top of its content, so a shrink-to-fit container would always shed the tail
+ * into the menu — it needs a bound *wider* than its content. Inline (at/above
+ * the breakpoint) we hand it the remaining row space via `flex-1`, with its own
+ * `justify-end` keeping the buttons at the trailing edge; once stacked it spans
+ * the full line instead (no `flex-1`, which would grow it vertically in the
+ * column). `never` is always inline.
+ */
+const actionsWidthClassName: Record<CardRowStackAt, string> = {
+  sm: "w-full @xs:w-auto @xs:min-w-0 @xs:flex-1",
+  md: "w-full @md:w-auto @md:min-w-0 @md:flex-1",
+  lg: "w-full @lg:w-auto @lg:min-w-0 @lg:flex-1",
+  never: "min-w-0 flex-1",
 }
 
 // Footer-style separator shown while the actions sit on their own stacked line;
@@ -88,14 +89,17 @@ interface CardRowActionsProps {
 }
 
 /**
- * Trailing actions for the card row. The "more" (⋯) menu sits on the LEFT and
- * the primary stays pinned at the trailing edge.
+ * Trailing actions for the card row — a thin adapter over {@link ButtonGroup}.
+ * The data-driven `primaryAction` / `secondaryActions` / `otherActions` triplet
+ * maps straight through; `ButtonGroup` owns the row layout, the width-driven
+ * overflow into the "⋯" menu, and pinning the primary at the trailing edge.
  *
- * Two layouts, toggled by the card's container width at `stackAt`:
- * - Wide (inline): all secondary buttons shown; the ⋯ holds only `otherActions`.
- * - Narrow: the row drops onto its own full-width line; there the cluster IS
- *   width-bounded, so we measure it (same engine as `OverflowList`) and shed
- *   secondary buttons right→left into the left ⋯ as it tightens.
+ * The card adds two things on top:
+ * - The wrapper stops click propagation so an action never triggers the row's
+ *   own `onClick` / overlay-link navigation.
+ * - `stackAt` drops the cluster onto its own full-width line (with a footer
+ *   hairline) below a container breakpoint; the breakpoint mapping is shared
+ *   with the row root via {@link cardRowClassName}.
  *
  * Pass `confirmAction` / `rejectAction` for the icon-only confirm/reject variant
  * (✗ then ✓), which replaces the standard actions.
@@ -111,197 +115,98 @@ export function CardRowActions({
 }: CardRowActionsProps) {
   const size = compact ? "sm" : "md"
 
-  // Hook must run unconditionally, before any early return.
-  const secondaryArray = Array.isArray(secondaryActions) ? secondaryActions : []
-  const {
-    containerRef,
-    measurementContainerRef,
-    customOverflowIndicatorRef,
-    visibleItems,
-    overflowItems,
-    isInitialized,
-  } = useOverflowCalculation(secondaryArray, GAP)
-
-  const chrome = cn(
+  const wrapperClassName = cn(
+    "relative z-[1]",
+    actionsWidthClassName[stackAt],
     stackedChrome[stackAt],
     stackAt !== "never" && compact && "mt-3 pt-3"
   )
 
+  const wrap = (group: React.ReactNode) => (
+    // Keep action clicks from bubbling to the row's onClick / overlay link.
+    <div className={wrapperClassName} onClick={(e) => e.stopPropagation()}>
+      {group}
+    </div>
+  )
+
   // Confirm/reject variant: icon-only outline buttons, reject (✗) then confirm (✓).
   if (confirmAction || rejectAction) {
-    return (
-      <div
-        className={cn(
-          "relative z-[1] flex flex-row items-center justify-end gap-2",
-          chrome
-        )}
-      >
-        {rejectAction && (
-          <F0Button
-            icon={Cross}
-            label={rejectAction.label ?? "Reject"}
-            hideLabel
-            variant="outline"
-            size={size}
-            disabled={rejectAction.disabled}
-            onClick={(e) => {
-              e.stopPropagation()
-              rejectAction.onClick()
-            }}
-            data-testid="reject-button"
-          />
-        )}
-        {confirmAction && (
-          <F0Button
-            icon={Check}
-            label={confirmAction.label ?? "Confirm"}
-            hideLabel
-            variant="outline"
-            size={size}
-            disabled={confirmAction.disabled}
-            onClick={(e) => {
-              e.stopPropagation()
-              confirmAction.onClick()
-            }}
-            data-testid="confirm-button"
-          />
-        )}
-      </div>
+    const variantActions: ButtonGroupButton[] = []
+    if (rejectAction) {
+      variantActions.push({
+        id: "reject",
+        icon: Cross,
+        label: rejectAction.label ?? "Reject",
+        hideLabel: true,
+        disabled: rejectAction.disabled,
+        onClick: rejectAction.onClick,
+      })
+    }
+    if (confirmAction) {
+      variantActions.push({
+        id: "confirm",
+        icon: Check,
+        label: confirmAction.label ?? "Confirm",
+        hideLabel: true,
+        disabled: confirmAction.disabled,
+        onClick: confirmAction.onClick,
+      })
+    }
+    return wrap(
+      <ButtonGroup secondaryActions={variantActions} size={size} gap={GAP} />
     )
   }
 
-  const secondaryLink =
-    secondaryActions && !Array.isArray(secondaryActions)
-      ? secondaryActions
+  const secondaryItems:
+    | ButtonGroupSecondaryItem[]
+    | ButtonGroupSecondaryLink
+    | undefined = Array.isArray(secondaryActions)
+    ? secondaryActions.map(
+        (action, index): ButtonGroupButton => ({
+          id: `secondary-${index}`,
+          label: action.label,
+          icon: action.icon,
+          onClick: action.onClick,
+        })
+      )
+    : secondaryActions
+      ? {
+          label: secondaryActions.label,
+          // `CardSecondaryLink.href` is loosely typed as optional; a link always
+          // carries one in practice, so pass it through unchanged.
+          href: secondaryActions.href as string,
+          target: secondaryActions.target,
+          disabled: secondaryActions.disabled,
+        }
       : undefined
-  const other = otherActions ?? []
 
-  // Before the first measurement, optimistically show everything so the row
-  // doesn't flash empty; the measured split takes over once initialized.
-  const shown = isInitialized ? visibleItems : secondaryArray
-  const overflowed = isInitialized ? overflowItems : []
-
-  const toDropdownItem = (action: CardSecondaryAction): DropdownItem => ({
-    label: action.label,
-    icon: action.icon,
-    onClick: action.onClick,
-  })
-
-  // Narrow ⋯ menu = collapsed secondaries, then the always-present otherActions,
-  // divided by a separator when both are present.
-  const narrowMenu: DropdownItem[] = [
-    ...overflowed.map(toDropdownItem),
-    ...(overflowed.length > 0 && other.length > 0
-      ? [{ type: "separator" } as DropdownItem]
-      : []),
-    ...other,
-  ]
+  const primary: ButtonGroupButton | undefined = primaryAction
+    ? {
+        id: "primary",
+        label: primaryAction.label,
+        icon: primaryAction.icon,
+        onClick: primaryAction.onClick,
+      }
+    : undefined
 
   const hasAnyAction =
-    primaryAction ||
-    secondaryArray.length > 0 ||
-    !!secondaryLink ||
-    other.length > 0
+    !!primary ||
+    (Array.isArray(secondaryActions)
+      ? secondaryActions.length > 0
+      : !!secondaryActions) ||
+    (otherActions?.length ?? 0) > 0
 
   if (!hasAnyAction) {
     return null
   }
 
-  const renderSecondary = (action: CardSecondaryAction, index: number) => (
-    <F0Button
-      key={index}
-      label={action.label}
-      icon={action.icon}
-      variant="outline"
+  return wrap(
+    <ButtonGroup
+      primaryAction={primary}
+      secondaryActions={secondaryItems}
+      otherActions={otherActions}
       size={size}
-      onClick={(e) => {
-        e.stopPropagation()
-        action.onClick()
-      }}
+      gap={GAP}
     />
-  )
-
-  const more = (items: DropdownItem[], ref?: Ref<HTMLDivElement>) =>
-    items.length > 0 ? (
-      <div ref={ref} onClick={(e) => e.stopPropagation()}>
-        <Dropdown items={items} size={size} />
-      </div>
-    ) : null
-
-  const link = secondaryLink ? (
-    <F0Link
-      href={secondaryLink.href}
-      target={secondaryLink.target}
-      disabled={secondaryLink.disabled}
-      onClick={(e) => e.stopPropagation()}
-      data-testid="secondary-link"
-    >
-      {secondaryLink.label}
-    </F0Link>
-  ) : null
-
-  const primary = primaryAction ? (
-    <F0Button
-      label={primaryAction.label}
-      icon={primaryAction.icon}
-      size={size}
-      onClick={(e) => {
-        e.stopPropagation()
-        primaryAction.onClick()
-      }}
-      data-testid="primary-button"
-    />
-  ) : null
-
-  return (
-    <>
-      {/* Wide (inline): all secondary buttons shown, ⋯ = otherActions. */}
-      <div
-        className={cn(
-          "relative z-[1] flex-row items-center justify-end gap-2",
-          wideClusterVisibility[stackAt]
-        )}
-      >
-        {more(other)}
-        {secondaryArray.map(renderSecondary)}
-        {link}
-        {primary}
-      </div>
-
-      {/* Narrow: own full-width line; measured left-overflow. Only rendered when
-          a breakpoint is set — with `never` the inline cluster above is enough,
-          and we avoid a hidden measurement subtree + its ResizeObserver. */}
-      {stackAt !== "never" && (
-        <div
-          className={cn(
-            "relative z-[1] flex-row items-center justify-end gap-2",
-            narrowClusterVisibility[stackAt],
-            chrome
-          )}
-        >
-          <div
-            ref={containerRef}
-            className="relative flex min-w-0 flex-1 items-center justify-end"
-            style={{ gap: GAP }}
-          >
-            {/* Hidden measurement copy of every secondary button. */}
-            <div
-              ref={measurementContainerRef}
-              aria-hidden="true"
-              className="pointer-events-none invisible absolute left-0 top-0 flex items-center whitespace-nowrap"
-              style={{ gap: GAP }}
-            >
-              {secondaryArray.map(renderSecondary)}
-            </div>
-
-            {more(narrowMenu, customOverflowIndicatorRef)}
-            {shown.map(renderSecondary)}
-          </div>
-
-          {link}
-          {primary}
-        </div>
-      )}
-    </>
   )
 }

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -1,9 +1,5 @@
 import { F0Icon, type IconType } from "@/components/F0Icon"
-import {
-  F0TagStatus,
-  type StatusVariant,
-  type TagStatusProps,
-} from "@/components/tags/F0TagStatus"
+import { type StatusVariant } from "@/components/tags/F0TagStatus"
 import { type DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { Check, Cross } from "@/icons/app"
 import { cn } from "@/lib/utils"
@@ -100,21 +96,18 @@ export interface CardRowConfirmAction {
   disabled?: boolean
 }
 
-/** Resolved-state indicator at the trailing edge: a coloured icon. */
-export interface CardRowStatusIcon {
+/**
+ * Resolved state shown at the trailing edge in place of the actions: a coloured
+ * icon (e.g. `Check` for accepted, `Cross` for rejected) carrying the outcome.
+ */
+export interface CardRowStatus {
   /** The icon to render (e.g. `Check` for accepted, `Cross` for rejected). */
   icon: IconType
-  /** Colour family — same variants as the status tag. */
+  /** Colour family. */
   variant: StatusVariant
   /** Accessible label; the icon carries meaning, so this is required. */
   label: string
 }
-
-/**
- * Resolved state shown in place of the actions: either a {@link F0TagStatus}
- * pill ({@link TagStatusProps}) or a {@link CardRowStatusIcon} coloured icon.
- */
-export type CardRowStatus = TagStatusProps | CardRowStatusIcon
 
 // Status variant → F0Icon colour token (no "neutral" icon colour; map to secondary).
 const statusIconColor: Record<
@@ -128,9 +121,6 @@ const statusIconColor: Record<
   critical: "critical",
 }
 
-const isStatusIcon = (status: CardRowStatus): status is CardRowStatusIcon =>
-  "icon" in status
-
 interface CardRowActionsProps {
   primaryAction?: CardPrimaryAction
   secondaryActions?: CardSecondaryAction[] | CardSecondaryLink
@@ -141,9 +131,9 @@ interface CardRowActionsProps {
   /** Reject (✗) icon-only action — enables the confirm/reject variant. */
   rejectAction?: CardRowConfirmAction
   /**
-   * Resolved-state indicator shown at the trailing edge in place of any actions
-   * (e.g. the "Accepted" / "Rejected" outcome of a confirm/reject row) — a
-   * status tag or a coloured icon. Takes precedence over every action prop.
+   * Resolved-state icon shown at the trailing edge in place of any actions
+   * (e.g. the "Accepted" / "Rejected" outcome of a confirm/reject row).
+   * Takes precedence over every action prop.
    */
   status?: CardRowStatus
   compact?: boolean
@@ -193,17 +183,13 @@ export function CardRowActions({
           stackAt !== "never" && compact && "mt-3 pt-3"
         )}
       >
-        {isStatusIcon(status) ? (
-          <F0Icon
-            icon={status.icon}
-            color={statusIconColor[status.variant]}
-            size="lg"
-            role="img"
-            aria-label={status.label}
-          />
-        ) : (
-          <F0TagStatus {...status} />
-        )}
+        <F0Icon
+          icon={status.icon}
+          color={statusIconColor[status.variant]}
+          size="lg"
+          role="img"
+          aria-label={status.label}
+        />
       </div>
     )
   }

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -58,6 +58,24 @@ const actionsWidthClassName: Record<CardRowStackAt, string> = {
   never: "min-w-0 flex-1",
 }
 
+// Visibility of the icon-only inline cluster — shown at/above the breakpoint
+// (and always, for `never`). Pairs with `stackedClusterVisibility` below; only
+// the confirm/reject variant renders both, to swap icon-only ↔ labelled on stack.
+const inlineClusterVisibility: Record<CardRowStackAt, string> = {
+  sm: "hidden @xs:flex",
+  md: "hidden @md:flex",
+  lg: "hidden @lg:flex",
+  never: "flex",
+}
+
+// Visibility of the labelled stacked cluster — shown only below the breakpoint.
+const stackedClusterVisibility: Record<CardRowStackAt, string> = {
+  sm: "flex @xs:hidden",
+  md: "flex @md:hidden",
+  lg: "flex @lg:hidden",
+  never: "hidden",
+}
+
 // Footer-style separator shown while the actions sit on their own stacked line;
 // removed once they go inline at the breakpoint.
 const stackedChrome: Record<CardRowStackAt, string> = {
@@ -101,8 +119,10 @@ interface CardRowActionsProps {
  *   hairline) below a container breakpoint; the breakpoint mapping is shared
  *   with the row root via {@link cardRowClassName}.
  *
- * Pass `confirmAction` / `rejectAction` for the icon-only confirm/reject variant
- * (✗ then ✓), which replaces the standard actions.
+ * Pass `confirmAction` / `rejectAction` for the confirm/reject variant — reject
+ * (✗, outline) then confirm (✓, solid primary), which replaces the standard
+ * actions. Icon-only while inline; the buttons reveal their labels once the row
+ * stacks onto its own line.
  */
 export function CardRowActions({
   primaryAction,
@@ -129,31 +149,78 @@ export function CardRowActions({
     </div>
   )
 
-  // Confirm/reject variant: icon-only outline buttons, reject (✗) then confirm (✓).
+  // Confirm/reject variant: reject (✗, outline) then confirm (✓, solid primary).
+  // Icon-only while inline; once the row stacks, the buttons drop onto their own
+  // line and reveal their labels. `hideLabel` is a static per-button prop and the
+  // stack is a container query (invisible to ButtonGroup), so we render both
+  // clusters and toggle them with CSS — mirroring the row root's breakpoint.
   if (confirmAction || rejectAction) {
-    const variantActions: ButtonGroupButton[] = []
-    if (rejectAction) {
-      variantActions.push({
-        id: "reject",
-        icon: Cross,
-        label: rejectAction.label ?? "Reject",
-        hideLabel: true,
-        disabled: rejectAction.disabled,
-        onClick: rejectAction.onClick,
-      })
+    const variant = (hideLabel: boolean) => {
+      const reject: ButtonGroupButton | undefined = rejectAction
+        ? {
+            id: "reject",
+            icon: Cross,
+            label: rejectAction.label ?? "Cancel",
+            hideLabel,
+            disabled: rejectAction.disabled,
+            onClick: rejectAction.onClick,
+          }
+        : undefined
+      const confirm: ButtonGroupButton | undefined = confirmAction
+        ? {
+            id: "confirm",
+            icon: Check,
+            label: confirmAction.label ?? "Confirm",
+            hideLabel,
+            disabled: confirmAction.disabled,
+            onClick: confirmAction.onClick,
+          }
+        : undefined
+      return (
+        <ButtonGroup
+          primaryAction={confirm}
+          secondaryActions={reject ? [reject] : undefined}
+          size={size}
+          gap={GAP}
+        />
+      )
     }
-    if (confirmAction) {
-      variantActions.push({
-        id: "confirm",
-        icon: Check,
-        label: confirmAction.label ?? "Confirm",
-        hideLabel: true,
-        disabled: confirmAction.disabled,
-        onClick: confirmAction.onClick,
-      })
+
+    const inline = (
+      // Icon-only, inline at the trailing edge.
+      <div
+        className={cn(
+          "relative z-[1] min-w-0 flex-1",
+          inlineClusterVisibility[stackAt]
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {variant(true)}
+      </div>
+    )
+
+    // `never` never stacks, so the labelled cluster (and its duplicate
+    // ButtonGroup) is skipped entirely.
+    if (stackAt === "never") {
+      return inline
     }
-    return wrap(
-      <ButtonGroup secondaryActions={variantActions} size={size} gap={GAP} />
+
+    return (
+      <>
+        {inline}
+        {/* Labelled, on its own full-width line below the breakpoint. */}
+        <div
+          className={cn(
+            "relative z-[1] w-full",
+            stackedClusterVisibility[stackAt],
+            stackedChrome[stackAt],
+            compact && "mt-3 pt-3"
+          )}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {variant(false)}
+        </div>
+      </>
     )
   }
 

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -47,14 +47,16 @@ export const cardRowClassName: Record<CardRowStackAt, string> = {
  * top of its content, so a shrink-to-fit container would always shed the tail
  * into the menu — it needs a bound *wider* than its content. Inline (at/above
  * the breakpoint) we hand it the remaining row space via `flex-1`, with its own
- * `justify-end` keeping the buttons at the trailing edge; once stacked it spans
- * the full line instead (no `flex-1`, which would grow it vertically in the
- * column). `never` is always inline.
+ * `justify-end` keeping the buttons at the trailing edge. Once stacked we leave
+ * it `auto`: the flex column stretches it to full width, and crucially that lets
+ * the `-mx-4` full-bleed footer extend symmetrically — an explicit `w-full`
+ * would clip the right edge, since a negative right margin can't widen a
+ * fixed-width box. `never` is always inline.
  */
 const actionsWidthClassName: Record<CardRowStackAt, string> = {
-  sm: "w-full @xs:w-auto @xs:min-w-0 @xs:flex-1",
-  md: "w-full @md:w-auto @md:min-w-0 @md:flex-1",
-  lg: "w-full @lg:w-auto @lg:min-w-0 @lg:flex-1",
+  sm: "@xs:min-w-0 @xs:flex-1",
+  md: "@md:min-w-0 @md:flex-1",
+  lg: "@lg:min-w-0 @lg:flex-1",
   never: "min-w-0 flex-1",
 }
 
@@ -208,10 +210,11 @@ export function CardRowActions({
     return (
       <>
         {inline}
-        {/* Labelled, on its own full-width line below the breakpoint. */}
+        {/* Labelled, on its own line below the breakpoint. Width left to the
+            flex column's stretch so the `-mx-4` footer bleeds symmetrically. */}
         <div
           className={cn(
-            "relative z-[1] w-full",
+            "relative z-[1]",
             stackedClusterVisibility[stackAt],
             stackedChrome[stackAt],
             compact && "mt-3 pt-3"

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -160,7 +160,7 @@ export function CardRowActions({
         ? {
             id: "reject",
             icon: Cross,
-            label: rejectAction.label ?? "Cancel",
+            label: rejectAction.label ?? "Reject",
             hideLabel,
             disabled: rejectAction.disabled,
             onClick: rejectAction.onClick,

--- a/packages/react/src/components/F0Card/index.tsx
+++ b/packages/react/src/components/F0Card/index.tsx
@@ -1,1 +1,2 @@
 export * from "./F0Card"
+export * from "./F0CardRow"


### PR DESCRIPTION
## What

Adds **`F0CardRow`** — the horizontal, row-shaped counterpart to `F0Card`:

- Optional **avatar** on the left (any avatar type: person, company, team, file, flag, icon, emoji, module, alert, date, pulse), rendered at a fixed `lg` size.
- **Title** + optional **description** (wraps across lines when long).
- Trailing **actions**: `primaryAction`, `secondaryActions`, `otherActions` (⋯ overflow menu), or an icon-only **confirm/reject** variant.
- Optional **alert** banner.
- **`stackAt`** container breakpoint (`sm`/`md`/`lg`/`never`, default `never`): below it the actions drop onto their own full-width line (with a footer hairline) and secondary buttons fold into the ⋯ menu; the primary stays pinned.

Includes a unit test suite and autodocs (description + use cases + stories).

## Notes

- **Built on `ButtonGroup` (#4339, now merged).** `CardRowActions` is a thin adapter over `ButtonGroup`: the `primaryAction` / `secondaryActions` / `otherActions` triplet maps straight through, and `ButtonGroup` owns the row layout, the width-driven ⋯ overflow, and pinning the primary at the trailing edge. The card layers on only its own concerns:
  - stops click propagation so an action never triggers the row's `onClick` / overlay-link navigation;
  - the stacked own-line **footer hairline** at the container breakpoint (`stackAt`, a container query — reacts to the card's own width, not the viewport);
  - the icon-only **confirm/reject** (✗ / ✓) variant, mapped to two pinned secondaries.
- The actions wrapper takes the remaining row space (`flex-1`) so `ButtonGroup` has a bound wider than its content to measure against — a shrink-to-fit container would shed its tail into the ⋯ menu.
- The `F0HILActionConfirmation` migration to `F0CardRow` and the removal of the experimental `F0Card` `oneLiner` variant stay with the cocreation PR (#4307), since both originate there. Once this lands, that PR (or a follow-up) can point F0HIL at `F0CardRow` and drop `oneLiner`.

## Verification

Type-check and the F0Card unit suite (45 tests) pass against the merged `ButtonGroup`. Driven through Storybook across the row patterns — inline (primary + ⋯ + secondary), confirm/reject, stacked own-line + footer, and genuine width-overflow (a secondary sheds into ⋯ while the primary stays pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
