### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "3.11.0",
+  "packages/react": "3.12.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.12.0](https://github.com/factorialco/f0/compare/f0-react-v3.11.0...f0-react-v3.12.0) (2026-06-19)
+
+
+### Features
+
+* **F0TableOfContent:** add footer action buttons ([#4489](https://github.com/factorialco/f0/issues/4489)) ([b4358ca](https://github.com/factorialco/f0/commit/b4358cacee6a6d01e8edb5c6d19cc4457cab42f3))
+
 ## [3.11.0](https://github.com/factorialco/f0/compare/f0-react-v3.10.0...f0-react-v3.11.0) (2026-06-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 3.12.0</summary>

## [3.12.0](https://github.com/factorialco/f0/compare/f0-react-v3.11.0...f0-react-v3.12.0) (2026-06-19)


### Features

* **F0TableOfContent:** add footer action buttons ([#4489](https://github.com/factorialco/f0/issues/4489)) ([b4358ca](https://github.com/factorialco/f0/commit/b4358cacee6a6d01e8edb5c6d19cc4457cab42f3))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).