### PR TITLE
feat(hourDistribution): per-datapoint neutralLabel for tooltip

### DIFF
--- a/packages/react/src/ui/value-display/types/barSeries/barSeries.tsx
+++ b/packages/react/src/ui/value-display/types/barSeries/barSeries.tsx
@@ -35,6 +35,8 @@ export interface BarSeriesDataPoint {
   secondaryValue?: number
   neutralValue?: number
   neutralFullHeight?: boolean
+  /** Per-point label for the neutral segment. Overrides any chart-level label when set. */
+  neutralLabel?: string
 }
 
 export interface BarSeriesCellValue {

--- a/packages/react/src/ui/value-display/types/hourDistribution/__stories__/hourDistribution.stories.tsx
+++ b/packages/react/src/ui/value-display/types/hourDistribution/__stories__/hourDistribution.stories.tsx
@@ -120,6 +120,48 @@ export const HourDistributionWithJustifiedAbsences: Story = {
   },
 }
 
+/** Per-point neutralLabel: weekends show "Non-workable", leave days show the leave type name. */
+export const HourDistributionWithMixedLabels: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Hour distribution",
+      render: () => ({
+        type: "hourDistribution",
+        value: {
+          dataPoints: [
+            { date: "2025-12-15", value: 480, plannedValue: 480 },
+            {
+              date: "2025-12-16",
+              value: 0,
+              plannedValue: 480,
+              justifiedAbsenceFullDay: true,
+              neutralLabel: "Sick leave",
+            },
+            { date: "2025-12-17", value: 360, plannedValue: 480 },
+            { date: "2025-12-18", value: 480, plannedValue: 480 },
+            { date: "2025-12-19", value: 480, plannedValue: 480 },
+            {
+              date: "2025-12-20",
+              value: 0,
+              justifiedAbsenceFullDay: true,
+              neutralLabel: "Non-workable",
+            },
+            {
+              date: "2025-12-21",
+              value: 0,
+              justifiedAbsenceFullDay: true,
+              neutralLabel: "Non-workable",
+            },
+          ],
+          workedLabel: "Worked",
+          justifiedAbsenceLabel: "Justified absence",
+        },
+      }),
+    },
+  },
+}
+
 export const HourDistributionEmpty: Story = {
   args: {
     item: mockItem,

--- a/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.test.tsx
+++ b/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.test.tsx
@@ -149,4 +149,74 @@ describe("HourDistributionCell", () => {
       )
     ).toBeInTheDocument()
   })
+
+  it("uses per-point neutralLabel over chart-level justifiedAbsenceLabel", () => {
+    const args: HourDistributionCellValue = {
+      dataPoints: [
+        {
+          date: "2025-12-18",
+          value: 240,
+          plannedValue: 480,
+          justifiedAbsenceValue: 120,
+          neutralLabel: "Sick leave",
+        },
+      ],
+      justifiedAbsenceLabel: "Justified absence",
+    }
+
+    const { container } = render(HourDistributionCell(args, defaultMeta))
+
+    expect(
+      container.querySelector('[role="img"][aria-label*="Sick leave 2h"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[role="img"][aria-label*="Justified absence"]')
+    ).not.toBeInTheDocument()
+  })
+
+  it("uses per-point neutralLabel for full-day neutral bars", () => {
+    const args: HourDistributionCellValue = {
+      dataPoints: [
+        {
+          date: "2025-12-18",
+          value: 0,
+          plannedValue: 480,
+          justifiedAbsenceFullDay: true,
+          neutralLabel: "Non-workable",
+        },
+      ],
+      justifiedAbsenceLabel: "Justified absence",
+    }
+
+    const { container } = render(HourDistributionCell(args, defaultMeta))
+
+    expect(
+      container.querySelector('[role="img"][aria-label*="Non-workable"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[role="img"][aria-label*="Justified absence"]')
+    ).not.toBeInTheDocument()
+  })
+
+  it("falls back to justifiedAbsenceLabel when neutralLabel is not set", () => {
+    const args: HourDistributionCellValue = {
+      dataPoints: [
+        {
+          date: "2025-12-18",
+          value: 0,
+          plannedValue: 480,
+          justifiedAbsenceFullDay: true,
+        },
+      ],
+      justifiedAbsenceLabel: "Ausencia justificada",
+    }
+
+    const { container } = render(HourDistributionCell(args, defaultMeta))
+
+    expect(
+      container.querySelector(
+        '[role="img"][aria-label*="Ausencia justificada"]'
+      )
+    ).toBeInTheDocument()
+  })
 })

--- a/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.tsx
+++ b/packages/react/src/ui/value-display/types/hourDistribution/hourDistribution.tsx
@@ -21,6 +21,8 @@ export interface HourDistributionDataPoint {
   justifiedAbsenceValue?: number
   /** Renders a full-height neutral bar for justified non-working days without a minute baseline. */
   justifiedAbsenceFullDay?: boolean
+  /** Per-point label for the neutral segment tooltip. Overrides the chart-level justifiedAbsenceLabel when set. */
+  neutralLabel?: string
 }
 
 export interface HourDistributionCellValue {
@@ -68,6 +70,7 @@ function toBarSeriesDataPoint(
     ...(point.justifiedAbsenceFullDay
       ? { neutralFullHeight: point.justifiedAbsenceFullDay }
       : {}),
+    ...(point.neutralLabel != null ? { neutralLabel: point.neutralLabel } : {}),
   }
 }
 
@@ -91,11 +94,12 @@ function toBarSeriesValue(args: HourDistributionCellValue): BarSeriesCellValue {
     formatValue: formatHours,
     formatTooltip: ({ point, formattedLabel, formattedValue }) => {
       const parts = [`${workedLabel} ${formattedValue}`]
+      const label = point.neutralLabel ?? absenceLabel
 
       if (point.neutralFullHeight) {
-        parts.push(absenceLabel)
+        parts.push(label)
       } else if (point.neutralValue != null && point.neutralValue > 0) {
-        parts.push(`${absenceLabel} ${formatHours(point.neutralValue)}`)
+        parts.push(`${label} ${formatHours(point.neutralValue)}`)
       }
 
       return `${formattedLabel} - ${parts.join(", ")}`


### PR DESCRIPTION
## Summary
- Adds `neutralLabel?: string` to `HourDistributionDataPoint` and `BarSeriesDataPoint`
- When set, the per-point label overrides the chart-level `justifiedAbsenceLabel` in the tooltip
- Backward-compatible: existing consumers without `neutralLabel` get the same behavior

## Why
The Factorial Time Tracking distribution column uses `hourDistribution` to show worked hours per day. Currently, weekends and actual absences both show "Justified absence" in the tooltip. With this change, consumers can pass a per-point label like "Non-workable", "Sick leave", or "Christmas Day" to differentiate them.

## Test plan
- [x] Existing tests still pass (10/10)
- [x] New tests: per-point label override for partial absences, full-day bars, and fallback behavior
- [x] New story: `HourDistributionWithMixedLabels` showing weekends vs leave types

🤖 Generated with [Claude Code](https://claude.com/claude-code)