### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.51.0",
+  "packages/react": "2.52.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.52.0](https://github.com/factorialco/f0/compare/f0-react-v2.51.0...f0-react-v2.52.0) (2026-06-09)
+
+
+### Features
+
+* **F0Dialog:** resource-aware header variant + opt-in metadata row gap ([#4313](https://github.com/factorialco/f0/issues/4313)) ([a92b0f2](https://github.com/factorialco/f0/commit/a92b0f2a5cd3789c73f4c5a49de46f725ef10f3a))
+
 ## [2.51.0](https://github.com/factorialco/f0/compare/f0-react-v2.50.0...f0-react-v2.51.0) (2026-06-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.51.0",
+  "version": "2.52.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.52.0</summary>

## [2.52.0](https://github.com/factorialco/f0/compare/f0-react-v2.51.0...f0-react-v2.52.0) (2026-06-09)


### Features

* **F0Dialog:** resource-aware header variant + opt-in metadata row gap ([#4313](https://github.com/factorialco/f0/issues/4313)) ([a92b0f2](https://github.com/factorialco/f0/commit/a92b0f2a5cd3789c73f4c5a49de46f725ef10f3a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).