### PR TITLE
fix(EditableTable): apply correct cursor per cell type

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DateCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DateCell.test.tsx
@@ -39,6 +39,11 @@ describe("DateCell", () => {
     item: { id: "1", startDate: "" },
   }
 
+  it("applies pointer cursor", () => {
+    const { container } = render(<DateCell {...defaultProps} />)
+    expect(container.firstChild).toHaveClass("cursor-pointer")
+  })
+
   it("forwards minDate and maxDate from dateConfig to F0DatePicker", () => {
     const minDate = new Date(2026, 0, 1)
     const maxDate = new Date(2026, 0, 31)

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DisabledCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DisabledCell.test.tsx
@@ -35,6 +35,11 @@ describe("DisabledCell", () => {
     expect(screen.getByText("John Doe")).toBeInTheDocument()
   })
 
+  it("applies not-allowed cursor", () => {
+    const { container } = render(<DisabledCell {...defaultProps} />)
+    expect(container.firstChild).toHaveClass("cursor-not-allowed")
+  })
+
   it("renders a hint icon when hint is provided", () => {
     render(
       <DisabledCell

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NonEditableCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NonEditableCell.test.tsx
@@ -35,6 +35,11 @@ describe("NonEditableCell", () => {
     expect(screen.getByText("John Doe")).toBeInTheDocument()
   })
 
+  it("applies default cursor", () => {
+    const { container } = render(<NonEditableCell {...defaultProps} />)
+    expect(container.firstChild).toHaveClass("cursor-default")
+  })
+
   it("renders a hint icon when hint is provided", () => {
     render(
       <NonEditableCell

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/SelectCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/SelectCell.test.tsx
@@ -194,6 +194,11 @@ describe("SelectCell", () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
+  it("applies pointer cursor", () => {
+    const { container } = render(<SelectCell {...defaultProps} />)
+    expect(container.firstChild).toHaveClass("cursor-pointer")
+  })
+
   it("renders non-editable fallback when selectConfig is missing", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/DateCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/DateCell.tsx
@@ -41,7 +41,12 @@ export function DateCell<R extends RecordType>({
   }
 
   return (
-    <BaseCell showRightBorder={!isLastColumn} error={error} hint={hint}>
+    <BaseCell
+      showRightBorder={!isLastColumn}
+      error={error}
+      hint={hint}
+      cursor="pointer"
+    >
       <div
         className={cn(
           "flex w-full min-w-0 items-center",

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
@@ -61,7 +61,7 @@ export function SelectCell<R extends RecordType>({
     : ({} as const)
 
   return (
-    <BaseCell error={error} isActive={isOpen} hint={hint}>
+    <BaseCell error={error} isActive={isOpen} hint={hint} cursor="pointer">
       <div
         className={cn(
           "flex w-full min-w-0 h-full",

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
@@ -14,13 +14,13 @@ export function DisabledCell<R extends RecordType>({
   const i18n = useI18n()
 
   return (
-    <BaseCell borderOnHover={false} hint={hint}>
+    <BaseCell borderOnHover={false} hint={hint} cursor="not-allowed">
       <div
         className={cn(
           editableColumn.align === "right" ? "justify-end" : "",
           "flex p-4 min-h-12 items-center border-0 h-full",
           "bg-f1-background-disabled h-full",
-          "cursor-pointer w-full"
+          "w-full"
         )}
       >
         {renderProperty(item, editableColumn, "editableTable", i18n)}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
@@ -15,11 +15,16 @@ export function NonEditableCell<R extends RecordType>({
   const i18n = useI18n()
 
   return (
-    <BaseCell showRightBorder={!isLastColumn} borderOnHover={false} hint={hint}>
+    <BaseCell
+      showRightBorder={!isLastColumn}
+      borderOnHover={false}
+      hint={hint}
+      cursor="default"
+    >
       <div
         className={cn(
           "flex w-full min-w-0",
-          "cursor-pointer items-center px-3",
+          "items-center px-3",
           editableColumn.align === "right" && "justify-end"
         )}
       >


### PR DESCRIPTION
## Summary

- `SelectCell` and `DateCell` now use `cursor-pointer` since clicking them triggers an action (dropdown/date picker)
- `NonEditableCell` now uses `cursor-default` — removed hardcoded `cursor-pointer` from inner div
- `DisabledCell` now uses `cursor-not-allowed` — removed hardcoded `cursor-pointer` from inner div
- `TextCell`, `NumberCell`, `MoneyCell` unchanged — `cursor-text` was already correct

Closes FCT-55896

## Test plan

Tested locally in Storybook.

https://github.com/user-attachments/assets/802176ea-dc29-42e5-967f-be2cc60ffbfa



🤖 Generated with [Claude Code](https://claude.com/claude-code)