### PR TITLE
feat(dialog 6/6): F0Wizard/F0WizardForm size prop + width deprecation (non-breaking)

### DIFF
--- a/packages/react/src/lib/providers/dialogs-alike/__stories__/dialog.mdx
+++ b/packages/react/src/lib/providers/dialogs-alike/__stories__/dialog.mdx
@@ -3,7 +3,7 @@ import * as DialogStories from "./dialog.stories"
 
 <Meta of={DialogStories} />
 
-# dialog
+# Dialogs API
 
 ## Introduction
 

--- a/packages/react/src/lib/providers/dialogs-alike/__stories__/dialog.stories.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/__stories__/dialog.stories.tsx
@@ -10,7 +10,7 @@ import { dialogsAlikeStore } from "../store"
 import { DialogActionValue } from "../types"
 
 const meta = {
-  title: "Dialogs",
+  title: "Dialogs API",
   parameters: {
     layout: "centered",
     docs: {

--- a/packages/react/src/lib/providers/dialogs-alike/__stories__/drawer.mdx
+++ b/packages/react/src/lib/providers/dialogs-alike/__stories__/drawer.mdx
@@ -3,7 +3,7 @@ import * as DrawerStories from "./drawer.stories"
 
 <Meta of={DrawerStories} />
 
-# drawer
+# Drawers API
 
 ## Introduction
 

--- a/packages/react/src/lib/providers/dialogs-alike/__stories__/drawer.stories.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/__stories__/drawer.stories.tsx
@@ -10,7 +10,7 @@ import { dialogsAlikeStore } from "../store"
 import { DialogActionValue } from "../types"
 
 const meta = {
-  title: "Drawers",
+  title: "Drawers API",
   parameters: {
     layout: "centered",
     docs: {

--- a/packages/react/src/patterns/F0WizardForm/F0WizardForm.tsx
+++ b/packages/react/src/patterns/F0WizardForm/F0WizardForm.tsx
@@ -207,6 +207,7 @@ function F0WizardFormPerSection<T extends F0PerSectionSchema>({
   onClose,
   title,
   width,
+  size,
   defaultStepIndex,
   nextLabel,
   previousLabel,
@@ -441,6 +442,7 @@ function F0WizardFormPerSection<T extends F0PerSectionSchema>({
       onClose={onClose}
       title={title}
       width={width}
+      size={size}
       defaultStepIndex={computedDefaultStepIndex}
       nextLabel={nextLabel}
       previousLabel={previousLabel}
@@ -582,6 +584,7 @@ function F0WizardFormSingleSchema<TSchema extends F0FormSchema>({
   onClose,
   title,
   width,
+  size,
   defaultStepIndex,
   nextLabel,
   previousLabel,
@@ -751,6 +754,7 @@ function F0WizardFormSingleSchema<TSchema extends F0FormSchema>({
       onClose={onClose}
       title={title}
       width={width}
+      size={size}
       defaultStepIndex={computedDefaultStepIndex}
       nextLabel={nextLabel}
       previousLabel={previousLabel}

--- a/packages/react/src/patterns/F0WizardForm/types.ts
+++ b/packages/react/src/patterns/F0WizardForm/types.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/patterns/F0Form/types"
 import type { RenderCustomFieldFunction } from "@/patterns/F0Form/types"
 
+import { F0DialogSize } from "@/components/dialog-alike/F0Dialog"
 import { DialogWidth } from "@/patterns/F0Dialog"
 
 export type F0FormSchema<T extends ZodRawShape = ZodRawShape> =
@@ -150,7 +151,10 @@ interface F0WizardFormBaseProps {
   isOpen: boolean
   onClose?: () => void
   title?: string
+  /** @deprecated Use `size` instead. */
   width?: DialogWidth
+  /** The size of the wizard dialog. Preferred over the deprecated `width`. */
+  size?: F0DialogSize
   defaultStepIndex?: number
   nextLabel?: string
   previousLabel?: string

--- a/packages/react/src/ui/F0Wizard/F0Wizard.tsx
+++ b/packages/react/src/ui/F0Wizard/F0Wizard.tsx
@@ -30,7 +30,8 @@ export const F0Wizard: FC<F0WizardProps> = ({
   isOpen,
   onClose = noop,
   title,
-  width = "xl",
+  width,
+  size,
   defaultStepIndex,
   nextLabel,
   previousLabel,
@@ -103,7 +104,7 @@ export const F0Wizard: FC<F0WizardProps> = ({
     <F0Dialog
       isOpen={isOpen}
       onClose={onClose}
-      width={width}
+      width={size && size !== "fullscreen" ? size : (width ?? "xl")}
       title={title}
       primaryAction={primaryAction}
       secondaryAction={secondaryAction}

--- a/packages/react/src/ui/F0Wizard/types.ts
+++ b/packages/react/src/ui/F0Wizard/types.ts
@@ -1,5 +1,6 @@
 import { ReactNode } from "react"
 
+import { F0DialogSize } from "@/components/dialog-alike/F0Dialog"
 import { DialogWidth } from "@/patterns/F0Dialog"
 
 export interface F0WizardStep {
@@ -26,7 +27,10 @@ export interface F0WizardProps {
   isOpen: boolean
   onClose?: () => void
   title?: string
+  /** @deprecated Use `size` instead. */
   width?: DialogWidth
+  /** The size of the wizard dialog. Preferred over the deprecated `width`. */
+  size?: F0DialogSize
   defaultStepIndex?: number
   nextLabel?: string
   previousLabel?: string


### PR DESCRIPTION
## Dialog/Drawer rollout — PR 6 of 6 (additive)

Stacked on #4367.

The only PR touching existing public components — kept strictly additive:
- Adds a new optional **`size`** prop (`F0DialogSize`) to **`F0Wizard`** and **`F0WizardForm`**, the preferred name going forward.
- Keeps **`width`** working, now marked `@deprecated`. `size` takes precedence when both are set; `"fullscreen"` falls back to prior `width` behavior.

### Guarantees
- ✅ `width` unchanged and still optional — existing call sites keep working.
- ✅ No component renamed; no required props added; `tsc` clean.

### Whole stack (all additive, no breaking changes)
1. #4363 — foundation bits (F0Button.block, i18n)
2. #4364 — forked Dialog primitives
3. #4365 — dialog-alike core + new F0Dialog (subpath-only)
4. #4366 — F0Drawer
5. #4367 — imperative provider + useDialog/useDrawer
6. **this** — F0Wizard/F0WizardForm `size` + `width` deprecation

The existing `@/patterns/F0Dialog` is left fully intact throughout; the breaking removal/rename work is intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)