### PR TITLE
fix(datacollection): keep kanban lanes from sticking on loading skeletons

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -215,7 +215,7 @@ export const KanbanCollection = <
           variant: l.variant,
           total: totalItems,
           hasMore,
-          loading: laneData?.isLoading ?? true,
+          loading: laneData ? laneData.isInitialLoading : true,
           loadingMore: laneData?.isLoadingMore || false,
           fetchMore: hasMore ? () => laneData.loadMore() : undefined,
         }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
@@ -1,5 +1,6 @@
-import { screen } from "@testing-library/react"
+import { screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
+import { Observable } from "zen-observable-ts"
 
 import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
 import {
@@ -115,5 +116,139 @@ describe("KanbanCollection - item click", () => {
     expect(onItemClick).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1, name: "John" })
     )
+  })
+})
+
+describe("KanbanCollection - lane loading", () => {
+  it("renders cards when data arrived but the source never settles loading", async () => {
+    const people: Person[] = [
+      { id: 1, name: "John" },
+      { id: 2, name: "Jane" },
+    ]
+
+    const source = {
+      ...createSource(people),
+      dataAdapter: {
+        fetchData: () =>
+          new Observable<{
+            loading: boolean
+            error: null
+            data: {
+              records: Person[]
+              total: number
+              perPage: number
+              type: "infinite-scroll"
+              cursor: string | null
+              hasMore: boolean
+            }
+          }>((subscriber) => {
+            subscriber.next({
+              loading: true,
+              error: null,
+              data: {
+                records: people,
+                total: people.length,
+                perPage: people.length,
+                type: "infinite-scroll",
+                cursor: null,
+                hasMore: false,
+              },
+            })
+          }),
+        paginationType: "infinite-scroll" as const,
+        perPage: people.length,
+      },
+      lanes: [{ id: "todo", filters: {} }],
+    }
+
+    zeroRender(
+      <KanbanCollection<
+        Person,
+        TestFilters,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        TestNavigationFilters,
+        GroupingDefinition<Person>
+      >
+        lanes={[{ id: "todo", title: "Todo" }]}
+        title={(p) => p.name}
+        description={(p) => p.name}
+        metadata={() => []}
+        source={source}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    const cards = await screen.findAllByTestId("card")
+    expect(cards).toHaveLength(2)
+    expect(screen.getAllByText("John").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Jane").length).toBeGreaterThan(0)
+    expect(screen.queryAllByTestId("skeleton")).toHaveLength(0)
+  })
+
+  it("clears the skeleton when an empty lane settles loading", async () => {
+    const emptyResponse = {
+      records: [] as Person[],
+      total: 0,
+      perPage: 10,
+      type: "infinite-scroll" as const,
+      cursor: null,
+      hasMore: false,
+    }
+
+    const source = {
+      ...createSource([]),
+      dataAdapter: {
+        fetchData: () =>
+          new Observable<{
+            loading: boolean
+            error: null
+            data: typeof emptyResponse
+          }>((subscriber) => {
+            subscriber.next({ loading: true, error: null, data: emptyResponse })
+            const settle = setTimeout(() => {
+              subscriber.next({
+                loading: false,
+                error: null,
+                data: emptyResponse,
+              })
+            }, 10)
+            return () => clearTimeout(settle)
+          }),
+        paginationType: "infinite-scroll" as const,
+        perPage: 10,
+      },
+      lanes: [{ id: "todo", filters: {} }],
+    }
+
+    zeroRender(
+      <KanbanCollection<
+        Person,
+        TestFilters,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        TestNavigationFilters,
+        GroupingDefinition<Person>
+      >
+        lanes={[{ id: "todo", title: "Todo" }]}
+        title={(p) => p.name}
+        description={(p) => p.name}
+        metadata={() => []}
+        source={source}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0)
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId("skeleton")).toHaveLength(0)
+    })
   })
 })

--- a/packages/react/src/ui/Kanban/Kanban.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.tsx
@@ -300,7 +300,13 @@ export function Kanban<TRecord extends RecordType>(
         <div className="relative mb-2 flex h-full items-start gap-2">
           {localLanes.map(
             (lane: KanbanLaneAttributes<TRecord>, laneIndex: number) => {
-              const total = lane.total ?? lane.items.length
+              const liveLane = lanes.find((l) => l.id === lane.id)
+              const loading = liveLane?.loading ?? lane.loading
+              const hasMore = liveLane?.hasMore ?? lane.hasMore
+              const loadingMore = liveLane?.loadingMore ?? lane.loadingMore
+              const fetchMore = liveLane?.fetchMore ?? lane.fetchMore
+              // snapshot-first: localLanes holds the optimistic count during a drag; prop total lags until refetch
+              const total = lane.total ?? liveLane?.total ?? lane.items.length
               return (
                 <div
                   key={lane.id ?? String(laneIndex)}
@@ -323,12 +329,12 @@ export function Kanban<TRecord extends RecordType>(
                       return node
                     }}
                     emptyState={lane.emptyState}
-                    loading={lane.loading}
+                    loading={loading}
                     variant={lane.variant}
                     total={total}
-                    hasMore={lane.hasMore}
-                    loadingMore={lane.loadingMore}
-                    fetchMore={lane.fetchMore}
+                    hasMore={hasMore}
+                    loadingMore={loadingMore}
+                    fetchMore={fetchMore}
                     onPrimaryAction={
                       onCreate && lane.id ? () => onCreate(lane.id!) : undefined
                     }


### PR DESCRIPTION
## Changes
- **Kanban visualization** — lane skeleton now keys on `isInitialLoading` instead of `isLoading`. A lane that has resolved once never re-shows a full skeleton on a background refetch or when `isLoading` is stranded.
- **`ui/Kanban`** — read-only display state (`loading`, `total`, `hasMore`, `loadingMore`, `fetchMore`) is read live from the `lanes` prop at render; `localLanes` now owns only drag item-order. Fixes empty lanes never clearing their skeleton (their item-signature never changes, so the old snapshot never re-synced) and keeps optimistic drag intact.

## Why
On any `OneDataCollection` kanban backed by `cache-and-network`, a lane could stay on a loading skeleton after its data loaded — counter correct, cards stuck — until the user toggled views. Affects all kanban consumers.

## Testing
- Added regression tests: a lane whose source emits `{loading:true, data}` and never settles still renders its cards; an empty lane that settles `loading → false` clears its skeleton.
- OneDataCollection + datasource suites green (635 tests); tsc / oxlint / oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
