### PR TITLE
feat(EditableTable): cellHint position + apply disabled state to hint

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -6,7 +6,13 @@ import { action } from "storybook/actions"
 import type { StatusVariant } from "@/components/tags/F0TagStatus/types"
 
 import { createDataSourceDefinition, RecordType } from "@/hooks/datasource"
-import { Delete, Pencil } from "@/icons/app"
+import {
+  AlertCircle,
+  Delete,
+  InfoCircle,
+  LockLocked,
+  Pencil,
+} from "@/icons/app"
 import { ROLES_MOCK } from "@/mocks"
 
 import { OneDataCollection } from "../../.."
@@ -1602,6 +1608,97 @@ export const EditableTableWithStatusPillSelect: Story = {
         ]}
         dataAdapter={dataAdapter}
         id="editable-table-status-pill-select/v1"
+      />
+    )
+  },
+}
+
+/**
+ * Demonstrates `cellHint`: an icon with a tooltip rendered inside the cell.
+ * - Salary shows a left-positioned warning when the value diverges from the
+ *   role's reference salary.
+ * - Email shows a right-positioned info hint.
+ * - Role is disabled with a lock hint, showing the hint sits inside the
+ *   disabled cell (shared disabled background).
+ */
+export const EditableTableWithCellHint: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Editable table using `cellHint` to render an icon + tooltip inside a cell. The hint icon can be placed at the start (`position: 'left'`, default) or end (`position: 'right'`) of the cell content. On disabled cells the hint shares the disabled background instead of rendering on white.",
+      },
+    },
+  },
+  render: () => {
+    const REFERENCE_SALARY = 50000
+
+    const initialItems = generateMockUsers(8).map((user, index) => ({
+      ...user,
+      // Make every other row diverge from the reference salary
+      salary: index % 2 === 0 ? 65000 : REFERENCE_SALARY,
+    }))
+
+    const { dataAdapter, onCellChange } = useEditableTableData(initialItems)
+
+    return (
+      <ExampleComponent
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              columns: [
+                {
+                  label: "Name",
+                  id: "name",
+                  editType: () => "text" as const,
+                  render: (item: MockUser) => item.name,
+                },
+                {
+                  label: "Email",
+                  id: "email",
+                  editType: () => "text" as const,
+                  render: (item: MockUser) => item.email,
+                  cellHint: () => ({
+                    icon: InfoCircle,
+                    message: "Used as the login identifier",
+                    position: "right" as const,
+                  }),
+                },
+                {
+                  label: "Salary",
+                  id: "salary",
+                  align: "right" as const,
+                  editType: () => "number" as const,
+                  numberConfig: { min: 0, units: "€" },
+                  render: (item: MockUser) => String(item.salary),
+                  cellHint: (item: MockUser) =>
+                    Number(item.salary) !== REFERENCE_SALARY
+                      ? {
+                          icon: AlertCircle,
+                          message: `Differs from reference salary (${REFERENCE_SALARY} €)`,
+                          iconColor: "warning" as const,
+                          position: "left" as const,
+                        }
+                      : undefined,
+                },
+                {
+                  label: "Role",
+                  id: "role",
+                  editType: () => "disabled" as const,
+                  render: (item: MockUser) => item.role,
+                  cellHint: () => ({
+                    icon: LockLocked,
+                    message: "Role is managed in the HR system",
+                  }),
+                },
+              ],
+              onCellChange,
+            },
+          },
+        ]}
+        dataAdapter={dataAdapter}
+        id="editable-table-cell-hint/v1"
       />
     )
   },

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
@@ -1,7 +1,8 @@
 import { ReactNode } from "react"
 
 import { F0Icon, type IconType, type F0IconProps } from "@/components/F0Icon"
-import { cn, focusRing } from "@/lib/utils"
+import { F0Box } from "@/lib/F0Box"
+import { cn } from "@/lib/utils"
 import {
   Tooltip,
   TooltipContent,
@@ -48,16 +49,16 @@ export function BaseCell({
     <TooltipProvider delayDuration={100}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <button
-            type="button"
+          <F0Box
+            role="img"
             aria-label={hint.message}
-            className={cn(
-              "pointer-events-auto flex shrink-0 cursor-pointer items-center rounded px-1",
-              focusRing()
-            )}
+            display="flex"
+            alignItems="center"
+            shrink={false}
+            paddingX="xs"
           >
             <F0Icon icon={hint.icon} size="md" color={hint.iconColor} />
-          </button>
+          </F0Box>
         </TooltipTrigger>
         <TooltipContent
           side="top"

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
@@ -20,6 +20,7 @@ const cursorClass = {
 
 export function BaseCell({
   readonly = false,
+  disabled = false,
   showRightBorder = true,
   cursor = "text",
   isActive = false,
@@ -29,14 +30,47 @@ export function BaseCell({
   children,
 }: {
   readonly?: boolean
+  disabled?: boolean
   showRightBorder?: boolean
   cursor?: "text" | "pointer" | "default" | "not-allowed"
   isActive?: boolean
   error?: string
-  hint?: { icon: IconType; message: string; iconColor?: F0IconProps["color"] }
+  hint?: {
+    icon: IconType
+    message: string
+    iconColor?: F0IconProps["color"]
+    position?: "left" | "right"
+  }
   borderOnHover?: boolean
   children: ReactNode
 }) {
+  const hintIcon = hint && !error && (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={hint.message}
+            className={cn(
+              "pointer-events-auto flex shrink-0 cursor-pointer items-center rounded px-1",
+              focusRing()
+            )}
+          >
+            <F0Icon icon={hint.icon} size="md" color={hint.iconColor} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className="border-black/10 max-w-64 cursor-default text-f1-foreground shadow-md"
+        >
+          <span className="text-sm font-medium text-f1-foreground">
+            {hint.message}
+          </span>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+
   return (
     <div
       className={cn(
@@ -51,37 +85,14 @@ export function BaseCell({
             : borderOnHover
               ? "shadow-none [&:not(:focus-within)]:hover:shadow-[inset_0_0_0_1px_hsl(var(--neutral-30))] focus-within:relative focus-within:z-[1] focus-within:border-r-0 focus-within:bg-f1-background focus-within:shadow-[inset_0_0_0_1px_hsl(var(--selected-50))]"
               : "shadow-none",
-        readonly && "bg-f1-background-secondary"
+        readonly && "bg-f1-background-secondary",
+        disabled && "bg-f1-background-disabled"
       )}
     >
       <ErrorTooltip message={error}>
-        {hint && !error && (
-          <TooltipProvider delayDuration={100}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={hint.message}
-                  className={cn(
-                    "pointer-events-auto flex shrink-0 cursor-pointer items-center rounded px-1",
-                    focusRing()
-                  )}
-                >
-                  <F0Icon icon={hint.icon} size="md" color={hint.iconColor} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent
-                side="top"
-                className="border-black/10 max-w-64 cursor-default text-f1-foreground shadow-md"
-              >
-                <span className="text-sm font-medium text-f1-foreground">
-                  {hint.message}
-                </span>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
+        {hint?.position !== "right" && hintIcon}
         <div className="min-w-0 flex-1">{children}</div>
+        {hint?.position === "right" && hintIcon}
       </ErrorTooltip>
     </div>
   )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
@@ -24,7 +24,12 @@ export type EditableCellProps<R extends RecordType> = {
   ) => void
   item: R
   isLastColumn?: boolean
-  hint?: { icon: IconType; message: string; iconColor?: F0IconProps["color"] }
+  hint?: {
+    icon: IconType
+    message: string
+    iconColor?: F0IconProps["color"]
+    position?: "left" | "right"
+  }
 }
 
 /** The edit mode for a column cell in the editable table. */

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
@@ -14,12 +14,11 @@ export function DisabledCell<R extends RecordType>({
   const i18n = useI18n()
 
   return (
-    <BaseCell borderOnHover={false} hint={hint}>
+    <BaseCell borderOnHover={false} hint={hint} disabled>
       <div
         className={cn(
           editableColumn.align === "right" ? "justify-end" : "",
           "flex p-4 min-h-12 items-center border-0 h-full",
-          "bg-f1-background-disabled h-full",
           "cursor-pointer w-full"
         )}
       >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -193,10 +193,13 @@ export type EditableTableColumnDefinition<
    *
    * Return `undefined` to hide the hint.
    *
+   * Use `position` to place the icon at the start (`"left"`, default) or end
+   * (`"right"`) of the cell content.
+   *
    * @example
    * cellHint: (item) => {
    *   if (item._inferredSalary != null && item.salary !== item._inferredSalary) {
-   *     return { icon: AlertCircle, message: `Differs from catalog (${item._inferredSalary})` }
+   *     return { icon: AlertCircle, message: `Differs from catalog (${item._inferredSalary})`, position: "right" }
    *   }
    * }
    */
@@ -205,6 +208,8 @@ export type EditableTableColumnDefinition<
         icon: IconType
         message: string
         iconColor?: F0IconProps["color"]
+        /** Where to place the icon relative to the cell content. Defaults to `"left"`. */
+        position?: "left" | "right"
       }
     | undefined
 }


### PR DESCRIPTION
## What

Two improvements to the Editable Table `cellHint`:

1. **`position` option** — `cellHint` can now return `position: "left" | "right"` to place the hint icon at the start (default) or end of the cell content.

2. **Disabled cell fix** — when a cell is disabled, the hint icon used to render on a white background while the content was greyed out, making it look like the hint lived *outside* the cell. The disabled background now covers the whole cell (icon included), so the hint reads as part of the disabled cell.

## How

- `types.ts` — added optional `position?: "left" | "right"` to the `cellHint` return type.
- `cells/index.ts` — added `position` to the shared `hint` prop.
- `BaseCell.tsx` — render the hint icon before or after the content based on `position`; added a `disabled` prop that applies `bg-f1-background-disabled` to the whole cell container.
- `DisabledCell.tsx` — pass `disabled` to `BaseCell` and drop the inner-div background so the disabled background spans the full cell.

All cell components already forward `hint` to `BaseCell`, so both behaviors work across every editable cell type.

## Usage

```ts
cellHint: (item) => ({
  icon: AlertCircle,
  message: "Inferred from catalog",
  position: "right",
})
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)