### PR TITLE
feat(avatars): align F0AvatarModule sizes to canonical scale + stabilize

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarModule/F0AvatarModule.tsx
+++ b/packages/react/src/components/avatars/F0AvatarModule/F0AvatarModule.tsx
@@ -1,4 +1,5 @@
 import { cva, type VariantProps } from "cva"
+import { useId } from "react"
 
 import { BaseAvatarProps } from "../internal/BaseAvatar"
 import { ModuleId, modules } from "./modules"
@@ -7,15 +8,16 @@ const moduleAvatarVariants = cva({
   base: "relative flex shrink-0 items-center justify-center",
   variants: {
     size: {
-      sm: "h-5 w-5",
-      md: "h-6 w-6",
-      lg: "h-8 w-8",
-      xs: "h-3 w-3",
-      xxs: "h-2.5 w-2.5",
+      "3xs": "h-2.5 w-2.5",
+      "2xs": "h-3 w-3",
+      xs: "h-5 w-5",
+      sm: "h-6 w-6",
+      md: "h-8 w-8",
+      lg: "h-10 w-10",
     },
   },
   defaultVariants: {
-    size: "md",
+    size: "sm",
   },
 })
 
@@ -23,15 +25,16 @@ const iconSizeVariants = cva({
   base: "relative text-f1-foreground-inverse drop-shadow",
   variants: {
     size: {
-      sm: "h-[14px] w-[14px]",
-      md: "h-[18px] w-[18px]",
-      lg: "h-6 w-6",
-      xs: "h-2 w-2",
-      xxs: "h-2 w-2",
+      "3xs": "h-2 w-2",
+      "2xs": "h-2 w-2",
+      xs: "h-[14px] w-[14px]",
+      sm: "h-[18px] w-[18px]",
+      md: "h-6 w-6",
+      lg: "h-7 w-7",
     },
   },
   defaultVariants: {
-    size: "md",
+    size: "sm",
   },
 })
 
@@ -45,11 +48,9 @@ const squirclePath =
 /**
  * Module avatar
  * @description A component that displays a module avatar
- * @experimental
- * @returns
  */
 export function F0AvatarModule({
-  size = "md",
+  size = "sm",
   module,
   ...props
 }: F0AvatarModuleProps) {
@@ -59,9 +60,7 @@ export function F0AvatarModule({
     console.warn(`ModuleAvatar: The module ${module} is not supported.`)
   }
 
-  const code = Math.random().toString(36).substring(2, 15)
-
-  const gradientId = `gradient-${code}`
+  const gradientId = `gradient-${useId().replace(/:/g, "")}`
 
   return (
     <div

--- a/packages/react/src/components/avatars/F0AvatarModule/__stories__/F0AvatarModule.mdx
+++ b/packages/react/src/components/avatars/F0AvatarModule/__stories__/F0AvatarModule.mdx
@@ -1,0 +1,137 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as ModuleStories from "./F0AvatarModule.stories"
+
+<Meta of={ModuleStories} />
+
+# AvatarModule
+
+A compact avatar that represents a **product module** (Time Tracking, Goals,
+Kudos…) as a colored squircle with the module's icon.
+
+---
+
+## Overview
+
+### Purpose
+
+- Identify which product module an item, action or surface belongs to
+- Give modules a consistent, recognizable visual across the product
+- Serve as the module **badge** layered on the corner of other avatars
+
+### Anatomy
+
+A module avatar is a squircle filled with the module's brand gradient and its
+icon centered on top. It is used both **standalone** (cards, breadcrumbs,
+upselling surfaces) and as the **module badge** rendered automatically in the
+corner of entity avatars.
+
+<Canvas of={ModuleStories.Default} />
+
+<Controls of={ModuleStories.Default} />
+
+### Variants
+
+#### Modules
+
+Each module maps to its own icon.
+
+<Canvas of={ModuleStories.Snapshot} />
+
+#### Sizes
+
+Module uses the shared avatar size scale for standalone use (`xs`–`lg`, same
+pixels as every other avatar). It also defines two smaller sub-sizes (`2xs`,
+`3xs`) reserved for the corner badge described below.
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Size</th>
+        <th className="text-left">Dimensions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>lg</code>
+        </td>
+        <td>40px</td>
+      </tr>
+      <tr>
+        <td>
+          <code>md</code>
+        </td>
+        <td>32px</td>
+      </tr>
+      <tr>
+        <td>
+          <code>sm</code> (default)
+        </td>
+        <td>24px</td>
+      </tr>
+      <tr>
+        <td>
+          <code>xs</code>
+        </td>
+        <td>20px</td>
+      </tr>
+      <tr>
+        <td>
+          <code>2xs</code> · badge
+        </td>
+        <td>12px</td>
+      </tr>
+      <tr>
+        <td>
+          <code>3xs</code> · badge
+        </td>
+        <td>10px</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+The `2xs` and `3xs` sub-sizes exist **only** so the module can render as a small
+badge in the corner of an entity avatar — marking which product module the item
+belongs to. They are too small to read on their own, so for a standalone module
+avatar use `xs` (20px) or larger.
+
+<Canvas of={ModuleStories.AsBadge} />
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- Showing the product module behind a card, breadcrumb or upsell surface
+- Marking the owning module on top of an entity avatar (as a badge)
+
+#### When NOT to use
+
+- **`2xs` / `3xs` for a standalone module avatar**: these sub-sizes exist only
+  so the module reads as a tiny corner badge on another avatar. On their own
+  they are too small to be legible — use `xs` (20px) or larger for standalone.
+- Representing a person, team or other entity: use the matching `F0Avatar*`
+  component.
+
+#### Adding a new module icon
+
+Module icons are a curated set. Add one only when a real product module needs
+it, and keep the set consistent:
+
+- **No duplicates.** Every module must have its own distinct icon. Never reuse
+  an icon that already represents another module, and never add a second copy of
+  an icon that is already in the set — one concept, one icon.
+- **Full colour, filled style.** Module icons are intentionally filled and
+  render in white on the module's colour squircle, unlike the mostly-outline
+  icon system. A new icon must be drawn in this filled style so it reads
+  consistently with the rest of the set.
+- **Factorial icon system only.** Match the style of Factorial's existing
+  icons. Don't import icons from external libraries (e.g. Lucide) or legacy
+  sources (e.g. Gamma) — they won't match in style.
+- **Source vs. usage.** The raw module SVGs live in the module icon set; in the
+  UI always render them through `F0AvatarModule`, never the raw SVG.

--- a/packages/react/src/components/avatars/F0AvatarModule/__stories__/F0AvatarModule.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarModule/__stories__/F0AvatarModule.stories.tsx
@@ -2,18 +2,19 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
+import { F0Avatar } from "../../F0Avatar"
 import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
 import { F0AvatarModule } from "../index"
 import { ModuleId, modules } from "../modules"
 
-const meta: Meta<typeof F0AvatarModule> = {
+const meta = {
   component: F0AvatarModule,
   title: "Avatars/AvatarModule",
-  tags: ["autodocs"],
+  tags: ["stable", "!autodocs"],
   argTypes: {
     size: {
       control: "radio",
-      options: ["sm", "md", "lg"],
+      options: ["xs", "sm", "md", "lg"],
     },
     ...getBaseAvatarArgTypes(["aria-label", "aria-labelledby"]),
     module: {
@@ -21,7 +22,7 @@ const meta: Meta<typeof F0AvatarModule> = {
       options: Object.keys(modules).sort((a, b) => a.localeCompare(b)),
     },
   },
-}
+} satisfies Meta<typeof F0AvatarModule>
 
 export default meta
 
@@ -30,7 +31,7 @@ type Story = StoryObj<typeof F0AvatarModule>
 export const Default: Story = {
   args: {
     module: "home",
-    size: "lg",
+    size: "md",
   },
 }
 
@@ -55,10 +56,29 @@ export const Snapshot: Story = {
             alignItems: "center",
           }}
         >
-          <F0AvatarModule module={module as ModuleId} size="lg" />
+          <F0AvatarModule module={module as ModuleId} size="md" />
           <span className="text-sm">{module}</span>
         </div>
       ))}
     </div>
+  ),
+}
+
+/**
+ * The most common use: the module rendered automatically as a badge in the
+ * corner of an entity avatar, marking which product module the item belongs to.
+ */
+export const AsBadge: Story = {
+  parameters: withSnapshot({}),
+  render: () => (
+    <F0Avatar
+      size="xl"
+      avatar={{
+        type: "person",
+        firstName: "Jane",
+        lastName: "Doe",
+        badge: { type: "module", module: "home" },
+      }}
+    />
   ),
 }

--- a/packages/react/src/components/avatars/F0AvatarModule/__tests__/F0AvatarModule.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarModule/__tests__/F0AvatarModule.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import { F0AvatarModule } from "../F0AvatarModule"
+
+describe("F0AvatarModule", () => {
+  it("renders the module avatar with its accessible label", () => {
+    const { container } = zeroRender(
+      <F0AvatarModule module="home" aria-label="Home" />
+    )
+
+    expect(container.querySelector('[aria-label="Home"]')).toBeInTheDocument()
+  })
+
+  it("warns when the module is not supported", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    // @ts-expect-error - unsupported module on purpose
+    zeroRender(<F0AvatarModule module="not-a-real-module" />)
+
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})

--- a/packages/react/src/components/avatars/internal/BaseAvatar/utils.ts
+++ b/packages/react/src/components/avatars/internal/BaseAvatar/utils.ts
@@ -169,11 +169,11 @@ export const getAvatarSize = (
   const sizeMap: Partial<
     Record<Exclude<AvatarSize, undefined>, F0AvatarModuleProps["size"]>
   > = {
-    "2xl": "md",
-    xl: "sm",
-    lg: "xs",
-    sm: "xs",
-    xs: "xxs",
+    "2xl": "sm",
+    xl: "xs",
+    lg: "2xs",
+    sm: "2xs",
+    xs: "3xs",
   } as const
 
   return size && sizeMap[size] ? (sizeMap[size] ?? sizeMap.sm) : sizeMap.sm

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem.tsx
@@ -68,7 +68,7 @@ const BreadcrumbContent = forwardRef<HTMLDivElement, BreadcrumbItemProps>(
           "module" in item &&
           item.module &&
           (isOnly || isFirst) && (
-            <F0AvatarModule module={item.module} size={isOnly ? "lg" : "sm"} />
+            <F0AvatarModule module={item.module} size={isOnly ? "md" : "xs"} />
           )}
         <span className="truncate">
           {!isLoading && "label" in item ? item.label : ""}

--- a/packages/react/src/experimental/Widgets/Content/ListItems/WidgetInboxListItem/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ListItems/WidgetInboxListItem/index.tsx
@@ -51,7 +51,7 @@ export function WidgetInboxListItem({
 
   return (
     <Wrapper onClick={handleOnClick} className={className}>
-      <F0AvatarModule module={module ?? "inbox"} size="md" />
+      <F0AvatarModule module={module ?? "inbox"} size="sm" />
       <div className="flex-1">
         <p className="line-clamp-1 font-medium">{title}</p>
         <p className="line-clamp-1 text-f1-foreground-secondary">{subtitle}</p>

--- a/packages/react/src/sds/Home/Communities/HighlightBanner/index.tsx
+++ b/packages/react/src/sds/Home/Communities/HighlightBanner/index.tsx
@@ -17,7 +17,7 @@ export const HighlightBanner = ({
   return (
     <div className="flex w-full flex-col items-start justify-between gap-4 rounded-md bg-gradient-to-r from-[#F5A51C]/30 via-[#E51943]/30 to-[#5596F6]/30 px-3 py-3 ring-1 ring-inset ring-f1-border-secondary sm:flex-row sm:items-center sm:px-4">
       <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
-        <F0AvatarModule module="kudos" size="lg" />
+        <F0AvatarModule module="kudos" size="md" />
         <div className="flex flex-col">
           <span className="font-medium text-f1-foreground">{title}</span>
           <span className="text-f1-foreground-secondary">{subtitle}</span>

--- a/packages/react/src/sds/UpsellingKit/ProductCard/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductCard/index.tsx
@@ -101,7 +101,7 @@ function _ProductCard({
                   <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
                     <F0AvatarModule
                       module={props.module as ModuleId}
-                      size="lg"
+                      size="md"
                     />
                   </div>
                 )}

--- a/packages/react/src/sds/UpsellingKit/ProductModal/components/CustomModal.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductModal/components/CustomModal.tsx
@@ -44,7 +44,7 @@ export function CustomModal({
       >
         <div className="flex flex-row items-center justify-between px-4 py-4">
           <DialogTitle className="flex flex-row items-center gap-2 text-lg font-semibold text-f1-foreground">
-            {module && <F0AvatarModule module={module} size="lg" />}
+            {module && <F0AvatarModule module={module} size="md" />}
             {title}
           </DialogTitle>
           <ButtonInternal

--- a/packages/react/src/sds/ai/F0AiProposalCard/F0AiProposalCard.tsx
+++ b/packages/react/src/sds/ai/F0AiProposalCard/F0AiProposalCard.tsx
@@ -69,7 +69,7 @@ export function F0AiProposalCard(props: F0AiProposalCardProps) {
       {...dataAttributes}
     >
       <div className="flex items-center gap-3 px-4 py-3">
-        {module && <F0AvatarModule module={module} size="lg" />}
+        {module && <F0AvatarModule module={module} size="md" />}
         <div className="min-w-0 flex-1">
           <h2 className="truncate text-lg font-semibold text-f1-foreground">
             {heading}

--- a/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
+++ b/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
@@ -77,7 +77,7 @@ export function F0CanvasCard({
     >
       <div className="flex w-full min-w-0 flex-row items-center gap-3">
         {avatar?.type === "module" && (
-          <F0AvatarModule module={avatar.module} size="lg" />
+          <F0AvatarModule module={avatar.module} size="md" />
         )}
         {avatar?.type === "file" && (
           <F0AvatarFile file={avatar.file} size="lg" />


### PR DESCRIPTION
## What

Aligns `F0AvatarModule`'s size scale to the canonical avatar names (`xs`/`sm`/`md`/`lg` = 20/24/32/40px) so it is consistent with the rest of the avatar family, and promotes it to **stable** (stable tags, `satisfies Meta`, Snapshot story, MDX docs, unit tests; removes `@experimental`; deterministic gradient id via `useId`).

The two badge-only sub-sizes (`2xs`/`3xs` = 12/10px) are kept for the corner-badge use and documented as not for standalone use.

## Migration (intentional `size` rename — not a blocker)

The `size` prop values were renamed (and shifted in pixels). **All internal consumers are already migrated in this PR.** If you use `F0AvatarModule` directly, remap:

| Before | After |
|---|---|
| `lg` | `md` |
| `md` | `sm` |
| `sm` | `xs` |

Plus a new larger `lg` (40px) and the badge-only `2xs`/`3xs`. The Public API check will flag this as a breaking change — expected, since the API changed on purpose.

## Verification
- Unit tests green; `F0Card` (CardAvatar consumer) 48/48 green.
- Typecheck clean for Module + all 8 consumers; lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)