### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.17.0",
+  "packages/react": "4.17.1",
   "packages/react-native": "0.56.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.17.1](https://github.com/factorialco/f0/compare/f0-react-v4.17.0...f0-react-v4.17.1) (2026-06-30)
+
+
+### Bug Fixes
+
+* **emoji-picker:** mount em-emoji-picker via createElement to avoid Illegal constructor ([#4594](https://github.com/factorialco/f0/issues/4594)) ([89304b5](https://github.com/factorialco/f0/commit/89304b5a3a49b1b7c25b2aeb6278f93763edb230))
+
 ## [4.17.0](https://github.com/factorialco/f0/compare/f0-react-v4.16.0...f0-react-v4.17.0) (2026-06-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.17.1</summary>

## [4.17.1](https://github.com/factorialco/f0/compare/f0-react-v4.17.0...f0-react-v4.17.1) (2026-06-30)


### Bug Fixes

* **emoji-picker:** mount em-emoji-picker via createElement to avoid Illegal constructor ([#4594](https://github.com/factorialco/f0/issues/4594)) ([89304b5](https://github.com/factorialco/f0/commit/89304b5a3a49b1b7c25b2aeb6278f93763edb230))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).