### PR TITLE
feat(F0Drawer): render the prev/next counter after the arrows in the side panel

### DIFF
--- a/packages/react/src/components/dialog-alike/common/Header.tsx
+++ b/packages/react/src/components/dialog-alike/common/Header.tsx
@@ -174,7 +174,9 @@ export const Header = ({
           />
         )}
         {controls.expand && controls.navigation && <Divider />}
-        {controls.navigation && <PageNavigation {...controls.navigation} />}
+        {controls.navigation && (
+          <PageNavigation {...controls.navigation} counterPosition="end" />
+        )}
       </>
     )
   }
@@ -232,7 +234,9 @@ export const Header = ({
           )}
         </div>
         <div className="flex flex-row gap-2">
-          {navigation && <PageNavigation {...navigation} />}
+          {navigation && (
+            <PageNavigation {...navigation} counterPosition="end" />
+          )}
           <Actions />
           {(navigation || otherActions) && <Divider />}
           <CloseButton />

--- a/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
@@ -68,14 +68,21 @@ function PageNavigationLink({
   )
 }
 
-export function PageNavigation({ previous, next, counter }: NavigationProps) {
+export function PageNavigation({
+  previous,
+  next,
+  counter,
+  counterPosition = "start",
+}: NavigationProps & { counterPosition?: "start" | "end" }) {
+  const counterElement = counter ? (
+    <span className="text-sm text-f1-foreground-secondary">
+      {counter.current}/{counter.total}
+    </span>
+  ) : null
+
   return (
     <div className="flex items-center gap-3">
-      {counter && (
-        <span className="text-sm text-f1-foreground-secondary">
-          {counter.current}/{counter.total}
-        </span>
-      )}
+      {counterPosition === "start" && counterElement}
       <div className="flex items-center gap-2">
         <PageNavigationLink
           icon={ChevronLeft}
@@ -88,6 +95,7 @@ export function PageNavigation({ previous, next, counter }: NavigationProps) {
           fallbackLabel="Next"
         />
       </div>
+      {counterPosition === "end" && counterElement}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Follow-up to #4568. In the side panel (`F0Drawer`) the `1/N` navigation
counter renders **before** the prev/next arrows; the design wants it
**after** them (e.g. the ATS candidate side panel). This adds a small,
additive layout option to the shared `PageNavigation` and opts the
dialog-alike header into it.

The full-page `PageHeader` is a separate component and is intentionally left
unchanged (counter before the arrows).

## Changes

**`experimental/Navigation/Header/PageNavigation/index.tsx`** — the shared
prev/next + counter control, used by both the full-page `PageHeader` and the
dialog-alike header.
- Adds an optional `counterPosition?: "start" | "end"`, default `"start"`.
- `PageNavigation` lays out the `1/N` counter and the prev/next button group
  in one flex row. Until now the counter was always first (left of the
  buttons). The prop now renders it either before (`"start"`) or after
  (`"end"`) the button group.
- The `"start"` default preserves current behavior exactly for every existing
  caller — nothing moves unless a caller opts into `"end"`.

**`components/dialog-alike/common/Header.tsx`** — the header shared by the
dialog-alike components (`F0Dialog` for center/fullscreen, `F0Drawer` for the
left/right side panel).
- Passes `counterPosition="end"` to `PageNavigation` at both spots it renders
  navigation: the resource-controls row (`controls.navigation`, used by the
  resource side panel) and the standard title row (`navigation`).
- Net effect: in the side panel the counter now sits to the **right** of the
  prev/next arrows, matching the design.

## Verification
- `tsc` clean, `oxlint` 0/0, `oxfmt` clean.

<img width="650" height="447" alt="Screenshot 2026-06-25 at 16 37 07" src="https://github.com/user-attachments/assets/e61b7e26-2c35-4c1a-9b14-b7abe1a3edeb" />

<img width="683" height="358" alt="Screenshot 2026-06-25 at 17 21 31" src="https://github.com/user-attachments/assets/c99d4ca0-93db-4e00-9c33-cd44f4baeca2" />
