### PR TITLE
fix(react): smooth F0ClarifyingPanel ↔ textarea transition

### DIFF
--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -347,17 +347,43 @@ export const F0AiChatTextArea = ({
 
             <AnimatePresence initial={false}>
               {isClarifying ? (
-                <div key="clarifying">{clarifyingUI}</div>
+                <motion.div
+                  key="clarifying"
+                  className="overflow-hidden"
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{
+                    height: 0,
+                    opacity: 0,
+                    transition: {
+                      duration: shouldReduceMotion ? 0 : 0.22,
+                      ease: [0.4, 0, 1, 1],
+                    },
+                  }}
+                  transition={{
+                    duration: shouldReduceMotion ? 0 : 0.4,
+                    ease: [0.4, 0, 0.2, 1],
+                  }}
+                >
+                  {clarifyingUI}
+                </motion.div>
               ) : (
                 <motion.div
                   key="input"
                   className="overflow-hidden"
-                  initial={{ height: "auto", opacity: 1 }}
+                  initial={{ height: 0, opacity: 0 }}
                   animate={{ height: "auto", opacity: 1 }}
-                  exit={{ height: 0, opacity: 0 }}
+                  exit={{
+                    height: 0,
+                    opacity: 0,
+                    transition: {
+                      duration: shouldReduceMotion ? 0 : 0.15,
+                      ease: [0.55, 0, 1, 0.45],
+                    },
+                  }}
                   transition={{
-                    duration: shouldReduceMotion ? 0 : 0.3,
-                    ease: "easeOut",
+                    duration: shouldReduceMotion ? 0 : 0.4,
+                    ease: [0.4, 0, 0.2, 1],
                   }}
                 >
                   {pendingQuote && (

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -217,6 +217,45 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
+// Interactive story to inspect the textarea ↔ clarifying panel transition.
+// Click "Trigger clarifying mode" to see the swap animation.
+export const TransitionDemo: Story = {
+  render: () => {
+    const ref = useRef<HTMLDivElement>(null)
+    const [clarifyingQuestion, setClarifyingQuestion] =
+      useState<ClarifyingQuestionState | null>(null)
+
+    const toggle = () => {
+      setClarifyingQuestion((prev) => (prev ? null : buildClarifyingState()))
+    }
+
+    return (
+      <div className="flex flex-col gap-4 w-[640px]">
+        <button
+          onClick={toggle}
+          className="self-start rounded border border-f1-border bg-f1-background px-3 py-1.5 text-sm font-medium text-f1-foreground hover:bg-f1-background-hover transition-colors"
+        >
+          {clarifyingQuestion
+            ? "← Volver al textarea"
+            : "Trigger clarifying mode →"}
+        </button>
+
+        <F0AiChatTextArea
+          ref={ref}
+          onSubmit={() => {}}
+          onStop={() => {}}
+          disclaimer={DISCLAIMER}
+          clarifyingUI={
+            clarifyingQuestion ? (
+              <F0ClarifyingPanel clarifyingQuestion={clarifyingQuestion} />
+            ) : undefined
+          }
+        />
+      </div>
+    )
+  },
+}
+
 export const WithRotatingPlaceholders: Story = {
   args: {
     placeholders: ROTATING_PLACEHOLDERS,

--- a/packages/react/src/sds/ai/F0ClarifyingPanel/F0ClarifyingPanel.tsx
+++ b/packages/react/src/sds/ai/F0ClarifyingPanel/F0ClarifyingPanel.tsx
@@ -25,37 +25,24 @@ interface F0ClarifyingPanelProps {
 }
 
 /**
- * Animated wrapper that mounts/unmounts the clarifying question panel.
+ * Clarifying question panel — content only, no mount animation.
  *
- * Uses Motion's native `height: "auto"` support — it measures the
- * content internally, so the same transition covers the initial
- * appearance, step changes with a different number of options, and
- * dismissal. No manual ResizeObserver.
+ * The parent slot (F0AiChatTextArea) owns the enter/exit animation so
+ * nested height animations don't conflict. Step-to-step transitions are
+ * still animated internally via F0ClarifyingPanelContent.
  *
- * Props-driven: the entire panel state (current step, navigation,
- * callbacks) lives in `clarifyingQuestion`. No coupling to `useAiChat`
- * — embedders can construct a state object themselves.
+ * When used standalone (e.g. Storybook), wrap in a motion.div with
+ * `overflow-hidden` and `height: 0 → "auto"`.
  */
 export const F0ClarifyingPanel = ({
   clarifyingQuestion,
   isSubmitDisabled,
 }: F0ClarifyingPanelProps) => {
-  const shouldReduceMotion = useReducedMotion()
-  const duration = shouldReduceMotion ? 0 : DURATION
-
   return (
-    <motion.div
-      initial={{ height: 0, opacity: 0 }}
-      animate={{ height: "auto", opacity: 1 }}
-      exit={{ height: 0, opacity: 0 }}
-      transition={{ duration, ease: EASE }}
-      className="overflow-hidden"
-    >
-      <F0ClarifyingPanelContent
-        clarifyingQuestion={clarifyingQuestion}
-        isSubmitDisabled={isSubmitDisabled}
-      />
-    </motion.div>
+    <F0ClarifyingPanelContent
+      clarifyingQuestion={clarifyingQuestion}
+      isSubmitDisabled={isSubmitDisabled}
+    />
   )
 }
 

--- a/packages/react/src/sds/ai/F0ClarifyingPanel/__stories__/F0ClarifyingPanel.stories.tsx
+++ b/packages/react/src/sds/ai/F0ClarifyingPanel/__stories__/F0ClarifyingPanel.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
+import { AnimatePresence, motion } from "motion/react"
 import { useCallback, useMemo, useState } from "react"
 
 import { F0ClarifyingPanel } from "../F0ClarifyingPanel"
@@ -240,28 +241,47 @@ const StoryShell = ({
 
   return (
     <div className="w-[360px] space-y-3">
-      <div className="rounded-lg border border-solid border-f1-border-secondary bg-f1-background">
-        {state ? (
-          <F0ClarifyingPanel
-            clarifyingQuestion={state}
-            isSubmitDisabled={isSubmitDisabled}
-          />
-        ) : (
-          <div className="flex flex-col gap-2 p-4">
-            <div className="text-sm font-medium text-f1-foreground">
-              Resolved:
-            </div>
-            <pre className="whitespace-pre-wrap text-sm text-f1-foreground-secondary">
-              {resolved.join("\n\n") || "(no responses yet)"}
-            </pre>
-            <button
-              className="self-start rounded-md border border-solid border-f1-border px-3 py-1 text-sm text-f1-foreground hover:bg-f1-background-secondary"
-              onClick={reset}
+      <div className="overflow-hidden rounded-lg border border-solid border-f1-border-secondary bg-f1-background">
+        <AnimatePresence initial={false}>
+          {state ? (
+            <motion.div
+              key="panel"
+              className="overflow-hidden"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
             >
-              Restart
-            </button>
-          </div>
-        )}
+              <F0ClarifyingPanel
+                clarifyingQuestion={state}
+                isSubmitDisabled={isSubmitDisabled}
+              />
+            </motion.div>
+          ) : (
+            <motion.div
+              key="resolved"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+            >
+              <div className="flex flex-col gap-2 p-4">
+                <div className="text-sm font-medium text-f1-foreground">
+                  Resolved:
+                </div>
+                <pre className="whitespace-pre-wrap text-sm text-f1-foreground-secondary">
+                  {resolved.join("\n\n") || "(no responses yet)"}
+                </pre>
+                <button
+                  className="self-start rounded-md border border-solid border-f1-border px-3 py-1 text-sm text-f1-foreground hover:bg-f1-background-secondary"
+                  onClick={reset}
+                >
+                  Restart
+                </button>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     </div>
   )

--- a/packages/react/src/sds/ai/F0ClarifyingPanel/components/OptionsList.tsx
+++ b/packages/react/src/sds/ai/F0ClarifyingPanel/components/OptionsList.tsx
@@ -1,4 +1,7 @@
+import { motion } from "motion/react"
 import { useEffect, useRef, useState, type Ref } from "react"
+
+import { useReducedMotion } from "@/lib/a11y"
 
 import type { ClarifyingOption, ClarifyingSelectionMode } from "../types"
 
@@ -45,6 +48,8 @@ export const OptionsList = ({
   onToggleCustomActive,
   onConfirm,
 }: OptionsListProps) => {
+  const shouldReduceMotion = useReducedMotion()
+
   // Roving tabindex: index of the currently-focused option.
   // When nothing is selected, default to the first option.
   const initialTabStop = (() => {
@@ -104,18 +109,28 @@ export const OptionsList = ({
       aria-label={question}
     >
       {options.map((option, idx) => (
-        <OptionRow
+        <motion.div
           key={option.id}
-          ref={(el) => {
-            itemRefs.current[idx] = el
+          initial={shouldReduceMotion ? false : { opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{
+            duration: shouldReduceMotion ? 0 : 0.2,
+            ease: [0.4, 0, 0.2, 1],
+            delay: shouldReduceMotion ? 0 : 0.12 + idx * 0.06,
           }}
-          option={option}
-          isSelected={selectedOptionIds.includes(option.id)}
-          mode={mode}
-          isTabStop={mode === "single" ? idx === tabStopIndex : undefined}
-          onToggle={onToggleOption}
-          onKeyNavigate={handleKeyNavigate}
-        />
+        >
+          <OptionRow
+            ref={(el) => {
+              itemRefs.current[idx] = el
+            }}
+            option={option}
+            isSelected={selectedOptionIds.includes(option.id)}
+            mode={mode}
+            isTabStop={mode === "single" ? idx === tabStopIndex : undefined}
+            onToggle={onToggleOption}
+            onKeyNavigate={handleKeyNavigate}
+          />
+        </motion.div>
       ))}
 
       {allowCustomAnswer && (


### PR DESCRIPTION
## Summary

Fixes the jump when the AI chat textarea transforms into `F0ClarifyingPanel` (clarifying questions mode) and back.

**Root cause:** `F0ClarifyingPanel` owned its own mount animation (`height: 0 → auto`) while `F0AiChatTextArea` used a plain `<div>` as the slot wrapper. With both in the DOM simultaneously (AnimatePresence sync mode), the form container height was the sum of both elements — causing an immediate jump before the animations could run. Nested `height: auto` animations also conflict in Framer Motion (child is measured at 0 when parent tries to measure).

**Changes:**

- **`F0ClarifyingPanel`** — removes outer `motion.div` animation. The component is now content-only; the parent slot owns enter/exit. Internal step-to-step fade transitions are unchanged.

- **`F0AiChatTextArea`** — the `<div key="clarifying">` slot becomes a `motion.div` with `overflow-hidden` and the correct animation. Asymmetric timing matches Claude.ai's pattern:
  - Panel **enter**: `400ms [0.4, 0, 0.2, 1]` (Material Design standard ease)
  - Panel **exit**: `220ms ease-in` — fast collapse so only the textarea has a deceleration phase
  - Textarea **enter** (return): symmetric `400ms [0.4, 0, 0.2, 1]` — cross-dissolve with the panel exit

- **`OptionsList`** — options enter with a `60ms` stagger cascade (`translateY(4px) → 0`), starting at `120ms` after the panel opens. Matches the natural cascading feel observed in Claude.ai. Respects `prefers-reduced-motion`.

- **`F0ClarifyingPanel` stories** — `StoryShell` wraps the panel in `AnimatePresence` + `motion.div` for standalone demos, since the component no longer self-animates.

## Test plan

- [ ] Open Storybook → **AI / F0AiChatTextArea / Transition Demo**
- [ ] Click "Trigger clarifying mode" — panel should expand smoothly with cascading options
- [ ] Click "← Volver al textarea" — panel should collapse quickly, textarea expands without jump
- [ ] Open **AI / F0ClarifyingPanel** — standalone enter/exit animation still works
- [ ] Verify `prefers-reduced-motion` disables all animations (OS setting or DevTools emulation)