### PR TITLE
feat(SurveyFormBuilder): lockable sections & questions

### DIFF
--- a/packages/react/src/components/tags/F0TagRaw/F0TagRaw.tsx
+++ b/packages/react/src/components/tags/F0TagRaw/F0TagRaw.tsx
@@ -2,13 +2,17 @@ import { forwardRef } from "react"
 
 import { F0Icon } from "@/components/F0Icon"
 import { useTextFormatEnforcer } from "@/lib/text"
+import { cn } from "@/lib/utils"
 
 import type { F0TagRawProps } from "./types"
 
 import { BaseTag } from "../internal/BaseTag"
 
 export const F0TagRaw = forwardRef<HTMLDivElement, F0TagRawProps>(
-  ({ text, additionalAccessibleText, icon, onlyIcon, info }, ref) => {
+  (
+    { text, additionalAccessibleText, icon, onlyIcon, info, className },
+    ref
+  ) => {
     useTextFormatEnforcer(
       text,
       { disallowEmpty: true },
@@ -18,7 +22,10 @@ export const F0TagRaw = forwardRef<HTMLDivElement, F0TagRawProps>(
     return (
       <BaseTag
         ref={ref}
-        className="border-[1px] border-solid border-f1-border-secondary"
+        className={cn(
+          "border-[1px] border-solid border-f1-border-secondary",
+          className
+        )}
         left={
           icon ? (
             <F0Icon

--- a/packages/react/src/components/tags/F0TagRaw/types.ts
+++ b/packages/react/src/components/tags/F0TagRaw/types.ts
@@ -13,6 +13,10 @@ export type F0TagRawProps = {
    * Info text to display an i icon and a tooltip next to the tag
    */
   info?: string
+  /**
+   * Extra classes merged onto the tag (e.g. to give it a background).
+   */
+  className?: string
 } & (
   | {
       icon: IconType

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -564,7 +564,7 @@ export const defaultTranslations = {
       lockedSectionNotice:
         "These questions are predefined and can't be edited, moved, or removed.",
       lockedQuestionNotice:
-        "This question is predefined and can't be edited, moved, or removed.",
+        "This question is predefined and can't be edited or removed.",
       sectionTitlePlaceholder: "Section title",
       lastQuestionDialogTitle: "Remove last question from section",
       lastQuestionDialogDescription:

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -561,8 +561,10 @@ export const defaultTranslations = {
       questionOptions: "Question options",
       actions: "Actions",
       locked: "Locked",
-      lockedNotice:
+      lockedSectionNotice:
         "These questions are predefined and can't be edited, moved, or removed.",
+      lockedQuestionNotice:
+        "This question is predefined and can't be edited, moved, or removed.",
       sectionTitlePlaceholder: "Section title",
       lastQuestionDialogTitle: "Remove last question from section",
       lastQuestionDialogDescription:

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -560,6 +560,7 @@ export const defaultTranslations = {
       questionType: "Question type",
       questionOptions: "Question options",
       actions: "Actions",
+      locked: "Locked",
       sectionTitlePlaceholder: "Section title",
       lastQuestionDialogTitle: "Remove last question from section",
       lastQuestionDialogDescription:

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -561,6 +561,8 @@ export const defaultTranslations = {
       questionOptions: "Question options",
       actions: "Actions",
       locked: "Locked",
+      lockedNotice:
+        "These questions are predefined and can't be edited, moved, or removed.",
       sectionTitlePlaceholder: "Section title",
       lastQuestionDialogTitle: "Remove last question from section",
       lastQuestionDialogDescription:

--- a/packages/react/src/sds/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
+++ b/packages/react/src/sds/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
@@ -396,6 +396,7 @@ function SurveyAnsweringFormInline({
   labels,
   useUpload,
   datasets,
+  hideResourceHeader = false,
 }: SurveyAnsweringFormInlineReadonlyProps) {
   const { t } = useI18n()
 
@@ -439,13 +440,15 @@ function SurveyAnsweringFormInline({
       datasets={datasets}
     >
       <div className="mx-auto flex w-full max-w-3xl flex-col">
-        <div className="mb-6">
-          <ResourceHeader
-            title={title}
-            description={description}
-            {...resourceHeader}
-          />
-        </div>
+        {!hideResourceHeader && (
+          <div className="mb-6">
+            <ResourceHeader
+              title={title}
+              description={description}
+              {...resourceHeader}
+            />
+          </div>
+        )}
         {loading ? (
           <SurveyAllQuestionsLoadingSkeleton />
         ) : !hasQuestions ? (

--- a/packages/react/src/sds/surveys/SurveyAnsweringForm/__tests__/SurveyAnsweringForm.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyAnsweringForm/__tests__/SurveyAnsweringForm.test.tsx
@@ -217,7 +217,7 @@ describe("SurveyAnsweringForm", () => {
                 id: "q1",
                 title: "Name",
                 type: "text" as const,
-                notice: { description: "Author-only notice" },
+                lockedNote: { description: "Author-only notice" },
               },
             },
           ]}

--- a/packages/react/src/sds/surveys/SurveyAnsweringForm/__tests__/SurveyAnsweringForm.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyAnsweringForm/__tests__/SurveyAnsweringForm.test.tsx
@@ -205,6 +205,31 @@ describe("SurveyAnsweringForm", () => {
     })
   })
 
+  describe("question notice", () => {
+    it("does not render an authoring notice in the answering form", () => {
+      render(
+        <SurveyAnsweringForm
+          {...defaultProps}
+          elements={[
+            {
+              type: "question",
+              question: {
+                id: "q1",
+                title: "Name",
+                type: "text" as const,
+                notice: { variant: "warning", title: "Author-only notice" },
+              },
+            },
+          ]}
+          onSubmit={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText("Name")).toBeInTheDocument()
+      expect(screen.queryByText("Author-only notice")).not.toBeInTheDocument()
+    })
+  })
+
   describe("validation on submit", () => {
     it("does not call onSubmit when required fields are empty", async () => {
       const onSubmit = vi.fn()

--- a/packages/react/src/sds/surveys/SurveyAnsweringForm/__tests__/SurveyAnsweringForm.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyAnsweringForm/__tests__/SurveyAnsweringForm.test.tsx
@@ -217,7 +217,7 @@ describe("SurveyAnsweringForm", () => {
                 id: "q1",
                 title: "Name",
                 type: "text" as const,
-                notice: { variant: "warning", title: "Author-only notice" },
+                notice: { description: "Author-only notice" },
               },
             },
           ]}

--- a/packages/react/src/sds/surveys/SurveyAnsweringForm/hooks/useSurveyFormSchema.tsx
+++ b/packages/react/src/sds/surveys/SurveyAnsweringForm/hooks/useSurveyFormSchema.tsx
@@ -237,7 +237,6 @@ function buildFieldForQuestion(
     description: q.description,
     type: q.type,
     required: q.required,
-    locked: q.locked,
   }
 
   switch (q.type) {
@@ -679,7 +678,7 @@ export function useSurveyFormSchema(
 
         if (mode === "all-questions") {
           sections[sectionId] = {
-            title: section.title,
+            title: section.title ?? "",
             description: section.description,
             withInset: true,
           }

--- a/packages/react/src/sds/surveys/SurveyAnsweringForm/types.ts
+++ b/packages/react/src/sds/surveys/SurveyAnsweringForm/types.ts
@@ -75,6 +75,11 @@ interface SurveyAnsweringFormDialogProps extends SurveyAnsweringFormSharedProps 
 /** Inline mode: read-only rendering embedded in the page, no dialog */
 interface SurveyAnsweringFormInlineProps extends SurveyAnsweringFormSharedProps {
   inline: true
+  /**
+   * Hide the built-in ResourceHeader (title + description). Useful when the
+   * embedding page already renders its own resource header above the form.
+   */
+  hideResourceHeader?: boolean
   mode?: never
   module?: never
   position?: never

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/QuestionItem.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/QuestionItem.tsx
@@ -45,7 +45,7 @@ export const QuestionItem = ({
     setDraggedItemId(null)
   }
 
-  const questionLocked = item.question.locked || containingSection?.locked
+  const questionLocked = containingSection?.locked
   const dragEnabled = !disabled && !answering && !questionLocked
 
   return (
@@ -66,25 +66,34 @@ export const QuestionItem = ({
         <div
           className={cn(
             "group/element flex flex-row items-start gap-1",
+            // Mirror the drag-and-drop gutter (handle w-6 + gap-1 ≈ 28px) on
+            // the right so every card keeps the same width.
+            !disabled && !answering && "pr-7",
             isDragging && "cursor-grabbing"
           )}
         >
-          {!disabled && !answering && (
-            <div
-              className={cn(
-                "mt-2 flex aspect-square w-6 scale-75 items-center opacity-0 hover:opacity-40 group-hover/element:opacity-40",
-                !isDragging && "cursor-grab",
-                !dragEnabled && "cursor-not-allowed"
-              )}
-              onPointerDown={(e) => {
-                if (dragEnabled) {
-                  dragControls.start(e)
-                }
-              }}
-            >
-              <F0Icon icon={Handle} size="sm" />
-            </div>
-          )}
+          {!disabled &&
+            !answering &&
+            (questionLocked ? (
+              // Blocked question: drop the drag affordance but keep the handle's
+              // gutter so the card stays the same width and alignment as the
+              // editable questions around it.
+              <div className="mt-2 aspect-square w-6 scale-75" aria-hidden />
+            ) : (
+              <div
+                className={cn(
+                  "mt-2 flex aspect-square w-6 scale-75 items-center opacity-0 hover:opacity-40 group-hover/element:opacity-40",
+                  !isDragging && "cursor-grab"
+                )}
+                onPointerDown={(e) => {
+                  if (dragEnabled) {
+                    dragControls.start(e)
+                  }
+                }}
+              >
+                <F0Icon icon={Handle} size="sm" />
+              </div>
+            ))}
           <QuestionComponent
             {...({
               ...item.question,

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/SectionHeaderItem.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/SectionHeaderItem.tsx
@@ -38,8 +38,6 @@ export const SectionHeaderItem = ({
     setDraggedItemId(null)
   }
 
-  const dragEnabled = !disabled && !answering && !item.section.locked
-
   return (
     <Reorder.Item
       value={item}
@@ -56,25 +54,32 @@ export const SectionHeaderItem = ({
           <div
             className={cn(
               "flex flex-row items-start gap-1 w-full",
+              // Mirror the drag-and-drop gutter (handle w-6 + gap-1 ≈ 28px) on
+              // the right so the header aligns with the cards' width.
+              !disabled && !answering && "pr-7",
               isDragging && "cursor-grabbing"
             )}
           >
-            {!disabled && !answering && (
-              <div
-                className={cn(
-                  "mt-2 flex aspect-square w-6 scale-75 items-center opacity-0 hover:opacity-40 group-hover/element:opacity-40",
-                  !isDragging && "cursor-grab",
-                  !dragEnabled && "cursor-not-allowed"
-                )}
-                onPointerDown={(e) => {
-                  if (dragEnabled) {
+            {!disabled &&
+              !answering &&
+              (item.section.locked ? (
+                // Blocked section: drop the drag affordance but keep the
+                // handle's gutter so the header stays aligned with the
+                // editable rows around it.
+                <div className="mt-2 aspect-square w-6 scale-75" aria-hidden />
+              ) : (
+                <div
+                  className={cn(
+                    "mt-2 flex aspect-square w-6 scale-75 items-center opacity-0 hover:opacity-40 group-hover/element:opacity-40",
+                    !isDragging && "cursor-grab"
+                  )}
+                  onPointerDown={(e) => {
                     dragControls.start(e)
-                  }
-                }}
-              >
-                <F0Icon icon={Handle} size="sm" />
-              </div>
-            )}
+                  }}
+                >
+                  <F0Icon icon={Handle} size="sm" />
+                </div>
+              ))}
             <SectionComponent {...item.section} hideQuestions />
           </div>
 

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/TableOfContent/useTableOfContentItems.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/TableOfContent/useTableOfContentItems.ts
@@ -303,8 +303,7 @@ export const useTableOfContentItems = (
           icon: getQuestionIcon(question.type as QuestionType),
           onClick: handleItemClick,
           ...(!disabled &&
-            !answering &&
-            !question.locked && {
+            !answering && {
               otherActions: buildQuestionActions(
                 question.id,
                 question.type as QuestionType,

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/SurveyFormBuilder.blockedQuestions.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/SurveyFormBuilder.blockedQuestions.test.tsx
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { SurveyFormBuilderElement } from "../../types"
+import { SurveyFormBuilder } from "../index"
+
+// --- Test fixtures ---
+
+const makeQuestion = (
+  id: string,
+  title: string,
+  opts: { description?: string } = {}
+): SurveyFormBuilderElement => ({
+  type: "question",
+  question: {
+    id,
+    title,
+    type: "text" as const,
+    ...(opts.description !== undefined && { description: opts.description }),
+  },
+})
+
+const makeSection = (
+  id: string,
+  title: string,
+  questions: { id: string; title: string; description?: string }[],
+  locked = false
+): SurveyFormBuilderElement => ({
+  type: "section",
+  section: {
+    id,
+    title,
+    questions: questions.map((q) => ({
+      id: q.id,
+      title: q.title,
+      ...(q.description !== undefined && { description: q.description }),
+      type: "text" as const,
+    })),
+    locked,
+  },
+})
+
+// --- Blocked questions UX/UI ---
+
+describe("SurveyFormBuilder — blocked questions", () => {
+  it("does not show the not-allowed cursor on an editable question card", () => {
+    const { container } = render(
+      <SurveyFormBuilder
+        elements={[makeQuestion("q1", "Editable")]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(container.querySelector("#co-creation-question-q1")).not.toHaveClass(
+      "cursor-not-allowed"
+    )
+  })
+
+  it("disables the title and description inputs of a question in a blocked section", () => {
+    render(
+      <SurveyFormBuilder
+        elements={[
+          makeSection(
+            "s1",
+            "Locked Section",
+            [
+              {
+                id: "q1",
+                title: "Blocked title",
+                description: "Blocked description",
+              },
+            ],
+            true
+          ),
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByDisplayValue("Blocked title")).toBeDisabled()
+    expect(screen.getByDisplayValue("Blocked description")).toBeDisabled()
+  })
+
+  it("keeps the title input editable on an unblocked question", () => {
+    render(
+      <SurveyFormBuilder
+        elements={[makeQuestion("q1", "Editable title")]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByDisplayValue("Editable title")).not.toBeDisabled()
+  })
+
+  it("propagates blocked UI to questions inside a blocked section", () => {
+    const { container } = render(
+      <SurveyFormBuilder
+        elements={[
+          makeSection(
+            "s1",
+            "Locked Section",
+            [{ id: "q1", title: "Q1" }],
+            true
+          ),
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    // The question never sets `locked` itself — it inherits it from the section.
+    expect(container.querySelector("#co-creation-question-q1")).toHaveClass(
+      "cursor-not-allowed"
+    )
+    expect(screen.getByDisplayValue("Q1")).toBeDisabled()
+  })
+
+  it("shows the not-allowed cursor over a blocked section header card", () => {
+    const { container } = render(
+      <SurveyFormBuilder
+        elements={[
+          makeSection(
+            "s1",
+            "Locked Section",
+            [{ id: "q1", title: "Q1" }],
+            true
+          ),
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(container.querySelector("#co-creation-section-s1")).toHaveClass(
+      "cursor-not-allowed"
+    )
+  })
+
+  it("does not show the not-allowed cursor on an editable section header card", () => {
+    const { container } = render(
+      <SurveyFormBuilder
+        elements={[
+          makeSection("s1", "Open Section", [{ id: "q1", title: "Q1" }]),
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(container.querySelector("#co-creation-section-s1")).not.toHaveClass(
+      "cursor-not-allowed"
+    )
+  })
+
+  it("renders a lock affordance instead of the actions menu on a question in a blocked section", () => {
+    const { rerender } = render(
+      <SurveyFormBuilder
+        elements={[
+          makeSection(
+            "s1",
+            "Locked Section",
+            [{ id: "q1", title: "Blocked" }],
+            true
+          ),
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    // Blocked question surfaces the static "Locked" button.
+    expect(screen.getByRole("button", { name: "Locked" })).toBeInTheDocument()
+
+    // An editable question has no lock affordance.
+    rerender(
+      <SurveyFormBuilder
+        elements={[makeQuestion("q1", "Editable")]}
+        onChange={vi.fn()}
+      />
+    )
+    expect(screen.queryByRole("button", { name: "Locked" })).toBeNull()
+  })
+})

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
@@ -120,6 +120,82 @@ describe("SurveyFormBuilder", () => {
     expect(notAllowed.length).toBeGreaterThanOrEqual(2) // section header + question
   })
 
+  it("removes the drag affordance for a locked question but keeps its gutter", () => {
+    // An editable question renders a grabbable drag handle.
+    const editable: SurveyFormBuilderElement[] = [
+      makeQuestion("q1", "Editable"),
+    ]
+    const { container: editableContainer } = render(
+      <SurveyFormBuilder elements={editable} onChange={vi.fn()} />
+    )
+    expect(
+      editableContainer.querySelectorAll("[class*='cursor-grab']").length
+    ).toBeGreaterThan(0)
+
+    const locked: SurveyFormBuilderElement[] = [
+      makeSection(
+        "s1",
+        "Locked Section",
+        [{ id: "q1", title: "Blocked" }],
+        true
+      ),
+    ]
+    const { container: lockedContainer } = render(
+      <SurveyFormBuilder elements={locked} onChange={vi.fn()} />
+    )
+    // No drag affordance on a locked question…
+    expect(
+      lockedContainer.querySelectorAll("[class*='cursor-grab']")
+    ).toHaveLength(0)
+    // …but the handle gutter is preserved so it stays aligned with editable ones.
+    expect(
+      lockedContainer.querySelectorAll("[class*='scale-75']").length
+    ).toBeGreaterThan(0)
+  })
+
+  it("shows a locked question's own note as a title-less tooltip on hover", async () => {
+    const elements: SurveyFormBuilderElement[] = [
+      {
+        type: "section",
+        section: {
+          id: "s1",
+          title: "Predefined section",
+          description: "These questions are predefined.",
+          locked: true,
+          questions: [
+            {
+              id: "q1",
+              title: "Blocked",
+              type: "text",
+              lockedNote: "This is the standard onboarding question.",
+            },
+          ],
+        },
+      },
+    ]
+
+    render(<SurveyFormBuilder elements={elements} onChange={vi.fn()} />)
+
+    // The note isn't shown inline — it surfaces as a tooltip on hover.
+    const card = document.getElementById("co-creation-question-q1")
+    expect(card).not.toBeNull()
+    expect(
+      screen.queryByText("This is the standard onboarding question.")
+    ).not.toBeInTheDocument()
+
+    await userEvent.hover(card!)
+
+    // Shows the question's own note…
+    expect(
+      (await screen.findAllByText("This is the standard onboarding question."))
+        .length
+    ).toBeGreaterThan(0)
+    // …and not the section's Locked-tag copy.
+    expect(
+      screen.queryByText("These questions are predefined.")
+    ).not.toBeInTheDocument()
+  })
+
   it("shows confirmation dialog when moving the last question out of a section", async () => {
     // This test verifies the dialog appears. We cannot simulate real DnD with
     // Reorder.Group in jsdom, so we test the component state by providing

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
@@ -167,7 +167,9 @@ describe("SurveyFormBuilder", () => {
               id: "q1",
               title: "Blocked",
               type: "text",
-              lockedNote: "This is the standard onboarding question.",
+              lockedNote: {
+                description: "This is the standard onboarding question.",
+              },
             },
           ],
         },

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
@@ -178,14 +178,17 @@ describe("SurveyFormBuilder", () => {
 
     render(<SurveyFormBuilder elements={elements} onChange={vi.fn()} />)
 
-    // The note isn't shown inline — it surfaces as a tooltip on hover.
+    // The note isn't shown inline — it surfaces as a tooltip when hovering the
+    // lock icon (not anywhere on the card).
     const card = document.getElementById("co-creation-question-q1")
     expect(card).not.toBeNull()
     expect(
       screen.queryByText("This is the standard onboarding question.")
     ).not.toBeInTheDocument()
 
-    await userEvent.hover(card!)
+    const lockIcon = card!.querySelector('button[aria-label="Locked"]')
+    expect(lockIcon).not.toBeNull()
+    await userEvent.hover(lockIcon!.parentElement!)
 
     // Shows the question's own note…
     expect(

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/useReorderHandler.test.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/useReorderHandler.test.ts
@@ -73,7 +73,7 @@ describe("useReorderHandler — locked sections", () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
-  it("rejects dropping a standalone question into a locked section", () => {
+  it("keeps a standalone question out of a locked section when dropped at its edge", () => {
     const { onChange, reorder } = setup([
       makeSection("locked", ["q1"], true),
       standalone("q2"),
@@ -83,7 +83,52 @@ describe("useReorderHandler — locked sections", () => {
       reorder([header("locked", true), question("q1"), question("q2")])
     })
 
-    expect(onChange).not.toHaveBeenCalled()
+    // The standalone can't join the frozen section; it settles just after it.
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const result = onChange.mock.calls[0][0] as SurveyFormBuilderElement[]
+    const locked = result.find(
+      (el): el is Extract<SurveyFormBuilderElement, { type: "section" }> =>
+        el.type === "section" && el.section.id === "locked"
+    )
+    expect(locked?.section.questions?.map((q) => q.id)).toEqual(["q1"])
+    expect(
+      result.some((el) => el.type === "question" && el.question.id === "q2")
+    ).toBe(true)
+  })
+
+  it("allows sorting standalone siblings around a locked section", () => {
+    // Regression: a locked section must not freeze its *siblings*. Items that
+    // live outside it (including standalone questions that follow it) stay
+    // freely sortable.
+    const { onChange, reorder } = setup([
+      standalone("a"),
+      makeSection("locked", ["q1"], true),
+      standalone("b"),
+    ])
+
+    // Drag "a" past the locked section to the very end.
+    act(() => {
+      reorder([
+        header("locked", true),
+        question("q1"),
+        question("b"),
+        question("a"),
+      ])
+    })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const result = onChange.mock.calls[0][0] as SurveyFormBuilderElement[]
+    // Locked section untouched; the two siblings reorder around it.
+    expect(
+      result.map((el) =>
+        el.type === "section" ? `section:${el.section.id}` : el.question.id
+      )
+    ).toEqual(["section:locked", "b", "a"])
+    const locked = result.find(
+      (el): el is Extract<SurveyFormBuilderElement, { type: "section" }> =>
+        el.type === "section" && el.section.id === "locked"
+    )
+    expect(locked?.section.questions?.map((q) => q.id)).toEqual(["q1"])
   })
 
   it("allows a cross-section move between unlocked sections when a locked section exists", () => {

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/useReorderHandler.test.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/__tests__/useReorderHandler.test.ts
@@ -1,0 +1,128 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { SurveyFormBuilderElement } from "../../types"
+import { useReorderHandler } from "../useReorderHandler"
+import { FlatFormItem, flattenElements } from "../utils"
+
+// --- Fixtures ---
+
+const makeSection = (
+  id: string,
+  questions: string[],
+  locked = false
+): SurveyFormBuilderElement => ({
+  type: "section",
+  section: {
+    id,
+    title: id,
+    questions: questions.map((qId) => ({
+      id: qId,
+      title: qId,
+      type: "text" as const,
+    })),
+    locked,
+  },
+})
+
+const question = (id: string): FlatFormItem => ({
+  type: "question",
+  id: `question-${id}`,
+  question: { id, title: id, type: "text" },
+})
+
+const header = (id: string, locked = false): FlatFormItem => ({
+  type: "section-header",
+  id: `section-header-${id}`,
+  section: { id, title: id, locked },
+})
+
+const standalone = (id: string): SurveyFormBuilderElement => ({
+  type: "question",
+  question: { id, title: id, type: "text" },
+})
+
+function setup(elements: SurveyFormBuilderElement[]) {
+  const onChange = vi.fn()
+  const flatItems = flattenElements(elements)
+  const { result } = renderHook(() =>
+    useReorderHandler({ flatItems, onChange })
+  )
+  return { onChange, reorder: result.current.handleFlatReorder }
+}
+
+describe("useReorderHandler — locked sections", () => {
+  it("rejects dropping a question from another section into a locked section", () => {
+    const { onChange, reorder } = setup([
+      makeSection("locked", ["q1"], true),
+      makeSection("open", ["q2"]),
+    ])
+
+    // Simulate dragging q2 (from the open section) into the locked section.
+    act(() => {
+      reorder([
+        header("locked", true),
+        question("q1"),
+        question("q2"),
+        header("open"),
+      ])
+    })
+
+    // The move must be rejected — onChange is never called, so the controlled
+    // list snaps the dragged question back to its origin.
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("rejects dropping a standalone question into a locked section", () => {
+    const { onChange, reorder } = setup([
+      makeSection("locked", ["q1"], true),
+      standalone("q2"),
+    ])
+
+    act(() => {
+      reorder([header("locked", true), question("q1"), question("q2")])
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("allows a cross-section move between unlocked sections when a locked section exists", () => {
+    const { onChange, reorder } = setup([
+      makeSection("locked", ["q1"], true),
+      makeSection("a", ["q2a", "q2b"]),
+      makeSection("b", ["q3"]),
+    ])
+
+    // Move q2b from section "a" into the unlocked section "b".
+    act(() => {
+      reorder([
+        header("locked", true),
+        question("q1"),
+        header("a"),
+        question("q2a"),
+        header("b"),
+        question("q3"),
+        question("q2b"),
+      ])
+    })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const result = onChange.mock.calls[0][0] as SurveyFormBuilderElement[]
+    const sectionB = result.find(
+      (el): el is Extract<SurveyFormBuilderElement, { type: "section" }> =>
+        el.type === "section" && el.section.id === "b"
+    )
+    expect(sectionB?.section.questions?.map((q) => q.id)).toEqual(["q3", "q2b"])
+  })
+
+  it("allows reordering questions within an unlocked section", () => {
+    const { onChange, reorder } = setup([makeSection("open", ["q1", "q2"])])
+
+    // Swap q1 and q2 within the same unlocked section.
+    act(() => {
+      reorder([header("open"), question("q2"), question("q1")])
+    })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -49,8 +49,9 @@ export const Default: Story = {
         type: "section",
         section: {
           id: "section-1",
-          title: "Section 1",
-          description: "Section 1 description",
+          title: "Company-wide questions",
+          description:
+            "These questions are predefined and can't be edited, moved, or removed.",
           locked: true,
           questions: [
             {
@@ -354,6 +355,55 @@ export const WithAllowCreate: Story = {
             "The employees dataset does not have onCreate, so no toggle appears.",
           type: "dropdown-single" as const,
           datasetKey: "employees",
+        },
+      },
+    ],
+  },
+}
+
+/**
+ * A blocked, predefined section: `locked` on the section disables its fields,
+ * removes its edit menu and drag handle, and makes the questions inside it
+ * non-interactive. Its title/description explain why it's fixed and surface as
+ * the "Locked" tag tooltip (and on hover over the questions). Questions can't be
+ * locked on their own — only via their section. The standalone question after
+ * it stays fully editable. The locked treatment never shows in the
+ * answering/preview form.
+ */
+export const WithBlockedSection: Story = {
+  args: {
+    elements: [
+      {
+        type: "section",
+        section: {
+          id: "section-enps",
+          title: "Predefined eNPS question",
+          description:
+            "This question powers your Employee NPS score, so it can't be edited, moved, or removed.",
+          locked: true,
+          questions: [
+            {
+              id: "q-enps",
+              title: "How likely are you to recommend us as a place to work?",
+              description: "0 is not at all likely, 10 is extremely likely.",
+              type: "rating" as const,
+              options: Array.from({ length: 11 }, (_, value) => ({
+                value,
+                label: String(value),
+              })),
+              required: true,
+              lockedNote:
+                "The standard eNPS question — its wording and 0–10 scale are fixed so scores stay comparable over time.",
+            },
+          ],
+        },
+      },
+      {
+        type: "question",
+        question: {
+          id: "q-reason",
+          title: "What's the main reason for your score?",
+          type: "longText" as const,
         },
       },
     ],

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -364,11 +364,11 @@ export const WithAllowCreate: Story = {
 /**
  * A blocked, predefined section: `locked` on the section disables its fields,
  * removes its edit menu and drag handle, and makes the questions inside it
- * non-interactive. Its title/description explain why it's fixed and surface as
- * the "Locked" tag tooltip (and on hover over the questions). Questions can't be
- * locked on their own — only via their section. The standalone question after
- * it stays fully editable. The locked treatment never shows in the
- * answering/preview form.
+ * non-interactive. The section's `notice` surfaces as the "Locked" tag tooltip;
+ * questions inside without their own `lockedNote` inherit it. The standalone
+ * question after it stays fully editable. The locked treatment never shows in
+ * the answering/preview form. (For locking individual questions outside a
+ * section, see "With Locked Questions".)
  */
 export const WithBlockedSection: Story = {
   args: {
@@ -410,6 +410,74 @@ export const WithBlockedSection: Story = {
           id: "q-reason",
           title: "What's the main reason for your score?",
           type: "longText" as const,
+        },
+      },
+    ],
+  },
+}
+
+/**
+ * Individually locked questions — `locked` on the question itself, with no
+ * surrounding section. Each shows the lock affordance instead of its actions
+ * menu and a tooltip on hover. The first two carry their own `lockedNote`
+ * (a predefined notice); the locked ones without a note fall back to the
+ * default question notice from the i18n provider
+ * (`surveyFormBuilder.labels.lockedQuestionNotice`). An editable question sits
+ * between them to show the lock is per-question.
+ */
+export const WithLockedQuestions: Story = {
+  args: {
+    elements: [
+      {
+        type: "question",
+        question: {
+          id: "q-legal-name",
+          title: "Full legal name",
+          type: "text" as const,
+          locked: true,
+          lockedNote: {
+            description:
+              "Synced from your HR profile, so it can't be edited here.",
+          },
+        },
+      },
+      {
+        type: "question",
+        question: {
+          id: "q-employee-id",
+          title: "Employee ID",
+          type: "text" as const,
+          locked: true,
+          lockedNote: {
+            description:
+              "Assigned by the system and used to match your record.",
+          },
+        },
+      },
+      {
+        type: "question",
+        question: {
+          id: "q-nickname",
+          title: "What should we call you?",
+          type: "text" as const,
+        },
+      },
+      {
+        type: "question",
+        question: {
+          id: "q-start-date",
+          title: "Start date",
+          type: "date" as const,
+          locked: true,
+        },
+      },
+      {
+        type: "question",
+        question: {
+          id: "q-department",
+          title: "Department",
+          type: "text" as const,
+          locked: true,
         },
       },
     ],

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -50,8 +50,8 @@ export const Default: Story = {
         section: {
           id: "section-1",
           title: "Company-wide questions",
-          description:
-            "These questions are predefined and can't be edited, moved, or removed.",
+          // No `notice`: a locked section without one falls back to the default
+          // lock notice from the i18n provider.
           locked: true,
           questions: [
             {
@@ -378,8 +378,12 @@ export const WithBlockedSection: Story = {
         section: {
           id: "section-enps",
           title: "Predefined eNPS question",
-          description:
-            "This question powers your Employee NPS score, so it can't be edited, moved, or removed.",
+          // Section-level lock notice: questions without their own `lockedNote`
+          // inherit this; the eNPS question below overrides it with its own.
+          notice: {
+            description:
+              "This question powers your Employee NPS score, so it can't be edited, moved, or removed.",
+          },
           locked: true,
           questions: [
             {

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -50,8 +50,8 @@ export const Default: Story = {
         section: {
           id: "section-1",
           title: "Company-wide questions",
-          // No `notice`: a locked section without one falls back to the default
-          // lock notice from the i18n provider.
+          // No `lockedNote`: a locked section without one falls back to the
+          // default lock notice from the i18n provider.
           locked: true,
           questions: [
             {
@@ -364,8 +364,8 @@ export const WithAllowCreate: Story = {
 /**
  * A blocked, predefined section: `locked` on the section disables its fields,
  * removes its edit menu and drag handle, and makes the questions inside it
- * non-interactive. The section's `notice` surfaces as the "Locked" tag tooltip;
- * questions inside without their own `lockedNote` inherit it. The standalone
+ * non-interactive. The section's `lockedNote` surfaces as the "Locked" tag
+ * tooltip; questions inside without their own `lockedNote` inherit it. The standalone
  * question after it stays fully editable. The locked treatment never shows in
  * the answering/preview form. (For locking individual questions outside a
  * section, see "With Locked Questions".)
@@ -378,9 +378,9 @@ export const WithBlockedSection: Story = {
         section: {
           id: "section-enps",
           title: "Predefined eNPS question",
-          // Section-level lock notice: questions without their own `lockedNote`
+          // Section-level lock note: questions without their own `lockedNote`
           // inherit this; the eNPS question below overrides it with its own.
-          notice: {
+          lockedNote: {
             description:
               "This question powers your Employee NPS score, so it can't be edited, moved, or removed.",
           },

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -392,8 +392,10 @@ export const WithBlockedSection: Story = {
                 label: String(value),
               })),
               required: true,
-              lockedNote:
-                "The standard eNPS question — its wording and 0–10 scale are fixed so scores stay comparable over time.",
+              lockedNote: {
+                description:
+                  "The standard eNPS question — its wording and 0–10 scale are fixed so scores stay comparable over time.",
+              },
             },
           ],
         },

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.tsx
@@ -211,7 +211,7 @@ const _SurveyFormBuilder = ({
                               index === 0 ? "" : "mt-8"
                             )}
                           >
-                            {groupItems.map((groupItem) => {
+                            {groupItems.map((groupItem, groupIndex) => {
                               if (groupItem.type === "section-header") {
                                 return (
                                   <SectionHeaderItem
@@ -224,12 +224,16 @@ const _SurveyFormBuilder = ({
                               if (groupItem.type === "question") {
                                 // The grey panel delimits the section, so the
                                 // "end of section" divider is suppressed here.
+                                // The first question sits closer to the header,
+                                // which has no inline description beneath it.
                                 return (
                                   <QuestionItem
                                     key={groupItem.id}
                                     item={groupItem}
                                     showEndOfSection={false}
-                                    className="mt-4"
+                                    className={
+                                      groupIndex === 1 ? "mt-2" : "mt-4"
+                                    }
                                   />
                                 )
                               }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/index.tsx
@@ -1,5 +1,5 @@
 import { motion, Reorder } from "motion/react"
-import { useEffect, useMemo } from "react"
+import { useEffect, useMemo, type ReactNode } from "react"
 
 import { withDataTestId } from "@/lib/data-testid"
 import { cn } from "@/lib/utils"
@@ -110,6 +110,16 @@ const _SurveyFormBuilder = ({
     return result
   }, [elements])
 
+  const lockedSectionIds = useMemo(() => {
+    const result = new Set<string>()
+    for (const element of elements) {
+      if (element.type === "section" && element.section.locked) {
+        result.add(element.section.id)
+      }
+    }
+    return result
+  }, [elements])
+
   const {
     handleFlatReorder,
     handleConfirmLastQuestionMove,
@@ -164,32 +174,103 @@ const _SurveyFormBuilder = ({
                 as="div"
               >
                 <div className="flex flex-col">
-                  {reorderableItems.map((item, index) => {
-                    const gapClass =
-                      index === 0
-                        ? ""
-                        : inSectionQuestionIds.has(item.id)
-                          ? "mt-4"
-                          : "mt-8"
+                  {(() => {
+                    const nodes: ReactNode[] = []
 
-                    if (item.type === "section-header") {
-                      return (
-                        <SectionHeaderItem
-                          key={item.id}
-                          item={item}
-                          className={gapClass}
-                        />
-                      )
+                    for (
+                      let index = 0;
+                      index < reorderableItems.length;
+                      index++
+                    ) {
+                      const item = reorderableItems[index]
+
+                      // A locked section renders as one muted grey rounded
+                      // panel wrapping its header and all of its questions. The
+                      // right padding mirrors the drag-and-drop gutter reserved
+                      // on the left so the cards sit symmetrically in the panel.
+                      if (
+                        item.type === "section-header" &&
+                        lockedSectionIds.has(item.section.id)
+                      ) {
+                        const groupItems: typeof reorderableItems = [item]
+                        let next = index + 1
+                        while (
+                          next < reorderableItems.length &&
+                          reorderableItems[next].type === "question" &&
+                          inSectionQuestionIds.has(reorderableItems[next].id)
+                        ) {
+                          groupItems.push(reorderableItems[next])
+                          next++
+                        }
+
+                        nodes.push(
+                          <div
+                            key={`locked-${item.section.id}`}
+                            className={cn(
+                              "rounded-2xl bg-f1-background-secondary pb-8 pt-4",
+                              index === 0 ? "" : "mt-8"
+                            )}
+                          >
+                            {groupItems.map((groupItem) => {
+                              if (groupItem.type === "section-header") {
+                                return (
+                                  <SectionHeaderItem
+                                    key={groupItem.id}
+                                    item={groupItem}
+                                    className=""
+                                  />
+                                )
+                              }
+                              if (groupItem.type === "question") {
+                                // The grey panel delimits the section, so the
+                                // "end of section" divider is suppressed here.
+                                return (
+                                  <QuestionItem
+                                    key={groupItem.id}
+                                    item={groupItem}
+                                    showEndOfSection={false}
+                                    className="mt-4"
+                                  />
+                                )
+                              }
+                              return null
+                            })}
+                          </div>
+                        )
+
+                        index = next - 1
+                        continue
+                      }
+
+                      const gapClass =
+                        index === 0
+                          ? ""
+                          : inSectionQuestionIds.has(item.id)
+                            ? "mt-4"
+                            : "mt-8"
+
+                      if (item.type === "section-header") {
+                        nodes.push(
+                          <SectionHeaderItem
+                            key={item.id}
+                            item={item}
+                            className={gapClass}
+                          />
+                        )
+                      } else if (item.type === "question") {
+                        nodes.push(
+                          <QuestionItem
+                            key={item.id}
+                            item={item}
+                            showEndOfSection={sectionEndIds.has(item.id)}
+                            className={gapClass}
+                          />
+                        )
+                      }
                     }
-                    return (
-                      <QuestionItem
-                        key={item.id}
-                        item={item}
-                        showEndOfSection={sectionEndIds.has(item.id)}
-                        className={gapClass}
-                      />
-                    )
-                  })}
+
+                    return nodes
+                  })()}
                 </div>
               </Reorder.Group>
               {shouldShowAddButton && <AddButton />}

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/useReorderHandler.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/useReorderHandler.ts
@@ -114,27 +114,6 @@ export function useReorderHandler({
         finalItems = reorderedItems
       }
 
-      // Reject moves that would drop a foreign question into a locked section.
-      // A locked section's membership is frozen: only the questions that
-      // originally belonged to it may stay inside it. If any other question
-      // ends up within a locked section, bail out without calling onChange so
-      // the controlled list snaps the dragged item back to its origin.
-      if (lockedSectionIds.size > 0) {
-        let activeSectionId: string | null = null
-        for (const item of finalItems) {
-          if (item.type === "section-header") {
-            activeSectionId = item.id
-          } else if (item.type === "question" && activeSectionId) {
-            if (
-              lockedSectionIds.has(activeSectionId) &&
-              !originalSectionQuestions.get(activeSectionId)?.has(item.id)
-            ) {
-              return
-            }
-          }
-        }
-      }
-
       // Build set of all question IDs that originally belonged to any section.
       const allInSectionQuestionIds = new Set<string>()
       for (const qIds of originalSectionQuestions.values()) {
@@ -148,6 +127,32 @@ export function useReorderHandler({
         finalItems,
         allInSectionQuestionIds
       )
+
+      // Reject moves that would drop a foreign question into a locked section.
+      // A locked section's membership is frozen: only the questions that
+      // originally belonged to it may sit inside it. We walk the section-end-
+      // aware list (a `section-end` closes the active section) so siblings that
+      // live *outside* the locked section — including standalone items that
+      // follow it — are never mistaken for members. If a foreign question ends
+      // up inside a locked section, bail out without calling onChange so the
+      // controlled list snaps the dragged item back to its origin.
+      if (lockedSectionIds.size > 0) {
+        let activeSectionId: string | null = null
+        for (const item of withSectionEnds) {
+          if (item.type === "section-header") {
+            activeSectionId = item.id
+          } else if (item.type === "section-end") {
+            activeSectionId = null
+          } else if (item.type === "question" && activeSectionId) {
+            if (
+              lockedSectionIds.has(activeSectionId) &&
+              !originalSectionQuestions.get(activeSectionId)?.has(item.id)
+            ) {
+              return
+            }
+          }
+        }
+      }
 
       // Detect if a section lost its last question (would become empty).
       const sectionWillBecomeEmpty = [

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/useReorderHandler.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/useReorderHandler.ts
@@ -114,6 +114,27 @@ export function useReorderHandler({
         finalItems = reorderedItems
       }
 
+      // Reject moves that would drop a foreign question into a locked section.
+      // A locked section's membership is frozen: only the questions that
+      // originally belonged to it may stay inside it. If any other question
+      // ends up within a locked section, bail out without calling onChange so
+      // the controlled list snaps the dragged item back to its origin.
+      if (lockedSectionIds.size > 0) {
+        let activeSectionId: string | null = null
+        for (const item of finalItems) {
+          if (item.type === "section-header") {
+            activeSectionId = item.id
+          } else if (item.type === "question" && activeSectionId) {
+            if (
+              lockedSectionIds.has(activeSectionId) &&
+              !originalSectionQuestions.get(activeSectionId)?.has(item.id)
+            ) {
+              return
+            }
+          }
+        }
+      }
+
       // Build set of all question IDs that originally belonged to any section.
       const allInSectionQuestionIds = new Set<string>()
       for (const qIds of originalSectionQuestions.values()) {

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -162,7 +162,8 @@ export const BaseQuestion = ({
         // (text/default) cursors.
         locked && !answering && "cursor-not-allowed [&_*]:!cursor-not-allowed",
         !isDragging && !answering && !locked && "hover:border-f1-border-hover",
-        !answering || !!description ? "gap-4" : "gap-2"
+        // Tighten the title↔input gap when no description sits between them.
+        showDescription ? "gap-4" : "gap-2"
       )}
     >
       <div className="flex flex-col gap-0.5">

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -138,14 +138,14 @@ export const BaseQuestion = ({
 
   // Blocked question: an instant, title-less tooltip shown on the lock icon. It
   // prefers the question's own `lockedNote`, falls back to the parent section's
-  // `notice`, and finally to a default so a locked question always says
+  // `lockedNote`, and finally to a default so a locked question always says
   // something.
   const lockTooltipProps: { description: string } | null = !locked
     ? null
     : {
         description:
           lockedNote?.description ??
-          containingSection?.notice?.description ??
+          containingSection?.lockedNote?.description ??
           t("surveyFormBuilder.labels.lockedQuestionNotice"),
       }
 

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -136,8 +136,8 @@ export const BaseQuestion = ({
   // always has something to say.
   const lockTooltipProps: { description: string } | null = !locked
     ? null
-    : lockedNote
-      ? { description: lockedNote }
+    : lockedNote?.description
+      ? { description: lockedNote.description }
       : containingSection?.notice?.description
         ? { description: containingSection.notice.description }
         : containingSection?.description

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -131,18 +131,17 @@ export const BaseQuestion = ({
   const showCursorNotAllowed = !answering && inputDisabled
 
   // Blocked question: an instant, title-less tooltip shown on the lock icon. It
-  // prefers the question's own `lockedNote` (what this specific question is) and
-  // otherwise falls back to the section's explanation so a locked question
-  // always has something to say.
+  // prefers the question's own `lockedNote`, falls back to the parent section's
+  // `notice`, and finally to a default so a locked question always says
+  // something.
   const lockTooltipProps: { description: string } | null = !locked
     ? null
-    : lockedNote?.description
-      ? { description: lockedNote.description }
-      : containingSection?.notice?.description
-        ? { description: containingSection.notice.description }
-        : containingSection?.description
-          ? { description: containingSection.description }
-          : null
+    : {
+        description:
+          lockedNote?.description ??
+          containingSection?.notice?.description ??
+          t("surveyFormBuilder.labels.lockedNotice"),
+      }
 
   const questionCard = (
     <div

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -41,6 +41,7 @@ export const BaseQuestion = ({
   required,
   type: questionType,
   hiddenActions,
+  locked: ownLocked,
   lockedNote,
 }: BaseQuestionProps) => {
   const {
@@ -55,9 +56,9 @@ export const BaseQuestion = ({
 
   const containingSection = getSectionContainingQuestion(id)
 
-  // A question is only ever locked by being inside a locked section — it can't
-  // be locked on its own.
-  const locked = !!containingSection?.locked
+  // A question is locked either on its own (`locked` prop) or by living inside a
+  // locked section.
+  const locked = !!containingSection?.locked || !!ownLocked
 
   const isWithinSection = !!containingSection
 
@@ -140,7 +141,7 @@ export const BaseQuestion = ({
         description:
           lockedNote?.description ??
           containingSection?.notice?.description ??
-          t("surveyFormBuilder.labels.lockedNotice"),
+          t("surveyFormBuilder.labels.lockedQuestionNotice"),
       }
 
   const questionCard = (
@@ -229,16 +230,21 @@ export const BaseQuestion = ({
             <div>
               {lockTooltipProps ? (
                 <Tooltip instant {...lockTooltipProps}>
-                  <F0Button
-                    icon={LockLocked}
-                    label={t("surveyFormBuilder.labels.locked")}
-                    size="md"
-                    variant="ghost"
-                    tooltip={false}
-                    hideLabel
-                    disabled
-                    withoutDisabledAppearance
-                  />
+                  {/* A disabled button doesn't fire hover events, so the
+                      tooltip hangs off this wrapper span (which stays
+                      pointer-interactive) rather than the button itself. */}
+                  <span className="inline-flex">
+                    <F0Button
+                      icon={LockLocked}
+                      label={t("surveyFormBuilder.labels.locked")}
+                      size="md"
+                      variant="ghost"
+                      tooltip={false}
+                      hideLabel
+                      disabled
+                      withoutDisabledAppearance
+                    />
+                  </span>
                 </Tooltip>
               ) : (
                 <F0Button
@@ -289,7 +295,7 @@ export const BaseQuestion = ({
           }
         />
       )}
-      {!disabled && !answering && !containingSection?.locked && (
+      {!disabled && !answering && !locked && (
         <div
           className={cn(
             "absolute bottom-0 left-1/2 translate-x-[-50%] translate-y-[50%] bg-f1-background opacity-0 group-hover/question:opacity-100",

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -131,6 +131,11 @@ export const BaseQuestion = ({
 
   const showCursorNotAllowed = !answering && inputDisabled
 
+  // A read-only question (locked/disabled) with no description has nothing to
+  // edit, so hide the input rather than show an editable-looking placeholder.
+  // Editable questions always render it so authors can add one.
+  const showDescription = !inputDisabled || !!description
+
   // Blocked question: an instant, title-less tooltip shown on the lock icon. It
   // prefers the question's own `lockedNote`, falls back to the parent section's
   // `notice`, and finally to a default so a locked question always says
@@ -267,7 +272,7 @@ export const BaseQuestion = ({
               {description}
             </p>
           ) : null
-        ) : (
+        ) : showDescription ? (
           <textarea
             value={description}
             aria-label={t("surveyFormBuilder.labels.description")}
@@ -282,7 +287,7 @@ export const BaseQuestion = ({
             )}
             style={TEXT_AREA_STYLE}
           />
-        )}
+        ) : null}
       </div>
       {children}
       {answering && (

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { F0Icon } from "@/components/F0Icon"
-import { AcademicCap, Add, Check, CheckDouble } from "@/icons/app"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { AcademicCap, Add, Check, CheckDouble, LockLocked } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import {
@@ -38,9 +39,9 @@ export const BaseQuestion = ({
   description,
   children,
   required,
-  locked: questionLocked,
   type: questionType,
   hiddenActions,
+  lockedNote,
 }: BaseQuestionProps) => {
   const {
     onQuestionChange,
@@ -54,7 +55,9 @@ export const BaseQuestion = ({
 
   const containingSection = getSectionContainingQuestion(id)
 
-  const locked = containingSection?.locked || questionLocked
+  // A question is only ever locked by being inside a locked section — it can't
+  // be locked on its own.
+  const locked = !!containingSection?.locked
 
   const isWithinSection = !!containingSection
 
@@ -127,12 +130,19 @@ export const BaseQuestion = ({
 
   const showCursorNotAllowed = !answering && inputDisabled
 
-  return (
+  const questionCard = (
     <div
       id={`co-creation-question-${id}`}
       className={cn(
-        "group/question relative flex w-full flex-col rounded-xl border border-solid border-f1-border bg-f1-background px-3 py-4",
-        !isDragging && !answering && "hover:border-f1-border-hover",
+        "group/question relative flex w-full flex-col rounded-xl border border-solid border-f1-border bg-f1-background px-3 py-3",
+        // Blocked question: it lives inside a locked section, so the card keeps
+        // the default white fill (the section's muted grey panel sets it apart)
+        // and a not-allowed cursor signals it can't be edited. The `[&_*]` rule
+        // forces that cursor onto every descendant (inputs, textareas, options)
+        // so hovering anything inside the card keeps it, overriding their own
+        // (text/default) cursors.
+        locked && !answering && "cursor-not-allowed [&_*]:!cursor-not-allowed",
+        !isDragging && !answering && !locked && "hover:border-f1-border-hover",
         !answering || !!description ? "gap-4" : "gap-2"
       )}
     >
@@ -196,6 +206,22 @@ export const BaseQuestion = ({
                   !isWithinSection || !isSingleQuestionInSection
                 }
                 hiddenActions={hiddenActions}
+              />
+            </div>
+          )}
+          {!answering && locked && (
+            // Blocked question: a static lock sits where the actions "⋯" menu
+            // would be, signalling the card is predefined and can't be edited.
+            <div>
+              <F0Button
+                icon={LockLocked}
+                label={t("surveyFormBuilder.labels.locked")}
+                size="md"
+                variant="ghost"
+                tooltip={false}
+                hideLabel
+                disabled
+                withoutDisabledAppearance
               />
             </div>
           )}
@@ -349,4 +375,28 @@ export const BaseQuestion = ({
       )}
     </div>
   )
+
+  // Blocked question: an instant, title-less tooltip on hover. It prefers the
+  // question's own `lockedNote` (what this specific question is) and otherwise
+  // falls back to the section's explanation so a locked question always shows
+  // something.
+  const lockTooltipProps: { description: string } | null = !locked
+    ? null
+    : lockedNote
+      ? { description: lockedNote }
+      : containingSection?.notice?.description
+        ? { description: containingSection.notice.description }
+        : containingSection?.description
+          ? { description: containingSection.description }
+          : null
+
+  if (lockTooltipProps && !answering) {
+    return (
+      <Tooltip instant {...lockTooltipProps}>
+        {questionCard}
+      </Tooltip>
+    )
+  }
+
+  return questionCard
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -130,6 +130,20 @@ export const BaseQuestion = ({
 
   const showCursorNotAllowed = !answering && inputDisabled
 
+  // Blocked question: an instant, title-less tooltip shown on the lock icon. It
+  // prefers the question's own `lockedNote` (what this specific question is) and
+  // otherwise falls back to the section's explanation so a locked question
+  // always has something to say.
+  const lockTooltipProps: { description: string } | null = !locked
+    ? null
+    : lockedNote
+      ? { description: lockedNote }
+      : containingSection?.notice?.description
+        ? { description: containingSection.notice.description }
+        : containingSection?.description
+          ? { description: containingSection.description }
+          : null
+
   const questionCard = (
     <div
       id={`co-creation-question-${id}`}
@@ -212,17 +226,33 @@ export const BaseQuestion = ({
           {!answering && locked && (
             // Blocked question: a static lock sits where the actions "⋯" menu
             // would be, signalling the card is predefined and can't be edited.
+            // Hovering just the lock (not the whole card) reveals why.
             <div>
-              <F0Button
-                icon={LockLocked}
-                label={t("surveyFormBuilder.labels.locked")}
-                size="md"
-                variant="ghost"
-                tooltip={false}
-                hideLabel
-                disabled
-                withoutDisabledAppearance
-              />
+              {lockTooltipProps ? (
+                <Tooltip instant {...lockTooltipProps}>
+                  <F0Button
+                    icon={LockLocked}
+                    label={t("surveyFormBuilder.labels.locked")}
+                    size="md"
+                    variant="ghost"
+                    tooltip={false}
+                    hideLabel
+                    disabled
+                    withoutDisabledAppearance
+                  />
+                </Tooltip>
+              ) : (
+                <F0Button
+                  icon={LockLocked}
+                  label={t("surveyFormBuilder.labels.locked")}
+                  size="md"
+                  variant="ghost"
+                  tooltip={false}
+                  hideLabel
+                  disabled
+                  withoutDisabledAppearance
+                />
+              )}
             </div>
           )}
         </div>
@@ -375,28 +405,6 @@ export const BaseQuestion = ({
       )}
     </div>
   )
-
-  // Blocked question: an instant, title-less tooltip on hover. It prefers the
-  // question's own `lockedNote` (what this specific question is) and otherwise
-  // falls back to the section's explanation so a locked question always shows
-  // something.
-  const lockTooltipProps: { description: string } | null = !locked
-    ? null
-    : lockedNote
-      ? { description: lockedNote }
-      : containingSection?.notice?.description
-        ? { description: containingSection.notice.description }
-        : containingSection?.description
-          ? { description: containingSection.description }
-          : null
-
-  if (lockTooltipProps && !answering) {
-    return (
-      <Tooltip instant {...lockTooltipProps}>
-        {questionCard}
-      </Tooltip>
-    )
-  }
 
   return questionCard
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/types.ts
@@ -22,10 +22,15 @@ export type BaseQuestionProps = {
   required?: boolean
   hiddenActions?: HiddenActions
   /**
-   * Optional notice shown in the lock tooltip when the question is locked (i.e.
-   * it sits inside a locked section). Use it to say what this specific question
-   * is — it takes precedence over the section's own `LockedSectionNotice`. It is
-   * NOT a lock flag: questions can only be locked via their section.
+   * Locks the question on its own — independent of any section. A question is
+   * also locked when its containing section is locked.
+   */
+  locked?: boolean
+  /**
+   * Optional notice shown in the lock tooltip when the question is locked. Use
+   * it to say what this specific question is — it takes precedence over the
+   * parent section's `LockedSectionNotice` and over the default question notice
+   * from the i18n provider.
    */
   lockedNote?: LockedQuestionNotice
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/types.ts
@@ -1,6 +1,11 @@
-import { HiddenAction, HiddenActions, QuestionType } from "../../types"
+import {
+  HiddenAction,
+  HiddenActions,
+  QuestionNotice,
+  QuestionType,
+} from "../../types"
 
-export type { HiddenAction, HiddenActions }
+export type { HiddenAction, HiddenActions, QuestionNotice }
 
 export type BaseQuestionProps = {
   id: string
@@ -9,8 +14,14 @@ export type BaseQuestionProps = {
   type: QuestionType
   children: React.ReactNode
   required?: boolean
-  locked?: boolean
   hiddenActions?: HiddenActions
+  /**
+   * Optional note shown as a tooltip when the question is locked (i.e. it sits
+   * inside a locked section). Use it to say what this specific question is —
+   * distinct from the section's own lock explanation. It is NOT a lock flag:
+   * questions can only be locked via their section.
+   */
+  lockedNote?: string
 }
 
 export type BaseQuestionPropsForOtherQuestionComponents = Omit<

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/types.ts
@@ -1,11 +1,17 @@
 import {
   HiddenAction,
   HiddenActions,
-  QuestionNotice,
+  LockedQuestionNotice,
+  LockedSectionNotice,
   QuestionType,
 } from "../../types"
 
-export type { HiddenAction, HiddenActions, QuestionNotice }
+export type {
+  HiddenAction,
+  HiddenActions,
+  LockedQuestionNotice,
+  LockedSectionNotice,
+}
 
 export type BaseQuestionProps = {
   id: string
@@ -16,12 +22,12 @@ export type BaseQuestionProps = {
   required?: boolean
   hiddenActions?: HiddenActions
   /**
-   * Optional note shown as a tooltip when the question is locked (i.e. it sits
-   * inside a locked section). Use it to say what this specific question is —
-   * distinct from the section's own lock explanation. It is NOT a lock flag:
-   * questions can only be locked via their section.
+   * Optional notice shown in the lock tooltip when the question is locked (i.e.
+   * it sits inside a locked section). Use it to say what this specific question
+   * is — it takes precedence over the section's own `LockedSectionNotice`. It is
+   * NOT a lock flag: questions can only be locked via their section.
    */
-  lockedNote?: string
+  lockedNote?: LockedQuestionNotice
 }
 
 export type BaseQuestionPropsForOtherQuestionComponents = Omit<

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/useQuestionDisabled.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/useQuestionDisabled.ts
@@ -1,14 +1,11 @@
 import { useSurveyFormBuilderContext } from "../../Context"
 
-export function useQuestionDisabled(questionProps: {
-  id: string
-  locked?: boolean
-}): boolean {
+export function useQuestionDisabled(questionProps: { id: string }): boolean {
   const { answering, getSectionContainingQuestion } =
     useSurveyFormBuilderContext()
 
   const containingSection = getSectionContainingQuestion(questionProps.id)
-  const questionLocked = questionProps.locked || containingSection?.locked
+  const questionLocked = containingSection?.locked
 
   return answering ? false : questionLocked || true
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/index.tsx
@@ -17,8 +17,18 @@ export const BaseScoreQuestion = ({
   value,
   ...baseQuestionComponentProps
 }: BaseScoreQuestionProps) => {
-  const { onQuestionChange, disabled, answering } =
-    useSurveyFormBuilderContext()
+  const {
+    onQuestionChange,
+    disabled,
+    answering,
+    getSectionContainingQuestion,
+  } = useSurveyFormBuilderContext()
+
+  // A question inside a locked section is non-interactive in the authoring
+  // view, but stays selectable for respondents (answering).
+  const locked = getSectionContainingQuestion(
+    baseQuestionComponentProps.id
+  )?.locked
 
   const ratingType = detectRatingOptionType(options)
   const isEmojiMode = ratingType === "emojis"
@@ -54,7 +64,7 @@ export const BaseScoreQuestion = ({
             selected={value === option.value}
             onClick={handleChangeValue}
             onChangeLabel={handleChangeLabel}
-            disabled={disabled && !answering}
+            disabled={(disabled || locked) && !answering}
             isEmojiMode={answering ? false : isEmojiMode}
           />
         ))}

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/index.tsx
@@ -26,9 +26,9 @@ export const BaseScoreQuestion = ({
 
   // A question inside a locked section is non-interactive in the authoring
   // view, but stays selectable for respondents (answering).
-  const locked = getSectionContainingQuestion(
-    baseQuestionComponentProps.id
-  )?.locked
+  const locked =
+    getSectionContainingQuestion(baseQuestionComponentProps.id)?.locked ||
+    baseQuestionComponentProps.locked
 
   const ratingType = detectRatingOptionType(options)
   const isEmojiMode = ratingType === "emojis"

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/CheckboxQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/CheckboxQuestion/index.tsx
@@ -33,8 +33,12 @@ export const CheckboxQuestion = ({
   label: labelProp,
   ...baseQuestionComponentProps
 }: CheckboxQuestionProps) => {
-  const { onQuestionChange, answering, disabled } =
-    useSurveyFormBuilderContext()
+  const {
+    onQuestionChange,
+    answering,
+    disabled,
+    getSectionContainingQuestion,
+  } = useSurveyFormBuilderContext()
 
   const questionDisabled = useQuestionDisabled(baseQuestionComponentProps)
 
@@ -43,31 +47,31 @@ export const CheckboxQuestion = ({
   if (answering) {
     return (
       <BaseQuestion {...baseQuestionComponentProps}>
-        <div className="px-0.5">
-          <F0Checkbox
-            id={baseQuestionComponentProps.id}
-            checked={value ?? false}
-            onCheckedChange={(checked) => {
-              onQuestionChange?.({
-                ...baseQuestionComponentProps,
-                type: "checkbox",
-                label: labelProp,
-                value: checked || null,
-              })
-            }}
-            disabled={questionDisabled}
-            title={labelProp}
-          />
-        </div>
+        <F0Checkbox
+          id={baseQuestionComponentProps.id}
+          checked={value ?? false}
+          onCheckedChange={(checked) => {
+            onQuestionChange?.({
+              ...baseQuestionComponentProps,
+              type: "checkbox",
+              label: labelProp,
+              value: checked || null,
+            })
+          }}
+          disabled={questionDisabled}
+          title={labelProp}
+        />
       </BaseQuestion>
     )
   }
 
-  const inputDisabled = disabled || baseQuestionComponentProps.locked
+  const inputDisabled =
+    disabled ||
+    getSectionContainingQuestion(baseQuestionComponentProps.id)?.locked
 
   return (
     <BaseQuestion {...baseQuestionComponentProps}>
-      <div className="flex items-start px-0.5">
+      <div className="flex items-start">
         <F0Checkbox checked={false} disabled hideLabel presentational />
         <textarea
           value={labelProp}

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/CheckboxQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/CheckboxQuestion/index.tsx
@@ -67,7 +67,8 @@ export const CheckboxQuestion = ({
 
   const inputDisabled =
     disabled ||
-    getSectionContainingQuestion(baseQuestionComponentProps.id)?.locked
+    getSectionContainingQuestion(baseQuestionComponentProps.id)?.locked ||
+    baseQuestionComponentProps.locked
 
   return (
     <BaseQuestion {...baseQuestionComponentProps}>

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/DateQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/DateQuestion/index.tsx
@@ -38,21 +38,19 @@ export const DateQuestion = ({
 
   return (
     <BaseQuestion {...baseQuestionComponentProps}>
-      <div className="px-0.5">
-        <F0FormField
-          field={field}
-          value={value ?? undefined}
-          onChange={(v) => {
-            onQuestionChange?.({
-              ...baseQuestionComponentProps,
-              type: "date",
-              value: (v as Date | null) ?? undefined,
-            })
-          }}
-          disabled={disabled}
-          hideLabel
-        />
-      </div>
+      <F0FormField
+        field={field}
+        value={value ?? undefined}
+        onChange={(v) => {
+          onQuestionChange?.({
+            ...baseQuestionComponentProps,
+            type: "date",
+            value: (v as Date | null) ?? undefined,
+          })
+        }}
+        disabled={disabled}
+        hideLabel
+      />
     </BaseQuestion>
   )
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/DropdownSingleQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/DropdownSingleQuestion/index.tsx
@@ -77,7 +77,7 @@ export const DropdownSingleQuestion = ({
 
   return (
     <BaseQuestion {...props}>
-      <div className="flex flex-col items-start px-0.5 [&>div]:w-full">
+      <div className="flex flex-col items-start [&>div]:w-full">
         <F0FormField
           field={field}
           value={isMulti ? (props.value ?? []) : (props.value ?? "")}

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/FileQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/FileQuestion/index.tsx
@@ -79,21 +79,19 @@ export const FileQuestion = ({
 
   return (
     <BaseQuestion {...baseQuestionComponentProps}>
-      <div className="px-0.5">
-        <F0FormField
-          field={field}
-          value={value ?? []}
-          onChange={(v) => {
-            onQuestionChange?.({
-              ...baseQuestionComponentProps,
-              type: "file",
-              value: (v as string[]) || null,
-            })
-          }}
-          disabled={disabled}
-          hideLabel
-        />
-      </div>
+      <F0FormField
+        field={field}
+        value={value ?? []}
+        onChange={(v) => {
+          onQuestionChange?.({
+            ...baseQuestionComponentProps,
+            type: "file",
+            value: (v as string[]) || null,
+          })
+        }}
+        disabled={disabled}
+        hideLabel
+      />
     </BaseQuestion>
   )
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/LinkQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/LinkQuestion/index.tsx
@@ -42,21 +42,19 @@ export const LinkQuestion = ({
 
   return (
     <BaseQuestion {...baseQuestionComponentProps}>
-      <div className="px-0.5">
-        <F0FormField
-          field={field}
-          value={answering ? (value ?? "") : placeholder}
-          onChange={(v) => {
-            onQuestionChange?.({
-              ...baseQuestionComponentProps,
-              type: "link",
-              value: (v as string) || null,
-            })
-          }}
-          disabled={disabled}
-          hideLabel
-        />
-      </div>
+      <F0FormField
+        field={field}
+        value={answering ? (value ?? "") : placeholder}
+        onChange={(v) => {
+          onQuestionChange?.({
+            ...baseQuestionComponentProps,
+            type: "link",
+            value: (v as string) || null,
+          })
+        }}
+        disabled={disabled}
+        hideLabel
+      />
     </BaseQuestion>
   )
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/NumericQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/NumericQuestion/index.tsx
@@ -42,34 +42,32 @@ export const NumericQuestion = ({
 
   return (
     <BaseQuestion {...baseQuestionComponentProps}>
-      <div className="px-0.5">
-        {answering ? (
-          <F0NumberInput
-            locale="en-US"
-            size="md"
-            value={value}
-            onChange={handleChangeText}
-            disabled={disabled}
-            label={t("surveyFormBuilder.answer.label")}
-            hideLabel={true}
-            required={baseQuestionComponentProps.required}
-            maxDecimals={0}
-            placeholder={placeholder}
-            icon={Numbers}
-          />
-        ) : (
-          <F0TextInput
-            type="text"
-            size="md"
-            value={placeholder}
-            onChange={() => {}}
-            disabled
-            label={t("surveyFormBuilder.answer.label")}
-            hideLabel={true}
-            icon={Numbers}
-          />
-        )}
-      </div>
+      {answering ? (
+        <F0NumberInput
+          locale="en-US"
+          size="md"
+          value={value}
+          onChange={handleChangeText}
+          disabled={disabled}
+          label={t("surveyFormBuilder.answer.label")}
+          hideLabel={true}
+          required={baseQuestionComponentProps.required}
+          maxDecimals={0}
+          placeholder={placeholder}
+          icon={Numbers}
+        />
+      ) : (
+        <F0TextInput
+          type="text"
+          size="md"
+          value={placeholder}
+          onChange={() => {}}
+          disabled
+          label={t("surveyFormBuilder.answer.label")}
+          hideLabel={true}
+          icon={Numbers}
+        />
+      )}
     </BaseQuestion>
   )
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
@@ -30,7 +30,7 @@ export const SelectQuestion = ({ options, ...props }: SelectQuestionProps) => {
 
   const containingSection = getSectionContainingQuestion(props.id)
 
-  const questionLocked = containingSection?.locked
+  const questionLocked = containingSection?.locked || props.locked
 
   const { t } = useI18n()
 

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
@@ -30,7 +30,7 @@ export const SelectQuestion = ({ options, ...props }: SelectQuestionProps) => {
 
   const containingSection = getSectionContainingQuestion(props.id)
 
-  const questionLocked = props.locked || containingSection?.locked
+  const questionLocked = containingSection?.locked
 
   const { t } = useI18n()
 

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/TextQuestion/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/QuestionTypes/TextQuestion/index.tsx
@@ -63,20 +63,18 @@ export const TextQuestion = ({
 
   return (
     <BaseQuestion {...baseQuestionComponentProps}>
-      <div className="px-0.5">
-        <F0FormField
-          field={field}
-          value={answering ? (value ?? "") : placeholder}
-          onChange={(v) => {
-            onQuestionChange?.({
-              ...baseQuestionComponentProps,
-              value: v as string,
-            })
-          }}
-          disabled={disabled}
-          hideLabel
-        />
-      </div>
+      <F0FormField
+        field={field}
+        value={answering ? (value ?? "") : placeholder}
+        onChange={(v) => {
+          onQuestionChange?.({
+            ...baseQuestionComponentProps,
+            value: v as string,
+          })
+        }}
+        disabled={disabled}
+        hideLabel
+      />
     </BaseQuestion>
   )
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Section/Item/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Section/Item/index.tsx
@@ -32,7 +32,7 @@ export const Item = ({ question }: ItemProps) => {
     setDraggedItemId(null)
   }
 
-  const questionLocked = question.locked || containingSection?.locked
+  const questionLocked = containingSection?.locked
 
   const dragEnabled = !disabled && !answering && !questionLocked
 

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
@@ -23,7 +23,7 @@ export const Section = ({
   id,
   title = "",
   description,
-  notice,
+  lockedNote,
   questions = [],
   locked,
   hideQuestions,
@@ -106,7 +106,7 @@ export const Section = ({
   // Hovering it surfaces why the section is blocked — its own
   // `LockedSectionNotice`, falling back to the provider's default lock notice.
   const lockedNoticeText =
-    notice?.description ?? t("surveyFormBuilder.labels.lockedSectionNotice")
+    lockedNote?.description ?? t("surveyFormBuilder.labels.lockedSectionNotice")
   const lockedTag =
     locked && !answering ? (
       <F0TagRaw

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
@@ -2,8 +2,10 @@ import { Reorder } from "motion/react"
 import { useEffect, useMemo, useRef, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
+import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import { Dropdown } from "@/experimental/Navigation/Dropdown"
-import { Delete, Ellipsis, LayersFront } from "@/icons/app"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { Delete, Ellipsis, LayersFront, LockLocked } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
@@ -19,7 +21,7 @@ const TEXT_AREA_STYLE: object = {
 
 export const Section = ({
   id,
-  title,
+  title = "",
   description,
   questions = [],
   locked,
@@ -86,73 +88,122 @@ export const Section = ({
 
   const inputDisabled = disabled || locked || answering
 
+  // When the section is read-only (locked/disabled/answering) an empty title or
+  // description has nothing to show and no way to edit, so it's hidden. When the
+  // section is editable the inputs always render — empty ones surface a
+  // placeholder so authors can fill them in.
+  const showTitle = !inputDisabled || !!title
+  const showDescription = !inputDisabled || !!description
+
   const titleRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     titleRef.current?.focus({ preventScroll: true })
   }, [])
 
+  // Blocked section: a white "LOCKED" tag sits at the rightmost of the title.
+  // The section description isn't shown inline; instead it's surfaced as a
+  // tooltip on the tag (see below).
+  const lockedTag =
+    locked && !answering ? (
+      <F0TagRaw
+        text={t("surveyFormBuilder.labels.locked")}
+        icon={LockLocked}
+        className="bg-f1-background"
+      />
+    ) : null
+
   return (
     <div
       id={`co-creation-section-${id}`}
-      className="group/section flex w-full flex-col gap-1 bg-f1-background"
+      className={cn(
+        "group/section flex w-full flex-col gap-1",
+        // Blocked section: the muted grey panel comes from the wrapper in
+        // Form, so the header stays transparent (letting it show through) and
+        // a not-allowed cursor signals it can't be edited. Editable sections
+        // keep their white background.
+        locked && !answering ? "cursor-not-allowed" : "bg-f1-background"
+      )}
     >
-      <div className="py-1 pl-5 pr-3">
-        <div className="flex flex-row">
-          <input
-            ref={titleRef}
-            type="text"
-            aria-label={t("surveyFormBuilder.labels.title")}
-            value={title}
-            placeholder={t("surveyFormBuilder.labels.sectionTitlePlaceholder")}
-            onChange={handleChangeTitle}
-            disabled={inputDisabled}
-            className={cn(
-              "w-full text-lg font-semibold disabled:text-f1-foreground [&::-webkit-search-cancel-button]:hidden",
-              inputDisabled && "cursor-not-allowed"
-            )}
-          />
-          {!disabled && !answering && !locked && (
-            <div
-              className={cn(
-                "opacity-0 group-hover/section:opacity-100",
-                actionsDropdownOpen && "opacity-100"
-              )}
-            >
-              <Dropdown
-                items={actions}
-                icon={Ellipsis}
-                open={actionsDropdownOpen}
-                onOpenChange={setActionsDropdownOpen}
-                align="start"
-              >
-                <F0Button
-                  icon={Ellipsis}
-                  label={t("surveyFormBuilder.actions.actions")}
-                  size="md"
-                  variant="ghost"
-                  tooltip={false}
-                  hideLabel
+      {(showTitle || showDescription || (locked && !answering)) && (
+        <div className="py-1 pl-5 pr-3">
+          {(showTitle || (locked && !answering)) && (
+            <div className="flex flex-row items-center gap-2">
+              {showTitle && (
+                <input
+                  ref={titleRef}
+                  type="text"
+                  aria-label={t("surveyFormBuilder.labels.title")}
+                  value={title}
+                  placeholder={t(
+                    "surveyFormBuilder.labels.sectionTitlePlaceholder"
+                  )}
+                  onChange={handleChangeTitle}
+                  disabled={inputDisabled}
+                  className={cn(
+                    "w-full text-lg font-semibold disabled:text-f1-foreground [&::-webkit-search-cancel-button]:hidden",
+                    inputDisabled && "cursor-not-allowed"
+                  )}
                 />
-              </Dropdown>
+              )}
+              {lockedTag && (
+                <div className="ml-auto flex shrink-0 items-center">
+                  {description ? (
+                    // The description explains why the section is blocked; it
+                    // surfaces on hover/focus of the tag instead of inline.
+                    <Tooltip description={description} instant>
+                      <span className="inline-flex">{lockedTag}</span>
+                    </Tooltip>
+                  ) : (
+                    lockedTag
+                  )}
+                </div>
+              )}
+              {!disabled && !answering && !locked && (
+                <div
+                  className={cn(
+                    "opacity-0 group-hover/section:opacity-100",
+                    actionsDropdownOpen && "opacity-100"
+                  )}
+                >
+                  <Dropdown
+                    items={actions}
+                    icon={Ellipsis}
+                    open={actionsDropdownOpen}
+                    onOpenChange={setActionsDropdownOpen}
+                    align="start"
+                  >
+                    <F0Button
+                      icon={Ellipsis}
+                      label={t("surveyFormBuilder.actions.actions")}
+                      size="md"
+                      variant="ghost"
+                      tooltip={false}
+                      hideLabel
+                    />
+                  </Dropdown>
+                </div>
+              )}
             </div>
           )}
+          {showDescription && !(locked && !answering) && (
+            <textarea
+              value={description}
+              aria-label={t("surveyFormBuilder.labels.description")}
+              placeholder={t(
+                "surveyFormBuilder.labels.sectionDescriptionPlaceholder"
+              )}
+              onChange={handleChangeDescription}
+              disabled={inputDisabled}
+              style={TEXT_AREA_STYLE}
+              className={cn(
+                "w-full resize-none text-f1-foreground-secondary placeholder:text-f1-foreground-tertiary disabled:text-f1-foreground-secondary [&::-webkit-search-cancel-button]:hidden",
+                inputDisabled && "cursor-not-allowed"
+              )}
+            />
+          )}
         </div>
-        <textarea
-          value={description}
-          aria-label={t("surveyFormBuilder.labels.description")}
-          placeholder={t(
-            "surveyFormBuilder.labels.sectionDescriptionPlaceholder"
-          )}
-          onChange={handleChangeDescription}
-          disabled={inputDisabled}
-          style={TEXT_AREA_STYLE}
-          className={cn(
-            "w-full resize-none text-f1-foreground-secondary placeholder:text-f1-foreground-tertiary disabled:text-f1-foreground-secondary [&::-webkit-search-cancel-button]:hidden",
-            inputDisabled && "cursor-not-allowed"
-          )}
-        />
-      </div>
+      )}
       {!hideQuestions && (
         <>
           <DragProvider>

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Section/index.tsx
@@ -23,6 +23,7 @@ export const Section = ({
   id,
   title = "",
   description,
+  notice,
   questions = [],
   locked,
   hideQuestions,
@@ -102,8 +103,10 @@ export const Section = ({
   }, [])
 
   // Blocked section: a white "LOCKED" tag sits at the rightmost of the title.
-  // The section description isn't shown inline; instead it's surfaced as a
-  // tooltip on the tag (see below).
+  // Hovering it surfaces why the section is blocked — its own
+  // `LockedSectionNotice`, falling back to the provider's default lock notice.
+  const lockedNoticeText =
+    notice?.description ?? t("surveyFormBuilder.labels.lockedSectionNotice")
   const lockedTag =
     locked && !answering ? (
       <F0TagRaw
@@ -148,15 +151,9 @@ export const Section = ({
               )}
               {lockedTag && (
                 <div className="ml-auto flex shrink-0 items-center">
-                  {description ? (
-                    // The description explains why the section is blocked; it
-                    // surfaces on hover/focus of the tag instead of inline.
-                    <Tooltip description={description} instant>
-                      <span className="inline-flex">{lockedTag}</span>
-                    </Tooltip>
-                  ) : (
-                    lockedTag
-                  )}
+                  <Tooltip description={lockedNoticeText} instant>
+                    <span className="inline-flex">{lockedTag}</span>
+                  </Tooltip>
                 </div>
               )}
               {!disabled && !answering && !locked && (

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Section/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Section/types.ts
@@ -4,9 +4,9 @@ export type SectionProps = {
   id: string
   /**
    * Section heading. Optional — a section may have no title (e.g. a predefined,
-   * blocked section that leads with a `notice` instead). In the editable view an
-   * empty title shows a placeholder so authors can add one; when the section is
-   * locked/read-only an empty title is hidden entirely.
+   * blocked section that leads with a `lockedNote` instead). In the editable
+   * view an empty title shows a placeholder so authors can add one; when the
+   * section is locked/read-only an empty title is hidden entirely.
    */
   title?: string
   description?: string
@@ -15,6 +15,6 @@ export type SectionProps = {
    * Optional explanation surfaced in the lock tooltip (authoring view only).
    * Pair with `locked` to say why a predefined section can't be edited or moved.
    */
-  notice?: LockedSectionNotice
+  lockedNote?: LockedSectionNotice
   questions?: QuestionElement[]
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Section/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Section/types.ts
@@ -1,4 +1,4 @@
-import { QuestionElement, QuestionNotice } from "../types"
+import { LockedSectionNotice, QuestionElement } from "../types"
 
 export type SectionProps = {
   id: string
@@ -12,9 +12,9 @@ export type SectionProps = {
   description?: string
   locked?: boolean
   /**
-   * Optional alert rendered above the section title (authoring view only). Pair
-   * with `locked` to explain why a predefined section can't be edited or moved.
+   * Optional explanation surfaced in the lock tooltip (authoring view only).
+   * Pair with `locked` to say why a predefined section can't be edited or moved.
    */
-  notice?: QuestionNotice
+  notice?: LockedSectionNotice
   questions?: QuestionElement[]
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Section/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Section/types.ts
@@ -1,9 +1,20 @@
-import { QuestionElement } from "../types"
+import { QuestionElement, QuestionNotice } from "../types"
 
 export type SectionProps = {
   id: string
-  title: string
+  /**
+   * Section heading. Optional — a section may have no title (e.g. a predefined,
+   * blocked section that leads with a `notice` instead). In the editable view an
+   * empty title shows a placeholder so authors can add one; when the section is
+   * locked/read-only an empty title is hidden entirely.
+   */
+  title?: string
   description?: string
   locked?: boolean
+  /**
+   * Optional alert rendered above the section title (authoring view only). Pair
+   * with `locked` to explain why a predefined section can't be edited or moved.
+   */
+  notice?: QuestionNotice
   questions?: QuestionElement[]
 }

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/types.ts
@@ -51,11 +51,19 @@ export type HiddenAction =
 export type HiddenActions = ReadonlyArray<HiddenAction>
 
 /**
- * Explanation surfaced for a locked question (authoring view only — never shown
- * in the answering/preview form). Rendered as a title-less tooltip on hover to
- * say why a predefined question can't be edited, moved, or removed.
+ * Explanation surfaced in a locked item's lock tooltip (authoring view only —
+ * never shown in the answering/preview form), saying why it can't be edited,
+ * moved, or removed. Rendered as a title-less popover on hovering the lock.
+ *
+ * A section and an individual question each carry their own notice; a locked
+ * question prefers its own `LockedQuestionNotice` and otherwise falls back to
+ * the section's `LockedSectionNotice`.
  */
-export type QuestionNotice = {
+export type LockedSectionNotice = {
+  description: string
+}
+
+export type LockedQuestionNotice = {
   description: string
 }
 

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/types.ts
@@ -1,5 +1,4 @@
 import type { UseFileUpload } from "@/patterns/F0Form/fields/file/types"
-import type { AlertVariant } from "@/components/F0Alert/types"
 import type { IconType } from "@/components/F0Icon/F0Icon"
 import type { F0SelectItemObject } from "@/components/F0Select/types"
 import type { DataSourceDefinition, RecordType } from "@/hooks/datasource"
@@ -52,16 +51,12 @@ export type HiddenAction =
 export type HiddenActions = ReadonlyArray<HiddenAction>
 
 /**
- * An alert rendered inside a question card (authoring view only — never shown
- * in the answering/preview form). Typically paired with `locked` to explain why
- * a predefined question can't be edited, moved, or removed.
+ * Explanation surfaced for a locked question (authoring view only — never shown
+ * in the answering/preview form). Rendered as a title-less tooltip on hover to
+ * say why a predefined question can't be edited, moved, or removed.
  */
 export type QuestionNotice = {
-  /** Defaults to "info" when omitted. */
-  variant?: AlertVariant
-  title: string
-  description?: string
-  icon?: IconType
+  description: string
 }
 
 export type BaseQuestionOnChangeParams = {

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/types.ts
@@ -1,4 +1,5 @@
 import type { UseFileUpload } from "@/patterns/F0Form/fields/file/types"
+import type { AlertVariant } from "@/components/F0Alert/types"
 import type { IconType } from "@/components/F0Icon/F0Icon"
 import type { F0SelectItemObject } from "@/components/F0Select/types"
 import type { DataSourceDefinition, RecordType } from "@/hooks/datasource"
@@ -49,6 +50,19 @@ export type HiddenAction =
   | "delete"
 
 export type HiddenActions = ReadonlyArray<HiddenAction>
+
+/**
+ * An alert rendered inside a question card (authoring view only — never shown
+ * in the answering/preview form). Typically paired with `locked` to explain why
+ * a predefined question can't be edited, moved, or removed.
+ */
+export type QuestionNotice = {
+  /** Defaults to "info" when omitted. */
+  variant?: AlertVariant
+  title: string
+  description?: string
+  icon?: IconType
+}
 
 export type BaseQuestionOnChangeParams = {
   id: string

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/types.ts
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/types.ts
@@ -55,9 +55,9 @@ export type HiddenActions = ReadonlyArray<HiddenAction>
  * never shown in the answering/preview form), saying why it can't be edited,
  * moved, or removed. Rendered as a title-less popover on hovering the lock.
  *
- * A section and an individual question each carry their own notice; a locked
- * question prefers its own `LockedQuestionNotice` and otherwise falls back to
- * the section's `LockedSectionNotice`.
+ * A section and an individual question each carry their own `lockedNote`; a
+ * locked question prefers its own `LockedQuestionNotice` and otherwise falls
+ * back to the section's `LockedSectionNotice`.
  */
 export type LockedSectionNotice = {
   description: string


### PR DESCRIPTION
## Description

Adds the ability to mark sections and individual questions in the `SurveyFormBuilder` as predefined and read-only. A locked item shows a lock affordance instead of its edit/drag controls, disables its inputs, and explains itself through a hover tooltip that falls back to a default notice from the F0Provider. This was extracted from the co-creation work in #4307, scoped down to just the survey changes.

## Screenshots

<img width="874" height="685" alt="Screenshot 2026-06-19 at 10 00 11" src="https://github.com/user-attachments/assets/a2942dd3-e73a-479f-94a1-6b25851c8f18" />
