### PR TITLE
fix(F0AvatarIcon): drop inverse dark background so icons stay legible

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
@@ -27,7 +27,7 @@ export const F0AvatarIcon = ({
   return (
     <div
       className={cn(
-        "flex aspect-square items-center justify-center border border-solid border-f1-border-secondary bg-f1-background dark:bg-f1-background-inverse-secondary",
+        "flex aspect-square items-center justify-center border border-solid border-f1-border-secondary bg-f1-background",
         sizes[size]
       )}
       aria-label={ariaLabel}


### PR DESCRIPTION
## Problem

`F0AvatarIcon` rendered its icon with `color="bold"` (`f1-icon-bold`, which is **white** in dark mode) on top of a `dark:bg-f1-background-inverse-secondary` chip (a **light** surface in dark mode). The result was white-on-white — icons were nearly invisible in dark mode.

This surfaced on the new survey co-creation welcome cards (`F0CardRow` with an `avatar={{ type: "icon" }}`), but the bug lives in the shared avatar component, so it affects **every icon avatar across the product** in dark mode.

## Fix

Use the default `f1-background` surface in both themes (drop the dark inverse override). The `f1-icon-bold` foreground then contrasts correctly:

| Mode | Chip bg | Icon | Result |
|------|---------|------|--------|
| Dark | `rgb(13,22,38)` | `rgb(255,255,255)` | white-on-dark ✓ |
| Light | `rgb(255,255,255)` | `rgb(13,22,38)` | near-black-on-white ✓ |

One-line change; all token-based, no hardcoded CSS.

## Verification

Inspected computed styles and screenshotted the avatar in both light and dark mode in Storybook — icons are crisp and legible in both.

## ⚠️ Blast radius

This is a **shared design-system component** used by every icon avatar. The visible change is dark mode only: icon chips go from a light "inverse" chip to the default surface. **Worth a Chromatic / visual-regression pass before merge** to confirm the new treatment reads well everywhere `F0AvatarIcon` is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)