### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.2.3",
+  "packages/react": "3.2.4",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.2.4](https://github.com/factorialco/f0/compare/f0-react-v3.2.3...f0-react-v3.2.4) (2026-06-15)
+
+
+### Bug Fixes
+
+* **dialog-alike:** portal center modals to a top-level overlay root ([#4421](https://github.com/factorialco/f0/issues/4421)) ([00018b5](https://github.com/factorialco/f0/commit/00018b55ebde8d4f6b5e070e33c42ff27ac8bee9))
+
 ## [3.2.3](https://github.com/factorialco/f0/compare/f0-react-v3.2.2...f0-react-v3.2.3) (2026-06-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.2.4</summary>

## [3.2.4](https://github.com/factorialco/f0/compare/f0-react-v3.2.3...f0-react-v3.2.4) (2026-06-15)


### Bug Fixes

* **dialog-alike:** portal center modals to a top-level overlay root ([#4421](https://github.com/factorialco/f0/issues/4421)) ([00018b5](https://github.com/factorialco/f0/commit/00018b55ebde8d4f6b5e070e33c42ff27ac8bee9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).