### PR TITLE
feat(OneDataCollection): support defaultSelected preset highlighted on load

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -27,6 +27,7 @@ import {
 import { SortingsDefinition } from "@/hooks/datasource/types/sortings.typings"
 import { DataError } from "@/hooks/datasource/useData"
 import { useLayout } from "@/layouts/LayoutProvider"
+import { DATA_COLLECTION_URL_PARAMS } from "@/lib/providers/datacollection/dataCollectionUrlParams"
 import { useI18n } from "@/lib/providers/i18n"
 import { useDebounceBoolean } from "@/lib/useDebounceBoolean"
 import { cn } from "@/lib/utils"
@@ -94,6 +95,31 @@ import { VisualizationRenderer } from "./visualizations/collection"
 
 const SUCCESS_DISMISS_MS = 1500
 const SHARE_COPIED_DISMISS_MS = 2000
+
+const coerceFilterLeavesToString = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(coerceFilterLeavesToString)
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, val]) => [
+        key,
+        coerceFilterLeavesToString(val),
+      ])
+    )
+  }
+  return value == null ? value : String(value)
+}
+
+const filtersMatchForDefaultPreset = (a: unknown, b: unknown): boolean =>
+  isEqual(coerceFilterLeavesToString(a), coerceFilterLeavesToString(b))
+
+const viewSnapshotsMatch = (
+  a: { filters?: unknown },
+  b: { filters?: unknown }
+): boolean =>
+  isEqual(
+    { ...a, filters: coerceFilterLeavesToString(a.filters) },
+    { ...b, filters: coerceFilterLeavesToString(b.filters) }
+  )
 
 /**
  * A component that renders a collection of data with filtering and visualization capabilities.
@@ -1065,11 +1091,12 @@ const OneDataCollectionComp = <
 
     if (!tracked.settled) {
       // Wait until the view first matches the preset before arming deselect.
-      if (isEqual(capturedState, tracked.snapshot)) tracked.settled = true
+      if (viewSnapshotsMatch(capturedState, tracked.snapshot))
+        tracked.settled = true
       return
     }
 
-    if (!isEqual(capturedState, tracked.snapshot)) {
+    if (!viewSnapshotsMatch(capturedState, tracked.snapshot)) {
       devSelectionRef.current = null
       preSelectionStateRef.current = null
       // Offer "Save view" after deselecting: the user diverged from a named view,
@@ -1363,6 +1390,32 @@ const OneDataCollectionComp = <
       setSessionBaseline(capturedState)
     }
   }, [storageReady, sessionBaseline, capturedState])
+
+  // On first load, highlight a `defaultSelected` preset whose filter is the boot
+  // filter — unless the URL (`dc_view`) or a restored marker already claimed the
+  // selection. Marker-only and once, so it never overrides the user.
+  const defaultPresetSelectionAppliedRef = useRef(false)
+  useEffect(() => {
+    if (defaultPresetSelectionAppliedRef.current || !storageReady) return
+    defaultPresetSelectionAppliedRef.current = true
+
+    if (selectedPresetId !== undefined) return
+    if (
+      typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).has(
+        DATA_COLLECTION_URL_PARAMS.preset
+      )
+    ) {
+      return
+    }
+
+    const defaultPreset = mergedPresets.find(
+      (preset) =>
+        preset.defaultSelected === true &&
+        filtersMatchForDefaultPreset(preset.filter ?? {}, activeCurrentFilters)
+    )
+    if (defaultPreset?.id) setSelectedPresetId(defaultPreset.id)
+  }, [storageReady, selectedPresetId, mergedPresets, activeCurrentFilters])
 
   // Two-way sync between the collection state and the URL query params. Enabled
   // by default for any collection (no `id` required); opt out with

--- a/packages/react/src/patterns/OneDataCollection/__tests__/presets.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/presets.test.tsx
@@ -13,7 +13,10 @@ import {
   DataCollectionStorage,
   DataCollectionStorageHandler,
 } from "@/lib/providers/datacollection/types"
-import type { PresetsDefinition } from "@/patterns/OneFilterPicker/types"
+import type {
+  FiltersState,
+  PresetsDefinition,
+} from "@/patterns/OneFilterPicker/types"
 
 import { useDataCollectionSource } from "../hooks/useDataCollectionSource"
 import {
@@ -929,5 +932,130 @@ describe("OneDataCollection - presets render resilience", () => {
       "[f0-react] FiltersPresets failed to render; hiding the presets row",
       expect.any(Error)
     )
+  })
+})
+
+const SELECTED_PRESET_CLASS = "bg-f1-background-selected-secondary"
+
+const presetChip = (label: string): HTMLElement | null =>
+  screen
+    .getAllByText(label)
+    .map((el) => el.closest("label"))
+    .find((el): el is HTMLLabelElement => el !== null) ?? null
+
+const qualifiedFilters = {
+  qualified: {
+    type: "in",
+    label: "Status",
+    options: {
+      options: [
+        { value: true, label: "Active" },
+        { value: false, label: "Rejected" },
+      ],
+    },
+  },
+} as const
+
+function DefaultSelectedHarness({
+  defaultSelectedKey,
+  bootFilter = { qualified: ["true"] },
+  urlSync = false,
+}: {
+  defaultSelectedKey: "active" | "rejected"
+  bootFilter?: unknown
+  urlSync?: boolean
+}) {
+  const presets: PresetsDefinition<typeof qualifiedFilters> = [
+    {
+      id: "active",
+      label: "Active",
+      filter: { qualified: [true] },
+      defaultSelected: defaultSelectedKey === "active",
+    },
+    {
+      id: "rejected",
+      label: "Rejected",
+      filter: { qualified: [false] },
+      defaultSelected: defaultSelectedKey === "rejected",
+    },
+  ]
+
+  const source = useDataCollectionSource({
+    filters: qualifiedFilters,
+    sortings,
+    grouping,
+    defaultFilters: bootFilter as FiltersState<typeof qualifiedFilters>,
+    dataAdapter: { fetchData: async () => ({ records }) },
+  })
+
+  return (
+    <OneDataCollection
+      id="default-selected-test/v1"
+      source={source}
+      visualizations={[
+        {
+          type: "table",
+          presets,
+          options: {
+            columns: [
+              {
+                label: "Name",
+                sorting: "name",
+                render: (item: Row) => item.name,
+              },
+            ],
+          },
+        },
+      ]}
+      disableUrlParams={!urlSync}
+    />
+  )
+}
+
+const renderDefaultSelected = (
+  props: Parameters<typeof DefaultSelectedHarness>[0]
+) => {
+  const { handler } = createStorageSpy()
+  return zeroRender(
+    <DataCollectionStorageProvider handler={handler}>
+      <DefaultSelectedHarness {...props} />
+    </DataCollectionStorageProvider>
+  )
+}
+
+describe("OneDataCollection - defaultSelected preset", () => {
+  it("selects the preset on load, matching a boolean preset filter against the serialized (string) boot filter", async () => {
+    renderDefaultSelected({ defaultSelectedKey: "active" })
+
+    await waitFor(() => expect(screen.getByText("John")).toBeInTheDocument())
+
+    await waitFor(() =>
+      expect(presetChip("Active")).toHaveClass(SELECTED_PRESET_CLASS)
+    )
+    expect(presetChip("Rejected")).not.toHaveClass(SELECTED_PRESET_CLASS)
+  })
+
+  it("does not select the preset when the boot filter differs", async () => {
+    renderDefaultSelected({
+      defaultSelectedKey: "active",
+      bootFilter: { qualified: ["false"] },
+    })
+
+    await waitFor(() => expect(screen.getByText("John")).toBeInTheDocument())
+
+    expect(presetChip("Active")).not.toHaveClass(SELECTED_PRESET_CLASS)
+    expect(presetChip("Rejected")).not.toHaveClass(SELECTED_PRESET_CLASS)
+  })
+
+  it("lets a URL view (dc_view) win over defaultSelected", async () => {
+    window.history.replaceState({}, "", "/?dc_view=rejected")
+    renderDefaultSelected({ defaultSelectedKey: "active", urlSync: true })
+
+    await waitFor(() => expect(screen.getByText("John")).toBeInTheDocument())
+
+    await waitFor(() =>
+      expect(presetChip("Rejected")).toHaveClass(SELECTED_PRESET_CLASS)
+    )
+    expect(presetChip("Active")).not.toHaveClass(SELECTED_PRESET_CLASS)
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/hooks/__tests__/usePerVisualizationFilters.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/__tests__/usePerVisualizationFilters.test.ts
@@ -219,8 +219,47 @@ describe("usePerVisualizationFilters", () => {
         })
       )
 
-      // Per-viz presets REPLACE source presets
-      expect(result.current.effectivePresets).toEqual(viewPresets)
+      // Per-viz presets REPLACE source presets, and capture their own
+      // visualization index so applying one doesn't snap back to the first view.
+      expect(result.current.effectivePresets).toEqual(
+        viewPresets.map((preset) => ({ ...preset, visualization: 0 }))
+      )
+    })
+
+    it("captures the visualization index on per-view presets that don't declare one", () => {
+      const sourceSetCurrentFilters = vi.fn()
+      const viewPresets = [
+        {
+          label: "Active",
+          filter: { department: ["Engineering"] as string[] },
+        },
+        {
+          label: "Pinned",
+          filter: { department: ["Marketing"] as string[] },
+          visualization: 0,
+        },
+      ]
+
+      const { result } = renderHook(() =>
+        usePerVisualizationFilters<AllFilters>({
+          sourceFilters: allFilters,
+          sourcePresets: undefined,
+          sourceCurrentFilters: {},
+          sourceSetCurrentFilters,
+          visualizations: [
+            { type: "table", options: {} },
+            { type: "card", options: {}, presets: viewPresets },
+          ],
+          currentVisualization: 1,
+        })
+      )
+
+      // The preset without a declared visualization gets the active index (1);
+      // one that already declares a visualization is left untouched.
+      expect(result.current.effectivePresets).toEqual([
+        { ...viewPresets[0], visualization: 1 },
+        viewPresets[1],
+      ])
     })
 
     it("should filter global presets to only include those relevant to the active view's filters", () => {

--- a/packages/react/src/patterns/OneDataCollection/hooks/usePerVisualizationFilters.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/usePerVisualizationFilters.ts
@@ -259,7 +259,11 @@ export const usePerVisualizationFilters = <Filters extends FiltersDefinition>({
     const vizPresets = viz?.presets
 
     if (vizPresets) {
-      return vizPresets
+      return vizPresets.map((preset) =>
+        preset.visualization === undefined
+          ? { ...preset, visualization: currentVisualization }
+          : preset
+      )
     }
 
     const effectiveFilterKeys = effectiveFilters

--- a/packages/react/src/patterns/OneFilterPicker/types.ts
+++ b/packages/react/src/patterns/OneFilterPicker/types.ts
@@ -142,6 +142,7 @@ export type PresetDefinition<Filters extends FiltersDefinition> = {
   itemsCount?: (
     filters: FiltersState<Filters>
   ) => Promise<number | undefined> | number | undefined
+  defaultSelected?: boolean
 }
 
 export type PresetsDefinition<Filters extends FiltersDefinition> =


### PR DESCRIPTION
## Changes

- **New `defaultSelected` flag on presets.** On first load, the flagged preset
  is selected when its filter equals the boot filter and nothing else has
  claimed the selection (no `dc_view` URL param, no restored marker). Closes the
  "filter applied but no chip highlighted" gap for collections that boot with a
  default filter. Marker-only and runs once, so it never overrides the user.
- **Serialization-tolerant filter matching.** Filter values round-trip through
  URL/storage as strings, so a preset's boolean `true` and the restored `"true"`
  must compare equal. The default-selection match and the existing
  settle/deselect comparison now coerce leaf values before comparing — without
  this a selected preset deselects the moment its values serialize.
- **Per-visualization presets capture their visualization index.** Previously
  they defaulted to index 0, so applying a preset from a non-default view (e.g.
  a kanban) snapped back to the first visualization and never settled as
  selected.
