### PR TITLE
feat(ai-chat): add dictation start/cancel tracking callbacks

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -276,6 +276,10 @@ export type AiChatTrackingOptions = {
   onWelcomeSuggestionClick?: (event: WelcomeSuggestionClickEvent) => void
   onNewChat?: () => void
   onMessage?: (message: F0Message) => void
+  /** Mic button pressed — fires on intent, even if mic permission is later denied. */
+  onDictationStart?: () => void
+  /** Dictation discarded by the user, while recording or mid-transcription. */
+  onDictationCancel?: () => void
 }
 
 /**

--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -166,9 +166,14 @@ export const F0AiChatTextArea = ({
   })
   const canRecord = !!onTranscribe && recorder.isSupported
   const handleStartRecording = useCallback(() => {
+    tracking?.onDictationStart?.()
     dictationBaseRef.current = inputValue
     void recorder.start()
-  }, [inputValue, recorder])
+  }, [inputValue, recorder, tracking])
+  const handleCancelRecording = useCallback(() => {
+    tracking?.onDictationCancel?.()
+    recorder.cancel()
+  }, [recorder, tracking])
 
   useEffect(() => {
     if (typeof window !== "undefined" && window.location.hash.length === 0) {
@@ -536,7 +541,7 @@ export const F0AiChatTextArea = ({
                     recordingStream={recorder.stream}
                     onStartRecording={handleStartRecording}
                     onStopRecording={recorder.stop}
-                    onCancelRecording={recorder.cancel}
+                    onCancelRecording={handleCancelRecording}
                   />
                 </motion.div>
               )}

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.dictation.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.dictation.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../components/TextareaField", () => ({
   ),
 }))
 
+import { AiChatStateProvider } from "../../F0AiChat/providers/AiChatStateProvider"
 import { F0AiChatTextArea } from "../F0AiChatTextArea"
 
 // Minimal MediaRecorder stand-in: stop() emits one chunk then fires onstop.
@@ -125,6 +126,61 @@ describe("F0AiChatTextArea voice dictation", () => {
         "world world"
       )
     )
+  })
+
+  it("fires tracking callbacks for dictation start and cancel", async () => {
+    installMediaMocks(async () => fakeStream())
+    const onDictationStart = vi.fn()
+    const onDictationCancel = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <AiChatStateProvider
+        enabled
+        tracking={{ onDictationStart, onDictationCancel }}
+      >
+        <F0AiChatTextArea onSubmit={vi.fn()} onTranscribe={vi.fn()} />
+      </AiChatStateProvider>
+    )
+
+    await user.click(screen.getByRole("button", { name: /record audio/i }))
+    expect(onDictationStart).toHaveBeenCalledTimes(1)
+    expect(onDictationCancel).not.toHaveBeenCalled()
+
+    await user.click(
+      await screen.findByRole("button", { name: /cancel recording/i })
+    )
+    expect(onDictationCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire the cancel tracking callback when dictation is confirmed", async () => {
+    installMediaMocks(async () => fakeStream())
+    const onDictationStart = vi.fn()
+    const onDictationCancel = vi.fn()
+    const onTranscribe: TranscribeFn = vi.fn(async () => "hello")
+    const user = userEvent.setup()
+
+    render(
+      <AiChatStateProvider
+        enabled
+        tracking={{ onDictationStart, onDictationCancel }}
+      >
+        <F0AiChatTextArea onSubmit={vi.fn()} onTranscribe={onTranscribe} />
+      </AiChatStateProvider>
+    )
+
+    await user.click(screen.getByRole("button", { name: /record audio/i }))
+    await user.click(
+      await screen.findByRole("button", { name: /stop and transcribe/i })
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+        "hello"
+      )
+    )
+    expect(onDictationStart).toHaveBeenCalledTimes(1)
+    expect(onDictationCancel).not.toHaveBeenCalled()
   })
 
   it("surfaces an error when microphone permission is denied", async () => {


### PR DESCRIPTION
## Summary

Adds two optional callbacks to the existing `tracking` pattern (`AiChatTrackingOptions`) so hosts can instrument the voice-dictation funnel in the One chat composer:

- `onDictationStart` — fired when the mic button is pressed (on intent, even if mic permission is later denied)
- `onDictationCancel` — fired when the user discards the dictation, both while recording and mid-transcription

`F0AiChatTextArea` fires them through the provider's `tracking` ref, same as `onWelcomeSuggestionClick`. The confirm path (stop → transcribe → success/error) is already observable by the host via its own `onTranscribe`, so no callback is added for it.

Consumer PR (factorial): wires these to Amplitude events `one_voice_dictation_started` / `one_voice_dictation_cancelled`.

## Test plan

- [x] `pnpm vitest run src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.dictation.test.tsx` — 6 tests, including 2 new: callbacks fire on start/cancel, and cancel does NOT fire when dictation is confirmed
- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean on changed files