### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.22.0",
+  "packages/react": "4.22.1",
   "packages/react-native": "0.56.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.22.1](https://github.com/factorialco/f0/compare/f0-react-v4.22.0...f0-react-v4.22.1) (2026-07-04)
+
+
+### Reverts
+
+* **F0Dialog:** restore F0Dialog, F0Drawer and dialog-alike to v3.12.0 behavior ([#4616](https://github.com/factorialco/f0/issues/4616)) ([6677d77](https://github.com/factorialco/f0/commit/6677d777125851ceb763f36867a0a26c64d9184c))
+
 ## [4.22.0](https://github.com/factorialco/f0/compare/f0-react-v4.21.1...f0-react-v4.22.0) (2026-07-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.22.0",
+  "version": "4.22.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.22.1</summary>

## [4.22.1](https://github.com/factorialco/f0/compare/f0-react-v4.22.0...f0-react-v4.22.1) (2026-07-04)


### Reverts

* **F0Dialog:** restore F0Dialog, F0Drawer and dialog-alike to v3.12.0 behavior ([#4616](https://github.com/factorialco/f0/issues/4616)) ([6677d77](https://github.com/factorialco/f0/commit/6677d777125851ceb763f36867a0a26c64d9184c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).