### PR TITLE
fix(F0Accordion): vertical actions dots, spacing and card shadow

### DIFF
--- a/packages/react/src/components/F0Accordion/F0Accordion.tsx
+++ b/packages/react/src/components/F0Accordion/F0Accordion.tsx
@@ -48,7 +48,7 @@ const F0AccordionBase = forwardRef<HTMLDivElement, F0AccordionProps>(
         {...rest}
         className={cn(
           "flex flex-col rounded-md border border-solid border-f1-border-secondary",
-          "overflow-hidden bg-f1-background"
+          "overflow-hidden bg-f1-background shadow"
         )}
       >
         {items.map((item, index) => (

--- a/packages/react/src/components/F0Accordion/F0AccordionSkeleton.tsx
+++ b/packages/react/src/components/F0Accordion/F0AccordionSkeleton.tsx
@@ -16,7 +16,7 @@ export const F0AccordionSkeleton = ({
       aria-live="polite"
       className={cn(
         "flex flex-col rounded-md border border-solid border-f1-border-secondary",
-        "overflow-hidden bg-f1-background"
+        "overflow-hidden bg-f1-background shadow"
       )}
     >
       {Array.from({ length: items }).map((_, index) => (
@@ -24,7 +24,7 @@ export const F0AccordionSkeleton = ({
           {index > 0 && <div className="h-px w-full bg-f1-border-secondary" />}
           <div className="flex items-center gap-3 px-4 py-3">
             <Skeleton className="h-4 flex-1 max-w-48" />
-            <Skeleton className="h-7 w-7 shrink-0 rounded" />
+            <Skeleton className="ml-auto h-7 w-7 shrink-0 rounded" />
           </div>
         </Fragment>
       ))}

--- a/packages/react/src/components/F0Accordion/components/AccordionActions.tsx
+++ b/packages/react/src/components/F0Accordion/components/AccordionActions.tsx
@@ -1,7 +1,7 @@
 import { F0Button } from "@/components/F0Button"
 import { F0SegmentedControl } from "@/experimental/Actions/F0SegmentedControl"
 import { Dropdown } from "@/experimental/Navigation/Dropdown"
-import { EllipsisHorizontal } from "@/icons/app"
+import { Ellipsis } from "@/icons/app"
 
 import { F0AccordionItemAction } from "../types"
 
@@ -35,7 +35,7 @@ export const AccordionActions = ({ actions }: AccordionActionsProps) => {
                 <F0Button
                   variant="outline"
                   size="sm"
-                  icon={EllipsisHorizontal}
+                  icon={Ellipsis}
                   label={action.ariaLabel}
                   hideLabel
                   disabled={action.disabled}

--- a/packages/react/src/components/F0Accordion/components/AccordionItem.tsx
+++ b/packages/react/src/components/F0Accordion/components/AccordionItem.tsx
@@ -51,12 +51,8 @@ export const AccordionItem = ({
               </span>
             </button>
           </CollapsibleTrigger>
-          {hasActions && (
-            <div className="flex items-center gap-2 px-2 py-3">
-              <AccordionActions actions={item.actions!} />
-            </div>
-          )}
-          <div className={cn("flex items-center py-3 pl-2 pr-4")}>
+          <div className="flex items-center gap-2 py-3 pl-2 pr-4">
+            {hasActions && <AccordionActions actions={item.actions!} />}
             <CollapsibleTrigger asChild>
               <F0Button
                 variant="outline"


### PR DESCRIPTION
## 🚪 Why?

Visual fixes on `F0Accordion` reported while using it (thanks @ReddyWish ):
- The actions button rendered the three dots **horizontally** instead of vertically.
- The spacing between the actions button and the expand/collapse arrow looked off.
- The container was **missing the subtle card shadow** from the design.

## 🔑 What?

- Use the vertical `Ellipsis` icon for the actions dropdown trigger (was `EllipsisHorizontal`).
- Group the actions and the expand/collapse control in a single wrapper so the gap between them is consistent (8px instead of the previous 16px from doubled padding).
- Add the subtle card `shadow` to the accordion container — matching the `sm` shadow token (`shadow`) introduced in #4354 — and mirror it on the skeleton.
- Right-align the chevron placeholder in the skeleton so it matches the real layout.

<img width="1246" height="343" alt="image" src="https://github.com/user-attachments/assets/21ba2331-7a09-4013-b7ba-2cb455a57db3" />
