### PR TITLE
fix(ButtonGroup): never collapse or squeeze a confirm/reject pair

### DIFF
--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -233,6 +233,9 @@ export function CardRowActions({
           secondaryActions={reject ? [reject] : undefined}
           size={size}
           gap={GAP}
+          // The confirm/reject pair must always stay inline — the reject button
+          // must never shed into the "⋯" menu.
+          canOverflow={false}
         />
       )
     }

--- a/packages/react/src/ui/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/ui/ButtonGroup/ButtonGroup.tsx
@@ -103,6 +103,12 @@ export interface ButtonGroupProps {
   fullWidthOnStack?: boolean
   /** Reverse the stacked column so the primary lands on top. */
   reverseOnStack?: boolean
+  /**
+   * When `false`, secondary buttons never shed into the "⋯" menu — they always
+   * render inline (e.g. a confirm/reject pair that must never collapse).
+   * `otherActions` still populate the menu when present. @default true
+   */
+  canOverflow?: boolean
   className?: string
 }
 
@@ -190,6 +196,7 @@ interface ButtonGroupBranchProps {
   size: ButtonSize
   gap: number
   align: "end" | "between"
+  canOverflow: boolean
 }
 
 /**
@@ -221,6 +228,7 @@ export function ButtonGroup({
   stack = "none",
   fullWidthOnStack = false,
   reverseOnStack = false,
+  canOverflow = true,
   className,
 }: ButtonGroupProps) {
   const rootRef = useRef<HTMLDivElement>(null)
@@ -265,6 +273,7 @@ export function ButtonGroup({
     size: resolvedSize,
     gap,
     align,
+    canOverflow,
   }
 
   return (
@@ -273,7 +282,10 @@ export function ButtonGroup({
       role="group"
       className={cn(
         isRowMode
-          ? "flex w-full items-center"
+          ? // Keep the pinned trailing items (splits, divider, primary) at their
+            // natural width; only the first child — the flex-1 cluster — shrinks,
+            // so the title truncates against it rather than squeezing the buttons.
+            "flex w-full items-center [&>*:not(:first-child)]:shrink-0"
           : buttonGroupVariants({
               align,
               stack,
@@ -331,6 +343,7 @@ function ButtonGroupRow({
   size,
   gap,
   align,
+  canOverflow,
 }: ButtonGroupBranchProps) {
   // Only plain buttons are width-measured; splits + separators are pinned/excluded.
   // Memoized so the reference is stable across renders — a fresh array would
@@ -357,8 +370,14 @@ function ButtonGroupRow({
   }, [measurementContainerRef])
 
   // Before the first measurement, optimistically show everything to avoid a flash.
-  const shownPlain = isInitialized ? visibleItems : plainSecondaries
-  const overflowedPlain = isInitialized ? overflowItems : []
+  // When `canOverflow` is false the group never sheds: every secondary stays
+  // inline and nothing is measured away into the "⋯" menu.
+  const shownPlain = !canOverflow
+    ? plainSecondaries
+    : isInitialized
+      ? visibleItems
+      : plainSecondaries
+  const overflowedPlain = !canOverflow ? [] : isInitialized ? overflowItems : []
   const shownIds = new Set(shownPlain.map((action) => action.id))
 
   const primaryNode = primaryAction
@@ -418,22 +437,28 @@ function ButtonGroupRow({
       <div
         ref={containerRef}
         className={cn(
-          "relative flex min-w-0 flex-1 items-center",
+          // `[&>*]:shrink-0` keeps each rendered secondary, separator, link and
+          // the "⋯" trigger at its natural width: the row overflows by shedding
+          // into the menu, never by squeezing a button to nothing.
+          "relative flex min-w-0 flex-1 items-center [&>*]:shrink-0",
           align === "end" && "justify-end"
         )}
         style={{ gap }}
       >
-        {/* Hidden measurement copy, used to compute the visible/overflow split. */}
-        <div
-          ref={measurementContainerRef}
-          aria-hidden="true"
-          className="pointer-events-none invisible absolute left-0 top-0 flex items-center whitespace-nowrap"
-          style={{ gap }}
-        >
-          {plainSecondaries.map((action) =>
-            renderActionButton(action, size, "outline")
-          )}
-        </div>
+        {/* Hidden measurement copy, used to compute the visible/overflow split.
+            Skipped when the group can't overflow — nothing is ever measured away. */}
+        {canOverflow && (
+          <div
+            ref={measurementContainerRef}
+            aria-hidden="true"
+            className="pointer-events-none invisible absolute left-0 top-0 flex items-center whitespace-nowrap"
+            style={{ gap }}
+          >
+            {plainSecondaries.map((action) =>
+              renderActionButton(action, size, "outline")
+            )}
+          </div>
+        )}
 
         {menuItems.length > 0 && (
           <div ref={customOverflowIndicatorRef}>

--- a/packages/react/src/ui/ButtonGroup/__stories__/ButtonGroup.behaviors.stories.tsx
+++ b/packages/react/src/ui/ButtonGroup/__stories__/ButtonGroup.behaviors.stories.tsx
@@ -4,6 +4,7 @@ import { type DropdownItem } from "@/experimental/Navigation/Dropdown"
 import {
   Archive,
   ArrowUp,
+  Check,
   Cross,
   Delete,
   Download,
@@ -394,5 +395,62 @@ export const OverflowMenu: Story = {
         </div>
       ))}
     </div>
+  ),
+}
+
+// =============================================================================
+// Composition — confirm/reject pair never collapses (canOverflow=false)
+// =============================================================================
+
+// An icon-only accept/reject pair (as used by F0HILActionConfirmation): reject
+// is a secondary, confirm the pinned primary.
+const reject = {
+  id: "reject",
+  label: "Reject",
+  icon: Cross,
+  hideLabel: true,
+  onClick: noop,
+}
+const confirm = {
+  id: "confirm",
+  label: "Confirm",
+  icon: Check,
+  hideLabel: true,
+  onClick: noop,
+}
+
+const PairBox = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{ width: 96 }}
+    className="rounded-lg border border-solid border-f1-border-secondary p-3"
+  >
+    {children}
+  </div>
+)
+
+/**
+ * An icon-only confirm/reject pair must never collapse. By default the row's
+ * overflow machinery reserves the ellipsis width and sheds the lone reject into
+ * the "⋯" menu (the bug). `canOverflow={false}` keeps both inline at any width.
+ */
+export const ConfirmRejectNeverCollapses: Story = {
+  name: "Confirm/reject never collapses",
+  render: () => (
+    <Cases>
+      <Case caption="Issue — default: the reject sheds into the ⋯ menu, leaving ⋯ + the confirm check">
+        <PairBox>
+          <ButtonGroup primaryAction={confirm} secondaryActions={[reject]} />
+        </PairBox>
+      </Case>
+      <Case caption="Fix — canOverflow={false}: the pair always stays inline">
+        <PairBox>
+          <ButtonGroup
+            primaryAction={confirm}
+            secondaryActions={[reject]}
+            canOverflow={false}
+          />
+        </PairBox>
+      </Case>
+    </Cases>
   ),
 }

--- a/packages/react/src/ui/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/packages/react/src/ui/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { ButtonGroup } from "../ButtonGroup"
+
+// The width-driven overflow (useOverflowCalculation) can't be exercised in
+// jsdom — every element measures 0, so nothing ever sheds into the "⋯" menu.
+// These tests instead cover the `canOverflow` prop, which is pure render logic:
+// when false the group renders every secondary inline and skips the hidden
+// width-measurement copy entirely. The accessible name of the row's overflow
+// trigger is "Toggle dropdown menu" (the Dropdown's default).
+const secondaries = [
+  { id: "one", label: "One", onClick: vi.fn() },
+  { id: "two", label: "Two", onClick: vi.fn() },
+  { id: "three", label: "Three", onClick: vi.fn() },
+]
+
+describe("ButtonGroup — canOverflow", () => {
+  it("keeps every secondary inline and skips the measurement copy when canOverflow is false", () => {
+    const { container } = render(
+      <ButtonGroup secondaryActions={secondaries} canOverflow={false} />
+    )
+
+    expect(screen.getByRole("button", { name: "One" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Two" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Three" })).toBeInTheDocument()
+
+    // No secondary sheds, so the overflow "⋯" trigger is never rendered.
+    expect(
+      screen.queryByRole("button", { name: "Toggle dropdown menu" })
+    ).not.toBeInTheDocument()
+
+    // The hidden measurement copy is skipped: only the 3 real buttons exist.
+    expect(container.querySelectorAll("button")).toHaveLength(3)
+  })
+
+  it("allows secondaries to shed into the ⋯ menu by default (canOverflow true)", () => {
+    // Contrast with the case above: by default the group can overflow, so it
+    // renders the "⋯" trigger (in jsdom, where widths measure 0, the secondaries
+    // shed into it). With canOverflow={false} that trigger never appears.
+    render(<ButtonGroup secondaryActions={secondaries} />)
+
+    expect(
+      screen.getByRole("button", { name: "Toggle dropdown menu" })
+    ).toBeInTheDocument()
+  })
+
+  it("still surfaces otherActions in the ⋯ menu when canOverflow is false", () => {
+    render(
+      <ButtonGroup
+        secondaryActions={secondaries}
+        otherActions={[{ label: "Archive", onClick: vi.fn() }]}
+        canOverflow={false}
+      />
+    )
+
+    // Secondaries stay inline …
+    expect(screen.getByRole("button", { name: "One" })).toBeInTheDocument()
+    // … and otherActions still populate the overflow menu.
+    expect(
+      screen.getByRole("button", { name: "Toggle dropdown menu" })
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Description

The accept/reject CardRow (`F0HILActionConfirmation`) routed its pair through `ButtonGroup` as `primaryAction={confirm}` + `secondaryActions={[reject]}`, which inherited the row's width-driven overflow machinery. As a result, in the inline icon-only layout the reject (✗) button collapsed into the "⋯" menu and the confirm (✓) button squeezed to nothing in the tight band just above the stack breakpoint — leaving an ellipsis with no visible primary. This standardizes a "never collapse / never squeeze" behaviour in `ButtonGroup` itself (rather than hand-rendering the pair) so the confirm/reject row always shows both buttons inline.

## Implementation details

- feat: add a `canOverflow` prop to `ButtonGroup` (default `true`); when `false`, secondary buttons never shed into the "⋯" menu — they always render inline and the hidden measurement copy is skipped (`otherActions` still populate the menu when present)

  <details>
  <summary>Why?</summary>

  `useOverflowCalculation` always reserves the ellipsis-button width upfront, so a lone icon-only secondary never fits and collapses entirely. A confirm/reject pair must never collapse, so it opts out of overflow rather than relying on the width heuristic.
  </details>

- fix: pin row item widths with `shrink-0` (cluster children plus the trailing primary/split buttons) so a `ButtonGroup` overflows by shedding into the menu, never by squeezing a button to invisibility — benefits every call site; the first child (the `flex-1` cluster) keeps its shrink so the title truncates against it

- fix: opt the `CardRowActions` confirm/reject branch into `canOverflow={false}` so the reject (✗) button can never shed into the "⋯" menu

## Verification

- Inline band (~470px): both ✗ and ✓ render at full size, no ellipsis
- Below the stack breakpoint: labelled stacked layout unchanged
- Regression: default `canOverflow` still sheds secondaries into "⋯", with no squeezing
- `tsc` clean, lint clean, `F0Card` unit tests 48/48 pass