### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.42.0",
+  "packages/react": "2.43.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.43.0](https://github.com/factorialco/f0/compare/f0-react-v2.42.0...f0-react-v2.43.0) (2026-06-08)
+
+
+### Features
+
+* **EditableTable:** pass changes map to onCellChange ([#4342](https://github.com/factorialco/f0/issues/4342)) ([7d7543a](https://github.com/factorialco/f0/commit/7d7543a41ec668db8e84a5e0099e9a3a07671bac))
+
 ## [2.42.0](https://github.com/factorialco/f0/compare/f0-react-v2.41.5...f0-react-v2.42.0) (2026-06-08)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.42.0",
+  "version": "2.43.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.43.0</summary>

## [2.43.0](https://github.com/factorialco/f0/compare/f0-react-v2.42.0...f0-react-v2.43.0) (2026-06-08)


### Features

* **EditableTable:** pass changes map to onCellChange ([#4342](https://github.com/factorialco/f0/issues/4342)) ([7d7543a](https://github.com/factorialco/f0/commit/7d7543a41ec668db8e84a5e0099e9a3a07671bac))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).