### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.0.0",
+  "packages/react": "4.0.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.0.1](https://github.com/factorialco/f0/compare/f0-react-v4.0.0...f0-react-v4.0.1) (2026-06-19)
+
+
+### Bug Fixes
+
+* **storybook:** render docs content inside I18nProvider ([#4520](https://github.com/factorialco/f0/issues/4520)) ([bc3ed04](https://github.com/factorialco/f0/commit/bc3ed0484ebf4ad931714db9a8561e6e12d52891))
+
 ## [4.0.0](https://github.com/factorialco/f0/compare/f0-react-v3.12.0...f0-react-v4.0.0) (2026-06-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.0.1</summary>

## [4.0.1](https://github.com/factorialco/f0/compare/f0-react-v4.0.0...f0-react-v4.0.1) (2026-06-19)


### Bug Fixes

* **storybook:** render docs content inside I18nProvider ([#4520](https://github.com/factorialco/f0/issues/4520)) ([bc3ed04](https://github.com/factorialco/f0/commit/bc3ed0484ebf4ad931714db9a8561e6e12d52891))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).