### PR TITLE
feat(navigation): id-based callback mode for prev/next arrows

### DIFF
--- a/packages/react/src/experimental/Navigation/Header/PageHeader/__tests__/usePageHeaderItemNavigation.test.ts
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/__tests__/usePageHeaderItemNavigation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { zeroRenderHook } from "@/testing/test-utils"
 
@@ -20,6 +20,10 @@ function makeInput(
     nextItem: { id: 3, name: "Third" },
     previousItemUrl: "/items/1",
     nextItemUrl: "/items/3",
+    hasPrevious: true,
+    hasNext: true,
+    goToPrevious: () => {},
+    goToNext: () => {},
     ...overrides,
   }
 }
@@ -92,9 +96,58 @@ describe("usePageHeaderItemNavigation", () => {
           nextItem: null,
           previousItemUrl: null,
           nextItemUrl: null,
+          hasPrevious: false,
+          hasNext: false,
         })
       )
     )
     expect(result.current).toBeNull()
+  })
+
+  describe("callback mode", () => {
+    it("wires onClick to goToPrevious/goToNext and omits urls", () => {
+      const goToPrevious = vi.fn()
+      const goToNext = vi.fn()
+      const { result } = zeroRenderHook(() =>
+        usePageHeaderItemNavigation(makeInput({ goToPrevious, goToNext }), {
+          mode: "callback",
+        })
+      )
+
+      expect(result.current?.previous?.url).toBeUndefined()
+      expect(result.current?.next?.url).toBeUndefined()
+
+      result.current?.previous?.onClick?.()
+      result.current?.next?.onClick?.()
+      expect(goToPrevious).toHaveBeenCalledTimes(1)
+      expect(goToNext).toHaveBeenCalledTimes(1)
+
+      // Counter unchanged from url mode
+      expect(result.current?.counter).toEqual({ current: 2, total: 10 })
+    })
+
+    it("gates arrow presence on hasPrevious/hasNext, not on urls", () => {
+      const { result } = zeroRenderHook(() =>
+        usePageHeaderItemNavigation(
+          // URLs present but hasPrevious false → no previous arrow in callback
+          // mode; hasNext true → next arrow despite this being callback-driven
+          makeInput({ hasPrevious: false, hasNext: true }),
+          { mode: "callback" }
+        )
+      )
+      expect(result.current?.previous).toBeUndefined()
+      expect(result.current?.next?.onClick).toBeTypeOf("function")
+    })
+
+    it("still uses getItemTitle for the arrow titles", () => {
+      const { result } = zeroRenderHook(() =>
+        usePageHeaderItemNavigation(makeInput(), {
+          mode: "callback",
+          getItemTitle: (item) => item.name,
+        })
+      )
+      expect(result.current?.previous?.title).toBe("First")
+      expect(result.current?.next?.title).toBe("Third")
+    })
   })
 })

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/usePageHeaderItemNavigation.ts
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/usePageHeaderItemNavigation.ts
@@ -16,6 +16,10 @@ export type PageHeaderItemNavigationInput<R extends RecordType> = Pick<
   | "absoluteIndex"
   | "totalItems"
   | "activeIndex"
+  | "hasPrevious"
+  | "hasNext"
+  | "goToPrevious"
+  | "goToNext"
 >
 
 export interface UsePageHeaderItemNavigationConfig<R extends RecordType> {
@@ -24,26 +28,39 @@ export interface UsePageHeaderItemNavigationConfig<R extends RecordType> {
    * accessible label on the prev/next buttons.
    */
   getItemTitle?: (item: R) => string
+  /**
+   * How the prev/next arrows navigate:
+   * - `"url"` (default): each arrow is a link to the item's `itemUrl` — for
+   *   full-page detail views where navigation changes the route.
+   * - `"callback"`: each arrow calls `goToPrevious`/`goToNext`, swapping the
+   *   active item in place — for a mounted sidepanel/dialog that never
+   *   changes the URL. Presence is gated by `hasPrevious`/`hasNext`.
+   * @default "url"
+   */
+  mode?: "url" | "callback"
 }
 
 /**
  * Converts an item-navigation result into the `NavigationProps` shape that
- * `PageHeader` accepts (directly or via `PageHeaderNavigationProvider`).
+ * `PageHeader` and `F0Dialog` accept (directly or via
+ * `PageHeaderNavigationProvider`).
  *
- * URLs are read from `previousItemUrl` / `nextItemUrl`, which are computed by
- * the `itemUrl` option on the navigation hook. A null URL omits that link
- * (the button renders disabled). The counter is included only when both the
- * absolute position and the total are known — never a misleading `0/n`.
+ * In `"url"` mode (default) the arrows are links to `previousItemUrl` /
+ * `nextItemUrl` (computed from the hook's `itemUrl`); a null URL omits that
+ * arrow. In `"callback"` mode the arrows call `goToPrevious`/`goToNext` and
+ * presence is gated by `hasPrevious`/`hasNext` — for in-place navigation that
+ * never touches the URL. The counter is included only when both the absolute
+ * position and the total are known — never a misleading `0/n`.
  *
- * Returns null when there is nothing useful to render (no input, or the
- * active item could not be located and no total is known), so it can be
- * passed straight to `PageHeaderNavigationProvider`.
+ * Returns null when there is nothing useful to render, so it can be passed
+ * straight to `PageHeaderNavigationProvider`.
  */
 export function usePageHeaderItemNavigation<R extends RecordType>(
   nav: PageHeaderItemNavigationInput<R> | null,
   config?: UsePageHeaderItemNavigationConfig<R>
 ): NavigationProps | null {
   const getItemTitle = config?.getItemTitle
+  const mode = config?.mode ?? "url"
 
   // Field-level memo deps keep the returned object identity stable across
   // re-renders that don't change the navigation state, so it can be passed
@@ -55,6 +72,10 @@ export function usePageHeaderItemNavigation<R extends RecordType>(
   const nextItemUrl = nav?.nextItemUrl ?? null
   const absoluteIndex = nav?.absoluteIndex ?? null
   const totalItems = nav?.totalItems
+  const hasPrevious = nav?.hasPrevious ?? false
+  const hasNext = nav?.hasNext ?? false
+  const goToPrevious = nav?.goToPrevious
+  const goToNext = nav?.goToNext
 
   return useMemo(() => {
     if (!hasInput) return null
@@ -64,38 +85,45 @@ export function usePageHeaderItemNavigation<R extends RecordType>(
         ? { current: absoluteIndex + 1, total: totalItems }
         : undefined
 
+    const title = (item: R | null, fallback: string) =>
+      (item !== null ? getItemTitle?.(item) : undefined) ?? fallback
+
+    // In callback mode an arrow exists whenever the controller says it can
+    // move that way; in url mode it exists only when a URL is resolvable.
     const previous =
-      previousItemUrl !== null
-        ? {
-            url: previousItemUrl,
-            title:
-              (previousItem !== null
-                ? getItemTitle?.(previousItem)
-                : undefined) ?? "Previous",
-          }
-        : undefined
+      mode === "callback"
+        ? hasPrevious
+          ? { onClick: goToPrevious, title: title(previousItem, "Previous") }
+          : undefined
+        : previousItemUrl !== null
+          ? { url: previousItemUrl, title: title(previousItem, "Previous") }
+          : undefined
 
     const next =
-      nextItemUrl !== null
-        ? {
-            url: nextItemUrl,
-            title:
-              (nextItem !== null ? getItemTitle?.(nextItem) : undefined) ??
-              "Next",
-          }
-        : undefined
+      mode === "callback"
+        ? hasNext
+          ? { onClick: goToNext, title: title(nextItem, "Next") }
+          : undefined
+        : nextItemUrl !== null
+          ? { url: nextItemUrl, title: title(nextItem, "Next") }
+          : undefined
 
     if (!previous && !next && !counter) return null
 
     return { previous, next, counter }
   }, [
     hasInput,
+    mode,
     previousItem,
     nextItem,
     previousItemUrl,
     nextItemUrl,
     absoluteIndex,
     totalItems,
+    hasPrevious,
+    hasNext,
+    goToPrevious,
+    goToNext,
     getItemTitle,
   ])
 }

--- a/packages/react/src/experimental/Navigation/Header/PageNavigation/__tests__/PageNavigation.test.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageNavigation/__tests__/PageNavigation.test.tsx
@@ -1,0 +1,54 @@
+import { screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { userEvent, zeroRender as render } from "@/testing/test-utils"
+
+import { PageNavigation } from "../index"
+
+describe("PageNavigation", () => {
+  it("renders the counter", () => {
+    render(<PageNavigation counter={{ current: 2, total: 10 }} />)
+    expect(screen.getByText("2/10")).toBeInTheDocument()
+  })
+
+  it("renders a link for a url target", () => {
+    render(<PageNavigation next={{ url: "/items/3", title: "Third" }} />)
+    const next = screen.getByRole("link", { name: "Third" })
+    expect(next).toHaveAttribute("href", "/items/3")
+  })
+
+  it("renders a button (no href) and fires onClick for a callback target", async () => {
+    const onClick = vi.fn()
+    render(<PageNavigation next={{ onClick, title: "Third" }} />)
+
+    const next = screen.getByRole("button", { name: "Third" })
+    expect(next).not.toHaveAttribute("href")
+
+    await userEvent.click(next)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("prefers onClick over url when both are present", async () => {
+    const onClick = vi.fn()
+    render(
+      <PageNavigation next={{ onClick, url: "/items/3", title: "Third" }} />
+    )
+    const next = screen.getByRole("button", { name: "Third" })
+    expect(next).not.toHaveAttribute("href")
+    await userEvent.click(next)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders both arrows disabled with no tooltip when targets are absent", () => {
+    render(<PageNavigation counter={{ current: 1, total: 5 }} />)
+    // A disabled arrow renders a non-interactive span (aria-disabled), not a
+    // link/button, and carries no native title (no "no-op" tooltip).
+    const previous = screen.getByLabelText("Previous")
+    const next = screen.getByLabelText("Next")
+    expect(previous).toHaveAttribute("aria-disabled", "true")
+    expect(next).toHaveAttribute("aria-disabled", "true")
+    expect(previous).not.toHaveAttribute("href")
+    expect(previous).not.toHaveAttribute("title")
+    expect(next).not.toHaveAttribute("title")
+  })
+})

--- a/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
@@ -2,15 +2,21 @@ import { ButtonInternal } from "@/components/F0Button/internal"
 import { IconType } from "@/components/F0Icon"
 import { ChevronDown, ChevronUp } from "@/icons/app"
 
+/**
+ * One prev/next target. Carry a `url` for full-page detail navigation
+ * (renders a link) OR an `onClick` for id-based navigation that swaps content
+ * in place — a mounted sidepanel/dialog that never changes the URL (renders a
+ * button). `onClick` wins when both are present.
+ */
+export type NavigationTarget = {
+  title: string
+  url?: string
+  onClick?: () => void
+}
+
 export type NavigationProps = {
-  previous?: {
-    url: string
-    title: string
-  }
-  next?: {
-    url: string
-    title: string
-  }
+  previous?: NavigationTarget
+  next?: NavigationTarget
   counter?: {
     current: number
     total: number
@@ -19,18 +25,33 @@ export type NavigationProps = {
 
 function PageNavigationLink({
   icon,
-  href,
-  label,
-  disabled,
+  target,
+  fallbackLabel,
 }: {
   icon: IconType
-  href: string
-  label: string
-  disabled?: boolean
+  target: NavigationTarget | undefined
+  fallbackLabel: string
 }) {
+  // No target → no previous/next element → disabled, no affordance.
+  const disabled = !target
+  const label = target?.title || fallbackLabel
+  // Prefer the id-based callback over a URL when both are provided.
+  const onClick = target?.onClick
+  const href = onClick ? undefined : target?.url
+
+  // `ButtonInternal` chooses anchor vs button by whether the `href` *key* is
+  // present. An enabled callback target renders as a button (so onClick
+  // fires); url and disabled targets stay on the link path — the disabled
+  // link renders a <span aria-disabled> that picks up the shared disabled
+  // styling (opacity + pointer-events-none). `type: "button"` keeps the
+  // callback arrow from submitting a surrounding form (e.g. a dialog body).
+  const elementProps = onClick
+    ? { onClick, type: "button" as const }
+    : { href: href ?? "" }
+
   return (
     <ButtonInternal
-      href={href}
+      {...elementProps}
       title={disabled ? undefined : label}
       aria-label={label}
       disabled={disabled}
@@ -58,15 +79,13 @@ export function PageNavigation({ previous, next, counter }: NavigationProps) {
       <div className="flex items-center gap-2">
         <PageNavigationLink
           icon={ChevronUp}
-          label={previous?.title || "Previous"}
-          href={previous?.url || ""}
-          disabled={!previous}
+          target={previous}
+          fallbackLabel="Previous"
         />
         <PageNavigationLink
           icon={ChevronDown}
-          label={next?.title || "Next"}
-          href={next?.url || ""}
-          disabled={!next}
+          target={next}
+          fallbackLabel="Next"
         />
       </div>
     </div>

--- a/packages/react/src/experimental/Navigation/Header/index.mdx
+++ b/packages/react/src/experimental/Navigation/Header/index.mdx
@@ -246,6 +246,12 @@ demonstrates all of it together.
   `controls={{ kind: "resource", navigation }}` and drive `activeItemId` from
   `onActiveItemChange`. See `Dialog` → _WithMountedSidepanelNavigation_.
 
+For the mounted-dialog case, pair callback arrows with an "Open detail"
+escape hatch: feed `F0Dialog`'s `controls.expand` a `url` set to the hook's
+`activeItemUrl` (derived from the source's `itemUrl`). In-place arrows browse
+the set; the expand link jumps to the item's full-page view and is
+cmd/middle-clickable.
+
 <div
   className="header-container"
   style={{

--- a/packages/react/src/experimental/Navigation/Header/index.mdx
+++ b/packages/react/src/experimental/Navigation/Header/index.mdx
@@ -234,6 +234,18 @@ including deep direct links — resolve their neighbors backend-side, so the
 arrows behave as if the whole filtered set were loaded. The story below
 demonstrates all of it together.
 
+`useDataCollectionItemNavigation` exposes the arrows in two modes via
+`navigationMode`, both producing the same `NavigationProps` contract:
+
+- **`"url"`** (default) — each arrow is a link to the item's `itemUrl`. Use it
+  for full-page detail views where prev/next changes the route (the PageHeader
+  story above).
+- **`"callback"`** — each arrow calls `goToPrevious`/`goToNext`, swapping the
+  active item **in place with no URL change**. Use it for a mounted
+  sidepanel/dialog: pass the result to `F0Dialog`'s
+  `controls={{ kind: "resource", navigation }}` and drive `activeItemId` from
+  `onActiveItemChange`. See `Dialog` → _WithMountedSidepanelNavigation_.
+
 <div
   className="header-container"
   style={{

--- a/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
+++ b/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
@@ -24,6 +24,9 @@ import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
 import { ActivityItemList } from "@/sds/inbox/Activity/ActivityItemList"
 import { Default as ActivityItemListDefault } from "@/sds/inbox/Activity/ActivityItemList/index.stories"
 
+import { PaginatedFetchOptions } from "@/hooks/datasource"
+import { useDataCollectionItemNavigation } from "@/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation"
+
 import { F0Dialog } from "../index"
 import { dialogPositions, dialogWidths } from "../types"
 
@@ -414,6 +417,98 @@ export const WithResourceHeaderAndFullscreenPosition: Story = {
     ...WithResourceHeader.args,
     position: "fullscreen",
   },
+}
+
+/**
+ * Mounted-sidepanel navigation driven by `useDataCollectionItemNavigation` in
+ * **callback mode**. The list on the left stays mounted; opening a row sets an
+ * active id and the dialog shows that record. The header's
+ * `controls={{ kind: "resource", navigation }}` is fed the hook's render-ready
+ * `navigation` — but because the hook runs with `navigationMode: "callback"`,
+ * the prev/next arrows call `goToPrevious`/`goToNext` and swap the active item
+ * **in place, with no URL change / no remount** (the same `NavigationProps`
+ * contract PageHeader uses in url mode). The `current/total` counter still
+ * comes from the collection.
+ */
+const SIDEPANEL_EMPLOYEES = Array.from({ length: 8 }, (_, i) => ({
+  id: `${i + 1}`,
+  name: `Employee ${i + 1}`,
+  role: i % 2 === 0 ? "Engineer" : "Designer",
+}))
+
+const SIDEPANEL_COLLECTION_ID = "storybook/dialog-sidepanel-employees/v1"
+
+const sidepanelSource = {
+  // One declared page holds the whole set, so navigation resolves entirely
+  // from the loaded window — the focus here is the callback arrows, not the
+  // neighbors fallback (covered by the PageHeader story).
+  dataAdapter: {
+    paginationType: "pages" as const,
+    perPage: 50,
+    fetchData: (_options: PaginatedFetchOptions<Record<string, never>>) => ({
+      type: "pages" as const,
+      records: SIDEPANEL_EMPLOYEES,
+      total: SIDEPANEL_EMPLOYEES.length,
+      perPage: 50,
+      currentPage: 1,
+      pagesCount: 1,
+    }),
+  },
+}
+
+const MountedSidepanelDemo = (args: ComponentProps<typeof F0Dialog>) => {
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const { navigation } = useDataCollectionItemNavigation({
+    source: sidepanelSource,
+    collectionId: SIDEPANEL_COLLECTION_ID,
+    activeItemId: activeId,
+    navigationMode: "callback",
+    onActiveItemChange: (id) => setActiveId(id === null ? null : String(id)),
+    getItemTitle: (employee) => String(employee.name),
+  })
+
+  const activeEmployee = SIDEPANEL_EMPLOYEES.find((e) => e.id === activeId)
+
+  return (
+    <div className="flex flex-col gap-2 p-4">
+      <span className="text-sm text-f1-foreground-secondary">
+        The list stays mounted; arrows in the panel navigate by id without
+        changing the URL.
+      </span>
+      {SIDEPANEL_EMPLOYEES.map((employee) => (
+        <F0Button
+          key={employee.id}
+          variant="outline"
+          label={`${employee.name} — ${employee.role}`}
+          onClick={() => setActiveId(employee.id)}
+        />
+      ))}
+      <F0Dialog
+        {...args}
+        isOpen={activeId !== null}
+        onClose={() => setActiveId(null)}
+        title={activeEmployee?.name ?? "Employee"}
+        controls={{ kind: "resource", navigation: navigation ?? undefined }}
+      >
+        <div className="flex flex-col gap-2 p-4">
+          <div className="text-lg font-semibold text-f1-foreground">
+            {activeEmployee?.name}
+          </div>
+          <div className="text-base text-f1-foreground-secondary">
+            {activeEmployee?.role}
+          </div>
+        </div>
+      </F0Dialog>
+    </div>
+  )
+}
+
+export const WithMountedSidepanelNavigation: Story = {
+  args: {
+    position: "right",
+  },
+  render: (args) => <MountedSidepanelDemo {...args} />,
 }
 
 export const WithFewItems: Story = {

--- a/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
+++ b/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
@@ -24,7 +24,7 @@ import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
 import { ActivityItemList } from "@/sds/inbox/Activity/ActivityItemList"
 import { Default as ActivityItemListDefault } from "@/sds/inbox/Activity/ActivityItemList/index.stories"
 
-import { PaginatedFetchOptions } from "@/hooks/datasource"
+import { PaginatedFetchOptions, RecordType } from "@/hooks/datasource"
 import { useDataCollectionItemNavigation } from "@/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation"
 
 import { F0Dialog } from "../index"
@@ -429,6 +429,10 @@ export const WithResourceHeaderAndFullscreenPosition: Story = {
  * **in place, with no URL change / no remount** (the same `NavigationProps`
  * contract PageHeader uses in url mode). The `current/total` counter still
  * comes from the collection.
+ *
+ * The "Open detail" expand button is a real link to the active item's
+ * `itemUrl` (the hook's `activeItemUrl`): in-place arrows for browsing,
+ * `expand` to jump to the full-page view (cmd/middle-clickable).
  */
 const SIDEPANEL_EMPLOYEES = Array.from({ length: 8 }, (_, i) => ({
   id: `${i + 1}`,
@@ -439,6 +443,9 @@ const SIDEPANEL_EMPLOYEES = Array.from({ length: 8 }, (_, i) => ({
 const SIDEPANEL_COLLECTION_ID = "storybook/dialog-sidepanel-employees/v1"
 
 const sidepanelSource = {
+  // `itemUrl` powers the "Open detail" expand link (full-page view), while
+  // the arrows navigate in place — both derived from the same declaration.
+  itemUrl: (employee: RecordType) => `#/employees/${employee.id}`,
   // One declared page holds the whole set, so navigation resolves entirely
   // from the loaded window — the focus here is the callback arrows, not the
   // neighbors fallback (covered by the PageHeader story).
@@ -459,7 +466,7 @@ const sidepanelSource = {
 const MountedSidepanelDemo = (args: ComponentProps<typeof F0Dialog>) => {
   const [activeId, setActiveId] = useState<string | null>(null)
 
-  const { navigation } = useDataCollectionItemNavigation({
+  const { navigation, activeItemUrl } = useDataCollectionItemNavigation({
     source: sidepanelSource,
     collectionId: SIDEPANEL_COLLECTION_ID,
     activeItemId: activeId,
@@ -489,7 +496,13 @@ const MountedSidepanelDemo = (args: ComponentProps<typeof F0Dialog>) => {
         isOpen={activeId !== null}
         onClose={() => setActiveId(null)}
         title={activeEmployee?.name ?? "Employee"}
-        controls={{ kind: "resource", navigation: navigation ?? undefined }}
+        controls={{
+          kind: "resource",
+          expand: activeItemUrl
+            ? { label: "Open detail", url: activeItemUrl }
+            : undefined,
+          navigation: navigation ?? undefined,
+        }}
       >
         <div className="flex flex-col gap-2 p-4">
           <div className="text-lg font-semibold text-f1-foreground">

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
@@ -126,14 +126,22 @@ export const F0DialogHeader = ({
 
     return (
       <>
-        {controls.expand && (
-          <ButtonInternal
-            variant="outline"
-            icon={Maximize}
-            onClick={controls.expand.onClick}
-            label={controls.expand.label}
-          />
-        )}
+        {controls.expand &&
+          (controls.expand.url !== undefined ? (
+            <ButtonInternal
+              variant="outline"
+              icon={Maximize}
+              href={controls.expand.url}
+              label={controls.expand.label}
+            />
+          ) : (
+            <ButtonInternal
+              variant="outline"
+              icon={Maximize}
+              onClick={controls.expand.onClick}
+              label={controls.expand.label}
+            />
+          ))}
         {controls.expand && controls.navigation && <Divider />}
         {controls.navigation && <PageNavigation {...controls.navigation} />}
       </>

--- a/packages/react/src/patterns/F0Dialog/types.ts
+++ b/packages/react/src/patterns/F0Dialog/types.ts
@@ -53,7 +53,14 @@ export type F0DialogActionsProps = {
 export type DialogControls =
   | {
       kind: "resource"
-      expand?: { label: string; onClick: () => void }
+      /**
+       * "Open detail" affordance. Provide `url` to render a link to the
+       * resource's full-page view (routed through the app's `LinkProvider`,
+       * so it is cmd/middle-clickable) — typically the active item's
+       * `itemUrl` from `useDataCollectionItemNavigation`. Provide `onClick`
+       * for imperative expansion. `url` wins when both are set.
+       */
+      expand?: { label: string; url?: string; onClick?: () => void }
       navigation?: NavigationProps
     }
   | {

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__tests__/useDataCollectionItemNavigation.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__tests__/useDataCollectionItemNavigation.test.tsx
@@ -297,6 +297,62 @@ describe("useDataCollectionItemNavigation", () => {
     })
   })
 
+  describe("callback navigation mode", () => {
+    it("exposes onClick arrows (no urls) that advance the active item in-window", async () => {
+      const fetchData = makeFetchData()
+      const onActiveItemChange = vi.fn()
+
+      const { result } = zeroRenderHook(() =>
+        useDataCollectionItemNavigation({
+          source: makeSource(fetchData),
+          collectionId: "test/items/v1",
+          defaultActiveItemId: 2,
+          navigationMode: "callback",
+          onActiveItemChange,
+        })
+      )
+
+      await waitFor(() => expect(result.current.navigation).not.toBeNull())
+
+      // Callback mode: onClick handlers, no urls
+      expect(result.current.navigation?.next?.url).toBeUndefined()
+      expect(result.current.navigation?.previous?.url).toBeUndefined()
+      expect(result.current.navigation?.counter).toEqual({
+        current: 2,
+        total: 25,
+      })
+
+      result.current.navigation?.next?.onClick?.()
+      await waitFor(() => expect(result.current.activeItemId).toBe(3))
+      expect(onActiveItemChange).toHaveBeenCalledWith(3)
+    })
+
+    it("advances off-window via the neighbors fallback", async () => {
+      const fetchData = makeFetchData()
+      const fetchItemNeighbors = makeFetchItemNeighbors()
+
+      const { result } = zeroRenderHook(() =>
+        useDataCollectionItemNavigation({
+          source: makeSource(fetchData, fetchItemNeighbors),
+          collectionId: "test/items/v1",
+          // Item 15 lives on page 2 — resolved id-relatively
+          defaultActiveItemId: 15,
+          navigationMode: "callback",
+        })
+      )
+
+      await waitFor(() => expect(result.current.navigation).not.toBeNull())
+      expect(result.current.navigation?.next?.url).toBeUndefined()
+      expect(result.current.navigation?.counter).toEqual({
+        current: 15,
+        total: 25,
+      })
+
+      result.current.navigation?.next?.onClick?.()
+      await waitFor(() => expect(result.current.activeItemId).toBe(16))
+    })
+  })
+
   it("degrades gracefully when the active item is not in the loaded window", async () => {
     const fetchData = makeFetchData()
 

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/types.ts
@@ -103,6 +103,16 @@ export interface UseDataCollectionItemNavigationProps<
    */
   currentFilters?: FiltersState<Filters>
   /**
+   * How the returned `navigation` arrows navigate:
+   * - `"url"` (default): links to each item's `itemUrl` — for full-page
+   *   detail views where prev/next changes the route.
+   * - `"callback"`: arrows call the controller's `goToPrevious`/`goToNext`,
+   *   swapping the active item in place with no URL change — for a mounted
+   *   sidepanel/dialog (drive `activeItemId` via `onActiveItemChange`).
+   * @default "url"
+   */
+  navigationMode?: "url" | "callback"
+  /**
    * Forwarded to `useDataCollectionSource` for `dataAdapter` memoization,
    * same convention as `useDataCollectionSource(source, deps)`.
    */

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/useDataCollectionItemNavigation.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/useDataCollectionItemNavigation.ts
@@ -107,6 +107,7 @@ export function useDataCollectionItemNavigation<
     enabled = true,
     restorePersistedState = true,
     currentFilters: currentFiltersOverride,
+    navigationMode = "url",
     deps = [],
   } = props
 
@@ -384,6 +385,7 @@ export function useDataCollectionItemNavigation<
 
   const navigation = usePageHeaderItemNavigation<R>(navigationState, {
     getItemTitle,
+    mode: navigationMode,
   })
 
   // True from the render an off-window gap appears until neighbors resolve —


### PR DESCRIPTION
## Description

`PageNavigation`/`NavigationProps` (the shared prev/next contract reused by `PageHeader` and `F0Dialog`'s resource header, extracted in [#4313](https://github.com/factorialco/f0/pull/4313)) only supported **URL-based** arrows rendered as links. That fits a full-page detail view, but the dialog's own primary use case — a **mounted sidepanel** that swaps content in place by changing the active item id, with no URL change / remount — couldn't be driven by `useDataCollectionItemNavigation` ([#4399](https://github.com/factorialco/f0/pull/4399) / [#4404](https://github.com/factorialco/f0/pull/4404)). This adds an opt-in **callback** navigation mode so the same hook and the same contract power both, and `F0Dialog` lights up with no changes.

## Implementation details

- feat: `NavigationProps` `previous`/`next` become `NavigationTarget = { title; url?; onClick? }` — a `url` renders a link (full-page detail), an `onClick` renders a button that navigates in place (mounted dialog/sidepanel); `onClick` wins when both are set. `url` going optional is additive/widening, so every existing url caller (`PageHeader`, the dialog) is untouched.
- feat: `usePageHeaderItemNavigation` gains `mode: "url" | "callback"`. Callback mode wires `onClick` to `goToPrevious`/`goToNext`, gates arrow presence on `hasPrevious`/`hasNext`, and omits urls; url-mode output is unchanged.
- feat: `useDataCollectionItemNavigation` gains `navigationMode` (default `"url"`), threaded into the projection. The neighbors fallback, no-flicker held navigation, and the counter all keep working in both modes.
- chore: `F0Dialog` callback-mode arrows work through `controls={{ kind: "resource", navigation }}` — `PageNavigation` already spreads `NavigationProps`, so the arrows needed no dialog change.
- feat: `F0Dialog`'s resource-controls `expand` ("Open detail") gains a `url` — it renders a real link to the resource's full-page view (routed through `LinkProvider`, cmd/middle-clickable), fed the active item's `itemUrl` (`activeItemUrl` from the hook). `url` is additive alongside the existing `onClick` (`url` wins; `onClick` becomes optional = widening). In the sidepanel: arrows browse in place, **Open detail** jumps to the full page.
- fix: callback arrows render `type="button"` (no accidental form submission); disabled arrows keep the non-interactive `<span aria-disabled>` styling (opacity, `pointer-events: none`, no tooltip).
- docs: new `WithMountedSidepanelNavigation` Dialog story + a url-vs-callback note in the Header MDX.
- test: new `PageNavigation` suite (button vs link, `onClick` preference, disabled span); `usePageHeaderItemNavigation` callback-mode cases; `useDataCollectionItemNavigation` callback-mode advancing `activeItemId` in-window and off-window (neighbors fallback).

## Verification

`tsc` clean, tests pass across the touched suites, format/lint green. Verified in Storybook: opening a row drives the dialog (3/8, Employee 3); the arrows are `<button>`s (no href) that swap the record in place and update the counter with **no URL change**; the **Open detail** control is an `<a href>` tracking the active item (`#/employees/3` → `#/employees/4` as you navigate); the edge arrow is a disabled non-interactive span (opacity 0.3, `pointer-events: none`, no tooltip). The `NavigationProps` and `expand` changes report as additive/widening (not breaking) under the api-surface checker.
