### PR TITLE
feat(F0Rating): add experimental rating scale component

### DIFF
--- a/packages/react/src/experimental/F0Rating/F0Rating.tsx
+++ b/packages/react/src/experimental/F0Rating/F0Rating.tsx
@@ -1,0 +1,120 @@
+import { useControllableState } from "@radix-ui/react-use-controllable-state"
+import { forwardRef } from "react"
+
+import { useI18n } from "@/lib/providers/i18n"
+import { cn, focusRing } from "@/lib/utils"
+import { ToggleGroup, ToggleGroupItem } from "@/ui/ToggleGroup"
+
+import { RatingSize, F0RatingProps } from "./types"
+
+const TILE_BASE =
+  "flex items-center justify-center border border-solid border-f1-border font-medium text-f1-foreground"
+
+const TILE_SIZE: Record<RatingSize, string> = {
+  sm: "size-6 rounded-sm text-xs",
+  md: "size-8 rounded text-sm",
+  lg: "size-10 rounded-md text-sm",
+}
+
+const TILE_SELECTED =
+  "border-f1-border-selected bg-f1-background-selected-secondary"
+
+export const F0Rating = forwardRef<HTMLDivElement, F0RatingProps>(
+  (
+    {
+      value,
+      defaultValue,
+      max = 5,
+      onChange,
+      readOnly = false,
+      disabled = false,
+      required = false,
+      size = "md",
+      ariaLabel,
+      ariaLabelledBy,
+    },
+    ref
+  ) => {
+    const { t } = useI18n()
+
+    const [localValue, setLocalValue] = useControllableState<number | null>({
+      prop: value,
+      defaultProp: defaultValue ?? null,
+      onChange,
+    })
+
+    const tiles = Array.from({ length: Math.max(0, max) }, (_, i) => i + 1)
+
+    const resolvedLabel = ariaLabelledBy
+      ? undefined
+      : (ariaLabel ??
+        (localValue != null
+          ? t("rating.ariaLabel", { value: localValue, max })
+          : t("rating.ariaLabelEmpty", { max })))
+
+    if (readOnly) {
+      return (
+        <div
+          ref={ref}
+          role="img"
+          aria-label={resolvedLabel}
+          aria-labelledby={ariaLabelledBy}
+          className="inline-flex items-center gap-2"
+        >
+          {tiles.map((tile) => (
+            <span
+              key={tile}
+              aria-hidden
+              className={cn(
+                TILE_BASE,
+                TILE_SIZE[size],
+                localValue === tile && TILE_SELECTED
+              )}
+            >
+              {tile}
+            </span>
+          ))}
+        </div>
+      )
+    }
+
+    const handleChange = (next: string) => {
+      const parsed = next === "" ? null : Number(next)
+      if (required && parsed === null) return
+      setLocalValue(parsed)
+    }
+
+    return (
+      <ToggleGroup
+        ref={ref}
+        type="single"
+        value={localValue != null ? String(localValue) : ""}
+        onValueChange={handleChange}
+        disabled={disabled}
+        aria-label={resolvedLabel}
+        aria-labelledby={ariaLabelledBy}
+        className="inline-flex items-center gap-2"
+      >
+        {tiles.map((tile) => (
+          <ToggleGroupItem
+            key={tile}
+            value={String(tile)}
+            disabled={disabled}
+            className={cn(
+              TILE_BASE,
+              TILE_SIZE[size],
+              "cursor-pointer transition-colors hover:border-f1-border-hover",
+              "data-[state=on]:border-f1-border-selected data-[state=on]:bg-f1-background-selected-secondary",
+              "disabled:cursor-default disabled:text-f1-foreground-disabled disabled:hover:border-f1-border",
+              focusRing()
+            )}
+          >
+            {tile}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    )
+  }
+)
+
+F0Rating.displayName = "F0Rating"

--- a/packages/react/src/experimental/F0Rating/__stories__/F0Rating.mdx
+++ b/packages/react/src/experimental/F0Rating/__stories__/F0Rating.mdx
@@ -1,0 +1,413 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as Stories from "./F0Rating.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+<Meta of={Stories} />
+
+# F0Rating
+
+A numeric rating scale that lets users grant a score from 1 to a configurable
+maximum, or displays an existing score as a read-only summary.
+
+---
+
+# Overview
+
+## Purpose
+
+- Captures a single numeric rating on a discrete scale (1…`max`).
+- Shows an existing score in a compact, non-interactive read-only view.
+- Provides one consistent rating control across forms and detail views.
+- Ships an accessible, localizable name out of the box.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Element</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Required</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>Group</code>
+        </td>
+        <td>
+          Container exposing the scale as a single-select group with an
+          accessible name.
+        </td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Tile</code>
+        </td>
+        <td>One selectable cell per value, labelled with its number.</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Selected tile</code>
+        </td>
+        <td>
+          The active value, highlighted with the selected border and background.
+        </td>
+        <td>No</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Sizes
+
+<Canvas of={Stories.Sizes} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Size</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">When to use</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>sm</code>
+        </td>
+        <td>Compact tiles (24px).</td>
+        <td>Dense rows, tables, or tight side panels.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>md</code>
+        </td>
+        <td>Default tile size (32px).</td>
+        <td>Most forms and detail views.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>lg</code>
+        </td>
+        <td>Large tiles (40px).</td>
+        <td>Primary, focal rating inputs.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## States
+
+Read-only renders a non-interactive, non-dimmed summary of the score.
+
+<Canvas of={Stories.ReadOnly} />
+
+Disabled is non-interactive and visually dimmed.
+
+<Canvas of={Stories.Disabled} />
+
+Empty shows the scale with no value selected.
+
+<Canvas of={Stories.Empty} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">State</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Visual indicator</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>Interactive</code>
+        </td>
+        <td>Default; the user can select or clear a value.</td>
+        <td>Hover and focus affordances on tiles.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>readOnly</code>
+        </td>
+        <td>Displays the score; cannot be changed.</td>
+        <td>Selected tile highlighted, no hover or focus.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>disabled</code>
+        </td>
+        <td>Inactive and not editable.</td>
+        <td>Dimmed text, default cursor.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+# Guidelines
+
+## Design Best Practices
+
+### When to use
+
+- Collecting a quick, discrete score (e.g. interview feedback, satisfaction).
+- Showing a previously granted score inside a card or detail view (`readOnly`).
+- Any place that needs a consistent 1…`max` scale across the product.
+
+### When NOT to use
+
+- Free-form or open-ended feedback: use a text input instead.
+- Choosing between unordered, labelled options: use `F0SegmentedControl`.
+- A continuous range (e.g. a percentage): use a slider.
+
+### How to use
+
+- Keep `max` small (5 is the default); large scales are hard to compare.
+- Use `readOnly` — not `disabled` — to display a score that simply can't change
+  in the current context.
+- Set `required` when the scale must always keep a value once one is chosen.
+
+## Content Best Practices
+
+- Pair the control with a visible label describing what is being rated.
+- Provide a meaningful accessible name via the visible label
+  (`ariaLabelledBy`) or `ariaLabel` when the default is not specific enough.
+
+<DoDonts
+  do={{
+    description:
+      "Use readOnly to present a score that the current user cannot edit.",
+  }}
+  dont={{
+    description:
+      "Use disabled to display a final score — it reads as temporarily unavailable, not as a result.",
+  }}
+/>
+
+## Layout
+
+- Tiles lay out in a single horizontal row with consistent spacing.
+- Place a label directly before the control on the same line or above it.
+
+## Accessibility
+
+- Interactive mode is a single-select group; arrow keys move between tiles and
+  Space/Enter selects the focused tile.
+- Read-only mode is exposed as a single labelled image, so assistive tech
+  announces the score rather than five separate cells.
+- A localized accessible name is provided by default; override it with
+  `ariaLabel` or point to a visible label with `ariaLabelledBy`.
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Key</th>
+        <th className="text-left">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <kbd>Tab</kbd>
+        </td>
+        <td>Move focus to the rating group.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>ArrowLeft</kbd> / <kbd>ArrowRight</kbd>
+        </td>
+        <td>Move between tiles.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Space</kbd> / <kbd>Enter</kbd>
+        </td>
+        <td>Select the focused tile; re-select to clear (unless required).</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+# Code
+
+## Import
+
+```tsx
+import { F0Rating } from "@factorialco/f0-react"
+```
+
+## Props
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+### Props Reference
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>value</code>
+        </td>
+        <td>
+          <code>number | null</code>
+        </td>
+        <td>-</td>
+        <td>The selected rating (1…`max`); `null` for none.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>defaultValue</code>
+        </td>
+        <td>
+          <code>number | null</code>
+        </td>
+        <td>-</td>
+        <td>Initial value when uncontrolled.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>max</code>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>
+          <code>5</code>
+        </td>
+        <td>Highest selectable rating; renders tiles for 1…`max`.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onChange</code>
+        </td>
+        <td>
+          <code>{"(value: number | null) => void"}</code>
+        </td>
+        <td>-</td>
+        <td>Called on selection; emits `null` when cleared.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>readOnly</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>Non-interactive, non-dimmed display of the value.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>disabled</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>Non-interactive and visually dimmed.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>required</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>Prevents clearing the value by re-selecting it.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>size</code>
+        </td>
+        <td>
+          <code>"sm" | "md" | "lg"</code>
+        </td>
+        <td>
+          <code>"md"</code>
+        </td>
+        <td>Tile size.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>ariaLabel</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>-</td>
+        <td>Overrides the default accessible name.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>ariaLabelledBy</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>-</td>
+        <td>ID of a visible label; used instead of `ariaLabel`.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+# Examples
+
+## Grant a rating
+
+<Canvas of={Stories.Default} />
+
+```tsx
+<F0Rating value={rating} onChange={setRating} ariaLabel="Interview score" />
+```
+
+## Read-only display
+
+<Canvas of={Stories.ReadOnly} />
+
+```tsx
+<F0Rating value={4} readOnly />
+```
+
+## Controlled
+
+<Canvas of={Stories.Controlled} />
+
+```tsx
+const [value, setValue] = useState<number | null>(2)
+
+return <F0Rating value={value} onChange={setValue} ariaLabel="Rating" />
+```

--- a/packages/react/src/experimental/F0Rating/__stories__/F0Rating.stories.tsx
+++ b/packages/react/src/experimental/F0Rating/__stories__/F0Rating.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import { F0Rating } from "../index"
+
+const meta = {
+  title: "F0Rating",
+  component: F0Rating,
+  tags: ["experimental"],
+  args: {
+    max: 5,
+    value: 2,
+    size: "md",
+    ariaLabel: "Rating",
+  },
+} satisfies Meta<typeof F0Rating>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  tags: ["!dev"],
+  parameters: withSnapshot({}),
+}
+
+export const ReadOnly: Story = {
+  tags: ["!dev"],
+  parameters: withSnapshot({}),
+  args: { readOnly: true, value: 4, ariaLabel: "Rating: 4 of 5" },
+}
+
+export const Disabled: Story = {
+  tags: ["!dev"],
+  parameters: withSnapshot({}),
+  args: { disabled: true, value: 3 },
+}
+
+export const Empty: Story = {
+  tags: ["!dev"],
+  parameters: withSnapshot({}),
+  args: { value: null },
+}
+
+export const Sizes: Story = {
+  tags: ["!dev"],
+  parameters: withSnapshot({}),
+  render: (args) => (
+    <div className="flex flex-col items-start gap-4">
+      <F0Rating {...args} size="sm" />
+      <F0Rating {...args} size="md" />
+      <F0Rating {...args} size="lg" />
+    </div>
+  ),
+}
+
+const ControlledExample = () => {
+  const [value, setValue] = useState<number | null>(2)
+  return <F0Rating value={value} onChange={setValue} ariaLabel="Rating" />
+}
+
+export const Controlled: Story = {
+  tags: ["!dev"],
+  render: () => <ControlledExample />,
+}

--- a/packages/react/src/experimental/F0Rating/__tests__/F0Rating.test.tsx
+++ b/packages/react/src/experimental/F0Rating/__tests__/F0Rating.test.tsx
@@ -1,0 +1,82 @@
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { F0Rating } from "../index"
+
+describe("F0Rating", () => {
+  it("renders a tile for each value up to `max`", () => {
+    render(<F0Rating max={5} ariaLabel="Rating" />)
+    for (const tile of ["1", "2", "3", "4", "5"]) {
+      expect(screen.getByText(tile)).toBeInTheDocument()
+    }
+    expect(screen.queryByText("6")).not.toBeInTheDocument()
+  })
+
+  it("marks the selected value", () => {
+    render(<F0Rating value={3} ariaLabel="Rating" />)
+    expect(screen.getByText("3").closest("button")).toHaveAttribute(
+      "data-state",
+      "on"
+    )
+    expect(screen.getByText("2").closest("button")).toHaveAttribute(
+      "data-state",
+      "off"
+    )
+  })
+
+  it("calls onChange with the selected value", async () => {
+    const onChange = vi.fn()
+    render(<F0Rating value={null} onChange={onChange} ariaLabel="Rating" />)
+    await userEvent.click(screen.getByText("4"))
+    expect(onChange).toHaveBeenCalledWith(4)
+  })
+
+  it("clears the value when the active tile is re-selected", async () => {
+    const onChange = vi.fn()
+    render(<F0Rating value={2} onChange={onChange} ariaLabel="Rating" />)
+    await userEvent.click(screen.getByText("2"))
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it("keeps the value when re-selected while `required`", async () => {
+    const onChange = vi.fn()
+    render(
+      <F0Rating value={2} required onChange={onChange} ariaLabel="Rating" />
+    )
+    await userEvent.click(screen.getByText("2"))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("does not call onChange when disabled", async () => {
+    const onChange = vi.fn()
+    render(
+      <F0Rating value={2} disabled onChange={onChange} ariaLabel="Rating" />
+    )
+    await userEvent.click(screen.getByText("4"))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("renders a non-interactive image with a localized default label in read-only mode", () => {
+    render(<F0Rating value={4} max={5} readOnly />)
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("img", { name: "Rating: 4 of 5" })
+    ).toBeInTheDocument()
+  })
+
+  it("uses the empty default label when there is no value", () => {
+    render(<F0Rating value={null} max={5} readOnly />)
+    expect(
+      screen.getByRole("img", { name: "Rating: not rated, out of 5" })
+    ).toBeInTheDocument()
+  })
+
+  it("prefers an explicit ariaLabel over the default", () => {
+    render(<F0Rating value={4} readOnly ariaLabel="Overall score" />)
+    expect(
+      screen.getByRole("img", { name: "Overall score" })
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/experimental/F0Rating/index.tsx
+++ b/packages/react/src/experimental/F0Rating/index.tsx
@@ -1,0 +1,10 @@
+import { withDataTestId } from "@/lib/data-testid"
+import { experimentalComponent } from "@/lib/experimental"
+
+import { F0Rating as F0RatingBase } from "./F0Rating"
+
+export * from "./types"
+
+export const F0Rating = withDataTestId(
+  experimentalComponent("F0Rating", F0RatingBase)
+)

--- a/packages/react/src/experimental/F0Rating/types.ts
+++ b/packages/react/src/experimental/F0Rating/types.ts
@@ -1,0 +1,17 @@
+import { WithDataTestIdProps } from "@/lib/data-testid"
+
+export const ratingSizes = ["sm", "md", "lg"] as const
+export type RatingSize = (typeof ratingSizes)[number]
+
+export interface F0RatingProps extends WithDataTestIdProps {
+  value?: number | null
+  defaultValue?: number | null
+  max?: number
+  onChange?: (value: number | null) => void
+  readOnly?: boolean
+  disabled?: boolean
+  required?: boolean
+  size?: RatingSize
+  ariaLabel?: string
+  ariaLabelledBy?: string
+}

--- a/packages/react/src/experimental/exports.ts
+++ b/packages/react/src/experimental/exports.ts
@@ -24,6 +24,7 @@ export * from "../kits/Charts/exports"
  */
 export * from "../components/F0ActionBar"
 export * from "./F0CardHorizontal"
+export * from "./F0Rating"
 export * from "./F0SegmentedBar"
 export * from "./F0VersionHistory"
 export * from "./Forms/exports"

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -497,6 +497,10 @@ export const defaultTranslations = {
     greaterThan: "It should be greater than {{min}}",
     lessThan: "It should be less than {{max}}",
   },
+  rating: {
+    ariaLabel: "Rating: {{value}} of {{max}}",
+    ariaLabelEmpty: "Rating: not rated, out of {{max}}",
+  },
   imageUpload: {
     uploading: "Uploading...",
     uploadError: "Upload failed",


### PR DESCRIPTION
Adds `F0Rating`, a standalone numeric rating control for granting a score (1…`max`) or displaying an existing one read-only. It's the f0-native rating used by the ATS "Notes" redesign, but it's intentionally generic so any form or detail view can use it. f0 had no general-purpose rating control, and the only numeric-tile UI that existed (`RatingQuestion`) is bound to the survey builder and can't be reused (see below).

**Docs page**: https://66a7a8d7d124220c363457cc-sxakgthkgq.chromatic.com/?path=/docs/experimental-f0rating--documentation

## Implementation details

- feat(F0Rating): single-select rating built on the `@/ui/ToggleGroup` primitive (keyboard a11y, roving focus); re-selecting the active tile clears it unless `required`
- feat(F0Rating): `readOnly` renders a non-interactive `role="img"` summary; `disabled` is non-interactive and dimmed
- feat(F0Rating): size tiles follow f0's interactive scale — `sm` 24px/`rounded-sm` 8px, `md` 32px/`rounded` 10px, `lg` 40px/`rounded-md` 12px; selected state uses `border-f1-border-selected` + `bg-f1-background-selected-secondary`
- feat(i18n): add `rating.ariaLabel` / `rating.ariaLabelEmpty` defaults so the accessible name is localized out of the box, with `ariaLabel`/`ariaLabelledBy` as overrides
- feat(experimental): export `F0Rating` from `experimental/exports.ts`
- docs(F0Rating): MDX docs (Overview/Guidelines/Code/Examples) + stories
- test(F0Rating): unit tests for selection, clear, required, disabled, read-only, and the localized default label

## Why a new component — and why `RatingQuestion` can't be reused

The design system already renders numeric rating tiles inside `RatingQuestion` → `BaseScoreQuestion` (under `sds/surveys/SurveyFormBuilder/`). It looks similar, but it cannot serve as a general rating control:

- **It requires the survey-builder context.** `BaseScoreQuestion` calls `useSurveyFormBuilderContext()`, which throws when there's no `SurveyFormBuilder` provider. Dropping it into a candidate note card or a form would crash.
- **It's a whole survey question, not a control.** It renders full question chrome via `<BaseQuestion>` (title, description, section locking, "answering" mode) — far more than a rating input.
- **Its API is survey-shaped.** Changes are emitted as `onQuestionChange({ id, type: "rating", value })`, not a plain `onChange(value)`; it also carries survey-only concerns (emoji scales, inline label editing).

The inverse — making `F0Rating` reuse it, or extending `RatingQuestion` for general use — would either couple a generic control to survey context or bloat it with survey-only features. So `F0Rating` is a clean, context-free control with a plain value API. The shared visual tile can be consolidated later (survey adopting `F0Rating`'s tile) as a follow-up; this PR doesn't touch survey code.

<img width="938" height="539" alt="Screenshot 2026-06-29 at 14 37 22" src="https://github.com/user-attachments/assets/f3fa4e07-ccb7-41ec-8070-9f16fca2e171" />

