### PR TITLE
fix(F0Dialog): render center & fullscreen dialogs above the fullscreen AI chat

### DIFF
--- a/packages/react/src/components/dialog-alike/F0Dialog/__stories__/F0Dialog.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__stories__/F0Dialog.stories.tsx
@@ -13,6 +13,10 @@ import CheckDoubleIcon from "@/icons/app/CheckDouble"
 import CrossIcon from "@/icons/app/Cross"
 import SaveIcon from "@/icons/app/Save"
 import ShareIcon from "@/icons/app/Share"
+import {
+  expectDialogPaintsAboveChat,
+  FullscreenChatFrame,
+} from "@/lib/storybook-utils/aiChatStacking"
 
 import { getDialogAlikeArgTypes } from "../../common/__stories__/argsTypes.ts"
 import { OTHER_ACTIONS, TABS } from "../../common/__stories__/mocks.ts"
@@ -63,7 +67,11 @@ const meta: Meta<typeof F0Dialog> = {
     },
   },
   decorators: [
-    (Story, { args: { isOpen, ...rest } }) => {
+    (Story, context) => {
+      const {
+        args: { isOpen, ...rest },
+        parameters,
+      } = context
       const [open, setOpen] = useState(isOpen)
 
       const handleClose = () => {
@@ -71,6 +79,13 @@ const meta: Meta<typeof F0Dialog> = {
       }
       const handleOpen = () => {
         setOpen(true)
+      }
+
+      // Stories that build their own ApplicationFrame (e.g. the fullscreen AI
+      // chat stacking demo) opt out of the default open-button + centering
+      // wrapper and drive the dialog themselves.
+      if (parameters.standaloneFrame) {
+        return <Story />
       }
 
       return (
@@ -371,4 +386,45 @@ export const EscapesAppStackingContext: Story = {
       <F0Dialog {...args} />
     </div>
   ),
+}
+
+// --- Opening a dialog over the real fullscreen AI chat -----------------------
+// The previous story simulates the isolate with a tinted panel. This one mounts
+// the actual ApplicationFrame with the AI chat locked open in fullscreen
+// (painting at z-20 inside the isolate) and opens a center F0Dialog on top of
+// it. The play function asserts the dialog stays above the chat.
+
+const OVER_CHAT_TITLE = "On top of the fullscreen chat"
+
+export const OverFullscreenAiChat: Story = {
+  parameters: {
+    standaloneFrame: true,
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "Opens a center F0Dialog while the AI chat is locked open in fullscreen. The chat paints at `z-20` inside the ApplicationFrame `isolate`; the dialog escapes to `#f0-overlay-root` so it — and its overlay — render above the chat. The play function hit-tests the dialog card to confirm nothing from the chat paints over it.",
+      },
+    },
+  },
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    title: OVER_CHAT_TITLE,
+    description: "The dialog and its overlay sit above the fullscreen chat.",
+    primaryAction: {
+      label: "Got it",
+      onClick: () => {},
+      closeOnClick: true,
+    },
+    children: <ExampleList itemsCount={3} />,
+  },
+  render: (args) => (
+    <FullscreenChatFrame>
+      <F0Dialog {...args} />
+    </FullscreenChatFrame>
+  ),
+  play: async () => {
+    await expectDialogPaintsAboveChat({ title: OVER_CHAT_TITLE })
+  },
 }

--- a/packages/react/src/components/dialog-alike/F0Dialog/__tests__/F0Dialog.aichat-stacking.test.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__tests__/F0Dialog.aichat-stacking.test.tsx
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, within } from "@/testing/test-utils"
+
+import { F0Dialog } from "../index"
+
+/**
+ * Regression cover for opening a center F0Dialog while the AI chat is in
+ * fullscreen.
+ *
+ * In `ApplicationFrame` the fullscreen chat paints at `z-20` **inside** a
+ * `relative isolate` stacking context, as a sibling of `#content` (`z-10`).
+ * Anything portaled into `#content` is therefore trapped below the chat. The
+ * center dialog escapes by portaling to the top-level `#f0-overlay-root`, which
+ * lives outside that isolate — so the dialog and its overlay paint above the
+ * chat regardless of the in-isolate z-index battle.
+ *
+ * We can't measure paint order in jsdom, so we assert the structural property
+ * that guarantees it: the dialog lands in `#f0-overlay-root` and never inside
+ * the simulated `#content` / fullscreen-chat subtree.
+ */
+describe("dialog-alike F0Dialog over a fullscreen AI chat", () => {
+  let overlayRoot: HTMLElement
+  let content: HTMLElement
+  let fullscreenChat: HTMLElement
+
+  beforeEach(() => {
+    // Mirror the ApplicationFrame shell: an isolate (`#content`) that holds the
+    // fullscreen chat, followed by the top-level overlay root (as F0Provider
+    // renders it). Order matters — later siblings win at equal z-index.
+    content = document.createElement("div")
+    content.id = "content"
+    content.className = "isolate"
+
+    fullscreenChat = document.createElement("div")
+    fullscreenChat.id = "fake-fullscreen-chat"
+    content.appendChild(fullscreenChat)
+
+    overlayRoot = document.createElement("div")
+    overlayRoot.id = "f0-overlay-root"
+
+    document.body.append(content, overlayRoot)
+  })
+
+  afterEach(() => {
+    content.remove()
+    overlayRoot.remove()
+    vi.clearAllMocks()
+  })
+
+  it("portals the dialog into #f0-overlay-root, escaping the chat's stacking context", () => {
+    render(
+      <F0Dialog isOpen onClose={vi.fn()} title="On top of the chat">
+        <p>Body</p>
+      </F0Dialog>
+    )
+
+    // The dialog renders in the overlay root...
+    const dialog = within(overlayRoot).getByText("On top of the chat")
+    expect(overlayRoot).toContainElement(dialog)
+
+    // ...and never inside #content or the fullscreen chat subtree.
+    expect(within(content).queryByText("On top of the chat")).toBeNull()
+    expect(fullscreenChat.contains(dialog)).toBe(false)
+  })
+
+  it("keeps the overlay root outside the isolate so it paints above the chat", () => {
+    render(
+      <F0Dialog isOpen onClose={vi.fn()} title="On top of the chat">
+        <p>Body</p>
+      </F0Dialog>
+    )
+
+    // The overlay root is a sibling of #content (not nested in the isolate)...
+    expect(content.contains(overlayRoot)).toBe(false)
+    // ...and comes after it in the DOM, so it wins the equal-z-index paint.
+    expect(
+      content.compareDocumentPosition(overlayRoot) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+})

--- a/packages/react/src/lib/storybook-utils/aiChatStacking.tsx
+++ b/packages/react/src/lib/storybook-utils/aiChatStacking.tsx
@@ -1,0 +1,99 @@
+import { ComponentProps, ReactNode } from "react"
+import { expect, waitFor, within } from "storybook/test"
+
+import { ApplicationFrame } from "@/patterns/ApplicationFrame"
+import { Page } from "@/patterns/Navigation/Page"
+import * as PageStories from "@/patterns/Navigation/Page/index.stories"
+import * as SidebarStories from "@/patterns/Navigation/Sidebar/index.stories"
+import { Sidebar } from "@/patterns/Navigation/Sidebar/Sidebar"
+import {
+  MockAiChatRuntimeProvider,
+  MockConnectedChatHeader,
+  MockConnectedChatInput,
+  MockConnectedMessagesContainer,
+} from "@/sds/ai/F0AiChat/__stories__/_mock"
+
+// AI chat locked open in fullscreen. In ApplicationFrame the fullscreen chat
+// paints at `z-20` inside a `relative isolate`, as a sibling of `#content`
+// (`z-10`) — so it covers the whole content area. A dialog opened here must
+// still render above it.
+const fullscreenChatAi: ComponentProps<typeof ApplicationFrame>["ai"] = {
+  enabled: true,
+  resizable: true,
+  initialMessage: [
+    "Operational work, automated by One",
+    "Ask anything about your company",
+  ],
+  defaultVisualizationMode: "fullscreen",
+  lockVisualizationMode: true,
+  chatHeader: <MockConnectedChatHeader />,
+  chatMessages: <MockConnectedMessagesContainer />,
+  chatInput: <MockConnectedChatInput />,
+}
+
+/**
+ * Renders the app shell with the AI chat locked open in fullscreen, then drops
+ * `children` (the dialog under test) into the main content area. Pair with
+ * {@link expectDialogPaintsAboveChat} in a `play` function to assert the dialog
+ * stays on top of the chat.
+ */
+export const FullscreenChatFrame = ({ children }: { children: ReactNode }) => (
+  <MockAiChatRuntimeProvider>
+    <ApplicationFrame
+      ai={fullscreenChatAi}
+      sidebar={<Sidebar {...SidebarStories.default.args} />}
+    >
+      <Page {...PageStories.Default.args} />
+      {children}
+    </ApplicationFrame>
+  </MockAiChatRuntimeProvider>
+)
+
+/**
+ * Verifies (in a real browser, via the Storybook test runner) that a center /
+ * fullscreen dialog paints above the fullscreen AI chat.
+ *
+ * The dialog escapes the ApplicationFrame isolate by portaling to the
+ * top-level `#f0-overlay-root`. We assert that structurally (the dialog lives
+ * in the overlay root) and visually: hit-testing the centre of the dialog card
+ * returns an element inside the overlay root, so nothing from the chat is
+ * painted over it.
+ */
+export async function expectDialogPaintsAboveChat({
+  title,
+}: {
+  title: string
+}) {
+  const doc = document
+  const overlayRoot = doc.getElementById("f0-overlay-root")
+  expect(
+    overlayRoot,
+    "#f0-overlay-root should exist (story must run under F0Provider)"
+  ).not.toBeNull()
+
+  // Structural guarantee: the dialog portals into the overlay root, outside the
+  // isolate where the fullscreen chat paints.
+  const titleEl = await within(overlayRoot!).findByText(title)
+
+  // The interactive dialog surface (`pointer-events-auto`) is the card we
+  // hit-test — the overlay/content wrappers are `pointer-events-none`.
+  const card =
+    titleEl.closest<HTMLElement>("[class*='pointer-events-auto']") ?? titleEl
+
+  await waitFor(
+    () => {
+      const rect = card.getBoundingClientRect()
+      expect(rect.width).toBeGreaterThan(0)
+      expect(rect.height).toBeGreaterThan(0)
+
+      const cx = rect.left + rect.width / 2
+      const cy = rect.top + rect.height / 2
+      const topmost = doc.elementFromPoint(cx, cy)
+      expect(topmost).not.toBeNull()
+      // Whatever paints on top at the dialog's centre belongs to the dialog
+      // portal — not the chat behind it.
+      expect(overlayRoot!.contains(topmost)).toBe(true)
+    },
+    { timeout: 3000 }
+  )
+}

--- a/packages/react/src/lib/storybook-utils/aiChatStacking.tsx
+++ b/packages/react/src/lib/storybook-utils/aiChatStacking.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, ReactNode } from "react"
+import { ComponentProps, ReactNode, useState } from "react"
 import { expect, waitFor, within } from "storybook/test"
 
 import { ApplicationFrame } from "@/patterns/ApplicationFrame"
@@ -31,23 +31,42 @@ const fullscreenChatAi: ComponentProps<typeof ApplicationFrame>["ai"] = {
   chatInput: <MockConnectedChatInput />,
 }
 
+// The chat's open + visualization-mode state is persisted to localStorage, so
+// a `sidepanel`/closed value left over from browsing other stories would
+// override `defaultVisualizationMode: "fullscreen"`. Clearing the keys before
+// the Ai provider initializes lets the fullscreen default take effect — with
+// no flash, since this runs in the parent's render before the provider mounts.
+const CHAT_OPEN_STORAGE_KEY = "ONE-ai-chat-open"
+const CHAT_VISUALIZATION_MODE_STORAGE_KEY = "ONE-ai-chat-visualization-mode"
+
 /**
  * Renders the app shell with the AI chat locked open in fullscreen, then drops
  * `children` (the dialog under test) into the main content area. Pair with
  * {@link expectDialogPaintsAboveChat} in a `play` function to assert the dialog
  * stays on top of the chat.
  */
-export const FullscreenChatFrame = ({ children }: { children: ReactNode }) => (
-  <MockAiChatRuntimeProvider>
-    <ApplicationFrame
-      ai={fullscreenChatAi}
-      sidebar={<Sidebar {...SidebarStories.default.args} />}
-    >
-      <Page {...PageStories.Default.args} />
-      {children}
-    </ApplicationFrame>
-  </MockAiChatRuntimeProvider>
-)
+export const FullscreenChatFrame = ({ children }: { children: ReactNode }) => {
+  // Lazy initializer runs once, before the Ai provider reads localStorage.
+  useState(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(CHAT_OPEN_STORAGE_KEY)
+      window.localStorage.removeItem(CHAT_VISUALIZATION_MODE_STORAGE_KEY)
+    }
+    return null
+  })
+
+  return (
+    <MockAiChatRuntimeProvider>
+      <ApplicationFrame
+        ai={fullscreenChatAi}
+        sidebar={<Sidebar {...SidebarStories.default.args} />}
+      >
+        <Page {...PageStories.Default.args} />
+        {children}
+      </ApplicationFrame>
+    </MockAiChatRuntimeProvider>
+  )
+}
 
 /**
  * Verifies (in a real browser, via the Storybook test runner) that a center /

--- a/packages/react/src/patterns/F0Dialog/F0DialogInternal.tsx
+++ b/packages/react/src/patterns/F0Dialog/F0DialogInternal.tsx
@@ -141,6 +141,12 @@ export const F0DialogInternal: FC<F0DialogInternalProps> = ({
     })
   }, [variant, position, localWidth])
 
+  // Center & fullscreen modals portal to the top-level overlay root so they
+  // escape app stacking contexts (e.g. the ApplicationFrame `isolate` layer
+  // where the fullscreen AI chat paints at z-20). Side drawers (left/right)
+  // stay docked inside `#content`.
+  const defaultContainerId = isSidePosition ? "content" : "f0-overlay-root"
+
   if (resourceHeader && !isSidePosition) {
     console.warn(
       "F0Dialog: `resourceHeader` is only applicable to side panel positions (left/right)"
@@ -208,6 +214,7 @@ export const F0DialogInternal: FC<F0DialogInternalProps> = ({
           className={contentClassName}
           onOpenAutoFocus={(e) => e.preventDefault()}
           container={containerProp}
+          defaultContainerId={defaultContainerId}
         >
           <F0DialogHeader {...headerProps} />
           <F0DialogContent disableContentPadding={disableContentPadding}>

--- a/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
+++ b/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
@@ -25,6 +25,10 @@ import { ActivityItemList } from "@/sds/inbox/Activity/ActivityItemList"
 import { Default as ActivityItemListDefault } from "@/sds/inbox/Activity/ActivityItemList/index.stories"
 
 import { PaginatedFetchOptions, RecordType } from "@/hooks/datasource"
+import {
+  expectDialogPaintsAboveChat,
+  FullscreenChatFrame,
+} from "@/lib/storybook-utils/aiChatStacking"
 import { useDataCollectionItemNavigation } from "@/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation"
 
 import { F0Dialog } from "../index"
@@ -63,7 +67,11 @@ const meta: Meta<typeof F0Dialog> = {
     ...dataTestIdArgs,
   },
   decorators: [
-    (Story, { args: { isOpen, ...rest } }) => {
+    (Story, context) => {
+      const {
+        args: { isOpen, ...rest },
+        parameters,
+      } = context
       const [open, setOpen] = useState(isOpen)
 
       const handleClose = () => {
@@ -71,6 +79,12 @@ const meta: Meta<typeof F0Dialog> = {
       }
       const handleOpen = () => {
         setOpen(true)
+      }
+
+      // Stories that build their own ApplicationFrame (e.g. the fullscreen AI
+      // chat stacking demo) opt out of the default frame + open-button wrapper.
+      if (parameters.standaloneFrame) {
+        return <Story />
       }
 
       return (
@@ -540,5 +554,78 @@ export const WithFewItems: Story = {
       onClick: () => {},
     },
     children: <ExamplePersonList numberOfItems={3} />,
+  },
+}
+
+// --- Opening a dialog over the fullscreen AI chat ----------------------------
+// Mounts the real ApplicationFrame with the AI chat locked open in fullscreen
+// (painting at z-20 inside the isolate) and opens an F0Dialog on top of it.
+// Center and fullscreen dialogs portal to the top-level `#f0-overlay-root`, so
+// they — and their overlay — escape the isolate and render above the chat. The
+// play function hit-tests the dialog card to confirm the chat never covers it.
+
+const OVER_CHAT_TITLE = "On top of the fullscreen chat"
+
+export const OverFullscreenAiChat: Story = {
+  parameters: {
+    standaloneFrame: true,
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "A center F0Dialog opened while the AI chat is locked open in fullscreen. The chat paints at `z-20` inside the ApplicationFrame `isolate`; the dialog escapes to `#f0-overlay-root` so it renders above the chat instead of being trapped behind it in `#content`.",
+      },
+    },
+  },
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    title: OVER_CHAT_TITLE,
+    description: "The dialog and its overlay sit above the fullscreen chat.",
+    primaryAction: {
+      label: "Got it",
+      onClick: () => {},
+    },
+    children: <ExampleList itemsCount={3} />,
+  },
+  render: (args) => (
+    <FullscreenChatFrame>
+      <F0Dialog {...args} />
+    </FullscreenChatFrame>
+  ),
+  play: async () => {
+    await expectDialogPaintsAboveChat({ title: OVER_CHAT_TITLE })
+  },
+}
+
+export const FullscreenDialogOverFullscreenAiChat: Story = {
+  parameters: {
+    standaloneFrame: true,
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          'Same scenario with a `position="fullscreen"` dialog. It also portals to `#f0-overlay-root`, so it covers the fullscreen chat rather than being clipped by the isolate.',
+      },
+    },
+  },
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    position: "fullscreen",
+    title: OVER_CHAT_TITLE,
+    primaryAction: {
+      label: "Got it",
+      onClick: () => {},
+    },
+    children: <ExamplePersonList numberOfItems={3} />,
+  },
+  render: (args) => (
+    <FullscreenChatFrame>
+      <F0Dialog {...args} />
+    </FullscreenChatFrame>
+  ),
+  play: async () => {
+    await expectDialogPaintsAboveChat({ title: OVER_CHAT_TITLE })
   },
 }

--- a/packages/react/src/patterns/F0Dialog/__tests__/F0Dialog.aichat-stacking.test.tsx
+++ b/packages/react/src/patterns/F0Dialog/__tests__/F0Dialog.aichat-stacking.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, within } from "@/testing/test-utils"
+
+import { F0Dialog } from "../index"
+
+/**
+ * Regression cover for opening an F0Dialog while the AI chat is in fullscreen.
+ *
+ * In `ApplicationFrame` the fullscreen chat paints at `z-20` **inside** a
+ * `relative isolate` stacking context, as a sibling of `#content` (`z-10`).
+ * Anything portaled into `#content` is therefore trapped below the chat.
+ *
+ * Center and fullscreen dialogs escape by portaling to the top-level
+ * `#f0-overlay-root`, which lives outside that isolate — so the dialog and its
+ * overlay paint above the chat. Side panels (left/right) intentionally stay
+ * docked inside `#content`.
+ *
+ * jsdom can't measure paint order, so we assert the structural property that
+ * guarantees it: where the dialog lands when it portals.
+ */
+describe("patterns F0Dialog over a fullscreen AI chat", () => {
+  let overlayRoot: HTMLElement
+  let content: HTMLElement
+  let fullscreenChat: HTMLElement
+
+  beforeEach(() => {
+    // Mirror the ApplicationFrame shell: an isolate (`#content`) that holds the
+    // fullscreen chat, followed by the top-level overlay root (as F0Provider
+    // renders it). Order matters — later siblings win at equal z-index.
+    content = document.createElement("div")
+    content.id = "content"
+    content.className = "isolate"
+
+    fullscreenChat = document.createElement("div")
+    fullscreenChat.id = "fake-fullscreen-chat"
+    content.appendChild(fullscreenChat)
+
+    overlayRoot = document.createElement("div")
+    overlayRoot.id = "f0-overlay-root"
+
+    document.body.append(content, overlayRoot)
+  })
+
+  afterEach(() => {
+    content.remove()
+    overlayRoot.remove()
+    vi.clearAllMocks()
+  })
+
+  it.each(["center", "fullscreen"] as const)(
+    "portals a %s dialog into #f0-overlay-root, escaping the chat's stacking context",
+    (position) => {
+      render(
+        <F0Dialog
+          isOpen
+          onClose={vi.fn()}
+          position={position}
+          title="On top of the chat"
+        >
+          <p>Body</p>
+        </F0Dialog>
+      )
+
+      const dialog = within(overlayRoot).getByText("On top of the chat")
+      expect(overlayRoot).toContainElement(dialog)
+
+      // Never inside #content or the fullscreen chat subtree.
+      expect(within(content).queryByText("On top of the chat")).toBeNull()
+      expect(fullscreenChat.contains(dialog)).toBe(false)
+    }
+  )
+
+  it.each(["left", "right"] as const)(
+    "docks a %s side panel inside #content",
+    (position) => {
+      render(
+        <F0Dialog
+          isOpen
+          onClose={vi.fn()}
+          position={position}
+          title="Docked side panel"
+        >
+          <p>Body</p>
+        </F0Dialog>
+      )
+
+      const dialog = within(content).getByText("Docked side panel")
+      expect(content).toContainElement(dialog)
+      expect(within(overlayRoot).queryByText("Docked side panel")).toBeNull()
+    }
+  )
+
+  it("keeps the overlay root outside the isolate so it paints above the chat", () => {
+    render(
+      <F0Dialog isOpen onClose={vi.fn()} title="On top of the chat">
+        <p>Body</p>
+      </F0Dialog>
+    )
+
+    expect(content.contains(overlayRoot)).toBe(false)
+    expect(
+      content.compareDocumentPosition(overlayRoot) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+})

--- a/packages/react/src/ui/Dialog/components/DialogContent.tsx
+++ b/packages/react/src/ui/Dialog/components/DialogContent.tsx
@@ -13,6 +13,13 @@ export const DialogContent = forwardRef<
     wrapperClassName?: string
     withTranslateAnimation?: boolean
     container?: HTMLElement | null
+    /**
+     * Id of the element to portal into when no explicit `container` is given.
+     * Resolved at mount; falls back to `#content`, then to `document.body`
+     * (Radix default) when neither element exists.
+     * @default "content"
+     */
+    defaultContainerId?: string
   }
 >(
   (
@@ -22,6 +29,7 @@ export const DialogContent = forwardRef<
       children,
       withTranslateAnimation = true,
       container: propContainer,
+      defaultContainerId = "content",
       ...props
     },
     ref
@@ -32,9 +40,17 @@ export const DialogContent = forwardRef<
       if (propContainer !== undefined) {
         setContainer(propContainer)
       } else {
-        setContainer(document.getElementById("content"))
+        // Prefer the requested default target (e.g. the top-level overlay root
+        // for center/fullscreen modals, escaping app stacking contexts), then
+        // the app shell's `#content`, and finally the document body so the
+        // dialog still renders in contexts that have neither.
+        setContainer(
+          document.getElementById(defaultContainerId) ??
+            document.getElementById("content") ??
+            document.body
+        )
       }
-    }, [propContainer])
+    }, [propContainer, defaultContainerId])
 
     if (container === undefined) return null
 


### PR DESCRIPTION
## Problem

In `ApplicationFrame` the fullscreen AI chat paints at **`z-20` inside a `relative isolate`** stacking context, as a sibling of `#content` (`z-10`). The **patterns** `F0Dialog` portaled into `#content`, so when opened over the fullscreen AI chat it was **trapped behind the chat**. The **dialog-alike** `F0Dialog` already escapes this by portaling its center dialog to the top-level `#f0-overlay-root`.

## Fix

- **`patterns/F0Dialog`** — center & fullscreen dialogs now portal to `#f0-overlay-root` (escaping the isolate, matching dialog-alike). Side panels (left/right) stay docked in `#content`.
- **shared `ui/Dialog/components/DialogContent`** — added an optional `defaultContainerId` prop. It defaults to `"content"`, so the other consumers (UpsellingKit, deprecated `Dialog`) are unaffected, with the same `#id → #content → document.body` fallback chain dialog-alike already uses.

## Tests

Unit tests (vitest/jsdom) for **both** F0Dialogs asserting the portal target — the structural property that determines paint order (jsdom can't measure stacking):
- center & fullscreen → `#f0-overlay-root`, never inside the simulated chat/`#content` subtree
- side panels → `#content`
- overlay root sits outside the isolate and after it in DOM order

7 new tests, all green; the full dialog-area suite (26 tests) passes.

## Stories

A shared helper `lib/storybook-utils/aiChatStacking.tsx` mounts the real `ApplicationFrame` with the AI chat locked open in fullscreen and provides `expectDialogPaintsAboveChat`, which hit-tests the dialog card via `document.elementFromPoint` (runs under `test-storybook` in a real browser):
- **dialog-alike** → `Dialog / OverFullscreenAiChat`
- **patterns** → `Dialog / OverFullscreenAiChat` and `Dialog / FullscreenDialogOverFullscreenAiChat`

Both decorators gained a `parameters.standaloneFrame` opt-out so these stories supply their own frame.
