### PR TITLE
fix(F0Dialog): clip tab divider and refine resource side-panel header

### DIFF
--- a/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
@@ -8,7 +8,7 @@ import { BreadcrumbItem } from "@/experimental/Navigation/Header/Breadcrumbs/int
 import { PageNavigation } from "@/experimental/Navigation/Header/PageNavigation"
 import { Tabs } from "@/patterns/Navigation/Tabs"
 import CrossIcon from "@/icons/app/Cross"
-import { ChevronLeft, Ellipsis, Maximize } from "@/icons/app"
+import { ArrowLeft, Ellipsis, Maximize } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { BreadcrumbList } from "@/ui/breadcrumb"
@@ -101,12 +101,14 @@ export const F0DialogHeader = ({
 
   const TabsStrip = () =>
     tabs ? (
-      <div className="-mx-2">
-        <Tabs
-          tabs={tabs}
-          activeTabId={activeTabId}
-          setActiveTabId={setActiveTabId}
-        />
+      <div className="overflow-hidden">
+        <div className="-mx-2">
+          <Tabs
+            tabs={tabs}
+            activeTabId={activeTabId}
+            setActiveTabId={setActiveTabId}
+          />
+        </div>
       </div>
     ) : null
 
@@ -117,7 +119,7 @@ export const F0DialogHeader = ({
       return (
         <ButtonInternal
           variant="outline"
-          icon={ChevronLeft}
+          icon={ArrowLeft}
           onClick={controls.onClick}
           label={controls.label}
         />
@@ -167,7 +169,9 @@ export const F0DialogHeader = ({
             <DialogTitle className="sr-only">
               {resourceHeader.title}
             </DialogTitle>
-            <BaseHeader {...resourceHeader} />
+            <div className="[&_.resource-header]:px-4">
+              <BaseHeader {...resourceHeader} />
+            </div>
           </>
         ) : (
           title && <DialogTitle className="sr-only">{title}</DialogTitle>


### PR DESCRIPTION
## Changes

- **Tab divider overflow.** The tab strip's `-mx-2` — a long-standing shim
  that realigns tab labels to the dialog's 16px gutter (the shared `Tabs`
  component ships a 24px page gutter) — widened the nav by 8px per side, so
  `TabNavigation`'s full-bleed bottom divider overran the rounded side-panel
  container. Wrap the strip in a container-width `overflow-hidden` so the
  bleed is clipped and the divider stops at the rounded edge. Tab alignment
  is unchanged.
- **Back control icon.** `ChevronLeft` → `ArrowLeft` (variant stays `outline`).
- **Resource header gutter.** Scope the dialog's `BaseHeader` to `px-4`
  (16px) via `[&_.resource-header]:px-4`, so the identity band aligns with
  the controls row. Scoped to the dialog — the full-page `ResourceHeader`
  keeps `px-page` (24px).

## Testing

- `oxlint` clean on the changed file.
- Verified locally (built via `f0-build.sh`, linked into factorial): on the candidate side panel the divider sits flush to the rounded edge, the back button shows the outlined arrow, and the resource header is at the 16px gutter; the full-page `ResourceHeader` is visually unchanged.

**Before:**


https://github.com/user-attachments/assets/ac3999cf-9386-439d-b22c-2e15e293822d

**After:**


https://github.com/user-attachments/assets/8e31a3c9-20c9-4161-84f5-f74ce9014b3c

