### PR TITLE
fix(rich-text): expose title as the editor textbox accessible name

### DIFF
--- a/packages/react/src/components/RichText/F0RichTextEditor/F0RichTextEditor.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/F0RichTextEditor.tsx
@@ -242,6 +242,15 @@ const F0RichTextEditorComponent = forwardRef<
     content: initialEditorState?.content || "",
     editable: !disabled,
     onUpdate: onEditorUpdate,
+    // Give the contenteditable an explicit textbox role and an accessible name;
+    // without this the editor is unnamed for screen readers and role+name queries.
+    editorProps: {
+      attributes: {
+        role: "textbox",
+        "aria-multiline": "true",
+        "aria-label": title,
+      },
+    },
     // Children subscribe to the editor state they need via useEditorState;
     // re-rendering the whole editor tree on every transaction is wasteful.
     shouldRerenderOnTransaction: false,

--- a/packages/react/src/components/RichText/F0RichTextEditor/__tests__/F0RichTextEditor.spec.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/__tests__/F0RichTextEditor.spec.tsx
@@ -13,6 +13,24 @@ import { F0RichTextEditor } from ".."
 import { I18nProvider, defaultTranslations } from "@/lib/providers/i18n"
 import { UserPlatformProvider } from "@/lib/providers/user-platafform/UserPlatformProvider"
 
+test("exposes the title as the accessible name of the editor textbox", async () => {
+  render(
+    <UserPlatformProvider platform="mac">
+      <I18nProvider translations={defaultTranslations}>
+        <F0RichTextEditor
+          title="What was your main goal?"
+          placeholder="Placeholder..."
+          onChange={vi.fn()}
+        />
+      </I18nProvider>
+    </UserPlatformProvider>
+  )
+
+  expect(
+    await screen.findByRole("textbox", { name: "What was your main goal?" })
+  ).toBeInTheDocument()
+})
+
 test("calls onFullscreenChange callback when fullscreen mode changes", async () => {
   const onFullscreenChange = vi.fn()
 


### PR DESCRIPTION
## Summary

`F0RichTextEditor`'s contenteditable had no role or accessible name — the `title` prop is only rendered in the visual header. As a result the editor is an unnamed editable for screen readers, and `getByRole('textbox', { name })` / Cypress `findByRole('textbox', { name })` queries cannot target it.

This sets `role="textbox"`, `aria-multiline="true"` and `aria-label={title}` on the editable via TipTap's `editorProps.attributes`.

## Why

Factorial's E2E suite (and a11y tooling) locate the review-answer editor by its accessible name (the question text). After the editor replaced the legacy `TextArea` (which exposed `aria-label={label}`), those queries broke because the editable had no name. This restores that contract and is a genuine accessibility improvement.

## Test plan

- [x] Added unit test asserting `getByRole('textbox', { name })` resolves to the editor
- [x] `pnpm vitest` for F0RichTextEditor passes