### PR TITLE
feat(avatars): add headcount_planning to F0AvatarModule module map

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarModule/modules.ts
+++ b/packages/react/src/components/avatars/F0AvatarModule/modules.ts
@@ -32,6 +32,7 @@ export const modules = {
   "finance-treasury": ModuleIcons.Treasury,
   "finance-workspace": ModuleIcons.Reports,
   goals: ModuleIcons.Goals,
+  headcount_planning: ModuleIcons.HeadcountPlanning,
   get_started: ModuleIcons.Rocket,
   home: ModuleIcons.Home,
   hub: ModuleIcons.Hub,


### PR DESCRIPTION
## Description

Registers the `headcount_planning` module ID in the `F0AvatarModule` component so it displays the correct HeadcountPlanning icon.

## Implementation details

- Adds `headcount_planning: ModuleIcons.HeadcountPlanning` to the module map in `F0AvatarModule/modules.ts`

## Ticket

[FCT-56338](https://factorialmakers.atlassian.net/browse/FCT-56338)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FCT-56338]: https://factorialmakers.atlassian.net/browse/FCT-56338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ