### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.6.0",
+  "packages/react": "4.7.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.7.0](https://github.com/factorialco/f0/compare/f0-react-v4.6.0...f0-react-v4.7.0) (2026-06-23)
+
+
+### Features
+
+* **Sidebar:** add text label (tag) to MenuItem ([#4527](https://github.com/factorialco/f0/issues/4527)) ([710b95a](https://github.com/factorialco/f0/commit/710b95a3c39c37731708709832c527dc0381617a))
+
 ## [4.6.0](https://github.com/factorialco/f0/compare/f0-react-v4.5.1...f0-react-v4.6.0) (2026-06-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.7.0</summary>

## [4.7.0](https://github.com/factorialco/f0/compare/f0-react-v4.6.0...f0-react-v4.7.0) (2026-06-23)


### Features

* **Sidebar:** add text label (tag) to MenuItem ([#4527](https://github.com/factorialco/f0/issues/4527)) ([710b95a](https://github.com/factorialco/f0/commit/710b95a3c39c37731708709832c527dc0381617a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).