### PR TITLE
test(button-group): assert measurement-copy branch instead of jsdom shed quirk

### DIFF
--- a/packages/react/src/ui/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/packages/react/src/ui/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -31,19 +31,22 @@ describe("ButtonGroup — canOverflow", () => {
       screen.queryByRole("button", { name: "Toggle dropdown menu" })
     ).not.toBeInTheDocument()
 
-    // The hidden measurement copy is skipped: only the 3 real buttons exist.
+    // The hidden width-measurement copy is skipped entirely: no aria-hidden
+    // duplicate buttons, just the 3 real ones.
+    expect(container.querySelector('[aria-hidden="true"] button')).toBeNull()
     expect(container.querySelectorAll("button")).toHaveLength(3)
   })
 
-  it("allows secondaries to shed into the ⋯ menu by default (canOverflow true)", () => {
-    // Contrast with the case above: by default the group can overflow, so it
-    // renders the "⋯" trigger (in jsdom, where widths measure 0, the secondaries
-    // shed into it). With canOverflow={false} that trigger never appears.
-    render(<ButtonGroup secondaryActions={secondaries} />)
+  it("renders the hidden width-measurement copy by default (canOverflow true)", () => {
+    // The direct counterpart of the code change (`{canOverflow && <copy>}`): by
+    // default the group keeps the hidden aria-hidden duplicate it measures to
+    // decide what sheds. Deterministic — it doesn't depend on any width being
+    // measured, unlike asserting that something actually shed into the menu.
+    const { container } = render(<ButtonGroup secondaryActions={secondaries} />)
 
     expect(
-      screen.getByRole("button", { name: "Toggle dropdown menu" })
-    ).toBeInTheDocument()
+      container.querySelector('[aria-hidden="true"] button')
+    ).not.toBeNull()
   })
 
   it("still surfaces otherActions in the ⋯ menu when canOverflow is false", () => {


### PR DESCRIPTION
## Description

Test-only follow-up to #4438. The `ButtonGroup` `canOverflow` test that shipped there had a brittle case (Test 2): it asserted the `⋯` overflow trigger renders *by default*, which only holds because jsdom measures every element at 0 width, so `useOverflowCalculation` sheds everything. A plausible change to the overflow hook (treat "unmeasured" as "show all") would break the test while production stays correct.

This swaps that for the **direct counterpart of the code change** — `{canOverflow && <hidden measurement copy>}`: assert the `aria-hidden` measurement copy is **present by default** and **skipped when `canOverflow={false}`**. Deterministic, independent of any measured width.

No production change; one test file.

## Screenshots (if applicable)

N/A — test-only.

## Implementation details

`packages/react/src/ui/ButtonGroup/__tests__/ButtonGroup.test.tsx`:
- Test 1 (`canOverflow={false}`): adds `expect(container.querySelector('[aria-hidden="true"] button')).toBeNull()` — the measurement copy is skipped (alongside the existing inline-button + no-trigger + 3-button assertions).
- Test 2: replaced "sheds into the ⋯ menu by default" with "renders the hidden width-measurement copy by default" → `expect(container.querySelector('[aria-hidden="true"] button')).not.toBeNull()`.
- Test 3 (`otherActions` still surface in the menu): unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
