### PR TITLE
feat(F0Drawer): resource-aware header — port PR #4313 into dialog-alike

### DIFF
--- a/packages/react/src/components/dialog-alike/F0Dialog/__stories__/DialogNotification.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__stories__/DialogNotification.stories.tsx
@@ -5,6 +5,8 @@ import { useState } from "react"
 import { Placeholder } from "@/icons/app"
 import CrossIcon from "@/icons/app/Cross"
 
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
 import { getDialogAlikeArgTypes } from "../../common/__stories__/argsTypes"
 import { DialogNotificationInternal } from "../internal/DialogNotification"
 import { dialogNotificationTypes } from "../types"
@@ -68,6 +70,7 @@ export default meta
 type Story = StoryObj<typeof DialogNotificationInternal>
 
 export const Default: Story = {
+  parameters: withSnapshot({}),
   args: {
     isOpen: true,
     title: "Team Status",
@@ -87,6 +90,7 @@ export const Default: Story = {
 }
 
 export const Critical: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...Default.args,
     type: "critical",
@@ -96,6 +100,7 @@ export const Critical: Story = {
 }
 
 export const Warning: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...Default.args,
     type: "warning",
@@ -105,6 +110,7 @@ export const Warning: Story = {
 }
 
 export const Positive: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...Default.args,
     type: "positive",

--- a/packages/react/src/components/dialog-alike/F0Dialog/__stories__/F0Dialog.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__stories__/F0Dialog.stories.tsx
@@ -18,6 +18,7 @@ import {
   expectDialogPaintsAboveChat,
   FullscreenChatFrame,
 } from "@/lib/storybook-utils/aiChatStacking"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { getDialogAlikeArgTypes } from "../../common/__stories__/argsTypes.ts"
 import { OTHER_ACTIONS, TABS } from "../../common/__stories__/mocks.ts"
@@ -116,6 +117,7 @@ const ExampleList = ({ itemsCount = 20 }: { itemsCount?: number }) => (
 )
 
 export const Default: Story = {
+  parameters: withSnapshot({}),
   args: {
     isOpen: true,
     onClose: () => {},
@@ -146,6 +148,7 @@ export const WithDataTestId: Story = {
 }
 
 export const Notification: Story = {
+  parameters: withSnapshot({}),
   args: {
     isOpen: true,
     onClose: () => {},
@@ -195,6 +198,7 @@ export const Modal: Story = {
 }
 
 export const WithSmSize: Story = {
+  parameters: withSnapshot({}),
   args: {
     isOpen: true,
     size: "sm",
@@ -207,6 +211,7 @@ export const WithSmSize: Story = {
 }
 
 export const WithMdSize: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...WithSmSize.args,
     size: "md",
@@ -214,6 +219,7 @@ export const WithMdSize: Story = {
 }
 
 export const WithLgSize: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...WithMdSize.args,
     size: "lg",
@@ -221,12 +227,14 @@ export const WithLgSize: Story = {
 }
 
 export const WithXlSize: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...WithLgSize.args,
     size: "xl",
   },
 }
 export const WithDescription: Story = {
+  parameters: withSnapshot({}),
   args: {
     isOpen: true,
     onClose: () => {},
@@ -261,6 +269,7 @@ export const WithPersonListItems: Story = {
 }
 
 export const WithFullscreenSize: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...Default.args,
     size: "fullscreen",
@@ -268,6 +277,7 @@ export const WithFullscreenSize: Story = {
 }
 
 export const WithFullscreenSizeAndActions: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...WithFullscreenSize.args,
     tabs: TABS,
@@ -319,17 +329,18 @@ export const WithMultiplePrimaryActions: Story = {
     },
     children: <ExampleList itemsCount={3} />,
   },
-  parameters: {
+  parameters: withSnapshot({
     docs: {
       description: {
         story:
           "When `primaryAction` receives an array of actions, it renders a `F0ButtonDropdown` allowing the user to select between multiple primary actions.",
       },
     },
-  },
+  }),
 }
 
 export const WithModule: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...Default.args,
     title: "Team Status",
@@ -345,6 +356,7 @@ export const WithModule: Story = {
 }
 
 export const WithModuleAndFullscreenSize: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...WithModule.args,
     size: "fullscreen",

--- a/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
@@ -13,6 +13,7 @@ import { Placeholder } from "@/icons/app"
 import SaveIcon from "@/icons/app/Save"
 import ShareIcon from "@/icons/app/Share"
 import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { getDialogAlikeArgTypes } from "../../common/__stories__/argsTypes"
 import { OTHER_ACTIONS, TABS } from "../../common/__stories__/mocks"
@@ -88,6 +89,7 @@ const ExampleList = ({ itemsCount = 20 }: { itemsCount?: number }) => (
 )
 
 export const Default: Story = {
+  parameters: withSnapshot({}),
   args: {
     isOpen: true,
     onClose: () => {},
@@ -104,6 +106,7 @@ export const Default: Story = {
 }
 
 export const LeftPosition: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...Default.args,
     position: "left",
@@ -130,6 +133,7 @@ export const Modal: Story = {
   },
 }
 export const WithDescription: Story = {
+  parameters: withSnapshot({}),
   args: {
     isOpen: true,
     onClose: () => {},
@@ -197,17 +201,18 @@ export const WithMultiplePrimaryActions: Story = {
     },
     children: <ExampleList itemsCount={3} />,
   },
-  parameters: {
+  parameters: withSnapshot({
     docs: {
       description: {
         story:
           "When `primaryAction` receives an array of actions, it renders a `F0ButtonDropdown` allowing the user to select between multiple primary actions.",
       },
     },
-  },
+  }),
 }
 
 export const WithModuleAndTabs: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...Default.args,
     title: "Team Status",
@@ -223,6 +228,7 @@ export const WithModuleAndTabs: Story = {
 }
 
 export const WithResourceHeader: Story = {
+  parameters: withSnapshot({}),
   args: {
     ...Default.args,
     position: "right",
@@ -298,14 +304,14 @@ export const WithNavigation: Story = {
       counter: { current: 3, total: 10 },
     },
   },
-  parameters: {
+  parameters: withSnapshot({
     docs: {
       description: {
         story:
           "Pass `navigation` to render prev/next arrows and an optional counter beside the close button in the standard title row.",
       },
     },
-  },
+  }),
 }
 
 /**
@@ -329,14 +335,14 @@ export const WithResourceHeaderProp: Story = {
     tabs: TABS,
     children: <ExampleList itemsCount={30} />,
   },
-  parameters: {
+  parameters: withSnapshot({
     docs: {
       description: {
         story:
           "Pass `resourceHeader` to render the identity band as pinned header chrome (vs. composing `<ResourceHeader>` in the body, which scrolls away). A visually-hidden `DialogTitle` keeps the accessible name, and `otherActions` appears in the top-right beside the close button. Scroll the body to see the band and tabs stay fixed.",
       },
     },
-  },
+  }),
 }
 
 /**
@@ -409,14 +415,14 @@ export const WithResourceControls: Story = {
     otherActions: OTHER_ACTIONS,
     disableContentPadding: false,
   },
-  parameters: {
+  parameters: withSnapshot({
     docs: {
       description: {
         story:
           "`controls={{ kind: 'resource' }}` renders the top chrome row with an expand affordance and prev/next navigation. The identity band sits below. Click the arrows to step through items.",
       },
     },
-  },
+  }),
 }
 
 /**
@@ -438,12 +444,12 @@ export const WithBackControls: Story = {
     otherActions: OTHER_ACTIONS,
     children: <ExampleList itemsCount={6} />,
   },
-  parameters: {
+  parameters: withSnapshot({
     docs: {
       description: {
         story:
           "`controls={{ kind: 'back' }}` is used when the drawer has drilled into a sub-page. The left slot shows a single back affordance; the identity band and close button remain.",
       },
     },
-  },
+  }),
 }

--- a/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
@@ -14,6 +14,11 @@ import SaveIcon from "@/icons/app/Save"
 import ShareIcon from "@/icons/app/Share"
 import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
+import { ApplicationFrame } from "@/patterns/ApplicationFrame"
+import { Page } from "@/patterns/Navigation/Page"
+import * as PageStories from "@/patterns/Navigation/Page/index.stories"
+import * as SidebarStories from "@/patterns/Navigation/Sidebar/index.stories"
+import { Sidebar } from "@/patterns/Navigation/Sidebar/Sidebar"
 
 import { getDialogAlikeArgTypes } from "../../common/__stories__/argsTypes"
 import { OTHER_ACTIONS, TABS } from "../../common/__stories__/mocks"
@@ -52,7 +57,11 @@ const meta: Meta<typeof F0Drawer> = {
     ...dataTestIdArgs,
   },
   decorators: [
-    (Story, { args: { isOpen, ...rest } }) => {
+    (Story, context) => {
+      const {
+        args: { isOpen, ...rest },
+        parameters,
+      } = context
       const [open, setOpen] = useState(isOpen)
 
       const handleClose = () => {
@@ -60,6 +69,13 @@ const meta: Meta<typeof F0Drawer> = {
       }
       const handleOpen = () => {
         setOpen(true)
+      }
+
+      // Stories that build their own ApplicationFrame (e.g. the sidebar
+      // showcase) opt out of the default open-button + centering wrapper and
+      // drive the drawer themselves.
+      if (parameters.standaloneFrame) {
+        return <Story />
       }
 
       return (
@@ -452,4 +468,51 @@ export const WithBackControls: Story = {
       },
     },
   }),
+}
+
+// ─── Drawer inside the app shell ──────────────────────────────────────────────
+
+/**
+ * The drawer rendered inside a real `ApplicationFrame`, to show how it sits
+ * relative to the sidebar. Side drawers portal into `#content` (not the
+ * top-level overlay root), so a right-positioned drawer docks at the right of
+ * the content area: the sidebar and page header stay visible and the drawer
+ * reads as a detail panel within the app rather than a full-viewport takeover.
+ * Use the `position` control to switch sides (`left` docks at the opposite
+ * edge, over the sidebar).
+ */
+export const InApplicationFrame: Story = {
+  parameters: { standaloneFrame: true, layout: "fullscreen" },
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    position: "right",
+    title: "Team Status",
+    otherActions: OTHER_ACTIONS,
+    primaryAction: {
+      label: "submit",
+      icon: Placeholder,
+      onClick: () => {},
+      closeOnClick: true,
+    },
+  },
+  render: (args) => {
+    const Wrapper = () => {
+      const [open, setOpen] = useState(true)
+
+      return (
+        <ApplicationFrame
+          sidebar={<Sidebar {...SidebarStories.default.args} />}
+        >
+          <Page {...PageStories.Default.args} />
+          <F0Button label="Open drawer" onClick={() => setOpen(true)} />
+          <F0Drawer {...args} isOpen={open} onClose={() => setOpen(false)}>
+            <ExampleList itemsCount={20} />
+          </F0Drawer>
+        </ApplicationFrame>
+      )
+    }
+
+    return <Wrapper />
+  },
 }

--- a/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
@@ -475,18 +475,16 @@ export const WithBackControls: Story = {
 /**
  * The drawer rendered inside a real `ApplicationFrame`, to show how it sits
  * relative to the sidebar. Side drawers portal into `#content` (not the
- * top-level overlay root), so a right-positioned drawer docks at the right of
- * the content area: the sidebar and page header stay visible and the drawer
- * reads as a detail panel within the app rather than a full-viewport takeover.
- * Use the `position` control to switch sides (`left` docks at the opposite
- * edge, over the sidebar).
+ * top-level overlay root), so the drawer docks within the content area beside
+ * the sidebar rather than covering the whole viewport. Use the `position`
+ * control to switch sides.
  */
 export const InApplicationFrame: Story = {
   parameters: { standaloneFrame: true, layout: "fullscreen" },
   args: {
     isOpen: true,
     onClose: () => {},
-    position: "right",
+    position: "left",
     title: "Team Status",
     otherActions: OTHER_ACTIONS,
     primaryAction: {
@@ -504,8 +502,11 @@ export const InApplicationFrame: Story = {
         <ApplicationFrame
           sidebar={<Sidebar {...SidebarStories.default.args} />}
         >
-          <Page {...PageStories.Default.args} />
-          <F0Button label="Open drawer" onClick={() => setOpen(true)} />
+          <Page {...PageStories.Default.args}>
+            <div className="p-4">
+              <F0Button label="Open drawer" onClick={() => setOpen(true)} />
+            </div>
+          </Page>
           <F0Drawer {...args} isOpen={open} onClose={() => setOpen(false)}>
             <ExampleList itemsCount={20} />
           </F0Drawer>

--- a/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
@@ -16,7 +16,7 @@ import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
 
 import { getDialogAlikeArgTypes } from "../../common/__stories__/argsTypes"
 import { OTHER_ACTIONS, TABS } from "../../common/__stories__/mocks"
-import { F0Drawer } from "../index"
+import { DrawerControls, F0Drawer } from "../index"
 import { drawerSizes } from "../types"
 
 const meta: Meta<typeof F0Drawer> = {
@@ -242,5 +242,203 @@ export const WithResourceHeader: Story = {
         otherActions={undefined}
       />
     ),
+  },
+}
+
+// ─── Resource-aware header stories ────────────────────────────────────────────
+
+const CANDIDATE_RESOURCE_HEADER: ComponentProps<typeof ResourceHeader> = {
+  title: "René Galindo",
+  description: "Senior Product Designer",
+  avatar: {
+    type: "person",
+    firstName: "René",
+    lastName: "Galindo",
+    src: "/avatars/person04.jpg",
+  },
+  status: {
+    label: "Stage",
+    text: "Interview",
+    variant: "warning",
+    actions: [],
+  },
+  metadata: [
+    {
+      label: "Applied",
+      value: { type: "date", formattedDate: "2026-05-12" },
+    },
+    {
+      label: "Manager",
+      value: {
+        type: "avatar",
+        variant: {
+          type: "person",
+          firstName: "Ilya",
+          lastName: "Zayats",
+          src: "/avatars/person05.jpg",
+        },
+        text: "Ilya Zayats",
+      },
+    },
+  ],
+}
+
+/**
+ * `navigation` in the standard title row — useful when the drawer shows
+ * one item from a list and the user should be able to step through
+ * without closing and reopening.
+ */
+export const WithNavigation: Story = {
+  args: {
+    ...Default.args,
+    title: "Team Status",
+    navigation: {
+      previous: { title: "Previous item", onClick: () => {} },
+      next: { title: "Next item", onClick: () => {} },
+      counter: { current: 3, total: 10 },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pass `navigation` to render prev/next arrows and an optional counter beside the close button in the standard title row.",
+      },
+    },
+  },
+}
+
+/**
+ * `resourceHeader` renders the resource identity band (avatar, title,
+ * description, status, metadata) directly in the header area instead of
+ * composing it inside the body. No controls row — the close button sits alone
+ * at the top right.
+ */
+export const WithResourceHeaderProp: Story = {
+  args: {
+    ...Default.args,
+    position: "right",
+    title: "René Galindo",
+    resourceHeader: CANDIDATE_RESOURCE_HEADER,
+    otherActions: OTHER_ACTIONS,
+    tabs: TABS,
+    children: <ExampleList itemsCount={8} />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pass `resourceHeader` to render the identity band in the header. A visually-hidden `DialogTitle` keeps the accessible name. `otherActions` appears in the top-right beside the close button.",
+      },
+    },
+  },
+}
+
+/**
+ * Full resource-aware layout: a controls row owns the top chrome
+ * (expand link + prev/next navigation), the identity band sits below it,
+ * and tabs follow. This is the ATS-style application preview pattern.
+ */
+export const WithResourceControls: Story = {
+  render: (args) => {
+    const CANDIDATES = [
+      "René Galindo",
+      "Ilya Zayats",
+      "Anna Pérez",
+      "Marc Torres",
+      "Sofía López",
+    ]
+
+    const Wrapper = () => {
+      const [open, setOpen] = useState(args.isOpen)
+      const [index, setIndex] = useState(0)
+
+      const controls: DrawerControls = {
+        kind: "resource",
+        expand: { label: "Open detail", onClick: () => {} },
+        navigation: {
+          previous:
+            index > 0
+              ? {
+                  title: CANDIDATES[index - 1],
+                  onClick: () => setIndex((i) => i - 1),
+                }
+              : undefined,
+          next:
+            index < CANDIDATES.length - 1
+              ? {
+                  title: CANDIDATES[index + 1],
+                  onClick: () => setIndex((i) => i + 1),
+                }
+              : undefined,
+          counter: { current: index + 1, total: CANDIDATES.length },
+        },
+      }
+
+      return (
+        <div className="flex flex-1 items-center justify-center rounded-md border border-solid border-f1-border-secondary bg-f1-background">
+          <F0Button label="Open drawer" onClick={() => setOpen(true)} />
+          <F0Drawer
+            {...args}
+            isOpen={open}
+            onClose={() => setOpen(false)}
+            title={CANDIDATES[index]}
+            resourceHeader={{
+              ...CANDIDATE_RESOURCE_HEADER,
+              title: CANDIDATES[index],
+            }}
+            controls={controls}
+            tabs={TABS}
+          >
+            <ExampleList itemsCount={6} />
+          </F0Drawer>
+        </div>
+      )
+    }
+
+    return <Wrapper />
+  },
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    otherActions: OTHER_ACTIONS,
+    disableContentPadding: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`controls={{ kind: 'resource' }}` renders the top chrome row with an expand affordance and prev/next navigation. The identity band sits below. Click the arrows to step through items.",
+      },
+    },
+  },
+}
+
+/**
+ * `controls={{ kind: "back" }}` represents a drilled-in sub-page inside
+ * the same drawer — the left slot shows a back button instead of the
+ * resource navigation.
+ */
+export const WithBackControls: Story = {
+  args: {
+    ...Default.args,
+    position: "right",
+    title: "René Galindo",
+    resourceHeader: CANDIDATE_RESOURCE_HEADER,
+    controls: {
+      kind: "back",
+      label: "Back to candidates",
+      onClick: () => {},
+    },
+    otherActions: OTHER_ACTIONS,
+    children: <ExampleList itemsCount={6} />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`controls={{ kind: 'back' }}` is used when the drawer has drilled into a sub-page. The left slot shows a single back affordance; the identity band and close button remain.",
+      },
+    },
   },
 }

--- a/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
@@ -313,6 +313,11 @@ export const WithNavigation: Story = {
  * description, status, metadata) directly in the header area instead of
  * composing it inside the body. No controls row — the close button sits alone
  * at the top right.
+ *
+ * Unlike composing a `<ResourceHeader>` inside `children` (see
+ * `WithResourceHeader`), the band is owned by the dialog as **pinned header
+ * chrome**: it stays fixed above the tabs while the body scrolls underneath.
+ * The long list below makes that pinning visible.
  */
 export const WithResourceHeaderProp: Story = {
   args: {
@@ -322,13 +327,13 @@ export const WithResourceHeaderProp: Story = {
     resourceHeader: CANDIDATE_RESOURCE_HEADER,
     otherActions: OTHER_ACTIONS,
     tabs: TABS,
-    children: <ExampleList itemsCount={8} />,
+    children: <ExampleList itemsCount={30} />,
   },
   parameters: {
     docs: {
       description: {
         story:
-          "Pass `resourceHeader` to render the identity band in the header. A visually-hidden `DialogTitle` keeps the accessible name. `otherActions` appears in the top-right beside the close button.",
+          "Pass `resourceHeader` to render the identity band as pinned header chrome (vs. composing `<ResourceHeader>` in the body, which scrolls away). A visually-hidden `DialogTitle` keeps the accessible name, and `otherActions` appears in the top-right beside the close button. Scroll the body to see the band and tabs stay fixed.",
       },
     },
   },

--- a/packages/react/src/components/dialog-alike/F0Drawer/index.tsx
+++ b/packages/react/src/components/dialog-alike/F0Drawer/index.tsx
@@ -12,6 +12,7 @@ export type {
   F0DrawerActionsProps,
   F0DrawerAction,
 } from "./types"
+export type { DrawerControls } from "../common/Header"
 
 /**
  * @experimental This is an experimental component use it at your own risk

--- a/packages/react/src/components/dialog-alike/F0Drawer/internal/DrawerInternal.tsx
+++ b/packages/react/src/components/dialog-alike/F0Drawer/internal/DrawerInternal.tsx
@@ -19,6 +19,9 @@ export const DrawerInternal: FC<DrawerInternalProps> = ({
   description,
   module,
   otherActions,
+  navigation,
+  resourceHeader,
+  controls,
   tabs,
   modal = false,
   activeTabId,
@@ -39,6 +42,9 @@ export const DrawerInternal: FC<DrawerInternalProps> = ({
           description={description}
           module={module}
           otherActions={otherActions}
+          navigation={navigation}
+          resourceHeader={resourceHeader}
+          controls={controls}
           tabs={tabs}
           activeTabId={activeTabId}
           setActiveTabId={setActiveTabId}
@@ -59,6 +65,9 @@ export const DrawerInternal: FC<DrawerInternalProps> = ({
     description,
     module,
     otherActions,
+    navigation,
+    resourceHeader,
+    controls,
     tabs,
     activeTabId,
     setActiveTabId,

--- a/packages/react/src/components/dialog-alike/F0Drawer/internal/internal-types.ts
+++ b/packages/react/src/components/dialog-alike/F0Drawer/internal/internal-types.ts
@@ -1,7 +1,17 @@
+import { NavigationProps } from "@/experimental/Navigation/Header/PageNavigation"
+import { ResourceHeaderProps } from "@/patterns/ResourceHeader"
+
+import { DrawerControls } from "../../common/Header"
 import { DialogAlikeInternalProps } from "../../common/types"
-import { F0DrawerPosition, DrawerSize } from "../types"
+import { DrawerSize, F0DrawerPosition } from "../types"
 
 export type DrawerInternalProps = Omit<DialogAlikeInternalProps, "size"> & {
   size?: DrawerSize
   position?: F0DrawerPosition
+  /** Side-panel navigation rendered in the title row, next to the close button. */
+  navigation?: NavigationProps
+  /** Resource identity band rendered below the controls row. */
+  resourceHeader?: ResourceHeaderProps
+  /** Controls the left slot of the controls row — back or resource (expand + prev/next). */
+  controls?: DrawerControls
 }

--- a/packages/react/src/components/dialog-alike/common/Header.tsx
+++ b/packages/react/src/components/dialog-alike/common/Header.tsx
@@ -4,7 +4,14 @@ import {
   DropdownInternalProps,
   DropdownItemObject,
 } from "@/experimental/Navigation/Dropdown/internal"
+import { BaseHeader } from "@/experimental/Information/Headers/BaseHeader"
 import { BreadcrumbItem } from "@/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem"
+import {
+  NavigationProps,
+  PageNavigation,
+} from "@/experimental/Navigation/Header/PageNavigation"
+import { ResourceHeaderProps } from "@/patterns/ResourceHeader"
+import { ChevronLeft, Maximize } from "@/icons/app"
 import CrossIcon from "@/icons/app/Cross"
 import { DialogModule } from "@/lib/providers/dialogs-alike/module-types"
 import { useI18n } from "@/lib/providers/i18n"
@@ -16,6 +23,18 @@ import { DrawerDescription } from "@/ui/drawer"
 
 import { useDialogWrapperContext } from "./DialogWrapperProvider"
 
+export type DrawerControls =
+  | {
+      kind: "resource"
+      expand?: { label: string; url?: string; onClick?: () => void }
+      navigation?: NavigationProps
+    }
+  | {
+      kind: "back"
+      label: string
+      onClick: () => void
+    }
+
 export type HeaderProps = {
   /**
    * Disables the close button of the dialog.
@@ -26,6 +45,12 @@ export type HeaderProps = {
   description?: string
   module?: DialogModule
   otherActions?: DropdownInternalProps["items"]
+  /** Side-panel navigation rendered in the title row, next to the close button. */
+  navigation?: NavigationProps
+  /** Resource identity band rendered below the controls row (drawers only). */
+  resourceHeader?: ResourceHeaderProps
+  /** Controls the left slot of the controls row — back or resource (expand + prev/next). */
+  controls?: DrawerControls
 } & Partial<Pick<TabsProps, "tabs" | "activeTabId" | "setActiveTabId">>
 
 export const Header = ({
@@ -33,6 +58,9 @@ export const Header = ({
   description,
   module,
   otherActions,
+  navigation,
+  resourceHeader,
+  controls,
   tabs,
   activeTabId,
   setActiveTabId,
@@ -95,6 +123,89 @@ export const Header = ({
     )
   }
 
+  const CloseButton = () => (
+    <ButtonInternal
+      variant="outline"
+      icon={CrossIcon}
+      disabled={disableClose}
+      onClick={onClose}
+      label={translations.actions.close}
+      hideLabel
+    />
+  )
+
+  const TabsStrip = () =>
+    tabs && tabs.length > 0 ? (
+      <div className="-mx-2">
+        <Tabs
+          tabs={tabs}
+          activeTabId={activeTabId}
+          setActiveTabId={setActiveTabId}
+        />
+      </div>
+    ) : null
+
+  const Controls = () => {
+    if (!controls) return null
+
+    if (controls.kind === "back") {
+      return (
+        <ButtonInternal
+          variant="outline"
+          icon={ChevronLeft}
+          onClick={controls.onClick}
+          label={controls.label}
+        />
+      )
+    }
+
+    const expandElementProps = controls.expand?.onClick
+      ? { onClick: controls.expand.onClick, type: "button" as const }
+      : { href: controls.expand?.url ?? "" }
+
+    return (
+      <>
+        {controls.expand && (
+          <ButtonInternal
+            variant="outline"
+            icon={Maximize}
+            {...expandElementProps}
+            label={controls.expand.label}
+          />
+        )}
+        {controls.expand && controls.navigation && <Divider />}
+        {controls.navigation && <PageNavigation {...controls.navigation} />}
+      </>
+    )
+  }
+
+  if (resourceHeader || controls) {
+    return (
+      <>
+        <div className="flex flex-row items-center justify-between gap-3 px-4 py-3">
+          <div className="flex flex-row items-center gap-2">
+            <Controls />
+          </div>
+          <div className="flex flex-row items-center gap-2">
+            <Actions />
+            <CloseButton />
+          </div>
+        </div>
+        {resourceHeader ? (
+          <>
+            <DialogTitle className="sr-only">
+              {resourceHeader.title ?? title}
+            </DialogTitle>
+            <BaseHeader {...resourceHeader} />
+          </>
+        ) : (
+          title && <DialogTitle className="sr-only">{title}</DialogTitle>
+        )}
+        <TabsStrip />
+      </>
+    )
+  }
+
   return (
     <>
       <div
@@ -121,27 +232,13 @@ export const Header = ({
           )}
         </div>
         <div className="flex flex-row gap-2">
+          {navigation && <PageNavigation {...navigation} />}
           <Actions />
-          {otherActions && <Divider />}
-          <ButtonInternal
-            variant="outline"
-            icon={CrossIcon}
-            disabled={disableClose}
-            onClick={onClose}
-            label={translations.actions.close}
-            hideLabel
-          />
+          {(navigation || otherActions) && <Divider />}
+          <CloseButton />
         </div>
       </div>
-      {tabs && tabs.length > 0 && (
-        <div className="-mx-2">
-          <Tabs
-            tabs={tabs}
-            activeTabId={activeTabId}
-            setActiveTabId={setActiveTabId}
-          />
-        </div>
-      )}
+      <TabsStrip />
     </>
   )
 }

--- a/packages/react/src/components/dialog-alike/common/Wrapper.tsx
+++ b/packages/react/src/components/dialog-alike/common/Wrapper.tsx
@@ -214,6 +214,10 @@ export const DialogWrapper = ({
             ref={setContentRef}
             container={container}
             defaultContainerId={defaultContainerId}
+            // Side drawers dock within `#content` (clear of the sidebar) by
+            // anchoring the fixed wrapper to the container box; center modals
+            // stay viewport-centered.
+            anchorToContainer={isSidePosition}
             wrapperClassName={dialogWrapperClassName({ position })}
             className={cn(
               dialogContentClassName({ size: localSize }),

--- a/packages/react/src/components/dialog-alike/common/Wrapper.tsx
+++ b/packages/react/src/components/dialog-alike/common/Wrapper.tsx
@@ -13,8 +13,8 @@ const dialogWrapperClassName = cva({
   variants: {
     position: {
       right:
-        "fixed flex flex-col rounded-md w-full left-auto right-0 items-end p-3",
-      left: "fixed flex flex-col rounded-md w-full left-0 items-start p-3",
+        "fixed flex flex-col rounded-md w-full left-auto right-0 items-end p-3 pl-2.5",
+      left: "fixed flex flex-col rounded-md w-full left-0 items-start p-3 pl-2.5",
       center: "p-6",
     },
   },

--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
@@ -1,7 +1,15 @@
 "use client"
 
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { forwardRef, useCallback, useEffect, useRef, useState } from "react"
+import {
+  CSSProperties,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+import { useIsomorphicLayoutEffect } from "usehooks-ts"
 
 type PointerDownOutsideEvent = CustomEvent<{
   originalEvent: PointerEvent
@@ -40,6 +48,14 @@ export const DialogContent = forwardRef<
      */
     defaultContainerId?: string
     animation?: DialogAnimation
+    /**
+     * Anchor the (fixed) wrapper to the resolved portal container's box rather
+     * than the viewport. Used by side drawers so they dock within the
+     * `#content` region — clear of the sidebar — instead of painting over it.
+     * Falls back to the viewport when the container is absent or the document
+     * body (e.g. outside ApplicationFrame: Storybook docs, tests).
+     */
+    anchorToContainer?: boolean
   }
 >(
   (
@@ -50,12 +66,17 @@ export const DialogContent = forwardRef<
       children,
       container: propContainer,
       defaultContainerId = "content",
+      anchorToContainer = false,
       ...props
     },
     ref
   ) => {
     const [container, setContainer] = useState<HTMLElement | null>()
     const contentRef = useRef<HTMLDivElement>(null)
+    // When anchoring, the fixed wrapper is positioned to overlay the container's
+    // box (kept in sync on resize/scroll). Empty → fall back to the class-based
+    // `inset-0` viewport positioning.
+    const [anchorStyle, setAnchorStyle] = useState<CSSProperties>({})
 
     // Shake the content when the dialog is opened and clicked outside in modal mode
     const shake = useCallback(() => {
@@ -84,6 +105,44 @@ export const DialogContent = forwardRef<
       }
     }, [propContainer, defaultContainerId])
 
+    // Track the container's box so the fixed wrapper overlays it exactly. Only
+    // when anchoring is requested and the container is a real shell element —
+    // a body/null container keeps the viewport (`inset-0`) fallback.
+    useIsomorphicLayoutEffect(() => {
+      if (
+        typeof document === "undefined" ||
+        !anchorToContainer ||
+        !container ||
+        container === document.body
+      ) {
+        setAnchorStyle({})
+        return
+      }
+
+      const update = () => {
+        const rect = container.getBoundingClientRect()
+        setAnchorStyle({
+          left: rect.left,
+          top: rect.top,
+          width: rect.width,
+          height: rect.height,
+          right: "auto",
+          bottom: "auto",
+        })
+      }
+
+      update()
+      const observer = new ResizeObserver(update)
+      observer.observe(container)
+      window.addEventListener("resize", update)
+      window.addEventListener("scroll", update, true)
+      return () => {
+        observer.disconnect()
+        window.removeEventListener("resize", update)
+        window.removeEventListener("scroll", update, true)
+      }
+    }, [anchorToContainer, container])
+
     const context = useDialogPrimitiveContext()
 
     if (container === undefined) return null
@@ -103,6 +162,7 @@ export const DialogContent = forwardRef<
           )}
           style={{
             transition: "all 2s 100ms !important",
+            ...anchorStyle,
           }}
           {...props}
           onClick={(e) => {

--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
@@ -105,22 +105,25 @@ export const DialogContent = forwardRef<
       }
     }, [propContainer, defaultContainerId])
 
-    // Track the container's box so the fixed wrapper overlays it exactly. Only
-    // when anchoring is requested and the container is a real shell element —
-    // a body/null container keeps the viewport (`inset-0`) fallback.
+    // Anchor to the content region's frame — the parent of the scrollable
+    // `#content`, not `#content` itself, which is `overflow-auto` and padded.
+    // The frame is a stable, non-scrolling box that spans the area beside the
+    // sidebar. Only when anchoring is requested and the container is a real
+    // shell element — a body/null container keeps the viewport (`inset-0`)
+    // fallback.
+    const anchorEl =
+      anchorToContainer && container && container !== document.body
+        ? (container.parentElement ?? container)
+        : null
+
     useIsomorphicLayoutEffect(() => {
-      if (
-        typeof document === "undefined" ||
-        !anchorToContainer ||
-        !container ||
-        container === document.body
-      ) {
+      if (typeof document === "undefined" || !anchorEl) {
         setAnchorStyle({})
         return
       }
 
       const update = () => {
-        const rect = container.getBoundingClientRect()
+        const rect = anchorEl.getBoundingClientRect()
         setAnchorStyle({
           left: rect.left,
           top: rect.top,
@@ -133,7 +136,7 @@ export const DialogContent = forwardRef<
 
       update()
       const observer = new ResizeObserver(update)
-      observer.observe(container)
+      observer.observe(anchorEl)
       window.addEventListener("resize", update)
       window.addEventListener("scroll", update, true)
       return () => {
@@ -141,7 +144,7 @@ export const DialogContent = forwardRef<
         window.removeEventListener("resize", update)
         window.removeEventListener("scroll", update, true)
       }
-    }, [anchorToContainer, container])
+    }, [anchorEl])
 
     const context = useDialogPrimitiveContext()
 

--- a/packages/react/src/patterns/F0Dialog/F0Dialog.tsx
+++ b/packages/react/src/patterns/F0Dialog/F0Dialog.tsx
@@ -11,10 +11,9 @@ import { F0DialogInternalProps } from "./internal-types"
  * `@/components/dialog-alike/F0Drawer` for side panels (`position: "left" | "right"`).
  *
  * This component is a backward-compatible shim that maps the legacy patterns
- * props onto those components. The following props no longer have an
- * equivalent in the dialog-alike API and are accepted but ignored:
- * `asBottomSheetInMobile` (mobile behaviour is handled internally),
- * `navigation`, `resourceHeader` and `controls`.
+ * props onto those components. `navigation`, `resourceHeader`, and `controls`
+ * are forwarded to `F0Drawer` when `position` is `"left"` or `"right"`.
+ * `asBottomSheetInMobile` is accepted but ignored (handled internally).
  */
 export const F0Dialog: FC<F0DialogInternalProps> = ({
   isOpen,
@@ -33,12 +32,11 @@ export const F0Dialog: FC<F0DialogInternalProps> = ({
   tabs,
   activeTabId,
   setActiveTabId,
-  // Deprecated props with no dialog-alike equivalent. Destructured so they are
-  // not forwarded; kept in the signature for backward compatibility.
+  // Accepted but ignored — mobile behaviour is handled internally.
   asBottomSheetInMobile: _asBottomSheetInMobile,
-  navigation: _navigation,
-  resourceHeader: _resourceHeader,
-  controls: _controls,
+  navigation,
+  resourceHeader,
+  controls,
 }) => {
   const commonProps = {
     isOpen,
@@ -56,7 +54,13 @@ export const F0Dialog: FC<F0DialogInternalProps> = ({
 
   if (position === "left" || position === "right") {
     return (
-      <F0Drawer position={position} {...commonProps}>
+      <F0Drawer
+        position={position}
+        navigation={navigation}
+        resourceHeader={resourceHeader}
+        controls={controls}
+        {...commonProps}
+      >
         {children}
       </F0Drawer>
     )


### PR DESCRIPTION
## Summary

Ports the [PR #4313](https://github.com/factorialco/f0/pull/4313) resource-aware header features into the dialog-alike components now that the patterns `F0Dialog` is a backward-compatible shim (from [PR #4552](https://github.com/factorialco/f0/pull/4552)), and fixes side-drawer positioning so drawers dock within the content area instead of painting over the sidebar.

Those header features were implemented in `patterns/F0Dialog/components/F0DialogHeader.tsx`, which PR #4552 deleted. This PR re-lands them in the dialog-alike stack — the place they should live going forward.

## Resource-aware header

**`common/Header.tsx`**
- New `DrawerControls` discriminated union (exported):
  - `{ kind: "resource", expand?, navigation? }` — top-level: "Open detail" + prev/next
  - `{ kind: "back", label, onClick }` — drilled-in sub-page
- New optional props on `HeaderProps`: `navigation`, `resourceHeader`, `controls`
- When `resourceHeader || controls` is set, renders the resource-aware layout: controls row (left: back/expand/nav, right: actions/close) + `BaseHeader` identity band + sr-only `DialogTitle` + tabs
- In the standard title/description layout, `navigation` renders a `PageNavigation` beside the close button

**`F0Drawer`**
- `DrawerInternalProps` gains `navigation`, `resourceHeader`, `controls`
- `DrawerInternal` threads them through to `Header`
- `F0Drawer/index.tsx` exports `DrawerControls`

**Patterns shim (`patterns/F0Dialog/F0Dialog.tsx`)**
- `navigation`, `resourceHeader`, and `controls` are now forwarded to `F0Drawer` for `position: "left" | "right"` — previously they were silently dropped

## Side-drawer positioning fix

Side drawers portal into `#content`, but their wrapper is `position: fixed`, so it was anchored to the viewport — a left drawer painted over the sidebar (and a right drawer aligned to the viewport edge rather than the content edge).

- Mirrors the toast approach: a new opt-in `anchorToContainer` prop on the `DialogContent` primitive measures the content region's box (via `getBoundingClientRect`, kept in sync with a `ResizeObserver` + resize/scroll listeners) and anchors the fixed wrapper to it. Enabled for side positions in `DialogWrapper`; center modals are unaffected.
- Anchors to the **parent of `#content`** (the stable, non-scrolling content frame) rather than the scrollable `#content` itself.
- Falls back to the viewport (`inset-0`) when there is no app shell — Storybook docs, tests, components opened outside `ApplicationFrame`.
- `pl-2.5` left padding on the side-drawer `role="dialog"` wrapper so the panel sits 10px from the content frame edge.

## Stories & snapshots

- New `F0Drawer` stories for the resource-aware header: `WithNavigation`, `WithResourceHeaderProp` (demonstrates the identity band staying pinned while the body scrolls), `WithResourceControls` (stateful prev/next), and `WithBackControls`.
- New `InApplicationFrame` story mounting `F0Drawer` inside a real `ApplicationFrame` (sidebar + page) to show how the drawer docks relative to the sidebar. Adds a `standaloneFrame` decorator escape hatch (mirroring F0Dialog).
- Added Chromatic snapshot coverage (`withSnapshot`) across the visually-distinct `F0Dialog`, `DialogNotification`, and `F0Drawer` stories — the dialog-alike surface previously had none. Behavioral/interaction stories (play functions, promise actions, stacking demos) stay non-snapshotted.