### PR TITLE
fix(storybook): render docs content inside I18nProvider

### DIFF
--- a/packages/react/.storybook/DocsContainer.tsx
+++ b/packages/react/.storybook/DocsContainer.tsx
@@ -57,8 +57,8 @@ export const DocsContainer: FC<PropsWithChildren<DocsContainerProps>> = (
           </div>
         )}
         <ImportBanner isDark={isDark} />
+        {children}
       </I18nProvider>
-      {children}
     </BaseContainer>
   )
 }


### PR DESCRIPTION
Storybook docs pages crashed with `useI18n must be used within an I18nProvider`
whenever a component rendered as **bare MDX JSX** (not via `<Canvas of={Story}>`)
called `useI18n` — e.g. the `<DoDonts>` examples in `F0AudioPlayer`.

Root cause: `DocsContainer` added `<I18nProvider>` only around its own chrome
(the experimental warning + import banner) and left `{children}` outside it.
Stories are unaffected because each carries the provider via the `preview.tsx`
decorators; only bare MDX renders fell through the gap. `F0AudioPlayer` was the
first component to both call `useI18n` and render bare in its docs — `F0Alert`
had silently worked around the same gap by hand-wrapping each example.

## Changes
- Move the docs page content (`{children}`) inside `DocsContainer`'s
  `<I18nProvider>`, so bare MDX renders get the same i18n context that stories do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)