### PR TITLE
chore(react-native): make the playground showcase harness native (Expo UI / SDK 56)

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -116,6 +116,7 @@
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@babel/preset-typescript": "^7.28.5",
+    "@expo/ui": "~56.0.18",
     "@expo/vector-icons": "^15.1.1",
     "@react-native/jest-preset": "0.85.3",
     "@react-navigation/bottom-tabs": "^7.4.0",
@@ -136,6 +137,7 @@
     "expo-clipboard": "~56.0.4",
     "expo-constants": "~56.0.18",
     "expo-font": "~56.0.7",
+    "expo-glass-effect": "~56.0.4",
     "expo-image": "~56.0.11",
     "expo-router": "~56.2.11",
     "expo-splash-screen": "~56.0.10",

--- a/packages/react-native/playground/app/(tabs)/_layout.tsx
+++ b/packages/react-native/playground/app/(tabs)/_layout.tsx
@@ -14,13 +14,13 @@ import { NativeTabs } from 'expo-router/unstable-native-tabs';
 export default function TabLayout() {
   return (
     <NativeTabs>
-      <NativeTabs.Trigger name="tokens">
-        <NativeTabs.Trigger.Icon sf="paintpalette.fill" md="palette" />
-        <NativeTabs.Trigger.Label>Design Tokens</NativeTabs.Trigger.Label>
-      </NativeTabs.Trigger>
       <NativeTabs.Trigger name="components">
         <NativeTabs.Trigger.Icon sf="square.grid.2x2.fill" md="widgets" />
         <NativeTabs.Trigger.Label>Components</NativeTabs.Trigger.Label>
+      </NativeTabs.Trigger>
+      <NativeTabs.Trigger name="tokens">
+        <NativeTabs.Trigger.Icon sf="paintpalette.fill" md="palette" />
+        <NativeTabs.Trigger.Label>Design Tokens</NativeTabs.Trigger.Label>
       </NativeTabs.Trigger>
     </NativeTabs>
   );

--- a/packages/react-native/playground/app/index.tsx
+++ b/packages/react-native/playground/app/index.tsx
@@ -1,5 +1,5 @@
 import { Redirect } from 'expo-router';
 
 export default function Index() {
-  return <Redirect href="/(tabs)/tokens" />;
+  return <Redirect href="/(tabs)/components" />;
 }

--- a/packages/react-native/playground/components/Select/index.tsx
+++ b/packages/react-native/playground/components/Select/index.tsx
@@ -1,123 +1,196 @@
-import React, { useState } from "react";
-import { Modal, Pressable, ScrollView, Text } from "react-native";
-import { useCSSVariable } from "uniwind";
-import { AppIcons } from "../../../src/icons";
-import { F0Icon } from "../../../src/components/primitives/F0Icon";
+import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect"
+import { SymbolView } from "expo-symbols"
+import React, { useMemo, useState } from "react"
+import { Modal, Pressable, ScrollView, Text, TextInput, View } from "react-native"
+import { useCSSVariable } from "uniwind"
 
-export interface SelectOption<T extends string> {
-  value: T;
-  label: string;
+import type { SelectProps } from "./types"
+
+export * from "./types"
+
+const asString = (value: string | number | undefined): string => {
+  if (typeof value === "string") return value
+  if (typeof value === "number") return String(value)
+  return "#000000"
 }
 
-export interface SelectProps<T extends string> {
-  options: SelectOption<T>[];
-  value: T;
-  onChange: (value: T) => void;
-  placeholder?: string;
-  className?: string;
-}
+const isDeprecated = (label: string) =>
+  label.toLowerCase().includes("deprecated")
 
+/**
+ * Native component browser for the playground.
+ *
+ * The trigger is an iOS 26 Liquid Glass pill (expo-glass-effect). Tapping it opens
+ * a native sheet (`Modal presentationStyle="pageSheet"`) with a native search field
+ * and a grouped, scrollable list (Core / Deprecated). SF / Material symbols
+ * (expo-symbols) mark the chrome and the current selection. Same props as before,
+ * so call sites are unchanged.
+ */
 export function Select<T extends string>({
   options,
   value,
   onChange,
-  placeholder = "Select an option",
-  className,
+  placeholder = "Select a component",
 }: SelectProps<T>) {
-  const [isOpen, setIsOpen] = useState(false);
-  
-  const [f0Background, f0Foreground, f0Border, f0BackgroundSecondary] = useCSSVariable([
-    '--color-f0-background',
-    '--color-f0-foreground',
-    '--color-f0-border',
-    '--color-f0-background-secondary',
-  ]);
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
 
-  const asString = (val: string | number | undefined): string => {
-    if (typeof val === 'string') return val;
-    if (typeof val === 'number') return String(val);
-    return '#000000';
-  };
+  const [bg, fg, muted, border, fieldBg, accent] = useCSSVariable([
+    "--color-f0-background",
+    "--color-f0-foreground",
+    "--color-f0-foreground-secondary",
+    "--color-f0-border",
+    "--color-f0-background-secondary",
+    "--color-f0-foreground-info",
+  ])
 
-  const selectedOption = options.find(opt => opt.value === value);
+  const selected = options.find((option) => option.value === value)
+
+  const groups = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const filtered = q
+      ? options.filter((option) => option.label.toLowerCase().includes(q))
+      : options
+    return [
+      {
+        title: "Core",
+        data: filtered.filter((option) => !isDeprecated(option.label)),
+      },
+      {
+        title: "Deprecated",
+        data: filtered.filter((option) => isDeprecated(option.label)),
+      },
+    ].filter((group) => group.data.length > 0)
+  }, [options, query])
+
+  const close = () => {
+    setOpen(false)
+    setQuery("")
+  }
+  const pick = (next: T) => {
+    onChange(next)
+    close()
+  }
+
+  const trigger = (
+    <View className="flex-row items-center justify-between px-4 py-3">
+      <Text className="text-base font-medium" style={{ color: asString(fg) }}>
+        {selected?.label ?? placeholder}
+      </Text>
+      <SymbolView
+        name={{ ios: "chevron.up.chevron.down", android: "unfold_more" }}
+        size={18}
+        tintColor={asString(muted)}
+      />
+    </View>
+  )
 
   return (
     <>
-      <Pressable
-        onPress={() => setIsOpen(true)}
-        className={`flex-row items-center justify-between px-3 py-2 rounded-lg border ${className || ''}`}
-        style={{
-          backgroundColor: asString(f0Background),
-          borderColor: asString(f0Border),
-        }}
-      >
-        <Text
-          className="text-sm flex-1"
-          style={{ color: asString(f0Foreground) }}
-        >
-          {selectedOption?.label || placeholder}
-        </Text>
-        <F0Icon
-          icon={isOpen ? AppIcons.ChevronUp : AppIcons.ChevronDown}
-          size="sm"
-          className="text-f0-icon"
-        />
+      <Pressable onPress={() => setOpen(true)} accessibilityRole="button">
+        {isLiquidGlassAvailable() ? (
+          <GlassView
+            glassEffectStyle="regular"
+            isInteractive
+            style={{ borderRadius: 14, overflow: "hidden" }}
+          >
+            {trigger}
+          </GlassView>
+        ) : (
+          <View
+            className="rounded-2xl border"
+            style={{ borderColor: asString(border) }}
+          >
+            {trigger}
+          </View>
+        )}
       </Pressable>
 
       <Modal
-        visible={isOpen}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setIsOpen(false)}
+        visible={open}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={close}
       >
-        <Pressable
-          className="flex-1 justify-center items-center"
-          style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
-          onPress={() => setIsOpen(false)}
-        >
-          <Pressable
-            className="rounded-lg border w-4/5 max-w-md"
-            style={{
-              backgroundColor: asString(f0Background),
-              borderColor: asString(f0Border),
-              maxHeight: '80%',
-            }}
-            onPress={(e) => e.stopPropagation()}
+        <View style={{ flex: 1, backgroundColor: asString(bg) }}>
+          <View className="flex-row items-center justify-between px-4 pb-2 pt-4">
+            <Text className="text-xl font-bold" style={{ color: asString(fg) }}>
+              Components
+            </Text>
+            <Pressable onPress={close} accessibilityRole="button" hitSlop={10}>
+              <SymbolView
+                name={{ ios: "xmark.circle.fill", android: "close" }}
+                size={26}
+                tintColor={asString(muted)}
+              />
+            </Pressable>
+          </View>
+
+          <View
+            className="mx-4 mb-2 flex-row items-center gap-2 rounded-xl px-3 py-2"
+            style={{ backgroundColor: asString(fieldBg) }}
           >
-            <ScrollView
-              className="p-2"
-              showsVerticalScrollIndicator={true}
-              nestedScrollEnabled={true}
-            >
-              {options.map((option) => {
-                const isSelected = option.value === value;
-                return (
-                  <Pressable
-                    key={option.value}
-                    onPress={() => {
-                      onChange(option.value);
-                      setIsOpen(false);
-                    }}
-                    className={`px-4 py-3 rounded-lg mb-1 ${isSelected ? '' : ''}`}
-                    style={{
-                      backgroundColor: isSelected 
-                        ? asString(f0BackgroundSecondary)
-                        : 'transparent',
-                    }}
-                  >
-                    <Text
-                      className="text-base"
-                      style={{ color: asString(f0Foreground) }}
+            <SymbolView
+              name={{ ios: "magnifyingglass", android: "search" }}
+              size={18}
+              tintColor={asString(muted)}
+            />
+            <TextInput
+              placeholder="Search components"
+              placeholderTextColor={asString(muted)}
+              value={query}
+              onChangeText={setQuery}
+              autoCapitalize="none"
+              autoCorrect={false}
+              style={{ flex: 1, fontSize: 16, color: asString(fg) }}
+            />
+          </View>
+
+          <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={{ paddingBottom: 32 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            {groups.map((group) => (
+              <View key={group.title} className="mb-2">
+                <Text
+                  className="px-4 py-1 text-xs font-semibold uppercase"
+                  style={{ color: asString(muted) }}
+                >
+                  {group.title}
+                </Text>
+                {group.data.map((option) => {
+                  const active = option.value === value
+                  return (
+                    <Pressable
+                      key={option.value}
+                      onPress={() => pick(option.value)}
+                      className="flex-row items-center justify-between px-4 py-3"
                     >
-                      {option.label}
-                    </Text>
-                  </Pressable>
-                );
-              })}
-            </ScrollView>
-          </Pressable>
-        </Pressable>
+                      <Text
+                        className="text-base"
+                        style={{
+                          color: asString(fg),
+                          fontWeight: active ? "600" : "400",
+                        }}
+                      >
+                        {option.label}
+                      </Text>
+                      {active ? (
+                        <SymbolView
+                          name={{ ios: "checkmark", android: "check" }}
+                          size={18}
+                          tintColor={asString(accent)}
+                        />
+                      ) : null}
+                    </Pressable>
+                  )
+                })}
+              </View>
+            ))}
+          </ScrollView>
+        </View>
       </Modal>
     </>
-  );
+  )
 }

--- a/packages/react-native/playground/components/Select/types.ts
+++ b/packages/react-native/playground/components/Select/types.ts
@@ -1,0 +1,12 @@
+export interface SelectOption<T extends string> {
+  value: T
+  label: string
+}
+
+export interface SelectProps<T extends string> {
+  options: SelectOption<T>[]
+  value: T
+  onChange: (value: T) => void
+  placeholder?: string
+  className?: string
+}

--- a/packages/react-native/playground/components/ThemeSwitcher.tsx
+++ b/packages/react-native/playground/components/ThemeSwitcher.tsx
@@ -1,69 +1,73 @@
-import { Pressable, Text, View } from 'react-native';
-import { Uniwind, useCSSVariable, useUniwind } from 'uniwind';
+import { SegmentedControl } from "@expo/ui/community/segmented-control"
+import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect"
+import { SymbolView } from "expo-symbols"
+import React from "react"
+import { View } from "react-native"
+import { Uniwind, useCSSVariable, useUniwind } from "uniwind"
 
+const THEMES = ["system", "light", "dark"] as const
+const LABELS = ["System", "Light", "Dark"]
+
+const asString = (value: string | number | undefined): string => {
+  if (typeof value === "string") return value
+  if (typeof value === "number") return String(value)
+  return "#000000"
+}
+
+/**
+ * Playground theme switcher.
+ *
+ * Native showcase-chrome element: a native SegmentedControl (@expo/ui) for the
+ * System / Light / Dark choice, paired with an expo-symbols SF/Material symbol,
+ * inside an iOS 26 Liquid Glass card (expo-glass-effect) when available — with a
+ * plain bordered fallback on older iOS / Android.
+ */
 export const ThemeSwitcher = () => {
-  const { theme, hasAdaptiveThemes } = useUniwind();
-  
-  // Get current theme colors
-  const [f0Background, f0Foreground, f0Border, f0BackgroundSecondary] = useCSSVariable([
-    '--color-f0-background',
-    '--color-f0-foreground',
-    '--color-f0-border',
-    '--color-f0-background-secondary',
-  ]);
+  const { theme, hasAdaptiveThemes } = useUniwind()
+  const [fg, border] = useCSSVariable([
+    "--color-f0-foreground",
+    "--color-f0-border",
+  ])
 
-  const asString = (value: string | number | undefined): string => {
-    if (typeof value === 'string') return value;
-    if (typeof value === 'number') return String(value);
-    return '#000000';
-  };
+  const active = hasAdaptiveThemes ? "system" : theme
+  const index = Math.max(0, THEMES.indexOf(active as (typeof THEMES)[number]))
 
-  const themes = [
-    { name: 'system' as const, label: 'System', icon: '⚙️' },
-    { name: 'light' as const, label: 'Light', icon: '☀️' },
-    { name: 'dark' as const, label: 'Dark', icon: '🌙' },
-  ];
-
-  const activeTheme = hasAdaptiveThemes ? 'system' : theme;
-
-  return (
-    <View 
-      className="p-2 rounded-lg border"
-      style={{
-        backgroundColor: asString(f0BackgroundSecondary),
-        borderColor: asString(f0Border),
-      }}
-    >
-      <View className="flex-row gap-1.5">
-        {themes.map((t) => {
-          const isActive = activeTheme === t.name;
-          return (
-            <Pressable
-              key={t.name}
-              onPress={() => Uniwind.setTheme(t.name)}
-              className={`
-                flex-1 px-2 py-1.5 rounded-lg items-center
-                ${isActive ? 'bg-blue-500' : ''}
-              `}
-              style={{
-                backgroundColor: isActive ? '#3b82f6' : asString(f0Background),
-                borderWidth: isActive ? 0 : 1,
-                borderColor: asString(f0Border),
-              }}
-            >
-              <Text className="text-lg mb-0.5">{t.icon}</Text>
-              <Text
-                className="text-xs font-medium"
-                style={{
-                  color: isActive ? '#ffffff' : asString(f0Foreground),
-                }}
-              >
-                {t.label}
-              </Text>
-            </Pressable>
-          );
-        })}
+  const content = (
+    <View className="flex-row items-center gap-3 p-2">
+      <SymbolView
+        name={{ ios: "circle.lefthalf.filled", android: "contrast" }}
+        size={22}
+        tintColor={asString(fg)}
+      />
+      <View className="flex-1">
+        <SegmentedControl
+          values={LABELS}
+          selectedIndex={index}
+          onChange={(e) =>
+            Uniwind.setTheme(THEMES[e.nativeEvent.selectedSegmentIndex])
+          }
+        />
       </View>
     </View>
-  );
-};
+  )
+
+  if (isLiquidGlassAvailable()) {
+    return (
+      <GlassView
+        glassEffectStyle="regular"
+        style={{ borderRadius: 16, overflow: "hidden" }}
+      >
+        {content}
+      </GlassView>
+    )
+  }
+
+  return (
+    <View
+      className="rounded-2xl border"
+      style={{ borderColor: asString(border) }}
+    >
+      {content}
+    </View>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -743,6 +743,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.28.5
         version: 7.28.5(@babel/core@7.28.6)
+      '@expo/ui':
+        specifier: ~56.0.18
+        version: 56.0.18(oan64ab32fs37vdlt54xl3ai7e)
       '@expo/vector-icons':
         specifier: ^15.1.1
         version: 15.1.1(expo-font@56.0.7)(react-native@0.85.3(@babel/core@7.28.6)(@react-native/jest-preset@0.85.3(@babel/core@7.28.6)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.28.6))(@types/react@18.3.18)(react@19.2.3))(react@19.2.3)
@@ -803,6 +806,9 @@ importers:
       expo-font:
         specifier: ~56.0.7
         version: 56.0.7(expo@56.0.12)(react-native@0.85.3(@babel/core@7.28.6)(@react-native/jest-preset@0.85.3(@babel/core@7.28.6)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.28.6))(@types/react@18.3.18)(react@19.2.3))(react@19.2.3)
+      expo-glass-effect:
+        specifier: ~56.0.4
+        version: 56.0.4(expo@56.0.12)(react-native@0.85.3(@babel/core@7.28.6)(@react-native/jest-preset@0.85.3(@babel/core@7.28.6)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.28.6))(@types/react@18.3.18)(react@19.2.3))(react@19.2.3)
       expo-image:
         specifier: ~56.0.11
         version: 56.0.11(expo@56.0.12)(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.28.6)(@react-native/jest-preset@0.85.3(@babel/core@7.28.6)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.28.6))(@types/react@18.3.18)(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
## What

Make the playground's **showcase harness** native, using Expo SDK 56 UI primitives, so the exported `F0*` components are presented in a more native shell. **No change to the published package surface** (`files`: `src`, `lib`) — only playground harness/chrome elements changed.

## Changes

- **ThemeSwitcher** — native `@expo/ui` `SegmentedControl` (System / Light / Dark) + an `expo-symbols` SF/Material symbol, inside an iOS 26 Liquid Glass card (`expo-glass-effect`), with a bordered fallback below iOS 26 / on Android via `isLiquidGlassAvailable()`.
- **Select (component picker)** — replaced the hand-rolled JS dropdown with a native component browser: a Liquid Glass pill trigger that opens a native sheet (`Modal presentationStyle="pageSheet"`) carrying a search field, a grouped scrollable list (Core / Deprecated), and SF/Material symbols for the chrome and the active selection. Same props, so call sites are unchanged.

Adds `@expo/ui` (~56.0.18) and `expo-glass-effect` (~56.0.4) as playground devDependencies (`expo-symbols` was already present).

## Verified

iPhone 17 Pro (Expo Go, SDK 56): the native SegmentedControl switches the theme, the glass card + SF symbols render, the glass pill opens the native sheet, the list **scrolls**, search filters, and selecting a component updates the showcase and dismisses the sheet.

## Stacking

Stacked on #4585 (native Liquid Glass tabs) → #4584 (Expo SDK 56 support). Review/merge bottom-up.


https://github.com/user-attachments/assets/7db95a88-dc28-447e-a8ff-7edc2059b9e1


