### PR TITLE
fix(F0NumberInput): show thousand separators when the input is not focused

### DIFF
--- a/packages/react/src/components/F0NumberInput/__tests__/F0NumberInput.test.tsx
+++ b/packages/react/src/components/F0NumberInput/__tests__/F0NumberInput.test.tsx
@@ -24,6 +24,52 @@ describe("F0NumberInput", () => {
     expect(input).toHaveValue("123,46")
   })
 
+  describe("thousand separators", () => {
+    test("renders grouping separators when not focused", () => {
+      render(
+        <F0NumberInput
+          locale="es-ES"
+          value={5000.54}
+          maxDecimals={2}
+          label="Number Input"
+        />
+      )
+      const input = screen.getByRole("textbox")
+      expect(input).toHaveValue("5.000,54")
+    })
+
+    test("shows the raw value while focused and restores grouping on blur", async () => {
+      render(
+        <F0NumberInput
+          locale="es-ES"
+          value={5000}
+          maxDecimals={2}
+          label="Number Input"
+        />
+      )
+      const input = screen.getByRole("textbox")
+
+      await userEvent.click(input)
+      expect(input).toHaveValue("5000")
+
+      await userEvent.tab()
+      expect(input).toHaveValue("5.000")
+    })
+
+    test("groups the typed value on blur in uncontrolled mode", async () => {
+      render(
+        <F0NumberInput locale="en-US" maxDecimals={2} label="Number Input" />
+      )
+      const input = screen.getByRole("textbox")
+
+      await userEvent.type(input, "12345.6")
+      expect(input).toHaveValue("12345.6")
+
+      await userEvent.tab()
+      expect(input).toHaveValue("12,345.6")
+    })
+  })
+
   describe("when the value is null", () => {
     test("renders an empty input", () => {
       render(<F0NumberInput locale="en-US" value={null} label="Number Input" />)

--- a/packages/react/src/components/F0NumberInput/internal.tsx
+++ b/packages/react/src/components/F0NumberInput/internal.tsx
@@ -25,10 +25,15 @@ import { InputInternalProps } from "@/components/F0TextInput/internal"
 import { Arrows } from "./components/Arrows"
 import { extractNumber } from "./internal/extractNumber"
 
-const formatValue = (value: number, locale: string, maxDecimals?: number) =>
+const formatValue = (
+  value: number,
+  locale: string,
+  maxDecimals?: number,
+  useGrouping = false
+) =>
   new Intl.NumberFormat(locale, {
     maximumFractionDigits: maxDecimals,
-    useGrouping: false,
+    useGrouping,
   }).format(value)
 
 export interface NumberInputPopoverConfig {
@@ -159,6 +164,7 @@ export const NumberInputInternal = forwardRef<
     disabled,
     readonly,
     loading,
+    onBlur,
     ...props
   },
   ref
@@ -177,6 +183,7 @@ export const NumberInputInternal = forwardRef<
   const [draftValue, setDraftValue] = useState<number | null>(
     value != null ? value : null
   )
+  const [isFocused, setIsFocused] = useState(false)
 
   const localHint = useMemo(() => {
     if (hint !== undefined) {
@@ -218,6 +225,26 @@ export const NumberInputInternal = forwardRef<
   }, [isDeferredPopover, popoverOpen, value])
 
   const inputValue = isDeferredPopover ? draftValue : value
+
+  // Grouping separators are display-only: they would break extractNumber and
+  // caret handling, so the raw ungrouped string comes back while editing.
+  const displayValue = useMemo(() => {
+    if (isFocused) return fieldValue
+    const numericValue =
+      inputValue !== undefined
+        ? inputValue
+        : (extractNumber(fieldValue, { maxDecimals })?.value ?? null)
+    return numericValue != null
+      ? formatValue(numericValue, locale, maxDecimals, true)
+      : fieldValue
+  }, [isFocused, fieldValue, inputValue, locale, maxDecimals])
+
+  const handleFocus = () => setIsFocused(true)
+  const handleBlur = () => {
+    setIsFocused(false)
+    onBlur?.()
+  }
+
   const inputOnChange = useMemo(
     () =>
       isDeferredPopover
@@ -321,9 +348,11 @@ export const NumberInputInternal = forwardRef<
         type="text"
         ref={ref}
         id={inputId}
-        value={fieldValue}
+        value={displayValue}
         inputMode={maxDecimals === 0 ? "numeric" : "decimal"}
         onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         {...props}
         label={usesExternalMessages ? (label ?? "") : label}
         hideLabel={hideLabel || usesExternalMessages}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
@@ -27,11 +27,24 @@ describe("NumberCell", () => {
     item: { id: "1", salary: 42000 },
   }
 
-  it("renders with the provided numeric value", () => {
+  it("renders with the provided numeric value with grouping separators", () => {
     render(<NumberCell {...defaultProps} />)
 
     const input = screen.getByRole("textbox")
+    expect(input).toHaveValue("42,000")
+  })
+
+  it("shows the raw value while editing and the grouped value on blur", async () => {
+    const user = userEvent.setup()
+
+    render(<NumberCell {...defaultProps} />)
+
+    const input = screen.getByRole("textbox")
+    await user.click(input)
     expect(input).toHaveValue("42000")
+
+    await user.tab()
+    expect(input).toHaveValue("42,000")
   })
 
   it("renders empty when value is an empty string", () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/hooks/useNumberCellLayout.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/hooks/useNumberCellLayout.ts
@@ -35,7 +35,6 @@ export function useNumberCellLayout<R extends RecordType>(
     () =>
       new Intl.NumberFormat(locale, {
         maximumFractionDigits: config?.maxDecimals,
-        useGrouping: false,
       }),
     [locale, config?.maxDecimals]
   )


### PR DESCRIPTION
## Summary

Fixes [FCT-55894](https://factorialmakers.atlassian.net/browse/FCT-55894) — thousand separators were missing in EditableTable salary/number inputs (they were present in summary totals but not in the line items).

- `F0NumberInput` now displays the value with locale-aware grouping separators while the input is **not focused** (`5000` → `5.000`, `5000.54` → `5.000,54` in `es-ES`; `5,000.54` in `en-US`).
- On focus the raw ungrouped value comes back, so typing, caret handling and parsing via `extractNumber` are untouched (it doesn't support grouping characters — see its TODO).
- Works in controlled, uncontrolled and deferred-popover modes; composes with the existing `onBlur`.
- `useNumberCellLayout` now measures the cell shrink-wrap width with grouping so the formatted value isn't clipped.

Since the fix lives in `F0NumberInput`, it also covers `MoneyCell` and every other consumer (F0Form number field, OneFilterPicker, surveys).

## Test plan

- New tests: grouped display on render (`es-ES` → `5.000,54`), raw-on-focus / grouped-on-blur, uncontrolled mode grouping on blur, and NumberCell grouped rendering.
- `vitest` green for `F0NumberInput` + EditableTable (150 tests) and for all other `F0NumberInput` consumers (571 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FCT-55894]: https://factorialmakers.atlassian.net/browse/FCT-55894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ