### PR TITLE
feat(OneTable): add onHeaderClick to table column headers

### DIFF
--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -47,6 +47,13 @@ interface TableHeadProps {
   onSortClick?: () => void
 
   /**
+   * Callback fired when the header label is clicked. Independent of sorting —
+   * when provided, the header label becomes an interactive button. Use this to
+   * trigger actions such as opening a side panel for the column.
+   */
+  onHeaderClick?: () => void
+
+  /**
    * Optional tooltip text. When provided, displays an info icon next to the header content
    * that shows this text in a tooltip when hovered.
    */
@@ -87,6 +94,7 @@ export function TableHead({
   minWidth,
   sortState = "none",
   onSortClick,
+  onHeaderClick,
   info,
   infoIcon = InfoCircleLine,
   sticky,
@@ -105,6 +113,17 @@ export function TableHead({
 
   const hasContent = onSortClick || info
 
+  const label =
+    typeof children === "string" ? (
+      <OneEllipsis className={cn(width !== "auto" && "overflow-hidden")}>
+        {children}
+      </OneEllipsis>
+    ) : (
+      <div className={cn("truncate", width !== "auto" && "overflow-hidden")}>
+        {children}
+      </div>
+    )
+
   const content = (
     <>
       <div
@@ -114,16 +133,19 @@ export function TableHead({
           align === "right" && "flex-row-reverse"
         )}
       >
-        {typeof children === "string" ? (
-          <OneEllipsis className={cn(width !== "auto" && "overflow-hidden")}>
-            {children}
-          </OneEllipsis>
-        ) : (
-          <div
-            className={cn("truncate", width !== "auto" && "overflow-hidden")}
+        {onHeaderClick ? (
+          <button
+            type="button"
+            onClick={onHeaderClick}
+            className={cn(
+              "flex min-w-0 items-center rounded-xs text-left transition-colors hover:text-f1-foreground-secondary",
+              focusRing()
+            )}
           >
-            {children}
-          </div>
+            {label}
+          </button>
+        ) : (
+          label
         )}
         {hasContent && (
           <div className="flex items-center">

--- a/packages/react/src/experimental/OneTable/index.stories.tsx
+++ b/packages/react/src/experimental/OneTable/index.stories.tsx
@@ -328,6 +328,49 @@ export const Sortable: Story = {
   },
 }
 
+export const ClickableHeader: Story = {
+  render: () => {
+    const [lastClicked, setLastClicked] = useState<string | null>(null)
+
+    return (
+      <div className="flex flex-col gap-4">
+        <span className="text-f1-foreground-secondary">
+          {lastClicked
+            ? `Last header clicked: ${lastClicked}`
+            : "Click a column header to trigger its action (e.g. open a side panel)."}
+        </span>
+        <OneTable>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead onHeaderClick={() => setLastClicked("Email")}>
+                Email
+              </TableHead>
+              {/* onHeaderClick works independently of sorting and can coexist with it */}
+              <TableHead
+                onHeaderClick={() => setLastClicked("Role")}
+                onSortClick={() => setLastClicked("Role (sorted)")}
+                sortState="asc"
+              >
+                Role
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sampleData.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell>{row.name}</TableCell>
+                <TableCell>{row.email}</TableCell>
+                <TableCell>{row.role}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </OneTable>
+      </div>
+    )
+  },
+}
+
 export const StickyColumn: Story = {
   render: () => (
     <OneTable>

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -670,3 +670,78 @@ export const BorderedTable: Story = {
     )
   },
 }
+
+export const TableWithClickableHeaders: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Columns can define an `onHeaderClick` callback that turns the column header label into an interactive button. " +
+          "This is useful for opening a side panel scoped to the clicked column (e.g. a month/period column). " +
+          "It works independently of sorting.",
+      },
+    },
+  },
+  render: () => {
+    const records = [
+      { id: 1, name: "Alice Johnson", jan: "1.200 €", feb: "1.350 €" },
+      { id: 2, name: "Bob Smith", jan: "980 €", feb: "1.020 €" },
+      { id: 3, name: "Carol Lee", jan: "1.450 €", feb: "1.500 €" },
+    ]
+
+    const source = useDataCollectionSource({
+      dataAdapter: {
+        fetchData: async () => ({ records }),
+      },
+    })
+
+    const [lastClicked, setLastClicked] = useState<string | null>(null)
+
+    return (
+      <div className="flex flex-col gap-4">
+        <span className="text-f1-foreground-secondary">
+          {lastClicked
+            ? `Opened panel for: ${lastClicked}`
+            : "Click a month header to open its (mock) side panel."}
+        </span>
+        <OneDataCollection
+          source={source}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                columns: [
+                  {
+                    label: "Name",
+                    render: (item) => ({
+                      type: "person" as const,
+                      value: {
+                        firstName: item.name.split(" ")[0],
+                        lastName: item.name.split(" ")[1],
+                      },
+                    }),
+                    id: "name",
+                  },
+                  {
+                    label: "January",
+                    align: "right",
+                    render: (item) => item.jan,
+                    id: "jan",
+                    onHeaderClick: () => setLastClicked("January"),
+                  },
+                  {
+                    label: "February",
+                    align: "right",
+                    render: (item) => item.feb,
+                    id: "feb",
+                    onHeaderClick: () => setLastClicked("February"),
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      </div>
+    )
+  },
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -931,6 +931,144 @@ describe("TableCollection", () => {
     })
   })
 
+  describe("header click", () => {
+    it("renders the header label as a button and calls onHeaderClick when clicked", async () => {
+      const user = userEvent.setup()
+      const onHeaderClick = vi.fn()
+
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={[
+            {
+              label: "name",
+              render: (item: Person) => item.name,
+              onHeaderClick,
+            },
+            { label: "email", render: (item: Person) => item.email },
+          ]}
+          source={createTestSource()}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      const headers = screen.getAllByRole("columnheader")
+      const nameHeader = headers.find((h) => h.textContent?.includes("name"))!
+      const headerButton = within(nameHeader).getByRole("button", {
+        name: "name",
+      })
+
+      await user.click(headerButton)
+
+      expect(onHeaderClick).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not render the header label as a button when onHeaderClick is not provided", async () => {
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={testColumns}
+          source={createTestSource()}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      const headers = screen.getAllByRole("columnheader")
+      const nameHeader = headers.find((h) => h.textContent?.includes("name"))!
+
+      expect(within(nameHeader).queryByRole("button")).not.toBeInTheDocument()
+    })
+
+    it("supports onHeaderClick independently of sorting on the same column", async () => {
+      const user = userEvent.setup()
+      const onHeaderClick = vi.fn()
+      const setCurrentSortingsMock = vi.fn()
+
+      const modifiedSource = {
+        ...createTestSource(),
+        currentSortings: null,
+        setCurrentSortings: setCurrentSortingsMock,
+        sortings: {
+          name: { label: "Name" },
+        },
+      }
+
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={[
+            {
+              label: "name",
+              render: (item: Person) => item.name,
+              sorting: "name" as const,
+              onHeaderClick,
+            },
+            { label: "email", render: (item: Person) => item.email },
+          ]}
+          source={modifiedSource}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      const nameHeader = screen.getAllByRole("columnheader")[0]
+
+      // Clicking the label button triggers onHeaderClick, not sorting
+      const labelButton = within(nameHeader).getByRole("button", {
+        name: "name",
+      })
+      await user.click(labelButton)
+      expect(onHeaderClick).toHaveBeenCalledTimes(1)
+      expect(setCurrentSortingsMock).not.toHaveBeenCalled()
+
+      // Clicking the separate sort button triggers sorting, not onHeaderClick
+      const sortButton = within(nameHeader).getByRole("button", {
+        name: "Sort",
+      })
+      await user.click(sortButton)
+      expect(setCurrentSortingsMock).toHaveBeenCalled()
+      expect(onHeaderClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe("column visibility", () => {
     it("hides columns with hidden: true on first render", async () => {
       const columnsWithHidden = [

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -53,7 +53,13 @@ export type TableColumnDefinition<
 > = WithOptionalSorting<R, Sortings> &
   Pick<
     ComponentProps<typeof TableHead>,
-    "hidden" | "info" | "infoIcon" | "sticky" | "width" | "minWidth"
+    | "hidden"
+    | "info"
+    | "infoIcon"
+    | "sticky"
+    | "width"
+    | "minWidth"
+    | "onHeaderClick"
   > & {
     /**
      * Optional summary configuration for this column


### PR DESCRIPTION
## What

Adds an optional `onHeaderClick` callback to `TableHead` and to the OneDataCollection **table column definition**. When provided, the column header label becomes an interactive button.

Key points:
- **Independent of sorting** — `onHeaderClick` and `onSortClick` can coexist on the same header (the sort button remains separate).
- The column-level prop is exposed via the existing `Pick<ComponentProps<typeof TableHead>, …>` in the table column type, so it flows through the existing `{...column}` spread in `Table.tsx` with no render changes.

## Why

Consumers need to trigger an action scoped to a clicked column header — e.g. the Financial Workspace **employee-cost** table opens a workforce/headcount side panel when a month header is clicked. The legacy table supported this via a per-header `onClick`; the OneDataCollection table had no equivalent, so the behavior was lost in the migration. This restores that capability at the design-system level.

## Changes

- `experimental/OneTable/TableHead/index.tsx` — new `onHeaderClick?` prop; label renders as a focusable button when set.
- `patterns/OneDataCollection/visualizations/collection/Table/types.ts` — expose `onHeaderClick` on the column definition.
- Stories:
  - `OneTable` → `ClickableHeader` (incl. coexistence with sorting).
  - OneDataCollection Table → `TableWithClickableHeaders` (column-level API).

## Follow-up (downstream)

Once released, bump `@factorialco/f0-react` in the `factorial` monolith and wire `onHeaderClick` into the Financial Workspace `DataCollectionTable` (separate PR).