### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.2.0",
+  "packages/react": "3.2.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.2.1](https://github.com/factorialco/f0/compare/f0-react-v3.2.0...f0-react-v3.2.1) (2026-06-15)
+
+
+### Bug Fixes
+
+* **datacollection:** keep kanban lanes from sticking on loading skeletons ([#4443](https://github.com/factorialco/f0/issues/4443)) ([35c25f4](https://github.com/factorialco/f0/commit/35c25f42e9d04c04d9017fd5b732d024e1b4c6a9))
+
 ## [3.2.0](https://github.com/factorialco/f0/compare/f0-react-v3.1.0...f0-react-v3.2.0) (2026-06-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.2.1</summary>

## [3.2.1](https://github.com/factorialco/f0/compare/f0-react-v3.2.0...f0-react-v3.2.1) (2026-06-15)


### Bug Fixes

* **datacollection:** keep kanban lanes from sticking on loading skeletons ([#4443](https://github.com/factorialco/f0/issues/4443)) ([35c25f4](https://github.com/factorialco/f0/commit/35c25f42e9d04c04d9017fd5b732d024e1b4c6a9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).