### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.21.0",
+  "packages/react": "4.21.1",
   "packages/react-native": "0.56.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.21.1](https://github.com/factorialco/f0/compare/f0-react-v4.21.0...f0-react-v4.21.1) (2026-07-03)
+
+
+### Bug Fixes
+
+* **F0Select:** re-enable pointer events on dropdowns portaled into non-modal dialogs ([#4609](https://github.com/factorialco/f0/issues/4609)) ([ab07ab2](https://github.com/factorialco/f0/commit/ab07ab2c1814e7789e5bfaf84df3d8b65e37647b))
+
 ## [4.21.0](https://github.com/factorialco/f0/compare/f0-react-v4.20.1...f0-react-v4.21.0) (2026-07-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.21.1</summary>

## [4.21.1](https://github.com/factorialco/f0/compare/f0-react-v4.21.0...f0-react-v4.21.1) (2026-07-03)


### Bug Fixes

* **F0Select:** re-enable pointer events on dropdowns portaled into non-modal dialogs ([#4609](https://github.com/factorialco/f0/issues/4609)) ([ab07ab2](https://github.com/factorialco/f0/commit/ab07ab2c1814e7789e5bfaf84df3d8b65e37647b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).