### PR TITLE
feat(avatars): promote F0AvatarList to stable

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
@@ -84,11 +84,19 @@ export const F0AvatarList = ({
         const description = extras.tooltipDescription
 
         const hasBadge = Boolean((avatar as { badge?: unknown }).badge)
+        // Clip the avatar to leave a notch for whatever overlaps it on the
+        // right: the next avatar, or — for the last one — the `+N` counter when
+        // it is forced via `remainingCount`. Without this the forced counter
+        // overlaps an unclipped last avatar and the mask looks broken.
+        const isLast = index === avatars.length - 1
+        const isOverlappedByForcedCounter =
+          isLast && initialRemainingCount !== undefined
+        const shouldClip = (!isLast || isOverlappedByForcedCounter) && !hasBadge
         const clippedAvatar = (
           <div
             className="flex h-fit w-fit shrink-0 items-center justify-center"
             style={
-              index !== avatars.length - 1 && !hasBadge
+              shouldClip
                 ? {
                     clipPath:
                       CLIP_MASK[type === "person" ? "rounded" : "base"][size],

--- a/packages/react/src/components/avatars/F0AvatarList/__stories__/F0AvatarList.mdx
+++ b/packages/react/src/components/avatars/F0AvatarList/__stories__/F0AvatarList.mdx
@@ -1,0 +1,116 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as ListStories from "./F0AvatarList.stories"
+
+<Meta of={ListStories} />
+
+# AvatarList
+
+A compact, overlapping stack of avatars that represents a **group of entities of
+the same type** (people, teams, companies, flags or files) — for example the
+members of a project or the attendees of an event.
+
+---
+
+## Overview
+
+### Purpose
+
+- Show that several entities are related or belong together, in little space
+- Summarise large groups with a trailing **`+N`** counter instead of a long row
+- Give quick access to each entity's name (and optional secondary detail)
+  through per-avatar tooltips
+
+### Anatomy
+
+The list renders each entity through the matching `F0Avatar*` component, stacks
+them with a slight overlap, and — when there are more than `max` — collapses the
+extras into a `+N` counter. Every avatar carries a tooltip with its name, and
+can show a secondary line (`tooltipDescription`) such as an email or role.
+
+<Canvas of={ListStories.Default} />
+
+<Controls of={ListStories.Default} />
+
+### Variants
+
+#### Types
+
+A list is homogeneous: every avatar shares the same `type`. AvatarList supports
+`person`, `team`, `company`, `flag` and `file`, rendering the matching avatar
+for each entry.
+
+<Canvas of={ListStories.AllTypes} />
+
+#### Overflow
+
+Use `max` to cap how many avatars are visible; the rest collapse into a `+N`
+counter. When you already know the total, pass `remainingCount` to set the
+number shown in the counter directly.
+
+<Canvas of={ListStories.WithRemainingCount} />
+
+Hovering the `+N` counter opens a popover listing the hidden avatars by name.
+
+<Canvas of={ListStories.OverflowPopover} />
+
+#### Tooltip detail
+
+Each entry may carry a `tooltipDescription` (e.g. an email or role) rendered as
+the tooltip's secondary line. Hover any avatar to see it.
+
+<Canvas of={ListStories.WithTooltipDescription} />
+
+#### Sizes
+
+AvatarList uses the shared avatar size scale, so a token means the same pixels
+as every other avatar. It supports the three smaller sizes; `md` (medium) is the
+default.
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Size</th>
+        <th className="text-left">Dimensions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>md</code> (medium, default)
+        </td>
+        <td>32px</td>
+      </tr>
+      <tr>
+        <td>
+          <code>sm</code> (small)
+        </td>
+        <td>24px</td>
+      </tr>
+      <tr>
+        <td>
+          <code>xs</code> (extra small)
+        </td>
+        <td>20px</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+## Guidelines
+
+### Design best practices
+
+#### When to use
+
+- Representing a group of related entities of the same type (project members,
+  event attendees, companies in a deal)
+- Condensing a long list into a fixed footprint with a `+N` overflow
+
+#### When NOT to use
+
+- A single entity: use the matching `F0Avatar*` component directly
+- Mixing entity types in one list: a list is homogeneous by design — render
+  separate lists instead

--- a/packages/react/src/components/avatars/F0AvatarList/__stories__/F0AvatarList.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/__stories__/F0AvatarList.stories.tsx
@@ -70,8 +70,9 @@ const dummyFiles = [
 ]
 
 const dummyFlags = [
-  { name: "flag", flag: "es" },
-  { name: "flag", flag: "fr" },
+  { name: "Spain", flag: "es" },
+  { name: "France", flag: "fr" },
+  { name: "Germany", flag: "de" },
 ]
 
 function getDummyAvatar<
@@ -155,7 +156,7 @@ function getDummyAvatars<
 const meta: Meta<typeof F0AvatarList> = {
   component: F0AvatarList,
   title: "Avatars/AvatarList",
-  tags: ["autodocs"],
+  tags: ["stable", "!autodocs"],
   args: {
     size: "md",
     type: "person",
@@ -187,65 +188,43 @@ const meta: Meta<typeof F0AvatarList> = {
       description: "The type of the avatars in the list",
     },
   },
-  decorators: [
-    (Story) => (
-      <div className="w-[270px]">
-        <Story />
-      </div>
-    ),
-  ],
 } satisfies Meta<typeof F0AvatarList>
 
 export default meta
 
 type Story = StoryObj<typeof F0AvatarList>
 
-export const Default: Story = {}
-
-export const Companies: Story = {
-  args: {
-    size: "md",
-    type: "company",
-    avatars: getDummyAvatars(3, "company"),
-  },
+export const Default: Story = {
+  args: { max: 3 },
 }
 
-export const Teams: Story = {
-  args: {
-    size: "md",
-    type: "team",
-    avatars: getDummyAvatars(3, "team"),
-  },
-}
-
-export const WithMaxAvatars: Story = {
-  args: {
-    ...Default.args,
-    type: "person",
-    avatars: getDummyAvatars(50, "person"),
-    max: 3,
-  },
-}
-
-export const LargeAvatarsList: Story = {
-  args: {
-    type: "person",
-    avatars: getDummyAvatars(50, "person"),
-  },
-}
-
-export const CompaniesWithMaxAvatars: Story = {
-  args: {
-    ...Companies.args,
-    type: "company",
-    avatars: getDummyAvatars(50, "company"),
-    max: 3,
-  },
+/**
+ * A list is homogeneous: every avatar shares the same `type`. AvatarList
+ * supports `person`, `team`, `company`, `flag` and `file`.
+ */
+export const AllTypes: Story = {
+  render: () => (
+    <div className="flex flex-row flex-wrap items-start gap-8">
+      {avatarVariants.map((type) => (
+        <div key={type} className="flex flex-col gap-1">
+          <span className="text-sm capitalize text-f1-foreground-secondary">
+            {type}
+          </span>
+          <F0AvatarList
+            type={type}
+            size="md"
+            max={3}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            avatars={getDummyAvatars(3, type) as any}
+          />
+        </div>
+      ))}
+    </div>
+  ),
 }
 
 export const WithRemainingCount: Story = {
   args: {
-    ...Default.args,
     type: "person",
     avatars: getDummyAvatars(7, "person"),
     remainingCount: 10,
@@ -274,37 +253,21 @@ function getDummyPeopleWithDescriptions(count: number) {
  */
 export const WithTooltipDescription: Story = {
   args: {
-    ...Default.args,
     type: "person",
     avatars: getDummyPeopleWithDescriptions(3),
-  },
-}
-
-/**
- * When `tooltipDescription` is present on overflowed avatars, the `+N` hover
- * popover renders the description as a secondary line under each name.
- * Default `tooltipScroll="vertical"` caps the popover height and scrolls.
- */
-export const OverflowPopoverWithDescriptions: Story = {
-  args: {
-    ...Default.args,
-    type: "person",
-    avatars: getDummyPeopleWithDescriptions(15),
     max: 3,
   },
 }
 
 /**
- * `tooltipScroll="none"` removes the popover height cap and lets it grow with
- * its content. Useful for short lists where scrolling is unnecessary.
+ * Hovering the `+N` counter opens a popover listing the hidden avatars by name.
+ * The popover caps its height and scrolls by default (`tooltipScroll="vertical"`).
  */
-export const OverflowPopoverNoScroll: Story = {
+export const OverflowPopover: Story = {
   args: {
-    ...Default.args,
     type: "person",
-    avatars: getDummyPeopleWithDescriptions(6),
+    avatars: getDummyAvatars(15, "person"),
     max: 3,
-    tooltipScroll: "none",
   },
 }
 


### PR DESCRIPTION
## What

Promotes `F0AvatarList` to **stable**:
- Rename `__storybook__` → `__stories__`; meta tagged `["stable","!autodocs"]`.
- Manual MDX docs: Overview (Purpose/Anatomy), Variants (Types, Overflow, Tooltip detail, Sizes), Guidelines. Sizes documented with names + pixels, aligned with the shared avatar scale.
- Trimmed to one representative story per section + Snapshot; `AllTypes` shows every supported type (person/team/company/flag/file) side by side. The overflow popover lists hidden avatars by name only (no emails).

## Bug fix (pre-existing)

When the `+N` counter is forced via `remainingCount`, the last avatar was not clipped, so the counter overlapped an unclipped avatar and the overlap mask looked broken. It is now clipped in that case too.

## Verification
- Unit tests 5/5 green; typecheck clean for `F0AvatarList`; lint/format clean.
- No API changes — non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)