### PR TITLE
fix(value-display): simplify delta cell styling and align cell paddings

### DIFF
--- a/packages/react/src/ui/value-display/const.ts
+++ b/packages/react/src/ui/value-display/const.ts
@@ -3,7 +3,7 @@
  * The base case is that the value display can not be centered manually as some value can use a lot of height (e.g. longText), and we want to center the texts, not wrapper.
  */
 export const tableDisplayClassNames = {
-  text: "pt-[2px]",
-  avatar: "pt-[2px]",
-  avatarList: "pt-[3px]",
+  text: "pt-0.5",
+  avatar: "pt-0.5",
+  avatarList: "pt-0.5",
 }

--- a/packages/react/src/ui/value-display/types/delta/delta.tsx
+++ b/packages/react/src/ui/value-display/types/delta/delta.tsx
@@ -2,7 +2,6 @@
  * Delta cell type for displaying single delta values.
  * Used for displaying changes or differences in data collections.
  */
-import { cn } from "@/lib/utils"
 import { ArrowDown, ArrowUp } from "@/icons/app"
 import { F0Icon, type IconType } from "@/components/F0Icon"
 
@@ -19,19 +18,17 @@ const iconMap: Record<DeltaStatus, IconType> = {
   negative: ArrowDown,
 }
 
-const colorMap: Record<DeltaStatus, string> = {
-  positive: "text-f1-foreground-positive",
-  negative: "text-f1-foreground-critical",
-}
-
 export const DeltaCell = (args: DeltaCellValue) => {
-  const icon = iconMap[args.deltaStatus]
-  const colorClass = colorMap[args.deltaStatus]
+  const { deltaStatus: status } = args
+  const icon = iconMap[status]
 
   return (
-    <div className={cn("flex items-center gap-1", colorClass)}>
-      {icon ? <F0Icon icon={icon} /> : null}
-      <span>{args.label}</span>
+    <div className="flex items-center gap-1 pt-0.5">
+      <F0Icon
+        icon={icon}
+        color={status == "positive" ? "positive" : "critical"}
+      />
+      <span className="text-f1-foreground font-normal">{args.label}</span>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Simplify the delta cell: drop the `colorMap`/`cn` indirection and the unused `cn` import, deriving the icon color (`positive`/`critical`) inline from `deltaStatus`.
- Render the delta label with neutral `text-f1-foreground font-normal` styling and add `pt-0.5` for vertical alignment within table cells.
- Normalize `tableDisplayClassNames` paddings to Tailwind's `pt-0.5` (replacing the arbitrary `pt-[2px]`/`pt-[3px]` values) so text, avatar and avatar list cells align consistently.

## Test plan
- [ ] Verify delta cells render the correct up/down arrow and positive/critical color in a DataCollection table.
- [ ] Verify text, avatar and avatar-list value-display cells stay vertically aligned.