### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.6.0",
+  "packages/react": "3.7.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.7.0](https://github.com/factorialco/f0/compare/f0-react-v3.6.0...f0-react-v3.7.0) (2026-06-17)
+
+
+### Features
+
+* **OneDataCollection:** graph (org chart) visualization ([#4311](https://github.com/factorialco/f0/issues/4311)) ([deb3350](https://github.com/factorialco/f0/commit/deb3350ed8bf3d7be392bab040bf4890dbd9aef4))
+
 ## [3.6.0](https://github.com/factorialco/f0/compare/f0-react-v3.5.1...f0-react-v3.6.0) (2026-06-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.7.0</summary>

## [3.7.0](https://github.com/factorialco/f0/compare/f0-react-v3.6.0...f0-react-v3.7.0) (2026-06-17)


### Features

* **OneDataCollection:** graph (org chart) visualization ([#4311](https://github.com/factorialco/f0/issues/4311)) ([deb3350](https://github.com/factorialco/f0/commit/deb3350ed8bf3d7be392bab040bf4890dbd9aef4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).