### PR TITLE
fix(datasource): duck-type observable detection in fetch result handling

### DIFF
--- a/packages/react/src/hooks/datasource/__test__/adaptDataAdapterToInfiniteScroll.test.ts
+++ b/packages/react/src/hooks/datasource/__test__/adaptDataAdapterToInfiniteScroll.test.ts
@@ -185,4 +185,51 @@ describe("adaptDataAdapterToInfiniteScroll", () => {
     })
     expect(emissions[2]).toEqual({ loading: false, error, data: null })
   })
+
+  it("maps foreign observables (different class identity, e.g. Apollo's zen-observable copy)", async () => {
+    // Observable-like with `subscribe`/`map` but NOT an instance of this
+    // package's Observable class — like an Apollo observable built from the
+    // consumer app's own zen-observable copy. Detection must be duck-typed,
+    // not `instanceof`.
+    const foreignObservable = {
+      map(fn: (state: PromiseState<unknown>) => PromiseState<unknown>) {
+        return new Observable<PromiseState<unknown>>((subscriber) => {
+          subscriber.next(fn({ loading: false, data: pageResponse(1) }))
+          subscriber.complete()
+        })
+      },
+      subscribe() {
+        throw new Error("not used: map() already returns a real Observable")
+      },
+    }
+    expect(foreignObservable).not.toBeInstanceOf(Observable)
+
+    const adapted = adaptDataAdapterToInfiniteScroll<TestRecord, TestFilters>({
+      paginationType: "pages",
+      fetchData: () =>
+        foreignObservable as unknown as Observable<
+          PromiseState<PageBasedPaginatedResponse<TestRecord>>
+        >,
+    })
+
+    const result = adapted.fetchData(fetchOptions(null))
+    // Regression: with `instanceof` detection the foreign observable fell
+    // through to the sync branch and came back as `{ records: undefined }`.
+    expect(result).toBeInstanceOf(Observable)
+
+    const emissions: PromiseState<unknown>[] = []
+    await new Promise<void>((resolve) => {
+      ;(result as Observable<PromiseState<unknown>>).subscribe({
+        next: (state) => emissions.push(state),
+        complete: resolve,
+      })
+    })
+
+    expect(emissions[0].data).toMatchObject({
+      type: "infinite-scroll",
+      records: RECORDS,
+      cursor: "2",
+      hasMore: true,
+    })
+  })
 })

--- a/packages/react/src/hooks/datasource/adaptDataAdapterToInfiniteScroll.ts
+++ b/packages/react/src/hooks/datasource/adaptDataAdapterToInfiniteScroll.ts
@@ -1,7 +1,11 @@
 import { Observable } from "zen-observable-ts"
 
+import {
+  isObservableLike,
+  isPromiseLike,
+  PromiseState,
+} from "@/lib/promise-to-observable"
 import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
-import { PromiseState } from "@/lib/promise-to-observable"
 
 import {
   DataAdapter,
@@ -33,7 +37,10 @@ const mapFetchResult = <T, U>(
   result: T | Promise<T> | Observable<PromiseState<T>>,
   map: (value: T) => U
 ): U | Promise<U> | Observable<PromiseState<U>> => {
-  if (result instanceof Observable) {
+  // Duck-typed checks (not `instanceof`): the observable/promise may come
+  // from the consumer app's own zen-observable/Promise copy, whose class
+  // identity differs from the ones in f0's bundle.
+  if (isObservableLike<T>(result)) {
     return result.map((state): PromiseState<U> => {
       const data = state.data
       if (data === undefined || data === null) {
@@ -42,10 +49,10 @@ const mapFetchResult = <T, U>(
       return { loading: state.loading, error: state.error, data: map(data) }
     })
   }
-  if (result instanceof Promise) {
+  if (isPromiseLike<T>(result)) {
     return result.then(map)
   }
-  return map(result)
+  return map(result as T)
 }
 
 /**

--- a/packages/react/src/hooks/datasource/itemNeighbors/__test__/resolveItemNeighbors.test.ts
+++ b/packages/react/src/hooks/datasource/itemNeighbors/__test__/resolveItemNeighbors.test.ts
@@ -68,6 +68,29 @@ describe("resolveItemNeighbors", () => {
     await expect(promise).rejects.toBe(error)
   })
 
+  it("resolves a foreign observable (different class identity, e.g. Apollo's zen-observable copy)", async () => {
+    // Observable-like with `subscribe` but NOT an instance of this package's
+    // Observable class. Detection must be duck-typed, not `instanceof` —
+    // otherwise the observable falls into the Promise.resolve branch and the
+    // promise resolves to the observable itself instead of the response.
+    const foreignObservable = {
+      subscribe(observer: {
+        next: (state: PromiseState<ItemNeighborsResponse<TestRecord>>) => void
+      }) {
+        observer.next({ loading: false, data: response })
+        return { unsubscribe: vi.fn(), closed: true }
+      },
+    }
+    expect(foreignObservable).not.toBeInstanceOf(Observable)
+
+    const { promise } = resolveItemNeighbors<TestRecord>(
+      foreignObservable as unknown as Observable<
+        PromiseState<ItemNeighborsResponse<TestRecord>>
+      >
+    )
+    await expect(promise).resolves.toEqual(response)
+  })
+
   it("cancel() prevents a pending promise from settling", async () => {
     let resolveFetch: (value: ItemNeighborsResponse<TestRecord>) => void
     const pending = new Promise<ItemNeighborsResponse<TestRecord>>(

--- a/packages/react/src/hooks/datasource/itemNeighbors/resolveItemNeighbors.ts
+++ b/packages/react/src/hooks/datasource/itemNeighbors/resolveItemNeighbors.ts
@@ -1,6 +1,6 @@
 import { Observable } from "zen-observable-ts"
 
-import { PromiseState } from "@/lib/promise-to-observable"
+import { isObservableLike, PromiseState } from "@/lib/promise-to-observable"
 
 import { ItemNeighborsResponse } from "../types/fetch.typings"
 
@@ -25,7 +25,9 @@ export function resolveItemNeighbors<R>(result: ItemNeighborsResult<R>): {
   promise: Promise<ItemNeighborsResponse<R>>
   cancel: () => void
 } {
-  if (result instanceof Observable) {
+  // Duck-typed (not `instanceof`): the observable may come from the consumer
+  // app's own zen-observable copy, whose class identity differs from f0's.
+  if (isObservableLike<ItemNeighborsResponse<R>>(result)) {
     let cancelled = false
     let subscription: ZenObservable.Subscription | null = null
     const promise = new Promise<ItemNeighborsResponse<R>>((resolve, reject) => {

--- a/packages/react/src/lib/promise-to-observable.ts
+++ b/packages/react/src/lib/promise-to-observable.ts
@@ -6,6 +6,29 @@ export interface PromiseState<T> {
   data?: T | null
 }
 
+/**
+ * Duck-typed observable check. `instanceof Observable` breaks across package
+ * boundaries — e.g. an Apollo observable built from the consumer app's copy of
+ * zen-observable has a different class identity than the one bundled into f0 —
+ * so detection follows `useData`'s convention: anything with a `subscribe`
+ * member is treated as an observable.
+ */
+export function isObservableLike<T>(
+  value: unknown
+): value is Observable<PromiseState<T>> {
+  return typeof value === "object" && value !== null && "subscribe" in value
+}
+
+/**
+ * Duck-typed promise check, for the same cross-package reason as
+ * `isObservableLike`. Check observables first: an object could in theory
+ * carry both members, and f0's fetch channels treat `subscribe` as the
+ * stronger signal.
+ */
+export function isPromiseLike<T>(value: unknown): value is Promise<T> {
+  return typeof value === "object" && value !== null && "then" in value
+}
+
 export function promiseToObservable<T>(
   promise: Promise<T>
 ): Observable<PromiseState<T>> {


### PR DESCRIPTION
## Problem

`adaptDataAdapterToInfiniteScroll` and `resolveItemNeighbors` detect observable fetch results with `result instanceof Observable`, where `Observable` is the `zen-observable-ts` copy **bundled into f0's dist**.

An observable created by the consumer app — e.g. an Apollo `watchQuery(...).map(...)` observable built from the app's own `zen-observable-ts` — has a different class identity, so `instanceof` returns `false`. The observable then falls through to the sync branch and gets mapped as if it were a plain response:

```
pagesResponseToInfiniteScroll(observable) → { type: "infinite-scroll", records: undefined, ... }
```

`useData` then hits `if ("records" in response)` (key present, value `undefined`) → `setData(undefined)` → crash in the grouping memo:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'map')
```

This fires for **any `collection-select` breadcrumb** (and any `F0Select` with a source) backed by a `pages` adapter whose `fetchData` returns an observable — the standard Apollo adapter shape in the Factorial app. Found while adopting the 2.61 collection-select breadcrumb (#4404) on the employee detail page.

`resolveItemNeighbors` has the same latent bug: a foreign observable lands in `Promise.resolve(observable)`, resolving the neighbors promise to the observable itself.

## Fix

Detect by duck typing (`"subscribe"` / `"then"` members) instead of `instanceof` — exactly what `useData` already does (`useData.ts` ~line 640), which is why the regular list path never crashed. Adds shared `isObservableLike` / `isPromiseLike` guards in `lib/promise-to-observable.ts` and uses them in both call sites.

## Tests

- `adaptDataAdapterToInfiniteScroll.test.ts`: foreign observable (not an instance of f0's `Observable` class) is mapped to infinite-scroll emissions with `records` defined.
- `resolveItemNeighbors.test.ts`: foreign observable resolves to the neighbors response.

Both fail on `main` and pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)