### PR TITLE
feat(datasource): add fetchItemNeighbors adapter capability for id-relative item navigation

### DIFF
--- a/packages/react/src/hooks/datasource/__stories__/itemNeighbors.mdx
+++ b/packages/react/src/hooks/datasource/__stories__/itemNeighbors.mdx
@@ -1,0 +1,124 @@
+import { Meta } from "@storybook/addon-docs/blocks"
+
+<Meta title="Datasource/itemNeighbors" />
+
+# Item neighbours (`fetchItemNeighbors` + `useItemNeighbors`)
+
+Id-relative neighbour fetching for detail-page prev/next navigation.
+
+## The problem
+
+A detail page reached via a **direct link / hard refresh** shows one item of a
+collection whose list was never mounted. Window-based navigation (walking the
+loaded records) cannot help: the item may live on page 7 of a paginated set,
+and no page is loaded. What the page needs is "the immediate previous/next
+item relative to **this id**, under the current filters/sortings/search" —
+something only the backend can answer efficiently.
+
+## The contract: `fetchItemNeighbors` on `DataAdapter`
+
+F0 defines the capability; the app/backend implements it. It is **optional**
+on both adapter variants:
+
+```ts
+fetchItemNeighbors?: (options: {
+  id: string | number          // the reference item (from the source idProvider)
+  filters: FiltersState<F>     // same values fetchData receives
+  sortings: SortingsStateMultiple
+  search?: string
+  // OneDataCollection adapters also receive navigationFilters automatically
+}) =>
+  | ItemNeighborsResponse<R>
+  | Promise<ItemNeighborsResponse<R>>
+  | Observable<PromiseState<ItemNeighborsResponse<R>>>
+```
+
+```ts
+type ItemNeighborsResponse<R> = {
+  previous: R | null // immediate neighbour, or null at the collection edge
+  next: R | null
+  position?: number // 1-indexed position of the reference item
+  total?: number // total records matching the filters/search
+}
+```
+
+Edge semantics:
+
+- At the first/last item of the filtered set, return `previous: null` /
+  `next: null` respectively.
+- If the reference item itself does **not** match the current filters, return
+  `{ previous: null, next: null }` (optionally with `total`) — consumers
+  disable navigation.
+- Observables are consumed **one-shot**: the first emission with `data`
+  resolves the request and the subscription is closed. Live updates to
+  neighbours are out of scope.
+
+## Canonical backend implementation (GraphQL cursors by id)
+
+The natural backend shape is a connection with id-relative cursor arguments —
+`afterId` / `beforeId` with `first: 1` returns the immediate neighbours, and
+`totalCount` on the before/after slices yields the position and total:
+
+```graphql
+query EmployeeNeighbors($id: ID!, $filters: EmployeeFilters) {
+  next: employeesConnection(afterEmployeeId: $id, first: 1, filters: $filters) {
+    nodes {
+      id
+      fullName
+    }
+  }
+  before: employeesConnection(beforeEmployeeId: $id, filters: $filters) {
+    totalCount
+  }
+  after: employeesConnection(afterEmployeeId: $id, filters: $filters) {
+    totalCount
+  }
+}
+```
+
+```ts
+fetchItemNeighbors: async ({ id, filters, search }) => {
+  const { next, previous, before, after } = await query(/* … */)
+  return {
+    previous: previous.nodes[0] ?? null,
+    next: next.nodes[0] ?? null,
+    position: before.totalCount + 1,
+    total: before.totalCount + after.totalCount + 1,
+  }
+}
+```
+
+## The consumer: `useItemNeighbors`
+
+```tsx
+const { isSupported, neighbors, isResolving, error } = useItemNeighbors({
+  dataAdapter: source.dataAdapter,
+  id: activeItemId, // null (or a symbol id) disables resolution
+  filters: mergedFilters, // the same values fetchData receives
+  sortings: composedSortings,
+  search: currentSearch,
+  enabled: activeIndex === -1, // e.g. only when the window lookup failed
+})
+```
+
+Behaviour:
+
+- `neighbors` only ever reflects the **current** `{id, filters, sortings,
+search}` — responses from superseded requests are dropped (no races on fast
+  prev/next clicks).
+- Responses are **cached per request key**: navigating back to an
+  already-visited id is instant. The cache clears whenever
+  filters/sortings/search change; errors are never cached.
+- `isSupported: false` (capability absent), `enabled: false` or `id: null` →
+  nothing is fetched and `neighbors` stays `null`, so consumers keep their
+  fallback (window-based) behaviour.
+
+## Known limitations
+
+- Client-side `itemPreFilter` post-processing can make the backend-reported
+  `position`/`total` disagree with what the list visually showed.
+- Grouped sources: pass the same composed sortings array `useData` sends to
+  `fetchData` (it includes the grouping field) so neighbour order matches the
+  list order.
+- One-shot Observable consumption: a neighbour deleted after resolution will
+  not live-update the detail header.

--- a/packages/react/src/hooks/datasource/index.ts
+++ b/packages/react/src/hooks/datasource/index.ts
@@ -1,4 +1,5 @@
 export * from "@/patterns/OneFilterPicker/types"
+export * from "./itemNeighbors"
 export * from "./types"
 export * from "./useData"
 export * from "./useDataSource"

--- a/packages/react/src/hooks/datasource/itemNeighbors/__stories__/useItemNeighbors.stories.tsx
+++ b/packages/react/src/hooks/datasource/itemNeighbors/__stories__/useItemNeighbors.stories.tsx
@@ -1,0 +1,189 @@
+import { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { ChevronLeft, ChevronRight } from "@/icons/app"
+
+import {
+  DataAdapter,
+  ItemNeighborsFetchOptions,
+  ItemNeighborsResponse,
+} from "../../types/fetch.typings"
+import { useItemNeighbors } from "../useItemNeighbors"
+
+const meta = {
+  title: "Datasource/useItemNeighbors",
+  parameters: {
+    layout: "padded",
+    a11y: { skipCi: true },
+    docs: {
+      description: {
+        component:
+          "Id-relative neighbour resolution through the optional `fetchItemNeighbors` capability on `DataAdapter`. Built for detail pages opened via a **direct link**: the item may live deep in the collection, on a page that was never loaded — instead of walking pages, the adapter asks the backend for the immediate neighbours (and position/total for the counter) under the current filters.",
+      },
+    },
+  },
+  tags: ["experimental", "!autodocs"],
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+type Employee = {
+  id: number
+  name: string
+  department: string
+}
+
+const DEPARTMENTS = ["Engineering", "Design", "Product", "Marketing"]
+
+const EMPLOYEES: Employee[] = Array.from({ length: 80 }, (_, i) => ({
+  id: i + 1,
+  name: `Employee ${i + 1}`,
+  department: DEPARTMENTS[i % DEPARTMENTS.length],
+}))
+
+const filters = {
+  department: {
+    type: "in" as const,
+    label: "Department",
+    options: {
+      options: DEPARTMENTS.map((d) => ({ value: d, label: d })),
+    },
+  },
+}
+
+type Filters = typeof filters
+
+const filteredEmployees = (departments: string[] | undefined) =>
+  EMPLOYEES.filter(
+    (employee) =>
+      !departments?.length || departments.includes(employee.department)
+  )
+
+// The app-side implementation of the capability: in a real app this is the
+// GraphQL `afterId`/`beforeId` + `first: 1` + `totalCount` cursor query.
+const fetchItemNeighbors = async (
+  options: ItemNeighborsFetchOptions<Filters>
+): Promise<ItemNeighborsResponse<Employee>> => {
+  await new Promise((resolve) => setTimeout(resolve, 400))
+  const results = filteredEmployees(options.filters.department)
+  const index = results.findIndex(
+    (employee) => employee.id === Number(options.id)
+  )
+  if (index === -1) {
+    return { previous: null, next: null, total: results.length }
+  }
+  return {
+    previous: index > 0 ? results[index - 1] : null,
+    next: index < results.length - 1 ? results[index + 1] : null,
+    position: index + 1,
+    total: results.length,
+  }
+}
+
+const makeAdapter = (
+  withCapability: boolean
+): DataAdapter<Employee, Filters> => ({
+  paginationType: "pages",
+  perPage: 10,
+  fetchData: (options) => {
+    const results = filteredEmployees(options.filters.department)
+    const currentPage =
+      "currentPage" in options.pagination
+        ? (options.pagination.currentPage ?? 1)
+        : 1
+    return {
+      type: "pages",
+      records: results.slice((currentPage - 1) * 10, currentPage * 10),
+      total: results.length,
+      perPage: 10,
+      currentPage,
+      pagesCount: Math.ceil(results.length / 10),
+    }
+  },
+  fetchItemNeighbors: withCapability ? fetchItemNeighbors : undefined,
+})
+
+const DetailPanel = ({ withCapability }: { withCapability: boolean }) => {
+  // Simulates a direct link to an employee deep in the collection (page 7)
+  const [activeId, setActiveId] = useState(63)
+  const [engineeringOnly, setEngineeringOnly] = useState(false)
+
+  const [adapter] = useState(() => ({
+    enabled: makeAdapter(true),
+    disabled: makeAdapter(false),
+  }))
+
+  const { isSupported, neighbors, isResolving } = useItemNeighbors({
+    dataAdapter: withCapability ? adapter.enabled : adapter.disabled,
+    id: activeId,
+    filters: engineeringOnly ? { department: ["Engineering"] } : {},
+    sortings: [],
+  })
+
+  const activeEmployee = EMPLOYEES.find((e) => e.id === activeId)
+
+  return (
+    <div className="flex max-w-xl flex-col gap-3 rounded-md border border-solid border-f1-border-secondary p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="font-medium text-f1-foreground">
+            {activeEmployee?.name}
+          </div>
+          <div className="text-sm text-f1-foreground-secondary">
+            {activeEmployee?.department}
+            {neighbors?.position !== undefined &&
+              ` — ${neighbors.position} of ${neighbors.total}`}
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <F0Button
+            variant="outline"
+            size="sm"
+            icon={ChevronLeft}
+            hideLabel
+            label="Previous"
+            disabled={!neighbors?.previous || isResolving}
+            onClick={() => {
+              if (neighbors?.previous) setActiveId(neighbors.previous.id)
+            }}
+          />
+          <F0Button
+            variant="outline"
+            size="sm"
+            icon={ChevronRight}
+            hideLabel
+            label="Next"
+            loading={isResolving}
+            disabled={!neighbors?.next || isResolving}
+            onClick={() => {
+              if (neighbors?.next) setActiveId(neighbors.next.id)
+            }}
+          />
+        </div>
+      </div>
+      <label className="flex items-center gap-2 text-sm text-f1-foreground-secondary">
+        <input
+          type="checkbox"
+          checked={engineeringOnly}
+          onChange={(event) => setEngineeringOnly(event.target.checked)}
+        />
+        Engineering only (neighbours and counter follow the filter)
+      </label>
+      <div className="text-sm text-f1-foreground-secondary">
+        {isSupported
+          ? "The list was never mounted: neighbours are resolved by id through fetchItemNeighbors. Revisited ids resolve instantly from cache."
+          : "This adapter does not implement fetchItemNeighbors — controls stay disabled (the snapshot fallback)."}
+      </div>
+    </div>
+  )
+}
+
+export const DirectLink: Story = {
+  render: () => <DetailPanel withCapability />,
+}
+
+export const CapabilityAbsent: Story = {
+  render: () => <DetailPanel withCapability={false} />,
+}

--- a/packages/react/src/hooks/datasource/itemNeighbors/__test__/resolveItemNeighbors.test.ts
+++ b/packages/react/src/hooks/datasource/itemNeighbors/__test__/resolveItemNeighbors.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest"
+import { Observable } from "zen-observable-ts"
+
+import { PromiseState } from "@/lib/promise-to-observable"
+
+import { ItemNeighborsResponse } from "../../types/fetch.typings"
+import { resolveItemNeighbors } from "../resolveItemNeighbors"
+
+type TestRecord = { id: number; name: string }
+
+const response: ItemNeighborsResponse<TestRecord> = {
+  previous: { id: 1, name: "One" },
+  next: { id: 3, name: "Three" },
+  position: 2,
+  total: 10,
+}
+
+describe("resolveItemNeighbors", () => {
+  it("resolves a synchronous response", async () => {
+    const { promise } = resolveItemNeighbors<TestRecord>(response)
+    await expect(promise).resolves.toEqual(response)
+  })
+
+  it("resolves a promise response", async () => {
+    const { promise } = resolveItemNeighbors<TestRecord>(
+      Promise.resolve(response)
+    )
+    await expect(promise).resolves.toEqual(response)
+  })
+
+  it("rejects a rejecting promise", async () => {
+    const error = new Error("boom")
+    const { promise } = resolveItemNeighbors<TestRecord>(Promise.reject(error))
+    await expect(promise).rejects.toBe(error)
+  })
+
+  it("resolves on the first data emission of an observable and unsubscribes", async () => {
+    const unsubscribe = vi.fn()
+    const observable = new Observable<
+      PromiseState<ItemNeighborsResponse<TestRecord>>
+    >((subscriber) => {
+      subscriber.next({ loading: true })
+      setTimeout(() => {
+        subscriber.next({ loading: false, data: response })
+        subscriber.next({
+          loading: false,
+          data: { ...response, position: 99 },
+        })
+      }, 0)
+      return unsubscribe
+    })
+
+    const { promise } = resolveItemNeighbors<TestRecord>(observable)
+    await expect(promise).resolves.toEqual(response)
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+
+  it("rejects on an error emission of an observable", async () => {
+    const error = new Error("fetch failed")
+    const observable = new Observable<
+      PromiseState<ItemNeighborsResponse<TestRecord>>
+    >((subscriber) => {
+      subscriber.next({ loading: true })
+      setTimeout(() => subscriber.next({ loading: false, error }), 0)
+    })
+
+    const { promise } = resolveItemNeighbors<TestRecord>(observable)
+    await expect(promise).rejects.toBe(error)
+  })
+
+  it("cancel() prevents a pending promise from settling", async () => {
+    let resolveFetch: (value: ItemNeighborsResponse<TestRecord>) => void
+    const pending = new Promise<ItemNeighborsResponse<TestRecord>>(
+      (resolve) => {
+        resolveFetch = resolve
+      }
+    )
+
+    const { promise, cancel } = resolveItemNeighbors<TestRecord>(pending)
+    const settled = vi.fn()
+    promise.then(settled, settled)
+
+    cancel()
+    resolveFetch!(response)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(settled).not.toHaveBeenCalled()
+  })
+
+  it("cancel() unsubscribes from an observable", () => {
+    const unsubscribe = vi.fn()
+    const observable = new Observable<
+      PromiseState<ItemNeighborsResponse<TestRecord>>
+    >(() => unsubscribe)
+
+    const { cancel } = resolveItemNeighbors<TestRecord>(observable)
+    cancel()
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/hooks/datasource/itemNeighbors/__test__/useItemNeighbors.spec.tsx
+++ b/packages/react/src/hooks/datasource/itemNeighbors/__test__/useItemNeighbors.spec.tsx
@@ -1,0 +1,292 @@
+import { waitFor } from "@testing-library/react"
+import { describe, expect, expectTypeOf, it, vi } from "vitest"
+
+import { DataCollectionDataAdapter } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
+import { zeroRenderHook } from "@/testing/test-utils"
+
+import {
+  DataAdapter,
+  ItemNeighborsFetchOptions,
+  ItemNeighborsResponse,
+  PaginatedDataAdapter,
+  PaginatedFetchOptions,
+} from "../../types/fetch.typings"
+import { SortingsStateMultiple } from "../../types/sortings.typings"
+import { useItemNeighbors } from "../useItemNeighbors"
+
+type TestRecord = { id: number; name: string }
+
+type TestFilters = {
+  department: { type: "in"; label: string; options: { options: [] } }
+}
+
+const ITEMS: TestRecord[] = Array.from({ length: 20 }, (_, i) => ({
+  id: i + 1,
+  name: `Item ${i + 1}`,
+}))
+
+const NO_SORTINGS: SortingsStateMultiple = []
+
+const neighborsOf = (id: number): ItemNeighborsResponse<TestRecord> => {
+  const index = ITEMS.findIndex((item) => item.id === id)
+  return {
+    previous: index > 0 ? ITEMS[index - 1] : null,
+    next: index >= 0 && index < ITEMS.length - 1 ? ITEMS[index + 1] : null,
+    position: index + 1,
+    total: ITEMS.length,
+  }
+}
+
+const makeAdapter = (
+  fetchItemNeighbors?: (
+    options: ItemNeighborsFetchOptions<
+      TestFilters,
+      PaginatedFetchOptions<TestFilters>
+    >
+  ) =>
+    | ItemNeighborsResponse<TestRecord>
+    | Promise<ItemNeighborsResponse<TestRecord>>
+): DataAdapter<TestRecord, TestFilters> => ({
+  paginationType: "pages",
+  perPage: 10,
+  fetchData: () => ({
+    type: "pages",
+    records: ITEMS.slice(0, 10),
+    total: ITEMS.length,
+    perPage: 10,
+    currentPage: 1,
+    pagesCount: 2,
+  }),
+  fetchItemNeighbors,
+})
+
+describe("useItemNeighbors", () => {
+  it("reports isSupported false and stays idle when the capability is absent", async () => {
+    const { result } = zeroRenderHook(() =>
+      useItemNeighbors({
+        dataAdapter: makeAdapter(undefined),
+        id: 5,
+        filters: {},
+        sortings: NO_SORTINGS,
+      })
+    )
+
+    expect(result.current.isSupported).toBe(false)
+    expect(result.current.neighbors).toBeNull()
+    expect(result.current.isResolving).toBe(false)
+  })
+
+  it("does not fetch when disabled or when id is null", async () => {
+    const fetchItemNeighbors = vi.fn(() => neighborsOf(5))
+
+    const { rerender } = zeroRenderHook(
+      ({ id, enabled }: { id: number | null; enabled: boolean }) =>
+        useItemNeighbors({
+          dataAdapter: makeAdapter(fetchItemNeighbors),
+          id,
+          filters: {},
+          sortings: NO_SORTINGS,
+          enabled,
+        }),
+      { initialProps: { id: null as number | null, enabled: true } }
+    )
+
+    rerender({ id: 5, enabled: false })
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(fetchItemNeighbors).not.toHaveBeenCalled()
+  })
+
+  it("resolves neighbours and passes filters/sortings/search through", async () => {
+    const fetchItemNeighbors = vi.fn(
+      (options: ItemNeighborsFetchOptions<TestFilters>) =>
+        neighborsOf(Number(options.id))
+    )
+    const sortings: SortingsStateMultiple = [{ field: "name", order: "asc" }]
+
+    const { result } = zeroRenderHook(() =>
+      useItemNeighbors({
+        dataAdapter: makeAdapter(fetchItemNeighbors),
+        id: 5,
+        filters: { department: ["Engineering"] },
+        sortings,
+        search: "item",
+      })
+    )
+
+    await waitFor(() => expect(result.current.neighbors).not.toBeNull())
+
+    expect(fetchItemNeighbors).toHaveBeenCalledWith({
+      id: 5,
+      filters: { department: ["Engineering"] },
+      sortings,
+      search: "item",
+    })
+    expect(result.current.neighbors).toEqual({
+      previous: ITEMS[3],
+      next: ITEMS[5],
+      position: 5,
+      total: 20,
+    })
+    expect(result.current.isResolving).toBe(false)
+  })
+
+  it("drops stale responses when the id changes mid-flight (race)", async () => {
+    const deferred = new Map<
+      number,
+      (value: ItemNeighborsResponse<TestRecord>) => void
+    >()
+    const fetchItemNeighbors = vi.fn(
+      (options: ItemNeighborsFetchOptions<TestFilters>) =>
+        new Promise<ItemNeighborsResponse<TestRecord>>((resolve) => {
+          deferred.set(Number(options.id), resolve)
+        })
+    )
+
+    const { result, rerender } = zeroRenderHook(
+      ({ id }: { id: number }) =>
+        useItemNeighbors({
+          dataAdapter: makeAdapter(fetchItemNeighbors),
+          id,
+          filters: {},
+          sortings: NO_SORTINGS,
+        }),
+      { initialProps: { id: 5 } }
+    )
+
+    rerender({ id: 6 })
+    await waitFor(() => expect(deferred.has(6)).toBe(true))
+
+    // Resolve the second request first, then the (stale) first one
+    deferred.get(6)!(neighborsOf(6))
+    await waitFor(() => expect(result.current.neighbors).not.toBeNull())
+    deferred.get(5)!(neighborsOf(5))
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(result.current.neighbors).toEqual(neighborsOf(6))
+  })
+
+  it("serves repeated ids from cache and clears it when filters change", async () => {
+    const fetchItemNeighbors = vi.fn(
+      (options: ItemNeighborsFetchOptions<TestFilters>) =>
+        Promise.resolve(neighborsOf(Number(options.id)))
+    )
+
+    const { result, rerender } = zeroRenderHook(
+      ({ id, filters }: { id: number; filters: { department?: string[] } }) =>
+        useItemNeighbors({
+          dataAdapter: makeAdapter(fetchItemNeighbors),
+          id,
+          filters,
+          sortings: NO_SORTINGS,
+        }),
+      { initialProps: { id: 5, filters: {} } }
+    )
+
+    await waitFor(() => expect(result.current.neighbors).not.toBeNull())
+    rerender({ id: 6, filters: {} })
+    await waitFor(() =>
+      expect(result.current.neighbors).toEqual(neighborsOf(6))
+    )
+    expect(fetchItemNeighbors).toHaveBeenCalledTimes(2)
+
+    // Back to a visited id: served synchronously from cache, no extra fetch
+    rerender({ id: 5, filters: {} })
+    await waitFor(() =>
+      expect(result.current.neighbors).toEqual(neighborsOf(5))
+    )
+    expect(fetchItemNeighbors).toHaveBeenCalledTimes(2)
+
+    // Context change clears the cache: the same id fetches again
+    rerender({ id: 5, filters: { department: ["Engineering"] } })
+    await waitFor(() => expect(fetchItemNeighbors).toHaveBeenCalledTimes(3))
+  })
+
+  it("exposes errors and calls onError, without caching them", async () => {
+    const onError = vi.fn()
+    const failure = new Error("backend down")
+    const fetchItemNeighbors = vi.fn(() => Promise.reject(failure))
+
+    const { result } = zeroRenderHook(() =>
+      useItemNeighbors({
+        dataAdapter: makeAdapter(fetchItemNeighbors),
+        id: 5,
+        filters: {},
+        sortings: NO_SORTINGS,
+        onError,
+      })
+    )
+
+    await waitFor(() => expect(result.current.error).not.toBeNull())
+    expect(result.current.error).toEqual({
+      message: "Error fetching item neighbors",
+      cause: failure,
+    })
+    expect(result.current.neighbors).toBeNull()
+    expect(onError).toHaveBeenCalledWith({
+      message: "Error fetching item neighbors",
+      cause: failure,
+    })
+  })
+
+  it("cancels the in-flight request on unmount", async () => {
+    let resolveFetch:
+      | ((value: ItemNeighborsResponse<TestRecord>) => void)
+      | undefined
+    const fetchItemNeighbors = vi.fn(
+      () =>
+        new Promise<ItemNeighborsResponse<TestRecord>>((resolve) => {
+          resolveFetch = resolve
+        })
+    )
+
+    const { unmount } = zeroRenderHook(() =>
+      useItemNeighbors({
+        dataAdapter: makeAdapter(fetchItemNeighbors),
+        id: 5,
+        filters: {},
+        sortings: NO_SORTINGS,
+      })
+    )
+
+    await waitFor(() => expect(fetchItemNeighbors).toHaveBeenCalled())
+    unmount()
+    // Settling after unmount must not throw or update state
+    resolveFetch?.(neighborsOf(5))
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  })
+})
+
+describe("fetchItemNeighbors contract (types)", () => {
+  it("is available on both DataAdapter variants", () => {
+    const paginated: PaginatedDataAdapter<TestRecord, TestFilters> = {
+      paginationType: "pages",
+      fetchData: () => ({
+        type: "pages",
+        records: [],
+        total: 0,
+        perPage: 10,
+        currentPage: 1,
+        pagesCount: 0,
+      }),
+      fetchItemNeighbors: () => ({ previous: null, next: null }),
+    }
+    expectTypeOf(paginated.fetchItemNeighbors).not.toBeNever()
+
+    const adapter: DataAdapter<TestRecord, TestFilters> = {
+      fetchData: () => ({ records: [] }),
+      fetchItemNeighbors: () => ({ previous: null, next: null }),
+    }
+    expect(adapter.fetchItemNeighbors).toBeDefined()
+  })
+
+  it("flows navigationFilters through DataCollectionDataAdapter options", () => {
+    type CollectionAdapter = DataCollectionDataAdapter<TestRecord, TestFilters>
+    type NeighborOptions = Parameters<
+      NonNullable<CollectionAdapter["fetchItemNeighbors"]>
+    >[0]
+
+    expectTypeOf<NeighborOptions>().toHaveProperty("id")
+    expectTypeOf<NeighborOptions>().toHaveProperty("filters")
+    expectTypeOf<NeighborOptions>().toHaveProperty("navigationFilters")
+  })
+})

--- a/packages/react/src/hooks/datasource/itemNeighbors/index.ts
+++ b/packages/react/src/hooks/datasource/itemNeighbors/index.ts
@@ -1,0 +1,7 @@
+export { resolveItemNeighbors } from "./resolveItemNeighbors"
+export type { ItemNeighborsResult } from "./resolveItemNeighbors"
+export { useItemNeighbors } from "./useItemNeighbors"
+export type {
+  UseItemNeighborsOptions,
+  UseItemNeighborsReturn,
+} from "./useItemNeighbors"

--- a/packages/react/src/hooks/datasource/itemNeighbors/resolveItemNeighbors.ts
+++ b/packages/react/src/hooks/datasource/itemNeighbors/resolveItemNeighbors.ts
@@ -1,0 +1,74 @@
+import { Observable } from "zen-observable-ts"
+
+import { PromiseState } from "@/lib/promise-to-observable"
+
+import { ItemNeighborsResponse } from "../types/fetch.typings"
+
+export type ItemNeighborsResult<R> =
+  | ItemNeighborsResponse<R>
+  | Promise<ItemNeighborsResponse<R>>
+  | Observable<PromiseState<ItemNeighborsResponse<R>>>
+
+/**
+ * Normalizes the three `fetchItemNeighbors` return channels (sync value,
+ * Promise, Observable of PromiseState) into a single one-shot Promise.
+ *
+ * Observables are consumed one-shot: the first emission carrying `data`
+ * resolves, the first emission carrying `error` rejects, and the
+ * subscription is closed either way — live updates are intentionally out of
+ * scope for neighbour resolution.
+ *
+ * `cancel()` unsubscribes/abandons the request: the returned promise then
+ * never settles, so a cancelled request can never reach consumer state.
+ */
+export function resolveItemNeighbors<R>(result: ItemNeighborsResult<R>): {
+  promise: Promise<ItemNeighborsResponse<R>>
+  cancel: () => void
+} {
+  if (result instanceof Observable) {
+    let cancelled = false
+    let subscription: ZenObservable.Subscription | null = null
+    const promise = new Promise<ItemNeighborsResponse<R>>((resolve, reject) => {
+      subscription = result.subscribe({
+        next: (state) => {
+          if (cancelled || state.loading) return
+          if (state.error) {
+            subscription?.unsubscribe()
+            reject(state.error)
+          } else if (state.data !== undefined && state.data !== null) {
+            subscription?.unsubscribe()
+            resolve(state.data)
+          }
+        },
+        error: (error) => {
+          if (!cancelled) reject(error)
+        },
+      })
+    })
+    return {
+      promise,
+      cancel: () => {
+        cancelled = true
+        subscription?.unsubscribe()
+      },
+    }
+  }
+
+  let cancelled = false
+  const promise = new Promise<ItemNeighborsResponse<R>>((resolve, reject) => {
+    Promise.resolve(result).then(
+      (response) => {
+        if (!cancelled) resolve(response)
+      },
+      (error) => {
+        if (!cancelled) reject(error)
+      }
+    )
+  })
+  return {
+    promise,
+    cancel: () => {
+      cancelled = true
+    },
+  }
+}

--- a/packages/react/src/hooks/datasource/itemNeighbors/useItemNeighbors.ts
+++ b/packages/react/src/hooks/datasource/itemNeighbors/useItemNeighbors.ts
@@ -1,0 +1,200 @@
+import { useEffect, useRef, useState } from "react"
+
+import {
+  FiltersDefinition,
+  FiltersState,
+} from "@/patterns/OneFilterPicker/types"
+
+import {
+  DataAdapter,
+  ItemNeighborsId,
+  ItemNeighborsResponse,
+} from "../types/fetch.typings"
+import { RecordType } from "../types/records.typings"
+import { SortingsStateMultiple } from "../types/sortings.typings"
+import { DataError } from "../useData"
+import { resolveItemNeighbors } from "./resolveItemNeighbors"
+
+export interface UseItemNeighborsOptions<
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+> {
+  /** The adapter that may implement the `fetchItemNeighbors` capability */
+  dataAdapter: DataAdapter<R, Filters>
+  /** Active item id. Null disables resolution (symbol ids cannot be used) */
+  id: ItemNeighborsId | null
+  /** Current filters — same values `fetchData` receives */
+  filters: FiltersState<Filters>
+  /** Current sortings — same composed array `fetchData` receives */
+  sortings: SortingsStateMultiple
+  /** Current search — same value `fetchData` receives */
+  search?: string
+  /**
+   * Gate: resolve only while true (e.g. only when the snapshot path failed
+   * to locate the item in the loaded window).
+   * @default true
+   */
+  enabled?: boolean
+  onError?: (error: DataError) => void
+}
+
+export interface UseItemNeighborsReturn<R extends RecordType> {
+  /** True when the adapter implements `fetchItemNeighbors` */
+  isSupported: boolean
+  /** Resolved neighbours for the CURRENT id+context, or null while unresolved */
+  neighbors: ItemNeighborsResponse<R> | null
+  isResolving: boolean
+  error: DataError | null
+}
+
+/** JSON-stringify with sorted object keys, so logically equal filter states
+ *  always produce the same request key. */
+const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`
+  }
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+      .join(",")}}`
+  }
+  return JSON.stringify(value) ?? "undefined"
+}
+
+const CACHE_MAX_ENTRIES = 50
+
+/**
+ * Resolves the previous/next neighbours of an item through the adapter's
+ * optional id-relative `fetchItemNeighbors` capability.
+ *
+ * Built for detail-page navigation on direct links: when the active item is
+ * not in any loaded page window, this asks the backend for its immediate
+ * neighbours (plus position/total for the counter) under the current
+ * filters/sortings/search instead of walking pages.
+ *
+ * Semantics:
+ * - `neighbors` only ever reflects the current `{id, filters, sortings,
+ *   search}` — stale responses from superseded requests are dropped.
+ * - Responses are cached per request key, so navigating back and forth
+ *   between already-visited ids is instant. The cache is cleared whenever
+ *   filters/sortings/search change; errors are never cached.
+ * - When the capability is absent (`isSupported: false`), disabled, or the
+ *   id is null, nothing is fetched and `neighbors` stays null — consumers
+ *   keep their fallback behaviour.
+ */
+export function useItemNeighbors<
+  R extends RecordType,
+  Filters extends FiltersDefinition,
+>({
+  dataAdapter,
+  id,
+  filters,
+  sortings,
+  search,
+  enabled = true,
+  onError,
+}: UseItemNeighborsOptions<R, Filters>): UseItemNeighborsReturn<R> {
+  const isSupported = dataAdapter.fetchItemNeighbors !== undefined
+
+  const contextKey = stableStringify({ filters, sortings, search })
+  const requestKey = id === null ? null : `${String(id)}|${contextKey}`
+
+  const [resolved, setResolved] = useState<{
+    key: string
+    neighbors: ItemNeighborsResponse<R>
+  } | null>(null)
+  const [isResolving, setIsResolving] = useState(false)
+  const [error, setError] = useState<{
+    key: string
+    error: DataError
+  } | null>(null)
+
+  // Latest-value refs: the resolution effect is keyed on the request only.
+  const adapterRef = useRef(dataAdapter)
+  adapterRef.current = dataAdapter
+  const onErrorRef = useRef(onError)
+  onErrorRef.current = onError
+  const optionsRef = useRef({ filters, sortings, search })
+  optionsRef.current = { filters, sortings, search }
+
+  const latestKeyRef = useRef<string | null>(null)
+  const cancelRef = useRef<(() => void) | null>(null)
+  const cacheRef = useRef(new Map<string, ItemNeighborsResponse<R>>())
+  const cacheContextRef = useRef(contextKey)
+
+  // The cache only holds responses for the current filter/sort/search context
+  if (cacheContextRef.current !== contextKey) {
+    cacheContextRef.current = contextKey
+    cacheRef.current.clear()
+  }
+
+  useEffect(() => {
+    latestKeyRef.current = requestKey
+    cancelRef.current?.()
+    cancelRef.current = null
+
+    if (!enabled || requestKey === null || id === null) {
+      setIsResolving(false)
+      return
+    }
+
+    const fetchItemNeighbors = adapterRef.current.fetchItemNeighbors
+    if (!fetchItemNeighbors) {
+      setIsResolving(false)
+      return
+    }
+
+    const cached = cacheRef.current.get(requestKey)
+    if (cached) {
+      setResolved({ key: requestKey, neighbors: cached })
+      setIsResolving(false)
+      return
+    }
+
+    setIsResolving(true)
+    const { promise, cancel } = resolveItemNeighbors<R>(
+      fetchItemNeighbors({ ...optionsRef.current, id })
+    )
+    cancelRef.current = cancel
+
+    promise.then(
+      (response) => {
+        if (latestKeyRef.current !== requestKey) return
+        cacheRef.current.set(requestKey, response)
+        if (cacheRef.current.size > CACHE_MAX_ENTRIES) {
+          const oldestKey = cacheRef.current.keys().next().value
+          if (oldestKey !== undefined) cacheRef.current.delete(oldestKey)
+        }
+        setResolved({ key: requestKey, neighbors: response })
+        setIsResolving(false)
+      },
+      (cause) => {
+        if (latestKeyRef.current !== requestKey) return
+        const dataError: DataError = {
+          message: "Error fetching item neighbors",
+          cause,
+        }
+        setError({ key: requestKey, error: dataError })
+        setIsResolving(false)
+        onErrorRef.current?.(dataError)
+      }
+    )
+
+    return () => {
+      cancelRef.current?.()
+      cancelRef.current = null
+    }
+  }, [requestKey, enabled, isSupported, id])
+
+  const isCurrent = requestKey !== null && enabled && isSupported
+
+  return {
+    isSupported,
+    neighbors:
+      isCurrent && resolved?.key === requestKey ? resolved.neighbors : null,
+    isResolving: isCurrent && isResolving,
+    error: isCurrent && error?.key === requestKey ? error.error : null,
+  }
+}

--- a/packages/react/src/hooks/datasource/types/fetch.typings.ts
+++ b/packages/react/src/hooks/datasource/types/fetch.typings.ts
@@ -135,6 +135,45 @@ export type PaginationInfo =
   | Omit<InfiniteScrollPaginatedResponse<unknown>, "records">
 
 /**
+ * Identifier used to reference an item in id-relative fetches.
+ * Symbols are excluded on purpose: the id must be serializable so it can
+ * cross a network boundary to a backend.
+ */
+export type ItemNeighborsId = string | number
+
+/**
+ * Options for an id-relative neighbours fetch. Derived from the adapter's own
+ * fetch options, so extended adapters (e.g. OneDataCollection's, which add
+ * `navigationFilters`) carry their extra context automatically. Pagination is
+ * stripped: the request is relative to an item id, not to a page.
+ */
+export type ItemNeighborsFetchOptions<
+  Filters extends FiltersDefinition,
+  Options extends BaseFetchOptions<Filters> = BaseFetchOptions<Filters>,
+> = Omit<Options, "pagination"> & {
+  /** Id of the reference item (as produced by the source's idProvider) */
+  id: ItemNeighborsId
+}
+
+/**
+ * Result of an id-relative neighbours fetch.
+ *
+ * `previous`/`next` are the immediate neighbours of the reference item under
+ * the given filters/sortings/search, or null at the collection edges. If the
+ * reference item itself does not match the current filters, return
+ * `{ previous: null, next: null }` (optionally with `total`) — consumers
+ * disable navigation in that case.
+ */
+export type ItemNeighborsResponse<R> = {
+  previous: R | null
+  next: R | null
+  /** 1-indexed position of the reference item in the filtered+sorted collection */
+  position?: number
+  /** Total number of records matching the current filters/search */
+  total?: number
+}
+
+/**
  * Base data adapter configuration for non-paginated collections
  * @template R - The type of records in the collection
  * @template Filters - The available filter configurations
@@ -164,6 +203,19 @@ export type BaseDataAdapter<
    * side-effects on reactive adapters (e.g. Apollo watchQuery).
    */
   exportFetchData?: (options: Options) => FetchReturn | Promise<FetchReturn>
+  /**
+   * Optional id-relative capability: fetch the immediate neighbours of an
+   * item under the current filters/sortings/search, without loading pages.
+   * Enables detail-page prev/next on direct links / hard refresh, where the
+   * item may not be in any loaded page window. One-shot semantics: when an
+   * Observable is returned, only the first settled emission is consumed.
+   */
+  fetchItemNeighbors?: (
+    options: ItemNeighborsFetchOptions<Filters, Options>
+  ) =>
+    | ItemNeighborsResponse<R>
+    | Promise<ItemNeighborsResponse<R>>
+    | Observable<PromiseState<ItemNeighborsResponse<R>>>
 }
 
 /**
@@ -199,6 +251,19 @@ export type PaginatedDataAdapter<
    * side-effects on reactive adapters (e.g. Apollo watchQuery).
    */
   exportFetchData?: (options: Options) => FetchReturn | Promise<FetchReturn>
+  /**
+   * Optional id-relative capability: fetch the immediate neighbours of an
+   * item under the current filters/sortings/search, without loading pages.
+   * Enables detail-page prev/next on direct links / hard refresh, where the
+   * item may not be in any loaded page window. One-shot semantics: when an
+   * Observable is returned, only the first settled emission is consumed.
+   */
+  fetchItemNeighbors?: (
+    options: ItemNeighborsFetchOptions<Filters, Options>
+  ) =>
+    | ItemNeighborsResponse<R>
+    | Promise<ItemNeighborsResponse<R>>
+    | Observable<PromiseState<ItemNeighborsResponse<R>>>
 }
 
 /**


### PR DESCRIPTION
## Description

Detail pages opened via a **direct link / hard refresh** show an item that may live deep in a paginated collection — not in any loaded page window. Window/snapshot-based navigation cannot resolve its neighbours, and walking pages to find it is wasteful. This PR defines the f0 side of the contract: an **optional id-relative capability on \`DataAdapter\`** that apps/backends implement (e.g. GraphQL \`afterId\`/\`beforeId\` cursor args with \`first: 1\` + \`totalCount\`).

> Part 2/3 of the detail-page navigation series ([#4399](https://github.com/factorialco/f0/pull/4399) is part 1 — the definition-fed \`useDataCollectionItemNavigation\` keystone). The wiring of this capability **into** that hook (resolve remote neighbours when \`activeIndex === -1\`) lands as a small follow-up once #4399 merges; this PR is fully independent and self-contained.

## Implementation details

**The contract** (\`types/fetch.typings.ts\`):

```ts
fetchItemNeighbors?: (options: { id, filters, sortings, search? }) =>
  | ItemNeighborsResponse<R>          // { previous, next, position?, total? }
  | Promise<ItemNeighborsResponse<R>>
  | Observable<PromiseState<ItemNeighborsResponse<R>>>
```

- On **both** adapter variants (precedent: \`exportFetchData\`), with full return-channel parity with \`fetchData\`.
- Options derive from the adapter's own \`Options\` generic, so \`DataCollectionDataAdapter\` automatically carries \`navigationFilters\` in the request — **zero changes** to OneDataCollection types (locked by a type test).
- \`id\` is \`string | number\` (no symbols — it must cross a network boundary). Edge semantics documented: nulls at collection edges; \`{ previous: null, next: null }\` when the item doesn't match the filters.
- Observables are consumed **one-shot** (first \`data\` emission, then unsubscribe) — live neighbour updates are explicitly out of scope.

**The consumers**:

- \`resolveItemNeighbors\`: pure normalizer of the three channels into a cancellable promise; a cancelled request can never settle into consumer state.
- \`useItemNeighbors({ dataAdapter, id, filters, sortings, search, enabled })\` → \`{ isSupported, neighbors, isResolving, error }\`:
  - Requests keyed by a stable serialization of \`{id, filters, sortings, search}\`; stale responses from superseded requests are dropped (fast prev/next clicks are race-free).
  - Per-key response cache (capped at 50) makes back/forward ping-pong instant; cleared whenever the filter/sort/search context changes; errors never cached.
  - Capability absent / disabled / null id → no fetch, \`neighbors: null\`: consumers keep the window-based fallback.
