### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "4.14.1",
-  "packages/react-native": "0.55.0",
+  "packages/react-native": "0.56.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.56.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.55.0...f0-react-native-v0.56.0) (2026-06-29)
+
+
+### Features
+
+* **react-native:** refresh icon set with new designs ([#4561](https://github.com/factorialco/f0/issues/4561)) ([dadefe3](https://github.com/factorialco/f0/commit/dadefe349a8076a5df4289fec2cc9f7ba72f68f3))
+
 ## [0.55.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.54.0...f0-react-native-v0.55.0) (2026-05-20)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.56.0</summary>

## [0.56.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.55.0...f0-react-native-v0.56.0) (2026-06-29)


### Features

* **react-native:** refresh icon set with new designs ([#4561](https://github.com/factorialco/f0/issues/4561)) ([dadefe3](https://github.com/factorialco/f0/commit/dadefe349a8076a5df4289fec2cc9f7ba72f68f3))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).