### PR TITLE
fix(Tooltip): strip native title from child to avoid double tooltip

### DIFF
--- a/packages/react/src/experimental/Navigation/Header/PageHeader/__tests__/PageHeaderNavigationContext.test.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/__tests__/PageHeaderNavigationContext.test.tsx
@@ -33,8 +33,10 @@ describe("PageHeader navigation context", () => {
 
   it("renders navigation from the prop when prop is provided", () => {
     render(<PageHeader module={defaultModule} navigation={propNavigation} />)
-    expect(screen.getByTitle("Prop Previous")).toBeInTheDocument()
-    expect(screen.getByTitle("Prop Next")).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", { name: "Prop Previous" })
+    ).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Prop Next" })).toBeInTheDocument()
     expect(screen.getByText("1/5")).toBeInTheDocument()
   })
 
@@ -44,8 +46,12 @@ describe("PageHeader navigation context", () => {
         <PageHeader module={defaultModule} />
       </PageHeaderNavigationProvider>
     )
-    expect(screen.getByTitle("Context Previous")).toBeInTheDocument()
-    expect(screen.getByTitle("Context Next")).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", { name: "Context Previous" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", { name: "Context Next" })
+    ).toBeInTheDocument()
     expect(screen.getByText("2/10")).toBeInTheDocument()
   })
 
@@ -55,10 +61,12 @@ describe("PageHeader navigation context", () => {
         <PageHeader module={defaultModule} navigation={propNavigation} />
       </PageHeaderNavigationProvider>
     )
-    expect(screen.getByTitle("Prop Previous")).toBeInTheDocument()
-    expect(screen.getByTitle("Prop Next")).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", { name: "Prop Previous" })
+    ).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Prop Next" })).toBeInTheDocument()
     expect(screen.getByText("1/5")).toBeInTheDocument()
-    expect(screen.queryByTitle("Context Previous")).toBeNull()
+    expect(screen.queryByRole("link", { name: "Context Previous" })).toBeNull()
   })
 
   it("renders nothing when context value is null", () => {
@@ -67,7 +75,7 @@ describe("PageHeader navigation context", () => {
         <PageHeader module={defaultModule} />
       </PageHeaderNavigationProvider>
     )
-    expect(screen.queryByTitle("Previous")).toBeNull()
-    expect(screen.queryByTitle("Next")).toBeNull()
+    expect(screen.queryByRole("link", { name: /previous/i })).toBeNull()
+    expect(screen.queryByRole("link", { name: /next/i })).toBeNull()
   })
 })

--- a/packages/react/src/experimental/Overlays/Tooltip/index.stories.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.stories.tsx
@@ -50,10 +50,11 @@ export const WithDataTestId: Story = {
 }
 
 /**
- * The child element carries a native HTML `title` attribute. Without stripping
+ * The child element carries a native HTML `title` attribute. Without handling
  * it, the browser would show its own tooltip on hover in addition to the F0
  * one, leaving the user with two overlapping tooltips. Hover the button: only
- * the F0 tooltip shows.
+ * the F0 tooltip shows. The title text is preserved as an `aria-label` so the
+ * accessible name survives even though the native tooltip is gone.
  */
 export const ChildWithNativeTitle: Story = {
   args: {
@@ -68,7 +69,12 @@ export const ChildWithNativeTitle: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const trigger = canvas.getByTestId("native-title-trigger")
-    // The native `title` should be stripped so only the F0 tooltip renders.
+    // The native `title` is removed so only the F0 tooltip renders...
     await expect(trigger).not.toHaveAttribute("title")
+    // ...but the accessible name is preserved via aria-label.
+    await expect(trigger).toHaveAttribute(
+      "aria-label",
+      "Native browser tooltip"
+    )
   },
 }

--- a/packages/react/src/experimental/Overlays/Tooltip/index.stories.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.stories.tsx
@@ -48,3 +48,27 @@ export const WithDataTestId: Story = {
     await expect(canvas.getByTestId("tooltip-test-id")).toBeInTheDocument()
   },
 }
+
+/**
+ * The child element carries a native HTML `title` attribute. Without stripping
+ * it, the browser would show its own tooltip on hover in addition to the F0
+ * one, leaving the user with two overlapping tooltips. Hover the button: only
+ * the F0 tooltip shows.
+ */
+export const ChildWithNativeTitle: Story = {
+  args: {
+    label: "Planned hours",
+    description: "Only the F0 tooltip should show — no native browser tooltip.",
+    children: (
+      <button title="Native browser tooltip" data-testid="native-title-trigger">
+        Hover me
+      </button>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const trigger = canvas.getByTestId("native-title-trigger")
+    // The native `title` should be stripped so only the F0 tooltip renders.
+    await expect(trigger).not.toHaveAttribute("title")
+  },
+}

--- a/packages/react/src/experimental/Overlays/Tooltip/index.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.tsx
@@ -9,6 +9,7 @@ import React, {
 
 import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
+import { stripNativeTitle } from "@/lib/strip-native-title"
 import {
   TooltipContent,
   Tooltip as TooltipPrimitive,
@@ -108,7 +109,7 @@ export function TooltipInternal({
             }}
             onBlur={() => close()}
           >
-            {children}
+            {stripNativeTitle(children)}
           </TooltipTrigger>
           <TooltipContent
             className={cn(

--- a/packages/react/src/lib/strip-native-title.test.tsx
+++ b/packages/react/src/lib/strip-native-title.test.tsx
@@ -1,0 +1,39 @@
+import { isValidElement, type ReactElement } from "react"
+import { describe, expect, test } from "vitest"
+
+import { stripNativeTitle } from "./strip-native-title"
+
+describe("stripNativeTitle", () => {
+  test("removes the title attribute from an element that has one", () => {
+    const result = stripNativeTitle(<button title="Save">Save</button>)
+    expect(isValidElement(result)).toBe(true)
+    expect((result as ReactElement).props.title).toBeUndefined()
+  })
+
+  test("returns the same element when there is no title", () => {
+    const element = <button>Save</button>
+    expect(stripNativeTitle(element)).toBe(element)
+  })
+
+  test("returns the same element when title is null", () => {
+    const element = <button title={undefined}>Save</button>
+    expect(stripNativeTitle(element)).toBe(element)
+  })
+
+  test("preserves other props while stripping the title", () => {
+    const result = stripNativeTitle(
+      <button title="Save" aria-label="Save" disabled>
+        Save
+      </button>
+    )
+    const props = (result as ReactElement).props
+    expect(props.title).toBeUndefined()
+    expect(props["aria-label"]).toBe("Save")
+    expect(props.disabled).toBe(true)
+  })
+
+  test("returns non-element children untouched", () => {
+    expect(stripNativeTitle("plain text")).toBe("plain text")
+    expect(stripNativeTitle(null)).toBe(null)
+  })
+})

--- a/packages/react/src/lib/strip-native-title.test.tsx
+++ b/packages/react/src/lib/strip-native-title.test.tsx
@@ -10,6 +10,35 @@ describe("stripNativeTitle", () => {
     expect((result as ReactElement).props.title).toBeUndefined()
   })
 
+  test("promotes the title to aria-label when there is no accessible name", () => {
+    const result = stripNativeTitle(<button title="Save">Save</button>)
+    const props = (result as ReactElement).props
+    expect(props.title).toBeUndefined()
+    expect(props["aria-label"]).toBe("Save")
+  })
+
+  test("keeps an existing aria-label instead of overriding it", () => {
+    const result = stripNativeTitle(
+      <button title="Native tooltip" aria-label="Save the document">
+        Save
+      </button>
+    )
+    const props = (result as ReactElement).props
+    expect(props.title).toBeUndefined()
+    expect(props["aria-label"]).toBe("Save the document")
+  })
+
+  test("does not add aria-label when the child has aria-labelledby", () => {
+    const result = stripNativeTitle(
+      <button title="Native tooltip" aria-labelledby="label-id">
+        Save
+      </button>
+    )
+    const props = (result as ReactElement).props
+    expect(props.title).toBeUndefined()
+    expect(props["aria-label"]).toBeUndefined()
+  })
+
   test("returns the same element when there is no title", () => {
     const element = <button>Save</button>
     expect(stripNativeTitle(element)).toBe(element)

--- a/packages/react/src/lib/strip-native-title.tsx
+++ b/packages/react/src/lib/strip-native-title.tsx
@@ -1,0 +1,22 @@
+import { cloneElement, isValidElement, type ReactNode } from "react"
+
+/**
+ * Removes the native HTML `title` attribute from a tooltip's child element.
+ *
+ * F0 tooltips wrap their child through Radix's `asChild` (Slot). When that
+ * child also carries a native `title` (e.g. an icon button), the browser shows
+ * its own tooltip on hover in addition to the F0 one, leaving the user with two
+ * overlapping tooltips. Stripping the `title` here keeps only the F0 tooltip.
+ */
+export function stripNativeTitle(children: ReactNode): ReactNode {
+  if (!isValidElement(children)) {
+    return children
+  }
+
+  const { title } = children.props as { title?: unknown }
+  if (title == null) {
+    return children
+  }
+
+  return cloneElement(children, { title: undefined })
+}

--- a/packages/react/src/lib/strip-native-title.tsx
+++ b/packages/react/src/lib/strip-native-title.tsx
@@ -1,22 +1,46 @@
 import { cloneElement, isValidElement, type ReactNode } from "react"
 
 /**
- * Removes the native HTML `title` attribute from a tooltip's child element.
+ * Suppresses the native browser tooltip from a tooltip's child element while
+ * preserving its accessibility.
  *
  * F0 tooltips wrap their child through Radix's `asChild` (Slot). When that
- * child also carries a native `title` (e.g. an icon button), the browser shows
- * its own tooltip on hover in addition to the F0 one, leaving the user with two
- * overlapping tooltips. Stripping the `title` here keeps only the F0 tooltip.
+ * child also carries a native HTML `title` (e.g. an icon button), the browser
+ * shows its own tooltip on hover in addition to the F0 one, leaving the user
+ * with two overlapping tooltips.
+ *
+ * The native browser tooltip is intrinsic to the `title` attribute — there's no
+ * way to keep `title` and hide only the bubble. So we remove `title` and, when
+ * the child has no other accessible name, promote the title text to an
+ * `aria-label`. Screen readers still announce it; the browser has no `title`
+ * left to render a tooltip from.
  */
 export function stripNativeTitle(children: ReactNode): ReactNode {
   if (!isValidElement(children)) {
     return children
   }
 
-  const { title } = children.props as { title?: unknown }
-  if (title == null) {
+  const props = children.props as {
+    title?: unknown
+    "aria-label"?: unknown
+    "aria-labelledby"?: unknown
+  }
+
+  if (props.title == null) {
     return children
   }
 
-  return cloneElement(children, { title: undefined })
+  const nextProps: { title: undefined; "aria-label"?: string } = {
+    title: undefined,
+  }
+
+  // Keep the title text as an accessible name when the child doesn't already
+  // have one, so suppressing the native tooltip doesn't drop accessibility.
+  const hasAccessibleName =
+    props["aria-label"] != null || props["aria-labelledby"] != null
+  if (!hasAccessibleName && typeof props.title === "string") {
+    nextProps["aria-label"] = props.title
+  }
+
+  return cloneElement(children, nextProps)
 }

--- a/packages/react/src/lib/tooltip-wrapper.tsx
+++ b/packages/react/src/lib/tooltip-wrapper.tsx
@@ -7,6 +7,8 @@ import {
   TooltipTrigger,
 } from "@/ui/tooltip"
 
+import { stripNativeTitle } from "./strip-native-title"
+
 interface TooltipWrapperProps {
   tooltip?: string
   children: ReactNode
@@ -21,7 +23,7 @@ export const TooltipWrapper: React.FC<TooltipWrapperProps> = ({
       <TooltipProvider delayDuration={100} disableHoverableContent>
         <TooltipPrimitive>
           <TooltipTrigger asChild className="pointer-events-auto">
-            {children}
+            {stripNativeTitle(children)}
           </TooltipTrigger>
           <TooltipContent className="pointer-events-none max-w-xs">
             <p className="font-semibold">{tooltip}</p>


### PR DESCRIPTION
## Problem

When wrapping a child that carries a native HTML `title` attribute (e.g. an icon button) with the F0 `Tooltip`, the browser shows its **own** tooltip on hover *in addition to* the F0 one — leaving the user with two overlapping tooltips.

This happens because both tooltip wrappers pass the child through Radix's `asChild` (a Slot), which merges the tooltip handlers onto your element rather than wrapping it. The element keeps its native `title`, so the browser renders a second tooltip.

## Fix

A small shared helper, `stripNativeTitle`, removes the native `title` from the wrapped child whenever an F0 tooltip is applied. When you explicitly attach an F0 tooltip, that *is* the tooltip you want — the native one is redundant.

- New `packages/react/src/lib/strip-native-title.tsx` — clones the single child element with `title: undefined`. No-op (same reference) when there's no `title`; passes non-element children through untouched.
- `experimental/Overlays/Tooltip/index.tsx` — wraps `children` with `stripNativeTitle(...)`.
- `lib/tooltip-wrapper.tsx` — same, for the internal `TooltipWrapper`.

## Tests

- `strip-native-title.test.tsx` — title removal, other-prop preservation, no-title same-reference, and non-element passthrough.
- New `ChildWithNativeTitle` story in `Tooltip/index.stories.tsx` with a `play` test asserting the rendered trigger has no `title` attribute. You can also visually confirm in Storybook: hover the button and only the F0 tooltip appears, even though the child declares `title="Native browser tooltip"`.

## Notes

This strips `title` only from the **immediate** child element — the same single-element contract Radix's `asChild` already requires, so it covers normal usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)