### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.57.0",
+  "packages/react": "2.58.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.58.0](https://github.com/factorialco/f0/compare/f0-react-v2.57.0...f0-react-v2.58.0) (2026-06-11)
+
+
+### Features
+
+* **ai-chat:** add dictation start/cancel tracking callbacks ([#4408](https://github.com/factorialco/f0/issues/4408)) ([9d49d92](https://github.com/factorialco/f0/commit/9d49d9265635713582ab19680f20348d21953f1b))
+
+
+### Bug Fixes
+
+* **ActionBar:** change button variant from ghost to outline  ([#4410](https://github.com/factorialco/f0/issues/4410)) ([a913e28](https://github.com/factorialco/f0/commit/a913e28ee3c5277442d4743eecc405d7846fc05c))
+
 ## [2.57.0](https://github.com/factorialco/f0/compare/f0-react-v2.56.0...f0-react-v2.57.0) (2026-06-10)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.57.0",
+  "version": "2.58.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.58.0</summary>

## [2.58.0](https://github.com/factorialco/f0/compare/f0-react-v2.57.0...f0-react-v2.58.0) (2026-06-11)


### Features

* **ai-chat:** add dictation start/cancel tracking callbacks ([#4408](https://github.com/factorialco/f0/issues/4408)) ([9d49d92](https://github.com/factorialco/f0/commit/9d49d9265635713582ab19680f20348d21953f1b))


### Bug Fixes

* **ActionBar:** change button variant from ghost to outline  ([#4410](https://github.com/factorialco/f0/issues/4410)) ([a913e28](https://github.com/factorialco/f0/commit/a913e28ee3c5277442d4743eecc405d7846fc05c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).