### PR TITLE
fix(F0CardRow): remove whole-card click target

### DIFF
--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -143,7 +143,10 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
       <Card
         ref={hasAlert ? undefined : ref}
         className={cn(
-          "group @container bg-f1-background shadow-none",
+          // Hover affordance without making the card a click target: the border
+          // and shadow react to hover, but there's no pointer cursor (the row
+          // isn't clickable — only its actions are).
+          "group @container bg-f1-background shadow-none transition-all hover:border-f1-border-hover hover:shadow-md",
           compact && "p-3",
           fullHeight && "h-full"
         )}

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -1,10 +1,9 @@
 import { forwardRef } from "react"
 
-import { F0Link } from "@/components/F0Link"
 import { DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { withDataTestId } from "@/lib/data-testid"
 import { withSkeleton } from "@/lib/skeleton"
-import { cn, focusRing } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 import { Card } from "@/ui/Card"
 import { Skeleton } from "@/ui/skeleton"
 import { Text } from "@/ui/Text"
@@ -99,11 +98,6 @@ export interface F0CardRowProps {
   stackAt?: CardRowStackAt
 
   /**
-   * When set, the whole row becomes a link to this href.
-   */
-  link?: string
-
-  /**
    * Stretch to fill the height of its container.
    */
   fullHeight?: boolean
@@ -114,17 +108,6 @@ export interface F0CardRowProps {
    * Use `visible` + `onDismiss` for controlled dismiss behaviour.
    */
   alert?: CardAlertProps
-
-  /**
-   * Called when the row is clicked.
-   */
-  onClick?: () => void
-
-  /**
-   * Disables the full-row overlay link so a parent can manage drag-and-drop while
-   * still allowing click navigation via `onClick`.
-   */
-  disableOverlayLink?: boolean
 }
 
 /**
@@ -148,11 +131,8 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
       status,
       inactive = false,
       compact = false,
-      link,
       fullHeight = false,
       alert,
-      onClick,
-      disableOverlayLink = false,
       stackAt = "never",
     },
     ref
@@ -163,11 +143,9 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
       <Card
         ref={hasAlert ? undefined : ref}
         className={cn(
-          "group relative @container bg-f1-background shadow-none transition-all",
+          "group @container bg-f1-background shadow-none",
           compact && "p-3",
-          fullHeight && "h-full",
-          link &&
-            "focus-within:border-f1-border-hover focus-within:shadow-md hover:border-f1-border-hover hover:shadow-md"
+          fullHeight && "h-full"
         )}
         style={
           hasAlert
@@ -177,20 +155,8 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
               }
             : undefined
         }
-        onClick={onClick}
         data-testid="card"
       >
-        {link && !disableOverlayLink && (
-          <F0Link
-            href={link}
-            variant="unstyled"
-            className={cn("z-1 absolute inset-0 block rounded-xl", focusRing())}
-            aria-label={title}
-          >
-            &nbsp;
-          </F0Link>
-        )}
-
         <div className={cardRowClassName[stackAt]}>
           <div className="flex min-w-0 flex-row items-center gap-3">
             {avatar && <CardAvatar avatar={avatar} size="lg" />}

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -53,10 +53,6 @@ const meta: Meta<typeof F0CardRow> = {
       control: "boolean",
       description: "Stretch to fill the height of the container.",
     },
-    link: {
-      control: "text",
-      description: "When set, the whole row becomes a link to this href.",
-    },
     // Function-bearing props: disable the control so it doesn't dump the
     // serialized mock fn() source. They still appear in the args table.
     primaryAction: {
@@ -83,10 +79,6 @@ const meta: Meta<typeof F0CardRow> = {
     alert: {
       control: false,
       description: "Alert banner displayed above the row.",
-    },
-    onClick: {
-      action: "clicked",
-      description: "Called when the row is clicked.",
     },
   },
   decorators: [

--- a/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
@@ -74,21 +74,12 @@ describe("F0CardRow", () => {
     })
   })
 
-  it("renders as a clickable link when link is provided", () => {
-    render(<F0CardRow title="Linked row" link="/test-link" />)
+  it("does not make the card background a click target", () => {
+    render(<F0CardRow title="Not clickable" description="Just text" />)
 
-    const link = screen.getByRole("link", { name: "Linked row" })
-    expect(link).toHaveAttribute("href", "/test-link")
-  })
-
-  it("calls onClick when the row is clicked", async () => {
-    const user = userEvent.setup()
-    const handleClick = vi.fn()
-
-    render(<F0CardRow title="Clickable" onClick={handleClick} />)
-
-    await user.click(screen.getByText("Clickable"))
-    expect(handleClick).toHaveBeenCalledTimes(1)
+    // The row itself exposes no link/button role — only its actions do.
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
   })
 
   it("calls primaryAction.onClick", async () => {

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -147,12 +147,9 @@ interface CardRowActionsProps {
  * maps straight through; `ButtonGroup` owns the row layout, the width-driven
  * overflow into the "⋯" menu, and pinning the primary at the trailing edge.
  *
- * The card adds two things on top:
- * - The wrapper stops click propagation so an action never triggers the row's
- *   own `onClick` / overlay-link navigation.
- * - `stackAt` drops the cluster onto its own full-width line (with a footer
- *   hairline) below a container breakpoint; the breakpoint mapping is shared
- *   with the row root via {@link cardRowClassName}.
+ * On top, `stackAt` drops the cluster onto its own full-width line (with a footer
+ * hairline) below a container breakpoint; the breakpoint mapping is shared with
+ * the row root via {@link cardRowClassName}.
  *
  * Pass `confirmAction` / `rejectAction` for the confirm/reject variant — reject
  * (✗, outline) then confirm (✓, solid primary), which replaces the standard
@@ -171,9 +168,8 @@ export function CardRowActions({
 }: CardRowActionsProps) {
   const size = compact ? "sm" : "md"
 
-  // Resolved state: a status tag replaces the actions. It's informational, so
-  // no click-stop / z-index — a row-level overlay link stays clickable through
-  // it. The outer flex drops it to its own line when stacked, with the footer.
+  // Resolved state: a status tag replaces the actions. It's informational.
+  // The outer flex drops it to its own line when stacked, with the footer.
   if (status) {
     return (
       <div
@@ -195,17 +191,13 @@ export function CardRowActions({
   }
 
   const wrapperClassName = cn(
-    "relative z-[1]",
     actionsWidthClassName[stackAt],
     stackedChrome[stackAt],
     stackAt !== "never" && compact && "mt-3 pt-3"
   )
 
   const wrap = (group: React.ReactNode) => (
-    // Keep action clicks from bubbling to the row's onClick / overlay link.
-    <div className={wrapperClassName} onClick={(e) => e.stopPropagation()}>
-      {group}
-    </div>
+    <div className={wrapperClassName}>{group}</div>
   )
 
   // Confirm/reject variant: reject (✗, outline) then confirm (✓, solid primary).
@@ -247,13 +239,7 @@ export function CardRowActions({
 
     const inline = (
       // Icon-only, inline at the trailing edge.
-      <div
-        className={cn(
-          "relative z-[1] min-w-0 flex-1",
-          inlineClusterVisibility[stackAt]
-        )}
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className={cn("min-w-0 flex-1", inlineClusterVisibility[stackAt])}>
         {variant(true)}
       </div>
     )
@@ -271,12 +257,10 @@ export function CardRowActions({
             flex column's stretch so the `-mx-4` footer bleeds symmetrically. */}
         <div
           className={cn(
-            "relative z-[1]",
             stackedClusterVisibility[stackAt],
             stackedChrome[stackAt],
             compact && "mt-3 pt-3"
           )}
-          onClick={(e) => e.stopPropagation()}
         >
           {variant(false)}
         </div>


### PR DESCRIPTION
## What

Card Row is intended to always carry action buttons, so making the **entire card background** a click target was unintended. This removes the row-level click target — only the action buttons (and any inline secondary link) are interactable now, not the card background.

The card still shows a **hover affordance** (border highlight + shadow lift) for visual feedback, but **without a pointer cursor**, so it never implies the whole surface is clickable.

## Changes

**[`F0CardRow.tsx`](https://github.com/factorialco/f0/blob/main/packages/react/src/components/F0Card/F0CardRow.tsx)**
- Removed the `onClick`, `link`, and `disableOverlayLink` props.
- Removed the absolute, full-bleed overlay `F0Link` that covered the whole row.
- Removed the now-unused `F0Link` / `focusRing` imports.
- Kept the `hover:border-f1-border-hover` + `hover:shadow-md` hover state (now applied unconditionally instead of only when `link` was set), but without `cursor-pointer` — `Card` only applies the pointer cursor when given an `href`/`onClick`, neither of which we pass, so the row stays non-clickable.

**[`CardRowActions.tsx`](https://github.com/factorialco/f0/blob/main/packages/react/src/components/F0Card/components/CardRowActions.tsx)**
- Removed the `stopPropagation` handlers and `relative z-[1]` classes — they existed solely to keep action clicks above/away from the removed overlay link.
- Updated stale doc comments that referenced the row's `onClick` / overlay link.

Stories and tests updated accordingly (the two row-level link/onClick tests are replaced by one asserting the card background exposes no link/button role of its own).

## Breaking change?

Technically the `onClick` / `link` / `disableOverlayLink` props are gone, but Card Row is brand new and the only consumer is `F0HILActionConfirmation`, which uses none of them — so nothing breaks. The regular `Card` and `F0Card` are untouched.

## Verification

- `F0Card` + `F0HILActionConfirmation` suites: 47 passing
- `tsc --noEmit`: clean for these files
- `oxlint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)