### PR TITLE
fix(emoji-picker): seed props before append so onEmojiSelect fires

### DIFF
--- a/packages/react/src/lib/EmojiPicker.test.tsx
+++ b/packages/react/src/lib/EmojiPicker.test.tsx
@@ -5,33 +5,61 @@ import { EmojiPicker } from "./EmojiPicker"
 
 const realCreateElement = document.createElement.bind(document)
 
-type UpdatableElement = HTMLElement & { update?: (props: object) => void }
+type PickerElement = HTMLElement & {
+  props?: { onEmojiSelect?: unknown; set?: unknown }
+  update?: (props: object) => void
+}
+
+// Stand-in for the real <em-emoji-picker>. emoji-mart's real element kicks off
+// an async, network-bound init on append that can't complete in jsdom; these
+// tests only assert how the wrapper wires props onto the element, so a plain
+// element avoids that noise.
+function stubPickerElement(): PickerElement {
+  const el = realCreateElement("div") as PickerElement
+  el.update = vi.fn()
+  return el
+}
 
 afterEach(() => {
   vi.restoreAllMocks()
 })
 
 describe("EmojiPicker", () => {
-  it("mounts the <em-emoji-picker> element via createElement, never `new`", () => {
-    const createElementSpy = vi.spyOn(document, "createElement")
+  it("mounts the element via createElement, never `new`", () => {
+    const stub = stubPickerElement()
+    const createElementSpy = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tag: string) =>
+        tag === "em-emoji-picker" ? stub : realCreateElement(tag)
+      )
 
     const { container } = render(<EmojiPicker data={{}} />)
 
     expect(createElementSpy).toHaveBeenCalledWith("em-emoji-picker")
-    expect(container.querySelector("em-emoji-picker")).not.toBeNull()
+    expect(container.contains(stub)).toBe(true)
   })
 
-  it("forwards props to the element through update()", () => {
-    const update = vi.fn()
+  it("seeds props onto the element before appending so callbacks are wired", () => {
+    // emoji-mart reads `this.props` in connectedCallback (fired on append) to
+    // build the picker; a post-append update() is dropped while its internal
+    // component ref doesn't exist yet. So props — crucially onEmojiSelect — must
+    // be present on the element *before* it is appended, otherwise selecting an
+    // emoji does nothing.
     const onEmojiSelect = vi.fn()
-    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
-      const el = realCreateElement(tag)
-      if (tag === "em-emoji-picker") {
-        const updatable = el as UpdatableElement
-        updatable.update = update
-      }
-      return el
+    const stub = stubPickerElement()
+    let propsAtAppendTime: PickerElement["props"]
+
+    const originalAppend = HTMLElement.prototype.appendChild
+    vi.spyOn(HTMLElement.prototype, "appendChild").mockImplementation(function (
+      this: HTMLElement,
+      node: Node
+    ) {
+      if (node === stub) propsAtAppendTime = stub.props
+      return originalAppend.call(this, node) as Node
     })
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) =>
+      tag === "em-emoji-picker" ? stub : realCreateElement(tag)
+    )
 
     render(
       <EmojiPicker
@@ -41,9 +69,9 @@ describe("EmojiPicker", () => {
       />
     )
 
-    expect(update).toHaveBeenCalled()
-    const lastArgs = update.mock.calls.at(-1)?.[0]
-    expect(lastArgs).toMatchObject({ set: "twitter", onEmojiSelect })
+    expect(stub.props).toMatchObject({ set: "twitter", onEmojiSelect })
+    // The seed must happen before the append, not after.
+    expect(propsAtAppendTime).toMatchObject({ set: "twitter", onEmojiSelect })
   })
 
   it("degrades to nothing instead of crashing when the element fails to construct", () => {

--- a/packages/react/src/lib/EmojiPicker.tsx
+++ b/packages/react/src/lib/EmojiPicker.tsx
@@ -6,7 +6,14 @@ import "emoji-mart"
 
 import { RenderErrorBoundary } from "@/lib/RenderErrorBoundary"
 
-type EmojiMartElement = HTMLElement & { update?: (props: object) => void }
+type EmojiMartElement = HTMLElement & {
+  // emoji-mart reads `this.props` inside connectedCallback (fired on append) to
+  // build the picker, and only wires later `update()` calls once its internal
+  // component ref exists. Seeding `props` before append is what `new Picker(props)`
+  // did implicitly via the constructor.
+  props?: object
+  update?: (props: object) => void
+}
 
 export type EmojiPickerProps = {
   data?: unknown
@@ -44,8 +51,13 @@ function EmojiPickerElement(props: EmojiPickerProps) {
       "em-emoji-picker"
     ) as EmojiMartElement
     elementRef.current = element
+    // Seed props *before* appending: connectedCallback reads `this.props`
+    // synchronously on append to build the picker. A post-append `update()`
+    // is dropped because emoji-mart's attributeChangedCallback bails while its
+    // internal component ref doesn't exist yet, leaving callbacks (onEmojiSelect)
+    // and options unset — so selecting an emoji would do nothing.
+    element.props = propsRef.current
     container.appendChild(element)
-    element.update?.(propsRef.current)
 
     return () => {
       element.remove()

--- a/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
+++ b/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
@@ -35,7 +35,7 @@ export const renderBodyWithEmojis = (body: string): ReactNode => {
         src={entity.url}
         alt={entity.text}
         draggable={false}
-        className="inline-block h-4 w-4 px-px align-[-0.15em]"
+        className="inline-block h-[17px] w-[17px] px-px align-[-0.2em]"
       />
     )
     cursor = end


### PR DESCRIPTION
## Description

Selecting an emoji in the F0Chat composer (and any picker built on `Reactions/Picker`) stopped doing anything after #4594. That PR switched the emoji-mart mount from `new Picker(props)` to `document.createElement("em-emoji-picker")` + `element.update(props)` to avoid the "Illegal constructor" crash — but emoji-mart reads `this.props` inside `connectedCallback` (fired synchronously on append) to build the picker, and its `attributeChangedCallback` (the path `update()` uses) bails while the internal component ref doesn't exist yet. So the post-append `update()` was dropped and the picker mounted with default props — leaving `onEmojiSelect` unset, so clicking an emoji did nothing.

The fix seeds `element.props` **before** appending — exactly what the old `new Picker(props)` did implicitly via the constructor — while keeping the `createElement` approach that avoids the duplicated-class crash. Later prop changes still flow through the existing `update()` effect once the component ref exists.

## Implementation details

- fix: seed `props` onto `<em-emoji-picker>` before `appendChild` in `lib/EmojiPicker.tsx`, so `connectedCallback` builds the picker with the real props (`onEmojiSelect`, `data`, `set`, …) instead of defaults
- test: replace the "forwards props through update()" test with one asserting props (incl. `onEmojiSelect`) are on the element **before** append; use a stub element so emoji-mart's async init doesn't run in jsdom
- fix: bump inline emoji render size in the chat body to 17px (`h-[17px] w-[17px]`, `align-[-0.2em]`) in `F0Chat/utils/render-body.tsx`

## Verification

- `pnpm tsc` — clean
- `vitest run --project=unit src/lib/EmojiPicker.test.tsx` — 3/3 passing, no unhandled errors
- `oxfmt` + `oxlint` — clean