### PR TITLE
feat(navigation): PaneledNav mega-menu pattern (WIP)

### DIFF
--- a/packages/react/src/patterns/Navigation/PaneledNav/GridGlyph.tsx
+++ b/packages/react/src/patterns/Navigation/PaneledNav/GridGlyph.tsx
@@ -1,0 +1,16 @@
+/**
+ * The 2×2-grid glyph used by the navigation trigger. F0 has no equivalent
+ * grid icon, so it is rendered from four rounded squares that inherit the
+ * trigger's `currentColor` (so it flips to white when the trigger is active).
+ */
+export const GridGlyph = () => (
+  <span
+    aria-hidden="true"
+    className="grid h-4 w-4 grid-cols-2 grid-rows-2 gap-[3px]"
+  >
+    <span className="block rounded-[2px] bg-current" />
+    <span className="block rounded-[2px] bg-current" />
+    <span className="block rounded-[2px] bg-current" />
+    <span className="block rounded-[2px] bg-current" />
+  </span>
+)

--- a/packages/react/src/patterns/Navigation/PaneledNav/PaneledNav.tsx
+++ b/packages/react/src/patterns/Navigation/PaneledNav/PaneledNav.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react"
+
+import { breakpoints } from "@factorialco/f0-core"
+import { useMediaQuery } from "usehooks-ts"
+
+import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
+import { F0Button } from "@/components/F0Button"
+import { F0Icon } from "@/components/F0Icon"
+import { Dropdown } from "@/experimental/Navigation/Dropdown"
+import { Bell } from "@/icons/app"
+import { Link } from "@/lib/linkHandler"
+import { cn, focusRing } from "@/lib/utils"
+import { F0OneSwitch } from "@/sds/ai/F0OneSwitch"
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
+
+import { GridGlyph } from "./GridGlyph"
+import { PaneledNavProps } from "./types"
+
+/**
+ * Topbar navigation with a 2×2-grid trigger that opens a multi-column
+ * mega-menu panel. Reproduces the `NavigationConcept` prototype using F0
+ * tokens and primitives, plus a right-side cluster: notifications bell, the
+ * "One" AI activation toggle, and a user avatar with a dropdown menu.
+ */
+export const PaneledNav = ({
+  sections,
+  columns = 4,
+  user,
+  userMenuItems,
+  onNotificationsClick,
+  notificationsBadge = false,
+}: PaneledNavProps) => {
+  const [open, setOpen] = useState(false)
+
+  // Adapt the column count to the viewport so the panel never overflows and
+  // labels never wrap on smaller screens (same responsive primitive as
+  // ApplicationFrame's FrameProvider): ≥lg → up to `columns`, md–lg → 3,
+  // sm–md → 2, phones → 1 (full-width list).
+  const belowSm = useMediaQuery(`(max-width: 640px)`, {
+    initializeWithValue: true,
+  })
+  const belowMd = useMediaQuery(`(max-width: ${breakpoints.md}px)`, {
+    initializeWithValue: true,
+  })
+  const belowLg = useMediaQuery(`(max-width: ${breakpoints.lg}px)`, {
+    initializeWithValue: true,
+  })
+  const effectiveColumns = Math.min(
+    columns,
+    belowSm ? 1 : belowMd ? 2 : belowLg ? 3 : columns
+  )
+
+  // On phones the panel fills the viewport (full-bleed list); on larger
+  // screens it's sized to its columns (~14rem each), capped to the viewport.
+  const panelWidth = belowSm
+    ? "calc(100vw - 1rem)"
+    : `min(calc(100vw - 1rem), ${effectiveColumns * 14}rem)`
+
+  return (
+    <header className="flex h-10 items-center gap-2 border-0 border-b border-solid border-f1-border bg-f1-background px-2">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label="Open navigation menu"
+            className={cn(
+              "flex size-8 items-center justify-center rounded-lg border border-solid border-f1-border bg-f1-background text-f1-foreground transition-[background-color,border-color,transform] duration-150 active:scale-[0.96]",
+              "hover:bg-f1-background-secondary",
+              "data-[state=open]:border-f1-background-selected-bold data-[state=open]:bg-f1-background-selected-bold data-[state=open]:text-f1-foreground-inverse",
+              focusRing()
+            )}
+          >
+            <GridGlyph />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          sideOffset={6}
+          className="max-w-[calc(100vw-1rem)] rounded-xl border-f1-border p-6 px-7 shadow-lg [max-width:var(--radix-popover-content-available-width)]"
+          style={{
+            width: panelWidth,
+            // CSS multi-column flows sections down-then-right in source order
+            // and balances them, so the reading order stays identical at every
+            // column count (unlike round-robin, which reshuffles on resize).
+            columnCount: effectiveColumns,
+            columnGap: "2rem",
+          }}
+        >
+          {sections.map((section) => (
+            <div
+              key={section.title}
+              className="mb-7 flex break-inside-avoid flex-col last:mb-0"
+            >
+              <h3 className="m-0 mb-1 text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-f1-foreground-secondary">
+                {section.title}
+              </h3>
+              <ul className="m-0 flex list-none flex-col gap-0.5 p-0">
+                {section.items.map((item) => (
+                  <li key={item.label}>
+                    <Link
+                      href={item.href}
+                      className={cn(
+                        "-mx-2.5 flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-[1.1875rem] font-medium leading-tight text-f1-foreground no-underline transition-colors",
+                        "hover:bg-f1-background-secondary hover:text-f1-foreground-selected focus-visible:bg-f1-background-secondary focus-visible:text-f1-foreground-selected",
+                        focusRing()
+                      )}
+                    >
+                      {item.icon && <F0Icon icon={item.icon} size="md" />}
+                      <span>{item.label}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </PopoverContent>
+      </Popover>
+
+      <div className="ml-auto flex items-center gap-2">
+        <div className="relative">
+          <F0Button
+            icon={Bell}
+            label="Notifications"
+            hideLabel
+            variant="ghost"
+            size="md"
+            onClick={onNotificationsClick}
+          />
+          {notificationsBadge && (
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute right-1.5 top-1.5 size-2 rounded-full bg-f1-background-critical-bold ring-2 ring-f1-background"
+            />
+          )}
+        </div>
+
+        <Dropdown align="end" items={userMenuItems}>
+          <button
+            type="button"
+            aria-label="Open user menu"
+            className={cn("rounded-full", focusRing())}
+          >
+            <F0AvatarPerson
+              firstName={user.firstName}
+              lastName={user.lastName}
+              src={user.src}
+              size="md"
+            />
+          </button>
+        </Dropdown>
+
+        <F0OneSwitch />
+      </div>
+    </header>
+  )
+}
+
+PaneledNav.displayName = "PaneledNav"

--- a/packages/react/src/patterns/Navigation/PaneledNav/__stories__/PaneledNav.stories.tsx
+++ b/packages/react/src/patterns/Navigation/PaneledNav/__stories__/PaneledNav.stories.tsx
@@ -1,0 +1,161 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import {
+  Briefcase,
+  Building,
+  Calendar,
+  ChartLine,
+  ChartPie,
+  Clock,
+  Envelope,
+  Exit,
+  File,
+  Flag,
+  Globe,
+  Heart,
+  Home,
+  Inbox,
+  Megaphone,
+  Money,
+  PalmTree,
+  People,
+  Person,
+  Plane,
+  Rocket,
+  Settings,
+  Shield,
+  Star,
+  Suitcase,
+  Target,
+} from "@/icons/app"
+import { F0AiChatProvider } from "@/sds/ai/F0AiChat"
+
+import { PaneledNav } from "../PaneledNav"
+import { NavSection } from "../types"
+
+// Sections modelled on F0's real product navigation (HR / people platform
+// modules), grouped the way the live sidebar groups them. Counts are
+// intentionally uneven to reflect a realistic product nav.
+const sections: NavSection[] = [
+  {
+    title: "Workspace",
+    items: [
+      { label: "Home", href: "/home", icon: Home },
+      { label: "Inbox", href: "/inbox", icon: Inbox },
+      { label: "Messaging", href: "/messaging", icon: Envelope },
+    ],
+  },
+  {
+    title: "People",
+    items: [
+      { label: "Organization", href: "/organization", icon: People },
+      { label: "Profiles", href: "/profiles", icon: Person },
+      { label: "Recruitment", href: "/recruitment", icon: Suitcase },
+      { label: "Onboarding", href: "/onboarding", icon: Rocket },
+      { label: "Time off", href: "/time-off", icon: PalmTree },
+    ],
+  },
+  {
+    title: "Time",
+    items: [
+      { label: "Calendar", href: "/calendar", icon: Calendar },
+      { label: "Clock in", href: "/clock-in", icon: Clock },
+    ],
+  },
+  {
+    title: "Finance",
+    items: [
+      { label: "Payroll", href: "/payroll", icon: Money },
+      { label: "Expenses", href: "/expenses", icon: File },
+      { label: "Invoices", href: "/invoices", icon: File },
+      { label: "Budgets", href: "/budgets", icon: ChartPie },
+      { label: "Reports", href: "/reports", icon: ChartLine },
+      { label: "Spending", href: "/spending", icon: Briefcase },
+    ],
+  },
+  {
+    title: "Company",
+    items: [
+      { label: "Documents", href: "/documents", icon: File },
+      { label: "Announcements", href: "/announcements", icon: Megaphone },
+      { label: "Goals", href: "/goals", icon: Target },
+      { label: "Spaces", href: "/spaces", icon: Building },
+      { label: "Travel", href: "/travel", icon: Plane },
+      { label: "Benefits", href: "/benefits", icon: Heart },
+    ],
+  },
+  {
+    title: "Talent",
+    items: [
+      { label: "Performance", href: "/performance", icon: Star },
+      { label: "Learning", href: "/learning", icon: Flag },
+      { label: "Engagement", href: "/engagement", icon: Heart },
+    ],
+  },
+  {
+    title: "Admin",
+    items: [
+      { label: "Settings", href: "/settings", icon: Settings },
+      { label: "Security", href: "/security", icon: Shield },
+      { label: "Integrations", href: "/integrations", icon: Globe },
+    ],
+  },
+]
+
+const userMenuItems = [
+  {
+    label: "My settings",
+    href: "/settings",
+    icon: Settings,
+  },
+  { type: "separator" as const },
+  {
+    label: "Log out",
+    icon: Exit,
+    critical: true,
+    onClick: () => console.log("log out"),
+  },
+]
+
+const meta = {
+  title: "Patterns/Navigation/PaneledNav",
+  component: PaneledNav,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    sections,
+    user: {
+      firstName: "Dani",
+      lastName: "Moreno",
+      src: "/avatars/person04.jpg",
+    },
+    userMenuItems,
+  },
+  decorators: [
+    (Story) => (
+      <F0AiChatProvider enabled>
+        <div className="min-h-[28rem] bg-f1-background-secondary">
+          <Story />
+        </div>
+      </F0AiChatProvider>
+    ),
+  ],
+} satisfies Meta<typeof PaneledNav>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const ThreeColumns: Story = {
+  args: {
+    columns: 3,
+  },
+}
+
+export const WithNotificationBadge: Story = {
+  args: {
+    notificationsBadge: true,
+  },
+}

--- a/packages/react/src/patterns/Navigation/PaneledNav/index.ts
+++ b/packages/react/src/patterns/Navigation/PaneledNav/index.ts
@@ -1,0 +1,2 @@
+export { PaneledNav } from "./PaneledNav"
+export type { NavLink, NavSection, PaneledNavProps } from "./types"

--- a/packages/react/src/patterns/Navigation/PaneledNav/types.ts
+++ b/packages/react/src/patterns/Navigation/PaneledNav/types.ts
@@ -1,0 +1,39 @@
+import { IconType } from "@/components/F0Icon"
+import { DropdownItem } from "@/experimental/Navigation/Dropdown"
+
+/** A single navigable link inside a mega-menu section. */
+export type NavLink = {
+  label: string
+  href: string
+  /** Optional leading icon shown next to the label. */
+  icon?: IconType
+}
+
+/** A titled group of links rendered as one block in the panel. */
+export type NavSection = {
+  title: string
+  items: NavLink[]
+}
+
+export type PaneledNavProps = {
+  /** Sections rendered inside the mega-menu, distributed across columns. */
+  sections: NavSection[]
+  /**
+   * Number of columns the panel is laid out in. Sections are distributed
+   * round-robin across them, matching the original concept.
+   * @default 4
+   */
+  columns?: number
+  /** The signed-in user, used to render the rightmost avatar (no text). */
+  user: {
+    firstName: string
+    lastName: string
+    src?: string
+  }
+  /** Items for the avatar dropdown menu (e.g. My settings, Log out). */
+  userMenuItems: DropdownItem[]
+  /** Invoked when the notifications bell is pressed. */
+  onNotificationsClick?: () => void
+  /** Shows an unread dot on the notifications bell when true. */
+  notificationsBadge?: boolean
+}


### PR DESCRIPTION
## Summary (WIP / draft)

Adds **`PaneledNav`** — a topbar navigation pattern with a 2×2-grid trigger that opens a multi-column **mega-menu panel**, recreating the `NavigationConcept` prototype using F0 tokens and primitives. Intended to eventually replace the current `Sidebar` behaviour (integration **not** done here — standalone component + Storybook only).

### What's included
- **Panel** — Radix `Popover` (free click-outside / Escape / focus-return), styled with `f1-*` tokens. The 2×2 grid trigger flips to the accent/selected state while open.
- **Order-stable responsive layout** — CSS multi-column (`column-count` + `break-inside-avoid`) so sections always read in source order, balanced, at every breakpoint: ≥1200px → up to `columns` (default 4), 900–1200 → 3, 640–900 → 2, phones → 1 (full-bleed). Driven by `useMediaQuery` + f0-core `breakpoints` (same primitive as `ApplicationFrame`).
- **Right cluster** (left→right): notifications bell (icon-only `F0Button`), user **avatar** (`F0AvatarPerson`, size `md`) with a settings/logout `Dropdown`, and the **One** AI activation toggle (`F0OneSwitch`, rightmost).
- **Story** — `Patterns/Navigation/PaneledNav` with realistic F0 module nav content (`Default`, `ThreeColumns`, `WithNotificationBadge`), wrapped in `F0AiChatProvider` so the One toggle renders.

### Files
- `packages/react/src/patterns/Navigation/PaneledNav/` — `PaneledNav.tsx`, `GridGlyph.tsx`, `types.ts`, `index.ts`, `__stories__/PaneledNav.stories.tsx`

### Verification
- `oxlint` and `tsc --noEmit` clean.
- Verified in Storybook across 1280 / 1000 / 375px: trigger toggles the panel, columns reflow, section reading order is identical at all widths, avatar dropdown shows My settings / Log out (critical), bell badge variant works.

### Notes / follow-ups (out of scope)
- Wiring into `ApplicationFrame` to actually replace the `Sidebar` is a later task.
- `F0OneSwitch` only renders when AI chat is enabled (intrinsic to that component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)