### PR TITLE
fix(OneFilterPicker): restore checkbox click selection in InFilter

### DIFF
--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__tests__/InFilter.test.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__tests__/InFilter.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event"
 import "@testing-library/jest-dom/vitest"
+import { useState } from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import { zeroRender as render, screen } from "@/testing/test-utils"
@@ -227,6 +228,140 @@ describe("InFilter", () => {
       await user.click(screen.getByText("Alice Johnson"))
 
       expect(onChange).toHaveBeenCalledWith(["user-1"])
+    })
+  })
+
+  // Regression coverage for the checkbox being unclickable: the presentational
+  // checkbox sits behind a pointer-events guard so a real click falls through to
+  // the row's onToggle. userEvent doesn't model that fall-through, so we disable
+  // its pointer-events check to dispatch directly on the checkbox — which still
+  // reproduces the broken case (the click used to be swallowed by the wrapper's
+  // stopPropagation and never reached onToggle).
+  describe("selecting via the checkbox", () => {
+    const staticSchema = (options: { value: string; label: string }[]) => ({
+      label: "Department",
+      options: { options },
+    })
+
+    it("selects a flat option when its checkbox is clicked", async () => {
+      const onChange = vi.fn()
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+
+      const options = [
+        { value: "eng", label: "Engineering" },
+        { value: "design", label: "Design" },
+      ]
+      mockedUseLoadOptions.mockReturnValue({
+        ...defaultLoadOptionsReturn,
+        options,
+      })
+
+      render(
+        <InFilter schema={staticSchema(options)} value={[]} onChange={onChange} />
+      )
+
+      await user.click(screen.getByRole("checkbox", { name: "Design" }))
+
+      expect(onChange).toHaveBeenCalledWith(["design"])
+    })
+
+    it("deselects an already-selected flat option when its checkbox is clicked", async () => {
+      const onChange = vi.fn()
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+
+      const options = [
+        { value: "eng", label: "Engineering" },
+        { value: "design", label: "Design" },
+      ]
+      mockedUseLoadOptions.mockReturnValue({
+        ...defaultLoadOptionsReturn,
+        options,
+      })
+
+      render(
+        <InFilter
+          schema={staticSchema(options)}
+          value={["eng"]}
+          onChange={onChange}
+        />
+      )
+
+      await user.click(screen.getByRole("checkbox", { name: "Engineering" }))
+
+      expect(onChange).toHaveBeenCalledWith([])
+    })
+
+    it("selects a nested parent option when its checkbox is clicked", async () => {
+      const onChange = vi.fn()
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+
+      // A parent with children forces the hierarchical InFilterOptionRow path
+      // (instead of InFilterFlatOption).
+      const options = [
+        {
+          value: "eng",
+          label: "Engineering",
+          children: {
+            filterKey: "team",
+            options: [{ value: "frontend", label: "Frontend" }],
+          },
+        },
+      ]
+      mockedUseLoadOptions.mockReturnValue({
+        ...defaultLoadOptionsReturn,
+        options,
+      })
+
+      render(
+        <InFilter
+          schema={{ label: "Department", options: { options } }}
+          value={[]}
+          onChange={onChange}
+        />
+      )
+
+      await user.click(screen.getByRole("checkbox", { name: "Engineering" }))
+
+      expect(onChange).toHaveBeenCalledWith(["eng"])
+    })
+
+    it("toggles exactly once inside a <form> without an infinite update loop", async () => {
+      // Inside a <form>, Radix renders a hidden BubbleInput that dispatches a
+      // synthetic click whenever `checked` changes. If that click reaches the
+      // row's onToggle it flips the value back and re-fires forever ("Maximum
+      // update depth exceeded"). This guards that the synthetic click stays
+      // swallowed while a real toggle still happens exactly once.
+      const onChange = vi.fn()
+      const user = userEvent.setup()
+
+      const options = [{ value: "eng", label: "Engineering" }]
+      mockedUseLoadOptions.mockReturnValue({
+        ...defaultLoadOptionsReturn,
+        options,
+      })
+
+      function StatefulInFilter() {
+        const [value, setValue] = useState<string[]>([])
+        return (
+          <form>
+            <InFilter
+              schema={staticSchema(options)}
+              value={value}
+              onChange={(next) => {
+                setValue(next as string[])
+                onChange(next)
+              }}
+            />
+          </form>
+        )
+      }
+
+      render(<StatefulInFilter />)
+
+      await user.click(screen.getByText("Engineering"))
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith(["eng"])
     })
   })
 })

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__tests__/InFilter.test.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__tests__/InFilter.test.tsx
@@ -257,7 +257,11 @@ describe("InFilter", () => {
       })
 
       render(
-        <InFilter schema={staticSchema(options)} value={[]} onChange={onChange} />
+        <InFilter
+          schema={staticSchema(options)}
+          value={[]}
+          onChange={onChange}
+        />
       )
 
       await user.click(screen.getByRole("checkbox", { name: "Design" }))

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterFlatOption.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterFlatOption.tsx
@@ -34,12 +34,19 @@ export function InFilterFlatOption<T extends string>({
         <span className="min-w-0 flex-1">
           <OneEllipsis>{option.label}</OneEllipsis>
         </span>
-        {/* The presentational checkbox is a Radix Checkbox; inside a <form> it
-            renders a hidden BubbleInput whose sync effect dispatches a click that
-            bubbles up to this row's onClick (onToggle), causing an infinite
-            select/deselect loop ("Maximum update depth exceeded"). The row itself
-            handles the click, so stop the checkbox-originated click here. */}
-        <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
+        {/* The presentational checkbox is purely visual — the row handles the
+            click via onToggle. `pointer-events-none` lets a real click on the
+            checkbox fall through to the row's onToggle (in and out of a <form>).
+            Inside a <form> Radix also renders a hidden BubbleInput whose sync
+            effect dispatches a synthetic click on each `checked` change; that
+            click (target = the hidden <input>) bubbles here and would re-trigger
+            onToggle in an infinite select/deselect loop, so stop just that one. */}
+        <div
+          className="pointer-events-none shrink-0"
+          onClick={(e) => {
+            if (e.target instanceof HTMLInputElement) e.stopPropagation()
+          }}
+        >
           <F0Checkbox
             id={optionId}
             title={option.label}

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterOptionRow.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterOptionRow.tsx
@@ -112,10 +112,19 @@ export function InFilterOptionRow<T extends string>({
             <span className="min-w-0 flex-1">
               <OneEllipsis>{option.label}</OneEllipsis>
             </span>
-            {/* Stop the checkbox-originated click (Radix BubbleInput sync click
-                inside a <form>) from bubbling to this row's onToggle, which would
-                cause an infinite select/deselect loop. The row handles the click. */}
-            <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
+            {/* The presentational checkbox is purely visual — the row handles
+                the click via onToggle. `pointer-events-none` lets a real click on
+                the checkbox fall through to the row's onToggle. Inside a <form>
+                Radix renders a hidden BubbleInput whose sync effect dispatches a
+                synthetic click on each `checked` change; that click (target = the
+                hidden <input>) bubbles here and would re-trigger onToggle in an
+                infinite loop, so stop just that one. */}
+            <div
+              className="pointer-events-none shrink-0"
+              onClick={(e) => {
+                if (e.target instanceof HTMLInputElement) e.stopPropagation()
+              }}
+            >
               <F0Checkbox
                 id={optionId}
                 title={option.label}


### PR DESCRIPTION
## Problem

Clicking a filter option's **checkbox** in `InFilter` — and anywhere the `FilterPicker` renders `"in"` filters — did nothing. Selection only toggled when clicking the option **label**.

## Root cause

Filter option rows render a *presentational* `F0Checkbox`; the actual toggle is handled by the row's `onClick={onToggle}`. The label worked because the `<span>` is a sibling of the checkbox wrapper, so its click bubbled straight to `onToggle`.

A previous fix ([#4484](https://github.com/factorialco/f0/pull/4484)) wrapped the checkbox in `<div onClick={(e) => e.stopPropagation()}>`. That was solving a genuine infinite-loop crash: inside a `<form>`, Radix's checkbox renders a hidden `BubbleInput` that dispatches a **synthetic** click whenever `checked` changes; that click bubbled to `onToggle`, flipped the state, and re-fired forever (`"Maximum update depth exceeded"`).

The problem: `stopPropagation` was **indiscriminate**. It swallowed *every* click in the checkbox's area — including a genuine user click — so the click never reached `onToggle`. That's the regression.

## Fix

In `InFilterFlatOption` and `InFilterOptionRow`, the checkbox wrapper now:

1. Adds **`pointer-events-none`** to the presentational checkbox so a real click falls through to the row's `onToggle` (works both inside and outside a `<form>`, and avoids Radix internally eating the click).
2. Narrows the `stopPropagation` to **only the synthetic `BubbleInput` click** (`e.target instanceof HTMLInputElement`), which still prevents the infinite loop without blocking genuine clicks.

The "Select All" checkbox was unaffected — it has its own `onCheckedChange` and isn't wrapped.

## Tests

Added a `describe("selecting via the checkbox")` block to `InFilter.test.tsx`:

- selects a flat option when its checkbox is clicked
- deselects an already-selected flat option when its checkbox is clicked
- selects a nested parent option when its checkbox is clicked (covers the previously untested `InFilterOptionRow` path)
- toggles exactly once inside a `<form>` without an infinite update loop (guards the original #4484 loop protection)

Verified the three checkbox-click tests **fail** against the pre-fix code and **pass** with the fix, while the form/loop test passes in both — confirming the targeted `stopPropagation` still prevents the loop. All 11 tests in the file pass; lint is clean.