### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.54.0",
+  "packages/react": "2.55.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.55.0](https://github.com/factorialco/f0/compare/f0-react-v2.54.0...f0-react-v2.55.0) (2026-06-09)
+
+
+### Features
+
+* **dialog 6/6:** F0Wizard/F0WizardForm size prop + width deprecation (non-breaking) ([#4368](https://github.com/factorialco/f0/issues/4368)) ([7a948f2](https://github.com/factorialco/f0/commit/7a948f24d849bca76d7ae1ecb9f8db4a52f49792))
+
 ## [2.54.0](https://github.com/factorialco/f0/compare/f0-react-v2.53.0...f0-react-v2.54.0) (2026-06-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.54.0",
+  "version": "2.55.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.55.0</summary>

## [2.55.0](https://github.com/factorialco/f0/compare/f0-react-v2.54.0...f0-react-v2.55.0) (2026-06-09)


### Features

* **dialog 6/6:** F0Wizard/F0WizardForm size prop + width deprecation (non-breaking) ([#4368](https://github.com/factorialco/f0/issues/4368)) ([7a948f2](https://github.com/factorialco/f0/commit/7a948f24d849bca76d7ae1ecb9f8db4a52f49792))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).