### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.41.4",
+  "packages/react": "2.41.5",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.41.5](https://github.com/factorialco/f0/compare/f0-react-v2.41.4...f0-react-v2.41.5) (2026-06-08)
+
+
+### Bug Fixes
+
+* **F0Form:** preserve cleared optional values after submit ([#4287](https://github.com/factorialco/f0/issues/4287)) ([925990e](https://github.com/factorialco/f0/commit/925990ea1d6793d987e8bae6c0c90a6b2649a993))
+
 ## [2.41.4](https://github.com/factorialco/f0/compare/f0-react-v2.41.3...f0-react-v2.41.4) (2026-06-08)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.41.4",
+  "version": "2.41.5",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.41.5</summary>

## [2.41.5](https://github.com/factorialco/f0/compare/f0-react-v2.41.4...f0-react-v2.41.5) (2026-06-08)


### Bug Fixes

* **F0Form:** preserve cleared optional values after submit ([#4287](https://github.com/factorialco/f0/issues/4287)) ([925990e](https://github.com/factorialco/f0/commit/925990ea1d6793d987e8bae6c0c90a6b2649a993))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).