### PR TITLE
fix(datacollection): prevent stuck kanban loading on view-restore bounce

### DIFF
--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -781,8 +781,10 @@ export function useData<
   useEffect(() => {
     return () => {
       cleanup.current?.()
+      // Reset on unmount so a fetch canceled mid-flight can't leave the shared source's isLoading stuck true.
+      setIsLoading(false)
     }
-  }, [])
+  }, [setIsLoading])
 
   const total = totalItems ? totalItems - filteredItemsCount : 0
 

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -211,6 +211,9 @@ export type OneDataCollectionProps<
    * - `false` or `undefined` disables the export action (default)
    */
   csvExport?: boolean | { filename?: string }
+
+  /** Visualization index rendered on mount, before async storage/URL restore — lets a consumer boot straight into the persisted view and skip the default→restore bounce. Defaults to 0. */
+  initialVisualization?: number
 }
 
 const OneDataCollectionComp = <
@@ -236,6 +239,7 @@ const OneDataCollectionComp = <
   disableUrlParams,
   tmpFullWidth,
   csvExport,
+  initialVisualization = 0,
 }: OneDataCollectionProps<
   R,
   Filters,
@@ -276,7 +280,8 @@ const OneDataCollectionComp = <
     sortings,
   } = source
 
-  const [currentVisualization, setCurrentVisualization] = useState(0)
+  const [currentVisualization, setCurrentVisualization] =
+    useState(initialVisualization)
 
   const {
     effectiveFilters,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -215,7 +215,7 @@ export const KanbanCollection = <
           variant: l.variant,
           total: totalItems,
           hasMore,
-          loading: laneData?.isLoading || false,
+          loading: laneData?.isLoading ?? true,
           loadingMore: laneData?.isLoadingMore || false,
           fetchMore: hasMore ? () => laneData.loadMore() : undefined,
         }

--- a/packages/react/src/ui/Kanban/Kanban.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.tsx
@@ -18,7 +18,7 @@ import { KanbanLane } from "./components/KanbanLane.tsx"
 export function Kanban<TRecord extends RecordType>(
   props: KanbanProps<TRecord>
 ): JSX.Element {
-  const { lanes, renderCard, getKey, className, dnd, loading, onCreate } = props
+  const { lanes, renderCard, getKey, className, dnd, onCreate } = props
 
   // Local source-of-truth for lanes to orchestrate moves centrally
   const [localLanes, setLocalLanes] = useState(
@@ -323,7 +323,7 @@ export function Kanban<TRecord extends RecordType>(
                       return node
                     }}
                     emptyState={lane.emptyState}
-                    loading={loading || lane.loading}
+                    loading={lane.loading}
                     variant={lane.variant}
                     total={total}
                     hasMore={lane.hasMore}


### PR DESCRIPTION
## Changes
- **`useData`** — reset the loading flag on unmount cleanup. A visualization that unmounts mid-fetch (e.g. during a view-restore) previously left `isLoading` stuck `true` on the shared source → permanent spinner.
- **`OneDataCollection`** — add optional `initialVisualization` prop (defaults to `0`). Lets a consumer that knows the persisted visualization synchronously boot straight into it, avoiding the default→restore "bounce" that remounts the active visualization and, for kanban, refetches every lane.
- **Kanban** — each lane's spinner now reflects its own loading state instead of `loading || lane.loading` (the board aggregate), so one slow/stuck lane no longer keeps every lane spinning.

## Why
On the ATS applications kanban, booting into table (index 0) then async-restoring kanban canceled the table query (stranding `source.isLoading = true` → permanent header spinner) and remounted every lane (double fetch). The aggregate lane spinner then held all lanes spinning until the last one settled.