### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.0.2",
+  "packages/react": "4.0.3",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.0.3](https://github.com/factorialco/f0/compare/f0-react-v4.0.2...f0-react-v4.0.3) (2026-06-22)
+
+
+### Bug Fixes
+
+* **F0CardHorizontal:** reserve action button width so the confirm/reject pair never shrinks ([#4525](https://github.com/factorialco/f0/issues/4525)) ([10b0b0b](https://github.com/factorialco/f0/commit/10b0b0b901cf16e8b3e4f45236cf58b60c072b66))
+
 ## [4.0.2](https://github.com/factorialco/f0/compare/f0-react-v4.0.1...f0-react-v4.0.2) (2026-06-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.0.3</summary>

## [4.0.3](https://github.com/factorialco/f0/compare/f0-react-v4.0.2...f0-react-v4.0.3) (2026-06-22)


### Bug Fixes

* **F0CardHorizontal:** reserve action button width so the confirm/reject pair never shrinks ([#4525](https://github.com/factorialco/f0/issues/4525)) ([10b0b0b](https://github.com/factorialco/f0/commit/10b0b0b901cf16e8b3e4f45236cf58b60c072b66))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).