### PR TITLE
fix(F0CardRow): restore opt-in whole-row click target

### DIFF
--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -1,9 +1,10 @@
 import { forwardRef } from "react"
 
+import { F0Link } from "@/components/F0Link"
 import { DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { withDataTestId } from "@/lib/data-testid"
 import { withSkeleton } from "@/lib/skeleton"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import { Card } from "@/ui/Card"
 import { Skeleton } from "@/ui/skeleton"
 import { Text } from "@/ui/Text"
@@ -108,6 +109,28 @@ export interface F0CardRowProps {
    * Use `visible` + `onDismiss` for controlled dismiss behaviour.
    */
   alert?: CardAlertProps
+
+  /**
+   * Opt-in: makes the whole row a link to this href. The row only becomes a
+   * click target (pointer cursor + hover affordance + overlay link) when `link`
+   * or `onClick` is set — otherwise it's a static row whose only interactive
+   * parts are its actions.
+   */
+  link?: string
+
+  /**
+   * Opt-in: called when the row is clicked. Like `link`, it turns the whole row
+   * into an explicit click target (pointer cursor + hover affordance). Use it
+   * for cards whose entire surface is the action (e.g. entry-point cards with no
+   * CTA button); leave it unset for rows that act only through their buttons.
+   */
+  onClick?: () => void
+
+  /**
+   * Disables the full-row overlay link (used with `link`) so a parent can manage
+   * drag-and-drop while still allowing click navigation via `onClick`.
+   */
+  disableOverlayLink?: boolean
 }
 
 /**
@@ -133,22 +156,29 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
       compact = false,
       fullHeight = false,
       alert,
+      link,
+      onClick,
+      disableOverlayLink = false,
       stackAt = "never",
     },
     ref
   ) {
     const hasAlert = !!alert && alert.visible !== false
+    // The row is a click target only when it explicitly opts in via `link` or
+    // `onClick`; otherwise it's static (only its actions are interactive). This
+    // keeps the hover affordance + pointer cursor tied to an actual click action.
+    const clickable = !!link || !!onClick
 
     const body = (
       <Card
         ref={hasAlert ? undefined : ref}
         className={cn(
-          // Hover affordance without making the card a click target: the border
-          // and shadow react to hover, but there's no pointer cursor (the row
-          // isn't clickable — only its actions are).
-          "group @container bg-f1-background shadow-none transition-all hover:border-f1-border-hover hover:shadow-md",
+          "group relative @container bg-f1-background shadow-none transition-all",
           compact && "p-3",
-          fullHeight && "h-full"
+          fullHeight && "h-full",
+          // Pointer + hover/focus affordance only when the whole row is clickable.
+          clickable &&
+            "cursor-pointer focus-within:border-f1-border-hover focus-within:shadow-md hover:border-f1-border-hover hover:shadow-md"
         )}
         style={
           hasAlert
@@ -158,8 +188,20 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
               }
             : undefined
         }
+        onClick={onClick}
         data-testid="card"
       >
+        {link && !disableOverlayLink && (
+          <F0Link
+            href={link}
+            variant="unstyled"
+            className={cn("z-1 absolute inset-0 block rounded-xl", focusRing())}
+            aria-label={title}
+          >
+            &nbsp;
+          </F0Link>
+        )}
+
         <div className={cardRowClassName[stackAt]}>
           <div className="flex min-w-0 flex-row items-center gap-3">
             {avatar && <CardAvatar avatar={avatar} size="lg" />}

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -53,6 +53,11 @@ const meta: Meta<typeof F0CardRow> = {
       control: "boolean",
       description: "Stretch to fill the height of the container.",
     },
+    link: {
+      control: "text",
+      description:
+        "Opt-in: makes the whole row a link to this href (adds pointer + hover).",
+    },
     // Function-bearing props: disable the control so it doesn't dump the
     // serialized mock fn() source. They still appear in the args table.
     primaryAction: {
@@ -79,6 +84,11 @@ const meta: Meta<typeof F0CardRow> = {
     alert: {
       control: false,
       description: "Alert banner displayed above the row.",
+    },
+    onClick: {
+      action: "clicked",
+      description:
+        "Opt-in: called when the row is clicked (adds pointer + hover).",
     },
   },
   decorators: [

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -168,8 +168,9 @@ export function CardRowActions({
 }: CardRowActionsProps) {
   const size = compact ? "sm" : "md"
 
-  // Resolved state: a status tag replaces the actions. It's informational.
-  // The outer flex drops it to its own line when stacked, with the footer.
+  // Resolved state: a status tag replaces the actions. It's informational, so
+  // no click-stop / z-index — a row-level overlay link stays clickable through
+  // it. The outer flex drops it to its own line when stacked, with the footer.
   if (status) {
     return (
       <div
@@ -191,13 +192,17 @@ export function CardRowActions({
   }
 
   const wrapperClassName = cn(
+    "relative z-[1]",
     actionsWidthClassName[stackAt],
     stackedChrome[stackAt],
     stackAt !== "never" && compact && "mt-3 pt-3"
   )
 
   const wrap = (group: React.ReactNode) => (
-    <div className={wrapperClassName}>{group}</div>
+    // Keep action clicks from bubbling to the row's onClick / overlay link.
+    <div className={wrapperClassName} onClick={(e) => e.stopPropagation()}>
+      {group}
+    </div>
   )
 
   // Confirm/reject variant: reject (✗, outline) then confirm (✓, solid primary).
@@ -239,7 +244,13 @@ export function CardRowActions({
 
     const inline = (
       // Icon-only, inline at the trailing edge.
-      <div className={cn("min-w-0 flex-1", inlineClusterVisibility[stackAt])}>
+      <div
+        className={cn(
+          "relative z-[1] min-w-0 flex-1",
+          inlineClusterVisibility[stackAt]
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
         {variant(true)}
       </div>
     )
@@ -257,10 +268,12 @@ export function CardRowActions({
             flex column's stretch so the `-mx-4` footer bleeds symmetrically. */}
         <div
           className={cn(
+            "relative z-[1]",
             stackedClusterVisibility[stackAt],
             stackedChrome[stackAt],
             compact && "mt-3 pt-3"
           )}
+          onClick={(e) => e.stopPropagation()}
         >
           {variant(false)}
         </div>


### PR DESCRIPTION
## Description

#4376 removed the whole-row click target from `F0CardRow` entirely (along with
the `link` / `onClick` / `disableOverlayLink` props), which broke consumers whose
entire card surface is the action (e.g. `F0AiChatWelcomeCards`).

This restores it, but **opt-in**: the pointer cursor, hover/focus affordance, and
overlay link only apply when `link` or `onClick` is set. Cards that pass neither
stay exactly as #4376 left them — static rows whose only interactive parts are
their actions.

## Screenshots (if applicable)

N/A — behavioural change. Verify under **Components / F0CardRow**: a row with
`onClick`/`link` shows a pointer cursor + hover border and is clickable; a row
with neither stays static.

## Implementation details

- Re-add `link`, `onClick`, `disableOverlayLink` to `F0CardRowProps`.
- Gate the affordance on `const clickable = !!link || !!onClick` — pointer cursor +
  `hover`/`focus-within` border/shadow + the absolute overlay `F0Link` only render
  when clickable.
- Restore `CardRowActions`' click-stops (`stopPropagation`) so action clicks don't
  bubble to a now-clickable row.
- Restore the `link` / `onClick` argTypes in the story.

> Note: branches off `main`, where `F0CardRow` still lives in `components/F0Card`.
> #4441 moves it to `experimental/F0CardRow`; whichever lands second needs a
> trivial rebase to the new path.