### PR TITLE
feat(ClockInControls): add locationSelectorElement slot for location drill-in

### DIFF
--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
+import { Office as OfficeIcon } from "@/icons/app"
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
 import { ClockInControls } from "./index"
@@ -132,5 +133,55 @@ describe("ClockInControls", () => {
     )
     screen.getByText(defaultLabels.clockIn).click()
     expect(onClockIn).toHaveBeenCalled()
+  })
+
+  it("renders a custom locationSelectorElement in place of the built-in location select", () => {
+    render(
+      <ClockInControls
+        data={[]}
+        trackedMinutes={0}
+        labels={defaultLabels}
+        locations={[{ id: "1", name: "Office", icon: OfficeIcon }]}
+        locationId="1"
+        onChangeLocationId={() => {}}
+        locationSelectorElement={<div>Custom location control</div>}
+      />
+    )
+    expect(screen.getByText("Custom location control")).toBeInTheDocument()
+    // The built-in location trigger is replaced, not rendered alongside.
+    expect(screen.queryByLabelText("Select location")).not.toBeInTheDocument()
+  })
+
+  it("renders the custom locationSelectorElement in the clocked-in state too", () => {
+    render(
+      <ClockInControls
+        labels={defaultLabels}
+        trackedMinutes={0}
+        data={[{ from: new Date(), to: new Date(), variant: "clocked-in" }]}
+        locations={[{ id: "1", name: "Office", icon: OfficeIcon }]}
+        locationId="1"
+        onChangeLocationId={() => {}}
+        locationSelectorElement={<div>Custom location control</div>}
+      />
+    )
+    expect(screen.getByText("Custom location control")).toBeInTheDocument()
+  })
+
+  it("does not render the location area (custom or built-in) when canShowLocation is false", () => {
+    render(
+      <ClockInControls
+        data={[]}
+        trackedMinutes={0}
+        labels={defaultLabels}
+        locations={[{ id: "1", name: "Office", icon: OfficeIcon }]}
+        locationId="1"
+        onChangeLocationId={() => {}}
+        canShowLocation={false}
+        locationSelectorElement={<div>Custom location control</div>}
+      />
+    )
+    expect(
+      screen.queryByText("Custom location control")
+    ).not.toBeInTheDocument()
   })
 })

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.stories.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import {
   Home as HomeIcon,
   Office as OfficeIcon,
@@ -237,5 +238,17 @@ export const WithHiddenLocationAndProject: Story = {
   args: {
     ...ClockedOut.args,
     canShowLocation: false,
+  },
+}
+
+export const WithCustomLocationSelector: Story = {
+  args: {
+    ...ClockedOut.args,
+    // When `locationSelectorElement` is provided it replaces the built-in flat
+    // location select, letting the consumer render its own control — e.g. a
+    // drill-in selector (location → workplace → work area).
+    locationSelectorElement: (
+      <F0TagRaw text="Office · Barcelona · Llucuna A-3" icon={OfficeIcon} />
+    ),
   },
 }

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.tsx
@@ -64,6 +64,14 @@ export interface ClockInControlsProps {
   onBreak?: (breakTypeId?: string) => void
   canShowProject?: boolean
   projectSelectorElement?: React.ReactNode
+  /**
+   * Optional custom location control. When provided, it replaces the built-in
+   * flat location `F0Select` (in both the editable clocked-out state and the
+   * read-only clocked-in state), letting the consumer supply its own control —
+   * e.g. a drill-in selector (location → workplace → work area). The consumer
+   * owns its data and editable/disabled state, mirroring `projectSelectorElement`.
+   */
+  locationSelectorElement?: React.ReactNode
   breakTypeName?: string
 }
 
@@ -88,6 +96,7 @@ export function ClockInControls({
   onChangeLocationId,
   canShowProject = true,
   projectSelectorElement,
+  locationSelectorElement,
   breakTypeName,
 }: ClockInControlsProps) {
   const { status, statusText, subtitle, statusColor } = getInfo({
@@ -151,6 +160,29 @@ export function ClockInControls({
   const canShowBreakTypeName = status === "break"
 
   const [locationPickerOpen, setLocationPickerOpen] = useState(false)
+
+  const builtInLocationControl = canSelectLocation ? (
+    <F0Select
+      label={labels.selectLocation}
+      hideLabel
+      value={locationId}
+      options={locationOptions}
+      onChange={onChangeLocationId}
+      open={locationPickerOpen}
+      onOpenChange={setLocationPickerOpen}
+      disabled={locationSelectorDisabled}
+    >
+      <div aria-label="Select location">
+        <Selector
+          text={location?.name}
+          placeholder={labels.selectLocation}
+          icon={location?.icon}
+        />
+      </div>
+    </F0Select>
+  ) : location ? (
+    <F0TagRaw text={location.name} icon={location.icon} />
+  ) : null
 
   return (
     <div className="@container">
@@ -271,40 +303,11 @@ export function ClockInControls({
           )}
         </div>
         <div className="mt-6 flex flex-row flex-wrap items-center justify-center gap-2 @xs:justify-start">
-          {canSelectLocation ? (
-            <>
-              <F0Select
-                label={labels.selectLocation}
-                hideLabel
-                value={locationId}
-                options={locationOptions}
-                onChange={onChangeLocationId}
-                open={locationPickerOpen}
-                onOpenChange={setLocationPickerOpen}
-                disabled={locationSelectorDisabled}
-              >
-                <div aria-label="Select location">
-                  <Selector
-                    text={location?.name}
-                    placeholder={labels.selectLocation}
-                    icon={location?.icon}
-                  />
-                </div>
-              </F0Select>
-              {canShowProject && projectSelectorElement}
-            </>
-          ) : (
-            <>
-              {canShowLocation && location && (
-                <>
-                  <F0TagRaw text={location.name} icon={location.icon} />
-                </>
-              )}
-              {canShowProject && projectSelectorElement}
-              {canShowBreakTypeName && breakTypeName && (
-                <F0TagRaw text={breakTypeName} />
-              )}
-            </>
+          {canShowLocation &&
+            (locationSelectorElement ?? builtInLocationControl)}
+          {canShowProject && projectSelectorElement}
+          {canShowBreakTypeName && breakTypeName && (
+            <F0TagRaw text={breakTypeName} />
           )}
         </div>
       </div>


### PR DESCRIPTION
## What

Adds an optional **`locationSelectorElement`** `ReactNode` prop to `ClockInControls`. When provided, it **replaces** the built-in flat location `F0Select` in both the editable (clocked-out) and read-only (clocked-in) states — letting consumers inject their own location control while owning its data and editable/disabled state.

This mirrors the existing `projectSelectorElement` slot exactly: F0 supplies the shell/slot; the consumer supplies the control.

## Why

Factorial Time Tracking (FCT-54069) needs the web clock-in widget's **Location** control to drill in: `Location-type → (Office) → Workplace → Work area`, as a single pill (no extra pills), reusing our existing `NavigationSelector` drill-in. The built-in location control is a flat select with no drill-in, and only a project slot existed. A slot keeps the drill-in logic in the consumer (like project) rather than baking a Factorial-specific hierarchy into the design system.

## Changes

- `ClockInControls` — new optional `locationSelectorElement` prop. Refactored the two-branch location render into a single `builtInLocationControl` const, rendered as `{canShowLocation && (locationSelectorElement ?? builtInLocationControl)}`.
- Storybook — `WithCustomLocationSelector` story.
- Tests — 3 cases (slot replaces built-in; renders in clocked-in state; hidden when `canShowLocation=false`).

## Backward compatibility

Non-breaking: the prop is optional and the built-in location select remains the default when the slot is absent. Existing consumers are unaffected.

## Note for consumers — read-only handling moves to the slot

Previously, in the clocked-in/break states the built-in location control
auto-rendered a **non-editable** `F0TagRaw`. With `locationSelectorElement`, the
consumer's element renders in that same spot in **all** states and F0 no longer
enforces read-only there. Consumers must render a non-interactive variant of
their control when clocked-in/break (same contract as `projectSelectorElement`).
The Factorial consumer (FCT-54069) does this.

Also note: `locationSelectorElement={null}` reverts to the **built-in** control
(nullish-coalescing), it does not hide it — hide via `canShowLocation={false}`.

## Validation

- `vitest` — 9/9 pass (ClockInControls spec)
- `oxlint` — 0 warnings / 0 errors
- `oxfmt --check` — clean
- `tsc` — no new errors in the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
