### PR TITLE
feat(kanban): allow palette color on lane headers

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -213,6 +213,7 @@ export const KanbanCollection = <
           title: l.title,
           items: l.items,
           variant: l.variant,
+          color: l.color,
           total: totalItems,
           hasMore,
           loading: laneData ? laneData.isInitialLoading : true,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/types.ts
@@ -1,6 +1,7 @@
 import { CardAvatarVariant } from "@/components/F0Card/components/CardAvatar"
 import { CardMetadataProperty } from "@/components/F0Card/types"
 import { IconType } from "@/components/F0Icon"
+import { NewColor } from "@/components/tags/F0TagDot"
 import { Variant } from "@/components/tags/F0TagStatus"
 import {
   FiltersDefinition,
@@ -18,6 +19,7 @@ export type KanbanLaneDefinition = {
   id: string
   title: string
   variant?: Variant
+  color?: NewColor
 }
 
 export type KanbanVisualizationOptions<

--- a/packages/react/src/ui/Kanban/Kanban.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.tsx
@@ -331,6 +331,7 @@ export function Kanban<TRecord extends RecordType>(
                     emptyState={lane.emptyState}
                     loading={loading}
                     variant={lane.variant}
+                    color={lane.color}
                     total={total}
                     hasMore={hasMore}
                     loadingMore={loadingMore}

--- a/packages/react/src/ui/Kanban/__stories__/Kanban.stories.tsx
+++ b/packages/react/src/ui/Kanban/__stories__/Kanban.stories.tsx
@@ -89,6 +89,52 @@ export const Default: Story = {
   },
 }
 
+export const PaletteColors: Story = {
+  args: {
+    lanes: [],
+    renderCard: () => null,
+    getKey: () => "",
+  },
+  render: function Render() {
+    const [instanceId] = useState(() => Symbol("kanban-instance"))
+    const lanes: KanbanProps<Task>["lanes"] = [
+      { id: "new", title: "New", items: mockLeft, color: "purple" },
+      {
+        id: "screening",
+        title: "Screening",
+        items: mockRight,
+        color: "viridian",
+      },
+      { id: "interview", title: "Interview", items: [], color: "yellow" },
+      { id: "assessment", title: "Assessment", items: [], color: "barbie" },
+      { id: "offer", title: "Offer", items: [], color: "malibu" },
+      { id: "hired", title: "Hired", items: [], color: "flubber" },
+    ]
+    return (
+      <DndProvider driver={createAtlaskitDriver(instanceId)}>
+        <Kanban<Task>
+          lanes={lanes}
+          getKey={(item: Task) => item.id}
+          renderCard={(item: Task, index: number, total: number) => (
+            <KanbanCard<Task>
+              drag={{
+                id: item.id,
+                type: "list-card",
+                data: { ...item },
+              }}
+              id={item.id}
+              index={index}
+              total={total}
+              title={item.title}
+              description={item.description}
+            />
+          )}
+        />
+      </DndProvider>
+    )
+  },
+}
+
 export const ProjectStatuses: Story = {
   args: {
     lanes: [],

--- a/packages/react/src/ui/Kanban/types.ts
+++ b/packages/react/src/ui/Kanban/types.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react"
 
+import type { NewColor } from "@/components/tags/F0TagDot"
 import type { Variant } from "@/components/tags/F0TagStatus"
 import type { RecordType } from "@/hooks/datasource"
 
@@ -17,6 +18,8 @@ export type KanbanLaneAttributes<TRecord extends RecordType> = {
   fetchMore?: () => void
   /** Visual variant to mirror project status */
   variant?: Variant
+  /** Palette color for the lane header dot; overrides variant when set */
+  color?: NewColor
   /** Total number of items in the lane (for display in header) */
   total?: number
   /** Future: filters that would be applied to the shared data source */

--- a/packages/react/src/ui/Lane/Lane.tsx
+++ b/packages/react/src/ui/Lane/Lane.tsx
@@ -23,6 +23,7 @@ export function Lane<Record extends RecordType>({
   emptyState,
   fetchMore,
   variant = "neutral",
+  color,
   loading = false,
   hasMore = false,
   loadingMore = false,
@@ -55,6 +56,7 @@ export function Lane<Record extends RecordType>({
       <LaneHeader
         label={title || "Lane"}
         variant={variant}
+        color={color}
         count={total ?? items.length}
         onPrimaryAction={onPrimaryAction}
       />

--- a/packages/react/src/ui/Lane/components/LaneHeader.tsx
+++ b/packages/react/src/ui/Lane/components/LaneHeader.tsx
@@ -1,4 +1,5 @@
 import { F0Button } from "@/components/F0Button"
+import { F0TagDot, NewColor } from "@/components/tags/F0TagDot"
 import { F0TagStatus, Variant } from "@/components/tags/F0TagStatus"
 import { Counter } from "@/ui/Counter"
 import { Plus } from "@/icons/app"
@@ -6,6 +7,7 @@ import { Plus } from "@/icons/app"
 type LaneHeaderProps = {
   label: string
   variant?: Variant
+  color?: NewColor
   count: number
   onPrimaryAction?: () => void
 }
@@ -13,6 +15,7 @@ type LaneHeaderProps = {
 export const LaneHeader = ({
   label,
   variant,
+  color,
   count,
   onPrimaryAction,
 }: LaneHeaderProps) => {
@@ -20,7 +23,11 @@ export const LaneHeader = ({
 
   return (
     <div className="flex items-center gap-2 px-1 pb-0.5 pt-2">
-      <F0TagStatus text={label} variant={variant || "neutral"} />
+      {color ? (
+        <F0TagDot text={label} color={color} />
+      ) : (
+        <F0TagStatus text={label} variant={variant || "neutral"} />
+      )}
       <Counter size="md" type="default" value={count} />
       {showPrimary && (
         <div className="ml-auto flex items-center gap-1 pr-1">

--- a/packages/react/src/ui/Lane/types.ts
+++ b/packages/react/src/ui/Lane/types.ts
@@ -1,6 +1,7 @@
 import { ReactNode } from "react"
 
 import type { IconType } from "@/components/F0Icon"
+import type { NewColor } from "@/components/tags/F0TagDot"
 import type { Variant } from "@/components/tags/F0TagStatus"
 import type { RecordType } from "@/hooks/datasource"
 
@@ -60,6 +61,12 @@ export interface LaneProps<Record extends RecordType> {
    * The variant of the lane
    */
   variant?: Variant
+
+  /**
+   * Palette color for the lane header dot. When set, the header renders an
+   * F0TagDot in this color instead of the semantic F0TagStatus variant.
+   */
+  color?: NewColor
 
   /**
    * The total number of items in the lane (for display in header)


### PR DESCRIPTION
Lets consumers color each Kanban lane header from the full base palette
instead of the 5 semantic statuses. Recruitment (ATS) needs lane colors
aligned with its stage palette (purple/viridian/yellow/barbie/malibu/
flubber) — the same `phaseColor`/`F0TagDot` source already used by the
application cards and the hiring-pipeline side panel.

## Changes
- New optional `color?: NewColor` on the lane API. When set, `LaneHeader`
  renders `<F0TagDot color>`; otherwise it keeps the existing
  `<F0TagStatus variant>`. Fully backwards-compatible.
- `color` threaded along the same path as `variant`:
  `KanbanLaneDefinition` (ODC) → `Kanban` mapping → `KanbanLaneAttributes`
  (ui) → `KanbanLane` → `LaneProps` → `Lane` → `LaneHeader`.
- Added a `PaletteColors` Kanban story.

<img width="939" height="532" alt="Screenshot 2026-06-30 at 16 14 10" src="https://github.com/user-attachments/assets/842397ce-96d4-4c3a-9109-809eef55d32a" />
