### PR TITLE
feat(surveys): restyle locked questions and add lockedClarification alert

### DIFF
--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Context.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Context.tsx
@@ -18,6 +18,7 @@ import {
 import {
   SurveyFormBuilderCallbacks,
   SurveyFormBuilderElement,
+  LockedClarification,
   QuestionElement,
   QuestionType,
   SectionElement,
@@ -35,11 +36,15 @@ type SurveyFormBuilderContextType = SurveyFormBuilderCallbacks & {
   getSectionContainingQuestion: (
     questionId: string
   ) => SectionElement | undefined
+  getLockedClarification: (sectionId: string) => LockedClarification | undefined
   isQuestionTypeAllowed: (questionType: QuestionType) => boolean
   errors?: Record<string, string>
   onFieldBlur?: (questionId: string) => void
   useUpload?: UseFileUpload
   datasets?: SurveyDatasets
+  lockedClarification?:
+    | LockedClarification
+    | Record<string, LockedClarification>
 }
 
 const SurveyFormBuilderContext = createContext<
@@ -58,6 +63,9 @@ type SurveyFormBuilderProviderProps = {
   onFieldBlur?: (questionId: string) => void
   useUpload?: UseFileUpload
   datasets?: SurveyDatasets
+  lockedClarification?:
+    | LockedClarification
+    | Record<string, LockedClarification>
 }
 
 export function SurveyFormBuilderProvider({
@@ -72,6 +80,7 @@ export function SurveyFormBuilderProvider({
   onFieldBlur,
   useUpload,
   datasets,
+  lockedClarification,
 }: SurveyFormBuilderProviderProps) {
   const elementsRef = useRef(elements)
   elementsRef.current = elements
@@ -395,6 +404,24 @@ export function SurveyFormBuilderProvider({
     return element?.type === "section" ? element.section : undefined
   }, [])
 
+  const getLockedClarification = useCallback(
+    (sectionId: string): LockedClarification | undefined => {
+      if (!lockedClarification) return undefined
+      // A single LockedClarification (has a string `title`) applies to every
+      // locked section; otherwise it's a per-section map keyed by section id.
+      if (
+        "title" in lockedClarification &&
+        typeof lockedClarification.title === "string"
+      ) {
+        return lockedClarification as LockedClarification
+      }
+      return (lockedClarification as Record<string, LockedClarification>)[
+        sectionId
+      ]
+    },
+    [lockedClarification]
+  )
+
   const isFirstRender = useRef(true)
 
   const isEmpty = !elements.length
@@ -431,6 +458,7 @@ export function SurveyFormBuilderProvider({
       onDuplicateElement: handleDuplicateElement,
       getIsSingleQuestionInSection,
       getSectionContainingQuestion,
+      getLockedClarification,
       disabled,
       answering,
       getQuestionById,
@@ -450,6 +478,7 @@ export function SurveyFormBuilderProvider({
       handleDuplicateElement,
       getIsSingleQuestionInSection,
       getSectionContainingQuestion,
+      getLockedClarification,
       disabled,
       answering,
       getQuestionById,

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/SectionHeaderItem.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/SectionHeaderItem.tsx
@@ -1,5 +1,6 @@
 import { Reorder, useDragControls } from "motion/react"
 
+import { F0Alert } from "@/components/F0Alert"
 import { F0Icon } from "@/components/F0Icon"
 import { Handle } from "@/icons/app"
 import { cn } from "@/lib/utils"
@@ -24,7 +25,12 @@ export const SectionHeaderItem = ({
   const { isDragging, setIsDragging, setDraggedItemId, draggedItemId } =
     useDragContext()
   const dragControls = useDragControls()
-  const { disabled, answering } = useSurveyFormBuilderContext()
+  const { disabled, answering, getLockedClarification } =
+    useSurveyFormBuilderContext()
+
+  const lockedClarification = item.section.locked
+    ? getLockedClarification(item.section.id)
+    : undefined
 
   const isDraggingThisSection = draggedItemId === item.section.id
 
@@ -52,6 +58,16 @@ export const SectionHeaderItem = ({
       className={className}
     >
       <div className="w-full">
+        {lockedClarification && (
+          <div className="mb-3">
+            <F0Alert
+              variant="info"
+              title={lockedClarification.title}
+              description={lockedClarification.description}
+              link={lockedClarification.link}
+            />
+          </div>
+        )}
         <div className="group/element w-full">
           <div
             className={cn(

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
@@ -163,6 +163,39 @@ describe("SurveyFormBuilder", () => {
     expect(screen.getByText("Second clarification")).toBeInTheDocument()
   })
 
+  it("does not select a rating option when its question is locked", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const elements: SurveyFormBuilderElement[] = [
+      {
+        type: "section",
+        section: {
+          id: "s1",
+          title: "Locked Section",
+          locked: true,
+          questions: [
+            {
+              id: "q-rating",
+              title: "Rate it",
+              type: "rating" as const,
+              options: [
+                { value: 1, label: "1" },
+                { value: 2, label: "2" },
+                { value: 3, label: "3" },
+              ],
+            },
+          ],
+        },
+      },
+    ]
+
+    render(<SurveyFormBuilder elements={elements} onChange={onChange} />)
+
+    await user.click(screen.getByTestId("score-edit-option-2"))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   it("does not show a lockedClarification alert for unlocked sections", () => {
     const elements: SurveyFormBuilderElement[] = [
       makeSection("s1", "Open Section", [{ id: "q1", title: "Q1" }], false),

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
@@ -120,6 +120,65 @@ describe("SurveyFormBuilder", () => {
     expect(notAllowed.length).toBeGreaterThanOrEqual(2) // section header + question
   })
 
+  it("shows a lockedClarification alert for a locked section", () => {
+    const elements: SurveyFormBuilderElement[] = [
+      makeSection("s1", "Locked Section", [{ id: "q1", title: "Q1" }], true),
+    ]
+
+    render(
+      <SurveyFormBuilder
+        elements={elements}
+        onChange={vi.fn()}
+        lockedClarification={{
+          title: "This section is locked",
+          description: "Its questions are shared across surveys.",
+        }}
+      />
+    )
+
+    expect(screen.getByText("This section is locked")).toBeInTheDocument()
+    expect(
+      screen.getByText("Its questions are shared across surveys.")
+    ).toBeInTheDocument()
+  })
+
+  it("resolves a per-section lockedClarification map by section id", () => {
+    const elements: SurveyFormBuilderElement[] = [
+      makeSection("s1", "Section One", [{ id: "q1", title: "Q1" }], true),
+      makeSection("s2", "Section Two", [{ id: "q2", title: "Q2" }], true),
+    ]
+
+    render(
+      <SurveyFormBuilder
+        elements={elements}
+        onChange={vi.fn()}
+        lockedClarification={{
+          s1: { title: "First clarification" },
+          s2: { title: "Second clarification" },
+        }}
+      />
+    )
+
+    expect(screen.getByText("First clarification")).toBeInTheDocument()
+    expect(screen.getByText("Second clarification")).toBeInTheDocument()
+  })
+
+  it("does not show a lockedClarification alert for unlocked sections", () => {
+    const elements: SurveyFormBuilderElement[] = [
+      makeSection("s1", "Open Section", [{ id: "q1", title: "Q1" }], false),
+    ]
+
+    render(
+      <SurveyFormBuilder
+        elements={elements}
+        onChange={vi.fn()}
+        lockedClarification={{ title: "Should not appear" }}
+      />
+    )
+
+    expect(screen.queryByText("Should not appear")).not.toBeInTheDocument()
+  })
+
   it("shows confirmation dialog when moving the last question out of a section", async () => {
     // This test verifies the dialog appears. We cannot simulate real DnD with
     // Reorder.Group in jsdom, so we test the component state by providing

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -89,6 +89,258 @@ export const Empty: Story = {
   },
 }
 
+export const LockedSectionWithClarification: Story = {
+  args: {
+    elements: [
+      {
+        type: "section",
+        section: {
+          id: "section-effectiveness",
+          title: "Overall effectiveness",
+          locked: true,
+          questions: [
+            {
+              id: "q-effectiveness",
+              title:
+                "How would you rate the overall effectiveness of the course?",
+              type: "select" as const,
+              required: true,
+              options: [
+                { value: "very-low", label: "Very low" },
+                { value: "low", label: "Low" },
+                { value: "average", label: "Average" },
+                { value: "high", label: "High" },
+                { value: "very-high", label: "Very high" },
+              ],
+            },
+            {
+              id: "q-recommend",
+              title: "How likely are you to recommend this course?",
+              type: "rating" as const,
+              required: true,
+              options: [
+                { value: 1, label: "1" },
+                { value: 2, label: "2" },
+                { value: 3, label: "3" },
+                { value: 4, label: "4" },
+                { value: 5, label: "5" },
+              ],
+            },
+            {
+              id: "q-comments",
+              title: "Any additional comments about the course?",
+              type: "longText" as const,
+            },
+          ],
+        },
+      },
+    ],
+    lockedClarification: {
+      title: "This section is locked",
+      description:
+        "Its questions are the same in every effectiveness survey, so results stay comparable across courses.",
+    },
+  },
+}
+
+export const LockedSectionsSharedClarification: Story = {
+  args: {
+    elements: [
+      {
+        type: "section",
+        section: {
+          id: "section-effectiveness",
+          title: "Overall effectiveness",
+          locked: true,
+          questions: [
+            {
+              id: "q-effectiveness",
+              title:
+                "How would you rate the overall effectiveness of the course?",
+              type: "select" as const,
+              required: true,
+              options: [
+                { value: "very-low", label: "Very low" },
+                { value: "low", label: "Low" },
+                { value: "average", label: "Average" },
+                { value: "high", label: "High" },
+                { value: "very-high", label: "Very high" },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        type: "section",
+        section: {
+          id: "section-satisfaction",
+          title: "Satisfaction",
+          locked: true,
+          questions: [
+            {
+              id: "q-satisfaction",
+              title: "How satisfied are you with the course?",
+              type: "rating" as const,
+              required: true,
+              options: [
+                { value: 1, label: "1" },
+                { value: 2, label: "2" },
+                { value: 3, label: "3" },
+                { value: 4, label: "4" },
+                { value: 5, label: "5" },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+    // A single LockedClarification object is applied to every locked section.
+    lockedClarification: {
+      title: "This section is locked",
+      description:
+        "Its questions are standard across all effectiveness surveys, so results stay comparable across courses.",
+    },
+  },
+}
+
+export const LockedSectionsPerSectionClarification: Story = {
+  args: {
+    elements: [
+      {
+        type: "section",
+        section: {
+          id: "section-effectiveness",
+          title: "Overall effectiveness",
+          locked: true,
+          questions: [
+            {
+              id: "q-effectiveness",
+              title:
+                "How would you rate the overall effectiveness of the course?",
+              type: "select" as const,
+              required: true,
+              options: [
+                { value: "very-low", label: "Very low" },
+                { value: "low", label: "Low" },
+                { value: "average", label: "Average" },
+                { value: "high", label: "High" },
+                { value: "very-high", label: "Very high" },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        type: "section",
+        section: {
+          id: "section-satisfaction",
+          title: "Satisfaction",
+          locked: true,
+          questions: [
+            {
+              id: "q-satisfaction",
+              title: "How satisfied are you with the course?",
+              type: "rating" as const,
+              required: true,
+              options: [
+                { value: 1, label: "1" },
+                { value: 2, label: "2" },
+                { value: 3, label: "3" },
+                { value: 4, label: "4" },
+                { value: 5, label: "5" },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+    lockedClarification: {
+      "section-effectiveness": {
+        title: "This section is locked",
+        description:
+          "Its questions are the same in every effectiveness survey, so results stay comparable across courses.",
+        link: {
+          label: "Learn more",
+          href: "https://factorial.co",
+        },
+      },
+      "section-satisfaction": {
+        title: "Standard satisfaction questions",
+        description:
+          "These questions are managed centrally and can't be edited.",
+      },
+    },
+  },
+}
+
+export const MixedLockedAndUnlockedSections: Story = {
+  args: {
+    elements: [
+      {
+        type: "question",
+        question: {
+          id: "q-standalone",
+          title: "What is your full name?",
+          type: "text" as const,
+          required: true,
+        },
+      },
+      {
+        type: "section",
+        section: {
+          id: "section-effectiveness",
+          title: "Overall effectiveness",
+          locked: true,
+          questions: [
+            {
+              id: "q-effectiveness",
+              title:
+                "How would you rate the overall effectiveness of the course?",
+              type: "select" as const,
+              required: true,
+              options: [
+                { value: "very-low", label: "Very low" },
+                { value: "low", label: "Low" },
+                { value: "average", label: "Average" },
+                { value: "high", label: "High" },
+                { value: "very-high", label: "Very high" },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        type: "section",
+        section: {
+          id: "section-feedback",
+          title: "Your feedback",
+          description: "This section is fully editable.",
+          questions: [
+            {
+              id: "q-feedback-1",
+              title: "What did you enjoy most about the course?",
+              type: "longText" as const,
+            },
+            {
+              id: "q-feedback-2",
+              title: "What could be improved?",
+              type: "longText" as const,
+            },
+          ],
+        },
+      },
+    ],
+    // Only the locked section has an entry; the editable section is left out.
+    lockedClarification: {
+      "section-effectiveness": {
+        title: "This section is locked",
+        description:
+          "Its questions are the same in every effectiveness survey, so results stay comparable across courses.",
+      },
+    },
+  },
+}
+
 export const ApplyingChanges: Story = {
   args: {
     ...Default.args,

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.tsx
@@ -48,6 +48,7 @@ const _SurveyFormBuilder = ({
   applyingChanges,
   useUpload,
   datasets,
+  lockedClarification,
 }: SurveyFormBuilderProps) => {
   const shouldShowAddButton = !disabled
 
@@ -141,6 +142,7 @@ const _SurveyFormBuilder = ({
       allowedQuestionTypes={allowedQuestionTypes}
       useUpload={useUpload}
       datasets={datasets}
+      lockedClarification={lockedClarification}
     >
       <DragProvider>
         <DragSelectGuard>

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { F0Icon } from "@/components/F0Icon"
-import { AcademicCap, Add, Check, CheckDouble } from "@/icons/app"
+import { AcademicCap, Add, Check, CheckDouble, LockLocked } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import {
@@ -132,8 +132,9 @@ export const BaseQuestion = ({
       id={`co-creation-question-${id}`}
       className={cn(
         "group/question relative flex w-full flex-col rounded-xl border border-solid border-f1-border bg-f1-background px-3 py-4",
-        !isDragging && !answering && "hover:border-f1-border-hover",
-        !answering || !!description ? "gap-4" : "gap-2"
+        !isDragging && !answering && !locked && "hover:border-f1-border-hover",
+        !answering || !!description ? "gap-4" : "gap-2",
+        !answering && locked && "cursor-not-allowed bg-f1-background-secondary"
       )}
     >
       <div className="flex flex-col gap-0.5">
@@ -197,6 +198,11 @@ export const BaseQuestion = ({
                 }
                 hiddenActions={hiddenActions}
               />
+            </div>
+          )}
+          {!answering && locked && (
+            <div className="flex shrink-0 items-center px-2 py-1 text-f1-foreground-secondary">
+              <F0Icon icon={LockLocked} size="md" />
             </div>
           )}
         </div>

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -134,7 +134,15 @@ export const BaseQuestion = ({
         "group/question relative flex w-full flex-col rounded-xl border border-solid border-f1-border bg-f1-background px-3 py-4",
         !isDragging && !answering && !locked && "hover:border-f1-border-hover",
         !answering || !!description ? "gap-4" : "gap-2",
-        !answering && locked && "cursor-not-allowed bg-f1-background-secondary"
+        // When locked, the whole card uses the secondary background. Nested
+        // surfaces are made transparent so they reveal that same background
+        // uniformly — secondary is translucent, so painting them secondary
+        // again would stack and look darker than the root. This covers the
+        // answer-preview inputs/textareas rendered through F0InputField (which
+        // are otherwise tertiary while disabled).
+        !answering &&
+          locked &&
+          "cursor-not-allowed bg-f1-background-secondary [&_[data-testid=input-field-wrapper]]:!bg-transparent"
       )}
     >
       <div className="flex flex-col gap-0.5">

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/index.tsx
@@ -17,8 +17,17 @@ export const BaseScoreQuestion = ({
   value,
   ...baseQuestionComponentProps
 }: BaseScoreQuestionProps) => {
-  const { onQuestionChange, disabled, answering } =
-    useSurveyFormBuilderContext()
+  const {
+    onQuestionChange,
+    disabled,
+    answering,
+    getSectionContainingQuestion,
+  } = useSurveyFormBuilderContext()
+
+  const containingSection = getSectionContainingQuestion(
+    baseQuestionComponentProps.id
+  )
+  const locked = baseQuestionComponentProps.locked || containingSection?.locked
 
   const ratingType = detectRatingOptionType(options)
   const isEmojiMode = ratingType === "emojis"
@@ -54,7 +63,7 @@ export const BaseScoreQuestion = ({
             selected={value === option.value}
             onClick={handleChangeValue}
             onChangeLabel={handleChangeLabel}
-            disabled={disabled && !answering}
+            disabled={!answering && (disabled || locked)}
             isEmojiMode={answering ? false : isEmojiMode}
           />
         ))}

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/SelectOption/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/SelectOption/index.tsx
@@ -13,9 +13,11 @@ import { OnClickOptionActionParams, SelectOptionProps } from "./types"
 function RadioIndicator({
   checked,
   disabled,
+  locked,
 }: {
   checked: boolean
   disabled?: boolean
+  locked?: boolean
 }) {
   return (
     <div
@@ -24,7 +26,12 @@ function RadioIndicator({
         "flex h-5 w-5 shrink-0 items-center justify-center rounded-full transition-colors",
         checked
           ? "bg-f1-background-selected-bold"
-          : "border border-solid border-f1-border bg-f1-background",
+          : cn(
+              "border border-solid border-f1-border",
+              // Transparent when locked so it reveals the (secondary) card
+              // background instead of stacking another translucent layer.
+              locked ? "bg-transparent" : "bg-f1-background"
+            ),
         disabled && "opacity-50"
       )}
     >
@@ -109,7 +116,12 @@ export const SelectOption = ({
     >
       <div
         className={cn(
-          "group relative flex min-h-9 items-center gap-3 rounded-md bg-f1-background py-0.5 pl-2 pr-0.5 hover:bg-f1-background-hover",
+          "group relative flex min-h-9 items-center gap-3 rounded-md py-0.5 pl-2 pr-0.5",
+          // Transparent when locked so the row blends into the secondary card
+          // background (no hover affordance since it isn't interactive).
+          locked
+            ? "bg-transparent"
+            : "bg-f1-background hover:bg-f1-background-hover",
           (disabled || answering) && "cursor-pointer",
           isDragging && "!cursor-grabbing active:!cursor-grabbing"
         )}
@@ -135,6 +147,7 @@ export const SelectOption = ({
             <RadioIndicator
               checked={answering ? !!selected : false}
               disabled={!answering}
+              locked={locked}
             />
           )}
         </div>

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
@@ -95,7 +95,10 @@ export const Section = ({
   return (
     <div
       id={`co-creation-section-${id}`}
-      className="group/section flex w-full flex-col gap-1 bg-f1-background"
+      className={cn(
+        "group/section flex w-full flex-col gap-1 bg-f1-background",
+        locked && "cursor-not-allowed"
+      )}
     >
       <div className="py-1 pl-5 pr-3">
         <div className="flex flex-row">

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/types.ts
@@ -59,6 +59,22 @@ export type BaseQuestionOnChangeParams = {
 
 export type SectionElement = Omit<SectionProps, "onAction" | "onChange">
 
+export type SectionId = string
+
+/**
+ * Explanatory content shown in an F0Alert at the top of a locked section,
+ * clarifying to the form builder why the section (and its questions) can't
+ * be edited.
+ */
+export type LockedClarification = {
+  title: string
+  description?: string
+  link?: {
+    label: string
+    href: string
+  }
+}
+
 type QuestionPropsToOmit = "onAction" | "onChange" | "onAddNewElement"
 
 export type QuestionElement =
@@ -211,4 +227,13 @@ export type SurveyFormBuilderProps = {
   applyingChanges?: boolean
   useUpload?: UseFileUpload
   datasets?: SurveyDatasets
+  /**
+   * Optional explanatory content for locked sections, rendered as an F0Alert
+   * at the top of the section. Pass a single object to apply the same
+   * clarification to every locked section, or a map keyed by section id to
+   * provide a per-section clarification.
+   */
+  lockedClarification?:
+    | LockedClarification
+    | Record<SectionId, LockedClarification>
 }


### PR DESCRIPTION
## Description

Updates the `SurveyFormBuilder` so locked sections/questions read clearly as locked, and adds a way to explain *why* a section is locked.

- **Locked question appearance** — locked question cards now use a muted `bg-f1-background-secondary` background, show a lock icon in the top-right corner (where the actions menu sits for editable questions), and apply a `cursor-not-allowed` cursor over the entire question card. `cursor-not-allowed` is also applied to the whole locked section.
- **`lockedClarification` prop** — a new optional prop that renders an `F0Alert` (info variant) at the top of each locked section. It accepts either:
  - a single `{ title, description?, link? }` object, applied to **every** locked section, or
  - a `Record<SectionId, { title, description?, link? }>` map, for **per-section** content.

## Screenshots (if applicable)

Matches the provided design: an info alert above the locked section title, with a lock icon on the question card and disabled inputs.

## Implementation details

- `types.ts` — added the public `LockedClarification` and `SectionId` types and the `lockedClarification` prop on `SurveyFormBuilderProps`.
- `Context.tsx` — threads `lockedClarification` through the provider and exposes a `getLockedClarification(sectionId)` resolver that detects the single-object form (has a string `title`) vs. the per-section map.
- `Form/index.tsx` — passes the prop into the provider.
- `Form/SectionHeaderItem.tsx` — renders the `F0Alert` full-width above the section header (drag-handle row) when the section is locked and a clarification resolves.
- `QuestionTypes/BaseQuestion/index.tsx` — muted background, lock icon, and `cursor-not-allowed` for locked questions.
- `Section/index.tsx` — `cursor-not-allowed` on the locked section container.

### Stories
Added four stories under `Surveys/SurveyFormBuilder`: a single locked section with multiple questions, two locked sections sharing one clarification, two locked sections with per-section clarifications, and a mixed locked/editable layout.

### Tests
Added tests covering the single-object alert, per-section map resolution, and the no-alert-when-unlocked case. Full `SurveyFormBuilder` Form suite passes (21 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)