### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "2.61.5",
+  "packages/react": "3.0.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [3.0.0](https://github.com/factorialco/f0/compare/f0-react-v2.61.5...f0-react-v3.0.0) (2026-06-12)
+
+
+### ⚠ BREAKING CHANGES
+
+* **f0-inputs:** 6 inputs migrate to forwardRef (component type identity changes, runtime-safe). F0NumberInput no longer exposes onPressEnter. F0TextInputProps is no longer generic (value: T -> string).
+
+### Features
+
+* **f0-inputs:** promote 6 text inputs to stable ([#4216](https://github.com/factorialco/f0/issues/4216)) ([fcb596e](https://github.com/factorialco/f0/commit/fcb596e623c6985e1bbb786ab7c1014427f2e82d))
+
 ## [2.61.5](https://github.com/factorialco/f0/compare/f0-react-v2.61.4...f0-react-v2.61.5) (2026-06-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "2.61.5",
+  "version": "3.0.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.0.0</summary>

## [3.0.0](https://github.com/factorialco/f0/compare/f0-react-v2.61.5...f0-react-v3.0.0) (2026-06-12)


### ⚠ BREAKING CHANGES

* **f0-inputs:** 6 inputs migrate to forwardRef (component type identity changes, runtime-safe). F0NumberInput no longer exposes onPressEnter. F0TextInputProps is no longer generic (value: T -> string).

### Features

* **f0-inputs:** promote 6 text inputs to stable ([#4216](https://github.com/factorialco/f0/issues/4216)) ([fcb596e](https://github.com/factorialco/f0/commit/fcb596e623c6985e1bbb786ab7c1014427f2e82d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).