### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.11.0",
+  "packages/react": "4.12.0",
   "packages/react-native": "0.55.0",
   "packages/core": "1.53.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.12.0](https://github.com/factorialco/f0/compare/f0-react-v4.11.0...f0-react-v4.12.0) (2026-06-25)
+
+
+### Features
+
+* **F0Drawer:** resource-aware header — port PR [#4313](https://github.com/factorialco/f0/issues/4313) into dialog-alike ([#4568](https://github.com/factorialco/f0/issues/4568)) ([39cd11b](https://github.com/factorialco/f0/commit/39cd11bd631f1917ee8de60b0fbcf1e3cb298f32))
+
 ## [4.11.0](https://github.com/factorialco/f0/compare/f0-react-v4.10.0...f0-react-v4.11.0) (2026-06-23)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.12.0</summary>

## [4.12.0](https://github.com/factorialco/f0/compare/f0-react-v4.11.0...f0-react-v4.12.0) (2026-06-25)


### Features

* **F0Drawer:** resource-aware header — port PR [#4313](https://github.com/factorialco/f0/issues/4313) into dialog-alike ([#4568](https://github.com/factorialco/f0/issues/4568)) ([39cd11b](https://github.com/factorialco/f0/commit/39cd11bd631f1917ee8de60b0fbcf1e3cb298f32))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).