### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.50.0",
+  "packages/react": "2.51.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.51.0](https://github.com/factorialco/f0/compare/f0-react-v2.50.0...f0-react-v2.51.0) (2026-06-09)
+
+
+### Features
+
+* **dialog 4/6:** new F0Drawer component (additive) ([#4366](https://github.com/factorialco/f0/issues/4366)) ([1a3cd91](https://github.com/factorialco/f0/commit/1a3cd9189bfcee531eb35cb8bee89243471cbc38))
+
 ## [2.50.0](https://github.com/factorialco/f0/compare/f0-react-v2.49.0...f0-react-v2.50.0) (2026-06-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.50.0",
+  "version": "2.51.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.51.0</summary>

## [2.51.0](https://github.com/factorialco/f0/compare/f0-react-v2.50.0...f0-react-v2.51.0) (2026-06-09)


### Features

* **dialog 4/6:** new F0Drawer component (additive) ([#4366](https://github.com/factorialco/f0/issues/4366)) ([1a3cd91](https://github.com/factorialco/f0/commit/1a3cd9189bfcee531eb35cb8bee89243471cbc38))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).