### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.8.5",
+  "packages/react": "3.8.6",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.8.6](https://github.com/factorialco/f0/compare/f0-react-v3.8.5...f0-react-v3.8.6) (2026-06-18)
+
+
+### Bug Fixes
+
+* **F0Dialog:** render center & fullscreen dialogs above the fullscreen AI chat ([#4507](https://github.com/factorialco/f0/issues/4507)) ([2a0fc7c](https://github.com/factorialco/f0/commit/2a0fc7c6b37bbaa483755725febc6ef16cda7de9))
+
 ## [3.8.5](https://github.com/factorialco/f0/compare/f0-react-v3.8.4...f0-react-v3.8.5) (2026-06-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.8.6</summary>

## [3.8.6](https://github.com/factorialco/f0/compare/f0-react-v3.8.5...f0-react-v3.8.6) (2026-06-18)


### Bug Fixes

* **F0Dialog:** render center & fullscreen dialogs above the fullscreen AI chat ([#4507](https://github.com/factorialco/f0/issues/4507)) ([2a0fc7c](https://github.com/factorialco/f0/commit/2a0fc7c6b37bbaa483755725febc6ef16cda7de9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).