### PR TITLE
fix(OneFilterPicker): stop checkbox click bubbling to option row inside a form

### DIFF
--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterFlatOption.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterFlatOption.tsx
@@ -34,7 +34,12 @@ export function InFilterFlatOption<T extends string>({
         <span className="min-w-0 flex-1">
           <OneEllipsis>{option.label}</OneEllipsis>
         </span>
-        <div className="shrink-0">
+        {/* The presentational checkbox is a Radix Checkbox; inside a <form> it
+            renders a hidden BubbleInput whose sync effect dispatches a click that
+            bubbles up to this row's onClick (onToggle), causing an infinite
+            select/deselect loop ("Maximum update depth exceeded"). The row itself
+            handles the click, so stop the checkbox-originated click here. */}
+        <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
           <F0Checkbox
             id={optionId}
             title={option.label}

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterOptionRow.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterOptionRow.tsx
@@ -112,7 +112,10 @@ export function InFilterOptionRow<T extends string>({
             <span className="min-w-0 flex-1">
               <OneEllipsis>{option.label}</OneEllipsis>
             </span>
-            <div className="shrink-0">
+            {/* Stop the checkbox-originated click (Radix BubbleInput sync click
+                inside a <form>) from bubbling to this row's onToggle, which would
+                cause an infinite select/deselect loop. The row handles the click. */}
+            <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
               <F0Checkbox
                 id={optionId}
                 title={option.label}


### PR DESCRIPTION
## Problem

Selecting a value in the OneFilterPicker option list **inside a `<form>`** (e.g. when the picker is embedded in an `F0WizardForm`) crashes with **"Maximum update depth exceeded"**. It works fine when the picker is rendered outside a form.

## Root cause

Each option row (`InFilterFlatOption` / `InFilterOptionRow`) renders a **presentational `F0Checkbox`**, which is a Radix Checkbox. Inside a `<form>`, Radix renders a hidden **`BubbleInput`** (for native form-state sync) whose `useEffect` **dispatches a synthetic `click` event** whenever `checked` changes.

That synthetic click **bubbles up to the option row's `onClick` (`onToggle`)**, so selecting a value immediately toggles it back off → re-render → the BubbleInput effect fires again → dispatches another click → infinite loop.

It only reproduces inside a `<form>` because Radix only mounts the `BubbleInput` when there is a form ancestor. (Other symptoms seen while debugging — Radix ScrollArea `setViewport`, OneEllipsis, etc. — were consequences of the runaway re-render, not the cause.)

## Fix

Stop propagation on the checkbox wrapper in both option-row components, so the checkbox-originated (synthetic) click never reaches the row handler. The row already owns the click; the presentational checkbox is decorative.

```tsx
<div className="shrink-0" onClick={(e) => e.stopPropagation()}>
  <F0Checkbox ... presentational hideLabel />
</div>
```

Files:
- `InFilterFlatOption.tsx`
- `InFilterOptionRow.tsx`

## Testing

- Reproduced in Storybook with the picker inside a `<form>`; selecting an option no longer loops.
- `OneFilterPicker` unit tests pass (77 passed).

## Note (optional, broader fix)

A more general fix would be for a `presentational` `F0Checkbox` to not mount Radix's `BubbleInput` at all (a decorative checkbox shouldn't participate in form state), which would prevent this class of bug for any "decorative checkbox inside a clickable container".

🤖 Generated with [Claude Code](https://claude.com/claude-code)