### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.8.3",
+  "packages/react": "3.8.4",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.8.4](https://github.com/factorialco/f0/compare/f0-react-v3.8.3...f0-react-v3.8.4) (2026-06-18)
+
+
+### Bug Fixes
+
+* **rich-text:** disable scroll anchoring on the notes editor scroll container ([#4485](https://github.com/factorialco/f0/issues/4485)) ([4ffc269](https://github.com/factorialco/f0/commit/4ffc269494617edb4c5f320ab660f832882a3e2c))
+
 ## [3.8.3](https://github.com/factorialco/f0/compare/f0-react-v3.8.2...f0-react-v3.8.3) (2026-06-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.8.4</summary>

## [3.8.4](https://github.com/factorialco/f0/compare/f0-react-v3.8.3...f0-react-v3.8.4) (2026-06-18)


### Bug Fixes

* **rich-text:** disable scroll anchoring on the notes editor scroll container ([#4485](https://github.com/factorialco/f0/issues/4485)) ([4ffc269](https://github.com/factorialco/f0/commit/4ffc269494617edb4c5f320ab660f832882a3e2c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).