### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.5.1",
+  "packages/react": "4.6.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.6.0](https://github.com/factorialco/f0/compare/f0-react-v4.5.1...f0-react-v4.6.0) (2026-06-23)
+
+
+### Features
+
+* **OneTable:** support structured rich header info ([#4488](https://github.com/factorialco/f0/issues/4488)) ([9948e77](https://github.com/factorialco/f0/commit/9948e77f310600db807fe96da5d98d7e8f920bf6))
+
 ## [4.5.1](https://github.com/factorialco/f0/compare/f0-react-v4.5.0...f0-react-v4.5.1) (2026-06-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.6.0</summary>

## [4.6.0](https://github.com/factorialco/f0/compare/f0-react-v4.5.1...f0-react-v4.6.0) (2026-06-23)


### Features

* **OneTable:** support structured rich header info ([#4488](https://github.com/factorialco/f0/issues/4488)) ([9948e77](https://github.com/factorialco/f0/commit/9948e77f310600db807fe96da5d98d7e8f920bf6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).