### PR TITLE
feat(OneDataCollection/table): add "striked" variant to referenceRowType

### DIFF
--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -99,6 +99,7 @@ const stickyScrolledBase =
 const stickyScrollClasses: Record<ReferenceType, string> = {
   none: `bg-f1-background ${stickyScrolledBase} before:bg-f1-background group-hover:before:bg-f1-background-hover`,
   striped: `bg-f1-background bg-[${stripedLines}] [background-size:100%_100px] ${stickyScrolledBase} before:bg-[${stripedLines},_var(--f1-background)] before:[background-size:100%_100px,_100%_100%] group-hover:before:bg-[${stripedLines},_var(--f1-background-hover)] group-hover:before:[background-size:100%_100px,_100%_100%]`,
+  striked: `bg-f1-background ${stickyScrolledBase} before:bg-f1-background group-hover:before:bg-f1-background-hover`,
 }
 
 export function TableCell({

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
@@ -93,7 +93,7 @@ type TableVisualizationOptions<T> = {
   allowColumnHiding?: boolean
 
   /**
-   * Marks rows as reference rows. Reference rows are rendered with patterns depending on the type returned.
+   * Maps a row to a visual variant. Supported variants: `"striped"`, `"striked"`, `"none"`.
    */
   referenceRowType?: (item: T) => ReferenceType
 }
@@ -389,6 +389,26 @@ that should be visually distinguished from regular records.
 ```
 
 <Canvas of={TableStories.ReferenceRowsVisualization} meta={TableStories} />
+
+### Striked Rows
+
+`referenceRowType` also accepts `"striked"` to render the row with line-through
+text + muted foreground.
+
+```tsx
+{
+  type: "table",
+  options: {
+    referenceRowType: (item) => (item.active ? "none" : "striked"),
+    columns: [
+      { label: "Name", render: (item) => item.name },
+      { label: "Email", render: (item) => item.email },
+    ],
+  },
+}
+```
+
+<Canvas of={TableStories.StrikedRowsVisualization} meta={TableStories} />
 
 ## Nested Tables
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -614,7 +614,12 @@ export const TableWithGroupedHeaders: Story = {
 export const StrikedRowsVisualization: Story = {
   render: () => {
     const records = [
-      { id: 1, name: "Alice Johnson", email: "alice@example.com", active: true },
+      {
+        id: 1,
+        name: "Alice Johnson",
+        email: "alice@example.com",
+        active: true,
+      },
       { id: 2, name: "Bob Smith", email: "bob@example.com", active: false },
       { id: 3, name: "Carol Lee", email: "carol@example.com", active: true },
       { id: 4, name: "Dan Park", email: "dan@example.com", active: false },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -611,6 +611,43 @@ export const TableWithGroupedHeaders: Story = {
   },
 }
 
+export const StrikedRowsVisualization: Story = {
+  render: () => {
+    const records = [
+      { id: 1, name: "Alice Johnson", email: "alice@example.com", active: true },
+      { id: 2, name: "Bob Smith", email: "bob@example.com", active: false },
+      { id: 3, name: "Carol Lee", email: "carol@example.com", active: true },
+      { id: 4, name: "Dan Park", email: "dan@example.com", active: false },
+    ]
+
+    const source = useDataCollectionSource({
+      dataAdapter: {
+        fetchData: async () => ({ records }),
+      },
+    })
+
+    return (
+      <div style={{ maxWidth: 600 }}>
+        <OneDataCollection
+          source={source}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                referenceRowType: (item) => (item.active ? "none" : "striked"),
+                columns: [
+                  { label: "Name", render: (item) => item.name, id: "name" },
+                  { label: "Email", render: (item) => item.email, id: "email" },
+                ],
+              },
+            },
+          ]}
+        />
+      </div>
+    )
+  },
+}
+
 export const BorderedTable: Story = {
   render: () => {
     const records = [

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -175,6 +175,39 @@ describe("TableCollection", () => {
     })
   })
 
+  describe("referenceRowType striked variant", () => {
+    it("applies line-through only to rows the predicate marks as striked", async () => {
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={testColumns}
+          source={createTestSource()}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+          referenceRowType={(item) => (item.id === 1 ? "striked" : "none")}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      const struckRow = screen.getByText(testData[0].name).closest("tr")
+      expect(struckRow?.className).toMatch(/line-through/)
+
+      const plainRow = screen.getByText(testData[1].name).closest("tr")
+      expect(plainRow?.className).not.toMatch(/line-through/)
+    })
+  })
+
   describe("features", () => {
     it("renders custom column formatting", async () => {
       const columnsWithCustomRender = [

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -90,8 +90,8 @@ export type RowProps<
   checkColumnWidth: number
   tableWithChildren: boolean
   nestedRowProps?: NestedRowProps
-  /** Optional predicate to mark a row as reference row with slanted background pattern. */
-  referenceRowType?: (item: R) => "none" | "striped"
+  /** Optional predicate to apply a row-level visual variant. */
+  referenceRowType?: (item: R) => "none" | "striped" | "striked"
   /** Custom cell renderer, passed through from Table to Row */
   cellRenderer?: React.ComponentType<CellRendererProps<R, Sortings, Summaries>>
   /** Row wrapper for child rows (provides per-row context, e.g. editing state) */

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -67,7 +67,7 @@ export type RowProps<
   tableWithChildren: boolean
   nestedRowProps?: NestedRowProps
   disableHover?: boolean
-  /** Optional predicate to mark a row as reference row with slanted background pattern. */
+  /** Optional predicate to apply a row-level visual variant. */
   referenceRowType?: (item: R) => ReferenceType
   /** Optional custom cell renderer. When provided, wraps each cell's content. */
   cellRenderer?: React.ComponentType<
@@ -111,6 +111,7 @@ const referenceTypeClasses: Record<ReferenceType, string> = {
   none: "",
   striped:
     "bg-[repeating-linear-gradient(45deg,transparent_0px,transparent_8px,hsl(var(--neutral-20))_8px,hsl(var(--neutral-20))_9px)] [background-size:100%_100px]",
+  striked: "[&_*]:line-through text-f1-foreground-secondary",
 }
 
 const RowComponentInner = <

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -96,7 +96,7 @@ export type TableColumnDefinition<
     headerGroupId?: string
   }
 
-export type ReferenceType = "none" | "striped"
+export type ReferenceType = "none" | "striped" | "striked"
 
 export type TableVisualizationOptions<
   R extends RecordType,
@@ -129,10 +129,7 @@ export type TableVisualizationOptions<
    */
   allowColumnHiding?: boolean
 
-  /**
-   * Marks one or more rows as reference rows.
-   * Reference rows are rendered with a slanted background pattern across the full row.
-   */
+  /** Maps a row to a visual variant: `"striped"`, `"striked"`, or `"none"`. */
   referenceRowType?: (item: R) => ReferenceType
   /**
    * Labels for header groups. Keys are headerGroupId values used in column


### PR DESCRIPTION
## Summary

<img width="1074" height="537" alt="Screenshot 2026-06-15 at 5 12 29 PM" src="https://github.com/user-attachments/assets/8ecad7db-0387-4a6b-b496-e2fc239addf5" />


Extends the existing `referenceRowType` prop on the Table / EditableTable visualization with a new `"striked"` variant.

- `"striped"` (existing) — slanted background pattern (reference / baseline rows)
- `"striked"` (new) — line-through text + muted foreground (cancelled / rejected / deactivated rows)
- `"none"` (default)

Implemented as a single new entry in the existing `referenceTypeClasses` map; no new props, no new types beyond the union member.

## Motivation

Need a row-level visual treatment for "rejected" headcount-planning requests once a plan is locked (Factorial ticket FCT-55976). The existing `referenceRowType` already models row-level variants cleanly via a discrete union — extending it keeps the API surface small and lets future variants land here too.

## Changes

- `Table/types.ts` — `ReferenceType` gains `"striked"`.
- `Table/components/Row.tsx` — adds the `striked` class entry (Tailwind `[&_*]:line-through text-f1-foreground-secondary`).
- `Table/components/NestedRow.tsx` — inline union widened to include `"striked"`.
- `OneTable/TableCell/index.tsx` — its `Record<ReferenceType, ...>` map gets a `striked` entry (same sticky scroll behavior as `"none"`; no background pattern).
- Storybook story `StrikedRowsVisualization` + MDX section.
- Unit test verifying the predicate gates the line-through class per row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)