### PR TITLE
fix(Table): include async-loaded nested children in select-all and hide unusable header checkbox

### DIFF
--- a/packages/react/src/hooks/datasource/useSelectable/typings.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/typings.ts
@@ -89,6 +89,13 @@ export type UseSelectableProps<
    * @default false
    */
   preserveSelectionOnDatasetChange?: boolean
+  /**
+   * Additional visible records that are not part of `data.records` but
+   * should participate in current-page selection (e.g. expanded nested
+   * children loaded asynchronously). They are included in "select all"
+   * and counted as part of the current page.
+   */
+  extraRecords?: readonly R[]
 }
 
 export type SelectionMeta<R extends RecordType> = {

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -20,6 +20,10 @@ import {
 } from "./typings"
 import { isGroupRecord, isRecordItem, parseSelectedState } from "./utils"
 
+// Stable default so callbacks/memos depending on `extraRecords` don't
+// recreate on every render when the prop is omitted.
+const NO_EXTRA_RECORDS: never[] = []
+
 /**
  * Custom hook to manage selection state for items and groups in a data table
  * Supports single/multi selection, grouped data, pagination, and filtering
@@ -41,6 +45,7 @@ export function useSelectable<
   allPagesSelection,
   resetOnPageChange = true,
   preserveSelectionOnDatasetChange = false,
+  extraRecords = NO_EXTRA_RECORDS,
 }: UseSelectableProps<R, Filters, Sortings, Grouping>): UseSelectableReturn<
   R,
   Filters
@@ -91,11 +96,17 @@ export function useSelectable<
 
   const totalKnownItemsCount = useMemo(() => {
     // In page-only selection mode, only count items in current page
+    // (including visible extra records such as expanded nested children)
     if (isPageOnlySelection) {
-      return data.records?.length || 0
+      return (data.records?.length || 0) + extraRecords.length
     }
     return paginationInfo ? paginationInfo.total : data.records?.length
-  }, [paginationInfo, data.records?.length, isPageOnlySelection])
+  }, [
+    paginationInfo,
+    data.records?.length,
+    isPageOnlySelection,
+    extraRecords.length,
+  ])
 
   const currentPageIdentifier = useMemo(() => {
     if (!paginationInfo) return null
@@ -226,9 +237,10 @@ export function useSelectable<
     const items = localSelectedState.items || new Map()
 
     // In page-only selection mode, only include items from current page
+    // (including visible extra records such as expanded nested children)
     const currentPageItemIds = isPageOnlySelection
       ? new Set(
-          data.records
+          [...data.records, ...extraRecords]
             .map((record) => getSelectable?.(record))
             .filter((id): id is SelectionId => id !== undefined)
         )
@@ -261,6 +273,7 @@ export function useSelectable<
     localSelectedState.items,
     isPageOnlySelection,
     data.records,
+    extraRecords,
     getSelectable,
   ])
 
@@ -613,12 +626,15 @@ export function useSelectable<
           handleSelectGroupChange(allGroupIds, checked)
         }
       } else {
-        const allItemIds = data.records
+        // Include visible extra records (e.g. expanded nested children) so
+        // "select all" covers every selectable row currently on screen.
+        const allRecords = [...data.records, ...extraRecords]
+        const allItemIds = allRecords
           .map((record) => getSelectable?.(record))
           .filter((id): id is SelectionId => id !== undefined)
 
         if (allItemIds.length > 0) {
-          handleSelectItemChangeInternal(allItemIds, checked)
+          handleSelectItemChangeInternal(allItemIds, checked, false, allRecords)
         }
       }
 
@@ -633,6 +649,7 @@ export function useSelectable<
       allSelectedCheck,
       isGrouped,
       data,
+      extraRecords,
       getSelectable,
       handleSelectGroupChange,
       handleSelectItemChangeInternal,
@@ -662,12 +679,15 @@ export function useSelectable<
           handleSelectGroupChange(allGroupIds, checked)
         }
       } else {
-        const allItemIds = data.records
+        // Include visible extra records (e.g. expanded nested children) so
+        // "select all items" also covers them.
+        const allRecords = [...data.records, ...extraRecords]
+        const allItemIds = allRecords
           .map((record) => getSelectable?.(record))
           .filter((id): id is SelectionId => id !== undefined)
 
         if (allItemIds.length > 0) {
-          handleSelectItemChangeInternal(allItemIds, checked)
+          handleSelectItemChangeInternal(allItemIds, checked, false, allRecords)
         }
 
         setLocalSelectedState((current) => {
@@ -696,6 +716,7 @@ export function useSelectable<
       totalKnownItemsCount,
       isGrouped,
       data,
+      extraRecords,
       getSelectable,
       handleSelectGroupChange,
       handleSelectItemChangeInternal,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -51,7 +51,10 @@ import { statusToChecked } from "../utils"
 import { Row } from "./components/Row"
 import { useColumns } from "./hooks/useColums"
 import { groupBorderClass, useHeaderGroups } from "./hooks/useHeaderGroups"
-import { NestedDataProvider } from "./providers/NestedProvider"
+import {
+  NestedDataProvider,
+  useNestedDataState,
+} from "./providers/NestedProvider"
 import { useSticky } from "./useSticky"
 export * from "./settings/SettingsRenderer"
 
@@ -223,6 +226,23 @@ export const TableCollection = <
   }
 
   /**
+   * Nested children state. Owned here (instead of inside NestedDataProvider)
+   * so async-loaded children of expanded rows can participate in selection.
+   */
+  const nestedData = useNestedDataState<R>()
+
+  // Children of expanded rows, loaded asynchronously via fetchChildren. They
+  // are visible on screen but not part of data.records, so they must be added
+  // explicitly to selection logic ("select all" + header checkbox state).
+  const visibleChildrenRecords = useMemo(
+    () =>
+      Object.entries(nestedData.fetchedData)
+        .filter(([rowId]) => nestedData.expandedRowIds[rowId])
+        .flatMap(([, response]) => response?.records ?? []),
+    [nestedData.fetchedData, nestedData.expandedRowIds]
+  )
+
+  /**
    * Item selection
    */
   const {
@@ -240,6 +260,7 @@ export const TableCollection = <
     onSelectItems,
     selectionMode: "multi",
     selectedState: source.defaultSelectedItems,
+    extraRecords: visibleChildrenRecords,
   })
   const summaryData = useMemo(() => {
     // Early return if no summaries configuration or summaries data is available
@@ -355,9 +376,19 @@ export const TableCollection = <
   // another page happen to equal the current page size.
   // Non-selectable rows (source.selectable returns undefined) are filtered out
   // so pages with mixed selectable/non-selectable rows still report correctly.
-  const currentPageSelectableIds = (data?.records ?? [])
+  // Visible children of expanded rows are included: they may be the only
+  // selectable rows when parents themselves are not selectable.
+  const currentPageSelectableIds = [
+    ...(data?.records ?? []),
+    ...visibleChildrenRecords,
+  ]
     .map((record) => source.selectable?.(record))
     .filter((id): id is SelectionId => id !== undefined)
+
+  // The header "select all" checkbox is only meaningful when at least one
+  // visible row is actually selectable. The column itself still renders (rows
+  // reserve the cell), but the checkbox is hidden.
+  const hasSelectableRows = currentPageSelectableIds.length > 0
 
   const allPageRowsSelected =
     currentPageSelectableIds.length > 0 &&
@@ -384,11 +415,9 @@ export const TableCollection = <
       ? i18n.status.selected.singular
       : i18n.status.selected.plural
 
-  const TableWrapper = tableWithChildren ? NestedDataProvider : Fragment
-
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
-      <TableWrapper>
+      <NestedDataProvider value={nestedData}>
         <div
           className={cn(
             bordered &&
@@ -479,14 +508,16 @@ export const TableCollection = <
                     }
                   >
                     <div className="ml-3.5 flex w-full items-center justify-start">
-                      <F0Checkbox
-                        checked={isAllSelected}
-                        indeterminate={hasSelection && !isAllSelected}
-                        onCheckedChange={handleSelectAll}
-                        title={i18n.actions.selectAll}
-                        hideLabel
-                        disabled={data?.records.length === 0}
-                      />
+                      {hasSelectableRows && (
+                        <F0Checkbox
+                          checked={isAllSelected}
+                          indeterminate={hasSelection && !isAllSelected}
+                          onCheckedChange={handleSelectAll}
+                          title={i18n.actions.selectAll}
+                          hideLabel
+                          disabled={data?.records.length === 0}
+                        />
+                      )}
                     </div>
                   </TableHead>
                 )}
@@ -983,7 +1014,7 @@ export const TableCollection = <
           setPage={setPage}
           className="pb-4"
         />
-      </TableWrapper>
+      </NestedDataProvider>
     </div>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -38,6 +38,7 @@ type Person = {
   name: string
   email: string
   displayName: string
+  hasChildren?: boolean
 }
 
 const testData: Person[] = [
@@ -2127,6 +2128,204 @@ describe("TableCollection", () => {
       await user.click(engineeringHeading)
 
       expect(onSelectItems.mock.calls.length).toBe(callCountAfterRender)
+    })
+  })
+
+  describe("selectable visibility and nested children selection", () => {
+    const parentPerson: Person = {
+      id: 1,
+      name: "Parent User",
+      email: "parent@example.com",
+      displayName: "Parent User",
+      hasChildren: true,
+    }
+
+    const childPeople: Person[] = [
+      {
+        id: 10,
+        name: "Child A",
+        email: "child.a@example.com",
+        displayName: "Child A",
+      },
+      {
+        id: 11,
+        name: "Child B",
+        email: "child.b@example.com",
+        displayName: "Child B",
+      },
+    ]
+
+    const createNestedSource = (
+      selectable: (item: Person) => number | undefined
+    ): DataCollectionSource<
+      Person,
+      TestFilters,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Person>,
+      TestNavigationFilters,
+      GroupingDefinition<Person>
+    > => ({
+      ...createTestSource([parentPerson]),
+      selectable,
+      itemsWithChildren: (item: Person) => !!item.hasChildren,
+      fetchChildren: () => ({
+        records: childPeople,
+        type: "basic" as const,
+      }),
+    })
+
+    it("hides the header select-all checkbox when no visible row is selectable", async () => {
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={testColumns}
+          source={{ ...createTestSource(), selectable: () => undefined }}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      // selectable is defined but returns undefined for every row, so neither
+      // row checkboxes nor the header select-all checkbox should render
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument()
+    })
+
+    it("shows the header checkbox once async-loaded children are selectable and selects them all", async () => {
+      const user = userEvent.setup()
+      const onSelectItems = vi.fn()
+
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={testColumns}
+          source={createNestedSource((item) =>
+            item.hasChildren ? undefined : item.id
+          )}
+          onSelectItems={onSelectItems}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Parent User")).toBeInTheDocument()
+      })
+
+      // Parent is not selectable and children are not loaded yet, so the
+      // header checkbox must be hidden
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument()
+
+      // Expand the parent row to load its children asynchronously
+      const parentRow = screen.getByText("Parent User").closest("tr")!
+      const chevron = parentRow.querySelector("[class*='cursor-pointer']")!
+      await user.click(chevron)
+
+      await waitFor(() => {
+        expect(screen.getByText("Child A")).toBeInTheDocument()
+      })
+
+      // Header checkbox appears now that selectable children are visible
+      const checkboxes = screen.getAllByRole("checkbox")
+      expect(checkboxes).toHaveLength(3) // header + 2 children
+
+      // Header select-all selects every visible selectable row (the children)
+      await user.click(checkboxes[0])
+
+      await waitFor(() => {
+        const headerCheckbox = screen.getAllByRole("checkbox")[0]
+        expect(headerCheckbox).toHaveAttribute("aria-checked", "true")
+      })
+
+      const childARow = screen.getByText("Child A").closest("tr")!
+      expect(within(childARow).getByRole("checkbox")).toHaveAttribute(
+        "aria-checked",
+        "true"
+      )
+      const childBRow = screen.getByText("Child B").closest("tr")!
+      expect(within(childBRow).getByRole("checkbox")).toHaveAttribute(
+        "aria-checked",
+        "true"
+      )
+
+      // The selection reported to the parent includes both children
+      expect(
+        onSelectItems.mock.calls.some(([selection]) =>
+          [10, 11].every((id) => selection.selectedIds.includes(id))
+        )
+      ).toBe(true)
+    })
+
+    it("deselects all visible children when the header checkbox is unchecked", async () => {
+      const user = userEvent.setup()
+
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={testColumns}
+          source={createNestedSource((item) =>
+            item.hasChildren ? undefined : item.id
+          )}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Parent User")).toBeInTheDocument()
+      })
+
+      const parentRow = screen.getByText("Parent User").closest("tr")!
+      const chevron = parentRow.querySelector("[class*='cursor-pointer']")!
+      await user.click(chevron)
+
+      await waitFor(() => {
+        expect(screen.getByText("Child A")).toBeInTheDocument()
+      })
+
+      // Select all, then deselect all via the header checkbox
+      await user.click(screen.getAllByRole("checkbox")[0])
+      await waitFor(() => {
+        expect(screen.getAllByRole("checkbox")[0]).toHaveAttribute(
+          "aria-checked",
+          "true"
+        )
+      })
+
+      await user.click(screen.getAllByRole("checkbox")[0])
+
+      await waitFor(() => {
+        screen.getAllByRole("checkbox").forEach((checkbox) => {
+          expect(checkbox).toHaveAttribute("aria-checked", "false")
+        })
+      })
     })
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
@@ -3,6 +3,7 @@ import {
   ReactNode,
   useCallback,
   useContext,
+  useMemo,
   useState,
 } from "react"
 
@@ -22,11 +23,15 @@ const NestedDataContext = createContext<
   NestedDataContextValue<RecordType> | undefined
 >(undefined)
 
-export const NestedDataProvider = <R extends RecordType>({
-  children,
-}: {
-  children: ReactNode
-}) => {
+/**
+ * Creates the nested-data state (fetched children + expansion state).
+ * Exposed so the table can own the state and read it (e.g. to include
+ * expanded children in select-all), while still providing it through
+ * NestedDataProvider via the `value` prop.
+ */
+export const useNestedDataState = <
+  R extends RecordType,
+>(): NestedDataContextValue<R> => {
   const [fetchedData, setFetchedData] = useState<
     Record<string, ChildrenResponse<R>>
   >({})
@@ -59,17 +64,37 @@ export const NestedDataProvider = <R extends RecordType>({
     })
   }, [])
 
+  return useMemo(
+    () => ({
+      fetchedData,
+      updateFetchedData,
+      clearFetchedData,
+      expandedRowIds,
+      setRowExpanded,
+    }),
+    [
+      fetchedData,
+      updateFetchedData,
+      clearFetchedData,
+      expandedRowIds,
+      setRowExpanded,
+    ]
+  )
+}
+
+export const NestedDataProvider = <R extends RecordType>({
+  children,
+  value,
+}: {
+  children: ReactNode
+  /** Externally-owned state (from useNestedDataState). When omitted, the provider owns its own. */
+  value?: NestedDataContextValue<R>
+}) => {
+  const ownValue = useNestedDataState<R>()
+
   return (
     <NestedDataContext.Provider
-      value={
-        {
-          fetchedData,
-          updateFetchedData,
-          clearFetchedData,
-          expandedRowIds,
-          setRowExpanded,
-        } as NestedDataContextValue<RecordType>
-      }
+      value={(value ?? ownValue) as NestedDataContextValue<RecordType>}
     >
       {children}
     </NestedDataContext.Provider>


### PR DESCRIPTION
## Description

Fixes two bugs in the data collection table's selection (shared by `Table` and `EditableTable` visualizations) when selectable rows are nested children loaded asynchronously via `fetchChildren`:

1. **The header select-all checkbox did nothing**: `handleSelectAll` in `useSelectable` only iterated `data.records` (top-level rows). Async-loaded children live in `NestedDataContext`, so when only children are selectable, the computed ID list was empty and clicking the checkbox was a no-op.
2. **The header checkbox always rendered**: it appeared whenever the `source.selectable` *function* was defined, even when it returned `undefined` for every visible row — showing a select-all checkbox that could never select anything.

## Screenshots (if applicable)

N/A — behavioral fix, no visual changes beyond the header checkbox now hiding when no visible row is selectable.

## Implementation details

- **`NestedProvider.tsx`**: extracted the provider's state into a `useNestedDataState` hook and made `NestedDataProvider` accept an optional `value`. `TableCollection` now owns the loaded-children/expansion state so the selection logic can read it (previously it was encapsulated inside the provider, below the component that renders the header).
- **`Table.tsx`**: computes `visibleChildrenRecords` (children of expanded rows already loaded) and:
  - passes them to `useSelectable` as `extraRecords`,
  - includes them in `currentPageSelectableIds` so the header checked/indeterminate state reflects them,
  - only renders the header `F0Checkbox` when at least one visible row is actually selectable (`hasSelectableRows`). The column is still reserved so the layout doesn't shift when children appear.
- **`useSelectable.ts`**: new optional `extraRecords` prop that participates in `handleSelectAll`, `handleSelectAllItems`, the page-only item count, and the `selectedIds`/`itemsStatus` filtering reported through `onSelectItems` (without this, selected children were filtered out of the callback in page-only mode). Records are also passed as fallback items so their references are stored in the selection state. The default is a stable empty array, so Card, List and F0Select (which don't pass it) keep their exact behavior.

Scope note: "select all" covers top-level rows plus children of **expanded** rows. Children that were loaded but whose parent is collapsed are not included.

### Tests

Three new tests in `Table.test.tsx`:
- header checkbox is hidden when `selectable` returns `undefined` for every visible row,
- expanding a parent whose async-loaded children are selectable shows the header checkbox and select-all selects all of them (including the `onSelectItems` report),
- unchecking the header checkbox deselects all visible children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)