### PR TITLE
fix(dialog-alike): restore pointer events + visibility for overlays in dialogs

### DIFF
--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/__tests__/useContainerAnchor.test.tsx
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/__tests__/useContainerAnchor.test.tsx
@@ -91,4 +91,29 @@ describe("useContainerAnchor", () => {
     expect(result.current).not.toBe(first)
     expect(result.current).toMatchObject({ width: 200, height: 200 })
   })
+
+  // The anchor's box can read 0×0 before the shell (#content) is laid out.
+  // Pinning the dialog to that box collapses it to an invisible 0×0 element
+  // (the dialog / side panel never appears). Keep the viewport-fill fallback
+  // until a real box is measurable, then anchor once it is.
+  it("does NOT collapse to a 0×0 box; keeps the fallback until the anchor is laid out", () => {
+    let rect: Partial<DOMRect> = { left: 0, top: 0, width: 0, height: 0 }
+    const el = document.createElement("div")
+    el.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 0, height: 0, ...rect }) as DOMRect
+
+    const { result } = renderHook(() => useContainerAnchor(el))
+    flushRaf()
+
+    // 0×0 anchor => stay on the viewport-fill fallback, not a collapsed box.
+    expect(result.current).toEqual({})
+
+    // Once the shell has a real box, anchor to it.
+    rect = { left: 0, top: 0, width: 800, height: 600 }
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+    })
+    flushRaf()
+    expect(result.current).toMatchObject({ width: 800, height: 600 })
+  })
 })

--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/useContainerAnchor.ts
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/useContainerAnchor.ts
@@ -21,6 +21,11 @@ export const useContainerAnchor = (
     const measure = () => {
       raf = 0
       const rect = anchorEl.getBoundingClientRect()
+      // If the anchor isn't laid out yet (0×0 box), keep the viewport-fill
+      // fallback (the `fixed inset-0` class) instead of pinning the dialog to a
+      // 0×0 box that renders nothing. The ResizeObserver re-measures and applies
+      // the real box once the anchor has one.
+      if (rect.width === 0 && rect.height === 0) return
       if (
         rect.left === prev.left &&
         rect.top === prev.top &&

--- a/packages/react/src/experimental/Navigation/Dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/__tests__/Dropdown.test.tsx
@@ -106,4 +106,15 @@ describe("Dropdown (experimental) — enabled regression", () => {
     await userEvent.click(trigger)
     expect(await screen.findByText("Create")).toBeInTheDocument()
   })
+
+  // Inside a non-modal dialog-alike the dialog content wrapper is
+  // `pointer-events-none` (so the backdrop stays click-through); portaled
+  // menu content must opt back in or its items are unclickable when the
+  // dropdown is used within a dialog/drawer.
+  it("keeps the open menu clickable under pointer-events-none ancestors", async () => {
+    render(<Dropdown items={items} />)
+    await userEvent.click(screen.getByRole("button"))
+    const menu = await screen.findByRole("menu")
+    expect(menu.className).toContain("pointer-events-auto")
+  })
 })

--- a/packages/react/src/ui/__test__/popover.test.tsx
+++ b/packages/react/src/ui/__test__/popover.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { Popover, PopoverContent, PopoverTrigger } from "../popover"
+
+describe("ui/popover", () => {
+  // Popover content is portaled into the dialog container when opened inside a
+  // non-modal dialog-alike, whose wrapper is `pointer-events-none` (so the
+  // backdrop stays click-through). The content must opt back in or it is
+  // unclickable when a popover is used within a dialog/drawer.
+  it("keeps the open popover content clickable under pointer-events-none ancestors", async () => {
+    render(
+      <Popover>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent data-testid="popover-content">content</PopoverContent>
+      </Popover>
+    )
+
+    await userEvent.click(screen.getByText("Open"))
+
+    const content = await screen.findByTestId("popover-content")
+    expect(content.className).toContain("pointer-events-auto")
+  })
+})

--- a/packages/react/src/ui/dropdown-menu.tsx
+++ b/packages/react/src/ui/dropdown-menu.tsx
@@ -49,7 +49,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "pointer-events-auto z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -67,7 +67,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border border-solid border-f1-border-secondary bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "pointer-events-auto z-50 min-w-[--radix-popper-anchor-width] overflow-hidden rounded-md border border-solid border-f1-border-secondary bg-f1-background text-f1-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         "origin-[var(--radix-dropdown-menu-content-transform-origin)]",
         className
       )}

--- a/packages/react/src/ui/popover.tsx
+++ b/packages/react/src/ui/popover.tsx
@@ -30,7 +30,7 @@ const PopoverContent = React.forwardRef<
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-72 rounded-xs border bg-f1-background p-4 text-f1-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "pointer-events-auto z-50 w-72 rounded-xs border bg-f1-background p-4 text-f1-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           "origin-[var(--radix-popover-content-transform-origin)]",
           "max-h-[var(--radix-popover-content-available-height)]",
           "overflow-auto",


### PR DESCRIPTION
## Description

Fixes two dialog-alike regressions that break interactive content inside side panels and confirmation dialogs on heavy pages (surfaced by E2E: an attendance side panel and a payroll confirmation dialog whose contents never became clickable/visible).

## Implementation details

- fix: opt portaled overlay content back into pointer events inside non-modal dialogs. The dialog-alike content wrapper is `pointer-events-none` (so a non-modal dialog's backdrop stays click-through), which also kills pointer events on overlays portaled into it. #4609 fixed this for `F0Select`; this applies the same `pointer-events-auto` opt-in to `DropdownMenuContent` / `DropdownMenuSubContent` and `PopoverContent`.
- fix: stop `useContainerAnchor` collapsing a side drawer to a `0×0` box. When the anchor element (the `#content` frame) reads `0×0` before layout, the drawer was pinned to an invisible `0×0` element and never appeared. Keep the viewport-fill fallback until a real box is measurable; the `ResizeObserver` anchors once it is.
- test: unit coverage for the pointer-events opt-in (dropdown menu + popover) and the anchor `0×0` guard.

## Testing

- `pnpm tsc` — clean
- Affected unit tests pass (16), including the 3 new ones
- Verified in Storybook (`F0Drawer` stories) that overlays inside a non-modal drawer are clickable and the drawer renders at full size

## Context

Consumed as an alpha by factorial PRs #103611 and #104435 (f0 4.x bump) to validate against the failing E2E specs before merge.