### PR TITLE
fix(breadcrumbs): collection-select survives item navigation + filter write-through to storage

### DIFF
--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/getBreadcrumbKey.ts
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/getBreadcrumbKey.ts
@@ -1,0 +1,16 @@
+import { BreadcrumbItemType } from "./types"
+
+/**
+ * Render key for a breadcrumb item. Most items are identified by their `id`,
+ * but a collection-select is identified by its COLLECTION: walking items of
+ * the same collection (prev/next on a detail page changes the item `id` and
+ * `value`) must NOT remount the select — a remount rebuilds its seeded source
+ * and refetches the dropdown's first page on every navigation. The changing
+ * parts (`label`, `value`, `defaultItem`, callbacks) flow through props.
+ * Changing the `collectionId` still remounts: new collection, new seeded
+ * source.
+ */
+export const getBreadcrumbKey = (item: BreadcrumbItemType | undefined) =>
+  item && "type" in item && item.type === "collection-select"
+    ? `collection-select-${item.collectionId}`
+    : item?.id

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/index.tsx
@@ -8,6 +8,7 @@ import {
 
 import { Breadcrumb, BreadcrumbList } from "@/ui/breadcrumb"
 
+import { getBreadcrumbKey } from "./getBreadcrumbKey"
 import { BreadcrumbItem } from "./internal/BreadcrumbItem"
 import { CollapsedBreadcrumbItem } from "./internal/CollapsedBreadcrumbItem"
 import { calculateBreadcrumbState } from "./layoutCalculation"
@@ -93,7 +94,7 @@ export function Breadcrumbs({ breadcrumbs, append }: BreadcrumbsProps) {
       style={{
         minWidth: state?.minWidth,
       }}
-      key={`breadcrumb-${breadcrumbs.at(-1)?.id ?? 0}`}
+      key={`breadcrumb-${getBreadcrumbKey(breadcrumbs.at(-1)) ?? 0}`}
     >
       <ol
         className="invisible absolute -left-full"
@@ -102,7 +103,7 @@ export function Breadcrumbs({ breadcrumbs, append }: BreadcrumbsProps) {
       >
         {breadcrumbs.map((item, index) => (
           <BreadcrumbItem
-            key={item.id}
+            key={getBreadcrumbKey(item)}
             item={item}
             isLast={index === breadcrumbs.length - 1}
             isFirst={index === 0}
@@ -116,7 +117,7 @@ export function Breadcrumbs({ breadcrumbs, append }: BreadcrumbsProps) {
           <BreadcrumbItem
             isOnly={state.isOnly}
             isFirst={true}
-            key={`first-item-${state.headItem.id}`}
+            key={`first-item-${getBreadcrumbKey(state.headItem)}`}
             item={state.headItem}
             isLast={false}
           />
@@ -134,7 +135,7 @@ export function Breadcrumbs({ breadcrumbs, append }: BreadcrumbsProps) {
               />
               {state.tailItems.map((item, index) => (
                 <BreadcrumbItem
-                  key={item.id}
+                  key={getBreadcrumbKey(item)}
                   item={item}
                   isLast={index === state.tailItems.length - 1}
                   isFirst={false}
@@ -148,7 +149,7 @@ export function Breadcrumbs({ breadcrumbs, append }: BreadcrumbsProps) {
             <>
               {state.tailItems.map((item, index) => (
                 <BreadcrumbItem
-                  key={item.id}
+                  key={getBreadcrumbKey(item)}
                   item={item}
                   isLast={index === state.tailItems.length - 1}
                   isFirst={false}

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/buildCollectionBoundSource.test.ts
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/buildCollectionBoundSource.test.ts
@@ -58,6 +58,22 @@ describe("buildCollectionBoundSource", () => {
     expect(result.currentFilters).toEqual({ department: ["Engineering"] })
   })
 
+  it("seeds an explicitly persisted empty filters state (user cleared them)", () => {
+    const result = buildCollectionBoundSource(
+      { ...source, currentFilters: { department: ["Engineering"] } },
+      { filters: {} }
+    )
+    expect(result.currentFilters).toEqual({})
+  })
+
+  it("keeps the definition's currentFilters when every persisted key is unknown", () => {
+    const result = buildCollectionBoundSource(
+      { ...source, currentFilters: { department: ["Engineering"] } },
+      { filters: { legacyFilter: "stale" } }
+    )
+    expect(result.currentFilters).toEqual({ department: ["Engineering"] })
+  })
+
   it("keeps every persisted filter when the source declares none", () => {
     const result = buildCollectionBoundSource(
       { ...source, filters: undefined },

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/buildCollectionBoundSource.ts
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/buildCollectionBoundSource.ts
@@ -69,17 +69,24 @@ export function buildCollectionBoundSource(
   const seedSortings = options?.seed?.sortings ?? true
   const showFilters = options?.showFilters ?? false
 
+  // An explicitly persisted empty state ({}) IS seeded — it means the user
+  // cleared the filters, and the list hydrates it as cleared too. But empty
+  // BY PRUNING (every persisted key unknown — schema drift, not user intent)
+  // keeps the definition's currentFilters, as before.
   let currentFilters = source.currentFilters
   if (seedFilters && storage) {
     const resolved = resolveDataCollectionFilters(storage)
-    if (resolved) {
+    if (resolved !== undefined) {
       const declaredFilters = source.filters
       const pruned: FiltersState<FiltersDefinition> = declaredFilters
         ? Object.fromEntries(
             Object.entries(resolved).filter(([key]) => key in declaredFilters)
           )
         : resolved
-      if (Object.keys(pruned).length > 0) {
+      if (
+        Object.keys(pruned).length > 0 ||
+        Object.keys(resolved).length === 0
+      ) {
         currentFilters = pruned
       }
     }

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.test.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.test.tsx
@@ -144,6 +144,51 @@ afterEach(() => {
   driver.filtersChange = null
 })
 
+// Type-level regression (validated by tsc, not vitest): a source declared
+// over a CONCRETE record/filters type — including record-consuming callbacks
+// like `selectable` and a concretely-typed adapter — must be assignable to
+// the record-erased breadcrumb item with no casts. Before
+// CollectionSelectSourceDefinition's bivariant callbacks, strictFunctionTypes
+// rejected every such source.
+type ConcreteFilters = {
+  department: {
+    type: "in"
+    label: string
+    options: { options: { value: string; label: string }[] }
+  }
+}
+const concretelyTypedItem = (
+  fetchData: (options: PaginatedFetchOptions<ConcreteFilters>) => Promise<{
+    type: "pages"
+    records: Employee[]
+    total: number
+    perPage: number
+    currentPage: number
+    pagesCount: number
+  }>
+): BreadcrumbCollectionSelectItemType => ({
+  id: "employee",
+  type: "collection-select",
+  label: "Alice",
+  collectionId: COLLECTION_ID,
+  source: {
+    selectable: (employee: Employee) => employee.id,
+    dataAdapter: {
+      paginationType: "pages",
+      perPage: 10,
+      fetchData,
+    },
+  },
+  mapOptions: (employee: Employee) => ({
+    value: employee.id,
+    label: employee.name,
+    item: employee,
+  }),
+  getItemHref: (value: string, employee?: Employee) =>
+    employee ? `/employees/${value}` : undefined,
+})
+void concretelyTypedItem
+
 describe("BreadcrumbCollectionSelect", () => {
   it("seeds the persisted filters and sortings into the fetch", async () => {
     localStorage.setItem(

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.test.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.test.tsx
@@ -196,6 +196,57 @@ describe("BreadcrumbCollectionSelect", () => {
     ).toBeGreaterThan(0)
   })
 
+  it("does not remount or refetch when walking items of the same collection (prev/next)", async () => {
+    const fetchData = makeFetchData()
+    const crumbs = (item: BreadcrumbCollectionSelectItemType) => [
+      { id: "employees", label: "Employees", href: "/employees" },
+      item,
+    ]
+
+    const { rerender } = render(
+      <Breadcrumbs breadcrumbs={crumbs(makeItem(fetchData))} />
+    )
+    await waitFor(() => expect(fetchData).toHaveBeenCalled())
+    const mountFetchCount = fetchData.mock.calls.length
+
+    // Detail-page prev/next: a NEW item id/value/label, same collectionId
+    rerender(
+      <Breadcrumbs
+        breadcrumbs={crumbs(
+          makeItem(fetchData, { id: "employee-2", value: "2", label: "Bob" })
+        )}
+      />
+    )
+
+    // The trigger follows the new item through props…
+    expect(
+      (await screen.findAllByRole("combobox", { name: "Bob" })).length
+    ).toBeGreaterThan(0)
+    // …without remounting the select: no new fetch of the dropdown page
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(fetchData).toHaveBeenCalledTimes(mountFetchCount)
+  })
+
+  it("remounts and refetches when the collectionId changes", async () => {
+    const fetchData = makeFetchData()
+
+    const { rerender } = render(
+      <Breadcrumbs breadcrumbs={[makeItem(fetchData)]} />
+    )
+    await waitFor(() => expect(fetchData).toHaveBeenCalled())
+    const mountFetchCount = fetchData.mock.calls.length
+
+    rerender(
+      <Breadcrumbs
+        breadcrumbs={[makeItem(fetchData, { collectionId: "test/teams/v1" })]}
+      />
+    )
+
+    await waitFor(() =>
+      expect(fetchData.mock.calls.length).toBeGreaterThan(mountFetchCount)
+    )
+  })
+
   it("navigates through the LinkProvider when an option is picked", async () => {
     const fetchData = makeFetchData()
     const navigatedTo = vi.fn()

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.test.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.test.tsx
@@ -9,6 +9,11 @@ import {
   RecordType,
 } from "@/hooks/datasource"
 import { LinkProvider } from "@/lib/linkHandler"
+import {
+  dataCollectionLocalStorageHandler,
+  DataCollectionStorageProvider,
+} from "@/lib/providers/datacollection"
+import { subscribeToDataCollectionStorageChanges } from "@/lib/providers/datacollection/dataCollectionStorageEvents"
 import { userEvent, zeroRender as render } from "@/testing/test-utils"
 
 import { Breadcrumbs } from "../../index"
@@ -29,6 +34,7 @@ global.ResizeObserver = class MockResizeObserver {
 // "pick" button that emits the selection a user click would produce.
 const driver = vi.hoisted(() => ({
   selection: null as { value: string; record?: unknown } | null,
+  filtersChange: null as Record<string, unknown> | null,
 }))
 
 vi.mock("../BreadcrumbSelect", async (importOriginal) => {
@@ -47,6 +53,18 @@ vi.mock("../BreadcrumbSelect", async (importOriginal) => {
               driver.selection!.record as Parameters<
                 NonNullable<typeof props.onChange>
               >[1]
+            )
+          }
+        />
+      )}
+      {driver.filtersChange && (
+        <button
+          aria-label="set-filters"
+          onClick={() =>
+            props.onFiltersChange?.(
+              driver.filtersChange as Parameters<
+                NonNullable<typeof props.onFiltersChange>
+              >[0]
             )
           }
         />
@@ -123,6 +141,7 @@ const makeItem = (
 afterEach(() => {
   localStorage.clear()
   driver.selection = null
+  driver.filtersChange = null
 })
 
 describe("BreadcrumbCollectionSelect", () => {
@@ -272,5 +291,123 @@ describe("BreadcrumbCollectionSelect", () => {
     await new Promise((resolve) => setTimeout(resolve, 20))
 
     expect(fetchData).toHaveBeenCalledTimes(1)
+  })
+
+  describe("editable filters write-through (showFilters)", () => {
+    const withStorageHandler = (children: React.ReactNode) => (
+      <DataCollectionStorageProvider
+        handler={dataCollectionLocalStorageHandler}
+      >
+        {children}
+      </DataCollectionStorageProvider>
+    )
+
+    it("persists filter changes to the collection storage, preserving the rest of the state", async () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          filters: { department: ["Engineering"] },
+          sortings: { field: "name", order: "desc" },
+          search: "ali",
+        })
+      )
+      const fetchData = makeFetchData()
+      const onFiltersChange = vi.fn()
+      driver.filtersChange = { department: ["Design"] }
+
+      render(
+        withStorageHandler(
+          <BreadcrumbCollectionSelect
+            item={makeItem(fetchData, { showFilters: true, onFiltersChange })}
+          />
+        )
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: "set-filters" }))
+
+      await waitFor(() => {
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+        expect(stored.filters).toEqual({ department: ["Design"] })
+      })
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      expect(stored.sortings).toEqual({ field: "name", order: "desc" })
+      expect(stored.search).toBe("ali")
+      expect(onFiltersChange).toHaveBeenCalledWith({ department: ["Design"] })
+    })
+
+    it("updates the per-visualization slot when one exists, so a re-read resolves the new filters", async () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          visualization: 1,
+          filters: { department: ["Engineering"] },
+          visualizationFilters: { "1": { department: ["Engineering"] } },
+        })
+      )
+      const fetchData = makeFetchData()
+      driver.filtersChange = { department: ["Design"] }
+
+      render(
+        withStorageHandler(
+          <BreadcrumbCollectionSelect
+            item={makeItem(fetchData, { showFilters: true })}
+          />
+        )
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: "set-filters" }))
+
+      await waitFor(() => {
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+        expect(stored.visualizationFilters["1"]).toEqual({
+          department: ["Design"],
+        })
+      })
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      expect(stored.filters).toEqual({ department: ["Design"] })
+    })
+
+    it("notifies subscribers of the collection id after the write", async () => {
+      const fetchData = makeFetchData()
+      const listener = vi.fn()
+      const unsubscribe = subscribeToDataCollectionStorageChanges(
+        COLLECTION_ID,
+        listener
+      )
+      driver.filtersChange = { department: ["Design"] }
+
+      render(
+        withStorageHandler(
+          <BreadcrumbCollectionSelect
+            item={makeItem(fetchData, { showFilters: true })}
+          />
+        )
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: "set-filters" }))
+      await waitFor(() => expect(listener).toHaveBeenCalledTimes(1))
+      unsubscribe()
+    })
+
+    it("does not write storage when filters are not editable", async () => {
+      const fetchData = makeFetchData()
+      const onFiltersChange = vi.fn()
+      driver.filtersChange = { department: ["Design"] }
+
+      render(
+        withStorageHandler(
+          <BreadcrumbCollectionSelect
+            item={makeItem(fetchData, { onFiltersChange })}
+          />
+        )
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: "set-filters" }))
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+      // The consumer callback still fires
+      expect(onFiltersChange).toHaveBeenCalledWith({ department: ["Design"] })
+    })
   })
 })

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.tsx
@@ -23,8 +23,12 @@ import { buildCollectionBoundSource } from "./buildCollectionBoundSource"
  *
  * 1. The persisted collection state is read exactly once (state initializer).
  * 2. `item.source` is captured on mount; later identity changes are ignored.
- *    `Breadcrumbs` keys items by `id`, so giving the item a new `id`
- *    remounts and re-captures — the documented way to swap sources.
+ *    `Breadcrumbs` keys collection-select items by `collectionId`, so
+ *    pointing the item at a different collection remounts and re-captures —
+ *    the documented way to swap sources. Changing only the item `id`/`value`
+ *    (walking items of the same collection, e.g. detail-page prev/next) does
+ *    NOT remount: the trigger updates through props, the seeded source and
+ *    its fetched dropdown page are kept.
  * 3. The seeded definition (and thus its dataAdapter) is built once, so the
  *    reference handed to F0Select never changes.
  * 4. `mapOptions`/`getItemHref`/`onSelect` are wrapped in stable callbacks

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.tsx
@@ -2,7 +2,12 @@ import { useCallback, useLayoutEffect, useRef, useState } from "react"
 
 import { FiltersDefinition, FiltersState, RecordType } from "@/hooks/datasource"
 import { Link } from "@/lib/linkHandler"
-import { readDataCollectionStorage } from "@/lib/providers/datacollection/readDataCollectionStorage"
+import { useDataCollectionStorage } from "@/lib/providers/datacollection"
+import { notifyDataCollectionStorageChange } from "@/lib/providers/datacollection/dataCollectionStorageEvents"
+import {
+  mergeDataCollectionFilters,
+  readDataCollectionStorage,
+} from "@/lib/providers/datacollection/readDataCollectionStorage"
 
 import { BreadcrumbCollectionSelectItemType } from "../../types"
 import { BreadcrumbSelect } from "../BreadcrumbSelect"
@@ -44,14 +49,40 @@ export function BreadcrumbCollectionSelect({
   const latestRef = useRef(item)
   latestRef.current = item
 
+  const storageHandler = useDataCollectionStorage()
+  const storageHandlerRef = useRef(storageHandler)
+  storageHandlerRef.current = storageHandler
+
   const stableMapOptions = useCallback(
     (record: RecordType) => latestRef.current.mapOptions(record),
     []
   )
 
+  // Editable filters (`showFilters`) write through to the collection's
+  // persisted state: the dropdown's filter picker edits "the list's filters",
+  // not a transient local copy. The write keeps every other persisted piece
+  // (sortings, search, settings, …) and updates the same slot
+  // `resolveDataCollectionFilters` reads, then notifies live collection-bound
+  // consumers (e.g. useDataCollectionItemNavigation re-seeds so prev/next +
+  // counter follow, and a later remount of this select re-seeds correctly).
   const stableOnFiltersChange = useCallback(
-    (filters: FiltersState<FiltersDefinition>) =>
-      latestRef.current.onFiltersChange?.(filters),
+    (filters: FiltersState<FiltersDefinition>) => {
+      const current = latestRef.current
+      current.onFiltersChange?.(filters)
+      if (!current.showFilters) return
+      const persist = async () => {
+        // NOTE: must await (not .then) — the default noop handler returns a
+        // plain object typed as a Promise.
+        const stored = await storageHandlerRef.current.get(current.collectionId)
+        await storageHandlerRef.current.set(
+          current.collectionId,
+          mergeDataCollectionFilters(stored ?? {}, filters)
+        )
+        notifyDataCollectionStorageChange(current.collectionId)
+      }
+      // Storage unavailable/unreadable → the dropdown still filters in-memory.
+      persist().catch(() => {})
+    },
     []
   )
 

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem.tsx
@@ -4,6 +4,7 @@ import { forwardRef, PropsWithChildren, ReactNode } from "react"
 import { F0AvatarModule } from "@/components/avatars/F0AvatarModule"
 import { BreadcrumbSelect } from "@/experimental/Navigation/Header"
 import { BreadcrumbSkeleton } from "@/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbSkeleton"
+import { getBreadcrumbKey } from "@/experimental/Navigation/Header/Breadcrumbs/getBreadcrumbKey"
 import { BreadcrumbItemType } from "@/experimental/Navigation/Header/Breadcrumbs/types"
 import { Link } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
@@ -29,7 +30,7 @@ const BreadcrumbItem = forwardRef<
   HTMLLIElement,
   PropsWithChildren<BreadcrumbItemProps>
 >(({ item, isLast, isOnly = false, isFirst = false, children }, ref) => (
-  <ShadBreadcrumbItem key={item.id} ref={ref}>
+  <ShadBreadcrumbItem key={getBreadcrumbKey(item)} ref={ref}>
     {!isFirst && <BreadcrumbSeparator />}
     <BreadcrumbContent
       item={item}

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/types.ts
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/types.ts
@@ -4,6 +4,7 @@ import { FiltersDefinition, FiltersState } from "@/patterns/OneFilterPicker"
 import { DropdownItemObject } from "@/experimental/Navigation/Dropdown"
 import { NavigationItem } from "@/experimental/Navigation/utils"
 import {
+  DataAdapter,
   DataSourceDefinition,
   GroupingDefinition,
   RecordType,
@@ -64,6 +65,48 @@ export type BreadcrumbSelectItemType = BreadcrumbBaseItemType & {
  * item objects never retrigger fetches. Give the item a new `id` to swap
  * sources.
  */
+/**
+ * Rewraps every function-valued member of `T` so its parameters are checked
+ * BIVARIANTLY (the method-syntax trick). The breadcrumb item union is
+ * record-erased (`RecordType`); under `strictFunctionTypes`, arrow-typed
+ * members like `selectable?: (item: R) => ...` or the adapter's
+ * `fetchData(options: PaginatedFetchOptions<Filters>)` would make a source
+ * declared over a CONCRETE record/filters type unassignable here. Sound in
+ * this context: each source is fully type-checked against its concrete types
+ * where it is declared, and the select only feeds records fetched from that
+ * same source back into these callbacks.
+ */
+type WithBivariantCallbacks<T> = {
+  // The [never] guard keeps `paginationType?: never` markers intact —
+  // `never` would otherwise match the function check.
+  [K in keyof T]: [NonNullable<T[K]>] extends [never]
+    ? T[K]
+    : NonNullable<T[K]> extends (...args: infer Args) => infer Return
+      ? { bivariant(...args: Args): Return }["bivariant"]
+      : T[K]
+}
+
+/**
+ * The record-erased source a collection-select breadcrumb accepts: a
+ * `DataSourceDefinition` whose callbacks (and data adapter) tolerate sources
+ * declared over concrete record/filter types.
+ */
+export type CollectionSelectSourceDefinition = WithBivariantCallbacks<
+  Omit<
+    DataSourceDefinition<
+      RecordType,
+      FiltersDefinition,
+      SortingsDefinition,
+      GroupingDefinition<RecordType>
+    >,
+    "dataAdapter"
+  >
+> & {
+  dataAdapter: WithBivariantCallbacks<
+    DataAdapter<RecordType, FiltersDefinition>
+  >
+}
+
 export type BreadcrumbCollectionSelectItemType = BreadcrumbBaseItemType & {
   type: "collection-select"
   /**
@@ -73,13 +116,9 @@ export type BreadcrumbCollectionSelectItemType = BreadcrumbBaseItemType & {
    */
   collectionId: string
   /** The declared data source — no mounted collection needed. */
-  source: DataSourceDefinition<
-    RecordType,
-    FiltersDefinition,
-    SortingsDefinition,
-    GroupingDefinition<RecordType>
-  >
-  mapOptions: (item: RecordType) => F0SelectItemProps<string, RecordType>
+  source: CollectionSelectSourceDefinition
+  /** Method syntax on purpose: bivariant, so concrete-record mappers fit. */
+  mapOptions(item: RecordType): F0SelectItemProps<string, RecordType>
   /** Current item id (the record the detail page is showing). */
   value?: string
   /**
@@ -110,15 +149,16 @@ export type BreadcrumbCollectionSelectItemType = BreadcrumbBaseItemType & {
     | {
         /**
          * Href to navigate to when an option is picked, routed through the
-         * app's LinkProvider. Return undefined to skip navigation.
+         * app's LinkProvider. Return undefined to skip navigation. Method
+         * syntax on purpose: bivariant, so concrete-record callbacks fit.
          */
-        getItemHref: (value: string, item?: RecordType) => string | undefined
-        onSelect?: (value: string, item?: RecordType) => void
+        getItemHref(value: string, item?: RecordType): string | undefined
+        onSelect?(value: string, item?: RecordType): void
       }
     | {
         getItemHref?: never
         /** Imperative escape hatch (e.g. router.push) when hrefs don't fit. */
-        onSelect: (value: string, item?: RecordType) => void
+        onSelect(value: string, item?: RecordType): void
       }
   )
 

--- a/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionStorageEvents.test.ts
+++ b/packages/react/src/lib/providers/datacollection/__tests__/dataCollectionStorageEvents.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  notifyDataCollectionStorageChange,
+  subscribeToDataCollectionStorageChanges,
+} from "../dataCollectionStorageEvents"
+
+describe("dataCollectionStorageEvents", () => {
+  it("notifies subscribers of the matching collection id only", () => {
+    const matching = vi.fn()
+    const other = vi.fn()
+    const unsubscribeMatching = subscribeToDataCollectionStorageChanges(
+      "employees/v1",
+      matching
+    )
+    const unsubscribeOther = subscribeToDataCollectionStorageChanges(
+      "teams/v1",
+      other
+    )
+
+    notifyDataCollectionStorageChange("employees/v1")
+
+    expect(matching).toHaveBeenCalledTimes(1)
+    expect(other).not.toHaveBeenCalled()
+
+    unsubscribeMatching()
+    unsubscribeOther()
+  })
+
+  it("stops notifying after unsubscribe", () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeToDataCollectionStorageChanges(
+      "employees/v1",
+      listener
+    )
+
+    notifyDataCollectionStorageChange("employees/v1")
+    unsubscribe()
+    notifyDataCollectionStorageChange("employees/v1")
+
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it("notifying with no subscribers is a no-op", () => {
+    expect(() =>
+      notifyDataCollectionStorageChange("nobody/listening/v1")
+    ).not.toThrow()
+  })
+
+  it("supports multiple subscribers on the same id", () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const unsubscribeFirst = subscribeToDataCollectionStorageChanges(
+      "employees/v1",
+      first
+    )
+    const unsubscribeSecond = subscribeToDataCollectionStorageChanges(
+      "employees/v1",
+      second
+    )
+
+    notifyDataCollectionStorageChange("employees/v1")
+
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenCalledTimes(1)
+
+    unsubscribeFirst()
+    unsubscribeSecond()
+  })
+})

--- a/packages/react/src/lib/providers/datacollection/__tests__/readDataCollectionStorage.test.ts
+++ b/packages/react/src/lib/providers/datacollection/__tests__/readDataCollectionStorage.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest"
 
 import { getDataCollectionStorageKey } from "../dataCollectionStorageKey"
 import {
+  mergeDataCollectionFilters,
   readDataCollectionStorage,
   resolveDataCollectionFilters,
 } from "../readDataCollectionStorage"
@@ -84,5 +85,65 @@ describe("resolveDataCollectionFilters", () => {
         },
       })
     ).toEqual({ team: { value: ["sales"] } })
+  })
+})
+
+describe("mergeDataCollectionFilters", () => {
+  it("replaces filters and preserves the rest of the storage", () => {
+    const merged = mergeDataCollectionFilters(
+      {
+        filters: { team: { value: ["eng"] } },
+        sortings: { field: "name", order: "asc" },
+        search: "ada",
+      },
+      { team: { value: ["design"] } }
+    )
+    expect(merged).toEqual({
+      filters: { team: { value: ["design"] } },
+      sortings: { field: "name", order: "asc" },
+      search: "ada",
+    })
+  })
+
+  it("updates the per-visualization slot the resolver reads, when one exists", () => {
+    const merged = mergeDataCollectionFilters(
+      {
+        visualization: 1,
+        filters: { team: { value: ["eng"] } },
+        visualizationFilters: {
+          "0": { team: { value: ["sales"] } },
+          "1": { team: { value: ["eng"] } },
+        },
+      },
+      { team: { value: ["design"] } }
+    )
+    // The slot resolveDataCollectionFilters would read now resolves the
+    // merged filters; the other visualization's slot is untouched
+    expect(resolveDataCollectionFilters(merged)).toEqual({
+      team: { value: ["design"] },
+    })
+    expect(merged.visualizationFilters?.["0"]).toEqual({
+      team: { value: ["sales"] },
+    })
+    expect(merged.filters).toEqual({ team: { value: ["design"] } })
+  })
+
+  it("does not create a per-visualization slot when none exists", () => {
+    const merged = mergeDataCollectionFilters(
+      { filters: { team: { value: ["eng"] } } },
+      { team: { value: ["design"] } }
+    )
+    expect(merged.visualizationFilters).toBeUndefined()
+  })
+
+  it("does not mutate the input storage", () => {
+    const storage = {
+      visualization: 0,
+      filters: { team: { value: ["eng"] } },
+      visualizationFilters: { "0": { team: { value: ["eng"] } } },
+    }
+    const before = JSON.stringify(storage)
+    mergeDataCollectionFilters(storage, { team: { value: ["design"] } })
+    expect(JSON.stringify(storage)).toBe(before)
   })
 })

--- a/packages/react/src/lib/providers/datacollection/dataCollectionStorageEvents.ts
+++ b/packages/react/src/lib/providers/datacollection/dataCollectionStorageEvents.ts
@@ -1,0 +1,49 @@
+/**
+ * In-memory change notifications for data collection storage keys.
+ *
+ * The storage handler contract (`DataCollectionStorageHandler`) is plain
+ * get/set — it has no way to tell other collection-bound consumers that the
+ * persisted state changed. This module fills that gap for same-document
+ * consumers: a writer calls `notifyDataCollectionStorageChange(collectionId)`
+ * after a successful `set`, and live consumers subscribed to that id re-read
+ * the storage (e.g. the breadcrumb collection-select's editable filters
+ * notifying `useDataCollectionItemNavigation` so prev/next + counter follow).
+ *
+ * Intentionally not a storage event bridge: cross-tab/server sync is the
+ * handler's concern. This is only "another component in this tree just wrote
+ * this key".
+ */
+
+type Listener = () => void
+
+const listenersByCollectionId = new Map<string, Set<Listener>>()
+
+/**
+ * Subscribes to write notifications for a collection id. Returns the
+ * unsubscribe function (effect-friendly).
+ */
+export const subscribeToDataCollectionStorageChanges = (
+  collectionId: string,
+  listener: Listener
+): (() => void) => {
+  let listeners = listenersByCollectionId.get(collectionId)
+  if (!listeners) {
+    listeners = new Set()
+    listenersByCollectionId.set(collectionId, listeners)
+  }
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0) listenersByCollectionId.delete(collectionId)
+  }
+}
+
+/**
+ * Notifies subscribers that the persisted state for a collection id was
+ * written. Call after the storage handler's `set` resolves.
+ */
+export const notifyDataCollectionStorageChange = (
+  collectionId: string
+): void => {
+  listenersByCollectionId.get(collectionId)?.forEach((listener) => listener())
+}

--- a/packages/react/src/lib/providers/datacollection/readDataCollectionStorage.ts
+++ b/packages/react/src/lib/providers/datacollection/readDataCollectionStorage.ts
@@ -56,3 +56,37 @@ export const resolveDataCollectionFilters = <
     storage.filters
   )
 }
+
+/**
+ * Write counterpart of `resolveDataCollectionFilters`: returns a new storage
+ * object with `filters` replaced, writing the SAME slot the resolver reads —
+ * when a per-visualization override exists for the persisted visualization,
+ * that slot is updated too, so a subsequent resolve sees the new filters
+ * instead of the stale override winning.
+ *
+ * Pure; the rest of the persisted state (sortings, search, settings, …) is
+ * preserved untouched.
+ */
+export const mergeDataCollectionFilters = <
+  CurrentFiltersState extends FiltersState<FiltersDefinition> =
+    FiltersState<FiltersDefinition>,
+>(
+  storage: DataCollectionStorage<CurrentFiltersState>,
+  filters: CurrentFiltersState
+): DataCollectionStorage<CurrentFiltersState> => {
+  const visualizationKey = String(storage.visualization ?? 0)
+  const hasVisualizationSlot =
+    storage.visualizationFilters?.[visualizationKey] !== undefined
+  return {
+    ...storage,
+    filters,
+    ...(hasVisualizationSlot
+      ? {
+          visualizationFilters: {
+            ...storage.visualizationFilters,
+            [visualizationKey]: filters,
+          },
+        }
+      : {}),
+  }
+}

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__tests__/seedFromStorage.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__tests__/seedFromStorage.test.ts
@@ -92,6 +92,13 @@ describe("seedFromStorage", () => {
     expect(applied?.filters).not.toHaveProperty("legacyFilter")
   })
 
+  it("applies an explicitly persisted empty filters state (user cleared them)", () => {
+    const target = makeTarget()
+    const applied = seedFromStorage({ filters: {} }, definition, target)
+    expect(target.setCurrentFilters).toHaveBeenCalledWith({})
+    expect(applied?.filters).toEqual({})
+  })
+
   it("applies nothing when every persisted filter key is unknown", () => {
     const target = makeTarget()
     const applied = seedFromStorage(

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__tests__/useDataCollectionItemNavigation.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__tests__/useDataCollectionItemNavigation.test.tsx
@@ -14,6 +14,7 @@ import {
   DataCollectionStorageHandler,
   DataCollectionStorageProvider,
 } from "@/lib/providers/datacollection"
+import { notifyDataCollectionStorageChange } from "@/lib/providers/datacollection/dataCollectionStorageEvents"
 import { TestProviders, zeroRenderHook } from "@/testing/test-utils"
 
 import { DataCollectionSourceDefinition } from "../../useDataCollectionSource"
@@ -584,6 +585,111 @@ describe("useDataCollectionItemNavigation", () => {
       await new Promise((resolve) => setTimeout(resolve, 20))
 
       expect(fetchItemNeighbors).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("storage write notifications", () => {
+    it("re-seeds and refetches when another consumer writes the persisted state", async () => {
+      const fetchData = makeFetchData()
+      const fetchItemNeighbors = makeFetchItemNeighbors()
+      let stored: DataCollectionStorage = {
+        filters: { department: ["Design"] },
+      }
+      const handler = makeStorageHandler(() => Promise.resolve(stored))
+
+      const { result } = zeroRenderHook(
+        () =>
+          useDataCollectionItemNavigation({
+            source: makeSource(fetchData, fetchItemNeighbors),
+            collectionId: "test/items/v1",
+            // Design item: position 1 of 12 under the persisted filters
+            activeItemId: 2,
+          }),
+        { wrapper: withStorage(handler) }
+      )
+
+      await waitFor(() =>
+        expect(result.current.navigation?.counter).toEqual({
+          current: 1,
+          total: 12,
+        })
+      )
+
+      // e.g. the breadcrumb select's editable filters cleared the filters
+      // and wrote through to storage
+      stored = { filters: {} }
+      notifyDataCollectionStorageChange("test/items/v1")
+
+      // Unfiltered, item 2 is position 2 of 25
+      await waitFor(() =>
+        expect(result.current.navigation?.counter).toEqual({
+          current: 2,
+          total: 25,
+        })
+      )
+      expect(fetchData.mock.calls.at(-1)![0].filters).toEqual({})
+    })
+
+    it("the controlled currentFilters override still wins after a notified write", async () => {
+      const fetchData = makeFetchData()
+      const fetchItemNeighbors = makeFetchItemNeighbors()
+      let stored: DataCollectionStorage = {}
+      const handler = makeStorageHandler(() => Promise.resolve(stored))
+
+      const { result } = zeroRenderHook(
+        () =>
+          useDataCollectionItemNavigation({
+            source: makeSource(fetchData, fetchItemNeighbors),
+            collectionId: "test/items/v1",
+            activeItemId: 2,
+            currentFilters: { department: ["Design"] },
+          }),
+        { wrapper: withStorage(handler) }
+      )
+
+      await waitFor(() =>
+        expect(result.current.navigation?.counter).toEqual({
+          current: 1,
+          total: 12,
+        })
+      )
+
+      stored = { filters: { department: ["Engineering"] } }
+      notifyDataCollectionStorageChange("test/items/v1")
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      // Every fetch ran under the override; the written filters never leaked
+      for (const call of fetchData.mock.calls) {
+        expect(call[0].filters).toEqual({ department: ["Design"] })
+      }
+      expect(result.current.navigation?.counter).toEqual({
+        current: 1,
+        total: 12,
+      })
+    })
+
+    it("ignores notifications for other collection ids", async () => {
+      const fetchData = makeFetchData()
+      const handler = makeStorageHandler({})
+
+      const { result } = zeroRenderHook(
+        () =>
+          useDataCollectionItemNavigation({
+            source: makeSource(fetchData),
+            collectionId: "test/items/v1",
+            activeItemId: 1,
+          }),
+        { wrapper: withStorage(handler) }
+      )
+
+      await waitFor(() => expect(result.current.isReady).toBe(true))
+      expect(handler.get).toHaveBeenCalledTimes(1)
+
+      notifyDataCollectionStorageChange("other/collection/v1")
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      expect(handler.get).toHaveBeenCalledTimes(1)
+      expect(fetchData).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/seedFromStorage.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/seedFromStorage.ts
@@ -76,16 +76,23 @@ export function seedFromStorage<
   const applied: AppliedCollectionState<R, Filters, Sortings, Grouping> = {}
   let anyApplied = false
 
-  // Filters — per-visualization resolution + pruning against the definition
+  // Filters — per-visualization resolution + pruning against the definition.
+  // An explicitly persisted empty state ({}) IS applied — it means the user
+  // cleared the filters, and the list hydrates it as cleared too. But empty
+  // BY PRUNING (every persisted key unknown — schema drift, not user intent)
+  // keeps the definition defaults, as before.
   const resolvedFilters = resolveDataCollectionFilters(storage)
-  if (resolvedFilters && definition.filters) {
+  if (resolvedFilters !== undefined && definition.filters) {
     const declaredFilters = definition.filters
     const pruned = Object.fromEntries(
       Object.entries(resolvedFilters).filter(([key]) =>
         isKeyOf(declaredFilters, key)
       )
     ) as FiltersState<Filters>
-    if (Object.keys(pruned).length > 0) {
+    if (
+      Object.keys(pruned).length > 0 ||
+      Object.keys(resolvedFilters).length === 0
+    ) {
       target.setCurrentFilters(pruned)
       applied.filters = pruned
       anyApplied = true

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/useDataCollectionItemNavigation.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/useDataCollectionItemNavigation.ts
@@ -18,6 +18,7 @@ import {
   DataCollectionStorage,
   useDataCollectionStorage,
 } from "@/lib/providers/datacollection"
+import { subscribeToDataCollectionStorageChanges } from "@/lib/providers/datacollection/dataCollectionStorageEvents"
 
 import { ItemActionsDefinition } from "../../item-actions"
 import { NavigationFiltersDefinition } from "../../navigationFilters/types"
@@ -209,6 +210,44 @@ export function useDataCollectionItemNavigation<
     applyFiltersOverride()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hydrated, overrideFiltersKey])
+
+  // Live re-seed: when another collection-bound consumer writes this
+  // collection's persisted state (e.g. the breadcrumb select's editable
+  // filters writing through), re-apply it so prev/next + counter follow
+  // without any app-side plumbing. The controlled override still wins: while
+  // it is set, the persisted filters are not seeded at all — applying them
+  // first and re-applying the override after would leak one fetch under the
+  // written filters.
+  useEffect(() => {
+    if (!enabled || !restorePersistedState) return
+    return subscribeToDataCollectionStorageChanges(collectionId, async () => {
+      try {
+        // NOTE: must await (not .then) — the default noop handler returns a
+        // plain object typed as a Promise.
+        const storage = (await storageHandlerRef.current.get(
+          collectionId
+        )) as DataCollectionStorage<FiltersState<Filters>>
+        if (!storage) return
+        const definition = dataSourceRef.current
+        seedFromStorage<R, Filters, Sortings, Grouping>(
+          storage,
+          {
+            filters:
+              overrideFiltersRef.current === undefined
+                ? definition.filters
+                : undefined,
+            sortings: definition.sortings,
+            search: definition.search,
+            grouping: definition.grouping,
+          },
+          definition
+        )
+      } catch {
+        // Unreadable persisted state — keep the current state.
+      }
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collectionId, enabled, restorePersistedState])
 
   const {
     data,


### PR DESCRIPTION
Two fixes that make the `collection-select` breadcrumb (#4404) + `useDataCollectionItemNavigation` (#4399) behave correctly on a detail page with prev/next navigation. Found adopting them for the employee detail page in the Factorial app.

## Fix 1 — don't remount the select when walking items of the same collection

`Breadcrumbs` keyed every crumb by `item.id` — the root container by the last crumb's id, and `BreadcrumbItem`'s own root by `item.id` again. A detail page walking items of the same collection (prev/next changes the breadcrumb item id/value) therefore **remounted the collection-select on every navigation**. A remount rebuilds the seeded source and `F0Select` fetches its dropdown page eagerly on mount → **the full list query refired on every arrow press**.

Collection-select crumbs are now keyed by `collectionId` (`getBreadcrumbKey`, used at every breadcrumb render-key site): same collection = same mounted select — the trigger's `label`/`value`/`defaultItem` update through props and the fetched dropdown page is kept. Different collection = remount with a freshly seeded source (the previous "swap" contract, with the right identity).

## Fix 2 — write filter refinements through to the collection's persisted state

Refining filters in the dropdown (`showFilters`) only updated the select's local runtime source: the persisted state under `datacollection-<collectionId>` kept the old filters, so prev/next didn't follow and any select remount re-seeded stale filters.

The persisted collection state is now the single source of truth:

1. **Write-through** — the select persists filter changes via the storage handler, preserving the rest of the state (sortings/search/settings) and updating the same slot `resolveDataCollectionFilters` reads (incl. the per-visualization override slot when one exists).
2. **Change notification** — a tiny in-memory pub/sub keyed by collection id (`dataCollectionStorageEvents`). Deliberately not a cross-tab/server bridge — that's the handler's concern; this is "another component in this tree just wrote this key".
3. **Live re-seed** — `useDataCollectionItemNavigation` subscribes and re-seeds from storage on notify, so arrows + counter follow the refined set with zero app-side plumbing. The controlled `currentFilters` override still wins: while set, written filters are not seeded at all (seeding then re-applying the override would leak one fetch under the written filters — caught by test).
4. **Explicit-empty semantics** — seeding (hook + select) applies an explicitly persisted empty filters state (`{}` = the user cleared the filters; the list hydrates it as cleared too). Empty **by pruning** (every persisted key unknown — schema drift) still keeps the definition defaults.

A nice consequence: going back to the list shows the filters refined in the breadcrumb — the list always re-hydrates from the same storage.

## Fix 3 — accept concretely-typed sources in the collection-select item (TS)

The item union is record-erased (`RecordType`); under `strictFunctionTypes` its arrow-typed callbacks (`source.selectable`, the adapter's `fetchData` — contravariant in the filters state —, `mapOptions`, `getItemHref`, `onSelect`) made every source declared over a concrete record/filters type unassignable, forcing consumers into casts. The item's `source` is now `CollectionSelectSourceDefinition` — the erased definition with every function-valued member rewrapped to check parameters bivariantly (method-syntax trick) — and the item's own record-consuming callbacks use method syntax. Sound at this boundary: each source is fully type-checked against its concrete types where declared, and the select only feeds records fetched from that same source back into these callbacks. Type-level regression test included (validated by tsc).

## Tests

- `BreadcrumbCollectionSelect` (via real `Breadcrumbs`): new item id/value with same `collectionId` does NOT refetch and the trigger shows the new label; changing `collectionId` remounts and refetches.
- Write-through: persists preserving the rest of the state; updates the per-visualization slot; notifies subscribers; no write when filters aren't editable.
- `useDataCollectionItemNavigation`: re-seeds + refetches on notify; override wins after a notified write; ignores other collection ids.
- `seedFromStorage` / `buildCollectionBoundSource` explicit-empty cases; `mergeDataCollectionFilters` + `dataCollectionStorageEvents` units.

`tsc` clean; 770 tests green across Header / OneDataCollection / datasource / F0Select / datacollection suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)