### PR TITLE
fix(ButtonGroup): drop numeric gap prop for fixed gap-md

### DIFF
--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -16,9 +16,6 @@ import {
   type CardSecondaryLink,
 } from "./CardActions"
 
-// Pixel gap between the trailing controls — mirrors the `gap-2` used elsewhere.
-const GAP = 8
-
 /**
  * Container breakpoint at which the card row switches between its inline and its
  * stacked (actions-on-their-own-line) layout. `never` keeps it inline at every
@@ -237,7 +234,6 @@ export function CardRowActions({
           primaryAction={confirm}
           secondaryActions={reject ? [reject] : undefined}
           size={size}
-          gap={GAP}
           // The confirm/reject pair must always stay inline — the reject button
           // must never shed into the "⋯" menu.
           canOverflow={false}
@@ -336,7 +332,6 @@ export function CardRowActions({
       secondaryActions={secondaryItems}
       otherActions={otherActions}
       size={size}
-      gap={GAP}
     />
   )
 }

--- a/packages/react/src/ui/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/ui/ButtonGroup/ButtonGroup.tsx
@@ -110,8 +110,6 @@ export interface ButtonGroupProps {
   otherActions?: DropdownItem[]
   /** Button + menu-trigger size. Responsive `{ base, md }` flips with `stack`. @default "md" */
   size?: ButtonGroupSize
-  /** Pixel gap between items. @default 8 */
-  gap?: number
   /** Row alignment. @default "end" */
   align?: "end" | "between"
   /** Stack into a column below the named viewport / container breakpoint. @default "none" */
@@ -130,6 +128,11 @@ export interface ButtonGroupProps {
 }
 
 const BREAKPOINT_PX = { sm: 640, md: 768, "container-md": 448 } as const
+
+// Fixed gap between items, in pixels. The visible spacing is rendered with the
+// `gap-md` Tailwind class; this constant feeds the width-measured overflow math
+// (which needs a number) and MUST stay in sync with the `gap-md` token (8px).
+const BUTTON_GROUP_GAP_PX = 8
 
 const isInlineSeparator = (
   item: ButtonGroupSecondaryItem
@@ -213,7 +216,6 @@ interface ButtonGroupBranchProps {
   secondaryLink?: ButtonGroupSecondaryLink
   otherActions: DropdownItem[]
   size: ButtonSize
-  gap: number
   align: "end" | "between"
   canOverflow: boolean
 }
@@ -242,7 +244,6 @@ export function ButtonGroup({
   secondaryActions,
   otherActions = [],
   size = "md",
-  gap = 8,
   align = "end",
   stack = "none",
   fullWidthOnStack = false,
@@ -290,7 +291,6 @@ export function ButtonGroup({
     secondaryLink,
     otherActions,
     size: resolvedSize,
-    gap,
     align,
     canOverflow,
   }
@@ -304,7 +304,7 @@ export function ButtonGroup({
           ? // Keep the pinned trailing items (splits, divider, primary) at their
             // natural width; only the first child — the flex-1 cluster — shrinks,
             // so the title truncates against it rather than squeezing the buttons.
-            "flex w-full items-center [&>*:not(:first-child)]:shrink-0"
+            "flex w-full items-center gap-md [&>*:not(:first-child)]:shrink-0"
           : buttonGroupVariants({
               align,
               stack,
@@ -313,7 +313,6 @@ export function ButtonGroup({
             }),
         className
       )}
-      style={{ gap }}
     >
       {isRowMode ? (
         <ButtonGroupRow key="row" {...branchProps} />
@@ -360,7 +359,6 @@ function ButtonGroupRow({
   secondaryLink,
   otherActions,
   size,
-  gap,
   align,
   canOverflow,
 }: ButtonGroupBranchProps) {
@@ -380,7 +378,7 @@ function ButtonGroupRow({
     visibleItems,
     overflowItems,
     isInitialized,
-  } = useOverflowCalculation(plainSecondaries, gap)
+  } = useOverflowCalculation(plainSecondaries, BUTTON_GROUP_GAP_PX)
 
   // `inert` isn't a typed JSX prop in this React version, so set it on the
   // measurement copy imperatively — it removes the copy from focus + a11y.
@@ -459,10 +457,9 @@ function ButtonGroupRow({
           // `[&>*]:shrink-0` keeps each rendered secondary, separator, link and
           // the "⋯" trigger at its natural width: the row overflows by shedding
           // into the menu, never by squeezing a button to nothing.
-          "relative flex min-w-0 flex-1 items-center [&>*]:shrink-0",
+          "relative flex min-w-0 flex-1 items-center gap-md [&>*]:shrink-0",
           align === "end" && "justify-end"
         )}
-        style={{ gap }}
       >
         {/* Hidden measurement copy, used to compute the visible/overflow split.
             Skipped when the group can't overflow — nothing is ever measured away. */}
@@ -470,8 +467,7 @@ function ButtonGroupRow({
           <div
             ref={measurementContainerRef}
             aria-hidden="true"
-            className="pointer-events-none invisible absolute left-0 top-0 flex items-center whitespace-nowrap"
-            style={{ gap }}
+            className="pointer-events-none invisible absolute left-0 top-0 flex items-center gap-md whitespace-nowrap"
           >
             {plainSecondaries.map((action) =>
               renderActionButton(action, size, "outline")

--- a/packages/react/src/ui/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/ui/ButtonGroup/ButtonGroup.tsx
@@ -132,7 +132,8 @@ const BREAKPOINT_PX = { sm: 640, md: 768, "container-md": 448 } as const
 // Fixed gap between items, in pixels. The visible spacing is rendered with the
 // `gap-md` Tailwind class; this constant feeds the width-measured overflow math
 // (which needs a number) and MUST stay in sync with the `gap-md` token (8px).
-const BUTTON_GROUP_GAP_PX = 8
+// Exported so a unit test can assert it against the token (see ButtonGroup.test).
+export const BUTTON_GROUP_GAP_PX = 8
 
 const isInlineSeparator = (
   item: ButtonGroupSecondaryItem

--- a/packages/react/src/ui/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/packages/react/src/ui/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -1,8 +1,9 @@
+import { betweenSpacing } from "@factorialco/f0-core"
 import { describe, expect, it, vi } from "vitest"
 
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
-import { ButtonGroup } from "../ButtonGroup"
+import { BUTTON_GROUP_GAP_PX, ButtonGroup } from "../ButtonGroup"
 
 // The width-driven overflow (useOverflowCalculation) can't be exercised in
 // jsdom — every element measures 0, so nothing ever sheds into the "⋯" menu.
@@ -61,5 +62,15 @@ describe("ButtonGroup — canOverflow", () => {
     expect(
       screen.getByRole("button", { name: "Toggle dropdown menu" })
     ).toBeInTheDocument()
+  })
+})
+
+describe("ButtonGroup — gap token", () => {
+  // The visible spacing is rendered with the `gap-md` class, but the overflow
+  // math needs a number, so BUTTON_GROUP_GAP_PX duplicates the token's pixel
+  // value. This guard fails the moment the two drift apart.
+  it("keeps BUTTON_GROUP_GAP_PX in sync with the gap-md token", () => {
+    const gapMdPx = parseFloat(String(betweenSpacing.md)) * 16 // 0.5rem → 8px
+    expect(BUTTON_GROUP_GAP_PX).toBe(gapMdPx)
   })
 })


### PR DESCRIPTION
## Description

`ButtonGroup` exposed a public `gap?: number` prop that was applied as an inline `style={{ gap }}`, overriding the `gap-md` (8px) base class and contradicting the component's documented intent that button spacing is a constant rhythm across surfaces, not a per-call knob. This removes the prop entirely and pins the spacing to the fixed `gap-md` token so every button group shares the same rhythm.

## Implementation details

- fix: remove the public `gap?: number` prop from `ButtonGroupProps` (and from the internal branch props)
- refactor: render spacing with the static `gap-md` Tailwind class on all three flex containers (root, row cluster, hidden measurement copy) instead of an inline style; the stacked branch already inherited `gap-md` from its variants
- refactor: add an internal `BUTTON_GROUP_GAP_PX = 8` constant to feed the width-measured overflow math, which still needs a numeric gap, with a note to keep it in sync with the `gap-md` token
- chore: drop the now-unused `gap={GAP}` usages and the `GAP` constant from `CardRowActions`, the only consumer

  <details>
  <summary>Breaking change note</summary>

  `gap` was part of the public API via the exported `ButtonGroupProps` type, so removing it is technically a breaking change to that type. No runtime consumer other than `CardRowActions` passed it, and it was passing the default value (8), so behaviour is unchanged.
  </details>

Verified: `tsc --noEmit` clean, `oxlint` clean, 52 unit tests pass (F0Card / ButtonGroup / OverflowList), and Storybook inspection confirms computed `gap: 8px` with the `gap-md` class and no inline style — visually identical to the previous default, overflow still sheds buttons one at a time.