### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.4.1",
+  "packages/react": "3.5.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.5.0](https://github.com/factorialco/f0/compare/f0-react-v3.4.1...f0-react-v3.5.0) (2026-06-17)
+
+
+### Features
+
+* **avatars:** add headcount_planning to F0AvatarModule module map ([#4467](https://github.com/factorialco/f0/issues/4467)) ([f34e73a](https://github.com/factorialco/f0/commit/f34e73adcc43b8767a2264123287129b933868d3))
+
 ## [3.4.1](https://github.com/factorialco/f0/compare/f0-react-v3.4.0...f0-react-v3.4.1) (2026-06-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.5.0</summary>

## [3.5.0](https://github.com/factorialco/f0/compare/f0-react-v3.4.1...f0-react-v3.5.0) (2026-06-17)


### Features

* **avatars:** add headcount_planning to F0AvatarModule module map ([#4467](https://github.com/factorialco/f0/issues/4467)) ([f34e73a](https://github.com/factorialco/f0/commit/f34e73adcc43b8767a2264123287129b933868d3))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).