### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.5.0",
+  "packages/react": "3.5.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.5.1](https://github.com/factorialco/f0/compare/f0-react-v3.5.0...f0-react-v3.5.1) (2026-06-17)
+
+
+### Bug Fixes
+
+* **F0Dialog:** clip tab divider and refine resource side-panel header ([#4463](https://github.com/factorialco/f0/issues/4463)) ([5e881fd](https://github.com/factorialco/f0/commit/5e881fd661525147475a7062a41794eddba30ff8))
+
 ## [3.5.0](https://github.com/factorialco/f0/compare/f0-react-v3.4.1...f0-react-v3.5.0) (2026-06-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.5.1</summary>

## [3.5.1](https://github.com/factorialco/f0/compare/f0-react-v3.5.0...f0-react-v3.5.1) (2026-06-17)


### Bug Fixes

* **F0Dialog:** clip tab divider and refine resource side-panel header ([#4463](https://github.com/factorialco/f0/issues/4463)) ([5e881fd](https://github.com/factorialco/f0/commit/5e881fd661525147475a7062a41794eddba30ff8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).