### PR TITLE
feat(F0TagStatus): add optional icon prop

### DIFF
--- a/packages/react/src/components/tags/F0TagStatus/F0TagStatus.tsx
+++ b/packages/react/src/components/tags/F0TagStatus/F0TagStatus.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from "react"
 
+import { F0Icon } from "@/components/F0Icon"
 import { BaseTag } from "@/components/tags/internal/BaseTag"
 import { useTextFormatEnforcer } from "@/lib/text"
 import { cn } from "@/lib/utils"
@@ -7,7 +8,7 @@ import { cn } from "@/lib/utils"
 import type { F0TagStatusProps } from "./types"
 
 export const F0TagStatus = forwardRef<HTMLDivElement, F0TagStatusProps>(
-  ({ text, additionalAccessibleText, variant }, ref) => {
+  ({ text, additionalAccessibleText, variant, icon }, ref) => {
     useTextFormatEnforcer(
       text,
       { disallowEmpty: true },
@@ -27,19 +28,36 @@ export const F0TagStatus = forwardRef<HTMLDivElement, F0TagStatusProps>(
           }[variant]
         )}
         left={
-          <div
-            className={cn(
-              "m-1 aspect-square w-2 rounded-full",
-              {
-                neutral: "bg-f1-icon",
-                info: "bg-f1-icon-info",
-                positive: "bg-f1-icon-positive",
-                warning: "bg-f1-icon-warning",
-                critical: "bg-f1-icon-critical",
-              }[variant]
-            )}
-            aria-hidden
-          />
+          icon ? (
+            <F0Icon
+              icon={icon}
+              size="sm"
+              className={
+                {
+                  neutral: "text-f1-icon",
+                  info: "text-f1-icon-info",
+                  positive: "text-f1-icon-positive",
+                  warning: "text-f1-icon-warning",
+                  critical: "text-f1-icon-critical",
+                }[variant]
+              }
+              aria-hidden
+            />
+          ) : (
+            <div
+              className={cn(
+                "m-1 aspect-square w-2 rounded-full",
+                {
+                  neutral: "bg-f1-icon",
+                  info: "bg-f1-icon-info",
+                  positive: "bg-f1-icon-positive",
+                  warning: "bg-f1-icon-warning",
+                  critical: "bg-f1-icon-critical",
+                }[variant]
+              )}
+              aria-hidden
+            />
+          )
         }
         additionalAccessibleText={additionalAccessibleText}
         text={text}

--- a/packages/react/src/components/tags/F0TagStatus/__storybook__/TagStatus.stories.tsx
+++ b/packages/react/src/components/tags/F0TagStatus/__storybook__/TagStatus.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { Phone } from "@/icons/app"
+import * as Icons from "@/icons/app"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0TagStatus } from "../"
@@ -28,6 +30,18 @@ const meta: Meta = {
       table: {
         type: {
           summary: "StatusVariant",
+        },
+      },
+    },
+    icon: {
+      control: "select",
+      description:
+        "Optional leading icon, rendered inside the tag in place of the status dot. Inherits the variant's semantic color.",
+      options: Object.keys(Icons),
+      mapping: Icons,
+      table: {
+        type: {
+          summary: "IconType",
         },
       },
     },
@@ -67,6 +81,14 @@ export const CriticalStatusTag: Story = {
   },
 }
 
+export const WithIcon: Story = {
+  args: {
+    variant: "info",
+    text: "Live call",
+    icon: Phone,
+  },
+}
+
 export const Snapshot: Story = {
   parameters: withSnapshot({}),
   render: () => (
@@ -74,6 +96,16 @@ export const Snapshot: Story = {
       <h3 className="text-lg font-semibold">All Status Tags</h3>
       {statuses.map((status) => (
         <F0TagStatus key={status} text={status} variant={status} />
+      ))}
+
+      <h3 className="text-lg font-semibold">With Icon</h3>
+      {statuses.map((status) => (
+        <F0TagStatus
+          key={`${status}-icon`}
+          text={status}
+          variant={status}
+          icon={Phone}
+        />
       ))}
 
       <F0TagStatus

--- a/packages/react/src/components/tags/F0TagStatus/types.ts
+++ b/packages/react/src/components/tags/F0TagStatus/types.ts
@@ -1,3 +1,5 @@
+import { IconType } from "@/components/F0Icon"
+
 export const statuses = [
   "neutral",
   "info",
@@ -13,6 +15,7 @@ export type StatusVariant = Variant
 export interface F0TagStatusProps {
   text: string
   variant: Variant
+  icon?: IconType
   /**
    * Sometimes you need to clarify the status for screen reader users
    * E.g., when showing a tooltip for sighted user, provide the tootip text to this prop because tooltips aren't accessible

--- a/packages/react/src/ui/value-display/types/status/status.tsx
+++ b/packages/react/src/ui/value-display/types/status/status.tsx
@@ -2,16 +2,18 @@
  * Status cell type for displaying status indicators with labels.
  * Used for showing the current state or condition of items in data collections.
  */
+import { IconType } from "@/components/F0Icon"
 import { F0TagStatus, StatusVariant } from "@/components/tags/F0TagStatus"
 
 interface StatusValue {
   status: StatusVariant
   label: string
+  icon?: IconType
 }
 export type StatusCellValue = StatusValue
 
 export const StatusCell = (args: StatusCellValue) => (
   <div data-cell-type="status">
-    <F0TagStatus variant={args.status} text={args.label} />
+    <F0TagStatus variant={args.status} text={args.label} icon={args.icon} />
   </div>
 )


### PR DESCRIPTION
Adds an optional `icon` prop to `F0TagStatus`. When provided, the icon renders
**inside** the tag in place of the status dot and inherits the variant's semantic
color (`neutral`/`info`/`positive`/`warning`/`critical`). Without it, behaviour is
unchanged (the colored dot).

Also threads `icon` through the value-display `StatusCell` so the
`OneDataCollection` `status` property can pass it. Documented in Storybook
(**Tags/TagStatus** → `WithIcon` and `Snapshot`).

<img width="916" height="248" alt="Screenshot 2026-06-30 at 11 44 23" src="https://github.com/user-attachments/assets/3d87dc7e-5d45-40ba-9a38-938d39c057e2" />

