### PR TITLE
fix(OneDataCollection): avoid full-table re-render churn on row data refresh

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -201,11 +201,22 @@ const RowComponentInner = <
   // Only the row that owns the rendered checkbox registers (not the one
   // delegating to NestedRow), so each selectable id is registered once.
   const willRenderOwnRow = !(rowWithChildren && hasChildrenLoaded)
+  // Register on mount and refresh the stored item when the row's data changes.
+  // `register` only re-syncs the registry when the id is new, so refreshing an
+  // existing row's item is cheap and does not re-render the table.
   useEffect(() => {
     if (id === undefined || !willRenderOwnRow || !registerSelectable) return
     registerSelectable(id, item)
-    return () => unregisterSelectable?.(id)
-  }, [id, item, willRenderOwnRow, registerSelectable, unregisterSelectable])
+  }, [id, item, willRenderOwnRow, registerSelectable])
+
+  // Unregister only when the row truly leaves (unmount, or it stops owning the
+  // rendered row) — NOT on every `item` identity change. Keeping `item` out of
+  // these deps avoids the unregister+register churn that fired a full-table
+  // re-render on every data refresh.
+  useEffect(() => {
+    if (id === undefined || !willRenderOwnRow || !unregisterSelectable) return
+    return () => unregisterSelectable(id)
+  }, [id, willRenderOwnRow, unregisterSelectable])
 
   if (rowWithChildren && hasChildrenLoaded) {
     return (

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/__tests__/SelectionRegistryProvider.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/__tests__/SelectionRegistryProvider.test.ts
@@ -1,0 +1,39 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { useCreateSelectionRegistry } from "../SelectionRegistryProvider"
+
+type Row = { id: string; name?: string }
+
+describe("useCreateSelectionRegistry", () => {
+  it("registers and unregisters ids", () => {
+    const { result } = renderHook(() => useCreateSelectionRegistry<Row>())
+
+    act(() => {
+      result.current.register("1", { id: "1" })
+      result.current.register("2", { id: "2" })
+    })
+    expect([...result.current.ids].sort()).toEqual(["1", "2"])
+
+    act(() => result.current.unregister("1"))
+    expect(result.current.ids).toEqual(["2"])
+  })
+
+  it("refreshes an existing entry's item without re-syncing ids", () => {
+    // Contract that Row relies on: when a row's data changes it re-registers
+    // the same id with a fresh item. That must update the stored entry but must
+    // NOT change `ids` referentially — otherwise every data refresh would
+    // re-render the whole table (the churn that drove the renderer OOM).
+    const { result } = renderHook(() => useCreateSelectionRegistry<Row>())
+
+    act(() => result.current.register("1", { id: "1", name: "old" }))
+    const idsBefore = result.current.ids
+    expect(idsBefore).toEqual(["1"])
+
+    act(() => result.current.register("1", { id: "1", name: "new" }))
+    expect(result.current.ids).toBe(idsBefore) // referentially stable → no re-render
+    expect(result.current.getEntries()).toEqual([
+      ["1", { id: "1", name: "new" }],
+    ])
+  })
+})


### PR DESCRIPTION
## Description

The per-row selection registry effect kept `item` in its dependency array, so every data refresh (new record object identities) unregistered and re-registered every selectable row. Each unregister/register pair re-synced the registry's `ids` state, re-rendering the whole table — an O(rows) re-render storm on each refresh that piled up renderer work and garbage on large `OneDataCollection` tables (a contributor to Chrome renderer OOM crashes in long E2E runs).

## Implementation details

- fix: split the row registration effect — register (and refresh the stored item) on data change without re-syncing when the id is unchanged, and unregister only when the row unmounts or stops owning its rendered row. Select-all over rendered/nested rows is unchanged.
- test: add a unit test pinning the registry contract (re-registering an existing id refreshes its item without changing `ids` referentially).