### PR TITLE
feat(OneTable): support structured rich header info

### DIFF
--- a/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
@@ -33,7 +33,7 @@ const renderHeader = (
 
 describe("TableHead rich header info", () => {
   it("uses the column label as the info trigger's accessible name by default", () => {
-    renderHeader({ render: () => <p>Body</p> })
+    renderHeader({ title: "Active employees", description: "Body" })
 
     expect(
       screen.getByRole("button", { name: "Active headcount" })
@@ -41,22 +41,30 @@ describe("TableHead rich header info", () => {
   })
 
   it("uses info.label as the accessible name when provided", () => {
-    renderHeader({ label: "About active headcount", render: () => <p>Body</p> })
+    renderHeader({
+      label: "About active headcount",
+      title: "Active employees",
+      description: "Body",
+    })
 
     expect(
       screen.getByRole("button", { name: "About active headcount" })
     ).toBeInTheDocument()
   })
 
-  it("renders the consumer-supplied content on hover", async () => {
+  it("renders the structured title and description on hover", async () => {
     renderHeader({
-      render: () => <p>Distinct active employees in the selected snapshot.</p>,
+      title: "Active employees",
+      description: "Distinct active employees in the selected snapshot.",
     })
 
     await userEvent.hover(
       screen.getByRole("button", { name: "Active headcount" })
     )
 
+    expect(
+      await screen.findByText("Active employees", {}, { timeout: 2000 })
+    ).toBeInTheDocument()
     expect(
       await screen.findByText(
         "Distinct active employees in the selected snapshot.",
@@ -66,20 +74,12 @@ describe("TableHead rich header info", () => {
     ).toBeInTheDocument()
   })
 
-  it("passes a close handle that dismisses the card, alongside the consumer action", async () => {
+  it("dismisses the card when the link action is clicked", async () => {
     const onAction = vi.fn()
     renderHeader({
-      render: ({ close }) => (
-        <button
-          type="button"
-          onClick={() => {
-            close()
-            onAction()
-          }}
-        >
-          Learn more
-        </button>
-      ),
+      title: "Active employees",
+      description: "Distinct active employees in the selected snapshot.",
+      link: { label: "Learn more", onClick: onAction },
     })
 
     await userEvent.hover(

--- a/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
+
+import {
+  OneTable,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../../index"
+import type { TableHeaderInfo } from "../../index"
+
+const renderHeader = (
+  info: string | TableHeaderInfo,
+  label = "Active headcount"
+) =>
+  zeroRender(
+    <OneTable>
+      <TableHeader>
+        <TableRow>
+          <TableHead info={info}>{label}</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>37</TableCell>
+        </TableRow>
+      </TableBody>
+    </OneTable>
+  )
+
+const richInfo = (
+  overrides: Partial<TableHeaderInfo> = {}
+): TableHeaderInfo => ({
+  title: "Active headcount",
+  meta: "Per employee · Count distinct",
+  description: "Distinct active employees in the selected snapshot.",
+  ...overrides,
+})
+
+describe("TableHead rich header info", () => {
+  it("exposes the info trigger with an accessible label from the title", () => {
+    renderHeader(richInfo())
+
+    expect(
+      screen.getByRole("button", { name: "Active headcount" })
+    ).toBeInTheDocument()
+  })
+
+  it("reveals the title, meta line and description on hover", async () => {
+    renderHeader(richInfo())
+
+    await userEvent.hover(
+      screen.getByRole("button", { name: "Active headcount" })
+    )
+
+    expect(
+      await screen.findByText(
+        "Per employee · Count distinct",
+        {},
+        { timeout: 2000 }
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Distinct active employees in the selected snapshot.")
+    ).toBeInTheDocument()
+  })
+
+  it("fires the action and dismisses the card when the action is clicked", async () => {
+    const onClick = vi.fn()
+    renderHeader(richInfo({ action: { label: "Learn more", onClick } }))
+
+    await userEvent.hover(
+      screen.getByRole("button", { name: "Active headcount" })
+    )
+    const learnMore = await screen.findByRole(
+      "button",
+      { name: "Learn more" },
+      { timeout: 2000 }
+    )
+    await userEvent.click(learnMore)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    await waitFor(() =>
+      expect(screen.queryByText("Learn more")).not.toBeInTheDocument()
+    )
+  })
+
+  it("omits the action button when no action is provided", async () => {
+    renderHeader(richInfo())
+
+    await userEvent.hover(
+      screen.getByRole("button", { name: "Active headcount" })
+    )
+    await screen.findByText(
+      "Distinct active employees in the selected snapshot.",
+      {},
+      { timeout: 2000 }
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "Learn more" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders a plain text tooltip when info is a string (backward compatible)", () => {
+    renderHeader("Short helper text", "Country")
+
+    // The header label still renders and the rich hover-card trigger (a button
+    // whose accessible name is the info text) is not used for the string path.
+    expect(screen.getByText("Country")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Short helper text" })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
@@ -31,26 +31,27 @@ const renderHeader = (
     </OneTable>
   )
 
-const richInfo = (
-  overrides: Partial<TableHeaderInfo> = {}
-): TableHeaderInfo => ({
-  title: "Active headcount",
-  meta: "Per employee · Count distinct",
-  description: "Distinct active employees in the selected snapshot.",
-  ...overrides,
-})
-
 describe("TableHead rich header info", () => {
-  it("exposes the info trigger with an accessible label from the title", () => {
-    renderHeader(richInfo())
+  it("uses the column label as the info trigger's accessible name by default", () => {
+    renderHeader({ render: () => <p>Body</p> })
 
     expect(
       screen.getByRole("button", { name: "Active headcount" })
     ).toBeInTheDocument()
   })
 
-  it("reveals the title, meta line and description on hover", async () => {
-    renderHeader(richInfo())
+  it("uses info.label as the accessible name when provided", () => {
+    renderHeader({ label: "About active headcount", render: () => <p>Body</p> })
+
+    expect(
+      screen.getByRole("button", { name: "About active headcount" })
+    ).toBeInTheDocument()
+  })
+
+  it("renders the consumer-supplied content on hover", async () => {
+    renderHeader({
+      render: () => <p>Distinct active employees in the selected snapshot.</p>,
+    })
 
     await userEvent.hover(
       screen.getByRole("button", { name: "Active headcount" })
@@ -58,19 +59,28 @@ describe("TableHead rich header info", () => {
 
     expect(
       await screen.findByText(
-        "Per employee · Count distinct",
+        "Distinct active employees in the selected snapshot.",
         {},
         { timeout: 2000 }
       )
     ).toBeInTheDocument()
-    expect(
-      screen.getByText("Distinct active employees in the selected snapshot.")
-    ).toBeInTheDocument()
   })
 
-  it("fires the action and dismisses the card when the action is clicked", async () => {
-    const onClick = vi.fn()
-    renderHeader(richInfo({ action: { label: "Learn more", onClick } }))
+  it("passes a close handle that dismisses the card, alongside the consumer action", async () => {
+    const onAction = vi.fn()
+    renderHeader({
+      render: ({ close }) => (
+        <button
+          type="button"
+          onClick={() => {
+            close()
+            onAction()
+          }}
+        >
+          Learn more
+        </button>
+      ),
+    })
 
     await userEvent.hover(
       screen.getByRole("button", { name: "Active headcount" })
@@ -82,27 +92,10 @@ describe("TableHead rich header info", () => {
     )
     await userEvent.click(learnMore)
 
-    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onAction).toHaveBeenCalledTimes(1)
     await waitFor(() =>
       expect(screen.queryByText("Learn more")).not.toBeInTheDocument()
     )
-  })
-
-  it("omits the action button when no action is provided", async () => {
-    renderHeader(richInfo())
-
-    await userEvent.hover(
-      screen.getByRole("button", { name: "Active headcount" })
-    )
-    await screen.findByText(
-      "Distinct active employees in the selected snapshot.",
-      {},
-      { timeout: 2000 }
-    )
-
-    expect(
-      screen.queryByRole("button", { name: "Learn more" })
-    ).not.toBeInTheDocument()
   })
 
   it("renders a plain text tooltip when info is a string (backward compatible)", () => {

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -2,13 +2,8 @@ import { AnimatePresence, motion } from "motion/react"
 import { useState } from "react"
 
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/ui/hover-card"
 import { TableHead as TableHeadRoot } from "@/ui/table"
-import {
-  TooltipContent,
-  Tooltip as TooltipPrimitive,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/ui/tooltip"
 
 import { F0Icon, IconType } from "../../../components/F0Icon"
 import { ArrowDown, InfoCircleLine } from "../../../icons/app"
@@ -78,10 +73,21 @@ function HeaderInfo({
   const [open, setOpen] = useState(false)
   const { action } = info
 
+  // Rich header info uses a HoverCard, not a Tooltip: the surface is
+  // hover-revealed but holds interactive content (the optional action), which
+  // is what HoverCard is for — Radix Tooltip is a non-interactive label
+  // primitive. We override HoverCard's dark default to a light surface per-call
+  // (same approach as `TagCounter`) rather than adding a primitive variant.
   return (
-    <TooltipProvider delayDuration={300} disableHoverableContent={false}>
-      <TooltipPrimitive open={open} onOpenChange={setOpen}>
-        <TooltipTrigger
+    <HoverCard
+      open={open}
+      onOpenChange={setOpen}
+      openDelay={300}
+      closeDelay={100}
+    >
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
           className={cn(
             "flex h-5 w-5 items-center justify-center rounded-xs text-f1-foreground-secondary",
             focusRing()
@@ -89,24 +95,24 @@ function HeaderInfo({
           aria-label={info.title ?? info.description}
         >
           <F0Icon icon={infoIcon} size="sm" />
-        </TooltipTrigger>
-        <TooltipContent variant="surface" className="pointer-events-auto">
-          <HeaderInfoCard
-            info={info}
-            // Dismiss the tooltip immediately when the action fires so it never
-            // lingers over the surface the action opens (e.g. a dialog).
-            onAction={
-              action
-                ? () => {
-                    setOpen(false)
-                    action.onClick()
-                  }
-                : undefined
-            }
-          />
-        </TooltipContent>
-      </TooltipPrimitive>
-    </TooltipProvider>
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent className="w-auto bg-f1-background px-2 py-1.5 text-f1-foreground shadow-md ring-1 ring-f1-border-secondary">
+        <HeaderInfoCard
+          info={info}
+          // Dismiss the card immediately when the action fires so it never
+          // lingers over the surface the action opens (e.g. a dialog).
+          onAction={
+            action
+              ? () => {
+                  setOpen(false)
+                  action.onClick()
+                }
+              : undefined
+          }
+        />
+      </HoverCardContent>
+    </HoverCard>
   )
 }
 

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -44,11 +44,11 @@ function HeaderInfo({
 }) {
   const [open, setOpen] = useState(false)
 
-  // f0 owns the hover surface (light card chrome, positioning, the info-icon
-  // trigger) and the dismiss mechanism; the consumer owns the body via
-  // `info.render`. A HoverCard (not a Tooltip) because the content is
-  // hover-revealed but may be interactive. The dark default surface is
-  // overridden to a light one per-call, matching `TagCounter`.
+  // f0 owns the hover surface (the dark info-card chrome, positioning, the
+  // info-icon trigger) and the dismiss mechanism; the consumer owns the body
+  // via `info.render`. A HoverCard (not a Tooltip) because the content is
+  // hover-revealed but may be interactive; it keeps HoverCard's default dark
+  // (inverse) surface, so consumer content should use inverse text tokens.
   return (
     <HoverCard
       open={open}
@@ -68,7 +68,7 @@ function HeaderInfo({
           <F0Icon icon={infoIcon} size="sm" />
         </button>
       </HoverCardTrigger>
-      <HoverCardContent className="w-auto max-w-xs bg-f1-background px-2 py-1.5 text-f1-foreground shadow-md ring-1 ring-f1-border-secondary">
+      <HoverCardContent className="w-auto max-w-xs px-3 py-2 shadow-md">
         {info.render({ close: () => setOpen(false) })}
       </HoverCardContent>
     </HoverCard>

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -44,11 +44,9 @@ function HeaderInfo({
 }) {
   const [open, setOpen] = useState(false)
 
-  // f0 owns the hover surface (the dark info-card chrome, positioning, the
-  // info-icon trigger) and the dismiss mechanism; the consumer owns the body
-  // via `info.render`. A HoverCard (not a Tooltip) because the content is
-  // hover-revealed but may be interactive; it keeps HoverCard's default dark
-  // (inverse) surface, so consumer content should use inverse text tokens.
+  // HoverCard (not Tooltip): the content is hover-revealed but may be
+  // interactive. f0 owns the (dark) surface and the `close` handle; the
+  // consumer owns the body via `info.render` and uses inverse text tokens.
   return (
     <HoverCard
       open={open}

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -13,19 +13,13 @@ import { getColWidth } from "../utils/colWidth"
 import { ColumnWidth } from "../utils/sizes"
 import { useTable } from "../utils/TableContext"
 
-/**
- * Rich header info shown in a hoverable card next to a column header. Unlike
- * the plain-string `info` (which renders a short text tooltip), this lets the
- * consumer render arbitrary content inside the card: f0 owns the hover surface
- * and the dismiss mechanism, the consumer owns the body.
- */
 export type TableHeaderInfo = {
-  /**
-   * Renders the card body. Receives `close` to dismiss the card — call it when
-   * the content navigates away or opens another surface (e.g. a "Learn more"
-   * dialog), so the card never lingers over what it opened.
-   */
-  render: (api: { close: () => void }) => React.ReactNode
+  title: string
+  description: string
+  link?: {
+    label: string
+    onClick: () => void
+  }
   /**
    * Accessible name for the info-icon trigger. Defaults to the column label
    * when the header's children are a string.
@@ -44,9 +38,8 @@ function HeaderInfo({
 }) {
   const [open, setOpen] = useState(false)
 
-  // HoverCard (not Tooltip): the content is hover-revealed but may be
-  // interactive. f0 owns the (dark) surface and the `close` handle; the
-  // consumer owns the body via `info.render` and uses inverse text tokens.
+  // HoverCard (not Tooltip): the content is hover-revealed but may contain a
+  // link action, while the plain string path remains a non-interactive Tooltip.
   return (
     <HoverCard
       open={open}
@@ -67,7 +60,27 @@ function HeaderInfo({
         </button>
       </HoverCardTrigger>
       <HoverCardContent className="w-auto max-w-xs px-3 py-2 shadow-md">
-        {info.render({ close: () => setOpen(false) })}
+        <div className="flex flex-col gap-1 whitespace-normal text-left">
+          <p>{info.title}</p>
+          <p className="text-f1-foreground-inverse-secondary">
+            {info.description}
+          </p>
+          {info.link && (
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false)
+                info.link?.onClick()
+              }}
+              className={cn(
+                "mt-1 w-fit rounded-xs font-medium text-f1-foreground-inverse underline underline-offset-2 transition-colors hover:text-f1-foreground-inverse-secondary",
+                focusRing()
+              )}
+            >
+              {info.link.label}
+            </button>
+          )}
+        </div>
       </HoverCardContent>
     </HoverCard>
   )
@@ -111,8 +124,7 @@ interface TableHeadProps {
   /**
    * Optional header info. When provided, displays an info icon next to the
    * header content. Pass a string for a short text tooltip, or a
-   * {@link TableHeaderInfo} object to render your own content inside a
-   * hoverable card.
+   * {@link TableHeaderInfo} object for a structured hoverable card.
    */
   info?: string | TableHeaderInfo
 

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -2,6 +2,12 @@ import { AnimatePresence, motion } from "motion/react"
 
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { TableHead as TableHeadRoot } from "@/ui/table"
+import {
+  TooltipContent,
+  Tooltip as TooltipPrimitive,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/ui/tooltip"
 
 import { F0Icon, IconType } from "../../../components/F0Icon"
 import { ArrowDown, InfoCircleLine } from "../../../icons/app"
@@ -10,6 +16,77 @@ import { cn, focusRing } from "../../../lib/utils"
 import { getColWidth } from "../utils/colWidth"
 import { ColumnWidth } from "../utils/sizes"
 import { useTable } from "../utils/TableContext"
+
+/**
+ * Rich header info shown in a hoverable card next to a column header. Unlike
+ * the plain-string `info` (which renders a short text tooltip), this supports a
+ * title, a muted meta line, a description, and an optional action — e.g. a
+ * "Learn more" link that opens a related detail surface.
+ */
+export type TableHeaderInfo = {
+  /** Bold title shown at the top of the card. Defaults to the column label. */
+  title?: string
+  /** Muted secondary line, e.g. "Per employee · Per year · In EUR". */
+  meta?: string
+  /** Description paragraph explaining what the column represents. */
+  description: string
+  /** Optional interactive action rendered as a link at the bottom of the card. */
+  action?: {
+    label: string
+    onClick: () => void
+  }
+}
+
+function HeaderInfoCard({ info }: { info: TableHeaderInfo }) {
+  return (
+    <div className="flex max-w-xs flex-col gap-1 whitespace-normal p-1 text-left">
+      {info.title && <p className="font-semibold">{info.title}</p>}
+      {info.meta && <p className="text-f1-foreground-secondary">{info.meta}</p>}
+      <p className="font-normal text-f1-foreground-secondary">
+        {info.description}
+      </p>
+      {info.action && (
+        <button
+          type="button"
+          onClick={info.action.onClick}
+          className={cn(
+            "mt-1 w-fit rounded-xs font-medium text-f1-foreground underline underline-offset-2",
+            focusRing()
+          )}
+        >
+          {info.action.label}
+        </button>
+      )}
+    </div>
+  )
+}
+
+function HeaderInfo({
+  info,
+  infoIcon,
+}: {
+  info: TableHeaderInfo
+  infoIcon: IconType
+}) {
+  return (
+    <TooltipProvider delayDuration={300} disableHoverableContent={false}>
+      <TooltipPrimitive>
+        <TooltipTrigger
+          className={cn(
+            "flex h-5 w-5 items-center justify-center rounded-xs text-f1-foreground-secondary",
+            focusRing()
+          )}
+          aria-label={info.title ?? info.description}
+        >
+          <F0Icon icon={infoIcon} size="sm" />
+        </TooltipTrigger>
+        <TooltipContent variant="surface" className="pointer-events-auto">
+          <HeaderInfoCard info={info} />
+        </TooltipContent>
+      </TooltipPrimitive>
+    </TooltipProvider>
+  )
+}
 
 interface TableHeadProps {
   children: React.ReactNode
@@ -47,10 +124,12 @@ interface TableHeadProps {
   onSortClick?: () => void
 
   /**
-   * Optional tooltip text. When provided, displays an info icon next to the header content
-   * that shows this text in a tooltip when hovered.
+   * Optional header info. When provided, displays an info icon next to the
+   * header content. Pass a string for a short text tooltip, or a
+   * {@link TableHeaderInfo} object for a richer hoverable card (title, meta
+   * line, description, and an optional action such as a "Learn more" link).
    */
-  info?: string
+  info?: string | TableHeaderInfo
 
   /**
    * Icon to display when info is provided.
@@ -129,17 +208,21 @@ export function TableHead({
           <div className="flex items-center">
             {info && (
               <div className="flex h-6 w-6 items-center justify-center text-f1-foreground-secondary">
-                <Tooltip label={info}>
-                  <div
-                    className={cn(
-                      "flex h-5 w-5 items-center justify-center rounded-xs",
-                      focusRing()
-                    )}
-                    tabIndex={0}
-                  >
-                    <F0Icon icon={infoIcon} size="sm" />
-                  </div>
-                </Tooltip>
+                {typeof info === "string" ? (
+                  <Tooltip label={info}>
+                    <div
+                      className={cn(
+                        "flex h-5 w-5 items-center justify-center rounded-xs",
+                        focusRing()
+                      )}
+                      tabIndex={0}
+                    >
+                      <F0Icon icon={infoIcon} size="sm" />
+                    </div>
+                  </Tooltip>
+                ) : (
+                  <HeaderInfo info={info} infoIcon={infoIcon} />
+                )}
               </div>
             )}
             {onSortClick && (

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -1,4 +1,5 @@
 import { AnimatePresence, motion } from "motion/react"
+import { useState } from "react"
 
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { TableHead as TableHeadRoot } from "@/ui/table"
@@ -37,7 +38,13 @@ export type TableHeaderInfo = {
   }
 }
 
-function HeaderInfoCard({ info }: { info: TableHeaderInfo }) {
+function HeaderInfoCard({
+  info,
+  onAction,
+}: {
+  info: TableHeaderInfo
+  onAction?: () => void
+}) {
   return (
     <div className="flex max-w-xs flex-col gap-1 whitespace-normal p-1 text-left">
       {info.title && <p className="font-semibold">{info.title}</p>}
@@ -48,7 +55,7 @@ function HeaderInfoCard({ info }: { info: TableHeaderInfo }) {
       {info.action && (
         <button
           type="button"
-          onClick={info.action.onClick}
+          onClick={onAction ?? info.action.onClick}
           className={cn(
             "mt-1 w-fit rounded-xs font-medium text-f1-foreground underline underline-offset-2",
             focusRing()
@@ -68,9 +75,12 @@ function HeaderInfo({
   info: TableHeaderInfo
   infoIcon: IconType
 }) {
+  const [open, setOpen] = useState(false)
+  const { action } = info
+
   return (
     <TooltipProvider delayDuration={300} disableHoverableContent={false}>
-      <TooltipPrimitive>
+      <TooltipPrimitive open={open} onOpenChange={setOpen}>
         <TooltipTrigger
           className={cn(
             "flex h-5 w-5 items-center justify-center rounded-xs text-f1-foreground-secondary",
@@ -81,7 +91,19 @@ function HeaderInfo({
           <F0Icon icon={infoIcon} size="sm" />
         </TooltipTrigger>
         <TooltipContent variant="surface" className="pointer-events-auto">
-          <HeaderInfoCard info={info} />
+          <HeaderInfoCard
+            info={info}
+            // Dismiss the tooltip immediately when the action fires so it never
+            // lingers over the surface the action opens (e.g. a dialog).
+            onAction={
+              action
+                ? () => {
+                    setOpen(false)
+                    action.onClick()
+                  }
+                : undefined
+            }
+          />
         </TooltipContent>
       </TooltipPrimitive>
     </TooltipProvider>

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -15,69 +15,40 @@ import { useTable } from "../utils/TableContext"
 
 /**
  * Rich header info shown in a hoverable card next to a column header. Unlike
- * the plain-string `info` (which renders a short text tooltip), this supports a
- * title, a muted meta line, a description, and an optional action — e.g. a
- * "Learn more" link that opens a related detail surface.
+ * the plain-string `info` (which renders a short text tooltip), this lets the
+ * consumer render arbitrary content inside the card: f0 owns the hover surface
+ * and the dismiss mechanism, the consumer owns the body.
  */
 export type TableHeaderInfo = {
-  /** Bold title shown at the top of the card. Defaults to the column label. */
-  title?: string
-  /** Muted secondary line, e.g. "Per employee · Per year · In EUR". */
-  meta?: string
-  /** Description paragraph explaining what the column represents. */
-  description: string
-  /** Optional interactive action rendered as a link at the bottom of the card. */
-  action?: {
-    label: string
-    onClick: () => void
-  }
-}
-
-function HeaderInfoCard({
-  info,
-  onAction,
-}: {
-  info: TableHeaderInfo
-  onAction?: () => void
-}) {
-  return (
-    <div className="flex max-w-xs flex-col gap-1 whitespace-normal p-1 text-left">
-      {info.title && <p className="font-semibold">{info.title}</p>}
-      {info.meta && <p className="text-f1-foreground-secondary">{info.meta}</p>}
-      <p className="font-normal text-f1-foreground-secondary">
-        {info.description}
-      </p>
-      {info.action && (
-        <button
-          type="button"
-          onClick={onAction ?? info.action.onClick}
-          className={cn(
-            "mt-1 w-fit rounded-xs font-medium text-f1-foreground underline underline-offset-2",
-            focusRing()
-          )}
-        >
-          {info.action.label}
-        </button>
-      )}
-    </div>
-  )
+  /**
+   * Renders the card body. Receives `close` to dismiss the card — call it when
+   * the content navigates away or opens another surface (e.g. a "Learn more"
+   * dialog), so the card never lingers over what it opened.
+   */
+  render: (api: { close: () => void }) => React.ReactNode
+  /**
+   * Accessible name for the info-icon trigger. Defaults to the column label
+   * when the header's children are a string.
+   */
+  label?: string
 }
 
 function HeaderInfo({
   info,
   infoIcon,
+  label,
 }: {
   info: TableHeaderInfo
   infoIcon: IconType
+  label?: string
 }) {
   const [open, setOpen] = useState(false)
-  const { action } = info
 
-  // Rich header info uses a HoverCard, not a Tooltip: the surface is
-  // hover-revealed but holds interactive content (the optional action), which
-  // is what HoverCard is for — Radix Tooltip is a non-interactive label
-  // primitive. We override HoverCard's dark default to a light surface per-call
-  // (same approach as `TagCounter`) rather than adding a primitive variant.
+  // f0 owns the hover surface (light card chrome, positioning, the info-icon
+  // trigger) and the dismiss mechanism; the consumer owns the body via
+  // `info.render`. A HoverCard (not a Tooltip) because the content is
+  // hover-revealed but may be interactive. The dark default surface is
+  // overridden to a light one per-call, matching `TagCounter`.
   return (
     <HoverCard
       open={open}
@@ -92,25 +63,13 @@ function HeaderInfo({
             "flex h-5 w-5 items-center justify-center rounded-xs text-f1-foreground-secondary",
             focusRing()
           )}
-          aria-label={info.title ?? info.description}
+          aria-label={info.label ?? label}
         >
           <F0Icon icon={infoIcon} size="sm" />
         </button>
       </HoverCardTrigger>
-      <HoverCardContent className="w-auto bg-f1-background px-2 py-1.5 text-f1-foreground shadow-md ring-1 ring-f1-border-secondary">
-        <HeaderInfoCard
-          info={info}
-          // Dismiss the card immediately when the action fires so it never
-          // lingers over the surface the action opens (e.g. a dialog).
-          onAction={
-            action
-              ? () => {
-                  setOpen(false)
-                  action.onClick()
-                }
-              : undefined
-          }
-        />
+      <HoverCardContent className="w-auto max-w-xs bg-f1-background px-2 py-1.5 text-f1-foreground shadow-md ring-1 ring-f1-border-secondary">
+        {info.render({ close: () => setOpen(false) })}
       </HoverCardContent>
     </HoverCard>
   )
@@ -154,8 +113,8 @@ interface TableHeadProps {
   /**
    * Optional header info. When provided, displays an info icon next to the
    * header content. Pass a string for a short text tooltip, or a
-   * {@link TableHeaderInfo} object for a richer hoverable card (title, meta
-   * line, description, and an optional action such as a "Learn more" link).
+   * {@link TableHeaderInfo} object to render your own content inside a
+   * hoverable card.
    */
   info?: string | TableHeaderInfo
 
@@ -249,7 +208,11 @@ export function TableHead({
                     </div>
                   </Tooltip>
                 ) : (
-                  <HeaderInfo info={info} infoIcon={infoIcon} />
+                  <HeaderInfo
+                    info={info}
+                    infoIcon={infoIcon}
+                    label={typeof children === "string" ? children : undefined}
+                  />
                 )}
               </div>
             )}

--- a/packages/react/src/experimental/OneTable/index.stories.tsx
+++ b/packages/react/src/experimental/OneTable/index.stories.tsx
@@ -246,6 +246,9 @@ export const InfoHeader: Story = {
   ),
 }
 
+// `info` only provides the hover surface — the consumer composes the card body
+// (here: title, muted meta line, description, and a "Learn more" action that
+// uses `close` to dismiss the card before opening another surface).
 export const RichInfoHeader: Story = {
   render: () => (
     <OneTable>
@@ -254,22 +257,43 @@ export const RichInfoHeader: Story = {
           <TableHead>Name</TableHead>
           <TableHead
             info={{
-              title: "Average base salary",
-              meta: "Per employee · Per year · In EUR",
-              description:
-                "Mean base salary of active full-time and part-time employees. Not FTE-adjusted.",
-              action: {
-                label: "Learn more",
-                onClick: () => alert("Open data catalog on this field"),
-              },
+              label: "About base salary",
+              render: ({ close }) => (
+                <div className="flex max-w-xs flex-col gap-1 whitespace-normal p-1 text-left">
+                  <p className="font-semibold">Average base salary</p>
+                  <p className="text-f1-foreground-secondary">
+                    Per employee · Per year · In EUR
+                  </p>
+                  <p className="font-normal text-f1-foreground-secondary">
+                    Mean base salary of active full-time and part-time
+                    employees. Not FTE-adjusted.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      close()
+                      alert("Open data catalog on this field")
+                    }}
+                    className="mt-1 w-fit font-medium underline underline-offset-2"
+                  >
+                    Learn more
+                  </button>
+                </div>
+              ),
             }}
           >
             Base salary
           </TableHead>
           <TableHead
             info={{
-              title: "Role",
-              description: "Access level assigned to the employee account.",
+              render: () => (
+                <div className="flex max-w-xs flex-col gap-1 whitespace-normal p-1 text-left">
+                  <p className="font-semibold">Role</p>
+                  <p className="font-normal text-f1-foreground-secondary">
+                    Access level assigned to the employee account.
+                  </p>
+                </div>
+              ),
             }}
           >
             Role

--- a/packages/react/src/experimental/OneTable/index.stories.tsx
+++ b/packages/react/src/experimental/OneTable/index.stories.tsx
@@ -246,6 +246,49 @@ export const InfoHeader: Story = {
   ),
 }
 
+export const RichInfoHeader: Story = {
+  render: () => (
+    <OneTable>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead
+            info={{
+              title: "Average base salary",
+              meta: "Per employee · Per year · In EUR",
+              description:
+                "Mean base salary of active full-time and part-time employees. Not FTE-adjusted.",
+              action: {
+                label: "Learn more",
+                onClick: () => alert("Open data catalog on this field"),
+              },
+            }}
+          >
+            Base salary
+          </TableHead>
+          <TableHead
+            info={{
+              title: "Role",
+              description: "Access level assigned to the employee account.",
+            }}
+          >
+            Role
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {sampleData.map((row) => (
+          <TableRow key={row.id}>
+            <TableCell>{row.name}</TableCell>
+            <TableCell>€42,000</TableCell>
+            <TableCell>{row.role}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </OneTable>
+  ),
+}
+
 type SortState = "asc" | "desc" | undefined
 type SortColumn = "name" | "email" | "role"
 

--- a/packages/react/src/experimental/OneTable/index.stories.tsx
+++ b/packages/react/src/experimental/OneTable/index.stories.tsx
@@ -246,8 +246,6 @@ export const InfoHeader: Story = {
   ),
 }
 
-// `info` only provides the (dark) hover surface — the consumer composes the
-// body here, using inverse text tokens and `close` to dismiss the card.
 export const RichInfoHeader: Story = {
   render: () => (
     <OneTable>
@@ -257,35 +255,20 @@ export const RichInfoHeader: Story = {
           <TableHead
             info={{
               label: "About base salary",
-              render: ({ close }) => (
-                <div className="flex flex-col gap-1 whitespace-normal text-left">
-                  <p>Annual base salary, in euros. Not FTE-adjusted.</p>
-                  <p className="text-f1-foreground-inverse-secondary">
-                    Per employee · Per year · In Euro
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      close()
-                      alert("Open data catalog on this field")
-                    }}
-                    className="mt-1 w-fit rounded-xs font-medium text-f1-foreground-inverse underline underline-offset-2 transition-colors hover:text-f1-foreground-inverse-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-special-ring"
-                  >
-                    Learn more
-                  </button>
-                </div>
-              ),
+              title: "Annual base salary",
+              description: "Per employee · Per year · In Euro",
+              link: {
+                label: "Learn more",
+                onClick: () => alert("Open data catalog on this field"),
+              },
             }}
           >
             Base salary
           </TableHead>
           <TableHead
             info={{
-              render: () => (
-                <div className="flex flex-col gap-1 whitespace-normal text-left">
-                  <p>Access level assigned to the employee account.</p>
-                </div>
-              ),
+              title: "Access level",
+              description: "Access level assigned to the employee account.",
             }}
           >
             Role

--- a/packages/react/src/experimental/OneTable/index.stories.tsx
+++ b/packages/react/src/experimental/OneTable/index.stories.tsx
@@ -246,10 +246,8 @@ export const InfoHeader: Story = {
   ),
 }
 
-// `info` only provides the hover surface (a dark/inverse card) — the consumer
-// composes the body (here: a description, a muted meta line, and a "Learn more"
-// action that uses `close` to dismiss the card before opening another surface).
-// Content uses inverse text tokens since the surface is dark.
+// `info` only provides the (dark) hover surface — the consumer composes the
+// body here, using inverse text tokens and `close` to dismiss the card.
 export const RichInfoHeader: Story = {
   render: () => (
     <OneTable>

--- a/packages/react/src/experimental/OneTable/index.stories.tsx
+++ b/packages/react/src/experimental/OneTable/index.stories.tsx
@@ -246,9 +246,10 @@ export const InfoHeader: Story = {
   ),
 }
 
-// `info` only provides the hover surface — the consumer composes the card body
-// (here: title, muted meta line, description, and a "Learn more" action that
-// uses `close` to dismiss the card before opening another surface).
+// `info` only provides the hover surface (a dark/inverse card) — the consumer
+// composes the body (here: a description, a muted meta line, and a "Learn more"
+// action that uses `close` to dismiss the card before opening another surface).
+// Content uses inverse text tokens since the surface is dark.
 export const RichInfoHeader: Story = {
   render: () => (
     <OneTable>
@@ -259,14 +260,10 @@ export const RichInfoHeader: Story = {
             info={{
               label: "About base salary",
               render: ({ close }) => (
-                <div className="flex max-w-xs flex-col gap-1 whitespace-normal p-1 text-left">
-                  <p className="font-semibold">Average base salary</p>
-                  <p className="text-f1-foreground-secondary">
-                    Per employee · Per year · In EUR
-                  </p>
-                  <p className="font-normal text-f1-foreground-secondary">
-                    Mean base salary of active full-time and part-time
-                    employees. Not FTE-adjusted.
+                <div className="flex flex-col gap-1 whitespace-normal text-left">
+                  <p>Annual base salary, in euros. Not FTE-adjusted.</p>
+                  <p className="text-f1-foreground-inverse-secondary">
+                    Per employee · Per year · In Euro
                   </p>
                   <button
                     type="button"
@@ -287,11 +284,8 @@ export const RichInfoHeader: Story = {
           <TableHead
             info={{
               render: () => (
-                <div className="flex max-w-xs flex-col gap-1 whitespace-normal p-1 text-left">
-                  <p className="font-semibold">Role</p>
-                  <p className="font-normal text-f1-foreground-secondary">
-                    Access level assigned to the employee account.
-                  </p>
+                <div className="flex flex-col gap-1 whitespace-normal text-left">
+                  <p>Access level assigned to the employee account.</p>
                 </div>
               ),
             }}

--- a/packages/react/src/experimental/OneTable/index.stories.tsx
+++ b/packages/react/src/experimental/OneTable/index.stories.tsx
@@ -269,7 +269,7 @@ export const RichInfoHeader: Story = {
                       close()
                       alert("Open data catalog on this field")
                     }}
-                    className="mt-1 w-fit font-medium underline underline-offset-2"
+                    className="mt-1 w-fit rounded-xs font-medium text-f1-foreground-inverse underline underline-offset-2 transition-colors hover:text-f1-foreground-inverse-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-special-ring"
                   >
                     Learn more
                   </button>

--- a/packages/react/src/patterns/OneDataCollection/property-render.ts
+++ b/packages/react/src/patterns/OneDataCollection/property-render.ts
@@ -21,9 +21,8 @@ export type PropertyDefinition<T> = {
 
   /**
    * Optional header info. Pass a string for a short text tooltip, or a
-   * {@link TableHeaderInfo} object for a richer hoverable card (title, meta
-   * line, description, and an optional action). Only rendered by the table
-   * visualization's column headers.
+   * {@link TableHeaderInfo} object to render your own content inside a
+   * hoverable card. Only rendered by the table visualization's column headers.
    */
   info?: string | TableHeaderInfo
 

--- a/packages/react/src/patterns/OneDataCollection/property-render.ts
+++ b/packages/react/src/patterns/OneDataCollection/property-render.ts
@@ -8,7 +8,11 @@ import {
 import { RecordType } from "@/hooks/datasource"
 import { TranslationsType } from "@/lib/providers/i18n/i18n-provider-defaults"
 
+import type { TableHeaderInfo } from "@/experimental/OneTable"
+
 import { VisualizationType } from "./visualizations/collection/types"
+
+export type { TableHeaderInfo }
 
 export type RendererDefinition = ValueDisplayRendererDefinition
 
@@ -16,10 +20,12 @@ export type PropertyDefinition<T> = {
   label: string
 
   /**
-   * Optional tooltip text. When provided, displays an info icon next to the header content
-   * that shows this text in a tooltip when hovered.
+   * Optional header info. Pass a string for a short text tooltip, or a
+   * {@link TableHeaderInfo} object for a richer hoverable card (title, meta
+   * line, description, and an optional action). Only rendered by the table
+   * visualization's column headers.
    */
-  info?: string
+  info?: string | TableHeaderInfo
 
   /**
    * Function that extracts and formats the value from an item.

--- a/packages/react/src/patterns/OneDataCollection/property-render.ts
+++ b/packages/react/src/patterns/OneDataCollection/property-render.ts
@@ -21,8 +21,8 @@ export type PropertyDefinition<T> = {
 
   /**
    * Optional header info. Pass a string for a short text tooltip, or a
-   * {@link TableHeaderInfo} object to render your own content inside a
-   * hoverable card. Only rendered by the table visualization's column headers.
+   * {@link TableHeaderInfo} object for a structured hoverable card. Only
+   * rendered by the table visualization's column headers.
    */
   info?: string | TableHeaderInfo
 

--- a/packages/react/src/ui/tooltip.tsx
+++ b/packages/react/src/ui/tooltip.tsx
@@ -13,14 +13,26 @@ const TooltipTrigger = TooltipPrimitive.Trigger
 
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & {
+    /**
+     * Visual surface of the tooltip.
+     * - `default`: dark, inverse surface used for short text tooltips.
+     * - `surface`: light card surface (no theme inversion) for richer content
+     *   such as an info card with interactive elements.
+     * @default "default"
+     */
+    variant?: "default" | "surface"
+  }
+>(({ className, sideOffset = 4, variant = "default", ...props }, ref) => (
   <TooltipPrimitive.Portal>
     <TooltipPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded bg-f1-background border border-solid border-f1-border-secondary dark px-2 py-1.5 leading-tight text-f1-foreground-inverse animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:origin-top data-[side=top]:origin-bottom data-[side=left]:origin-right data-[side=right]:origin-left",
+        "z-50 overflow-hidden rounded bg-f1-background border border-solid border-f1-border-secondary px-2 py-1.5 leading-tight animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:origin-top data-[side=top]:origin-bottom data-[side=left]:origin-right data-[side=right]:origin-left",
+        variant === "default"
+          ? "dark text-f1-foreground-inverse"
+          : "text-f1-foreground shadow-md",
         "break-words",
         className
       )}

--- a/packages/react/src/ui/tooltip.tsx
+++ b/packages/react/src/ui/tooltip.tsx
@@ -13,26 +13,14 @@ const TooltipTrigger = TooltipPrimitive.Trigger
 
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & {
-    /**
-     * Visual surface of the tooltip.
-     * - `default`: dark, inverse surface used for short text tooltips.
-     * - `surface`: light card surface (no theme inversion) for richer content
-     *   such as an info card with interactive elements.
-     * @default "default"
-     */
-    variant?: "default" | "surface"
-  }
->(({ className, sideOffset = 4, variant = "default", ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
   <TooltipPrimitive.Portal>
     <TooltipPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded bg-f1-background border border-solid border-f1-border-secondary px-2 py-1.5 leading-tight animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:origin-top data-[side=top]:origin-bottom data-[side=left]:origin-right data-[side=right]:origin-left",
-        variant === "default"
-          ? "dark text-f1-foreground-inverse"
-          : "text-f1-foreground shadow-md",
+        "z-50 overflow-hidden rounded bg-f1-background border border-solid border-f1-border-secondary dark px-2 py-1.5 leading-tight text-f1-foreground-inverse animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:origin-top data-[side=top]:origin-bottom data-[side=left]:origin-right data-[side=right]:origin-left",
         "break-words",
         className
       )}


### PR DESCRIPTION
## Why

`OneTable` / `OneDataCollection` column headers expose `info` as a plain string, rendered as a short dark text tooltip. Catalog-backed columns need a richer header affordance with a title, description, and optional "Learn more" link, while keeping the design-system surface and content structure controlled by F0.

## What

`TableHead.info` and `PropertyDefinition.info` now accept `string | TableHeaderInfo`:

- `string` -> unchanged short text tooltip.
- `TableHeaderInfo` -> structured hoverable card rendered by F0.

```ts
type TableHeaderInfo = {
  title: string
  description: string
  link?: {
    label: string
    onClick: () => void
  }
  // Accessible name for the info icon. Defaults to the column label.
  label?: string
}
```

F0 owns the hover surface, content layout, inverse text styling, focus ring, and dismiss behavior. Consumers provide only the data/action fields.

## Why HoverCard

The card is hover-revealed but can contain an interactive link action, so it uses F0's `HoverCard`, not `Tooltip`. The legacy string `info` path still uses the existing non-interactive tooltip and remains backward compatible.

## Accessibility

- `label` controls the info icon accessible name; when omitted, string column labels are used.
- The link action is a real button with F0 focus-ring styling.
- Clicking the link closes the hover card before invoking the consumer action.

## Testing

- `pnpm --filter @factorialco/f0-react run format`
- `pnpm --filter @factorialco/f0-react run tsc`
- `pnpm --filter @factorialco/f0-react run lint`
- `pnpm run vitest --project=unit --reporter=dot src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx` from `packages/react`

## Consumer

Unblocks the Factorial AI Reports feature by allowing semantic dashboard columns to pass structured catalog metadata and a `Learn more` action. The Factorial PR should consume this structured object rather than a custom render callback.
