### PR TITLE
feat(EditableTable): render cellHint icon on the right for read-only cells (FCT-56432)

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -383,12 +383,12 @@ export const EditableTableWithDisabledCells: Story = {
   },
 }
 
-export const EditableTableWithNonEditableHint: Story = {
+export const EditableTableWithCellHint: Story = {
   parameters: {
     docs: {
       description: {
         story:
-          "Non-editable cells (`editType: () => 'display-only'`) render with the read-only background, and their `cellHint` icon sits to the right of the content (FCT-56432). Here the Role column is read-only with a hint; Email stays editable for contrast.",
+          "A `cellHint` (ⓘ tooltip) renders its icon to the right of the cell content for read-only cell types (FCT-56432). Here the Role column is `disabled` (gray background) with a hint; Email stays editable for contrast.",
       },
     },
   },
@@ -414,7 +414,7 @@ export const EditableTableWithNonEditableHint: Story = {
                 if (col.editType !== undefined && col.id === "role") {
                   return {
                     ...col,
-                    editType: () => "display-only" as const,
+                    editType: () => "disabled" as const,
                     cellHint: () => ({
                       icon: InfoCircleLine,
                       iconColor: "secondary" as const,
@@ -430,7 +430,7 @@ export const EditableTableWithNonEditableHint: Story = {
           },
         ]}
         dataAdapter={dataAdapter}
-        id="editable-table-non-editable-hint/v1"
+        id="editable-table-cell-hint/v1"
       />
     )
   },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -6,7 +6,7 @@ import { action } from "storybook/actions"
 import type { StatusVariant } from "@/components/tags/F0TagStatus/types"
 
 import { createDataSourceDefinition, RecordType } from "@/hooks/datasource"
-import { Delete, Pencil } from "@/icons/app"
+import { Delete, InfoCircleLine, Pencil } from "@/icons/app"
 import { ROLES_MOCK } from "@/mocks"
 
 import { OneDataCollection } from "../../.."
@@ -378,6 +378,59 @@ export const EditableTableWithDisabledCells: Story = {
         ]}
         dataAdapter={dataAdapter}
         id="editable-table-disabled-cells/v1"
+      />
+    )
+  },
+}
+
+export const EditableTableWithNonEditableHint: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Non-editable cells (`editType: () => 'display-only'`) render with the read-only background, and their `cellHint` icon sits to the right of the content (FCT-56432). Here the Role column is read-only with a hint; Email stays editable for contrast.",
+      },
+    },
+  },
+  render: () => {
+    const mockVisualizations = getMockVisualizations()
+    const { dataAdapter, onCellChange } = useEditableTableData()
+
+    const baseOptions = (
+      mockVisualizations.editableTable as Extract<
+        typeof mockVisualizations.editableTable,
+        { type: "editableTable" }
+      >
+    ).options
+
+    return (
+      <ExampleComponent
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              ...baseOptions,
+              columns: baseOptions.columns.map((col) => {
+                if (col.editType !== undefined && col.id === "role") {
+                  return {
+                    ...col,
+                    editType: () => "display-only" as const,
+                    cellHint: () => ({
+                      icon: InfoCircleLine,
+                      iconColor: "secondary" as const,
+                      message:
+                        "This value is managed elsewhere and can't be edited here.",
+                    }),
+                  }
+                }
+                return col
+              }),
+              onCellChange,
+            },
+          },
+        ]}
+        dataAdapter={dataAdapter}
+        id="editable-table-non-editable-hint/v1"
       />
     )
   },

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/BaseCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/BaseCell.test.tsx
@@ -3,6 +3,8 @@ import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it } from "vitest"
 
+import InfoCircleLine from "@/icons/app/InfoCircleLine"
+
 import { zeroRender as render } from "../../../../../../testing/test-utils"
 import { BaseCell } from "../components/cells/BaseCell"
 
@@ -132,6 +134,37 @@ describe("BaseCell", () => {
 
     const cell = container.firstChild as HTMLElement
     expect(cell.className).toContain("bg-f1-background-secondary")
+  })
+
+  it("renders the hint icon before the content by default", () => {
+    render(
+      <BaseCell hint={{ icon: InfoCircleLine, message: "More info" }}>
+        <span>Cell content</span>
+      </BaseCell>
+    )
+
+    const button = screen.getByRole("button", { name: "More info" })
+    const content = screen.getByText("Cell content")
+    expect(
+      button.compareDocumentPosition(content) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it("renders the hint icon after the content when hintPosition is right", () => {
+    render(
+      <BaseCell
+        hint={{ icon: InfoCircleLine, message: "More info" }}
+        hintPosition="right"
+      >
+        <span>Cell content</span>
+      </BaseCell>
+    )
+
+    const button = screen.getByRole("button", { name: "More info" })
+    const content = screen.getByText("Cell content")
+    expect(
+      content.compareDocumentPosition(button) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
   })
 
   it("preserves input focus when error transitions from undefined to a string", async () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DisabledCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DisabledCell.test.tsx
@@ -53,6 +53,21 @@ describe("DisabledCell", () => {
     ).toBeInTheDocument()
   })
 
+  it("renders the hint icon after the cell content", () => {
+    render(
+      <DisabledCell
+        {...defaultProps}
+        hint={{ icon: InfoCircleLine, message: "Locked by policy" }}
+      />
+    )
+
+    const button = screen.getByRole("button", { name: "Locked by policy" })
+    const content = screen.getByText("John Doe")
+    expect(
+      content.compareDocumentPosition(button) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
   it("does not render a hint icon when hint is omitted", () => {
     render(<DisabledCell {...defaultProps} />)
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NonEditableCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NonEditableCell.test.tsx
@@ -40,11 +40,6 @@ describe("NonEditableCell", () => {
     expect(container.firstChild).toHaveClass("cursor-default")
   })
 
-  it("applies the read-only background", () => {
-    const { container } = render(<NonEditableCell {...defaultProps} />)
-    expect(container.firstChild).toHaveClass("bg-f1-background-secondary")
-  })
-
   it("renders the hint icon after the cell content", () => {
     render(
       <NonEditableCell

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NonEditableCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NonEditableCell.test.tsx
@@ -40,6 +40,28 @@ describe("NonEditableCell", () => {
     expect(container.firstChild).toHaveClass("cursor-default")
   })
 
+  it("applies the read-only background", () => {
+    const { container } = render(<NonEditableCell {...defaultProps} />)
+    expect(container.firstChild).toHaveClass("bg-f1-background-secondary")
+  })
+
+  it("renders the hint icon after the cell content", () => {
+    render(
+      <NonEditableCell
+        {...defaultProps}
+        hint={{ icon: InfoCircleLine, message: "Backfilling Jane's position" }}
+      />
+    )
+
+    const button = screen.getByRole("button", {
+      name: "Backfilling Jane's position",
+    })
+    const content = screen.getByText("John Doe")
+    expect(
+      content.compareDocumentPosition(button) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
   it("renders a hint icon when hint is provided", () => {
     render(
       <NonEditableCell

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
@@ -26,6 +26,7 @@ export function BaseCell({
   borderOnHover = true,
   error,
   hint,
+  hintPosition = "left",
   children,
 }: {
   readonly?: boolean
@@ -34,9 +35,37 @@ export function BaseCell({
   isActive?: boolean
   error?: string
   hint?: { icon: IconType; message: string; iconColor?: F0IconProps["color"] }
+  hintPosition?: "left" | "right"
   borderOnHover?: boolean
   children: ReactNode
 }) {
+  const hintIcon = hint && !error && (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={hint.message}
+            className={cn(
+              "pointer-events-auto flex shrink-0 cursor-pointer items-center rounded px-1",
+              focusRing()
+            )}
+          >
+            <F0Icon icon={hint.icon} size="md" color={hint.iconColor} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className="border-black/10 max-w-64 cursor-default text-f1-foreground shadow-md"
+        >
+          <span className="text-sm font-medium text-f1-foreground">
+            {hint.message}
+          </span>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+
   return (
     <div
       className={cn(
@@ -55,33 +84,9 @@ export function BaseCell({
       )}
     >
       <ErrorTooltip message={error}>
-        {hint && !error && (
-          <TooltipProvider delayDuration={100}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={hint.message}
-                  className={cn(
-                    "pointer-events-auto flex shrink-0 cursor-pointer items-center rounded px-1",
-                    focusRing()
-                  )}
-                >
-                  <F0Icon icon={hint.icon} size="md" color={hint.iconColor} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent
-                side="top"
-                className="border-black/10 max-w-64 cursor-default text-f1-foreground shadow-md"
-              >
-                <span className="text-sm font-medium text-f1-foreground">
-                  {hint.message}
-                </span>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
+        {hintPosition === "left" && hintIcon}
         <div className="min-w-0 flex-1">{children}</div>
+        {hintPosition === "right" && hintIcon}
       </ErrorTooltip>
     </div>
   )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
@@ -14,7 +14,12 @@ export function DisabledCell<R extends RecordType>({
   const i18n = useI18n()
 
   return (
-    <BaseCell borderOnHover={false} hint={hint} cursor="not-allowed">
+    <BaseCell
+      borderOnHover={false}
+      hint={hint}
+      hintPosition="right"
+      cursor="not-allowed"
+    >
       <div
         className={cn(
           editableColumn.align === "right" ? "justify-end" : "",

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
@@ -16,7 +16,6 @@ export function NonEditableCell<R extends RecordType>({
 
   return (
     <BaseCell
-      readonly
       showRightBorder={!isLastColumn}
       borderOnHover={false}
       hint={hint}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
@@ -16,9 +16,11 @@ export function NonEditableCell<R extends RecordType>({
 
   return (
     <BaseCell
+      readonly
       showRightBorder={!isLastColumn}
       borderOnHover={false}
       hint={hint}
+      hintPosition="right"
       cursor="default"
     >
       <div


### PR DESCRIPTION

<img width="532" height="684" alt="Screenshot 2026-06-29 at 11 38 14 AM" src="https://github.com/user-attachments/assets/84f83c3e-5bdc-4fb0-b0a7-c39fa88ef68e" />


## What & why

Jira: [FCT-56432](https://factorialmakers.atlassian.net/browse/FCT-56432) — QA on the HC Planning "Backfill" column. The `cellHint` (ⓘ tooltip) icon should sit on the **right** of the cell content, not the left.

`BaseCell` hardcoded the hint icon before the cell content, so it always rendered on the left with no way to change it. This PR makes the position configurable and applies "right" to the read-only cell types.

> Note: the gray read-only background is **not** part of this PR — that is achieved on the consumer side by using `editType: 'disabled'` (which already renders `DisabledCell` with the disabled background). This change is scoped to the hint icon position only.

## Changes

- **`BaseCell`**: add an opt-in `hintPosition?: "left" | "right"` prop (default `"left"`, so every existing usage is unchanged). When `"right"`, the hint icon renders after the cell content.
- **`NonEditableCell`** (`display-only`) and **`DisabledCell`** (`disabled`): pass `hintPosition="right"`, so a `cellHint` on a read-only cell renders its icon to the right.

## Tests / Storybook

- Unit tests for hint positioning in `BaseCell`, `NonEditableCell`, and `DisabledCell`.
- New story **Data Collection › Visualizations › Editable Table › `EditableTableWithCellHint`** — the Role column is `disabled` (gray) with a hint, showing the icon on the right; Email stays editable for contrast.
- `vitest` green (24), `oxlint`/`oxfmt` clean.

Implemented-with: factorial-firefighter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FCT-56432]: https://factorialmakers.atlassian.net/browse/FCT-56432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ