### PR TITLE
feat(F0AiMessagesContainer): per-step content slot in Thinking

### DIFF
--- a/packages/react/src/sds/ai/F0ActionItem/F0ActionItem.tsx
+++ b/packages/react/src/sds/ai/F0ActionItem/F0ActionItem.tsx
@@ -16,7 +16,12 @@ const ICON_MOTION = {
   exit: { opacity: 0 },
 }
 
-export const F0ActionItem = ({ title, status, inGroup }: F0ActionItemProps) => {
+export const F0ActionItem = ({
+  title,
+  status,
+  inGroup,
+  content,
+}: F0ActionItemProps) => {
   const shouldReduceMotion = useReducedMotion()
   const transition = {
     duration: shouldReduceMotion ? 0 : 0.18,
@@ -68,15 +73,20 @@ export const F0ActionItem = ({ title, status, inGroup }: F0ActionItemProps) => {
           )}
         </AnimatePresence>
       </div>
-      {title && (
-        <p
-          className={cn(
-            "text-pretty leading-5",
-            (executing || writing) && "shine-text"
+      {(title || content) && (
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          {title && (
+            <p
+              className={cn(
+                "text-pretty leading-5",
+                (executing || writing) && "shine-text"
+              )}
+            >
+              {title}
+            </p>
           )}
-        >
-          {title}
-        </p>
+          {content && <div className="min-w-0">{content}</div>}
+        </div>
       )}
     </div>
   )

--- a/packages/react/src/sds/ai/F0ActionItem/types.ts
+++ b/packages/react/src/sds/ai/F0ActionItem/types.ts
@@ -1,3 +1,5 @@
+import { type ReactNode } from "react"
+
 /**
  * Props for the F0ActionItem component
  */
@@ -14,6 +16,13 @@ export interface F0ActionItemProps {
    * Whether the action item is part of a group
    */
   inGroup?: boolean
+  /**
+   * Optional freeform content rendered beneath the title, aligned with it
+   * (inside the text column, past the status icon). The component owns the
+   * layout; the consumer composes whatever renders here. The Thinking
+   * accordion uses it to attach rich per-step content.
+   */
+  content?: ReactNode
 }
 
 export const actionItemStatuses = [

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
@@ -236,14 +236,17 @@ const Messages = ({
         {turn.userMessages.map((message, index) =>
           renderUserMessage(message, index)
         )}
-        {turn.thinking && turn.thinking.titles.length > 0 && (
-          <Thinking
-            titles={turn.thinking.titles}
-            title={translations.ai.thoughtsGroupTitle}
-            inProgress={turn.thinking.inProgress}
-            isWriting={turn.thinking.isWriting}
-          />
-        )}
+        {turn.thinking &&
+          ((turn.thinking.items?.length ?? 0) > 0 ||
+            (turn.thinking.titles?.length ?? 0) > 0) && (
+            <Thinking
+              titles={turn.thinking.titles}
+              items={turn.thinking.items}
+              title={translations.ai.thoughtsGroupTitle}
+              inProgress={turn.thinking.inProgress}
+              isWriting={turn.thinking.isWriting}
+            />
+          )}
         {turn.assistantMessages.map((message, index) =>
           renderAssistantMessage(message, index)
         )}

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/__stories__/F0AiMessagesContainer.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/__stories__/F0AiMessagesContainer.stories.tsx
@@ -62,6 +62,56 @@ const turnWithThinking = (): RenderableTurn => {
   }
 }
 
+// Demonstrates the generic per-step content slot: the consumer composes
+// whatever it wants (here, simple "source"/"field" pills) under a step title.
+// f0 owns only the accordion + step chrome — it knows nothing about pills.
+const Pill = ({ children }: { children: React.ReactNode }) => (
+  <span className="inline-flex items-center rounded-full border border-solid border-f1-border bg-f1-background-secondary px-2 py-0.5 text-sm text-f1-foreground">
+    {children}
+  </span>
+)
+
+const turnWithRichThinking = (): RenderableTurn => {
+  const target = assistantMessage(
+    "a2r",
+    "Voluntary turnover was **4.2%** over the last 6 months, highest in the EU entity."
+  )
+  return {
+    userMessages: [
+      userMessage("u2r", "Voluntary turnover last 6 months by legal entity"),
+    ],
+    thinking: {
+      items: [
+        {
+          title: "Pulling the latest employee data",
+          content: (
+            <div className="flex flex-wrap gap-1">
+              <Pill>Employee data</Pill>
+            </div>
+          ),
+        },
+        {
+          title: "Assembling the columns for your turnover breakdown",
+          content: (
+            <div className="flex flex-wrap gap-1">
+              <Pill>Employee name</Pill>
+              <Pill>Team</Pill>
+              <Pill>Base salary</Pill>
+            </div>
+          ),
+        },
+        { title: "Breaking your turnover rate down by legal entity" },
+      ],
+    },
+    assistantMessages: [target],
+    isInProgress: false,
+    feedback: {
+      content: target.content as string,
+      targetMessage: target,
+    },
+  }
+}
+
 const turnStreamingThinkingIndicator = (): RenderableTurn => ({
   userMessages: [userMessage("u3", "What does my calendar look like today?")],
   assistantMessages: [],
@@ -159,6 +209,13 @@ export const Conversation: Story = {
     turns: [completedTurn(), turnWithThinking()],
     feedback: noopFeedback,
     onReplyQuote: (text) => console.log("reply quote", text),
+  },
+}
+
+export const WithRichThinking: Story = {
+  args: {
+    turns: [turnWithRichThinking()],
+    feedback: noopFeedback,
   },
 }
 

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/__tests__/Thinking.test.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/__tests__/Thinking.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { Thinking } from "../components/Thinking"
+
+describe("Thinking", () => {
+  it("renders plain titles (back-compat)", () => {
+    zeroRender(
+      <Thinking titles={["Looking up data", "Grouping by department"]} />
+    )
+    expect(screen.getByText("Looking up data")).toBeInTheDocument()
+    expect(screen.getByText("Grouping by department")).toBeInTheDocument()
+  })
+
+  it("renders per-step rich content from items", () => {
+    zeroRender(
+      <Thinking
+        items={[
+          {
+            title: "Pulling the latest employee data",
+            content: <span data-testid="source-pill">Employee data</span>,
+          },
+          { title: "Breaking down by legal entity" },
+        ]}
+      />
+    )
+    expect(
+      screen.getByText("Pulling the latest employee data")
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("source-pill")).toHaveTextContent("Employee data")
+    // A step without content still renders its title.
+    expect(
+      screen.getByText("Breaking down by legal entity")
+    ).toBeInTheDocument()
+  })
+
+  it("prefers items over titles when both are provided", () => {
+    zeroRender(
+      <Thinking titles={["ignored title"]} items={[{ title: "rich title" }]} />
+    )
+    expect(screen.getByText("rich title")).toBeInTheDocument()
+    expect(screen.queryByText("ignored title")).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/Thinking.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/Thinking.tsx
@@ -7,10 +7,11 @@ import { F0ActionItem } from "../../F0ActionItem"
 
 import { CollapsibleMessage } from "./CollapsibleMessage"
 
-import { ThinkingProps } from "../types"
+import { ThinkingProps, ThinkingStep } from "../types"
 
 export const Thinking = ({
   titles,
+  items,
   title,
   inProgress,
   isWriting,
@@ -32,7 +33,10 @@ export const Thinking = ({
   const headerTitle = inProgress
     ? translations.ai.thoughtsGroupTitle
     : (title ?? translations.ai.thoughtsGroupTitle)
-  const lastIndex = titles.length - 1
+  // `items` (rich, optional content) wins over `titles` (plain back-compat).
+  const steps: ThinkingStep[] =
+    items ?? (titles ?? []).map((stepTitle) => ({ title: stepTitle }))
+  const lastIndex = steps.length - 1
   const itemStatus = (index: number): "executing" | "completed" => {
     if (!inProgress || isWriting) return "completed"
     return index === lastIndex ? "executing" : "completed"
@@ -47,14 +51,15 @@ export const Thinking = ({
       lockOpen={inProgress}
     >
       <div className="flex flex-col gap-3 pb-4">
-        {titles.map((stepTitle, index) => (
+        {steps.map((step, index) => (
           <div key={index} className="relative">
             <F0ActionItem
-              title={stepTitle}
+              title={step.title}
+              content={step.content}
               status={itemStatus(index)}
               inGroup
             />
-            {index < titles.length - 1 && (
+            {index < steps.length - 1 && (
               <div
                 aria-hidden
                 className="absolute -bottom-3 left-2 ml-px top-5 w-px bg-f1-border-secondary rounded"

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/index.ts
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/index.ts
@@ -10,4 +10,8 @@ export {
   type UserReaction,
 } from "./components/feedback/FeedbackProvider"
 
-export { type RenderableTurn, type ThinkingProps } from "./types"
+export {
+  type RenderableTurn,
+  type ThinkingProps,
+  type ThinkingStep,
+} from "./types"

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/types.ts
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/types.ts
@@ -1,3 +1,22 @@
+import { type ReactNode } from "react"
+
+/**
+ * A single reasoning step in the Thinking accordion: a title plus optional
+ * freeform content rendered beneath it. f0 owns the accordion container and
+ * the step chrome (icon, connector, collapse); the consumer composes whatever
+ * `content` renders (catalog pills, citations, charts, …), so the design
+ * system stays domain-agnostic.
+ */
+export type ThinkingStep = {
+  /** Step sentence shown next to the status icon. */
+  title: string
+  /**
+   * Optional freeform content rendered under the title, inside the
+   * collapsible. Omit for a plain text-only step.
+   */
+  content?: ReactNode
+}
+
 /**
  * Loose message shape used by the headless container and its
  * subcomponents. Mirrors the CopilotKit `Message`/`AIMessage` shape
@@ -47,10 +66,18 @@ export type RenderableTurn = {
   userMessages: Message[]
   /**
    * Optional collapsible "thinking" header rendered between user and
-   * assistant blocks. Titles are pre-parsed upstream.
+   * assistant blocks. Steps are pre-parsed upstream — provide plain
+   * `titles` and/or rich `items` (a per-step content slot). When both are
+   * present, `items` wins.
    */
   thinking?: {
-    titles: string[]
+    /** Plain step titles. Back-compat shorthand for `items` without content. */
+    titles?: string[]
+    /**
+     * Per-step items with an optional freeform `content` slot rendered under
+     * each title. Takes precedence over `titles`.
+     */
+    items?: ThinkingStep[]
     /**
      * Whether this turn is still streaming. The collapsible stays locked
      * open while true (no chevron, no toggle) and auto-collapses on the
@@ -90,8 +117,16 @@ export type RenderableTurn = {
 
 /** Props for the Thinking collapsible section. */
 export type ThinkingProps = {
-  /** Pre-parsed step titles to show inside the collapsed group. */
-  titles: string[]
+  /**
+   * Pre-parsed step titles to show inside the collapsed group. Back-compat
+   * shorthand for `items` with no content; ignored when `items` is provided.
+   */
+  titles?: string[]
+  /**
+   * Per-step items with an optional freeform `content` slot rendered under
+   * each title. Takes precedence over `titles`.
+   */
+  items?: ThinkingStep[]
   /** Section heading (defaults to "Thoughts" from i18n). */
   title?: string
   /**


### PR DESCRIPTION
## What

The `Thinking` accordion accepted only `titles: string[]`, so reasoning steps could not carry richer content. This adds an **optional, domain-agnostic per-step content slot** so consumers can render whatever they want beneath a step title (catalog pills, citations, charts, …) while f0 keeps owning the accordion, the step chrome (icon, connector, collapse) and the streaming layout.

This mirrors the freeform-render-slot idiom already used for OneTable rich header info: **f0 owns the container, the consumer composes the content.** f0 never learns about the consumer's domain.

## Changes

- New `ThinkingStep = { title: string; content?: ReactNode }`; optional `items?: ThinkingStep[]` on `ThinkingProps` and `RenderableTurn.thinking`. `titles` stays for back-compat (now optional). When both are given, `items` wins.
- `F0ActionItem` gains an optional `content?: ReactNode`, rendered under the title and aligned with it inside the text column.
- `F0AiMessagesContainer` render guard + pass-through updated; new public export `ThinkingStep`.
- Story `WithRichThinking` demonstrates a consumer composing pills under steps.
- Unit tests: titles back-compat, rich content rendering, items-over-titles precedence.

## Compatibility

All changes are **additive / widening** (new optional props, a required prop made optional, a new export) — no breaking API-surface change. Existing `titles`-based callers are untouched.

## Why now

First consumer is the **chain-of-thought catalog trace** in Factorial ONE (the agent emits stable catalog refs per reasoning step; the product renders source/field pills with tooltips + click-through to the semantic catalog modal). That work nests the trace *inside* the Reasoning accordion, which this slot enables. The slot is intentionally generic so future reasoning content reuses it with no further f0 change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)