### PR TITLE
fix(ai): keep chat steady on canvas toggle

### DIFF
--- a/packages/react/src/patterns/ApplicationFrame/index.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.tsx
@@ -387,7 +387,11 @@ function ApplicationFrameContent({
                     }
                   }}
                 >
-                  <F0AiChat />
+                  <F0AiChat
+                    revealChatOnCanvasToggle={
+                      ai?.revealChatOnCanvasToggle ?? true
+                    }
+                  />
                 </motion.div>
               )}
             </motion.div>

--- a/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/F0AiChat.tsx
@@ -31,6 +31,13 @@ export interface F0AiChatProps {
   messages?: ReactNode
   /** Input slot rendered at the bottom (textarea + suggestions + disclaimer). */
   input?: ReactNode
+  /**
+   * When false, the chat content does NOT re-fade when the canvas opens/closes
+   * with the chat docked on the side: `sidepanel` and `canvas` are treated as
+   * one state for the mode-change reveal, so toggling the canvas is seamless.
+   * Fullscreen transitions still reveal. Defaults to true.
+   */
+  revealChatOnCanvasToggle?: boolean
 }
 
 const F0AiChatProviderComponent = ({
@@ -98,6 +105,7 @@ const F0AiChatComponent = ({
   header: headerProp,
   messages: messagesProp,
   input: inputProp,
+  revealChatOnCanvasToggle = true,
 }: F0AiChatProps) => {
   const {
     enabled,
@@ -117,9 +125,18 @@ const F0AiChatComponent = ({
   // place (busy), hide the content the instant the mode flips and reveal it
   // already settled with a soft fade. Hold ≈ the chat window's resize
   // animation (see ApplicationFrame: ~0.15s entering, ~0.4s exiting).
+  // When the host opts out (`revealChatOnCanvasToggle={false}`), collapse
+  // sidepanel + canvas into a single "docked" reveal state so opening/closing
+  // the canvas with the chat on the side isn't seen as a mode change and the
+  // chat content doesn't re-fade. Fullscreen transitions stay distinct and still
+  // reveal (their layout change is substantial).
+  const revealValue: VisualizationMode | "docked" =
+    !revealChatOnCanvasToggle && visualizationMode !== "fullscreen"
+      ? "docked"
+      : visualizationMode
   const { motionProps: contentReveal } = useRevealOnChange(
-    visualizationMode,
-    (prev: VisualizationMode, next: VisualizationMode) =>
+    revealValue,
+    (prev, next) =>
       next === "fullscreen" ? 220 : prev === "fullscreen" ? 460 : 260
   )
 

--- a/packages/react/src/sds/ai/F0AiChat/types.ts
+++ b/packages/react/src/sds/ai/F0AiChat/types.ts
@@ -346,6 +346,14 @@ export type AiChatProviderProps = {
    */
   canvasEntities?: Record<string, CanvasEntityDefinition>
   /**
+   * When false, the chat content does NOT re-fade when the canvas opens/closes
+   * with the chat docked as a side panel (the `sidepanel`↔`canvas` mode-change
+   * reveal is suppressed), so toggling the canvas is seamless. The canvas
+   * panel's own open/close animation is unaffected, and fullscreen transitions
+   * still reveal. Defaults to true.
+   */
+  revealChatOnCanvasToggle?: boolean
+  /**
    * Credits configuration. When provided, a credits button is shown in the chat header.
    * Groups fetchUsage, upgradePlanUrl, and company/plan display info.
    */


### PR DESCRIPTION
## Description

`F0AiChat` re-faded its content on every visualization-mode change (via `useRevealOnChange`) to mask layout reflow. With the chat docked as a side panel, opening or closing the canvas flips `sidepanel`↔`canvas`, so the chat re-faded on every toggle even though its content barely changes. This adds an opt-in `revealChatOnCanvasToggle` flag (default `true`, so behaviour is unchanged for existing consumers); when disabled it collapses `sidepanel` and `canvas` into a single reveal state, keeping the chat steady while toggling the canvas. Fullscreen transitions still reveal, and the canvas panel's own open/close animation is untouched.

Extracted as a standalone fix from the Creation-with-AI work — the cocreation PR #4307 cherry-picks this commit and sets the flag to `false` in its story.

## Implementation details

- fix: add an opt-in `revealChatOnCanvasToggle` prop to `F0AiChat` and the `ApplicationFrame` `ai` config (defaults to `true`)
- fix: when disabled, treat `sidepanel` and `canvas` as one mode-change reveal state so toggling the canvas no longer re-fades the chat content; fullscreen transitions still reveal

🤖 Generated with [Claude Code](https://claude.com/claude-code)