### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.14.0",
+  "packages/react": "4.14.1",
   "packages/react-native": "0.55.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.14.1](https://github.com/factorialco/f0/compare/f0-react-v4.14.0...f0-react-v4.14.1) (2026-06-29)
+
+
+### Bug Fixes
+
+* **RichText:** re-wire PasteSanitizer into editor extension lists ([#4574](https://github.com/factorialco/f0/issues/4574)) ([8f90c03](https://github.com/factorialco/f0/commit/8f90c03b26f1701accce84ed1a7dc70abb2977fc))
+
 ## [4.14.0](https://github.com/factorialco/f0/compare/f0-react-v4.13.0...f0-react-v4.14.0) (2026-06-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.14.1</summary>

## [4.14.1](https://github.com/factorialco/f0/compare/f0-react-v4.14.0...f0-react-v4.14.1) (2026-06-29)


### Bug Fixes

* **RichText:** re-wire PasteSanitizer into editor extension lists ([#4574](https://github.com/factorialco/f0/issues/4574)) ([8f90c03](https://github.com/factorialco/f0/commit/8f90c03b26f1701accce84ed1a7dc70abb2977fc))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).