### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.10.0",
+  "packages/react": "4.11.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.11.0](https://github.com/factorialco/f0/compare/f0-react-v4.10.0...f0-react-v4.11.0) (2026-06-23)
+
+
+### Features
+
+* **F0TextInput:** add private input type ([#4456](https://github.com/factorialco/f0/issues/4456)) ([30d6ca1](https://github.com/factorialco/f0/commit/30d6ca10ecdc985e4ad9bbf9a8b6921521c25c0e))
+
 ## [4.10.0](https://github.com/factorialco/f0/compare/f0-react-v4.9.1...f0-react-v4.10.0) (2026-06-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.11.0</summary>

## [4.11.0](https://github.com/factorialco/f0/compare/f0-react-v4.10.0...f0-react-v4.11.0) (2026-06-23)


### Features

* **F0TextInput:** add private input type ([#4456](https://github.com/factorialco/f0/issues/4456)) ([30d6ca1](https://github.com/factorialco/f0/commit/30d6ca10ecdc985e4ad9bbf9a8b6921521c25c0e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).