### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.2.5",
+  "packages/react": "3.2.6",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.2.6](https://github.com/factorialco/f0/compare/f0-react-v3.2.5...f0-react-v3.2.6) (2026-06-15)
+
+
+### Bug Fixes
+
+* **ButtonGroup:** never collapse or squeeze a confirm/reject pair ([#4438](https://github.com/factorialco/f0/issues/4438)) ([916c724](https://github.com/factorialco/f0/commit/916c7241d3b8abd064f30a063b9fe96cef4ddf56))
+
 ## [3.2.5](https://github.com/factorialco/f0/compare/f0-react-v3.2.4...f0-react-v3.2.5) (2026-06-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.2.6</summary>

## [3.2.6](https://github.com/factorialco/f0/compare/f0-react-v3.2.5...f0-react-v3.2.6) (2026-06-15)


### Bug Fixes

* **ButtonGroup:** never collapse or squeeze a confirm/reject pair ([#4438](https://github.com/factorialco/f0/issues/4438)) ([916c724](https://github.com/factorialco/f0/commit/916c7241d3b8abd064f30a063b9fe96cef4ddf56))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).