### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.18.0",
+  "packages/react": "4.19.0",
   "packages/react-native": "0.56.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.19.0](https://github.com/factorialco/f0/compare/f0-react-v4.18.0...f0-react-v4.19.0) (2026-07-01)
+
+
+### Features
+
+* **EditableTable:** render cellHint icon on the right for read-only cells (FCT-56432) ([#4580](https://github.com/factorialco/f0/issues/4580)) ([202e8de](https://github.com/factorialco/f0/commit/202e8de0356c0aef0ac591c6863e8ad52ad1ebbf))
+
 ## [4.18.0](https://github.com/factorialco/f0/compare/f0-react-v4.17.1...f0-react-v4.18.0) (2026-06-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.19.0</summary>

## [4.19.0](https://github.com/factorialco/f0/compare/f0-react-v4.18.0...f0-react-v4.19.0) (2026-07-01)


### Features

* **EditableTable:** render cellHint icon on the right for read-only cells (FCT-56432) ([#4580](https://github.com/factorialco/f0/issues/4580)) ([202e8de](https://github.com/factorialco/f0/commit/202e8de0356c0aef0ac591c6863e8ad52ad1ebbf))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).