### PR TITLE
fix(value-display): fix categoryBarChart tooltip in clickable cells

### DIFF
--- a/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.mdx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.mdx
@@ -28,9 +28,27 @@ type value = {
 
 <Canvas of={CategoryBarChartStories.WorkLocation} />
 
+#### InsideClickableTableCell
+
+Replicates OneTable's cell mechanics (a `pointer-events-none` content wrapper plus a stretched navigation link). The chart segments re-enable pointer events so the tooltip opens on hover/focus while a click still navigates the row.
+
+<Canvas of={CategoryBarChartStories.InsideClickableTableCell} />
+
+#### DataCollectionExample
+
+The cell inside a OneDataCollection-like table with clickable rows: tooltips open on hover/focus while a click navigates the row.
+
+<Canvas of={CategoryBarChartStories.DataCollectionExample} />
+
 #### WithCustomColors
 
 <Canvas of={CategoryBarChartStories.WithCustomColors} />
+
+#### HiddenTooltip
+
+Set `hideTooltip: true` on the value to suppress the per-segment tooltip. Segments still render and stay focusable.
+
+<Canvas of={CategoryBarChartStories.HiddenTooltip} />
 
 #### Empty
 

--- a/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.stories.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.stories.tsx
@@ -1,6 +1,77 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
+import { useRef } from "react"
+
+import { cn } from "@/lib/utils"
 
 import { Cell, mockItem } from "../../../__stories__/shared"
+
+/**
+ * Replicates OneTable's TableCell mechanics: the content wrapper is
+ * `pointer-events-none` and a stretched link (`pointer-events-auto`) captures
+ * the row-navigation click, which the wrapper forwards via `onClick`. The chart
+ * segments re-enable pointer events so the tooltip still opens on hover/focus
+ * while a click still navigates the row.
+ */
+function ClickableTableCell({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  const linkRef = useRef<HTMLAnchorElement>(null)
+  return (
+    <div className={cn("relative", className)}>
+      <div
+        className="pointer-events-none relative z-[1]"
+        onClick={() => linkRef.current?.click()}
+      >
+        {children}
+      </div>
+      <a
+        ref={linkRef}
+        href="#row-navigation"
+        className="pointer-events-auto absolute inset-0 z-0 block"
+        aria-label="Open row"
+      />
+    </div>
+  )
+}
+
+const TEAM_ROWS = [
+  {
+    team: "Engineering",
+    dataPoints: [
+      { name: "Office", value: 15 },
+      { name: "Remote", value: 10 },
+      { name: "Hybrid", value: 5 },
+    ],
+  },
+  {
+    team: "Design",
+    dataPoints: [
+      { name: "Office", value: 6 },
+      { name: "Remote", value: 12 },
+      { name: "Hybrid", value: 2 },
+    ],
+  },
+  {
+    team: "Sales",
+    dataPoints: [
+      { name: "Office", value: 20 },
+      { name: "Remote", value: 3 },
+      { name: "Hybrid", value: 7 },
+    ],
+  },
+  {
+    team: "Customer Support",
+    dataPoints: [
+      { name: "Office", value: 4 },
+      { name: "Remote", value: 9 },
+      { name: "Hybrid", value: 9 },
+    ],
+  },
+]
 
 const meta = {
   title: "Value Display/CategoryBarChart",
@@ -10,10 +81,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Horizontal stacked proportional bar chart cell. Displays category distribution as colored segments with tooltip on hover. Mirrors the standalone CategoryBarChart kit but sized for table cells.",
-      },
-      source: {
-        code: null,
+          "Horizontal stacked proportional bar chart cell. Displays category distribution as colored segments with a tooltip on hover/focus. Mirrors the standalone CategoryBarChart kit but sized for table cells.\n\n- **Tooltip**: shown by default per segment (color dot + name + value/percentage). Set `hideTooltip: true` on the value to suppress it.\n- **Clickable cells**: inside OneDataCollection the cell sits in a `pointer-events-none` wrapper with a stretched navigation link. The bar segments re-enable pointer events so the tooltip still opens, while a click on the cell navigates the row.",
       },
     },
   },
@@ -39,6 +107,23 @@ export const GenderDistribution: Story = {
       }),
     },
   },
+  parameters: {
+    docs: {
+      source: {
+        code: `// No explicit colors → auto-assigned from the categorical palette by index
+{
+  type: "categoryBarChart",
+  value: {
+    dataPoints: [
+      { name: "Female", value: 12 },
+      { name: "Male", value: 8 },
+      { name: "Non-binary", value: 2 },
+    ],
+  },
+}`,
+      },
+    },
+  },
 }
 
 export const WorkLocation: Story = {
@@ -57,6 +142,148 @@ export const WorkLocation: Story = {
         },
       }),
     },
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `{
+  type: "categoryBarChart",
+  value: {
+    dataPoints: [
+      { name: "Office", value: 15 },
+      { name: "Remote", value: 10 },
+      { name: "Hybrid", value: 5 },
+    ],
+  },
+}`,
+      },
+    },
+  },
+}
+
+export const InsideClickableTableCell: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Work location",
+      render: () => ({
+        type: "categoryBarChart",
+        value: {
+          dataPoints: [
+            { name: "Office", value: 15 },
+            { name: "Remote", value: 10 },
+            { name: "Hybrid", value: 5 },
+          ],
+        },
+      }),
+    },
+  },
+  decorators: [
+    (Story) => (
+      <ClickableTableCell className="w-72 rounded border border-solid border-f1-border-secondary p-2">
+        <Story />
+      </ClickableTableCell>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**Clickable cell**: the cell content sits in a `pointer-events-none` wrapper with a stretched navigation link on top (OneTable's pattern). Because the bar segments set `pointer-events-auto`, the tooltip still opens on hover/focus, while clicking anywhere in the cell navigates the row (here `#row-navigation`). This is what makes the tooltip work inside OneDataCollection rows.",
+      },
+      source: {
+        code: `// OneTable cell wrapper: content is pointer-events-none, a stretched
+// <Link> captures the row click. The bar segments use pointer-events-auto
+// (see categoryBarChart.tsx), so the tooltip opens AND the click navigates.
+<div className="relative">
+  <div className="pointer-events-none" onClick={() => linkRef.current?.click()}>
+    {/* categoryBarChart cell */}
+  </div>
+  <a ref={linkRef} href={rowHref} className="pointer-events-auto absolute inset-0" />
+</div>`,
+      },
+    },
+  },
+}
+
+type DataCollectionArgs = {
+  /** When true, wrap each cell in OneTable's clickable mechanics. */
+  clickableCells: boolean
+}
+
+export const DataCollectionExample: StoryObj<DataCollectionArgs> = {
+  args: {
+    clickableCells: true,
+  },
+  argTypes: {
+    clickableCells: {
+      name: "Clickable cells",
+      control: "boolean",
+      description:
+        "Wrap each cell in OneTable's clickable mechanics (pointer-events-none content + stretched navigation link). When off, the cells are plain (no row navigation), which is how the tooltip behaves outside OneDataCollection.",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The categoryBarChart cell inside a OneDataCollection-like table. Use the **Clickable cells** control to toggle OneTable's clickable mechanics: when on, hovering/focusing a segment opens the tooltip while clicking the cell navigates the row; when off, the cells are plain. Toggle light/dark in the toolbar to check the tooltip in both themes.",
+      },
+      source: {
+        code: `// Each row renders a categoryBarChart cell. The \`clickableCells\` flag
+// toggles OneTable's clickable wrapper (pointer-events + stretched link).
+const value = {
+  type: "categoryBarChart",
+  value: {
+    dataPoints: [
+      { name: "Office", value: 15 },
+      { name: "Remote", value: 10 },
+      { name: "Hybrid", value: 5 },
+    ],
+  },
+}`,
+      },
+    },
+  },
+  render: ({ clickableCells }) => {
+    const wrap = (node: React.ReactNode) =>
+      clickableCells ? <ClickableTableCell>{node}</ClickableTableCell> : node
+    return (
+      <table className="w-full max-w-2xl border-collapse text-sm">
+        <thead>
+          <tr className="border-0 border-b border-solid border-f1-border-secondary text-left text-f1-foreground-secondary">
+            <th className="py-2 pr-4 font-medium">Team</th>
+            <th className="py-2 font-medium">Work location</th>
+          </tr>
+        </thead>
+        <tbody>
+          {TEAM_ROWS.map((row) => (
+            <tr
+              key={row.team}
+              className="border-0 border-b border-solid border-f1-border-secondary hover:bg-f1-background-hover"
+            >
+              <td className="py-3 pr-4 align-middle text-f1-foreground">
+                {wrap(row.team)}
+              </td>
+              <td className="w-1/2 py-3 align-middle">
+                {wrap(
+                  <Cell
+                    item={mockItem}
+                    property={{
+                      label: "Work location",
+                      render: () => ({
+                        type: "categoryBarChart",
+                        value: { dataPoints: row.dataPoints },
+                      }),
+                    }}
+                  />
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
   },
 }
 
@@ -77,6 +304,63 @@ export const WithCustomColors: Story = {
       }),
     },
   },
+  parameters: {
+    docs: {
+      source: {
+        code: `{
+  type: "categoryBarChart",
+  value: {
+    dataPoints: [
+      { name: "A", value: 40, color: "categorical-1" },
+      { name: "B", value: 30, color: "categorical-3" },
+      { name: "C", value: 20, color: "categorical-5" },
+    ],
+  },
+}`,
+      },
+    },
+  },
+}
+
+export const HiddenTooltip: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Work location",
+      render: () => ({
+        type: "categoryBarChart",
+        value: {
+          hideTooltip: true,
+          dataPoints: [
+            { name: "Office", value: 15 },
+            { name: "Remote", value: 10 },
+            { name: "Hybrid", value: 5 },
+          ],
+        },
+      }),
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**Tooltip flag**: tooltips are on by default. Set `hideTooltip: true` to suppress them — segments still render and stay focusable, but no tooltip opens on hover/focus. Useful when the surrounding UI already explains the values, or to avoid tooltip noise in dense tables.",
+      },
+      source: {
+        code: `{
+  type: "categoryBarChart",
+  value: {
+    hideTooltip: true, // segments render, but no tooltip on hover/focus
+    dataPoints: [
+      { name: "Office", value: 15 },
+      { name: "Remote", value: 10 },
+      { name: "Hybrid", value: 5 },
+    ],
+  },
+}`,
+      },
+    },
+  },
 }
 
 export const SingleCategory: Story = {
@@ -92,6 +376,18 @@ export const SingleCategory: Story = {
       }),
     },
   },
+  parameters: {
+    docs: {
+      source: {
+        code: `{
+  type: "categoryBarChart",
+  value: {
+    dataPoints: [{ name: "Only one", value: 100 }],
+  },
+}`,
+      },
+    },
+  },
 }
 
 export const Empty: Story = {
@@ -105,6 +401,19 @@ export const Empty: Story = {
           dataPoints: [],
         },
       }),
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Empty `dataPoints` renders a fallback dash (`–`).",
+      },
+      source: {
+        code: `{
+  type: "categoryBarChart",
+  value: { dataPoints: [] }, // renders a fallback dash
+}`,
+      },
     },
   },
 }

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.test.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.test.tsx
@@ -125,6 +125,23 @@ describe("CategoryBarChartCell", () => {
     ).toBeInTheDocument()
   })
 
+  it("enables pointer events on segments so the tooltip works inside a clickable table cell", () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [
+        { name: "Female", value: 12 },
+        { name: "Male", value: 8 },
+      ],
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    const segments = container.querySelectorAll('[role="img"][aria-label*="%"]')
+    expect(segments.length).toBeGreaterThan(0)
+    segments.forEach((segment) => {
+      expect(segment).toHaveClass("pointer-events-auto")
+    })
+  })
+
   it("handles duplicate names with unique keys", () => {
     const args: CategoryBarChartCellValue = {
       dataPoints: [

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
@@ -82,7 +82,7 @@ export const CategoryBarChartCell = (
             return (
               <Tooltip key={`${point.name}-${index}`}>
                 <TooltipTrigger
-                  className="h-full cursor-default overflow-hidden rounded-2xs"
+                  className="pointer-events-auto h-full cursor-default overflow-hidden rounded-2xs"
                   style={{ width: `${percentage}%` }}
                   asChild
                 >
@@ -97,13 +97,13 @@ export const CategoryBarChartCell = (
                 {!args.hideTooltip && (
                   <TooltipContent className="flex items-center gap-1 text-sm">
                     <div
-                      className="h-2.5 w-2.5 shrink-0 translate-y-px rounded-full"
+                      className="h-2.5 w-2.5 shrink-0 rounded-full"
                       style={{ backgroundColor: color }}
                     />
-                    <span className="pl-0.5 pr-2 text-f1-foreground-inverse-secondary dark:text-f1-foreground-secondary">
+                    <span className="pl-0.5 pr-2 text-f1-foreground-inverse-secondary">
                       {point.name}
                     </span>
-                    <span className="font-mono font-medium tabular-nums text-f1-foreground-inverse dark:text-f1-foreground">
+                    <span className="font-mono font-medium tabular-nums text-f1-foreground-inverse">
                       {point.value} ({formatPercentage(point.value, total)}%)
                     </span>
                   </TooltipContent>


### PR DESCRIPTION
## Description

The `categoryBarChart` value-display cell tooltip did not open inside OneDataCollection rows, because OneTable wraps cell content in a `pointer-events-none` element with a stretched navigation link, so the bar segments never received hover/focus. This makes the tooltip work again inside clickable cells (while a click still navigates the row), refines the tooltip colors to use the inverse foreground tokens directly, vertically centers the color dot, and documents the tooltip and clickable-cell behaviour in Storybook.

## Screenshots (if applicable)

**Tooltip — light mode:**

<img width="477" height="361" alt="image" src="https://github.com/user-attachments/assets/296bd49f-49c5-4890-adb1-107fe4008c5f" />

**Tooltip -- darkmode.**

<img width="477" height="361" alt="image" src="https://github.com/user-attachments/assets/fae6bdff-ccda-4a8b-9abf-cfb74641afe8" />

**Tooltip inside a clickable cell (DataCollectionExample):**

<img width="467" height="328" alt="image" src="https://github.com/user-attachments/assets/04d16b1b-8e57-4efe-a654-57bfedc913c4" />

## Implementation details

- fix: add `pointer-events-auto` to the bar segment trigger so the tooltip opens inside OneTable's `pointer-events-none` cell wrapper, matching the newer `Overlays/Tooltip` pattern; clicking the cell still navigates the row
- fix: vertically center the tooltip color dot (drop the `translate-y-px` nudge; rely on `items-center`)
- refactor: use the inverse foreground tokens directly for the tooltip text (`text-f1-foreground-inverse` / `-inverse-secondary`), dropping the dead `dark:` overrides that never applied under the tooltip's forced-dark surface
- test: assert segments expose `pointer-events-auto`
- docs: restore the per-story "Show code" snippets (the meta nulled them out) and document the `hideTooltip` flag and clickable-cell behaviour
- docs: add `InsideClickableTableCell`, `DataCollectionExample` (with a `clickableCells` toggle) and `HiddenTooltip` stories


---


## Edited: 
To fix old screenshots