### PR TITLE
fix(F0CardRow): align avatar & actions as the row grows

### DIFF
--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -89,11 +89,6 @@ export interface F0CardRowProps {
   inactive?: boolean
 
   /**
-   * Compact layout: tighter padding and smaller controls.
-   */
-  compact?: boolean
-
-  /**
    * Container width at which the actions drop to their own line (below it) vs.
    * sit inline (at/above it). `never` keeps them inline at every width.
    * @default "never"
@@ -155,7 +150,6 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
       rejectAction,
       status,
       inactive = false,
-      compact = false,
       fullHeight = false,
       alert,
       link,
@@ -176,7 +170,6 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
         ref={hasAlert ? undefined : ref}
         className={cn(
           "group relative @container bg-f1-background shadow-none transition-all",
-          compact && "p-3",
           fullHeight && "h-full",
           // Pointer + hover/focus affordance only when the whole row is clickable.
           clickable &&
@@ -243,7 +236,6 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
             confirmAction={confirmAction}
             rejectAction={rejectAction}
             status={status}
-            compact={compact}
             stackAt={stackAt}
           />
         </div>
@@ -264,21 +256,16 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
 
 F0CardRowBase.displayName = "F0CardRow"
 
-const F0CardRowSkeleton = ({ compact = false }: { compact?: boolean }) => {
+const F0CardRowSkeleton = () => {
   return (
     <Card
-      className={cn(
-        "group relative bg-f1-background shadow-none",
-        compact && "p-3"
-      )}
+      className={cn("group relative bg-f1-background shadow-none")}
       aria-busy="true"
       aria-live="polite"
     >
       <div className="flex flex-row items-center justify-between gap-4">
         <div className="flex min-w-0 flex-row items-center gap-3">
-          <Skeleton
-            className={cn("h-10 w-10 rounded-full", compact && "h-8 w-8")}
-          />
+          <Skeleton className="h-10 w-10 rounded-full" />
           <div className="flex flex-col gap-1">
             <Skeleton className="h-3 w-32 rounded-md" />
             <Skeleton className="h-3 w-20 rounded-md" />

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -23,6 +23,7 @@ import {
   type CardRowStackAt,
   type CardRowStatus,
   cardRowClassName,
+  cardRowLeadingAlignClassName,
 } from "./components/CardRowActions"
 import { type CardAlertProps } from "./types"
 
@@ -207,6 +208,9 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
           <div
             className={cn(
               "flex min-w-0 flex-row gap-3",
+              // Centre a short single-line group against the taller controls, but
+              // let it fill from the top once it grows (see the class doc).
+              cardRowLeadingAlignClassName[stackAt],
               // Keep the avatar pinned to the top so it stays aligned with the
               // title when the row grows (e.g. a long wrapping description).
               avatar ? "items-start" : "items-center"
@@ -218,7 +222,7 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
                 variant="body"
                 content={title}
                 className={cn(
-                  "font-medium",
+                  "break-words font-medium",
                   inactive && "text-f1-foreground-secondary line-through"
                 )}
               />
@@ -226,7 +230,7 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
                 <Text
                   variant="description"
                   content={description}
-                  className={cn(inactive && "line-through")}
+                  className={cn("break-words", inactive && "line-through")}
                 />
               )}
             </div>

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -204,7 +204,14 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
         )}
 
         <div className={cardRowClassName[stackAt]}>
-          <div className="flex min-w-0 flex-row items-center gap-3">
+          <div
+            className={cn(
+              "flex min-w-0 flex-row gap-3",
+              // Keep the avatar pinned to the top so it stays aligned with the
+              // title when the row grows (e.g. a long wrapping description).
+              avatar ? "items-start" : "items-center"
+            )}
+          >
             {avatar && <CardAvatar avatar={avatar} size="lg" />}
             <div className="flex min-w-0 flex-col gap-0">
               <Text

--- a/packages/react/src/components/F0Card/F0CardRow.tsx
+++ b/packages/react/src/components/F0Card/F0CardRow.tsx
@@ -237,6 +237,7 @@ const F0CardRowBase = forwardRef<HTMLDivElement, F0CardRowProps>(
             rejectAction={rejectAction}
             status={status}
             stackAt={stackAt}
+            hasAvatar={!!avatar}
           />
         </div>
       </Card>

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -50,10 +50,6 @@ const meta: Meta<typeof F0CardRow> = {
         "Container width at which the actions drop to their own line. `never` keeps them inline at every width.",
       table: { defaultValue: { summary: "never" } },
     },
-    compact: {
-      control: "boolean",
-      description: "Tighter padding and smaller controls.",
-    },
     inactive: {
       control: "boolean",
       description:

--- a/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/F0CardRow.stories.tsx
@@ -303,6 +303,31 @@ export const WithAvatar: Story = {
   },
 }
 
+/**
+ * The title and description wrap when long, so the row grows to fit. The avatar
+ * and the trailing actions stay pinned to the top (rather than drifting to the
+ * vertical centre), so both keep aligning with the title's first line. Long
+ * unbroken strings — URLs, ids — break instead of overrunning the actions.
+ */
+export const LongContent: Story = {
+  args: {
+    avatar: {
+      type: "person",
+      firstName: "Jane",
+      lastName: "Cooper",
+      src: image,
+    },
+    title: "Jane Cooper",
+    description:
+      "Product designer leading the design system team across web and mobile, with a bio long enough to wrap onto several lines — ref https://example.com/people/jane-cooper-design-systems-lead-2026",
+    primaryAction: { label: "Open", onClick: clickAlert("Open") },
+    secondaryActions: [{ label: "Edit", onClick: clickAlert("Edit") }],
+  },
+  parameters: {
+    docs: { story: { inline: false, height: "220px" } },
+  },
+}
+
 export const WithAlert: Story = {
   args: {
     avatar: {

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -83,6 +83,23 @@ const actionsWidthClassName: Record<CardRowStackAt, string> = {
   never: "flex-1",
 }
 
+/**
+ * Top nudge that vertically centres the trailing controls against the avatar.
+ * The row is top-aligned (`items-start`), so a button (shorter than the `lg`
+ * avatar) would otherwise sit a few pixels high. `pt-1` drops it onto the
+ * avatar's centre line. Applied only when the row has an avatar, and scoped to
+ * the inline breakpoint — once stacked the controls own their own line where the
+ * footer chrome owns the spacing. Because the avatar stays pinned to the top,
+ * this keeps the controls centred on it whether the row is standard height or
+ * grown, so no card-height check is needed.
+ */
+const actionsAvatarOffsetClassName: Record<CardRowStackAt, string> = {
+  sm: "@xs:pt-1",
+  md: "@md:pt-1",
+  lg: "@lg:pt-1",
+  never: "pt-1",
+}
+
 // Visibility of the icon-only inline cluster — shown at/above the breakpoint
 // (and always, for `never`). Pairs with `stackedClusterVisibility` below; only
 // the confirm/reject variant renders both, to swap icon-only ↔ labelled on stack.
@@ -159,6 +176,12 @@ interface CardRowActionsProps {
   status?: CardRowStatus
   /** Container breakpoint at which the actions drop to their own line. */
   stackAt?: CardRowStackAt
+  /**
+   * Whether the row has a leading avatar. When true the trailing controls are
+   * nudged down to sit on the avatar's centre line (see
+   * {@link actionsAvatarOffsetClassName}).
+   */
+  hasAvatar?: boolean
 }
 
 /**
@@ -184,8 +207,13 @@ export function CardRowActions({
   rejectAction,
   status,
   stackAt = "never",
+  hasAvatar = false,
 }: CardRowActionsProps) {
   const size = "md"
+  // Centre the trailing controls on the avatar in a standard-height row.
+  const avatarOffset = hasAvatar
+    ? actionsAvatarOffsetClassName[stackAt]
+    : undefined
 
   // Resolved state: a status tag replaces the actions. It's informational, so
   // no click-stop / z-index — a row-level overlay link stays clickable through
@@ -193,7 +221,11 @@ export function CardRowActions({
   if (status) {
     return (
       <div
-        className={cn("flex items-center justify-end", stackedChrome[stackAt])}
+        className={cn(
+          "flex items-center justify-end",
+          avatarOffset,
+          stackedChrome[stackAt]
+        )}
       >
         <F0Icon
           icon={status.icon}
@@ -209,6 +241,7 @@ export function CardRowActions({
   const wrapperClassName = cn(
     "relative z-[1]",
     actionsWidthClassName[stackAt],
+    avatarOffset,
     stackedChrome[stackAt]
   )
 
@@ -264,6 +297,7 @@ export function CardRowActions({
       <div
         className={cn(
           "relative z-[1] min-w-0 flex-1",
+          avatarOffset,
           inlineClusterVisibility[stackAt]
         )}
         onClick={(e) => e.stopPropagation()}

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -66,17 +66,21 @@ export const cardRowLeadingAlignClassName: Record<CardRowStackAt, string> = {
  * top of its content, so a shrink-to-fit container would always shed the tail
  * into the menu — it needs a bound *wider* than its content. Inline (at/above
  * the breakpoint) we hand it the remaining row space via `flex-1`, with its own
- * `justify-end` keeping the buttons at the trailing edge. Once stacked we leave
- * it `auto`: the flex column stretches it to full width, and crucially that lets
- * the `-mx-4` full-bleed footer extend symmetrically — an explicit `w-full`
- * would clip the right edge, since a negative right margin can't widen a
- * fixed-width box. `never` is always inline.
+ * `justify-end` keeping the buttons at the trailing edge. We deliberately omit
+ * `min-w-0` so the wrapper keeps its min-content floor: a long leading title or
+ * description can't squeeze it to zero width (which would let the trailing
+ * button overrun the text and spill past the card edge). The row's `gap` then
+ * guarantees a little breathing room between the text and the buttons. Once
+ * stacked we leave it `auto`: the flex column stretches it to full width, and
+ * crucially that lets the `-mx-4` full-bleed footer extend symmetrically — an
+ * explicit `w-full` would clip the right edge, since a negative right margin
+ * can't widen a fixed-width box. `never` is always inline.
  */
 const actionsWidthClassName: Record<CardRowStackAt, string> = {
-  sm: "@xs:min-w-0 @xs:flex-1",
-  md: "@md:min-w-0 @md:flex-1",
-  lg: "@lg:min-w-0 @lg:flex-1",
-  never: "min-w-0 flex-1",
+  sm: "@xs:flex-1",
+  md: "@md:flex-1",
+  lg: "@lg:flex-1",
+  never: "flex-1",
 }
 
 // Visibility of the icon-only inline cluster — shown at/above the breakpoint

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -100,6 +100,21 @@ const actionsAvatarOffsetClassName: Record<CardRowStackAt, string> = {
   never: "pt-1",
 }
 
+/**
+ * When the row has an avatar, the status icon's slot is grown to the avatar's
+ * height (`lg` = 40px / `min-h-10`) so `items-center` drops the icon onto the
+ * avatar's centre line. The icon is shorter than a button, so the button's
+ * `pt-1` nudge would leave it a few pixels high — matching the slot height and
+ * centring lands it exactly, at any icon size. Inline-scoped; once stacked the
+ * status keeps its natural height on its own line.
+ */
+const statusAvatarSlotClassName: Record<CardRowStackAt, string> = {
+  sm: "@xs:min-h-10",
+  md: "@md:min-h-10",
+  lg: "@lg:min-h-10",
+  never: "min-h-10",
+}
+
 // Visibility of the icon-only inline cluster — shown at/above the breakpoint
 // (and always, for `never`). Pairs with `stackedClusterVisibility` below; only
 // the confirm/reject variant renders both, to swap icon-only ↔ labelled on stack.
@@ -223,7 +238,7 @@ export function CardRowActions({
       <div
         className={cn(
           "flex items-center justify-end",
-          avatarOffset,
+          hasAvatar && statusAvatarSlotClassName[stackAt],
           stackedChrome[stackAt]
         )}
       >
@@ -241,8 +256,10 @@ export function CardRowActions({
   const wrapperClassName = cn(
     "relative z-[1]",
     actionsWidthClassName[stackAt],
-    avatarOffset,
-    stackedChrome[stackAt]
+    // After stackedChrome: its `@{bp}:pt-0` reset and our `@{bp}:pt-1` are the
+    // same utility, so ours must come last to win once the row goes inline.
+    stackedChrome[stackAt],
+    avatarOffset
   )
 
   const wrap = (group: React.ReactNode) => (

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -153,7 +153,6 @@ interface CardRowActionsProps {
    * Takes precedence over every action prop.
    */
   status?: CardRowStatus
-  compact?: boolean
   /** Container breakpoint at which the actions drop to their own line. */
   stackAt?: CardRowStackAt
 }
@@ -180,10 +179,9 @@ export function CardRowActions({
   confirmAction,
   rejectAction,
   status,
-  compact = false,
   stackAt = "never",
 }: CardRowActionsProps) {
-  const size = compact ? "sm" : "md"
+  const size = "md"
 
   // Resolved state: a status tag replaces the actions. It's informational, so
   // no click-stop / z-index — a row-level overlay link stays clickable through
@@ -191,11 +189,7 @@ export function CardRowActions({
   if (status) {
     return (
       <div
-        className={cn(
-          "flex items-center justify-end",
-          stackedChrome[stackAt],
-          stackAt !== "never" && compact && "mt-3 pt-3"
-        )}
+        className={cn("flex items-center justify-end", stackedChrome[stackAt])}
       >
         <F0Icon
           icon={status.icon}
@@ -211,8 +205,7 @@ export function CardRowActions({
   const wrapperClassName = cn(
     "relative z-[1]",
     actionsWidthClassName[stackAt],
-    stackedChrome[stackAt],
-    stackAt !== "never" && compact && "mt-3 pt-3"
+    stackedChrome[stackAt]
   )
 
   const wrap = (group: React.ReactNode) => (
@@ -290,8 +283,7 @@ export function CardRowActions({
           className={cn(
             "relative z-[1]",
             stackedClusterVisibility[stackAt],
-            stackedChrome[stackAt],
-            compact && "mt-3 pt-3"
+            stackedChrome[stackAt]
           )}
           onClick={(e) => e.stopPropagation()}
         >

--- a/packages/react/src/components/F0Card/components/CardRowActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardRowActions.tsx
@@ -38,10 +38,27 @@ export type CardRowStackAt = "sm" | "md" | "lg" | "never"
  * `md`. `@xs < @md < @lg` keeps sm < md < lg as expected.
  */
 export const cardRowClassName: Record<CardRowStackAt, string> = {
-  sm: "flex flex-col @xs:flex-row @xs:items-center @xs:justify-between @xs:gap-4",
-  md: "flex flex-col @md:flex-row @md:items-center @md:justify-between @md:gap-4",
-  lg: "flex flex-col @lg:flex-row @lg:items-center @lg:justify-between @lg:gap-4",
-  never: "flex flex-row items-center justify-between gap-4",
+  sm: "flex flex-col @xs:flex-row @xs:items-start @xs:justify-between @xs:gap-4",
+  md: "flex flex-col @md:flex-row @md:items-start @md:justify-between @md:gap-4",
+  lg: "flex flex-col @lg:flex-row @lg:items-start @lg:justify-between @lg:gap-4",
+  never: "flex flex-row items-start justify-between gap-4",
+}
+
+/**
+ * Cross-axis alignment of the leading (avatar + text) group within the inline
+ * row. The row pins its items to the top (`items-start` above) so the avatar and
+ * actions stay level with the title's first line as the row grows. A leading
+ * group that's *shorter* than the trailing controls — e.g. a single line of text
+ * next to a taller button — should instead sit vertically centred against them.
+ * `self-center` does exactly that: it only takes visible effect while the group
+ * is shorter than the row, so a tall wrapped group still fills from the top.
+ * Scoped to the inline breakpoint so the stacked column keeps its default stretch.
+ */
+export const cardRowLeadingAlignClassName: Record<CardRowStackAt, string> = {
+  sm: "@xs:self-center",
+  md: "@md:self-center",
+  lg: "@lg:self-center",
+  never: "self-center",
 }
 
 /**


### PR DESCRIPTION
Description

`F0CardRow` centred its content vertically, so when a row grew (e.g. a long, wrapping description) the avatar and trailing actions drifted to the middle, away from the title — and long or unbroken text could overrun the actions and spill past the card's right edge. This pins the row to the top so the avatar and actions stay level with the title's first line, while short single-line rows still sit vertically centred; wraps long text within its own column; reserves space for the actions so they can't be overrun; and centres the controls (buttons, confirm/reject icons, and the status icon) on the avatar. It also removes the unused `compact` variant and adds a story covering the grown-row layout. These commits were cherry-picked out of the `cocreation-patterns-definition` branch so the CardRow fixes can ship on their own.

## Screenshots (if applicable)

Visual/layout change — no Figma (bug fix). Verified in Storybook across the **Card Row** stories:

- `Default` — single-line row stays vertically centred against the buttons
- `With Avatar` — buttons centred on the avatar in a standard-height row
- `Long Content` — avatar + actions stay top-aligned as the row grows; long text wraps within its column instead of overrunning the actions
- `Accepted` / `Rejected` — status icon centred on the avatar
- `Stacking` — centred while inline; footer separator + spacing intact once stacked

## Implementation details

- fix: top-align the avatar so it stays level with the title as the row grows
- fix: keep the trailing actions top-aligned on grow, and wrap long/unbroken text (`break-words`) instead of letting it overrun the actions (adds a `Long Content` story)
- fix: reserve space for the actions so a long title/description can't squeeze the wrapper to zero width and overrun the text
- fix: centre the buttons and confirm/reject icons on the avatar in a standard-height row
- fix: centre the status icon on the avatar and fix the avatar nudge for the stacking variants while inline
- refactor: drop the unused `compact` variant

  <details>
  <summary>Why?</summary>

  `compact` was self-contained to `F0CardRow` (it is not inherited from the underlying `Card`) and unused by any consumer. Removing it keeps the row to its single `md` control size.
  </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<img width="676" height="146" alt="CardHorizontal long text" src="https://github.com/user-attachments/assets/7388ee33-4d50-4297-9854-fe9d9e341675" />
<img width="675" height="178" alt="CardHorizontal long text fix" src="https://github.com/user-attachments/assets/441c53ed-d1cf-4a1f-898b-a5e60dbe942e" />