### PR TITLE
feat(experimental): add F0AudienceSelector and F0AudienceListItem

### DIFF
--- a/packages/react/src/components/OneChip/index.tsx
+++ b/packages/react/src/components/OneChip/index.tsx
@@ -36,6 +36,13 @@ interface BaseChipProps extends VariantProps<typeof chipVariants> {
    * */
   onClose?: () => void
 
+  /**
+   * Accessible label for the close button, so chips remain distinguishable
+   * to screen readers (e.g. "Remove Ada Lovelace")
+   * @default "Close"
+   */
+  closeLabel?: string
+
   deactivated?: boolean
 }
 
@@ -70,6 +77,7 @@ const _Chip = ({
   variant,
   onClick,
   onClose,
+  closeLabel,
   avatar,
   icon,
 }: ChipProps) => {
@@ -113,7 +121,7 @@ const _Chip = ({
             focusRing()
           )}
           tabIndex={0}
-          aria-label="Close"
+          aria-label={closeLabel ?? "Close"}
         >
           <F0Icon icon={CrossedCircle} size="sm" />
         </button>

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/F0AudienceSelector.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/F0AudienceSelector.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react"
+
+import { F0Alert } from "@/components/F0Alert"
+import { F0InputField } from "@/components/F0InputField"
+import { type RecordType } from "@/hooks/datasource"
+import { Search } from "@/icons/app"
+import { DataTestIdWrapper } from "@/lib/data-testid"
+import { useI18n } from "@/lib/providers/i18n"
+import { Popover, PopoverAnchor } from "@/ui/popover"
+
+import { AudienceDropdown } from "./components/AudienceDropdown"
+import { AudienceField } from "./components/AudienceField"
+import { useAudienceSearch } from "./hooks/useAudienceSearch"
+import type { AudienceOptionItem } from "./internal-types"
+import {
+  audienceEntityKey,
+  type F0AudienceEntity,
+  type F0AudienceSelectorProps,
+} from "./types"
+
+export const F0AudienceSelector = <R extends RecordType = RecordType>({
+  source,
+  mapEntity,
+  value,
+  onChange,
+  suggestions,
+  trailing,
+  warning,
+  onOpenChange,
+  searchEmptyMessage,
+  label,
+  hideLabel,
+  placeholder,
+  disabled,
+  loading,
+  error,
+  dataTestId,
+}: F0AudienceSelectorProps<R>) => {
+  const i18n = useI18n()
+  const reactId = useId()
+  const listboxId = `audience-listbox-${reactId}`
+
+  const anchorRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const selectedKeys = useMemo(
+    () => new Set(value.map(audienceEntityKey)),
+    [value]
+  )
+
+  const {
+    query,
+    setQuery,
+    isSearching,
+    options,
+    isLoading,
+    isLoadingMore,
+    loadMore,
+    hasMore,
+  } = useAudienceSearch({ source, mapEntity, listboxId, selectedKeys })
+
+  const suggestionItems = useMemo<AudienceOptionItem[]>(
+    () =>
+      (suggestions ?? []).map((option, index) => {
+        const key = audienceEntityKey(option.entity)
+        return {
+          option,
+          key,
+          domId: `${listboxId}-suggestion-${index}`,
+          selected: selectedKeys.has(key),
+          disabled: !!option.disabledReason,
+        }
+      }),
+    [suggestions, selectedKeys, listboxId]
+  )
+
+  const items = isSearching ? options : suggestionItems
+
+  const [open, setOpen] = useState(false)
+  const [activeKey, setActiveKey] = useState<string | null>(null)
+
+  const changeOpen = (next: boolean) => {
+    if (next === open) {
+      return
+    }
+    setOpen(next)
+    onOpenChange?.(next)
+  }
+
+  // Keep the active option valid as results change: fall back to the first
+  // enabled option whenever the previous one is gone or disabled.
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    setActiveKey((previous) => {
+      if (items.some((item) => item.key === previous && !item.disabled)) {
+        return previous
+      }
+      return items.find((item) => !item.disabled)?.key ?? null
+    })
+  }, [items, open])
+
+  const activeItem = items.find((item) => item.key === activeKey)
+
+  const toggleItem = (item: AudienceOptionItem) => {
+    if (item.disabled) {
+      return
+    }
+    onChange(
+      selectedKeys.has(item.key)
+        ? value.filter((entity) => audienceEntityKey(entity) !== item.key)
+        : [...value, item.option.entity]
+    )
+    // The dropdown stays open for further picks; the query resets
+    setQuery("")
+    inputRef.current?.focus()
+  }
+
+  const removeEntity = (entity: F0AudienceEntity) => {
+    const key = audienceEntityKey(entity)
+    onChange(value.filter((candidate) => audienceEntityKey(candidate) !== key))
+  }
+
+  const moveActive = (direction: 1 | -1) => {
+    const enabled = items.filter((item) => !item.disabled)
+    if (enabled.length === 0) {
+      return
+    }
+    const currentIndex = enabled.findIndex((item) => item.key === activeKey)
+    const nextIndex =
+      currentIndex === -1
+        ? direction === 1
+          ? 0
+          : enabled.length - 1
+        : (currentIndex + direction + enabled.length) % enabled.length
+    setActiveKey(enabled[nextIndex].key)
+  }
+
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (event.key) {
+      case "Backspace":
+        if (query === "" && value.length > 0) {
+          onChange(value.slice(0, -1))
+        }
+        break
+      case "ArrowDown":
+      case "ArrowUp":
+        event.preventDefault()
+        if (!open) {
+          changeOpen(true)
+          return
+        }
+        moveActive(event.key === "ArrowDown" ? 1 : -1)
+        break
+      case "Enter":
+        if (open && activeItem) {
+          event.preventDefault()
+          toggleItem(activeItem)
+        }
+        break
+      case "Escape":
+        // Close only the dropdown — never an enclosing dialog
+        if (open) {
+          event.preventDefault()
+          event.stopPropagation()
+          changeOpen(false)
+        }
+        break
+    }
+  }
+
+  const emptyMessage = isSearching
+    ? (searchEmptyMessage ?? i18n.audience.selector.noResults)
+    : i18n.audience.selector.typeToSearch
+
+  return (
+    <DataTestIdWrapper dataTestId={dataTestId}>
+      <div className="flex w-full flex-col gap-2">
+        <Popover open={open} onOpenChange={changeOpen}>
+          <PopoverAnchor asChild>
+            <div ref={anchorRef} className="w-full">
+              <F0InputField
+                label={label}
+                hideLabel={hideLabel}
+                placeholder={placeholder}
+                disabled={disabled}
+                error={error}
+                loading={loading || (open && isLoading)}
+                loadingIndicator={{ asOverlay: true }}
+                size="md"
+                canGrow
+                icon={Search}
+                role="combobox"
+                aria-controls={listboxId}
+                aria-expanded={open}
+                inputRef={inputRef}
+                value={query}
+                isEmpty={(current) => value.length === 0 && !current}
+                onChange={(next) => {
+                  setQuery(next)
+                  changeOpen(true)
+                }}
+                onFocus={() => changeOpen(true)}
+                append={value.length > 0 ? trailing : undefined}
+              >
+                <AudienceField
+                  entities={value}
+                  onRemoveEntity={removeEntity}
+                  onKeyDown={handleInputKeyDown}
+                  aria-activedescendant={
+                    open && activeItem ? activeItem.domId : undefined
+                  }
+                  aria-autocomplete="list"
+                />
+              </F0InputField>
+            </div>
+          </PopoverAnchor>
+          <AudienceDropdown
+            listboxId={listboxId}
+            label={label}
+            items={items}
+            activeKey={activeKey}
+            isLoading={isLoading}
+            isLoadingMore={isLoadingMore}
+            hasMore={hasMore}
+            loadMore={loadMore}
+            emptyMessage={emptyMessage}
+            onToggle={toggleItem}
+            onActivate={(item) => setActiveKey(item.key)}
+            onInteractOutside={(event) => {
+              // Clicking the field itself must not dismiss the dropdown
+              if (anchorRef.current?.contains(event.target as Node)) {
+                event.preventDefault()
+              }
+            }}
+          />
+        </Popover>
+        {warning && !open && (
+          <F0Alert
+            variant="warning"
+            title={warning.title}
+            description={warning.description}
+          />
+        )}
+      </div>
+    </DataTestIdWrapper>
+  )
+}

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/__stories__/F0AudienceSelector.mdx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/__stories__/F0AudienceSelector.mdx
@@ -1,0 +1,132 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks"
+import * as Stories from "./F0AudienceSelector.stories"
+
+<Meta of={Stories} />
+
+# F0AudienceSelector
+
+Bulk selector for arbitrary people or **groups of people**: teams, legal
+entities, workplaces, roles, permission groups and the company-wide
+"everyone". Selected entities render as removable chips inside the field.
+Groups are selected **atomically** — picking a team adds one team chip, never
+its expanded members.
+
+Built for share dialogs (Sharing v2), but domain-neutral: any feature that
+needs an audience can use it.
+
+---
+
+# Overview
+
+<Canvas of={Stories.Default} />
+
+## Data contract
+
+The component never fetches by itself and is **never called with an empty
+query**. Consumers pass a narrowed data adapter plus a record mapper:
+
+```tsx
+const source = useMemo(
+  () => ({
+    dataAdapter: {
+      fetchData: async ({ search }) => ({
+        // ONE flat list, all kinds interleaved — ranking is owned by the
+        // backend/consumer; the component renders records in the given order
+        records: await searchGranteeCandidates(search),
+      }),
+    },
+    search: { debounceTime: 300 }, // the default
+  }),
+  []
+)
+
+<F0AudienceSelector
+  label="Share with people, teams & groups"
+  source={source}
+  mapEntity={(node) => ({
+    entity: granteeToEntity(node),
+    disabledReason: alreadyHasAccess(node)
+      ? t("share.alreadyHasAccess")
+      : isCurrentUser(node)
+        ? t("share.thatsYou")
+        : undefined,
+  })}
+  value={selection}
+  onChange={setSelection}
+/>
+```
+
+Keep `source` referentially stable (module scope or `useMemo`) — a new adapter
+identity on every render restarts the search engine.
+
+Identity is **composite** (`kind` + `id`): ids may collide across kinds. Use
+the exported `audienceEntityKey(entity)` for dedupe and lookups.
+
+## Mapping to the Resource Registry sharing surface
+
+Today (person-only writes via parent verbs taking
+`PermissionsSharingSelectionInput { employeeIds, role }`):
+
+```ts
+const sharingSelection = {
+  employeeIds: selection
+    .filter((entity) => entity.kind === "individual")
+    .map((entity) => entity.id),
+  role,
+}
+```
+
+Tomorrow (grantee union — see `share.yml` in the permissions component):
+
+```ts
+const sharingSelection = {
+  grantees: selection.map((entity) => ({ kind: entity.kind, id: entity.id })),
+  role,
+}
+```
+
+Nothing in the component changes when group grantees land — group kinds simply
+start appearing in the adapter's results.
+
+## Suggestions
+
+With an empty query the adapter is not called; pass `suggestions` (e.g. direct
+reports and their team) or the component shows a "Start typing to search"
+empty state.
+
+<Canvas of={Stories.WithSuggestions} />
+
+## Unavailable options
+
+`disabledReason` disables the row and **replaces** its subtitle — the copy is
+domain knowledge and always comes from the consumer.
+
+<Canvas of={Stories.DisabledReasons} />
+
+## Batch role dropdown and warnings
+
+`trailing` renders inside the field only while entities are selected — the
+share dialog's batch role dropdown. `warning` renders an alert below the field
+and hides while the dropdown is open; computing it (e.g. out-of-reporting-line)
+is consumer-side.
+
+<Canvas of={Stories.WithTrailingRoleDropdown} />
+<Canvas of={Stories.WithWarning} />
+
+## Keyboard and dialogs
+
+- Picking an option keeps the dropdown open and clears the query.
+- `Backspace` with an empty query removes the last chip.
+- `ArrowUp`/`ArrowDown` move the active option (disabled options are skipped),
+  `Enter` toggles it.
+- `Escape` closes **only the dropdown** and does not propagate — inside an
+  `F0Dialog` the dialog stays open; a second `Escape` closes it.
+
+<Canvas of={Stories.InsideDialog} />
+
+## Share dialog recipe
+
+The full composition a share modal builds from this kit, together with
+`F0AudienceListItem`:
+
+<Canvas of={Stories.ShareDialogRecipe} />

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/__stories__/F0AudienceSelector.stories.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/__stories__/F0AudienceSelector.stories.tsx
@@ -1,0 +1,378 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useMemo, useState } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { F0Dialog } from "@/components/dialog-alike/F0Dialog"
+import { F0AudienceListItem } from "@/experimental/Lists/F0AudienceListItem"
+import { Dropdown } from "@/experimental/Navigation/Dropdown"
+import { ChevronDown } from "@/icons/app"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import { F0AudienceSelector } from "../index"
+import {
+  audienceEntityKey,
+  type F0AudienceEntity,
+  type F0AudienceOption,
+  type F0AudienceSelectorProps,
+} from "../types"
+import {
+  createAudienceAdapter,
+  createInfiniteAudienceAdapter,
+  employees,
+  everyone,
+  mapRecordToOption,
+  suggestions,
+  teams,
+  type AudienceRecord,
+} from "./mocks"
+
+// Stable adapter instances so story re-renders never re-init the datasource
+const DEFAULT_ADAPTER = createAudienceAdapter()
+const SLOW_ADAPTER = createAudienceAdapter({ latencyMs: 1500 })
+const EMPTY_ADAPTER = createAudienceAdapter({ results: [] })
+const INFINITE_ADAPTER = createInfiniteAudienceAdapter()
+
+const meta = {
+  title: "Components/F0AudienceSelector",
+  component: F0AudienceSelector,
+  tags: ["experimental"],
+  args: {
+    label: "Share with people, teams & groups",
+    source: { dataAdapter: createAudienceAdapter() },
+    mapEntity: (record) => mapRecordToOption(record as AudienceRecord),
+    value: [],
+    onChange: () => {},
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Bulk selector for arbitrary people or groups of people (teams, legal entities, workplaces, roles, permission groups). Selected entities render as chips inside the field; groups are selected atomically. Data arrives through a narrowed data adapter that is never called with an empty query.",
+      },
+    },
+  },
+} satisfies Meta<typeof F0AudienceSelector>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const SelectorDemo = ({
+  adapter,
+  ...props
+}: Partial<F0AudienceSelectorProps<AudienceRecord>> & {
+  adapter?:
+    | ReturnType<typeof createAudienceAdapter>
+    | ReturnType<typeof createInfiniteAudienceAdapter>
+}) => {
+  const [value, setValue] = useState<F0AudienceEntity[]>([])
+  const dataAdapter = adapter ?? DEFAULT_ADAPTER
+  const source = useMemo(() => ({ dataAdapter }), [dataAdapter])
+
+  return (
+    <div className="max-w-[560px]">
+      <F0AudienceSelector<AudienceRecord>
+        label="Share with people, teams & groups"
+        hideLabel
+        placeholder="Search people, teams & groups"
+        source={source}
+        mapEntity={mapRecordToOption}
+        value={value}
+        onChange={setValue}
+        {...props}
+      />
+    </div>
+  )
+}
+
+export const Default: Story = {
+  render: () => <SelectorDemo />,
+}
+
+export const WithSuggestions: Story = {
+  render: () => <SelectorDemo suggestions={suggestions} />,
+}
+
+const CURRENT_USER_ID = employees[1].id // Marie Curie
+const EXISTING_ACCESS = new Set([audienceEntityKey(employees[0])]) // Ada
+
+export const DisabledReasons: Story = {
+  render: () => (
+    <SelectorDemo
+      mapEntity={(record: AudienceRecord): F0AudienceOption => ({
+        entity: record.entity,
+        disabledReason:
+          record.entity.kind === "individual" &&
+          record.entity.id === CURRENT_USER_ID
+            ? "That's you"
+            : EXISTING_ACCESS.has(audienceEntityKey(record.entity))
+              ? "Already has access"
+              : undefined,
+      })}
+    />
+  ),
+}
+
+const RoleTrailingDropdown = () => {
+  const [role, setRole] = useState("Viewer")
+  return (
+    <Dropdown
+      items={["Owner", "Editor", "Viewer"].map((label) => ({
+        label,
+        onClick: () => setRole(label),
+      }))}
+    >
+      <F0Button
+        variant="ghost"
+        size="sm"
+        label={role}
+        icon={ChevronDown}
+        iconPosition="right"
+      />
+    </Dropdown>
+  )
+}
+
+export const WithTrailingRoleDropdown: Story = {
+  render: () => <SelectorDemo trailing={<RoleTrailingDropdown />} />,
+}
+
+const WarningDemo = () => {
+  const [value, setValue] = useState<F0AudienceEntity[]>([employees[2]])
+  const source = useMemo(() => ({ dataAdapter: createAudienceAdapter() }), [])
+  const outOfLine = value.filter(
+    (entity) => entity.kind === "individual" && entity.id === employees[2].id
+  )
+
+  return (
+    <div className="max-w-[560px]">
+      <F0AudienceSelector<AudienceRecord>
+        label="Share with people, teams & groups"
+        hideLabel
+        placeholder="Search people, teams & groups"
+        source={source}
+        mapEntity={mapRecordToOption}
+        value={value}
+        onChange={setValue}
+        warning={
+          outOfLine.length > 0
+            ? {
+                title: "Sharing outside your reporting line",
+                description: `${outOfLine[0].name} isn't in your reporting line. They'll be able to view this confidential policy.`,
+              }
+            : undefined
+        }
+      />
+    </div>
+  )
+}
+
+export const WithWarning: Story = {
+  render: () => <WarningDemo />,
+}
+
+export const LoadingAndEmptyStates: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <div>
+        <p className="mb-2 text-f1-foreground-secondary">
+          Slow adapter (1.5s latency)
+        </p>
+        <SelectorDemo adapter={SLOW_ADAPTER} />
+      </div>
+      <div>
+        <p className="mb-2 text-f1-foreground-secondary">
+          Adapter with no results
+        </p>
+        <SelectorDemo adapter={EMPTY_ADAPTER} />
+      </div>
+    </div>
+  ),
+}
+
+export const InfiniteScroll: Story = {
+  render: () => <SelectorDemo adapter={INFINITE_ADAPTER} />,
+}
+
+const InsideDialogDemo = () => {
+  const [isOpen, setIsOpen] = useState(true)
+  return (
+    <>
+      <F0Button label="Share this policy" onClick={() => setIsOpen(true)} />
+      <F0Dialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title="Share this policy"
+      >
+        <div className="flex flex-col gap-2 p-4">
+          <SelectorDemo suggestions={suggestions} />
+          <p className="text-f1-foreground-secondary">
+            Escape closes only the dropdown while it is open; a second Escape
+            closes the dialog.
+          </p>
+        </div>
+      </F0Dialog>
+    </>
+  )
+}
+
+export const InsideDialog: Story = {
+  render: () => <InsideDialogDemo />,
+}
+
+/**
+ * The full share-dialog composition the CIAM ShareModal builds from this kit:
+ * the selector (with a batch role dropdown and a Share button), the access
+ * list rows (expandable groups) and a general-access footer.
+ */
+const ShareDialogRecipeDemo = () => {
+  const [isOpen, setIsOpen] = useState(true)
+  const [selection, setSelection] = useState<F0AudienceEntity[]>([])
+  const [accessList, setAccessList] = useState<F0AudienceEntity[]>([
+    employees[1],
+    teams[0],
+    employees[0],
+  ])
+  const source = useMemo(() => ({ dataAdapter: createAudienceAdapter() }), [])
+  const accessKeys = new Set(accessList.map(audienceEntityKey))
+
+  return (
+    <>
+      <F0Button label="Share this policy" onClick={() => setIsOpen(true)} />
+      <F0Dialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title="Share this policy"
+      >
+        <div className="flex flex-col gap-2 p-4">
+          <div className="flex items-start gap-2">
+            <div className="min-w-0 flex-1">
+              <F0AudienceSelector<AudienceRecord>
+                label="Share with people, teams & groups"
+                hideLabel
+                placeholder="Search people, teams & groups"
+                source={source}
+                mapEntity={(record) => ({
+                  entity: record.entity,
+                  disabledReason: accessKeys.has(
+                    audienceEntityKey(record.entity)
+                  )
+                    ? "Already has access"
+                    : undefined,
+                })}
+                value={selection}
+                onChange={setSelection}
+                suggestions={suggestions}
+                trailing={<RoleTrailingDropdown />}
+              />
+            </div>
+            <F0Button
+              label="Share"
+              disabled={selection.length === 0}
+              onClick={() => {
+                setAccessList((current) => [...current, ...selection])
+                setSelection([])
+              }}
+            />
+          </div>
+          <div className="flex flex-col">
+            {accessList.map((entity, index) => (
+              <F0AudienceListItem
+                key={audienceEntityKey(entity)}
+                entity={entity}
+                isYou={index === 0}
+                right={
+                  index === 0 ? (
+                    <span className="font-medium text-f1-foreground">
+                      Owner
+                    </span>
+                  ) : (
+                    <RoleTrailingDropdown />
+                  )
+                }
+                members={
+                  entity.kind !== "individual"
+                    ? {
+                        fetch: () =>
+                          new Promise((resolve) =>
+                            setTimeout(
+                              () =>
+                                resolve([
+                                  {
+                                    id: "m1",
+                                    firstName: "Diego",
+                                    lastName: "Hernández",
+                                    subtitle: "Payroll Specialist",
+                                  },
+                                  {
+                                    id: "m2",
+                                    firstName: "Grace",
+                                    lastName: "Hopper",
+                                    subtitle: "Principal Engineer",
+                                  },
+                                ]),
+                              600
+                            )
+                          ),
+                        note: "New members in this group automatically gain access.",
+                      }
+                    : undefined
+                }
+              />
+            ))}
+          </div>
+          <div className="border-0 border-t border-solid border-f1-border-secondary pt-2">
+            <p className="text-sm font-medium text-f1-foreground-secondary">
+              General access
+            </p>
+            <F0AudienceListItem
+              entity={everyone}
+              right={<RoleTrailingDropdown />}
+            />
+          </div>
+        </div>
+      </F0Dialog>
+    </>
+  )
+}
+
+export const ShareDialogRecipe: Story = {
+  render: () => <ShareDialogRecipeDemo />,
+}
+
+/** Static variants consolidated for Chromatic visual-regression coverage. */
+export const Snapshot: Story = {
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex w-[560px] flex-col gap-4">
+      <F0AudienceSelector<AudienceRecord>
+        label="Empty"
+        hideLabel
+        placeholder="Search people, teams & groups"
+        source={{ dataAdapter: DEFAULT_ADAPTER }}
+        mapEntity={mapRecordToOption}
+        value={[]}
+        onChange={() => {}}
+      />
+      <F0AudienceSelector<AudienceRecord>
+        label="With chips"
+        hideLabel
+        source={{ dataAdapter: DEFAULT_ADAPTER }}
+        mapEntity={mapRecordToOption}
+        value={[employees[0], teams[0]]}
+        onChange={() => {}}
+      />
+      <F0AudienceSelector<AudienceRecord>
+        label="With warning"
+        hideLabel
+        source={{ dataAdapter: DEFAULT_ADAPTER }}
+        mapEntity={mapRecordToOption}
+        value={[employees[2]]}
+        onChange={() => {}}
+        warning={{
+          title: "Sharing outside your reporting line",
+          description: "Alan Turing isn't in your reporting line.",
+        }}
+      />
+    </div>
+  ),
+}

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/__stories__/mocks.ts
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/__stories__/mocks.ts
@@ -1,0 +1,211 @@
+import type {
+  BaseFetchOptions,
+  FiltersDefinition,
+  PaginatedFetchOptions,
+} from "@/hooks/datasource"
+
+import type { F0AudienceEntity, F0AudienceOption } from "../types"
+
+export type AudienceRecord = { entity: F0AudienceEntity }
+
+const individual = (
+  id: string,
+  firstName: string,
+  lastName: string,
+  subtitle: string
+): F0AudienceEntity => ({
+  kind: "individual",
+  id,
+  name: `${firstName} ${lastName}`,
+  firstName,
+  lastName,
+  subtitle,
+})
+
+export const employees: F0AudienceEntity[] = [
+  individual("emp-001", "Ada", "Lovelace", "VP of Engineering"),
+  individual("emp-002", "Marie", "Curie", "Head of People"),
+  individual("emp-003", "Alan", "Turing", "Staff Engineer"),
+  individual("emp-004", "Grace", "Hopper", "Principal Engineer"),
+  individual("emp-005", "Katherine", "Johnson", "Data Analyst"),
+  individual("emp-006", "Sofía", "Castillo", "People Partner"),
+  individual("emp-007", "Aarav", "Singh", "Product Manager"),
+  individual("emp-008", "Lin", "Chen", "Backend Engineer"),
+  individual("emp-009", "Diego", "Hernández", "Payroll Specialist"),
+  individual("emp-010", "Amara", "Okafor", "Product Designer"),
+  individual("emp-011", "Hellen", "Nguyen", "HR Admin"),
+  individual("emp-012", "Yusuf", "Karim", "Account Executive"),
+  individual("emp-013", "Elena", "Petrova", "Legal Counsel"),
+  individual("emp-014", "Tom", "Anderson", "Sales Manager"),
+  individual("emp-015", "Priya", "Sharma", "QA Engineer"),
+  individual("emp-016", "Jonas", "Weber", "Finance Manager"),
+  individual("emp-017", "Chloé", "Dubois", "Marketing Lead"),
+  individual("emp-018", "Marco", "Rossi", "Customer Success"),
+  individual("emp-019", "Fatima", "Al-Sayed", "Office Manager"),
+  individual("emp-020", "Leo", "Johansson", "IT Support"),
+]
+
+export const teams: F0AudienceEntity[] = [
+  { kind: "team", id: "team-payroll", name: "Payroll", memberCount: 3 },
+  {
+    kind: "team",
+    id: "team-people-ops",
+    name: "People Operations",
+    memberCount: 5,
+  },
+  { kind: "team", id: "team-platform", name: "Platform", memberCount: 8 },
+  { kind: "team", id: "team-design", name: "Design", memberCount: 4 },
+  { kind: "team", id: "team-sales", name: "Sales", memberCount: 6 },
+  { kind: "team", id: "team-finance", name: "Finance", memberCount: 3 },
+  { kind: "team", id: "team-marketing", name: "Marketing", memberCount: 4 },
+  { kind: "team", id: "team-support", name: "Support", memberCount: 5 },
+]
+
+export const legalEntities: F0AudienceEntity[] = [
+  {
+    kind: "legal_entity",
+    id: "le-es",
+    name: "Factorial S.L.",
+    memberCount: 14,
+  },
+  {
+    kind: "legal_entity",
+    id: "le-de",
+    name: "Factorial GmbH",
+    memberCount: 6,
+  },
+]
+
+export const workplaces: F0AudienceEntity[] = [
+  { kind: "workplace", id: "loc-bcn", name: "Barcelona", memberCount: 10 },
+  { kind: "workplace", id: "loc-mad", name: "Madrid", memberCount: 4 },
+  { kind: "workplace", id: "loc-ber", name: "Berlin", memberCount: 3 },
+  { kind: "workplace", id: "loc-remote", name: "Remote", memberCount: 3 },
+]
+
+export const permissionGroups: F0AudienceEntity[] = [
+  {
+    kind: "permission_group",
+    id: "pg-hr-admins",
+    name: "HR Admins",
+    memberCount: 2,
+  },
+  {
+    kind: "permission_group",
+    id: "pg-finance-admins",
+    name: "Finance Admins",
+    memberCount: 2,
+  },
+  {
+    kind: "permission_group",
+    id: "pg-people-leads",
+    name: "People Team Leads",
+    memberCount: 3,
+  },
+]
+
+export const everyone: F0AudienceEntity = {
+  kind: "everyone",
+  id: "everyone",
+  name: "Everyone at Factorial",
+  memberCount: 20,
+}
+
+export const directory: F0AudienceEntity[] = [
+  ...employees,
+  ...teams,
+  ...legalEntities,
+  ...workplaces,
+  ...permissionGroups,
+]
+
+const searchableText = (entity: F0AudienceEntity) =>
+  entity.kind === "individual" ? (entity.subtitle ?? "") : ""
+
+/**
+ * The ranking the real backend would own: name startsWith < name includes <
+ * subtitle includes, then alphabetical — all kinds interleaved in one list.
+ */
+export const searchDirectory = (query: string): AudienceRecord[] => {
+  const normalized = query.trim().toLowerCase()
+  const rank = (entity: F0AudienceEntity) => {
+    const name = entity.name.toLowerCase()
+    if (name.startsWith(normalized)) {
+      return 0
+    }
+    if (name.includes(normalized)) {
+      return 1
+    }
+    if (searchableText(entity).toLowerCase().includes(normalized)) {
+      return 2
+    }
+    return Infinity
+  }
+  return directory
+    .map((entity) => ({ entity, rank: rank(entity) }))
+    .filter(({ rank: value }) => value !== Infinity)
+    .sort(
+      (a, b) =>
+        a.rank - b.rank || a.entity.name.localeCompare(b.entity.name, "en")
+    )
+    .map(({ entity }) => ({ entity }))
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export const createAudienceAdapter = ({
+  latencyMs = 250,
+  maxResults = 12,
+  results,
+}: {
+  latencyMs?: number
+  maxResults?: number
+  /** Force a fixed result set (e.g. [] for the empty state) */
+  results?: AudienceRecord[]
+} = {}) =>
+  ({
+    fetchData: async ({ search }: BaseFetchOptions<FiltersDefinition>) => {
+      await delay(latencyMs)
+      return {
+        records: results ?? searchDirectory(search ?? "").slice(0, maxResults),
+      }
+    },
+  })
+
+export const createInfiniteAudienceAdapter = ({
+  latencyMs = 250,
+  perPage = 6,
+}: { latencyMs?: number; perPage?: number } = {}) => ({
+  paginationType: "infinite-scroll" as const,
+  perPage,
+  fetchData: async ({
+    search,
+    pagination,
+  }: PaginatedFetchOptions<FiltersDefinition>) => {
+    await delay(latencyMs)
+    const all = searchDirectory(search ?? "")
+    const offset = pagination.cursor ? parseInt(pagination.cursor, 10) : 0
+    const records = all.slice(offset, offset + perPage)
+    return {
+      records,
+      total: all.length,
+      perPage,
+      type: "infinite-scroll" as const,
+      cursor: String(offset + perPage),
+      hasMore: offset + perPage < all.length,
+    }
+  },
+})
+
+export const mapRecordToOption = (
+  record: AudienceRecord
+): F0AudienceOption => ({
+  entity: record.entity,
+})
+
+/** e.g. two direct reports and the team you lead, per the share-panel design */
+export const suggestions: F0AudienceOption[] = [
+  { entity: employees[2] },
+  { entity: employees[8] },
+  { entity: teams[0] },
+]

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/__tests__/F0AudienceSelector.test.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/__tests__/F0AudienceSelector.test.tsx
@@ -1,0 +1,587 @@
+import { userEvent } from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
+
+import { F0AudienceSelector } from "../index"
+import type {
+  F0AudienceEntity,
+  F0AudienceOption,
+  F0AudienceSelectorProps,
+} from "../types"
+
+type Rec = { entity: F0AudienceEntity }
+
+const individualEntity = (id: string, name: string): F0AudienceEntity => {
+  const [firstName, ...rest] = name.split(" ")
+  return { kind: "individual", id, name, firstName, lastName: rest.join(" ") }
+}
+
+const ada: F0AudienceEntity = {
+  kind: "individual",
+  id: "1",
+  name: "Ada Lovelace",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  subtitle: "VP of Engineering",
+}
+
+const alan: F0AudienceEntity = {
+  kind: "individual",
+  id: "2",
+  name: "Alan Turing",
+  firstName: "Alan",
+  lastName: "Turing",
+  subtitle: "Staff Engineer",
+}
+
+const payroll: F0AudienceEntity = {
+  kind: "team",
+  id: "1",
+  name: "Payroll",
+  memberCount: 3,
+}
+
+const staffRole: F0AudienceEntity = {
+  kind: "role",
+  id: "staff-engineer",
+  name: "Staff Engineer",
+  memberCount: 1,
+}
+
+const directory = [ada, alan, payroll, staffRole]
+
+const createAdapter = (records: F0AudienceEntity[] = directory) => {
+  const fetchData = vi.fn(({ search }: { search?: string }) => ({
+    records: records
+      .filter((entity) =>
+        entity.name.toLowerCase().includes((search ?? "").toLowerCase())
+      )
+      .map((entity) => ({ entity })),
+  }))
+  return { fetchData }
+}
+
+const identityMapper = (record: Rec): F0AudienceOption => ({
+  entity: record.entity,
+})
+
+const renderSelector = ({
+  adapter = createAdapter(),
+  onChange = vi.fn(),
+  ...props
+}: Partial<Omit<F0AudienceSelectorProps<Rec>, "source">> & {
+  adapter?: ReturnType<typeof createAdapter>
+} = {}) => {
+  const result = render(
+    <F0AudienceSelector<Rec>
+      label="Audience"
+      source={{ dataAdapter: adapter, search: { debounceTime: 0 } }}
+      mapEntity={identityMapper}
+      value={[]}
+      onChange={onChange}
+      {...props}
+    />
+  )
+  return { ...result, adapter, onChange }
+}
+
+const getInput = () => screen.getByRole("combobox")
+
+const searchFor = async (
+  user: ReturnType<typeof userEvent.setup>,
+  text: string
+) => {
+  await user.type(getInput(), text)
+  await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+}
+
+describe("F0AudienceSelector", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("renders chips for the selected entities, mixing kinds", () => {
+    renderSelector({ value: [ada, payroll] })
+
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument()
+    expect(screen.getByText("Payroll")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Remove Ada Lovelace" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Remove Payroll" })
+    ).toBeInTheDocument()
+  })
+
+  it("searches with the debounced query and renders name and subtitle", async () => {
+    const user = userEvent.setup()
+    const { adapter } = renderSelector()
+
+    await searchFor(user, "ada")
+
+    await waitFor(() =>
+      expect(screen.getByText("Ada Lovelace")).toBeInTheDocument()
+    )
+    expect(screen.getByText("VP of Engineering")).toBeInTheDocument()
+    expect(adapter.fetchData).toHaveBeenCalledWith(
+      expect.objectContaining({ search: "ada" })
+    )
+  })
+
+  it("localizes group subtitles with plural member counts", async () => {
+    const user = userEvent.setup()
+    renderSelector()
+
+    await searchFor(user, "payroll")
+    await waitFor(() =>
+      expect(screen.getByText("3 people · Team")).toBeInTheDocument()
+    )
+
+    await user.clear(getInput())
+    await searchFor(user, "staff")
+    await waitFor(() =>
+      expect(screen.getByText("1 person · Role")).toBeInTheDocument()
+    )
+  })
+
+  it("debounces the query so only the settled value hits the adapter", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const adapter = createAdapter()
+    render(
+      <F0AudienceSelector<Rec>
+        label="Debounced"
+        source={{ dataAdapter: adapter, search: { debounceTime: 300 } }}
+        mapEntity={identityMapper}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    )
+
+    await user.type(getInput(), "ada")
+    expect(adapter.fetchData).not.toHaveBeenCalledWith(
+      expect.objectContaining({ search: "a" })
+    )
+    vi.advanceTimersByTime(350)
+
+    await waitFor(() =>
+      expect(adapter.fetchData).toHaveBeenCalledWith(
+        expect.objectContaining({ search: "ada" })
+      )
+    )
+    const searched = adapter.fetchData.mock.calls
+      .map(([options]) => options.search)
+      .filter(Boolean)
+    expect(searched).toEqual(["ada"])
+  })
+
+  it("never calls the adapter with an empty query", async () => {
+    const user = userEvent.setup()
+    const { adapter } = renderSelector()
+
+    await user.click(getInput())
+    await user.type(getInput(), "ada")
+    await user.clear(getInput())
+    await waitFor(() => {
+      const searched = adapter.fetchData.mock.calls.map(
+        ([options]) => options.search
+      )
+      expect(searched.every((search) => (search ?? "").trim() !== "")).toBe(
+        true
+      )
+    })
+  })
+
+  it("never calls an explicit no-pagination adapter with an empty query", async () => {
+    const user = userEvent.setup()
+    // An adapter that opts into "no-pagination" is still gated on empty query
+    const fetchData = vi.fn(({ search }: { search?: string }) => ({
+      records: directory
+        .filter((entity) =>
+          entity.name.toLowerCase().includes((search ?? "").toLowerCase())
+        )
+        .map((entity) => ({ entity })),
+    }))
+    render(
+      <F0AudienceSelector<Rec>
+        label="Audience"
+        source={{
+          dataAdapter: { paginationType: "no-pagination", fetchData },
+          search: { debounceTime: 0 },
+        }}
+        mapEntity={identityMapper}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    )
+
+    await user.click(getInput())
+    await waitFor(() =>
+      expect(screen.getByText("Start typing to search")).toBeInTheDocument()
+    )
+    await user.type(getInput(), "ada")
+    await waitFor(() =>
+      expect(screen.getByText("Ada Lovelace")).toBeInTheDocument()
+    )
+    const searched = fetchData.mock.calls.map(([options]) => options.search)
+    expect(searched.every((search) => (search ?? "").trim() !== "")).toBe(true)
+  })
+
+  it("replaces the subtitle with disabledReason and blocks selection", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderSelector({
+      onChange,
+      mapEntity: (record: Rec) => ({
+        entity: record.entity,
+        disabledReason:
+          record.entity.id === alan.id ? "Already has access" : undefined,
+      }),
+    })
+
+    await searchFor(user, "alan")
+    await waitFor(() =>
+      expect(screen.getByText("Already has access")).toBeInTheDocument()
+    )
+    expect(screen.queryByText("Staff Engineer")).not.toBeInTheDocument()
+
+    const option = screen.getByRole("option", { name: /Alan Turing/ })
+    expect(option).toHaveAttribute("aria-disabled", "true")
+    await user.click(option)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("appends the entity on pick, keeps the dropdown open and clears the query", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderSelector({ onChange })
+
+    await searchFor(user, "ada")
+    await waitFor(() =>
+      expect(
+        screen.getByRole("option", { name: /Ada Lovelace/ })
+      ).toBeInTheDocument()
+    )
+    await user.click(screen.getByRole("option", { name: /Ada Lovelace/ }))
+
+    expect(onChange).toHaveBeenCalledWith([ada])
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+    expect(getInput()).toHaveValue("")
+  })
+
+  it("removes an already-selected entity when its option is clicked again", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderSelector({ value: [ada], onChange })
+
+    await searchFor(user, "ada")
+    const option = await screen.findByRole("option", { name: /Ada Lovelace/ })
+    expect(option).toHaveAttribute("aria-selected", "true")
+    await user.click(option)
+
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it("treats the same id under two kinds as independent selections", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    // ada and payroll share id "1" with different kinds
+    renderSelector({ value: [ada], onChange })
+
+    await searchFor(user, "payroll")
+    const option = await screen.findByRole("option", { name: /Payroll/ })
+    expect(option).toHaveAttribute("aria-selected", "false")
+    await user.click(option)
+
+    expect(onChange).toHaveBeenCalledWith([ada, payroll])
+  })
+
+  it("removes the last chip with Backspace only when the query is empty", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderSelector({ value: [ada, payroll], onChange })
+
+    await user.type(getInput(), "x{Backspace}")
+    expect(onChange).not.toHaveBeenCalled()
+
+    await user.clear(getInput())
+    await user.type(getInput(), "{Backspace}")
+    expect(onChange).toHaveBeenCalledWith([ada])
+  })
+
+  it("removes an entity from its chip close button", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderSelector({ value: [ada, payroll], onChange })
+
+    await user.click(screen.getByRole("button", { name: "Remove Payroll" }))
+    expect(onChange).toHaveBeenCalledWith([ada])
+  })
+
+  it("shows suggestions on focus without fetching", async () => {
+    const user = userEvent.setup()
+    const { adapter } = renderSelector({
+      suggestions: [{ entity: alan }, { entity: payroll }],
+    })
+
+    await user.click(getInput())
+    await waitFor(() =>
+      expect(
+        screen.getByRole("option", { name: /Alan Turing/ })
+      ).toBeInTheDocument()
+    )
+    expect(screen.getByRole("option", { name: /Payroll/ })).toBeInTheDocument()
+    // The consumer's adapter must never run for the empty (suggestions) query
+    expect(adapter.fetchData).not.toHaveBeenCalled()
+  })
+
+  it("shows the type-to-search and no-results empty states", async () => {
+    const user = userEvent.setup()
+    renderSelector()
+
+    await user.click(getInput())
+    await waitFor(() =>
+      expect(screen.getByText("Start typing to search")).toBeInTheDocument()
+    )
+
+    await user.type(getInput(), "zzzz")
+    await waitFor(() =>
+      expect(screen.getByText("No matches found")).toBeInTheDocument()
+    )
+  })
+
+  it("honors the searchEmptyMessage override", async () => {
+    const user = userEvent.setup()
+    renderSelector({ searchEmptyMessage: "Nobody here" })
+
+    await searchFor(user, "zzzz")
+    await waitFor(() =>
+      expect(screen.getByText("Nobody here")).toBeInTheDocument()
+    )
+  })
+
+  it("renders the trailing slot only while entities are selected", () => {
+    const { rerender, adapter } = renderSelector({
+      trailing: <span>Role dropdown</span>,
+    })
+    expect(screen.queryByText("Role dropdown")).not.toBeInTheDocument()
+
+    rerender(
+      <F0AudienceSelector<Rec>
+        label="Audience"
+        source={{ dataAdapter: adapter, search: { debounceTime: 0 } }}
+        mapEntity={identityMapper}
+        value={[ada]}
+        onChange={vi.fn()}
+        trailing={<span>Role dropdown</span>}
+      />
+    )
+    expect(screen.getByText("Role dropdown")).toBeInTheDocument()
+  })
+
+  it("hides the warning while the dropdown is open", async () => {
+    const user = userEvent.setup()
+    renderSelector({
+      value: [alan],
+      warning: {
+        title: "Sharing outside your reporting line",
+        description: "Alan Turing isn't in your reporting line.",
+      },
+    })
+
+    expect(
+      screen.getByText("Sharing outside your reporting line")
+    ).toBeInTheDocument()
+
+    await user.click(getInput())
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Sharing outside your reporting line")
+      ).not.toBeInTheDocument()
+    )
+  })
+
+  it("closes only the dropdown on Escape and propagates once closed", async () => {
+    const user = userEvent.setup()
+    const outerKeyDown = vi.fn()
+    render(
+      <div onKeyDown={outerKeyDown}>
+        <F0AudienceSelector<Rec>
+          label="Audience"
+          source={{
+            dataAdapter: createAdapter(),
+            search: { debounceTime: 0 },
+          }}
+          mapEntity={identityMapper}
+          value={[]}
+          onChange={vi.fn()}
+        />
+      </div>
+    )
+
+    await user.click(getInput())
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+
+    await user.keyboard("{Escape}")
+    await waitFor(() =>
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    )
+    expect(
+      outerKeyDown.mock.calls.filter(([event]) => event.key === "Escape")
+    ).toHaveLength(0)
+
+    await user.keyboard("{Escape}")
+    expect(
+      outerKeyDown.mock.calls.filter(([event]) => event.key === "Escape")
+    ).toHaveLength(1)
+  })
+
+  it("moves aria-activedescendant with the arrow keys skipping disabled options and toggles with Enter", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderSelector({
+      onChange,
+      mapEntity: (record: Rec) => ({
+        entity: record.entity,
+        disabledReason:
+          record.entity.kind === "individual" && record.entity.id === ada.id
+            ? "That's you"
+            : undefined,
+      }),
+    })
+
+    // "a" matches Ada (disabled), Alan, Payroll and Staff Engineer
+    await searchFor(user, "a")
+    const alanOption = await screen.findByRole("option", {
+      name: /Alan Turing/,
+    })
+
+    // First enabled option is active by default (Ada is disabled)
+    await waitFor(() =>
+      expect(getInput()).toHaveAttribute("aria-activedescendant", alanOption.id)
+    )
+
+    await user.keyboard("{ArrowDown}")
+    const payrollOption = screen.getByRole("option", { name: /Payroll/ })
+    expect(getInput()).toHaveAttribute(
+      "aria-activedescendant",
+      payrollOption.id
+    )
+
+    await user.keyboard("{ArrowUp}")
+    expect(getInput()).toHaveAttribute("aria-activedescendant", alanOption.id)
+
+    await user.keyboard("{Enter}")
+    expect(onChange).toHaveBeenCalledWith([alan])
+  })
+
+  it("clears the chips when the controlled value is emptied", () => {
+    const { rerender, adapter } = renderSelector({ value: [ada] })
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument()
+
+    rerender(
+      <F0AudienceSelector<Rec>
+        label="Audience"
+        source={{ dataAdapter: adapter, search: { debounceTime: 0 } }}
+        mapEntity={identityMapper}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    )
+    expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument()
+  })
+
+  it("passes dataTestId through", () => {
+    renderSelector({ dataTestId: "audience-selector" })
+    expect(screen.getByTestId("audience-selector")).toBeInTheDocument()
+  })
+
+  it("paginates an infinite-scroll adapter: gates empty query and appends pages on loadMore", async () => {
+    // Capture the IntersectionObserver callback so we can drive the sentinel
+    // (JSDOM has no real IntersectionObserver)
+    let intersect: (() => void) | null = null
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor(cb: (entries: { isIntersecting: boolean }[]) => void) {
+          intersect = () => cb([{ isIntersecting: true }])
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords() {
+          return []
+        }
+      }
+    )
+
+    const perPage = 3
+    const all = Array.from({ length: 7 }, (_, i) =>
+      individualEntity(`p${i}`, `Page Person ${i}`)
+    )
+    const fetchData = vi.fn(
+      ({
+        search,
+        pagination,
+      }: {
+        search?: string
+        pagination: { cursor?: string | null }
+      }) => {
+        const offset = pagination.cursor ? parseInt(pagination.cursor, 10) : 0
+        const matched = all.filter((e) =>
+          e.name.toLowerCase().includes((search ?? "").toLowerCase())
+        )
+        const records = matched
+          .slice(offset, offset + perPage)
+          .map((entity) => ({ entity }))
+        return {
+          records,
+          total: matched.length,
+          perPage,
+          type: "infinite-scroll" as const,
+          cursor: String(offset + perPage),
+          hasMore: offset + perPage < matched.length,
+        }
+      }
+    )
+
+    const user = userEvent.setup()
+    render(
+      <F0AudienceSelector<Rec>
+        label="Audience"
+        source={{
+          dataAdapter: {
+            paginationType: "infinite-scroll",
+            perPage,
+            fetchData,
+          },
+          search: { debounceTime: 0 },
+        }}
+        mapEntity={identityMapper}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    )
+
+    // Empty query never reaches the consumer adapter
+    await user.click(getInput())
+    await waitFor(() =>
+      expect(screen.getByText("Start typing to search")).toBeInTheDocument()
+    )
+    expect(fetchData).not.toHaveBeenCalled()
+
+    // First page renders perPage options
+    await user.type(getInput(), "page")
+    await waitFor(() =>
+      expect(screen.getAllByRole("option")).toHaveLength(perPage)
+    )
+
+    // Driving the sentinel loads and appends the next page
+    await waitFor(() => expect(intersect).not.toBeNull())
+    intersect!()
+    await waitFor(() =>
+      expect(screen.getAllByRole("option").length).toBeGreaterThan(perPage)
+    )
+  })
+})

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceAvatar.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceAvatar.tsx
@@ -1,0 +1,43 @@
+import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
+import { Briefcase, Globe, Marker, Shield } from "@/icons/app"
+
+import type { F0AudienceEntity } from "../types"
+
+/**
+ * Single source of audience-kind iconography. Individuals, teams and legal
+ * entities use their semantic avatars; the remaining group kinds render as
+ * icon tiles.
+ */
+export const getAudienceEntityAvatar = (
+  entity: F0AudienceEntity
+): AvatarVariant => {
+  switch (entity.kind) {
+    case "individual":
+      return {
+        type: "person",
+        firstName: entity.firstName,
+        lastName: entity.lastName,
+        src: entity.src,
+      }
+    case "team":
+      return { type: "team", name: entity.name }
+    case "legal_entity":
+      return { type: "company", name: entity.name }
+    case "workplace":
+      return { type: "icon", icon: Marker }
+    case "role":
+      return { type: "icon", icon: Briefcase }
+    case "permission_group":
+      return { type: "icon", icon: Shield }
+    case "everyone":
+      return { type: "icon", icon: Globe }
+  }
+}
+
+export const AudienceAvatar = ({
+  entity,
+  size,
+}: {
+  entity: F0AudienceEntity
+  size?: "xs" | "sm" | "md"
+}) => <F0Avatar avatar={getAudienceEntityAvatar(entity)} size={size} />

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceChip.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceChip.tsx
@@ -1,0 +1,24 @@
+import { Chip } from "@/components/OneChip"
+import { useI18n } from "@/lib/providers/i18n"
+
+import type { F0AudienceEntity } from "../types"
+import { getAudienceEntityAvatar } from "./AudienceAvatar"
+
+export const AudienceChip = ({
+  entity,
+  onRemove,
+}: {
+  entity: F0AudienceEntity
+  onRemove: (entity: F0AudienceEntity) => void
+}) => {
+  const { t } = useI18n()
+
+  return (
+    <Chip
+      label={entity.name}
+      avatar={getAudienceEntityAvatar(entity)}
+      onClose={() => onRemove(entity)}
+      closeLabel={t("audience.selector.removeItem", { name: entity.name })}
+    />
+  )
+}

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceDropdown.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceDropdown.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from "react"
+
+import { useI18n } from "@/lib/providers/i18n"
+import { PopoverContent } from "@/ui/popover"
+
+import type { AudienceOptionItem } from "../internal-types"
+import { AudienceOptionRow } from "./AudienceOptionRow"
+
+type AudienceDropdownProps = {
+  listboxId: string
+  label: string
+  items: AudienceOptionItem[]
+  activeKey: string | null
+  isLoading: boolean
+  isLoadingMore: boolean
+  hasMore: boolean
+  loadMore: () => void
+  emptyMessage: string
+  onToggle: (item: AudienceOptionItem) => void
+  onActivate: (item: AudienceOptionItem) => void
+  onInteractOutside: React.ComponentProps<
+    typeof PopoverContent
+  >["onInteractOutside"]
+}
+
+export const AudienceDropdown = ({
+  listboxId,
+  label,
+  items,
+  activeKey,
+  isLoading,
+  isLoadingMore,
+  hasMore,
+  loadMore,
+  emptyMessage,
+  onToggle,
+  onActivate,
+  onInteractOutside,
+}: AudienceDropdownProps) => {
+  const i18n = useI18n()
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel || !hasMore) {
+      return
+    }
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting) && !isLoadingMore) {
+        loadMore()
+      }
+    })
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [hasMore, isLoadingMore, loadMore])
+
+  const showEmptyState = !isLoading && items.length === 0
+
+  return (
+    <PopoverContent
+      align="start"
+      sideOffset={4}
+      className="max-h-80 w-[var(--radix-popover-trigger-width)] rounded-lg p-1 shadow-lg"
+      // The input keeps focus: this is a combobox, not a menu
+      onOpenAutoFocus={(event) => event.preventDefault()}
+      onInteractOutside={onInteractOutside}
+    >
+      {/* Status messages live outside the listbox (which must contain only
+          options) and in a live region so state changes are announced. */}
+      <div role="status" aria-live="polite">
+        {isLoading && items.length === 0 && (
+          <div className="flex justify-center px-2 py-6 text-f1-foreground-secondary">
+            {i18n.audience.selector.loading}
+          </div>
+        )}
+        {showEmptyState && (
+          <div className="flex justify-center px-2 py-6 text-f1-foreground-secondary">
+            {emptyMessage}
+          </div>
+        )}
+      </div>
+      <div id={listboxId} role="listbox" aria-label={label}>
+        {items.map((item) => (
+          <AudienceOptionRow
+            key={item.key}
+            item={item}
+            active={item.key === activeKey}
+            onToggle={onToggle}
+            onActivate={onActivate}
+          />
+        ))}
+      </div>
+      {hasMore && (
+        <div
+          ref={sentinelRef}
+          className="flex justify-center px-2 py-2 text-f1-foreground-secondary"
+        >
+          {isLoadingMore ? i18n.audience.selector.loading : null}
+        </div>
+      )}
+    </PopoverContent>
+  )
+}

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceDropdown.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceDropdown.tsx
@@ -79,7 +79,12 @@ export const AudienceDropdown = ({
           </div>
         )}
       </div>
-      <div id={listboxId} role="listbox" aria-label={label}>
+      <div
+        id={listboxId}
+        role="listbox"
+        aria-label={label}
+        aria-multiselectable="true"
+      >
         {items.map((item) => (
           <AudienceOptionRow
             key={item.key}

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceField.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceField.tsx
@@ -1,0 +1,52 @@
+import { forwardRef, useImperativeHandle, useRef } from "react"
+
+import { cn } from "@/lib/utils"
+
+import { audienceEntityKey, type F0AudienceEntity } from "../types"
+import { AudienceChip } from "./AudienceChip"
+
+/**
+ * The element F0InputField clones as its child: selected entities as chips
+ * plus the inline combobox input. Input-specific props (value, onChange,
+ * aria-*, id, role, disabled) are injected by F0InputField and forwarded to
+ * the real `<input>`; the injected className carries the field padding and is
+ * applied to the wrapper so chips sit inside the padded area.
+ */
+type AudienceFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  entities: F0AudienceEntity[]
+  onRemoveEntity: (entity: F0AudienceEntity) => void
+}
+
+export const AudienceField = forwardRef<HTMLInputElement, AudienceFieldProps>(
+  ({ entities, onRemoveEntity, className, ...inputProps }, forwardedRef) => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    useImperativeHandle(forwardedRef, () => inputRef.current!)
+
+    return (
+      <div
+        className={cn(
+          className,
+          "flex h-auto w-full min-w-0 flex-wrap items-center gap-1 py-1"
+        )}
+        onClick={() => inputRef.current?.focus()}
+      >
+        {entities.map((entity) => (
+          <AudienceChip
+            key={audienceEntityKey(entity)}
+            entity={entity}
+            onRemove={onRemoveEntity}
+          />
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          autoComplete="off"
+          {...inputProps}
+          className="h-7 min-w-20 flex-1 border-none bg-transparent text-f1-foreground outline-none"
+        />
+      </div>
+    )
+  }
+)
+
+AudienceField.displayName = "AudienceField"

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceOptionRow.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/components/AudienceOptionRow.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from "react"
+
+import { cn } from "@/lib/utils"
+import { Checkbox } from "@/ui/checkbox"
+
+import { useAudienceEntitySubtitle } from "../hooks/useAudienceEntitySubtitle"
+import type { AudienceOptionItem } from "../internal-types"
+import { AudienceAvatar } from "./AudienceAvatar"
+
+export const AudienceOptionRow = ({
+  item,
+  active,
+  onToggle,
+  onActivate,
+}: {
+  item: AudienceOptionItem
+  active: boolean
+  onToggle: (item: AudienceOptionItem) => void
+  onActivate: (item: AudienceOptionItem) => void
+}) => {
+  const getSubtitle = useAudienceEntitySubtitle()
+  const rowRef = useRef<HTMLDivElement>(null)
+  const { entity } = item.option
+
+  // Keep the keyboard-active option visible when arrow-navigating a
+  // scrollable dropdown
+  useEffect(() => {
+    if (active) {
+      rowRef.current?.scrollIntoView({ block: "nearest" })
+    }
+  }, [active])
+  const subtitle = item.option.disabledReason ?? getSubtitle(entity)
+
+  return (
+    <div
+      ref={rowRef}
+      id={item.domId}
+      role="option"
+      aria-selected={item.selected}
+      aria-disabled={item.disabled || undefined}
+      className={cn(
+        "flex items-center gap-2 rounded px-2 py-1.5 transition-colors",
+        item.disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+        active && !item.disabled && "bg-f1-background-hover"
+      )}
+      // Keep focus in the combobox input while picking
+      onPointerDown={(event) => event.preventDefault()}
+      onPointerMove={() => onActivate(item)}
+      onClick={() => {
+        if (!item.disabled) {
+          onToggle(item)
+        }
+      }}
+    >
+      <AudienceAvatar entity={entity} size="sm" />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate font-medium text-f1-foreground">
+          {entity.name}
+        </span>
+        {subtitle && (
+          <span className="truncate text-sm text-f1-foreground-secondary">
+            {subtitle}
+          </span>
+        )}
+      </div>
+      <span aria-hidden="true" className="pointer-events-none">
+        <Checkbox
+          checked={item.selected}
+          disabled={item.disabled}
+          tabIndex={-1}
+        />
+      </span>
+    </div>
+  )
+}

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/hooks/useAudienceEntitySubtitle.ts
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/hooks/useAudienceEntitySubtitle.ts
@@ -1,0 +1,42 @@
+import { useI18n } from "@/lib/providers/i18n"
+
+import type { AudienceGroupKind, F0AudienceEntity } from "../types"
+
+const kindTranslationKey = {
+  team: "team",
+  legal_entity: "legalEntity",
+  workplace: "workplace",
+  role: "role",
+  permission_group: "permissionGroup",
+  everyone: "everyone",
+} as const satisfies Record<AudienceGroupKind, string>
+
+/**
+ * Individuals show their consumer-provided subtitle (e.g. job title); group
+ * kinds show the localized "{{count}} people · {{kind}}" line owned by f0.
+ *
+ * Returned inline (no useCallback): `t` from the i18n provider is a fresh
+ * closure each render, so memoization would never hold, and the result is
+ * only used during render — not as an effect dependency.
+ */
+export const useAudienceEntitySubtitle = () => {
+  const { t, ...i18n } = useI18n()
+
+  return (entity: F0AudienceEntity): string | undefined => {
+    if (entity.kind === "individual") {
+      return entity.subtitle
+    }
+    const kindLabel =
+      i18n.audience.selector.kind[kindTranslationKey[entity.kind]]
+    if (entity.memberCount === undefined) {
+      return kindLabel
+    }
+    const countLabel = t(
+      entity.memberCount === 1
+        ? "audience.selector.memberCount.one"
+        : "audience.selector.memberCount.other",
+      { count: entity.memberCount }
+    )
+    return `${countLabel} · ${kindLabel}`
+  }
+}

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/hooks/useAudienceSearch.ts
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/hooks/useAudienceSearch.ts
@@ -1,0 +1,168 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useDebounceCallback } from "usehooks-ts"
+
+import {
+  getDataSourcePaginationType,
+  useData,
+  useDataSource,
+  type BaseDataAdapter,
+  type BaseFetchOptions,
+  type DataAdapter,
+  type FiltersDefinition,
+  type PaginatedDataAdapter,
+  type PaginatedFetchOptions,
+  type RecordType,
+} from "@/hooks/datasource"
+
+import type { AudienceOptionItem } from "../internal-types"
+import {
+  audienceEntityKey,
+  type F0AudienceOption,
+  type F0AudienceSelectorSource,
+} from "../types"
+
+const DEFAULT_DEBOUNCE_MS = 300
+
+/**
+ * Narrows the consumer's data adapter into the selector's search engine:
+ * debounced query, loading states and infinite-scroll come from the standard
+ * datasource hooks; an empty query never reaches the consumer's `fetchData`
+ * (the `suggestions` prop owns that state).
+ */
+export function useAudienceSearch<R extends RecordType>({
+  source,
+  mapEntity,
+  listboxId,
+  selectedKeys,
+}: {
+  source: F0AudienceSelectorSource<R>
+  mapEntity: (item: R) => F0AudienceOption
+  listboxId: string
+  selectedKeys: ReadonlySet<string>
+}) {
+  const paginationType = getDataSourcePaginationType(source.dataAdapter)
+  if (paginationType === "pages") {
+    throw new Error(
+      "F0AudienceSelector only supports `infinite-scroll` or `no-pagination` data adapters"
+    )
+  }
+
+  const gatedAdapter = useMemo<DataAdapter<R, FiltersDefinition>>(() => {
+    const adapter = source.dataAdapter
+    // Wrap the consumer's adapter so an empty query short-circuits to an empty
+    // result of the adapter's own pagination shape — the consumer's fetchData
+    // is never called without a query.
+    if (adapter.paginationType === "infinite-scroll") {
+      const paginated = adapter as PaginatedDataAdapter<R, FiltersDefinition>
+      return {
+        ...paginated,
+        fetchData: (options: PaginatedFetchOptions<FiltersDefinition>) =>
+          options.search?.trim()
+            ? paginated.fetchData(options)
+            : {
+                records: [],
+                total: 0,
+                perPage: paginated.perPage ?? 0,
+                type: "infinite-scroll" as const,
+                cursor: null,
+                hasMore: false,
+              },
+      }
+    }
+    // Base (and explicit "no-pagination") adapters both fetch with
+    // BaseFetchOptions and return a plain record list.
+    const base = adapter as BaseDataAdapter<
+      R,
+      FiltersDefinition,
+      BaseFetchOptions<FiltersDefinition>
+    >
+    return {
+      ...base,
+      fetchData: (options: BaseFetchOptions<FiltersDefinition>) =>
+        options.search?.trim() ? base.fetchData(options) : { records: [] },
+    }
+  }, [source.dataAdapter])
+
+  const localSource = useDataSource<R>(
+    {
+      dataAdapter: gatedAdapter,
+      search: { enabled: true, sync: true },
+    },
+    [gatedAdapter]
+  )
+  const { setCurrentSearch, currentSearch } = localSource
+
+  const { data, isLoading, isLoadingMore, loadMore, paginationInfo } =
+    useData<R>(localSource)
+
+  const [query, setQueryState] = useState("")
+
+  const debouncedSetSearch = useDebounceCallback(
+    setCurrentSearch,
+    source.search?.debounceTime ?? DEFAULT_DEBOUNCE_MS
+  )
+
+  // Cancel pending trailing-edge timers on true unmount only (see the same
+  // workaround in F0Select: usehooks-ts' internal unmount cleanup cancels a
+  // different debounce instance than the one callers invoke).
+  const debouncedSetSearchRef = useRef(debouncedSetSearch)
+  debouncedSetSearchRef.current = debouncedSetSearch
+  useEffect(() => {
+    return () => {
+      debouncedSetSearchRef.current.cancel()
+    }
+  }, [])
+
+  const setQuery = (value: string) => {
+    setQueryState(value)
+    if (value.trim()) {
+      debouncedSetSearch(value)
+    } else {
+      // Clearing must be instant so suggestions reappear without lag
+      debouncedSetSearch.cancel()
+      setCurrentSearch(undefined)
+    }
+  }
+
+  const options = useMemo<AudienceOptionItem[]>(() => {
+    const seen = new Set<string>()
+    const items: AudienceOptionItem[] = []
+    data.records.forEach((record) => {
+      const option = mapEntity(record)
+      const key = audienceEntityKey(option.entity)
+      // Adapters merging several backend queries may repeat an entity
+      if (seen.has(key)) {
+        return
+      }
+      seen.add(key)
+      items.push({
+        option,
+        key,
+        domId: `${listboxId}-option-${items.length}`,
+        selected: selectedKeys.has(key),
+        disabled: !!option.disabledReason,
+      })
+    })
+    return items
+  }, [data.records, mapEntity, listboxId, selectedKeys])
+
+  const isSearching = query.trim().length > 0
+  // While the debounce is pending the fetched records belong to a previous
+  // query — surface that gap as loading instead of flashing stale results.
+  const isDebouncing =
+    isSearching && query.trim() !== (currentSearch ?? "").trim()
+
+  const hasMore =
+    paginationInfo?.type === "infinite-scroll" ? paginationInfo.hasMore : false
+
+  return {
+    query,
+    setQuery,
+    isSearching,
+    options,
+    isLoading: isLoading || isDebouncing,
+    isLoadingMore,
+    loadMore,
+    hasMore,
+  }
+}

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/index.tsx
@@ -4,6 +4,12 @@ import { F0AudienceSelector as F0AudienceSelectorComponent } from "./F0AudienceS
 
 export * from "./types"
 
+// Shared audience primitives, consumed by sibling audience components (e.g.
+// F0AudienceListItem) through this public barrel rather than by reaching into
+// the selector's private component/hook folders.
+export { AudienceAvatar } from "./components/AudienceAvatar"
+export { useAudienceEntitySubtitle } from "./hooks/useAudienceEntitySubtitle"
+
 /**
  * @experimental This is an experimental component use it at your own risk
  */

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/index.tsx
@@ -1,0 +1,13 @@
+import { experimentalComponent } from "@/lib/experimental"
+
+import { F0AudienceSelector as F0AudienceSelectorComponent } from "./F0AudienceSelector"
+
+export * from "./types"
+
+/**
+ * @experimental This is an experimental component use it at your own risk
+ */
+export const F0AudienceSelector = experimentalComponent(
+  "F0AudienceSelector",
+  F0AudienceSelectorComponent
+)

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/internal-types.ts
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/internal-types.ts
@@ -1,0 +1,13 @@
+import type { F0AudienceOption } from "./types"
+
+/**
+ * A dropdown option enriched with everything the listbox needs to render it:
+ * composite identity, DOM id for aria-activedescendant and selection state.
+ */
+export type AudienceOptionItem = {
+  option: F0AudienceOption
+  key: string
+  domId: string
+  selected: boolean
+  disabled: boolean
+}

--- a/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/types.ts
+++ b/packages/react/src/experimental/Forms/Fields/F0AudienceSelector/types.ts
@@ -1,0 +1,129 @@
+import type { InputFieldProps } from "@/components/F0InputField"
+import type {
+  DataAdapter,
+  FiltersDefinition,
+  RecordType,
+} from "@/hooks/datasource"
+import type { WithDataTestIdProps } from "@/lib/data-testid"
+
+/**
+ * The kinds of entities an audience can be built from: a person or an atomic
+ * group of people. Group kinds mirror the Sharing v2 grantee vocabulary of the
+ * Resource Registry so selections map losslessly onto share grantees.
+ */
+export const audienceEntityKinds = [
+  "individual",
+  "team",
+  "legal_entity",
+  "workplace",
+  "role",
+  "permission_group",
+  "everyone",
+] as const
+
+export type AudienceEntityKind = (typeof audienceEntityKinds)[number]
+
+export type AudienceGroupKind = Exclude<AudienceEntityKind, "individual">
+
+export type F0AudienceIndividual = {
+  kind: "individual"
+  id: string
+  name: string
+  firstName: string
+  lastName: string
+  /** Avatar image url */
+  src?: string
+  /** Secondary line in the option row, e.g. the job title */
+  subtitle?: string
+}
+
+export type F0AudienceGroup = {
+  kind: AudienceGroupKind
+  id: string
+  name: string
+  /** When provided, renders the localized "{{count}} people · {{kind}}" subtitle */
+  memberCount?: number
+}
+
+/**
+ * An atomic selectable entity: a person or a group of people. Identity is
+ * COMPOSITE (kind + id) — ids may collide across kinds. Groups are selected
+ * atomically (a team chip), never expanded into their members.
+ */
+export type F0AudienceEntity = F0AudienceIndividual | F0AudienceGroup
+
+export type F0AudienceOption = {
+  entity: F0AudienceEntity
+  /**
+   * When set, the option renders disabled (not selectable) and this text
+   * REPLACES the subtitle — e.g. "Already has access", "That's you".
+   * The copy is domain knowledge, so it is always consumer-provided.
+   */
+  disabledReason?: string
+}
+
+/** Composite selection key, exported for consumer-side dedupe and lookups */
+export const audienceEntityKey = (
+  entity: Pick<F0AudienceEntity, "kind" | "id">
+): string => `${entity.kind}:${entity.id}`
+
+/**
+ * Narrowed datasource contract: async fetching plus search behavior only.
+ * `fetchData` receives the DEBOUNCED query in `options.search` and must return
+ * ONE flat list with all kinds interleaved — ranking is owned by the
+ * consumer/backend, the component renders records in the given order.
+ * It is never called with an empty query (the `suggestions` prop covers that
+ * state). Pagination: `infinite-scroll` or `no-pagination` only.
+ */
+export type F0AudienceSelectorSource<R extends RecordType = RecordType> = {
+  dataAdapter: DataAdapter<R, FiltersDefinition>
+  search?: {
+    /** Debounce applied to the query before fetching @default 300 */
+    debounceTime?: number
+  }
+}
+
+export type F0AudienceSelectorProps<R extends RecordType = RecordType> = {
+  source: F0AudienceSelectorSource<R>
+  /** Maps a fetched record to the entity contract (mirrors F0Select's `mapOptions`) */
+  mapEntity: (item: R) => F0AudienceOption
+
+  /**
+   * Selected entities, rendered as removable chips inside the field in
+   * insertion order (controlled). Entities are self-contained so chips can
+   * survive query clearing without any id lookup.
+   */
+  value: F0AudienceEntity[]
+  onChange: (value: F0AudienceEntity[]) => void
+
+  /**
+   * Shown while the query is empty (e.g. direct reports and their team).
+   * Without suggestions, an empty query renders the "Start typing to search"
+   * empty state — the data adapter is never called with an empty query.
+   */
+  suggestions?: F0AudienceOption[]
+
+  /**
+   * Rendered right-aligned inside the field, only while at least one entity
+   * is selected — intended for a batch role dropdown. A slot rather than a
+   * curated prop: role semantics belong to the consumer.
+   */
+  trailing?: React.ReactNode
+
+  /**
+   * Warning alert below the field, hidden while the dropdown is open — e.g.
+   * "Sharing outside your reporting line". The computation is consumer-side.
+   */
+  warning?: {
+    title: string
+    description?: string
+  }
+
+  onOpenChange?: (open: boolean) => void
+  /** Overrides the localized "No matches found" empty state */
+  searchEmptyMessage?: string
+} & Pick<
+  InputFieldProps<string>,
+  "label" | "hideLabel" | "placeholder" | "disabled" | "loading" | "error"
+> &
+  WithDataTestIdProps

--- a/packages/react/src/experimental/Forms/Fields/exports.ts
+++ b/packages/react/src/experimental/Forms/Fields/exports.ts
@@ -1,5 +1,6 @@
 export { F0Select as Select } from "../../../components/F0Select"
 export * from "../../../components/F0Select/types"
+export * from "./F0AudienceSelector"
 export * from "./F1SearchBox"
 export * from "./Input"
 export * from "./NumberInput"

--- a/packages/react/src/experimental/Lists/F0AudienceListItem/F0AudienceListItem.tsx
+++ b/packages/react/src/experimental/Lists/F0AudienceListItem/F0AudienceListItem.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { F0Icon } from "@/components/F0Icon"
-import { AudienceAvatar } from "@/experimental/Forms/Fields/F0AudienceSelector/components/AudienceAvatar"
-import { useAudienceEntitySubtitle } from "@/experimental/Forms/Fields/F0AudienceSelector/hooks/useAudienceEntitySubtitle"
+import {
+  AudienceAvatar,
+  useAudienceEntitySubtitle,
+} from "@/experimental/Forms/Fields/F0AudienceSelector"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { ChevronDown, ChevronUp, Warning } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"

--- a/packages/react/src/experimental/Lists/F0AudienceListItem/F0AudienceListItem.tsx
+++ b/packages/react/src/experimental/Lists/F0AudienceListItem/F0AudienceListItem.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { F0Icon } from "@/components/F0Icon"
+import { AudienceAvatar } from "@/experimental/Forms/Fields/F0AudienceSelector/components/AudienceAvatar"
+import { useAudienceEntitySubtitle } from "@/experimental/Forms/Fields/F0AudienceSelector/hooks/useAudienceEntitySubtitle"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { ChevronDown, ChevronUp, Warning } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn, focusRing } from "@/lib/utils"
+
+import { MemberList, type MemberListStatus } from "./components/MemberList"
+import type { F0AudienceListItemProps, F0AudienceMember } from "./types"
+
+export const F0AudienceListItem = ({
+  entity,
+  isYou = false,
+  warning,
+  right,
+  members,
+  expanded,
+  onExpandedChange,
+}: F0AudienceListItemProps) => {
+  const i18n = useI18n()
+  const getSubtitle = useAudienceEntitySubtitle()
+
+  const expandable = !!members && entity.kind !== "individual"
+
+  const [internalExpanded, setInternalExpanded] = useState(false)
+  const isExpanded = expandable && (expanded ?? internalExpanded)
+
+  const [memberList, setMemberList] = useState<{
+    status: MemberListStatus
+    members: F0AudienceMember[]
+  } | null>(null)
+  const fetchStartedRef = useRef(false)
+
+  const setExpanded = (next: boolean) => {
+    if (expanded === undefined) {
+      setInternalExpanded(next)
+    }
+    onExpandedChange?.(next)
+  }
+
+  const loadMembers = useCallback(() => {
+    if (!members) {
+      return
+    }
+    fetchStartedRef.current = true
+    setMemberList({ status: "loading", members: [] })
+    members.fetch().then(
+      (result) => setMemberList({ status: "loaded", members: result }),
+      // Surface the failure with a retry affordance instead of a blank body
+      () => setMemberList({ status: "error", members: [] })
+    )
+  }, [members])
+
+  // Fetch on first expand regardless of whether it came from the internal
+  // toggle or the controlled `expanded` prop; cache for the row's lifetime.
+  // `fetchStartedRef` makes this a no-op on re-renders (a group's members prop
+  // may be a fresh object identity each render), so it fires exactly once.
+  useEffect(() => {
+    if (!isExpanded || fetchStartedRef.current) {
+      return
+    }
+    loadMembers()
+  }, [isExpanded, loadMembers])
+
+  const subtitle = getSubtitle(entity)
+  const name = isYou
+    ? `${entity.name} ${i18n.audience.listItem.you}`
+    : entity.name
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 py-2">
+        {expandable ? (
+          <button
+            type="button"
+            aria-expanded={isExpanded}
+            aria-label={i18n.t(
+              isExpanded
+                ? "audience.listItem.hideMembers"
+                : "audience.listItem.showMembers",
+              { name: entity.name }
+            )}
+            onClick={() => setExpanded(!isExpanded)}
+            className={cn(
+              "group relative shrink-0 cursor-pointer rounded-md border-0 bg-transparent p-0",
+              focusRing()
+            )}
+          >
+            <span
+              aria-hidden="true"
+              className="block transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0"
+            >
+              <AudienceAvatar entity={entity} size="md" />
+            </span>
+            <span
+              aria-hidden="true"
+              className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+            >
+              <F0Icon icon={isExpanded ? ChevronUp : ChevronDown} size="md" />
+            </span>
+          </button>
+        ) : (
+          <div className="shrink-0">
+            <AudienceAvatar entity={entity} size="md" />
+          </div>
+        )}
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate font-medium text-f1-foreground">
+              {name}
+            </span>
+            {warning && (
+              <Tooltip description={warning}>
+                <button
+                  type="button"
+                  aria-label={warning}
+                  className={cn(
+                    "flex h-6 w-6 shrink-0 cursor-default items-center justify-center rounded-md border border-solid border-f1-border-warning bg-f1-background-warning p-0",
+                    focusRing()
+                  )}
+                >
+                  <F0Icon
+                    icon={Warning}
+                    size="sm"
+                    className="text-f1-icon-warning"
+                  />
+                </button>
+              </Tooltip>
+            )}
+          </div>
+          {subtitle && (
+            <span className="truncate text-f1-foreground-secondary">
+              {subtitle}
+            </span>
+          )}
+        </div>
+        {right && <div className="shrink-0">{right}</div>}
+      </div>
+      {isExpanded && memberList && (
+        <MemberList
+          status={memberList.status}
+          members={memberList.members}
+          note={members?.note}
+          onRetry={() => loadMembers()}
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/react/src/experimental/Lists/F0AudienceListItem/__stories__/F0AudienceListItem.mdx
+++ b/packages/react/src/experimental/Lists/F0AudienceListItem/__stories__/F0AudienceListItem.mdx
@@ -1,0 +1,47 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks"
+import * as Stories from "./F0AudienceListItem.stories"
+
+<Meta of={Stories} />
+
+# F0AudienceListItem
+
+Access-list row for a person or a group of people, sharing the
+`F0AudienceEntity` contract with `F0AudienceSelector`. Used to render "people
+with access" lists in share dialogs.
+
+---
+
+# Overview
+
+<Canvas of={Stories.Individual} />
+
+## Anatomy
+
+- **Avatar / expand control** — individuals show their person avatar; group
+  rows with a `members` prop turn the avatar into an expand/collapse control
+  on hover and focus.
+- **Name** — with an optional localized "(You)" suffix (`isYou`) and an
+  optional warning chip (`warning`, e.g. "Outside your reporting line") with
+  the text as its tooltip.
+- **Subtitle** — individuals show their consumer-provided subtitle (job
+  title); groups show the localized `{n} people · Kind` line.
+- **Right slot** — the product's role dropdown, a static role label or a
+  pending tag. Role semantics stay with the consumer.
+
+<Canvas of={Stories.CurrentUser} />
+<Canvas of={Stories.WithWarning} />
+
+## Expandable groups
+
+Group rows expand into a lazily-fetched member list: `members.fetch` is called
+**once** on first expand and cached for the row's lifetime. An optional
+`members.note` renders after the list — e.g. "New members in this group
+automatically gain access." Expansion is uncontrolled by default and
+controllable via `expanded`/`onExpandedChange`.
+
+<Canvas of={Stories.Group} />
+<Canvas of={Stories.EmptyGroup} />
+
+## Access list composition
+
+<Canvas of={Stories.AccessList} />

--- a/packages/react/src/experimental/Lists/F0AudienceListItem/__stories__/F0AudienceListItem.stories.tsx
+++ b/packages/react/src/experimental/Lists/F0AudienceListItem/__stories__/F0AudienceListItem.stories.tsx
@@ -1,0 +1,199 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { F0Button } from "@/components/F0Button"
+import type { F0AudienceEntity } from "@/experimental/Forms/Fields/F0AudienceSelector"
+import { ChevronDown } from "@/icons/app"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import { F0AudienceListItem } from "../index"
+import type { F0AudienceMember } from "../types"
+
+const ada: F0AudienceEntity = {
+  kind: "individual",
+  id: "emp-001",
+  name: "Ada Lovelace",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  subtitle: "VP of Engineering",
+}
+
+const marie: F0AudienceEntity = {
+  kind: "individual",
+  id: "emp-002",
+  name: "Marie Curie",
+  firstName: "Marie",
+  lastName: "Curie",
+  subtitle: "Head of People",
+}
+
+const payroll: F0AudienceEntity = {
+  kind: "team",
+  id: "team-payroll",
+  name: "Payroll",
+  memberCount: 3,
+}
+
+const everyone: F0AudienceEntity = {
+  kind: "everyone",
+  id: "everyone",
+  name: "Everyone at Factorial",
+  memberCount: 20,
+}
+
+const members: F0AudienceMember[] = [
+  {
+    id: "m1",
+    firstName: "Diego",
+    lastName: "Hernández",
+    subtitle: "Payroll Specialist",
+  },
+  {
+    id: "m2",
+    firstName: "Grace",
+    lastName: "Hopper",
+    subtitle: "Principal Engineer",
+  },
+  {
+    id: "m3",
+    firstName: "Lin",
+    lastName: "Chen",
+    subtitle: "Backend Engineer",
+  },
+]
+
+const fetchMembers = (
+  result: F0AudienceMember[] = members,
+  delayMs = 600
+): (() => Promise<F0AudienceMember[]>) => {
+  return () =>
+    new Promise((resolve) => setTimeout(() => resolve(result), delayMs))
+}
+
+const roleDropdown = (
+  <F0Button
+    variant="ghost"
+    size="sm"
+    label="Viewer"
+    icon={ChevronDown}
+    iconPosition="right"
+  />
+)
+
+const meta = {
+  title: "Components/F0AudienceListItem",
+  component: F0AudienceListItem,
+  tags: ["experimental"],
+  args: {
+    entity: ada,
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Access-list row for a person or a group of people. Group rows can expand into a lazily-fetched member list. The right slot hosts the product's role dropdown, a static role label or a pending tag.",
+      },
+    },
+  },
+} satisfies Meta<typeof F0AudienceListItem>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Individual: Story = {
+  args: {
+    entity: ada,
+    right: roleDropdown,
+  },
+}
+
+export const CurrentUser: Story = {
+  args: {
+    entity: marie,
+    isYou: true,
+    right: <span className="font-medium text-f1-foreground">Owner</span>,
+  },
+}
+
+export const WithWarning: Story = {
+  args: {
+    entity: ada,
+    warning: "Outside your reporting line",
+    right: roleDropdown,
+  },
+}
+
+export const Group: Story = {
+  args: {
+    entity: payroll,
+    right: roleDropdown,
+    members: {
+      fetch: fetchMembers(),
+      note: "New members in this group automatically gain access.",
+    },
+  },
+}
+
+export const EmptyGroup: Story = {
+  args: {
+    entity: payroll,
+    right: roleDropdown,
+    members: {
+      fetch: fetchMembers([]),
+      note: "New members in this group automatically gain access.",
+    },
+  },
+}
+
+export const Everyone: Story = {
+  args: {
+    entity: everyone,
+    right: roleDropdown,
+  },
+}
+
+export const AccessList: Story = {
+  render: () => (
+    <div className="flex max-w-[560px] flex-col">
+      <F0AudienceListItem
+        entity={marie}
+        isYou
+        right={<span className="font-medium text-f1-foreground">Owner</span>}
+      />
+      <F0AudienceListItem
+        entity={payroll}
+        right={roleDropdown}
+        members={{
+          fetch: fetchMembers(),
+          note: "New members in this group automatically gain access.",
+        }}
+      />
+      <F0AudienceListItem
+        entity={ada}
+        warning="Outside your reporting line"
+        right={roleDropdown}
+      />
+    </div>
+  ),
+}
+
+/** Static variants consolidated for Chromatic visual-regression coverage. */
+export const Snapshot: Story = {
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex max-w-[560px] flex-col">
+      <F0AudienceListItem
+        entity={marie}
+        isYou
+        right={<span className="font-medium text-f1-foreground">Owner</span>}
+      />
+      <F0AudienceListItem entity={ada} right={roleDropdown} />
+      <F0AudienceListItem
+        entity={ada}
+        warning="Outside your reporting line"
+        right={roleDropdown}
+      />
+      <F0AudienceListItem entity={payroll} right={roleDropdown} />
+      <F0AudienceListItem entity={everyone} right={roleDropdown} />
+    </div>
+  ),
+}

--- a/packages/react/src/experimental/Lists/F0AudienceListItem/__tests__/F0AudienceListItem.test.tsx
+++ b/packages/react/src/experimental/Lists/F0AudienceListItem/__tests__/F0AudienceListItem.test.tsx
@@ -1,0 +1,210 @@
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import type { F0AudienceEntity } from "@/experimental/Forms/Fields/F0AudienceSelector"
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
+
+import { F0AudienceListItem } from "../index"
+import type { F0AudienceMember } from "../types"
+
+const ada: F0AudienceEntity = {
+  kind: "individual",
+  id: "1",
+  name: "Ada Lovelace",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  subtitle: "VP of Engineering",
+}
+
+const payroll: F0AudienceEntity = {
+  kind: "team",
+  id: "team-payroll",
+  name: "Payroll",
+  memberCount: 3,
+}
+
+const payrollMembers: F0AudienceMember[] = [
+  { id: "m1", firstName: "Grace", lastName: "Hopper", subtitle: "Engineer" },
+  { id: "m2", firstName: "Lin", lastName: "Chen" },
+]
+
+describe("F0AudienceListItem", () => {
+  it("renders the entity name and subtitle", () => {
+    render(<F0AudienceListItem entity={ada} />)
+
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument()
+    expect(screen.getByText("VP of Engineering")).toBeInTheDocument()
+  })
+
+  it("appends the localized (You) suffix", () => {
+    render(<F0AudienceListItem entity={ada} isYou />)
+
+    expect(screen.getByText("Ada Lovelace (You)")).toBeInTheDocument()
+  })
+
+  it("renders the localized group subtitle", () => {
+    render(<F0AudienceListItem entity={payroll} />)
+
+    expect(screen.getByText("3 people · Team")).toBeInTheDocument()
+  })
+
+  it("renders an accessible warning chip", () => {
+    render(
+      <F0AudienceListItem entity={ada} warning="Outside your reporting line" />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Outside your reporting line" })
+    ).toBeInTheDocument()
+  })
+
+  it("renders the right slot", () => {
+    render(<F0AudienceListItem entity={ada} right={<span>Viewer</span>} />)
+
+    expect(screen.getByText("Viewer")).toBeInTheDocument()
+  })
+
+  it("is not expandable for individuals even with a members prop", () => {
+    render(
+      <F0AudienceListItem
+        entity={ada}
+        members={{ fetch: () => Promise.resolve(payrollMembers) }}
+      />
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "Show members of Payroll" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("is not expandable for groups without a members prop", () => {
+    render(<F0AudienceListItem entity={payroll} />)
+
+    expect(
+      screen.queryByRole("button", { name: "Show members of Payroll" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("fetches members once on first expand and renders them with the note", async () => {
+    const user = userEvent.setup()
+    const fetch = vi.fn(() => Promise.resolve(payrollMembers))
+    render(
+      <F0AudienceListItem
+        entity={payroll}
+        members={{
+          fetch,
+          note: "New members in this group automatically gain access.",
+        }}
+      />
+    )
+
+    const toggle = screen.getByRole("button", {
+      name: "Show members of Payroll",
+    })
+    await user.click(toggle)
+
+    await waitFor(() =>
+      expect(screen.getByText("Grace Hopper")).toBeInTheDocument()
+    )
+    expect(screen.getByText("Lin Chen")).toBeInTheDocument()
+    expect(
+      screen.getByText("New members in this group automatically gain access.")
+    ).toBeInTheDocument()
+    expect(toggle).toHaveAttribute("aria-expanded", "true")
+
+    // Collapse and expand again: no refetch
+    await user.click(
+      screen.getByRole("button", { name: "Hide members of Payroll" })
+    )
+    expect(screen.queryByText("Grace Hopper")).not.toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", { name: "Show members of Payroll" })
+    )
+    await waitFor(() =>
+      expect(screen.getByText("Grace Hopper")).toBeInTheDocument()
+    )
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows the empty state for groups without members", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0AudienceListItem
+        entity={payroll}
+        members={{ fetch: () => Promise.resolve([]) }}
+      />
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Show members of Payroll" })
+    )
+    await waitFor(() =>
+      expect(screen.getByText("No current members")).toBeInTheDocument()
+    )
+  })
+
+  it("supports controlled expansion", async () => {
+    const user = userEvent.setup()
+    const onExpandedChange = vi.fn()
+    const { rerender } = render(
+      <F0AudienceListItem
+        entity={payroll}
+        members={{ fetch: () => Promise.resolve(payrollMembers) }}
+        expanded={false}
+        onExpandedChange={onExpandedChange}
+      />
+    )
+
+    expect(screen.queryByText("Grace Hopper")).not.toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", { name: "Show members of Payroll" })
+    )
+    expect(onExpandedChange).toHaveBeenCalledWith(true)
+    // Still collapsed: the parent owns the state
+    expect(screen.queryByText("Grace Hopper")).not.toBeInTheDocument()
+
+    rerender(
+      <F0AudienceListItem
+        entity={payroll}
+        members={{ fetch: () => Promise.resolve(payrollMembers) }}
+        expanded
+        onExpandedChange={onExpandedChange}
+      />
+    )
+    await waitFor(() =>
+      expect(screen.getByText("Grace Hopper")).toBeInTheDocument()
+    )
+  })
+
+  it("surfaces a fetch error with a retry that reloads the members", async () => {
+    const user = userEvent.setup()
+    const fetch = vi
+      .fn<() => Promise<F0AudienceMember[]>>()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce(payrollMembers)
+    render(<F0AudienceListItem entity={payroll} members={{ fetch }} />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Show members of Payroll" })
+    )
+    // First fetch rejects: the row shows an error with a retry affordance,
+    // not a blank body
+    await waitFor(() =>
+      expect(screen.getByText("Couldn't load members")).toBeInTheDocument()
+    )
+    expect(screen.queryByText("Grace Hopper")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Try again" }))
+    await waitFor(() =>
+      expect(screen.getByText("Grace Hopper")).toBeInTheDocument()
+    )
+    expect(screen.queryByText("Couldn't load members")).not.toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it("passes dataTestId through", () => {
+    render(<F0AudienceListItem entity={ada} dataTestId="audience-row" />)
+
+    expect(screen.getByTestId("audience-row")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/experimental/Lists/F0AudienceListItem/components/MemberList.tsx
+++ b/packages/react/src/experimental/Lists/F0AudienceListItem/components/MemberList.tsx
@@ -23,7 +23,12 @@ export const MemberList = ({
   const i18n = useI18n()
 
   return (
-    <div className="ml-4 flex flex-col gap-1 border-0 border-l border-solid border-f1-border-secondary pb-2 pl-6">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy={status === "loading"}
+      className="ml-4 flex flex-col gap-1 border-0 border-l border-solid border-f1-border-secondary pb-2 pl-6"
+    >
       {status === "loading" && (
         <>
           <Skeleton className="h-5 w-40" />

--- a/packages/react/src/experimental/Lists/F0AudienceListItem/components/MemberList.tsx
+++ b/packages/react/src/experimental/Lists/F0AudienceListItem/components/MemberList.tsx
@@ -1,0 +1,89 @@
+import { F0Avatar } from "@/components/avatars/F0Avatar"
+import { F0Button } from "@/components/F0Button"
+import { F0Icon } from "@/components/F0Icon"
+import { Person } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+import { Skeleton } from "@/ui/skeleton"
+
+import type { F0AudienceMember } from "../types"
+
+export type MemberListStatus = "loading" | "loaded" | "error"
+
+export const MemberList = ({
+  status,
+  members,
+  note,
+  onRetry,
+}: {
+  status: MemberListStatus
+  members: F0AudienceMember[]
+  note?: string
+  onRetry?: () => void
+}) => {
+  const i18n = useI18n()
+
+  return (
+    <div className="ml-4 flex flex-col gap-1 border-0 border-l border-solid border-f1-border-secondary pb-2 pl-6">
+      {status === "loading" && (
+        <>
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-5 w-32" />
+        </>
+      )}
+      {status === "error" && (
+        <div className="flex items-center gap-2 py-1">
+          <span className="text-f1-foreground-secondary">
+            {i18n.audience.listItem.loadError}
+          </span>
+          {onRetry && (
+            <F0Button
+              variant="ghost"
+              size="sm"
+              label={i18n.audience.listItem.retry}
+              onClick={onRetry}
+            />
+          )}
+        </div>
+      )}
+      {status === "loaded" && members.length === 0 && (
+        <span className="py-1 text-f1-foreground-secondary">
+          {i18n.audience.listItem.noMembers}
+        </span>
+      )}
+      {status === "loaded" &&
+        members.map((member) => (
+          <div key={member.id} className="flex items-center gap-2 py-1">
+            <F0Avatar
+              avatar={{
+                type: "person",
+                firstName: member.firstName,
+                lastName: member.lastName,
+                src: member.src,
+              }}
+              size="xs"
+            />
+            <span className="truncate text-f1-foreground">
+              {member.firstName} {member.lastName}
+            </span>
+            {member.subtitle && (
+              <span className="truncate text-sm text-f1-foreground-secondary">
+                {member.subtitle}
+              </span>
+            )}
+          </div>
+        ))}
+      {status === "loaded" && note && (
+        <div className="flex items-center gap-2 py-1">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-dashed border-f1-border">
+            <F0Icon
+              icon={Person}
+              size="sm"
+              className="text-f1-icon-secondary"
+            />
+          </span>
+          <span className="text-f1-foreground-secondary">{note}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/react/src/experimental/Lists/F0AudienceListItem/index.tsx
+++ b/packages/react/src/experimental/Lists/F0AudienceListItem/index.tsx
@@ -1,0 +1,13 @@
+import { withDataTestId } from "@/lib/data-testid"
+import { experimentalComponent } from "@/lib/experimental"
+
+import { F0AudienceListItem as F0AudienceListItemComponent } from "./F0AudienceListItem"
+
+export * from "./types"
+
+/**
+ * @experimental This is an experimental component use it at your own risk
+ */
+export const F0AudienceListItem = withDataTestId(
+  experimentalComponent("F0AudienceListItem", F0AudienceListItemComponent)
+)

--- a/packages/react/src/experimental/Lists/F0AudienceListItem/types.ts
+++ b/packages/react/src/experimental/Lists/F0AudienceListItem/types.ts
@@ -1,0 +1,36 @@
+import type { F0AudienceEntity } from "@/experimental/Forms/Fields/F0AudienceSelector"
+import type { WithDataTestIdProps } from "@/lib/data-testid"
+
+export type F0AudienceMember = {
+  id: string
+  firstName: string
+  lastName: string
+  /** Avatar image url */
+  src?: string
+  /** Secondary line, e.g. the job title */
+  subtitle?: string
+}
+
+export type F0AudienceListItemProps = {
+  entity: F0AudienceEntity
+  /** Appends the localized "(You)" suffix to the name */
+  isYou?: boolean
+  /**
+   * Renders a warning chip next to the name with this text as its tooltip —
+   * e.g. "Outside your reporting line". The copy is consumer-provided.
+   */
+  warning?: string
+  /** Right-aligned slot: a role dropdown, a static role label, a pending tag… */
+  right?: React.ReactNode
+  /**
+   * Group kinds only: presence makes the row expandable. Members are fetched
+   * lazily ONCE on first expand and cached for the lifetime of the row.
+   */
+  members?: {
+    fetch: () => Promise<F0AudienceMember[]>
+    /** Trailing note, e.g. "New members in this group automatically gain access." */
+    note?: string
+  }
+  expanded?: boolean
+  onExpandedChange?: (expanded: boolean) => void
+} & WithDataTestIdProps

--- a/packages/react/src/experimental/exports.ts
+++ b/packages/react/src/experimental/exports.ts
@@ -30,6 +30,7 @@ export * from "./Forms/exports"
 export * from "./Information/exports"
 export * from "./Lists/DetailsItem"
 export * from "./Lists/DetailsItemsList"
+export * from "./Lists/F0AudienceListItem"
 export * from "./Lists/OnePersonListItem"
 export * from "./Navigation/exports"
 /**

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -585,6 +585,34 @@ export const defaultTranslations = {
     createWithValue: 'Create "{{value}}"',
     createEmptyMessage: "Try another search or create a new item",
   },
+  audience: {
+    selector: {
+      typeToSearch: "Start typing to search",
+      noResults: "No matches found",
+      loading: "Loading...",
+      removeItem: "Remove {{name}}",
+      kind: {
+        team: "Team",
+        legalEntity: "Legal entity",
+        workplace: "Workplace",
+        role: "Role",
+        permissionGroup: "Permission group",
+        everyone: "Company-wide",
+      },
+      memberCount: {
+        one: "{{count}} person",
+        other: "{{count}} people",
+      },
+    },
+    listItem: {
+      you: "(You)",
+      showMembers: "Show members of {{name}}",
+      hideMembers: "Hide members of {{name}}",
+      noMembers: "No current members",
+      loadError: "Couldn't load members",
+      retry: "Try again",
+    },
+  },
   numberInput: {
     between: "It should be between {{min}} and {{max}}",
     greaterThan: "It should be greater than {{min}}",


### PR DESCRIPTION
## Description

Adds two experimental components that together form the building kit for CIAM's Sharing v2 share panel. `F0AudienceSelector` is a data-agnostic, chips-in-field combobox for bulk-selecting individual people or atomic groups of people (teams, legal entities, workplaces, roles, permission groups, or everyone). `F0AudienceListItem` is the matching access-list row, whose group variants expand into a lazily-fetched member list. Both land under `experimental/` per the F0 promotion rule, and keep group-grantee kinds behind the consumer's data adapter until the backend grantee union lands.

## Screenshots (if applicable)

**The full share panel the CIAM ShareModal composes from this kit** — selector + batch role + Share, the access list with expandable groups, and a general-access footer:

> 
<img width="1440" height="1012" alt="share-dialog-recipe" src="https://github.com/user-attachments/assets/d17a5d48-b6cf-46c2-9be5-cdd35f252d7e" />

**`F0AudienceSelector`** — searching returns a mix of people, teams and groups, each multi-selectable:

> 
<img width="1440" height="456" alt="selector-dropdown" src="https://github.com/user-attachments/assets/0b9e8d3d-3ebe-4d88-8b63-178b2dcfcd4f" />


Selected entities render as removable chips; an optional warning surfaces out-of-reporting-line shares:

> 
<img width="1376" height="252" alt="selector-warning" src="https://github.com/user-attachments/assets/6dcc839f-f2e7-4658-8984-73e2d644d53e" />


**`F0AudienceListItem`** — group rows expand into a lazily-fetched member list:

> 
<img width="1216" height="616" alt="access-list" src="https://github.com/user-attachments/assets/55fa7079-2887-438b-ac22-5de42109eb8b" />


## Implementation details

- feat: add `F0AudienceSelector` — chips-in-field combobox with adapter-driven search, empty-query suggestions, full keyboard/a11y, an optional trailing slot (e.g. batch role) and an out-of-reporting-line warning

  <details>
  <summary>Data contract</summary>

  The component is data-agnostic: the consumer passes `source: { dataAdapter, search? }` plus `mapEntity`, and the empty query never reaches the consumer's `fetchData` (a dedicated `suggestions` prop covers it). A composite identity `${kind}:${id}` maps losslessly onto today's `PermissionsSharingSelectionInput` (`employeeIds` + `role`) and the future grantee union, so group kinds can stay dark until the backend union ships.
  </details>

- feat: add `F0AudienceListItem` — access-list row with lazy, expandable group members and an error/retry state
- feat: add `audience.*` i18n defaults for the selector and list item
- feat: add a `closeLabel` prop to `OneChip` so chip remove buttons stay distinguishable to screen readers
- chore: register both components in the `experimental/` barrels
