### PR TITLE
feat: namespaced `dialogs`/`drawers` API + `forms.open({ mode })` helper

### DIFF
--- a/packages/react/src/components/exports.ts
+++ b/packages/react/src/components/exports.ts
@@ -56,6 +56,8 @@ export * from "../patterns/F0FormField"
  * @deprecated F0WizardForm has moved to @/patterns/F0WizardForm. Import from there instead.
  */
 export * from "../patterns/F0WizardForm"
+// Imperative `forms.open({ mode: "dialog" | "wizard" })` API.
+export * from "../patterns/forms"
 export * from "./F0Heading"
 export * from "./F0Icon"
 export * from "./F0Link"

--- a/packages/react/src/lib/exports.ts
+++ b/packages/react/src/lib/exports.ts
@@ -11,7 +11,7 @@ export { experimentalComponent as experimental } from "./experimental"
 export { OneEllipsis } from "./OneEllipsis"
 export { PrivacyModeProvider, usePrivacyMode } from "./privacyMode"
 export * from "./providers/datacollection/exports"
-export { dialog, drawer } from "./providers/dialogs-alike"
+export { dialogs, drawers } from "./providers/dialogs-alike"
 export type {
   DialogDefinition,
   DialogActions,

--- a/packages/react/src/lib/providers/dialogs-alike/__stories__/dialog.mdx
+++ b/packages/react/src/lib/providers/dialogs-alike/__stories__/dialog.mdx
@@ -9,7 +9,7 @@ import * as DialogStories from "./dialog.stories"
 
 ### Definition
 
-The `dialog` API provides a simplified, promise-based API for managing dialogs in React applications. It wraps the `F0Dialog` component internally, handling all state management and providing a streamlined developer experience.
+The dialogs API provides a simplified, promise-based API for managing dialogs in React applications. It wraps the `F0Dialog` component internally, handling all state management and providing a streamlined developer experience.
 
 ### Purpose
 
@@ -19,9 +19,9 @@ The `dialog` API provides a simplified, promise-based API for managing dialogs i
 - **Consistent experience:** Standardized dialog patterns across the application
 - **Less code:** Reduce the amount of code needed to display dialogs significantly
 
-## Why the dialog API?
+## Why the dialogs API?
 
-The `dialog` API was created to provide a simpler and smoother experience, avoiding the need to write a lot of code. Here's a comparison showing how much simpler it is to use the dialog API versus managing `F0Dialog` directly:
+The dialogs API was created to provide a simpler and smoother experience, avoiding the need to write a lot of code. Here's a comparison showing how much simpler it is to use the dialogs API versus managing `F0Dialog` directly:
 
 ### Before: Using F0Dialog directly
 
@@ -70,16 +70,16 @@ function DeleteItemButton() {
 }
 ```
 
-### After: Using the dialog API
+### After: Using the dialogs API
 
-With the `dialog` API, the same functionality is achieved with much less code:
+With the dialogs API, the same functionality is achieved with much less code:
 
 ```tsx
-import { dialog, F0Button } from "@factorialco/f0-react"
+import { dialogs, F0Button } from "@factorialco/f0-react"
 
 function DeleteItemButton() {
   const handleClick = async () => {
-    const result = await dialog.confirm({
+    const result = await dialogs.confirmation({
       title: "Delete Item",
       msg: "Are you sure you want to delete this item? This action cannot be undone.",
     })
@@ -100,26 +100,26 @@ The API handles all the state management, dialog rendering, and cleanup automati
 
 Notification dialogs are centered, modal-style dialogs used to **inform the user** or **ask for a decision**. There are three ways to open one — they all render the same notification UI (an icon, title and message styled by a severity `type`), but they differ in the buttons they build for you:
 
-| Method                | Buttons it builds                                  | Resolves with                                              | Reach for it when…                                                                                                            |
-| --------------------- | -------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `dialog.alert`        | One confirm button (default **Ok**)                | the confirm `value` (default `true`)                       | You only need to **inform** the user and have them acknowledge — there's no choice to make.                                   |
-| `dialog.confirm`      | Confirm **+** cancel (default **Ok** / **Cancel**) | `true` when confirmed, `false` when cancelled or dismissed | You need a **yes/no decision** before continuing — e.g. confirming a destructive action.                                      |
-| `dialog.notification` | Whatever you pass in `actions`                     | the clicked action's `value`                               | You need **custom actions** — custom labels/values, more than two buttons, a dropdown — beyond the `alert`/`confirm` presets. |
+| Method                 | Buttons it builds                                  | Resolves with                                              | Reach for it when…                                                                                                                                 |
+| ---------------------- | -------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dialogs.alert`        | One confirm button (default **Ok**)                | the confirm `value` (default `true`)                       | You only need to **inform** the user and have them acknowledge — there's no choice to make.                                                        |
+| `dialogs.confirmation` | Confirm **+** cancel (default **Ok** / **Cancel**) | `true` when confirmed, `false` when cancelled or dismissed | You need a **yes/no decision** before continuing — e.g. confirming a destructive action.                                                           |
+| `dialogs.notification` | Whatever you pass in `actions`                     | the clicked action's `value`                               | You need **custom actions** — custom labels/values, more than two buttons, a dropdown — beyond the `dialogs.alert`/`dialogs.confirmation` presets. |
 
-`alert` and `confirm` are thin convenience wrappers over `notification`: they pre-build the `actions` for you. Use them for the common cases, and drop down to `notification` only when you need full control over the buttons.
+`dialogs.alert` and `dialogs.confirmation` are thin convenience wrappers over `dialogs.notification`: they pre-build the `actions` for you. Use them for the common cases, and drop down to `dialogs.notification` only when you need full control over the buttons.
 
 All three accept a severity `type` — `info` (default), `warning`, `critical` or `positive` — which sets the icon and color, plus a `title` and a `msg` body.
 
 ### Notification (custom actions)
 
-The `notification` method is the general form: you provide the `actions` yourself, so it can render any combination of buttons. Use it when neither `alert` nor `confirm` fits.
+The `dialogs.notification` function is the general form: you provide the `actions` yourself, so it can render any combination of buttons. Use it when neither `dialogs.alert` nor `dialogs.confirmation` fits.
 
 ```tsx
-import { dialog, F0Button } from "@factorialco/f0-react"
+import { dialogs, F0Button } from "@factorialco/f0-react"
 
 function MyComponent() {
   const showNotification = async () => {
-    await dialog.notification({
+    await dialogs.notification({
       title: "Notification Title",
       msg: "This is a notification message",
       type: "critical",
@@ -140,14 +140,14 @@ function MyComponent() {
 
 ### Alert Dialog
 
-The `alert` method displays a simple alert dialog with a single confirmation button. It returns a promise that resolves when the user clicks the confirm button.
+The `dialogs.alert` function displays a simple alert dialog with a single confirmation button. It returns a promise that resolves when the user clicks the confirm button.
 
 ```tsx
-import { dialog, F0Button } from "@factorialco/f0-react"
+import { dialogs, F0Button } from "@factorialco/f0-react"
 
 function MyComponent() {
   const showAlert = async () => {
-    await dialog.alert({
+    await dialogs.alert({
       title: "Alert Title",
       msg: "This is an alert message",
     })
@@ -162,14 +162,14 @@ function MyComponent() {
 
 ### Confirm Dialog
 
-The `confirm` method displays a confirmation dialog with both confirm and cancel buttons. It returns a promise that resolves to `true` if confirmed, or `false` if cancelled.
+The `dialogs.confirmation` function displays a confirmation dialog with both confirm and cancel buttons. It returns a promise that resolves to `true` if confirmed, or `false` if cancelled.
 
 ```tsx
-import { dialog, F0Button } from "@factorialco/f0-react"
+import { dialogs, F0Button } from "@factorialco/f0-react"
 
 function MyComponent() {
   const handleDelete = async () => {
-    const result = await dialog.confirm({
+    const result = await dialogs.confirmation({
       title: "Delete Item",
       msg: "Are you sure you want to delete this item?",
     })
@@ -191,15 +191,15 @@ function MyComponent() {
 
 ### Custom Dialog
 
-The `openDialog` method provides full control over the dialog content and actions. It accepts a dialog definition and returns a promise that resolves with the value of the action clicked.
+The `dialogs.open` function provides full control over the dialog content and actions. It accepts a dialog definition and returns a promise that resolves with the value of the action clicked.
 
 ```tsx
-import { dialog, F0Button } from "@factorialco/f0-react"
+import { dialogs, F0Button } from "@factorialco/f0-react"
 import { Delete, Pencil } from "@factorialco/f0-react/icons/app"
 
 function MyComponent() {
   const showCustomDialog = async () => {
-    const result = await dialog.open({
+    const result = await dialogs.open({
       title: "Dialog Title",
       description: "Dialog Description",
       content: <div>Custom dialog content goes here</div>,
@@ -241,24 +241,22 @@ The `DialogActionValue` can be a primitive value or a function that returns a Pr
 #### Confirm with Async Operation
 
 ```tsx
-import { dialog, F0Button } from "@factorialco/f0-react"
+import { dialogs, F0Button } from "@factorialco/f0-react"
 
 function MyComponent() {
   const handleSave = async () => {
-    const result = await dialog.confirm(
-      "Save Changes",
-      "Do you want to save?",
-      {
-        confirm: {
-          value: async () => {
-            // Simulate API call
-            await new Promise((resolve) => setTimeout(resolve, 2000))
-            return "saved"
-          },
-          label: "Save",
+    const result = await dialogs.confirmation({
+      title: "Save Changes",
+      msg: "Do you want to save?",
+      confirm: {
+        value: async () => {
+          // Simulate API call
+          await new Promise((resolve) => setTimeout(resolve, 2000))
+          return "saved"
         },
-      }
-    )
+        label: "Save",
+      },
+    })
 
     console.log("Result:", result) // "saved" after promise resolves
   }
@@ -272,11 +270,11 @@ function MyComponent() {
 #### Dialog with Promise-Based Primary Actions
 
 ```tsx
-import { dialog, F0Button } from "@factorialco/f0-react"
+import { dialogs, F0Button } from "@factorialco/f0-react"
 
 function MyComponent() {
   const showDialog = async () => {
-    const result = await dialog.open({
+    const result = await dialogs.open({
       title: "Process Data",
       description: "Choose an action",
       content: <div>Processing options...</div>,
@@ -311,19 +309,19 @@ function MyComponent() {
 
 By default, clicking any action closes the dialog. When `keepOpen: true` is set on a `DialogAction`, the dialog **resolves the promise but stays open** — the item is not removed from the screen.
 
-The action's `value` (including a function `value`) still runs on **every** click, so `keepOpen` is ideal for "apply"-style actions that mutate something without dismissing the dialog. To actually close it afterwards, either click a different action that does _not_ set `keepOpen`, or call `dialog.close(id)` with the `id` you passed to `dialog.open`.
+The action's `value` (including a function `value`) still runs on **every** click, so `keepOpen` is ideal for "apply"-style actions that mutate something without dismissing the dialog. To actually close it afterwards, either click a different action that does _not_ set `keepOpen`, or call `dialogs.close(id)` with the `id` you passed to `dialogs.open`.
 
-> Note: a promise resolves only once. The `await dialog.open(...)` call returns the first time a `keepOpen` action is clicked, but the dialog remains visible and the action keeps firing on subsequent clicks.
+> Note: a promise resolves only once. The `await dialogs.open(...)` call returns the first time a `keepOpen` action is clicked, but the dialog remains visible and the action keeps firing on subsequent clicks.
 
 ```tsx
 import { useState } from "react"
-import { dialog, F0Button } from "@factorialco/f0-react"
+import { dialogs, F0Button } from "@factorialco/f0-react"
 
 function MyComponent() {
   const [count, setCount] = useState(0)
 
   const showKeepOpenDialog = () => {
-    dialog.open({
+    dialogs.open({
       id: "keep-open-demo",
       title: "Keep Open",
       content: <div>Click Increment a few times — the dialog stays open.</div>,
@@ -355,11 +353,11 @@ When an action's `value` is a promise-returning function, the dialog **blocks** 
 Set `nonBlocking: true` on the action to opt out of that behavior — the other actions (and close) stay interactive while this action's promise is pending.
 
 ```tsx
-import { dialog, F0Button } from "@factorialco/f0-react"
+import { dialogs, F0Button } from "@factorialco/f0-react"
 
 function MyComponent() {
   const showNonBlockingDialog = async () => {
-    const result = await dialog.open({
+    const result = await dialogs.open({
       title: "Non-Blocking Action",
       content: <div>Click "Start", then notice "Cancel" is still enabled.</div>,
       actions: {
@@ -391,16 +389,16 @@ function MyComponent() {
 
 ### Modal
 
-By default a dialog can be dismissed by clicking the overlay (outside the dialog) or pressing <kbd>Escape</kbd>. Pass `modal: true` to make the dialog **require an explicit action** — clicking outside plays a subtle shake animation instead of closing, and <kbd>Escape</kbd> is ignored. The only way to close a modal dialog is through one of its actions (or programmatically via `dialog.close(id)`).
+By default a dialog can be dismissed by clicking the overlay (outside the dialog) or pressing <kbd>Escape</kbd>. Pass `modal: true` to make the dialog **require an explicit action** — clicking outside plays a subtle shake animation instead of closing, and <kbd>Escape</kbd> is ignored. The only way to close a modal dialog is through one of its actions (or programmatically via `dialogs.close(id)`).
 
 Use it for decisions the user must consciously resolve — e.g. confirming a destructive action or completing a required step — where an accidental dismissal would be costly.
 
 ```tsx
-import { dialog, F0Button } from "@factorialco/f0-react"
+import { dialogs, F0Button } from "@factorialco/f0-react"
 
 function MyComponent() {
   const showModalDialog = async () => {
-    const result = await dialog.open({
+    const result = await dialogs.open({
       title: "Modal Dialog",
       description:
         "This dialog cannot be closed by clicking outside or pressing Escape.",

--- a/packages/react/src/lib/providers/dialogs-alike/__stories__/dialog.stories.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/__stories__/dialog.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from "react"
 import { F0Button } from "@/components/F0Button"
 import { Delete, Pencil } from "@/icons/app"
 
-import { dialog } from "../imperative"
+import { dialogs } from "../imperative"
 import { dialogsAlikeStore } from "../store"
 import { DialogActionValue } from "../types"
 
@@ -36,7 +36,7 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   render: () => {
     const dialogTrigger = async () => {
-      const res = await dialog.open({
+      const res = await dialogs.open({
         title: "Dialog Title",
         description: "Dialog Description",
         content: <div>Dialog Content</div>,
@@ -57,7 +57,7 @@ export const Default: Story = {
     }
 
     const alertTrigger = async () => {
-      const res = await dialog.alert({
+      const res = await dialogs.alert({
         title: "Alert Title",
         msg: "Alert Message",
       })
@@ -65,7 +65,7 @@ export const Default: Story = {
     }
 
     const notificationTrigger = async () => {
-      const res = await dialog.notification({
+      const res = await dialogs.notification({
         title: "Notification Title",
         msg: "Notification Message",
         actions: {
@@ -79,7 +79,7 @@ export const Default: Story = {
     }
 
     const confirmTrigger = async () => {
-      const res = await dialog.confirm({
+      const res = await dialogs.confirmation({
         title: "Confirm Title",
         msg: "Confirm Message",
         type: "critical",
@@ -93,7 +93,7 @@ export const Default: Story = {
         },
       })
       if (res) {
-        dialog.alert({ title: "Item deleted", msg: "Item has been deleted" })
+        dialogs.alert({ title: "Item deleted", msg: "Item has been deleted" })
       }
       console.log(res)
     }
@@ -120,7 +120,7 @@ export const Notification: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const notificationTrigger = async () => {
-      const res = await dialog.notification({
+      const res = await dialogs.notification({
         title: "Notification Title",
         msg: "Notification Message",
         type: "positive",
@@ -151,7 +151,7 @@ export const Alert: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const alertTrigger = async () => {
-      const res = await dialog.alert({
+      const res = await dialogs.alert({
         title: "Alert Title",
         msg: "Alert Message",
       })
@@ -172,7 +172,7 @@ export const Confirm: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const alertTrigger = async () => {
-      const res = await dialog.confirm({
+      const res = await dialogs.confirmation({
         title: "Confirm Title",
         msg: "Confirm Message",
       })
@@ -193,7 +193,7 @@ export const ConfirmWithPromiseAndCustomLabel: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const alertTrigger = async () => {
-      const res = await dialog.confirm({
+      const res = await dialogs.confirmation({
         title: "Confirm Title",
         msg: "Confirm Message",
         confirm: {
@@ -223,7 +223,7 @@ export const Dialog: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await dialog.open({
+      const res = await dialogs.open({
         title: "Dialog Title",
         description: "Dialog Description",
         content: <div>Dialog Content</div>,
@@ -268,7 +268,7 @@ export const DialogFullScreen: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await dialog.open({
+      const res = await dialogs.open({
         title: "Dialog Title",
         size: "fullscreen",
         description: "Dialog Description",
@@ -314,7 +314,7 @@ export const DialogWithDropdownAndPromises: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await dialog.open({
+      const res = await dialogs.open({
         title: "Dialog Title",
         description: "Dialog Description",
         content: <div>Dialog Content</div>,
@@ -368,7 +368,7 @@ export const DialogTriggersADialog: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await dialog.open({
+      const res = await dialogs.open({
         title: "Dialog Title",
         description: "Dialog Description",
         content: <div>Dialog Content</div>,
@@ -385,7 +385,7 @@ export const DialogTriggersADialog: Story = {
               value: async () => {
                 return `Confirm-result-${
                   (
-                    await dialog.confirm({
+                    await dialogs.confirmation({
                       title: "Confirm Title",
                       msg: "Confirm Message",
                     })
@@ -413,7 +413,7 @@ export const DialogWithModule: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await dialog.open({
+      const res = await dialogs.open({
         title: "Performance Review",
         description: "Quarterly performance review discussion",
         module: {
@@ -448,13 +448,13 @@ export const DialogWithModule: Story = {
 // `keepOpen`: the action resolves the promise but the dialog is NOT removed,
 // so it stays open. The action's `value` function still runs on every click,
 // which makes it ideal for "apply"-style actions. Close it with a non-keepOpen
-// action (here "Done") or `dialog.close(id)`.
+// action (here "Done") or `dialogs.close(id)`.
 export const KeepOpen: Story = {
   render: () => {
     const [count, setCount] = useState(0)
 
     const trigger = () => {
-      dialog.open({
+      dialogs.open({
         id: "keep-open-demo",
         title: "Keep Open",
         description:
@@ -497,7 +497,7 @@ export const NonBlocking: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const result = await dialog.open({
+      const result = await dialogs.open({
         title: "Non-Blocking Action",
         description:
           'The primary action runs for 3s. Because it is nonBlocking, "Cancel" stays clickable while it runs.',
@@ -536,7 +536,7 @@ export const Modal: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await dialog.open({
+      const res = await dialogs.open({
         title: "Modal Dialog",
         description:
           "This is a modal dialog that cannot be closed by clicking outside or pressing Escape",

--- a/packages/react/src/lib/providers/dialogs-alike/__stories__/drawer.mdx
+++ b/packages/react/src/lib/providers/dialogs-alike/__stories__/drawer.mdx
@@ -7,17 +7,17 @@ import * as DrawerStories from "./drawer.stories"
 
 ## Introduction
 
-`drawer` is an imperative API for opening side drawers from anywhere in your app — including outside React (event handlers, callbacks, utilities). It wraps the `F0Drawer` component internally and handles all state management for you.
+The drawers API is an imperative API for opening side drawers from anywhere in your app — including outside React (event handlers, callbacks, utilities). It wraps the `F0Drawer` component internally and handles all state management for you.
 
 ```tsx
-import { drawer } from "@factorialco/f0-react"
+import { drawers } from "@factorialco/f0-react"
 ```
 
 > Requires your app to be wrapped in `<F0Provider>` (which mounts the renderer that displays the drawers).
 
 ### Why imperative functions?
 
-- **No hooks, no boilerplate:** call `drawer.open(...)` directly — no `useState`, no conditional rendering, no `useDrawer()`.
+- **No hooks, no boilerplate:** call `drawers.open(...)` directly — no `useState`, no conditional rendering, no `useDrawer()`.
 - **Promise-based:** `await` the result; it resolves with the `value` of the action the user picked.
 - **Callable anywhere:** from components, event handlers, or plain functions.
 
@@ -49,14 +49,14 @@ function EditItemButton() {
 }
 ```
 
-### After: using the `drawer` API
+### After: using the drawers API
 
 ```tsx
-import { drawer, F0Button } from "@factorialco/f0-react"
+import { drawers, F0Button } from "@factorialco/f0-react"
 
 function EditItemButton() {
   const handleClick = async () => {
-    const result = await drawer.open({
+    const result = await drawers.open({
       title: "Edit Item",
       content: <div>Form content goes here...</div>,
       actions: {
@@ -76,12 +76,12 @@ function EditItemButton() {
 
 ## Basic Usage
 
-`drawer.open` accepts a drawer definition and returns a promise that resolves with the value of the action the user clicked.
+`drawers.open` accepts a drawer definition and returns a promise that resolves with the value of the action the user clicked.
 
 ```tsx
-import { drawer } from "@factorialco/f0-react"
+import { drawers } from "@factorialco/f0-react"
 
-const result = await drawer.open({
+const result = await drawers.open({
   title: "Drawer Title",
   description: "Drawer Description",
   content: <div>Custom drawer content goes here</div>,
@@ -101,7 +101,7 @@ console.log("User selected:", result)
 Drawers can be positioned on the `left` or `right` (default).
 
 ```tsx
-await drawer.open({
+await drawers.open({
   title: "Left Drawer",
   position: "left",
   content: <div>Content...</div>,
@@ -118,7 +118,7 @@ await drawer.open({
 When `primary` or `secondary` is given an **array** of actions, the footer renders them as a dropdown menu. Each item resolves the promise with its own `value`, and items can be individually `disabled`.
 
 ```tsx
-await drawer.open({
+await drawers.open({
   title: "Drawer with Dropdown Actions",
   description: "This drawer has multiple secondary actions",
   content: <div>Check the actions menu</div>,
@@ -137,10 +137,10 @@ await drawer.open({
 
 ### Promise-Based Actions
 
-An action `value` can be a primitive **or** a function that returns a Promise. When a function is provided, the drawer stays open until the promise resolves, the button shows a loading state, and all actions are disabled during the async operation (unless `nonBlocking` is `true`). The resolved value becomes the result of `drawer.open`.
+An action `value` can be a primitive **or** a function that returns a Promise. When a function is provided, the drawer stays open until the promise resolves, the button shows a loading state, and all actions are disabled during the async operation (unless `nonBlocking` is `true`). The resolved value becomes the result of `drawers.open`.
 
 ```tsx
-const result = await drawer.open({
+const result = await drawers.open({
   title: "Drawer with Async Action",
   description: "The primary action takes time to resolve",
   content: <div>Click the primary action to see the loading state</div>,
@@ -159,16 +159,16 @@ const result = await drawer.open({
 
 ### Modal
 
-By default a drawer slides in alongside the page and can be dismissed by clicking outside or pressing <kbd>Escape</kbd>. Pass `modal: true` to add a backdrop overlay that **blocks interaction with the rest of the page** and makes the drawer require an explicit action — clicking outside no longer dismisses it and <kbd>Escape</kbd> is ignored. Close it through one of its actions or programmatically via `drawer.close(id)`.
+By default a drawer slides in alongside the page and can be dismissed by clicking outside or pressing <kbd>Escape</kbd>. Pass `modal: true` to add a backdrop overlay that **blocks interaction with the rest of the page** and makes the drawer require an explicit action — clicking outside no longer dismisses it and <kbd>Escape</kbd> is ignored. Close it through one of its actions or programmatically via `drawers.close(id)`.
 
 Use it when the drawer holds a task the user should finish or explicitly cancel (e.g. an edit form with unsaved changes) rather than dismiss by accident.
 
 ```tsx
-import { drawer, F0Button } from "@factorialco/f0-react"
+import { drawers, F0Button } from "@factorialco/f0-react"
 
 function MyComponent() {
   const showModalDrawer = async () => {
-    const result = await drawer.open({
+    const result = await drawers.open({
       title: "Modal Drawer",
       description: "This drawer blocks interaction with the page behind it.",
       content: <div>Use one of the actions below to close it.</div>,
@@ -190,10 +190,10 @@ function MyComponent() {
 
 ### Closing programmatically
 
-Pass an `id` when opening, then call `drawer.close(id)` to close it from elsewhere (its promise resolves with `undefined`).
+Pass an `id` when opening, then call `drawers.close(id)` to close it from elsewhere (its promise resolves with `undefined`).
 
 ```tsx
-drawer.open({
+drawers.open({
   id: "my-drawer",
   title: "...",
   content: <div />,
@@ -201,5 +201,5 @@ drawer.open({
 })
 
 // later, from anywhere:
-drawer.close("my-drawer")
+drawers.close("my-drawer")
 ```

--- a/packages/react/src/lib/providers/dialogs-alike/__stories__/drawer.stories.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/__stories__/drawer.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from "react"
 import { F0Button } from "@/components/F0Button"
 import { Delete, Pencil } from "@/icons/app"
 
-import { drawer } from "../imperative"
+import { drawers } from "../imperative"
 import { dialogsAlikeStore } from "../store"
 import { DialogActionValue } from "../types"
 
@@ -36,7 +36,7 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   render: () => {
     const drawerTrigger = async () => {
-      const res = await drawer.open({
+      const res = await drawers.open({
         title: "Drawer Title",
         description: "Drawer Description",
         content: <div>Drawer Content</div>,
@@ -69,7 +69,7 @@ export const DrawerLeft: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await drawer.open({
+      const res = await drawers.open({
         title: "Left Drawer",
         description: "This drawer opens from the left",
         position: "left",
@@ -104,7 +104,7 @@ export const DrawerWithDropdown: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await drawer.open({
+      const res = await drawers.open({
         title: "Drawer with Dropdown Actions",
         description: "This drawer has multiple secondary actions",
         content: <div>Check the actions menu</div>,
@@ -149,7 +149,7 @@ export const DrawerWithPromises: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await drawer.open({
+      const res = await drawers.open({
         title: "Drawer with Async Action",
         description: "The primary action takes time to resolve",
         content: <div>Click the primary action to see the loading state</div>,
@@ -184,7 +184,7 @@ export const DrawerWithModule: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await drawer.open({
+      const res = await drawers.open({
         title: "Time Off Request",
         description: "Request time off for your vacation",
         module: {
@@ -221,7 +221,7 @@ export const DrawerModal: Story = {
     const [res, setRes] = useState<DialogActionValue>(undefined)
 
     const trigger = async () => {
-      const res = await drawer.open({
+      const res = await drawers.open({
         title: "Modal Drawer",
         description: "This drawer behaves like a modal (blocks interaction)",
         modal: true,

--- a/packages/react/src/lib/providers/dialogs-alike/__tests__/imperative.test.ts
+++ b/packages/react/src/lib/providers/dialogs-alike/__tests__/imperative.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { dialog, drawer } from "../imperative"
+import { dialogs, drawers } from "../imperative"
 import { dialogsAlikeStore } from "../store"
 
 // The imperative API stores raw items in the module store and exposes
@@ -26,9 +26,9 @@ describe("imperative dialog / drawer API", () => {
     warnSpy.mockRestore()
   })
 
-  describe("dialog.open", () => {
+  describe("dialogs.open", () => {
     it("adds a default-variant item to the store", () => {
-      dialog.open({
+      dialogs.open({
         id: "d1",
         title: "Title",
         description: "Desc",
@@ -44,7 +44,7 @@ describe("imperative dialog / drawer API", () => {
     })
 
     it("resolves with the clicked action value and removes the item", async () => {
-      const promise = dialog.open({
+      const promise = dialogs.open({
         id: "d1",
         title: "Title",
         content: "content",
@@ -59,7 +59,7 @@ describe("imperative dialog / drawer API", () => {
     })
 
     it("resolves undefined and removes the item when closed (overlay/esc)", async () => {
-      const promise = dialog.open({
+      const promise = dialogs.open({
         id: "d1",
         title: "Title",
         content: "content",
@@ -73,7 +73,7 @@ describe("imperative dialog / drawer API", () => {
     })
 
     it("keeps the item open after a keepOpen action (but still resolves)", async () => {
-      const promise = dialog.open({
+      const promise = dialogs.open({
         id: "d1",
         title: "Title",
         content: "content",
@@ -91,7 +91,7 @@ describe("imperative dialog / drawer API", () => {
     })
 
     it("auto-generates an id when none is provided", () => {
-      dialog.open({
+      dialogs.open({
         title: "Title",
         content: "content",
         actions: { primary: { value: "ok", label: "OK" } },
@@ -101,16 +101,16 @@ describe("imperative dialog / drawer API", () => {
     })
   })
 
-  describe("dialog.close", () => {
+  describe("dialogs.close", () => {
     it("closes an open dialog by id and resolves its promise with undefined", async () => {
-      const promise = dialog.open({
+      const promise = dialogs.open({
         id: "d1",
         title: "Title",
         content: "content",
         actions: { primary: { value: "ok", label: "OK" } },
       })
 
-      dialog.close("d1")
+      dialogs.close("d1")
 
       await expect(promise).resolves.toBeUndefined()
       expect(dialogsAlikeStore.getSnapshot()).toHaveLength(0)
@@ -118,14 +118,14 @@ describe("imperative dialog / drawer API", () => {
 
     it("falls back to removing the item if no close callback is registered", () => {
       dialogsAlikeStore.addItem({ id: "orphan" } as any)
-      dialog.close("orphan")
+      dialogs.close("orphan")
       expect(dialogsAlikeStore.getSnapshot()).toHaveLength(0)
     })
   })
 
-  describe("dialog.notification", () => {
+  describe("dialogs.notification", () => {
     it("adds a notification-variant item defaulting to type 'info'", () => {
-      dialog.notification({
+      dialogs.notification({
         title: "Heads up",
         msg: "Something happened",
         actions: { primary: { value: "ok", label: "OK" } },
@@ -138,7 +138,7 @@ describe("imperative dialog / drawer API", () => {
     })
 
     it("honors an explicit type", () => {
-      dialog.notification({
+      dialogs.notification({
         title: "Careful",
         msg: "Warning",
         type: "warning",
@@ -148,9 +148,9 @@ describe("imperative dialog / drawer API", () => {
     })
   })
 
-  describe("dialog.alert", () => {
+  describe("dialogs.alert", () => {
     it("builds a single primary action with the default 'ok' label", () => {
-      dialog.alert({ title: "Done", msg: "Saved" })
+      dialogs.alert({ title: "Done", msg: "Saved" })
       const item = currentItem()
       expect(item.variant).toBe("notification")
       expect(item.actions.primary.label).toBe("Ok")
@@ -163,21 +163,21 @@ describe("imperative dialog / drawer API", () => {
         ok: "Aceptar",
         cancel: "Cancelar",
       })
-      dialog.alert({ title: "Done", msg: "Saved" })
+      dialogs.alert({ title: "Done", msg: "Saved" })
       expect(currentItem().actions.primary.label).toBe("Aceptar")
     })
 
     it("resolves with the confirm value when clicked", async () => {
-      const promise = dialog.alert({ title: "Done", msg: "Saved" })
+      const promise = dialogs.alert({ title: "Done", msg: "Saved" })
       const item = currentItem()
       item.onClickAction(item.actions.primary, true)
       await expect(promise).resolves.toBe(true)
     })
   })
 
-  describe("dialog.confirm", () => {
+  describe("dialogs.confirmation", () => {
     it("builds primary + secondary actions with default ok/cancel labels", () => {
-      dialog.confirm({ title: "Sure?", msg: "Confirm this" })
+      dialogs.confirmation({ title: "Sure?", msg: "Confirm this" })
       const item = currentItem()
       expect(item.actions.primary.label).toBe("Ok")
       expect(item.actions.primary.value).toBe(true)
@@ -186,14 +186,17 @@ describe("imperative dialog / drawer API", () => {
     })
 
     it("resolves false when the cancel action is clicked", async () => {
-      const promise = dialog.confirm({ title: "Sure?", msg: "Confirm this" })
+      const promise = dialogs.confirmation({
+        title: "Sure?",
+        msg: "Confirm this",
+      })
       const item = currentItem()
       item.onClickAction(item.actions.secondary, false)
       await expect(promise).resolves.toBe(false)
     })
 
     it("supports custom confirm value and label", () => {
-      dialog.confirm({
+      dialogs.confirmation({
         title: "Delete?",
         msg: "This cannot be undone",
         confirm: { value: "deleted", label: "Delete" },
@@ -204,9 +207,9 @@ describe("imperative dialog / drawer API", () => {
     })
   })
 
-  describe("drawer.open", () => {
+  describe("drawers.open", () => {
     it("adds a drawer-variant item to the store", () => {
-      drawer.open({
+      drawers.open({
         id: "dr1",
         title: "Edit",
         content: "form",
@@ -218,7 +221,7 @@ describe("imperative dialog / drawer API", () => {
     })
 
     it("resolves with the clicked value and removes the item", async () => {
-      const promise = drawer.open({
+      const promise = drawers.open({
         id: "dr1",
         title: "Edit",
         content: "form",
@@ -230,14 +233,14 @@ describe("imperative dialog / drawer API", () => {
       expect(dialogsAlikeStore.getSnapshot()).toHaveLength(0)
     })
 
-    it("can be closed programmatically with drawer.close", async () => {
-      const promise = drawer.open({
+    it("can be closed programmatically with drawers.close", async () => {
+      const promise = drawers.open({
         id: "dr1",
         title: "Edit",
         content: "form",
         actions: { primary: { value: "save", label: "Save" } },
       })
-      drawer.close("dr1")
+      drawers.close("dr1")
       await expect(promise).resolves.toBeUndefined()
       expect(dialogsAlikeStore.getSnapshot()).toHaveLength(0)
     })
@@ -245,7 +248,7 @@ describe("imperative dialog / drawer API", () => {
 
   describe("provider warning", () => {
     it("warns when no <F0Provider> is mounted", () => {
-      dialog.open({
+      dialogs.open({
         title: "Title",
         content: "content",
         actions: { primary: { value: "ok", label: "OK" } },
@@ -257,7 +260,7 @@ describe("imperative dialog / drawer API", () => {
 
     it("does not warn when a renderer is mounted", () => {
       const handle = dialogsAlikeStore.acquireRenderer()
-      dialog.open({
+      dialogs.open({
         title: "Title",
         content: "content",
         actions: { primary: { value: "ok", label: "OK" } },

--- a/packages/react/src/lib/providers/dialogs-alike/imperative.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/imperative.tsx
@@ -19,7 +19,7 @@ import {
 } from "./types"
 
 // Programmatic-close callbacks, keyed by dialog/drawer id. Kept at module level
-// (not in a React ref) so `dialog.close(id)` / `drawer.close(id)` work from
+// (not in a React ref) so `dialogs.close(id)` / `drawers.close(id)` work from
 // anywhere.
 const closeCallbacks = new Map<DialogId, () => void>()
 
@@ -81,7 +81,7 @@ const openDialogInternal = (
     }
 
     closeCallbacks.set(id, onCloseDialog)
-    warnIfNoProvider("dialog.open()")
+    warnIfNoProvider("dialogs.open()")
     dialogsAlikeStore.addItem(item)
   })
 }
@@ -105,7 +105,7 @@ const openDrawerInternal = (
     }
 
     closeCallbacks.set(id, onCloseDialog)
-    warnIfNoProvider("drawer.open()")
+    warnIfNoProvider("drawers.open()")
     dialogsAlikeStore.addItem(item)
   })
 }
@@ -119,36 +119,47 @@ const close = (id: DialogId) => {
   }
 }
 
+// -----------------------------------------------------------------------------
+// Public imperative API. The `dialogs` and `drawers` namespaces open/close
+// dialogs and drawers from anywhere — including outside React. They require
+// `<F0Provider>` (which mounts `DialogsAlikeLayoutProvider`) to be present in
+// the tree.
+// -----------------------------------------------------------------------------
+
+const notification = (
+  options: NotificationDialogOptions
+): Promise<DialogActionValue> =>
+  openDialogInternal({
+    type: options.type ?? "info",
+    variant: "notification",
+    description: options.msg,
+    id: options.id || nanoid(),
+    title: options.title,
+    content: <></>,
+    actions: options.actions,
+  })
+
 /**
  * Imperative API for centered dialogs. Requires `<F0Provider>` (which mounts
  * `DialogsAlikeLayoutProvider`) to be present in the tree.
  *
  * @example
- * const result = await dialog.open({ title, content, actions: { primary: { label: "OK", value: true } } })
+ * import { dialogs } from "@factorialco/f0-react"
+ *
+ * const result = await dialogs.open({ title, content, actions: { primary: { label: "OK", value: true } } })
  */
-export const dialog = {
+export const dialogs = {
   /** Open a dialog. Resolves with the value of the action the user picked. */
   open: (definition: Optional<DialogDefinition, "id">) =>
     openDialogInternal({ ...definition, variant: "default" }),
 
   /** Open a notification-style dialog (info/warning/critical/positive). */
-  notification: (
-    options: NotificationDialogOptions
-  ): Promise<DialogActionValue> =>
-    openDialogInternal({
-      type: options.type ?? "info",
-      variant: "notification",
-      description: options.msg,
-      id: options.id || nanoid(),
-      title: options.title,
-      content: <></>,
-      actions: options.actions,
-    }),
+  notification,
 
   /** Notification dialog with a single confirm action (defaults to "Ok"). */
   alert: (options: AlertDialogOptions): Promise<DialogActionValue> => {
     const labels = dialogsAlikeStore.getDefaultActionLabels()
-    return dialog.notification({
+    return notification({
       ...options,
       actions: {
         primary: {
@@ -160,9 +171,9 @@ export const dialog = {
   },
 
   /** Notification dialog with confirm + cancel actions (defaults to Ok/Cancel). */
-  confirm: (options: ConfirmDialogOptions): Promise<DialogActionValue> => {
+  confirmation: (options: ConfirmDialogOptions): Promise<DialogActionValue> => {
     const labels = dialogsAlikeStore.getDefaultActionLabels()
-    return dialog.notification({
+    return notification({
       ...options,
       actions: {
         primary: {
@@ -185,9 +196,11 @@ export const dialog = {
  * Imperative API for side drawers. Requires `<F0Provider>` to be present.
  *
  * @example
- * const result = await drawer.open({ title, content, actions: { primary: { label: "Save", value: "save" } } })
+ * import { drawers } from "@factorialco/f0-react"
+ *
+ * const result = await drawers.open({ title, content, actions: { primary: { label: "Save", value: "save" } } })
  */
-export const drawer = {
+export const drawers = {
   /** Open a drawer. Resolves with the value of the action the user picked. */
   open: (definition: Optional<DrawerDefinition, "id">) =>
     openDrawerInternal({ ...definition, variant: "drawer" }),

--- a/packages/react/src/lib/providers/dialogs-alike/index.ts
+++ b/packages/react/src/lib/providers/dialogs-alike/index.ts
@@ -1,5 +1,5 @@
 export * from "./DialogsAlikeLayoutProvider"
-export { dialog, drawer } from "./imperative"
+export { dialogs, drawers } from "./imperative"
 export type {
   DialogDefinition,
   DialogActions,

--- a/packages/react/src/lib/providers/f0/f0-provider.tsx
+++ b/packages/react/src/lib/providers/f0/f0-provider.tsx
@@ -19,6 +19,7 @@ import { PrivacyModeProvider } from "../../privacyMode"
 import { cn } from "../../utils"
 import { XRayProvider } from "../../xray"
 import { DialogsAlikeLayoutProvider } from "../dialogs-alike/DialogsAlikeLayoutProvider"
+import { FormOverlaysProvider } from "../form-overlays"
 import { DataCollectionStorageProvider } from "../datacollection/DataCollectionStorageProvider"
 import { DataCollectionStorageHandler } from "../datacollection/types"
 import { I18nProvider, I18nProviderProps } from "../i18n"
@@ -153,13 +154,15 @@ export const F0Provider: React.FC<{
                               desktop: "#f0-overlay-root",
                             }}
                           >
-                            <FormComponentContext.Provider
-                              value={formComponent}
-                            >
-                              <FormCardValueFormatterProvider>
-                                {children}
-                              </FormCardValueFormatterProvider>
-                            </FormComponentContext.Provider>
+                            <FormOverlaysProvider>
+                              <FormComponentContext.Provider
+                                value={formComponent}
+                              >
+                                <FormCardValueFormatterProvider>
+                                  {children}
+                                </FormCardValueFormatterProvider>
+                              </FormComponentContext.Provider>
+                            </FormOverlaysProvider>
                           </ToastProvider>
                         </DialogsAlikeLayoutProvider>
                       </DataCollectionStorageProvider>

--- a/packages/react/src/lib/providers/form-overlays/FormOverlaysProvider.tsx
+++ b/packages/react/src/lib/providers/form-overlays/FormOverlaysProvider.tsx
@@ -1,0 +1,148 @@
+import {
+  Fragment,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react"
+import { createPortal } from "react-dom"
+
+import { formOverlaysStore, FormOverlayStoreItem } from "./store"
+
+type FormOverlaysProviderProps = {
+  children: React.ReactNode
+}
+
+// How long a removed overlay is kept mounted (with isOpen=false) so its close
+// animation can play before it is actually unmounted. Slightly longer than the
+// dialog/wizard CSS exit animation so it always finishes.
+const EXIT_ANIMATION_MS = 200
+
+/*
+  Renders the overlays mounted through `forms.open`. The
+  open overlays live in `formOverlaysStore` (a module-level store), so they can
+  be opened from anywhere — including outside React. This provider subscribes to
+  that store and portals the overlays into the document body.
+
+  As with `dialogs-alike`, several providers can be mounted at once (e.g. one per
+  story canvas on a Storybook docs page) and they all read the same store, so
+  only the elected renderer actually mounts the portal.
+*/
+export const FormOverlaysProvider = ({
+  children,
+}: FormOverlaysProviderProps) => {
+  const items = useSyncExternalStore(
+    formOverlaysStore.subscribe,
+    formOverlaysStore.getSnapshot,
+    formOverlaysStore.getServerSnapshot
+  )
+
+  const [rendererId, setRendererId] = useState<number | null>(null)
+
+  // Register this provider as a candidate renderer; release on unmount.
+  useEffect(() => {
+    const handle = formOverlaysStore.acquireRenderer()
+    setRendererId(handle.id)
+    return handle.release
+  }, [])
+
+  // Re-render when the elected renderer changes (so we take over if the previous
+  // renderer unmounts).
+  const activeRendererId = useSyncExternalStore(
+    formOverlaysStore.subscribeRenderer,
+    formOverlaysStore.getActiveRendererId,
+    () => null
+  )
+  const isRenderer = rendererId !== null && rendererId === activeRendererId
+
+  return (
+    <>
+      {isRenderer &&
+        typeof document !== "undefined" &&
+        createPortal(<FormOverlays items={items} />, document.body)}
+      {children}
+    </>
+  )
+}
+
+type FormOverlaysProps = {
+  items: FormOverlayStoreItem[]
+}
+
+const FormOverlays = ({ items }: FormOverlaysProps) => {
+  // `items` (from the store) is the source of truth for what should be OPEN.
+  // We keep just-removed items in `renderedItems` (rendered with isOpen=false)
+  // so their close animation can play before they unmount. Without this the
+  // overlay is removed from the tree instantly and the exit animation is
+  // skipped.
+  const [renderedItems, setRenderedItems] = useState(items)
+  const previousItemsRef = useRef(items)
+  const exitTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
+
+  useEffect(() => {
+    const liveIds = new Set(items.map((item) => item.id))
+    const previousItems = previousItemsRef.current
+    previousItemsRef.current = items
+
+    // An item is live again (e.g. re-opened): cancel any pending exit cleanup.
+    for (const id of liveIds) {
+      const timer = exitTimers.current.get(id)
+      if (timer) {
+        clearTimeout(timer)
+        exitTimers.current.delete(id)
+      }
+    }
+
+    // An item just left the store: schedule its removal once its exit animation
+    // has had time to play.
+    for (const previousItem of previousItems) {
+      if (liveIds.has(previousItem.id)) continue
+      if (exitTimers.current.has(previousItem.id)) continue
+      const timer = setTimeout(() => {
+        exitTimers.current.delete(previousItem.id)
+        setRenderedItems((current) =>
+          current.filter((item) => item.id !== previousItem.id)
+        )
+      }, EXIT_ANIMATION_MS)
+      exitTimers.current.set(previousItem.id, timer)
+    }
+
+    setRenderedItems((previous) => {
+      // Live items first (fresh render fns, correct order)...
+      const next = [...items]
+      // ...then retain previously-rendered items that are no longer live so they
+      // can animate out.
+      for (const previousItem of previous) {
+        if (liveIds.has(previousItem.id)) continue
+        if (next.some((item) => item.id === previousItem.id)) continue
+        next.push(previousItem)
+      }
+      const unchanged =
+        next.length === previous.length &&
+        next.every((item, index) => item === previous[index])
+      return unchanged ? previous : next
+    })
+  }, [items])
+
+  useEffect(() => {
+    const timers = exitTimers.current
+    return () => {
+      for (const timer of timers.values()) clearTimeout(timer)
+      timers.clear()
+    }
+  }, [])
+
+  // Whether a rendered overlay should currently be open (still in the store).
+  const openIds = useMemo(() => new Set(items.map((item) => item.id)), [items])
+
+  return (
+    <>
+      {renderedItems.map((item) => (
+        <Fragment key={item.id}>
+          {item.render({ isOpen: openIds.has(item.id) })}
+        </Fragment>
+      ))}
+    </>
+  )
+}

--- a/packages/react/src/lib/providers/form-overlays/__tests__/imperative.test.tsx
+++ b/packages/react/src/lib/providers/form-overlays/__tests__/imperative.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { mountFormOverlay, unmountFormOverlay } from "../imperative"
+import { formOverlaysStore } from "../store"
+
+const currentItem = () => {
+  const items = formOverlaysStore.getSnapshot()
+  return items[items.length - 1]
+}
+
+const noopRender = () => null
+
+describe("form overlays imperative API", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    formOverlaysStore.clear()
+    // No <F0Provider> is mounted in these unit tests, so the imperative
+    // functions warn. Silence it (one dedicated test asserts the warning).
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  describe("mountFormOverlay", () => {
+    it("adds an overlay item to the store and returns its id", () => {
+      const id = mountFormOverlay({ id: "o1", render: noopRender })
+
+      expect(id).toBe("o1")
+      expect(formOverlaysStore.getSnapshot()).toHaveLength(1)
+      expect(currentItem().id).toBe("o1")
+      expect(typeof currentItem().render).toBe("function")
+    })
+
+    it("auto-generates an id when none is provided", () => {
+      const id = mountFormOverlay({ render: noopRender })
+      expect(id).toEqual(expect.any(String))
+      expect(id.length).toBeGreaterThan(0)
+      expect(currentItem().id).toBe(id)
+    })
+
+    it("renders with isOpen derived from the caller", () => {
+      const render = vi.fn(noopRender)
+      mountFormOverlay({ id: "o1", render })
+      // The provider drives `isOpen`; here we just confirm the render fn is
+      // stored and callable with the api shape.
+      currentItem().render({ isOpen: true })
+      expect(render).toHaveBeenCalledWith({ isOpen: true })
+    })
+  })
+
+  describe("unmountFormOverlay", () => {
+    it("runs onDismiss and removes the overlay by id", () => {
+      const onDismiss = vi.fn()
+      mountFormOverlay({ id: "o1", render: noopRender, onDismiss })
+
+      unmountFormOverlay("o1")
+
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+      expect(formOverlaysStore.getSnapshot()).toHaveLength(0)
+    })
+
+    it("is idempotent (onDismiss fires at most once)", () => {
+      const onDismiss = vi.fn()
+      mountFormOverlay({ id: "o1", render: noopRender, onDismiss })
+
+      unmountFormOverlay("o1")
+      unmountFormOverlay("o1")
+
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+      expect(formOverlaysStore.getSnapshot()).toHaveLength(0)
+    })
+
+    it("falls back to removing the item if no dismiss callback is registered", () => {
+      formOverlaysStore.addItem({ id: "orphan", render: noopRender })
+      unmountFormOverlay("orphan")
+      expect(formOverlaysStore.getSnapshot()).toHaveLength(0)
+    })
+  })
+
+  describe("provider warning", () => {
+    it("warns when no <F0Provider> is mounted", () => {
+      mountFormOverlay({ render: noopRender })
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no <F0Provider>")
+      )
+    })
+
+    it("does not warn when a renderer is mounted", () => {
+      const handle = formOverlaysStore.acquireRenderer()
+      mountFormOverlay({ render: noopRender })
+      expect(warnSpy).not.toHaveBeenCalled()
+      handle.release()
+    })
+  })
+})

--- a/packages/react/src/lib/providers/form-overlays/imperative.tsx
+++ b/packages/react/src/lib/providers/form-overlays/imperative.tsx
@@ -1,0 +1,71 @@
+import { nanoid } from "nanoid"
+
+import { DialogId } from "../dialogs-alike/types"
+import { formOverlaysStore, FormOverlayRenderApi } from "./store"
+
+export type { FormOverlayRenderApi }
+
+export type FormOverlayDefinition = {
+  /** Overlay id. Auto-generated if not provided. */
+  id?: DialogId
+  /**
+   * Renders the overlay. Receives `isOpen` — drive your dialog/wizard's
+   * `isOpen` prop with it so it can animate out before unmounting.
+   */
+  render: (api: FormOverlayRenderApi) => React.ReactNode
+  /**
+   * Called when the overlay is dismissed via `unmountFormOverlay(id)` (e.g.
+   * programmatic close). The render callback's own close handler should cover
+   * user-initiated dismissals.
+   */
+  onDismiss?: () => void
+}
+
+// Dismiss callbacks keyed by overlay id, kept at module level (not in a React
+// ref) so `unmountFormOverlay(id)` works from anywhere.
+const dismissCallbacks = new Map<DialogId, () => void>()
+
+const warnIfNoProvider = (method: string) => {
+  if (
+    process.env.NODE_ENV !== "production" &&
+    !formOverlaysStore.hasProvider()
+  ) {
+    console.warn(
+      `[f0] ${method} was called but no <F0Provider> is mounted, so the form ` +
+        `overlay will not render. Make sure your app is wrapped in <F0Provider>.`
+    )
+  }
+}
+
+/**
+ * Mount a self-contained overlay (a node that renders its own dialog/wizard).
+ * Returns the overlay id. Requires `<F0Provider>` to be mounted.
+ *
+ * This is an internal seam used by `forms.open`; it is
+ * not part of the public API.
+ */
+export const mountFormOverlay = (
+  definition: FormOverlayDefinition
+): DialogId => {
+  const id = definition.id || nanoid()
+  const dismiss = () => {
+    if (!dismissCallbacks.has(id)) return
+    dismissCallbacks.delete(id)
+    definition.onDismiss?.()
+    formOverlaysStore.removeItem(id)
+  }
+  dismissCallbacks.set(id, dismiss)
+  warnIfNoProvider("mountFormOverlay()")
+  formOverlaysStore.addItem({ id, render: definition.render })
+  return id
+}
+
+/** Dismiss an overlay by id (runs its `onDismiss`, then removes it). */
+export const unmountFormOverlay = (id: DialogId) => {
+  const dismiss = dismissCallbacks.get(id)
+  if (dismiss) {
+    dismiss()
+  } else {
+    formOverlaysStore.removeItem(id)
+  }
+}

--- a/packages/react/src/lib/providers/form-overlays/index.ts
+++ b/packages/react/src/lib/providers/form-overlays/index.ts
@@ -1,0 +1,8 @@
+export { FormOverlaysProvider } from "./FormOverlaysProvider"
+export {
+  mountFormOverlay,
+  unmountFormOverlay,
+  type FormOverlayDefinition,
+  type FormOverlayRenderApi,
+} from "./imperative"
+export { formOverlaysStore } from "./store"

--- a/packages/react/src/lib/providers/form-overlays/store.ts
+++ b/packages/react/src/lib/providers/form-overlays/store.ts
@@ -1,0 +1,115 @@
+import { ReactNode } from "react"
+
+import { DialogId } from "../dialogs-alike/types"
+
+/**
+ * Module-level store backing the imperative `forms.open`
+ * helpers.
+ *
+ * Unlike `dialogs-alike` (which owns the dialog chrome and footer actions),
+ * a form overlay is a self-contained React node that renders — and animates —
+ * its OWN dialog/wizard. The store therefore holds opaque render functions and
+ * stays out of the way: it just tracks which overlays are open so they can be
+ * mounted from anywhere (including outside React) and portaled by
+ * `FormOverlaysProvider`.
+ */
+
+export type FormOverlayRenderApi = {
+  /** Whether the overlay is still open (in the store) or animating out. */
+  isOpen: boolean
+}
+
+export type FormOverlayStoreItem = {
+  id: DialogId
+  render: (api: FormOverlayRenderApi) => ReactNode
+}
+
+type Listener = () => void
+
+const EMPTY: FormOverlayStoreItem[] = []
+
+let items: FormOverlayStoreItem[] = EMPTY
+const listeners = new Set<Listener>()
+
+// Mounted provider/renderer registry. Multiple FormOverlaysProvider instances
+// can be mounted at once (e.g. one per story canvas on a Storybook docs page).
+// They all read this single store, so only ONE should actually render the
+// overlays — otherwise every overlay is rendered N times (N stacked modals
+// fight over focus). We elect the renderer as the lowest mounted id; when it
+// unmounts the next lowest takes over automatically.
+let rendererSeq = 0
+const mountedRenderers = new Set<number>()
+const rendererListeners = new Set<Listener>()
+
+const emit = () => {
+  for (const listener of listeners) listener()
+}
+
+const emitRenderer = () => {
+  for (const listener of rendererListeners) listener()
+}
+
+export const formOverlaysStore = {
+  subscribe(listener: Listener) {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  },
+  getSnapshot() {
+    return items
+  },
+  getServerSnapshot() {
+    return EMPTY
+  },
+  addItem(item: FormOverlayStoreItem) {
+    items = [...items, item]
+    emit()
+  },
+  removeItem(id: DialogId) {
+    if (!items.some((item) => item.id === id)) return
+    items = items.filter((item) => item.id !== id)
+    emit()
+  },
+  /** Remove all open overlays. Mainly useful to isolate Storybook stories/tests. */
+  clear() {
+    if (items.length === 0) return
+    items = EMPTY
+    emit()
+  },
+  /**
+   * Register a mounted provider as a candidate renderer. Returns the assigned
+   * id and a `release` to call on unmount. Pair with `subscribeRenderer` +
+   * `getActiveRendererId` to know whether this instance should render.
+   */
+  acquireRenderer() {
+    rendererSeq += 1
+    const id = rendererSeq
+    mountedRenderers.add(id)
+    emitRenderer()
+    return {
+      id,
+      release() {
+        mountedRenderers.delete(id)
+        emitRenderer()
+      },
+    }
+  },
+  /** The elected renderer (lowest mounted id), or null if none mounted. */
+  getActiveRendererId(): number | null {
+    let min: number | null = null
+    for (const id of mountedRenderers) {
+      if (min === null || id < min) min = id
+    }
+    return min
+  },
+  subscribeRenderer(listener: Listener) {
+    rendererListeners.add(listener)
+    return () => {
+      rendererListeners.delete(listener)
+    }
+  },
+  hasProvider() {
+    return mountedRenderers.size > 0
+  },
+}

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.mdx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Unstyled } from "@storybook/addon-docs/blocks"
 import * as Stories from "./F0Form.stories"
+import * as WizardStories from "../../F0WizardForm/__stories__/F0WizardForm.stories"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 <Meta of={Stories} />
@@ -426,9 +427,91 @@ Use `disabled` as a function to conditionally enable or disable fields, with opt
 
 <Canvas of={Stories.ServerValidation} />
 
-## Form in dialog
+## Opening a form imperatively — `forms.open`
+
+`forms.open({ formDefinition, as })` opens a form from anywhere — no `useState` /
+`useF0Form` / `formRef` wiring — and `await`s the outcome. Choose the
+presentation with `as`: `"dialog"` for a single-screen form, or `"wizard"` for a
+multi-step [`F0WizardForm`](?path=/docs/patterns-forms-f0wizardform--documentation).
+Requires `<F0Provider>` to be mounted.
+
+### As a dialog
+
+Pass `mode: "dialog"` to open the form in a single-screen dialog:
+
+```tsx
+import { forms, f0FormField, useF0FormDefinition } from "@factorialco/f0-react"
+import { z } from "zod"
+
+const formDefinition = useF0FormDefinition({
+  name: "add-member",
+  schema: z.object({
+    name: f0FormField.text({ label: "Name", minLength: 2 }),
+    email: f0FormField.email({ label: "Email" }),
+  }),
+  defaultValues: { name: "", email: "" },
+  onSubmit: async ({ data }) => {
+    await save(data)
+    return { success: true }
+  },
+})
+
+const result = await forms.open({
+  formDefinition,
+  mode: "dialog",
+  title: "Add team member",
+  description: "They will receive an invitation email.",
+})
+
+if (result.submitted) {
+  // result.data is the validated, typed form values
+}
+```
+
+Behavior:
+
+- **Submit succeeds** → the dialog closes and the promise resolves with
+  `{ submitted: true, data }`.
+- **Validation fails** → the dialog stays open with inline field errors.
+- **Cancel / close button** → resolves with `{ submitted: false }`.
+
+The dialog is **modal by default**, so an outside click or Escape won't dismiss
+it (and discard in-progress input) — pass `modal: false` to allow that. The
+dialog footer supplies the submit and cancel buttons (override their labels with
+`labels: { submit, cancel }`), so you don't need `submitConfig.hideSubmitButton`
+— `forms.open` sets it for you.
 
 <Canvas of={Stories.FormInDialog} />
+
+### As a wizard
+
+Pass `mode: "wizard"` to open the same typed definition as a multi-step
+[`F0WizardForm`](?path=/docs/patterns-forms-f0wizardform--documentation). Group
+fields into steps with `sections` on the definition; `forms.open` resolves once
+the **final** step submits:
+
+```tsx
+const result = await forms.open({
+  formDefinition,
+  mode: "wizard",
+  title: "Add employee",
+})
+
+if (result.completed) {
+  // result.data is the validated, typed full-form values
+}
+```
+
+Behavior:
+
+- **Final step submits successfully** → the wizard auto-closes and the promise
+  resolves with `{ completed: true, data }`.
+- **Dismissed / closed** → resolves with `{ completed: false }`.
+
+If the definition uses `linkAfterLastStepSubmit`, the page navigates away and the
+promise will not resolve.
+
+<Canvas of={WizardStories.OpenFormWizard} />
 
 ## File fields
 

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -6,7 +6,6 @@ import { z } from "zod"
 import { F0Button } from "@/components/F0Button"
 import { createDataSourceDefinition } from "@/hooks/datasource"
 import { ExternalLink, Plus, Settings } from "@/icons/app"
-import { F0Dialog } from "@/patterns/F0Dialog"
 import { useF0FormDefinition } from "@/patterns/F0WizardForm"
 
 import type {
@@ -16,11 +15,12 @@ import type {
 } from "../fields/types"
 import type { RenderCustomFieldSelectConfig } from "../types"
 
+import { forms } from "@/patterns/forms"
+
 import {
   f0FormField,
   F0Form,
   F0SectionConfig,
-  useF0Form,
   RenderCustomFieldProps,
   F0FormRef,
 } from "../index"
@@ -2489,23 +2489,25 @@ export const SelectWithDataSource: Story = {
 }
 
 /**
- * Form inside a Dialog using `useF0Form` hook for external control.
+ * Form inside a Dialog using the imperative `forms.open` helper.
  *
- * The `useF0Form` hook provides:
- * - `formRef`: Pass to F0Form to enable external control
- * - `submit()`: Programmatically submit the form (validates first)
- * - `reset()`: Reset the form to default values
- * - `isDirty()`: Check if the form has unsaved changes
- * - `isSubmitting`: Whether the form is currently submitting
- * - `hasErrors`: Whether the form has validation errors
+ * `forms.open({ formDefinition, mode: "dialog", title })` opens the form in a
+ * `dialog-alike` dialog and returns a promise:
+ * - resolves `{ submitted: true, data }` when the form submits successfully
+ *   (the dialog closes automatically),
+ * - resolves `{ submitted: false }` when cancelled, dismissed, or closed.
  *
- * This is useful when the submit button needs to be outside the form,
- * such as in a dialog's footer with F0Dialog.
+ * Validation failures keep the dialog open with inline errors — no manual
+ * `useF0Form` / `formRef` wiring needed. Requires `<F0Provider>` to be mounted.
  */
 export const FormInDialog: Story = {
+  // `forms.open` mounts a fixed, centered modal via a portal. On the inline docs
+  // page many `F0Provider`s coexist (one per canvas), so the portal target is
+  // ambiguous and the modal mispositions. Render this demo in its own iframe so
+  // it has a single provider and the dialog centers correctly.
+  parameters: { docs: { story: { inline: false, height: "600px" } } },
   render() {
-    const [open, setOpen] = useState(false)
-    const { formRef, submit, isSubmitting, hasErrors } = useF0Form()
+    const [lastResult, setLastResult] = useState<string | null>(null)
 
     const formSchema = z.object({
       name: f0FormField.text({
@@ -2536,43 +2538,36 @@ export const FormInDialog: Story = {
         email: "",
         role: undefined,
       },
-      submitConfig: { type: "default", hideSubmitButton: true },
       onSubmit: async ({ data }) => {
         await sleep(1000)
         console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
-        setOpen(false)
         return { success: true }
       },
     })
 
+    const handleAdd = async () => {
+      const result = await forms.open({
+        formDefinition,
+        mode: "dialog",
+        title: "Add Team Member",
+        description:
+          "Add a new member to your team. They will receive an invitation email.",
+        labels: { submit: "Add Member" },
+      })
+      setLastResult(
+        result.submitted
+          ? `Added ${result.data.name} (${result.data.role})`
+          : "Cancelled"
+      )
+    }
+
     return (
-      <>
-        <F0Button
-          label="Add Team Member"
-          icon={Plus}
-          onClick={() => setOpen(true)}
-        />
-        <F0Dialog
-          isOpen={open}
-          onClose={() => setOpen(false)}
-          title="Add Team Member"
-          description="Add a new member to your team. They will receive an invitation email."
-          primaryAction={{
-            label: "Add Member",
-            icon: Plus,
-            onClick: submit,
-            loading: isSubmitting,
-            disabled: hasErrors,
-          }}
-          secondaryAction={{
-            label: "Cancel",
-            onClick: () => setOpen(false),
-          }}
-          disableContentPadding
-        >
-          <F0Form formDefinition={formDefinition} formRef={formRef} />
-        </F0Dialog>
-      </>
+      <div className="flex flex-col items-start gap-3">
+        <F0Button label="Add Team Member" icon={Plus} onClick={handleAdd} />
+        {lastResult && (
+          <p className="text-f1-foreground-secondary text-sm">{lastResult}</p>
+        )}
+      </div>
     )
   },
 }

--- a/packages/react/src/patterns/F0Form/__tests__/openFormDialog.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/openFormDialog.test.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from "react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { z } from "zod"
+import "@testing-library/jest-dom/vitest"
+
+import {
+  FormOverlaysProvider,
+  formOverlaysStore,
+} from "@/lib/providers/form-overlays"
+import {
+  render,
+  screen,
+  TestProviders,
+  userEvent,
+  waitFor,
+} from "@/testing/test-utils"
+
+import { useF0FormDefinition } from "@/patterns/F0WizardForm"
+
+import { forms } from "@/patterns/forms"
+
+import { f0FormField } from "../f0Schema"
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <TestProviders>
+    <FormOverlaysProvider>{children}</FormOverlaysProvider>
+  </TestProviders>
+)
+
+function Harness() {
+  const [result, setResult] = useState("")
+
+  const formDefinition = useF0FormDefinition({
+    name: "open-form-dialog-test",
+    schema: z.object({
+      name: f0FormField.text({ label: "Name", minLength: 2 }),
+    }),
+    defaultValues: { name: "" },
+    onSubmit: async ({ data }) => ({ success: true, value: data }),
+  })
+
+  const handleOpen = async () => {
+    const r = await forms.open({
+      formDefinition,
+      mode: "dialog",
+      title: "Add member",
+    })
+    setResult(r.submitted ? `ok:${r.data.name}` : "cancelled")
+  }
+
+  return (
+    <>
+      <button onClick={handleOpen}>open</button>
+      <div data-testid="result">{result}</div>
+    </>
+  )
+}
+
+describe('forms.open mode "dialog" (integration)', () => {
+  beforeEach(() => formOverlaysStore.clear())
+  afterEach(() => formOverlaysStore.clear())
+
+  it("resolves { submitted: false } when cancelled", async () => {
+    const user = userEvent.setup()
+    render(<Harness />, { wrapper: Wrapper })
+
+    await user.click(screen.getByText("open"))
+    await user.click(await screen.findByRole("button", { name: "Cancel" }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("result")).toHaveTextContent("cancelled")
+    )
+  })
+
+  it("resolves { submitted: true, data } after a successful submit", async () => {
+    const user = userEvent.setup()
+    render(<Harness />, { wrapper: Wrapper })
+
+    await user.click(screen.getByText("open"))
+
+    const input = await screen.findByLabelText("Name")
+    await user.type(input, "Alice")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("result")).toHaveTextContent("ok:Alice")
+    )
+  })
+
+  it("keeps the dialog open when validation fails", async () => {
+    const user = userEvent.setup()
+    render(<Harness />, { wrapper: Wrapper })
+
+    await user.click(screen.getByText("open"))
+    // Submit with the required field empty.
+    await user.click(await screen.findByRole("button", { name: "Save" }))
+
+    // Dialog is still on screen; result not resolved.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument()
+    )
+    expect(screen.getByTestId("result")).toHaveTextContent("")
+  })
+})

--- a/packages/react/src/patterns/F0Form/index.tsx
+++ b/packages/react/src/patterns/F0Form/index.tsx
@@ -131,6 +131,13 @@ export { useSchemaDefinition, getSchemaDefinition } from "./useSchemaDefinition"
 export { evaluateRenderIf } from "./fields/utils"
 export { generateAnchorId } from "./context"
 
+// `openFormDialog` is the building block behind `forms.open({ mode: "dialog" })`
+// (assembled in `patterns/forms`). It is not part of the public surface.
+export type {
+  OpenFormDialogOptions,
+  OpenFormDialogResult,
+} from "./openFormDialog"
+
 // Export form control hook
 export { useF0Form } from "./useF0Form"
 export type {

--- a/packages/react/src/patterns/F0Form/openFormDialog.tsx
+++ b/packages/react/src/patterns/F0Form/openFormDialog.tsx
@@ -1,0 +1,187 @@
+import { nanoid } from "nanoid"
+import { useMemo, useRef } from "react"
+import { z } from "zod"
+
+import { F0Dialog, F0DialogSize } from "@/components/dialog-alike/F0Dialog"
+import { useI18n } from "@/lib/providers/i18n"
+import {
+  mountFormOverlay,
+  unmountFormOverlay,
+} from "@/lib/providers/form-overlays"
+import type { DialogId, DialogModule } from "@/lib/providers/dialogs-alike"
+import type {
+  F0FormDefinitionSingleSchema,
+  F0FormSchema,
+} from "@/patterns/F0WizardForm/types"
+
+import { F0Form } from "./F0Form"
+import type { F0FormPropsWithSingleSchemaDefinition } from "./types"
+import { useF0Form } from "./useF0Form"
+
+// F0Form is an overloaded generic; spreading generic props in JSX trips overload
+// resolution. Cast to the concrete definition-props signature for the call site.
+const FormView = F0Form as (
+  props: F0FormPropsWithSingleSchemaDefinition<F0FormSchema>
+) => React.ReactElement
+
+export type OpenFormDialogResult<TSchema extends F0FormSchema> =
+  | { submitted: true; data: z.infer<TSchema> }
+  | { submitted: false }
+
+export type OpenFormDialogOptions<TSchema extends F0FormSchema> = {
+  /** The form definition created with `useF0FormDefinition`. */
+  formDefinition: F0FormDefinitionSingleSchema<TSchema>
+  /** The dialog title. */
+  title: string
+  /** Optional supporting description below the title. */
+  description?: string
+  /** The dialog size. @default "md" */
+  size?: F0DialogSize
+  /** Module shown in the dialog header. */
+  module?: DialogModule
+  /**
+   * When true, the dialog can only be closed via its actions (no overlay click
+   * or Escape) — so in-progress input isn't lost by an accidental dismissal.
+   * @default true
+   */
+  modal?: boolean
+  /** Overlay id. Auto-generated if not provided. */
+  id?: DialogId
+  /** Override the footer button labels (default to i18n save/cancel). */
+  labels?: {
+    submit?: string
+    cancel?: string
+  }
+}
+
+type FormDialogContentProps<TSchema extends F0FormSchema> = {
+  options: OpenFormDialogOptions<TSchema>
+  isOpen: boolean
+  onSubmitted: (data: z.infer<TSchema>) => void
+  onCancel: () => void
+}
+
+/**
+ * Renders an `F0Form` inside a `dialog-alike` `F0Dialog`, wiring the dialog's
+ * footer submit/cancel to the form. This is the proven `useF0Form` + `F0Dialog`
+ * pattern, packaged so `openFormDialog` can mount it imperatively.
+ */
+function FormDialogContent<TSchema extends F0FormSchema>({
+  options,
+  isOpen,
+  onSubmitted,
+  onCancel,
+}: FormDialogContentProps<TSchema>) {
+  const { actions } = useI18n()
+  const {
+    formDefinition,
+    title,
+    description,
+    size,
+    module,
+    modal = true,
+    labels,
+  } = options
+  const { formRef, submit, isSubmitting, hasErrors } = useF0Form()
+
+  // The dialog footer owns submit, so hide the form's own button. We also
+  // capture the submitted data on success WITHOUT mutating the caller's
+  // definition — shallow-clone with a wrapped onSubmit instead.
+  const submittedDataRef = useRef<z.infer<TSchema> | undefined>(undefined)
+  const dialogDefinition = useMemo<F0FormDefinitionSingleSchema<TSchema>>(
+    () => ({
+      ...formDefinition,
+      submitConfig: { ...formDefinition.submitConfig, hideSubmitButton: true },
+      onSubmit: async (arg) => {
+        const result = await formDefinition.onSubmit(arg)
+        if (result.success) submittedDataRef.current = arg.data
+        return result
+      },
+    }),
+    [formDefinition]
+  )
+
+  const handleSubmit = async () => {
+    submittedDataRef.current = undefined
+    try {
+      // Rejects on validation failure — the dialog stays open with inline
+      // errors. Only a successful submit advances past this point.
+      await submit()
+    } catch {
+      return
+    }
+    if (submittedDataRef.current !== undefined) {
+      onSubmitted(submittedDataRef.current)
+    }
+  }
+
+  return (
+    <F0Dialog
+      isOpen={isOpen}
+      onClose={onCancel}
+      title={title}
+      description={description}
+      size={size}
+      module={module}
+      modal={modal}
+      primaryAction={{
+        label: labels?.submit ?? actions.save,
+        onClick: handleSubmit,
+        loading: isSubmitting,
+        disabled: hasErrors,
+      }}
+      secondaryAction={{
+        label: labels?.cancel ?? actions.cancel,
+        onClick: onCancel,
+      }}
+      disableContentPadding
+    >
+      <FormView
+        formDefinition={
+          dialogDefinition as unknown as F0FormDefinitionSingleSchema<F0FormSchema>
+        }
+        formRef={formRef}
+      />
+    </F0Dialog>
+  )
+}
+
+/**
+ * Open an `F0Form` in a dialog imperatively and await the outcome.
+ *
+ * Resolves with `{ submitted: true, data }` once the form submits successfully
+ * (the dialog closes automatically), or `{ submitted: false }` if the user
+ * cancels, dismisses, or it is closed programmatically. Validation failures keep
+ * the dialog open with inline errors. Requires `<F0Provider>` to be mounted.
+ *
+ * @example
+ * const result = await forms.open({ formDefinition, mode: "dialog", title: "Add member" })
+ * if (result.submitted) save(result.data)
+ */
+export function openFormDialog<TSchema extends F0FormSchema>(
+  options: OpenFormDialogOptions<TSchema>
+): Promise<OpenFormDialogResult<TSchema>> {
+  return new Promise((resolve) => {
+    const id = options.id ?? nanoid()
+    let settled = false
+    const finish = (result: OpenFormDialogResult<TSchema>) => {
+      if (settled) return
+      settled = true
+      resolve(result)
+      unmountFormOverlay(id)
+    }
+
+    mountFormOverlay({
+      id,
+      onDismiss: () => finish({ submitted: false }),
+      render: ({ isOpen }) => (
+        <FormDialogContent
+          options={options}
+          isOpen={isOpen}
+          onSubmitted={(data) => finish({ submitted: true, data })}
+          onCancel={() => finish({ submitted: false })}
+        />
+      ),
+    })
+  })
+}

--- a/packages/react/src/patterns/F0WizardForm/__stories__/F0WizardForm.mdx
+++ b/packages/react/src/patterns/F0WizardForm/__stories__/F0WizardForm.mdx
@@ -1,0 +1,114 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks"
+import * as Stories from "./F0WizardForm.stories"
+
+<Meta of={Stories} />
+
+# F0WizardForm
+
+A multi-step form built on the same typed Zod schema + `f0FormField` metadata as
+[`F0Form`](?path=/docs/forms-f0form--docs). Fields are grouped into steps either
+by tagging them with a `section` (single-schema mode) or by providing a record of
+schemas keyed by section (per-section mode, where each step submits independently).
+
+The wizard renders its **own** dialog. Control it declaratively with `isOpen` /
+`onClose` (below), or open it imperatively with `forms.open({ mode: "wizard" })` —
+documented in the
+[F0Form docs](?path=/docs/patterns-forms-f0form--documentation).
+
+---
+
+# Overview
+
+## Architecture
+
+Like `F0Form`, the wizard is built on two pieces:
+
+1. **`useF0FormDefinition`** — accepts the schema(s), defaults, sections, and
+   submit handler, and returns a `formDefinition` object.
+2. **`<F0WizardForm />`** — renders the stepped form inside a dialog.
+
+```tsx
+const formDefinition = useF0FormDefinition({
+  name: "add-employee",
+  schema, // fields tagged with `section`
+  sections: {
+    general: { title: "General information" },
+    work: { title: "Work details" },
+  },
+  onSubmit: async ({ data }) => {
+    await save(data)
+    return { success: true }
+  },
+})
+```
+
+---
+
+# Opening the wizard
+
+## Declarative — `<F0WizardForm isOpen onClose>`
+
+Render the component directly when you want to own the open state (e.g. keep it
+in a parent reducer):
+
+```tsx
+const [open, setOpen] = useState(false)
+
+<F0WizardForm
+  formDefinition={formDefinition}
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  title="Add employee"
+/>
+```
+
+<Canvas of={Stories.SingleSchema} />
+
+## Imperative — `forms.open({ mode: "wizard" })`
+
+To open the wizard from anywhere without wiring `isOpen` / `onClose`, pass the
+definition to `forms.open` with `mode: "wizard"` and `await` the result:
+
+```tsx
+const result = await forms.open({
+  formDefinition,
+  mode: "wizard",
+  title: "Add employee",
+})
+
+if (result.completed) {
+  // result.data is the validated, typed full-form values
+}
+```
+
+<Canvas of={Stories.OpenFormWizard} />
+
+> `forms.open` is the shared form-opening helper — see the
+> [F0Form docs](?path=/docs/patterns-forms-f0form--documentation) for the full
+> API, including the `mode: "dialog"` variant and the complete list of options.
+
+---
+
+# Per-section schema mode
+
+Provide a record of schemas keyed by section. Each section is validated and
+submitted independently, so `onSubmit` receives the current `sectionId`, that
+section's `data`, and the cumulative `fullData`.
+
+<Canvas of={Stories.PerSectionSchema} />
+
+---
+
+# Code
+
+## Import
+
+```tsx
+import {
+  F0WizardForm,
+  forms,
+  useF0FormDefinition,
+  f0FormField,
+} from "@factorialco/f0-react"
+import { z } from "zod"
+```

--- a/packages/react/src/patterns/F0WizardForm/__stories__/F0WizardForm.stories.tsx
+++ b/packages/react/src/patterns/F0WizardForm/__stories__/F0WizardForm.stories.tsx
@@ -9,6 +9,8 @@ import { ApplicationFrame } from "@/patterns/ApplicationFrame"
 import ApplicationFrameStoryMeta from "@/patterns/ApplicationFrame/index.stories"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
+import { forms } from "@/patterns/forms"
+
 import { F0WizardForm, useF0FormDefinition } from "../index"
 
 const meta: Meta<typeof F0WizardForm> = {
@@ -20,7 +22,7 @@ const meta: Meta<typeof F0WizardForm> = {
       story: { inline: false, height: "720px" },
     },
   },
-  tags: ["autodocs"],
+  tags: ["!autodocs"],
 }
 
 export default meta
@@ -170,6 +172,71 @@ function GoalPeriodWizardStory() {
  */
 export const WithPeriodField: Story = {
   render: () => <GoalPeriodWizardStory />,
+}
+
+// =============================================================================
+// Imperative forms.open (wizard)
+// =============================================================================
+
+/**
+ * Live demo for `forms.open({ mode: "wizard" })`. The API is documented in the
+ * [F0Form docs](?path=/docs/patterns-forms-f0form--documentation).
+ */
+function OpenFormWizardStory() {
+  const [lastResult, setLastResult] = useState<string | null>(null)
+
+  const definition = useF0FormDefinition({
+    name: "open-wizard-single",
+    schema: singleSchema,
+    defaultValues: { email: "alicia.keys@factorial.co" },
+    sections: {
+      general: { title: "General information" },
+      personal: { title: "Personal details" },
+      work: { title: "Work details" },
+    },
+    onSubmit: async ({ data }) => {
+      console.log("Form submitted:", data)
+      await new Promise((r) => setTimeout(r, 1500))
+      return { success: true, message: "Employee saved successfully" }
+    },
+  })
+
+  const handleOpen = async () => {
+    const result = await forms.open({
+      formDefinition: definition,
+      mode: "wizard",
+      title: "Add employee",
+    })
+    setLastResult(
+      result.completed
+        ? `Completed: ${result.data.firstName ?? result.data.email}`
+        : "Dismissed"
+    )
+  }
+
+  return (
+    <ApplicationFrame
+      {...(ApplicationFrameStoryMeta.args as ComponentProps<
+        typeof ApplicationFrame
+      >)}
+    >
+      <div className="flex flex-1 flex-col items-center justify-center gap-3">
+        <F0Button label="Open wizard" onClick={handleOpen} />
+        {lastResult && (
+          <p className="text-f1-foreground-secondary">{lastResult}</p>
+        )}
+      </div>
+    </ApplicationFrame>
+  )
+}
+
+export const OpenFormWizard: Story = {
+  // `forms.open` mounts a fixed, centered modal via a portal. On the inline docs
+  // page many `F0Provider`s coexist (one per canvas), so the portal target is
+  // ambiguous and the modal mispositions. Render this demo in its own iframe so
+  // it has a single provider and the wizard centers correctly.
+  parameters: { docs: { story: { inline: false, height: "640px" } } },
+  render: () => <OpenFormWizardStory />,
 }
 
 // =============================================================================

--- a/packages/react/src/patterns/F0WizardForm/__tests__/openFormWizard.test.tsx
+++ b/packages/react/src/patterns/F0WizardForm/__tests__/openFormWizard.test.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from "react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { z } from "zod"
+import "@testing-library/jest-dom/vitest"
+
+import {
+  FormOverlaysProvider,
+  formOverlaysStore,
+  unmountFormOverlay,
+} from "@/lib/providers/form-overlays"
+import { f0FormField } from "@/patterns/F0Form/f0Schema"
+import {
+  render,
+  screen,
+  TestProviders,
+  userEvent,
+  waitFor,
+} from "@/testing/test-utils"
+
+import { forms } from "@/patterns/forms"
+
+import { useF0FormDefinition } from "../useF0FormDefinition"
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <TestProviders>
+    <FormOverlaysProvider>{children}</FormOverlaysProvider>
+  </TestProviders>
+)
+
+const schema = z.object({
+  firstName: f0FormField.text({ label: "First name", section: "general" }),
+  role: f0FormField.text({ label: "Role", section: "work" }),
+})
+
+function Harness() {
+  const [result, setResult] = useState("")
+
+  const formDefinition = useF0FormDefinition({
+    name: "open-form-wizard-test",
+    schema,
+    defaultValues: { firstName: "", role: "" },
+    sections: {
+      general: { title: "General" },
+      work: { title: "Work" },
+    },
+    submitConfig: { label: "Finish" },
+    onSubmit: async ({ data }) => ({ success: true, value: data }),
+  })
+
+  const handleOpen = async () => {
+    const r = await forms.open({
+      formDefinition,
+      mode: "wizard",
+      title: "Onboarding",
+      nextLabel: "Continue",
+    })
+    setResult(
+      r.completed ? `done:${r.data.firstName}/${r.data.role}` : "dismissed"
+    )
+  }
+
+  return (
+    <>
+      <button onClick={handleOpen}>open</button>
+      <div data-testid="result">{result}</div>
+    </>
+  )
+}
+
+describe(`forms.open mode "wizard" (integration)`, () => {
+  beforeEach(() => formOverlaysStore.clear())
+  afterEach(() => formOverlaysStore.clear())
+
+  it("resolves { completed: true, data } after the final step submits", async () => {
+    const user = userEvent.setup()
+    render(<Harness />, { wrapper: Wrapper })
+
+    await user.click(screen.getByText("open"))
+
+    // Step 1 (general)
+    await user.type(await screen.findByLabelText("First name"), "Alice")
+    await user.click(screen.getByRole("button", { name: "Continue" }))
+
+    // Step 2 (work) — advancing past step 1 must NOT have completed the wizard.
+    expect(screen.getByTestId("result")).toHaveTextContent("")
+    await user.type(await screen.findByLabelText("Role"), "Engineer")
+    await user.click(screen.getByRole("button", { name: "Finish" }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("result")).toHaveTextContent(
+        "done:Alice/Engineer"
+      )
+    )
+  })
+
+  it("resolves { completed: false } when dismissed before finishing", async () => {
+    const user = userEvent.setup()
+    render(<Harness />, { wrapper: Wrapper })
+
+    await user.click(screen.getByText("open"))
+    await user.type(await screen.findByLabelText("First name"), "Alice")
+
+    // Programmatic dismissal (e.g. navigation) before reaching the last step.
+    await waitFor(() => expect(formOverlaysStore.getSnapshot()).toHaveLength(1))
+    unmountFormOverlay(formOverlaysStore.getSnapshot()[0].id)
+
+    await waitFor(() =>
+      expect(screen.getByTestId("result")).toHaveTextContent("dismissed")
+    )
+  })
+})

--- a/packages/react/src/patterns/F0WizardForm/index.tsx
+++ b/packages/react/src/patterns/F0WizardForm/index.tsx
@@ -14,6 +14,13 @@ import { F0WizardForm as F0WizardFormComponent } from "./F0WizardForm"
 export { useF0FormDefinition } from "./useF0FormDefinition"
 export type { AsyncOrSync } from "./useF0FormDefinition"
 
+// `openFormWizard` is the building block behind `forms.open({ mode: "wizard" })`
+// (assembled in `patterns/forms`). It is not part of the public surface.
+export type {
+  OpenFormWizardOptions,
+  OpenFormWizardResult,
+} from "./openFormWizard"
+
 export type {
   F0FormDefinition,
   F0FormDefinitionSingleSchema,

--- a/packages/react/src/patterns/F0WizardForm/openFormWizard.tsx
+++ b/packages/react/src/patterns/F0WizardForm/openFormWizard.tsx
@@ -1,0 +1,187 @@
+import { nanoid } from "nanoid"
+import { useMemo, useRef } from "react"
+import { z } from "zod"
+
+import { F0DialogSize } from "@/components/dialog-alike/F0Dialog"
+import type { DialogId } from "@/lib/providers/dialogs-alike"
+import {
+  mountFormOverlay,
+  unmountFormOverlay,
+} from "@/lib/providers/form-overlays"
+
+import { F0WizardForm as F0WizardFormComponent } from "./F0WizardForm"
+import type {
+  F0FormDefinition,
+  F0FormDefinitionPerSection,
+  F0FormDefinitionSingleSchema,
+  F0FormSchema,
+  F0PerSectionSchema,
+  F0WizardFormSingleSchemaProps,
+  F0WizardFormStep,
+  InferPerSectionValues,
+} from "./types"
+
+// F0WizardForm is an overloaded generic; spreading union-typed props in JSX
+// trips overload resolution. Cast to one concrete signature for the call site
+// (it detects single/per-section at runtime from `formDefinition._brand`).
+const WizardForm = F0WizardFormComponent as (
+  props: F0WizardFormSingleSchemaProps<F0FormSchema>
+) => React.ReactElement
+
+type WizardData<T extends F0FormSchema | F0PerSectionSchema> =
+  T extends F0FormSchema
+    ? z.infer<T>
+    : T extends F0PerSectionSchema
+      ? InferPerSectionValues<T>
+      : never
+
+export type OpenFormWizardResult<T extends F0FormSchema | F0PerSectionSchema> =
+  | { completed: true; data: WizardData<T> }
+  | { completed: false }
+
+export type OpenFormWizardOptions<T extends F0FormSchema | F0PerSectionSchema> =
+  {
+    /** The form definition created with `useF0FormDefinition`. */
+    formDefinition: F0FormDefinition<T>
+    /** The wizard dialog title. */
+    title?: string
+    /** The wizard dialog size. */
+    size?: F0DialogSize
+    /** Overlay id. Auto-generated if not provided. */
+    id?: DialogId
+    /** Custom step definitions (otherwise derived from sections). */
+    steps?: F0WizardFormStep[]
+    /** Step to open on. */
+    defaultStepIndex?: number
+    nextLabel?: string
+    previousLabel?: string
+    /** Allow clicking ahead to non-incomplete steps. @default false */
+    allowStepSkipping?: boolean
+    /** Skip to the first incomplete step on open. @default false */
+    autoSkipCompletedSteps?: boolean
+    onStepChanged?: (stepIndex: number) => void
+  }
+
+// Shallow-clone the definition with a wrapped onSubmit that reports the latest
+// full values on every successful step submit — WITHOUT mutating the caller's
+// definition. `capture` records data + marks a (possibly final) completion.
+function wrapWizardDefinition<T extends F0FormSchema | F0PerSectionSchema>(
+  formDefinition: F0FormDefinition<T>,
+  capture: (data: WizardData<T>) => void
+): F0FormDefinition<T> {
+  if (formDefinition._brand === "per-section") {
+    const def = formDefinition as F0FormDefinitionPerSection<F0PerSectionSchema>
+    const wrapped: F0FormDefinitionPerSection<F0PerSectionSchema> = {
+      ...def,
+      onSubmit: async (arg) => {
+        const result = await def.onSubmit(arg)
+        if (result.success) capture(arg.fullData as WizardData<T>)
+        return result
+      },
+    }
+    return wrapped as F0FormDefinition<T>
+  }
+
+  const def = formDefinition as F0FormDefinitionSingleSchema<F0FormSchema>
+  const wrapped: F0FormDefinitionSingleSchema<F0FormSchema> = {
+    ...def,
+    onSubmit: async (arg) => {
+      const result = await def.onSubmit(arg)
+      if (result.success) capture(arg.data as WizardData<T>)
+      return result
+    },
+  }
+  return wrapped as F0FormDefinition<T>
+}
+
+type WizardOverlayProps<T extends F0FormSchema | F0PerSectionSchema> = {
+  options: OpenFormWizardOptions<T>
+  isOpen: boolean
+  onResolve: (result: OpenFormWizardResult<T>) => void
+}
+
+function WizardOverlay<T extends F0FormSchema | F0PerSectionSchema>({
+  options,
+  isOpen,
+  onResolve,
+}: WizardOverlayProps<T>) {
+  const { formDefinition, onStepChanged, ...wizardProps } = options
+
+  // `completed` flips true on each successful submit and is reset whenever the
+  // wizard advances to another step (so only the LAST step's success — which
+  // does not advance — survives until close). Since `autoCloseOnLastStepSubmit`
+  // is forced on, a self-close means the final step succeeded.
+  const completedRef = useRef(false)
+  const dataRef = useRef<WizardData<T> | undefined>(undefined)
+
+  const wrapped = useMemo(
+    () =>
+      wrapWizardDefinition<T>(formDefinition, (data) => {
+        completedRef.current = true
+        dataRef.current = data
+      }),
+    [formDefinition]
+  )
+
+  const handleStepChanged = (stepIndex: number) => {
+    completedRef.current = false
+    onStepChanged?.(stepIndex)
+  }
+
+  const handleClose = () => {
+    if (completedRef.current && dataRef.current !== undefined) {
+      onResolve({ completed: true, data: dataRef.current })
+    } else {
+      onResolve({ completed: false })
+    }
+  }
+
+  const props = {
+    ...wizardProps,
+    formDefinition: wrapped,
+    isOpen,
+    onClose: handleClose,
+    onStepChanged: handleStepChanged,
+    autoCloseOnLastStepSubmit: true,
+  } as unknown as F0WizardFormSingleSchemaProps<F0FormSchema>
+
+  return <WizardForm {...props} />
+}
+
+/**
+ * Open an `F0WizardForm` (multi-step form) imperatively and await the outcome.
+ *
+ * Resolves with `{ completed: true, data }` once the final step submits
+ * successfully (the wizard auto-closes), or `{ completed: false }` if the user
+ * dismisses it or it is closed programmatically. Requires `<F0Provider>` to be
+ * mounted.
+ *
+ * Note: if the underlying definition navigates away via `linkAfterLastStepSubmit`,
+ * the page changes and this promise will not resolve.
+ *
+ * @example
+ * const result = await forms.open({ formDefinition, mode: "wizard", title: "Onboarding" })
+ * if (result.completed) save(result.data)
+ */
+export function openFormWizard<T extends F0FormSchema | F0PerSectionSchema>(
+  options: OpenFormWizardOptions<T>
+): Promise<OpenFormWizardResult<T>> {
+  return new Promise((resolve) => {
+    const id = options.id ?? nanoid()
+    let settled = false
+    const finish = (result: OpenFormWizardResult<T>) => {
+      if (settled) return
+      settled = true
+      resolve(result)
+      unmountFormOverlay(id)
+    }
+
+    mountFormOverlay({
+      id,
+      onDismiss: () => finish({ completed: false }),
+      render: ({ isOpen }) => (
+        <WizardOverlay options={options} isOpen={isOpen} onResolve={finish} />
+      ),
+    })
+  })
+}

--- a/packages/react/src/patterns/forms/index.ts
+++ b/packages/react/src/patterns/forms/index.ts
@@ -1,0 +1,51 @@
+import { openFormDialog } from "@/patterns/F0Form/openFormDialog"
+import type {
+  OpenFormDialogOptions,
+  OpenFormDialogResult,
+} from "@/patterns/F0Form/openFormDialog"
+import { openFormWizard } from "@/patterns/F0WizardForm/openFormWizard"
+import type {
+  OpenFormWizardOptions,
+  OpenFormWizardResult,
+} from "@/patterns/F0WizardForm/openFormWizard"
+import type {
+  F0FormSchema,
+  F0PerSectionSchema,
+} from "@/patterns/F0WizardForm/types"
+
+/** Open a form in a dialog. */
+function openForm<TSchema extends F0FormSchema>(
+  options: { mode: "dialog" } & OpenFormDialogOptions<TSchema>
+): Promise<OpenFormDialogResult<TSchema>>
+/** Open a form in a multi-step wizard. */
+function openForm<T extends F0FormSchema | F0PerSectionSchema>(
+  options: { mode: "wizard" } & OpenFormWizardOptions<T>
+): Promise<OpenFormWizardResult<T>>
+function openForm(
+  options: { mode: "dialog" | "wizard" } & Record<string, unknown>
+): Promise<unknown> {
+  const { mode, ...rest } = options
+  if (mode === "wizard") {
+    return openFormWizard(rest as OpenFormWizardOptions<F0FormSchema>)
+  }
+  return openFormDialog(rest as OpenFormDialogOptions<F0FormSchema>)
+}
+
+/**
+ * Imperative API for opening forms. Pick the presentation with `mode` —
+ * `"dialog"` for a single-screen form, `"wizard"` for a multi-step form.
+ * Requires `<F0Provider>` to be mounted.
+ *
+ * @example
+ * const result = await forms.open({ formDefinition, mode: "dialog", title: "Add member" })
+ * if (result.submitted) save(result.data)
+ *
+ * @example
+ * const result = await forms.open({ formDefinition, mode: "wizard", title: "Onboarding" })
+ * if (result.completed) save(result.data)
+ */
+export const forms = { open: openForm }
+
+// The option/result types stay public through `@/patterns/F0Form` and
+// `@/patterns/F0WizardForm`; re-exporting them here too would make the
+// `export *` barrels ambiguous, so they are intentionally not re-exported.


### PR DESCRIPTION
## What

Reworks the imperative overlay APIs to read as plural namespace objects (mirroring `toasts`), and adds a single entry point for opening forms imperatively. Rebased onto `main` — no longer stacked on `feat/imperative-verb-naming`.

### Dialogs / drawers (breaking)

The imperative dialog/drawer API is now namespaced:

| Before | After |
| --- | --- |
| `dialog.open` | `dialogs.open` |
| `dialog.notification` | `dialogs.notification` |
| `dialog.alert` | `dialogs.alert` |
| `dialog.confirm` | `dialogs.confirmation` |
| `dialog.close` | `dialogs.close` |
| `drawer.open` | `drawers.open` |
| `drawer.close` | `drawers.close` |

**Breaking change:** the singular `dialog` / `drawer` exports are gone — import `dialogs` / `drawers` instead.

### Forms

New `forms.open` helper opens an `F0Form` from anywhere, picking the presentation with `mode`:

```ts
const r = await forms.open({ formDefinition, mode: "dialog", title })   // → { submitted, data }
const r = await forms.open({ formDefinition, mode: "wizard", title })   // → { completed, data }
```

It's backed by a generic form-overlays provider (module-level store + portal + exit animation + renderer election), mounted inside `F0Provider`. The helper lives in `patterns/` so form-agnostic `lib/` stays free of form-specific React.

## Docs

- The `forms.open` API is documented in one place — the **F0Form** docs — covering both modes.
- **F0WizardForm** showcases the wizard mode with a live demo and links back to F0Form for the full reference.
- The two imperative demos render with `inline: false` so each gets its own provider on the docs page (a fixed-position modal otherwise mis-portals across the many providers a docs page mounts).

## Testing

- Unit/integration tests updated and passing (`dialogs`/`drawers` imperative suite; `forms.open` dialog + wizard integration).
- Manually verified both demos open centered in Storybook docs.

