### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.0.0",
+  "packages/react": "3.0.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.1](https://github.com/factorialco/f0/compare/f0-react-v3.0.0...f0-react-v3.0.1) (2026-06-12)
+
+
+### Bug Fixes
+
+* **breadcrumbs:** collection-select survives item navigation + filter write-through to storage ([#4433](https://github.com/factorialco/f0/issues/4433)) ([5d2e361](https://github.com/factorialco/f0/commit/5d2e36155dc63e0982ad22015a8483069e4f41c1))
+
 ## [3.0.0](https://github.com/factorialco/f0/compare/f0-react-v2.61.5...f0-react-v3.0.0) (2026-06-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.0.1</summary>

## [3.0.1](https://github.com/factorialco/f0/compare/f0-react-v3.0.0...f0-react-v3.0.1) (2026-06-12)


### Bug Fixes

* **breadcrumbs:** collection-select survives item navigation + filter write-through to storage ([#4433](https://github.com/factorialco/f0/issues/4433)) ([5d2e361](https://github.com/factorialco/f0/commit/5d2e36155dc63e0982ad22015a8483069e4f41c1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).