### PR TITLE
feat(tags): add size prop to F0TagRaw (md/sm)

### DIFF
--- a/packages/react/src/components/tags/F0TagRaw/F0TagRaw.tsx
+++ b/packages/react/src/components/tags/F0TagRaw/F0TagRaw.tsx
@@ -10,7 +10,7 @@ import { BaseTag } from "../internal/BaseTag"
 
 export const F0TagRaw = forwardRef<HTMLDivElement, F0TagRawProps>(
   (
-    { text, additionalAccessibleText, icon, onlyIcon, info, className },
+    { text, additionalAccessibleText, icon, onlyIcon, info, className, size },
     ref
   ) => {
     useTextFormatEnforcer(
@@ -26,6 +26,7 @@ export const F0TagRaw = forwardRef<HTMLDivElement, F0TagRawProps>(
           "border-[1px] border-solid border-f1-border-secondary",
           className
         )}
+        size={size}
         left={
           icon ? (
             <F0Icon

--- a/packages/react/src/components/tags/F0TagRaw/__storybook__/TagRaw.stories.tsx
+++ b/packages/react/src/components/tags/F0TagRaw/__storybook__/TagRaw.stories.tsx
@@ -20,6 +20,15 @@ const meta: Meta = {
     },
   },
   argTypes: {
+    size: {
+      control: "inline-radio",
+      description: "The size of the tag",
+      options: ["md", "sm"],
+      table: {
+        defaultValue: { summary: "md" },
+        type: { summary: '"md" | "sm"' },
+      },
+    },
     onlyIcon: {
       control: "boolean",
       description: "Whether to only display the icon and not the label",
@@ -60,6 +69,23 @@ export const IconTag: Story = {
   },
 }
 
+export const Sizes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The tag is available in two sizes: `md` (default, 14px) and `sm` (12px).",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col items-start gap-3">
+      <F0TagRaw text="Medium" icon={Ai} size="md" />
+      <F0TagRaw text="Small" icon={Ai} size="sm" />
+    </div>
+  ),
+}
+
 export const Snapshot: Story = {
   parameters: withSnapshot({}),
   render: () => (
@@ -69,6 +95,8 @@ export const Snapshot: Story = {
       <F0TagRaw text="Label" />
       <F0TagRaw text="Label" icon={Ai} />
       <F0TagRaw text="Label" onlyIcon icon={Ai} />
+      <F0TagRaw text="Label" icon={Ai} size="sm" />
+      <F0TagRaw text="Label" size="sm" />
     </div>
   ),
 }

--- a/packages/react/src/components/tags/F0TagRaw/types.ts
+++ b/packages/react/src/components/tags/F0TagRaw/types.ts
@@ -17,6 +17,11 @@ export type F0TagRawProps = {
    * Extra classes merged onto the tag (e.g. to give it a background).
    */
   className?: string
+  /**
+   * The size of the tag
+   * @default "md"
+   */
+  size?: "md" | "sm"
 } & (
   | {
       icon: IconType

--- a/packages/react/src/components/tags/internal/BaseTag/index.tsx
+++ b/packages/react/src/components/tags/internal/BaseTag/index.tsx
@@ -20,6 +20,11 @@ type BaseTagProps = {
   // Hides the info icon
   shape?: "rounded" | "square"
   /**
+   * The size of the tag
+   * @default "md"
+   */
+  size?: "md" | "sm"
+  /**
    * Whether to hide the label
    */
   hideLabel?: boolean
@@ -48,6 +53,7 @@ export const BaseTag = forwardRef<HTMLDivElement, BaseTagProps>(
       hint,
       info,
       shape = "rounded",
+      size = "md",
       hideLabel,
       deactivated,
     },
@@ -60,7 +66,9 @@ export const BaseTag = forwardRef<HTMLDivElement, BaseTagProps>(
         <div
           ref={ref}
           className={cn(
-            "inline-flex w-fit max-w-full flex-row items-center justify-start gap-1 py-0.5 pr-2 text-base font-medium text-f1-foreground",
+            "inline-flex w-fit max-w-full flex-row items-center justify-start gap-1 py-0.5 pr-2 font-medium text-f1-foreground",
+            size === "md" && "text-base",
+            size === "sm" && "text-sm",
             !text && "aspect-square w-6 items-center justify-center p-1",
             !left ? "pl-2" : "pl-1",
             shape === "rounded" && "rounded-full",


### PR DESCRIPTION
## Description

Adds a `size` prop to the `F0TagRaw` component so it can be rendered in two sizes: `md` (default) and `sm`.

## Why

Until now the tag only had a single, fixed size with `text-base` (14px) typography. In denser UIs (compact lists, inline metadata, table cells) a smaller tag is needed, but there was no supported way to get one without ad-hoc overrides. This adds a first-class, token-based small variant.

## Implementation details

- **`internal/BaseTag`** — added a `size?: "md" | "sm"` prop (default `"md"`), the shared core that all tag variants render through. `md` keeps the current `text-base` (14px); `sm` uses `text-sm`, the design-system typography token for **12px** (`fontSize.sm` = `0.75rem`). Only the typography token changes — padding/shape are untouched.
- **`F0TagRaw`** — exposed the `size` prop in its types and forwarded it to `BaseTag`.
- **Storybook** — added a `size` control (inline radio `md`/`sm`), a new `Sizes` story showing both side by side, and `sm` examples in the snapshot story for visual regression coverage.

Defaults to `"md"`, so existing usages are unaffected.

## Screenshots

Available in Storybook under **Tags/TagRaw → Sizes**.

<img width="348" height="274" alt="image" src="https://github.com/user-attachments/assets/6edaa077-0e21-4f26-8830-812121dcd987" />

<img width="1284" height="662" alt="image" src="https://github.com/user-attachments/assets/494c3608-32eb-4b55-9d0e-8853989f526b" />

