### PR TITLE
fix(ResourceHeader): make showBottomBorder render bottom-only without Tailwind preflight

### DIFF
--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -123,7 +123,10 @@ export function BaseHeader({
     <div
       className={cn(
         "resource-header px-page flex flex-col gap-3 pb-5 pt-3",
-        showBottomBorder && "border-b border-solid border-f1-border"
+        // `border-0` zeroes all sides first so this renders bottom-only even in apps that
+        // don't load the Tailwind preflight border reset (otherwise `border-solid` would
+        // light up all four sides at the CSS-initial `medium` width).
+        showBottomBorder && "border-0 border-b border-solid border-f1-border"
       )}
     >
       <div


### PR DESCRIPTION
## Description

`ResourceHeader`'s `showBottomBorder` (added in #4274) renders a **full box border** instead of a bottom-only divider in apps that load f0's compiled CSS **without the Tailwind preflight** border reset.

## Root cause

The class string was:

```
showBottomBorder && "border-b border-solid border-f1-border"
```

- `border-solid` sets `border-style: solid` on **all four** sides.
- `border-b` sets only the **bottom** width to `1px`.
- The other three sides have no explicit width. With Tailwind preflight (`*{border-width:0}`) they stay at `0` → bottom-only. **Without** preflight they fall back to the CSS-initial `medium` (~3px) and, now that their style is `solid`, they render → **full box**.

Factorial's main app loads f0's compiled CSS standalone (no preflight base layer), so it hit this.

## Fix

Prepend `border-0` to zero all sides first, then re-enable the bottom:

```
showBottomBorder && "border-0 border-b border-solid border-f1-border"
```

This is preflight-independent — bottom-only in either environment.

## Validation

- `tsc` + `oxlint` clean; `oxfmt` applied.
- Verified via a static render against f0's compiled `styles.css`: the old classes produce a full box; `border-0 border-b …` produces a single bottom line.

Found while adopting `showBottomBorder` in the Factorial monorepo (factorialco/factorial#100997).

🤖 Generated with [Claude Code](https://claude.com/claude-code)