### PR TITLE
feat(avatars): promote F0AvatarDate + F0AvatarAlert to stable

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarAlert/__stories__/F0AvatarAlert.mdx
+++ b/packages/react/src/components/avatars/F0AvatarAlert/__stories__/F0AvatarAlert.mdx
@@ -1,0 +1,53 @@
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
+import * as AlertStories from "./F0AvatarAlert.stories"
+
+<Meta of={AlertStories} />
+
+# AvatarAlert
+
+An avatar-sized status indicator that signals a state through an icon and color.
+
+---
+
+## Overview
+
+### Purpose
+
+Represent a specific, meaningful status of an item — critical, warning, info or
+positive.
+
+### Anatomy
+
+An alert avatar is square and pairs a status icon with a matching semantic
+color, both driven by the `type` prop: `critical`, `warning`, `info` or
+`positive`. It is available in sizes `sm`–`lg`.
+
+<Canvas of={AlertStories.Default} />
+
+<Controls of={AlertStories.Default} />
+
+### Variants
+
+#### Types
+
+Each type maps to a fixed icon and semantic color.
+
+<Canvas of={AlertStories.Snapshot} />
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- Flagging the status or severity of an item where an avatar-sized marker fits
+
+#### When NOT to use
+
+- As a generic attention-grabber or decoration — reserve it for a genuine
+  status; overusing it dilutes the signal
+- Representing an entity (person, team, …): use `F0Avatar` or the matching
+  `F0Avatar*` component
+- Inline or text-level status: use a Badge or Tag instead

--- a/packages/react/src/components/avatars/F0AvatarAlert/__stories__/F0AvatarAlert.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarAlert/__stories__/F0AvatarAlert.stories.tsx
@@ -9,10 +9,10 @@ import {
   F0AvatarAlert,
 } from "../F0AvatarAlert"
 
-const meta: Meta<typeof F0AvatarAlert> = {
+const meta = {
   component: F0AvatarAlert,
   title: "Avatars/AvatarAlert",
-  tags: ["autodocs"],
+  tags: ["stable", "!autodocs"],
   parameters: {
     docs: {
       description: {
@@ -37,7 +37,7 @@ const meta: Meta<typeof F0AvatarAlert> = {
       },
     },
   },
-}
+} satisfies Meta<typeof F0AvatarAlert>
 
 export default meta
 type Story = StoryObj<typeof F0AvatarAlert>
@@ -45,6 +45,10 @@ type Story = StoryObj<typeof F0AvatarAlert>
 const SIZES = alertAvatarSizes
 const TYPES = alertAvatarTypes
 export const Default: Story = {
+  args: { type: "info", size: "lg" },
+}
+
+export const Snapshot: Story = {
   parameters: withSnapshot({}),
   render: () => (
     <div className="flex w-fit flex-col gap-2">

--- a/packages/react/src/components/avatars/F0AvatarDate/__stories__/F0AvatarDate.mdx
+++ b/packages/react/src/components/avatars/F0AvatarDate/__stories__/F0AvatarDate.mdx
@@ -1,0 +1,44 @@
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
+import * as DateStories from "./F0AvatarDate.stories"
+
+<Meta of={DateStories} />
+
+# AvatarDate
+
+The avatar for a date, shown as a compact calendar chip.
+
+---
+
+## Overview
+
+### Purpose
+
+- Represent a date — an event, deadline or milestone — at a glance
+- Give date-bound items a recognizable, consistent marker in lists and cards
+
+### Anatomy
+
+A date avatar stacks the abbreviated month over the day number in a compact
+chip. Because it conveys the date as text rather than an image or icon, it
+renders at a single fixed size instead of the shared size scale: at the smaller
+sizes the month and day would become too small to stay legible.
+
+<Canvas of={DateStories.Default} />
+
+<Controls of={DateStories.Default} />
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- Marking events, deadlines or other date-stamped items
+- Calendars, timelines and scheduling surfaces
+
+#### When NOT to use
+
+- Representing a person, team or other entity: use `F0Avatar` or the matching
+  `F0Avatar*` component

--- a/packages/react/src/components/avatars/F0AvatarDate/__stories__/F0AvatarDate.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarDate/__stories__/F0AvatarDate.stories.tsx
@@ -5,10 +5,10 @@ import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
 import { F0AvatarDate } from "../F0AvatarDate"
 
-const meta: Meta<typeof F0AvatarDate> = {
+const meta = {
   component: F0AvatarDate,
   title: "Avatars/AvatarDate",
-  tags: ["autodocs"],
+  tags: ["stable", "!autodocs"],
   parameters: {
     docs: {
       description: {
@@ -25,7 +25,7 @@ const meta: Meta<typeof F0AvatarDate> = {
       description: "The date to display in the avatar",
     },
   },
-}
+} satisfies Meta<typeof F0AvatarDate>
 
 export default meta
 
@@ -38,6 +38,11 @@ export const Default: Story = {
   args: {
     date: exampleDate,
   },
+  // The Storybook "date" control emits a timestamp on change; coerce back to a
+  // Date so the control stays interactive without breaking the component.
+  render: ({ date, ...args }) => (
+    <F0AvatarDate date={new Date(date)} {...args} />
+  ),
 }
 
 export const Snapshot: Story = {

--- a/packages/react/src/components/avatars/F0AvatarDate/__tests__/F0AvatarDate.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarDate/__tests__/F0AvatarDate.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { F0AvatarDate } from "../F0AvatarDate"
+
+describe("F0AvatarDate", () => {
+  it("renders the day of the month from the given date", () => {
+    zeroRender(
+      <F0AvatarDate date={new Date(2026, 0, 14)} aria-label="14 January 2026" />
+    )
+
+    expect(screen.getByText("14")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What

Promotes two **specialized** avatars to `stable`: **F0AvatarDate** and **F0AvatarAlert**.

## Changes per component

- Maturity tag `["stable", "!autodocs"]`, `satisfies Meta`, a `Snapshot` story, focused MDX docs, and `__storybook__` → `__stories__` folder rename.
- **F0AvatarDate**: docs explain why it uses a single fixed size (it shows the date as text, which wouldn't stay legible at the smaller sizes). The `Default` story coerces the Storybook `date` control's timestamp back to a `Date` so the control stays interactive without breaking the component.
- **F0AvatarAlert**: split the matrix story into `Default` (single example) + `Snapshot` (all types × sizes); docs scope it to a *genuine, meaningful status* and explicitly warn against using it as a generic attention-grabber.

## Verification

- Lifecycle DoD (`check-one`): **0 issues** on both
- Unit tests **12/12** · `oxlint` 0/0 · `tsc` clean

## Scope / not included

The other specialized avatars are handled separately (each carries a design decision):
- **Pulse** → to be **relocated out of F0 avatars** (it's a mood/check-in feature, used in DaytimePage + MoodTracker)
- **Module** → size-naming collision to resolve first
- **List** → reconsider as `AvatarGroup`/`AvatarStack`

Entity-type avatars (F0Avatar + Person/Team/Company/File/Flag/Emoji/Icon) are in #4326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Implemented-with: factorial-f0