### PR TITLE
feat(OneDataCollection): add toolbar upsell button option

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -47,6 +47,7 @@ import {
   filterActions,
   getPrimaryActions,
   getSecondaryActions,
+  getUpsellAction,
   MAX_EXPANDED_ACTIONS,
 } from "./actions"
 import {
@@ -301,6 +302,7 @@ const OneDataCollectionComp = <
     primaryActions,
     primaryActionsLabel,
     secondaryActions,
+    upsellAction,
     // Summary
     totalItemSummary,
     currentGrouping,
@@ -413,6 +415,11 @@ const OneDataCollectionComp = <
     [secondaryActions]
   )
 
+  const upsellActionItem = useMemo(
+    () => getUpsellAction(upsellAction),
+    [upsellAction]
+  )
+
   // Export action - only available when csvExport is enabled
   const csvExportFilename =
     csvExport && typeof csvExport === "object"
@@ -479,6 +486,7 @@ const OneDataCollectionComp = <
   const hasCollectionsActions =
     primaryActionItems?.length > 0 ||
     allSecondaryActions?.length > 0 ||
+    !!upsellActionItem ||
     !!csvExport
 
   /**
@@ -1622,6 +1630,7 @@ const OneDataCollectionComp = <
                       primaryActionsLabel={primaryActionsLabel}
                       secondaryActions={secondaryActionsItems}
                       otherActions={otherActionsItems}
+                      upsellAction={upsellActionItem}
                     />
                   </>
                 )}

--- a/packages/react/src/patterns/OneDataCollection/__stories__/actions/collection-actions.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/actions/collection-actions.stories.tsx
@@ -199,6 +199,82 @@ export const BasicActionsExample: Story = {
   },
 }
 
+// Upsell button next to the full toolbar: search, settings, and a primary action.
+export const UpsellActionExample: Story = {
+  render: () => {
+    const dataSource = useDataCollectionSource({
+      search: { enabled: true },
+      sortings: {
+        name: { label: "Name" },
+        email: { label: "Email" },
+      },
+      dataAdapter: {
+        fetchData: () => Promise.resolve({ records: mockUsers }),
+      },
+      primaryActions: () => ({
+        label: "Create user",
+        icon: Ai,
+        onClick: () => console.log(`Creating a user`),
+      }),
+      upsellAction: () => ({
+        label: "Upgrade to unlock",
+        onClick: () => console.log("Open upsell modal"),
+      }),
+    })
+
+    return <BaseStory dataSource={dataSource} />
+  },
+}
+
+// Upsell button alongside secondary actions.
+export const UpsellActionWithSecondaryExample: Story = {
+  render: () => {
+    const dataSource = useDataCollectionSource({
+      dataAdapter: {
+        fetchData: () => Promise.resolve({ records: mockUsers }),
+      },
+      upsellAction: () => ({
+        label: "Upgrade to unlock",
+        onClick: () => console.log("Open upsell modal"),
+      }),
+      secondaryActions: {
+        expanded: 2,
+        actions: () => [
+          {
+            label: "Export",
+            icon: Upload,
+            onClick: () => console.log("Export"),
+          },
+          {
+            label: "Import",
+            icon: Download,
+            onClick: () => console.log("Import"),
+          },
+        ],
+      },
+    })
+
+    return <BaseStory dataSource={dataSource} />
+  },
+}
+
+// Upsell button as the only toolbar action.
+export const UpsellActionOnlyExample: Story = {
+  render: () => {
+    const dataSource = useDataCollectionSource({
+      dataAdapter: {
+        fetchData: () => Promise.resolve({ records: mockUsers }),
+      },
+      upsellAction: () => ({
+        label: "Upgrade to unlock",
+        onClick: () => console.log("Open upsell modal"),
+      }),
+    })
+
+    return <BaseStory dataSource={dataSource} />
+  },
+}
+
 // Basic story showing all action types
 export const MultiplePrimaryActionsExample: Story = {
   render: () => {

--- a/packages/react/src/patterns/OneDataCollection/actions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/actions.tsx
@@ -146,3 +146,21 @@ export const filterActions = (
       ),
     }
   })
+
+/** Upsell button rendered in the collection toolbar. */
+export type UpsellActionDefinition = {
+  label: string
+  onClick: () => void | Promise<void>
+  /** Show the upsell icon. Defaults to true. */
+  showIcon?: boolean
+  /** Button variant. Defaults to "outlinePromote". */
+  variant?: "promote" | "outlinePromote"
+  disabled?: boolean
+}
+
+/** Returns the upsell action, or undefined to hide it. */
+export type UpsellActionDefinitionFn = () => UpsellActionDefinition | undefined
+
+export const getUpsellAction = (
+  upsellAction: UpsellActionDefinitionFn | undefined
+): UpsellActionDefinition | undefined => upsellAction?.()

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
@@ -6,11 +6,13 @@ import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
 import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { Ellipsis } from "@/icons/app"
+import UpsellIcon from "@/icons/app/Upsell"
 
 import {
   PrimaryActionItemDefinition,
   SecondaryActionGroup,
   SecondaryActionItem,
+  UpsellActionDefinition,
 } from "../../actions"
 
 type CollectionActionProps = {
@@ -18,6 +20,7 @@ type CollectionActionProps = {
   primaryActionsLabel?: string
   secondaryActions?: SecondaryActionItem[]
   otherActions?: SecondaryActionGroup[]
+  upsellAction?: UpsellActionDefinition
 }
 
 export const CollectionActions = ({
@@ -25,6 +28,7 @@ export const CollectionActions = ({
   primaryActionsLabel,
   secondaryActions,
   otherActions,
+  upsellAction,
 }: CollectionActionProps) => {
   const primaryActionsButtons = (
     Array.isArray(primaryActions) ? primaryActions : [primaryActions]
@@ -56,7 +60,8 @@ export const CollectionActions = ({
   if (
     primaryActionsButtons.length === 0 &&
     secondaryActionsButtons.length === 0 &&
-    dropdownItems.length === 0
+    dropdownItems.length === 0 &&
+    !upsellAction
   )
     return null
 
@@ -130,6 +135,17 @@ export const CollectionActions = ({
           <React.Fragment key={action.label}>{button}</React.Fragment>
         )
       })}
+
+      {upsellAction && (
+        <F0Button
+          size="md"
+          variant={upsellAction.variant ?? "outlinePromote"}
+          label={upsellAction.label}
+          icon={upsellAction.showIcon === false ? undefined : UpsellIcon}
+          onClick={upsellAction.onClick}
+          disabled={upsellAction.disabled}
+        />
+      )}
 
       {dropdownItems.length > 0 && (
         <Dropdown

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/__tests__/CollectionActions.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/__tests__/CollectionActions.test.tsx
@@ -1,14 +1,27 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { IconType } from "@/components/F0Icon"
-import { zeroRender as render, screen } from "@/testing/test-utils"
+import { fireEvent, zeroRender as render, screen } from "@/testing/test-utils"
 
 import { PrimaryActionItemDefinition } from "../../../actions"
 import { CollectionActions } from "../CollectionActions"
 
 vi.mock("@/components/F0Button", () => ({
-  F0Button: ({ label, onClick, ...props }: Record<string, unknown>) => (
-    <button data-testid="f0-button" onClick={onClick as () => void} {...props}>
+  F0Button: ({
+    label,
+    onClick,
+    variant,
+    size,
+    icon: _icon,
+    ...props
+  }: Record<string, unknown>) => (
+    <button
+      data-testid="f0-button"
+      data-variant={variant as string}
+      data-size={size as string}
+      onClick={onClick as () => void}
+      {...props}
+    >
       {label as string}
     </button>
   ),
@@ -104,6 +117,10 @@ vi.mock("@/experimental/Overlays/Tooltip", () => ({
 
 vi.mock("@/icons/app", () => ({
   Ellipsis: () => <div data-testid="ellipsis-icon">...</div>,
+}))
+
+vi.mock("@/icons/app/Upsell", () => ({
+  default: () => <div data-testid="upsell-icon">upsell</div>,
 }))
 
 const mockIcon: IconType = (() => (
@@ -328,6 +345,68 @@ describe("CollectionActions", () => {
 
       expect(screen.queryByTestId("tooltip")).not.toBeInTheDocument()
       expect(screen.getByText("Export")).toBeInTheDocument()
+    })
+  })
+
+  describe("upsell action", () => {
+    it("renders the upsell button with the outlinePromote variant and md size by default", () => {
+      render(
+        <CollectionActions
+          upsellAction={{
+            label: "Upgrade plan",
+            onClick: vi.fn(),
+          }}
+        />
+      )
+
+      const button = screen.getByText("Upgrade plan").closest("button")
+      expect(button).toBeInTheDocument()
+      expect(button).toHaveAttribute("data-variant", "outlinePromote")
+      expect(button).toHaveAttribute("data-size", "md")
+    })
+
+    it("lets the host override the variant via the upsellAction definition", () => {
+      render(
+        <CollectionActions
+          upsellAction={{
+            label: "Upgrade plan",
+            onClick: vi.fn(),
+            variant: "promote",
+          }}
+        />
+      )
+
+      expect(
+        screen.getByText("Upgrade plan").closest("button")
+      ).toHaveAttribute("data-variant", "promote")
+    })
+
+    it("renders the upsell button even when there are no other actions", () => {
+      render(
+        <CollectionActions
+          upsellAction={{ label: "Upgrade", onClick: vi.fn() }}
+        />
+      )
+
+      expect(screen.getByText("Upgrade")).toBeInTheDocument()
+    })
+
+    it("does not render the upsell button when upsellAction is absent", () => {
+      render(
+        <CollectionActions
+          primaryActions={[{ label: "New", icon: mockIcon, onClick: vi.fn() }]}
+        />
+      )
+
+      expect(screen.queryByText("Upgrade")).not.toBeInTheDocument()
+    })
+
+    it("invokes onClick when the upsell button is clicked", () => {
+      const onClick = vi.fn()
+      render(<CollectionActions upsellAction={{ label: "Upgrade", onClick }} />)
+
+      fireEvent.click(screen.getByText("Upgrade"))
+      expect(onClick).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
@@ -19,6 +19,7 @@ import type { AvatarVariant } from "@/components/avatars/F0Avatar"
 import {
   PrimaryActionsDefinitionFn,
   SecondaryActionsDefinition,
+  UpsellActionDefinitionFn,
 } from "../../actions"
 import { ItemActionsDefinition } from "../../item-actions"
 import {
@@ -153,6 +154,9 @@ export type DataCollectionSourceDefinition<
   primaryActionsLabel?: string
   /** Available secondary actions that can be performed on the collection */
   secondaryActions?: SecondaryActionsDefinition
+  /** Optional upsell button rendered in the collection toolbar. Opt-in per
+   * collection: return a definition to show it, or undefined to hide it. */
+  upsellAction?: UpsellActionDefinitionFn
   /** Available summaries fields. If not provided, summaries is not allowed. */
   summaries?: Summaries & {
     label?: string // Optional label for the summaries row


### PR DESCRIPTION
## Description

Adds an opt-in `upsellAction` to the OneDataCollection source so any data table (including the editable table) can render an upsell button in its toolbar, based on the host's upsell configuration. The button renders via `F0Button` with the promote styling and the Upsell icon, and on click triggers a host-owned upsell modal. Part of FCT-56869; the host wiring (eligibility + DatoCMS-backed FeatureModal) lands in a follow-up in `factorial/frontend`.

## Screenshots
<img width="1592" height="249" alt="Screenshot 2026-06-29 at 10 53 11 AM" src="https://github.com/user-attachments/assets/09279f5e-0c9d-4a03-a092-537e666c4539" />



## Implementation details

- feat: add an opt-in `upsellAction` to the data collection source, rendered in the toolbar (rightmost) as an `F0Button` with the Upsell icon and the `outlinePromote` variant + `md` size by default; both variant and icon are host-overridable
- test: cover toolbar upsell rendering, default variant/size, host variant override, absence, and click handling in CollectionActions
- docs: add three `UpsellAction*` Storybook stories under Data Collection → Collection Actions

No shared components are modified — the change is contained within OneDataCollection.