### PR TITLE
feat(SurveyFormBuilder): redesign the blocked section

### DIFF
--- a/packages/react/src/components/tags/F0TagRaw/F0TagRaw.tsx
+++ b/packages/react/src/components/tags/F0TagRaw/F0TagRaw.tsx
@@ -2,13 +2,17 @@ import { forwardRef } from "react"
 
 import { F0Icon } from "@/components/F0Icon"
 import { useTextFormatEnforcer } from "@/lib/text"
+import { cn } from "@/lib/utils"
 
 import type { F0TagRawProps } from "./types"
 
 import { BaseTag } from "../internal/BaseTag"
 
 export const F0TagRaw = forwardRef<HTMLDivElement, F0TagRawProps>(
-  ({ text, additionalAccessibleText, icon, onlyIcon, info }, ref) => {
+  (
+    { text, additionalAccessibleText, icon, onlyIcon, info, className },
+    ref
+  ) => {
     useTextFormatEnforcer(
       text,
       { disallowEmpty: true },
@@ -18,7 +22,10 @@ export const F0TagRaw = forwardRef<HTMLDivElement, F0TagRawProps>(
     return (
       <BaseTag
         ref={ref}
-        className="border-[1px] border-solid border-f1-border-secondary"
+        className={cn(
+          "border-[1px] border-solid border-f1-border-secondary",
+          className
+        )}
         left={
           icon ? (
             <F0Icon

--- a/packages/react/src/components/tags/F0TagRaw/types.ts
+++ b/packages/react/src/components/tags/F0TagRaw/types.ts
@@ -13,6 +13,10 @@ export type F0TagRawProps = {
    * Info text to display an i icon and a tooltip next to the tag
    */
   info?: string
+  /**
+   * Extra classes merged onto the tag (e.g. to give it a background).
+   */
+  className?: string
 } & (
   | {
       icon: IconType

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/QuestionItem.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/QuestionItem.tsx
@@ -66,25 +66,34 @@ export const QuestionItem = ({
         <div
           className={cn(
             "group/element flex flex-row items-start gap-1",
+            // Mirror the drag-and-drop gutter (handle w-6 + gap-1 ≈ 28px) on
+            // the right so every card keeps the same width.
+            !disabled && !answering && "pr-7",
             isDragging && "cursor-grabbing"
           )}
         >
-          {!disabled && !answering && (
-            <div
-              className={cn(
-                "mt-2 flex aspect-square w-6 scale-75 items-center opacity-0 hover:opacity-40 group-hover/element:opacity-40",
-                !isDragging && "cursor-grab",
-                !dragEnabled && "cursor-not-allowed"
-              )}
-              onPointerDown={(e) => {
-                if (dragEnabled) {
-                  dragControls.start(e)
-                }
-              }}
-            >
-              <F0Icon icon={Handle} size="sm" />
-            </div>
-          )}
+          {!disabled &&
+            !answering &&
+            (questionLocked ? (
+              // Blocked question: drop the drag affordance but keep the handle's
+              // gutter so the card stays the same width and alignment as the
+              // editable questions around it.
+              <div className="mt-2 aspect-square w-6 scale-75" aria-hidden />
+            ) : (
+              <div
+                className={cn(
+                  "mt-2 flex aspect-square w-6 scale-75 items-center opacity-0 hover:opacity-40 group-hover/element:opacity-40",
+                  !isDragging && "cursor-grab"
+                )}
+                onPointerDown={(e) => {
+                  if (dragEnabled) {
+                    dragControls.start(e)
+                  }
+                }}
+              >
+                <F0Icon icon={Handle} size="sm" />
+              </div>
+            ))}
           <QuestionComponent
             {...({
               ...item.question,

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/SectionHeaderItem.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/SectionHeaderItem.tsx
@@ -38,8 +38,6 @@ export const SectionHeaderItem = ({
     setDraggedItemId(null)
   }
 
-  const dragEnabled = !disabled && !answering && !item.section.locked
-
   return (
     <Reorder.Item
       value={item}
@@ -56,25 +54,32 @@ export const SectionHeaderItem = ({
           <div
             className={cn(
               "flex flex-row items-start gap-1 w-full",
+              // Mirror the drag-and-drop gutter (handle w-6 + gap-1 ≈ 28px) on
+              // the right so the header aligns with the cards' width.
+              !disabled && !answering && "pr-7",
               isDragging && "cursor-grabbing"
             )}
           >
-            {!disabled && !answering && (
-              <div
-                className={cn(
-                  "mt-2 flex aspect-square w-6 scale-75 items-center opacity-0 hover:opacity-40 group-hover/element:opacity-40",
-                  !isDragging && "cursor-grab",
-                  !dragEnabled && "cursor-not-allowed"
-                )}
-                onPointerDown={(e) => {
-                  if (dragEnabled) {
+            {!disabled &&
+              !answering &&
+              (item.section.locked ? (
+                // Blocked section: drop the drag affordance but keep the
+                // handle's gutter so the header stays aligned with the
+                // editable rows around it.
+                <div className="mt-2 aspect-square w-6 scale-75" aria-hidden />
+              ) : (
+                <div
+                  className={cn(
+                    "mt-2 flex aspect-square w-6 scale-75 items-center opacity-0 hover:opacity-40 group-hover/element:opacity-40",
+                    !isDragging && "cursor-grab"
+                  )}
+                  onPointerDown={(e) => {
                     dragControls.start(e)
-                  }
-                }}
-              >
-                <F0Icon icon={Handle} size="sm" />
-              </div>
-            )}
+                  }}
+                >
+                  <F0Icon icon={Handle} size="sm" />
+                </div>
+              ))}
             <SectionComponent {...item.section} hideQuestions />
           </div>
 

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -49,8 +49,9 @@ export const Default: Story = {
         type: "section",
         section: {
           id: "section-1",
-          title: "Section 1",
-          description: "Section 1 description",
+          title: "Company-wide questions",
+          description:
+            "These questions are predefined and can't be edited, moved, or removed.",
           locked: true,
           questions: [
             {
@@ -354,6 +355,47 @@ export const WithAllowCreate: Story = {
             "The employees dataset does not have onCreate, so no toggle appears.",
           type: "dropdown-single" as const,
           datasetKey: "employees",
+        },
+      },
+    ],
+  },
+}
+
+/**
+ * A blocked, predefined question: `locked` disables its fields, removes its edit
+ * menu and drag handle, and makes its inputs non-interactive, while `notice`
+ * renders an in-card alert explaining why it's fixed. The remaining question
+ * stays fully editable. The notice never shows in the answering/preview form.
+ */
+export const WithBlockedQuestion: Story = {
+  args: {
+    elements: [
+      {
+        type: "question",
+        question: {
+          id: "q-enps",
+          title: "How likely are you to recommend us as a place to work?",
+          description: "0 is not at all likely, 10 is extremely likely.",
+          type: "rating" as const,
+          options: Array.from({ length: 11 }, (_, value) => ({
+            value,
+            label: String(value),
+          })),
+          required: true,
+          locked: true,
+          notice: {
+            title: "Predefined eNPS question",
+            description:
+              "This question powers your Employee NPS score, so it can't be edited, moved, or removed.",
+          },
+        },
+      },
+      {
+        type: "question",
+        question: {
+          id: "q-reason",
+          title: "What's the main reason for your score?",
+          type: "longText" as const,
         },
       },
     ],

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.tsx
@@ -1,5 +1,5 @@
 import { motion, Reorder } from "motion/react"
-import { useEffect, useMemo } from "react"
+import { useEffect, useMemo, type ReactNode } from "react"
 
 import { withDataTestId } from "@/lib/data-testid"
 import { cn } from "@/lib/utils"
@@ -110,6 +110,16 @@ const _SurveyFormBuilder = ({
     return result
   }, [elements])
 
+  const lockedSectionIds = useMemo(() => {
+    const result = new Set<string>()
+    for (const element of elements) {
+      if (element.type === "section" && element.section.locked) {
+        result.add(element.section.id)
+      }
+    }
+    return result
+  }, [elements])
+
   const {
     handleFlatReorder,
     handleConfirmLastQuestionMove,
@@ -164,32 +174,103 @@ const _SurveyFormBuilder = ({
                 as="div"
               >
                 <div className="flex flex-col">
-                  {reorderableItems.map((item, index) => {
-                    const gapClass =
-                      index === 0
-                        ? ""
-                        : inSectionQuestionIds.has(item.id)
-                          ? "mt-4"
-                          : "mt-8"
+                  {(() => {
+                    const nodes: ReactNode[] = []
 
-                    if (item.type === "section-header") {
-                      return (
-                        <SectionHeaderItem
-                          key={item.id}
-                          item={item}
-                          className={gapClass}
-                        />
-                      )
+                    for (
+                      let index = 0;
+                      index < reorderableItems.length;
+                      index++
+                    ) {
+                      const item = reorderableItems[index]
+
+                      // A locked section renders as one muted grey rounded
+                      // panel wrapping its header and all of its questions. The
+                      // right padding mirrors the drag-and-drop gutter reserved
+                      // on the left so the cards sit symmetrically in the panel.
+                      if (
+                        item.type === "section-header" &&
+                        lockedSectionIds.has(item.section.id)
+                      ) {
+                        const groupItems: typeof reorderableItems = [item]
+                        let next = index + 1
+                        while (
+                          next < reorderableItems.length &&
+                          reorderableItems[next].type === "question" &&
+                          inSectionQuestionIds.has(reorderableItems[next].id)
+                        ) {
+                          groupItems.push(reorderableItems[next])
+                          next++
+                        }
+
+                        nodes.push(
+                          <div
+                            key={`locked-${item.section.id}`}
+                            className={cn(
+                              "rounded-2xl bg-f1-background-secondary pb-8 pt-4",
+                              index === 0 ? "" : "mt-8"
+                            )}
+                          >
+                            {groupItems.map((groupItem) => {
+                              if (groupItem.type === "section-header") {
+                                return (
+                                  <SectionHeaderItem
+                                    key={groupItem.id}
+                                    item={groupItem}
+                                    className=""
+                                  />
+                                )
+                              }
+                              if (groupItem.type === "question") {
+                                // The grey panel delimits the section, so the
+                                // "end of section" divider is suppressed here.
+                                return (
+                                  <QuestionItem
+                                    key={groupItem.id}
+                                    item={groupItem}
+                                    showEndOfSection={false}
+                                    className="mt-4"
+                                  />
+                                )
+                              }
+                              return null
+                            })}
+                          </div>
+                        )
+
+                        index = next - 1
+                        continue
+                      }
+
+                      const gapClass =
+                        index === 0
+                          ? ""
+                          : inSectionQuestionIds.has(item.id)
+                            ? "mt-4"
+                            : "mt-8"
+
+                      if (item.type === "section-header") {
+                        nodes.push(
+                          <SectionHeaderItem
+                            key={item.id}
+                            item={item}
+                            className={gapClass}
+                          />
+                        )
+                      } else if (item.type === "question") {
+                        nodes.push(
+                          <QuestionItem
+                            key={item.id}
+                            item={item}
+                            showEndOfSection={sectionEndIds.has(item.id)}
+                            className={gapClass}
+                          />
+                        )
+                      }
                     }
-                    return (
-                      <QuestionItem
-                        key={item.id}
-                        item={item}
-                        showEndOfSection={sectionEndIds.has(item.id)}
-                        className={gapClass}
-                      />
-                    )
-                  })}
+
+                    return nodes
+                  })()}
                 </div>
               </Reorder.Group>
               {shouldShowAddButton && <AddButton />}

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from "react"
 
+import { F0Alert } from "@/components/F0Alert"
 import { F0Button } from "@/components/F0Button"
 import { F0Icon } from "@/components/F0Icon"
-import { AcademicCap, Add, Check, CheckDouble } from "@/icons/app"
+import { AcademicCap, Add, Check, CheckDouble, LockLocked } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import {
@@ -41,6 +42,7 @@ export const BaseQuestion = ({
   locked: questionLocked,
   type: questionType,
   hiddenActions,
+  notice,
 }: BaseQuestionProps) => {
   const {
     onQuestionChange,
@@ -55,6 +57,8 @@ export const BaseQuestion = ({
   const containingSection = getSectionContainingQuestion(id)
 
   const locked = containingSection?.locked || questionLocked
+
+  const inLockedSection = !!containingSection?.locked
 
   const isWithinSection = !!containingSection
 
@@ -131,11 +135,34 @@ export const BaseQuestion = ({
     <div
       id={`co-creation-question-${id}`}
       className={cn(
-        "group/question relative flex w-full flex-col rounded-xl border border-solid border-f1-border bg-f1-background px-3 py-4",
-        !isDragging && !answering && "hover:border-f1-border-hover",
+        "group/question relative flex w-full flex-col rounded-xl border border-solid border-f1-border px-3 py-3",
+        // Blocked question: a not-allowed cursor signals it can't be edited.
+        // The `[&_*]` rule forces that cursor onto every descendant (inputs,
+        // textareas, options) so hovering anything inside the card keeps the
+        // not-allowed cursor, overriding their own (text/default) cursors.
+        // Inside a locked section the card keeps the default white fill (the
+        // section's muted grey panel sets it apart); a standalone blocked
+        // question still gets the muted grey fill to stand out on its own.
+        locked && !answering
+          ? cn(
+              "cursor-not-allowed [&_*]:!cursor-not-allowed",
+              inLockedSection
+                ? "bg-f1-background"
+                : "bg-f1-background-secondary"
+            )
+          : "bg-f1-background",
+        !isDragging && !answering && !locked && "hover:border-f1-border-hover",
         !answering || !!description ? "gap-4" : "gap-2"
       )}
     >
+      {notice && !answering && (
+        <F0Alert
+          variant={notice.variant ?? "info"}
+          title={notice.title}
+          description={notice.description}
+          icon={notice.icon}
+        />
+      )}
       <div className="flex flex-col gap-0.5">
         <div className="flex flex-row gap-2">
           <div className="relative w-full">
@@ -196,6 +223,22 @@ export const BaseQuestion = ({
                   !isWithinSection || !isSingleQuestionInSection
                 }
                 hiddenActions={hiddenActions}
+              />
+            </div>
+          )}
+          {!answering && locked && (
+            // Blocked question: a static lock sits where the actions "⋯" menu
+            // would be, signalling the card is predefined and can't be edited.
+            <div>
+              <F0Button
+                icon={LockLocked}
+                label={t("surveyFormBuilder.labels.locked")}
+                size="md"
+                variant="ghost"
+                tooltip={false}
+                hideLabel
+                disabled
+                withoutDisabledAppearance
               />
             </div>
           )}

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
@@ -2,8 +2,10 @@ import { Reorder } from "motion/react"
 import { useEffect, useMemo, useRef, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
+import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import { Dropdown } from "@/experimental/Navigation/Dropdown"
-import { Delete, Ellipsis, LayersFront } from "@/icons/app"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { Delete, Ellipsis, LayersFront, LockLocked } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
@@ -19,7 +21,7 @@ const TEXT_AREA_STYLE: object = {
 
 export const Section = ({
   id,
-  title,
+  title = "",
   description,
   questions = [],
   locked,
@@ -86,73 +88,122 @@ export const Section = ({
 
   const inputDisabled = disabled || locked || answering
 
+  // When the section is read-only (locked/disabled/answering) an empty title or
+  // description has nothing to show and no way to edit, so it's hidden. When the
+  // section is editable the inputs always render — empty ones surface a
+  // placeholder so authors can fill them in.
+  const showTitle = !inputDisabled || !!title
+  const showDescription = !inputDisabled || !!description
+
   const titleRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     titleRef.current?.focus({ preventScroll: true })
   }, [])
 
+  // Blocked section: a white "LOCKED" tag sits at the rightmost of the title.
+  // The section description isn't shown inline; instead it's surfaced as a
+  // tooltip on the tag (see below).
+  const lockedTag =
+    locked && !answering ? (
+      <F0TagRaw
+        text={t("surveyFormBuilder.labels.locked")}
+        icon={LockLocked}
+        className="bg-f1-background"
+      />
+    ) : null
+
   return (
     <div
       id={`co-creation-section-${id}`}
-      className="group/section flex w-full flex-col gap-1 bg-f1-background"
+      className={cn(
+        "group/section flex w-full flex-col gap-1",
+        // Blocked section: the muted grey panel comes from the wrapper in
+        // Form, so the header stays transparent (letting it show through) and
+        // a not-allowed cursor signals it can't be edited. Editable sections
+        // keep their white background.
+        locked && !answering ? "cursor-not-allowed" : "bg-f1-background"
+      )}
     >
-      <div className="py-1 pl-5 pr-3">
-        <div className="flex flex-row">
-          <input
-            ref={titleRef}
-            type="text"
-            aria-label={t("surveyFormBuilder.labels.title")}
-            value={title}
-            placeholder={t("surveyFormBuilder.labels.sectionTitlePlaceholder")}
-            onChange={handleChangeTitle}
-            disabled={inputDisabled}
-            className={cn(
-              "w-full text-lg font-semibold disabled:text-f1-foreground [&::-webkit-search-cancel-button]:hidden",
-              inputDisabled && "cursor-not-allowed"
-            )}
-          />
-          {!disabled && !answering && !locked && (
-            <div
-              className={cn(
-                "opacity-0 group-hover/section:opacity-100",
-                actionsDropdownOpen && "opacity-100"
-              )}
-            >
-              <Dropdown
-                items={actions}
-                icon={Ellipsis}
-                open={actionsDropdownOpen}
-                onOpenChange={setActionsDropdownOpen}
-                align="start"
-              >
-                <F0Button
-                  icon={Ellipsis}
-                  label={t("surveyFormBuilder.actions.actions")}
-                  size="md"
-                  variant="ghost"
-                  tooltip={false}
-                  hideLabel
+      {(showTitle || showDescription || (locked && !answering)) && (
+        <div className="py-1 pl-5 pr-3">
+          {(showTitle || (locked && !answering)) && (
+            <div className="flex flex-row items-center gap-2">
+              {showTitle && (
+                <input
+                  ref={titleRef}
+                  type="text"
+                  aria-label={t("surveyFormBuilder.labels.title")}
+                  value={title}
+                  placeholder={t(
+                    "surveyFormBuilder.labels.sectionTitlePlaceholder"
+                  )}
+                  onChange={handleChangeTitle}
+                  disabled={inputDisabled}
+                  className={cn(
+                    "w-full text-lg font-semibold disabled:text-f1-foreground [&::-webkit-search-cancel-button]:hidden",
+                    inputDisabled && "cursor-not-allowed"
+                  )}
                 />
-              </Dropdown>
+              )}
+              {lockedTag && (
+                <div className="ml-auto flex shrink-0 items-center">
+                  {description ? (
+                    // The description explains why the section is blocked; it
+                    // surfaces on hover/focus of the tag instead of inline.
+                    <Tooltip description={description} instant>
+                      <span className="inline-flex">{lockedTag}</span>
+                    </Tooltip>
+                  ) : (
+                    lockedTag
+                  )}
+                </div>
+              )}
+              {!disabled && !answering && !locked && (
+                <div
+                  className={cn(
+                    "opacity-0 group-hover/section:opacity-100",
+                    actionsDropdownOpen && "opacity-100"
+                  )}
+                >
+                  <Dropdown
+                    items={actions}
+                    icon={Ellipsis}
+                    open={actionsDropdownOpen}
+                    onOpenChange={setActionsDropdownOpen}
+                    align="start"
+                  >
+                    <F0Button
+                      icon={Ellipsis}
+                      label={t("surveyFormBuilder.actions.actions")}
+                      size="md"
+                      variant="ghost"
+                      tooltip={false}
+                      hideLabel
+                    />
+                  </Dropdown>
+                </div>
+              )}
             </div>
           )}
+          {showDescription && !(locked && !answering) && (
+            <textarea
+              value={description}
+              aria-label={t("surveyFormBuilder.labels.description")}
+              placeholder={t(
+                "surveyFormBuilder.labels.sectionDescriptionPlaceholder"
+              )}
+              onChange={handleChangeDescription}
+              disabled={inputDisabled}
+              style={TEXT_AREA_STYLE}
+              className={cn(
+                "w-full resize-none text-f1-foreground-secondary placeholder:text-f1-foreground-tertiary disabled:text-f1-foreground-secondary [&::-webkit-search-cancel-button]:hidden",
+                inputDisabled && "cursor-not-allowed"
+              )}
+            />
+          )}
         </div>
-        <textarea
-          value={description}
-          aria-label={t("surveyFormBuilder.labels.description")}
-          placeholder={t(
-            "surveyFormBuilder.labels.sectionDescriptionPlaceholder"
-          )}
-          onChange={handleChangeDescription}
-          disabled={inputDisabled}
-          style={TEXT_AREA_STYLE}
-          className={cn(
-            "w-full resize-none text-f1-foreground-secondary placeholder:text-f1-foreground-tertiary disabled:text-f1-foreground-secondary [&::-webkit-search-cancel-button]:hidden",
-            inputDisabled && "cursor-not-allowed"
-          )}
-        />
-      </div>
+      )}
       {!hideQuestions && (
         <>
           <DragProvider>


### PR DESCRIPTION
## Description

Redesigns the **blocked (locked) section** in the `SurveyFormBuilder`. Extracted from #4307 (co-creation patterns) so the SurveyFormBuilder/`F0TagRaw` changes can be reviewed and merged on their own; #4307 is stacked on top of this branch.

A locked section now reads as a single muted grey rounded panel with a white "Locked" tag in its title, replacing the previous explanatory alert.

## Screenshots (if applicable)

| Light | Dark |
| --- | --- |
| Grey `rounded-2xl` panel wrapping the section header + its question cards, white "Locked" tag at the right of the title, white default cards inside. | Same treatment using semantic tokens. |

_(Storybook: **Surveys → SurveyFormBuilder → Default**.)_

## Implementation details

- **Whole-section panel**: a locked section's header + its questions are grouped into one `rounded-2xl bg-f1-background-secondary` wrapper (`Form/index.tsx`). Verified safe inside `Reorder.Group` (framer-motion orders by measured position + context, not DOM nesting; locked items aren't draggable).
- **Alert → "Locked" tag**: the section notice/alert is removed; a white `F0TagRaw` (lock icon + "Locked") sits at the right of the title. The section description is no longer shown inline — it's surfaced as an **instant tooltip** on the tag.
- **Cards**: locked question cards roll back to the default white card styling, drop the hover-border effect, and force the `not-allowed` cursor on every descendant (`[&_*]:!cursor-not-allowed`). Right padding mirrors the drag-and-drop gutter so all cards share the same width.
- **`F0TagRaw`**: adds an optional `className` passthrough (backward compatible) so the tag can render white.

Builder-only: the answering/preview renderer (`SurveyAnsweringForm`) is untouched and shows locked sections as regular questions.