### PR TITLE
fix(F0NumberInput): show thousand separators when not focused

### DIFF
--- a/packages/react/src/components/F0NumberInput/__tests__/F0NumberInput.test.tsx
+++ b/packages/react/src/components/F0NumberInput/__tests__/F0NumberInput.test.tsx
@@ -24,6 +24,71 @@ describe("F0NumberInput", () => {
     expect(input).toHaveValue("123,46")
   })
 
+  describe("thousand separators", () => {
+    test("groups the value when not focused (en-US)", () => {
+      render(
+        <F0NumberInput
+          locale="en-US"
+          value={5000}
+          maxDecimals={0}
+          label="Number Input"
+        />
+      )
+      expect(screen.getByRole("textbox")).toHaveValue("5,000")
+    })
+
+    test("groups the value when not focused (es-ES)", () => {
+      render(
+        <F0NumberInput
+          locale="es-ES"
+          value={5000.54}
+          maxDecimals={2}
+          label="Number Input"
+        />
+      )
+      expect(screen.getByRole("textbox")).toHaveValue("5.000,54")
+    })
+
+    test("shows the raw value on focus and re-groups on blur", async () => {
+      render(
+        <F0NumberInput
+          locale="en-US"
+          value={5000}
+          maxDecimals={0}
+          label="Number Input"
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      expect(input).toHaveValue("5,000")
+
+      await userEvent.click(input)
+      expect(input).toHaveValue("5000")
+
+      await userEvent.tab()
+      expect(input).toHaveValue("5,000")
+    })
+
+    test("calls onBlur when the input loses focus", async () => {
+      const onBlur = vi.fn()
+      render(
+        <F0NumberInput
+          locale="en-US"
+          value={5000}
+          maxDecimals={0}
+          onBlur={onBlur}
+          label="Number Input"
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await userEvent.click(input)
+      await userEvent.tab()
+
+      expect(onBlur).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe("when the value is null", () => {
     test("renders an empty input", () => {
       render(<F0NumberInput locale="en-US" value={null} label="Number Input" />)

--- a/packages/react/src/components/F0NumberInput/internal.tsx
+++ b/packages/react/src/components/F0NumberInput/internal.tsx
@@ -27,10 +27,15 @@ import { InputFieldProps } from "@/components/F0InputField"
 import { Arrows } from "./components/Arrows"
 import { extractNumber } from "./internal/extractNumber"
 
-const formatValue = (value: number, locale: string, maxDecimals?: number) =>
+const formatValue = (
+  value: number,
+  locale: string,
+  maxDecimals?: number,
+  useGrouping = false
+) =>
   new Intl.NumberFormat(locale, {
     maximumFractionDigits: maxDecimals,
-    useGrouping: false,
+    useGrouping,
   }).format(value)
 
 export interface NumberInputPopoverConfig {
@@ -186,6 +191,7 @@ export const NumberInputInternal = forwardRef<
     disabled,
     readonly,
     loading,
+    onBlur,
     ...props
   },
   ref
@@ -204,6 +210,7 @@ export const NumberInputInternal = forwardRef<
   const [draftValue, setDraftValue] = useState<number | null>(
     value != null ? value : null
   )
+  const [isFocused, setIsFocused] = useState(false)
 
   const localHint = useMemo(() => {
     if (hint !== undefined) {
@@ -245,6 +252,26 @@ export const NumberInputInternal = forwardRef<
   }, [isDeferredPopover, popoverOpen, value])
 
   const inputValue = isDeferredPopover ? draftValue : value
+
+  // Grouping separators are display-only: they would break extractNumber and
+  // caret handling, so the raw ungrouped string comes back while editing.
+  const displayValue = useMemo(() => {
+    if (isFocused) return fieldValue
+    const numericValue =
+      inputValue !== undefined
+        ? inputValue
+        : (extractNumber(fieldValue, { maxDecimals })?.value ?? null)
+    return numericValue != null
+      ? formatValue(numericValue, locale, maxDecimals, true)
+      : fieldValue
+  }, [isFocused, fieldValue, inputValue, locale, maxDecimals])
+
+  const handleFocus = () => setIsFocused(true)
+  const handleBlur = () => {
+    setIsFocused(false)
+    onBlur?.()
+  }
+
   const inputOnChange = useMemo(
     () =>
       isDeferredPopover
@@ -348,9 +375,11 @@ export const NumberInputInternal = forwardRef<
         type="text"
         ref={ref}
         id={inputId}
-        value={fieldValue}
+        value={displayValue}
         inputMode={maxDecimals === 0 ? "numeric" : "decimal"}
         onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         {...props}
         label={usesExternalMessages ? (label ?? "") : label}
         hideLabel={hideLabel || usesExternalMessages}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
@@ -27,11 +27,24 @@ describe("NumberCell", () => {
     item: { id: "1", salary: 42000 },
   }
 
-  it("renders with the provided numeric value", () => {
+  it("renders with the provided numeric value with grouping separators", () => {
     render(<NumberCell {...defaultProps} />)
 
     const input = screen.getByRole("textbox")
+    expect(input).toHaveValue("42,000")
+  })
+
+  it("shows the raw value while editing and the grouped value on blur", async () => {
+    const user = userEvent.setup()
+
+    render(<NumberCell {...defaultProps} />)
+
+    const input = screen.getByRole("textbox")
+    await user.click(input)
     expect(input).toHaveValue("42000")
+
+    await user.tab()
+    expect(input).toHaveValue("42,000")
   })
 
   it("renders empty when value is an empty string", () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/hooks/useNumberCellLayout.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/hooks/useNumberCellLayout.ts
@@ -35,7 +35,6 @@ export function useNumberCellLayout<R extends RecordType>(
     () =>
       new Intl.NumberFormat(locale, {
         maximumFractionDigits: config?.maxDecimals,
-        useGrouping: false,
       }),
     [locale, config?.maxDecimals]
   )


### PR DESCRIPTION
## Description

Editable number and money cells (`F0NumberInput`, used by the EditableTable Number/Money cells) rendered values without thousand separators (`50000` instead of `50,000`), while read-only/display cells formatted correctly. This surfaced in Headcount Planning salary inputs for new and approved headcount rows (FCT-55894). The input now shows locale-aware grouping separators while blurred and reverts to the raw ungrouped value on focus so typing and parsing are unaffected.

## Implementation details

- fix: add locale-aware thousand separators to `F0NumberInput` display when the input is not focused (`50000` → `50,000` en-US, `5000.54` → `5.000,54` es-ES); raw value returns on focus

  <details>
  <summary>Why blur-only?</summary>

  Grouping separators inside the editable string would break `extractNumber` parsing and caret/selection handling mid-edit. Keeping the raw value while focused means `handleChange`, `handleBeforeInput`, clamping, and the deferred-popover path are all untouched — grouping is purely a display concern applied on blur.
  </details>

- fix: account for grouping separators in EditableTable number-cell width measurement (`useNumberCellLayout`) so wider grouped values aren't clipped
- test: cover grouped-on-blur / raw-on-focus behavior and `onBlur` passthrough in `F0NumberInput` and `NumberCell` specs

## Notes

- No consumer (factorial) code change required — the fix is entirely within `F0NumberInput`, so all money/number input cells benefit automatically.
- Visual change: best verified in the `F0NumberInput` and EditableTable money-cell Storybook stories.


https://github.com/user-attachments/assets/0b12c419-9895-415b-adcc-82b392eb2778

