### PR TITLE
fix(PageHeader): use left/right chevrons for prev/next navigation

### DIFF
--- a/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
@@ -1,6 +1,6 @@
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { IconType } from "@/components/F0Icon"
-import { ChevronDown, ChevronUp } from "@/icons/app"
+import { ChevronLeft, ChevronRight } from "@/icons/app"
 
 /**
  * One prev/next target. Carry a `url` for full-page detail navigation
@@ -78,12 +78,12 @@ export function PageNavigation({ previous, next, counter }: NavigationProps) {
       )}
       <div className="flex items-center gap-2">
         <PageNavigationLink
-          icon={ChevronUp}
+          icon={ChevronLeft}
           target={previous}
           fallbackLabel="Previous"
         />
         <PageNavigationLink
-          icon={ChevronDown}
+          icon={ChevronRight}
           target={next}
           fallbackLabel="Next"
         />


### PR DESCRIPTION
## What

Swaps the prev/next navigation arrows in `PageNavigation` (used by `PageHeader`) from vertical up/down chevrons to horizontal left/right chevrons.

- Previous: `ChevronUp` → `ChevronLeft`
- Next: `ChevronDown` → `ChevronRight`

## Why

This aligns better with the behavior we have on the frontend of letting the user trigger these buttons with their **left/right arrow keys** on the keyboard. With horizontal chevrons, the icon direction now matches the keys that drive the navigation, making the affordance clearer.
