### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.2.0",
+  "packages/react": "4.3.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.3.0](https://github.com/factorialco/f0/compare/f0-react-v4.2.0...f0-react-v4.3.0) (2026-06-22)
+
+
+### Features
+
+* **hourDistribution:** per-datapoint neutralLabel for tooltip ([#4382](https://github.com/factorialco/f0/issues/4382)) ([09019e3](https://github.com/factorialco/f0/commit/09019e361d13818f9652e85c60bdb12eb873a0f3))
+
 ## [4.2.0](https://github.com/factorialco/f0/compare/f0-react-v4.1.0...f0-react-v4.2.0) (2026-06-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.3.0</summary>

## [4.3.0](https://github.com/factorialco/f0/compare/f0-react-v4.2.0...f0-react-v4.3.0) (2026-06-22)


### Features

* **hourDistribution:** per-datapoint neutralLabel for tooltip ([#4382](https://github.com/factorialco/f0/issues/4382)) ([09019e3](https://github.com/factorialco/f0/commit/09019e361d13818f9652e85c60bdb12eb873a0f3))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).