### PR TITLE
refactor(avatars): move F0AvatarPulse to sds/Home + drop it from F0Card

### DIFF
--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -275,7 +275,7 @@ export const WithAlert: Story = {
 
 /**
  * The `avatar` prop accepts every single-avatar type in the system — person,
- * company, team, file, flag, icon, emoji, module, alert, date and pulse — each
+ * company, team, file, flag, icon, emoji, module, alert and date — each
  * rendered at a single, fixed size on the left (the size is not configurable).
  */
 export const AvatarTypes: Story = {
@@ -351,18 +351,6 @@ export const AvatarTypes: Story = {
         avatar={{ type: "date", date: new Date(2026, 5, 5) }}
         title="Team offsite"
         description="Date avatar"
-        primaryAction={{ label: "Open", onClick: fn() }}
-      />
-      <F0CardRow
-        avatar={{
-          type: "pulse",
-          firstName: "Jane",
-          lastName: "Cooper",
-          pulse: "positive",
-          onPulseClick: fn(),
-        }}
-        title="Jane Cooper"
-        description="Pulse avatar"
         primaryAction={{ label: "Open", onClick: fn() }}
       />
     </div>

--- a/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/F0CardRow.test.tsx
@@ -59,12 +59,6 @@ describe("F0CardRow", () => {
       { type: "module", module: "goals" },
       { type: "alert", variant: "warning" },
       { type: "date", date: new Date(2026, 5, 5) },
-      {
-        type: "pulse",
-        firstName: "Jane",
-        lastName: "Cooper",
-        onPulseClick: vi.fn(),
-      },
     ]
 
     avatars.forEach((avatar) => {

--- a/packages/react/src/components/F0Card/components/CardAvatar.tsx
+++ b/packages/react/src/components/F0Card/components/CardAvatar.tsx
@@ -11,7 +11,6 @@ import {
   F0AvatarModule,
   type ModuleId,
 } from "@/components/avatars/F0AvatarModule"
-import { F0AvatarPulse, type Pulse } from "@/components/avatars/F0AvatarPulse"
 import { IconType } from "@/components/F0Icon"
 import { cn } from "@/lib/utils"
 
@@ -23,14 +22,6 @@ type CardAvatarVariant =
   | { type: "module"; module: ModuleId }
   | { type: "alert"; variant: AlertAvatarProps["type"] }
   | { type: "date"; date: Date }
-  | {
-      type: "pulse"
-      firstName: string
-      lastName: string
-      src?: string
-      pulse?: Pulse
-      onPulseClick: () => void
-    }
 
 type CardAvatarSize = "sm" | "md" | "lg"
 
@@ -83,18 +74,6 @@ const AvatarRender = ({
   if (avatar.type === "date") {
     // F0AvatarDate has a fixed intrinsic size (no size prop).
     return <F0AvatarDate date={avatar.date} />
-  }
-  if (avatar.type === "pulse") {
-    // F0AvatarPulse has a fixed intrinsic size (no size prop).
-    return (
-      <F0AvatarPulse
-        firstName={avatar.firstName}
-        lastName={avatar.lastName}
-        src={avatar.src}
-        pulse={avatar.pulse}
-        onPulseClick={avatar.onPulseClick}
-      />
-    )
   }
   return <F0Avatar avatar={avatar} size={size} />
 }

--- a/packages/react/src/components/RichText/CoreEditor/Extensions/MoodTracker/index.tsx
+++ b/packages/react/src/components/RichText/CoreEditor/Extensions/MoodTracker/index.tsx
@@ -7,11 +7,7 @@ import {
 } from "@tiptap/react"
 import React, { useState } from "react"
 
-import {
-  Pulse,
-  pulseIcon,
-  pulseIconColor,
-} from "@/components/avatars/F0AvatarPulse"
+import { Pulse, pulseIcon, pulseIconColor } from "@/lib/mood"
 import { F0Button } from "@/components/F0Button"
 import { F0Icon } from "@/components/F0Icon"
 import { Dropdown } from "@/experimental/Navigation/Dropdown"

--- a/packages/react/src/components/avatars/F0AvatarPulse/index.tsx
+++ b/packages/react/src/components/avatars/F0AvatarPulse/index.tsx
@@ -1,2 +1,0 @@
-export { F0AvatarPulse, pulseIcon, pulseIconColor } from "./F0AvatarPulse"
-export type { Pulse } from "./F0AvatarPulse"

--- a/packages/react/src/lib/mood.ts
+++ b/packages/react/src/lib/mood.ts
@@ -1,0 +1,33 @@
+import { F0IconProps, IconType } from "@/components/F0Icon"
+import {
+  FaceNegative,
+  FaceNeutral,
+  FacePositive,
+  FaceSuperNegative,
+  FaceSuperPositive,
+} from "@/icons/app"
+
+export const pulses = [
+  "superNegative",
+  "negative",
+  "neutral",
+  "positive",
+  "superPositive",
+] as const
+export type Pulse = (typeof pulses)[number]
+
+export const pulseIcon: Record<Pulse, IconType> = {
+  superNegative: FaceSuperNegative,
+  negative: FaceNegative,
+  neutral: FaceNeutral,
+  positive: FacePositive,
+  superPositive: FaceSuperPositive,
+}
+
+export const pulseIconColor: Record<Pulse, F0IconProps["color"]> = {
+  superNegative: "mood-super-negative",
+  negative: "mood-negative",
+  neutral: "mood-neutral",
+  positive: "mood-positive",
+  superPositive: "mood-super-positive",
+}

--- a/packages/react/src/sds/Home/DaytimePage/index.stories.tsx
+++ b/packages/react/src/sds/Home/DaytimePage/index.stories.tsx
@@ -9,7 +9,7 @@ import { ApplicationFrame } from "@/patterns/ApplicationFrame"
 import { DaytimePage, DaytimePageProps } from "./index"
 
 const meta: Meta<typeof DaytimePage> = {
-  title: "DaytimePage",
+  title: "Home/DaytimePage",
   component: DaytimePage,
   tags: ["autodocs", "experimental"],
   parameters: {

--- a/packages/react/src/sds/Home/DaytimePage/index.tsx
+++ b/packages/react/src/sds/Home/DaytimePage/index.tsx
@@ -2,7 +2,6 @@ import { cva, type VariantProps } from "cva"
 import { ComponentProps } from "react"
 
 import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
-import { F0AvatarPulse } from "@/components/avatars/F0AvatarPulse"
 import { F0Button } from "@/components/F0Button"
 import { OneSwitch as OnePromotionSwitch } from "@/experimental/AiPromotionChat/OneSwitch"
 import Menu from "@/icons/app/Menu"
@@ -10,6 +9,7 @@ import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 import { cn } from "@/lib/utils"
 import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
+import { F0AvatarPulse } from "@/sds/Home/F0AvatarPulse"
 import { F0OneSwitch } from "@/sds/ai/F0OneSwitch"
 
 const daytimePageVariants = cva({

--- a/packages/react/src/sds/Home/F0AvatarPulse/F0AvatarPulse.tsx
+++ b/packages/react/src/sds/Home/F0AvatarPulse/F0AvatarPulse.tsx
@@ -2,45 +2,14 @@ import { AnimatePresence, motion } from "motion/react"
 import { ComponentProps, useState } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { F0Icon, F0IconProps, IconType } from "@/components/F0Icon"
-import {
-  FaceNegative,
-  FaceNeutral,
-  FacePositive,
-  FaceSuperNegative,
-  FaceSuperPositive,
-  Reaction,
-} from "@/icons/app"
+import { F0Icon } from "@/components/F0Icon"
+import { Reaction } from "@/icons/app"
 import { EmojiImage } from "@/lib/emojis"
+import { Pulse, pulseIcon, pulseIconColor } from "@/lib/mood"
 import { useI18n } from "@/lib/providers/i18n"
 import { Action } from "@/ui/Action"
 
-import { BaseAvatar } from "../internal/BaseAvatar"
-
-export const pulses = [
-  "superNegative",
-  "negative",
-  "neutral",
-  "positive",
-  "superPositive",
-] as const
-export type Pulse = (typeof pulses)[number]
-
-export const pulseIcon: Record<Pulse, IconType> = {
-  superNegative: FaceSuperNegative,
-  negative: FaceNegative,
-  neutral: FaceNeutral,
-  positive: FacePositive,
-  superPositive: FaceSuperPositive,
-}
-
-export const pulseIconColor: Record<Pulse, F0IconProps["color"]> = {
-  superNegative: "mood-super-negative",
-  negative: "mood-negative",
-  neutral: "mood-neutral",
-  positive: "mood-positive",
-  superPositive: "mood-super-positive",
-}
+import { BaseAvatar } from "@/components/avatars/internal/BaseAvatar"
 
 type BaseAvatarProps = ComponentProps<typeof BaseAvatar>
 

--- a/packages/react/src/sds/Home/F0AvatarPulse/__storybook__/F0AvatarPulse.stories.tsx
+++ b/packages/react/src/sds/Home/F0AvatarPulse/__storybook__/F0AvatarPulse.stories.tsx
@@ -3,12 +3,14 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { mockImage } from "@/testing/mocks/images"
 
-import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
-import { F0AvatarPulse, F0AvatarPulseProps, pulses } from "../F0AvatarPulse"
+import { getBaseAvatarArgTypes } from "@/components/avatars/internal/BaseAvatar/__stories__/utils"
+import { pulses } from "@/lib/mood"
+
+import { F0AvatarPulse, F0AvatarPulseProps } from "../F0AvatarPulse"
 
 const meta: Meta<typeof F0AvatarPulse> = {
   component: F0AvatarPulse,
-  title: "Avatars/AvatarPulse",
+  title: "Home/AvatarPulse",
   tags: ["autodocs"],
   parameters: {
     docs: {

--- a/packages/react/src/sds/Home/F0AvatarPulse/index.tsx
+++ b/packages/react/src/sds/Home/F0AvatarPulse/index.tsx
@@ -1,0 +1,2 @@
+export { F0AvatarPulse } from "./F0AvatarPulse"
+export type { F0AvatarPulseProps } from "./F0AvatarPulse"


### PR DESCRIPTION
## What

F0AvatarPulse is a specific **mood/check-in** feature (Home `DaytimePage` + RichText `MoodTracker`), not a base avatar primitive. It shouldn't live among the avatar components, and — being an **sds-level** component — it shouldn't be supported inside **main-F0 components** either.

## Changes

- **Move** `F0AvatarPulse` → `sds/Home/F0AvatarPulse`; regroup its story (and the sibling `DaytimePage` story) under `Home/` in Storybook.
- **Extract** the shared mood vocabulary (`pulses`, `Pulse`, `pulseIcon`, `pulseIconColor`) to **`lib/mood`** so the components-level `MoodTracker` consumes it **without a `components → sds` layering inversion**.
- Update `DaytimePage` and `MoodTracker` imports.
- **Drop the `pulse` type from `F0Card`'s `CardAvatar`** (and its `F0CardRow` story/test examples): a components-level card must not depend on an sds component. ⚠️ This card-avatar type was only exercised by **stories/tests, never product code**.

## Notes

- **Relocation only** — `F0AvatarPulse` is **not stabilized** here.
- Branch is rebuilt on the latest `main`.
- ⚠️ Removing `type: "pulse"` from `CardAvatar`'s union is a breaking change to `F0CardRow`'s `avatar` prop API — intended, and unused by product code.

## Verification

- `tsc` no new errors · `oxlint` 0/0 · format ✅ · F0Card + sds/Home tests **95/95**

🤖 Generated with [Claude Code](https://claude.com/claude-code)