### PR TITLE
feat(surveys): add SampleQuestion component

### DIFF
--- a/packages/react/src/sds/surveys/SampleQuestion/index.stories.tsx
+++ b/packages/react/src/sds/surveys/SampleQuestion/index.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { SampleQuestion } from "."
+
+const meta: Meta<typeof SampleQuestion> = {
+  title: "Surveys/SampleQuestion",
+  component: SampleQuestion,
+  tags: ["autodocs", "experimental"],
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div className="w-[480px]">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof SampleQuestion>
+
+export const Rating: Story = {
+  args: {
+    type: "rating",
+    question: "How satisfied are you with the overall quality of the course?",
+    minLabel: "Very low",
+    maxLabel: "Very high",
+  },
+}
+
+export const Choice: Story = {
+  args: {
+    type: "choice",
+    question: "Which of these is correct?",
+    options: ["The correct answer", "Another option"],
+  },
+}

--- a/packages/react/src/sds/surveys/SampleQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SampleQuestion/index.tsx
@@ -1,0 +1,104 @@
+import { F0Box, type F0BoxProps } from "@/lib/F0Box"
+
+import { SampleQuestionProps } from "./types"
+
+export type { SampleQuestionProps } from "./types"
+
+/**
+ * A non-interactive preview of a survey question, used to illustrate what a
+ * given survey type produces (for example inside the survey type selector).
+ * It is purely presentational — the inputs are mocked placeholders, not real
+ * form fields.
+ */
+export function SampleQuestion(props: SampleQuestionProps) {
+  return (
+    <F0Box
+      display="flex"
+      flexDirection="column"
+      gap="lg"
+      padding="lg"
+      background="secondary"
+      borderRadius="lg"
+    >
+      <p className="m-0 text-sm font-semibold text-f1-foreground">
+        {props.question}
+      </p>
+      {props.type === "rating" ? (
+        <RatingScale
+          steps={props.steps ?? 5}
+          minLabel={props.minLabel}
+          maxLabel={props.maxLabel}
+        />
+      ) : (
+        <ChoiceList options={props.options} />
+      )}
+    </F0Box>
+  )
+}
+
+function RatingScale({
+  steps,
+  minLabel,
+  maxLabel,
+}: {
+  steps: number
+  minLabel?: string
+  maxLabel?: string
+}) {
+  const columns = String(steps) as F0BoxProps["columns"]
+
+  return (
+    <F0Box display="flex" flexDirection="column" gap="sm">
+      <F0Box display="grid" columns={columns} gap="sm">
+        {Array.from({ length: steps }).map((_, i) => (
+          <F0Box
+            key={i}
+            height="8"
+            border="default"
+            borderRadius="md"
+            background="primary"
+          />
+        ))}
+      </F0Box>
+      {(minLabel || maxLabel) && (
+        <F0Box display="flex" justifyContent="between" alignItems="center">
+          <span className="text-xs text-f1-foreground-secondary">
+            {minLabel}
+          </span>
+          <span className="text-xs text-f1-foreground-secondary">
+            {maxLabel}
+          </span>
+        </F0Box>
+      )}
+    </F0Box>
+  )
+}
+
+function ChoiceList({ options }: { options: string[] }) {
+  return (
+    <F0Box display="flex" flexDirection="column" gap="md">
+      {options.map((option) => (
+        <F0Box
+          key={option}
+          display="flex"
+          alignItems="center"
+          gap="md"
+          paddingX="md"
+          paddingY="sm"
+          border="default"
+          borderRadius="md"
+          background="primary"
+        >
+          <F0Box
+            shrink={false}
+            width="4"
+            height="4"
+            border="thick"
+            borderRadius="full"
+          />
+          <span className="text-sm text-f1-foreground-secondary">{option}</span>
+        </F0Box>
+      ))}
+    </F0Box>
+  )
+}

--- a/packages/react/src/sds/surveys/SampleQuestion/types.ts
+++ b/packages/react/src/sds/surveys/SampleQuestion/types.ts
@@ -1,0 +1,23 @@
+/** A mocked rating-scale question (e.g. Very low → Very high). */
+export type SampleRatingQuestion = {
+  type: "rating"
+  /** The question prompt shown above the scale */
+  question: string
+  /** Number of rating steps to render (default 5) */
+  steps?: number
+  /** Caption under the lowest step */
+  minLabel?: string
+  /** Caption under the highest step */
+  maxLabel?: string
+}
+
+/** A mocked single-choice question. */
+export type SampleChoiceQuestion = {
+  type: "choice"
+  /** The question prompt shown above the options */
+  question: string
+  /** The answer options, rendered as non-interactive radio rows */
+  options: string[]
+}
+
+export type SampleQuestionProps = SampleRatingQuestion | SampleChoiceQuestion


### PR DESCRIPTION
## Description

Adds a reusable `SampleQuestion` component to `sds/surveys` — a non-interactive preview of a survey question used to illustrate what a survey produces. It supports a `rating` variant (a scale with optional min/max captions) and a `choice` variant (single-choice radio rows), and is built entirely from `F0Box` layout primitives.

<img width="991" height="426" alt="Screenshot 2026-06-18 at 10 59 30" src="https://github.com/user-attachments/assets/9d6d1471-e0b7-4880-b8fd-352c9b9030e6" />

## Implementation details

- feat: add `SampleQuestion` component to `sds/surveys` with `rating` and `choice` variants
- feat: add `SampleQuestion` stories (`Rating`, `Choice`)
- chore: build the component with `F0Box` rather than raw `div`s