### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.61.2",
+  "packages/react": "2.61.3",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.61.3](https://github.com/factorialco/f0/compare/f0-react-v2.61.2...f0-react-v2.61.3) (2026-06-12)
+
+
+### Bug Fixes
+
+* **api-surface:** summarize translation key changes instead of flagging every export ([#4426](https://github.com/factorialco/f0/issues/4426)) ([72af4a7](https://github.com/factorialco/f0/commit/72af4a7469beb46a54a191ddd14d5ac12d52d9b2))
+
 ## [2.61.2](https://github.com/factorialco/f0/compare/f0-react-v2.61.1...f0-react-v2.61.2) (2026-06-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.61.2",
+  "version": "2.61.3",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.61.3</summary>

## [2.61.3](https://github.com/factorialco/f0/compare/f0-react-v2.61.2...f0-react-v2.61.3) (2026-06-12)


### Bug Fixes

* **api-surface:** summarize translation key changes instead of flagging every export ([#4426](https://github.com/factorialco/f0/issues/4426)) ([72af4a7](https://github.com/factorialco/f0/commit/72af4a7469beb46a54a191ddd14d5ac12d52d9b2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).