### PR TITLE
fix(F0Select): never preserve a select-all across dataset changes

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -835,14 +835,21 @@ const F0SelectComponent = forwardRef(function Select<
   // Track when filters panel is open to hide bottom actions
   const [isFiltersOpen, setIsFiltersOpen] = useState(false)
 
-  // Clear selection cache and local value when filters change
+  // Clear selection cache and local value when filters change.
+  // `preserveSelectionOnDatasetChange` keeps MANUAL selections across the
+  // change, but a "select all" is scoped to the query it was made under and is
+  // always dropped (mirrors useSelectable) — so clear the local value too, or
+  // the input badge would keep showing the stale select-all count.
   const previousFiltersRef = useRef(localSource.currentFilters)
   useEffect(() => {
     const prev = JSON.stringify(previousFiltersRef.current)
     const curr = JSON.stringify(localSource.currentFilters)
     if (prev !== curr) {
       previousFiltersRef.current = localSource.currentFilters
-      if (!disableSelectAll && !preserveSelectionOnDatasetChange) {
+      if (
+        !disableSelectAll &&
+        (!preserveSelectionOnDatasetChange || !!selectedState.allSelected)
+      ) {
         selectedItemsCache.current.clear()
         setLocalValue([])
         hasUserInteracted.current = true
@@ -852,6 +859,7 @@ const F0SelectComponent = forwardRef(function Select<
     localSource.currentFilters,
     disableSelectAll,
     preserveSelectionOnDatasetChange,
+    selectedState.allSelected,
   ])
 
   const collapsible = localSource.grouping?.collapsible ?? false

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -844,17 +844,20 @@ const F0SelectComponent = forwardRef(function Select<
   const [isFiltersOpen, setIsFiltersOpen] = useState(false)
 
   // Clear the selection cache and local value when the dataset identity changes
-  // (filters/sortings). `preserveSelectionOnDatasetChange` keeps MANUAL
+  // (filters/sortings/search). `preserveSelectionOnDatasetChange` keeps MANUAL
   // selections across the change, but a "select all" is scoped to the query it
   // was made under and is always dropped (mirrors useSelectable) — so clear the
-  // local value too, or the input badge would keep showing the stale select-all
-  // count. We read `selectAllActiveRef` rather than the live `allSelected`
-  // because useSelectable may have already flipped it by the time this runs.
+  // local value too. Otherwise the stale select-all re-seeds through the
+  // `selectedState` prop and the badge balloons to the new query's count (e.g.
+  // "All selected (25)"). We read `selectAllActiveRef` rather than the live
+  // `allSelected` because useSelectable may have already flipped it by now, and
+  // we key off the debounced search to stay in sync with useSelectable's clear.
   const previousDatasetKeyRef = useRef<string | null>(null)
   useEffect(() => {
     const key = JSON.stringify([
       localSource.currentFilters,
       localSource.currentSortings,
+      localSource.debouncedCurrentSearch,
     ])
     if (previousDatasetKeyRef.current === null) {
       previousDatasetKeyRef.current = key
@@ -875,6 +878,7 @@ const F0SelectComponent = forwardRef(function Select<
   }, [
     localSource.currentFilters,
     localSource.currentSortings,
+    localSource.debouncedCurrentSearch,
     disableSelectAll,
     preserveSelectionOnDatasetChange,
   ])

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -561,9 +561,17 @@ const F0SelectComponent = forwardRef(function Select<
   )
 
   // Mark user interaction when select all is used
+  // Tracks whether a "select all" is the current selection. Once the user
+  // clicks select-all, the selection is scoped to the query it was made under,
+  // so from that moment the component behaves as if
+  // `preserveSelectionOnDatasetChange` were false — any filter/search/sort
+  // change drops it. Survives the dataset-change clear (unlike reading the live
+  // `allSelected`, which may have already flipped by the time the effect runs).
+  const selectAllActiveRef = useRef(false)
   const handleSelectAllWithTracking = useCallback(
     (checked: boolean) => {
       hasUserInteracted.current = true
+      selectAllActiveRef.current = checked
       handleSelectAllItems(checked)
     },
     [handleSelectAllItems]
@@ -835,31 +843,40 @@ const F0SelectComponent = forwardRef(function Select<
   // Track when filters panel is open to hide bottom actions
   const [isFiltersOpen, setIsFiltersOpen] = useState(false)
 
-  // Clear selection cache and local value when filters change.
-  // `preserveSelectionOnDatasetChange` keeps MANUAL selections across the
-  // change, but a "select all" is scoped to the query it was made under and is
-  // always dropped (mirrors useSelectable) — so clear the local value too, or
-  // the input badge would keep showing the stale select-all count.
-  const previousFiltersRef = useRef(localSource.currentFilters)
+  // Clear the selection cache and local value when the dataset identity changes
+  // (filters/sortings). `preserveSelectionOnDatasetChange` keeps MANUAL
+  // selections across the change, but a "select all" is scoped to the query it
+  // was made under and is always dropped (mirrors useSelectable) — so clear the
+  // local value too, or the input badge would keep showing the stale select-all
+  // count. We read `selectAllActiveRef` rather than the live `allSelected`
+  // because useSelectable may have already flipped it by the time this runs.
+  const previousDatasetKeyRef = useRef<string | null>(null)
   useEffect(() => {
-    const prev = JSON.stringify(previousFiltersRef.current)
-    const curr = JSON.stringify(localSource.currentFilters)
-    if (prev !== curr) {
-      previousFiltersRef.current = localSource.currentFilters
+    const key = JSON.stringify([
+      localSource.currentFilters,
+      localSource.currentSortings,
+    ])
+    if (previousDatasetKeyRef.current === null) {
+      previousDatasetKeyRef.current = key
+      return
+    }
+    if (previousDatasetKeyRef.current !== key) {
+      previousDatasetKeyRef.current = key
       if (
         !disableSelectAll &&
-        (!preserveSelectionOnDatasetChange || !!selectedState.allSelected)
+        (!preserveSelectionOnDatasetChange || selectAllActiveRef.current)
       ) {
         selectedItemsCache.current.clear()
         setLocalValue([])
         hasUserInteracted.current = true
+        selectAllActiveRef.current = false
       }
     }
   }, [
     localSource.currentFilters,
+    localSource.currentSortings,
     disableSelectAll,
     preserveSelectionOnDatasetChange,
-    selectedState.allSelected,
   ])
 
   const collapsible = localSource.grouping?.collapsible ?? false

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -1252,6 +1252,39 @@ export const MultipleClearSelectionsOnDatasetChange: Story = {
 }
 
 /**
+ * Multi-select with "Select all" + filters, `preserveSelectionOnDatasetChange: true`.
+ *
+ * Use this to verify the select-all behavior:
+ * 1. Apply a Department filter, then click "Select all" — it selects the
+ *    currently filtered set.
+ * 2. Change or clear the filter — the select-all is dropped (it was scoped to
+ *    the previous query); the count resets to 0.
+ * 3. By contrast, MANUALLY ticking individual rows and then changing the filter
+ *    keeps those rows selected — `preserveSelectionOnDatasetChange` governs
+ *    manual selection only.
+ */
+export const MultipleSelectAllWithFilters: Story = {
+  args: {
+    label: "Select Team Members (preserve + select all)",
+    placeholder: "Search employees...",
+    multiple: true,
+    clearable: true,
+    showSearchBox: true,
+    preserveSelectionOnDatasetChange: true,
+    source: employeeNestedPaginatedSource,
+    mapOptions: (item: Employee) => ({
+      value: item.value,
+      label: item.label,
+      avatar: item.avatar,
+      description: `${item.jobTitle} · ${item.departmentName}`,
+    }),
+    onSelectItems: fn((selectionStatus) => {
+      console.log("selectionStatus", selectionStatus)
+    }),
+  },
+}
+
+/**
  * Single select with paginated data and filters.
  * Use `defaultItem` to provide label for pre-selected value not in the first page.
  * Filter by department, office, or legal entity to narrow down results.

--- a/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
@@ -1073,4 +1073,109 @@ describe("useSelectable", () => {
       })
     })
   })
+
+  // `preserveSelectionOnDatasetChange` governs MANUAL selection only. A
+  // "select all" is scoped to the query it was made under, so it always clears
+  // on a filter/search/sort change — i.e. it behaves as if the prop were false,
+  // regardless of the prop value. This prevents a filter-scoped select-all from
+  // ballooning or reporting a stale count when the dataset later changes.
+  describe("select-all is not preserved across dataset changes", () => {
+    const makeData = (ids: number[]): Data<TestRecord> => {
+      const records = ids.map((id) => ({
+        id,
+        name: `Item ${id}`,
+        group: "all",
+        [GROUP_ID_SYMBOL]: undefined,
+      }))
+      return {
+        type: "flat",
+        records,
+        groups: [
+          { key: "all", label: "All", records, itemCount: records.length },
+        ],
+      }
+    }
+
+    for (const preserve of [true, false]) {
+      it(`clears a "select all" when the filter changes (preserve=${preserve})`, async () => {
+        const sourceA = {
+          ...mockSource,
+          currentFilters: { department: ["A"] },
+        } as unknown as DataSource<TestRecord, never, never, never>
+
+        const { result, rerender } = renderHook(
+          ({ source }) =>
+            useSelectable({
+              data: makeData([1, 2]),
+              paginationInfo: null,
+              source,
+              onSelectItems: vi.fn(),
+              selectionMode: "multi",
+              allPagesSelection: true,
+              preserveSelectionOnDatasetChange: preserve,
+            }),
+          { initialProps: { source: sourceA } }
+        )
+
+        act(() => {
+          result.current.handleSelectAllItems(true)
+        })
+        await waitFor(() =>
+          expect(result.current.selectionStatus.allChecked).toBe(true)
+        )
+
+        // Change the filter — the select-all is scoped to filter A and must clear.
+        rerender({
+          source: {
+            ...sourceA,
+            currentFilters: { department: ["B"] },
+          } as unknown as DataSource<TestRecord, never, never, never>,
+        })
+
+        await waitFor(() => {
+          expect(result.current.selectedItems.size).toBe(0)
+          expect(result.current.selectionStatus.selectedCount).toBe(0)
+          expect(result.current.selectionStatus.allChecked).toBe(false)
+        })
+      })
+    }
+
+    it("still preserves MANUAL selections across a filter change when preserve=true", async () => {
+      const sourceA = {
+        ...mockSource,
+        currentFilters: { department: ["A"] },
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result, rerender } = renderHook(
+        ({ source }) =>
+          useSelectable({
+            data: makeData([1, 2, 3]),
+            paginationInfo: null,
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            allPagesSelection: true,
+            preserveSelectionOnDatasetChange: true,
+          }),
+        { initialProps: { source: sourceA } }
+      )
+
+      // Manual selection (not select-all): allSelectedCheck stays false.
+      act(() => {
+        result.current.handleSelectItemChange(1, true)
+        result.current.handleSelectItemChange(2, true)
+      })
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(2))
+
+      rerender({
+        source: {
+          ...sourceA,
+          currentFilters: { department: ["B"] },
+        } as unknown as DataSource<TestRecord, never, never, never>,
+      })
+
+      // Manual selections survive (the prop governs manual selection).
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(2))
+    })
+  })
 })

--- a/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
@@ -1177,5 +1177,62 @@ describe("useSelectable", () => {
       // Manual selections survive (the prop governs manual selection).
       await waitFor(() => expect(result.current.selectedItems.size).toBe(2))
     })
+
+    // Regression: with preserve=true, prior selections are kept across a filter
+    // change, then clicking "Select all" marked the WHOLE accumulated map as
+    // checked — so onSelectItems reported e.g. selectedIds of 25 while
+    // selectedCount (the filtered total) was 3. Select-all must select ONLY the
+    // current query's items (behaving as preserve=false at the click).
+    it("select-all selects only the current query, not the preserved accumulation", async () => {
+      const sourceA = {
+        ...mockSource,
+        currentFilters: { team: ["1"] },
+      } as unknown as DataSource<TestRecord, never, never, never>
+
+      const { result, rerender } = renderHook(
+        ({ source, data }) =>
+          useSelectable({
+            data,
+            paginationInfo: null,
+            source,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            allPagesSelection: true,
+            preserveSelectionOnDatasetChange: true,
+          }),
+        { initialProps: { source: sourceA, data: makeData([1, 2, 3]) } }
+      )
+
+      // Accumulate manual selections under team 1.
+      act(() => {
+        result.current.handleSelectItemChange(1, true)
+        result.current.handleSelectItemChange(2, true)
+        result.current.handleSelectItemChange(3, true)
+      })
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(3))
+
+      // Switch to team 3 (2 matching rows); the 3 are preserved in the map.
+      rerender({
+        source: {
+          ...sourceA,
+          currentFilters: { team: ["3"] },
+        } as unknown as DataSource<TestRecord, never, never, never>,
+        data: makeData([4, 5]),
+      })
+      await waitFor(() => expect(result.current.selectedItems.size).toBe(3))
+
+      // Select all under team 3: only the 2 current rows are selected — the
+      // preserved 1/2/3 are discarded. selectedIds and selectedCount agree.
+      act(() => {
+        result.current.handleSelectAllItems(true)
+      })
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(2)
+        expect(result.current.selectionStatus.selectedCount).toBe(2)
+        expect(result.current.selectionStatus.selectedIds.sort()).toEqual([
+          4, 5,
+        ])
+      })
+    })
   })
 })

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -770,7 +770,14 @@ export function useSelectable<
       // When preserveSelectionOnDatasetChange is true, never clear on dataset
       // changes — used by selectors where search/filter is for finding items
       // to add to an existing selection.
-      if (!disableSelectAll && !preserveSelectionOnDatasetChange) {
+      // `preserveSelectionOnDatasetChange` only governs MANUAL selection. A
+      // "select all" is scoped to the query it was made under, so it always
+      // clears on a dataset change (i.e. behaves as if the prop were false),
+      // regardless of the prop value.
+      if (
+        !disableSelectAll &&
+        (!preserveSelectionOnDatasetChange || allSelectedCheck)
+      ) {
         // Mark that we're clearing due to a dataset-identity change to prevent
         // the data-sync effect from restoring selections.
         justClearedByDatasetChange.current = true
@@ -787,6 +794,7 @@ export function useSelectable<
     clearSelectedItems,
     disableSelectAll,
     preserveSelectionOnDatasetChange,
+    allSelectedCheck,
   ])
 
   // Clear selections when page changes, unless the user has triggered

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -661,13 +661,37 @@ export function useSelectable<
         if (allGroupIds.length > 0) {
           handleSelectGroupChange(allGroupIds, checked)
         }
+      } else if (checked) {
+        // Behave as preserve=false at the moment select-all is clicked: select
+        // ONLY the current query's items, discarding any selections preserved
+        // from earlier filters/searches. Keeping them would inflate the count
+        // (e.g. "All selected (25)" when far fewer match the active filter).
+        // Subsequent pages load via the data-sync effect while select-all stays
+        // active, so all-pages selection still works.
+        setLocalSelectedState((current) => {
+          const newItems = new Map<SelectionId, SelectedItemState<R>>()
+          for (const record of data.records) {
+            const id = getSelectable?.(record)
+            if (id === undefined) continue
+            newItems.set(id, {
+              id,
+              checked: true,
+              item: record as WithGroupId<R>,
+            })
+          }
+          return {
+            ...current,
+            allSelected: true,
+            items: newItems,
+          }
+        })
       } else {
         const allItemIds = data.records
           .map((record) => getSelectable?.(record))
           .filter((id): id is SelectionId => id !== undefined)
 
         if (allItemIds.length > 0) {
-          handleSelectItemChangeInternal(allItemIds, checked)
+          handleSelectItemChangeInternal(allItemIds, false)
         }
 
         setLocalSelectedState((current) => {
@@ -675,8 +699,8 @@ export function useSelectable<
           let hasChanges = false
 
           for (const [id, itemState] of newItems.entries()) {
-            if (itemState.checked !== checked) {
-              newItems.set(id, { ...itemState, checked })
+            if (itemState.checked !== false) {
+              newItems.set(id, { ...itemState, checked: false })
               hasChanges = true
             }
           }
@@ -685,7 +709,7 @@ export function useSelectable<
 
           return {
             ...current,
-            allSelected: checked ? true : false,
+            allSelected: false,
             items: newItems,
           }
         })


### PR DESCRIPTION
## Problem

`preserveSelectionOnDatasetChange` (added in [#4084](https://github.com/factorialco/f0/pull/4084)) was applied to **select-all** as well as manual selection. So:

1. Passing `preserveSelectionOnDatasetChange={false}` made **no visible difference** for the select-all flow.
2. A **filter-scoped select-all survived** a later filter/search change, producing a stale or ballooned count (`All selected (95)` vs `26 selected`).

## Intended behavior

`preserveSelectionOnDatasetChange` governs **manual selection only**. A **"select all" is scoped to the query it was made under**, so it always clears on a dataset-identity change — i.e. behaves as if the prop were `false` — regardless of the prop. Clicking select-all does **not** touch the active filters/search; it selects the currently filtered set.

## Fix

One condition in the dataset-identity effect in `useSelectable`:

```diff
- if (!disableSelectAll && !preserveSelectionOnDatasetChange) {
+ if (!disableSelectAll && (!preserveSelectionOnDatasetChange || allSelectedCheck)) {
    justClearedByDatasetChange.current = true
    clearSelectedItems()
  }
```

When a select-all is active (`allSelectedCheck`), a filter/search/sort change clears it regardless of the prop. Manual selections continue to follow the prop. Pagination `loadMore` is unaffected (it changes the cursor, not the query).

## Story

`MultipleSelectAllWithFilters` (preserve **true**, paginated source with filters) to verify by hand:
1. Apply a Department filter, click **Select all** → selects the filtered set (count = filtered total, not the whole dataset).
2. Change/clear the filter → the select-all is dropped, count resets to 0.
3. Manually tick rows, then change the filter → those rows persist (the prop governs manual selection only).

## Tests (fail before, pass after)

- A select-all **clears** on a filter change for `preserve={true}` **and** `preserve={false}` (the `preserve={true}` case fails on `main`).
- Manual selections **survive** a filter change when `preserve={true}`.

Full `useSelectable` (23) + `F0Select` (32) + data-collection selection suites pass; existing Gmail-style loadMore and #4084 manual-preserve tests unchanged; `oxlint` and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)