### PR TITLE
fix(EntitySelect): defer trigger padding to F0InputField to fix md avatar spacing

### DIFF
--- a/packages/react/src/deprecated/EntitySelect/Trigger/index.tsx
+++ b/packages/react/src/deprecated/EntitySelect/Trigger/index.tsx
@@ -140,9 +140,14 @@ export const Trigger = ({
           "my-auto flex items-center pr-1",
           placeholder && "text-f1-foreground-secondary",
           value && "text-f1-foreground",
-          (flattenedList.length === 1 && !hiddenAvatar) || (icon && !value)
-            ? "pl-8"
-            : "pl-2"
+          // When an avatar or icon is shown, F0InputField already applies the
+          // size-aware left padding (pl-8 for sm, pl-9 for md) to clear it.
+          // Hardcoding pl-8 here would override pl-9 and glue the text to the
+          // avatar at size="md", so only set the left padding when there is none.
+          !(
+            (flattenedList.length === 1 && !hiddenAvatar) ||
+            (icon && !value)
+          ) && "pl-2"
         )}
       >
         <OneEllipsis


### PR DESCRIPTION
## Description

Fixes the avatar/name spacing in the `EntitySelect` trigger when `size="md"` and a single entity is selected: the avatar was rendered flush against the value text (no gap).

## Screenshots 
### Before
<img width="1390" height="1070" alt="Screenshot 2026-06-18 at 13 58 05" src="https://github.com/user-attachments/assets/a6f068a6-90a7-46c9-972f-c8c9bfc9e364" />

### After
<img width="1638" height="1155" alt="Screenshot 2026-06-18 at 14 10 38" src="https://github.com/user-attachments/assets/c93698d6-7554-488a-a6c2-29632382710d" />

## Implementation details

The trigger hardcoded `pl-8` on the selected-value `<span>` whenever an avatar or icon was shown:

```tsx
(flattenedList.length === 1 && !hiddenAvatar) || (icon && !value) ? "pl-8" : "pl-2"
```

That `className` is passed down to `F0InputField`, which clones the child and **merges it _after_ its own size-aware left padding** (`pl-8` for `sm`, `pl-9` for `md`). Since `cn` uses `tailwind-merge` (last conflicting class wins), the trigger's `pl-8` overrode `F0InputField`'s `pl-9`. At `size="md"` the avatar sits at `left-3` (12px) + 20px = 32px, but the text then started at `pl-8` (32px) too → flush against the avatar.

Fix: when an avatar/icon is present, the trigger no longer emits a left padding and defers to `F0InputField`'s size-aware padding. Result:

- `sm`: unchanged (`pl-8`, ~4px gap).
- `md`: now `pl-9` (36px) → ~4px gap. ✅

The `pl-2` is kept only for the no-avatar/no-icon case (e.g. multi-selection "N selected" or `hiddenAvatar`).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
