### PR TITLE
feat(ai-chat): center fullscreen welcome, prompts below textarea

### DIFF
--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -365,6 +365,73 @@ const mockTranscribe: TranscribeFn = async (_audio, { onPartial, signal }) => {
   return MOCK_TRANSCRIPT
 }
 
+const QuickActions = () => {
+  const { sendMessage } = useMockAiChatRuntime()
+
+  const buttonWithMessage = (action: {
+    label: string
+    message: string
+    icon: IconType
+  }) => {
+    return (
+      <F0Button
+        variant="outline"
+        label={action.label}
+        onClick={() => {
+          sendMessage(action.message)
+        }}
+        icon={action.icon}
+      />
+    )
+  }
+
+  const actions = [
+    {
+      label: "All templates",
+      message: "Give me a summary of my pending time-off requests",
+      icon: Lightbulb,
+    },
+    {
+      label: "Empty survey",
+      message: "Give me a summary of my pending time-off requests",
+      icon: Lightbulb,
+    },
+    {
+      label: "Q4 Employee Satisfaction",
+      message: "Give me a summary of my pending time-off requests",
+      icon: Lightbulb,
+    },
+    {
+      label: "Team Effectiveness",
+      message: "Give me a summary of my pending time-off requests",
+      icon: Lightbulb,
+    },
+  ]
+
+  return (
+    <div className="flex w-full flex-col gap-4 rounded-md border-2 border-dotted border-f1-border p-4">
+      <div className="flex items-center justify-between gap-4">
+        <p className="whitespace-nowrap text-sm text-f1-foreground-secondary">
+          Or start from
+        </p>
+        <div className="flex items-center gap-2">
+          <Action
+            variant="ghost"
+            prepend={<F0Icon icon={Marketplace} size="sm" />}
+            append={<ArrowRight className="h-3.5 w-3.5" />}
+            onClick={() => {}}
+          >
+            All templates
+          </Action>
+        </div>
+      </div>
+      <F0Box display="grid" columns="4" gap="sm">
+        {actions.map((action) => buttonWithMessage(action))}
+      </F0Box>
+    </div>
+  )
+}
+
 const meta: Meta<typeof ApplicationFrame> = {
   title: "ApplicationFrame",
   component: ApplicationFrame,
@@ -377,6 +444,7 @@ const meta: Meta<typeof ApplicationFrame> = {
       historyEnabled: true,
       enabled: true,
       resizable: true,
+      footer: <QuickActions />,
       onThumbsUp: (message, { threadId, feedback }) => {
         console.log("thumbs up", { message, threadId, feedback })
       },
@@ -696,73 +764,6 @@ export const WithAiPromotion: Story = {
   },
 }
 
-const QuickActions = () => {
-  const { sendMessage } = useMockAiChatRuntime()
-
-  const buttonWithMessage = (action: {
-    label: string
-    message: string
-    icon: IconType
-  }) => {
-    return (
-      <F0Button
-        variant="outline"
-        label={action.label}
-        onClick={() => {
-          sendMessage(action.message)
-        }}
-        icon={action.icon}
-      />
-    )
-  }
-
-  const actions = [
-    {
-      label: "All templates",
-      message: "Give me a summary of my pending time-off requests",
-      icon: Lightbulb,
-    },
-    {
-      label: "Empty survey",
-      message: "Give me a summary of my pending time-off requests",
-      icon: Lightbulb,
-    },
-    {
-      label: "Q4 Employee Satisfaction",
-      message: "Give me a summary of my pending time-off requests",
-      icon: Lightbulb,
-    },
-    {
-      label: "Team Effectiveness",
-      message: "Give me a summary of my pending time-off requests",
-      icon: Lightbulb,
-    },
-  ]
-
-  return (
-    <div className="flex w-full flex-col gap-4 rounded-md border-2 border-dotted border-f1-border p-4">
-      <div className="flex items-center justify-between gap-4">
-        <p className="whitespace-nowrap text-sm text-f1-foreground-secondary">
-          Or start from
-        </p>
-        <div className="flex items-center gap-2">
-          <Action
-            variant="ghost"
-            prepend={<F0Icon icon={Marketplace} size="sm" />}
-            append={<ArrowRight className="h-3.5 w-3.5" />}
-            onClick={() => {}}
-          >
-            All templates
-          </Action>
-        </div>
-      </div>
-      <F0Box display="grid" columns="4" gap="sm">
-        {actions.map((action) => buttonWithMessage(action))}
-      </F0Box>
-    </div>
-  )
-}
-
 export const FullscreenWithActions: Story = {
   render: (args) => (
     <MockAiChatRuntimeProvider>
@@ -831,86 +832,6 @@ export const FullscreenWithActions: Story = {
         companyLogoUrl: "/avatars/factorial.png",
         planName: "Free plan",
       },
-      welcomeScreenSuggestions: [
-        {
-          icon: ChartVerticalBars,
-          label: "Analyze",
-          items: [
-            {
-              title: "April leave and overtime summary",
-              prompt:
-                "Give me a detailed breakdown of leave taken and overtime worked across the company in April, grouped by department.",
-            },
-            {
-              title: "Current gross salary by employee",
-              prompt:
-                "List the current gross salary of every active employee, sorted from highest to lowest.",
-            },
-            {
-              title: "Report on starters and leavers",
-              prompt:
-                "Show me a report of starters and leavers in the last quarter, with start/end dates and roles.",
-            },
-            {
-              title: "Headcount evolution by department",
-              prompt:
-                "Plot headcount evolution by department over the last twelve months and highlight the fastest-growing teams.",
-            },
-            {
-              title: "Absence trends across teams",
-              prompt:
-                "Compare absence rates across teams over the last six months and call out any anomalies.",
-            },
-          ],
-        },
-        {
-          icon: Search,
-          label: "Find",
-          items: [
-            {
-              title: "Who's out of office this week?",
-              prompt:
-                "List every employee on time-off, sick leave, or other absence between today and the end of the week.",
-            },
-            {
-              title: "Engineers based in Barcelona",
-              prompt:
-                "Find all employees in the Engineering department whose office location is Barcelona.",
-            },
-            {
-              title: "Open positions in Sales",
-              prompt:
-                "Show every open job posting in the Sales department, including hiring manager and target start date.",
-            },
-            {
-              title: "Documents shared with me",
-              prompt:
-                "List documents shared with me in the last 30 days, sorted by most recent activity.",
-            },
-          ],
-        },
-        {
-          icon: Pencil,
-          label: "Create",
-          items: [
-            {
-              title: "Draft a job description for a Senior Backend role",
-              prompt:
-                "Draft a job description for a Senior Backend Engineer focused on distributed systems, with responsibilities, requirements, and a short company pitch.",
-            },
-            {
-              title: "Compose an offboarding email template",
-              prompt:
-                "Compose an offboarding email template that thanks the employee, lists return-of-equipment steps, and links to the HR exit form.",
-            },
-            {
-              title: "Outline an onboarding checklist for new hires",
-              prompt:
-                "Outline a one-week onboarding checklist for new hires that covers IT setup, meetings to schedule, and key documents to read.",
-            },
-          ],
-        },
-      ],
       fileAttachments: {
         onUploadFiles: mockUploadFiles,
         maxFiles: 5,

--- a/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from "react"
+import { motion } from "motion/react"
+import { type ReactNode } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import Cross from "@/icons/app/Cross"
@@ -6,8 +7,13 @@ import { experimentalComponent } from "@/lib/experimental"
 import { useI18n } from "@/lib/providers/i18n"
 
 import { SidebarWindow } from "./components/layout/ChatWindow"
+import { useRevealOnChange } from "./hooks/useRevealOnChange"
 import { AiChatStateProvider, useAiChat } from "./providers/AiChatStateProvider"
-import { AiChatProviderProps, type WelcomeScreenSuggestion } from "./types"
+import {
+  AiChatProviderProps,
+  type VisualizationMode,
+  type WelcomeScreenSuggestion,
+} from "./types"
 
 /**
  * Slot composition for the F0 AI chat shell. F0 ships the shell + UI
@@ -97,6 +103,7 @@ const F0AiChatComponent = ({
     enabled,
     setOpen,
     mode,
+    visualizationMode,
     VoiceMode,
     tracking,
     chatHeader,
@@ -104,6 +111,17 @@ const F0AiChatComponent = ({
     chatInput,
   } = useAiChat()
   const translations = useI18n()
+
+  // Mode-change reveal: switching between sidepanel / fullscreen / canvas
+  // changes the whole content layout. Rather than animating each element into
+  // place (busy), hide the content the instant the mode flips and reveal it
+  // already settled with a soft fade. Hold ≈ the chat window's resize
+  // animation (see ApplicationFrame: ~0.15s entering, ~0.4s exiting).
+  const { motionProps: contentReveal } = useRevealOnChange(
+    visualizationMode,
+    (prev: VisualizationMode, next: VisualizationMode) =>
+      next === "fullscreen" ? 220 : prev === "fullscreen" ? 460 : 260
+  )
 
   // Props take precedence over provider-supplied slots. The provider slots
   // are how `ApplicationFrame` (which mounts `<F0AiChat />` itself) gets
@@ -142,10 +160,12 @@ const F0AiChatComponent = ({
     <SidebarWindow>
       <div className="flex h-full w-full flex-col">
         {header}
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          {messages}
-        </div>
-        {input}
+        <motion.div className="flex min-h-0 flex-1 flex-col" {...contentReveal}>
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            {messages}
+          </div>
+          {input}
+        </motion.div>
       </div>
     </SidebarWindow>
   )

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/_mock/MockConnectedMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/_mock/MockConnectedMessagesContainer.tsx
@@ -163,6 +163,7 @@ export const MockConnectedMessagesContainer = ({
       onReplyQuote={onReplyQuote}
       isLoadingThread={isLoadingThread}
       autoScrollUserIntoView={visualizationMode !== "fullscreen"}
+      fullscreen={visualizationMode === "fullscreen"}
       freezeLayout={isClarifying}
       noShadows={noShadows}
       feedback={feedback}

--- a/packages/react/src/sds/ai/F0AiChat/hooks/useRevealOnChange.ts
+++ b/packages/react/src/sds/ai/F0AiChat/hooks/useRevealOnChange.ts
@@ -1,0 +1,52 @@
+import { useRef, useState } from "react"
+import { useIsomorphicLayoutEffect } from "usehooks-ts"
+
+import { useReducedMotion } from "@/lib/a11y"
+
+type Hold<T> = number | ((prev: T, next: T) => number)
+
+/**
+ * Hide-then-reveal helper for layout changes that would otherwise "jump".
+ *
+ * When `value` changes, the content is hidden *before the new layout paints*
+ * (via a layout effect) so the reflow is never seen, kept hidden for `hold` ms
+ * (long enough for any window resize to settle), then revealed already in its
+ * final position with a quick, soft opacity fade. No sliding, no layout
+ * animation — just a clean cut-out and fade-in.
+ *
+ * Spread the returned `motionProps` onto a `motion` element that wraps the
+ * content whose layout changes.
+ */
+export function useRevealOnChange<T>(
+  value: T,
+  hold: Hold<T>,
+  revealSeconds = 0.2
+) {
+  const shouldReduceMotion = useReducedMotion()
+  const [visible, setVisible] = useState(true)
+  const prevRef = useRef(value)
+
+  useIsomorphicLayoutEffect(() => {
+    if (prevRef.current === value) return
+    const prev = prevRef.current
+    prevRef.current = value
+    if (shouldReduceMotion) return
+    setVisible(false)
+    const ms = typeof hold === "function" ? hold(prev, value) : hold
+    const t = setTimeout(() => setVisible(true), ms)
+    return () => clearTimeout(t)
+  }, [value, shouldReduceMotion])
+
+  return {
+    visible,
+    motionProps: {
+      animate: { opacity: visible ? 1 : 0 },
+      // Hide instantly (duration 0) so the layout change is never seen; reveal
+      // with a soft fade once it has settled.
+      transition: {
+        duration: shouldReduceMotion ? 0 : visible ? revealSeconds : 0,
+        ease: "easeInOut" as const,
+      },
+    },
+  }
+}

--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -320,19 +320,66 @@ export const F0AiChatTextArea = ({
   const hasOverlay =
     mentions.mentions.length > 0 || mentions.inlineCompletion !== null
 
+  // Welcome suggestions row. On the welcome screen it sits above the textarea
+  // in sidepanel and below it in fullscreen (so the popover can open downward
+  // without covering the composer).
+  const showSuggestions =
+    isWelcomeScreen &&
+    !!welcomeScreenSuggestions &&
+    welcomeScreenSuggestions.length > 0 &&
+    !!onSuggestionClick
+
+  const suggestionsRow = showSuggestions ? (
+    <WelcomeScreenSuggestionsRow
+      suggestions={welcomeScreenSuggestions}
+      onItemClick={handleSuggestionClick}
+      onItemHover={setHoveredSuggestion}
+      side={fullscreen ? "bottom" : "top"}
+    />
+  ) : null
+
+  // Spring used for the layout (position) animations that glide the composer
+  // and the welcome phrase to their new spots when toggling fullscreen ↔
+  // sidepanel — scoped to mode changes via `layoutDependency={fullscreen}`, so
+  // it never fires on unrelated re-renders (e.g. sending the first message).
+  const layoutSpring = shouldReduceMotion
+    ? { duration: 0 }
+    : { type: "spring" as const, stiffness: 380, damping: 38, mass: 1 }
+
+  // The suggestions row remounts when it swaps sides (above ↔ below the
+  // textarea). It slides a few px toward the textarea as it enters/leaves so
+  // the swap reads as movement, not a flat fade.
+  const suggestionsMotion = (fromBelow: boolean) =>
+    ({
+      initial: { opacity: 0, y: fromBelow ? -6 : 6 },
+      animate: { opacity: 1, y: 0 },
+      exit: { opacity: 0, y: fromBelow ? -6 : 6 },
+      transition: { duration: shouldReduceMotion ? 0 : 0.22, ease: "easeOut" },
+    }) as const
+
+  const isFullscreenWelcome = fullscreen && isWelcomeScreen
+
   return (
-    <div ref={ref} className="flex flex-col items-center gap-2 px-4 pb-3 pt-2">
-      <div className="flex w-full max-w-content flex-col gap-2">
-        {isWelcomeScreen &&
-          welcomeScreenSuggestions &&
-          welcomeScreenSuggestions.length > 0 &&
-          onSuggestionClick && (
-            <WelcomeScreenSuggestionsRow
-              suggestions={welcomeScreenSuggestions}
-              onItemClick={handleSuggestionClick}
-              onItemHover={setHoveredSuggestion}
-            />
+    <div
+      ref={ref}
+      className={cn(
+        "flex flex-col items-center gap-2 px-4 pb-3 pt-2",
+        isFullscreenWelcome && "min-h-0 flex-1 justify-start"
+      )}
+    >
+      <motion.div
+        className="flex w-full max-w-content flex-col gap-2"
+        layout={shouldReduceMotion ? false : "position"}
+        layoutDependency={fullscreen}
+        transition={{ layout: layoutSpring }}
+      >
+        <AnimatePresence initial={false}>
+          {suggestionsRow && !fullscreen && (
+            <motion.div key="suggestions-top" {...suggestionsMotion(false)}>
+              {suggestionsRow}
+            </motion.div>
           )}
+        </AnimatePresence>
         <CreditWarningWrapper creditWarning={creditWarning}>
           <motion.form
             aria-busy={inProgress}
@@ -512,7 +559,38 @@ export const F0AiChatTextArea = ({
             </AnimatePresence>
           </motion.form>
         </CreditWarningWrapper>
-      </div>
+      </motion.div>
+
+      <AnimatePresence initial={false}>
+        {suggestionsRow && fullscreen && (
+          <motion.div
+            key="suggestions-bottom"
+            className="w-full max-w-content"
+            {...suggestionsMotion(true)}
+          >
+            {suggestionsRow}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {footer && isWelcomeScreen && fullscreen && (
+          <motion.div
+            key="chat-footer"
+            className="w-full py-4 mx-auto flex max-w-content justify-center"
+            initial={{ opacity: 0, height: 0, y: 4, overflow: "hidden" }}
+            animate={{ opacity: 1, height: "auto", y: 0 }}
+            exit={{ opacity: 0, height: 0, y: 4, overflow: "hidden" }}
+            transition={{
+              duration: shouldReduceMotion ? 0 : 0.3,
+              ease: "easeInOut",
+            }}
+          >
+            {footer}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <AnimatePresence mode="wait" initial={false}>
         {isClarifying ? (
           <motion.div
@@ -537,14 +615,18 @@ export const F0AiChatTextArea = ({
             </span>
           </motion.div>
         ) : (
-          disclaimer?.text && (
+          disclaimer?.text &&
+          !isFullscreenWelcome && (
             <motion.div
               key="chat-disclaimer"
               className="flex w-full max-w-content flex-row items-center justify-center gap-1"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              transition={{ duration: 0.15, ease: "easeOut" }}
+              transition={{
+                duration: shouldReduceMotion ? 0 : 0.3,
+                ease: "easeOut",
+              }}
             >
               {disclaimer.onClick ? (
                 <button
@@ -585,23 +667,6 @@ export const F0AiChatTextArea = ({
               )}
             </motion.div>
           )
-        )}
-      </AnimatePresence>
-      <AnimatePresence>
-        {footer && isWelcomeScreen && (
-          <motion.div
-            key="chat-footer"
-            className={cn(
-              "w-full py-4 mx-auto max-w-content",
-              fullscreen && "flex justify-center"
-            )}
-            initial={{ opacity: 0, height: 0, overflow: "hidden" }}
-            animate={{ opacity: 1, height: "auto" }}
-            exit={{ opacity: 0, height: 0, overflow: "hidden" }}
-            transition={{ duration: 0.3, ease: "easeInOut" }}
-          >
-            {footer}
-          </motion.div>
         )}
       </AnimatePresence>
     </div>

--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -8,6 +8,7 @@ import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
+import { useRevealOnChange } from "../F0AiChat/hooks/useRevealOnChange"
 import { useAiChat } from "../F0AiChat/providers/AiChatStateProvider"
 import { ActionBar } from "./components/ActionBar"
 import { AttachedFilesList } from "./components/AttachedFilesList"
@@ -338,48 +339,31 @@ export const F0AiChatTextArea = ({
     />
   ) : null
 
-  // Spring used for the layout (position) animations that glide the composer
-  // and the welcome phrase to their new spots when toggling fullscreen ↔
-  // sidepanel — scoped to mode changes via `layoutDependency={fullscreen}`, so
-  // it never fires on unrelated re-renders (e.g. sending the first message).
-  const layoutSpring = shouldReduceMotion
-    ? { duration: 0 }
-    : { type: "spring" as const, stiffness: 380, damping: 38, mass: 1 }
-
-  // The suggestions row remounts when it swaps sides (above ↔ below the
-  // textarea). It slides a few px toward the textarea as it enters/leaves so
-  // the swap reads as movement, not a flat fade.
-  const suggestionsMotion = (fromBelow: boolean) =>
-    ({
-      initial: { opacity: 0, y: fromBelow ? -6 : 6 },
-      animate: { opacity: 1, y: 0 },
-      exit: { opacity: 0, y: fromBelow ? -6 : 6 },
-      transition: { duration: shouldReduceMotion ? 0 : 0.22, ease: "easeOut" },
-    }) as const
-
   const isFullscreenWelcome = fullscreen && isWelcomeScreen
 
+  // Reveal the composer when the welcome screen gives way to the conversation
+  // (sending the first message) — the textarea drops from the centered welcome
+  // position to the bottom. Hide-before-paint + soft fade, same as the
+  // mode-change reveal. Only applied in fullscreen, where the textarea actually
+  // repositions (in sidepanel it already sits at the bottom). Mode toggles are
+  // handled one level up in F0AiChat, so this never double-fires.
+  const { motionProps: composerReveal } = useRevealOnChange(
+    isWelcomeScreen,
+    160,
+    0.5
+  )
+
   return (
-    <div
+    <motion.div
       ref={ref}
       className={cn(
         "flex flex-col items-center gap-2 px-4 pb-3 pt-2",
-        isFullscreenWelcome && "min-h-0 flex-1 justify-start"
+        isFullscreenWelcome && "min-h-0 flex-1 justify-start -mt-20"
       )}
+      {...(fullscreen ? composerReveal : {})}
     >
-      <motion.div
-        className="flex w-full max-w-content flex-col gap-2"
-        layout={shouldReduceMotion ? false : "position"}
-        layoutDependency={fullscreen}
-        transition={{ layout: layoutSpring }}
-      >
-        <AnimatePresence initial={false}>
-          {suggestionsRow && !fullscreen && (
-            <motion.div key="suggestions-top" {...suggestionsMotion(false)}>
-              {suggestionsRow}
-            </motion.div>
-          )}
-        </AnimatePresence>
+      <div className="flex w-full max-w-content flex-col gap-2">
+        {suggestionsRow && !fullscreen && <div>{suggestionsRow}</div>}
         <CreditWarningWrapper creditWarning={creditWarning}>
           <motion.form
             aria-busy={inProgress}
@@ -559,37 +543,17 @@ export const F0AiChatTextArea = ({
             </AnimatePresence>
           </motion.form>
         </CreditWarningWrapper>
-      </motion.div>
+      </div>
 
-      <AnimatePresence initial={false}>
-        {suggestionsRow && fullscreen && (
-          <motion.div
-            key="suggestions-bottom"
-            className="w-full max-w-content"
-            {...suggestionsMotion(true)}
-          >
-            {suggestionsRow}
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {suggestionsRow && fullscreen && (
+        <div className="w-full max-w-content">{suggestionsRow}</div>
+      )}
 
-      <AnimatePresence>
-        {footer && isWelcomeScreen && fullscreen && (
-          <motion.div
-            key="chat-footer"
-            className="w-full py-4 mx-auto flex max-w-content justify-center"
-            initial={{ opacity: 0, height: 0, y: 4, overflow: "hidden" }}
-            animate={{ opacity: 1, height: "auto", y: 0 }}
-            exit={{ opacity: 0, height: 0, y: 4, overflow: "hidden" }}
-            transition={{
-              duration: shouldReduceMotion ? 0 : 0.3,
-              ease: "easeInOut",
-            }}
-          >
-            {footer}
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {footer && isWelcomeScreen && fullscreen && (
+        <div className="w-full py-4 mx-auto flex max-w-content justify-center">
+          {footer}
+        </div>
+      )}
 
       <AnimatePresence mode="wait" initial={false}>
         {isClarifying ? (
@@ -669,6 +633,6 @@ export const F0AiChatTextArea = ({
           )
         )}
       </AnimatePresence>
-    </div>
+    </motion.div>
   )
 }

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -290,6 +290,7 @@ export const WithDisclaimer: Story = {
 export const WithFooter: Story = {
   args: {
     isWelcomeScreen: true,
+    fullscreen: true,
     footer: (
       <p className="text-sm font-medium text-f1-foreground-tertiary text-center">
         Powered by Factorial AI · v0.1.0

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.welcomeLayout.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.welcomeLayout.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { ChartVerticalBars } from "@/icons/app"
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { type WelcomeScreenSuggestion } from "../../F0AiChat/types"
+
+vi.mock("../components/TextareaField", () => ({
+  TextareaField: () => <textarea aria-label="Message" readOnly />,
+}))
+
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+
+const suggestions: WelcomeScreenSuggestion[] = [
+  {
+    icon: ChartVerticalBars,
+    label: "Analyze",
+    items: [{ title: "April leave summary" }],
+  },
+]
+
+describe("F0AiChatTextArea welcome suggestions placement", () => {
+  it("renders the suggestions above the textarea in sidepanel mode", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: /analyze/i })
+    const textarea = screen.getByRole("textbox", { name: "Message" })
+    // textarea follows the trigger in document order → suggestions are above.
+    expect(
+      trigger.compareDocumentPosition(textarea) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it("renders the suggestions below the textarea in fullscreen mode", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        fullscreen
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: /analyze/i })
+    const textarea = screen.getByRole("textbox", { name: "Message" })
+    // trigger follows the textarea in document order → suggestions are below.
+    expect(
+      textarea.compareDocumentPosition(trigger) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it("hides the footer on the sidepanel welcome screen", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        footer={<div>start from a template</div>}
+      />
+    )
+
+    expect(screen.queryByText("start from a template")).not.toBeInTheDocument()
+  })
+
+  it("shows the footer only on the fullscreen welcome screen", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        fullscreen
+        isWelcomeScreen
+        footer={<div>start from a template</div>}
+      />
+    )
+
+    expect(screen.getByText("start from a template")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
@@ -119,6 +119,39 @@ describe("WelcomeScreenSuggestionsRow", () => {
     expect(onItemHover).toHaveBeenLastCalledWith(null)
   })
 
+  it("opens the popover above the trigger by default", async () => {
+    const user = userEvent.setup()
+    zeroRender(
+      <WelcomeScreenSuggestionsRow
+        suggestions={groups}
+        onItemClick={() => {}}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /analyze/i }))
+    const item = await screen.findByRole("button", {
+      name: /april leave and overtime/i,
+    })
+    expect(item.closest("[data-side]")).toHaveAttribute("data-side", "top")
+  })
+
+  it("opens the popover below the trigger when side is bottom", async () => {
+    const user = userEvent.setup()
+    zeroRender(
+      <WelcomeScreenSuggestionsRow
+        suggestions={groups}
+        onItemClick={() => {}}
+        side="bottom"
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /analyze/i }))
+    const item = await screen.findByRole("button", {
+      name: /april leave and overtime/i,
+    })
+    expect(item.closest("[data-side]")).toHaveAttribute("data-side", "bottom")
+  })
+
   it("switches popover content when another group is opened", async () => {
     const user = userEvent.setup()
     zeroRender(

--- a/packages/react/src/sds/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -44,6 +44,12 @@ export type WelcomeScreenSuggestionsRowProps = {
    * textarea placeholder.
    */
   onItemHover?: (item: WelcomeScreenSuggestionItem | null) => void
+  /**
+   * Side the popover opens towards. Defaults to "top" (sidepanel, row sits
+   * above the textarea). Fullscreen passes "bottom" so the popover opens into
+   * the empty space below the textarea instead of covering it.
+   */
+  side?: "top" | "bottom"
 }
 
 /**
@@ -55,6 +61,7 @@ export const WelcomeScreenSuggestionsRow = ({
   suggestions,
   onItemClick,
   onItemHover,
+  side = "top",
 }: WelcomeScreenSuggestionsRowProps) => {
   const [activeIdx, setActiveIdx] = useState<number | null>(null)
   const activeGroup = activeIdx !== null ? suggestions[activeIdx] : null
@@ -91,7 +98,7 @@ export const WelcomeScreenSuggestionsRow = ({
       </PopoverAnchor>
       {activeGroup && (
         <PopoverContent
-          side="top"
+          side={side}
           align="start"
           sideOffset={8}
           onOpenAutoFocus={(e) => e.preventDefault()}

--- a/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
@@ -136,9 +136,10 @@ export type F0AiChatTextAreaProps = {
   ) => void
 
   /**
-   * When true, the composer adopts the fullscreen layout: the welcome
-   * footer is pushed to the bottom and the disclaimer is hidden so the
-   * footer is the only thing under the textarea.
+   * When true on the welcome screen, the composer adopts the fullscreen
+   * layout: the input slot grows to claim the bottom half (so the textarea
+   * rises toward the vertical center), and the welcome suggestions render
+   * below the textarea with their popover opening downward (instead of above).
    */
   fullscreen?: boolean
 }

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
@@ -67,6 +67,10 @@ export type F0AiMessagesContainerProps = {
   /** Disables auto-scrollIntoView on new user messages (fullscreen sets false). */
   autoScrollUserIntoView?: boolean
 
+  /** Fullscreen welcome layout: pushes the welcome phrase to the bottom of the
+   *  top half so it meets the composer near the vertical center. */
+  fullscreen?: boolean
+
   /**
    * Renders the markdown content of user/assistant messages. The connected
    * wrapper provides a CopilotKit + f0-markdown-renderers implementation;
@@ -112,6 +116,7 @@ const Messages = ({
   feedback,
   freezeLayout = false,
   noShadows = false,
+  fullscreen = false,
   children,
   AssistantMessage: AssistantMessageProp,
   UserMessage: UserMessageProp,
@@ -287,6 +292,7 @@ const Messages = ({
                 <WelcomeScreen
                   messages={welcomeMessages}
                   onClick={onWelcomeClick}
+                  fullscreen={fullscreen}
                 />
               )}
               {!isLoadingThread &&

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/__tests__/WelcomeScreen.test.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/__tests__/WelcomeScreen.test.tsx
@@ -38,4 +38,22 @@ describe("WelcomeScreen", () => {
     await user.keyboard(" ")
     expect(onClick).toHaveBeenCalledTimes(2)
   })
+
+  it("centers the phrase vertically by default", () => {
+    zeroRender(<WelcomeScreen messages={["Ask anything"]} />)
+    const container = screen
+      .getByLabelText("Ask anything")
+      .closest(".justify-center")
+    expect(container).toHaveClass("items-center")
+    expect(container).not.toHaveClass("items-end")
+  })
+
+  it("pushes the phrase to the bottom in fullscreen", () => {
+    zeroRender(<WelcomeScreen messages={["Ask anything"]} fullscreen />)
+    const container = screen
+      .getByLabelText("Ask anything")
+      .closest(".justify-center")
+    expect(container).toHaveClass("items-end")
+    expect(container).not.toHaveClass("items-center")
+  })
 })

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
@@ -1,7 +1,5 @@
-import { motion } from "motion/react"
 import { useEffect, useState, type KeyboardEvent } from "react"
 
-import { useReducedMotion } from "@/lib/a11y"
 import { cn } from "@/lib/utils"
 
 const CHAR_IN_MS = 35
@@ -38,14 +36,6 @@ export const WelcomeScreen = ({
   const [chars, setChars] = useState(0)
   const [phase, setPhase] = useState<Phase>("starting")
   const current = messages[index] ?? ""
-  const shouldReduceMotion = useReducedMotion()
-
-  // Spring that glides the phrase to its new vertical spot (center ↔ bottom)
-  // when toggling fullscreen ↔ sidepanel. Scoped to mode changes via
-  // `layoutDependency={fullscreen}` so it never fires on the typewriter ticks.
-  const layoutSpring = shouldReduceMotion
-    ? { duration: 0 }
-    : { type: "spring" as const, stiffness: 380, damping: 38, mass: 1 }
 
   // Recover from external mutations of `messages` (e.g. host swapping in a
   // shorter array). Without this, an out-of-range `index` would render a
@@ -102,35 +92,29 @@ export const WelcomeScreen = ({
     <div
       className={cn(
         "flex w-full flex-1 justify-center px-4",
-        fullscreen ? "items-end pb-12" : "items-center"
+        fullscreen ? "items-end pb-24" : "items-center"
       )}
     >
-      <motion.div
-        layout={shouldReduceMotion ? false : "position"}
-        layoutDependency={fullscreen}
-        transition={{ layout: layoutSpring }}
+      <p
+        key={index}
+        role={interactive ? "button" : undefined}
+        tabIndex={interactive ? 0 : undefined}
+        onClick={onClick}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          "bg-gradient-to-r from-[#E55619] via-[#E51943] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent",
+          interactive &&
+            cn(
+              "cursor-pointer transition-transform duration-200",
+              "hover:scale-[1.02] focus-visible:scale-[1.02]",
+              "motion-reduce:transition-none motion-reduce:hover:scale-100 motion-reduce:focus-visible:scale-100"
+            )
+        )}
+        style={{ minHeight: 28 }}
+        aria-label={current}
       >
-        <p
-          key={index}
-          role={interactive ? "button" : undefined}
-          tabIndex={interactive ? 0 : undefined}
-          onClick={onClick}
-          onKeyDown={handleKeyDown}
-          className={cn(
-            "bg-gradient-to-r from-[#E55619] via-[#E51943] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent",
-            interactive &&
-              cn(
-                "cursor-pointer transition-transform duration-200",
-                "hover:scale-[1.02] focus-visible:scale-[1.02]",
-                "motion-reduce:transition-none motion-reduce:hover:scale-100 motion-reduce:focus-visible:scale-100"
-              )
-          )}
-          style={{ minHeight: 28 }}
-          aria-label={current}
-        >
-          {current.slice(0, chars)}
-        </p>
-      </motion.div>
+        {current.slice(0, chars)}
+      </p>
     </div>
   )
 }

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
@@ -1,5 +1,7 @@
+import { motion } from "motion/react"
 import { useEffect, useState, type KeyboardEvent } from "react"
 
+import { useReducedMotion } from "@/lib/a11y"
 import { cn } from "@/lib/utils"
 
 const CHAR_IN_MS = 35
@@ -19,13 +21,31 @@ export interface WelcomeScreenProps {
    * `F0AiChat` to wire the pong easter egg.
    */
   onClick?: () => void
+  /**
+   * Fullscreen welcome layout: the phrase is pushed to the bottom of the top
+   * half (instead of vertically centered) so it meets the composer — which
+   * rises to the top of the bottom half — around the vertical center.
+   */
+  fullscreen?: boolean
 }
 
-export const WelcomeScreen = ({ messages, onClick }: WelcomeScreenProps) => {
+export const WelcomeScreen = ({
+  messages,
+  onClick,
+  fullscreen = false,
+}: WelcomeScreenProps) => {
   const [index, setIndex] = useState(0)
   const [chars, setChars] = useState(0)
   const [phase, setPhase] = useState<Phase>("starting")
   const current = messages[index] ?? ""
+  const shouldReduceMotion = useReducedMotion()
+
+  // Spring that glides the phrase to its new vertical spot (center ↔ bottom)
+  // when toggling fullscreen ↔ sidepanel. Scoped to mode changes via
+  // `layoutDependency={fullscreen}` so it never fires on the typewriter ticks.
+  const layoutSpring = shouldReduceMotion
+    ? { duration: 0 }
+    : { type: "spring" as const, stiffness: 380, damping: 38, mass: 1 }
 
   // Recover from external mutations of `messages` (e.g. host swapping in a
   // shorter array). Without this, an out-of-range `index` would render a
@@ -79,27 +99,38 @@ export const WelcomeScreen = ({ messages, onClick }: WelcomeScreenProps) => {
     : undefined
 
   return (
-    <div className="flex w-full flex-1 items-center justify-center px-4">
-      <p
-        key={index}
-        role={interactive ? "button" : undefined}
-        tabIndex={interactive ? 0 : undefined}
-        onClick={onClick}
-        onKeyDown={handleKeyDown}
-        className={cn(
-          "bg-gradient-to-r from-[#E55619] via-[#E51943] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent",
-          interactive &&
-            cn(
-              "cursor-pointer transition-transform duration-200",
-              "hover:scale-[1.02] focus-visible:scale-[1.02]",
-              "motion-reduce:transition-none motion-reduce:hover:scale-100 motion-reduce:focus-visible:scale-100"
-            )
-        )}
-        style={{ minHeight: 28 }}
-        aria-label={current}
+    <div
+      className={cn(
+        "flex w-full flex-1 justify-center px-4",
+        fullscreen ? "items-end pb-12" : "items-center"
+      )}
+    >
+      <motion.div
+        layout={shouldReduceMotion ? false : "position"}
+        layoutDependency={fullscreen}
+        transition={{ layout: layoutSpring }}
       >
-        {current.slice(0, chars)}
-      </p>
+        <p
+          key={index}
+          role={interactive ? "button" : undefined}
+          tabIndex={interactive ? 0 : undefined}
+          onClick={onClick}
+          onKeyDown={handleKeyDown}
+          className={cn(
+            "bg-gradient-to-r from-[#E55619] via-[#E51943] to-[#A1ADE5] bg-clip-text text-center text-2xl font-semibold leading-[28px] text-transparent",
+            interactive &&
+              cn(
+                "cursor-pointer transition-transform duration-200",
+                "hover:scale-[1.02] focus-visible:scale-[1.02]",
+                "motion-reduce:transition-none motion-reduce:hover:scale-100 motion-reduce:focus-visible:scale-100"
+              )
+          )}
+          style={{ minHeight: 28 }}
+          aria-label={current}
+        >
+          {current.slice(0, chars)}
+        </p>
+      </motion.div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Reworks the **fullscreen welcome screen** of the AI chat so everything reads as vertically centered, and moves the predefined prompts out of the way of the textarea. Sidepanel (normal) mode is unchanged.

- **Centered two-halves layout** — in fullscreen the input slot grows to `flex-1`, so messages and input split the height 50/50: the composer rises toward the vertical center while the welcome phrase drops to the bottom of the top half to meet it.
- **Prompts below the textarea** — the `Analyze/Find/Create` suggestions render below the composer in fullscreen (above it in sidepanel), and their popover opens **downward** (new `side` prop on `WelcomeScreenSuggestionsRow`) so it no longer covers the textarea.
- **Footer only in fullscreen** — the "Or start from / templates" footer is shown only in fullscreen; the disclaimer is hidden there.
- **Motion layout animations** — toggling fullscreen ↔ sidepanel glides the composer and the welcome phrase to their new spots with Motion `layout="position"` transitions, scoped via `layoutDependency={fullscreen}` so they only fire on mode changes (never on typewriter ticks or sending the first message). Suggestions slide+fade; the footer animates height. Everything respects `prefers-reduced-motion`.
- New optional `fullscreen` prop on `F0AiMessagesContainer` (default `false`, backward compatible), threaded to `WelcomeScreen` and wired in the mock connected messages container.

> Note: the production factorial wrapper will need to pass `fullscreen` to `F0AiMessagesContainer` to get the centered layout in prod; the prop is optional and defaults to the previous behavior.

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm vitest run src/sds/ai` — 196 passing (added tests for prompt placement, popover side, welcome alignment, footer gating)
- [ ] Storybook visual check: `AI/F0AiChatTextArea → FullscreenWelcome` and `Patterns/ApplicationFrame → FullscreenWithActions`
  - [ ] Composer and welcome phrase sit near the vertical center; prompts below the textarea; popover opens downward
  - [ ] Toggling the header fullscreen button glides smoothly between modes
  - [ ] Sidepanel (normal) welcome is visually identical to before