### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.49.0",
+  "packages/react": "2.50.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.50.0](https://github.com/factorialco/f0/compare/f0-react-v2.49.0...f0-react-v2.50.0) (2026-06-09)
+
+
+### Features
+
+* **F0Slider:** add slider component ([#4285](https://github.com/factorialco/f0/issues/4285)) ([d2b2974](https://github.com/factorialco/f0/commit/d2b2974fafaed9dee10301ead8428c47e4c45311))
+
 ## [2.49.0](https://github.com/factorialco/f0/compare/f0-react-v2.48.0...f0-react-v2.49.0) (2026-06-08)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.49.0",
+  "version": "2.50.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.50.0</summary>

## [2.50.0](https://github.com/factorialco/f0/compare/f0-react-v2.49.0...f0-react-v2.50.0) (2026-06-09)


### Features

* **F0Slider:** add slider component ([#4285](https://github.com/factorialco/f0/issues/4285)) ([d2b2974](https://github.com/factorialco/f0/commit/d2b2974fafaed9dee10301ead8428c47e4c45311))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).