### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.2.1",
+  "packages/react": "3.2.2",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.2.2](https://github.com/factorialco/f0/compare/f0-react-v3.2.1...f0-react-v3.2.2) (2026-06-15)
+
+
+### Bug Fixes
+
+* **EditableTable:** debounce onCellChange for typing cells ([#4412](https://github.com/factorialco/f0/issues/4412)) ([4f9819e](https://github.com/factorialco/f0/commit/4f9819e948509581c036c5fa4765c4f0e93665e8))
+
 ## [3.2.1](https://github.com/factorialco/f0/compare/f0-react-v3.2.0...f0-react-v3.2.1) (2026-06-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.2.2</summary>

## [3.2.2](https://github.com/factorialco/f0/compare/f0-react-v3.2.1...f0-react-v3.2.2) (2026-06-15)


### Bug Fixes

* **EditableTable:** debounce onCellChange for typing cells ([#4412](https://github.com/factorialco/f0/issues/4412)) ([4f9819e](https://github.com/factorialco/f0/commit/4f9819e948509581c036c5fa4765c4f0e93665e8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).