### PR TITLE
feat: expose full base color palette for F0TagDot

### DIFF
--- a/packages/react-native/src/components/F0Tag/F0Tag.types.ts
+++ b/packages/react-native/src/components/F0Tag/F0Tag.types.ts
@@ -18,6 +18,10 @@ export const dotTagColors = [
   "flubber",
   "indigo",
   "camel",
+  "radical",
+  "orange",
+  "red",
+  "grass",
 ] as const
 
 /**

--- a/packages/react-native/src/components/F0Tag/__tests__/__snapshots__/F0Tag.spec.tsx.snap
+++ b/packages/react-native/src/components/F0Tag/__tests__/__snapshots__/F0Tag.spec.tsx.snap
@@ -1555,6 +1555,278 @@ exports[`F0Tag Snapshot - dot colors 11`] = `
 </View>
 `;
 
+exports[`F0Tag Snapshot - dot colors 12`] = `
+<View
+  className="flex max-w-full min-w-0 shrink flex-row items-center justify-start gap-1"
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    className="flex max-w-full min-w-0 shrink flex-row items-center justify-start gap-1 overflow-hidden py-0.5 pr-2 text-f0-foreground pl-1 rounded-full border border-solid border-f0-border-secondary"
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "transform": [
+            {
+              "scale": 1,
+            },
+          ],
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      aria-hidden={true}
+      className="m-1 aspect-square w-2 rounded-full"
+      style={
+        {
+          "backgroundColor": "hsl(348 80% 50%)",
+        }
+      }
+    />
+    <Text
+      className="max-w-full shrink no-underline normal-case tracking-normal text-[16px] leading-[24px] font-medium text-f0-foreground text-left"
+      ellipsizeMode="tail"
+      numberOfLines={1}
+    >
+      radical
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`F0Tag Snapshot - dot colors 13`] = `
+<View
+  className="flex max-w-full min-w-0 shrink flex-row items-center justify-start gap-1"
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    className="flex max-w-full min-w-0 shrink flex-row items-center justify-start gap-1 overflow-hidden py-0.5 pr-2 text-f0-foreground pl-1 rounded-full border border-solid border-f0-border-secondary"
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "transform": [
+            {
+              "scale": 1,
+            },
+          ],
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      aria-hidden={true}
+      className="m-1 aspect-square w-2 rounded-full"
+      style={
+        {
+          "backgroundColor": "hsl(25 95% 53%)",
+        }
+      }
+    />
+    <Text
+      className="max-w-full shrink no-underline normal-case tracking-normal text-[16px] leading-[24px] font-medium text-f0-foreground text-left"
+      ellipsizeMode="tail"
+      numberOfLines={1}
+    >
+      orange
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`F0Tag Snapshot - dot colors 14`] = `
+<View
+  className="flex max-w-full min-w-0 shrink flex-row items-center justify-start gap-1"
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    className="flex max-w-full min-w-0 shrink flex-row items-center justify-start gap-1 overflow-hidden py-0.5 pr-2 text-f0-foreground pl-1 rounded-full border border-solid border-f0-border-secondary"
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "transform": [
+            {
+              "scale": 1,
+            },
+          ],
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      aria-hidden={true}
+      className="m-1 aspect-square w-2 rounded-full"
+      style={
+        {
+          "backgroundColor": "hsl(5 100% 65%)",
+        }
+      }
+    />
+    <Text
+      className="max-w-full shrink no-underline normal-case tracking-normal text-[16px] leading-[24px] font-medium text-f0-foreground text-left"
+      ellipsizeMode="tail"
+      numberOfLines={1}
+    >
+      red
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`F0Tag Snapshot - dot colors 15`] = `
+<View
+  className="flex max-w-full min-w-0 shrink flex-row items-center justify-start gap-1"
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    className="flex max-w-full min-w-0 shrink flex-row items-center justify-start gap-1 overflow-hidden py-0.5 pr-2 text-f0-foreground pl-1 rounded-full border border-solid border-f0-border-secondary"
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "transform": [
+            {
+              "scale": 1,
+            },
+          ],
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      aria-hidden={true}
+      className="m-1 aspect-square w-2 rounded-full"
+      style={
+        {
+          "backgroundColor": "hsl(160 84% 39%)",
+        }
+      }
+    />
+    <Text
+      className="max-w-full shrink no-underline normal-case tracking-normal text-[16px] leading-[24px] font-medium text-f0-foreground text-left"
+      ellipsizeMode="tail"
+      numberOfLines={1}
+    >
+      grass
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`F0Tag Snapshot - person, team and company variants 1`] = `
 <View
   className="flex max-w-full min-w-0 shrink flex-row items-center justify-start gap-1"

--- a/packages/react/src/components/tags/F0TagDot/__storybook__/TagDot.stories.tsx
+++ b/packages/react/src/components/tags/F0TagDot/__storybook__/TagDot.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          "This is a component that is used to display a dot tag. They should be used to display categories, but not for statuses. Use the `TagStatus` component instead.",
+          "This is a component that is used to display a dot tag. The full base color palette is available through the `color` prop. They should be used to display categories, but not for statuses — even though status-like hues (`red`, `orange`, `grass`) are available, use the `TagStatus` component when you mean an actual status.",
       },
     },
   },

--- a/packages/react/src/components/tags/F0TagDot/types.ts
+++ b/packages/react/src/components/tags/F0TagDot/types.ts
@@ -14,6 +14,10 @@ export const tagDotColors = [
   "flubber",
   "indigo",
   "camel",
+  "radical",
+  "orange",
+  "red",
+  "grass",
 ] as const satisfies BaseColor[]
 
 export type NewColor = Extract<BaseColor, (typeof tagDotColors)[number]>


### PR DESCRIPTION
## Changes

`F0TagDot` (and RN `F0Tag.Dot`) only allow-listed 11 of the 15 chromatic
base-color families. The omitted four — `radical`, `orange`, `red`,
`grass` — are exactly the hues consumers reach for, so the gap pushed
them onto the `customColor` escape hatch with raw `hsl(var(--*))` vars.

- **react** — add `radical`, `orange`, `red`, `grass` to `tagDotColors`.
  `NewColor` and the value-display `dotTag` cell derive from this list,
  so the colors flow through automatically.
- **react-native** — same four added to `dotTagColors` for parity.
- **docs** — TagDot Storybook description now notes the full palette is
  available and steers actual *status* use cases to `TagStatus`.

> Note: `red`/`orange`/`grass` sit close to the `critical`/`warning`/
> `positive` hues. `F0TagDot` is for categories, not statuses — the doc
> note reinforces using `TagStatus` when a status is meant.
