### PR TITLE
fix(OneDataCollection/table): respect minWidth when offsetting frozen columns

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1,3 +1,4 @@
+import { expect, within } from "@storybook/test"
 import { Meta, StoryObj } from "@storybook/react-vite"
 import { useState, useMemo } from "react"
 
@@ -45,6 +46,88 @@ export const ReferenceRowsVisualization: Story = {
 
 export const TableFrozenCols: Story = {
   render: () => <ExampleComponent frozenColumns={2} />,
+}
+
+export const TableFrozenColsWithMinWidth: Story = {
+  render: () => {
+    const records = Array.from({ length: 6 }, (_, i) => ({
+      id: i + 1,
+      name: `Person ${i + 1}`,
+      email: `person${i + 1}@example.com`,
+      role: "Engineer",
+      department: "Product",
+      location: "Madrid",
+      manager: "Alice",
+    }))
+
+    const source = useDataCollectionSource({
+      dataAdapter: { fetchData: async () => ({ records }) },
+    })
+
+    return (
+      <div style={{ maxWidth: 600 }}>
+        <OneDataCollection
+          source={source}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                frozenColumns: 2,
+                columns: [
+                  {
+                    id: "name",
+                    label: "Name",
+                    minWidth: 200,
+                    render: (item) => item.name,
+                  },
+                  {
+                    id: "email",
+                    label: "Email",
+                    minWidth: 150,
+                    render: (item) => item.email,
+                  },
+                  { id: "role", label: "Role", render: (item) => item.role },
+                  {
+                    id: "department",
+                    label: "Department",
+                    render: (item) => item.department,
+                  },
+                  {
+                    id: "location",
+                    label: "Location",
+                    render: (item) => item.location,
+                  },
+                  {
+                    id: "manager",
+                    label: "Manager",
+                    render: (item) => item.manager,
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const nameCell = await canvas.findByText("Person 1")
+    const emailCell = await canvas.findByText("person1@example.com")
+    const nameTd = nameCell.closest("td")
+    const emailTd = emailCell.closest("td")
+
+    // Both frozen columns get position: sticky.
+    expect(nameTd && getComputedStyle(nameTd).position).toBe("sticky")
+    expect(emailTd && getComputedStyle(emailTd).position).toBe("sticky")
+
+    // The first frozen column anchors at left:0.
+    expect(nameTd && getComputedStyle(nameTd).left).toBe("0px")
+
+    // The second frozen column must offset by the first's minWidth (200px),
+    // not collapse to left:0 and overlap the first column.
+    expect(emailTd && getComputedStyle(emailTd).left).toBe("200px")
+  },
 }
 
 export const TableColumnOrderingAndHidden: Story = {

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1,5 +1,5 @@
-import { expect, within } from "@storybook/test"
 import { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, within } from "storybook/test"
 import { useState, useMemo } from "react"
 
 import { F0Button } from "@/components/F0Button"

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -117,15 +117,9 @@ export const TableFrozenColsWithMinWidth: Story = {
     const nameTd = nameCell.closest("td")
     const emailTd = emailCell.closest("td")
 
-    // Both frozen columns get position: sticky.
     expect(nameTd && getComputedStyle(nameTd).position).toBe("sticky")
     expect(emailTd && getComputedStyle(emailTd).position).toBe("sticky")
-
-    // The first frozen column anchors at left:0.
     expect(nameTd && getComputedStyle(nameTd).left).toBe("0px")
-
-    // The second frozen column must offset by the first's minWidth (200px),
-    // not collapse to left:0 and overlap the first column.
     expect(emailTd && getComputedStyle(emailTd).left).toBe("200px")
   },
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/useSticky.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/useSticky.test.ts
@@ -32,9 +32,6 @@ describe("useSticky", () => {
   })
 
   it("falls back to minWidth when a frozen column has no explicit width", () => {
-    // Repro for the regression where the second frozen column landed at left:0
-    // (overlapping the first) because column[0].width was undefined and the
-    // reducer ignored its declared minWidth.
     const { result } = renderHook(() =>
       useSticky(2, [{ minWidth: 200 }, { minWidth: 100 }], false)
     )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/useSticky.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/useSticky.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { useSticky } from "../useSticky"
+
+const CHECK_COL = 56
+
+describe("useSticky", () => {
+  it("returns undefined for cells beyond the frozen range", () => {
+    const { result } = renderHook(() =>
+      useSticky(2, [{ width: 100 }, { width: 100 }, { width: 100 }], false)
+    )
+    expect(result.current.getStickyPosition(2)).toBeUndefined()
+  })
+
+  it("stacks frozen columns by their explicit width", () => {
+    const { result } = renderHook(() =>
+      useSticky(2, [{ width: 100 }, { width: 200 }], false)
+    )
+    expect(result.current.getStickyPosition(0)).toEqual({ left: 0 })
+    expect(result.current.getStickyPosition(1)).toEqual({ left: 100 })
+  })
+
+  it("offsets frozen columns by the checkbox column when selectable", () => {
+    const { result } = renderHook(() =>
+      useSticky(2, [{ width: 100 }, { width: 200 }], true)
+    )
+    expect(result.current.getStickyPosition(0)).toEqual({ left: CHECK_COL })
+    expect(result.current.getStickyPosition(1)).toEqual({
+      left: CHECK_COL + 100,
+    })
+  })
+
+  it("falls back to minWidth when a frozen column has no explicit width", () => {
+    // Repro for the regression where the second frozen column landed at left:0
+    // (overlapping the first) because column[0].width was undefined and the
+    // reducer ignored its declared minWidth.
+    const { result } = renderHook(() =>
+      useSticky(2, [{ minWidth: 200 }, { minWidth: 100 }], false)
+    )
+    expect(result.current.getStickyPosition(1)).toEqual({ left: 200 })
+  })
+
+  it("prefers width over minWidth when both are set", () => {
+    const { result } = renderHook(() =>
+      useSticky(2, [{ width: 120, minWidth: 200 }, { width: 100 }], false)
+    )
+    expect(result.current.getStickyPosition(1)).toEqual({ left: 120 })
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/useSticky.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/useSticky.ts
@@ -23,7 +23,7 @@ export const useSticky = <
             left: columns
               .slice(0, Math.max(0, cellIndex))
               .reduce(
-                (acc, column) => acc + (column.width ?? 0),
+                (acc, column) => acc + (column.width ?? column.minWidth ?? 0),
                 checkColumnWidth
               ),
           }


### PR DESCRIPTION
## Summary

### Before

https://github.com/user-attachments/assets/9e6cbdac-e2ef-43b4-a84a-0fab5aceb3ef


### After


https://github.com/user-attachments/assets/3d5eb0e8-b263-4bb1-a9f7-6a23fa2a75fe



`useSticky` was computing each frozen column's `left:` by summing only `column.width` of the preceding columns. When a frozen column declared **only** `minWidth` (which the table renderer respects as the floor width), the reducer fell back to `0` — so the next frozen column landed at the same horizontal position and visually overlapped the previous one.

Fix: fall back to `column.minWidth` after `column.width`, matching how the table actually lays the columns out.

## Repro (visible in Storybook)

Two columns frozen, first declares `minWidth: 200`, no `width`. On `main`, the second column's sticky cells render at `left: 0px` and overlap the first. With this fix, they render at `left: 200px`.

The new `Data Collection › Visualizations › Table › TableFrozenColsWithMinWidth` story locks the regression with a `play` test that asserts the computed `left:` directly.

## Diff

- `Table/useSticky.ts` (+1 / −1) — fallback to `column.minWidth ?? 0`.
- `Table/__tests__/useSticky.test.ts` (new, 5 tests) — explicit-width baseline, checkbox-offset baseline, the regression, and `width` precedence over `minWidth`.
- `__stories__/visualizations/table/table.stories.tsx` (+83) — new story + `play` assertion that the second frozen column resolves to `left: 200px`.

## Test plan

- [x] `pnpm vitest run src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/useSticky.test.ts` — 5/5 pass.
- [x] `pnpm lint` + `pnpm exec oxfmt --check` on touched files — clean.
- [ ] Open Storybook → *Data Collection › Visualizations › Table › TableFrozenColsWithMinWidth* and confirm the "Name" + "Email" columns sit side by side with no overlap; scroll right to verify both stay pinned.
- [ ] Regression check: the existing `TableFrozenCols` story (columns with explicit `width`) renders unchanged.

## Why this matters downstream

This unblocks the Factorial monorepo PR https://github.com/factorialco/factorial/pull/102282 which pins Status + Period cost on the Headcount Planning Employee Sheet — both columns only declare `minWidth`, so before this fix the Period cost column would slide on top of the Status column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)