### PR TITLE
fix(RichText): re-wire PasteSanitizer into editor extension lists

### DIFF
--- a/packages/react/src/components/RichText/F0NotesTextEditor/extensions.ts
+++ b/packages/react/src/components/RichText/F0NotesTextEditor/extensions.ts
@@ -14,6 +14,7 @@ import {
   ImageExtension,
   LinkExtension,
   MoodTrackerExtension,
+  PasteSanitizer,
   PersistSelection,
   StarterKitExtension,
   TableExtension,
@@ -46,6 +47,7 @@ export const createNotesTextEditorExtensions = ({
 }: CreateNotesTextEditorExtensionsProps) => {
   return [
     StarterKitExtension,
+    PasteSanitizer,
     UnderlineExtension,
     TextStyleExtension,
     TypographyExtension,

--- a/packages/react/src/components/RichText/F0RichTextEditor/utils/extensions.ts
+++ b/packages/react/src/components/RichText/F0RichTextEditor/utils/extensions.ts
@@ -6,6 +6,7 @@ import {
   LinkExtension,
   MentionedUser,
   MentionsConfig,
+  PasteSanitizer,
   PersistSelection,
   StarterKitExtension,
   TaskListExtension,
@@ -38,6 +39,7 @@ const ExtensionsConfiguration = ({
 }: ExtensionsConfigurationProps) => {
   return [
     StarterKitExtension,
+    PasteSanitizer,
     UnderlineExtension,
     TextStyleExtension,
     ColorExtension,


### PR DESCRIPTION
## Description

The NBSP paste fix from [#4269](https://github.com/factorialco/f0/pull/4269) is no longer being applied. The "promote RichText to stable" refactor (#3394) dropped `PasteSanitizer` from the `F0NotesTextEditor` and `F0RichTextEditor` extension arrays, so pasting content from PDFs/Word (words joined by U+00A0) again produces a single unbreakable token that the browser splits mid-word (e.g. `Profesion|al`).

The extension itself survived the refactor (it still lives in `internal/Extensions/PasteSanitizer`), it just stopped being wired into the editors. Confirmed missing in production by inspecting the live policies editor (`view.someProp('transformPastedHTML')` returns undefined).

## Implementation details

- Add `PasteSanitizer` back to the extension list in `F0NotesTextEditor/extensions.ts` and `F0RichTextEditor/utils/extensions.ts`, restoring the original #4269 wiring.