### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.9.0",
+  "packages/react": "4.9.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.9.1](https://github.com/factorialco/f0/compare/f0-react-v4.9.0...f0-react-v4.9.1) (2026-06-23)
+
+
+### Bug Fixes
+
+* **EditableTable:** fade disabled cell text (FCT-56243) ([#4547](https://github.com/factorialco/f0/issues/4547)) ([11b23ae](https://github.com/factorialco/f0/commit/11b23ae97cf1da9923bfab019e96566f4e5a17db))
+
 ## [4.9.0](https://github.com/factorialco/f0/compare/f0-react-v4.8.0...f0-react-v4.9.0) (2026-06-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.9.1</summary>

## [4.9.1](https://github.com/factorialco/f0/compare/f0-react-v4.9.0...f0-react-v4.9.1) (2026-06-23)


### Bug Fixes

* **EditableTable:** fade disabled cell text (FCT-56243) ([#4547](https://github.com/factorialco/f0/issues/4547)) ([11b23ae](https://github.com/factorialco/f0/commit/11b23ae97cf1da9923bfab019e96566f4e5a17db))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).