### PR TITLE
docs(ai): deprecate F0HILActionConfirmation + F0CanvasCard

### DIFF
--- a/packages/react/src/sds/ai/F0HILActionConfirmation/F0HILActionConfirmation.tsx
+++ b/packages/react/src/sds/ai/F0HILActionConfirmation/F0HILActionConfirmation.tsx
@@ -2,6 +2,13 @@ import { F0CardHorizontal } from "@/experimental/F0CardHorizontal"
 
 import { F0HILActionConfirmationProps } from "./types"
 
+/**
+ * @deprecated Being replaced by `F0CardHorizontal` (`@/experimental/F0CardHorizontal`),
+ * which this component already wraps. Use `F0CardHorizontal` directly: `confirmAction` /
+ * `rejectAction` for the pending state, `status` for the resolved outcome, and
+ * `secondaryActions` for a single CTA. The co-creation flow no longer uses this component —
+ * don't add new usages.
+ */
 export const F0HILActionConfirmation = ({
   text,
   description,

--- a/packages/react/src/sds/ai/F0HILActionConfirmation/F0HILActionConfirmation.tsx
+++ b/packages/react/src/sds/ai/F0HILActionConfirmation/F0HILActionConfirmation.tsx
@@ -8,6 +8,7 @@ import { F0HILActionConfirmationProps } from "./types"
  * `rejectAction` for the pending state, `status` for the resolved outcome, and
  * `secondaryActions` for a single CTA. The co-creation flow no longer uses this component —
  * don't add new usages.
+ * @removeIn 5.0.0
  */
 export const F0HILActionConfirmation = ({
   text,

--- a/packages/react/src/sds/ai/F0HILActionConfirmation/__stories__/F0HILActionConfirmation.stories.tsx
+++ b/packages/react/src/sds/ai/F0HILActionConfirmation/__stories__/F0HILActionConfirmation.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
       },
     },
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "deprecated"],
   decorators: [
     (Story) => (
       <div className="w-full max-w-[480px]">

--- a/packages/react/src/sds/ai/F0HILActionConfirmation/types.ts
+++ b/packages/react/src/sds/ai/F0HILActionConfirmation/types.ts
@@ -6,6 +6,8 @@ import type { F0CardHorizontalProps } from "@/experimental/F0CardHorizontal"
  * Renders an inline approve/reject row built on `F0CardHorizontal`'s confirm/reject
  * variant: the prompt as the row title, with icon-only ✓ (confirm) and ✗
  * (reject) buttons at the trailing edge.
+ *
+ * @deprecated Being replaced by `F0CardHorizontal`. See {@link F0HILActionConfirmation}.
  */
 export type F0HILActionConfirmationProps = {
   /**

--- a/packages/react/src/sds/ai/F0HILActionConfirmation/types.ts
+++ b/packages/react/src/sds/ai/F0HILActionConfirmation/types.ts
@@ -8,6 +8,7 @@ import type { F0CardHorizontalProps } from "@/experimental/F0CardHorizontal"
  * (reject) buttons at the trailing edge.
  *
  * @deprecated Being replaced by `F0CardHorizontal`. See {@link F0HILActionConfirmation}.
+ * @removeIn 5.0.0
  */
 export type F0HILActionConfirmationProps = {
   /**

--- a/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
+++ b/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
@@ -30,6 +30,7 @@ type CanvasCardAction =
       hideLabel?: boolean
     }
 
+/** @deprecated Being replaced by `F0CardHorizontal`. See {@link F0CanvasCard}. */
 export type F0CanvasCardProps = {
   /** Avatar to display: a module icon or a file-type badge */
   avatar?: CanvasCardAvatar
@@ -48,6 +49,13 @@ export type F0CanvasCardProps = {
 /**
  * Shared inline card rendered in the AI chat for any canvas entity.
  * Shows an avatar, title, optional description, and a configurable action button.
+ *
+ * @deprecated Being replaced by `F0CardHorizontal` (`@/experimental/F0CardHorizontal`).
+ * The co-creation flow already renders these cards with `F0CardHorizontal` directly
+ * (Open/Close → `primaryAction`; superseded → a faded `opacity-50 pointer-events-none`
+ * wrapper). Don't add new usages; migrate the remaining one
+ * (`F0AiMessagesContainer/FormCard`) once its inline `children` preview has an
+ * `F0CardHorizontal`-friendly home.
  */
 export function F0CanvasCard({
   avatar,

--- a/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
+++ b/packages/react/src/sds/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
@@ -30,7 +30,10 @@ type CanvasCardAction =
       hideLabel?: boolean
     }
 
-/** @deprecated Being replaced by `F0CardHorizontal`. See {@link F0CanvasCard}. */
+/**
+ * @deprecated Being replaced by `F0CardHorizontal`. See {@link F0CanvasCard}.
+ * @removeIn 5.0.0
+ */
 export type F0CanvasCardProps = {
   /** Avatar to display: a module icon or a file-type badge */
   avatar?: CanvasCardAvatar
@@ -56,6 +59,7 @@ export type F0CanvasCardProps = {
  * wrapper). Don't add new usages; migrate the remaining one
  * (`F0AiMessagesContainer/FormCard`) once its inline `children` preview has an
  * `F0CardHorizontal`-friendly home.
+ * @removeIn 5.0.0
  */
 export function F0CanvasCard({
   avatar,

--- a/packages/react/src/sds/ai/canvas/F0CanvasCard/__stories__/F0CanvasCard.stories.tsx
+++ b/packages/react/src/sds/ai/canvas/F0CanvasCard/__stories__/F0CanvasCard.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "deprecated"],
   decorators: [
     (Story) => (
       <div className="w-96">


### PR DESCRIPTION
## Description

Marks `F0HILActionConfirmation` and `F0CanvasCard` as `@deprecated` in favour of `F0CardHorizontal`. `F0HILActionConfirmation` is already a thin wrapper around `F0CardHorizontal`, and the co-creation flow renders canvas cards with `F0CardHorizontal` directly — so both are superseded. This is a docs-only change (JSDoc notices pointing to the replacement); there is no behaviour change and no consumer is affected.

Extracted from the co-creation patterns PR (#4307).

## Implementation details

- docs: add `@deprecated` notices to `F0HILActionConfirmation` (component + props type) directing callers to use `F0CardHorizontal` directly
- docs: add `@deprecated` notices to `F0CanvasCard` (component + props type); notes the one remaining consumer (`F0AiMessagesContainer/FormCard`) to migrate later