### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.22.1",
+  "packages/react": "4.22.2",
   "packages/react-native": "0.56.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.22.2](https://github.com/factorialco/f0/compare/f0-react-v4.22.1...f0-react-v4.22.2) (2026-07-04)
+
+
+### Bug Fixes
+
+* **emoji-picker:** seed props before append so onEmojiSelect fires ([#4619](https://github.com/factorialco/f0/issues/4619)) ([f65810f](https://github.com/factorialco/f0/commit/f65810fca1488879cf772d210a84ad14c1318931))
+
 ## [4.22.1](https://github.com/factorialco/f0/compare/f0-react-v4.22.0...f0-react-v4.22.1) (2026-07-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.22.1",
+  "version": "4.22.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.22.2</summary>

## [4.22.2](https://github.com/factorialco/f0/compare/f0-react-v4.22.1...f0-react-v4.22.2) (2026-07-04)


### Bug Fixes

* **emoji-picker:** seed props before append so onEmojiSelect fires ([#4619](https://github.com/factorialco/f0/issues/4619)) ([f65810f](https://github.com/factorialco/f0/commit/f65810fca1488879cf772d210a84ad14c1318931))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).