### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.55.1",
+  "packages/react": "2.55.2",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.55.2](https://github.com/factorialco/f0/compare/f0-react-v2.55.1...f0-react-v2.55.2) (2026-06-10)
+
+
+### Bug Fixes
+
+* **F0Accordion:** vertical actions dots, spacing and card shadow ([#4396](https://github.com/factorialco/f0/issues/4396)) ([a350dcf](https://github.com/factorialco/f0/commit/a350dcfc06364d955887302d04f900d5174ba6ad))
+
 ## [2.55.1](https://github.com/factorialco/f0/compare/f0-react-v2.55.0...f0-react-v2.55.1) (2026-06-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.55.1",
+  "version": "2.55.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.55.2</summary>

## [2.55.2](https://github.com/factorialco/f0/compare/f0-react-v2.55.1...f0-react-v2.55.2) (2026-06-10)


### Bug Fixes

* **F0Accordion:** vertical actions dots, spacing and card shadow ([#4396](https://github.com/factorialco/f0/issues/4396)) ([a350dcf](https://github.com/factorialco/f0/commit/a350dcfc06364d955887302d04f900d5174ba6ad))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).