### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.4.0",
+  "packages/react": "4.4.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.4.1](https://github.com/factorialco/f0/compare/f0-react-v4.4.0...f0-react-v4.4.1) (2026-06-23)
+
+
+### Bug Fixes
+
+* **EditableTable:** apply correct cursor per cell type ([#4532](https://github.com/factorialco/f0/issues/4532)) ([a343391](https://github.com/factorialco/f0/commit/a343391a7afa5b6c92813d9ba0cb66bfc560894b))
+
 ## [4.4.0](https://github.com/factorialco/f0/compare/f0-react-v4.3.2...f0-react-v4.4.0) (2026-06-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.4.1</summary>

## [4.4.1](https://github.com/factorialco/f0/compare/f0-react-v4.4.0...f0-react-v4.4.1) (2026-06-23)


### Bug Fixes

* **EditableTable:** apply correct cursor per cell type ([#4532](https://github.com/factorialco/f0/issues/4532)) ([a343391](https://github.com/factorialco/f0/commit/a343391a7afa5b6c92813d9ba0cb66bfc560894b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).