### PR TITLE
feat(F0CardHorizontal): add disabled and descriptionAsSingleLine props

### DIFF
--- a/packages/react/src/experimental/F0CardHorizontal/F0CardHorizontal.tsx
+++ b/packages/react/src/experimental/F0CardHorizontal/F0CardHorizontal.tsx
@@ -135,6 +135,19 @@ export interface F0CardHorizontalProps {
    * drag-and-drop while still allowing click navigation via `onClick`.
    */
   disableOverlayLink?: boolean
+
+  /**
+   * Dims the whole card and disables interaction (including its actions and any
+   * row-level link/click). Purely a visual + interaction affordance.
+   */
+  disabled?: boolean
+
+  /**
+   * Renders the description on a single line, truncating overflow with an
+   * ellipsis (and a tooltip with the full text) instead of wrapping. Has no
+   * effect when there's no `description`.
+   */
+  descriptionAsSingleLine?: boolean
 }
 
 /**
@@ -163,6 +176,8 @@ const F0CardHorizontalBase = forwardRef<HTMLDivElement, F0CardHorizontalProps>(
       onClick,
       disableOverlayLink = false,
       stackAt = "never",
+      disabled = false,
+      descriptionAsSingleLine = false,
     },
     ref
   ) {
@@ -170,7 +185,7 @@ const F0CardHorizontalBase = forwardRef<HTMLDivElement, F0CardHorizontalProps>(
     // The row is a click target only when it explicitly opts in via `link` or
     // `onClick`; otherwise it's static (only its actions are interactive). This
     // keeps the hover affordance + pointer cursor tied to an actual click action.
-    const clickable = !!link || !!onClick
+    const clickable = (!!link || !!onClick) && !disabled
 
     const body = (
       <Card
@@ -180,7 +195,8 @@ const F0CardHorizontalBase = forwardRef<HTMLDivElement, F0CardHorizontalProps>(
           fullHeight && "h-full",
           // Pointer + hover/focus affordance only when the whole row is clickable.
           clickable &&
-            "cursor-pointer focus-within:border-f1-border-hover focus-within:shadow-md hover:border-f1-border-hover hover:shadow-md"
+            "cursor-pointer focus-within:border-f1-border-hover focus-within:shadow-md hover:border-f1-border-hover hover:shadow-md",
+          disabled && "pointer-events-none opacity-50"
         )}
         style={
           hasAlert
@@ -190,7 +206,7 @@ const F0CardHorizontalBase = forwardRef<HTMLDivElement, F0CardHorizontalProps>(
               }
             : undefined
         }
-        onClick={onClick}
+        onClick={disabled ? undefined : onClick}
         data-testid="card"
       >
         {link && !disableOverlayLink && (
@@ -230,7 +246,11 @@ const F0CardHorizontalBase = forwardRef<HTMLDivElement, F0CardHorizontalProps>(
                 <Text
                   variant="description"
                   content={description}
-                  className={cn("break-words", inactive && "line-through")}
+                  ellipsis={descriptionAsSingleLine || undefined}
+                  className={cn(
+                    !descriptionAsSingleLine && "break-words",
+                    inactive && "line-through"
+                  )}
                 />
               )}
             </div>

--- a/packages/react/src/experimental/F0CardHorizontal/__stories__/F0CardHorizontal.stories.tsx
+++ b/packages/react/src/experimental/F0CardHorizontal/__stories__/F0CardHorizontal.stories.tsx
@@ -61,6 +61,16 @@ const meta: Meta<typeof F0CardHorizontal> = {
       description:
         "Disables the full-card overlay link (used with `link`) so a parent can manage drag-and-drop while still allowing click navigation via `onClick`.",
     },
+    disabled: {
+      control: "boolean",
+      description:
+        "Dims the whole card and disables interaction (its actions and any row-level link/click).",
+    },
+    descriptionAsSingleLine: {
+      control: "boolean",
+      description:
+        "Renders the description on a single line, truncating overflow with an ellipsis (and a tooltip) instead of wrapping.",
+    },
     // Function-bearing props: disable the control so it doesn't dump the
     // serialized mock fn() source. They still appear in the args table.
     primaryAction: {
@@ -164,6 +174,30 @@ export const ClickableCard: Story = {
     title: "Company goals",
     description: "Click anywhere on the card to open",
     onClick: clickAlert("Card"),
+  },
+}
+
+/**
+ * Disabled state: pass `disabled` to dim the whole card and switch off all
+ * interaction — its action buttons and any row-level link/click. Purely a
+ * visual + interaction affordance.
+ */
+export const Disabled: Story = {
+  args: {
+    avatar: { type: "module", module: "goals" },
+    title: "Company goals",
+    description: "This card is disabled",
+    disabled: true,
+    primaryAction: {
+      label: "Open",
+      onClick: clickAlert("Open"),
+    },
+    secondaryActions: [
+      {
+        label: "Edit",
+        onClick: clickAlert("Edit"),
+      },
+    ],
   },
 }
 
@@ -384,6 +418,29 @@ export const LongContent: Story = {
   },
   parameters: {
     docs: { story: { inline: false, height: "220px" } },
+  },
+}
+
+/**
+ * Pass `descriptionAsSingleLine` to keep the description on one line — overflow
+ * is truncated with an ellipsis (and a tooltip with the full text) instead of
+ * wrapping. Mirrors the single-line description behaviour of the deprecated
+ * `F0CanvasCard`; use it for dense lists where a fixed row height matters.
+ */
+export const SingleLineDescription: Story = {
+  args: {
+    avatar: {
+      type: "person",
+      firstName: "Jane",
+      lastName: "Cooper",
+      src: image,
+    },
+    title: "Jane Cooper",
+    description:
+      "Product designer leading the design system team across web and mobile, with a bio long enough to wrap onto several lines — ref https://example.com/people/jane-cooper-design-systems-lead-2026",
+    descriptionAsSingleLine: true,
+    primaryAction: { label: "Open", onClick: clickAlert("Open") },
+    secondaryActions: [{ label: "Edit", onClick: clickAlert("Edit") }],
   },
 }
 


### PR DESCRIPTION
## Summary

Adds two optional props to the experimental `F0CardHorizontal`, closing capability gaps with the deprecated `F0CanvasCard` as we migrate usages over.

- **`disabled?: boolean`** — dims the card (`opacity-50`) and switches off all interaction (its action buttons and any row-level `link`/`onClick`, via `pointer-events-none`). `clickable` is forced off so the hover/focus affordance and pointer cursor are suppressed too. Matches the established `opacity-50 pointer-events-none` disabled pattern used elsewhere in the codebase.
- **`descriptionAsSingleLine?: boolean`** — renders the description on a single line, truncating overflow with an ellipsis + tooltip instead of wrapping. Implemented by reusing `Text`'s existing `ellipsis` prop (the same `OneEllipsis` path `F0CanvasCard` uses), so the truncation behaviour is the proven one. No effect when there's no `description`.

Both default to `false`, so existing usages are unaffected.

## Storybook

- New `Disabled` story (dimmed card with primary + secondary actions).
- New `SingleLineDescription` story, reusing the same long bio as `LongContent` so wrapping vs. single-line truncation can be compared directly.
- Added matching boolean controls for both props.

## Testing

- `storybook dev` builds cleanly; both stories render and are registered in the story index.
- Pre-commit hooks (oxfmt, oxlint, cycle-dependencies) pass.
