### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.8.0",
+  "packages/react": "3.8.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.8.1](https://github.com/factorialco/f0/compare/f0-react-v3.8.0...f0-react-v3.8.1) (2026-06-18)
+
+
+### Bug Fixes
+
+* add missing SurveySampleQuestion export ([#4498](https://github.com/factorialco/f0/issues/4498)) ([7cbefe7](https://github.com/factorialco/f0/commit/7cbefe72c67a71dc5a6359b855070f5a08385e70))
+
 ## [3.8.0](https://github.com/factorialco/f0/compare/f0-react-v3.7.2...f0-react-v3.8.0) (2026-06-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.8.1</summary>

## [3.8.1](https://github.com/factorialco/f0/compare/f0-react-v3.8.0...f0-react-v3.8.1) (2026-06-18)


### Bug Fixes

* add missing SurveySampleQuestion export ([#4498](https://github.com/factorialco/f0/issues/4498)) ([7cbefe7](https://github.com/factorialco/f0/commit/7cbefe72c67a71dc5a6359b855070f5a08385e70))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).