### PR TITLE
feat(ai): welcome cards + suggestions above composer

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
@@ -40,6 +40,7 @@ const F0AiChatProviderComponent = ({
   chatMessages,
   chatInput,
   welcomeScreenSuggestions,
+  welcomeScreenCards,
   disclaimer,
   resizable = false,
   defaultVisualizationMode,
@@ -72,6 +73,7 @@ const F0AiChatProviderComponent = ({
       chatMessages={chatMessages}
       chatInput={chatInput}
       welcomeScreenSuggestions={welcomeScreenSuggestions}
+      welcomeScreenCards={welcomeScreenCards}
       disclaimer={disclaimer}
       resizable={resizable}
       defaultVisualizationMode={defaultVisualizationMode}

--- a/packages/react/src/sds/ai/F0AiChat/__stories__/_mock/MockConnectedChatInput.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/_mock/MockConnectedChatInput.tsx
@@ -33,6 +33,7 @@ export const MockConnectedChatInput = () => {
     visualizationMode,
     creditWarning,
     welcomeScreenSuggestions,
+    welcomeScreenCards,
     tracking,
     openGame,
   } = useAiChat()
@@ -70,6 +71,13 @@ export const MockConnectedChatInput = () => {
     [sendMessage, tracking]
   )
 
+  const handleCardSelect = useCallback(
+    (message: string) => {
+      sendMessage(message)
+    },
+    [sendMessage]
+  )
+
   return (
     <F0AiChatTextArea
       ref={containerRef}
@@ -91,6 +99,8 @@ export const MockConnectedChatInput = () => {
       fullscreen={fullscreen}
       welcomeScreenSuggestions={welcomeScreenSuggestions}
       onSuggestionClick={handleSuggestionClick}
+      welcomeScreenCards={welcomeScreenCards}
+      onCardSelect={handleCardSelect}
     />
   )
 }

--- a/packages/react/src/sds/ai/F0AiChat/index.ts
+++ b/packages/react/src/sds/ai/F0AiChat/index.ts
@@ -24,6 +24,7 @@ export type {
   DashboardCanvasContent,
   DataDownloadCanvasContent,
   F0AIMessage,
+  F0AiChatWelcomeCard,
   F0Message,
   F0ToolCall,
   FormCanvasContent,

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -17,8 +17,8 @@ import {
   type PendingQuote,
   type TranscribeFn,
   type VisualizationMode,
-  F0AiChatWelcomeCard,
-  WelcomeScreenSuggestion,
+  type F0AiChatWelcomeCard,
+  type WelcomeScreenSuggestion,
 } from "./types"
 
 /**

--- a/packages/react/src/sds/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/internal-types.ts
@@ -17,6 +17,7 @@ import {
   type PendingQuote,
   type TranscribeFn,
   type VisualizationMode,
+  F0AiChatWelcomeCard,
   WelcomeScreenSuggestion,
 } from "./types"
 
@@ -33,6 +34,7 @@ export interface AiChatState {
   chatMessages?: React.ReactNode
   chatInput?: React.ReactNode
   welcomeScreenSuggestions?: WelcomeScreenSuggestion[]
+  welcomeScreenCards?: F0AiChatWelcomeCard[]
   disclaimer?: AiChatDisclaimer
   resizable?: boolean
   defaultVisualizationMode?: VisualizationMode
@@ -83,6 +85,10 @@ export type AiChatProviderReturnValue = {
   welcomeScreenSuggestions: WelcomeScreenSuggestion[]
   setWelcomeScreenSuggestions: React.Dispatch<
     React.SetStateAction<WelcomeScreenSuggestion[]>
+  >
+  welcomeScreenCards: F0AiChatWelcomeCard[]
+  setWelcomeScreenCards: React.Dispatch<
+    React.SetStateAction<F0AiChatWelcomeCard[]>
   >
   onThumbsUp?: (
     message: F0AIMessage,

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -15,15 +15,15 @@ import {
 
 import { useI18n } from "@/lib/providers/i18n"
 
-import { AiChatProviderReturnValue, AiChatState } from "../internal-types"
+import type { AiChatProviderReturnValue, AiChatState } from "../internal-types"
 import {
   type AiChatMode,
   type CanvasContent,
   type PendingContext,
   type PendingQuote,
   type VisualizationMode,
-  F0AiChatWelcomeCard,
-  WelcomeScreenSuggestion,
+  type F0AiChatWelcomeCard,
+  type WelcomeScreenSuggestion,
 } from "../types"
 import { DEFAULT_CHAT_WIDTH } from "../utils/constants"
 

--- a/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -22,6 +22,7 @@ import {
   type PendingContext,
   type PendingQuote,
   type VisualizationMode,
+  F0AiChatWelcomeCard,
   WelcomeScreenSuggestion,
 } from "../types"
 import { DEFAULT_CHAT_WIDTH } from "../utils/constants"
@@ -57,6 +58,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   chatMessages,
   chatInput,
   welcomeScreenSuggestions: initialWelcomeScreenSuggestions = [],
+  welcomeScreenCards: initialWelcomeScreenCards = [],
   disclaimer,
   resizable = false,
   defaultVisualizationMode = "sidepanel",
@@ -114,6 +116,9 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   const [welcomeScreenSuggestions, setWelcomeScreenSuggestions] = useState<
     WelcomeScreenSuggestion[]
   >(initialWelcomeScreenSuggestions)
+  const [welcomeScreenCards, setWelcomeScreenCards] = useState<
+    F0AiChatWelcomeCard[]
+  >(initialWelcomeScreenCards)
   const i18n = useI18n()
   const [placeholders, setPlaceholders] = useState<string[]>([
     i18n.t("ai.inputPlaceholder"),
@@ -262,6 +267,8 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         chatInput,
         welcomeScreenSuggestions,
         setWelcomeScreenSuggestions,
+        welcomeScreenCards,
+        setWelcomeScreenCards,
         onThumbsUp,
         onThumbsDown,
         placeholders,
@@ -358,6 +365,7 @@ const REAL_VALUES: Partial<AiChatProviderReturnValue> = {
   shouldPlayEntranceAnimation: true,
   placeholders: [],
   welcomeScreenSuggestions: [],
+  welcomeScreenCards: [],
 }
 
 const NO_PROVIDER_CONTEXT = new Proxy({} as AiChatProviderReturnValue, {

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -294,6 +294,11 @@ export type AiChatProviderProps = {
    */
   initialMessage?: string | string[]
   welcomeScreenSuggestions?: WelcomeScreenSuggestion[]
+  /**
+   * Action/prompt cards rendered below the composer on the fullscreen welcome
+   * screen. The chat owns layout and, for prompt cards, the send.
+   */
+  welcomeScreenCards?: F0AiChatWelcomeCard[]
   disclaimer?: AiChatDisclaimer
   /**
    * Enable resizable chat window
@@ -423,6 +428,29 @@ export type WelcomeScreenSuggestion = {
   icon: IconType
   label: string
   items: WelcomeScreenSuggestionItem[]
+}
+
+/**
+ * A card shown below the composer on the fullscreen welcome screen, rendered
+ * as an `F0CardHorizontal`. Two kinds:
+ * - **Prompt cards** carry a `message` the chat sends when the card is clicked.
+ * - **Action cards** carry an `onClick` (e.g. open a dialog) which takes
+ *   precedence over `message`.
+ *
+ * Data-driven and runtime-agnostic — the chat owns the layout and, for prompt
+ * cards, the send.
+ */
+export type F0AiChatWelcomeCard = {
+  icon: IconType
+  title: string
+  description?: string
+  /** Prompt cards: the message the chat sends when the card is clicked. */
+  message?: string
+  /**
+   * Action cards: custom click handler (e.g. open a dialog). Takes precedence
+   * over `message` when both are present.
+   */
+  onClick?: () => void
 }
 
 /**

--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -16,6 +16,7 @@ import { CreditWarningWrapper } from "./components/CreditWarningWrapper"
 import { MentionPopover } from "./components/MentionPopover"
 import { PendingQuoteChip } from "./components/PendingQuoteChip"
 import { TextareaField } from "./components/TextareaField"
+import { WelcomeScreenCardsRow } from "./components/WelcomeScreenCardsRow"
 import { WelcomeScreenSuggestionsRow } from "./components/WelcomeScreenSuggestionsRow"
 import type {
   WelcomeScreenSuggestion,
@@ -81,6 +82,8 @@ export const F0AiChatTextArea = ({
   fullscreen = false,
   welcomeScreenSuggestions,
   onSuggestionClick,
+  welcomeScreenCards,
+  onCardSelect,
   ref,
 }: F0AiChatTextAreaProps) => {
   const translation = useI18n()
@@ -326,9 +329,9 @@ export const F0AiChatTextArea = ({
   const hasOverlay =
     mentions.mentions.length > 0 || mentions.inlineCompletion !== null
 
-  // Welcome suggestions row. On the welcome screen it sits above the textarea
-  // in sidepanel and below it in fullscreen (so the popover can open downward
-  // without covering the composer).
+  // Welcome suggestions row. On the welcome screen it always sits above the
+  // textarea (both sidepanel and fullscreen); the popover opens upward so it
+  // doesn't cover the composer.
   const showSuggestions =
     isWelcomeScreen &&
     !!welcomeScreenSuggestions &&
@@ -340,9 +343,18 @@ export const F0AiChatTextArea = ({
       suggestions={welcomeScreenSuggestions}
       onItemClick={handleSuggestionClick}
       onItemHover={setHoveredSuggestion}
-      side={fullscreen ? "bottom" : "top"}
+      side="top"
     />
   ) : null
+
+  // Welcome cards sit below the composer on the fullscreen welcome screen
+  // (same gate the footer slot uses). Prompt cards send their message through
+  // `onCardSelect`; action cards run their own `onClick`.
+  const showWelcomeCards =
+    isWelcomeScreen &&
+    fullscreen &&
+    !!welcomeScreenCards &&
+    welcomeScreenCards.length > 0
 
   const isFullscreenWelcome = fullscreen && isWelcomeScreen
 
@@ -368,7 +380,7 @@ export const F0AiChatTextArea = ({
       {...(fullscreen ? composerReveal : {})}
     >
       <div className="flex w-full max-w-content flex-col gap-2">
-        {suggestionsRow && !fullscreen && <div>{suggestionsRow}</div>}
+        {suggestionsRow && <div>{suggestionsRow}</div>}
         <CreditWarningWrapper creditWarning={creditWarning}>
           <motion.form
             aria-busy={inProgress}
@@ -550,8 +562,13 @@ export const F0AiChatTextArea = ({
         </CreditWarningWrapper>
       </div>
 
-      {suggestionsRow && fullscreen && (
-        <div className="w-full max-w-content">{suggestionsRow}</div>
+      {showWelcomeCards && (
+        <div className="w-full max-w-content pt-2">
+          <WelcomeScreenCardsRow
+            cards={welcomeScreenCards}
+            onCardSelect={onCardSelect}
+          />
+        </div>
       )}
 
       {footer && isWelcomeScreen && fullscreen && (

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react"
 import { F0AiChatTextArea } from "../F0AiChatTextArea"
 import type { F0AiChatTextAreaSubmitPayload } from "../types"
 
+import { File, Marketplace } from "@/icons/app"
 import { mockTranscribe } from "@/lib/storybook-utils/ai-mocks"
 
 import { F0ClarifyingPanel } from "../../F0ClarifyingPanel"
@@ -12,6 +13,7 @@ import type {
   AiChatCreditWarning,
   AiChatDisclaimer,
   AiChatFileAttachmentConfig,
+  F0AiChatWelcomeCard,
   PendingContext,
   PendingQuote,
   PersonProfile,
@@ -91,6 +93,21 @@ const CREDIT_WARNING: AiChatCreditWarning = {
   onDismiss: () => console.log("dismiss clicked"),
 }
 
+const WELCOME_CARDS: F0AiChatWelcomeCard[] = [
+  {
+    icon: File,
+    title: "Empty survey",
+    description: "Start from scratch",
+    message: "Create an empty survey.",
+  },
+  {
+    icon: Marketplace,
+    title: "Templates",
+    description: "Browse pre-made surveys",
+    onClick: () => console.log("open templates"),
+  },
+]
+
 const noop = () => {}
 
 const buildClarifyingState = (
@@ -135,6 +152,7 @@ type WrapperProps = {
   creditWarning?: AiChatCreditWarning
   disclaimer?: AiChatDisclaimer
   footer?: React.ReactNode
+  welcomeScreenCards?: F0AiChatWelcomeCard[]
   isWelcomeScreen?: boolean
   fullscreen?: boolean
   inProgress?: boolean
@@ -151,6 +169,7 @@ const Wrapper = ({
   creditWarning,
   disclaimer,
   footer,
+  welcomeScreenCards,
   isWelcomeScreen,
   fullscreen,
   inProgress,
@@ -194,6 +213,13 @@ const Wrapper = ({
         searchPersons={searchPersons}
         disclaimer={disclaimer}
         footer={footer}
+        welcomeScreenCards={welcomeScreenCards}
+        onCardSelect={(message) =>
+          setSubmissions((prev) => [
+            ...prev,
+            { text: message, files: [], context: null, quote: null },
+          ])
+        }
         isWelcomeScreen={isWelcomeScreen}
         fullscreen={fullscreen}
       />
@@ -308,6 +334,15 @@ export const FullscreenWelcome: Story = {
         Powered by Factorial AI · v0.1.0
       </p>
     ),
+  },
+}
+
+export const WithWelcomeCards: Story = {
+  args: {
+    isWelcomeScreen: true,
+    fullscreen: true,
+    welcomeScreenCards: WELCOME_CARDS,
+    disclaimer: DISCLAIMER,
   },
 }
 

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.welcomeLayout.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.welcomeLayout.test.tsx
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { ChartVerticalBars } from "@/icons/app"
+import { ChartVerticalBars, File } from "@/icons/app"
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
-import { type WelcomeScreenSuggestion } from "../../F0AiChat/types"
+import {
+  type F0AiChatWelcomeCard,
+  type WelcomeScreenSuggestion,
+} from "../../F0AiChat/types"
 
 vi.mock("../components/TextareaField", () => ({
   TextareaField: () => <textarea aria-label="Message" readOnly />,
@@ -39,7 +42,7 @@ describe("F0AiChatTextArea welcome suggestions placement", () => {
     ).toBeTruthy()
   })
 
-  it("renders the suggestions below the textarea in fullscreen mode", () => {
+  it("renders the suggestions above the textarea in fullscreen mode", () => {
     render(
       <F0AiChatTextArea
         onSubmit={() => {}}
@@ -52,11 +55,49 @@ describe("F0AiChatTextArea welcome suggestions placement", () => {
 
     const trigger = screen.getByRole("button", { name: /analyze/i })
     const textarea = screen.getByRole("textbox", { name: "Message" })
-    // trigger follows the textarea in document order → suggestions are below.
+    // textarea follows the trigger in document order → suggestions are above.
     expect(
-      textarea.compareDocumentPosition(trigger) &
+      trigger.compareDocumentPosition(textarea) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
+  })
+
+  it("renders welcome cards below the textarea on the fullscreen welcome screen", () => {
+    const cards: F0AiChatWelcomeCard[] = [
+      { icon: File, title: "Empty survey", message: "Create an empty survey." },
+    ]
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        fullscreen
+        isWelcomeScreen
+        welcomeScreenCards={cards}
+        onCardSelect={() => {}}
+      />
+    )
+
+    const textarea = screen.getByRole("textbox", { name: "Message" })
+    const card = screen.getByText("Empty survey")
+    // card follows the textarea in document order → cards are below.
+    expect(
+      textarea.compareDocumentPosition(card) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it("does not render welcome cards on the sidepanel welcome screen", () => {
+    const cards: F0AiChatWelcomeCard[] = [
+      { icon: File, title: "Empty survey", message: "Create an empty survey." },
+    ]
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenCards={cards}
+        onCardSelect={() => {}}
+      />
+    )
+
+    expect(screen.queryByText("Empty survey")).not.toBeInTheDocument()
   })
 
   it("hides the footer on the sidepanel welcome screen", () => {

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/WelcomeScreenCardsRow.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/WelcomeScreenCardsRow.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
+
+import { File, Marketplace } from "@/icons/app"
+
+import { type F0AiChatWelcomeCard } from "../../F0AiChat/types"
+import { WelcomeScreenCardsRow } from "../components/WelcomeScreenCardsRow"
+
+const clickCard = async (title: string) => {
+  const card = screen.getByText(title).closest('[data-testid="card"]')
+  expect(card).not.toBeNull()
+  await userEvent.click(card as HTMLElement)
+}
+
+describe("WelcomeScreenCardsRow", () => {
+  it("renders every card's title and description", () => {
+    const cards: F0AiChatWelcomeCard[] = [
+      {
+        icon: File,
+        title: "Empty survey",
+        description: "Start from scratch",
+        message: "Create an empty survey.",
+      },
+      {
+        icon: Marketplace,
+        title: "Templates",
+        description: "Browse pre-made surveys",
+        message: "Show me the survey templates.",
+      },
+    ]
+
+    render(<WelcomeScreenCardsRow cards={cards} onCardSelect={vi.fn()} />)
+
+    expect(screen.getByText("Empty survey")).toBeInTheDocument()
+    expect(screen.getByText("Start from scratch")).toBeInTheDocument()
+    expect(screen.getByText("Templates")).toBeInTheDocument()
+    expect(screen.getByText("Browse pre-made surveys")).toBeInTheDocument()
+  })
+
+  it("calls onCardSelect with the message when a prompt card is clicked", async () => {
+    const onCardSelect = vi.fn()
+    const cards: F0AiChatWelcomeCard[] = [
+      { icon: File, title: "Empty survey", message: "Create an empty survey." },
+    ]
+
+    render(<WelcomeScreenCardsRow cards={cards} onCardSelect={onCardSelect} />)
+    await clickCard("Empty survey")
+
+    expect(onCardSelect).toHaveBeenCalledTimes(1)
+    expect(onCardSelect).toHaveBeenCalledWith("Create an empty survey.")
+  })
+
+  it("calls onClick (not onCardSelect) when an action card is clicked", async () => {
+    const onCardSelect = vi.fn()
+    const onClick = vi.fn()
+    const cards: F0AiChatWelcomeCard[] = [
+      {
+        icon: Marketplace,
+        title: "Templates",
+        message: "ignored when onClick is present",
+        onClick,
+      },
+    ]
+
+    render(<WelcomeScreenCardsRow cards={cards} onCardSelect={onCardSelect} />)
+    await clickCard("Templates")
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onCardSelect).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChatTextArea/components/WelcomeScreenCardsRow.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/components/WelcomeScreenCardsRow.tsx
@@ -1,0 +1,45 @@
+import { F0CardHorizontal } from "@/experimental/F0CardHorizontal"
+
+import type { F0AiChatWelcomeCard } from "../../F0AiChat/types"
+
+export type WelcomeScreenCardsRowProps = {
+  cards: F0AiChatWelcomeCard[]
+  /**
+   * Fired with a prompt card's `message` when it's clicked. Action cards (with
+   * their own `onClick`) bypass this — `onClick` takes precedence.
+   */
+  onCardSelect?: (message: string) => void
+}
+
+/**
+ * Grid of action/prompt cards shown below the composer on the fullscreen
+ * welcome screen, rendered with `F0CardHorizontal`. Prompt cards (with a
+ * `message`) call `onCardSelect`; action cards run their own `onClick`, which
+ * takes precedence when both are present.
+ */
+export const WelcomeScreenCardsRow = ({
+  cards,
+  onCardSelect,
+}: WelcomeScreenCardsRowProps) => {
+  if (cards.length === 0) return null
+
+  return (
+    <div className="grid w-full grid-cols-2 gap-3">
+      {cards.map((card) => (
+        <F0CardHorizontal
+          key={card.title}
+          avatar={{ type: "icon", icon: card.icon }}
+          title={card.title}
+          description={card.description}
+          onClick={() => {
+            if (card.onClick) {
+              card.onClick()
+            } else if (card.message) {
+              onCardSelect?.(card.message)
+            }
+          }}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/react/src/sds/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -45,9 +45,10 @@ export type WelcomeScreenSuggestionsRowProps = {
    */
   onItemHover?: (item: WelcomeScreenSuggestionItem | null) => void
   /**
-   * Side the popover opens towards. Defaults to "top" (sidepanel, row sits
-   * above the textarea). Fullscreen passes "bottom" so the popover opens into
-   * the empty space below the textarea instead of covering it.
+   * Side the popover opens towards. Defaults to "top" — the row sits above the
+   * textarea, so the popover opens upward into the empty space rather than
+   * covering the composer. "bottom" remains available for layouts that place
+   * the row below the textarea.
    */
   side?: "top" | "bottom"
 }

--- a/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
@@ -9,6 +9,7 @@ import type {
   PersonProfile,
   TranscribeFn,
   UploadedFile,
+  F0AiChatWelcomeCard,
   WelcomeScreenSuggestion,
   WelcomeScreenSuggestionItem,
 } from "../F0AiChat/types"
@@ -136,10 +137,22 @@ export type F0AiChatTextAreaProps = {
   ) => void
 
   /**
+   * Action/prompt cards rendered as a grid below the composer on the
+   * fullscreen welcome screen. Prompt cards (with a `message`) call
+   * `onCardSelect`; action cards (with an `onClick`) run their own handler.
+   */
+  welcomeScreenCards?: F0AiChatWelcomeCard[]
+  /**
+   * Called with a prompt card's `message` when it's clicked. Wire this to the
+   * chat's send. Action cards bypass it via their own `onClick`.
+   */
+  onCardSelect?: (message: string) => void
+
+  /**
    * When true on the welcome screen, the composer adopts the fullscreen
    * layout: the input slot grows to claim the bottom half (so the textarea
-   * rises toward the vertical center), and the welcome suggestions render
-   * below the textarea with their popover opening downward (instead of above).
+   * rises toward the vertical center) and the welcome cards render below it.
+   * The welcome suggestions row sits above the composer in both layouts.
    */
   fullscreen?: boolean
 }


### PR DESCRIPTION
## Description

Combines #4534 and #4537 into a single change and drops the standalone `F0AiChatWelcomeCards` component. Welcome cards are now a first-class, data-driven feature of the chat: callers pass a `welcomeScreenCards` array (symmetric with `welcomeScreenSuggestions`) and the chat owns the layout and — for prompt cards — the send, instead of hand-wiring a component through the generic `footer` slot. The welcome suggestions row now also always renders above the composer, so its popover opens upward into empty space rather than covering the input. Supersedes #4534 and #4537.

## Screenshots (if applicable)

Welcome cards below the composer (fullscreen welcome screen):

<img width="852" alt="welcome cards" src="https://github.com/user-attachments/assets/c2c644ba-9682-4692-a91c-6c199a9b16ef" />

Suggestions row above the composer:

<img width="766" alt="suggestions above the composer" src="https://github.com/user-attachments/assets/a39d8c20-ade2-434b-a020-25f7778c7604" />

## Implementation details

- feat: add `welcomeScreenCards` to the F0AiChat provider + the `F0AiChatWelcomeCard` type, threaded through to `F0AiChatTextArea` (mirrors the existing `welcomeScreenSuggestions` pattern)
- feat: render welcome cards from data via a new internal `WelcomeScreenCardsRow`, shown below the composer on the fullscreen welcome screen — prompt cards send their `message`, action cards run their own `onClick` (which takes precedence)
- refactor: drop the standalone `F0AiChatWelcomeCards` component; cards are no longer hand-wired through the generic `footer` slot (which stays available for legal / powered-by content)
- refactor: always render the welcome suggestions row above the composer with the popover opening upward; drop the fullscreen "below" branch
- test: unit tests for `WelcomeScreenCardsRow` (prompt-card select, action-card precedence, rendering) and welcome-layout placement (cards below in fullscreen, absent in sidepanel)
- docs: add a `WithWelcomeCards` story to `F0AiChatTextArea`

🤖 Generated with [Claude Code](https://claude.com/claude-code)