### PR TITLE
feat(value-display): support 15 base-color palette in categoryBarChart

### DIFF
--- a/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.mdx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.mdx
@@ -14,7 +14,7 @@ type value = {
   dataPoints: Array<{
     name: string          // category label shown in tooltip
     value: number         // absolute count
-    color?: string        // optional color name or hex; falls back to categorical palette
+    color?: CategoryBarColor // optional: a 15-palette base-color token (e.g. "viridian", "yellow", "barbie") OR a legacy token ("categorical-1"…"categorical-8", "feedback-*"); falls back to the categorical palette by index
   }>
   hideTooltip?: boolean   // when true, suppresses hover tooltips
 }
@@ -43,6 +43,10 @@ The cell inside a OneDataCollection-like table with clickable rows: tooltips ope
 #### WithCustomColors
 
 <Canvas of={CategoryBarChartStories.WithCustomColors} />
+
+#### LegacyColors
+
+<Canvas of={CategoryBarChartStories.LegacyColors} />
 
 #### HiddenTooltip
 

--- a/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.stories.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.stories.tsx
@@ -115,9 +115,9 @@ export const GenderDistribution: Story = {
   type: "categoryBarChart",
   value: {
     dataPoints: [
-      { name: "Female", value: 12 },
-      { name: "Male", value: 8 },
-      { name: "Non-binary", value: 2 },
+      { name: "Female", value: 12 },     // categorical-1
+      { name: "Male", value: 8 },        // categorical-2
+      { name: "Non-binary", value: 2 },  // categorical-3
     ],
   },
 }`,
@@ -296,9 +296,9 @@ export const WithCustomColors: Story = {
         type: "categoryBarChart",
         value: {
           dataPoints: [
-            { name: "A", value: 40, color: "categorical-1" },
-            { name: "B", value: 30, color: "categorical-3" },
-            { name: "C", value: 20, color: "categorical-5" },
+            { name: "A", value: 40, color: "viridian" },
+            { name: "B", value: 30, color: "yellow" },
+            { name: "C", value: 20, color: "barbie" },
           ],
         },
       }),
@@ -307,13 +307,50 @@ export const WithCustomColors: Story = {
   parameters: {
     docs: {
       source: {
-        code: `{
+        code: `// Base-color tokens from the 15-color F0DataChart palette
+{
   type: "categoryBarChart",
   value: {
     dataPoints: [
-      { name: "A", value: 40, color: "categorical-1" },
-      { name: "B", value: 30, color: "categorical-3" },
-      { name: "C", value: 20, color: "categorical-5" },
+      { name: "A", value: 40, color: "viridian" },
+      { name: "B", value: 30, color: "yellow" },
+      { name: "C", value: 20, color: "barbie" },
+    ],
+  },
+}`,
+      },
+    },
+  },
+}
+
+export const LegacyColors: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Category",
+      render: () => ({
+        type: "categoryBarChart",
+        value: {
+          dataPoints: [
+            { name: "Categorical", value: 40, color: "categorical-3" },
+            { name: "Positive", value: 30, color: "feedback-positive" },
+            { name: "Negative", value: 20, color: "feedback-negative" },
+          ],
+        },
+      }),
+    },
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `// Legacy kits/Charts tokens are still supported (categorical-* / feedback-*)
+{
+  type: "categoryBarChart",
+  value: {
+    dataPoints: [
+      { name: "Categorical", value: 40, color: "categorical-3" },
+      { name: "Positive", value: 30, color: "feedback-positive" },
+      { name: "Negative", value: 20, color: "feedback-negative" },
     ],
   },
 }`,

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.test.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.test.tsx
@@ -97,9 +97,9 @@ describe("CategoryBarChartCell", () => {
     ).toBeInTheDocument()
   })
 
-  it("applies token color when color is provided", () => {
+  it("applies a base-color token when color is provided", () => {
     const args: CategoryBarChartCellValue = {
-      dataPoints: [{ name: "Test", value: 10, color: "categorical-3" }],
+      dataPoints: [{ name: "Test", value: 10, color: "viridian" }],
     }
 
     const { container } = render(CategoryBarChartCell(args, defaultMeta))
@@ -107,6 +107,45 @@ describe("CategoryBarChartCell", () => {
     const segment = container.querySelector('[role="img"][aria-label*="%"]')
     expect(segment).toBeInTheDocument()
     expect(segment?.getAttribute("style")).toContain("background-color")
+  })
+
+  it("supports the location base-color tokens (viridian / yellow / barbie)", () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [
+        { name: "Work from home", value: 5, color: "viridian" },
+        { name: "Office", value: 3, color: "yellow" },
+        { name: "Business trip", value: 2, color: "barbie" },
+      ],
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    const segments = container.querySelectorAll('[role="img"][aria-label*="%"]')
+    expect(segments.length).toBe(3)
+    segments.forEach((segment) => {
+      expect(segment.getAttribute("style")).toContain("background-color")
+    })
+  })
+
+  it("still supports legacy kits/Charts tokens (categorical-* / feedback-*)", () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [
+        { name: "A", value: 5, color: "categorical-3" },
+        { name: "B", value: 3, color: "feedback-positive" },
+      ],
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    const segments = container.querySelectorAll('[role="img"][aria-label*="%"]')
+    expect(segments.length).toBe(2)
+    // legacy tokens resolve to a CSS var
+    expect(segments[0]?.getAttribute("style")).toContain(
+      "--chart-categorical-3"
+    )
+    expect(segments[1]?.getAttribute("style")).toContain(
+      "--chart-feedback-positive"
+    )
   })
 
   it("still renders segments when hideTooltip is true", () => {

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
@@ -1,5 +1,10 @@
 import { getCategoricalColor, getColor } from "@/kits/Charts/utils/colors"
 import {
+  type ChartColorToken,
+  chartColorTokens,
+  resolveChartColorToken,
+} from "@/kits/F0DataChart/utils/colors"
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -10,10 +15,54 @@ import { tableDisplayClassNames } from "../../const"
 import { ValueDisplayRendererContext } from "../../renderers"
 import { cn } from "@/lib/utils"
 
+/**
+ * Legacy `kits/Charts` color tokens, resolved as `hsl(var(--chart-*))`.
+ * Kept for backward compatibility alongside the F0DataChart base-color palette.
+ */
+const LEGACY_CHART_COLORS = [
+  "categorical-1",
+  "categorical-2",
+  "categorical-3",
+  "categorical-4",
+  "categorical-5",
+  "categorical-6",
+  "categorical-7",
+  "categorical-8",
+  "feedback-negative",
+  "feedback-neutral",
+  "feedback-positive",
+] as const
+
+type LegacyChartColor = (typeof LEGACY_CHART_COLORS)[number]
+
+/**
+ * A segment color. Accepts both color systems:
+ * - a 15-palette base-color token (`"viridian"`, `"yellow"`, `"barbie"`, …),
+ *   resolved through `kits/F0DataChart`; or
+ * - a legacy `kits/Charts` token (`"categorical-1"…"categorical-8"`,
+ *   `"feedback-positive"`, …), resolved as a CSS `--chart-*` variable.
+ */
+export type CategoryBarColor = ChartColorToken | LegacyChartColor
+
+const BASE_COLOR_TOKENS = new Set<string>(chartColorTokens)
+
+/** Resolve a segment color from either supported palette. */
+function resolveSegmentColor(color: CategoryBarColor): string {
+  return BASE_COLOR_TOKENS.has(color)
+    ? resolveChartColorToken(color as ChartColorToken)
+    : getColor(color)
+}
+
 export interface CategoryBarDataPoint {
   name: string
   value: number
-  color?: string
+  /**
+   * Color of the segment. Supports both the 15 chromatic F0 base-color tokens
+   * (e.g. `"viridian"`, `"yellow"`, `"barbie"`) and the legacy chart tokens
+   * (`"categorical-1"…"categorical-8"`, `"feedback-*"`). When omitted, a color
+   * is auto-assigned by index from the shared chart palette.
+   */
+  color?: CategoryBarColor
 }
 
 export interface CategoryBarChartCellValue {
@@ -74,7 +123,7 @@ export const CategoryBarChartCell = (
           {dataPoints.map((point, index) => {
             const percentage = (point.value / total) * 100
             const color = point.color
-              ? getColor(point.color)
+              ? resolveSegmentColor(point.color)
               : getCategoricalColor(index)
 
             if (percentage === 0) return null


### PR DESCRIPTION
## Description

Add support for the shared **`kits/F0DataChart`** color system (the **15 chromatic F0 base-color tokens** — `viridian`, `yellow`, `barbie`, `lilac`, `indigo`, …) to the `categoryBarChart` value-display cell, **without dropping** the legacy `kits/Charts` tokens it already supported.

`CategoryBarDataPoint.color` is now typed as `CategoryBarColor` — the union of both palettes — and a small resolver picks the right system per token. **No breaking change**: existing `categorical-1`…`categorical-8` and `feedback-*` callers keep working, and segments without an explicit color keep using the legacy categorical palette by index, so default visuals are unchanged.

This is driven by the need to support the location colors used by consumers, which map cleanly onto base-color tokens:

| Location key      | Requested HSL (≈)        | Base-color token | Token HSL      |
|-------------------|--------------------------|------------------|----------------|
| `work_from_home`  | `hsl(173, 65%, 35%)`     | `viridian` (50)  | `184 92% 35%`  |
| `office`          | `hsl(43, 90%, 53%)`      | `yellow` (50)    | `38 92% 54%`   |
| `business_trip`   | `hsl(343, 100%, 76%)`    | `barbie` (50)    | `331 84% 63%`  |

> The requested HSLs are approximations; the canonical design-system equivalences are `viridian` / `yellow` / `barbie`, all part of the 15-token palette.

## Screenshots (if applicable)

**Legacy tokens** (`LegacyColors` — `categorical-*` / `feedback-*`, still supported):


<img width="1314" height="504" alt="Screenshot 2026-06-22 at 09 58 39" src="https://github.com/user-attachments/assets/e4bc30c6-fb19-4d02-bf01-f1db774219be" />

**F0DataChart Colors** (15-palette base-color token (e.g. "viridian", "yellow", "barbie"):

<img width="1314" height="504" alt="Screenshot 2026-06-22 at 09 58 28" src="https://github.com/user-attachments/assets/03e77543-1481-42f3-b51e-a8663575e270" />

**Default palette, no explicit color** (`GenderDistribution` — auto-assigned categorical palette, unchanged):

<img width="1314" height="492" alt="Screenshot 2026-06-22 at 10 03 18" src="https://github.com/user-attachments/assets/ccd43c3a-137b-41d7-8209-9db3d4167c99" />


## Implementation details

Scope: **only the `categoryBarChart` cell** is modified — the shared `kits/Charts` and `kits/F0DataChart` libraries are untouched.

**Before** — `categoryBarChart.tsx` resolved colors only via `getColor` / `getCategoricalColor` (`kits/Charts`) → `hsl(var(--chart-*))`, limited to 8 `categorical-*` + 3 `feedback-*` tokens, with `color?: string`.

**After:**
- `CategoryBarDataPoint.color` is typed `CategoryBarColor = ChartColorToken | LegacyChartColor` (both palettes).
- `resolveSegmentColor(color)` helper:
  - base-color token (in `chartColorTokens`) → `resolveChartColorToken()` (F0DataChart, hex).
  - otherwise → legacy `getColor()` (`hsl(var(--chart-*))`).
- **Segments without a `color` keep using `getCategoricalColor(index)`** (legacy categorical palette) — default visuals unchanged.
- Storybook: restored the "Show code" snippets (the meta had nulled them out) and added a `LegacyColors` story showcasing `categorical-*` / `feedback-*`.
- MDX docs updated.
- Tests cover both palettes: base-color tokens (incl. the 3 location tokens) **and** legacy `categorical-*` / `feedback-*`.

Files changed (all under `categoryBarChart/`): component, test, story, MDX.

Verification: `vitest` (11 passed), `tsc --noEmit` (clean), `oxlint` (clean).

### Notes for review
- The legacy token list (`categorical-*` / `feedback-*`) is declared locally in the cell since the `kits/Charts` library does not export it and we deliberately keep that library untouched. If we later want to remove that small duplication, the clean path is to export the token lists from `kits/Charts`.
- Open question: keep both palettes indefinitely, or treat the legacy tokens as deprecated and migrate to base-colors only later? The semantic `feedback-*` tokens may be worth keeping as a dedicated option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
