### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.61.1",
+  "packages/react": "2.61.2",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.61.2](https://github.com/factorialco/f0/compare/f0-react-v2.61.1...f0-react-v2.61.2) (2026-06-11)
+
+
+### Bug Fixes
+
+* **OverflowList:** never render stale items across an items-prop change ([#4422](https://github.com/factorialco/f0/issues/4422)) ([25b9366](https://github.com/factorialco/f0/commit/25b9366162565bc1898b8a7474fd92e72c96cea2))
+
 ## [2.61.1](https://github.com/factorialco/f0/compare/f0-react-v2.61.0...f0-react-v2.61.1) (2026-06-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.61.1",
+  "version": "2.61.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.61.2</summary>

## [2.61.2](https://github.com/factorialco/f0/compare/f0-react-v2.61.1...f0-react-v2.61.2) (2026-06-11)


### Bug Fixes

* **OverflowList:** never render stale items across an items-prop change ([#4422](https://github.com/factorialco/f0/issues/4422)) ([25b9366](https://github.com/factorialco/f0/commit/25b9366162565bc1898b8a7474fd92e72c96cea2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).