### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.7.0",
+  "packages/react": "3.7.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.7.1](https://github.com/factorialco/f0/compare/f0-react-v3.7.0...f0-react-v3.7.1) (2026-06-18)
+
+
+### Bug Fixes
+
+* **F0Select:** never preserve a select-all across dataset changes ([#4479](https://github.com/factorialco/f0/issues/4479)) ([3ad4aea](https://github.com/factorialco/f0/commit/3ad4aeae64179e57f4db11194d3412664cd0c1be))
+
 ## [3.7.0](https://github.com/factorialco/f0/compare/f0-react-v3.6.0...f0-react-v3.7.0) (2026-06-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.7.1</summary>

## [3.7.1](https://github.com/factorialco/f0/compare/f0-react-v3.7.0...f0-react-v3.7.1) (2026-06-18)


### Bug Fixes

* **F0Select:** never preserve a select-all across dataset changes ([#4479](https://github.com/factorialco/f0/issues/4479)) ([3ad4aea](https://github.com/factorialco/f0/commit/3ad4aeae64179e57f4db11194d3412664cd0c1be))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).