### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.8.6",
+  "packages/react": "3.9.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.9.0](https://github.com/factorialco/f0/compare/f0-react-v3.8.6...f0-react-v3.9.0) (2026-06-19)
+
+
+### Features
+
+* **avatars:** align F0AvatarModule sizes to canonical scale + stabilize ([#4415](https://github.com/factorialco/f0/issues/4415)) ([426e013](https://github.com/factorialco/f0/commit/426e0134715175b69916f3c1fd5ea9957ebfd318))
+
 ## [3.8.6](https://github.com/factorialco/f0/compare/f0-react-v3.8.5...f0-react-v3.8.6) (2026-06-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.8.6",
+  "version": "3.9.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.9.0</summary>

## [3.9.0](https://github.com/factorialco/f0/compare/f0-react-v3.8.6...f0-react-v3.9.0) (2026-06-19)


### Features

* **avatars:** align F0AvatarModule sizes to canonical scale + stabilize ([#4415](https://github.com/factorialco/f0/issues/4415)) ([426e013](https://github.com/factorialco/f0/commit/426e0134715175b69916f3c1fd5ea9957ebfd318))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).