### PR TITLE
fix(OneDataCollection): support select-all in nested/tree tables (FCT-56547)

### DIFF
--- a/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
@@ -1235,4 +1235,130 @@ describe("useSelectable", () => {
       })
     })
   })
+
+  describe("Nested/tree data (registry-backed select all)", () => {
+    // Top-level rows are non-selectable parents; selectable rows are nested
+    // children absent from data.records, reported via getRenderedSelectableEntries.
+    const PARENT_IDS = new Set([1000, 2000])
+    const parentRecords = [
+      { id: 1000, name: "New headcount", group: "g" },
+      { id: 2000, name: "Actual headcount", group: "g" },
+    ].map((item) => ({ ...item, [GROUP_ID_SYMBOL]: undefined }))
+
+    const childRecords = [1, 2, 3, 4, 5, 6].map((id) => ({
+      id,
+      name: `Child ${id}`,
+      group: "g",
+      [GROUP_ID_SYMBOL]: undefined,
+    }))
+
+    const nestedData: Data<TestRecord> = {
+      type: "flat",
+      records: parentRecords,
+      groups: [
+        {
+          key: "all",
+          label: "All",
+          records: parentRecords,
+          itemCount: parentRecords.length,
+        },
+      ],
+    }
+
+    const nestedSource = {
+      ...mockSource,
+      selectable: (item: TestRecord) =>
+        PARENT_IDS.has(item.id) ? undefined : item.id,
+    } as typeof mockSource
+
+    const paginationInfo: PaginationInfo = {
+      type: "pages",
+      total: childRecords.length,
+      currentPage: 1,
+      perPage: childRecords.length,
+      pagesCount: 1,
+    }
+
+    const renderedEntries = () =>
+      childRecords.map((item) => [item.id, item] as [number, TestRecord])
+
+    it("handleSelectAll selects every rendered child row (not just data.records)", async () => {
+      const { result } = renderHook(() =>
+        useSelectable({
+          data: nestedData,
+          paginationInfo,
+          source: nestedSource,
+          onSelectItems: vi.fn(),
+          selectionMode: "multi",
+          allPagesSelection: true,
+          getRenderedSelectableEntries: renderedEntries,
+        })
+      )
+
+      act(() => {
+        result.current.handleSelectAll(true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(6)
+        expect(
+          result.current.selectionStatus.selectedIds
+            .slice()
+            .sort((a, b) => Number(a) - Number(b))
+        ).toEqual([1, 2, 3, 4, 5, 6])
+      })
+    })
+
+    it("regression: without the registry, select-all is a no-op (data.records holds only non-selectable parents)", async () => {
+      const { result } = renderHook(() =>
+        useSelectable({
+          data: nestedData,
+          paginationInfo,
+          source: nestedSource,
+          onSelectItems: vi.fn(),
+          selectionMode: "multi",
+          allPagesSelection: true,
+          // getRenderedSelectableEntries intentionally omitted
+        })
+      )
+
+      act(() => {
+        result.current.handleSelectAll(true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(0)
+      })
+    })
+
+    it("handleSelectAllItems selects all rendered children and preserves the pre-existing selection (no wipe)", async () => {
+      const { result } = renderHook(() =>
+        useSelectable({
+          data: nestedData,
+          paginationInfo,
+          source: nestedSource,
+          onSelectItems: vi.fn(),
+          selectionMode: "multi",
+          allPagesSelection: true,
+          getRenderedSelectableEntries: renderedEntries,
+        })
+      )
+
+      act(() => {
+        result.current.handleSelectItemChange(childRecords[0], true)
+      })
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(1)
+      })
+
+      act(() => {
+        result.current.handleSelectAllItems(true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(6)
+        expect(result.current.selectedItems.has(1)).toBe(true)
+      })
+    })
+  })
 })

--- a/packages/react/src/hooks/datasource/useSelectable/typings.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/typings.ts
@@ -89,6 +89,11 @@ export type UseSelectableProps<
    * @default false
    */
   preserveSelectionOnDatasetChange?: boolean
+  /**
+   * Selectable rows currently rendered (incl. nested children), so "select all"
+   * reaches rows absent from `data.records`. Falls back to `data.records`.
+   */
+  getRenderedSelectableEntries?: () => Array<[SelectionId, R]>
 }
 
 export type SelectionMeta<R extends RecordType> = {

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -41,6 +41,7 @@ export function useSelectable<
   allPagesSelection,
   resetOnPageChange = true,
   preserveSelectionOnDatasetChange = false,
+  getRenderedSelectableEntries,
 }: UseSelectableProps<R, Filters, Sortings, Grouping>): UseSelectableReturn<
   R,
   Filters
@@ -558,6 +559,20 @@ export function useSelectable<
     [isGrouped, data, getSelectable, handleSelectItemChangeInternal]
   )
 
+  // Selectable rows a "select all" can act on: rendered-row registry when
+  // present (covers nested children), else `data.records`.
+  const collectSelectableEntries = useCallback((): Array<[SelectionId, R]> => {
+    const rendered = getRenderedSelectableEntries?.() ?? []
+    if (rendered.length > 0) return rendered
+
+    return data.records
+      .map((record): [SelectionId, R] | undefined => {
+        const id = getSelectable?.(record)
+        return id === undefined ? undefined : [id, record]
+      })
+      .filter((entry): entry is [SelectionId, R] => entry !== undefined)
+  }, [getRenderedSelectableEntries, data.records, getSelectable])
+
   // Public Selection Handlers
 
   /**
@@ -601,7 +616,10 @@ export function useSelectable<
         return
       }
 
-      const currentPageCount = data.records?.length || 0
+      const selectableEntries =
+        isGrouped && data.type === "grouped" ? [] : collectSelectableEntries()
+      const currentPageCount =
+        selectableEntries.length || data.records?.length || 0
 
       if (checked) {
         setSelectAllTotal((prev) => (prev !== null ? prev : currentPageCount))
@@ -613,12 +631,16 @@ export function useSelectable<
           handleSelectGroupChange(allGroupIds, checked)
         }
       } else {
-        const allItemIds = data.records
-          .map((record) => getSelectable?.(record))
-          .filter((id): id is SelectionId => id !== undefined)
+        const allItemIds = selectableEntries.map(([id]) => id)
+        const fallbackItems = selectableEntries.map(([, item]) => item)
 
         if (allItemIds.length > 0) {
-          handleSelectItemChangeInternal(allItemIds, checked)
+          handleSelectItemChangeInternal(
+            allItemIds,
+            checked,
+            false,
+            fallbackItems
+          )
         }
       }
 
@@ -633,7 +655,7 @@ export function useSelectable<
       allSelectedCheck,
       isGrouped,
       data,
-      getSelectable,
+      collectSelectableEntries,
       handleSelectGroupChange,
       handleSelectItemChangeInternal,
     ]
@@ -668,15 +690,14 @@ export function useSelectable<
         // (e.g. "All selected (25)" when far fewer match the active filter).
         // Subsequent pages load via the data-sync effect while select-all stays
         // active, so all-pages selection still works.
+        const selectableEntries = collectSelectableEntries()
         setLocalSelectedState((current) => {
           const newItems = new Map<SelectionId, SelectedItemState<R>>()
-          for (const record of data.records) {
-            const id = getSelectable?.(record)
-            if (id === undefined) continue
+          for (const [id, item] of selectableEntries) {
             newItems.set(id, {
               id,
               checked: true,
-              item: record as WithGroupId<R>,
+              item: item as WithGroupId<R>,
             })
           }
           return {
@@ -686,9 +707,7 @@ export function useSelectable<
           }
         })
       } else {
-        const allItemIds = data.records
-          .map((record) => getSelectable?.(record))
-          .filter((id): id is SelectionId => id !== undefined)
+        const allItemIds = collectSelectableEntries().map(([id]) => id)
 
         if (allItemIds.length > 0) {
           handleSelectItemChangeInternal(allItemIds, false)
@@ -720,7 +739,7 @@ export function useSelectable<
       totalKnownItemsCount,
       isGrouped,
       data,
-      getSelectable,
+      collectSelectableEntries,
       handleSelectGroupChange,
       handleSelectItemChangeInternal,
     ]

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -112,7 +112,7 @@ export const EditableTableWithSelectableRows: Story = {
     const { dataAdapter, onCellChange } = useEditableTableData()
     return (
       <ExampleComponent
-        selectable={() => ""}
+        selectable={(item) => item.id}
         visualizations={[
           {
             type: "editableTable" as const,
@@ -129,6 +129,80 @@ export const EditableTableWithSelectableRows: Story = {
         ]}
         dataAdapter={dataAdapter}
         id="editable-table-selectable/v1"
+      />
+    )
+  },
+}
+
+/**
+ * Nested editable table with selection (FCT-56547): non-selectable parent rows
+ * whose lazily-loaded children are selectable. Expand a parent, then use the
+ * header "Select all" checkbox or the "Select all N items" banner — select-all
+ * must select all loaded children without wiping the current selection.
+ */
+export const EditableTableWithNestedSelectableRows: Story = {
+  render: () => {
+    const mockVisualizations = getMockVisualizations({ table: {} })
+
+    // Build two non-selectable parent rows, each owning unique-id leaf rows.
+    const nestedData = useMemo<MockUser[]>(() => {
+      const base = generateMockUsers(8)
+      const makeParent = (
+        parent: MockUser,
+        label: string,
+        childSlice: MockUser[]
+      ): MockUser => ({
+        ...parent,
+        name: label,
+        children: childSlice.map((child, i) => ({
+          ...child,
+          id: `${parent.id}-child-${i + 1}`,
+          name: `${label} · request ${i + 1}`,
+          children: undefined,
+        })),
+      })
+
+      return [
+        makeParent(
+          { ...base[0], id: "parent-new" },
+          "New headcount",
+          base.slice(1, 4)
+        ),
+        makeParent(
+          { ...base[4], id: "parent-actual" },
+          "Actual headcount",
+          base.slice(5, 8)
+        ),
+      ]
+    }, [])
+
+    const { dataAdapter, onCellChange } = useEditableTableData(nestedData)
+
+    return (
+      <ExampleComponent
+        // Parents (rows with children) are not selectable; only leaf rows are.
+        selectable={(item) => (item.children?.length ? undefined : item.id)}
+        allPagesSelection
+        bulkActions={() => ({
+          primary: [{ id: "approve", label: "Approve" }],
+          secondary: [{ id: "delete", label: "Delete" }],
+        })}
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              ...(
+                mockVisualizations.editableTable as Extract<
+                  typeof mockVisualizations.editableTable,
+                  { type: "editableTable" }
+                >
+              ).options,
+              onCellChange,
+            },
+          },
+        ]}
+        dataAdapter={dataAdapter}
+        id="editable-table-nested-selectable/v1"
       />
     )
   },

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -52,6 +52,7 @@ import { Row } from "./components/Row"
 import { useColumns } from "./hooks/useColums"
 import { groupBorderClass, useHeaderGroups } from "./hooks/useHeaderGroups"
 import { NestedDataProvider } from "./providers/NestedProvider"
+import { useCreateSelectionRegistry } from "./providers/SelectionRegistryProvider"
 import { useSticky } from "./useSticky"
 export * from "./settings/SettingsRenderer"
 
@@ -222,9 +223,7 @@ export const TableCollection = <
     return `index:${String(index)}`
   }
 
-  /**
-   * Item selection
-   */
+  const selectionRegistry = useCreateSelectionRegistry<R>()
   const {
     selectedItems,
     allSelectedStatus,
@@ -240,6 +239,7 @@ export const TableCollection = <
     onSelectItems,
     selectionMode: "multi",
     selectedState: source.defaultSelectedItems,
+    getRenderedSelectableEntries: selectionRegistry.getEntries,
   })
   const summaryData = useMemo(() => {
     // Early return if no summaries configuration or summaries data is available
@@ -353,11 +353,12 @@ export const TableCollection = <
   // allPagesSelection modes — unlike comparing the cross-page selectedCount to
   // data.records.length, which can produce false positives when selections from
   // another page happen to equal the current page size.
-  // Non-selectable rows (source.selectable returns undefined) are filtered out
-  // so pages with mixed selectable/non-selectable rows still report correctly.
-  const currentPageSelectableIds = (data?.records ?? [])
-    .map((record) => source.selectable?.(record))
-    .filter((id): id is SelectionId => id !== undefined)
+  const currentPageSelectableIds =
+    selectionRegistry.ids.length > 0
+      ? selectionRegistry.ids
+      : (data?.records ?? [])
+          .map((record) => source.selectable?.(record))
+          .filter((id): id is SelectionId => id !== undefined)
 
   const allPageRowsSelected =
     currentPageSelectableIds.length > 0 &&
@@ -699,6 +700,10 @@ export const TableCollection = <
                                 cellRenderer={cellRenderer}
                                 headerGroups={headerGroups}
                                 fromVisualization={fromVisualization}
+                                registerSelectable={selectionRegistry.register}
+                                unregisterSelectable={
+                                  selectionRegistry.unregister
+                                }
                               />
                             )
                             if (RowWrapper) {
@@ -743,6 +748,8 @@ export const TableCollection = <
                       cellRenderer={cellRenderer}
                       fromVisualization={fromVisualization}
                       headerGroups={headerGroups}
+                      registerSelectable={selectionRegistry.register}
+                      unregisterSelectable={selectionRegistry.unregister}
                     />
                   )
                   if (RowWrapper) {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedSelection.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedSelection.test.tsx
@@ -1,0 +1,170 @@
+import { waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import type { GroupingDefinition, SortingsDefinition } from "@/hooks/datasource"
+
+import { FiltersDefinition } from "@/hooks/datasource"
+import { screen, zeroRender as render } from "@/testing/test-utils"
+import { TextCell } from "@/ui/value-display/types/text"
+
+import { DataCollectionSource } from "../../../../hooks/useDataCollectionSource/types"
+import { ItemActionsDefinition } from "../../../../item-actions"
+import { NavigationFiltersDefinition } from "../../../../navigationFilters/types"
+import { SummariesDefinition } from "../../../../summary"
+import { EditableTableCollection } from "../../EditableTable/EditableTable"
+
+vi.mock("../../../property", () => ({
+  propertyRenderers: {
+    text: TextCell,
+  },
+}))
+
+class MockIntersectionObserver implements IntersectionObserver {
+  root: Document | Element | null = null
+  rootMargin = ""
+  thresholds: readonly number[] = []
+  disconnect = vi.fn()
+  observe = vi.fn()
+  takeRecords = vi.fn()
+  unobserve = vi.fn()
+}
+window.IntersectionObserver = MockIntersectionObserver
+
+type Person = { id: string; name: string; children?: Person[] }
+
+const parents: Person[] = [
+  {
+    id: "p1",
+    name: "Parent",
+    children: [
+      { id: "c1", name: "Child One" },
+      { id: "c2", name: "Child Two" },
+    ],
+  },
+  {
+    id: "p2",
+    name: "Parent Two",
+    children: [{ id: "c3", name: "Child Three" }],
+  },
+]
+
+const columns = [{ label: "name", render: (item: Person) => item.name }]
+
+const createSource = (
+  onSelectItems: () => void
+): DataCollectionSource<
+  Person,
+  FiltersDefinition,
+  SortingsDefinition,
+  SummariesDefinition,
+  ItemActionsDefinition<Person>,
+  NavigationFiltersDefinition,
+  GroupingDefinition<Person>
+> =>
+  ({
+    currentFilters: {},
+    setCurrentFilters: vi.fn(),
+    currentSortings: null,
+    setCurrentSortings: vi.fn(),
+    currentNavigationFilters: {},
+    setCurrentNavigationFilters: vi.fn(),
+    navigationFilters: undefined,
+    currentSearch: undefined,
+    debouncedCurrentSearch: undefined,
+    setCurrentSearch: vi.fn(),
+    isLoading: false,
+    setIsLoading: vi.fn(),
+    currentGrouping: undefined,
+    setCurrentGrouping: vi.fn(),
+    selectable: (item: Person) => (item.children?.length ? undefined : item.id),
+    allPagesSelection: true,
+    itemsWithChildren: (item: Person) => !!item.children?.length,
+    fetchChildren: ({ item }: { item: Person }) => ({
+      records: item.children ?? [],
+    }),
+    dataAdapter: {
+      paginationType: "pages",
+      fetchData: async () => ({
+        records: parents,
+        type: "pages",
+        total: parents.length,
+        perPage: 20,
+        currentPage: 1,
+        pagesCount: 1,
+      }),
+    },
+    onSelectItems,
+  }) as unknown as DataCollectionSource<
+    Person,
+    FiltersDefinition,
+    SortingsDefinition,
+    SummariesDefinition,
+    ItemActionsDefinition<Person>,
+    NavigationFiltersDefinition,
+    GroupingDefinition<Person>
+  >
+
+const expandParent = async (user: ReturnType<typeof userEvent.setup>) => {
+  const chevron = document.querySelector(".lucide-chevron-right")
+  expect(chevron).not.toBeNull()
+  await user.click(chevron as Element)
+  await waitFor(() => {
+    expect(screen.getByTitle("Select c1")).toBeInTheDocument()
+  })
+}
+
+describe("Table nested-row selection (registry-backed select all)", () => {
+  it("header select-all checks every loaded nested child", async () => {
+    const user = userEvent.setup()
+    render(
+      <EditableTableCollection
+        columns={columns}
+        source={createSource(vi.fn())}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(screen.getByText("Parent")).toBeInTheDocument())
+    await expandParent(user)
+
+    const headerCheckbox = screen.getAllByRole("checkbox")[0]
+    await user.click(headerCheckbox)
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Select c1")).toBeChecked()
+      expect(screen.getByTitle("Select c2")).toBeChecked()
+    })
+  })
+
+  it("'Select all N items' selects nested children without wiping the existing selection", async () => {
+    const user = userEvent.setup()
+    render(
+      <EditableTableCollection
+        columns={columns}
+        source={createSource(vi.fn())}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(screen.getByText("Parent")).toBeInTheDocument())
+    await expandParent(user)
+
+    await user.click(screen.getByTitle("Select c1"))
+    await waitFor(() => expect(screen.getByTitle("Select c1")).toBeChecked())
+
+    const selectAllItems = await screen.findByRole("button", {
+      name: /select all/i,
+    })
+    await user.click(selectAllItems)
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Select c1")).toBeChecked()
+      expect(screen.getByTitle("Select c2")).toBeChecked()
+    })
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -23,6 +23,7 @@ import type { TableVisualizationType } from "@/patterns/OneDataCollection/types"
 import {
   GroupingDefinition,
   RecordType,
+  SelectionId,
   SortingsDefinition,
 } from "@/hooks/datasource"
 import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
@@ -98,6 +99,8 @@ export type RowProps<
   rowWrapper?: React.ComponentType<RowWrapperProps<R>>
   fromVisualization?: TableVisualizationType
   headerGroups: HeaderGroupEntry[] | null
+  registerSelectable?: (id: SelectionId, item: R) => void
+  unregisterSelectable?: (id: SelectionId) => void
 }
 
 const NestedRowContent = <

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react"
+import { forwardRef, useEffect } from "react"
 
 import type { IconType } from "@/components/F0Icon"
 import type { TableVisualizationType } from "@/patterns/OneDataCollection/types"
@@ -7,6 +7,7 @@ import { TableCell, TableRow } from "@/experimental/OneTable"
 import {
   GroupingDefinition,
   RecordType,
+  SelectionId,
   SortingsDefinition,
 } from "@/hooks/datasource"
 import { NestedVariant } from "@/hooks/datasource/types/nested.typings"
@@ -77,6 +78,8 @@ export type RowProps<
   rowWrapper?: React.ComponentType<RowWrapperProps<R>>
   fromVisualization?: TableVisualizationType
   headerGroups: HeaderGroupEntry[] | null
+  registerSelectable?: (id: SelectionId, item: R) => void
+  unregisterSelectable?: (id: SelectionId) => void
 }
 
 export type AddRowAction = {
@@ -144,6 +147,8 @@ const RowComponentInner = <
     rowWrapper,
     fromVisualization,
     headerGroups,
+    registerSelectable,
+    unregisterSelectable,
   }: RowProps<
     R,
     Filters,
@@ -192,6 +197,15 @@ const RowComponentInner = <
   const hasChildrenLoaded =
     nestedRowProps?.hasLoadedChildren === undefined ||
     nestedRowProps?.hasLoadedChildren
+
+  // Only the row that owns the rendered checkbox registers (not the one
+  // delegating to NestedRow), so each selectable id is registered once.
+  const willRenderOwnRow = !(rowWithChildren && hasChildrenLoaded)
+  useEffect(() => {
+    if (id === undefined || !willRenderOwnRow || !registerSelectable) return
+    registerSelectable(id, item)
+    return () => unregisterSelectable?.(id)
+  }, [id, item, willRenderOwnRow, registerSelectable, unregisterSelectable])
 
   if (rowWithChildren && hasChildrenLoaded) {
     return (

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -228,6 +228,8 @@ const RowComponentInner = <
         headerGroups={headerGroups}
         key={key}
         fromVisualization={fromVisualization}
+        registerSelectable={registerSelectable}
+        unregisterSelectable={unregisterSelectable}
       />
     )
   }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/SelectionRegistryProvider.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/SelectionRegistryProvider.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useMemo, useRef, useState } from "react"
+
+import { RecordType } from "@/hooks/datasource"
+import { SelectionId } from "@/hooks/datasource/types/selection.typings"
+
+export interface SelectionRegistryValue<R extends RecordType = RecordType> {
+  register: (id: SelectionId, item: R) => void
+  unregister: (id: SelectionId) => void
+  ids: SelectionId[]
+  getEntries: () => Array<[SelectionId, R]>
+}
+
+/**
+ * Tracks selectable rows currently rendered (including lazily-loaded nested
+ * children) so "select all" reaches rows absent from `data.records`.
+ */
+export const useCreateSelectionRegistry = <
+  R extends RecordType,
+>(): SelectionRegistryValue<R> => {
+  const entriesRef = useRef<Map<SelectionId, R>>(new Map())
+  const [ids, setIds] = useState<SelectionId[]>([])
+
+  const syncIds = useCallback(() => {
+    setIds(Array.from(entriesRef.current.keys()))
+  }, [])
+
+  const register = useCallback(
+    (id: SelectionId, item: R) => {
+      const isNew = !entriesRef.current.has(id)
+      entriesRef.current.set(id, item)
+      if (isNew) syncIds()
+    },
+    [syncIds]
+  )
+
+  const unregister = useCallback(
+    (id: SelectionId) => {
+      if (entriesRef.current.delete(id)) syncIds()
+    },
+    [syncIds]
+  )
+
+  const getEntries = useCallback(
+    () => Array.from(entriesRef.current.entries()),
+    []
+  )
+
+  return useMemo(
+    () => ({ register, unregister, ids, getEntries }),
+    [register, unregister, ids, getEntries]
+  )
+}


### PR DESCRIPTION
## BEFORE

https://github.com/user-attachments/assets/32555e18-2364-4bbc-b696-a43be4fba693



## AFTER

https://github.com/user-attachments/assets/e78afe7b-411c-4e9b-828a-d518ccc40442




## Problem

In nested/tree tables (`itemsWithChildren` + `fetchChildren`) the header **Select all** checkbox and the **Select all N items** banner did nothing — and clicking "Select all N items" could **wipe** the current selection.

Root cause: `useSelectable`'s select-all handlers iterated only `data.records`, which for a tree table holds just the top-level (often non-selectable) parent rows. The actual selectable rows are lazily-loaded children that never enter `data.records`, so select-all found nothing — and the "Select all N items" rebuild left an empty set.

Reported via the HC Planning "Employee sheet" (Jira **FCT-56547**), whose top-level rows are non-selectable `New headcount` / `Actual headcount` parents.

## Fix

A **selection registry** tracks every selectable row currently rendered, including loaded nested children. Each rendered selectable `Row` registers its `(id, item)` via props; `handleSelectAll` and `handleSelectAllItems` act on the registry (registry-first, `data.records` fallback) **additively**, so an existing selection is preserved rather than wiped. The master-checkbox state is also sourced from the registry.

### Known limitation
"Select all N items" can only select children that are **loaded** (expanded); unloaded children can't be added client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Implemented-with: factorial-firefighter