### PR TITLE
fix(EditableTable): fade disabled cell text (FCT-56243)

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -336,6 +336,53 @@ export const EditableTableWithEditableCallback: Story = {
   },
 }
 
+export const EditableTableWithDisabledCells: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Disabled cells (`editType: () => 'disabled'`) render with the disabled background and secondary foreground color, so they read as inactive (FCT-56243). Here the Role column is disabled; Email stays editable for contrast.",
+      },
+    },
+  },
+  render: () => {
+    const mockVisualizations = getMockVisualizations()
+    const { dataAdapter, onCellChange } = useEditableTableData()
+
+    const baseOptions = (
+      mockVisualizations.editableTable as Extract<
+        typeof mockVisualizations.editableTable,
+        { type: "editableTable" }
+      >
+    ).options
+
+    return (
+      <ExampleComponent
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              ...baseOptions,
+              columns: baseOptions.columns.map((col) => {
+                if (col.editType !== undefined && col.id === "role") {
+                  return {
+                    ...col,
+                    editType: () => "disabled" as const,
+                  }
+                }
+                return col
+              }),
+              onCellChange,
+            },
+          },
+        ]}
+        dataAdapter={dataAdapter}
+        id="editable-table-disabled-cells/v1"
+      />
+    )
+  },
+}
+
 export const EditableTableWithColumnReordering: Story = {
   parameters: {
     docs: {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
@@ -20,7 +20,8 @@ export function DisabledCell<R extends RecordType>({
           editableColumn.align === "right" ? "justify-end" : "",
           "flex p-4 min-h-12 items-center border-0 h-full",
           "bg-f1-background-disabled h-full",
-          "w-full"
+          "w-full",
+          "[&_*]:text-f1-foreground-secondary"
         )}
       >
         {renderProperty(item, editableColumn, "editableTable", i18n)}


### PR DESCRIPTION

<img width="1264" height="544" alt="Screenshot 2026-06-23 at 11 10 56 AM" src="https://github.com/user-attachments/assets/d0f46988-489d-4694-9685-204f5f832bba" />


## 🚪 Why?

### Problem
Disabled cells in the editable table rendered their text in the same full-strength color as editable cells, so a disabled cell was visually indistinguishable from an editable one.

## 🔑 What?
- Disabled cells now render their value in the secondary foreground (`text-f1-foreground-secondary`) alongside the existing disabled background, so they read as inactive.
- Added a Storybook story (`EditableTableWithDisabledCells`) showcasing the disabled-cell appearance.



## 🏡 Context
- [💼 Jira](https://factorialmakers.atlassian.net/browse/FCT-56243)

## 🏷️ Skill tags
`skill:frontend`
