### PR TITLE
fix(F0CardHorizontal): reserve action button width so the confirm/reject pair never shrinks

### DIFF
--- a/packages/react/src/experimental/F0CardHorizontal/components/CardHorizontalActions.tsx
+++ b/packages/react/src/experimental/F0CardHorizontal/components/CardHorizontalActions.tsx
@@ -309,10 +309,13 @@ export function CardHorizontalActions({
     }
 
     const inline = (
-      // Icon-only, inline at the trailing edge.
+      // Icon-only, inline at the trailing edge. Like the standard actions
+      // wrapper, we deliberately omit `min-w-0` so the box keeps its min-content
+      // floor: the confirm/reject pair reserves its width and the leading title
+      // truncates against it, instead of the buttons being squeezed to nothing.
       <div
         className={cn(
-          "relative z-[1] min-w-0 flex-1",
+          "relative z-[1] flex-1",
           avatarOffset,
           inlineClusterVisibility[stackAt]
         )}

--- a/packages/react/src/ui/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/ui/ButtonGroup/ButtonGroup.tsx
@@ -458,7 +458,14 @@ function ButtonGroupRow({
           // `[&>*]:shrink-0` keeps each rendered secondary, separator, link and
           // the "⋯" trigger at its natural width: the row overflows by shedding
           // into the menu, never by squeezing a button to nothing.
-          "relative flex min-w-0 flex-1 items-center gap-md [&>*]:shrink-0",
+          "relative flex flex-1 items-center gap-md [&>*]:shrink-0",
+          // `min-w-0` only when the cluster can shed: it lets the cluster shrink
+          // below its content so the title truncates against it and plain
+          // secondaries spill into the "⋯" menu. When the group can't overflow
+          // (e.g. a confirm/reject pair), dropping `min-w-0` keeps the cluster's
+          // min-content floor so the buttons reserve their width and are never
+          // squeezed to nothing — there's no menu to catch what gets squeezed out.
+          canOverflow && "min-w-0",
           align === "end" && "justify-end"
         )}
       >

--- a/packages/react/src/ui/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/packages/react/src/ui/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -50,6 +50,28 @@ describe("ButtonGroup — canOverflow", () => {
     ).not.toBeNull()
   })
 
+  // Regression guard: jsdom can't measure layout, but the squeeze bug was a pure
+  // class decision — the row cluster only carries `min-w-0` (which lets it shrink
+  // below its content) when the group can actually shed buttons into the "⋯"
+  // menu. When it can't overflow, the cluster must keep its min-content floor so
+  // a confirm/reject pair reserves its width instead of being squeezed to nothing.
+  it("keeps the row cluster's min-content floor (no min-w-0) when canOverflow is false", () => {
+    const { container } = render(
+      <ButtonGroup secondaryActions={secondaries} canOverflow={false} />
+    )
+    const cluster = container.querySelector('[role="group"]')
+      ?.firstElementChild as HTMLElement
+    expect(cluster.className).toContain("flex-1")
+    expect(cluster.className).not.toContain("min-w-0")
+  })
+
+  it("lets the row cluster shrink (min-w-0) when canOverflow is true", () => {
+    const { container } = render(<ButtonGroup secondaryActions={secondaries} />)
+    const cluster = container.querySelector('[role="group"]')
+      ?.firstElementChild as HTMLElement
+    expect(cluster.className).toContain("min-w-0")
+  })
+
   it("still surfaces otherActions in the ⋯ menu when canOverflow is false", () => {
     render(
       <ButtonGroup


### PR DESCRIPTION
## Description

The confirm/reject (✗ / ✓) buttons of `F0CardHorizontal` (the primitive behind `F0HILActionConfirmation` and the Co-creation standard flow) could be **squeezed to nothing and disappear entirely** at narrow widths instead of holding their place at the trailing edge.

Reproducible at `patterns-co-creation-standard-flow--hil-conversation` (last card) and any inline confirm/reject row narrowed past its content width.

## Screenshots (if applicable)

**Before** — at ~360px the ✓/✗ pair collapses to a single clipped, chrome-less icon:

The confirm button vanishes; the reject button degrades to a bare glyph.

**After** — at ~360px (and down to ~260px) both buttons keep full size; the title wraps/truncates against them:

The buttons reserve their width at every width.

The `stackAt` stacking path (labelled buttons drop onto their own footer line below the breakpoint, e.g. `F0HILActionConfirmation`'s default `stackAt="sm"`) is unchanged.

## Implementation details

The squeeze came from two `min-w-0`s that let the parent flex row collapse the actions below their min-content size:

1. **`CardHorizontalActions` inline confirm/reject wrapper** used `min-w-0 flex-1`, so the card row could shrink it to zero. The standard actions wrapper already omits `min-w-0` for exactly this reason (to keep a min-content floor) — the confirm/reject `inline` branch now matches it (`flex-1` only).

2. **`ButtonGroup`'s row cluster** always carried `min-w-0 flex-1`. Removing the min-content floor is only desirable when the group can shed buttons into the "⋯" overflow menu — that's what lets the title truncate against a shrinking cluster. With `canOverflow={false}` (the confirm/reject pair, the only consumer that sets it) there is no menu to catch what gets squeezed out, so the buttons were simply clipped. The cluster now applies `min-w-0` **only when `canOverflow` is true**.

Net effect: when a `ButtonGroup` can't overflow, its buttons reserve their natural width and the leading content truncates/wraps against them — they never resize.

Added two regression tests guarding the cluster's `min-w-0` ↔ `canOverflow` relationship. Typecheck, lint, and the F0CardHorizontal + ButtonGroup unit suites all pass.