### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.2.6",
+  "packages/react": "3.2.7",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.2.7](https://github.com/factorialco/f0/compare/f0-react-v3.2.6...f0-react-v3.2.7) (2026-06-15)
+
+
+### Bug Fixes
+
+* **value-display:** simplify delta cell styling and align cell paddings ([#4461](https://github.com/factorialco/f0/issues/4461)) ([344a746](https://github.com/factorialco/f0/commit/344a7467c13a5036802d995161b8756020d14121))
+
 ## [3.2.6](https://github.com/factorialco/f0/compare/f0-react-v3.2.5...f0-react-v3.2.6) (2026-06-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.2.7</summary>

## [3.2.7](https://github.com/factorialco/f0/compare/f0-react-v3.2.6...f0-react-v3.2.7) (2026-06-15)


### Bug Fixes

* **value-display:** simplify delta cell styling and align cell paddings ([#4461](https://github.com/factorialco/f0/issues/4461)) ([344a746](https://github.com/factorialco/f0/commit/344a7467c13a5036802d995161b8756020d14121))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).