### PR TITLE
refactor(ai): welcome suggestions above the composer

### DIFF
--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -326,9 +326,9 @@ export const F0AiChatTextArea = ({
   const hasOverlay =
     mentions.mentions.length > 0 || mentions.inlineCompletion !== null
 
-  // Welcome suggestions row. On the welcome screen it sits above the textarea
-  // in sidepanel and below it in fullscreen (so the popover can open downward
-  // without covering the composer).
+  // Welcome suggestions row. On the welcome screen it always sits above the
+  // textarea (both sidepanel and fullscreen); the popover opens upward so it
+  // doesn't cover the composer.
   const showSuggestions =
     isWelcomeScreen &&
     !!welcomeScreenSuggestions &&
@@ -340,7 +340,7 @@ export const F0AiChatTextArea = ({
       suggestions={welcomeScreenSuggestions}
       onItemClick={handleSuggestionClick}
       onItemHover={setHoveredSuggestion}
-      side={fullscreen ? "bottom" : "top"}
+      side="top"
     />
   ) : null
 
@@ -368,7 +368,7 @@ export const F0AiChatTextArea = ({
       {...(fullscreen ? composerReveal : {})}
     >
       <div className="flex w-full max-w-content flex-col gap-2">
-        {suggestionsRow && !fullscreen && <div>{suggestionsRow}</div>}
+        {suggestionsRow && <div>{suggestionsRow}</div>}
         <CreditWarningWrapper creditWarning={creditWarning}>
           <motion.form
             aria-busy={inProgress}
@@ -549,10 +549,6 @@ export const F0AiChatTextArea = ({
           </motion.form>
         </CreditWarningWrapper>
       </div>
-
-      {suggestionsRow && fullscreen && (
-        <div className="w-full max-w-content">{suggestionsRow}</div>
-      )}
 
       {footer && isWelcomeScreen && fullscreen && (
         <div className="w-full py-4 mx-auto flex max-w-content justify-center">

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.welcomeLayout.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.welcomeLayout.test.tsx
@@ -39,7 +39,7 @@ describe("F0AiChatTextArea welcome suggestions placement", () => {
     ).toBeTruthy()
   })
 
-  it("renders the suggestions below the textarea in fullscreen mode", () => {
+  it("renders the suggestions above the textarea in fullscreen mode", () => {
     render(
       <F0AiChatTextArea
         onSubmit={() => {}}
@@ -52,9 +52,9 @@ describe("F0AiChatTextArea welcome suggestions placement", () => {
 
     const trigger = screen.getByRole("button", { name: /analyze/i })
     const textarea = screen.getByRole("textbox", { name: "Message" })
-    // trigger follows the textarea in document order → suggestions are below.
+    // textarea follows the trigger in document order → suggestions are above.
     expect(
-      textarea.compareDocumentPosition(trigger) &
+      trigger.compareDocumentPosition(textarea) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
   })

--- a/packages/react/src/sds/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -45,9 +45,10 @@ export type WelcomeScreenSuggestionsRowProps = {
    */
   onItemHover?: (item: WelcomeScreenSuggestionItem | null) => void
   /**
-   * Side the popover opens towards. Defaults to "top" (sidepanel, row sits
-   * above the textarea). Fullscreen passes "bottom" so the popover opens into
-   * the empty space below the textarea instead of covering it.
+   * Side the popover opens towards. Defaults to "top" — the row sits above the
+   * textarea, so the popover opens upward into the empty space rather than
+   * covering the composer. "bottom" remains available for layouts that place
+   * the row below the textarea.
    */
   side?: "top" | "bottom"
 }


### PR DESCRIPTION
## Description

On the F0AiChat welcome screen, when the triggering team supplies `welcomeScreenSuggestions`, the suggestions row now sits **above** the composer in fullscreen too (previously it sat below in fullscreen, above in sidepanel). With the row above, the suggestion popover opens upward into empty space instead of covering the composer. When no suggestions are supplied the row simply doesn't render — unchanged.

Extracted from the co-creation patterns PR (#4307). Note: this changes existing fullscreen placement, so it's worth a design sign-off.

## Implementation details

- refactor: always render the welcome suggestions row above the textarea; drop the fullscreen "below" branch
- refactor: `WelcomeScreenSuggestionsRow` popover defaults to opening upward (`side="top"`); `"bottom"` remains available
- test: update the welcome-layout test to assert the row renders above the textarea in fullscreen


<img width="766" height="250" alt="suggestions 2" src="https://github.com/user-attachments/assets/a39d8c20-ade2-434b-a020-25f7778c7604" />
