### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.2.7",
+  "packages/react": "3.3.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.52.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.3.0](https://github.com/factorialco/f0/compare/f0-react-v3.2.7...f0-react-v3.3.0) (2026-06-16)
+
+
+### Features
+
+* **OneDataCollection/table:** add "striked" variant to referenceRowType ([#4460](https://github.com/factorialco/f0/issues/4460)) ([ecd3d26](https://github.com/factorialco/f0/commit/ecd3d26d96cb1d854b3c0917779d6bd1ef1fcb3b))
+
 ## [3.2.7](https://github.com/factorialco/f0/compare/f0-react-v3.2.6...f0-react-v3.2.7) (2026-06-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.2.7",
+  "version": "3.3.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.3.0</summary>

## [3.3.0](https://github.com/factorialco/f0/compare/f0-react-v3.2.7...f0-react-v3.3.0) (2026-06-16)


### Features

* **OneDataCollection/table:** add "striked" variant to referenceRowType ([#4460](https://github.com/factorialco/f0/issues/4460)) ([ecd3d26](https://github.com/factorialco/f0/commit/ecd3d26d96cb1d854b3c0917779d6bd1ef1fcb3b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).