### PR TITLE
fix(SurveyFormBuilder): foreground input text in dark mode

### DIFF
--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -186,7 +186,7 @@ export const BaseQuestion = ({
                   onChange={handleChangeTitle}
                   disabled={inputDisabled}
                   className={cn(
-                    "w-full resize-none px-2 py-1 text-lg font-semibold disabled:text-f1-foreground [&::-webkit-search-cancel-button]:hidden",
+                    "w-full resize-none px-2 py-1 text-lg font-semibold text-f1-foreground placeholder:text-f1-foreground-tertiary [&::-webkit-search-cancel-button]:hidden",
                     showCursorNotAllowed && "cursor-not-allowed"
                   )}
                   style={TEXT_AREA_STYLE}

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/SelectOption/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/SelectOption/index.tsx
@@ -163,7 +163,7 @@ export const SelectOption = ({
             )}
             value={label}
             onChange={handleChangeLabel}
-            className="flex-1 resize-none font-medium"
+            className="flex-1 resize-none font-medium text-f1-foreground placeholder:text-f1-foreground-tertiary"
             style={TEXT_AREA_STYLE}
           />
         ) : (

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
@@ -144,7 +144,7 @@ export const Section = ({
                   onChange={handleChangeTitle}
                   disabled={inputDisabled}
                   className={cn(
-                    "w-full text-lg font-semibold disabled:text-f1-foreground [&::-webkit-search-cancel-button]:hidden",
+                    "w-full text-lg font-semibold text-f1-foreground placeholder:text-f1-foreground-tertiary [&::-webkit-search-cancel-button]:hidden",
                     inputDisabled && "cursor-not-allowed"
                   )}
                 />


### PR DESCRIPTION
## Description

In dark mode, the typed-in value of the question title, section title, and select-option inputs rendered as black instead of the theme foreground (white). These form controls set a text color only for the disabled state (or none at all), and because Tailwind Preflight is disabled in this repo, form controls don't inherit the page's `text-f1-foreground` — they fall back to the browser's default (black) text color regardless of theme. This sets the foreground color explicitly so the inputs read correctly in both light and dark mode.

## Implementation details

- fix: set `text-f1-foreground` on the question title, section title, and select-option inputs so their value text uses the theme foreground in dark mode
- fix: tokenize the placeholder with `placeholder:text-f1-foreground-tertiary`, matching the description and checkbox inputs that already rendered correctly