### PR TITLE
docs(F0CardHorizontal): stack the card Do/Don't vertically

### DIFF
--- a/packages/react/src/experimental/F0CardHorizontal/__stories__/F0CardHorizontal.mdx
+++ b/packages/react/src/experimental/F0CardHorizontal/__stories__/F0CardHorizontal.mdx
@@ -157,6 +157,7 @@ than a couple of metadata facts, or a grid/tile layout.
 />
 
 <DoDonts
+  stacked
   do={{
     description: "Use F0CardHorizontal for a dense, scannable list.",
     children: <Canvas of={Stories.HorizontalCardStack} sourceState="none" />,

--- a/packages/react/src/lib/storybook-utils/do-donts.tsx
+++ b/packages/react/src/lib/storybook-utils/do-donts.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode } from "react"
 
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
+import { cn } from "@/lib/utils"
 
 interface DoDontsProps {
   do: {
@@ -13,13 +14,25 @@ interface DoDontsProps {
     guidelines?: Array<string>
     children?: ReactNode
   }
+  /**
+   * Stack the Do and Don't blocks vertically instead of side by side. Use it when
+   * each block holds wide content (e.g. a full-width card example) that would
+   * overflow a half-width column. Defaults to the side-by-side layout.
+   */
+  stacked?: boolean
 }
 
 export const DoDonts: FC<DoDontsProps> = ({
   do: doExample,
   dont: dontExample,
+  stacked = false,
 }) => (
-  <div className="grid gap-4 [&:not(:first-child)]:mt-4 md:grid-cols-2">
+  <div
+    className={cn(
+      "grid gap-4 [&:not(:first-child)]:mt-4",
+      !stacked && "md:grid-cols-2"
+    )}
+  >
     <div className="flex flex-col gap-4 rounded-lg bg-f1-background-tertiary p-5">
       <div className="w-fit">
         <F0TagStatus text="Do" variant="positive" />


### PR DESCRIPTION
## Description

The `F0CardHorizontal` "do / don't" comparison renders each block's card example at a fixed 560px, but the shared `DoDonts` helper lays the two blocks side by side (`md:grid-cols-2`). In a half-width column the card lists overflowed and clipped — the third list row and the trailing "Open" buttons were cut off. This stacks the two blocks vertically so each gets the full content width and the examples render intact.

## Screenshots (if applicable)

Docs → Experimental/CardHorizontal → "Design best practices". The **Do** (dense horizontal-card list) and **Don't** (stacked `F0Card`s) blocks now sit one above the other at full width, with no clipping. Verified locally in Storybook; Chromatic will capture the updated docs page.

## Implementation details

- feat(storybook): add an opt-in `stacked` prop to the shared `DoDonts` helper that forces a single column — the default side-by-side layout used by the other docs pages is unchanged
- docs(F0CardHorizontal): pass `stacked` to the card-list do/don't so the wide card examples no longer overflow their column