### PR TITLE
fix(rich-text): disable scroll anchoring on the notes editor scroll container

### DIFF
--- a/packages/react/src/components/RichText/F0NotesTextEditor/F0NotesTextEditor.tsx
+++ b/packages/react/src/components/RichText/F0NotesTextEditor/F0NotesTextEditor.tsx
@@ -382,7 +382,7 @@ const F0NotesTextEditorComponent = forwardRef<
           </motion.div>
         )}
       </AnimatePresence>
-      <ScrollArea className="h-full gap-6">
+      <ScrollArea className="notes-text-editor-scroll h-full gap-6">
         {alert && (
           <div className="mx-auto w-full max-w-[824px] sm:px-14 px-0">
             <F0Alert {...alert} />

--- a/packages/react/src/components/RichText/F0NotesTextEditor/index.css
+++ b/packages/react/src/components/RichText/F0NotesTextEditor/index.css
@@ -275,3 +275,11 @@ Placeholder component
 .notes-text-editor .resize-cursor {
   @apply cursor-col-resize;
 }
+
+/* The editor manages its own scrolling (ProseMirror scrolls the caret into view).
+   Browser scroll anchoring fights that: on each re-render it re-anchors and shifts
+   the viewport down — visibly on large documents. Disable it for the editor's
+   scroll container only. */
+.notes-text-editor-scroll [data-scroll-container] {
+  overflow-anchor: none;
+}

--- a/packages/react/src/components/RichText/F0NotesTextEditor/index.css
+++ b/packages/react/src/components/RichText/F0NotesTextEditor/index.css
@@ -276,10 +276,7 @@ Placeholder component
   @apply cursor-col-resize;
 }
 
-/* The editor manages its own scrolling (ProseMirror scrolls the caret into view).
-   Browser scroll anchoring fights that: on each re-render it re-anchors and shifts
-   the viewport down — visibly on large documents. Disable it for the editor's
-   scroll container only. */
+/* The editor manages its own scrolling (ProseMirror scrolls the caret into view) */
 .notes-text-editor-scroll [data-scroll-container] {
   overflow-anchor: none;
 }


### PR DESCRIPTION
## What

Disables the browser's scroll anchoring on the Notes editor's scroll container, scoped to the editor only, no other `ScrollArea` affected.

[FCT-54787 - Page scrolls automatically when typing/deleting in policies](https://factorialmakers.atlassian.net/browse/FCT-54787)

**IT'S HAPPENING TO THIS CLIENT BUT I COULDN'T REPLICATE IT.**

Editing certain policies scrolls the viewport (video on the ticket). **It only reproduces on the customer's account** (tested), never on Testdeverdad or in local dev, despite a lot of attempts:

- Using the same failing policy content, imported every way I could: copy-pasting the content, extracting the `content` field through the prod Rails console, and pulling it straight from the HTTP response. None reproduced in main or my local env.
- Compared what's fetched on load vs what's sent and returned on autosave: the content is identical. So it doesn't seem a content, serialization, or normalization problem triggering a refresh.

## Potential Root Cause

The browser's **scroll anchoring**. On each edit the browser re-anchors the scroll viewport and over-corrects the position. There's no `scrollTo`/`scrollIntoView` in our code for this path. The editor already manages its own scrolling (ProseMirror keeps the caret in view), so anchoring is unwanted here anyway.

## Fix tested

Confirmed directly in production on the exact failing policy by adding `overflow-anchor: none` to that scroll container via the browser inspector stopped the scrolling immediately, with no side effects observed (scrolling, typing and layout all behaved normally). This PR is that same rule applied in code, on the same container.

[FCT-54787]: https://factorialmakers.atlassian.net/browse/FCT-54787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ