### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.0.4",
+  "packages/react": "4.1.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.1.0](https://github.com/factorialco/f0/compare/f0-react-v4.0.4...f0-react-v4.1.0) (2026-06-22)
+
+
+### Features
+
+* **F0Form:** add native period field type ([#4470](https://github.com/factorialco/f0/issues/4470)) ([99998fc](https://github.com/factorialco/f0/commit/99998fc77a550c2e8c322090e94c34c904e374a0))
+
 ## [4.0.4](https://github.com/factorialco/f0/compare/f0-react-v4.0.3...f0-react-v4.0.4) (2026-06-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.1.0</summary>

## [4.1.0](https://github.com/factorialco/f0/compare/f0-react-v4.0.4...f0-react-v4.1.0) (2026-06-22)


### Features

* **F0Form:** add native period field type ([#4470](https://github.com/factorialco/f0/issues/4470)) ([99998fc](https://github.com/factorialco/f0/commit/99998fc77a550c2e8c322090e94c34c904e374a0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).