### PR TITLE
fix(api-surface): classify unions and intersections structurally

### DIFF
--- a/packages/react/.scripts/__tests__/check-api-surface.test.ts
+++ b/packages/react/.scripts/__tests__/check-api-surface.test.ts
@@ -226,6 +226,108 @@ describe("check-api-surface — does NOT flag non-breaking changes", () => {
   })
 })
 
+describe("check-api-surface — unions and intersections", () => {
+  // The F0SelectProps shape: a shared base intersected into several variants,
+  // exported as a union, consumed by a component.
+  const variantUnion = (base: string) => `
+    export declare type SelectProps =
+      | (${base} & { clearable?: false; value?: string } & { source: { fetch: () => void }; options?: never })
+      | (${base} & { clearable?: false; value?: string } & { source?: never; options: Array<string> })
+      | (${base} & { clearable: true; value?: string } & { source: { fetch: () => void }; options?: never })
+      | (${base} & { clearable: true; value?: string } & { source?: never; options: Array<string> });
+    export declare const Select: (props: SelectProps) => unknown;
+  `
+  const UNION_BASE = variantUnion("{ open?: boolean; label: string }")
+
+  it("treats an optional prop added to a union-of-intersections base as safe", () => {
+    const diff = f0(
+      UNION_BASE,
+      variantUnion(
+        "{ open?: boolean; label: string; onFiltersChange?: (filters: Record<string, unknown>) => void }"
+      )
+    )
+    expect(diff.breaking).toHaveLength(0)
+  })
+
+  it("flags a required prop added to a union-of-intersections base", () => {
+    const diff = f0(
+      UNION_BASE,
+      variantUnion("{ open?: boolean; label: string; mode: string }")
+    )
+    const changed = diff.breaking.find((b) => b.name === "SelectProps")
+    expect(changed?.reasons?.some((r) => /required.*mode/i.test(r))).toBe(true)
+    // The same reason from every variant collapses into one line
+    expect(
+      changed?.reasons?.filter((r) => /required.*mode/i.test(r))
+    ).toHaveLength(1)
+  })
+
+  it("flags a prop removed from a union-of-intersections base", () => {
+    const diff = f0(UNION_BASE, variantUnion("{ label: string }"))
+    const changed = diff.breaking.find((b) => b.name === "SelectProps")
+    expect(changed?.reasons?.some((r) => r.includes("open"))).toBe(true)
+  })
+
+  it("flags a retyped prop inside a union variant", () => {
+    const diff = f0(
+      UNION_BASE,
+      variantUnion("{ open?: boolean; label: number }")
+    )
+    expect(names(diff)).toContain("SelectProps")
+  })
+
+  it("flags a change in the number of union variants", () => {
+    const diff = f0(
+      UNION_BASE,
+      `
+      export declare type SelectProps =
+        | ({ open?: boolean; label: string } & { clearable?: false; value?: string } & { source: { fetch: () => void }; options?: never })
+        | ({ open?: boolean; label: string } & { clearable?: false; value?: string } & { source?: never; options: Array<string> });
+      export declare const Select: (props: SelectProps) => unknown;
+      `
+    )
+    const changed = diff.breaking.find((b) => b.name === "SelectProps")
+    expect(changed?.reasons?.some((r) => /union variants/i.test(r))).toBe(true)
+  })
+
+  it("treats an optional prop added to a plain intersection as safe", () => {
+    const diff = f0(
+      `
+      export declare type CardProps = { title: string } & { footer?: string };
+      `,
+      `
+      export declare type CardProps = { title: string } & { footer?: string; sticky?: boolean };
+      `
+    )
+    expect(diff.breaking).toHaveLength(0)
+  })
+
+  it("flags a member removed from a plain intersection", () => {
+    const diff = f0(
+      `
+      export declare type CardProps = { title: string } & { footer?: string };
+      `,
+      `
+      export declare type CardProps = { title: string } & {};
+      `
+    )
+    const changed = diff.breaking.find((b) => b.name === "CardProps")
+    expect(changed?.reasons?.some((r) => r.includes("footer"))).toBe(true)
+  })
+
+  it("still compares non-object intersections (branded primitives) by text", () => {
+    const diff = f0(
+      `
+      export declare type Row = { id: string & { __brand: "id" } };
+      `,
+      `
+      export declare type Row = { id: number & { __brand: "id" } };
+      `
+    )
+    expect(names(diff)).toContain("Row")
+  })
+})
+
 describe("check-api-surface — determinism", () => {
   it("reports no changes for identical surfaces in different directories", () => {
     // Same content, different temp dirs (different absolute paths): the

--- a/packages/react/.scripts/check-api-surface.ts
+++ b/packages/react/.scripts/check-api-surface.ts
@@ -29,11 +29,16 @@
  * rollup noise (the `F0TextInputProps_2` suffixes / dangling `./types` imports)
  * instead of diffing raw `.d.ts` text.
  *
- * Known simplification: leaf types (unions, primitives, external types) are
- * compared by their normalized string, so a *widening* of a leaf type (e.g. a
- * prop `string` → `string | number`, which is safe for an input) is reported as
- * breaking. Object/parameter shape changes — the common case — are classified
- * precisely.
+ * Unions are compared variant-by-variant (pairwise) and intersections of
+ * object shapes are flattened into one merged member set — so an optional
+ * prop added to a base type that feeds a union of prop variants (the
+ * `F0SelectProps` shape) classifies as additive, not as "the union changed".
+ *
+ * Known simplification: leaf types (primitives, external types, non-object
+ * unions/intersections) are compared by their normalized string, so a
+ * *widening* of a leaf type (e.g. a prop `string` → `string | number`, which
+ * is safe for an input) is reported as breaking. Object/parameter shape
+ * changes — the common case — are classified precisely.
  *
  * Usage:
  *   tsx .scripts/check-api-surface.ts --base <dir> --head <dir> [--json]
@@ -62,10 +67,12 @@ const MAX_DEPTH = 4
 
 /**
  * A normalized, structural representation of a type used for comparison.
- *  - `object`: an object/props type, compared member by member.
+ *  - `object`: an object/props type, compared member by member. Intersections
+ *    of object shapes are flattened into this (the checker merges members).
  *  - `callable`: a function/component, compared signature by signature.
- *  - `opaque`: anything else (union, primitive, external type), compared by
- *    its normalized string.
+ *  - `union`: a union, compared variant by variant (pairwise by position).
+ *  - `opaque`: anything else (primitive, external type, non-object
+ *    union/intersection constituents), compared by its normalized string.
  */
 export type ApiItem =
   | {
@@ -83,6 +90,7 @@ export type ApiItem =
         ret: ApiItem
       }>
     }
+  | { k: "union"; members: ApiItem[] }
   | { k: "opaque"; text: string }
 
 interface ExportSnapshot {
@@ -298,6 +306,15 @@ function isExternal(type: ts.Type, dirAbsolute: string): boolean {
   })
 }
 
+/** An intersection composed purely of object shapes (no primitives, no type
+ * parameters), which the checker can flatten into one merged member set. */
+function isPlainObjectIntersection(type: ts.Type): boolean {
+  if (!type.isIntersection()) return false
+  return type.types.every(
+    (t) => !!(t.flags & ts.TypeFlags.Object) || isPlainObjectIntersection(t)
+  )
+}
+
 function buildApiItem(
   type: ts.Type,
   checker: ts.TypeChecker,
@@ -313,8 +330,32 @@ function buildApiItem(
   })
 
   if (depth <= 0 || visited.has(type)) return opaque()
-  // Unions/intersections are compared as a whole (leaf), not member-expanded.
-  if (type.isUnion() || type.isIntersection()) return opaque()
+
+  // Union variants are compared pairwise (same position), so an optional
+  // prop added to a shared base that feeds several variants classifies as
+  // additive instead of "the whole union changed".
+  if (type.isUnion()) {
+    const next = new Set(visited).add(type)
+    return {
+      k: "union",
+      members: type.types.map((t) =>
+        buildApiItem(t, checker, dirAbsolute, depth - 1, next)
+      ),
+    }
+  }
+
+  // Intersections of plain object shapes fall through to the object branch
+  // as one merged member set (the checker's getProperties() combines the
+  // constituents). Anything else — branded primitives, callable
+  // constituents — stays an opaque leaf, compared by text as before.
+  if (
+    type.isIntersection() &&
+    (!isPlainObjectIntersection(type) ||
+      type.getCallSignatures().length > 0 ||
+      type.getConstructSignatures().length > 0)
+  ) {
+    return opaque()
+  }
 
   const callSigs = type.getCallSignatures()
   const ctorSigs = type.getConstructSignatures()
@@ -361,7 +402,8 @@ function buildApiItem(
   // stay opaque instead of leaking their prototype methods (e.g. the
   // program-specific `__@iterator@N`). Arrays/built-ins are Object types but
   // are caught by `isExternal` (declared in lib/node_modules) and stay opaque.
-  const isObjectType = !!(type.flags & ts.TypeFlags.Object)
+  const isObjectType =
+    !!(type.flags & ts.TypeFlags.Object) || type.isIntersection()
   const props = type.getProperties()
   const indexInfos = checker.getIndexInfosOfType(type)
   const isObjectLike = props.length > 0 || indexInfos.length > 0
@@ -442,6 +484,23 @@ function classifyItem(before: ApiItem, after: ApiItem, path: string): string[] {
     return before.text !== after.text
       ? [`${path || "type"} changed: \`${before.text}\` → \`${after.text}\``]
       : []
+  }
+
+  if (before.k === "union" && after.k === "union") {
+    if (before.members.length !== after.members.length) {
+      return [
+        `${path || "type"} union variants changed (${before.members.length} → ${after.members.length})`,
+      ]
+    }
+    // Variants are compared at the same path so identical reasons coming
+    // from a change in a shared base dedupe into a single line.
+    const reasons = new Set<string>()
+    before.members.forEach((b, i) => {
+      for (const reason of classifyItem(b, after.members[i], path)) {
+        reasons.add(reason)
+      }
+    })
+    return [...reasons]
   }
 
   if (before.k === "object" && after.k === "object") {


### PR DESCRIPTION
## Description

The public-API breaking-change checker compared unions and intersections as opaque text, so an additive **optional** prop on a base type that feeds a union of prop variants — the `F0SelectProps` shape — re-serialized every union branch and was flagged as breaking. This produced a false positive on [#4404](https://github.com/factorialco/f0/pull/4404), where `BreadcrumbSelect`/`BreadcrumbSelectProps` were reported as breaking although the only delta was the new optional `onFiltersChange`. The checker now classifies these structurally, so additive-optional changes inside unions/intersections are recognized as safe while genuinely breaking ones keep being flagged.

## Implementation details

- fix: compare union types variant-by-variant (pairwise by position) instead of as one opaque string

  <details>
  <summary>Variance and dedup details</summary>

  Identical reasons surfacing from a change in a shared base (e.g. the same required prop added to all four `F0SelectProps` variants) dedupe into a single line in the PR comment. A change in the number of union variants is still reported as breaking — pairing by position is conservative: a misaligned pairing can only over-report, never hide a breaking change.
  </details>

- fix: flatten intersections of plain object shapes into one merged member set (via the checker's `getProperties()`) and compare member-by-member
- chore: keep the opaque text comparison for everything else (branded primitives, callable constituents), preserving the existing conservative behavior
- test: 8 new regression tests covering the union-of-intersections shape — additive optional prop safe; required add, member removal, retype, and variant-count change breaking; plain intersections; branded primitives

🤖 Generated with [Claude Code](https://claude.com/claude-code)