### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.52.0",
+  "packages/react": "2.53.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.53.0](https://github.com/factorialco/f0/compare/f0-react-v2.52.0...f0-react-v2.53.0) (2026-06-09)
+
+
+### Features
+
+* **ai-chat:** center fullscreen welcome, prompts below textarea ([#4377](https://github.com/factorialco/f0/issues/4377)) ([8bbcc22](https://github.com/factorialco/f0/commit/8bbcc227e4934a22db64ed7bb69a4ccc550fdb8c))
+
 ## [2.52.0](https://github.com/factorialco/f0/compare/f0-react-v2.51.0...f0-react-v2.52.0) (2026-06-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.52.0",
+  "version": "2.53.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.53.0</summary>

## [2.53.0](https://github.com/factorialco/f0/compare/f0-react-v2.52.0...f0-react-v2.53.0) (2026-06-09)


### Features

* **ai-chat:** center fullscreen welcome, prompts below textarea ([#4377](https://github.com/factorialco/f0/issues/4377)) ([8bbcc22](https://github.com/factorialco/f0/commit/8bbcc227e4934a22db64ed7bb69a4ccc550fdb8c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).