### PR TITLE
fix(F0Form): resolve defaultValues function at mount when defaultValuesParamsSchema is set

### DIFF
--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -407,7 +407,8 @@ function F0FormFromSingleDefinition<TSchema extends F0FormSchema>({
 
   const { resolved: resolvedDefaults, isLoading: isLoadingDefaults } =
     useAsyncDefaultValues<Partial<z.infer<TSchema>>>(
-      def.asyncDefaultValues ?? def.defaultValues
+      def.asyncDefaultValues ?? def.defaultValuesFn ?? def.defaultValues,
+      def.defaultValuesParamsSchema
     )
 
   const adaptedOnSubmit = useCallback(
@@ -457,7 +458,8 @@ function F0FormFromPerSectionDefinition<T extends F0PerSectionSchema>({
 
   const { resolved: resolvedDefaults, isLoading: isLoadingDefaults } =
     useAsyncDefaultValues<{ [K in keyof T]?: Partial<z.infer<T[K]>> }>(
-      def.asyncDefaultValues ?? def.defaultValues
+      def.asyncDefaultValues ?? def.defaultValuesFn ?? def.defaultValues,
+      def.defaultValuesParamsSchema
     )
 
   const fullDataRef = useRef<Record<string, unknown>>(

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -3088,6 +3088,87 @@ export const WithDefaultValuesParamsSchema: Story = {
 }
 
 /**
+ * Per-section form definition with `defaultValuesParamsSchema`.
+ *
+ * Same as `WithDefaultValuesParamsSchema` but with a per-section schema:
+ * `defaultValues` is a function receiving typed params and returning values
+ * keyed by section ID. At mount time it's resolved with empty params (`{}`),
+ * showing loading indicators until the values arrive.
+ */
+export const WithDefaultValuesParamsSchemaPerSection: Story = {
+  render() {
+    const schema = {
+      personal: z.object({
+        firstName: f0FormField.text({
+          label: "First Name",
+          placeholder: "Enter first name",
+        }),
+        lastName: f0FormField.text({
+          label: "Last Name",
+          placeholder: "Enter last name",
+        }),
+      }),
+      contact: z.object({
+        email: f0FormField.email({
+          label: "Email",
+          placeholder: "you@example.com",
+        }),
+      }),
+    }
+
+    const employees: Record<
+      string,
+      { firstName: string; lastName: string; email: string }
+    > = {
+      "emp-1": {
+        firstName: "Jane",
+        lastName: "Doe",
+        email: "jane.doe@factorial.co",
+      },
+      "emp-2": {
+        firstName: "John",
+        lastName: "Smith",
+        email: "john.smith@factorial.co",
+      },
+    }
+
+    const formDefinition = useF0FormDefinition({
+      name: "edit-employee-per-section",
+      schema,
+      sections: {
+        personal: { title: "Personal Information" },
+        contact: { title: "Contact Details" },
+      },
+      defaultValuesParamsSchema: z.object({
+        employeeId: z.string().describe("The ID of the employee to edit"),
+      }),
+      defaultValues: async ({ employeeId }) => {
+        await sleep(1500)
+        // At mount time params is {} so employeeId is undefined — fall back
+        const employee = employeeId ? employees[employeeId] : employees["emp-1"]
+        return {
+          personal: {
+            firstName: employee?.firstName ?? "",
+            lastName: employee?.lastName ?? "",
+          },
+          contact: { email: employee?.email ?? "" },
+        }
+      },
+      onSubmit: async ({ sectionId, data }) => {
+        await sleep(1000)
+        console.info(
+          `Section "${sectionId}" submitted: ${JSON.stringify(data, null, 2)}`
+        )
+        return { success: true }
+      },
+      submitConfig: { label: "Save" },
+    })
+
+    return <F0Form formDefinition={formDefinition} />
+  },
+}
+
+/**
  * Demonstrates using `formRef.current.actionBar.wiggle({ errorHighlight })`
  * to programmatically trigger the action bar wiggle animation from outside the form.
  *

--- a/packages/react/src/patterns/F0Form/__tests__/F0FormAsyncDefaults.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0FormAsyncDefaults.test.tsx
@@ -75,6 +75,47 @@ function PerSectionForm({
   return <F0Form formDefinition={formDefinition} />
 }
 
+const paramsSchema = z.object({
+  userId: z.string().describe("The ID of the user to edit"),
+})
+
+function SingleSchemaFormWithParams({
+  defaultValues,
+}: {
+  defaultValues: (
+    params: Partial<z.infer<typeof paramsSchema>>
+  ) => Promise<Partial<z.infer<typeof singleSchema>>>
+}) {
+  const formDefinition = useF0FormDefinition({
+    name: "params-test-single",
+    schema: singleSchema,
+    defaultValuesParamsSchema: paramsSchema,
+    defaultValues,
+    onSubmit: async () => ({ success: true }),
+  })
+
+  return <F0Form formDefinition={formDefinition} />
+}
+
+function PerSectionFormWithParams({
+  defaultValues,
+}: {
+  defaultValues: (params: Partial<z.infer<typeof paramsSchema>>) => Promise<{
+    personal?: Partial<{ name: string }>
+    contact?: Partial<{ email: string }>
+  }>
+}) {
+  const formDefinition = useF0FormDefinition({
+    name: "params-test-per-section",
+    schema: perSectionSchema,
+    defaultValuesParamsSchema: paramsSchema,
+    defaultValues,
+    onSubmit: async () => ({ success: true }),
+  })
+
+  return <F0Form formDefinition={formDefinition} />
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -193,6 +234,94 @@ describe("F0Form async defaultValues (per-section)", () => {
   })
 })
 
+describe("F0Form defaultValues fn with defaultValuesParamsSchema (single schema)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("shows loading indicators while the params defaultValues fn is resolving", () => {
+    const fn = () =>
+      new Promise<Partial<z.infer<typeof singleSchema>>>((resolve) => {
+        setTimeout(() => resolve({ name: "Alice", email: "a@b.com" }), 1000)
+      })
+
+    render(<SingleSchemaFormWithParams defaultValues={fn} />)
+
+    expect(screen.getByLabelText("Name")).toBeInTheDocument()
+    expect(screen.getByLabelText("Name")).toHaveAttribute("aria-busy", "true")
+  })
+
+  it("resolves the fn at mount with empty params and renders the values", async () => {
+    const fn = vi.fn(async (params: Partial<z.infer<typeof paramsSchema>>) => ({
+      name: params.userId ?? "Fallback Alice",
+      email: "alice@test.com",
+    }))
+
+    render(<SingleSchemaFormWithParams defaultValues={fn} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toHaveValue("Fallback Alice")
+    })
+
+    expect(screen.getByLabelText("Email")).toHaveValue("alice@test.com")
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith({})
+  })
+})
+
+describe("F0Form defaultValues fn with defaultValuesParamsSchema (per-section)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("shows loading indicators while the params defaultValues fn is resolving", () => {
+    const fn = () =>
+      new Promise<{
+        personal?: Partial<{ name: string }>
+        contact?: Partial<{ email: string }>
+      }>((resolve) => {
+        setTimeout(
+          () =>
+            resolve({
+              personal: { name: "Alice" },
+              contact: { email: "a@b.com" },
+            }),
+          1000
+        )
+      })
+
+    render(<PerSectionFormWithParams defaultValues={fn} />)
+
+    expect(screen.getByLabelText("Name")).toBeInTheDocument()
+    expect(screen.getByLabelText("Name")).toHaveAttribute("aria-busy", "true")
+  })
+
+  it("resolves the fn at mount with empty params and renders the values", async () => {
+    const fn = vi.fn(async (params: Partial<z.infer<typeof paramsSchema>>) => ({
+      personal: { name: params.userId ?? "Fallback Alice" },
+      contact: { email: "alice@test.com" },
+    }))
+
+    render(<PerSectionFormWithParams defaultValues={fn} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toHaveValue("Fallback Alice")
+    })
+
+    expect(screen.getByLabelText("Email")).toHaveValue("alice@test.com")
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith({})
+  })
+})
+
 describe("useF0FormDefinition does not resolve async defaultValues", () => {
   it("does not call the async defaultValues function", () => {
     const asyncFn = vi.fn(
@@ -249,6 +378,32 @@ describe("useF0FormDefinition does not resolve async defaultValues", () => {
     expect(result.current.asyncDefaultValues).toBe(asyncFn)
     expect(result.current.defaultValues).toBeUndefined()
     expect(result.current.isLoading).toBe(false)
+  })
+
+  it("does not call the fn when defaultValuesParamsSchema is provided", () => {
+    const fn = vi.fn(
+      async (_params: Partial<z.infer<typeof paramsSchema>>) =>
+        ({ name: "Alice", email: "a@b.com" }) as Partial<
+          z.infer<typeof singleSchema>
+        >
+    )
+
+    const { result } = zeroRenderHook(() =>
+      useF0FormDefinition({
+        name: "no-resolve-params-test",
+        schema: singleSchema,
+        defaultValuesParamsSchema: paramsSchema,
+        defaultValues: fn,
+        onSubmit: async () => ({ success: true }),
+      })
+    )
+
+    // The hook must not resolve — that happens when F0Form renders, and the
+    // AI registry calls the same fn with actual params on presentForm.
+    expect(fn).not.toHaveBeenCalled()
+    expect(result.current.defaultValuesFn).toBe(fn)
+    expect(result.current.asyncDefaultValues).toBeUndefined()
+    expect(result.current.defaultValues).toBeUndefined()
   })
 
   it("passes sync defaultValues directly without wrapping", () => {

--- a/packages/react/src/patterns/F0WizardForm/useF0FormDefinition.ts
+++ b/packages/react/src/patterns/F0WizardForm/useF0FormDefinition.ts
@@ -176,7 +176,7 @@ export function useAsyncDefaultValues<T>(
   const [resolved, setResolved] = useState<T | undefined>(
     isAsync ? undefined : (defaultValues as T | undefined)
   )
-  const [isLoading, setIsLoading] = useState(isAsync && !hasParamsSchema)
+  const [isLoading, setIsLoading] = useState(isAsync)
 
   // Keep a ref to the function to avoid re-running the effect on every render
   const asyncFnRef = useRef(defaultValues)
@@ -187,31 +187,20 @@ export function useAsyncDefaultValues<T>(
 
   useEffect(() => {
     if (typeof asyncFnRef.current !== "function") return
-    // When a params schema is declared, the function requires typed params
-    // that aren't available at mount time — resolution is delegated to the
-    // consumer (e.g. canvas layer) which calls with actual validated params.
-    if (hasParamsSchema) return
 
     const controller = new AbortController()
     setIsLoading(true)
 
     const fn = asyncFnRef.current
 
-    // Safety check: if the function expects params and a schema is somehow
-    // provided, validate before calling to prevent calling with wrong args.
-    if (paramsSchemaRef.current) {
-      const parseResult = paramsSchemaRef.current.safeParse(controller.signal)
-      if (!parseResult.success) {
-        setIsLoading(false)
-        return () => {
-          controller.abort()
-        }
-      }
-    }
-
-    const promise = (fn as (signal: AbortSignal) => Promise<T>)(
-      controller.signal
-    )
+    // With a params schema, the function expects typed params (from AI
+    // presentForm). None exist at mount, so resolve with empty params ({});
+    // the AI registry later calls the same function with actual params.
+    // The empty object is intentionally NOT validated against the schema —
+    // it typically has required fields the function must handle as absent.
+    const promise = paramsSchemaRef.current
+      ? (fn as (params: Record<string, unknown>) => Promise<T>)({})
+      : (fn as (signal: AbortSignal) => Promise<T>)(controller.signal)
 
     promise
       .then((data) => {


### PR DESCRIPTION
## Description

When a form definition provides `defaultValues` as a **function** together with `defaultValuesParamsSchema`, the rendered `F0Form` never resolved the values at mount — the form stayed empty with no loading state. This contradicted the documented behavior of the `WithDefaultValuesParamsSchema` story: *"For rendered forms, `defaultValues` is resolved at mount time with empty params (`{}`)"*.

Root cause (two cooperating gaps):
1. `useAsyncDefaultValues` returned early when a params schema was present (`if (hasParamsSchema) return`) and initialized `isLoading` to `false`, so the function was never called and no loading UI showed.
2. `F0FormFromSingleDefinition` / `F0FormFromPerSectionDefinition` only passed `def.asyncDefaultValues ?? def.defaultValues` to the hook — with a params schema the function lives in `def.defaultValuesFn`, which was never passed.

## Implementation details

- **`useF0FormDefinition.ts` → `useAsyncDefaultValues`**: when a params schema is present, the function is now resolved at mount with empty params (`{}`) instead of being skipped; `isLoading` starts `true` for any function defaults. The empty object is intentionally **not** validated against the schema (it typically has required fields the function must handle as absent — same contract the stories already document). Also removed an unreachable "safety check" that parsed the `AbortSignal` against the params schema. The AI registry flow is unchanged: `presentForm` keeps calling the same function with actual validated params, and virtual registration still never invokes it (covered by existing tests).
- **`F0Form.tsx`**: both definition renderers now pass `def.defaultValuesFn` and `def.defaultValuesParamsSchema` into `useAsyncDefaultValues` (`asyncDefaultValues` and `defaultValuesFn` are mutually exclusive by construction).
- **Tests (`F0FormAsyncDefaults.test.tsx`)**: new cases for function `defaultValues` + `defaultValuesParamsSchema` in both single-schema and per-section modes — loading indicators at mount, resolved values rendered, and the function called exactly once with `{}`. All four failed before the fix (form mounted empty, fn never called). Plus a regression guard pinning that `useF0FormDefinition` itself never calls the function.
- **Story**: new `WithDefaultValuesParamsSchemaPerSection` story; the existing single-schema story now works as documented.

**Out of scope** (pre-existing, same bug class): `F0WizardForm` reads only sync `defaultValues` from definitions — it never resolves `asyncDefaultValues` or `defaultValuesFn` at all. Needs its own fix.
