### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.58.0",
+  "packages/react": "2.59.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.59.0](https://github.com/factorialco/f0/compare/f0-react-v2.58.0...f0-react-v2.59.0) (2026-06-11)
+
+
+### Features
+
+* **avatars:** promote F0AvatarDate + F0AvatarAlert to stable ([#4385](https://github.com/factorialco/f0/issues/4385)) ([2ca1559](https://github.com/factorialco/f0/commit/2ca155974b519e8b55e1db12a1d9ad81163dd6ef))
+
 ## [2.58.0](https://github.com/factorialco/f0/compare/f0-react-v2.57.0...f0-react-v2.58.0) (2026-06-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.58.0",
+  "version": "2.59.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.59.0</summary>

## [2.59.0](https://github.com/factorialco/f0/compare/f0-react-v2.58.0...f0-react-v2.59.0) (2026-06-11)


### Features

* **avatars:** promote F0AvatarDate + F0AvatarAlert to stable ([#4385](https://github.com/factorialco/f0/issues/4385)) ([2ca1559](https://github.com/factorialco/f0/commit/2ca155974b519e8b55e1db12a1d9ad81163dd6ef))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).