### PR TITLE
feat(F0AudioPlayer): add expandable detail panel with Summary/Transcript tabs

### DIFF
--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
@@ -51,10 +51,14 @@ const F0AudioPlayerCardBase = forwardRef<
     defaultProp: defaultExpanded,
     onChange: onExpandedChange,
   })
-  const [activeTab, setActiveTab] = useState(details?.[0]?.value)
-  const activeContent =
-    details?.find((tab) => tab.value === activeTab)?.content ??
-    details?.[0]?.content
+  const [selectedTab, setSelectedTab] = useState(details?.[0]?.value)
+  // Guard against a stale selection if `details` changes (e.g. a recycled
+  // card in a list): fall back to the first tab so the highlight and content
+  // stay in sync.
+  const activeTab = details?.some((tab) => tab.value === selectedTab)
+    ? selectedTab
+    : details?.[0]?.value
+  const activeContent = details?.find((tab) => tab.value === activeTab)?.content
 
   return (
     <div
@@ -106,6 +110,7 @@ const F0AudioPlayerCardBase = forwardRef<
                 }
                 onClick={() => setExpanded(!isExpanded)}
                 aria-expanded={isExpanded}
+                aria-controls={detailsId}
               />
             )}
             {(controller.playbackRates.length > 0 || actions) && (
@@ -141,7 +146,7 @@ const F0AudioPlayerCardBase = forwardRef<
         <motion.div
           id={detailsId}
           role="region"
-          aria-label={title}
+          aria-label={i18n.audioPlayer.details}
           initial={false}
           animate={{
             height: isExpanded ? "auto" : 0,
@@ -161,7 +166,7 @@ const F0AudioPlayerCardBase = forwardRef<
                 active={tab.value === activeTab}
                 asChild
               >
-                <button type="button" onClick={() => setActiveTab(tab.value)}>
+                <button type="button" onClick={() => setSelectedTab(tab.value)}>
                   {tab.label}
                 </button>
               </TabNavigationLink>

--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
@@ -1,6 +1,13 @@
-import { forwardRef } from "react"
+import { useControllableState } from "@radix-ui/react-use-controllable-state"
+import { motion } from "motion/react"
+import { forwardRef, useId, useState, type CSSProperties } from "react"
 
+import { F0Button } from "@/components/F0Button"
+import { useReducedMotion } from "@/lib/a11y"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
+import { ScrollArea } from "@/ui/scrollarea"
+import { TabNavigation, TabNavigationLink } from "@/ui/tab-navigation"
 
 import { AudioScrubber } from "./components/AudioScrubber"
 import { PlaybackMenu } from "./components/PlaybackMenu"
@@ -25,10 +32,29 @@ const F0AudioPlayerCardBase = forwardRef<
     disabled = false,
     ariaLabel,
     size = "md",
+    details,
+    expanded,
+    defaultExpanded = false,
+    onExpandedChange,
+    detailsMaxHeight = 200,
   } = props
 
+  const i18n = useI18n()
   const controller = usePlayerController(props)
   const dataAttributes = getDataAttributes(props)
+  const shouldReduceMotion = useReducedMotion()
+  const detailsId = useId()
+
+  const hasDetails = Boolean(details && details.length > 0)
+  const [isExpanded = false, setExpanded] = useControllableState<boolean>({
+    prop: expanded,
+    defaultProp: defaultExpanded,
+    onChange: onExpandedChange,
+  })
+  const [activeTab, setActiveTab] = useState(details?.[0]?.value)
+  const activeContent =
+    details?.find((tab) => tab.value === activeTab)?.content ??
+    details?.[0]?.content
 
   return (
     <div
@@ -67,15 +93,30 @@ const F0AudioPlayerCardBase = forwardRef<
             )}
           </div>
         </div>
-        {(controller.playbackRates.length > 0 || actions) && (
-          <div className="shrink-0">
-            <PlaybackMenu
-              playbackRate={controller.playbackRate}
-              playbackRates={controller.playbackRates}
-              onRateChange={controller.setPlaybackRate}
-              disabled={disabled}
-              extraItems={actions}
-            />
+        {(hasDetails || controller.playbackRates.length > 0 || actions) && (
+          <div className="flex shrink-0 items-center gap-2">
+            {hasDetails && (
+              <F0Button
+                variant="outline"
+                size="sm"
+                label={
+                  isExpanded
+                    ? i18n.audioPlayer.hideDetail
+                    : i18n.audioPlayer.viewDetail
+                }
+                onClick={() => setExpanded(!isExpanded)}
+                aria-expanded={isExpanded}
+              />
+            )}
+            {(controller.playbackRates.length > 0 || actions) && (
+              <PlaybackMenu
+                playbackRate={controller.playbackRate}
+                playbackRates={controller.playbackRates}
+                onRateChange={controller.setPlaybackRate}
+                disabled={disabled}
+                extraItems={actions}
+              />
+            )}
           </div>
         )}
       </div>
@@ -95,6 +136,53 @@ const F0AudioPlayerCardBase = forwardRef<
           size={size}
         />
       </div>
+
+      {hasDetails && (
+        <motion.div
+          id={detailsId}
+          role="region"
+          aria-label={title}
+          initial={false}
+          animate={{
+            height: isExpanded ? "auto" : 0,
+            opacity: isExpanded ? 1 : 0,
+            visibility: isExpanded ? "visible" : "hidden",
+          }}
+          transition={{
+            duration: shouldReduceMotion ? 0 : 0.15,
+            ease: [0.165, 0.84, 0.44, 1],
+          }}
+          className="-mx-3 overflow-hidden"
+        >
+          <TabNavigation className="px-0">
+            {details?.map((tab) => (
+              <TabNavigationLink
+                key={tab.value}
+                active={tab.value === activeTab}
+                asChild
+              >
+                <button type="button" onClick={() => setActiveTab(tab.value)}>
+                  {tab.label}
+                </button>
+              </TabNavigationLink>
+            ))}
+          </TabNavigation>
+          <div className="px-3 pt-2.5">
+            <ScrollArea
+              style={
+                {
+                  "--audio-details-max-h": `${detailsMaxHeight}px`,
+                } as CSSProperties
+              }
+              className="[&_[data-scroll-container]]:max-h-[var(--audio-details-max-h)]"
+            >
+              <div className="break-words pr-1 text-sm text-f1-foreground">
+                {activeContent}
+              </div>
+            </ScrollArea>
+          </div>
+        </motion.div>
+      )}
     </div>
   )
 })

--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
@@ -86,11 +86,11 @@ const F0AudioPlayerCardBase = forwardRef<
             onToggle={controller.toggle}
           />
           <div className="flex min-w-0 flex-col">
-            <span className="truncate text-sm font-medium text-f1-foreground">
+            <span className="truncate text-base font-medium text-f1-foreground">
               {title}
             </span>
             {subtitle && (
-              <span className="truncate text-sm text-f1-foreground-secondary">
+              <span className="truncate text-base text-f1-foreground-secondary">
                 {subtitle}
               </span>
             )}
@@ -178,7 +178,7 @@ const F0AudioPlayerCardBase = forwardRef<
               }
               className="[&_[data-scroll-container]]:max-h-[var(--audio-details-max-h)]"
             >
-              <div className="break-words pr-1 text-sm text-f1-foreground">
+              <div className="break-words pr-1 text-base text-f1-foreground">
                 {activeContent}
               </div>
             </ScrollArea>

--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
@@ -3,11 +3,11 @@ import { motion } from "motion/react"
 import { forwardRef, useState, type CSSProperties } from "react"
 
 import { F0Button } from "@/components/F0Button"
+import { F0SegmentedControl } from "@/experimental/Actions/F0SegmentedControl"
 import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { ScrollArea } from "@/ui/scrollarea"
-import { TabNavigation, TabNavigationLink } from "@/ui/tab-navigation"
 
 import { AudioScrubber } from "./components/AudioScrubber"
 import { PlaybackMenu } from "./components/PlaybackMenu"
@@ -147,6 +147,7 @@ const F0AudioPlayerCardBase = forwardRef<
           initial={false}
           animate={{
             height: isExpanded ? "auto" : 0,
+            marginTop: isExpanded ? 0 : "-0.625rem",
             opacity: isExpanded ? 1 : 0,
             visibility: isExpanded ? "visible" : "hidden",
           }}
@@ -154,22 +155,21 @@ const F0AudioPlayerCardBase = forwardRef<
             duration: shouldReduceMotion ? 0 : 0.15,
             ease: [0.165, 0.84, 0.44, 1],
           }}
-          className="-mx-3 overflow-hidden"
+          className="overflow-hidden"
         >
-          <TabNavigation className="px-0">
-            {details?.map((tab) => (
-              <TabNavigationLink
-                key={tab.value}
-                active={tab.value === activeTab}
-                asChild
-              >
-                <button type="button" onClick={() => setSelectedTab(tab.value)}>
-                  {tab.label}
-                </button>
-              </TabNavigationLink>
-            ))}
-          </TabNavigation>
-          <div className="px-3 pt-2.5">
+          <F0SegmentedControl
+            fullWidth
+            ariaLabel={i18n.audioPlayer.details}
+            value={activeTab}
+            onChange={setSelectedTab}
+            items={
+              details?.map((tab) => ({
+                value: tab.value,
+                label: tab.label,
+              })) ?? []
+            }
+          />
+          <div className="pt-2.5">
             <ScrollArea
               style={
                 {

--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
@@ -1,6 +1,6 @@
 import { useControllableState } from "@radix-ui/react-use-controllable-state"
 import { motion } from "motion/react"
-import { forwardRef, useId, useState, type CSSProperties } from "react"
+import { forwardRef, useState, type CSSProperties } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { useReducedMotion } from "@/lib/a11y"
@@ -43,7 +43,6 @@ const F0AudioPlayerCardBase = forwardRef<
   const controller = usePlayerController(props)
   const dataAttributes = getDataAttributes(props)
   const shouldReduceMotion = useReducedMotion()
-  const detailsId = useId()
 
   const hasDetails = Boolean(details && details.length > 0)
   const [isExpanded = false, setExpanded] = useControllableState<boolean>({
@@ -110,7 +109,6 @@ const F0AudioPlayerCardBase = forwardRef<
                 }
                 onClick={() => setExpanded(!isExpanded)}
                 aria-expanded={isExpanded}
-                aria-controls={detailsId}
               />
             )}
             {(controller.playbackRates.length > 0 || actions) && (
@@ -144,7 +142,6 @@ const F0AudioPlayerCardBase = forwardRef<
 
       {hasDetails && (
         <motion.div
-          id={detailsId}
           role="region"
           aria-label={i18n.audioPlayer.details}
           initial={false}

--- a/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.mdx
+++ b/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.mdx
@@ -571,6 +571,7 @@ Render the controls in a non-interactive state while a recording is unavailable.
   semantics, not radio semantics).
 - Icons are decorative — the labels, title, and time text carry the meaning.
 - When `details` are provided, the "View detail" / "Hide detail" toggle exposes
-  `aria-expanded`, and the panel is a labelled `role="region"`. The Summary /
-  Transcript tabs reuse the same `TabNavigation` primitive as the page and
-  side-panel tabs, so they share its look and keyboard navigation.
+  `aria-expanded` and `aria-controls` pointing at the panel, which is a
+  labelled `role="region"`. The Summary / Transcript tabs reuse the same
+  `TabNavigation` primitive as the page and side-panel tabs, so they share its
+  look and keyboard navigation.

--- a/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.mdx
+++ b/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.mdx
@@ -264,6 +264,53 @@ audio use `useAudioRecorder` with `RecordingWaveform` instead.
           <code>onClick</code>, and <code>critical</code> flag.
         </td>
       </tr>
+      <tr>
+        <td>
+          <code>details</code>
+        </td>
+        <td>
+          <code>AudioPlayerDetailTab[]</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Tabbed content revealed by a "View detail" toggle in the header — each
+          tab has a <code>value</code>, a (translated) <code>label</code>, and{" "}
+          <code>content</code>. Omit to render a plain recording card.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>expanded</code> / <code>defaultExpanded</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>
+          Controlled / initial expanded state of the detail panel. Pair{" "}
+          <code>expanded</code> with <code>onExpandedChange</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>detailsMaxHeight</code>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>
+          <code>200</code>
+        </td>
+        <td>—</td>
+        <td>
+          Max height (px) of the scrollable detail area before its content
+          scrolls.
+        </td>
+      </tr>
     </tbody>
   </table>
 </Unstyled>
@@ -420,6 +467,12 @@ audio use `useAudioRecorder` with `RecordingWaveform` instead.
   exposed through `F0AudioPlayerCard`'s kebab. The bare `F0AudioPlayer` has no
   speed control. Pass `playbackRates={[]}` to show only the `actions` in the
   kebab.
+- **Expandable details are optional.** Pass `details` to add a "View detail"
+  toggle that expands the card into a tabbed, scrollable panel (e.g. a Summary
+  and a Transcript). Without `details` the card is unchanged. The toggle stays
+  usable even when the player is `disabled` (that only governs audio controls),
+  the panel is height-capped by `detailsMaxHeight` (default `200px`) and scrolls
+  beyond it, and tab labels come from the consumer already translated.
 
 ### Usage examples
 
@@ -435,6 +488,16 @@ Append items such as a download to the kebab via `actions` — they render below
 the speed options, after a separator.
 
 <Canvas of={Stories.CardWithActions} />
+
+**Card with expandable details**
+
+Pass `details` to add a "View detail" toggle. Expanding the card reveals a
+tabbed panel (here, a Summary and a Transcript) inside a height-restricted
+scroll area.
+
+<Canvas of={Stories.CardWithDetails} />
+
+<Canvas of={Stories.CardWithDetailsExpanded} />
 
 **Disabled**
 
@@ -507,3 +570,7 @@ Render the controls in a non-interactive state while a recording is unavailable.
   is conveyed visually with a check icon (the options use standard menu
   semantics, not radio semantics).
 - Icons are decorative — the labels, title, and time text carry the meaning.
+- When `details` are provided, the "View detail" / "Hide detail" toggle exposes
+  `aria-expanded`, and the panel is a labelled `role="region"`. The Summary /
+  Transcript tabs reuse the same `TabNavigation` primitive as the page and
+  side-panel tabs, so they share its look and keyboard navigation.

--- a/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.mdx
+++ b/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.mdx
@@ -571,7 +571,6 @@ Render the controls in a non-interactive state while a recording is unavailable.
   semantics, not radio semantics).
 - Icons are decorative — the labels, title, and time text carry the meaning.
 - When `details` are provided, the "View detail" / "Hide detail" toggle exposes
-  `aria-expanded` and `aria-controls` pointing at the panel, which is a
-  labelled `role="region"`. The Summary / Transcript tabs reuse the same
-  `TabNavigation` primitive as the page and side-panel tabs, so they share its
-  look and keyboard navigation.
+  `aria-expanded`, and the panel is a labelled `role="region"`. The Summary /
+  Transcript tabs reuse the same `TabNavigation` primitive as the page and
+  side-panel tabs, so they share its look and keyboard navigation.

--- a/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.stories.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.stories.tsx
@@ -79,6 +79,56 @@ export const WithDataTestId: Story = {
   args: { dataTestId: "audio-player" },
 }
 
+// Sample copy lifted from the design, long enough to demonstrate the
+// height-restricted scrollable transcript.
+const SAMPLE_SUMMARY =
+  "The AI call confirmed that Alex is available for night shifts and weekends, " +
+  "lives in Barajas with a commute under 40 minutes, is comfortable with " +
+  "physically demanding work, owns a motorcycle, and has salary expectations " +
+  "within range. He also confirmed a strong background in warehouse and " +
+  "logistics operations, but said he would only be able to start in 2 weeks. " +
+  "The main concern from the call is that he showed limited evidence of " +
+  "previous experience using digital tools for picking, which remains a key " +
+  "mandatory requirement for this role."
+
+const SAMPLE_TRANSCRIPT = Array.from({ length: 8 }, (_, i) =>
+  i % 2 === 0
+    ? "Interviewer: Can you tell me about your availability for night shifts and weekends?"
+    : "Alex: Yes, I'm fully available for night shifts and weekends, and my commute is under 40 minutes."
+).join("\n\n")
+
+const DETAILS = [
+  { value: "summary", label: "Summary", content: <p>{SAMPLE_SUMMARY}</p> },
+  {
+    value: "transcript",
+    label: "Transcript",
+    content: <p className="whitespace-pre-line">{SAMPLE_TRANSCRIPT}</p>,
+  },
+]
+
+// Collapsed by default — the "View detail" button toggles the tabbed panel.
+export const CardWithDetails: StoryObj<typeof F0AudioPlayerCard> = {
+  render: (args) => <F0AudioPlayerCard {...args} />,
+  args: {
+    src: SAMPLE_SRC,
+    title: "AI Call with Alex Williams",
+    subtitle: "May 9, 2025 - 10:00am",
+    details: DETAILS,
+  },
+}
+
+// Same card, starting expanded so the Summary/Transcript tabs are visible.
+export const CardWithDetailsExpanded: StoryObj<typeof F0AudioPlayerCard> = {
+  render: (args) => <F0AudioPlayerCard {...args} />,
+  args: {
+    src: SAMPLE_SRC,
+    title: "AI Call with Alex Williams",
+    subtitle: "May 9, 2025 - 10:00am",
+    details: DETAILS,
+    defaultExpanded: true,
+  },
+}
+
 export const Snapshot: Story = {
   ...withSnapshot({}),
   render: (args) => (
@@ -89,6 +139,13 @@ export const Snapshot: Story = {
         {...args}
         title="AI Call with Alex Williams"
         subtitle="May 9, 2025 - 10:00am"
+      />
+      <F0AudioPlayerCard
+        {...args}
+        title="AI Call with Alex Williams"
+        subtitle="May 9, 2025 - 10:00am"
+        details={DETAILS}
+        defaultExpanded
       />
     </div>
   ),

--- a/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
@@ -212,4 +212,53 @@ describe("F0AudioPlayerCard", () => {
     expect(screen.getByRole("button", { name: "Play" })).toBeDisabled()
     expect(screen.getByRole("button", { name: "View detail" })).toBeEnabled()
   })
+
+  it("links the toggle to the detail panel via aria-controls", () => {
+    render(
+      <F0AudioPlayerCard
+        src="test.mp3"
+        title="AI Call"
+        details={DETAILS}
+        defaultExpanded
+      />
+    )
+    const toggle = screen.getByRole("button", { name: "Hide detail" })
+    const controls = toggle.getAttribute("aria-controls")
+    expect(controls).toBeTruthy()
+    const region = screen.getByRole("region")
+    expect(region).toHaveAttribute("id", controls)
+  })
+
+  it("falls back to the first tab when details change to a new set", async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <F0AudioPlayerCard
+        src="test.mp3"
+        title="AI Call"
+        details={DETAILS}
+        defaultExpanded
+      />
+    )
+
+    // Select the second tab, then swap in a brand-new details array.
+    await user.click(screen.getByRole("button", { name: "Transcript" }))
+    rerender(
+      <F0AudioPlayerCard
+        src="test.mp3"
+        title="AI Call"
+        details={[
+          { value: "notes", label: "Notes", content: <p>Notes text</p> },
+          { value: "score", label: "Score", content: <p>Score text</p> },
+        ]}
+        defaultExpanded
+      />
+    )
+
+    // The stale "transcript" selection is gone, so the first new tab is active.
+    expect(screen.getByText("Notes text")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Notes" })).toHaveAttribute(
+      "data-active",
+      "true"
+    )
+  })
 })

--- a/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
@@ -213,22 +213,6 @@ describe("F0AudioPlayerCard", () => {
     expect(screen.getByRole("button", { name: "View detail" })).toBeEnabled()
   })
 
-  it("links the toggle to the detail panel via aria-controls", () => {
-    render(
-      <F0AudioPlayerCard
-        src="test.mp3"
-        title="AI Call"
-        details={DETAILS}
-        defaultExpanded
-      />
-    )
-    const toggle = screen.getByRole("button", { name: "Hide detail" })
-    const controls = toggle.getAttribute("aria-controls")
-    expect(controls).toBeTruthy()
-    const region = screen.getByRole("region")
-    expect(region).toHaveAttribute("id", controls)
-  })
-
   it("falls back to the first tab when details change to a new set", async () => {
     const user = userEvent.setup()
     const { rerender } = render(

--- a/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
@@ -125,4 +125,91 @@ describe("F0AudioPlayerCard", () => {
     // The f0 Dropdown defers item onClick by ~200ms.
     await waitFor(() => expect(getAudio().playbackRate).toBe(1.5))
   })
+
+  const DETAILS = [
+    { value: "summary", label: "Summary", content: <p>Summary text</p> },
+    {
+      value: "transcript",
+      label: "Transcript",
+      content: <p>Transcript text</p>,
+    },
+  ]
+
+  it("does not render a detail toggle when no details are given", () => {
+    render(<F0AudioPlayerCard src="test.mp3" title="AI Call" />)
+    expect(
+      screen.queryByRole("button", { name: "View detail" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("toggles the detail panel and flips the button label", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0AudioPlayerCard src="test.mp3" title="AI Call" details={DETAILS} />
+    )
+
+    const toggle = screen.getByRole("button", { name: "View detail" })
+    expect(toggle).toHaveAttribute("aria-expanded", "false")
+
+    await user.click(toggle)
+    const hide = screen.getByRole("button", { name: "Hide detail" })
+    expect(hide).toHaveAttribute("aria-expanded", "true")
+
+    await user.click(hide)
+    expect(screen.getByRole("button", { name: "View detail" })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    )
+  })
+
+  it("switches between the summary and transcript tabs", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0AudioPlayerCard
+        src="test.mp3"
+        title="AI Call"
+        details={DETAILS}
+        defaultExpanded
+      />
+    )
+
+    expect(screen.getByText("Summary text")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Transcript" }))
+    expect(screen.getByText("Transcript text")).toBeInTheDocument()
+  })
+
+  it("supports a controlled expanded state", async () => {
+    const user = userEvent.setup()
+    const onExpandedChange = vi.fn()
+    render(
+      <F0AudioPlayerCard
+        src="test.mp3"
+        title="AI Call"
+        details={DETAILS}
+        expanded={false}
+        onExpandedChange={onExpandedChange}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "View detail" }))
+    expect(onExpandedChange).toHaveBeenCalledWith(true)
+    // Still collapsed because the prop didn't change (controlled).
+    expect(
+      screen.getByRole("button", { name: "View detail" })
+    ).toBeInTheDocument()
+  })
+
+  it("keeps the detail toggle usable while the player is disabled", () => {
+    render(
+      <F0AudioPlayerCard
+        src="test.mp3"
+        title="AI Call"
+        details={DETAILS}
+        disabled
+      />
+    )
+    expect(screen.getByRole("button", { name: "Play" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "View detail" })).toBeEnabled()
+  })
 })

--- a/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
@@ -175,7 +175,7 @@ describe("F0AudioPlayerCard", () => {
 
     expect(screen.getByText("Summary text")).toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: "Transcript" }))
+    await user.click(screen.getByRole("radio", { name: "Transcript" }))
     expect(screen.getByText("Transcript text")).toBeInTheDocument()
   })
 
@@ -225,7 +225,7 @@ describe("F0AudioPlayerCard", () => {
     )
 
     // Select the second tab, then swap in a brand-new details array.
-    await user.click(screen.getByRole("button", { name: "Transcript" }))
+    await user.click(screen.getByRole("radio", { name: "Transcript" }))
     rerender(
       <F0AudioPlayerCard
         src="test.mp3"
@@ -240,9 +240,9 @@ describe("F0AudioPlayerCard", () => {
 
     // The stale "transcript" selection is gone, so the first new tab is active.
     expect(screen.getByText("Notes text")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Notes" })).toHaveAttribute(
-      "data-active",
-      "true"
+    expect(screen.getByRole("radio", { name: "Notes" })).toHaveAttribute(
+      "data-state",
+      "on"
     )
   })
 })

--- a/packages/react/src/components/F0AudioPlayer/index.tsx
+++ b/packages/react/src/components/F0AudioPlayer/index.tsx
@@ -6,6 +6,7 @@ import { F0AudioPlayerCardBase } from "./F0AudioPlayerCard"
 
 export type {
   AudioPlayerMenuAction,
+  AudioPlayerDetailTab,
   F0AudioPlayerProps,
   F0AudioPlayerCardProps,
   F0AudioPlayerSize,

--- a/packages/react/src/components/F0AudioPlayer/types.ts
+++ b/packages/react/src/components/F0AudioPlayer/types.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from "react"
+
 import { IconType } from "@/components/F0Icon"
 import { DataAttributes } from "@/global.types"
 import { WithDataTestIdProps } from "@/lib/data-testid"
@@ -10,6 +12,15 @@ export interface AudioPlayerMenuAction {
   icon?: IconType
   onClick: () => void
   critical?: boolean
+}
+
+export interface AudioPlayerDetailTab {
+  /** Stable value used to identify the tab. */
+  value: string
+  /** Visible (already translated) tab label, e.g. "Summary". */
+  label: string
+  /** Tab panel content, rendered inside a scrollable area. */
+  content: ReactNode
 }
 
 export interface F0AudioPlayerProps
@@ -121,4 +132,34 @@ export interface F0AudioPlayerCardProps extends F0AudioPlayerProps {
    * is always rendered by the card.
    */
   actions?: AudioPlayerMenuAction[]
+
+  /**
+   * Tabbed detail content revealed by a "View detail" toggle in the header
+   * (e.g. a Summary and a Transcript tab). When omitted or empty, no toggle and
+   * no panel are rendered and the card behaves like a plain recording player.
+   */
+  details?: AudioPlayerDetailTab[]
+
+  /**
+   * Controlled expanded state of the detail panel. Pair with
+   * `onExpandedChange`.
+   */
+  expanded?: boolean
+
+  /**
+   * Initial expanded state of the detail panel when uncontrolled.
+   * @default false
+   */
+  defaultExpanded?: boolean
+
+  /**
+   * Fired when the detail panel expands or collapses.
+   */
+  onExpandedChange?: (expanded: boolean) => void
+
+  /**
+   * Max height (in pixels) of the scrollable detail area before it scrolls.
+   * @default 200
+   */
+  detailsMaxHeight?: number
 }

--- a/packages/react/src/components/F0Button/internal-types.ts
+++ b/packages/react/src/components/F0Button/internal-types.ts
@@ -31,11 +31,6 @@ export type ButtonInternalProps = Pick<
      */
     "aria-expanded"?: boolean
     /**
-     * Forwarded to the underlying button. Use together with `aria-expanded` to
-     * point at the id of the region the button shows/hides.
-     */
-    "aria-controls"?: string
-    /**
      * Forwarded to the underlying button. Use `-1` to take the button out of the
      * tab order (e.g. when a parent manages focus via roving tabindex).
      */

--- a/packages/react/src/components/F0Button/internal-types.ts
+++ b/packages/react/src/components/F0Button/internal-types.ts
@@ -31,6 +31,11 @@ export type ButtonInternalProps = Pick<
      */
     "aria-expanded"?: boolean
     /**
+     * Forwarded to the underlying button. Use together with `aria-expanded` to
+     * point at the id of the region the button shows/hides.
+     */
+    "aria-controls"?: string
+    /**
      * Forwarded to the underlying button. Use `-1` to take the button out of the
      * tab order (e.g. when a parent manages focus via roving tabindex).
      */

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -43,6 +43,8 @@ export const defaultTranslations = {
     options: "Recording options",
     playbackSpeed: "Playback speed",
     position: "{{current}} of {{total}}",
+    viewDetail: "View detail",
+    hideDetail: "Hide detail",
   },
   actions: {
     add: "Add",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -45,6 +45,7 @@ export const defaultTranslations = {
     position: "{{current}} of {{total}}",
     viewDetail: "View detail",
     hideDetail: "Hide detail",
+    details: "Recording details",
   },
   actions: {
     add: "Add",


### PR DESCRIPTION
## Changes
- `F0AudioPlayerCard` gains an optional `details` prop — an array of
  `{ value, label, content }` tabs (labels passed already translated,
  mirroring the existing `actions` prop). When provided, a "View detail" /
  "Hide detail" outline button appears in the header and toggles an
  expandable panel below the progress bar.
- The panel reuses the `TabNavigation` / `TabNavigationLink` primitive
  (same underline tabs as page/side-panel nav) and an `@/ui/ScrollArea`
  for the content, capped at `detailsMaxHeight` (default `200`, overridable)
  and scrollable beyond it.
- Expanded state is controlled or uncontrolled: `expanded`,
  `defaultExpanded`, `onExpandedChange` (follows the card's existing
  `playing` pattern).
- Animated expand/collapse via `motion/react`, respecting reduced motion.
  The panel is a labelled `role="region"` and the toggle exposes
  `aria-expanded`.
- New i18n defaults: `audioPlayer.viewDetail` / `audioPlayer.hideDetail`.
  Exposes the `AudioPlayerDetailTab` type.
- Backward compatible: without `details`, the card and the bare
  `F0AudioPlayer` are unchanged. The detail toggle remains usable even
  when the player is `disabled` (that only governs audio controls).


https://github.com/user-attachments/assets/3f69f417-9910-4137-ac9f-9c1d3126e1e6







