### PR TITLE
fix(i18n): fall back to default translations outside a provider

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
+++ b/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 
 import { aiTranslations } from "@/sds/ai/F0AiChat"
 
@@ -56,16 +56,14 @@ describe("I18nProvider", () => {
     expect(screen.getByTestId("translation")).toHaveTextContent("Desar")
   })
 
-  it("throws error when useI18n is used outside provider", () => {
-    // Suppress console.error for this test as we expect an error
-    const consoleSpy = vi.spyOn(console, "error")
-    consoleSpy.mockImplementation(() => {})
+  it("falls back to default translations when used outside a provider", () => {
+    // No provider: the hook must not throw — it degrades to the built-in
+    // (English) defaults so the subtree still renders.
+    render(<TestComponent />)
 
-    expect(() => {
-      render(<TestComponent />)
-    }).toThrow("useI18n must be used within an I18nProvider")
-
-    consoleSpy.mockRestore()
+    expect(screen.getByTestId("translation")).toHaveTextContent(
+      defaultTranslations.actions.save
+    )
   })
 
   // Type tests - these will fail at compile time if types are wrong

--- a/packages/react/src/lib/providers/i18n/i18n-provider.tsx
+++ b/packages/react/src/lib/providers/i18n/i18n-provider.tsx
@@ -2,7 +2,11 @@
 
 import { createContext, ReactNode, useContext } from "react"
 
-import { TranslationKey, TranslationsType } from "./i18n-provider-defaults"
+import {
+  defaultTranslations,
+  TranslationKey,
+  TranslationsType,
+} from "./i18n-provider-defaults"
 
 export type I18nContextType = TranslationsType & {
   t: (key: TranslationKey, args?: Record<string, string | number>) => string
@@ -65,16 +69,30 @@ export function I18nProvider({
   )
 }
 
+// Context backed by the built-in (English) defaults, used as a fallback when
+// `useI18n` is called outside an `I18nProvider`.
+const defaultI18nContext: I18nContextType = {
+  ...defaultTranslations,
+  t: (key: TranslationKey, args: Record<string, string | number> = {}) => {
+    let translation = getKey(key, defaultTranslations)
+    if (translation === undefined) {
+      return key
+    }
+    for (const [argKey, value] of Object.entries(args)) {
+      translation = translation.replace(`{{${argKey}}}`, value.toString())
+    }
+    return translation
+  },
+}
+
 export function useI18n(): TranslationsType & {
   t: (key: TranslationKey, args?: Record<string, string | number>) => string
 } {
-  const context = useContext(I18nContext)
-
-  if (context === null) {
-    throw new Error("useI18n must be used within an I18nProvider")
-  }
-
-  return context
+  // Degrade gracefully to the default (English) translations instead of
+  // throwing, so components that read i18n outside an `I18nProvider` (portaled
+  // content, components rendered standalone or in unit tests without a wrapper)
+  // render with defaults rather than crashing the whole subtree.
+  return useContext(I18nContext) ?? defaultI18nContext
 }
 
 export const buildTranslations = (


### PR DESCRIPTION
## Description

`useI18n` threw `useI18n must be used within an I18nProvider` when called without a provider. That turns into a hard crash for any consumer that renders an f0 component which reads i18n outside the provider tree — for example `BaseHeader`/`ResourceHeader`, which started calling `useI18n` in #4307 (for the close-button label) and is rendered standalone (and in consumer unit tests) without a wrapping provider.

This makes `useI18n` degrade gracefully to the built-in (English) defaults instead of throwing, so those components render with default labels rather than crashing the whole subtree. Apps still provide their own translations via `I18nProvider` exactly as before.

## Implementation details

- fix: `useI18n` returns `useContext(I18nContext) ?? defaultI18nContext` instead of throwing when there is no provider.
- fix: add a module-level `defaultI18nContext` backed by `defaultTranslations` (with a `t` that resolves against the defaults and returns the key when missing).
- test: update the provider spec (was "throws outside provider" → now "falls back to default translations").

## Testing

- `pnpm tsc` — clean
- i18n provider spec passes; no other test asserted the throw.

## Context

Unblocks the f0 4.x bump in factorial (PRs #103611 / #104435): the `RequestTypeDetailHeader` frontend spec (renders `ResourceHeader → BaseHeader` without a provider) crashed on 4.22.0 due to #4307. Independent of the dialog-alike fix being evaluated in parallel.