### PR TITLE
feat(value-display): add categoryBar distribution cell

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -416,6 +416,21 @@ export const getMockVisualizations = (options?: {
             order: options?.table?.allowColumnReordering ? 4 : undefined,
           },
           {
+            id: "genderSplit",
+            label: "Gender",
+            width: 160,
+            render: (item) => ({
+              type: "categoryBar",
+              value: {
+                items: [
+                  { label: "Female", value: 30 + (item.index % 4) * 10 },
+                  { label: "Male", value: 40 - (item.index % 3) * 5 },
+                  { label: "Non-binary", value: 15 + (item.index % 2) * 5 },
+                ],
+              },
+            }),
+          },
+          {
             id: "email2",
             label: "Email 2",
             render: (item) => item.email,

--- a/packages/react/src/ui/value-display/renderers.tsx
+++ b/packages/react/src/ui/value-display/renderers.tsx
@@ -5,6 +5,7 @@ import { AlertTagCell } from "./types/alertTag"
 import { AmountCell } from "./types/amount"
 import { AvatarListCell } from "./types/avatarList"
 import { BarSeriesCell } from "./types/barSeries"
+import { CategoryBarCell } from "./types/categoryBar"
 import { CompanyCell } from "./types/company"
 import { CompoundCell } from "./types/compound"
 import { CountCell } from "./types/count"
@@ -55,6 +56,7 @@ export const valueDisplayRenderers = {
   percentage: PercentageCell,
   progressBar: ProgressBarCell,
   barSeries: BarSeriesCell,
+  categoryBar: CategoryBarCell,
   hourDistribution: HourDistributionCell,
   company: CompanyCell,
   team: TeamCell,

--- a/packages/react/src/ui/value-display/types/categoryBar/__stories__/categoryBar.stories.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBar/__stories__/categoryBar.stories.tsx
@@ -1,0 +1,96 @@
+import { Meta, StoryObj } from "@storybook/react-vite"
+
+import { Cell, mockItem } from "../../../__stories__/shared"
+
+const meta = {
+  title: "Value Display/CategoryBar",
+  component: Cell,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Category bar cell: a proportional distribution across categories (e.g. gender or department breakdowns) rendered inside a data collection. Delegates to CategoryBarChart.",
+      },
+      source: {
+        code: null,
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Gender",
+      render: () => ({
+        type: "categoryBar",
+        value: {
+          items: [
+            { label: "Female", value: 20 },
+            { label: "Male", value: 55 },
+            { label: "Non-binary", value: 25 },
+          ],
+        },
+      }),
+    },
+  },
+}
+
+export const WithCustomColors: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Department",
+      render: () => ({
+        type: "categoryBar",
+        value: {
+          items: [
+            { label: "Engineering", value: 40, color: "categorical-3" },
+            { label: "Sales", value: 35, color: "categorical-5" },
+            { label: "Operations", value: 25, color: "categorical-7" },
+          ],
+        },
+      }),
+    },
+  },
+}
+
+export const WithLegend: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Gender",
+      render: () => ({
+        type: "categoryBar",
+        value: {
+          legend: true,
+          items: [
+            { label: "Female", value: 20 },
+            { label: "Male", value: 55 },
+            { label: "Non-binary", value: 25 },
+          ],
+        },
+      }),
+    },
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Gender",
+      render: () => ({
+        type: "categoryBar",
+        value: {
+          items: [],
+        },
+      }),
+    },
+  },
+}

--- a/packages/react/src/ui/value-display/types/categoryBar/categoryBar.test.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBar/categoryBar.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ValueDisplayRendererContext } from "../../renderers"
+import { CategoryBarCell, CategoryBarValue } from "./categoryBar"
+
+const defaultMeta: ValueDisplayRendererContext = {
+  visualization: "table",
+}
+
+describe("CategoryBarCell", () => {
+  it("renders fallback dash when items is empty", () => {
+    const args: CategoryBarValue = { items: [] }
+
+    render(CategoryBarCell(args, defaultMeta))
+
+    expect(screen.getByText("–")).toBeInTheDocument()
+    expect(screen.getByText("–")).toHaveAttribute(
+      "data-cell-type",
+      "categoryBar"
+    )
+  })
+
+  it("renders fallback dash when all values are zero", () => {
+    const args: CategoryBarValue = {
+      items: [
+        { label: "A", value: 0 },
+        { label: "B", value: 0 },
+      ],
+    }
+
+    render(CategoryBarCell(args, defaultMeta))
+
+    expect(screen.getByText("–")).toBeInTheDocument()
+  })
+
+  it("renders one segment per non-zero item", () => {
+    const args: CategoryBarValue = {
+      items: [
+        { label: "Female", value: 20 },
+        { label: "Male", value: 55 },
+        { label: "Non-binary", value: 25 },
+      ],
+    }
+
+    const { container } = render(CategoryBarCell(args, defaultMeta))
+
+    expect(
+      container.querySelector('[data-cell-type="categoryBar"]')
+    ).toBeInTheDocument()
+    const segments = container.querySelectorAll('[role="img"]')
+    expect(segments.length).toBe(3)
+  })
+
+  it("uses each segment label as its accessible title", () => {
+    const args: CategoryBarValue = {
+      items: [{ label: "Female", value: 100 }],
+    }
+
+    const { container } = render(CategoryBarCell(args, defaultMeta))
+
+    expect(
+      container.querySelector('[role="img"][title="Female"]')
+    ).toBeInTheDocument()
+  })
+
+  it("renders a legend when legend is true", () => {
+    const args: CategoryBarValue = {
+      legend: true,
+      items: [
+        { label: "Female", value: 20 },
+        { label: "Male", value: 80 },
+      ],
+    }
+
+    render(CategoryBarCell(args, defaultMeta))
+
+    expect(screen.getByRole("list")).toBeInTheDocument()
+    expect(screen.getAllByRole("listitem").length).toBe(2)
+  })
+})

--- a/packages/react/src/ui/value-display/types/categoryBar/categoryBar.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBar/categoryBar.tsx
@@ -1,0 +1,48 @@
+import { CategoryBarChart } from "@/kits/Charts/CategoryBarChart"
+
+import { ValueDisplayRendererContext } from "../../renderers"
+
+export interface CategoryBarItem {
+  label: string
+  value: number
+  color?: string
+}
+
+export interface CategoryBarValue {
+  items: CategoryBarItem[]
+  legend?: boolean
+  hideTooltip?: boolean
+}
+
+export const CategoryBarCell = (
+  args: CategoryBarValue,
+  _meta: ValueDisplayRendererContext
+) => {
+  const items = args?.items ?? []
+  const total = items.reduce((sum, item) => sum + item.value, 0)
+
+  if (items.length === 0 || total <= 0) {
+    return (
+      <span
+        className="text-f1-foreground-secondary"
+        data-cell-type="categoryBar"
+      >
+        –
+      </span>
+    )
+  }
+
+  return (
+    <div className="w-full" data-cell-type="categoryBar">
+      <CategoryBarChart
+        data={items.map((item) => ({
+          name: item.label,
+          value: item.value,
+          color: item.color,
+        }))}
+        legend={args.legend ?? false}
+        hideTooltip={args.hideTooltip ?? false}
+      />
+    </div>
+  )
+}

--- a/packages/react/src/ui/value-display/types/categoryBar/index.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBar/index.tsx
@@ -1,0 +1,1 @@
+export * from "./categoryBar"


### PR DESCRIPTION
Context: extracted from the distribution use case in #4378. A category
distribution shown *inside a data collection* belongs as a value-display
cell, not a freestanding component — and CategoryBarChart already renders
the bar (segments, color tokens, tooltips, role="img").

## Changes
- New `categoryBar` value-display cell (`src/ui/value-display/types/categoryBar/`) that delegates to `CategoryBarChart`.
- Registered `categoryBar` in `valueDisplayRenderers`, so `OneDataCollection` columns can return `{ type: "categoryBar", value: { items: [{ label, value, color? }] } }` with no extra plumbing.
- Per-segment `color` accepts chart tokens (`categorical-1..8`, `feedback-*`); omitted colors auto-assign from the categorical palette. Empty / all-zero renders a `–` fallback.
- a11y inherited from `CategoryBarChart` (`role="img"` per segment) — not `progressbar`.
- Stories: isolated cell (`Value Display/CategoryBar`: Default, WithCustomColors, WithLegend, Empty) + a `Gender` column added to the Table visualization mock data.

## Testing
- `pnpm vitest run src/ui/value-display/types/categoryBar` — 5/5 pass
- `pnpm tsc` — 0 errors
- oxlint 0/0, oxfmt clean
- Storybook: `Value Display/CategoryBar` and `Data Collection/Visualizations/Table`