### PR TITLE
fix(F0Select): re-enable pointer events on dropdowns portaled into non-modal dialogs

### DIFF
--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -117,6 +117,23 @@ describe("Select", () => {
     })
   })
 
+  it("keeps the open dropdown clickable under pointer-events-none ancestors (select-in-dialog)", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={mockOptions}
+        onChange={() => {}}
+      />
+    )
+
+    await openSelect(user)
+
+    expect(screen.getByRole("listbox").className).toContain(
+      "pointer-events-auto"
+    )
+  })
+
   it("shows options when clicked", async () => {
     const user = userEvent.setup()
     render(

--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -254,7 +254,7 @@ const SelectContent = forwardRef<
           "relative z-50 text-f1-foreground",
           asList
             ? "flex w-full h-full flex-col"
-            : "flex min-w-[8rem] flex-col overflow-hidden",
+            : "pointer-events-auto flex min-w-[8rem] flex-col overflow-hidden",
           !asList &&
             "rounded-md border border-solid border-f1-border-secondary bg-f1-background shadow-md data-[state=closed]:fade-out-0 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-safe:data-[state=open]:animate-in motion-safe:data-[state=closed]:animate-out motion-safe:data-[state=open]:fade-in-0 motion-safe:data-[state=closed]:zoom-out-95 motion-safe:data-[state=open]:zoom-in-95 motion-safe:data-[side=bottom]:slide-in-from-top-2",
           !asList &&


### PR DESCRIPTION
## Description

Since #4552, the legacy `F0Dialog` renders through dialog-alike, whose `DialogWrapper` mounts Radix `Dialog` with `modal={false}` (the old `ui/Dialog` was modal). The F0Select dropdown portals into the dialog's fixed `pointer-events-none` wrapper and, having a portal container, renders its `DismissableLayer` with `disableOutsidePointerEvents={false}`. Radix layers only self-apply inline `pointer-events: auto` while some layer has disabled **body** pointer events — which the old modal dialog did and the non-modal one never does. Net effect since 4.10.0: **the open dropdown computes `pointer-events: none`** — it paints on top (the cover is transparent) but every mouse click falls through to the dialog card behind it.

Consequences:
- Users can't click picker options inside dialogs (or the fallen-through click closes the dropdown as an outside-pointerdown).
- In Cypress, the option click retries actionability for the full command timeout, snapshotting the DOM every pass → the renderer balloons to ~330k DOM nodes (JS heap stays flat) → native OOM → **"Chrome Renderer process just crashed"** on `finance/budgets/budget_allocations` and `performance_feedback/feedback`, blocking the f0-react 4.x monorepo bump (factorialco/factorial#104435).

## Implementation details

- `SelectContent`: add `pointer-events-auto` to the popper branch of the content className, so the dropdown re-enables pointer events itself instead of relying on a modal ancestor having disabled body pointer events. No-op in the modal case (the layer already sets inline `pointer-events: auto` there) and for `asList` mode (rendered inline, not portaled).
- Regression test: the open listbox must carry `pointer-events-auto`.

## Testing

- `elementFromPoint` sampling on the real app (prod build, 4.20.1): option hit-test-covered 79/79 samples before, lands on the option after; unforced click registers and the multiselect stays open with "Apply selection" reachable.
- Local Cypress runs against a prod-mode build of the monorepo with this fix patched in: `feedback.feature` 4/4 passing and `budget_allocations.feature` 1/1 passing — both were 100%-reproducible renderer crashes without it.
- `F0Select` vitest suite: 33/33 passing.


https://github.com/user-attachments/assets/315bb781-e4c9-406a-919d-35892a876590

