### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.4.0",
+  "packages/react": "3.4.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.4.1](https://github.com/factorialco/f0/compare/f0-react-v3.4.0...f0-react-v3.4.1) (2026-06-16)
+
+
+### Bug Fixes
+
+* **OneDataCollection/table:** respect minWidth when offsetting frozen columns ([#4466](https://github.com/factorialco/f0/issues/4466)) ([f707da4](https://github.com/factorialco/f0/commit/f707da4c6c8bb9bd05c1f68be04df49ca736ccf4))
+
 ## [3.4.0](https://github.com/factorialco/f0/compare/f0-react-v3.3.0...f0-react-v3.4.0) (2026-06-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.4.1</summary>

## [3.4.1](https://github.com/factorialco/f0/compare/f0-react-v3.4.0...f0-react-v3.4.1) (2026-06-16)


### Bug Fixes

* **OneDataCollection/table:** respect minWidth when offsetting frozen columns ([#4466](https://github.com/factorialco/f0/issues/4466)) ([f707da4](https://github.com/factorialco/f0/commit/f707da4c6c8bb9bd05c1f68be04df49ca736ccf4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).