### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.8.1",
+  "packages/react": "3.8.2",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.8.2](https://github.com/factorialco/f0/compare/f0-react-v3.8.1...f0-react-v3.8.2) (2026-06-18)
+
+
+### Bug Fixes
+
+* missing rename of SurveySampleQuestion component ([#4500](https://github.com/factorialco/f0/issues/4500)) ([353efab](https://github.com/factorialco/f0/commit/353efabfbcc5c9d6dac69a3655b5103bab5f1667))
+
 ## [3.8.1](https://github.com/factorialco/f0/compare/f0-react-v3.8.0...f0-react-v3.8.1) (2026-06-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.8.2</summary>

## [3.8.2](https://github.com/factorialco/f0/compare/f0-react-v3.8.1...f0-react-v3.8.2) (2026-06-18)


### Bug Fixes

* missing rename of SurveySampleQuestion component ([#4500](https://github.com/factorialco/f0/issues/4500)) ([353efab](https://github.com/factorialco/f0/commit/353efabfbcc5c9d6dac69a3655b5103bab5f1667))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).