### PR TITLE
feat(dialog 1/6): foundation bits for dialog-alike (additive)

### DIFF
--- a/packages/react/src/components/F0Button/F0Button.tsx
+++ b/packages/react/src/components/F0Button/F0Button.tsx
@@ -17,6 +17,7 @@ const privateProps = [
   "noTitle",
   "noAutoTooltip",
   "style",
+  "block",
 ] as const
 
 export type F0ButtonProps = Omit<

--- a/packages/react/src/components/F0Button/internal-types.ts
+++ b/packages/react/src/components/F0Button/internal-types.ts
@@ -112,6 +112,12 @@ export type ButtonInternalProps = Pick<
      * The style of the button.
      */
     style?: React.CSSProperties
+
+    /**
+     * @private
+     * If true, the button will stretch to the full width of its container.
+     */
+    block?: boolean
   } & ( // Target can only be used if href is provided
     | {
         /**

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -41,6 +41,7 @@ const ButtonInternal = forwardRef<
     noAutoTooltip,
     noTitle,
     iconRotate = false,
+    block = false,
     counterValue,
     ...props
   },
@@ -142,6 +143,7 @@ const ButtonInternal = forwardRef<
         loading={isLoading}
         className={cn(
           "max-w-full",
+          block && "w-full",
           withoutDisabledAppearance &&
             disabled &&
             "disabled:pointer-events-none disabled:opacity-100 disabled:cursor-default",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -41,6 +41,7 @@ export const defaultTranslations = {
     save: "Save",
     send: "Send",
     cancel: "Cancel",
+    ok: "Ok",
     delete: "Delete",
     copy: "Copy",
     paste: "Paste",


### PR DESCRIPTION
## Dialog/Drawer rollout — PR 1 of 6 (additive, no breaking changes)

First of a stacked series that introduces the new **dialog-alike** system (`F0Dialog` v2 + new `F0Drawer`) **additively**, leaving the existing `@/patterns/F0Dialog` untouched.

### This PR
Just the small shared additive pieces the new system needs:
- **F0Button**: new optional private `block` prop (stretch to full width).
- **i18n**: new `ok` default translation key.

### Guarantees
- ✅ No component renamed.
- ✅ No existing prop removed or made required.
- ✅ `tsc` clean; old `F0Dialog` untouched.

### Stack
1. **PR 1 — foundation bits** ← this PR
2. PR 2 — dialog-alike shared primitives (forked, private copies; `ui/Dialog` untouched)
3. PR 3 — `F0Drawer` + `useDrawer`
4. PR 4 — new `F0Dialog` + `useDialog` (exposed via subpath to avoid name collision)
5. PR 5 — imperative dialog provider + `F0Provider` wiring
6. PR 6 — backward-compatible consumer adoption + deprecation aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)