### PR TITLE
feat(datasource): definition-fed collection item navigation with PageHeader wiring

### DIFF
--- a/packages/react/src/experimental/Navigation/Header/PageHeader/PageHeaderNavigationContext.ts
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/PageHeaderNavigationContext.ts
@@ -1,0 +1,31 @@
+import { createContext, useContext } from "react"
+
+import type { NavigationProps } from "../PageNavigation"
+
+export const PageHeaderNavigationContext =
+  createContext<NavigationProps | null>(null)
+
+/**
+ * Provider that lets a page component inject navigation data into PageHeader
+ * without needing to pass it down as a prop. PageHeader reads this context
+ * only when its own `navigation` prop is undefined, so the prop always wins.
+ *
+ * @example
+ * ```tsx
+ * const { navigation } = useDataCollectionItemNavigation({ source, collectionId, activeItemId })
+ * return (
+ *   <PageHeaderNavigationProvider value={navigation}>
+ *     <MyDetailPage />
+ *   </PageHeaderNavigationProvider>
+ * )
+ * ```
+ */
+export const PageHeaderNavigationProvider = PageHeaderNavigationContext.Provider
+
+/**
+ * Returns the navigation value injected by the nearest
+ * `PageHeaderNavigationProvider`, or null when no provider is present.
+ */
+export function usePageHeaderNavigation(): NavigationProps | null {
+  return useContext(PageHeaderNavigationContext)
+}

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/__tests__/PageHeaderNavigationContext.test.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/__tests__/PageHeaderNavigationContext.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+import React from "react"
+
+import { PageHeader } from "../index"
+import { PageHeaderNavigationProvider } from "../PageHeaderNavigationContext"
+
+const defaultModule = {
+  id: "time-tracking" as const,
+  name: "Time Tracking",
+  href: "/time-tracking",
+}
+
+const propNavigation = {
+  previous: { url: "/prop-prev", title: "Prop Previous" },
+  next: { url: "/prop-next", title: "Prop Next" },
+  counter: { current: 1, total: 5 },
+}
+
+const contextNavigation = {
+  previous: { url: "/ctx-prev", title: "Context Previous" },
+  next: { url: "/ctx-next", title: "Context Next" },
+  counter: { current: 2, total: 10 },
+}
+
+describe("PageHeader navigation context", () => {
+  it("renders nothing when neither prop nor context navigation is provided", () => {
+    render(<PageHeader module={defaultModule} />)
+    expect(screen.queryByRole("link", { name: /previous/i })).toBeNull()
+    expect(screen.queryByRole("link", { name: /next/i })).toBeNull()
+  })
+
+  it("renders navigation from the prop when prop is provided", () => {
+    render(<PageHeader module={defaultModule} navigation={propNavigation} />)
+    expect(screen.getByTitle("Prop Previous")).toBeInTheDocument()
+    expect(screen.getByTitle("Prop Next")).toBeInTheDocument()
+    expect(screen.getByText("1/5")).toBeInTheDocument()
+  })
+
+  it("renders navigation from context when no prop is provided", () => {
+    render(
+      <PageHeaderNavigationProvider value={contextNavigation}>
+        <PageHeader module={defaultModule} />
+      </PageHeaderNavigationProvider>
+    )
+    expect(screen.getByTitle("Context Previous")).toBeInTheDocument()
+    expect(screen.getByTitle("Context Next")).toBeInTheDocument()
+    expect(screen.getByText("2/10")).toBeInTheDocument()
+  })
+
+  it("prop takes precedence over context when both are provided", () => {
+    render(
+      <PageHeaderNavigationProvider value={contextNavigation}>
+        <PageHeader module={defaultModule} navigation={propNavigation} />
+      </PageHeaderNavigationProvider>
+    )
+    expect(screen.getByTitle("Prop Previous")).toBeInTheDocument()
+    expect(screen.getByTitle("Prop Next")).toBeInTheDocument()
+    expect(screen.getByText("1/5")).toBeInTheDocument()
+    expect(screen.queryByTitle("Context Previous")).toBeNull()
+  })
+
+  it("renders nothing when context value is null", () => {
+    render(
+      <PageHeaderNavigationProvider value={null}>
+        <PageHeader module={defaultModule} />
+      </PageHeaderNavigationProvider>
+    )
+    expect(screen.queryByTitle("Previous")).toBeNull()
+    expect(screen.queryByTitle("Next")).toBeNull()
+  })
+})

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/__tests__/usePageHeaderItemNavigation.test.ts
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/__tests__/usePageHeaderItemNavigation.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRenderHook } from "@/testing/test-utils"
+
+import {
+  PageHeaderItemNavigationInput,
+  usePageHeaderItemNavigation,
+} from "../usePageHeaderItemNavigation"
+
+type TestRecord = { id: number; name: string }
+
+function makeInput(
+  overrides: Partial<PageHeaderItemNavigationInput<TestRecord>> = {}
+): PageHeaderItemNavigationInput<TestRecord> {
+  return {
+    activeIndex: 1,
+    absoluteIndex: 1,
+    totalItems: 10,
+    previousItem: { id: 1, name: "First" },
+    nextItem: { id: 3, name: "Third" },
+    previousItemUrl: "/items/1",
+    nextItemUrl: "/items/3",
+    ...overrides,
+  }
+}
+
+describe("usePageHeaderItemNavigation", () => {
+  it("returns null when input is null", () => {
+    const { result } = zeroRenderHook(() => usePageHeaderItemNavigation(null))
+    expect(result.current).toBeNull()
+  })
+
+  it("maps the navigation result to NavigationProps", () => {
+    const { result } = zeroRenderHook(() =>
+      usePageHeaderItemNavigation(makeInput())
+    )
+    expect(result.current?.previous?.url).toBe("/items/1")
+    expect(result.current?.next?.url).toBe("/items/3")
+    expect(result.current?.counter).toEqual({ current: 2, total: 10 })
+  })
+
+  it("uses getItemTitle for the link titles", () => {
+    const { result } = zeroRenderHook(() =>
+      usePageHeaderItemNavigation(makeInput(), {
+        getItemTitle: (item) => item.name,
+      })
+    )
+    expect(result.current?.previous?.title).toBe("First")
+    expect(result.current?.next?.title).toBe("Third")
+  })
+
+  it("falls back to Previous/Next titles when getItemTitle is absent", () => {
+    const { result } = zeroRenderHook(() =>
+      usePageHeaderItemNavigation(makeInput())
+    )
+    expect(result.current?.previous?.title).toBe("Previous")
+    expect(result.current?.next?.title).toBe("Next")
+  })
+
+  it("omits links whose URL is null", () => {
+    const { result } = zeroRenderHook(() =>
+      usePageHeaderItemNavigation(
+        makeInput({ previousItemUrl: null, previousItem: null })
+      )
+    )
+    expect(result.current?.previous).toBeUndefined()
+    expect(result.current?.next?.url).toBe("/items/3")
+  })
+
+  it("omits the counter when the absolute index is unknown", () => {
+    const { result } = zeroRenderHook(() =>
+      usePageHeaderItemNavigation(makeInput({ absoluteIndex: null }))
+    )
+    expect(result.current?.counter).toBeUndefined()
+  })
+
+  it("omits the counter when the total is unknown", () => {
+    const { result } = zeroRenderHook(() =>
+      usePageHeaderItemNavigation(makeInput({ totalItems: undefined }))
+    )
+    expect(result.current?.counter).toBeUndefined()
+  })
+
+  it("returns null when fully degraded (no links, no counter)", () => {
+    const { result } = zeroRenderHook(() =>
+      usePageHeaderItemNavigation(
+        makeInput({
+          activeIndex: -1,
+          absoluteIndex: null,
+          totalItems: undefined,
+          previousItem: null,
+          nextItem: null,
+          previousItemUrl: null,
+          nextItemUrl: null,
+        })
+      )
+    )
+    expect(result.current).toBeNull()
+  })
+})

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "motion/react"
-import { ReactElement, useRef, useState } from "react"
+import { ReactElement, useContext, useRef, useState } from "react"
 
 import type { StatusVariant } from "@/components/tags/F0TagStatus"
 
@@ -23,6 +23,18 @@ import { Breadcrumbs, BreadcrumbsProps } from "../Breadcrumbs"
 import { FavoriteButton } from "../Favorites"
 import { NavigationProps, PageNavigation } from "../PageNavigation"
 import { ProductUpdates, ProductUpdatesProp } from "../ProductUpdates"
+import { PageHeaderNavigationContext } from "./PageHeaderNavigationContext"
+
+export {
+  PageHeaderNavigationContext,
+  PageHeaderNavigationProvider,
+  usePageHeaderNavigation,
+} from "./PageHeaderNavigationContext"
+export {
+  usePageHeaderItemNavigation,
+  type PageHeaderItemNavigationInput,
+  type UsePageHeaderItemNavigationConfig,
+} from "./usePageHeaderItemNavigation"
 
 export type PageAction = {
   label: string
@@ -83,6 +95,10 @@ export function PageHeader({
   oneSwitchAutoOpen,
 }: HeaderProps) {
   const { sidebarState, toggleSidebar } = useSidebar()
+  const contextNavigation = useContext(PageHeaderNavigationContext)
+  // The prop always wins; context is the fallback for pages that inject
+  // navigation from below (e.g. useDataCollectionItemNavigation).
+  const effectiveNavigation = navigation ?? contextNavigation ?? undefined
 
   const breadcrumbsTree: typeof breadcrumbs = [
     {
@@ -192,11 +208,11 @@ export function PageHeader({
         )}
         {!embedded &&
           hasStatus &&
-          (navigation || hasActions || hasProductUpdates) && (
+          (effectiveNavigation || hasActions || hasProductUpdates) && (
             <div className="h-4 w-px bg-f1-border-secondary" />
           )}
-        {navigation && <PageNavigation {...navigation} />}
-        {navigation && hasActions && (
+        {effectiveNavigation && <PageNavigation {...effectiveNavigation} />}
+        {effectiveNavigation && hasActions && (
           <div className="h-4 w-px bg-f1-border-secondary" />
         )}
         {(hasProductUpdates || hasActions) && (

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/usePageHeaderItemNavigation.ts
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/usePageHeaderItemNavigation.ts
@@ -1,0 +1,101 @@
+import { useMemo } from "react"
+
+import type {
+  RecordType,
+  UseDataSourceItemNavigationReturn,
+} from "@/hooks/datasource"
+
+import type { NavigationProps } from "../PageNavigation"
+
+export type PageHeaderItemNavigationInput<R extends RecordType> = Pick<
+  UseDataSourceItemNavigationReturn<R>,
+  | "previousItem"
+  | "nextItem"
+  | "previousItemUrl"
+  | "nextItemUrl"
+  | "absoluteIndex"
+  | "totalItems"
+  | "activeIndex"
+>
+
+export interface UsePageHeaderItemNavigationConfig<R extends RecordType> {
+  /**
+   * Returns a human-readable title for a navigation link. Used as the
+   * accessible label on the prev/next buttons.
+   */
+  getItemTitle?: (item: R) => string
+}
+
+/**
+ * Converts an item-navigation result into the `NavigationProps` shape that
+ * `PageHeader` accepts (directly or via `PageHeaderNavigationProvider`).
+ *
+ * URLs are read from `previousItemUrl` / `nextItemUrl`, which are computed by
+ * the `itemUrl` option on the navigation hook. A null URL omits that link
+ * (the button renders disabled). The counter is included only when both the
+ * absolute position and the total are known — never a misleading `0/n`.
+ *
+ * Returns null when there is nothing useful to render (no input, or the
+ * active item could not be located and no total is known), so it can be
+ * passed straight to `PageHeaderNavigationProvider`.
+ */
+export function usePageHeaderItemNavigation<R extends RecordType>(
+  nav: PageHeaderItemNavigationInput<R> | null,
+  config?: UsePageHeaderItemNavigationConfig<R>
+): NavigationProps | null {
+  const getItemTitle = config?.getItemTitle
+
+  // Field-level memo deps keep the returned object identity stable across
+  // re-renders that don't change the navigation state, so it can be passed
+  // to a context provider without churning consumers.
+  const hasInput = nav !== null
+  const previousItem = nav?.previousItem ?? null
+  const nextItem = nav?.nextItem ?? null
+  const previousItemUrl = nav?.previousItemUrl ?? null
+  const nextItemUrl = nav?.nextItemUrl ?? null
+  const absoluteIndex = nav?.absoluteIndex ?? null
+  const totalItems = nav?.totalItems
+
+  return useMemo(() => {
+    if (!hasInput) return null
+
+    const counter =
+      absoluteIndex !== null && totalItems !== undefined
+        ? { current: absoluteIndex + 1, total: totalItems }
+        : undefined
+
+    const previous =
+      previousItemUrl !== null
+        ? {
+            url: previousItemUrl,
+            title:
+              (previousItem !== null
+                ? getItemTitle?.(previousItem)
+                : undefined) ?? "Previous",
+          }
+        : undefined
+
+    const next =
+      nextItemUrl !== null
+        ? {
+            url: nextItemUrl,
+            title:
+              (nextItem !== null ? getItemTitle?.(nextItem) : undefined) ??
+              "Next",
+          }
+        : undefined
+
+    if (!previous && !next && !counter) return null
+
+    return { previous, next, counter }
+  }, [
+    hasInput,
+    previousItem,
+    nextItem,
+    previousItemUrl,
+    nextItemUrl,
+    absoluteIndex,
+    totalItems,
+    getItemTitle,
+  ])
+}

--- a/packages/react/src/hooks/datasource/__test__/useData.spec.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useData.spec.tsx
@@ -444,6 +444,42 @@ describe("useData", () => {
       expect(unsubscribeCalls).toBe(initialUnsubscribeCalls + 1)
     })
   })
+
+  describe("with the enabled option", () => {
+    it("does not fetch while enabled is false and keeps isInitialLoading", async () => {
+      const fetchData = vi.fn(() => ({ records: mockData }))
+      const source = createMockDataSource(fetchData)
+
+      const { result } = renderHook(() => useData(source, { enabled: false }))
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      })
+
+      expect(fetchData).not.toHaveBeenCalled()
+      expect(result.current.isInitialLoading).toBe(true)
+    })
+
+    it("fetches exactly once when enabled becomes true", async () => {
+      const fetchData = vi.fn(() => ({ records: mockData }))
+      const source = createMockDataSource(fetchData)
+
+      const { result, rerender } = renderHook(
+        ({ enabled }: { enabled: boolean }) => useData(source, { enabled }),
+        { initialProps: { enabled: false } }
+      )
+
+      rerender({ enabled: true })
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      })
+
+      expect(fetchData).toHaveBeenCalledTimes(1)
+      expect(result.current.data).toMatchObject({ records: mockData })
+      expect(result.current.isInitialLoading).toBe(false)
+    })
+  })
 })
 
 // Test the filter merging utility function

--- a/packages/react/src/hooks/datasource/index.ts
+++ b/packages/react/src/hooks/datasource/index.ts
@@ -2,6 +2,7 @@ export * from "@/patterns/OneFilterPicker/types"
 export * from "./types"
 export * from "./useData"
 export * from "./useDataSource"
+export * from "./useDataSourceItemNavigation"
 export * from "./useGroups"
 export type {
   AllSelectionStatus,

--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -54,6 +54,14 @@ export interface UseDataOptions<
 > {
   filters?: Partial<FiltersState<Filters>>
   /**
+   * When false, suspends all data fetching: the initial fetch effect does not
+   * run until `enabled` becomes true. Useful to delay the first fetch until
+   * async state (e.g. persisted filters) has been applied to the source.
+   * `isInitialLoading` stays true while disabled.
+   * @default true
+   */
+  enabled?: boolean
+  /**
    * A function that is called when an error occurs during data fetching.
    * It is called with the error object.
    * @param error - The error object.
@@ -234,6 +242,7 @@ export function useData<
   source: DataSource<R, Filters, Sortings, Grouping>,
   {
     filters,
+    enabled = true,
     onError,
     fetchParamsProvider = defaultFetchDataAndUpdateOptions,
     onResponse,
@@ -747,6 +756,7 @@ export function useData<
 
   useEffect(
     () => {
+      if (!enabled) return
       if (!isLoadingMoreRef.current) {
         setIsLoading(true)
         // Seed the first page-based fetch from `currentPage` (if provided), then
@@ -771,6 +781,7 @@ export function useData<
       fetchDataAndUpdate,
       mergedFilters,
       setIsLoading,
+      enabled,
       dataAdapter.paginationType,
       searchValue.current,
       // eslint-disable-next-line react-hooks/exhaustive-deps -- deps are handled by the caller

--- a/packages/react/src/hooks/datasource/useDataSourceItemNavigation/__stories__/useDataSourceItemNavigation.stories.tsx
+++ b/packages/react/src/hooks/datasource/useDataSourceItemNavigation/__stories__/useDataSourceItemNavigation.stories.tsx
@@ -1,0 +1,485 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useMemo } from "react"
+
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import {
+  createDataSourceDefinition,
+  PaginatedDataAdapter,
+  useData,
+  useDataSource,
+} from "../../index"
+import { useDataSourceItemNavigation } from "../useDataSourceItemNavigation"
+
+type Item = {
+  id: number
+  name: string
+  email: string
+  department: string
+}
+
+const DEPARTMENTS = ["Engineering", "Design", "Product", "Marketing"]
+
+const generateItems = (count: number): Item[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    name: `User ${i + 1}`,
+    email: `user${i + 1}@example.com`,
+    department: DEPARTMENTS[i % DEPARTMENTS.length],
+  }))
+
+const ALL_ITEMS = generateItems(23)
+
+const itemFilters = {
+  department: {
+    type: "in" as const,
+    label: "Department",
+    options: {
+      options: DEPARTMENTS.map((d) => ({ value: d, label: d })),
+    },
+  },
+}
+
+type ItemFilters = typeof itemFilters
+
+const meta = {
+  title: "Datasource/useDataSourceItemNavigation",
+  parameters: {
+    a11y: { skipCi: true },
+    docs: {
+      description: {
+        component:
+          "Hook for navigating through paginated data items with prev/next controls. Automatically handles page transitions at boundaries.",
+      },
+    },
+  },
+  tags: ["experimental", "!autodocs"],
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// --- Page-Based Story ---
+
+const createPageBasedAdapter = (
+  perPage: number
+): PaginatedDataAdapter<Item, ItemFilters> => ({
+  paginationType: "pages",
+  perPage,
+  fetchData: async ({ filters, pagination }) => {
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    let filtered = ALL_ITEMS
+    if (filters.department && filters.department.length > 0) {
+      filtered = filtered.filter((item) =>
+        (filters.department as string[]).includes(item.department)
+      )
+    }
+    const page = pagination.currentPage ?? 1
+    const start = (page - 1) * perPage
+    const records = filtered.slice(start, start + perPage)
+    return {
+      records,
+      total: filtered.length,
+      perPage,
+      type: "pages" as const,
+      currentPage: page,
+      pagesCount: Math.ceil(filtered.length / perPage),
+    }
+  },
+})
+
+const PageBasedDemo = () => {
+  const perPage = 5
+  const definition = useMemo(
+    () =>
+      createDataSourceDefinition({
+        filters: itemFilters,
+        dataAdapter: createPageBasedAdapter(perPage),
+      }),
+    []
+  )
+  const dataSource = useDataSource(definition)
+  const { data, paginationInfo, setPage, isLoading, loadMore } =
+    useData(dataSource)
+
+  const {
+    activeItemId,
+    activeItem,
+    goToNext,
+    goToPrevious,
+    hasNext,
+    hasPrevious,
+    setActiveItemId,
+    isNavigating,
+    nextItemUrl,
+    previousItemUrl,
+  } = useDataSourceItemNavigation({
+    dataSource,
+    data,
+    paginationInfo,
+    setPage,
+    loadMore,
+    isLoading,
+    idProvider: (item) => (item as Item).id,
+    itemUrl: (item) => `/users/${(item as Item).id}`,
+  })
+
+  const activeFilter =
+    (dataSource.currentFilters.department as string[] | undefined) ?? []
+
+  return (
+    <div style={{ fontFamily: "sans-serif", maxWidth: 500 }}>
+      <h3>Page-Based Navigation</h3>
+
+      <div style={{ marginBottom: 12 }}>
+        <strong style={{ fontSize: "0.85em" }}>Filter by department:</strong>
+        <div
+          style={{ display: "flex", gap: 4, marginTop: 4, flexWrap: "wrap" }}
+        >
+          {DEPARTMENTS.map((dept) => {
+            const isSelected = activeFilter.includes(dept)
+            return (
+              <button
+                key={dept}
+                onClick={() => {
+                  const next = isSelected
+                    ? activeFilter.filter((d) => d !== dept)
+                    : [...activeFilter, dept]
+                  dataSource.setCurrentFilters((prev) => ({
+                    ...prev,
+                    department: next.length > 0 ? next : undefined,
+                  }))
+                }}
+                style={{
+                  padding: "4px 10px",
+                  borderRadius: 12,
+                  border: "1px solid #ccc",
+                  background: isSelected ? "#2196f3" : "white",
+                  color: isSelected ? "white" : "#333",
+                  cursor: "pointer",
+                  fontSize: "0.8em",
+                }}
+              >
+                {dept}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          alignItems: "center",
+          marginBottom: 16,
+        }}
+      >
+        <button disabled={!hasPrevious || isNavigating} onClick={goToPrevious}>
+          ← Previous
+        </button>
+        <button disabled={!hasNext || isNavigating} onClick={goToNext}>
+          Next →
+        </button>
+        {isNavigating && <span style={{ color: "#888" }}>Loading…</span>}
+      </div>
+
+      {(previousItemUrl || nextItemUrl) && (
+        <div style={{ marginBottom: 8, fontSize: "0.85em", color: "#666" }}>
+          {previousItemUrl && (
+            <span>
+              ← <a href={previousItemUrl}>{previousItemUrl}</a>
+            </span>
+          )}
+          {previousItemUrl && nextItemUrl && " | "}
+          {nextItemUrl && (
+            <span>
+              <a href={nextItemUrl}>{nextItemUrl}</a> →
+            </span>
+          )}
+        </div>
+      )}
+
+      {activeItem && (
+        <div
+          style={{
+            padding: 12,
+            marginBottom: 16,
+            background: "#e8f4fd",
+            borderRadius: 8,
+            border: "1px solid #b3d9f2",
+          }}
+        >
+          <strong>Active:</strong> {(activeItem as Item).name} —{" "}
+          {(activeItem as Item).department} ({(activeItem as Item).email})
+        </div>
+      )}
+
+      {paginationInfo?.type === "pages" && (
+        <div style={{ marginBottom: 8, fontSize: "0.85em", color: "#666" }}>
+          Page {paginationInfo.currentPage} of {paginationInfo.pagesCount} •{" "}
+          {paginationInfo.total} total items
+        </div>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {isLoading && data.records.length === 0 ? (
+          <div style={{ padding: 16, color: "#888" }}>Loading…</div>
+        ) : (
+          data.records.map((item) => {
+            const record = item as unknown as Item
+            const isActive = record.id === activeItemId
+            return (
+              <div
+                key={record.id}
+                onClick={() => setActiveItemId(record.id)}
+                style={{
+                  padding: "8px 12px",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  border: isActive ? "2px solid #2196f3" : "1px solid #e0e0e0",
+                  background: isActive ? "#e3f2fd" : "white",
+                  transition: "all 0.15s",
+                }}
+              >
+                <strong>{record.name}</strong>
+                <span
+                  style={{ marginLeft: 8, color: "#888", fontSize: "0.85em" }}
+                >
+                  {record.department}
+                </span>
+                <span
+                  style={{ marginLeft: 8, color: "#aaa", fontSize: "0.8em" }}
+                >
+                  {record.email}
+                </span>
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+export const PageBased: Story = {
+  render: () => <PageBasedDemo />,
+}
+
+// --- Infinite Scroll Story ---
+
+const createInfiniteScrollAdapter = (
+  perPage: number
+): PaginatedDataAdapter<Item, ItemFilters> => ({
+  paginationType: "infinite-scroll",
+  perPage,
+  fetchData: async ({ filters, pagination }) => {
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    let filtered = ALL_ITEMS
+    if (filters.department && filters.department.length > 0) {
+      filtered = filtered.filter((item) =>
+        (filters.department as string[]).includes(item.department)
+      )
+    }
+    const cursor = pagination.cursor ? parseInt(pagination.cursor, 10) : 0
+    const records = filtered.slice(cursor, cursor + perPage)
+    const nextCursor = cursor + perPage
+    return {
+      records,
+      total: filtered.length,
+      perPage,
+      type: "infinite-scroll" as const,
+      cursor: nextCursor < filtered.length ? String(nextCursor) : null,
+      hasMore: nextCursor < filtered.length,
+    }
+  },
+})
+
+const InfiniteScrollDemo = () => {
+  const perPage = 5
+  const definition = useMemo(
+    () =>
+      createDataSourceDefinition({
+        filters: itemFilters,
+        dataAdapter: createInfiniteScrollAdapter(perPage),
+      }),
+    []
+  )
+  const dataSource = useDataSource(definition)
+  const { data, paginationInfo, setPage, isLoading, isLoadingMore, loadMore } =
+    useData(dataSource)
+
+  const {
+    activeItemId,
+    activeItem,
+    goToNext,
+    goToPrevious,
+    hasNext,
+    hasPrevious,
+    setActiveItemId,
+    isNavigating,
+    nextItemUrl,
+    previousItemUrl,
+  } = useDataSourceItemNavigation({
+    dataSource,
+    data,
+    paginationInfo,
+    setPage,
+    loadMore,
+    isLoading: isLoading || isLoadingMore,
+    idProvider: (item) => (item as Item).id,
+    itemUrl: (item) => `/users/${(item as Item).id}`,
+  })
+
+  return (
+    <div style={{ fontFamily: "sans-serif", maxWidth: 500 }}>
+      <h3>Infinite Scroll Navigation</h3>
+
+      <div style={{ marginBottom: 12 }}>
+        <strong style={{ fontSize: "0.85em" }}>Filter by department:</strong>
+        <div
+          style={{ display: "flex", gap: 4, marginTop: 4, flexWrap: "wrap" }}
+        >
+          {DEPARTMENTS.map((dept) => {
+            const currentFilter =
+              (dataSource.currentFilters.department as string[] | undefined) ??
+              []
+            const isSelected = currentFilter.includes(dept)
+            return (
+              <button
+                key={dept}
+                onClick={() => {
+                  const next = isSelected
+                    ? currentFilter.filter((d) => d !== dept)
+                    : [...currentFilter, dept]
+                  dataSource.setCurrentFilters((prev) => ({
+                    ...prev,
+                    department: next.length > 0 ? next : undefined,
+                  }))
+                }}
+                style={{
+                  padding: "4px 10px",
+                  borderRadius: 12,
+                  border: "1px solid #ccc",
+                  background: isSelected ? "#2196f3" : "white",
+                  color: isSelected ? "white" : "#333",
+                  cursor: "pointer",
+                  fontSize: "0.8em",
+                }}
+              >
+                {dept}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          alignItems: "center",
+          marginBottom: 16,
+        }}
+      >
+        <button disabled={!hasPrevious || isNavigating} onClick={goToPrevious}>
+          ← Previous
+        </button>
+        <button disabled={!hasNext || isNavigating} onClick={goToNext}>
+          Next →
+        </button>
+        {isNavigating && <span style={{ color: "#888" }}>Loading…</span>}
+      </div>
+
+      {(previousItemUrl || nextItemUrl) && (
+        <div style={{ marginBottom: 8, fontSize: "0.85em", color: "#666" }}>
+          {previousItemUrl && (
+            <span>
+              ← <a href={previousItemUrl}>{previousItemUrl}</a>
+            </span>
+          )}
+          {previousItemUrl && nextItemUrl && " | "}
+          {nextItemUrl && (
+            <span>
+              <a href={nextItemUrl}>{nextItemUrl}</a> →
+            </span>
+          )}
+        </div>
+      )}
+
+      {activeItem && (
+        <div
+          style={{
+            padding: 12,
+            marginBottom: 16,
+            background: "#e8f4fd",
+            borderRadius: 8,
+            border: "1px solid #b3d9f2",
+          }}
+        >
+          <strong>Active:</strong> {(activeItem as Item).name} —{" "}
+          {(activeItem as Item).department} ({(activeItem as Item).email})
+        </div>
+      )}
+
+      <div style={{ marginBottom: 8, fontSize: "0.85em", color: "#666" }}>
+        {data.records.length} items loaded
+        {paginationInfo?.type === "infinite-scroll" &&
+          paginationInfo.hasMore &&
+          " • More available"}
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {isLoading && data.records.length === 0 ? (
+          <div style={{ padding: 16, color: "#888" }}>Loading…</div>
+        ) : (
+          data.records.map((item) => {
+            const record = item as unknown as Item
+            const isActive = record.id === activeItemId
+            return (
+              <div
+                key={record.id}
+                onClick={() => setActiveItemId(record.id)}
+                style={{
+                  padding: "8px 12px",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  border: isActive ? "2px solid #2196f3" : "1px solid #e0e0e0",
+                  background: isActive ? "#e3f2fd" : "white",
+                  transition: "all 0.15s",
+                }}
+              >
+                <strong>{record.name}</strong>
+                <span
+                  style={{ marginLeft: 8, color: "#888", fontSize: "0.85em" }}
+                >
+                  {record.department}
+                </span>
+                <span
+                  style={{ marginLeft: 8, color: "#aaa", fontSize: "0.8em" }}
+                >
+                  {record.email}
+                </span>
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+export const InfiniteScroll: Story = {
+  render: () => <InfiniteScrollDemo />,
+}
+
+export const Snapshot: Story = {
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex gap-6">
+      <PageBasedDemo />
+      <InfiniteScrollDemo />
+    </div>
+  ),
+}

--- a/packages/react/src/hooks/datasource/useDataSourceItemNavigation/__tests__/useDataSourceItemNavigation.test.ts
+++ b/packages/react/src/hooks/datasource/useDataSourceItemNavigation/__tests__/useDataSourceItemNavigation.test.ts
@@ -1,0 +1,1213 @@
+import { act, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRenderHook } from "@/testing/test-utils"
+
+import { DataSource } from "../../types/datasource.typings"
+import { PaginationInfo } from "../../types/fetch.typings"
+import { Data, GROUP_ID_SYMBOL } from "../../useData"
+import { UseDataSourceItemNavigationProps } from "../types"
+import { useDataSourceItemNavigation } from "../useDataSourceItemNavigation"
+
+type TestRecord = { id: number; name: string }
+
+const mockDataSource = {
+  dataAdapter: {} as never,
+  currentFilters: {},
+  setCurrentFilters: vi.fn(),
+  currentSortings: null,
+  setCurrentSortings: vi.fn(),
+  currentSearch: undefined,
+  debouncedCurrentSearch: undefined,
+  setCurrentSearch: vi.fn(),
+  isLoading: false,
+  setIsLoading: vi.fn(),
+  setCurrentGrouping: vi.fn(),
+  idProvider: (item: TestRecord) => item.id,
+} as unknown as DataSource<TestRecord, never, never, never>
+
+const makeRecords = (count: number, startId = 1): TestRecord[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: startId + i,
+    name: `Item ${startId + i}`,
+  }))
+
+const makeData = (records: TestRecord[]): Data<TestRecord> => ({
+  records: records.map((r) => ({ ...r, [GROUP_ID_SYMBOL]: undefined })),
+  type: "flat",
+  groups: [],
+})
+
+const makePagePaginationInfo = (
+  currentPage: number,
+  pagesCount: number,
+  total: number,
+  perPage = 5
+): PaginationInfo => ({
+  type: "pages",
+  currentPage,
+  pagesCount,
+  total,
+  perPage,
+})
+
+const makeInfiniteScrollPaginationInfo = (
+  hasMore: boolean,
+  total: number,
+  perPage = 5
+): PaginationInfo => ({
+  type: "infinite-scroll",
+  cursor: hasMore ? "cursor-next" : null,
+  hasMore,
+  total,
+  perPage,
+})
+
+const defaultProps = (
+  overrides: Partial<UseDataSourceItemNavigationProps<TestRecord>> = {}
+): UseDataSourceItemNavigationProps<TestRecord> => ({
+  dataSource: mockDataSource,
+  data: makeData(makeRecords(5)),
+  paginationInfo: makePagePaginationInfo(1, 3, 15),
+  setPage: vi.fn(),
+  loadMore: vi.fn(),
+  isLoading: false,
+  idProvider: (item) => item.id,
+  ...overrides,
+})
+
+describe("useDataSourceItemNavigation", () => {
+  describe("initial state", () => {
+    it("starts with null activeItemId when no default is provided", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps())
+      )
+
+      expect(result.current.activeItemId).toBeNull()
+      expect(result.current.activeItem).toBeNull()
+      expect(result.current.hasNext).toBe(false)
+      expect(result.current.hasPrevious).toBe(false)
+      expect(result.current.isNavigating).toBe(false)
+    })
+
+    it("uses defaultActiveItemId for initial state", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ defaultActiveItemId: 3 }))
+      )
+
+      expect(result.current.activeItemId).toBe(3)
+      expect(result.current.activeItem).toEqual(
+        expect.objectContaining({ id: 3, name: "Item 3" })
+      )
+    })
+
+    it("uses controlled activeItemId prop", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ activeItemId: 2 }))
+      )
+
+      expect(result.current.activeItemId).toBe(2)
+      expect(result.current.activeItem).toEqual(
+        expect.objectContaining({ id: 2, name: "Item 2" })
+      )
+    })
+
+    it("supports controlled null activeItemId", () => {
+      const { result, rerender } = zeroRenderHook(
+        (props: UseDataSourceItemNavigationProps<TestRecord>) =>
+          useDataSourceItemNavigation(props),
+        {
+          initialProps: defaultProps({ activeItemId: 2 }),
+        }
+      )
+
+      expect(result.current.activeItemId).toBe(2)
+
+      rerender(defaultProps({ activeItemId: null }))
+
+      expect(result.current.activeItemId).toBeNull()
+      expect(result.current.activeItem).toBeNull()
+    })
+  })
+
+  describe("setActiveItemId", () => {
+    it("updates active item when called", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps())
+      )
+
+      act(() => {
+        result.current.setActiveItemId(4)
+      })
+
+      expect(result.current.activeItemId).toBe(4)
+      expect(result.current.activeItem).toEqual(
+        expect.objectContaining({ id: 4, name: "Item 4" })
+      )
+    })
+
+    it("fires onActiveItemChange callback", () => {
+      const onActiveItemChange = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ onActiveItemChange }))
+      )
+
+      act(() => {
+        result.current.setActiveItemId(3)
+      })
+
+      expect(onActiveItemChange).toHaveBeenCalledWith(3)
+    })
+
+    it("sets activeItem to null when ID is not found in records", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps())
+      )
+
+      act(() => {
+        result.current.setActiveItemId(999)
+      })
+
+      expect(result.current.activeItemId).toBe(999)
+      expect(result.current.activeItem).toBeNull()
+    })
+
+    it("sets active item to null", () => {
+      const onActiveItemChange = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({ defaultActiveItemId: 2, onActiveItemChange })
+        )
+      )
+
+      act(() => {
+        result.current.setActiveItemId(null)
+      })
+
+      expect(result.current.activeItemId).toBeNull()
+      expect(result.current.activeItem).toBeNull()
+      expect(onActiveItemChange).toHaveBeenCalledWith(null)
+    })
+  })
+
+  describe("goToNext", () => {
+    it("navigates to the next item within the page", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ defaultActiveItemId: 2 }))
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(result.current.activeItemId).toBe(3)
+    })
+
+    it("does nothing when activeItemId is null", () => {
+      const setPage = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ setPage }))
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(result.current.activeItemId).toBeNull()
+      expect(setPage).not.toHaveBeenCalled()
+    })
+
+    it("calls setPage for next page when at the last item (page-based)", () => {
+      const setPage = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            setPage,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(setPage).toHaveBeenCalledWith(2)
+    })
+
+    it("does nothing at the last item of the last page", () => {
+      const setPage = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makePagePaginationInfo(3, 3, 15),
+            setPage,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(setPage).not.toHaveBeenCalled()
+      expect(result.current.activeItemId).toBe(5)
+    })
+
+    it("calls loadMore when at the last item (infinite-scroll)", () => {
+      const loadMore = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+            loadMore,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(loadMore).toHaveBeenCalled()
+    })
+
+    it("does nothing at the last item when no more data (infinite-scroll)", () => {
+      const loadMore = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makeInfiniteScrollPaginationInfo(false, 5),
+            loadMore,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(loadMore).not.toHaveBeenCalled()
+      expect(result.current.activeItemId).toBe(5)
+    })
+  })
+
+  describe("goToPrevious", () => {
+    it("navigates to the previous item within the page", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ defaultActiveItemId: 3 }))
+      )
+
+      act(() => {
+        result.current.goToPrevious()
+      })
+
+      expect(result.current.activeItemId).toBe(2)
+    })
+
+    it("does nothing when activeItemId is null", () => {
+      const setPage = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ setPage }))
+      )
+
+      act(() => {
+        result.current.goToPrevious()
+      })
+
+      expect(result.current.activeItemId).toBeNull()
+      expect(setPage).not.toHaveBeenCalled()
+    })
+
+    it("calls setPage for previous page when at the first item (page-based)", () => {
+      const setPage = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 1,
+            paginationInfo: makePagePaginationInfo(2, 3, 15),
+            setPage,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToPrevious()
+      })
+
+      expect(setPage).toHaveBeenCalledWith(1)
+    })
+
+    it("does nothing at the first item of the first page", () => {
+      const setPage = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 1,
+            paginationInfo: makePagePaginationInfo(1, 3, 15),
+            setPage,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToPrevious()
+      })
+
+      expect(setPage).not.toHaveBeenCalled()
+      expect(result.current.activeItemId).toBe(1)
+    })
+
+    it("does nothing at the first item (infinite-scroll)", () => {
+      const setPage = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 1,
+            paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+            setPage,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToPrevious()
+      })
+
+      expect(setPage).not.toHaveBeenCalled()
+      expect(result.current.activeItemId).toBe(1)
+    })
+  })
+
+  describe("hasNext / hasPrevious", () => {
+    it("hasNext is true when not at the last item", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ defaultActiveItemId: 3 }))
+      )
+
+      expect(result.current.hasNext).toBe(true)
+    })
+
+    it("hasNext is true at last item when more pages exist", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makePagePaginationInfo(1, 3, 15),
+          })
+        )
+      )
+
+      expect(result.current.hasNext).toBe(true)
+    })
+
+    it("hasNext is false at last item of last page", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makePagePaginationInfo(3, 3, 15),
+          })
+        )
+      )
+
+      expect(result.current.hasNext).toBe(false)
+    })
+
+    it("hasPrevious is true when not at the first item", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ defaultActiveItemId: 3 }))
+      )
+
+      expect(result.current.hasPrevious).toBe(true)
+    })
+
+    it("hasPrevious is true at first item when previous pages exist", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 1,
+            paginationInfo: makePagePaginationInfo(2, 3, 15),
+          })
+        )
+      )
+
+      expect(result.current.hasPrevious).toBe(true)
+    })
+
+    it("hasPrevious is false at first item of first page", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 1,
+            paginationInfo: makePagePaginationInfo(1, 3, 15),
+          })
+        )
+      )
+
+      expect(result.current.hasPrevious).toBe(false)
+    })
+
+    it("exposes index and loaded item metadata", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            data: makeData(makeRecords(5, 6)),
+            defaultActiveItemId: 8,
+            paginationInfo: makePagePaginationInfo(2, 3, 15),
+          })
+        )
+      )
+
+      expect(result.current.activeIndex).toBe(2)
+      expect(result.current.absoluteIndex).toBe(7)
+      expect(result.current.loadedItemsCount).toBe(5)
+      expect(result.current.totalItems).toBe(15)
+      expect(result.current.previousItem).toEqual(
+        expect.objectContaining({ id: 7 })
+      )
+      expect(result.current.nextItem).toEqual(
+        expect.objectContaining({ id: 9 })
+      )
+    })
+  })
+
+  describe("pending navigation resolution (page-based)", () => {
+    it("resolves to first item after navigating to next page", () => {
+      const setPage = vi.fn()
+
+      const { result, rerender } = zeroRenderHook(
+        (props: UseDataSourceItemNavigationProps<TestRecord>) =>
+          useDataSourceItemNavigation(props),
+        {
+          initialProps: defaultProps({
+            defaultActiveItemId: 5,
+            setPage,
+          }),
+        }
+      )
+
+      // Trigger next page navigation
+      act(() => {
+        result.current.goToNext()
+      })
+      expect(setPage).toHaveBeenCalledWith(2)
+
+      // Simulate loading state (data hasn't changed yet)
+      rerender(
+        defaultProps({
+          paginationInfo: makePagePaginationInfo(2, 3, 15),
+          setPage,
+          isLoading: true,
+        })
+      )
+
+      // Simulate page 2 data arriving
+      const page2Records = makeRecords(5, 6)
+      rerender(
+        defaultProps({
+          data: makeData(page2Records),
+          paginationInfo: makePagePaginationInfo(2, 3, 15),
+          setPage,
+          isLoading: false,
+        })
+      )
+
+      expect(result.current.activeItemId).toBe(6)
+      expect(result.current.activeItem).toEqual(
+        expect.objectContaining({ id: 6, name: "Item 6" })
+      )
+    })
+
+    it("does not resolve before the requested next page arrives", () => {
+      const setPage = vi.fn()
+      const { result, rerender } = zeroRenderHook(
+        (props: UseDataSourceItemNavigationProps<TestRecord>) =>
+          useDataSourceItemNavigation(props),
+        {
+          initialProps: defaultProps({
+            defaultActiveItemId: 5,
+            setPage,
+          }),
+        }
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(result.current.isNavigating).toBe(true)
+
+      rerender(
+        defaultProps({
+          data: makeData(makeRecords(5)),
+          paginationInfo: makePagePaginationInfo(1, 3, 15),
+          setPage,
+          isLoading: false,
+        })
+      )
+
+      expect(result.current.activeItemId).toBe(5)
+      expect(result.current.isNavigating).toBe(true)
+    })
+
+    it("clears pending next-page navigation when setPage throws synchronously", () => {
+      const error = new Error("setPage failed")
+      const setPage = vi.fn(() => {
+        throw error
+      })
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            setPage,
+          })
+        )
+      )
+
+      let thrownError: unknown
+      act(() => {
+        try {
+          result.current.goToNext()
+        } catch (error) {
+          thrownError = error
+        }
+      })
+
+      expect(thrownError).toBe(error)
+      expect(result.current.activeItemId).toBe(5)
+      expect(result.current.isNavigating).toBe(false)
+    })
+
+    it("cancels pending next-page navigation when active item is set manually", () => {
+      const setPage = vi.fn()
+      const { result, rerender } = zeroRenderHook(
+        (props: UseDataSourceItemNavigationProps<TestRecord>) =>
+          useDataSourceItemNavigation(props),
+        {
+          initialProps: defaultProps({
+            defaultActiveItemId: 5,
+            setPage,
+          }),
+        }
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+      expect(result.current.isNavigating).toBe(true)
+
+      act(() => {
+        result.current.setActiveItemId(3)
+      })
+
+      expect(result.current.activeItemId).toBe(3)
+      expect(result.current.isNavigating).toBe(false)
+
+      rerender(
+        defaultProps({
+          data: makeData(makeRecords(5, 6)),
+          paginationInfo: makePagePaginationInfo(2, 3, 15),
+          setPage,
+          isLoading: false,
+        })
+      )
+
+      expect(result.current.activeItemId).toBe(3)
+    })
+
+    it("clears pending next-page navigation when no loading transition is observed", async () => {
+      const setPage = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            setPage,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(result.current.activeItemId).toBe(5)
+
+      await waitFor(() => {
+        expect(result.current.isNavigating).toBe(false)
+      })
+    })
+
+    it("clears pending navigation when the requested page returns no records", () => {
+      const setPage = vi.fn()
+      const { result, rerender } = zeroRenderHook(
+        (props: UseDataSourceItemNavigationProps<TestRecord>) =>
+          useDataSourceItemNavigation(props),
+        {
+          initialProps: defaultProps({
+            defaultActiveItemId: 5,
+            setPage,
+          }),
+        }
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      rerender(
+        defaultProps({
+          data: makeData([]),
+          paginationInfo: makePagePaginationInfo(2, 3, 15),
+          setPage,
+          isLoading: false,
+        })
+      )
+
+      expect(result.current.activeItemId).toBe(5)
+      expect(result.current.isNavigating).toBe(false)
+    })
+
+    it("resolves to last item after navigating to previous page", () => {
+      const setPage = vi.fn()
+      const records = makeRecords(5, 6)
+
+      const { result, rerender } = zeroRenderHook(
+        (props: UseDataSourceItemNavigationProps<TestRecord>) =>
+          useDataSourceItemNavigation(props),
+        {
+          initialProps: defaultProps({
+            defaultActiveItemId: 6,
+            data: makeData(records),
+            paginationInfo: makePagePaginationInfo(2, 3, 15),
+            setPage,
+          }),
+        }
+      )
+
+      // Trigger previous page navigation
+      act(() => {
+        result.current.goToPrevious()
+      })
+      expect(setPage).toHaveBeenCalledWith(1)
+
+      // Simulate page 1 data arriving
+      const page1Records = makeRecords(5)
+      rerender(
+        defaultProps({
+          data: makeData(page1Records),
+          paginationInfo: makePagePaginationInfo(1, 3, 15),
+          setPage,
+          isLoading: false,
+        })
+      )
+
+      expect(result.current.activeItemId).toBe(5)
+      expect(result.current.activeItem).toEqual(
+        expect.objectContaining({ id: 5, name: "Item 5" })
+      )
+    })
+
+    it("clears pending previous-page navigation when setPage throws synchronously", () => {
+      const error = new Error("setPage failed")
+      const setPage = vi.fn(() => {
+        throw error
+      })
+      const records = makeRecords(5, 6)
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 6,
+            data: makeData(records),
+            paginationInfo: makePagePaginationInfo(2, 3, 15),
+            setPage,
+          })
+        )
+      )
+
+      let thrownError: unknown
+      act(() => {
+        try {
+          result.current.goToPrevious()
+        } catch (error) {
+          thrownError = error
+        }
+      })
+
+      expect(thrownError).toBe(error)
+      expect(result.current.activeItemId).toBe(6)
+      expect(result.current.isNavigating).toBe(false)
+    })
+
+    it("clears pending previous-page navigation when no loading transition is observed", async () => {
+      const setPage = vi.fn()
+      const records = makeRecords(5, 6)
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 6,
+            data: makeData(records),
+            paginationInfo: makePagePaginationInfo(2, 3, 15),
+            setPage,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToPrevious()
+      })
+
+      expect(result.current.activeItemId).toBe(6)
+
+      await waitFor(() => {
+        expect(result.current.isNavigating).toBe(false)
+      })
+    })
+  })
+
+  describe("pending navigation resolution (infinite-scroll)", () => {
+    it("resolves to next item after loadMore appends data", () => {
+      const loadMore = vi.fn()
+      const records = makeRecords(5)
+
+      const { result, rerender } = zeroRenderHook(
+        (props: UseDataSourceItemNavigationProps<TestRecord>) =>
+          useDataSourceItemNavigation(props),
+        {
+          initialProps: defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+            loadMore,
+          }),
+        }
+      )
+
+      // Trigger loadMore
+      act(() => {
+        result.current.goToNext()
+      })
+      expect(loadMore).toHaveBeenCalled()
+
+      // Simulate appended data (original 5 + 5 new)
+      const appendedRecords = [...records, ...makeRecords(5, 6)]
+      rerender(
+        defaultProps({
+          data: makeData(appendedRecords),
+          paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+          loadMore,
+          isLoading: false,
+        })
+      )
+
+      expect(result.current.activeItemId).toBe(6)
+      expect(result.current.activeItem).toEqual(
+        expect.objectContaining({ id: 6, name: "Item 6" })
+      )
+    })
+
+    it("ignores repeated next navigation while loadMore is pending", () => {
+      const loadMore = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+            loadMore,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToNext()
+        result.current.goToNext()
+      })
+
+      expect(loadMore).toHaveBeenCalledTimes(1)
+      expect(result.current.isNavigating).toBe(true)
+    })
+
+    it("clears pending navigation when loadMore finishes without appended data", () => {
+      const loadMore = vi.fn()
+      const { result, rerender } = zeroRenderHook(
+        (props: UseDataSourceItemNavigationProps<TestRecord>) =>
+          useDataSourceItemNavigation(props),
+        {
+          initialProps: defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+            loadMore,
+          }),
+        }
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      rerender(
+        defaultProps({
+          defaultActiveItemId: 5,
+          paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+          loadMore,
+          isLoading: true,
+        })
+      )
+      rerender(
+        defaultProps({
+          defaultActiveItemId: 5,
+          paginationInfo: makeInfiniteScrollPaginationInfo(false, 5),
+          loadMore,
+          isLoading: false,
+        })
+      )
+
+      expect(result.current.activeItemId).toBe(5)
+      expect(result.current.isNavigating).toBe(false)
+    })
+
+    it("cancels pending loadMore navigation when active item is set manually", () => {
+      const loadMore = vi.fn()
+      const { result, rerender } = zeroRenderHook(
+        (props: UseDataSourceItemNavigationProps<TestRecord>) =>
+          useDataSourceItemNavigation(props),
+        {
+          initialProps: defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+            loadMore,
+          }),
+        }
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+      expect(result.current.isNavigating).toBe(true)
+
+      act(() => {
+        result.current.setActiveItemId(3)
+      })
+
+      expect(result.current.activeItemId).toBe(3)
+      expect(result.current.isNavigating).toBe(false)
+
+      rerender(
+        defaultProps({
+          data: makeData([...makeRecords(5), ...makeRecords(5, 6)]),
+          paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+          loadMore,
+          isLoading: false,
+        })
+      )
+
+      expect(result.current.activeItemId).toBe(3)
+    })
+
+    it("clears pending navigation when loadMore synchronously returns no appended data", async () => {
+      const loadMore = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+            loadMore,
+          })
+        )
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(loadMore).toHaveBeenCalledTimes(1)
+      expect(result.current.activeItemId).toBe(5)
+
+      await waitFor(() => {
+        expect(result.current.isNavigating).toBe(false)
+      })
+    })
+
+    it("resolves synchronous loadMore when appended data is already available", async () => {
+      const loadMore = vi.fn()
+      const appendedRecords = [...makeRecords(5), ...makeRecords(1, 6)]
+      const { result, rerender } = zeroRenderHook(
+        (props: UseDataSourceItemNavigationProps<TestRecord>) =>
+          useDataSourceItemNavigation(props),
+        {
+          initialProps: defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+            loadMore,
+          }),
+        }
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      rerender(
+        defaultProps({
+          data: makeData(appendedRecords),
+          paginationInfo: makeInfiniteScrollPaginationInfo(true, 15),
+          loadMore,
+        })
+      )
+
+      await waitFor(() => {
+        expect(result.current.isNavigating).toBe(false)
+      })
+      expect(result.current.activeItemId).toBe(6)
+    })
+  })
+
+  describe("no pagination", () => {
+    it("navigates within data when paginationInfo is null", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 3,
+            paginationInfo: null,
+          })
+        )
+      )
+
+      expect(result.current.hasNext).toBe(true)
+      expect(result.current.hasPrevious).toBe(true)
+
+      act(() => {
+        result.current.goToNext()
+      })
+      expect(result.current.activeItemId).toBe(4)
+
+      act(() => {
+        result.current.goToPrevious()
+      })
+      expect(result.current.activeItemId).toBe(3)
+    })
+
+    it("hasNext is false at last item with no pagination", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 5,
+            paginationInfo: null,
+          })
+        )
+      )
+
+      expect(result.current.hasNext).toBe(false)
+    })
+
+    it("hasPrevious is false at first item with no pagination", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 1,
+            paginationInfo: null,
+          })
+        )
+      )
+
+      expect(result.current.hasPrevious).toBe(false)
+    })
+  })
+
+  describe("idProvider", () => {
+    it("uses dataSource.idProvider when no override is provided", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 3,
+            idProvider: undefined,
+          })
+        )
+      )
+
+      // mockDataSource.idProvider returns item.id (number)
+      expect(result.current.activeItem).toEqual(
+        expect.objectContaining({ id: 3, name: "Item 3" })
+      )
+    })
+
+    it("falls back to item.id without coercing ID type", () => {
+      const dataSourceWithoutIdProvider = {
+        ...mockDataSource,
+        idProvider: undefined,
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            dataSource: dataSourceWithoutIdProvider,
+            defaultActiveItemId: 3,
+            idProvider: undefined,
+          })
+        )
+      )
+
+      expect(result.current.activeItem).toEqual(
+        expect.objectContaining({ id: 3, name: "Item 3" })
+      )
+    })
+
+    it("uses custom idProvider", () => {
+      const records: TestRecord[] = [
+        { id: 1, name: "alpha" },
+        { id: 2, name: "beta" },
+        { id: 3, name: "gamma" },
+      ]
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            data: makeData(records),
+            defaultActiveItemId: "beta",
+            idProvider: (item) => (item as TestRecord).name,
+          })
+        )
+      )
+
+      expect(result.current.activeItem).toEqual(
+        expect.objectContaining({ id: 2, name: "beta" })
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+      expect(result.current.activeItemId).toBe("gamma")
+    })
+
+    it("supports symbol IDs from dataSource.idProvider", () => {
+      const first = Symbol("first")
+      const second = Symbol("second")
+      const records: TestRecord[] = [
+        { id: 1, name: "first" },
+        { id: 2, name: "second" },
+      ]
+      const dataSource = {
+        ...mockDataSource,
+        idProvider: (item: TestRecord) => (item.id === 1 ? first : second),
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            dataSource,
+            data: makeData(records),
+            defaultActiveItemId: first,
+            idProvider: undefined,
+          })
+        )
+      )
+
+      expect(result.current.activeItem).toEqual(
+        expect.objectContaining({ id: 1, name: "first" })
+      )
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(result.current.activeItemId).toBe(second)
+    })
+  })
+
+  describe("activeItemUrl / nextItemUrl / previousItemUrl", () => {
+    const itemUrl = (item: TestRecord) => `/items/${item.id}`
+
+    it("returns null for URLs when no itemUrl is provided", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ defaultActiveItemId: 3 }))
+      )
+
+      expect(result.current.activeItemUrl).toBeNull()
+      expect(result.current.nextItemUrl).toBeNull()
+      expect(result.current.previousItemUrl).toBeNull()
+    })
+
+    it("returns null for URLs when no active item", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(defaultProps({ itemUrl }))
+      )
+
+      expect(result.current.activeItemUrl).toBeNull()
+      expect(result.current.nextItemUrl).toBeNull()
+      expect(result.current.previousItemUrl).toBeNull()
+    })
+
+    it("returns active, next, and previous URLs for a middle item", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({ defaultActiveItemId: 3, itemUrl })
+        )
+      )
+
+      expect(result.current.activeItemUrl).toBe("/items/3")
+      expect(result.current.previousItemUrl).toBe("/items/2")
+      expect(result.current.nextItemUrl).toBe("/items/4")
+    })
+
+    it("returns null for previousItemUrl at first item", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({ defaultActiveItemId: 1, itemUrl })
+        )
+      )
+
+      expect(result.current.previousItemUrl).toBeNull()
+      expect(result.current.nextItemUrl).toBe("/items/2")
+    })
+
+    it("returns null for nextItemUrl at last item in page", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({ defaultActiveItemId: 5, itemUrl })
+        )
+      )
+
+      expect(result.current.nextItemUrl).toBeNull()
+      expect(result.current.previousItemUrl).toBe("/items/4")
+    })
+
+    it("updates URLs after navigation", () => {
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({ defaultActiveItemId: 2, itemUrl })
+        )
+      )
+
+      expect(result.current.activeItemUrl).toBe("/items/2")
+      expect(result.current.previousItemUrl).toBe("/items/1")
+      expect(result.current.nextItemUrl).toBe("/items/3")
+
+      act(() => {
+        result.current.goToNext()
+      })
+
+      expect(result.current.activeItemUrl).toBe("/items/3")
+      expect(result.current.previousItemUrl).toBe("/items/2")
+      expect(result.current.nextItemUrl).toBe("/items/4")
+    })
+
+    it("handles itemUrl returning undefined for some items", () => {
+      const conditionalUrl = (item: TestRecord) =>
+        item.id === 4 ? undefined : `/items/${item.id}`
+
+      const { result } = zeroRenderHook(() =>
+        useDataSourceItemNavigation(
+          defaultProps({
+            defaultActiveItemId: 3,
+            itemUrl: conditionalUrl,
+          })
+        )
+      )
+
+      expect(result.current.activeItemUrl).toBe("/items/3")
+      expect(result.current.previousItemUrl).toBe("/items/2")
+      expect(result.current.nextItemUrl).toBeNull()
+    })
+  })
+})

--- a/packages/react/src/hooks/datasource/useDataSourceItemNavigation/index.ts
+++ b/packages/react/src/hooks/datasource/useDataSourceItemNavigation/index.ts
@@ -1,0 +1,8 @@
+export { resolveWindowNeighbors } from "./resolveWindowNeighbors"
+export type { NeighborResolution } from "./resolveWindowNeighbors"
+export { useDataSourceItemNavigation } from "./useDataSourceItemNavigation"
+export type {
+  DataSourceItemId,
+  UseDataSourceItemNavigationProps,
+  UseDataSourceItemNavigationReturn,
+} from "./types"

--- a/packages/react/src/hooks/datasource/useDataSourceItemNavigation/resolveWindowNeighbors.ts
+++ b/packages/react/src/hooks/datasource/useDataSourceItemNavigation/resolveWindowNeighbors.ts
@@ -1,0 +1,52 @@
+import { RecordType } from "../types/records.typings"
+import { DataSourceItemId } from "./types"
+
+export type NeighborResolution<R extends RecordType> = {
+  /** Index of the active item within the loaded records, or -1 when not found */
+  activeIndex: number
+  activeItem: R | null
+  previousItem: R | null
+  nextItem: R | null
+  /**
+   * How the neighbours were resolved. "window" means they were located in the
+   * loaded records. Reserved extension point for id-relative adapter
+   * resolution (e.g. a `fetchItemNeighbors` capability).
+   */
+  resolvedBy: "window"
+}
+
+/**
+ * Locates the active item and its immediate neighbours within the currently
+ * loaded records ("the window"). Pure — the single place neighbour resolution
+ * happens, so alternative resolution strategies can be merged at this point.
+ */
+export function resolveWindowNeighbors<R extends RecordType>({
+  records,
+  activeItemId,
+  idProvider,
+}: {
+  records: readonly R[]
+  activeItemId: DataSourceItemId | null
+  idProvider: (item: R, index?: number) => DataSourceItemId
+}): NeighborResolution<R> {
+  if (activeItemId == null) {
+    return {
+      activeIndex: -1,
+      activeItem: null,
+      previousItem: null,
+      nextItem: null,
+      resolvedBy: "window",
+    }
+  }
+  const index = records.findIndex(
+    (record, i) => idProvider(record, i) === activeItemId
+  )
+  return {
+    activeIndex: index,
+    activeItem: index >= 0 ? records[index] : null,
+    previousItem: index > 0 ? records[index - 1] : null,
+    nextItem:
+      index >= 0 && index < records.length - 1 ? records[index + 1] : null,
+    resolvedBy: "window",
+  }
+}

--- a/packages/react/src/hooks/datasource/useDataSourceItemNavigation/types.ts
+++ b/packages/react/src/hooks/datasource/useDataSourceItemNavigation/types.ts
@@ -1,0 +1,72 @@
+import { PaginationInfo } from "../types/fetch.typings"
+import { RecordType } from "../types/records.typings"
+import { Data, UseDataReturn } from "../useData"
+
+export type DataSourceItemId = string | number | symbol
+
+export interface UseDataSourceItemNavigationProps<R extends RecordType> {
+  /** The data source returned by `useDataSource`. Used to extract `idProvider` */
+  dataSource: {
+    idProvider?: <Item extends R>(
+      item: Item,
+      index?: number
+    ) => DataSourceItemId
+  }
+  /** The data returned by `useData` */
+  data: Data<R>
+  /** Pagination info returned by `useData` */
+  paginationInfo: PaginationInfo | null
+  /** Navigate to a specific page (from `useData`) */
+  setPage: UseDataReturn<R>["setPage"]
+  /** Load more items for infinite-scroll (from `useData`) */
+  loadMore: UseDataReturn<R>["loadMore"]
+  /** Whether `useData` is currently loading data */
+  isLoading: boolean
+  /** Overrides `dataSource.idProvider`. Extracts a unique ID from a record. Falls back to `item.id` */
+  idProvider?: (item: R, index?: number) => DataSourceItemId
+  /** Returns the URL for a given item. Used to derive `nextItemUrl` / `previousItemUrl` */
+  itemUrl?: (item: R) => string | undefined
+  /** Controlled active item ID */
+  activeItemId?: DataSourceItemId | null
+  /** Default active item ID (uncontrolled) */
+  defaultActiveItemId?: DataSourceItemId | null
+  /** Callback when active item changes */
+  onActiveItemChange?: (id: DataSourceItemId | null) => void
+}
+
+export interface UseDataSourceItemNavigationReturn<R extends RecordType> {
+  /** The currently active item ID */
+  activeItemId: DataSourceItemId | null
+  /** The currently active item record, or null if not found in loaded data */
+  activeItem: R | null
+  /** The active item index within the currently loaded records */
+  activeIndex: number
+  /** The active item index within the full collection when it can be inferred */
+  absoluteIndex: number | null
+  /** Number of records currently loaded into the datasource */
+  loadedItemsCount: number
+  /** Total number of matching records when pagination exposes it */
+  totalItems: number | undefined
+  /** The previous loaded item record, or null if unavailable */
+  previousItem: R | null
+  /** The next loaded item record, or null if unavailable */
+  nextItem: R | null
+  /** URL of the active item (derived via `itemUrl`), or null if unavailable */
+  activeItemUrl: string | null
+  /** Navigate to the next item. Fetches next page if at boundary */
+  goToNext: () => void
+  /** Navigate to the previous item. Fetches previous page if at boundary */
+  goToPrevious: () => void
+  /** Whether there is a next item (or more pages to load) */
+  hasNext: boolean
+  /** Whether there is a previous item (or previous pages to load) */
+  hasPrevious: boolean
+  /** Directly set the active item ID */
+  setActiveItemId: (id: DataSourceItemId | null) => void
+  /** True while waiting for a page transition to resolve the pending navigation */
+  isNavigating: boolean
+  /** URL of the next loaded item (derived via `itemUrl`), or null if unavailable */
+  nextItemUrl: string | null
+  /** URL of the previous loaded item (derived via `itemUrl`), or null if unavailable */
+  previousItemUrl: string | null
+}

--- a/packages/react/src/hooks/datasource/useDataSourceItemNavigation/useDataSourceItemNavigation.ts
+++ b/packages/react/src/hooks/datasource/useDataSourceItemNavigation/useDataSourceItemNavigation.ts
@@ -1,0 +1,388 @@
+import { useControllableState } from "@radix-ui/react-use-controllable-state"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { RecordType } from "../types/records.typings"
+import { resolveWindowNeighbors } from "./resolveWindowNeighbors"
+import {
+  UseDataSourceItemNavigationProps,
+  UseDataSourceItemNavigationReturn,
+  DataSourceItemId,
+} from "./types"
+
+type PendingNavigation =
+  | { type: "first"; targetPage: number }
+  | { type: "last"; targetPage: number }
+  | {
+      type: "next-after-current"
+      previousId: DataSourceItemId | null
+      loadedItemsCount: number
+    }
+  | null
+
+const defaultIdProvider = (
+  item: RecordType,
+  index?: number
+): DataSourceItemId =>
+  "id" in item &&
+  (typeof item.id === "string" ||
+    typeof item.id === "number" ||
+    typeof item.id === "symbol")
+    ? item.id
+    : (index ?? JSON.stringify(item))
+
+export function useDataSourceItemNavigation<R extends RecordType>(
+  props: UseDataSourceItemNavigationProps<R>
+): UseDataSourceItemNavigationReturn<R> {
+  const {
+    dataSource,
+    data,
+    paginationInfo,
+    setPage,
+    loadMore,
+    isLoading,
+    idProvider: idProviderOverride,
+    itemUrl,
+    activeItemId: activeItemIdProp,
+    defaultActiveItemId,
+    onActiveItemChange,
+  } = props
+
+  const idProvider = useMemo(() => {
+    if (idProviderOverride) return idProviderOverride
+    if (dataSource.idProvider) {
+      return (item: R, index?: number) => dataSource.idProvider!(item, index)
+    }
+    return defaultIdProvider
+  }, [idProviderOverride, dataSource.idProvider])
+
+  const [activeItemIdState, setActiveItemIdRaw] =
+    useControllableState<DataSourceItemId | null>({
+      prop: activeItemIdProp,
+      defaultProp: defaultActiveItemId ?? null,
+      onChange: (value) => onActiveItemChange?.(value ?? null),
+    })
+
+  const activeItemId: DataSourceItemId | null = activeItemIdState ?? null
+
+  const pendingNavigation = useRef<PendingNavigation>(null)
+  const pendingSawLoading = useRef(false)
+  const pendingClearTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [isPendingNavigation, setIsPendingNavigation] = useState(false)
+
+  const clearPendingTimeout = useCallback(() => {
+    if (pendingClearTimeout.current === null) return
+    clearTimeout(pendingClearTimeout.current)
+    pendingClearTimeout.current = null
+  }, [])
+
+  const clearPendingNavigation = useCallback(() => {
+    clearPendingTimeout()
+    pendingNavigation.current = null
+    pendingSawLoading.current = false
+    setIsPendingNavigation(false)
+  }, [clearPendingTimeout])
+
+  const setActiveItemId = useCallback(
+    (id: DataSourceItemId | null) => {
+      clearPendingNavigation()
+      setActiveItemIdRaw(id)
+    },
+    [clearPendingNavigation, setActiveItemIdRaw]
+  )
+
+  const records = data.records
+  const recordsRef = useRef(records)
+  const isLoadingRef = useRef(isLoading)
+  const paginationInfoRef = useRef(paginationInfo)
+  const idProviderRef = useRef(idProvider)
+  const setActiveItemIdRef = useRef(setActiveItemId)
+
+  recordsRef.current = records
+  isLoadingRef.current = isLoading
+  paginationInfoRef.current = paginationInfo
+  idProviderRef.current = idProvider
+  setActiveItemIdRef.current = setActiveItemId
+
+  const schedulePendingFallbackClear = useCallback(() => {
+    clearPendingTimeout()
+    pendingClearTimeout.current = setTimeout(() => {
+      pendingClearTimeout.current = null
+      if (
+        pendingNavigation.current === null ||
+        pendingSawLoading.current ||
+        isLoadingRef.current
+      ) {
+        return
+      }
+
+      const pending = pendingNavigation.current
+      if (pending.type === "first" || pending.type === "last") {
+        const currentPaginationInfo = paginationInfoRef.current
+        if (currentPaginationInfo?.type === "pages") {
+          if (currentPaginationInfo.currentPage === pending.targetPage) return
+          clearPendingNavigation()
+        }
+      } else if (pending.type === "next-after-current") {
+        const currentRecords = recordsRef.current
+        if (currentRecords.length > pending.loadedItemsCount) {
+          const prevIndex =
+            pending.previousId == null
+              ? -1
+              : currentRecords.findIndex(
+                  (record, i) =>
+                    idProviderRef.current(record, i) === pending.previousId
+                )
+          const nextItem = currentRecords[prevIndex + 1]
+          if (nextItem) {
+            setActiveItemIdRef.current(
+              idProviderRef.current(nextItem, prevIndex + 1)
+            )
+          }
+        }
+      }
+
+      clearPendingNavigation()
+    }, 0)
+  }, [clearPendingNavigation, clearPendingTimeout])
+
+  useEffect(() => clearPendingTimeout, [clearPendingTimeout])
+
+  useEffect(() => {
+    if (!isPendingNavigation || pendingNavigation.current === null) return
+    schedulePendingFallbackClear()
+  }, [isPendingNavigation, schedulePendingFallbackClear])
+
+  const { activeIndex, activeItem, previousItem, nextItem } = useMemo(
+    () => resolveWindowNeighbors({ records, activeItemId, idProvider }),
+    [records, activeItemId, idProvider]
+  )
+
+  const absoluteIndex = useMemo(() => {
+    if (activeIndex === -1 || !paginationInfo) return null
+    if (paginationInfo.type === "pages") {
+      return (
+        (paginationInfo.currentPage - 1) * paginationInfo.perPage + activeIndex
+      )
+    }
+    return activeIndex
+  }, [activeIndex, paginationInfo])
+
+  const hasMorePages = useMemo(() => {
+    if (!paginationInfo) return false
+    if (paginationInfo.type === "pages") {
+      return paginationInfo.currentPage < paginationInfo.pagesCount
+    }
+    if (paginationInfo.type === "infinite-scroll") {
+      return paginationInfo.hasMore
+    }
+    return false
+  }, [paginationInfo])
+
+  const hasPreviousPages = useMemo(() => {
+    if (!paginationInfo) return false
+    if (paginationInfo.type === "pages") {
+      return paginationInfo.currentPage > 1
+    }
+    // Infinite-scroll: all previous items are already loaded
+    return false
+  }, [paginationInfo])
+
+  const hasNext = useMemo(() => {
+    if (activeIndex === -1) return false
+    if (activeIndex < records.length - 1) return true
+    return hasMorePages
+  }, [activeIndex, records.length, hasMorePages])
+
+  const hasPrevious = useMemo(() => {
+    if (activeIndex === -1) return false
+    if (activeIndex > 0) return true
+    return hasPreviousPages
+  }, [activeIndex, hasPreviousPages])
+
+  const goToNext = useCallback(() => {
+    if (pendingNavigation.current !== null || isLoading) return
+    if (activeIndex === -1) return
+
+    if (activeIndex < records.length - 1) {
+      const nextLoadedItem = records[activeIndex + 1]
+      setActiveItemId(idProvider(nextLoadedItem, activeIndex + 1))
+      return
+    }
+
+    // At the last item — need to fetch more data
+    if (!hasMorePages || !paginationInfo) return
+
+    if (paginationInfo.type === "pages") {
+      pendingNavigation.current = {
+        type: "first",
+        targetPage: paginationInfo.currentPage + 1,
+      }
+      setIsPendingNavigation(true)
+      try {
+        setPage(paginationInfo.currentPage + 1)
+      } catch (error) {
+        clearPendingNavigation()
+        throw error
+      }
+    } else if (paginationInfo.type === "infinite-scroll") {
+      pendingNavigation.current = {
+        type: "next-after-current",
+        previousId: activeItemId,
+        loadedItemsCount: records.length,
+      }
+      setIsPendingNavigation(true)
+      loadMore()
+    }
+  }, [
+    activeIndex,
+    activeItemId,
+    isLoading,
+    records,
+    hasMorePages,
+    paginationInfo,
+    setPage,
+    loadMore,
+    idProvider,
+    setActiveItemId,
+    clearPendingNavigation,
+  ])
+
+  const goToPrevious = useCallback(() => {
+    if (pendingNavigation.current !== null || isLoading) return
+    if (activeIndex === -1) return
+
+    if (activeIndex > 0) {
+      const prevLoadedItem = records[activeIndex - 1]
+      setActiveItemId(idProvider(prevLoadedItem, activeIndex - 1))
+      return
+    }
+
+    // At the first item — need to fetch previous page (page-based only)
+    if (!hasPreviousPages || !paginationInfo) return
+
+    if (paginationInfo.type === "pages") {
+      pendingNavigation.current = {
+        type: "last",
+        targetPage: paginationInfo.currentPage - 1,
+      }
+      setIsPendingNavigation(true)
+      try {
+        setPage(paginationInfo.currentPage - 1)
+      } catch (error) {
+        clearPendingNavigation()
+        throw error
+      }
+    }
+  }, [
+    activeIndex,
+    isLoading,
+    records,
+    hasPreviousPages,
+    paginationInfo,
+    setPage,
+    idProvider,
+    setActiveItemId,
+    clearPendingNavigation,
+  ])
+
+  // Resolve pending navigation after data changes
+  useEffect(() => {
+    if (pendingNavigation.current === null) return
+    if (isLoading) {
+      pendingSawLoading.current = true
+      return
+    }
+    if (records.length === 0) {
+      clearPendingNavigation()
+      return
+    }
+
+    const pending = pendingNavigation.current
+
+    if (pending.type === "first") {
+      if (
+        paginationInfo?.type === "pages" &&
+        paginationInfo.currentPage !== pending.targetPage
+      ) {
+        if (pendingSawLoading.current) clearPendingNavigation()
+        return
+      }
+      const firstItem = records[0]
+      setActiveItemId(idProvider(firstItem, 0))
+    } else if (pending.type === "last") {
+      if (
+        paginationInfo?.type === "pages" &&
+        paginationInfo.currentPage !== pending.targetPage
+      ) {
+        if (pendingSawLoading.current) clearPendingNavigation()
+        return
+      }
+      const lastItem = records[records.length - 1]
+      setActiveItemId(idProvider(lastItem, records.length - 1))
+    } else if (pending.type === "next-after-current") {
+      if (records.length <= pending.loadedItemsCount) {
+        if (pendingSawLoading.current) clearPendingNavigation()
+        return
+      }
+      if (pending.previousId != null) {
+        const prevIndex = records.findIndex(
+          (record, i) => idProvider(record, i) === pending.previousId
+        )
+        if (prevIndex >= 0 && prevIndex < records.length - 1) {
+          const nextItem = records[prevIndex + 1]
+          setActiveItemId(idProvider(nextItem, prevIndex + 1))
+        } else {
+          clearPendingNavigation()
+          return
+        }
+      }
+    }
+
+    clearPendingNavigation()
+  }, [
+    records,
+    isLoading,
+    paginationInfo,
+    idProvider,
+    setActiveItemId,
+    clearPendingNavigation,
+  ])
+
+  const isNavigating =
+    isPendingNavigation || (pendingNavigation.current !== null && isLoading)
+
+  const nextItemUrl = useMemo(() => {
+    if (!itemUrl || !nextItem) return null
+    return itemUrl(nextItem) ?? null
+  }, [itemUrl, nextItem])
+
+  const activeItemUrl = useMemo(() => {
+    if (!itemUrl || !activeItem) return null
+    return itemUrl(activeItem) ?? null
+  }, [itemUrl, activeItem])
+
+  const previousItemUrl = useMemo(() => {
+    if (!itemUrl || !previousItem) return null
+    return itemUrl(previousItem) ?? null
+  }, [itemUrl, previousItem])
+
+  return {
+    activeItemId,
+    activeItem,
+    activeIndex,
+    absoluteIndex,
+    loadedItemsCount: records.length,
+    totalItems: paginationInfo?.total,
+    previousItem,
+    nextItem,
+    activeItemUrl,
+    goToNext,
+    goToPrevious,
+    hasNext,
+    hasPrevious,
+    setActiveItemId,
+    isNavigating,
+    nextItemUrl,
+    previousItemUrl,
+  }
+}

--- a/packages/react/src/patterns/OneDataCollection/exports.ts
+++ b/packages/react/src/patterns/OneDataCollection/exports.ts
@@ -9,6 +9,7 @@ export type * from "./types"
 // For backwards compatibility
 export * from "@/hooks/datasource/types"
 export * from "./hooks/useDataCollectionData"
+export * from "./hooks/useDataCollectionItemNavigation"
 export * from "./hooks/useDataCollectionSource"
 export * from "./hooks/useInfiniteScrollPagination"
 export { useExportAction } from "./hooks/useExportAction"

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__stories__/useDataCollectionItemNavigation.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__stories__/useDataCollectionItemNavigation.stories.tsx
@@ -1,0 +1,242 @@
+import { Meta, StoryObj } from "@storybook/react-vite"
+import { useMemo, useState } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { PageHeaderNavigationProvider } from "@/experimental/Navigation/Header/PageHeader"
+import { PageNavigation } from "@/experimental/Navigation/Header/PageNavigation"
+import { PaginatedFetchOptions } from "@/hooks/datasource"
+import {
+  dataCollectionLocalStorageHandler,
+  DataCollectionStorageProvider,
+} from "@/lib/providers/datacollection"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+import { DEPARTMENTS_MOCK, generateMockUsers, MockUser } from "@/mocks"
+
+import { OneDataCollection } from "../../../index"
+import {
+  DataCollectionSourceDefinition,
+  useDataCollectionSource,
+} from "../../useDataCollectionSource"
+import { useDataCollectionItemNavigation } from "../useDataCollectionItemNavigation"
+
+const meta = {
+  title: "Data Collection/useDataCollectionItemNavigation",
+  parameters: {
+    layout: "padded",
+    a11y: { skipCi: true },
+    docs: {
+      description: {
+        component:
+          "Detail-page prev/next navigation fed from a **declared** data collection source definition + the originating list's `collectionId`. The hook reads the filters/sortings/search the list persisted through the storage handler, seeds them into the source, and exposes render-ready `NavigationProps` — so it works on a direct link / hard refresh where the list was never mounted.",
+      },
+    },
+  },
+  tags: ["experimental", "!autodocs"],
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const users = generateMockUsers(35)
+
+const COLLECTION_ID = "storybook/item-navigation-demo/v1"
+
+const filters = {
+  department: {
+    type: "in" as const,
+    label: "Department",
+    options: {
+      options: DEPARTMENTS_MOCK.map((d) => ({ value: d, label: d })),
+    },
+  },
+}
+
+const sortings = {
+  name: { label: "Name" },
+}
+
+type Filters = typeof filters
+type Sortings = typeof sortings
+
+const PER_PAGE = 10
+
+// The single shared declaration: the list AND the detail page use this.
+const userListSourceDefinition: DataCollectionSourceDefinition<
+  MockUser,
+  Filters,
+  Sortings
+> = {
+  filters,
+  sortings,
+  search: { enabled: true },
+  itemUrl: (user) => `#/users/${user.id}`,
+  dataAdapter: {
+    paginationType: "pages",
+    perPage: PER_PAGE,
+    fetchData: async (options: PaginatedFetchOptions<Filters>) => {
+      await new Promise((resolve) => setTimeout(resolve, 150))
+      const departments = options.filters.department
+      let results = users.filter(
+        (user) => !departments?.length || departments.includes(user.department)
+      )
+      if (options.search) {
+        const search = options.search.toLowerCase()
+        results = results.filter((user) =>
+          user.name.toLowerCase().includes(search)
+        )
+      }
+      const sorting = options.sortings.find((s) => s.field === "name")
+      if (sorting) {
+        results = [...results].sort(
+          (a, b) =>
+            a.name.localeCompare(b.name) * (sorting.order === "asc" ? 1 : -1)
+        )
+      }
+      const currentPage =
+        "currentPage" in options.pagination
+          ? (options.pagination.currentPage ?? 1)
+          : 1
+      const start = (currentPage - 1) * PER_PAGE
+      return {
+        type: "pages" as const,
+        records: results.slice(start, start + PER_PAGE),
+        total: results.length,
+        perPage: PER_PAGE,
+        currentPage,
+        pagesCount: Math.ceil(results.length / PER_PAGE),
+      }
+    },
+  },
+}
+
+const UserList = ({ onOpenUser }: { onOpenUser: (id: string) => void }) => {
+  const source = useDataCollectionSource<MockUser, Filters, Sortings>({
+    ...userListSourceDefinition,
+    itemOnClick: (user) => () => onOpenUser(user.id),
+  })
+
+  return (
+    <OneDataCollection
+      id={COLLECTION_ID}
+      source={source}
+      visualizations={[
+        {
+          type: "table",
+          options: {
+            columns: [
+              { label: "Name", render: (user: MockUser) => user.name },
+              {
+                label: "Department",
+                render: (user: MockUser) => user.department,
+              },
+            ],
+          },
+        },
+      ]}
+    />
+  )
+}
+
+const UserDetail = ({
+  userId,
+  onNavigate,
+}: {
+  userId: string
+  onNavigate: (id: string) => void
+}) => {
+  const itemNavigation = useDataCollectionItemNavigation({
+    source: userListSourceDefinition,
+    collectionId: COLLECTION_ID,
+    activeItemId: userId,
+    onActiveItemChange: (id) => {
+      if (typeof id === "string") onNavigate(id)
+    },
+    getItemTitle: (user) => user.name,
+  })
+
+  const { navigation, activeItem, isReady, appliedCollectionState } =
+    itemNavigation
+
+  return (
+    <PageHeaderNavigationProvider value={navigation}>
+      <div className="flex flex-col gap-3 rounded-md border border-solid border-f1-border-secondary p-4">
+        <div className="flex items-center justify-between">
+          <div className="font-medium text-f1-foreground">
+            {activeItem?.name ??
+              (isReady ? "Not in loaded window" : "Loading…")}
+          </div>
+          <div className="flex items-center gap-2">
+            {/* PageHeader renders this same thing from the provided context;
+                shown standalone here to keep the story focused */}
+            {navigation && <PageNavigation {...navigation} />}
+            <F0Button
+              variant="outline"
+              size="sm"
+              label="Previous"
+              disabled={!itemNavigation.hasPrevious}
+              onClick={itemNavigation.goToPrevious}
+            />
+            <F0Button
+              variant="outline"
+              size="sm"
+              label="Next"
+              disabled={!itemNavigation.hasNext}
+              loading={itemNavigation.isNavigating}
+              onClick={itemNavigation.goToNext}
+            />
+          </div>
+        </div>
+        <div className="text-sm text-f1-foreground-secondary">
+          {activeItem
+            ? `${activeItem.email} — ${activeItem.department}`
+            : "Open an item from the list, or deep-link by id."}
+        </div>
+        <div className="text-sm text-f1-foreground-secondary">
+          Seeded from storage:{" "}
+          <code>{JSON.stringify(appliedCollectionState) ?? "null"}</code>
+        </div>
+      </div>
+    </PageHeaderNavigationProvider>
+  )
+}
+
+const DetailNavigationDemo = () => {
+  const [listMounted, setListMounted] = useState(true)
+  const [activeUserId, setActiveUserId] = useState<string | null>(null)
+  const firstUserId = useMemo(() => users[0].id, [])
+
+  return (
+    <DataCollectionStorageProvider handler={dataCollectionLocalStorageHandler}>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-2">
+          <F0Button
+            variant="outline"
+            size="sm"
+            label={listMounted ? "Unmount list" : "Mount list"}
+            onClick={() => setListMounted((mounted) => !mounted)}
+          />
+          <F0Button
+            variant="outline"
+            size="sm"
+            label="Direct link to first user"
+            onClick={() => setActiveUserId(firstUserId)}
+          />
+          <span className="text-sm text-f1-foreground-secondary">
+            Filter/sort/search the list, open a user, then unmount the list:
+            navigation keeps following the persisted list state — the
+            direct-link scenario.
+          </span>
+        </div>
+        {activeUserId && (
+          <UserDetail userId={activeUserId} onNavigate={setActiveUserId} />
+        )}
+        {listMounted && <UserList onOpenUser={setActiveUserId} />}
+      </div>
+    </DataCollectionStorageProvider>
+  )
+}
+
+export const DetailPageNavigation: Story = {
+  parameters: withSnapshot({}),
+  render: () => <DetailNavigationDemo />,
+}

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__tests__/seedFromStorage.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__tests__/seedFromStorage.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { seedFromStorage, SeedTarget } from "../seedFromStorage"
+
+type TestRecord = { id: number; name: string; department: string }
+
+const definition = {
+  filters: {
+    department: {
+      type: "in" as const,
+      label: "Department",
+      options: { options: [] },
+    },
+  },
+  sortings: {
+    name: { label: "Name" },
+  },
+  search: { enabled: true },
+  grouping: {
+    collapsible: false as const,
+    groupBy: {
+      department: {
+        name: "Department",
+        label: (groupId: string) => groupId,
+      },
+    },
+  },
+}
+
+const makeTarget = () =>
+  ({
+    setCurrentFilters: vi.fn(),
+    setCurrentSortings: vi.fn(),
+    setCurrentSearch: vi.fn(),
+    setCurrentGrouping: vi.fn(),
+  }) satisfies SeedTarget<
+    TestRecord,
+    typeof definition.filters,
+    typeof definition.sortings,
+    typeof definition.grouping
+  >
+
+describe("seedFromStorage", () => {
+  it("returns null and applies nothing for empty storage", () => {
+    const target = makeTarget()
+    expect(seedFromStorage({}, definition, target)).toBeNull()
+    expect(target.setCurrentFilters).not.toHaveBeenCalled()
+    expect(target.setCurrentSortings).not.toHaveBeenCalled()
+    expect(target.setCurrentSearch).not.toHaveBeenCalled()
+    expect(target.setCurrentGrouping).not.toHaveBeenCalled()
+  })
+
+  it("applies persisted filters declared in the definition", () => {
+    const target = makeTarget()
+    const applied = seedFromStorage(
+      { filters: { department: ["Engineering"] } },
+      definition,
+      target
+    )
+    expect(target.setCurrentFilters).toHaveBeenCalledWith({
+      department: ["Engineering"],
+    })
+    expect(applied?.filters).toEqual({ department: ["Engineering"] })
+  })
+
+  it("resolves per-visualization filters over the top-level ones", () => {
+    const target = makeTarget()
+    seedFromStorage(
+      {
+        filters: { department: ["Marketing"] },
+        visualization: 1,
+        visualizationFilters: { "1": { department: ["Engineering"] } },
+      },
+      definition,
+      target
+    )
+    expect(target.setCurrentFilters).toHaveBeenCalledWith({
+      department: ["Engineering"],
+    })
+  })
+
+  it("prunes persisted filter keys absent from the definition", () => {
+    const target = makeTarget()
+    const applied = seedFromStorage(
+      { filters: { department: ["Engineering"], legacyFilter: "stale" } },
+      definition,
+      target
+    )
+    expect(target.setCurrentFilters).toHaveBeenCalledWith({
+      department: ["Engineering"],
+    })
+    expect(applied?.filters).not.toHaveProperty("legacyFilter")
+  })
+
+  it("applies nothing when every persisted filter key is unknown", () => {
+    const target = makeTarget()
+    const applied = seedFromStorage(
+      { filters: { legacyFilter: "stale" } },
+      definition,
+      target
+    )
+    expect(target.setCurrentFilters).not.toHaveBeenCalled()
+    expect(applied).toBeNull()
+  })
+
+  it("applies nothing when the definition declares no filters", () => {
+    const target = makeTarget()
+    const applied = seedFromStorage(
+      { filters: { department: ["Engineering"] } },
+      { ...definition, filters: undefined },
+      target
+    )
+    expect(target.setCurrentFilters).not.toHaveBeenCalled()
+    expect(applied).toBeNull()
+  })
+
+  it("applies a persisted sorting whose field is declared", () => {
+    const target = makeTarget()
+    const applied = seedFromStorage(
+      { sortings: { field: "name", order: "desc" } },
+      definition,
+      target
+    )
+    expect(target.setCurrentSortings).toHaveBeenCalledWith({
+      field: "name",
+      order: "desc",
+    })
+    expect(applied?.sortings).toEqual({ field: "name", order: "desc" })
+  })
+
+  it("applies an explicit null sorting (user cleared it on the list)", () => {
+    const target = makeTarget()
+    const applied = seedFromStorage({ sortings: null }, definition, target)
+    expect(target.setCurrentSortings).toHaveBeenCalledWith(null)
+    expect(applied?.sortings).toBeNull()
+  })
+
+  it("skips sortings that are undefined (never persisted)", () => {
+    const target = makeTarget()
+    seedFromStorage({ filters: {} }, definition, target)
+    expect(target.setCurrentSortings).not.toHaveBeenCalled()
+  })
+
+  it("skips a persisted sorting whose field is not declared", () => {
+    const target = makeTarget()
+    seedFromStorage(
+      { sortings: { field: "hireDate", order: "asc" } },
+      definition,
+      target
+    )
+    expect(target.setCurrentSortings).not.toHaveBeenCalled()
+  })
+
+  it("applies search only when the definition enables it", () => {
+    const target = makeTarget()
+    const applied = seedFromStorage({ search: "alice" }, definition, target)
+    expect(target.setCurrentSearch).toHaveBeenCalledWith("alice")
+    expect(applied?.search).toBe("alice")
+
+    const disabledTarget = makeTarget()
+    const appliedDisabled = seedFromStorage(
+      { search: "alice" },
+      { ...definition, search: { enabled: false } },
+      disabledTarget
+    )
+    expect(disabledTarget.setCurrentSearch).not.toHaveBeenCalled()
+    expect(appliedDisabled).toBeNull()
+  })
+
+  it("applies a persisted grouping whose field is declared", () => {
+    const target = makeTarget()
+    const applied = seedFromStorage(
+      { grouping: { field: "department", order: "asc" } },
+      definition,
+      target
+    )
+    expect(target.setCurrentGrouping).toHaveBeenCalledWith({
+      field: "department",
+      order: "asc",
+    })
+    expect(applied?.grouping).toEqual({ field: "department", order: "asc" })
+  })
+
+  it("skips a persisted grouping whose field is not declared", () => {
+    const target = makeTarget()
+    seedFromStorage(
+      { grouping: { field: "country", order: "asc" } },
+      definition,
+      target
+    )
+    expect(target.setCurrentGrouping).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__tests__/useDataCollectionItemNavigation.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__tests__/useDataCollectionItemNavigation.test.tsx
@@ -1,0 +1,337 @@
+import { waitFor } from "@testing-library/react"
+import { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  PaginatedFetchOptions,
+  RecordType,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+import {
+  DataCollectionStorage,
+  DataCollectionStorageHandler,
+  DataCollectionStorageProvider,
+} from "@/lib/providers/datacollection"
+import { TestProviders, zeroRenderHook } from "@/testing/test-utils"
+
+import { DataCollectionSourceDefinition } from "../../useDataCollectionSource"
+import { useDataCollectionItemNavigation } from "../useDataCollectionItemNavigation"
+
+interface TestRecord extends RecordType {
+  id: number
+  name: string
+  department: string
+}
+
+const DEPARTMENTS = ["Engineering", "Design"]
+
+const ALL_ITEMS: TestRecord[] = Array.from({ length: 25 }, (_, i) => ({
+  id: i + 1,
+  name: `User ${i + 1}`,
+  department: DEPARTMENTS[i % DEPARTMENTS.length],
+}))
+
+const testFilters = {
+  department: {
+    type: "in" as const,
+    label: "Department",
+    options: {
+      options: DEPARTMENTS.map((d) => ({ value: d, label: d })),
+    },
+  },
+}
+
+type TestFilters = typeof testFilters
+
+const testSortings = {
+  name: { label: "Name" },
+} satisfies SortingsDefinition
+
+const PER_PAGE = 10
+
+const makeFetchData = () =>
+  vi.fn((options: PaginatedFetchOptions<TestFilters>) => {
+    const departments = options.filters.department
+    let results = ALL_ITEMS.filter(
+      (item) => !departments?.length || departments.includes(item.department)
+    )
+    if (options.search) {
+      results = results.filter((item) =>
+        item.name.toLowerCase().includes(options.search!.toLowerCase())
+      )
+    }
+    const currentPage =
+      "currentPage" in options.pagination
+        ? (options.pagination.currentPage ?? 1)
+        : 1
+    const start = (currentPage - 1) * PER_PAGE
+    return Promise.resolve({
+      type: "pages" as const,
+      records: results.slice(start, start + PER_PAGE),
+      total: results.length,
+      perPage: PER_PAGE,
+      currentPage,
+      pagesCount: Math.ceil(results.length / PER_PAGE),
+    })
+  })
+
+const makeSource = (
+  fetchData: ReturnType<typeof makeFetchData>
+): DataCollectionSourceDefinition<
+  TestRecord,
+  TestFilters,
+  typeof testSortings
+> =>
+  ({
+    filters: testFilters,
+    sortings: testSortings,
+    search: { enabled: true, sync: true },
+    itemUrl: (item: TestRecord) => `/items/${item.id}`,
+    dataAdapter: {
+      paginationType: "pages",
+      perPage: PER_PAGE,
+      fetchData,
+    },
+  }) as DataCollectionSourceDefinition<
+    TestRecord,
+    TestFilters,
+    typeof testSortings
+  >
+
+const makeStorageHandler = (
+  storage: DataCollectionStorage | (() => Promise<DataCollectionStorage>)
+): DataCollectionStorageHandler => ({
+  get: vi.fn(() =>
+    typeof storage === "function" ? storage() : Promise.resolve(storage)
+  ),
+  set: vi.fn(() => Promise.resolve()),
+})
+
+const withStorage = (handler: DataCollectionStorageHandler) => {
+  const StorageWrapper = ({ children }: { children: ReactNode }) => (
+    <TestProviders>
+      <DataCollectionStorageProvider handler={handler}>
+        {children}
+      </DataCollectionStorageProvider>
+    </TestProviders>
+  )
+  return StorageWrapper
+}
+
+describe("useDataCollectionItemNavigation", () => {
+  it("fetches exactly once, with the persisted state seeded", async () => {
+    const fetchData = makeFetchData()
+    const handler = makeStorageHandler({
+      filters: { department: ["Engineering"] },
+      sortings: { field: "name", order: "desc" },
+      search: "user",
+    })
+
+    const { result } = zeroRenderHook(
+      () =>
+        useDataCollectionItemNavigation({
+          source: makeSource(fetchData),
+          collectionId: "test/items/v1",
+          activeItemId: 1,
+        }),
+      { wrapper: withStorage(handler) }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+
+    expect(handler.get).toHaveBeenCalledWith("test/items/v1")
+    expect(fetchData).toHaveBeenCalledTimes(1)
+    const options = fetchData.mock.calls[0][0]
+    expect(options.filters).toEqual({ department: ["Engineering"] })
+    expect(options.sortings).toEqual(
+      expect.arrayContaining([{ field: "name", order: "desc" }])
+    )
+    expect(options.search).toBe("user")
+    expect(result.current.appliedCollectionState).toEqual({
+      filters: { department: ["Engineering"] },
+      sortings: { field: "name", order: "desc" },
+      search: "user",
+    })
+  })
+
+  it("falls back to definition defaults when storage is empty", async () => {
+    const fetchData = makeFetchData()
+
+    const { result } = zeroRenderHook(() =>
+      useDataCollectionItemNavigation({
+        source: makeSource(fetchData),
+        collectionId: "test/items/v1",
+        activeItemId: 1,
+      })
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+
+    expect(fetchData).toHaveBeenCalledTimes(1)
+    expect(fetchData.mock.calls[0][0].filters).toEqual({})
+    expect(result.current.appliedCollectionState).toBeNull()
+  })
+
+  it("falls back to definition defaults when the handler rejects", async () => {
+    const fetchData = makeFetchData()
+    const handler = makeStorageHandler(() =>
+      Promise.reject(new Error("storage unavailable"))
+    )
+
+    const { result } = zeroRenderHook(
+      () =>
+        useDataCollectionItemNavigation({
+          source: makeSource(fetchData),
+          collectionId: "test/items/v1",
+          activeItemId: 1,
+        }),
+      { wrapper: withStorage(handler) }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    expect(fetchData).toHaveBeenCalledTimes(1)
+    expect(result.current.appliedCollectionState).toBeNull()
+  })
+
+  it("skips the storage read when restorePersistedState is false", async () => {
+    const fetchData = makeFetchData()
+    const handler = makeStorageHandler({
+      filters: { department: ["Engineering"] },
+    })
+
+    const { result } = zeroRenderHook(
+      () =>
+        useDataCollectionItemNavigation({
+          source: makeSource(fetchData),
+          collectionId: "test/items/v1",
+          activeItemId: 1,
+          restorePersistedState: false,
+        }),
+      { wrapper: withStorage(handler) }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    expect(handler.get).not.toHaveBeenCalled()
+    expect(fetchData.mock.calls[0][0].filters).toEqual({})
+  })
+
+  it("does not fetch while disabled", async () => {
+    const fetchData = makeFetchData()
+    const handler = makeStorageHandler({})
+
+    const { result } = zeroRenderHook(
+      () =>
+        useDataCollectionItemNavigation({
+          source: makeSource(fetchData),
+          collectionId: "test/items/v1",
+          activeItemId: 1,
+          enabled: false,
+        }),
+      { wrapper: withStorage(handler) }
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(handler.get).not.toHaveBeenCalled()
+    expect(fetchData).not.toHaveBeenCalled()
+    expect(result.current.isReady).toBe(false)
+  })
+
+  it("exposes navigation with prev/next URLs and a counter", async () => {
+    const fetchData = makeFetchData()
+
+    const { result } = zeroRenderHook(() =>
+      useDataCollectionItemNavigation({
+        source: makeSource(fetchData),
+        collectionId: "test/items/v1",
+        activeItemId: 2,
+        getItemTitle: (item) => item.name,
+      })
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+
+    expect(result.current.activeIndex).toBe(1)
+    expect(result.current.hasPrevious).toBe(true)
+    expect(result.current.hasNext).toBe(true)
+    expect(result.current.navigation).toEqual({
+      previous: { url: "/items/1", title: "User 1" },
+      next: { url: "/items/3", title: "User 3" },
+      counter: { current: 2, total: 25 },
+    })
+  })
+
+  it("degrades gracefully when the active item is not in the loaded window", async () => {
+    const fetchData = makeFetchData()
+
+    const { result } = zeroRenderHook(() =>
+      useDataCollectionItemNavigation({
+        source: makeSource(fetchData),
+        collectionId: "test/items/v1",
+        // Item 25 lives on page 3 — not in the first loaded window
+        activeItemId: 25,
+      })
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+
+    expect(result.current.activeIndex).toBe(-1)
+    expect(result.current.hasNext).toBe(false)
+    expect(result.current.hasPrevious).toBe(false)
+    expect(result.current.navigation).toBeNull()
+    // No crash, no loop
+    expect(fetchData).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not refetch when the active item id changes (loop regression)", async () => {
+    const fetchData = makeFetchData()
+
+    const { result, rerender } = zeroRenderHook(
+      ({ activeItemId }: { activeItemId: number }) =>
+        useDataCollectionItemNavigation({
+          source: makeSource(fetchData),
+          collectionId: "test/items/v1",
+          activeItemId,
+        }),
+      { initialProps: { activeItemId: 1 } }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    expect(fetchData).toHaveBeenCalledTimes(1)
+
+    rerender({ activeItemId: 2 })
+    rerender({ activeItemId: 3 })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(result.current.activeItemId).toBe(3)
+    expect(fetchData).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-hydrates when the collectionId changes", async () => {
+    const fetchData = makeFetchData()
+    const handler = makeStorageHandler({
+      filters: { department: ["Engineering"] },
+    })
+
+    const { result, rerender } = zeroRenderHook(
+      ({ collectionId }: { collectionId: string }) =>
+        useDataCollectionItemNavigation({
+          source: makeSource(fetchData),
+          collectionId,
+          activeItemId: 1,
+        }),
+      {
+        wrapper: withStorage(handler),
+        initialProps: { collectionId: "test/items/v1" },
+      }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    expect(handler.get).toHaveBeenCalledTimes(1)
+
+    rerender({ collectionId: "test/items/v2" })
+    await waitFor(() =>
+      expect(handler.get).toHaveBeenCalledWith("test/items/v2")
+    )
+    expect(handler.get).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/index.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/index.ts
@@ -1,0 +1,8 @@
+export { seedFromStorage } from "./seedFromStorage"
+export type { SeedableDefinition, SeedTarget } from "./seedFromStorage"
+export { useDataCollectionItemNavigation } from "./useDataCollectionItemNavigation"
+export type {
+  AppliedCollectionState,
+  UseDataCollectionItemNavigationProps,
+  UseDataCollectionItemNavigationReturn,
+} from "./types"

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/seedFromStorage.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/seedFromStorage.ts
@@ -1,0 +1,139 @@
+import {
+  FiltersDefinition,
+  FiltersState,
+  GroupingDefinition,
+  RecordType,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+import { SearchOptions } from "@/hooks/datasource/types/search.typings"
+import { DataCollectionStorage } from "@/lib/providers/datacollection"
+import { resolveDataCollectionFilters } from "@/lib/providers/datacollection/readDataCollectionStorage"
+
+import { AppliedCollectionState } from "./types"
+
+const isKeyOf = <T extends object>(
+  obj: T,
+  key: PropertyKey
+): key is keyof T & string => typeof key === "string" && key in obj
+
+export interface SeedableDefinition<
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Grouping extends GroupingDefinition<R>,
+> {
+  filters?: Filters
+  sortings?: Sortings
+  search?: SearchOptions
+  grouping?: Grouping
+}
+
+export interface SeedTarget<
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Grouping extends GroupingDefinition<R>,
+> {
+  setCurrentFilters: (filters: FiltersState<Filters>) => void
+  setCurrentSortings: (
+    sortings: { field: keyof Sortings; order: "asc" | "desc" } | null
+  ) => void
+  setCurrentSearch: (search: string | undefined) => void
+  setCurrentGrouping: (
+    grouping:
+      | { field: keyof Grouping["groupBy"]; order?: "asc" | "desc" }
+      | undefined
+  ) => void
+}
+
+/**
+ * Applies a OneDataCollection's persisted state onto a data source's runtime
+ * setters, validating every piece against the declared definition first so
+ * stale persisted keys (schema drift, renamed filters) never reach the
+ * adapter.
+ *
+ * - Filters: resolved per-visualization (`visualizationFilters` wins over
+ *   `filters`), then pruned to the keys declared in `definition.filters`.
+ * - Sortings: a single `{ field, order } | null` — `null` is an explicit
+ *   user "clear sorting" and is applied; `undefined` keeps the defaults.
+ * - Search: applied only when the definition enables search.
+ * - Grouping: applied only when the persisted field is a declared groupBy —
+ *   grouping changes record order, and prev/next must match the list.
+ *
+ * Pure besides invoking the given setters. Returns what was applied, or null
+ * when the storage contributed nothing.
+ */
+export function seedFromStorage<
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Grouping extends GroupingDefinition<R>,
+>(
+  storage: DataCollectionStorage<FiltersState<Filters>>,
+  definition: SeedableDefinition<R, Filters, Sortings, Grouping>,
+  target: SeedTarget<R, Filters, Sortings, Grouping>
+): AppliedCollectionState<R, Filters, Sortings, Grouping> | null {
+  const applied: AppliedCollectionState<R, Filters, Sortings, Grouping> = {}
+  let anyApplied = false
+
+  // Filters — per-visualization resolution + pruning against the definition
+  const resolvedFilters = resolveDataCollectionFilters(storage)
+  if (resolvedFilters && definition.filters) {
+    const declaredFilters = definition.filters
+    const pruned = Object.fromEntries(
+      Object.entries(resolvedFilters).filter(([key]) =>
+        isKeyOf(declaredFilters, key)
+      )
+    ) as FiltersState<Filters>
+    if (Object.keys(pruned).length > 0) {
+      target.setCurrentFilters(pruned)
+      applied.filters = pruned
+      anyApplied = true
+    }
+  }
+
+  // Sortings — null means the user explicitly cleared the sorting
+  const storedSortings = storage.sortings
+  if (storedSortings === null) {
+    target.setCurrentSortings(null)
+    applied.sortings = null
+    anyApplied = true
+  } else if (
+    storedSortings &&
+    definition.sortings &&
+    isKeyOf(definition.sortings, storedSortings.field)
+  ) {
+    const sortings = {
+      field: storedSortings.field,
+      order: storedSortings.order,
+    }
+    target.setCurrentSortings(sortings)
+    applied.sortings = sortings
+    anyApplied = true
+  }
+
+  // Search — only when the definition enables it
+  if (typeof storage.search === "string" && definition.search?.enabled) {
+    target.setCurrentSearch(storage.search)
+    applied.search = storage.search
+    anyApplied = true
+  }
+
+  // Grouping — only when the persisted field is a declared groupBy
+  const storedGrouping = storage.grouping
+  if (
+    storedGrouping?.field !== undefined &&
+    definition.grouping &&
+    isKeyOf(definition.grouping.groupBy, storedGrouping.field)
+  ) {
+    const grouping = {
+      field: storedGrouping.field,
+      order: storedGrouping.order,
+    }
+    target.setCurrentGrouping(grouping)
+    applied.grouping = grouping
+    anyApplied = true
+  }
+
+  return anyApplied ? applied : null
+}

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/types.ts
@@ -1,0 +1,147 @@
+import type { NavigationProps } from "@/experimental/Navigation/Header/PageNavigation"
+import {
+  Data,
+  DataSourceItemId,
+  FiltersDefinition,
+  FiltersState,
+  GroupingDefinition,
+  GroupingState,
+  PaginationInfo,
+  RecordType,
+  SortingsDefinition,
+  SortingsState,
+  UseDataSourceItemNavigationReturn,
+} from "@/hooks/datasource"
+
+import { ItemActionsDefinition } from "../../item-actions"
+import { NavigationFiltersDefinition } from "../../navigationFilters/types"
+import { SummariesDefinition } from "../../summary"
+import {
+  DataCollectionSource,
+  DataCollectionSourceDefinition,
+} from "../useDataCollectionSource"
+
+/**
+ * The slice of persisted collection state that was actually applied to the
+ * data source during hydration. `sortings: null` means the user had
+ * explicitly cleared the sorting on the originating list.
+ */
+export type AppliedCollectionState<
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+  Sortings extends SortingsDefinition,
+  Grouping extends GroupingDefinition<R>,
+> = {
+  filters?: FiltersState<Filters>
+  sortings?: SortingsState<Sortings>
+  search?: string
+  grouping?: GroupingState<R, Grouping>
+}
+
+export interface UseDataCollectionItemNavigationProps<
+  R extends RecordType = RecordType,
+  Filters extends FiltersDefinition = FiltersDefinition,
+  Sortings extends SortingsDefinition = SortingsDefinition,
+  Summaries extends SummariesDefinition = SummariesDefinition,
+  ItemActions extends ItemActionsDefinition<R> = ItemActionsDefinition<R>,
+  NavigationFilters extends NavigationFiltersDefinition =
+    NavigationFiltersDefinition,
+  Grouping extends GroupingDefinition<R> = GroupingDefinition<R>,
+> {
+  /**
+   * The declared data source definition — the same one the originating list
+   * passes to `useDataCollectionSource` / `OneDataCollection`. `itemUrl`
+   * comes from here unless overridden.
+   */
+  source: DataCollectionSourceDefinition<
+    R,
+    Filters,
+    Sortings,
+    Summaries,
+    ItemActions,
+    NavigationFilters,
+    Grouping
+  >
+  /**
+   * The `id` of the originating `OneDataCollection` (e.g.
+   * `organization/employees/v1`). Its persisted filters/sortings/search are
+   * read through the data collection storage handler and seeded into the
+   * source, so navigation matches what the user saw on the list — even on a
+   * direct link where the list was never mounted.
+   */
+  collectionId: string
+  /** Controlled active item ID — typically the detail route param. */
+  activeItemId?: DataSourceItemId | null
+  /** Default active item ID for uncontrolled usage. */
+  defaultActiveItemId?: DataSourceItemId | null
+  /** Callback fired whenever the active item changes. */
+  onActiveItemChange?: (id: DataSourceItemId | null) => void
+  /** Overrides the source idProvider. */
+  idProvider?: (item: R, index?: number) => DataSourceItemId
+  /** Overrides `source.itemUrl`. */
+  itemUrl?: (item: R) => string | undefined
+  /** Accessible titles for the PageHeader prev/next links. */
+  getItemTitle?: (item: R) => string
+  /**
+   * Gates everything: while false neither the persisted state is read nor
+   * any data fetched.
+   * @default true
+   */
+  enabled?: boolean
+  /**
+   * When false, skips reading the persisted collection state and fetches
+   * with the definition defaults.
+   * @default true
+   */
+  restorePersistedState?: boolean
+  /**
+   * Forwarded to `useDataCollectionSource` for `dataAdapter` memoization,
+   * same convention as `useDataCollectionSource(source, deps)`.
+   */
+  deps?: ReadonlyArray<unknown>
+}
+
+export interface UseDataCollectionItemNavigationReturn<
+  R extends RecordType = RecordType,
+  Filters extends FiltersDefinition = FiltersDefinition,
+  Sortings extends SortingsDefinition = SortingsDefinition,
+  Summaries extends SummariesDefinition = SummariesDefinition,
+  ItemActions extends ItemActionsDefinition<R> = ItemActionsDefinition<R>,
+  NavigationFilters extends NavigationFiltersDefinition =
+    NavigationFiltersDefinition,
+  Grouping extends GroupingDefinition<R> = GroupingDefinition<R>,
+> extends UseDataSourceItemNavigationReturn<R> {
+  /** True once persisted state was applied AND the first fetch resolved. */
+  isReady: boolean
+  /**
+   * Render-ready PageHeader navigation. Pass it to the `navigation` prop or
+   * inject it via `PageHeaderNavigationProvider`. Null while there is
+   * nothing useful to render (e.g. the active item is not in the loaded
+   * window on a deep direct link).
+   */
+  navigation: NavigationProps | null
+  /**
+   * What was actually read and applied from the persisted collection state,
+   * or null when nothing was (empty storage, restore disabled, read error).
+   */
+  appliedCollectionState: AppliedCollectionState<
+    R,
+    Filters,
+    Sortings,
+    Grouping
+  > | null
+  /** The runtime data source created from the definition (escape hatch). */
+  dataSource: DataCollectionSource<
+    R,
+    Filters,
+    Sortings,
+    Summaries,
+    ItemActions,
+    NavigationFilters,
+    Grouping
+  >
+  /** The fetched data backing the navigation (escape hatch). */
+  data: Data<R>
+  paginationInfo: PaginationInfo | null
+  isLoading: boolean
+}

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/useDataCollectionItemNavigation.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/useDataCollectionItemNavigation.ts
@@ -1,0 +1,230 @@
+import { useEffect, useRef, useState } from "react"
+
+import { usePageHeaderItemNavigation } from "@/experimental/Navigation/Header/PageHeader"
+import {
+  FiltersDefinition,
+  FiltersState,
+  GroupingDefinition,
+  RecordType,
+  SortingsDefinition,
+  useData,
+  useDataSourceItemNavigation,
+} from "@/hooks/datasource"
+import {
+  DataCollectionStorage,
+  useDataCollectionStorage,
+} from "@/lib/providers/datacollection"
+
+import { ItemActionsDefinition } from "../../item-actions"
+import { NavigationFiltersDefinition } from "../../navigationFilters/types"
+import { SummariesDefinition } from "../../summary"
+import { useDataCollectionSource } from "../useDataCollectionSource"
+import { seedFromStorage } from "./seedFromStorage"
+import {
+  AppliedCollectionState,
+  UseDataCollectionItemNavigationProps,
+  UseDataCollectionItemNavigationReturn,
+} from "./types"
+
+/**
+ * Item navigation (prev/next + counter + PageHeader wiring) fed from a
+ * **declared** data collection source definition plus the `collectionId` of
+ * the originating list — not from a mounted collection.
+ *
+ * Because it never needs the list mounted, it works on a direct link / hard
+ * refresh of a detail page: the persisted filters/sortings/search the list
+ * wrote through the data collection storage handler are read by
+ * `collectionId`, validated against the definition, and seeded into the
+ * source before the first fetch (exactly one fetch, with the right state).
+ *
+ * Persisted state intentionally wins over `source.currentFilters` /
+ * `currentSortings`: the definition values apply on mount and the hydrated
+ * state lands right after, mirroring what the user last saw on the list.
+ *
+ * @example
+ * ```tsx
+ * const { navigation } = useDataCollectionItemNavigation({
+ *   source: employeesSourceDefinition, // same definition the list uses
+ *   collectionId: "organization/employees/v1", // same id the list uses
+ *   activeItemId: routeParams.employeeId,
+ *   getItemTitle: (employee) => employee.name,
+ * })
+ * return (
+ *   <PageHeaderNavigationProvider value={navigation}>
+ *     <EmployeeDetailPage />
+ *   </PageHeaderNavigationProvider>
+ * )
+ * ```
+ */
+export function useDataCollectionItemNavigation<
+  R extends RecordType = RecordType,
+  Filters extends FiltersDefinition = FiltersDefinition,
+  Sortings extends SortingsDefinition = SortingsDefinition,
+  Summaries extends SummariesDefinition = SummariesDefinition,
+  ItemActions extends ItemActionsDefinition<R> = ItemActionsDefinition<R>,
+  NavigationFilters extends NavigationFiltersDefinition =
+    NavigationFiltersDefinition,
+  Grouping extends GroupingDefinition<R> = GroupingDefinition<R>,
+>(
+  props: UseDataCollectionItemNavigationProps<
+    R,
+    Filters,
+    Sortings,
+    Summaries,
+    ItemActions,
+    NavigationFilters,
+    Grouping
+  >
+): UseDataCollectionItemNavigationReturn<
+  R,
+  Filters,
+  Sortings,
+  Summaries,
+  ItemActions,
+  NavigationFilters,
+  Grouping
+> {
+  const {
+    source,
+    collectionId,
+    activeItemId,
+    defaultActiveItemId,
+    onActiveItemChange,
+    idProvider,
+    itemUrl,
+    getItemTitle,
+    enabled = true,
+    restorePersistedState = true,
+    deps = [],
+  } = props
+
+  const storageHandler = useDataCollectionStorage()
+  const dataSource = useDataCollectionSource<
+    R,
+    Filters,
+    Sortings,
+    Summaries,
+    ItemActions,
+    NavigationFilters,
+    Grouping
+  >(source, deps)
+
+  type Applied = AppliedCollectionState<R, Filters, Sortings, Grouping>
+
+  // Hydration is two-phase: the persisted state is applied via the source
+  // setters (settled: false), and the fetch is enabled one render later
+  // (settled: true). The extra render lets useData's internal search ref
+  // settle, so the first fetch runs exactly once with the seeded state.
+  const [hydration, setHydration] = useState<{
+    key: string
+    applied: Applied | null
+    settled: boolean
+  } | null>(null)
+  const hydrated = hydration?.key === collectionId && hydration.settled
+
+  // Latest-value refs so the hydration effect stays gated on collectionId
+  // only — inline-recreated definitions/handlers never retrigger it.
+  const dataSourceRef = useRef(dataSource)
+  dataSourceRef.current = dataSource
+  const storageHandlerRef = useRef(storageHandler)
+  storageHandlerRef.current = storageHandler
+  const hydratedKeyRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+    if (hydratedKeyRef.current === collectionId) return
+    if (!restorePersistedState) {
+      hydratedKeyRef.current = collectionId
+      setHydration({ key: collectionId, applied: null, settled: false })
+      return
+    }
+    let cancelled = false
+    const hydrate = async () => {
+      let applied: Applied | null = null
+      try {
+        // NOTE: must await (not .then) — the default noop handler returns a
+        // plain object typed as a Promise.
+        const storage = (await storageHandlerRef.current.get(
+          collectionId
+        )) as DataCollectionStorage<FiltersState<Filters>>
+        if (storage && !cancelled) {
+          applied = seedFromStorage<R, Filters, Sortings, Grouping>(
+            storage,
+            dataSourceRef.current,
+            dataSourceRef.current
+          )
+        }
+      } catch {
+        // Unreadable persisted state — the definition defaults apply.
+      }
+      if (cancelled) return
+      hydratedKeyRef.current = collectionId
+      setHydration({ key: collectionId, applied, settled: false })
+    }
+    hydrate()
+    return () => {
+      cancelled = true
+    }
+  }, [collectionId, enabled, restorePersistedState])
+
+  const {
+    data,
+    paginationInfo,
+    setPage,
+    loadMore,
+    isLoading,
+    isInitialLoading,
+  } = useData<R, Filters, Sortings, Grouping>(
+    dataSource,
+    {
+      // The first fetch waits for hydration so it runs exactly once, with
+      // the seeded state — never a defaults-first double fetch.
+      enabled: enabled && hydrated,
+      fetchParamsProvider: (options) => ({
+        ...options,
+        navigationFilters: dataSource.currentNavigationFilters,
+      }),
+    },
+    [JSON.stringify(dataSource.currentNavigationFilters)]
+  )
+
+  // Phase 2: flips settled one render after the state was applied. Declared
+  // after useData so it runs once its internal effects have observed the
+  // seeded values.
+  useEffect(() => {
+    setHydration((current) =>
+      current && current.key === collectionId && !current.settled
+        ? { ...current, settled: true }
+        : current
+    )
+  }, [hydration, collectionId])
+
+  const itemNavigation = useDataSourceItemNavigation<R>({
+    dataSource,
+    data,
+    paginationInfo,
+    setPage,
+    loadMore,
+    isLoading,
+    idProvider,
+    itemUrl: itemUrl ?? source.itemUrl,
+    activeItemId,
+    defaultActiveItemId,
+    onActiveItemChange,
+  })
+
+  const navigation = usePageHeaderItemNavigation<R>(itemNavigation, {
+    getItemTitle,
+  })
+
+  return {
+    ...itemNavigation,
+    isReady: hydrated && !isInitialLoading,
+    navigation,
+    appliedCollectionState: hydration?.applied ?? null,
+    dataSource,
+    data,
+    paginationInfo,
+    isLoading,
+  }
+}


### PR DESCRIPTION
## Description

Detail pages need prev/next navigation (with a correct \`current/total\` counter) that follows the **same filtered/sorted/searched set the user was looking at on the originating list** — and it must work on a **direct link / hard refresh**, where the list's \`OneDataCollection\` is not mounted, so no mounted-collection handle or runtime registry can solve it.

This PR adds the keystone: **\`useDataCollectionItemNavigation\`**, item navigation fed from a **declared** source definition + the originating list's \`collectionId\`. F0 reads the persisted filters/sortings/search/grouping through the data collection storage handler, validates them against the definition, seeds the source, and fetches **exactly once** with the seeded state.

```tsx
const { navigation } = useDataCollectionItemNavigation({
  source: employeesSourceDefinition, // the same definition the list uses
  collectionId: "organization/employees/v1", // the same id the list uses
  activeItemId: routeParams.employeeId,
  getItemTitle: (employee) => employee.name,
})

return (
  <PageHeaderNavigationProvider value={navigation}>
    <EmployeeDetailPage />
  </PageHeaderNavigationProvider>
)
```

> Part 1/3 of the detail-page navigation series. Part 2 adds an optional id-relative \`fetchItemNeighbors\` capability on \`DataAdapter\` (direct-link neighbours beyond the loaded window). Part 3 adds a collection-bound breadcrumb jump-to select.
>
> **Note on #3964:** this intentionally reuses the \`useDataSourceItemNavigation\` core from that PR but supersedes its mounted-collection controller approach for the detail-page use case — a mounted-collection registry cannot work on direct links. The name \`useDataCollectionItemNavigation\` is deliberately the same; the API is definition-fed instead of instance-fed.

## Implementation details

- **\`useDataSourceItemNavigation\`** (\`hooks/datasource/useDataSourceItemNavigation/\`): core window-based item navigation — active item lookup, prev/next, boundary \`setPage\`/\`loadMore\` with pending-navigation resolution, URL derivation. Neighbour resolution is isolated in a pure \`resolveWindowNeighbors\` so part 2 can merge adapter-resolved (id-relative) neighbours at a single point.
- **\`useData\` \`enabled\` option**: suspends fetching until async seeding has been applied — the first fetch happens once, with the right state, instead of a defaults-first double fetch. Hydration is two-phase (apply setters → settle one render later) so \`useData\`'s internal search ref stabilizes before the fetch is enabled.
- **\`seedFromStorage\`** (pure): per-visualization filter resolution (\`visualizationFilters[visualization] ?? filters\`), pruning of persisted keys absent from the definition (schema drift safety), single-object sortings semantics (\`null\` = explicit clear, \`undefined\` = keep defaults), search only when the definition enables it, grouping only when the field is declared.
- **PageHeader**: \`PageHeaderNavigationContext\` lets a page inject navigation from below; the \`navigation\` prop always wins. \`usePageHeaderItemNavigation\` maps the hook result to \`NavigationProps\`, omitting the counter when position/total are unknown (never a misleading \`0/n\`), with field-level memoization so the context value identity is stable.
- **Degradation contract** (until part 2): active id not in the loaded window → \`activeIndex -1\`, disabled controls, \`navigation: null\`. No crash, no loop, no extra fetches.
- Loop-safety is built in: hydration is \`collectionId\`-gated, all setters are value-idempotent, the adapter is memoized on \`deps\` — consumers never hand-roll id-gated ref pushes.
