### PR TITLE
feat(F0SegmentedBar): add segmented score/rating bar

### DIFF
--- a/packages/react/src/experimental/F0SegmentedBar/F0SegmentedBar.tsx
+++ b/packages/react/src/experimental/F0SegmentedBar/F0SegmentedBar.tsx
@@ -26,13 +26,13 @@ const F0SegmentedBarBase = forwardRef<HTMLDivElement, F0SegmentedBarProps>(
       <div
         ref={ref}
         role="progressbar"
-        aria-label={label ?? i18n.t("segmentedBar.label")}
+        aria-label={label}
         aria-valuemin={0}
         aria-valuemax={segmentCount}
         aria-valuenow={filled}
-        aria-valuetext={i18n.t("segmentedBar.valueText", {
-          value: filled,
-          max: segmentCount,
+        aria-valuetext={i18n.t("audioPlayer.position", {
+          current: filled,
+          total: segmentCount,
         })}
         className={cn("flex h-2 w-full gap-1")}
       >

--- a/packages/react/src/experimental/F0SegmentedBar/F0SegmentedBar.tsx
+++ b/packages/react/src/experimental/F0SegmentedBar/F0SegmentedBar.tsx
@@ -1,0 +1,61 @@
+import { forwardRef } from "react"
+
+import { getColor } from "@/kits/Charts/utils/colors"
+import { withDataTestId } from "@/lib/data-testid"
+import { experimentalComponent } from "@/lib/experimental"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+
+import { F0SegmentedBarProps } from "./types"
+
+export type { F0SegmentedBarProps, SegmentColorToken } from "./types"
+
+const F0SegmentedBarBase = forwardRef<HTMLDivElement, F0SegmentedBarProps>(
+  ({ value, max, color = "categorical-1", label }, ref) => {
+    const i18n = useI18n()
+
+    const segmentCount = Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0
+    const filled = Number.isFinite(value)
+      ? Math.max(0, Math.min(Math.floor(value), segmentCount))
+      : 0
+    const segments = Array.from({ length: segmentCount }, (_, i) => i < filled)
+
+    const filledColor = getColor(color)
+
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-label={label ?? i18n.t("segmentedBar.label")}
+        aria-valuemin={0}
+        aria-valuemax={segmentCount}
+        aria-valuenow={filled}
+        aria-valuetext={i18n.t("segmentedBar.valueText", {
+          value: filled,
+          max: segmentCount,
+        })}
+        className={cn("flex h-2 w-full gap-1")}
+      >
+        {segments.map((active, i) => (
+          <div
+            key={i}
+            className={cn(
+              "flex-1 rounded-full bg-f1-background-secondary",
+              "transition-all duration-300 ease-in-out motion-reduce:transition-none"
+            )}
+            style={active ? { backgroundColor: filledColor } : undefined}
+          />
+        ))}
+      </div>
+    )
+  }
+)
+
+F0SegmentedBarBase.displayName = "F0SegmentedBar"
+
+/**
+ * @experimental This is an experimental component, use it at your own risk.
+ */
+export const F0SegmentedBar = withDataTestId(
+  experimentalComponent("F0SegmentedBar", F0SegmentedBarBase)
+)

--- a/packages/react/src/experimental/F0SegmentedBar/__stories__/F0SegmentedBar.mdx
+++ b/packages/react/src/experimental/F0SegmentedBar/__stories__/F0SegmentedBar.mdx
@@ -185,7 +185,7 @@ configurations.
 
 - Decide the colour on the consumer side by mapping the score to a token; the component performs no score → colour logic.
 - Keep `max` small and constant within a given list so bars stay comparable.
-- Pass a `label` (e.g. the competency name) so the bar is self-describing for assistive technology.
+- Pass a `label` (e.g. the competency name) — it is required so the bar is always self-describing for assistive technology.
 
 ## Content Best Practices
 
@@ -213,8 +213,8 @@ configurations.
 
 - Uses `role="progressbar"` with `aria-valuemin`, `aria-valuemax` and `aria-valuenow` reflecting the clamped score.
 - `aria-valuetext` announces `"{value} of {max}"` so screen readers read the rating rather than a raw number.
-- `aria-label` is set from `label`, falling back to a translated generic "Segmented bar" when no label is given, so the bar always has an accessible name.
-- All component-owned strings (`aria-valuetext`, the fallback label) are resolved through `useI18n()`.
+- `aria-label` is set from the required `label`, so the bar always has an accessible name.
+- `aria-valuetext` is resolved through `useI18n()`, reusing the shared `audioPlayer.position` (`"{{current}} of {{total}}"`) string.
 
 ---
 
@@ -286,14 +286,12 @@ import { F0SegmentedBar } from "@factorialco/f0-react"
       </tr>
       <tr>
         <td>
-          <code>label</code>
+          <code>label</code> <span className="text-red-500">*</span>
         </td>
         <td>
           <code>string</code>
         </td>
-        <td>
-          <code>"Segmented bar"</code>
-        </td>
+        <td>-</td>
         <td>
           Accessible label (e.g. the competency name). Sets{" "}
           <code>aria-label</code>.

--- a/packages/react/src/experimental/F0SegmentedBar/__stories__/F0SegmentedBar.mdx
+++ b/packages/react/src/experimental/F0SegmentedBar/__stories__/F0SegmentedBar.mdx
@@ -1,0 +1,355 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import * as Stories from "./F0SegmentedBar.stories"
+
+<Meta of={Stories} />
+
+# F0SegmentedBar
+
+Displays a value as a discrete, segmented bar: it fills `value` segments out of
+`max` in a consumer-chosen design-system colour, rendering the remaining
+segments as a neutral track. Useful for short ordinal scales such as ratings or
+competency levels.
+
+---
+
+# Overview
+
+## Purpose
+
+- Represents a rating on a small, fixed scale (e.g. bad / normal / great) at a glance.
+- Encodes the level through a single colour while keeping the scale size visible.
+- Provides a measure-toward-a-maximum semantic via the `progressbar` role.
+- Keeps colour and labelling decisions with the consumer, so the same primitive serves many modules.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Element</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Required</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>Track</code>
+        </td>
+        <td>The full-width container holding all segments.</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Filled segment</code>
+        </td>
+        <td>
+          One of the first <code>value</code> segments, painted in the chosen
+          colour token.
+        </td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Empty segment</code>
+        </td>
+        <td>
+          A remaining segment shown as the secondary-background track colour.
+        </td>
+        <td>No</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Variants
+
+The bar has no built-in visual variants — its appearance is driven entirely by
+`value`, `max` and the `color` token. The examples below show the range of
+configurations.
+
+### Rating scale (consumer-mapped colour)
+
+<Canvas of={Stories.RatingScale} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Configuration</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">When to use</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>max=3</code>
+        </td>
+        <td>Three-point scale (e.g. bad / normal / great).</td>
+        <td>Short qualitative ratings such as competency levels.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>max=5</code>
+        </td>
+        <td>Five-point scale.</td>
+        <td>Finer-grained ratings while keeping discrete steps.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Five-point scale
+
+<Canvas of={Stories.FivePointScale} />
+
+## States
+
+<Canvas of={Stories.Empty} />
+<Canvas of={Stories.Full} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">State</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Visual indicator</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>Empty</code>
+        </td>
+        <td>
+          <code>value=0</code> — no segments filled.
+        </td>
+        <td>All segments use the track colour.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Partial</code>
+        </td>
+        <td>
+          <code>0 &lt; value &lt; max</code>.
+        </td>
+        <td>Leading segments coloured, the rest as track.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Full</code>
+        </td>
+        <td>
+          <code>value=max</code> — every segment filled.
+        </td>
+        <td>All segments use the chosen colour token.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Clamped</code>
+        </td>
+        <td>
+          <code>value &gt; max</code> or <code>value &lt; 0</code>.
+        </td>
+        <td>Renders as Full / Empty respectively; never overflows.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+# Guidelines
+
+## Design Best Practices
+
+### When to use
+
+- To show a rating on a small, fixed ordinal scale where the maximum is meaningful.
+- When the level should read at a glance through colour (e.g. red → low, orange → mid, green → high).
+- For repeated rows of comparable scores, such as a list of competencies.
+
+### When NOT to use
+
+- For a continuous percentage toward a goal: use `Progress` instead.
+- For a part-to-whole breakdown of categories (e.g. gender or department split): use the `categoryBar` value-display cell instead.
+- For a single numeric stat with no scale: use `F0BigNumber` instead.
+
+### How to use
+
+- Decide the colour on the consumer side by mapping the score to a token; the component performs no score → colour logic.
+- Keep `max` small and constant within a given list so bars stay comparable.
+- Pass a `label` (e.g. the competency name) so the bar is self-describing for assistive technology.
+
+## Content Best Practices
+
+- The component renders only the bar. Render the name, any "Required" tag and the description yourself, next to it.
+- Use `label` for the same human-readable name shown beside the bar, not a redundant phrase like "segmented bar".
+
+<DoDonts
+  do={{
+    description:
+      "Map each rating to a meaningful colour token on the consumer side (e.g. negative/neutral/positive) and pass the competency name as the label.",
+  }}
+  dont={{
+    description:
+      "Hard-code an arbitrary categorical colour unrelated to the level, or leave the bar unlabelled inside a list of scores.",
+  }}
+/>
+
+## Layout
+
+- The bar fills the full width of its container (`w-full`); constrain it with the parent.
+- Segments are equal width (`flex-1`) with a small fixed gap and fully rounded (pill) ends; height is fixed at `h-2`.
+- Fill changes animate with a short ease-in-out transition.
+
+## Accessibility
+
+- Uses `role="progressbar"` with `aria-valuemin`, `aria-valuemax` and `aria-valuenow` reflecting the clamped score.
+- `aria-valuetext` announces `"{value} of {max}"` so screen readers read the rating rather than a raw number.
+- `aria-label` is set from `label`, falling back to a translated generic "Segmented bar" when no label is given, so the bar always has an accessible name.
+- All component-owned strings (`aria-valuetext`, the fallback label) are resolved through `useI18n()`.
+
+---
+
+# Code
+
+## Import
+
+```tsx
+import { F0SegmentedBar } from "@factorialco/f0-react"
+```
+
+## Props
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+### Props Reference
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>value</code> <span className="text-red-500">*</span>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>-</td>
+        <td>Number of filled segments (the rating). Clamped to [0, max].</td>
+      </tr>
+      <tr>
+        <td>
+          <code>max</code> <span className="text-red-500">*</span>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>-</td>
+        <td>
+          Total number of segments (the scale size). Values ≤ 0 render no
+          segments.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>color</code>
+        </td>
+        <td>
+          <code>SegmentColorToken</code>
+        </td>
+        <td>
+          <code>"categorical-1"</code>
+        </td>
+        <td>
+          Colour token for the filled segments. One of{" "}
+          <code>categorical-1..8</code>, <code>feedback-positive</code>,{" "}
+          <code>feedback-neutral</code>, <code>feedback-negative</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>label</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>
+          <code>"Segmented bar"</code>
+        </td>
+        <td>
+          Accessible label (e.g. the competency name). Sets{" "}
+          <code>aria-label</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>dataTestId</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>-</td>
+        <td>
+          Test identifier forwarded by <code>withDataTestId</code>.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+# Examples
+
+## Basic usage
+
+<Canvas of={Stories.Default} />
+
+```tsx
+<F0SegmentedBar value={2} max={3} />
+```
+
+## Consumer-mapped rating scale
+
+<Canvas of={Stories.RatingScale} />
+
+```tsx
+<F0SegmentedBar value={1} max={3} color="feedback-negative" label="UX Design" />
+<F0SegmentedBar value={2} max={3} color="feedback-neutral" label="Prototyping" />
+<F0SegmentedBar value={3} max={3} color="feedback-positive" label="User Research" />
+```
+
+## Five-point scale
+
+<Canvas of={Stories.FivePointScale} />
+
+```tsx
+<F0SegmentedBar value={4} max={5} color="categorical-2" />
+```
+
+## Clamping
+
+<Canvas of={Stories.Clamped} />
+
+```tsx
+// value is clamped to max — renders as a full bar
+<F0SegmentedBar value={7} max={3} />
+```

--- a/packages/react/src/experimental/F0SegmentedBar/__stories__/F0SegmentedBar.stories.tsx
+++ b/packages/react/src/experimental/F0SegmentedBar/__stories__/F0SegmentedBar.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { SegmentColorToken } from "../types"
+
+import { F0SegmentedBar } from "../index"
+
+const meta = {
+  title: "F0SegmentedBar",
+  component: F0SegmentedBar,
+  tags: ["experimental"],
+  args: {
+    value: 2,
+    max: 3,
+  },
+} satisfies Meta<typeof F0SegmentedBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  tags: ["!dev"],
+}
+
+type RatingRow = {
+  label: string
+  value: number
+  color: SegmentColorToken
+}
+
+const competencies: RatingRow[] = [
+  { label: "UX Design", value: 1, color: "feedback-negative" },
+  { label: "Prototyping", value: 2, color: "feedback-neutral" },
+  { label: "User Research", value: 3, color: "feedback-positive" },
+]
+
+/**
+ * The ATS competency side panel case: the consumer maps each rating to a colour
+ * token (red = bad, orange = normal, green = great) and renders the name itself.
+ */
+export const RatingScale: Story = {
+  tags: ["!dev"],
+  render: () => (
+    <div className="flex w-72 flex-col gap-4">
+      {competencies.map((row) => (
+        <div key={row.label} className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-f1-foreground">
+            {row.label}
+          </span>
+          <F0SegmentedBar
+            value={row.value}
+            max={3}
+            color={row.color}
+            label={row.label}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+}
+
+export const FivePointScale: Story = {
+  tags: ["!dev"],
+  args: {
+    value: 4,
+    max: 5,
+    color: "categorical-2",
+  },
+}
+
+export const Empty: Story = {
+  tags: ["!dev"],
+  args: {
+    value: 0,
+    max: 3,
+  },
+}
+
+export const Full: Story = {
+  tags: ["!dev"],
+  args: {
+    value: 3,
+    max: 3,
+    color: "feedback-positive",
+  },
+}
+
+/** `value` greater than `max` clamps to `max`. */
+export const Clamped: Story = {
+  tags: ["!dev"],
+  args: {
+    value: 7,
+    max: 3,
+  },
+}
+
+export const WithLabel: Story = {
+  tags: ["!dev"],
+  args: {
+    value: 2,
+    max: 3,
+    label: "Stakeholder Communication",
+  },
+}

--- a/packages/react/src/experimental/F0SegmentedBar/__stories__/F0SegmentedBar.stories.tsx
+++ b/packages/react/src/experimental/F0SegmentedBar/__stories__/F0SegmentedBar.stories.tsx
@@ -11,6 +11,7 @@ const meta = {
   args: {
     value: 2,
     max: 3,
+    label: "Competency",
   },
 } satisfies Meta<typeof F0SegmentedBar>
 

--- a/packages/react/src/experimental/F0SegmentedBar/__tests__/F0SegmentedBar.test.tsx
+++ b/packages/react/src/experimental/F0SegmentedBar/__tests__/F0SegmentedBar.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest"
+
+import { getColor } from "@/kits/Charts/utils/colors"
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { F0SegmentedBar } from "../index"
+
+const getSegments = () =>
+  Array.from(screen.getByRole("progressbar").children) as HTMLElement[]
+
+describe("F0SegmentedBar", () => {
+  it("renders `max` segments", () => {
+    render(<F0SegmentedBar value={2} max={3} />)
+    expect(getSegments()).toHaveLength(3)
+  })
+
+  it("fills `value` segments with the resolved colour and leaves the rest on the track", () => {
+    render(<F0SegmentedBar value={2} max={3} color="feedback-positive" />)
+    const segments = getSegments()
+
+    expect(segments[0]).toHaveStyle({
+      backgroundColor: getColor("feedback-positive"),
+    })
+    expect(segments[1]).toHaveStyle({
+      backgroundColor: getColor("feedback-positive"),
+    })
+    // Empty segments carry no inline colour and fall back to the track class.
+    expect(segments[2].style.backgroundColor).toBe("")
+    expect(segments[2]).toHaveClass("bg-f1-background-secondary")
+  })
+
+  it("defaults the filled colour to categorical-1", () => {
+    render(<F0SegmentedBar value={1} max={2} />)
+    expect(getSegments()[0]).toHaveStyle({
+      backgroundColor: getColor("categorical-1"),
+    })
+  })
+
+  it("clamps `value` greater than `max`", () => {
+    render(<F0SegmentedBar value={5} max={3} />)
+    const bar = screen.getByRole("progressbar")
+    expect(bar).toHaveAttribute("aria-valuenow", "3")
+    expect(bar).toHaveAttribute("aria-valuetext", "3 of 3")
+    getSegments().forEach((segment) =>
+      expect(segment).toHaveStyle({
+        backgroundColor: getColor("categorical-1"),
+      })
+    )
+  })
+
+  it("clamps `value` below zero", () => {
+    render(<F0SegmentedBar value={-2} max={3} />)
+    const bar = screen.getByRole("progressbar")
+    expect(bar).toHaveAttribute("aria-valuenow", "0")
+    getSegments().forEach((segment) => {
+      expect(segment.style.backgroundColor).toBe("")
+      expect(segment).toHaveClass("bg-f1-background-secondary")
+    })
+  })
+
+  it("exposes the progressbar a11y contract", () => {
+    render(<F0SegmentedBar value={2} max={3} label="UX Design" />)
+    const bar = screen.getByRole("progressbar")
+    expect(bar).toHaveAttribute("aria-label", "UX Design")
+    expect(bar).toHaveAttribute("aria-valuemin", "0")
+    expect(bar).toHaveAttribute("aria-valuemax", "3")
+    expect(bar).toHaveAttribute("aria-valuenow", "2")
+    expect(bar).toHaveAttribute("aria-valuetext", "2 of 3")
+  })
+
+  it("falls back to a translated label when none is provided", () => {
+    render(<F0SegmentedBar value={1} max={3} />)
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-label",
+      "Segmented bar"
+    )
+  })
+
+  it("renders no segments and does not throw when max <= 0", () => {
+    render(<F0SegmentedBar value={2} max={0} />)
+    const bar = screen.getByRole("progressbar")
+    expect(bar.children).toHaveLength(0)
+    expect(bar).toHaveAttribute("aria-valuemax", "0")
+    expect(bar).toHaveAttribute("aria-valuenow", "0")
+  })
+
+  it("floors a fractional value instead of over-filling", () => {
+    render(<F0SegmentedBar value={2.5} max={3} color="feedback-positive" />)
+    const bar = screen.getByRole("progressbar")
+    expect(bar).toHaveAttribute("aria-valuenow", "2")
+    expect(bar).toHaveAttribute("aria-valuetext", "2 of 3")
+    const segments = getSegments()
+    expect(segments[1]).toHaveStyle({
+      backgroundColor: getColor("feedback-positive"),
+    })
+    expect(segments[2].style.backgroundColor).toBe("")
+  })
+
+  it("does not leak NaN when max or value is not finite", () => {
+    render(<F0SegmentedBar value={Number.NaN} max={Number.NaN} />)
+    const bar = screen.getByRole("progressbar")
+    expect(bar.children).toHaveLength(0)
+    expect(bar).toHaveAttribute("aria-valuemax", "0")
+    expect(bar).toHaveAttribute("aria-valuenow", "0")
+  })
+
+  it("does not throw when max is Infinity", () => {
+    render(<F0SegmentedBar value={2} max={Number.POSITIVE_INFINITY} />)
+    const bar = screen.getByRole("progressbar")
+    expect(bar.children).toHaveLength(0)
+    expect(bar).toHaveAttribute("aria-valuemax", "0")
+  })
+})

--- a/packages/react/src/experimental/F0SegmentedBar/__tests__/F0SegmentedBar.test.tsx
+++ b/packages/react/src/experimental/F0SegmentedBar/__tests__/F0SegmentedBar.test.tsx
@@ -10,12 +10,19 @@ const getSegments = () =>
 
 describe("F0SegmentedBar", () => {
   it("renders `max` segments", () => {
-    render(<F0SegmentedBar value={2} max={3} />)
+    render(<F0SegmentedBar value={2} max={3} label="UX Design" />)
     expect(getSegments()).toHaveLength(3)
   })
 
   it("fills `value` segments with the resolved colour and leaves the rest on the track", () => {
-    render(<F0SegmentedBar value={2} max={3} color="feedback-positive" />)
+    render(
+      <F0SegmentedBar
+        value={2}
+        max={3}
+        color="feedback-positive"
+        label="UX Design"
+      />
+    )
     const segments = getSegments()
 
     expect(segments[0]).toHaveStyle({
@@ -30,14 +37,14 @@ describe("F0SegmentedBar", () => {
   })
 
   it("defaults the filled colour to categorical-1", () => {
-    render(<F0SegmentedBar value={1} max={2} />)
+    render(<F0SegmentedBar value={1} max={2} label="UX Design" />)
     expect(getSegments()[0]).toHaveStyle({
       backgroundColor: getColor("categorical-1"),
     })
   })
 
   it("clamps `value` greater than `max`", () => {
-    render(<F0SegmentedBar value={5} max={3} />)
+    render(<F0SegmentedBar value={5} max={3} label="UX Design" />)
     const bar = screen.getByRole("progressbar")
     expect(bar).toHaveAttribute("aria-valuenow", "3")
     expect(bar).toHaveAttribute("aria-valuetext", "3 of 3")
@@ -49,7 +56,7 @@ describe("F0SegmentedBar", () => {
   })
 
   it("clamps `value` below zero", () => {
-    render(<F0SegmentedBar value={-2} max={3} />)
+    render(<F0SegmentedBar value={-2} max={3} label="UX Design" />)
     const bar = screen.getByRole("progressbar")
     expect(bar).toHaveAttribute("aria-valuenow", "0")
     getSegments().forEach((segment) => {
@@ -68,16 +75,8 @@ describe("F0SegmentedBar", () => {
     expect(bar).toHaveAttribute("aria-valuetext", "2 of 3")
   })
 
-  it("falls back to a translated label when none is provided", () => {
-    render(<F0SegmentedBar value={1} max={3} />)
-    expect(screen.getByRole("progressbar")).toHaveAttribute(
-      "aria-label",
-      "Segmented bar"
-    )
-  })
-
   it("renders no segments and does not throw when max <= 0", () => {
-    render(<F0SegmentedBar value={2} max={0} />)
+    render(<F0SegmentedBar value={2} max={0} label="UX Design" />)
     const bar = screen.getByRole("progressbar")
     expect(bar.children).toHaveLength(0)
     expect(bar).toHaveAttribute("aria-valuemax", "0")
@@ -85,7 +84,14 @@ describe("F0SegmentedBar", () => {
   })
 
   it("floors a fractional value instead of over-filling", () => {
-    render(<F0SegmentedBar value={2.5} max={3} color="feedback-positive" />)
+    render(
+      <F0SegmentedBar
+        value={2.5}
+        max={3}
+        color="feedback-positive"
+        label="UX Design"
+      />
+    )
     const bar = screen.getByRole("progressbar")
     expect(bar).toHaveAttribute("aria-valuenow", "2")
     expect(bar).toHaveAttribute("aria-valuetext", "2 of 3")
@@ -97,7 +103,9 @@ describe("F0SegmentedBar", () => {
   })
 
   it("does not leak NaN when max or value is not finite", () => {
-    render(<F0SegmentedBar value={Number.NaN} max={Number.NaN} />)
+    render(
+      <F0SegmentedBar value={Number.NaN} max={Number.NaN} label="UX Design" />
+    )
     const bar = screen.getByRole("progressbar")
     expect(bar.children).toHaveLength(0)
     expect(bar).toHaveAttribute("aria-valuemax", "0")
@@ -105,7 +113,13 @@ describe("F0SegmentedBar", () => {
   })
 
   it("does not throw when max is Infinity", () => {
-    render(<F0SegmentedBar value={2} max={Number.POSITIVE_INFINITY} />)
+    render(
+      <F0SegmentedBar
+        value={2}
+        max={Number.POSITIVE_INFINITY}
+        label="UX Design"
+      />
+    )
     const bar = screen.getByRole("progressbar")
     expect(bar.children).toHaveLength(0)
     expect(bar).toHaveAttribute("aria-valuemax", "0")

--- a/packages/react/src/experimental/F0SegmentedBar/index.tsx
+++ b/packages/react/src/experimental/F0SegmentedBar/index.tsx
@@ -1,0 +1,1 @@
+export * from "./F0SegmentedBar"

--- a/packages/react/src/experimental/F0SegmentedBar/types.ts
+++ b/packages/react/src/experimental/F0SegmentedBar/types.ts
@@ -10,5 +10,5 @@ export interface F0SegmentedBarProps extends WithDataTestIdProps {
   value: number
   max: number
   color?: SegmentColorToken
-  label?: string
+  label: string
 }

--- a/packages/react/src/experimental/F0SegmentedBar/types.ts
+++ b/packages/react/src/experimental/F0SegmentedBar/types.ts
@@ -1,0 +1,14 @@
+import { WithDataTestIdProps } from "@/lib/data-testid"
+
+export type SegmentColorToken =
+  | `categorical-${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8}`
+  | "feedback-positive"
+  | "feedback-neutral"
+  | "feedback-negative"
+
+export interface F0SegmentedBarProps extends WithDataTestIdProps {
+  value: number
+  max: number
+  color?: SegmentColorToken
+  label?: string
+}

--- a/packages/react/src/experimental/exports.ts
+++ b/packages/react/src/experimental/exports.ts
@@ -24,6 +24,7 @@ export * from "../kits/Charts/exports"
  */
 export * from "../components/F0ActionBar"
 export * from "./F0CardHorizontal"
+export * from "./F0SegmentedBar"
 export * from "./F0VersionHistory"
 export * from "./Forms/exports"
 export * from "./Information/exports"

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -707,6 +707,10 @@ export const defaultTranslations = {
     submit: "Submit",
     stepOf: "Step {{current}} of {{total}}",
   },
+  segmentedBar: {
+    label: "Segmented bar",
+    valueText: "{{value}} of {{max}}",
+  },
 } as const
 
 type TranslationShape<T> = {

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -707,10 +707,6 @@ export const defaultTranslations = {
     submit: "Submit",
     stepOf: "Step {{current}} of {{total}}",
   },
-  segmentedBar: {
-    label: "Segmented bar",
-    valueText: "{{value}} of {{max}}",
-  },
 } as const
 
 type TranslationShape<T> = {


### PR DESCRIPTION
A focused, standalone primitive for displaying a value as a discrete,
segmented bar. First consumer is the ATS competency side panel
(red/orange/green per level).

[FoSegmentedBar documentation](https://66a7a8d7d124220c363457cc-vicyelppmb.chromatic.com/?path=/docs/experimental-f0segmentedbar--documentation)

## Changes
- `experimental/F0SegmentedBar/` — `F0SegmentedBar.tsx`, `types.ts`, `index.tsx`
  - `value`/`max` segmented bar, `color?: SegmentColorToken`, optional `label`
  - `value` floored and clamped to `[0, max]`; non-positive/non-finite
    `max` renders an empty bar (no NaN, no Infinity crash)
  - `role="progressbar"` with i18n'd `aria-valuetext`; `aria-label` from
    `label` with a translated fallback; `motion-reduce:transition-none`
  - track + pill styling aligned with the existing `Progress` primitive
- `lib/providers/i18n` — `segmentedBar.label`, `segmentedBar.valueText` defaults
- `experimental/exports.ts` — export `F0SegmentedBar`
- Stories (`tags: ["experimental"]`) + MDX docs (Overview/Guidelines/Code/Examples)

<img width="701" height="185" alt="Screenshot 2026-06-19 at 09 28 12" src="https://github.com/user-attachments/assets/7ce87992-0983-460b-82ab-36ad26f99e89" />

<img width="952" height="293" alt="Screenshot 2026-06-19 at 09 28 54" src="https://github.com/user-attachments/assets/01e76da6-e42a-439a-b2f3-c03695455910" />
