### PR TITLE
fix(dialog-alike): render dialog/drawer when #content is absent (Storybook docs, tests)

### DIFF
--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
@@ -64,7 +64,12 @@ export const DialogContent = forwardRef<
       if (propContainer !== undefined) {
         setContainer(propContainer)
       } else {
-        setContainer(document.getElementById("content"))
+        // Prefer the app's content area (e.g. ApplicationFrame's `#content`),
+        // but fall back to document.body so the dialog/drawer still renders in
+        // contexts without that element (Storybook docs, tests, apps that don't
+        // use ApplicationFrame). Without this, the Radix portal target is null
+        // and nothing renders.
+        setContainer(document.getElementById("content") ?? document.body)
       }
     }, [propContainer])
 


### PR DESCRIPTION
## Problem
In Storybook **docs**, the `F0Drawer` (and `F0Dialog`) doesn't render at all — a portal issue.

## Cause
The forked `DialogContent` (dialog-alike's private dialog primitive) resolves its portal target as:

```ts
setContainer(document.getElementById("content"))   // no fallback
```

`#content` only exists inside **`ApplicationFrame`** (`patterns/ApplicationFrame` renders `id="content"`). In Storybook docs — and in tests, or any app not using `ApplicationFrame` — that element is absent, so `getElementById` returns `null`. The Radix portal then has a `null` target and renders nothing.

## Fix
Fall back to `document.body` when `#content` isn't present — the exact pattern already used in `OneDataCollection` (`document.getElementById("content") ?? document.body`):

```ts
setContainer(document.getElementById("content") ?? document.body)
```

App behavior is unchanged (it still prefers `#content` when present); docs/tests now render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)