### PR TITLE
fix(OverflowList): never render stale items across an items-prop change

### DIFF
--- a/packages/react/src/lib/RenderErrorBoundary.tsx
+++ b/packages/react/src/lib/RenderErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import { Component, type ReactNode } from "react"
+
+interface RenderErrorBoundaryProps {
+  children: ReactNode
+  /** Rendered when a descendant throws during render. Defaults to nothing. */
+  fallback?: ReactNode
+  /** Called with the thrown error, e.g. to log it with context. */
+  onError?: (error: Error) => void
+}
+
+interface RenderErrorBoundaryState {
+  hasError: boolean
+}
+
+/**
+ * Boundary for non-critical UI: a render error in `children` degrades to
+ * `fallback` instead of propagating and unmounting the whole tree above it.
+ *
+ * The fallback is permanent for the lifetime of the boundary instance — there
+ * is no retry — so only wrap subtrees the user can live without.
+ */
+export class RenderErrorBoundary extends Component<
+  RenderErrorBoundaryProps,
+  RenderErrorBoundaryState
+> {
+  state: RenderErrorBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): RenderErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error) {
+    this.props.onError?.(error)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? null
+    }
+    return this.props.children
+  }
+}

--- a/packages/react/src/patterns/OneDataCollection/__tests__/presets.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/presets.test.tsx
@@ -894,3 +894,40 @@ describe("OneDataCollection - share preset", () => {
     })
   })
 })
+
+describe("OneDataCollection - presets render resilience", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("keeps rendering and fetching data when the presets row throws during render", async () => {
+    // Silence React's error-boundary logging and our own degradation report
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    renderHarness({
+      presets: [
+        {
+          id: "broken",
+          label: "Broken preset",
+          filter: {},
+          // Runs during the presets row render — simulates any render crash
+          // in FiltersPresets (e.g. the OverflowList stale-items regression)
+          itemsCount: () => {
+            throw new Error("presets render crash")
+          },
+        },
+      ],
+    })
+
+    // The collection survives: data is fetched and rows render
+    await waitFor(() => expect(screen.getByText("John")).toBeInTheDocument())
+    expect(screen.getByText("Jane")).toBeInTheDocument()
+
+    // The presets row degraded to nothing instead of taking down the tree
+    expect(screen.queryByText("Broken preset")).not.toBeInTheDocument()
+    expect(consoleError).toHaveBeenCalledWith(
+      "[f0-react] FiltersPresets failed to render; hiding the presets row",
+      expect.any(Error)
+    )
+  })
+})

--- a/packages/react/src/patterns/OneFilterPicker/OneFilterPicker.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/OneFilterPicker.tsx
@@ -3,6 +3,7 @@ import { useContext, useEffect, useMemo, useRef, useState } from "react"
 
 import { useEventEmitter } from "@/patterns/OneDataCollection/useEventEmitter"
 import { DataTestIdWrapper } from "@/lib/data-testid"
+import { RenderErrorBoundary } from "@/lib/RenderErrorBoundary"
 import { cn } from "@/lib/utils"
 
 import type { FiltersDefinition, FiltersMode, FiltersState } from "./types"
@@ -281,18 +282,29 @@ const FiltersPresets = () => {
 
   return (
     presets && (
-      <FiltersPresetsComponent
-        presets={presets}
-        presetsLoading={presetsLoading}
-        value={value}
-        onPresetsChange={handlePresetClick}
-        selectedPresetId={selectedPresetId}
-        onSelectPreset={handleSelectPreset}
-        editablePresetIds={editablePresetIds}
-        onEditPreset={onEditPreset}
-        presetActionState={presetActionState}
-        onPresetAction={onPresetAction}
-      />
+      // The presets row is non-critical chrome: if it throws while rendering,
+      // hide it instead of unmounting the whole collection (and its fetching)
+      <RenderErrorBoundary
+        onError={(error) =>
+          console.error(
+            "[f0-react] FiltersPresets failed to render; hiding the presets row",
+            error
+          )
+        }
+      >
+        <FiltersPresetsComponent
+          presets={presets}
+          presetsLoading={presetsLoading}
+          value={value}
+          onPresetsChange={handlePresetClick}
+          selectedPresetId={selectedPresetId}
+          onSelectPreset={handleSelectPreset}
+          editablePresetIds={editablePresetIds}
+          onEditPreset={onEditPreset}
+          presetActionState={presetActionState}
+          onPresetAction={onPresetAction}
+        />
+      </RenderErrorBoundary>
     )
   )
 }

--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersPresets.test.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersPresets.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import "@testing-library/jest-dom/vitest"
 import { screen, userEvent, zeroRender } from "@/testing/test-utils"
 
@@ -482,5 +482,80 @@ describe("FiltersPresets - groups, separator and save chip", () => {
     expect(
       screen.queryByRole("button", { name: "Save view" })
     ).not.toBeInTheDocument()
+  })
+})
+
+describe("FiltersPresets - Loading transition", () => {
+  // OverflowList commits its visible/overflow split after render, so the
+  // loading→loaded flip produces one render where the new callbacks could see
+  // the numeric skeleton items. Regression for the f0-react 2.50.0 crash:
+  // "Cannot read properties of undefined (reading 'itemsCount')".
+  const CONTAINER_WIDTH = 800
+  const ITEM_WIDTH = 50
+
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      get() {
+        return CONTAINER_WIDTH
+      },
+    })
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      width: ITEM_WIDTH,
+      height: 32,
+      top: 0,
+      left: 0,
+      bottom: 32,
+      right: ITEM_WIDTH,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect)
+  })
+
+  afterEach(() => {
+    delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth
+    vi.restoreAllMocks()
+  })
+
+  it("does not crash when presets finish loading after the skeleton phase", () => {
+    const presets: PresetsDefinition<FiltersDefinition> = [
+      {
+        id: "all",
+        label: "All expenses",
+        filter: {},
+        itemsCount: () => 5,
+      },
+      {
+        id: "pending",
+        label: "Pending",
+        filter: { status: ["pending"] },
+        itemsCount: () => 2,
+      },
+    ]
+
+    const { rerender } = zeroRender(
+      <FiltersPresets
+        presets={[]}
+        presetsLoading
+        value={{}}
+        onPresetsChange={vi.fn()}
+        onSelectPreset={vi.fn()}
+      />
+    )
+
+    rerender(
+      <FiltersPresets
+        presets={presets}
+        presetsLoading={false}
+        value={{}}
+        onPresetsChange={vi.fn()}
+        onSelectPreset={vi.fn()}
+        selectedPresetId="all"
+      />
+    )
+
+    expect(getVisibleByText("All expenses")).toBeInTheDocument()
+    expect(getVisibleByText("Pending")).toBeInTheDocument()
   })
 })

--- a/packages/react/src/ui/OverflowList/index.test.tsx
+++ b/packages/react/src/ui/OverflowList/index.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { OverflowList } from "."
+
+type RowItem = { preset: { label: string } }
+
+const CONTAINER_WIDTH = 800
+const ITEM_WIDTH = 50
+
+/**
+ * jsdom reports zero for all layout measurements, which keeps every item out
+ * of the visible list. Give the container and items real widths so the
+ * overflow calculation commits a non-empty split.
+ */
+function mockLayout() {
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return CONTAINER_WIDTH
+    },
+  })
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+    width: ITEM_WIDTH,
+    height: 32,
+    top: 0,
+    left: 0,
+    bottom: 32,
+    right: ITEM_WIDTH,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect)
+}
+
+const renderSkeleton = (item: number) => <span>skeleton-{item}</span>
+const renderRow = (item: RowItem) => <span>{item.preset.label}</span>
+
+describe("OverflowList", () => {
+  beforeEach(() => {
+    mockLayout()
+  })
+
+  afterEach(() => {
+    delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth
+    vi.restoreAllMocks()
+  })
+
+  it("renders the current items after a type-changing rerender (loading skeletons → content)", () => {
+    const { rerender } = zeroRender(
+      <OverflowList
+        items={[0, 1, 2, 3]}
+        renderListItem={renderSkeleton}
+        renderDropdownItem={renderSkeleton}
+      />
+    )
+
+    // The calculation effect has committed a split of the numeric items.
+    // Swapping to object items at the same tree position must never render
+    // the stale numbers through the new render callbacks (regression: crashed
+    // with "Cannot read properties of undefined (reading 'itemsCount')" in
+    // FiltersPresets when presets finished loading).
+    const rows: RowItem[] = [
+      { preset: { label: "First" } },
+      { preset: { label: "Second" } },
+    ]
+    rerender(
+      <OverflowList
+        items={rows}
+        renderListItem={renderRow}
+        renderDropdownItem={renderRow}
+      />
+    )
+
+    expect(screen.getAllByText("First").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Second").length).toBeGreaterThan(0)
+    expect(screen.queryByText("skeleton-0")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing when items becomes empty", () => {
+    const rows: RowItem[] = [{ preset: { label: "First" } }]
+    const { rerender } = zeroRender(
+      <OverflowList
+        items={rows}
+        renderListItem={renderRow}
+        renderDropdownItem={renderRow}
+      />
+    )
+    expect(screen.getAllByText("First").length).toBeGreaterThan(0)
+
+    rerender(
+      <OverflowList
+        items={[] as RowItem[]}
+        renderListItem={renderRow}
+        renderDropdownItem={renderRow}
+      />
+    )
+    expect(screen.queryByText("First")).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
+++ b/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useResizeObserver } from "usehooks-ts"
 
 // Hysteresis margin (px): once items overflow, require this much extra space
@@ -34,14 +34,12 @@ export function useOverflowCalculation<T>(
   const measurementContainerRef = useRef<HTMLDivElement>(null)
   const prevVisibleCountRef = useRef<number | null>(null)
 
-  // Combined state for visible and overflow items
-  const [itemsState, setItemsState] = useState<{
-    visibleItems: T[]
-    overflowItems: T[]
-  }>({
-    visibleItems: [],
-    overflowItems: [],
-  })
+  // Split point between visible and overflow items. Stored as a count — not
+  // the item arrays — so renders always slice the current `items` prop and a
+  // changed prop can never be paired with items from a previous list (the
+  // recalculation effect runs after render). `null` until the first
+  // calculation completes.
+  const [visibleCount, setVisibleCount] = useState<number | null>(null)
 
   // Track initialization
   const [isInitialized, setIsInitialized] = useState(false)
@@ -104,12 +102,7 @@ export function useOverflowCalculation<T>(
   // Calculate which items should be visible and which should overflow
   const calculateVisibleItems = useCallback(() => {
     if (items.length === 0) {
-      setItemsState((prev) => {
-        if (prev.visibleItems.length === 0 && prev.overflowItems.length === 0) {
-          return prev
-        }
-        return { visibleItems: [], overflowItems: [] }
-      })
+      // Derived slices are empty for an empty list regardless of the count
       return
     }
 
@@ -125,56 +118,51 @@ export function useOverflowCalculation<T>(
 
     // Always reserve overflow button width upfront so items drop one at a time
     const reservedWidth = currentContainerWidth - overflowButtonWidth - gap
-    let visibleCount = calculateVisibleItemCount({
+    let nextVisibleCount = calculateVisibleItemCount({
       itemWidths: itemWidthsWithGap,
       availableWidth: reservedWidth,
     })
 
     // If all items fit even with the reserved space, show them all without the button
     if (
-      visibleCount >= items.length &&
+      nextVisibleCount >= items.length &&
       (options?.max === undefined || items.length <= options.max)
     ) {
-      visibleCount = calculateVisibleItemCount({
+      nextVisibleCount = calculateVisibleItemCount({
         itemWidths: itemWidthsWithGap,
         availableWidth: currentContainerWidth,
       })
     }
 
     const effectiveWidth =
-      visibleCount >= items.length ? currentContainerWidth : reservedWidth
+      nextVisibleCount >= items.length ? currentContainerWidth : reservedWidth
 
     // Hysteresis: require extra margin before showing more items.
     // Absorbs ~17px oscillation from scrollbar appearing/disappearing.
     const prev = prevVisibleCountRef.current
-    if (prev !== null && visibleCount > prev) {
+    if (prev !== null && nextVisibleCount > prev) {
       const countWithMargin = calculateVisibleItemCount({
         itemWidths: itemWidthsWithGap,
         availableWidth: effectiveWidth - HYSTERESIS_PX,
       })
-      if (countWithMargin < visibleCount) {
-        visibleCount = Math.max(countWithMargin, prev)
+      if (countWithMargin < nextVisibleCount) {
+        nextVisibleCount = Math.max(countWithMargin, prev)
       }
     }
-    prevVisibleCountRef.current = visibleCount
+    prevVisibleCountRef.current = nextVisibleCount
 
-    let visibleItems = visibleCount === 0 ? [] : items.slice(0, visibleCount)
-    let overflowItems = visibleCount === 0 ? items : items.slice(visibleCount)
-
+    // A single overflow item whose width matches the overflow button can be
+    // shown directly instead of collapsing behind the indicator
     if (
-      overflowItems.length === 1 &&
-      !!visibleItems.length &&
+      items.length - nextVisibleCount === 1 &&
+      nextVisibleCount > 0 &&
       itemWidths.length > 0 &&
       overflowButtonWidth === itemWidths[itemWidths.length - 1] - gap
     ) {
-      visibleItems = items
-      overflowItems = []
+      nextVisibleCount = items.length
     }
 
-    setItemsState({
-      visibleItems,
-      overflowItems,
-    })
+    setVisibleCount(nextVisibleCount)
   }, [items, gap, measureItemWidths, calculateVisibleItemCount, options?.max])
 
   // Reset hysteresis when the number of items changes
@@ -191,13 +179,25 @@ export function useOverflowCalculation<T>(
     setIsInitialized(true)
   }, [])
 
+  // Slice the current items on every render so the split is always applied to
+  // the latest `items` prop, even before the recalculation effect runs
+  const { visibleItems, overflowItems } = useMemo(() => {
+    if (visibleCount === null) {
+      return { visibleItems: [] as T[], overflowItems: [] as T[] }
+    }
+    return {
+      visibleItems: items.slice(0, visibleCount),
+      overflowItems: items.slice(visibleCount),
+    }
+  }, [items, visibleCount])
+
   return {
     containerRef,
     overflowButtonRef,
     customOverflowIndicatorRef,
     measurementContainerRef,
-    visibleItems: itemsState.visibleItems,
-    overflowItems: itemsState.overflowItems,
+    visibleItems,
+    overflowItems,
     isInitialized,
   }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Released as hotfix [`f0-react@2.61.2`](https://github.com/factorialco/f0/releases/tag/f0-react-v2.61.2)** (release PR [#4423](https://github.com/factorialco/f0/pull/4423)). This crash was making the inbox list/page not show up in production — the render error unmounted the entire data collection — so the fix was shipped immediately as a patch hotfix rather than waiting for the regular release cycle.

## Description

Fixes the production crash `Uncaught TypeError: Cannot read properties of undefined (reading 'itemsCount')` ([Sentry issue](https://factorial.sentry.io/issues/7543674951/?project=101394)) that started crashing data collection pages in factorial after the bump to f0-react ≥ 2.50.0 — e.g. all four expenses views, worked around downstream in [factorial#101693](https://github.com/factorialco/factorial/pull/101693) by hardcoding `presetsLoading: false`.

**Root cause:** `useOverflowCalculation` stored the `visibleItems`/`overflowItems` arrays in React state and only recalculated them in an effect, so a render with a new `items` prop could pair the **new** render callbacks with **items from the previous list**. `FiltersPresets` renders an `OverflowList` with numeric skeleton items (`[0,1,2,3]`) while `presetsLoading` and preset row objects when loaded — at the same tree position, so React reuses the instance and the stale numbers reach the preset renderers for one render. This was latent until #4344 changed the item shape from the preset itself to a `{ kind, preset, presetId }` wrapper: `(2).itemsCount?.()` was harmless, but destructuring `preset` out of a stale number yields `undefined`, and `preset.itemsCount` throws. Since the crash propagated past `OneFilterPicker`, it unmounted the entire data collection — rendering and fetching included.

## Implementation details

Two layers, one commit each:

**1. Root-cause fix (`useOverflowCalculation`)**
Store the visible/overflow split as a **count** (`visibleCount: number | null`) instead of the item arrays, and derive both arrays by slicing the live `items` prop at render time. A changed prop can never be paired with items from a previous list, which kills the whole bug class (any `OverflowList` whose items change shape, not just presets). The empty-items special case from #3794 falls out naturally, and `ButtonGroup` — the other consumer of the hook — gets the same protection for free.

**2. Defense in depth (`OneFilterPicker`)**
The presets row is non-critical chrome, so it is now wrapped in a new internal `RenderErrorBoundary` (not part of the public API): if `FiltersPresets` ever throws during render again, the row is hidden and the error logged (`[f0-react] FiltersPresets failed to render; hiding the presets row`), while the collection keeps rendering and fetching.

### Tests

- `OverflowList` regression test: type-changing rerender (numeric skeletons → object rows) at the same tree position. Fails on the old hook with the stale-items TypeError.
- `FiltersPresets` regression test mirroring production: `presetsLoading` flips to false with `itemsCount` presets. Fails on the old hook with the **exact Sentry error** (`reading 'itemsCount'`) — this is the upstream regression test factorial#101693 deferred to f0.
- `OneDataCollection` resilience test: a preset whose `itemsCount` throws during render — the collection still fetches and renders rows, the presets row degrades to nothing, and the degradation is logged. Fails without the boundary (the crash unmounts the collection).

All consumer suites pass (`OverflowList`, `ButtonGroup`, `OneFilterPicker`, `F0Card`, `OneDataCollection` presets, API-surface check).

Once released, the downstream `presetsLoading: false` workarounds (factorial#101693 and copies) can be reverted to restore the presets loading skeletons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
