### PR TITLE
ci: add agentic code-quality checks (warning-only)

### DIFF
--- a/.github/agent-prompts/a11y.md
+++ b/.github/agent-prompts/a11y.md
@@ -1,0 +1,83 @@
+# Accessibility Review — PR #{{PR_NUMBER}}
+
+You are an accessibility engineer reviewing pull request #{{PR_NUMBER}} on `{{REPO}}` (branch `{{HEAD_BRANCH}}` → `{{BASE_BRANCH}}`). This is an authorized internal review of Factorial's F0 design system, run automatically in CI with the repository owner's consent.
+
+## Goal
+
+Catch WCAG 2.1 / 2.2 Level AA violations introduced by this PR — missing labels, broken keyboard support, missing focus rings, missing reduced-motion handling, and bad ARIA usage.
+
+## Instructions
+
+1. Read the PR diff from `/tmp/pr.diff` (already fetched for you).
+2. **Scope: only the PR changes.** Cover exclusively the lines added or modified in this PR. Do not flag pre-existing accessibility issues in unchanged code. You may read surrounding context to confirm a finding, but every issue you report must be caused by or introduced in this diff.
+3. When you need more context about a component (e.g. to confirm a button is truly icon-only or that an animation has no `useReducedMotion()` guard), read the relevant source files.
+4. Load the skills below to understand F0 a11y patterns, then apply them only to the PR changes.
+
+## Skills to Load
+
+- `vendor/skills/a11y/SKILL.md` — Detailed WCAG patterns for interactive and animated F0 components.
+- `packages/react/AGENTS.md` — F0 component conventions (look at the Accessibility section).
+
+## Critical Focus Areas
+
+Think in categories, not examples. These are starting points — look for analogous issues beyond the specific patterns listed.
+
+### Semantic HTML & ARIA
+
+- Interactive `<div>`/`<span>` used where a semantic element (`<button>`, `<a>`, `<input>`, `<label>`) would fit.
+- Missing or wrong `role` on a non-semantic element doing an interactive job.
+- ARIA attribute used incorrectly (`aria-labelledby` pointing to a non-existent id, `aria-hidden` on a focusable element, etc.).
+
+### Keyboard Accessibility
+
+- Interactive non-button element (`<div onClick={...}>`) without `tabIndex={0}` AND keyboard handler (`onKeyDown` covering Enter/Space).
+- Custom focus trap or modal without restoring focus on close.
+- Tab order broken by positive `tabIndex` values or DOM order issues.
+
+### Screen Reader Support
+
+- Icon-only button missing an accessible name (`aria-label` or `sr-only` text).
+- Loading/skeleton state missing `aria-live="polite"` or `aria-busy`.
+- Status messages rendered without an `aria-live` region.
+
+### Focus Indication
+
+- Focusable element missing `focusRing()` helper (or equivalent visible focus indicator).
+- Custom outline/box-shadow removed without an accessible replacement.
+
+### Motion
+
+- Animated component without `useReducedMotion()` check.
+- CSS-only animation that bypasses motion preferences.
+
+### Forms
+
+- `<input>` / `<textarea>` / `<select>` without an associated `<label>` (either wrapping, `htmlFor`, or `aria-labelledby`).
+- Error messages not linked to the input via `aria-describedby` / `aria-invalid`.
+
+## When Flagging Issues
+
+- Explain the user impact in plain terms (e.g. "screen reader users won't know what this button does").
+- Cite the relevant WCAG criterion (e.g. WCAG 1.1.1, 2.1.1, 2.4.7) when the violation maps cleanly to one.
+- Cite the relevant file and code snippet from the diff.
+- Propose a concrete fix.
+
+## Confidence & False Positive Avoidance
+
+- **Only flag issues you are highly confident about.** If unsure whether something is actually an a11y violation, do NOT flag it. Err on the side of passing.
+- **Give the author benefit of the doubt.** If a component could be wrapped by a parent that provides the accessible name, or could already have the missing handler in a layer you can't see, assume it does.
+- **Verify before flagging.** Read enough surrounding context (parent components, hooks used) to confirm the issue is real — for example, do not flag "no `useReducedMotion()`" if the underlying Tailwind/framer-motion primitive already respects the preference.
+- **Do not flag stylistic preferences or minor deviations** that don't cause measurable a11y harm.
+- **When in doubt, pass.** A false positive that adds noise to a PR is more costly than a minor issue slipping through.
+
+## Verdict
+
+After your review, you MUST output a verdict line in exactly this format:
+
+If no blocking a11y issues found:
+
+<!-- VERDICT: {"pass": true, "summary": "No blocking accessibility issues found. WCAG AA looks intact for this change."} -->
+
+If blocking a11y issues found:
+
+<!-- VERDICT: {"pass": false, "summary": "Found N a11y issue(s): brief description of the most critical ones"} -->

--- a/.github/agent-prompts/code-review.md
+++ b/.github/agent-prompts/code-review.md
@@ -1,0 +1,90 @@
+# Code Review — PR #{{PR_NUMBER}}
+
+You are a senior frontend engineer reviewing pull request #{{PR_NUMBER}} on `{{REPO}}` (branch `{{HEAD_BRANCH}}` → `{{BASE_BRANCH}}`). This is an authorized internal code review of Factorial's F0 design system repository, run automatically in CI with the repository owner's consent.
+
+## Goal
+
+Enforce F0 React component conventions on the diff: TypeScript strictness, component structure (`forwardRef`/`displayName`, `F0` prefix, no direct Radix imports, public exports), testing standards (`zeroRender`, `.test.tsx`, no snapshots), Storybook `Snapshot` story presence, and basic security (`dangerouslySetInnerHTML`).
+
+## Instructions
+
+1. Read the PR diff from `/tmp/pr.diff` (already fetched for you).
+2. **Scope: only the PR changes.** Cover exclusively the lines added or modified in this PR. Do not flag pre-existing issues in unchanged code. You may read surrounding context to understand the change, but every finding must be caused by or introduced in this diff.
+3. When you need more context about a file, read the relevant source files — but only to inform judgment about the changed lines.
+4. Load the skills below to understand F0 conventions, then apply them only to the PR changes.
+
+## Skills to Load
+
+- `vendor/skills/f0-code-review/SKILL.md` — F0 code review checklist (blocking vs suggestion classification, all categories).
+- `packages/react/AGENTS.md` — Full F0 component conventions (naming, folder structure, props, testing, styling, i18n, a11y, commands).
+
+## Critical Focus Areas
+
+Think in categories, not examples. These are starting points — look for analogous issues beyond the specific patterns listed.
+
+### TypeScript
+
+- `any` or `as any` anywhere in the diff (blocking).
+- `import * as React` instead of named imports (blocking).
+- Default exports on components (blocking).
+- New circular imports introduced by the diff (blocking).
+
+### Component Structure
+
+- Missing `displayName` on new `forwardRef` components.
+- Direct Radix/third-party primitive import instead of using `@/ui/` wrappers.
+- New component name missing the `F0` prefix.
+- New component placed in `experimental/` directly instead of using `experimentalComponent` from `@/lib/experimental.ts`.
+- Internal components or `internal-types.ts` exported publicly.
+- New component not added to `exports.ts`.
+
+### Testing
+
+- New/changed component missing a test file.
+- Test files named `.spec.ts` instead of `.test.tsx`.
+- `render` from `@testing-library/react` used instead of `zeroRender` from `@/testing/test-utils.tsx`.
+- `jest.fn()` used instead of `vi.fn()`.
+- Snapshot testing introduced (use explicit assertions only).
+
+### Storybook
+
+- New component without a `Snapshot` story using `withSnapshot({})` (Chromatic coverage).
+
+### Security
+
+- `dangerouslySetInnerHTML` introduced without explicit justification in the diff.
+
+### Suggestions (non-blocking, still report)
+
+- Comments describing "what" instead of "why".
+- `className` exposed on a public component API (should be private).
+- Union type props not using the const array pattern (`export const xs = [...] as const`).
+- CSS modules / CSS-in-JS instead of Tailwind; CVA imported from `"class-variance-authority"` instead of `"cva"`; inline `style` for values expressible as Tailwind classes.
+- Hardcoded user-facing strings (should use `useI18n()`).
+
+## When Flagging Issues
+
+- Explain the concern in plain terms.
+- Cite the relevant file and code snippet from the diff.
+- Propose a concrete alternative that preserves the original intent.
+- Classify each finding implicitly: blocking issues vs. suggestions per the categories above. Blocking issues drive `pass: false`. Suggestions alone do not need to fail the verdict — mention them in the summary if helpful.
+
+## Confidence & False Positive Avoidance
+
+- **Only flag issues you are highly confident about.** If unsure whether something is actually a violation, do NOT flag it. Err on the side of passing.
+- **Give the author benefit of the doubt.** If a pattern could be intentional or has a reasonable justification, assume it is intentional.
+- **Verify before flagging.** Read enough surrounding context to confirm the issue is real.
+- **Do not flag stylistic preferences or minor deviations** that don't cause measurable harm.
+- **When in doubt, pass.** A false positive that adds noise to a PR is more costly than a minor issue slipping through.
+
+## Verdict
+
+After your review, you MUST output a verdict line in exactly this format:
+
+If no blocking issues found:
+
+<!-- VERDICT: {"pass": true, "summary": "No blocking code review issues. The changes follow F0 conventions."} -->
+
+If blocking issues found:
+
+<!-- VERDICT: {"pass": false, "summary": "Found N blocking issue(s): brief description of the most critical ones"} -->

--- a/.github/agent-prompts/storybook.md
+++ b/.github/agent-prompts/storybook.md
@@ -1,0 +1,72 @@
+# Storybook & Docs Review — PR #{{PR_NUMBER}}
+
+You are a Storybook and documentation reviewer for Factorial's F0 design system, reviewing pull request #{{PR_NUMBER}} on `{{REPO}}` (branch `{{HEAD_BRANCH}}` → `{{BASE_BRANCH}}`). This is an authorized internal review run automatically in CI with the repository owner's consent.
+
+## Goal
+
+Make sure every changed component has a story file, a `Snapshot` story for Chromatic, MDX documentation when required, and that new props / variants introduced by the diff are visible in both stories and MDX.
+
+## Instructions
+
+1. Read the PR diff from `/tmp/pr.diff` (already fetched for you).
+2. **Scope: only the PR changes.** For every component touched in the diff, read its source and its `__stories__/` directory (the `.stories.tsx` and `.mdx` files). Verify the conventions listed below. Do not flag pre-existing gaps in unchanged components.
+3. When you need more context about how a story or MDX should look, read sibling components' stories as reference.
+4. Load the skills below before reviewing.
+
+## Skills to Load
+
+- `vendor/skills/f0-storybook-stories/SKILL.md` — Story file conventions (meta, tags, argTypes, Snapshot pattern).
+- `vendor/skills/f0-storybook-testing/SKILL.md` — Storybook test patterns (`play` functions, interaction tests).
+- `vendor/skills/f0-docs/SKILL.md` — MDX documentation conventions (anatomy, props table, Canvas references).
+- `packages/react/AGENTS.md` — F0 component conventions.
+
+## Critical Focus Areas
+
+### Structural Checks (Conventions)
+
+- A `.stories.tsx` file exists for every changed component (blocking if missing for a new component).
+- Meta uses `satisfies Meta<typeof Component>` (not `as Meta`).
+- Tags include `["autodocs", "stable"]` or `["autodocs", "experimental"]`.
+- A `Snapshot` story exists with `parameters: withSnapshot({})` and renders meaningful variants in a flex layout (blocking if missing for a new component).
+- ArgTypes for union props reference the component's exported const arrays directly (not duplicated string literals).
+
+### MDX Documentation Checks
+
+- A new component MUST have an MDX file (`__stories__/*.mdx`). Missing MDX on a new component is BLOCKING — report it as "New component {Name} has no MDX documentation".
+- A pre-existing component without MDX is a SUGGESTION, not blocking.
+- Every new prop added in this diff must be documented in the MDX anatomy or props table (BLOCKING if missing).
+- Every new variant / state added in this diff must be covered by the MDX (variants table or example) (BLOCKING if missing).
+- `<Canvas of={Stories.X} />` references in MDX must point to stories that exist (BLOCKING if dangling).
+
+### Story Coverage Checks (New Behavior)
+
+- Every new prop added in this diff has a corresponding story or argType that demonstrates it.
+- Every new variant or state (new size, color, loading state, error state) is represented in at least one story — ideally also in the `Snapshot` story so Chromatic captures it.
+- If a prop was removed or renamed, stories referencing the old name are updated.
+- Interactive components with new interactions have at least one `play` function story covering the new interaction (suggestion, not blocking).
+
+## When Flagging Issues
+
+- Cite the relevant file from the diff (component source, `.stories.tsx`, or `.mdx`).
+- Explain what's missing and why it matters (Chromatic coverage, contributor onboarding, consumer discoverability).
+- Propose a concrete fix (the exact story or MDX block to add).
+
+## Confidence & False Positive Avoidance
+
+- **Only flag issues you are highly confident about.** If unsure whether a component is genuinely new vs. just renamed/moved, do NOT flag it as missing MDX. Err on the side of passing.
+- **Give the author benefit of the doubt.** If a prop is internal-only (not in the public API) it doesn't need MDX coverage.
+- **Verify before flagging.** Read the `__stories__/` directory to confirm the file or story really is missing.
+- **Do not flag stylistic preferences** (story ordering, argType wording) that don't cause measurable harm.
+- **When in doubt, pass.** A false positive that adds noise to a PR is more costly than a minor docs gap slipping through.
+
+## Verdict
+
+After your review, you MUST output a verdict line in exactly this format:
+
+If no blocking Storybook/MDX issues found:
+
+<!-- VERDICT: {"pass": true, "summary": "No blocking Storybook or MDX issues. Stories and docs cover the changes."} -->
+
+If blocking issues found:
+
+<!-- VERDICT: {"pass": false, "summary": "Found N Storybook/docs issue(s): brief description of the most critical ones"} -->

--- a/.github/agent-prompts/test-coverage.md
+++ b/.github/agent-prompts/test-coverage.md
@@ -1,0 +1,69 @@
+# Test Coverage Review — PR #{{PR_NUMBER}}
+
+You are a test coverage reviewer for Factorial's F0 design system, reviewing pull request #{{PR_NUMBER}} on `{{REPO}}` (branch `{{HEAD_BRANCH}}` → `{{BASE_BRANCH}}`). This is an authorized internal review run automatically in CI with the repository owner's consent.
+
+## Goal
+
+Make sure new behavior introduced in this PR is exercised by tests. **You are NOT verifying that tests pass** — CI already does that. You ARE verifying that the new behavior has corresponding assertions.
+
+## Instructions
+
+1. Read the PR diff from `/tmp/pr.diff` (already fetched for you).
+2. **Scope: only the PR changes.** For every component or hook touched in the diff, read both the source file and its `__tests__/` file(s). Confirm that the new behavior introduced by this diff has corresponding tests. Do not flag pre-existing untested code in unchanged areas.
+3. When you need more context, read sibling tests for reference patterns.
+4. Load the skill below before reviewing.
+
+## Skills to Load
+
+- `vendor/skills/f0-unit-testing/SKILL.md` — F0 unit testing conventions (`zeroRender`, `.test.tsx`, `userEvent`, helpers).
+
+## Critical Focus Areas
+
+### Existence Checks
+
+- Every changed component has a `.test.tsx` file (never `.spec.ts`). Missing test file for a new component is BLOCKING.
+- Tests use `zeroRender` from `@/testing/test-utils.tsx`, not `render` from `@testing-library/react` (BLOCKING — already enforced in Code Review prompt, mention here only if you see it in newly added tests).
+
+### Behavioral Coverage Checks
+
+For each new behavior introduced in this PR:
+
+- **New prop**: at least one test exercises it (with a non-default value). BLOCKING if a new prop has zero coverage.
+- **New conditional branch** (`if`/`else`, ternary, `switch`): both truthy and falsy paths exercised. BLOCKING if a whole branch is uncovered.
+- **New callback prop** (`onSelect`, `onChange`, `onSubmit`, etc.): at least one test verifies the callback is invoked with the expected arguments. BLOCKING if missing.
+- **New error / warning** thrown or logged: a test verifies the throw or log. SUGGESTION (not blocking) unless the error is part of the public contract.
+- **New state transition** (loading → loaded, collapsed → expanded, idle → submitting): a test exercises the before and after states. BLOCKING if completely untested.
+- **Removed / renamed prop**: tests referencing the old name are cleaned up (no dead assertions). SUGGESTION.
+
+### What NOT to flag
+
+- Test files that exist and exercise the new behavior — even if coverage isn't 100% on edge cases (those are suggestions at most).
+- Pre-existing untested behavior in code that hasn't changed in this diff.
+- Snapshot tests (handled by the Code Review check — flag there, not here).
+- Tests passing/failing (handled by `test.yaml`).
+
+## When Flagging Issues
+
+- Cite the source file and the new behavior (prop, branch, callback) that lacks coverage.
+- Cite the test file that should contain the test (or report it's missing entirely).
+- Suggest concretely what to test (e.g. "Add a test that renders `<F0Foo variant='loading' />` and asserts the loading indicator is present").
+
+## Confidence & False Positive Avoidance
+
+- **Only flag issues you are highly confident about.** If unsure whether a piece of behavior is genuinely new (vs. a refactor that preserves behavior covered elsewhere), do NOT flag it. Err on the side of passing.
+- **Give the author benefit of the doubt.** If existing tests indirectly exercise the new branch through a higher-level scenario, that counts as coverage — do not require a separate test.
+- **Verify before flagging.** Read enough of the existing test file to confirm coverage really is missing.
+- **Do not flag stylistic preferences** (`fireEvent` vs `userEvent`, test naming, helper extraction). Mention them only as suggestions if they're clearly degrading the test.
+- **When in doubt, pass.** A false positive that adds noise to a PR is more costly than a minor coverage gap slipping through.
+
+## Verdict
+
+After your review, you MUST output a verdict line in exactly this format:
+
+If no blocking coverage gaps found:
+
+<!-- VERDICT: {"pass": true, "summary": "No blocking test coverage gaps. New behavior is exercised."} -->
+
+If blocking coverage gaps found:
+
+<!-- VERDICT: {"pass": false, "summary": "Found N coverage gap(s): brief description of the most critical ones"} -->

--- a/.github/scripts/agentic-check.sh
+++ b/.github/scripts/agentic-check.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+#
+# agentic-check.sh
+#
+# Runs an agentic check against a pull request using a prompt file.
+# The agent's verdict determines the check's pass/fail status.
+#
+# Required environment variables:
+#   PR_NUMBER              - The pull request number
+#   PROMPT_FILE            - Path to the prompt markdown file (relative to repo root)
+#   MODEL                  - The model to use (e.g. azure-cognitive-services/gpt-5.3-codex)
+#   GH_TOKEN               - GitHub token for API calls and PR comments
+#   AZURE_API_KEY          - Azure API key for OpenCode CLI authentication
+#   AZURE_RESOURCE_NAME    - Azure resource name for OpenCode CLI
+#   GITHUB_REPOSITORY      - owner/repo (auto-set by GitHub Actions)
+#
+# Optional environment variables:
+#   CHECK_NAME             - Human-readable check name (e.g. "Security Review")
+#   CHECK_EMOJI            - Emoji for the check (e.g. "🔒")
+#
+
+set -euo pipefail
+
+GITHUB_API="https://api.github.com"
+
+# --- Helpers ---
+
+# Redact common secret patterns from output before posting to PR comments.
+# GitHub masks secrets in logs but not in API-posted comments.
+redact_secrets() {
+	local text="$1"
+	# Redact GitHub tokens
+	text=$(printf '%s' "${text}" | sed -E 's/ghp_[A-Za-z0-9]{36}/[REDACTED]/g')
+	text=$(printf '%s' "${text}" | sed -E 's/gho_[A-Za-z0-9]{36}/[REDACTED]/g')
+	text=$(printf '%s' "${text}" | sed -E 's/ghs_[A-Za-z0-9]{36}/[REDACTED]/g')
+	text=$(printf '%s' "${text}" | sed -E 's/github_pat_[A-Za-z0-9_]{80,}/[REDACTED]/g')
+	# Redact generic API key patterns (long hex/base64 strings after common key labels)
+	text=$(printf '%s' "${text}" | sed -E 's/(api[_-]?key|token|secret|password|credential)["\x27]?\s*[:=]\s*["\x27]?[A-Za-z0-9+\/\-_]{20,}/\1=[REDACTED]/gi')
+	printf '%s' "${text}"
+}
+
+# --- Validation ---
+
+if [[ -z "${PR_NUMBER:-}" ]]; then
+	echo "::error::PR_NUMBER is required"
+	exit 1
+fi
+
+if [[ -z "${PROMPT_FILE:-}" ]]; then
+	echo "::error::PROMPT_FILE is required"
+	exit 1
+fi
+
+if [[ ! -f "${PROMPT_FILE}" ]]; then
+	echo "::error::Prompt file not found: ${PROMPT_FILE}"
+	exit 1
+fi
+
+if [[ -z "${MODEL:-}" ]]; then
+	echo "::error::MODEL is required"
+	exit 1
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+	echo "::error::GH_TOKEN is required"
+	exit 1
+fi
+
+if [[ -z "${AZURE_API_KEY:-}" ]]; then
+	echo "::error::AZURE_API_KEY is required"
+	exit 1
+fi
+
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+	echo "::error::GITHUB_REPOSITORY is required"
+	exit 1
+fi
+
+# --- Verify OpenCode CLI ---
+
+if ! command -v opencode &>/dev/null; then
+	echo "::error::OpenCode CLI is not installed. Add an 'Install OpenCode CLI' step before running this script."
+	exit 1
+fi
+
+# --- Prepare prompt ---
+
+echo "::group::Preparing prompt"
+
+# Fetch PR metadata for template substitution
+PR_JSON=$(curl -sS \
+	-H "Authorization: Bearer ${GH_TOKEN}" \
+	-H "Accept: application/vnd.github+json" \
+	"${GITHUB_API}/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" 2>/dev/null || echo '{}')
+BASE_BRANCH=$(echo "${PR_JSON}" | jq -r '.base.ref // "main"')
+HEAD_BRANCH=$(echo "${PR_JSON}" | jq -r '.head.ref // "unknown"')
+PR_AUTHOR=$(echo "${PR_JSON}" | jq -r '.user.login // "unknown"')
+
+# Read prompt and substitute placeholders
+PROMPT=$(cat "${PROMPT_FILE}")
+PROMPT="${PROMPT//\{\{PR_NUMBER\}\}/${PR_NUMBER}}"
+PROMPT="${PROMPT//\{\{BASE_BRANCH\}\}/${BASE_BRANCH}}"
+PROMPT="${PROMPT//\{\{HEAD_BRANCH\}\}/${HEAD_BRANCH}}"
+PROMPT="${PROMPT//\{\{REPO\}\}/${GITHUB_REPOSITORY}}"
+
+echo "Prompt file: ${PROMPT_FILE}"
+echo "PR: #${PR_NUMBER} (${HEAD_BRANCH} -> ${BASE_BRANCH}, author: ${PR_AUTHOR})"
+echo "Model: ${MODEL}"
+echo ""
+echo "--- Prompt content ---"
+echo "${PROMPT}"
+echo "--- End prompt ---"
+echo "::endgroup::"
+
+# --- Fetch PR diff ---
+
+echo "::group::Fetching PR diff"
+DIFF_FILE="/tmp/pr.diff"
+HTTP_STATUS=$(curl -sS -w '%{http_code}' -o "${DIFF_FILE}" \
+	-H "Authorization: Bearer ${GH_TOKEN}" \
+	-H "Accept: application/vnd.github.v3.diff" \
+	"${GITHUB_API}/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
+
+if [[ "${HTTP_STATUS}" == "406" ]]; then
+	echo "::warning::PR diff is too large for the GitHub API (HTTP 406). Skipping agentic check."
+	cat "${DIFF_FILE}" || true
+	rm -f "${DIFF_FILE}"
+	cat >>"${GITHUB_STEP_SUMMARY}" <<EOF
+## ⏭️ ${CHECK_EMOJI:-} ${CHECK_NAME:-Agentic Check} — Skipped
+
+PR diff exceeds GitHub's maximum diff size (HTTP 406). The diff is too large to fetch via the API.
+
+Consider breaking this PR into smaller, focused changes.
+EOF
+	if [[ "${PR_AUTHOR}" == "factorio-bot" ]] && [[ "${HEAD_BRANCH}" == auto_feature/* ]]; then
+		echo "verdict=ok" >>"${GITHUB_OUTPUT}"
+	else
+		echo "verdict=ko" >>"${GITHUB_OUTPUT}"
+	fi
+	exit 0
+fi
+
+if [[ "${HTTP_STATUS}" != "200" ]]; then
+	echo "::error::Failed to fetch PR diff (HTTP ${HTTP_STATUS})"
+	cat "${DIFF_FILE}" || true
+	rm -f "${DIFF_FILE}"
+	exit 1
+fi
+
+# Filter out auto-generated files that are large and not useful for review
+awk '
+  /^diff --git/ { skip = ($0 ~ /sorbet\/rbi\//); }
+  !skip { print }
+' "${DIFF_FILE}" > "${DIFF_FILE}.filtered" && mv "${DIFF_FILE}.filtered" "${DIFF_FILE}"
+
+DIFF_SIZE=$(wc -c <"${DIFF_FILE}" | tr -d ' ')
+DIFF_FILES=$(grep -c '^diff --git' "${DIFF_FILE}" || true)
+DIFF_ADDITIONS=$(grep -c '^+[^+]' "${DIFF_FILE}" || true)
+DIFF_DELETIONS=$(grep -c '^-[^-]' "${DIFF_FILE}" || true)
+echo "PR diff fetched (after filtering generated files): ${DIFF_SIZE} bytes, ${DIFF_FILES} files changed, +${DIFF_ADDITIONS}/-${DIFF_DELETIONS} lines"
+echo "Files in diff:"
+grep '^diff --git' "${DIFF_FILE}" | sed 's|diff --git a/||;s| b/.*||' || true
+echo "::endgroup::"
+
+# --- Check diff size ---
+
+DIFF_LINES=$((DIFF_ADDITIONS + DIFF_DELETIONS))
+if [[ -z "${MAX_DIFF_LINES:-}" ]]; then
+	MAX_DIFF_LINES="10000"
+elif [[ ! "${MAX_DIFF_LINES}" =~ ^[0-9]+$ ]]; then
+	echo "::error::Invalid MAX_DIFF_LINES value '${MAX_DIFF_LINES}'. Must be an integer. Falling back to default 10000."
+	MAX_DIFF_LINES="10000"
+fi
+
+if [[ "${DIFF_LINES}" -gt "${MAX_DIFF_LINES}" ]]; then
+	echo "::notice::PR diff is too large (${DIFF_LINES} lines > ${MAX_DIFF_LINES} max). Skipping agentic check."
+	cat >>"${GITHUB_STEP_SUMMARY}" <<EOF
+## ⏭️ ${CHECK_EMOJI:-} ${CHECK_NAME:-Agentic Check} — Skipped
+
+PR diff too large to review meaningfully: **${DIFF_LINES} lines** changed (${DIFF_FILES} files, +${DIFF_ADDITIONS}/-${DIFF_DELETIONS}).
+
+Threshold: ${MAX_DIFF_LINES} lines. Consider breaking this PR into smaller, focused changes.
+EOF
+	NON_LOCALE_FILES=$(grep '^diff --git' "${DIFF_FILE}" | sed 's|diff --git a/||;s| b/.*||' | \
+		grep -Ecv '^(backend/components/[^/]+/config/locales/|backend/config/locales/|frontend/src/modules/[^/]+/locales/|frontend/src/translations/|webpage/lang/|webpage/compiled-lang/|factorial-id/frontend/.*/translations/|factorial-id/config/locales/|mobile/src/locales/)' || true)
+	if [[ "${PR_AUTHOR}" == "factorio-bot" ]] && \
+		[[ "${HEAD_BRANCH}" == auto_feature/* ]] && \
+		[[ "${NON_LOCALE_FILES}" == "0" ]]; then
+		echo "verdict=ok" >>"${GITHUB_OUTPUT}"
+	else
+		echo "verdict=ko" >>"${GITHUB_OUTPUT}"
+	fi
+	exit 0
+fi
+
+# --- Run OpenCode CLI (with retries) ---
+#
+# The model occasionally emits a canned safety refusal ("I'm sorry, but I cannot
+# assist with that request.") instead of performing the review. Refusals are
+# stochastic — re-running the same prompt usually succeeds — so retry before
+# giving up. A run with no parseable VERDICT marker is an agent/model failure,
+# not a review finding, and must not be reported as "issues found".
+
+if [[ -z "${MAX_ATTEMPTS:-}" ]] || [[ ! "${MAX_ATTEMPTS}" =~ ^[0-9]+$ ]] || [[ "${MAX_ATTEMPTS}" -lt 1 ]]; then
+	MAX_ATTEMPTS="3"
+fi
+
+# Stagger concurrent calls to reduce API burst (once, not per retry)
+JITTER=$((RANDOM % 10))
+echo "Startup jitter: sleeping ${JITTER}s to stagger concurrent API calls"
+sleep ${JITTER}
+
+# Write the prepared prompt (with substitutions) to a temp file for OpenCode
+PROMPT_TEMP="/tmp/agentic-check-prompt-${PR_NUMBER}.md"
+printf '%s' "${PROMPT}" > "${PROMPT_TEMP}"
+
+OUTPUT_FILE=$(mktemp)
+VERDICT_LINE=""
+LAST_FAILURE=""
+
+for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
+	echo "::group::Running OpenCode agent (attempt ${ATTEMPT}/${MAX_ATTEMPTS})"
+	echo "Command: opencode run --model \"${MODEL}\" --file <prompt-file> -- \"Execute the review.\""
+	echo "Prompt length: ${#PROMPT} characters"
+	echo ""
+
+	# Stream output to both the log (via tee) and the file for later parsing.
+	# This gives real-time visibility in the Actions log.
+	set +e
+	opencode run \
+		--model "${MODEL}" \
+		--file "${PROMPT_TEMP}" \
+		-- "Execute the review described in the prompt file. The PR diff is at /tmp/pr.diff." \
+		2>&1 | tee "${OUTPUT_FILE}"
+	EXIT_CODE=${PIPESTATUS[0]}
+	set -e
+
+	echo ""
+	echo "opencode exited with code: ${EXIT_CODE}"
+	echo "Output size: $(wc -c <"${OUTPUT_FILE}" | tr -d ' ') bytes"
+	echo "::endgroup::"
+
+	if [[ ${EXIT_CODE} -ne 0 ]]; then
+		LAST_FAILURE="opencode exited with code ${EXIT_CODE}"
+	else
+		AGENT_OUTPUT=$(cat "${OUTPUT_FILE}")
+		# Extract the VERDICT JSON from the output (POSIX-compatible, no PCRE)
+		VERDICT_LINE=$(printf '%s\n' "${AGENT_OUTPUT}" | sed -n 's/.*<!-- VERDICT:[[:space:]]*\({.*}\).*/\1/p' | head -n 1 || true)
+
+		if [[ -z "${VERDICT_LINE}" ]]; then
+			LAST_FAILURE="no VERDICT marker in agent output (the model may have refused to review)"
+			echo "--- Agent output (searching for VERDICT) ---"
+			# Show last 100 lines to help debug why no verdict was produced
+			printf '%s\n' "${AGENT_OUTPUT}" | tail -100
+			echo "--- End agent output ---"
+			echo ""
+			echo "Expected format: <!-- VERDICT: {\"pass\": true/false, \"summary\": \"...\"} -->"
+		elif ! echo "${VERDICT_LINE}" | jq empty >/dev/null 2>&1; then
+			LAST_FAILURE="invalid VERDICT JSON"
+			echo "Raw verdict line: ${VERDICT_LINE}"
+			VERDICT_LINE=""
+		else
+			# Valid verdict obtained
+			break
+		fi
+	fi
+
+	if [[ ${ATTEMPT} -lt ${MAX_ATTEMPTS} ]]; then
+		echo "::warning::Attempt ${ATTEMPT}/${MAX_ATTEMPTS} failed: ${LAST_FAILURE}. Retrying in 5s..."
+		sleep 5
+	fi
+done
+
+rm -f "${PROMPT_TEMP}" "${OUTPUT_FILE}"
+
+if [[ -z "${VERDICT_LINE}" ]]; then
+	# All attempts failed to produce a parseable verdict. This is an agent/model
+	# failure (crash, refusal, or malformed output), not a review finding, so
+	# report it as "error" (non-blocking) rather than "ko" (issues found).
+	echo "::error::Agent did not produce a structured verdict after ${MAX_ATTEMPTS} attempts. Last failure: ${LAST_FAILURE}"
+	echo "verdict=error" >>"${GITHUB_OUTPUT}"
+	cat >>"${GITHUB_STEP_SUMMARY}" <<EOF
+## ⚠️ ${CHECK_EMOJI:-} ${CHECK_NAME:-Agentic Check}
+
+Agent did not produce a structured verdict after ${MAX_ATTEMPTS} attempts (last failure: ${LAST_FAILURE}).
+
+The PR was **not** reviewed for this dimension — manual review recommended.
+
+> Check the [Actions log]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) for details.
+EOF
+	exit 1
+fi
+
+# --- Parse verdict ---
+
+echo "::group::Parsing verdict"
+
+PASS=$(echo "${VERDICT_LINE}" | jq -r '.pass // false')
+SUMMARY=$(echo "${VERDICT_LINE}" | jq -r '.summary // "No summary provided"')
+echo "Verdict found: pass=${PASS}"
+echo "Summary: ${SUMMARY}"
+
+echo "::endgroup::"
+
+# --- Write verdict to job summary ---
+
+# Redact the summary on both pass and fail paths — prompt injection could embed secrets
+# in the verdict JSON regardless of the pass/fail outcome.
+SAFE_SUMMARY=$(redact_secrets "${SUMMARY}")
+
+if [[ "${PASS}" == "true" ]]; then
+	echo "Agent check passed."
+	echo "verdict=ok" >>"${GITHUB_OUTPUT}"
+	cat >>"${GITHUB_STEP_SUMMARY}" <<EOF
+## ✅ ${CHECK_EMOJI:-} ${CHECK_NAME:-Agentic Check}
+
+${SAFE_SUMMARY}
+EOF
+	exit 0
+fi
+
+cat >>"${GITHUB_STEP_SUMMARY}" <<EOF
+## ❌ ${CHECK_EMOJI:-} ${CHECK_NAME:-Agentic Check}
+
+${SAFE_SUMMARY}
+
+> Full agent output is available in the [Actions log]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID).
+EOF
+
+echo "::error::Agent check failed: ${SAFE_SUMMARY}"
+echo "verdict=ko" >>"${GITHUB_OUTPUT}"
+# Use multiline output syntax with random delimiter to safely pass the summary
+DELIM="EOF_$(openssl rand -hex 8)"
+echo "verdict_text<<${DELIM}" >>"${GITHUB_OUTPUT}"
+echo "${SAFE_SUMMARY}" >>"${GITHUB_OUTPUT}"
+echo "${DELIM}" >>"${GITHUB_OUTPUT}"
+exit 1

--- a/.github/workflows/agentic-checks.yaml
+++ b/.github/workflows/agentic-checks.yaml
@@ -1,0 +1,179 @@
+name: 🤖 Agentic Checks
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/react/components/**"
+      - "packages/react/patterns/**"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+jobs:
+  agentic-check:
+    name: ${{ matrix.emoji }} ${{ matrix.name }}
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false
+    runs-on: build-s
+    timeout-minutes: 60
+    concurrency:
+      group: 🤖-agentic-checks-agentic-check-agentic-check-${{ matrix.id }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        id:
+          - code-review
+          - a11y
+          - storybook
+          - test-coverage
+        include:
+          - id: code-review
+            name: Code Review
+            emoji: 🧐
+            prompt: .github/agent-prompts/code-review.md
+          - id: a11y
+            name: Accessibility
+            emoji: ♿
+            prompt: .github/agent-prompts/a11y.md
+          - id: storybook
+            name: Storybook
+            emoji: 📚
+            prompt: .github/agent-prompts/storybook.md
+          - id: test-coverage
+            name: Test Coverage
+            emoji: 🧪
+            prompt: .github/agent-prompts/test-coverage.md
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PROMPT_FILE: ${{ matrix.prompt }}
+      CHECK_NAME: ${{ matrix.name }}
+      CHECK_EMOJI: ${{ matrix.emoji }}
+      MODEL: azure-cognitive-services/gpt-5.3-codex
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Runner uptime
+        run: uptime
+      - name: Repository last commit
+        run: which git && (git log -n 1 --pretty=format:"%h %s %an %ar" || true)
+      - name: Runner disk space
+        run: df -h
+      - name: Host machine IP
+        run: |-
+          echo "🐳 Pod: ${{ runner.name }}"
+          echo "🖥️ Self hosted machine ip: $(curl -s --max-time 5 https://api.ipify.org || echo '<unavailable>')"
+      - timeout-minutes: 5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Install OpenCode CLI
+        run: npm install -g opencode-ai@1.15.5
+      - id: run-agentic-check
+        name: Run Agentic Check
+        continue-on-error: true
+        env:
+          AZURE_API_KEY: ${{ secrets.DX_AI_WORKFLOWS_API_KEY }}
+          AZURE_RESOURCE_NAME: platform-dx-ai
+          OPENCODE_CONFIG_CONTENT: >-
+            {"snapshot":false,"small_model":"azure-cognitive-services/gpt-5.3-codex","permission":{"external_directory":{"/tmp/*":"allow"}},"provider":{"azure-cognitive-services":{"models":{"gpt-5.3-codex":{"name":"GPT
+            5.3 Codex"}}}}}
+        run: |-
+          SCRIPT_LOG=$(mktemp)
+
+          set +e
+          bash .github/scripts/agentic-check.sh 2>&1 | tee "$SCRIPT_LOG"
+          SCRIPT_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          # Check if the script already wrote a verdict to GITHUB_OUTPUT
+          SCRIPT_VERDICT=$(grep "^verdict=" "$GITHUB_OUTPUT" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+
+          if [[ -n "$SCRIPT_VERDICT" ]]; then
+            VERDICT="$SCRIPT_VERDICT"
+            echo "Verdict (from script GITHUB_OUTPUT): ${VERDICT}"
+          elif [[ $SCRIPT_EXIT -eq 0 ]]; then
+            VERDICT="ok"
+            echo "Verdict (exit code 0): ok"
+          elif grep -q "Agent check failed" "$SCRIPT_LOG"; then
+            VERDICT="ko"
+            echo "Verdict (exit code ${SCRIPT_EXIT}, detected agent failure): ko"
+          else
+            VERDICT="error"
+            echo "::error::Script exited ${SCRIPT_EXIT} without verdict. Verdict: error"
+          fi
+
+          rm -f "$SCRIPT_LOG"
+
+          # Always write from wrapper to guarantee the step output is set
+          echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
+          # Write fallback verdict_text if the script did not provide one
+          if ! grep -q "^verdict_text" "$GITHUB_OUTPUT" 2>/dev/null; then
+            echo "verdict_text=Check the Run Agentic Check step logs for details." >> "$GITHUB_OUTPUT"
+          fi
+          echo "Final verdict written to GITHUB_OUTPUT: ${VERDICT}"
+      - name: OpenCode Stats
+        if: always() && !cancelled() && steps.run-agentic-check.conclusion != 'skipped' && steps.run-agentic-check.outcome != 'cancelled'
+        continue-on-error: true
+        env:
+          AZURE_API_KEY: ${{ secrets.DX_AI_WORKFLOWS_API_KEY }}
+          AZURE_RESOURCE_NAME: platform-dx-ai
+          OPENCODE_CONFIG_CONTENT: >-
+            {"snapshot":false,"small_model":"azure-cognitive-services/gpt-5.3-codex","permission":{"external_directory":{"/tmp/*":"allow"}},"provider":{"azure-cognitive-services":{"models":{"gpt-5.3-codex":{"name":"GPT
+            5.3 Codex"}}}}}
+        run: |-
+          echo "::group::OpenCode usage statistics"
+          opencode stats || echo "opencode stats failed (non-fatal)"
+          echo "::endgroup::"
+      # Datadog reporting is disabled until we want aggregated telemetry on verdicts.
+      # Re-enable by uncommenting this step and making sure secret `DATADOG_CODEMONITOR_API_TOKEN`
+      # is available in `factorialco/f0`.
+      # - name: Report to Datadog
+      #   if: always() && !cancelled() && steps.run-agentic-check.conclusion != 'skipped' && steps.run-agentic-check.outcome != 'cancelled'
+      #   env:
+      #     DATADOG_API_KEY: ${{ secrets.DATADOG_CODEMONITOR_API_TOKEN }}
+      #     AGENTIC_VERDICT: ${{ steps.run-agentic-check.outputs.verdict }}
+      #   run: |-
+      #     VERDICT="${AGENTIC_VERDICT}"
+      #     # Default to "error" if the step was killed before writing an output (e.g. OOM)
+      #     if [[ -z "$VERDICT" ]]; then VERDICT="error"; fi
+      #
+      #     case "$VERDICT" in
+      #       ok)      ALERT_TYPE="success" ;;
+      #       ko)      ALERT_TYPE="warning" ;;
+      #       error)   ALERT_TYPE="error"   ;;
+      #       *)       ALERT_TYPE="error"   ;;
+      #     esac
+      #
+      #     WORKFLOW_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      #     PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+      #
+      #     DD_MARKER="%%%"
+      #     TEXT="${DD_MARKER}
+      #     **Check**: ${{ matrix.name }}
+      #     **Verdict**: ${VERDICT}
+      #     **PR**: [#${{ github.event.pull_request.number }}](${PR_URL})
+      #     **Repo**: ${{ github.repository }}
+      #     **Workflow run**: [View run](${WORKFLOW_RUN_URL})
+      #     ${DD_MARKER}"
+      #
+      #     PAYLOAD=$(jq -n \
+      #       --arg title "Agentic Check: ${{ matrix.name }} - ${VERDICT}" \
+      #       --arg text "$TEXT" \
+      #       --arg alert_type "$ALERT_TYPE" \
+      #       --arg aggregation_key "agentic-check-${{ github.event.pull_request.number }}-${{ matrix.id }}" \
+      #       --argjson tags '["service:agentic-checks","source:github-actions"]' \
+      #       --arg check "${{ matrix.id }}" \
+      #       --arg verdict "$VERDICT" \
+      #       --arg pr "${{ github.event.pull_request.number }}" \
+      #       --arg repo "${{ github.repository }}" \
+      #       '{ title: $title, text: $text, alert_type: $alert_type, aggregation_key: $aggregation_key, source_type_name: "Github", tags: ($tags + ["check:" + $check, "verdict:" + $verdict, "pr:" + $pr, "repo:" + $repo]) }')
+      #
+      #     curl -sS -X POST "https://api.datadoghq.eu/api/v1/events" \
+      #       -H "Content-Type: application/json" \
+      #       -H "DD-API-KEY: ${DATADOG_API_KEY}" \
+      #       -d "$PAYLOAD"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/agentic-checks.yaml` that runs 4 OpenCode-based reviews (Code Review, Accessibility, Storybook & Docs, Test Coverage) in parallel on every PR.
- Triggers **only** when the diff touches `packages/react/components/**` or `packages/react/patterns/**`.
- **Warning-only**: no step fails the check on a `ko` verdict — results live in the job summary. Branch protection is unaffected. Easy to promote to blocking later (re-add the `Fail on ko verdict` step + a merge gatekeeper job).
- Each review uses a prompt derived from `vendor/skills/f0-quality-gate/SKILL.md`, so the CI reviewers apply the same checklist as the local quality gate.
- Datadog reporting step is committed but commented out — re-enable once we want aggregated telemetry.

## Notes

- Runner: `build-s` (rationale in the plan — these jobs are network-bound, the heavy lifting happens on Azure OpenAI, not on the runner).
- Secret required: `DX_AI_WORKFLOWS_API_KEY` (already used by other F0 workflows? — confirm it's available in `factorialco/f0`).
- Script `.github/scripts/agentic-check.sh` is a byte-for-byte copy of the monorepo's version. No f0-specific logic.

## Test plan

- [ ] Confirm secret `DX_AI_WORKFLOWS_API_KEY` is available in repo settings.
- [ ] Open a PR that **does not** touch `packages/react/{components,patterns}/**` → workflow should not start.
- [ ] Open a PR that touches `packages/react/components/<something>.tsx` → all 4 jobs should run in parallel.
- [ ] Verify a `ko` verdict does **not** block merge (warning only).
- [ ] Review the 4 job summaries on a real PR; calibrate prompts if false positives are noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)