### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.2.2",
+  "packages/react": "3.2.3",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.2.3](https://github.com/factorialco/f0/compare/f0-react-v3.2.2...f0-react-v3.2.3) (2026-06-15)
+
+
+### Bug Fixes
+
+* **rich-text:** expose title as the editor textbox accessible name ([#4449](https://github.com/factorialco/f0/issues/4449)) ([8e0b41c](https://github.com/factorialco/f0/commit/8e0b41c30e0280c8383d435e0ad0c2026ef6a94f))
+
 ## [3.2.2](https://github.com/factorialco/f0/compare/f0-react-v3.2.1...f0-react-v3.2.2) (2026-06-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.2.3</summary>

## [3.2.3](https://github.com/factorialco/f0/compare/f0-react-v3.2.2...f0-react-v3.2.3) (2026-06-15)


### Bug Fixes

* **rich-text:** expose title as the editor textbox accessible name ([#4449](https://github.com/factorialco/f0/issues/4449)) ([8e0b41c](https://github.com/factorialco/f0/commit/8e0b41c30e0280c8383d435e0ad0c2026ef6a94f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).