### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.61.4",
+  "packages/react": "2.61.5",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.61.5](https://github.com/factorialco/f0/compare/f0-react-v2.61.4...f0-react-v2.61.5) (2026-06-12)
+
+
+### Bug Fixes
+
+* **F0CardRow:** remove whole-card click target ([#4376](https://github.com/factorialco/f0/issues/4376)) ([b057f40](https://github.com/factorialco/f0/commit/b057f4090501088737649c6047b0203ffd9fda46))
+
 ## [2.61.4](https://github.com/factorialco/f0/compare/f0-react-v2.61.3...f0-react-v2.61.4) (2026-06-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.61.4",
+  "version": "2.61.5",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 2.61.5</summary>

## [2.61.5](https://github.com/factorialco/f0/compare/f0-react-v2.61.4...f0-react-v2.61.5) (2026-06-12)


### Bug Fixes

* **F0CardRow:** remove whole-card click target ([#4376](https://github.com/factorialco/f0/issues/4376)) ([b057f40](https://github.com/factorialco/f0/commit/b057f4090501088737649c6047b0203ffd9fda46))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).