### PR TITLE
feat(F0Box): expose subtle "sm" boxShadow token

### DIFF
--- a/packages/react/src/lib/F0Box/__stories__/F0Box.stories.tsx
+++ b/packages/react/src/lib/F0Box/__stories__/F0Box.stories.tsx
@@ -289,7 +289,7 @@ const meta = {
     // Shadow
     boxShadow: {
       control: "select",
-      options: [undefined, "none", "md", "lg", "xl"],
+      options: [undefined, "none", "sm", "md", "lg", "xl"],
     },
     // Divider
     divider: { control: "select", options: [undefined, "x", "y"] },
@@ -2766,7 +2766,7 @@ export const Shadow: Story = {
       </Label>
 
       <F0Box display="flex" gap="xl" flexWrap="wrap" alignItems="end">
-        {(["none", "md", "lg", "xl"] as const).map((s) => (
+        {(["none", "sm", "md", "lg", "xl"] as const).map((s) => (
           <F0Box
             key={s}
             width="32"

--- a/packages/react/src/lib/F0Box/types.ts
+++ b/packages/react/src/lib/F0Box/types.ts
@@ -304,4 +304,4 @@ export type ZIndexToken = "auto" | "0" | "10" | "20" | "30" | "40" | "50"
 /** Border style */
 export type BorderStyleToken = "solid" | "dashed" | "dotted" | "double" | "none"
 
-export type BoxShadowToken = "none" | "md" | "lg" | "xl"
+export type BoxShadowToken = "none" | "sm" | "md" | "lg" | "xl"

--- a/packages/react/src/lib/F0Box/utils/shadow.ts
+++ b/packages/react/src/lib/F0Box/utils/shadow.ts
@@ -3,6 +3,7 @@ import type { BoxShadowToken } from "../types"
 export const shadowVariants = {
   boxShadow: {
     none: "shadow-none",
+    sm: "shadow",
     md: "shadow-md",
     lg: "shadow-lg",
     xl: "shadow-xl",


### PR DESCRIPTION
## Changes
- `BoxShadowToken`: add `"sm"`
- `utils/shadow.ts`: map `sm` → the existing `shadow` (DEFAULT) class — **no new shadow value**, just exposes what's already in the theme
- F0Box `Shadow` Storybook story + `boxShadow` control updated to include `sm`

`sm` surfaces the already-defined DEFAULT elevation
(`0 2px 20px 0 hsl(var(--shadow) / 0.04)`), a step lighter than `md`.
Additive only — `none/md/lg/xl` behave exactly as before, so no existing
F0Box usage is affected.

Motivation: the ATS hiring pipeline boxes want a subtler elevation than `md`,
but there's currently no token between `md` and `none`.