### PR TITLE
revert(F0Dialog): restore patterns implementation (isolate renderer OOM from #4552)

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -13,7 +13,7 @@ import {
 } from "react"
 import { useDebounceCallback } from "usehooks-ts"
 
-import { DialogWrapperContext as F0DialogContext } from "@/components/dialog-alike/common/DialogWrapperProvider"
+import { F0DialogContext } from "@/patterns/F0Dialog"
 import { F0Button } from "@/components/F0Button"
 import { Plus } from "@/icons/app"
 import {

--- a/packages/react/src/components/dialog-alike/F0Dialog/__stories__/F0Dialog.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__stories__/F0Dialog.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { ComponentProps, FC, useState } from "react"
-import { expect, within } from "storybook/test"
 
 import { F0Button } from "@/components/F0Button"
 import {
@@ -130,20 +129,6 @@ export const Default: Story = {
       closeOnClick: true,
     },
     children: <ExampleList itemsCount={20} />,
-  },
-}
-
-export const WithDataTestId: Story = {
-  args: {
-    isOpen: true,
-    onClose: () => {},
-    title: "Dialog with Test ID",
-    dataTestId: "my-test-dialog",
-    children: <ExampleList itemsCount={2} />,
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement)
-    await expect(canvas.getByTestId("my-test-dialog")).toBeInTheDocument()
   },
 }
 

--- a/packages/react/src/components/dialog-alike/common/DialogWrapperProvider.tsx
+++ b/packages/react/src/components/dialog-alike/common/DialogWrapperProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext } from "react"
 
-import type { DialogAlikePosition as Position } from "./types"
+import { DialogAlikePosition as Position } from "./types"
 
 export type DialogWrapperContextType = {
   open: boolean

--- a/packages/react/src/components/exports.ts
+++ b/packages/react/src/components/exports.ts
@@ -31,9 +31,7 @@ export * from "./F0ChipList"
 export * from "./F0DatePicker"
 export * from "./F0Alert"
 /**
- * @deprecated This `F0Dialog` is a backward-compatible shim. Use `F0Dialog`
- * from `@/components/dialog-alike/F0Dialog` for center/fullscreen dialogs, or
- * `F0Drawer` from `@/components/dialog-alike/F0Drawer` for side panels.
+ * @deprecated F0Dialog has moved to @/patterns/F0Dialog. Import from there instead.
  */
 export * from "../patterns/F0Dialog"
 export * from "./dialog-alike/F0Drawer"

--- a/packages/react/src/deprecated/EntitySelect/index.tsx
+++ b/packages/react/src/deprecated/EntitySelect/index.tsx
@@ -9,7 +9,7 @@ import {
 import { useDebounceValue } from "usehooks-ts"
 
 import { cn } from "@/lib/utils"
-import { DialogWrapperContext as F0DialogContext } from "@/components/dialog-alike/common/DialogWrapperProvider"
+import { F0DialogContext } from "@/patterns/F0Dialog"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
 import { Content } from "./Content"

--- a/packages/react/src/patterns/F0Dialog/F0Dialog.tsx
+++ b/packages/react/src/patterns/F0Dialog/F0Dialog.tsx
@@ -1,79 +1,10 @@
 import { FC } from "react"
 
-import { F0Dialog as DialogAlike } from "@/components/dialog-alike/F0Dialog"
-import { F0Drawer } from "@/components/dialog-alike/F0Drawer"
-
+import { F0DialogInternal } from "./F0DialogInternal"
 import { F0DialogInternalProps } from "./internal-types"
 
-/**
- * @deprecated Use `F0Dialog` from `@/components/dialog-alike/F0Dialog` for
- * center and fullscreen dialogs, or `F0Drawer` from
- * `@/components/dialog-alike/F0Drawer` for side panels (`position: "left" | "right"`).
- *
- * This component is a backward-compatible shim that maps the legacy patterns
- * props onto those components. `navigation`, `resourceHeader`, and `controls`
- * are forwarded to `F0Drawer` when `position` is `"left"` or `"right"`.
- * `asBottomSheetInMobile` is accepted but ignored (handled internally).
- */
-export const F0Dialog: FC<F0DialogInternalProps> = ({
-  isOpen,
-  onClose,
-  position = "center",
-  width = "md",
-  primaryAction,
-  secondaryAction,
-  title,
-  description,
-  module,
-  otherActions,
-  children,
-  disableContentPadding,
-  container,
-  tabs,
-  activeTabId,
-  setActiveTabId,
-  // Accepted but ignored — mobile behaviour is handled internally.
-  asBottomSheetInMobile: _asBottomSheetInMobile,
-  navigation,
-  resourceHeader,
-  controls,
-}) => {
-  const commonProps = {
-    isOpen,
-    onClose,
-    primaryAction,
-    secondaryAction,
-    title,
-    description,
-    module,
-    otherActions,
-    disableContentPadding,
-    container,
-    ...(tabs ? { tabs, activeTabId, setActiveTabId } : {}),
-  }
-
-  if (position === "left" || position === "right") {
-    return (
-      <F0Drawer
-        position={position}
-        navigation={navigation}
-        resourceHeader={resourceHeader}
-        controls={controls}
-        {...commonProps}
-      >
-        {children}
-      </F0Drawer>
-    )
-  }
-
-  return (
-    <DialogAlike
-      size={position === "fullscreen" ? "fullscreen" : width}
-      {...commonProps}
-    >
-      {children}
-    </DialogAlike>
-  )
+export const F0Dialog: FC<F0DialogInternalProps> = (props) => {
+  return <F0DialogInternal {...props} />
 }
 
 F0Dialog.displayName = "F0Dialog"

--- a/packages/react/src/patterns/F0Dialog/F0DialogInternal.tsx
+++ b/packages/react/src/patterns/F0Dialog/F0DialogInternal.tsx
@@ -1,0 +1,231 @@
+import { cva } from "cva"
+import { FC, useCallback, useMemo, useState } from "react"
+
+import { Dialog, DialogContent } from "@/ui/Dialog/dialog"
+import { Drawer, DrawerContent, DrawerOverlay } from "@/ui/drawer"
+
+import { F0DialogContent } from "./components/F0DialogContent"
+import { F0DialogFooter } from "./components/F0DialogFooter"
+import { F0DialogHeader } from "./components/F0DialogHeader"
+import { F0DialogProvider } from "./components/F0DialogProvider"
+import { F0DialogInternalProps } from "./internal-types"
+import { useIsSmallScreen } from "./utils"
+
+const dialogWrapperClassName = cva({
+  variants: {
+    variant: {
+      bottomSheet: "max-h-[95vh] bg-f1-background",
+      sidePosition: "absolute flex flex-col rounded-md w-full",
+      center: "flex",
+      fullscreen: "",
+    },
+    position: {
+      right: "left-auto right-0 items-end p-3",
+      left: "left-0 items-start p-3",
+      center: "",
+      fullscreen: "inset-6",
+    },
+  },
+  defaultVariants: {
+    variant: "center",
+  },
+})
+
+const dialogContentClassName = cva({
+  variants: {
+    variant: {
+      bottomSheet: "max-h-[95vh] bg-f1-background",
+      sidePosition:
+        "flex h-full w-full flex-col rounded-md border border-solid border-f1-border-secondary",
+      center: "flex max-h-[95vh] flex-1 flex-col rounded-xl",
+      fullscreen: "h-full w-full rounded-xl",
+    },
+    position: {
+      left: "",
+      right: "",
+      center: "",
+      fullscreen: "",
+    },
+    width: {
+      sm: "max-w-[480px]",
+      md: "max-w-[640px]",
+      lg: "max-w-[800px]",
+      xl: "max-w-[960px]",
+    },
+  },
+  compoundVariants: [
+    {
+      variant: "fullscreen",
+      width: ["sm", "md", "lg", "xl"],
+      class: "max-w-full",
+    },
+  ],
+  defaultVariants: {
+    variant: "center",
+  },
+})
+
+export const F0DialogInternal: FC<F0DialogInternalProps> = ({
+  asBottomSheetInMobile = true,
+  position = "center",
+  onClose,
+  isOpen,
+  children,
+  width = "md",
+  primaryAction,
+  secondaryAction,
+  title,
+  description,
+  module,
+  otherActions,
+  navigation,
+  resourceHeader,
+  controls,
+  tabs,
+  activeTabId,
+  setActiveTabId,
+  disableContentPadding,
+  container: containerProp,
+}) => {
+  // Use state to store the container element so we can trigger re-renders
+  // when it's set. This ensures child components like F0Select get the
+  // correct portalContainer after the dialog content mounts.
+  const [containerElement, setContainerElement] =
+    useState<HTMLDivElement | null>(null)
+
+  // Callback ref to update both the ref and state
+  const setContentRef = useCallback((node: HTMLDivElement | null) => {
+    // Update state to trigger re-render so children get the new container
+    setContainerElement(node)
+  }, [])
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onClose()
+    }
+  }
+
+  const isSmallScreen = useIsSmallScreen()
+
+  const isSidePosition = position === "left" || position === "right"
+
+  const variant = useMemo(() => {
+    if (isSmallScreen && asBottomSheetInMobile) {
+      return "bottomSheet"
+    }
+    if (position === "fullscreen") {
+      return "fullscreen"
+    }
+    if (isSidePosition) {
+      return "sidePosition"
+    }
+    return "center"
+  }, [isSmallScreen, asBottomSheetInMobile, isSidePosition, position])
+
+  // Side panel positions (left/right) accept width variants
+  const localWidth = useMemo(() => {
+    if (width && !["center", "left", "right"].includes(position)) {
+      console.warn(
+        "F0Dialog: `width` prop is only applicable to center and side panel positions"
+      )
+    }
+
+    return width
+  }, [variant, width, position])
+
+  const contentClassName = useMemo(() => {
+    return dialogContentClassName({
+      variant,
+      position,
+      width: localWidth,
+    })
+  }, [variant, position, localWidth])
+
+  // Center & fullscreen modals portal to the top-level overlay root so they
+  // escape app stacking contexts (e.g. the ApplicationFrame `isolate` layer
+  // where the fullscreen AI chat paints at z-20). Side drawers (left/right)
+  // stay docked inside `#content`.
+  const defaultContainerId = isSidePosition ? "content" : "f0-overlay-root"
+
+  if (resourceHeader && !isSidePosition) {
+    console.warn(
+      "F0Dialog: `resourceHeader` is only applicable to side panel positions (left/right)"
+    )
+  }
+
+  const headerProps = {
+    title,
+    description,
+    module,
+    otherActions,
+    navigation,
+    resourceHeader,
+    controls,
+    tabs,
+    activeTabId,
+    setActiveTabId,
+  }
+
+  if (isSmallScreen && asBottomSheetInMobile) {
+    return (
+      <F0DialogProvider
+        isOpen={isOpen}
+        onClose={onClose}
+        position={position}
+        portalContainer={containerElement}
+        shownBottomSheet
+      >
+        <Drawer open={isOpen} onOpenChange={handleOpenChange}>
+          <DrawerOverlay className="bg-f1-background-overlay" />
+          <DrawerContent ref={setContentRef} className={contentClassName}>
+            <F0DialogHeader {...headerProps} />
+            <F0DialogContent disableContentPadding={disableContentPadding}>
+              {children}
+            </F0DialogContent>
+            <F0DialogFooter
+              primaryAction={primaryAction}
+              secondaryAction={secondaryAction}
+            />
+          </DrawerContent>
+        </Drawer>
+      </F0DialogProvider>
+    )
+  }
+
+  return (
+    <F0DialogProvider
+      isOpen={isOpen}
+      onClose={onClose}
+      position={position}
+      portalContainer={containerElement}
+    >
+      <Dialog
+        open={isOpen}
+        onOpenChange={handleOpenChange}
+        modal={position === "center" || position === "fullscreen"}
+      >
+        <DialogContent
+          ref={setContentRef}
+          withTranslateAnimation={!isSidePosition}
+          wrapperClassName={dialogWrapperClassName({
+            variant,
+            position,
+          })}
+          className={contentClassName}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          container={containerProp}
+          defaultContainerId={defaultContainerId}
+        >
+          <F0DialogHeader {...headerProps} />
+          <F0DialogContent disableContentPadding={disableContentPadding}>
+            {children}
+          </F0DialogContent>
+          <F0DialogFooter
+            primaryAction={primaryAction}
+            secondaryAction={secondaryAction}
+          />
+        </DialogContent>
+      </Dialog>
+    </F0DialogProvider>
+  )
+}

--- a/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
+++ b/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
@@ -1,0 +1,631 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { ComponentProps, FC, useState } from "react"
+import { expect, within } from "storybook/test"
+
+import { F0Button } from "@/components/F0Button"
+import { ApplicationFrame } from "@/patterns/ApplicationFrame"
+import ApplicationFrameStoryMeta from "@/patterns/ApplicationFrame/index.stories"
+import { ResourceHeader } from "@/patterns/ResourceHeader"
+import { Default as ResourceHeaderDefault } from "@/patterns/ResourceHeader/index.stories"
+import {
+  OnePersonListItem,
+  OnePersonListItemProps,
+} from "@/experimental/Lists/OnePersonListItem"
+import { Default as OnePersonListItemDefault } from "@/experimental/Lists/OnePersonListItem/index.stories"
+import { Placeholder } from "@/icons/app"
+import CheckDoubleIcon from "@/icons/app/CheckDouble"
+import CrossIcon from "@/icons/app/Cross"
+import DeleteIcon from "@/icons/app/Delete"
+import PencilIcon from "@/icons/app/Pencil"
+import SaveIcon from "@/icons/app/Save"
+import ShareIcon from "@/icons/app/Share"
+import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
+import { ActivityItemList } from "@/sds/inbox/Activity/ActivityItemList"
+import { Default as ActivityItemListDefault } from "@/sds/inbox/Activity/ActivityItemList/index.stories"
+
+import { PaginatedFetchOptions, RecordType } from "@/hooks/datasource"
+import {
+  expectDialogPaintsAboveChat,
+  FullscreenChatFrame,
+} from "@/lib/storybook-utils/aiChatStacking"
+import { useDataCollectionItemNavigation } from "@/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation"
+
+import { F0Dialog } from "../index"
+import { dialogPositions, dialogWidths } from "../types"
+
+const meta: Meta<typeof F0Dialog> = {
+  title: "Dialog",
+  component: F0Dialog,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      story: { inline: false, height: "720px" },
+    },
+  },
+  tags: ["autodocs", "experimental"],
+  argTypes: {
+    position: {
+      description: "The position of the dialog",
+      control: {
+        type: "select",
+        options: dialogPositions,
+      },
+    },
+    width: {
+      description:
+        "The width of the dialog. Applies to center and side panel positions (left/right)",
+      control: {
+        type: "select",
+        options: dialogWidths,
+      },
+      table: {
+        type: { summary: "sm | md | lg | xl" },
+        defaultValue: { summary: "md" },
+      },
+    },
+    ...dataTestIdArgs,
+  },
+  decorators: [
+    (Story, context) => {
+      const {
+        args: { isOpen, ...rest },
+        parameters,
+      } = context
+      const [open, setOpen] = useState(isOpen)
+
+      const handleClose = () => {
+        setOpen(false)
+      }
+      const handleOpen = () => {
+        setOpen(true)
+      }
+
+      // Stories that build their own ApplicationFrame (e.g. the fullscreen AI
+      // chat stacking demo) opt out of the default frame + open-button wrapper.
+      if (parameters.standaloneFrame) {
+        return <Story />
+      }
+
+      return (
+        <ApplicationFrame
+          {...(ApplicationFrameStoryMeta.args as ComponentProps<
+            typeof ApplicationFrame
+          >)}
+        >
+          <div className="flex flex-1 items-center justify-center rounded-md border border-solid border-f1-border-secondary bg-f1-background">
+            <F0Button label="Open dialog" onClick={handleOpen} />
+            <Story args={{ ...rest, isOpen: open, onClose: handleClose }} />
+          </div>
+        </ApplicationFrame>
+      )
+    },
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof F0Dialog>
+
+const TABS = [
+  {
+    id: "out-of-office",
+    label: "Out of office",
+  },
+  {
+    id: "missing-clock-in",
+    label: "Missing clock in",
+  },
+  {
+    id: "clocked-in",
+    label: "Clocked in",
+  },
+  {
+    id: "in-a-break",
+    label: "In a break",
+  },
+]
+
+const OTHER_ACTIONS = [
+  {
+    label: "Edit",
+    icon: PencilIcon,
+    onClick: () => {},
+  },
+  {
+    label: "Delete",
+    icon: DeleteIcon,
+    critical: true,
+    onClick: () => {},
+  },
+]
+
+const ExampleList = ({ itemsCount = 20 }: { itemsCount?: number }) => (
+  <div className="flex flex-col gap-4">
+    {Array.from({ length: itemsCount }, (_, i) => (
+      <div
+        key={i}
+        className="rounded-sm border border-solid border-f1-border-secondary p-4"
+      >
+        List Item {i + 1}
+      </div>
+    ))}
+  </div>
+)
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    title: "Team Status",
+    otherActions: OTHER_ACTIONS,
+    primaryAction: {
+      label: "submit",
+      icon: Placeholder,
+      onClick: () => {},
+    },
+    children: <ExampleList itemsCount={2} />,
+  },
+}
+
+export const WithDataTestId: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    title: "Dialog with Test ID",
+    dataTestId: "my-test-dialog",
+    children: <ExampleList itemsCount={2} />,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByTestId("my-test-dialog")).toBeInTheDocument()
+  },
+}
+
+export const WithSmWidth: Story = {
+  args: {
+    isOpen: true,
+    width: "sm",
+    onClose: () => {},
+    title: "Team Status",
+    otherActions: OTHER_ACTIONS,
+    tabs: TABS,
+    children: <ExampleList />,
+  },
+}
+
+export const WithMdWidth: Story = {
+  args: {
+    ...WithSmWidth.args,
+    width: "md",
+  },
+}
+
+export const WithLgWidth: Story = {
+  args: {
+    ...WithMdWidth.args,
+    width: "lg",
+  },
+}
+
+export const WithXlWidth: Story = {
+  args: {
+    ...WithLgWidth.args,
+    width: "xl",
+  },
+}
+export const WithDescription: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    title: "Team Status",
+    description:
+      "This is a description of the team status. Very long text that should wrap properly and not overflow the container boundaries.",
+    otherActions: OTHER_ACTIONS,
+    tabs: TABS,
+    children: <ExampleList />,
+  },
+}
+
+const ExamplePersonList: FC<{ numberOfItems?: number }> = ({
+  numberOfItems = 20,
+}) => (
+  <div className="flex flex-col gap-0.5">
+    {Array.from({ length: numberOfItems }, (_, i) => (
+      <OnePersonListItem
+        key={i}
+        {...(OnePersonListItemDefault.args as OnePersonListItemProps)}
+      />
+    ))}
+  </div>
+)
+
+export const WithPersonListItems: Story = {
+  args: {
+    ...Default.args,
+    tabs: TABS,
+    children: <ExamplePersonList />,
+  },
+}
+
+export const WithLeftPosition: Story = {
+  args: {
+    ...Default.args,
+    position: "left",
+    title: "Activity",
+    otherActions: OTHER_ACTIONS,
+    children: (
+      <ActivityItemList
+        {...(ActivityItemListDefault.args as ComponentProps<
+          typeof ActivityItemList
+        >)}
+      />
+    ),
+  },
+}
+
+export const WithRightPosition: Story = {
+  args: {
+    ...Default.args,
+    position: "right",
+  },
+}
+
+export const WithLeftPositionLgWidth: Story = {
+  args: {
+    ...WithLeftPosition.args,
+    width: "lg",
+  },
+}
+
+export const WithFullscreenPosition: Story = {
+  args: {
+    ...Default.args,
+    position: "fullscreen",
+  },
+}
+
+export const WithFullscreenPositionAndActions: Story = {
+  args: {
+    ...WithFullscreenPosition.args,
+    tabs: TABS,
+    primaryAction: {
+      label: "Approve",
+      icon: CheckDoubleIcon,
+      onClick: () => {},
+    },
+    secondaryAction: {
+      label: "Reject",
+      icon: CrossIcon,
+      onClick: () => {},
+    },
+    children: <ExamplePersonList numberOfItems={3} />,
+  },
+}
+
+export const WithMultiplePrimaryActions: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    title: "Document Editor",
+    description: "Edit your document and choose how to save it.",
+    primaryAction: [
+      {
+        value: "save",
+        label: "Save",
+        icon: SaveIcon,
+        onClick: () => console.log("Save clicked"),
+      },
+      {
+        value: "save-draft",
+        label: "Save as draft",
+        onClick: () => console.log("Save as draft clicked"),
+      },
+      {
+        value: "save-publish",
+        label: "Save and publish",
+        icon: ShareIcon,
+        onClick: () => console.log("Save and publish clicked"),
+      },
+    ],
+    secondaryAction: {
+      label: "Cancel",
+      onClick: () => {},
+    },
+    children: <ExampleList itemsCount={3} />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When `primaryAction` receives an array of actions, it renders a `F0ButtonDropdown` allowing the user to select between multiple primary actions.",
+      },
+    },
+  },
+}
+
+export const WithMultipleSecondaryActions: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    title: "Document Review",
+    description: "Review the document details and choose an action.",
+    primaryAction: {
+      label: "Approve",
+      icon: CheckDoubleIcon,
+      onClick: () => {},
+    },
+    secondaryAction: [
+      {
+        value: "reject",
+        label: "Reject",
+        icon: CrossIcon,
+        onClick: () => console.log("Reject clicked"),
+      },
+      {
+        value: "request-changes",
+        label: "Request changes",
+        icon: PencilIcon,
+        onClick: () => console.log("Request changes clicked"),
+      },
+    ],
+    children: <ExampleList itemsCount={3} />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When `secondaryAction` receives an array of actions, it renders a `F0ButtonDropdown` (outline variant) allowing the user to select between multiple secondary actions. The first item is the default action.",
+      },
+    },
+  },
+}
+
+export const WithModule: Story = {
+  args: {
+    ...Default.args,
+    position: "right",
+    title: "Team Status",
+    module: {
+      id: "benefits",
+      label: "Benefits",
+      href: "/benefits",
+    },
+    otherActions: OTHER_ACTIONS,
+    tabs: TABS,
+    children: <ExamplePersonList />,
+  },
+}
+
+export const WithModuleAndFullscreenPosition: Story = {
+  args: {
+    ...WithModule.args,
+    position: "fullscreen",
+  },
+}
+
+export const WithResourceHeader: Story = {
+  args: {
+    ...Default.args,
+    position: "right",
+    title: "Resource Header",
+    module: {
+      id: "timeoff",
+      label: "Time Off",
+      href: "/timeoff",
+    },
+    children: (
+      <ResourceHeader
+        {...(ResourceHeaderDefault.args as ComponentProps<
+          typeof ResourceHeader
+        >)}
+        primaryAction={undefined}
+        secondaryActions={undefined}
+        otherActions={undefined}
+      />
+    ),
+  },
+}
+
+export const WithResourceHeaderAndFullscreenPosition: Story = {
+  args: {
+    ...WithResourceHeader.args,
+    position: "fullscreen",
+  },
+}
+
+/**
+ * Mounted-sidepanel navigation driven by `useDataCollectionItemNavigation` in
+ * **callback mode**. The list on the left stays mounted; opening a row sets an
+ * active id and the dialog shows that record. The header's
+ * `controls={{ kind: "resource", navigation }}` is fed the hook's render-ready
+ * `navigation` — but because the hook runs with `navigationMode: "callback"`,
+ * the prev/next arrows call `goToPrevious`/`goToNext` and swap the active item
+ * **in place, with no URL change / no remount** (the same `NavigationProps`
+ * contract PageHeader uses in url mode). The `current/total` counter still
+ * comes from the collection.
+ *
+ * The "Open detail" expand button is a real link to the active item's
+ * `itemUrl` (the hook's `activeItemUrl`): in-place arrows for browsing,
+ * `expand` to jump to the full-page view (cmd/middle-clickable).
+ */
+const SIDEPANEL_EMPLOYEES = Array.from({ length: 8 }, (_, i) => ({
+  id: `${i + 1}`,
+  name: `Employee ${i + 1}`,
+  role: i % 2 === 0 ? "Engineer" : "Designer",
+}))
+
+const SIDEPANEL_COLLECTION_ID = "storybook/dialog-sidepanel-employees/v1"
+
+const sidepanelSource = {
+  // `itemUrl` powers the "Open detail" expand link (full-page view), while
+  // the arrows navigate in place — both derived from the same declaration.
+  itemUrl: (employee: RecordType) => `#/employees/${employee.id}`,
+  // One declared page holds the whole set, so navigation resolves entirely
+  // from the loaded window — the focus here is the callback arrows, not the
+  // neighbors fallback (covered by the PageHeader story).
+  dataAdapter: {
+    paginationType: "pages" as const,
+    perPage: 50,
+    fetchData: (_options: PaginatedFetchOptions<Record<string, never>>) => ({
+      type: "pages" as const,
+      records: SIDEPANEL_EMPLOYEES,
+      total: SIDEPANEL_EMPLOYEES.length,
+      perPage: 50,
+      currentPage: 1,
+      pagesCount: 1,
+    }),
+  },
+}
+
+const MountedSidepanelDemo = (args: ComponentProps<typeof F0Dialog>) => {
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const { navigation, activeItemUrl } = useDataCollectionItemNavigation({
+    source: sidepanelSource,
+    collectionId: SIDEPANEL_COLLECTION_ID,
+    activeItemId: activeId,
+    navigationMode: "callback",
+    onActiveItemChange: (id) => setActiveId(id === null ? null : String(id)),
+    getItemTitle: (employee) => String(employee.name),
+  })
+
+  const activeEmployee = SIDEPANEL_EMPLOYEES.find((e) => e.id === activeId)
+
+  return (
+    <div className="flex flex-col gap-2 p-4">
+      <span className="text-sm text-f1-foreground-secondary">
+        The list stays mounted; arrows in the panel navigate by id without
+        changing the URL.
+      </span>
+      {SIDEPANEL_EMPLOYEES.map((employee) => (
+        <F0Button
+          key={employee.id}
+          variant="outline"
+          label={`${employee.name} — ${employee.role}`}
+          onClick={() => setActiveId(employee.id)}
+        />
+      ))}
+      <F0Dialog
+        {...args}
+        isOpen={activeId !== null}
+        onClose={() => setActiveId(null)}
+        title={activeEmployee?.name ?? "Employee"}
+        controls={{
+          kind: "resource",
+          expand: activeItemUrl
+            ? { label: "Open detail", url: activeItemUrl }
+            : undefined,
+          navigation: navigation ?? undefined,
+        }}
+      >
+        <div className="flex flex-col gap-2 p-4">
+          <div className="text-lg font-semibold text-f1-foreground">
+            {activeEmployee?.name}
+          </div>
+          <div className="text-base text-f1-foreground-secondary">
+            {activeEmployee?.role}
+          </div>
+        </div>
+      </F0Dialog>
+    </div>
+  )
+}
+
+export const WithMountedSidepanelNavigation: Story = {
+  args: {
+    position: "right",
+  },
+  render: (args) => <MountedSidepanelDemo {...args} />,
+}
+
+export const WithFewItems: Story = {
+  args: {
+    ...Default.args,
+    position: "right",
+    tabs: TABS,
+    primaryAction: {
+      label: "Approve",
+      icon: CheckDoubleIcon,
+      onClick: () => {},
+    },
+    secondaryAction: {
+      label: "Reject",
+      icon: CrossIcon,
+      onClick: () => {},
+    },
+    children: <ExamplePersonList numberOfItems={3} />,
+  },
+}
+
+// --- Opening a dialog over the fullscreen AI chat ----------------------------
+// Mounts the real ApplicationFrame with the AI chat locked open in fullscreen
+// (painting at z-20 inside the isolate) and opens an F0Dialog on top of it.
+// Center and fullscreen dialogs portal to the top-level `#f0-overlay-root`, so
+// they — and their overlay — escape the isolate and render above the chat. The
+// play function hit-tests the dialog card to confirm the chat never covers it.
+
+const OVER_CHAT_TITLE = "On top of the fullscreen chat"
+
+export const OverFullscreenAiChat: Story = {
+  parameters: {
+    standaloneFrame: true,
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "A center F0Dialog opened while the AI chat is locked open in fullscreen. The chat paints at `z-20` inside the ApplicationFrame `isolate`; the dialog escapes to `#f0-overlay-root` so it renders above the chat instead of being trapped behind it in `#content`.",
+      },
+    },
+  },
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    title: OVER_CHAT_TITLE,
+    description: "The dialog and its overlay sit above the fullscreen chat.",
+    primaryAction: {
+      label: "Got it",
+      onClick: () => {},
+    },
+    children: <ExampleList itemsCount={3} />,
+  },
+  render: (args) => (
+    <FullscreenChatFrame>
+      <F0Dialog {...args} />
+    </FullscreenChatFrame>
+  ),
+  play: async () => {
+    await expectDialogPaintsAboveChat({ title: OVER_CHAT_TITLE })
+  },
+}
+
+export const FullscreenDialogOverFullscreenAiChat: Story = {
+  parameters: {
+    standaloneFrame: true,
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          'Same scenario with a `position="fullscreen"` dialog. It also portals to `#f0-overlay-root`, so it covers the fullscreen chat rather than being clipped by the isolate.',
+      },
+    },
+  },
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    position: "fullscreen",
+    title: OVER_CHAT_TITLE,
+    primaryAction: {
+      label: "Got it",
+      onClick: () => {},
+    },
+    children: <ExamplePersonList numberOfItems={3} />,
+  },
+  render: (args) => (
+    <FullscreenChatFrame>
+      <F0Dialog {...args} />
+    </FullscreenChatFrame>
+  ),
+  play: async () => {
+    await expectDialogPaintsAboveChat({ title: OVER_CHAT_TITLE })
+  },
+}

--- a/packages/react/src/patterns/F0Dialog/__tests__/F0Dialog.aichat-stacking.test.tsx
+++ b/packages/react/src/patterns/F0Dialog/__tests__/F0Dialog.aichat-stacking.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, within } from "@/testing/test-utils"
+
+import { F0Dialog } from "../index"
+
+/**
+ * Regression cover for opening an F0Dialog while the AI chat is in fullscreen.
+ *
+ * In `ApplicationFrame` the fullscreen chat paints at `z-20` **inside** a
+ * `relative isolate` stacking context, as a sibling of `#content` (`z-10`).
+ * Anything portaled into `#content` is therefore trapped below the chat.
+ *
+ * Center and fullscreen dialogs escape by portaling to the top-level
+ * `#f0-overlay-root`, which lives outside that isolate — so the dialog and its
+ * overlay paint above the chat. Side panels (left/right) intentionally stay
+ * docked inside `#content`.
+ *
+ * jsdom can't measure paint order, so we assert the structural property that
+ * guarantees it: where the dialog lands when it portals.
+ */
+describe("patterns F0Dialog over a fullscreen AI chat", () => {
+  let overlayRoot: HTMLElement
+  let content: HTMLElement
+  let fullscreenChat: HTMLElement
+
+  beforeEach(() => {
+    // Mirror the ApplicationFrame shell: an isolate (`#content`) that holds the
+    // fullscreen chat, followed by the top-level overlay root (as F0Provider
+    // renders it). Order matters — later siblings win at equal z-index.
+    content = document.createElement("div")
+    content.id = "content"
+    content.className = "isolate"
+
+    fullscreenChat = document.createElement("div")
+    fullscreenChat.id = "fake-fullscreen-chat"
+    content.appendChild(fullscreenChat)
+
+    overlayRoot = document.createElement("div")
+    overlayRoot.id = "f0-overlay-root"
+
+    document.body.append(content, overlayRoot)
+  })
+
+  afterEach(() => {
+    content.remove()
+    overlayRoot.remove()
+    vi.clearAllMocks()
+  })
+
+  it.each(["center", "fullscreen"] as const)(
+    "portals a %s dialog into #f0-overlay-root, escaping the chat's stacking context",
+    (position) => {
+      render(
+        <F0Dialog
+          isOpen
+          onClose={vi.fn()}
+          position={position}
+          title="On top of the chat"
+        >
+          <p>Body</p>
+        </F0Dialog>
+      )
+
+      const dialog = within(overlayRoot).getByText("On top of the chat")
+      expect(overlayRoot).toContainElement(dialog)
+
+      // Never inside #content or the fullscreen chat subtree.
+      expect(within(content).queryByText("On top of the chat")).toBeNull()
+      expect(fullscreenChat.contains(dialog)).toBe(false)
+    }
+  )
+
+  it.each(["left", "right"] as const)(
+    "docks a %s side panel inside #content",
+    (position) => {
+      render(
+        <F0Dialog
+          isOpen
+          onClose={vi.fn()}
+          position={position}
+          title="Docked side panel"
+        >
+          <p>Body</p>
+        </F0Dialog>
+      )
+
+      const dialog = within(content).getByText("Docked side panel")
+      expect(content).toContainElement(dialog)
+      expect(within(overlayRoot).queryByText("Docked side panel")).toBeNull()
+    }
+  )
+
+  it("keeps the overlay root outside the isolate so it paints above the chat", () => {
+    render(
+      <F0Dialog isOpen onClose={vi.fn()} title="On top of the chat">
+        <p>Body</p>
+      </F0Dialog>
+    )
+
+    expect(content.contains(overlayRoot)).toBe(false)
+    expect(
+      content.compareDocumentPosition(overlayRoot) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+})

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogContent.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogContent.tsx
@@ -1,0 +1,99 @@
+import { AnimatePresence, motion } from "motion/react"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { LayoutProvider } from "@/layouts/LayoutProvider"
+import { cn } from "@/lib/utils"
+import { ScrollArea, ScrollBar } from "@/ui/scrollarea"
+
+import { useF0Dialog } from "./F0DialogProvider"
+
+export type F0DialogContentProps = {
+  children: React.ReactNode
+  /**
+   * Disable the default padding from the dialog content area
+   * @default false
+   */
+  disableContentPadding?: boolean
+}
+
+const ScrollShadow = ({ position }: { position: "top" | "bottom" }) => (
+  <motion.div
+    initial={{ opacity: 0 }}
+    animate={{ opacity: 0.6 }}
+    exit={{ opacity: 0 }}
+    transition={{ duration: 0.2, ease: "easeOut" }}
+    className={cn(
+      "pointer-events-none absolute inset-x-0 z-10 h-4",
+      position === "top"
+        ? [
+            "top-0",
+            "bg-gradient-to-b from-f1-background-secondary to-transparent",
+            "after:top-0",
+          ]
+        : [
+            "bottom-0",
+            "bg-gradient-to-t from-f1-background-secondary to-transparent",
+            "after:bottom-0",
+          ]
+    )}
+  />
+)
+
+export const F0DialogContent = ({
+  children,
+  disableContentPadding = false,
+}: F0DialogContentProps) => {
+  const { position } = useF0Dialog()
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const [isAtTop, setIsAtTop] = useState(true)
+  const [isAtBottom, setIsAtBottom] = useState(true)
+
+  const handleScroll = useCallback(() => {
+    const el = viewportRef.current
+    if (!el) return
+    const { scrollTop, scrollHeight, clientHeight } = el
+    setIsAtTop(scrollTop <= 0)
+    setIsAtBottom(scrollTop + clientHeight >= scrollHeight - 1)
+  }, [])
+
+  useEffect(() => {
+    const el = viewportRef.current
+    if (!el) return
+    el.addEventListener("scroll", handleScroll, { passive: true })
+    handleScroll()
+
+    const observer = new ResizeObserver(() => handleScroll())
+    observer.observe(el)
+
+    return () => {
+      el.removeEventListener("scroll", handleScroll)
+      observer.disconnect()
+    }
+  }, [handleScroll])
+
+  return (
+    <div className="relative flex flex-1 flex-col overflow-hidden">
+      <ScrollArea
+        viewportRef={viewportRef}
+        className={cn(
+          "[*[data-state=visible]_div]:bg-f1-background flex flex-1 flex-col",
+          "[&_.resource-header]:p-0 [&_.resource-header]:pr-1",
+          !disableContentPadding && "px-4 [&>div]:py-4",
+          position === "fullscreen" &&
+            "h-full [&>div]:h-full [&>div>div]:h-full"
+        )}
+      >
+        <LayoutProvider layout={null}>{children}</LayoutProvider>
+        <ScrollBar
+          orientation="vertical"
+          className="[&_div]:bg-f1-background"
+        />
+      </ScrollArea>
+
+      <AnimatePresence>
+        {!isAtTop && <ScrollShadow position="top" key="shadow-top" />}
+        {!isAtBottom && <ScrollShadow position="bottom" key="shadow-bottom" />}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogFooter.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogFooter.tsx
@@ -1,0 +1,110 @@
+import { F0Button } from "@/components/F0Button"
+import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
+
+import {
+  F0DialogActionsProps,
+  F0DialogPrimaryAction,
+  F0DialogPrimaryActionItem,
+  F0DialogSecondaryAction,
+  F0DialogSecondaryActionItem,
+} from "../types"
+
+const isPrimaryActionArray = (
+  action: F0DialogPrimaryAction | F0DialogPrimaryActionItem[]
+): action is F0DialogPrimaryActionItem[] => {
+  return Array.isArray(action)
+}
+
+const isSecondaryActionArray = (
+  action: F0DialogSecondaryAction | F0DialogSecondaryActionItem[]
+): action is F0DialogSecondaryActionItem[] => {
+  return Array.isArray(action)
+}
+
+export const F0DialogFooter = ({
+  primaryAction,
+  secondaryAction,
+}: F0DialogActionsProps) => {
+  const hasSecondaryAction = secondaryAction
+  const hasPrimaryAction = primaryAction
+
+  if (!hasPrimaryAction && !hasSecondaryAction) {
+    return null
+  }
+
+  const renderPrimaryAction = () => {
+    if (!hasPrimaryAction) return null
+
+    if (isPrimaryActionArray(primaryAction)) {
+      return (
+        <F0ButtonDropdown
+          items={primaryAction.map((action) => ({
+            value: action.value,
+            label: action.label,
+            icon: action.icon,
+          }))}
+          onClick={(value) => {
+            const action = primaryAction.find((a) => a.value === value)
+            action?.onClick()
+          }}
+          variant="default"
+        />
+      )
+    }
+
+    return (
+      <F0Button
+        label={primaryAction.label}
+        onClick={primaryAction.onClick}
+        variant="default"
+        icon={primaryAction.icon}
+        iconPosition={primaryAction.iconPosition}
+        disabled={primaryAction.disabled}
+        loading={primaryAction.loading}
+      />
+    )
+  }
+
+  const renderSecondaryAction = () => {
+    if (!hasSecondaryAction) return null
+
+    if (isSecondaryActionArray(secondaryAction)) {
+      return (
+        <F0ButtonDropdown
+          items={secondaryAction.map((action) => ({
+            value: action.value,
+            label: action.label,
+            icon: action.icon,
+          }))}
+          onClick={(value) => {
+            const action = secondaryAction.find((a) => a.value === value)
+            action?.onClick()
+          }}
+          variant="outline"
+        />
+      )
+    }
+
+    return (
+      <F0Button
+        label={secondaryAction.label}
+        onClick={secondaryAction.onClick}
+        variant="outline"
+        icon={secondaryAction.icon}
+        iconPosition={secondaryAction.iconPosition}
+        disabled={secondaryAction.disabled}
+        loading={secondaryAction.loading}
+      />
+    )
+  }
+
+  return (
+    <div className="flex flex-row items-center justify-between border-x-0 border-b-0 border-t border-solid border-f1-border-secondary px-4 py-3">
+      <div className="flex-1" />
+      <div className="flex flex-row items-center gap-2">
+        {renderSecondaryAction()}
+        {renderPrimaryAction()}
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
@@ -1,0 +1,223 @@
+import { ButtonInternal } from "@/components/F0Button/internal"
+import {
+  DropdownInternal,
+  DropdownItemObject,
+} from "@/experimental/Navigation/Dropdown/internal"
+import { BaseHeader } from "@/experimental/Information/Headers/BaseHeader"
+import { BreadcrumbItem } from "@/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem"
+import { PageNavigation } from "@/experimental/Navigation/Header/PageNavigation"
+import { Tabs } from "@/patterns/Navigation/Tabs"
+import CrossIcon from "@/icons/app/Cross"
+import { ArrowLeft, Ellipsis, Maximize } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+import { BreadcrumbList } from "@/ui/breadcrumb"
+import { DialogTitle } from "@/ui/Dialog/dialog"
+import { DrawerDescription } from "@/ui/drawer"
+
+import { F0DialogHeaderProps } from "../internal-types"
+import { useF0Dialog } from "./F0DialogProvider"
+
+export const F0DialogHeader = ({
+  title,
+  description,
+  module,
+  otherActions,
+  navigation,
+  resourceHeader,
+  controls,
+  tabs,
+  activeTabId,
+  setActiveTabId,
+}: F0DialogHeaderProps) => {
+  const translations = useI18n()
+
+  const { onClose } = useF0Dialog()
+  const hasTabs = !!tabs
+
+  const Divider = () => {
+    return <div className="h-4 w-px self-center bg-f1-background-secondary" />
+  }
+
+  const otherActionItems =
+    otherActions?.filter(
+      (action): action is DropdownItemObject =>
+        action.type !== "separator" && action.type !== "label"
+    ) ?? []
+
+  const Actions = () => {
+    if (!otherActionItems.length || !otherActions) return null
+
+    const hasCriticalAction = otherActionItems.some((action) => action.critical)
+
+    if (otherActionItems.length <= 2 && !hasCriticalAction) {
+      return (
+        <div className="flex flex-row gap-2">
+          {otherActionItems.map((action) => (
+            <ButtonInternal
+              key={action.label}
+              variant="outline"
+              icon={action.icon}
+              onClick={action.onClick}
+              label={action.label}
+              hideLabel
+            />
+          ))}
+        </div>
+      )
+    }
+
+    return <DropdownInternal items={otherActions} icon={Ellipsis} />
+  }
+
+  const Module = () => {
+    if (!module) return null
+
+    return (
+      <BreadcrumbList>
+        <BreadcrumbItem
+          item={{
+            id: module.id,
+            label: module.label,
+            href: module.href,
+            module: module.id,
+          }}
+          isLast={false}
+          isFirst={true}
+        />
+      </BreadcrumbList>
+    )
+  }
+
+  const CloseButton = () => (
+    <ButtonInternal
+      variant="outline"
+      icon={CrossIcon}
+      onClick={onClose}
+      label={translations.actions.close}
+      hideLabel
+    />
+  )
+
+  const TabsStrip = () =>
+    tabs ? (
+      <div className="overflow-hidden">
+        <div className="-mx-2">
+          <Tabs
+            tabs={tabs}
+            activeTabId={activeTabId}
+            setActiveTabId={setActiveTabId}
+          />
+        </div>
+      </div>
+    ) : null
+
+  const Controls = () => {
+    if (!controls) return null
+
+    if (controls.kind === "back") {
+      return (
+        <ButtonInternal
+          variant="outline"
+          icon={ArrowLeft}
+          onClick={controls.onClick}
+          label={controls.label}
+        />
+      )
+    }
+
+    return (
+      <>
+        {controls.expand &&
+          (controls.expand.url !== undefined ? (
+            <ButtonInternal
+              variant="outline"
+              icon={Maximize}
+              href={controls.expand.url}
+              label={controls.expand.label}
+            />
+          ) : (
+            <ButtonInternal
+              variant="outline"
+              icon={Maximize}
+              onClick={controls.expand.onClick}
+              label={controls.expand.label}
+            />
+          ))}
+        {controls.expand && controls.navigation && <Divider />}
+        {controls.navigation && <PageNavigation {...controls.navigation} />}
+      </>
+    )
+  }
+
+  // `navigation` alone is intentionally excluded so legacy title/module dialogs stay on the branch below.
+  if (resourceHeader || controls) {
+    return (
+      <>
+        <div className="flex flex-row items-center justify-between gap-3 px-4 py-3">
+          <div className="flex flex-row items-center gap-2">
+            <Controls />
+          </div>
+          <div className="flex flex-row items-center gap-2">
+            <Actions />
+            <CloseButton />
+          </div>
+        </div>
+        {/* BaseHeader shows the title as a styled span, so emit a visually-hidden DialogTitle for the accessible name. */}
+        {resourceHeader ? (
+          <>
+            <DialogTitle className="sr-only">
+              {resourceHeader.title}
+            </DialogTitle>
+            <div className="[&_.resource-header]:px-4">
+              <BaseHeader {...resourceHeader} />
+            </div>
+          </>
+        ) : (
+          title && <DialogTitle className="sr-only">{title}</DialogTitle>
+        )}
+        <TabsStrip />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <div
+        className={cn(
+          "flex flex-row items-start justify-between gap-3 px-4 py-3",
+          !hasTabs &&
+            "border border-x-0 border-b border-t-0 border-solid border-f1-border-secondary"
+        )}
+      >
+        <div className="flex flex-row items-center gap-3">
+          {(module || title || !!description) && (
+            <div className="flex flex-col gap-1">
+              {module ? (
+                <Module />
+              ) : (
+                title && (
+                  <DialogTitle className="py-1 text-lg font-semibold text-f1-foreground">
+                    {title}
+                  </DialogTitle>
+                )
+              )}
+              {!!description && (
+                <DrawerDescription className="text-base text-f1-foreground-secondary">
+                  {description}
+                </DrawerDescription>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="flex flex-row items-center gap-2">
+          {navigation && <PageNavigation {...navigation} />}
+          <Actions />
+          {(navigation || otherActions) && <Divider />}
+          <CloseButton />
+        </div>
+      </div>
+      <TabsStrip />
+    </>
+  )
+}

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogProvider.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogProvider.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext } from "react"
+
+import { F0DialogContextType, F0DialogProviderProps } from "../internal-types"
+
+export const F0DialogContext = createContext<F0DialogContextType>({
+  open: false,
+  onClose: () => {},
+  position: "center",
+  shownBottomSheet: false,
+  portalContainer: null,
+})
+
+export const F0DialogProvider = ({
+  isOpen,
+  onClose,
+  shownBottomSheet = false,
+  position,
+  children,
+  portalContainer,
+}: F0DialogProviderProps) => {
+  return (
+    <F0DialogContext.Provider
+      value={{
+        open: isOpen,
+        onClose,
+        position,
+        shownBottomSheet,
+        portalContainer,
+      }}
+    >
+      {children}
+    </F0DialogContext.Provider>
+  )
+}
+
+export const useF0Dialog = () => {
+  const context = useContext(F0DialogContext)
+  return context
+}

--- a/packages/react/src/patterns/F0Dialog/index.tsx
+++ b/packages/react/src/patterns/F0Dialog/index.tsx
@@ -3,34 +3,11 @@ import { experimentalComponent } from "@/lib/experimental"
 
 import { F0Dialog as F0DialogComponent } from "./F0Dialog"
 
-import type { Context } from "react"
-
-import { DialogWrapperContext } from "@/components/dialog-alike/common/DialogWrapperProvider"
-
-import type { F0DialogContextType } from "./internal-types"
-
-/**
- * @deprecated These context utilities are re-exported from the dialog-alike
- * implementation. Import them from `@/components/dialog-alike/F0Dialog` instead.
- */
 export {
-  DialogWrapperProvider as F0DialogProvider,
-  useDialogWrapperContext as useF0Dialog,
-} from "@/components/dialog-alike/common/DialogWrapperProvider"
-
-/**
- * The dialog-alike context, retyped under the original name so the public
- * `Context<F0DialogContextType>` signature is preserved (the runtime value is
- * the same context the dialog-alike components populate).
- * @deprecated Import `F0DialogContext` from `@/components/dialog-alike/F0Dialog`.
- */
-export const F0DialogContext: Context<F0DialogContextType> =
-  DialogWrapperContext
-/**
- * @deprecated Use the types from `@/components/dialog-alike/F0Dialog`
- * (`F0DialogSize`, `F0DialogAction`, `F0DialogActionsProps`) or
- * `@/components/dialog-alike/F0Drawer` instead.
- */
+  F0DialogContext,
+  F0DialogProvider,
+  useF0Dialog,
+} from "./components/F0DialogProvider"
 export type {
   DialogControls,
   DialogPosition,
@@ -43,10 +20,7 @@ export type {
 } from "./types"
 
 /**
- * @deprecated Use `F0Dialog` from `@/components/dialog-alike/F0Dialog` for
- * center/fullscreen dialogs, or `F0Drawer` from
- * `@/components/dialog-alike/F0Drawer` for side panels. This is a
- * backward-compatible shim that maps the legacy props onto those components.
+ * @experimental This is an experimental component use it at your own risk
  */
 const F0Dialog = withDataTestId(
   experimentalComponent("F0Dialog", F0DialogComponent)

--- a/packages/react/src/patterns/F0Dialog/internal-types.ts
+++ b/packages/react/src/patterns/F0Dialog/internal-types.ts
@@ -16,22 +16,6 @@ import {
   F0DialogSecondaryActionItem,
 } from "./types"
 
-// Mirrors the shape of the dialog-alike `DialogWrapperContextType` (the actual
-// runtime context). Kept under this name so the public `F0DialogContext` export
-// keeps its original `Context<F0DialogContextType>` type signature.
-export type F0DialogContextType = {
-  open: boolean
-  onClose: () => void
-  shownBottomSheet: boolean
-  position: DialogPosition
-  /**
-   * The dialog's content container element.
-   * Use this as the `portalContainer` prop for components like F0Select
-   * to ensure dropdowns render inside the dialog.
-   */
-  portalContainer: HTMLDivElement | null
-}
-
 export type F0DialogHeaderProps = {
   title?: string
   description?: string
@@ -45,6 +29,28 @@ export type F0DialogHeaderProps = {
   resourceHeader?: ResourceHeaderProps
   controls?: DialogControls
 } & Partial<Pick<TabsProps, "tabs" | "activeTabId" | "setActiveTabId">>
+
+export type F0DialogContextType = {
+  open: boolean
+  onClose: () => void
+  shownBottomSheet: boolean
+  position: DialogPosition
+  /**
+   * The dialog's content container element.
+   * Use this as the `portalContainer` prop for components like F0Select
+   * to ensure dropdowns render inside the dialog.
+   */
+  portalContainer: HTMLDivElement | null
+}
+
+export type F0DialogProviderProps = {
+  isOpen: boolean
+  onClose: () => void
+  shownBottomSheet?: boolean
+  position: DialogPosition
+  children: ReactNode
+  portalContainer: HTMLDivElement | null
+}
 
 export type F0DialogInternalProps = {
   // Whether the dialog is open

--- a/packages/react/src/patterns/F0Dialog/utils.ts
+++ b/packages/react/src/patterns/F0Dialog/utils.ts
@@ -1,0 +1,6 @@
+import { useMediaQuery } from "usehooks-ts"
+
+export const useIsSmallScreen = () =>
+  useMediaQuery("(max-width: 560px)", {
+    initializeWithValue: false,
+  })

--- a/packages/react/src/patterns/F0WizardForm/types.ts
+++ b/packages/react/src/patterns/F0WizardForm/types.ts
@@ -13,6 +13,7 @@ import type {
 import type { RenderCustomFieldFunction } from "@/patterns/F0Form/types"
 
 import { F0DialogSize } from "@/components/dialog-alike/F0Dialog"
+import { DialogWidth } from "@/patterns/F0Dialog"
 
 export type F0FormSchema<T extends ZodRawShape = ZodRawShape> =
   | z.ZodObject<T>
@@ -151,7 +152,7 @@ interface F0WizardFormBaseProps {
   onClose?: () => void
   title?: string
   /** @deprecated Use `size` instead. */
-  width?: Exclude<F0DialogSize, "fullscreen">
+  width?: DialogWidth
   /** The size of the wizard dialog. Preferred over the deprecated `width`. */
   size?: F0DialogSize
   defaultStepIndex?: number

--- a/packages/react/src/patterns/OneDataCollection/__tests__/presets.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/presets.test.tsx
@@ -696,9 +696,12 @@ describe("OneDataCollection - presets", () => {
       )!
     )
 
-    // The edit dialog surfaces a Remove action as a header button (dialog-alike
-    // renders up to two header actions as buttons rather than an overflow menu).
-    await user.click(await screen.findByRole("button", { name: "Remove" }))
+    // The edit dialog exposes a Remove action in its overflow menu (no separate
+    // confirmation step).
+    await user.click(
+      await screen.findByRole("button", { name: "Toggle dropdown menu" })
+    )
+    await user.click(await screen.findByRole("menuitem", { name: "Remove" }))
     await waitFor(() =>
       expect(screen.queryByText("Temp view")).not.toBeInTheDocument()
     )
@@ -835,9 +838,12 @@ describe("OneDataCollection - share preset", () => {
         (el) => !el.closest('[aria-hidden="true"]')
       )!
     )
-    // Share is surfaced as a header button (dialog-alike renders up to two
-    // header actions as buttons rather than an overflow menu).
-    await user.click(await screen.findByRole("button", { name: "Share view" }))
+    await user.click(
+      await screen.findByRole("button", { name: "Toggle dropdown menu" })
+    )
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Share view" })
+    )
 
     // The dropdown defers the action slightly (Radix close/animation workaround).
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))

--- a/packages/react/src/patterns/OneDataCollection/components/PresetFormDialog/PresetFormDialog.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/PresetFormDialog/PresetFormDialog.tsx
@@ -2,7 +2,7 @@ import { z } from "zod"
 
 import { Delete, Share } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
-import { F0Dialog } from "@/components/dialog-alike/F0Dialog"
+import { F0Dialog } from "@/patterns/F0Dialog"
 import { f0FormField, F0Form, useF0Form } from "@/patterns/F0Form"
 import { useF0FormDefinition } from "@/patterns/F0WizardForm"
 

--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersControls.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersControls.tsx
@@ -4,7 +4,7 @@ import { useContext, useEffect, useId, useMemo, useRef, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { DialogWrapperContext as F0DialogContext } from "@/components/dialog-alike/common/DialogWrapperProvider"
+import { F0DialogContext } from "@/patterns/F0Dialog"
 import { FilterPickerInternal } from "@/patterns/F0FilterPickerContent/internal"
 import { Filter } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"

--- a/packages/react/src/sds/ai/F0AiMessagesContainer/components/feedback/FeedbackModal.tsx
+++ b/packages/react/src/sds/ai/F0AiMessagesContainer/components/feedback/FeedbackModal.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 
-import { F0Dialog } from "@/components/dialog-alike/F0Dialog"
+import { F0Dialog } from "@/patterns/F0Dialog"
 import { F0TextInput } from "@/components/F0TextInput"
 import { useI18n } from "@/lib/providers/i18n"
 
@@ -53,9 +53,10 @@ export const FeedbackModal = ({
 
   return (
     <F0Dialog
+      position="center"
       isOpen
       onClose={handleClose}
-      size="md"
+      width="md"
       title={title}
       container={null}
       primaryAction={{

--- a/packages/react/src/sds/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
+++ b/packages/react/src/sds/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
@@ -1,14 +1,14 @@
 import { useCallback, useRef, useState, useMemo } from "react"
 
+import type { DialogPosition } from "@/patterns/F0Dialog/types"
 import type { F0FormSubmitResult } from "@/patterns/F0Form/types"
 
-import { F0Dialog } from "@/components/dialog-alike/F0Dialog"
-import { F0Drawer } from "@/components/dialog-alike/F0Drawer"
 import { OneEmptyState } from "@/components/OneEmptyState"
 import { ArrowLeft, ArrowRight, Maximize, Minimize } from "@/icons/app"
 import { F0Box } from "@/lib/F0Box"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
+import { F0Dialog } from "@/patterns/F0Dialog"
 import { F0Form } from "@/patterns/F0Form/F0Form"
 import { useF0Form } from "@/patterns/F0Form/useF0Form"
 import { ResourceHeader } from "@/patterns/ResourceHeader"
@@ -19,7 +19,6 @@ import type {
   SurveyAnsweringFormInlineReadonlyProps,
   SurveyAnsweringFormPreviewProps,
   SurveyAnsweringFormProps,
-  SurveyDialogPosition,
   SurveySubmitAnswers,
 } from "./types"
 
@@ -115,10 +114,10 @@ function SurveyAnsweringFormDialog({
     datasets
   )
 
-  const position: SurveyDialogPosition = isFullscreen
+  const position: DialogPosition = isFullscreen
     ? "fullscreen"
     : nonFullscreenPosition
-  const isSidePosition = position === "left" || position === "right"
+  const dialogWidth = position === "center" ? "xl" : undefined
 
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -281,119 +280,108 @@ function SurveyAnsweringFormDialog({
   const disableContentPadding =
     position === "center" || position === "fullscreen"
 
-  const sharedProps = {
-    isOpen,
-    onClose,
-    title,
-    module,
-    primaryAction,
-    secondaryAction,
-    otherActions,
-    disableContentPadding,
-  }
-
-  const body = (
-    <SurveyFormBuilderProvider
-      answering
-      elements={elements}
-      onChange={noop}
-      datasets={datasets}
-    >
-      <div
-        className={cn(
-          "relative flex h-full min-h-full flex-col @container",
-          isStepped && !isFullscreen && "min-h-[600px]"
-        )}
-      >
-        {showTableOfContent && (
-          <TableOfContent elements={elements} onChange={noop} answering />
-        )}
-        {showStepperProgress && (
-          <div className="absolute left-0 right-0 top-0 [&>div>div>div]:h-1 [&>div>div>div]:rounded-none">
-            <ProgressBarCell label="Value" value={stepper.progress} hideLabel />
-          </div>
-        )}
-        <div
-          className={cn(
-            "mx-auto flex w-full flex-1 justify-center flex-col @lg:w-[750px] max-w-full pt-0",
-            disableContentPadding && "px-4 py-12"
-          )}
-        >
-          <div className="mb-6">
-            <ResourceHeader
-              title={title}
-              description={description}
-              {...resourceHeader}
-            />
-          </div>
-          {loading ? (
-            mode === "stepped" ? (
-              <SurveySteppedLoadingSkeleton />
-            ) : (
-              <SurveyAllQuestionsLoadingSkeleton />
-            )
-          ) : !hasQuestions ? (
-            <F0Box
-              display="flex"
-              flexDirection="column"
-              height="full"
-              justifyContent="center"
-              alignItems="center"
-              paddingX="lg"
-            >
-              <OneEmptyState
-                emoji={emptyLabels.emoji}
-                title={emptyLabels.title}
-                description={emptyLabels.description}
-              />
-            </F0Box>
-          ) : null}
-          {showSectionHeader && (
-            <div className="py-1 pl-5">
-              <span className="text-lg font-semibold text-f1-foreground">
-                {stepper.currentQuestion?.sectionTitle}
-              </span>
-              {stepper.currentQuestion?.sectionDescription && (
-                <p className="text-f1-foreground-secondary">
-                  {stepper.currentQuestion?.sectionDescription}
-                </p>
-              )}
-            </div>
-          )}
-          {hasQuestions && !loading && (
-            <F0Form
-              key={isStepped ? stepper.currentStep : undefined}
-              formRef={formRef}
-              name="survey-answering"
-              schema={schema}
-              defaultValues={formDefaultValues}
-              onSubmit={handleF0Submit}
-              submitConfig={{
-                hideSubmitButton: true,
-              }}
-              errorTriggerMode={errorTriggerMode}
-              sections={sections}
-            />
-          )}
-        </div>
-      </div>
-    </SurveyFormBuilderProvider>
-  )
-
-  if (isSidePosition) {
-    return (
-      <F0Drawer position={position} {...sharedProps}>
-        {body}
-      </F0Drawer>
-    )
-  }
-
   return (
     <F0Dialog
-      size={position === "fullscreen" ? "fullscreen" : "xl"}
-      {...sharedProps}
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      module={module}
+      position={position}
+      width={dialogWidth}
+      primaryAction={primaryAction}
+      secondaryAction={secondaryAction}
+      otherActions={otherActions}
+      disableContentPadding={disableContentPadding}
     >
-      {body}
+      <SurveyFormBuilderProvider
+        answering
+        elements={elements}
+        onChange={noop}
+        datasets={datasets}
+      >
+        <div
+          className={cn(
+            "relative flex h-full min-h-full flex-col @container",
+            isStepped && !isFullscreen && "min-h-[600px]"
+          )}
+        >
+          {showTableOfContent && (
+            <TableOfContent elements={elements} onChange={noop} answering />
+          )}
+          {showStepperProgress && (
+            <div className="absolute left-0 right-0 top-0 [&>div>div>div]:h-1 [&>div>div>div]:rounded-none">
+              <ProgressBarCell
+                label="Value"
+                value={stepper.progress}
+                hideLabel
+              />
+            </div>
+          )}
+          <div
+            className={cn(
+              "mx-auto flex w-full flex-1 justify-center flex-col @lg:w-[750px] max-w-full pt-0",
+              disableContentPadding && "px-4 py-12"
+            )}
+          >
+            <div className="mb-6">
+              <ResourceHeader
+                title={title}
+                description={description}
+                {...resourceHeader}
+              />
+            </div>
+            {loading ? (
+              mode === "stepped" ? (
+                <SurveySteppedLoadingSkeleton />
+              ) : (
+                <SurveyAllQuestionsLoadingSkeleton />
+              )
+            ) : !hasQuestions ? (
+              <F0Box
+                display="flex"
+                flexDirection="column"
+                height="full"
+                justifyContent="center"
+                alignItems="center"
+                paddingX="lg"
+              >
+                <OneEmptyState
+                  emoji={emptyLabels.emoji}
+                  title={emptyLabels.title}
+                  description={emptyLabels.description}
+                />
+              </F0Box>
+            ) : null}
+            {showSectionHeader && (
+              <div className="py-1 pl-5">
+                <span className="text-lg font-semibold text-f1-foreground">
+                  {stepper.currentQuestion?.sectionTitle}
+                </span>
+                {stepper.currentQuestion?.sectionDescription && (
+                  <p className="text-f1-foreground-secondary">
+                    {stepper.currentQuestion?.sectionDescription}
+                  </p>
+                )}
+              </div>
+            )}
+            {hasQuestions && !loading && (
+              <F0Form
+                key={isStepped ? stepper.currentStep : undefined}
+                formRef={formRef}
+                name="survey-answering"
+                schema={schema}
+                defaultValues={formDefaultValues}
+                onSubmit={handleF0Submit}
+                submitConfig={{
+                  hideSubmitButton: true,
+                }}
+                errorTriggerMode={errorTriggerMode}
+                sections={sections}
+              />
+            )}
+          </div>
+        </div>
+      </SurveyFormBuilderProvider>
     </F0Dialog>
   )
 }

--- a/packages/react/src/sds/surveys/SurveyAnsweringForm/types.ts
+++ b/packages/react/src/sds/surveys/SurveyAnsweringForm/types.ts
@@ -1,4 +1,5 @@
 import type { ModuleId } from "@/components/avatars/F0AvatarModule"
+import type { DialogPosition } from "@/patterns/F0Dialog/types"
 import type { UseFileUpload } from "@/patterns/F0Form/fields/file/types"
 import type { F0FormErrorTriggerMode } from "@/patterns/F0Form/types"
 import type { ResourceHeaderProps } from "@/patterns/ResourceHeader"
@@ -36,9 +37,6 @@ export type SurveyFormSubmitResult =
 
 export type SurveyAnsweringFormMode = "stepped" | "all-questions"
 
-/** Where the answering dialog is anchored. */
-export type SurveyDialogPosition = "center" | "left" | "right" | "fullscreen"
-
 type SurveyAnsweringFormModule = {
   id: ModuleId
   label: string
@@ -66,7 +64,7 @@ interface SurveyAnsweringFormDialogProps extends SurveyAnsweringFormSharedProps 
   inline?: false
   mode: SurveyAnsweringFormMode
   module: SurveyAnsweringFormModule
-  position?: SurveyDialogPosition
+  position?: DialogPosition
   isOpen: boolean
   onClose: () => void
   allowToChangeFullscreen?: boolean

--- a/packages/react/src/sds/surveys/SurveyFormBuilder/Form/TableOfContent/index.tsx
+++ b/packages/react/src/sds/surveys/SurveyFormBuilder/Form/TableOfContent/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext } from "react"
 
-import { DialogWrapperContext as F0DialogContext } from "@/components/dialog-alike/common/DialogWrapperProvider"
+import { F0DialogContext } from "@/patterns/F0Dialog/components/F0DialogProvider"
 import { F0TableOfContentPopover } from "@/components/F0TableOfContentPopover/F0TableOfContentPopover"
 import { IdStructure } from "@/experimental/Navigation/F0TableOfContent/types"
 import { useI18n } from "@/lib/providers/i18n"

--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -13,7 +13,7 @@ import {
 
 import { useReducedMotion } from "@/lib/a11y"
 import { cn } from "@/lib/utils"
-import { DialogWrapperContext as F0DialogContext } from "@/components/dialog-alike/common/DialogWrapperProvider"
+import { F0DialogContext } from "@/patterns/F0Dialog"
 import { ScrollArea } from "@/ui/scrollarea"
 import { Spinner } from "@/ui/Spinner"
 


### PR DESCRIPTION
## Description

Reverts #4552 (`refactor(F0Dialog): deprecate patterns F0Dialog in favor of dialog-alike`, shipped in v4.10.0), restoring the original `patterns/F0Dialog` implementation (`F0DialogInternal` + its own Header/Footer/Content/Provider) instead of routing every `F0Dialog` through the `dialog-alike` layer.

## Why

A version bisect of factorial's E2E suite pinned a Chrome **renderer OOM** regression to the range **(f0 4.8.0 → 4.11.0]** — every `OneDataCollection`-heavy page that opens dialogs/sidepanels crashes the renderer on f0 ≥ 4.10/4.12 but is clean on ≤ 4.8. #4552 (v4.10.0) is the strongest suspect: it re-routes **all** `patterns/F0Dialog` usages (dialogs, sidepanels, confirm modals — used pervasively across factorial) through the heavier `dialog-alike` render path (children-keyed memo, `localIsOpen` state machine, portal into the shared overlay root, long transition).

This revert is to **isolate #4552 as the cause**: build an alpha from this branch, pin factorial to it, and re-run the E2E. If the cluster stops crashing, #4552 is confirmed and we design a proper fix.

## Notes

- `tsc` passes against current `main` (the pre-#4552 patterns/F0Dialog is self-consistent with 4.16).
- Diagnostic/temporary — not necessarily for merge as-is; the real fix may differ once the cause is confirmed.