### PR TITLE
feat(ai): add optional turn rewind to F0AiMessagesContainer

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -83,6 +83,7 @@ export const defaultTranslations = {
     moveDown: "Move down",
     thumbsUp: "Like",
     thumbsDown: "Dislike",
+    rewind: "Rewind to this point",
     other: "Other actions",
     toggle: "Toggle",
     toggleDropdownMenu: "Toggle dropdown menu",

--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -81,11 +81,12 @@ export const F0AiChatTextArea = ({
   fullscreen = false,
   welcomeScreenSuggestions,
   onSuggestionClick,
+  initialText,
   ref,
 }: F0AiChatTextAreaProps) => {
   const translation = useI18n()
   const shouldReduceMotion = useReducedMotion()
-  const [inputValue, setInputValue] = useState("")
+  const [inputValue, setInputValue] = useState(initialText ?? "")
   const [cursorPosition, setCursorPosition] = useState(0)
   const [isPreSending, setIsPreSending] = useState(false)
   // Set when the user hits send while an attachment is still uploading: the

--- a/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
@@ -45,6 +45,8 @@ export type F0AiChatTextAreaSubmitPayload = {
 
 export type F0AiChatTextAreaProps = {
   ref: RefObject<HTMLDivElement>
+  /** Pre-fills the textarea on first render. Use with a changing `key` to restore text after undo. */
+  initialText?: string
   /** Emitted when the user submits. Awaited so the textarea can stay disabled. */
   onSubmit: (payload: F0AiChatTextAreaSubmitPayload) => void | Promise<void>
   /** Called when the user clicks the stop button while a response is streaming. */

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
@@ -42,8 +42,6 @@ export type F0AiMessagesContainerProps = {
   onRegenerate?: (messageId: string) => void
   /** Called when the user copies an assistant message's content. */
   onCopy?: (content: string) => void
-  /** Called when the user clicks the undo button on a turn. Receives the turn index. */
-  onUndo?: (turnIndex: number) => void
 
   /** Pre-processed turns to render (assembled by the connected wrapper). */
   turns: RenderableTurn[]
@@ -124,7 +122,6 @@ const Messages = ({
   UserMessage: UserMessageProp,
   onRegenerate,
   onCopy,
-  onUndo,
 }: F0AiMessagesContainerProps) => {
   const { modal, handleSubmit, handleClose } = useFeedbackSubmit(
     feedback ?? noopFeedback
@@ -255,18 +252,15 @@ const Messages = ({
         )}
         {turn.endIndicator === "activity" && <F0ActionItem status="writing" />}
         {(() => {
-          // Undo shows only when a handler is wired, the turn isn't still
-          // streaming, and the turn hasn't opted out (`canUndo === false`, e.g.
-          // no checkpoint behind it or a clarifying flow is mid-flight).
-          const showUndo =
-            !!onUndo && !turn.isInProgress && turn.canUndo !== false
-          if (!turn.feedback && !showUndo) return null
+          // The rewind button shows only when the turn supplies an `onUndo`
+          // handler; the consumer decides per turn whether a rewind target exists.
+          if (!turn.feedback && !turn.onUndo) return null
           return (
             <TurnFeedback
               content={turn.feedback?.content ?? ""}
               targetMessage={turn.feedback?.targetMessage ?? {}}
               onCopy={turn.feedback ? onCopy : undefined}
-              onUndo={showUndo ? () => onUndo!(turnIndex) : undefined}
+              onUndo={turn.onUndo}
             />
           )
         })()}

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
@@ -42,6 +42,8 @@ export type F0AiMessagesContainerProps = {
   onRegenerate?: (messageId: string) => void
   /** Called when the user copies an assistant message's content. */
   onCopy?: (content: string) => void
+  /** Called when the user clicks the undo button on a turn. Receives the turn index. */
+  onUndo?: (turnIndex: number) => void
 
   /** Pre-processed turns to render (assembled by the connected wrapper). */
   turns: RenderableTurn[]
@@ -122,6 +124,7 @@ const Messages = ({
   UserMessage: UserMessageProp,
   onRegenerate,
   onCopy,
+  onUndo,
 }: F0AiMessagesContainerProps) => {
   const { modal, handleSubmit, handleClose } = useFeedbackSubmit(
     feedback ?? noopFeedback
@@ -251,13 +254,22 @@ const Messages = ({
           <F0ActionItem title={translations.ai.thinking} status="executing" />
         )}
         {turn.endIndicator === "activity" && <F0ActionItem status="writing" />}
-        {turn.feedback && (
-          <TurnFeedback
-            content={turn.feedback.content}
-            targetMessage={turn.feedback.targetMessage}
-            onCopy={onCopy}
-          />
-        )}
+        {(() => {
+          // Undo shows only when a handler is wired, the turn isn't still
+          // streaming, and the turn hasn't opted out (`canUndo === false`, e.g.
+          // no checkpoint behind it or a clarifying flow is mid-flight).
+          const showUndo =
+            !!onUndo && !turn.isInProgress && turn.canUndo !== false
+          if (!turn.feedback && !showUndo) return null
+          return (
+            <TurnFeedback
+              content={turn.feedback?.content ?? ""}
+              targetMessage={turn.feedback?.targetMessage ?? {}}
+              onCopy={turn.feedback ? onCopy : undefined}
+              onUndo={showUndo ? () => onUndo!(turnIndex) : undefined}
+            />
+          )
+        })()}
         {isLastTurn && <ActiveFormCard />}
       </div>
     )

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/feedback/TurnFeedback.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/feedback/TurnFeedback.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react"
 
 import { F0Icon } from "@/components/F0Icon"
+import { TooltipInternal } from "@/experimental/Overlays/Tooltip"
 import {
+  Reset,
   ThumbsDown,
   ThumbsDownFilled,
   ThumbsUp,
@@ -22,12 +24,15 @@ interface TurnFeedbackProps {
   targetMessage: AIMessage
   /** Optional copy callback (called after the user clicks copy). */
   onCopy?: (content: string) => void
+  /** When provided, renders an undo button that rolls back this turn. */
+  onUndo?: () => void
 }
 
 export const TurnFeedback = ({
   content,
   targetMessage,
   onCopy,
+  onUndo,
 }: TurnFeedbackProps) => {
   const translations = useI18n()
   const { open: openFeedbackModal } = useFeedbackModal()
@@ -89,6 +94,24 @@ export const TurnFeedback = ({
           />
         </div>
       </Action>
+      {onUndo && (
+        <TooltipInternal description={translations.actions.rewind} instant>
+          <Action
+            onClick={(e) => {
+              onUndo()
+              e.currentTarget.blur()
+            }}
+            compact={true}
+            mode="only"
+            variant="ghost"
+            aria-label={translations.actions.rewind}
+          >
+            <div className="flex min-w-0 flex-1 items-center justify-center gap-1">
+              <F0Icon size="md" icon={Reset} color="default" />
+            </div>
+          </Action>
+        </TooltipInternal>
+      )}
     </div>
   )
 }

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/types.ts
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/types.ts
@@ -87,12 +87,11 @@ export type RenderableTurn = {
     targetMessage: Message
   }
   /**
-   * Whether this turn can be rolled back via the undo button. Defaults to
-   * shown when an `onUndo` handler is provided; set to `false` to hide undo
-   * for a specific turn (e.g. turns with no checkpoint behind them, or while a
-   * clarifying flow is mid-flight). Only consulted when `onUndo` is set.
+   * When provided, the turn renders a rewind button that calls this on click.
+   * Omit it to hide rewind for the turn (e.g. the last turn, turns with no
+   * checkpoint behind them, or while a clarifying flow is mid-flight).
    */
-  canUndo?: boolean
+  onUndo?: () => void
 }
 
 /** Props for the Thinking collapsible section. */

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/types.ts
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/types.ts
@@ -86,6 +86,13 @@ export type RenderableTurn = {
     /** Reference message attached to feedback submissions. */
     targetMessage: Message
   }
+  /**
+   * Whether this turn can be rolled back via the undo button. Defaults to
+   * shown when an `onUndo` handler is provided; set to `false` to hide undo
+   * for a specific turn (e.g. turns with no checkpoint behind them, or while a
+   * clarifying flow is mid-flight). Only consulted when `onUndo` is set.
+   */
+  canUndo?: boolean
 }
 
 /** Props for the Thinking collapsible section. */


### PR DESCRIPTION
## Description

Adds an optional **rewind** affordance to the F0AiChat messages feedback row, letting consumers offer "rewind to this point" on prior turns. Split out of the co-creation mock work so these shipped-component API additions can be reviewed and merged independently of the mock/story.

## Screenshots (if applicable)

n/a — additive props; no visual change unless a consumer wires `onUndo`.

## Implementation details

- **F0AiMessagesContainer**: new optional `onUndo?(turnIndex)` prop and per-turn `RenderableTurn.canUndo` gating. The feedback footer renders the rewind control only when `onUndo` is wired **and** the turn opts in (`canUndo !== false`). Consumers that don't pass `onUndo` render exactly as before.
- **TurnFeedback**: rewind button using the `Reset` icon, with a localized label/tooltip via a new `actions.rewind` ("Rewind to this point") i18n key (immediate `TooltipInternal`).
- **F0AiChatTextArea**: new optional `initialText` prop to pre-fill the composer (used with a changing `key` to restore text after a rewind).

All additions are optional and backward-compatible — no behavior change unless a consumer opts in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<img width="356" height="166" alt="Undo on chat" src="https://github.com/user-attachments/assets/9a33e457-7570-476e-b84c-9a865a07b9fd" />

