### PR TITLE
feat(F0Graph): open centered on a node (first-frame focus)

### DIFF
--- a/packages/react/src/patterns/F0Graph/F0Graph.tsx
+++ b/packages/react/src/patterns/F0Graph/F0Graph.tsx
@@ -112,6 +112,16 @@ export interface F0GraphProps<T = unknown> {
   // ---- Navigation ----
   focusedNode?: string
   highlightedNodes?: Set<string>
+  /**
+   * Id of a node to frame on the **first paint**, instead of the default
+   * fit-to-all. The initial viewport opens already centered on this node with
+   * no animation — use it to open "already looking at" a node (e.g. the current
+   * user). The node must exist in the initial `nodes` (expand its ancestors
+   * before mount); if it's absent, this falls back to the normal fit-to-all.
+   * Only affects the initial frame — later `focusedNode` / "Find me" reveals
+   * still animate with the smooth pan.
+   */
+  initialFocusNodeId?: string
 
   // ---- Layout ----
   /** Layout sizing hint passed to the built-in layout engine. Defaults to 256. Override for compact nodes (icons, file rows). */

--- a/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
+++ b/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
@@ -718,6 +718,30 @@ export const LargeTree: Story = {
   },
 }
 
+/**
+ * `initialFocusNodeId`: open already centered on a specific node instead of
+ * fitting the whole tree. The graph mounts framed on a deep, off-center member
+ * (no fit-to-all, no pan) — the "open looking at me" behaviour used by the
+ * org chart. Compare with `LargeTree` (same data) which opens fit-to-all.
+ */
+export const InitialFocus: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Opens framed on `initialFocusNodeId` (a deep, off-center node) on the first paint — no fit-to-all then pan. The node must be present in the initial `nodes` (here `defaultExpandDepth: 2` makes members visible); if it's absent, F0Graph falls back to fit-to-all.",
+      },
+    },
+  },
+  args: {
+    nodes: makeLargeTree(600),
+    renderNode: renderEmployee,
+    showControls: true,
+    defaultExpandDepth: 2,
+    initialFocusNodeId: "dept-4-member-100",
+  },
+}
+
 // ─── Viewport virtualization (A0 harness + A1 windowing) ───────────
 
 /**

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.focusNoRefire.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.focusNoRefire.test.tsx
@@ -1,0 +1,125 @@
+import React, { act } from "react"
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import type { GraphNode } from "../types"
+import { F0Graph } from "../F0Graph"
+
+// Spy React Flow instance so we can count fly-to (fitView) calls. Only the
+// public `useReactFlow` is mocked — the ReactFlow component renders normally.
+// (Name must start with `mock` for the hoisted vi.mock factory.)
+const mockReactFlow = {
+  fitView: vi.fn(),
+  setCenter: vi.fn(),
+  getZoom: () => 1,
+  getNode: vi.fn(),
+  fitBounds: vi.fn(),
+  zoomIn: vi.fn(),
+  zoomOut: vi.fn(),
+  setViewport: vi.fn(),
+  getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>()
+  return { ...actual, useReactFlow: () => mockReactFlow }
+})
+
+const NODES: GraphNode<string>[] = [
+  { id: "root", parentId: null, data: "Root", childrenCount: 2 },
+  { id: "a", parentId: "root", data: "A" },
+  { id: "b", parentId: "root", data: "B" },
+]
+
+const renderNodeFn = (node: GraphNode<string>) => (
+  <span data-testid={`node-${node.id}`}>{node.data}</span>
+)
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockReactFlow.fitView.mockClear()
+})
+afterEach(() => vi.useRealTimers())
+
+const settle = () => act(() => vi.advanceTimersByTime(200))
+
+describe("F0Graph — focusedNode fly-to does not re-fire on layout changes", () => {
+  it("does not re-center when focusedNode is unchanged across a collapse", () => {
+    const { rerender } = zeroRender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          focusedNode="root"
+          expandedNodes={new Set(["root"])}
+        />
+      </div>
+    )
+    settle()
+    const afterEntry = mockReactFlow.fitView.mock.calls.length
+    expect(afterEntry).toBeGreaterThanOrEqual(1) // flew once on entry
+
+    // Collapse `root` (layout change) — focusedNode is still "root".
+    rerender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          focusedNode="root"
+          expandedNodes={new Set()}
+        />
+      </div>
+    )
+    settle()
+
+    // No extra fly-to: the effect only reacts to a focusedNode change.
+    expect(mockReactFlow.fitView.mock.calls.length).toBe(afterEntry)
+  })
+
+  it("still flies when focusedNode changes to a new value", () => {
+    const { rerender } = zeroRender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          focusedNode="root"
+          expandedNodes={new Set(["root"])}
+        />
+      </div>
+    )
+    settle()
+    const afterEntry = mockReactFlow.fitView.mock.calls.length
+
+    rerender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          focusedNode="a"
+          expandedNodes={new Set(["root"])}
+        />
+      </div>
+    )
+    settle()
+
+    expect(mockReactFlow.fitView.mock.calls.length).toBe(afterEntry + 1)
+    expect(mockReactFlow.fitView).toHaveBeenLastCalledWith(
+      expect.objectContaining({ nodes: [{ id: "a" }] })
+    )
+  })
+})

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.focusNoRefire.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.focusNoRefire.test.tsx
@@ -91,6 +91,41 @@ describe("F0Graph — focusedNode fly-to does not re-fire on layout changes", ()
     expect(mockReactFlow.fitView.mock.calls.length).toBe(afterEntry)
   })
 
+  it("applies the initial fit once and does not re-fit on a later collapse", () => {
+    // `initialFocusNodeId` set, no `focusedNode`: the graph frames the target
+    // once on entry and must NOT re-fit when a subsequent collapse changes the
+    // layout (the org-chart "open framed, then never yanked" contract).
+    const { rerender } = zeroRender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          initialFocusNodeId="root"
+          expandedNodes={new Set(["root"])}
+        />
+      </div>
+    )
+    settle()
+    const afterEntry = mockReactFlow.fitView.mock.calls.length
+    expect(afterEntry).toBeGreaterThanOrEqual(1) // framed once on entry
+
+    // Collapse `root` — layout changes, but the focus target never did.
+    rerender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          initialFocusNodeId="root"
+          expandedNodes={new Set()}
+        />
+      </div>
+    )
+    settle()
+
+    // No re-fit: the initial frame is one-shot.
+    expect(mockReactFlow.fitView.mock.calls.length).toBe(afterEntry)
+  })
+
   it("still flies when focusedNode changes to a new value", () => {
     const { rerender } = zeroRender(
       <div style={{ width: 800, height: 600 }}>

--- a/packages/react/src/patterns/F0Graph/__tests__/utils.test.ts
+++ b/packages/react/src/patterns/F0Graph/__tests__/utils.test.ts
@@ -9,6 +9,7 @@ import {
   computeLayoutBounds,
   deriveEdgesFromTree,
   nodeIntersectsRect,
+  resolveInitialFitViewNodes,
   type ViewportRect,
 } from "../utils"
 
@@ -133,5 +134,21 @@ describe("computeLayoutBounds", () => {
       width: 240,
       height: 190,
     })
+  })
+})
+
+describe("resolveInitialFitViewNodes", () => {
+  const present = new Set(["a", "b", "me"])
+
+  it("returns undefined (fit-all) when no target is given", () => {
+    expect(resolveInitialFitViewNodes(undefined, present)).toBeUndefined()
+  })
+
+  it("frames the target when it is present", () => {
+    expect(resolveInitialFitViewNodes("me", present)).toEqual([{ id: "me" }])
+  })
+
+  it("falls back to fit-all when the target isn't present (never a blank frame)", () => {
+    expect(resolveInitialFitViewNodes("ghost", present)).toBeUndefined()
   })
 })

--- a/packages/react/src/patterns/F0Graph/__tests__/utils.test.ts
+++ b/packages/react/src/patterns/F0Graph/__tests__/utils.test.ts
@@ -138,17 +138,33 @@ describe("computeLayoutBounds", () => {
 })
 
 describe("resolveInitialFitViewNodes", () => {
-  const present = new Set(["a", "b", "me"])
+  const present = new Set(["root", "c1", "c2", "me"])
 
   it("returns undefined (fit-all) when no target is given", () => {
-    expect(resolveInitialFitViewNodes(undefined, present)).toBeUndefined()
+    expect(resolveInitialFitViewNodes(undefined, [], present)).toBeUndefined()
   })
 
-  it("frames the target when it is present", () => {
-    expect(resolveInitialFitViewNodes("me", present)).toEqual([{ id: "me" }])
+  it("frames the target alone when it has no children", () => {
+    expect(resolveInitialFitViewNodes("me", [], present)).toEqual([
+      { id: "me" },
+    ])
+  })
+
+  it("frames the target together with its direct children (show first level)", () => {
+    expect(resolveInitialFitViewNodes("root", ["c1", "c2"], present)).toEqual([
+      { id: "root" },
+      { id: "c1" },
+      { id: "c2" },
+    ])
+  })
+
+  it("drops children that aren't present, keeps the target", () => {
+    expect(
+      resolveInitialFitViewNodes("root", ["c1", "ghost"], present)
+    ).toEqual([{ id: "root" }, { id: "c1" }])
   })
 
   it("falls back to fit-all when the target isn't present (never a blank frame)", () => {
-    expect(resolveInitialFitViewNodes("ghost", present)).toBeUndefined()
+    expect(resolveInitialFitViewNodes("ghost", ["c1"], present)).toBeUndefined()
   })
 })

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -429,19 +429,24 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
     enabled: !enableNodeWindowing || viewportReady,
   })
 
-  // Initial frame: when `initialFocusNodeId` is set, open centered on that node
-  // (React Flow's `fitViewOptions.nodes`, capped zoom for context) instead of
-  // fit-to-all — no animation. Frozen at the first render with nodes present so
-  // React Flow's one-shot initial fit reads a stable value; falls back to
-  // fit-all when the target isn't present.
+  // Initial frame: when `initialFocusNodeId` is set, open framed on that node
+  // AND its direct children (React Flow's `fitViewOptions.nodes`, capped zoom)
+  // so the first level is visible — instead of fit-to-all, and without zooming
+  // in on the single node. No animation. Frozen at the first render with nodes
+  // present so React Flow's one-shot initial fit reads a stable value; falls
+  // back to fit-all when the target isn't present.
   const initialFitRef = useRef<
-    { nodes: [{ id: string }]; maxZoom: number } | undefined
+    { nodes: Array<{ id: string }>; maxZoom: number } | undefined
   >(undefined)
   const initialFitResolvedRef = useRef(false)
   if (!initialFitResolvedRef.current && renderedNodeIds.length > 0) {
     initialFitResolvedRef.current = true
+    const childIds = initialFocusNodeId
+      ? (nodeMap.get(initialFocusNodeId)?.children.map((c) => c.id) ?? [])
+      : []
     const nodes = resolveInitialFitViewNodes(
       initialFocusNodeId,
+      childIds,
       new Set(renderedNodeIds)
     )
     initialFitRef.current = nodes

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -23,6 +23,7 @@ import {
   EMPTY_HIGHLIGHTED_NODES,
   FIT_VIEW_PADDING_LOOSE,
   FOCUS_SETTLE_DELAY_MS,
+  INITIAL_FOCUS_MAX_ZOOM,
   LARGE_GRAPH_SNAP_THRESHOLD,
   NODE_CLICK_DISTANCE_SQ,
 } from "../../constants"
@@ -57,6 +58,7 @@ import type {
   LayoutDirection,
   PositionedNode,
 } from "../../types"
+import { resolveInitialFitViewNodes } from "../../utils"
 import { F0GraphControls } from "../F0GraphControls"
 import { type EdgeVariant, type F0GraphEdgeProps } from "../F0GraphEdge"
 import { F0GraphEdgeBase } from "../F0GraphEdge/F0GraphEdge"
@@ -148,6 +150,7 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
     onSelectedNodesChange,
     onPaneClick: onPaneClickProp,
     focusedNode,
+    initialFocusNodeId,
     highlightedNodes: highlightedProp,
     nodeWidth: nodeWidthProp,
     nodeHeight: nodeHeightProp,
@@ -426,6 +429,27 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
     enabled: !enableNodeWindowing || viewportReady,
   })
 
+  // Initial frame: when `initialFocusNodeId` is set, open centered on that node
+  // (React Flow's `fitViewOptions.nodes`, capped zoom for context) instead of
+  // fit-to-all — no animation. Frozen at the first render with nodes present so
+  // React Flow's one-shot initial fit reads a stable value; falls back to
+  // fit-all when the target isn't present.
+  const initialFitRef = useRef<
+    { nodes: [{ id: string }]; maxZoom: number } | undefined
+  >(undefined)
+  const initialFitResolvedRef = useRef(false)
+  if (!initialFitResolvedRef.current && renderedNodeIds.length > 0) {
+    initialFitResolvedRef.current = true
+    const nodes = resolveInitialFitViewNodes(
+      initialFocusNodeId,
+      new Set(renderedNodeIds)
+    )
+    initialFitRef.current = nodes
+      ? { nodes, maxZoom: Math.min(INITIAL_FOCUS_MAX_ZOOM, maxZoom) }
+      : undefined
+  }
+  const initialFitViewOptions = initialFitRef.current
+
   // ── Fly to the consumer-controlled focused node ──
   useEffect(() => {
     if (focusedNode) {
@@ -581,6 +605,7 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
                         }}
                         proOptions={{ hideAttribution: true }}
                         fitView
+                        fitViewOptions={initialFitViewOptions}
                         nodesDraggable={false}
                         nodesConnectable={false}
                         elementsSelectable={false}

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -10,6 +10,7 @@ import {
 import {
   type ReactNode,
   memo,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -347,6 +348,23 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
 
   const highlightedNodes = highlightedProp ?? EMPTY_HIGHLIGHTED_NODES
 
+  // Keep the toggled node visually fixed on collapse/expand: when the layout
+  // repositions the anchor, pan the camera by the same delta (in screen px)
+  // rather than offsetting node positions — no snap-back, and reveal/fit keep
+  // reading raw positions. Runs before paint (React Flow's `setViewport` is
+  // synchronous), so there is no flicker.
+  const handleAnchorReflow = useCallback(
+    (dx: number, dy: number) => {
+      const vp = reactFlow.getViewport()
+      reactFlow.setViewport({
+        x: vp.x + dx * vp.zoom,
+        y: vp.y + dy * vp.zoom,
+        zoom: vp.zoom,
+      })
+    },
+    [reactFlow]
+  )
+
   // ── React Flow render model (layout + anchor + rf nodes/edges) ──
   const {
     visibleTreeNodes,
@@ -363,6 +381,7 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
     nodeMap,
     expandedNodes,
     anchorNodeRef,
+    onAnchorReflow: handleAnchorReflow,
     resolvedEdgesProp,
     stableRenderNode,
     nodeTagTypes,

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -430,10 +430,9 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
   })
 
   // Initial frame: when `initialFocusNodeId` is set, open framed on that node
-  // AND its direct children (React Flow's `fitViewOptions.nodes`, capped zoom)
-  // so the first level is visible — instead of fit-to-all, and without zooming
-  // in on the single node. No animation. Frozen at the first render with nodes
-  // present so React Flow's one-shot initial fit reads a stable value; falls
+  // AND its direct children (capped zoom) so the first level is visible —
+  // instead of fit-to-all, and without zooming in on the single node. Frozen at
+  // the first render with nodes present so the fit reads a stable value; falls
   // back to fit-all when the target isn't present.
   const initialFitRef = useRef<
     { nodes: Array<{ id: string }>; maxZoom: number } | undefined
@@ -454,6 +453,20 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
       : undefined
   }
   const initialFitViewOptions = initialFitRef.current
+
+  // Apply the initial frame exactly once, imperatively — never via React Flow's
+  // `fitView` prop. That prop queues a fit deferred until the container/nodes
+  // are measured, and once it fires it clears `fitViewOptions`; a later layout
+  // change (the first collapse/expand) then re-fires it as a fit-all, snapping
+  // the focused node away. Fitting ourselves, guarded by a ref, guarantees a
+  // single fit framed on `initialFitViewOptions` and no re-fit on any later
+  // layout change. Consumer-driven reveals still fly via the effect below.
+  const didInitialFitRef = useRef(false)
+  useEffect(() => {
+    if (didInitialFitRef.current || renderedNodeIds.length === 0) return
+    didInitialFitRef.current = true
+    reactFlow.fitView(initialFitViewOptions)
+  }, [renderedNodeIds.length, initialFitViewOptions, reactFlow])
 
   // ── Fly to the consumer-controlled focused node ──
   // Latest fly-to logic, read via a ref so the effect below depends ONLY on
@@ -620,14 +633,9 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
                           ge?.onEdgeClick?.(ge)
                         }}
                         proOptions={{ hideAttribution: true }}
-                        // One-shot initial frame: disable React Flow's `fitView`
-                        // once the viewport has settled so a later layout change
-                        // (collapse/expand) can never re-fit and reposition the
-                        // focused root. `viewportReady` flips on the first
-                        // `onViewportChange` — which the initial fit triggers,
-                        // so the initial frame itself is never cancelled.
-                        fitView={!viewportReady}
-                        fitViewOptions={initialFitViewOptions}
+                        // No `fitView` prop: the initial frame is applied once,
+                        // imperatively (see `didInitialFitRef` above), so a later
+                        // layout change can never re-fire React Flow's queued fit.
                         nodesDraggable={false}
                         nodesConnectable={false}
                         elementsSelectable={false}

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -620,7 +620,18 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
                           ge?.onEdgeClick?.(ge)
                         }}
                         proOptions={{ hideAttribution: true }}
-                        fitView
+                        // One-shot initial frame. React Flow defers its queued
+                        // `fitView` until the container is measured; if that
+                        // lands late, it would otherwise re-fire on the first
+                        // layout change (e.g. a collapse) after clearing
+                        // `fitViewOptions` — snapping the graph to fit-all and
+                        // repositioning the focused root. Disabling the prop
+                        // once the viewport has settled (or the user has moved)
+                        // makes the initial fit truly one-shot: collapse/expand
+                        // never re-fit. `viewportReady` flips on the first
+                        // `onViewportChange`, which the initial fit itself
+                        // triggers, so the initial frame is never cancelled.
+                        fitView={!viewportReady}
                         fitViewOptions={initialFitViewOptions}
                         nodesDraggable={false}
                         nodesConnectable={false}

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -456,23 +456,34 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
   const initialFitViewOptions = initialFitRef.current
 
   // ── Fly to the consumer-controlled focused node ──
+  // Latest fly-to logic, read via a ref so the effect below depends ONLY on
+  // `focusedNode`. Otherwise the effect would re-run on every layout-affecting
+  // change (collapse/expand recomputes `centerOnNode`'s identity) and re-center
+  // on the same node even though the focus never changed.
+  const flyToFocusedRef = useRef<(id: string) => void>(() => {})
+  flyToFocusedRef.current = (id: string) => {
+    // Windowing: the target may be off-screen and absent from React Flow's
+    // store, so center on its layout position instead of an id-based fitView
+    // (which silently no-ops for a missing node).
+    if (enableNodeWindowing && centerOnNode(id, 300)) return
+    reactFlow.fitView({
+      nodes: [{ id }],
+      duration: 300,
+      padding: FIT_VIEW_PADDING_LOOSE,
+    })
+  }
   useEffect(() => {
-    if (focusedNode) {
-      // Slight delay to allow layout to settle
-      const timer = setTimeout(() => {
-        // Windowing: the target may be off-screen and absent from React Flow's
-        // store, so center on its layout position instead of an id-based
-        // fitView (which silently no-ops for a missing node).
-        if (enableNodeWindowing && centerOnNode(focusedNode, 300)) return
-        reactFlow.fitView({
-          nodes: [{ id: focusedNode }],
-          duration: 300,
-          padding: FIT_VIEW_PADDING_LOOSE,
-        })
-      }, FOCUS_SETTLE_DELAY_MS)
-      return () => clearTimeout(timer)
-    }
-  }, [focusedNode, reactFlow, enableNodeWindowing, centerOnNode])
+    if (!focusedNode) return
+    // Fires only when `focusedNode` transitions to a new value (entry,
+    // search-select, "Find me") — never on layout re-renders while it's
+    // unchanged. Slight delay so the layout settles before flying.
+    const target = focusedNode
+    const timer = setTimeout(
+      () => flyToFocusedRef.current(target),
+      FOCUS_SETTLE_DELAY_MS
+    )
+    return () => clearTimeout(timer)
+  }, [focusedNode])
 
   // ── Split context values (wrappers subscribe to only what they need) ──
   const zoomContextValue = useMemo(

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -620,17 +620,12 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
                           ge?.onEdgeClick?.(ge)
                         }}
                         proOptions={{ hideAttribution: true }}
-                        // One-shot initial frame. React Flow defers its queued
-                        // `fitView` until the container is measured; if that
-                        // lands late, it would otherwise re-fire on the first
-                        // layout change (e.g. a collapse) after clearing
-                        // `fitViewOptions` — snapping the graph to fit-all and
-                        // repositioning the focused root. Disabling the prop
-                        // once the viewport has settled (or the user has moved)
-                        // makes the initial fit truly one-shot: collapse/expand
-                        // never re-fit. `viewportReady` flips on the first
-                        // `onViewportChange`, which the initial fit itself
-                        // triggers, so the initial frame is never cancelled.
+                        // One-shot initial frame: disable React Flow's `fitView`
+                        // once the viewport has settled so a later layout change
+                        // (collapse/expand) can never re-fit and reposition the
+                        // focused root. `viewportReady` flips on the first
+                        // `onViewportChange` — which the initial fit triggers,
+                        // so the initial frame itself is never cancelled.
                         fitView={!viewportReady}
                         fitViewOptions={initialFitViewOptions}
                         nodesDraggable={false}

--- a/packages/react/src/patterns/F0Graph/constants.ts
+++ b/packages/react/src/patterns/F0Graph/constants.ts
@@ -56,3 +56,9 @@ export const NODE_WINDOW_QUANTIZE_STEP = 200
 // trades polish for responsiveness on large graphs. Tuned by feel — the
 // 200-node case still animates, the 4000-node case stays interactive.
 export const LARGE_GRAPH_SNAP_THRESHOLD = 700
+
+// Max zoom for the `initialFocusNodeId` first-frame fit. Fitting a single node
+// would otherwise clamp to the graph's `maxZoom` (2×) and open uncomfortably
+// zoomed-in; capping lower opens the node with surrounding context (parent /
+// siblings / reports visible). The user can still zoom in further afterwards.
+export const INITIAL_FOCUS_MAX_ZOOM = 1

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.test.ts
@@ -225,3 +225,71 @@ describe("useGraphRenderModel — node windowing", () => {
     ).toEqual(["child"])
   })
 })
+
+describe("useGraphRenderModel — anchor viewport compensation", () => {
+  beforeEach(() => {
+    mockViewportRect = null
+  })
+
+  it("reports the anchor's (dx, dy) delta so the owner can pan the viewport", () => {
+    const onAnchorReflow = vi.fn()
+    const anchorNodeRef = { current: null } as MutableRefObject<string | null>
+    const roots = [treeNode("a", null, 0)]
+    const { rerender } = renderHook(
+      (opts: Parameters<typeof useGraphRenderModel>[0]) =>
+        useGraphRenderModel(opts),
+      {
+        wrapper,
+        initialProps: {
+          ...baseOptions(roots, []),
+          anchorNodeRef,
+          onAnchorReflow,
+          layoutEngineProp: fixedLayout({ a: { x: 100, y: 0 } }),
+        },
+      }
+    )
+
+    // Simulate a toggle: mark the node as the anchor and let the layout move it
+    // (dagre would re-center it). The delta must be reported once.
+    anchorNodeRef.current = "a"
+    onAnchorReflow.mockClear()
+    rerender({
+      ...baseOptions(roots, []),
+      anchorNodeRef,
+      onAnchorReflow,
+      layoutEngineProp: fixedLayout({ a: { x: 0, y: 0 } }),
+    })
+
+    expect(onAnchorReflow).toHaveBeenCalledWith(100, 0)
+  })
+
+  it("does not pan when the anchor node's position is unchanged", () => {
+    const onAnchorReflow = vi.fn()
+    const anchorNodeRef = { current: null } as MutableRefObject<string | null>
+    const roots = [treeNode("a", null, 0)]
+    const { rerender } = renderHook(
+      (opts: Parameters<typeof useGraphRenderModel>[0]) =>
+        useGraphRenderModel(opts),
+      {
+        wrapper,
+        initialProps: {
+          ...baseOptions(roots, []),
+          anchorNodeRef,
+          onAnchorReflow,
+          layoutEngineProp: fixedLayout({ a: { x: 100, y: 0 } }),
+        },
+      }
+    )
+
+    anchorNodeRef.current = "a"
+    onAnchorReflow.mockClear()
+    rerender({
+      ...baseOptions(roots, []),
+      anchorNodeRef,
+      onAnchorReflow,
+      layoutEngineProp: fixedLayout({ a: { x: 100, y: 0 } }),
+    })
+
+    expect(onAnchorReflow).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -54,6 +54,12 @@ interface UseGraphRenderModelOptions<T> {
   nodeMap: Map<string, TreeNode<T>>
   expandedNodes: Set<string>
   anchorNodeRef: MutableRefObject<string | null>
+  /**
+   * Called (before paint) when a toggle-driven reflow repositions the anchor
+   * node by `(dx, dy)` in flow-space. The owner translates the viewport by the
+   * same amount so the anchor stays visually fixed — node positions stay raw.
+   */
+  onAnchorReflow?: (dx: number, dy: number) => void
   resolvedEdgesProp?: GraphEdge[]
   stableRenderNode: (
     node: GraphNode<unknown>,
@@ -111,6 +117,7 @@ export function useGraphRenderModel<T>({
   nodeMap,
   expandedNodes,
   anchorNodeRef,
+  onAnchorReflow,
   resolvedEdgesProp,
   stableRenderNode,
   nodeTagTypes,
@@ -335,26 +342,28 @@ export function useGraphRenderModel<T>({
     return { dx: 0, dy: 0 }
   }, [layout.nodes, anchorNodeRef])
 
-  // Persist positions and clear the anchor once the toggle has settled (safe for
-  // strict mode). In lazy mode an expand resolves in two phases: the node is
-  // marked expanded first, then its children arrive asynchronously. Clearing the
-  // anchor on the first commit would leave the big reflow (when many children
-  // appear) uncompensated and the view would jump. So keep the anchor until the
-  // toggled node's children are actually loaded.
+  // Keep the toggled node visually fixed across a reflow by translating the
+  // VIEWPORT (not the node positions). When the layout engine repositions the
+  // anchor — e.g. dagre re-centers a parent over its children, so collapsing
+  // shifts the parent's x — the anchor's (dx, dy) delta is handed to
+  // `onAnchorReflow`, which pans the camera by the same amount before paint.
+  // Node positions stay raw, so `getNodePosition`/`contentBounds` (reveal, fit)
+  // stay consistent, and there is no offset to "release" (the old node-offset
+  // held the node for one commit then snapped back on the next — e.g. a node
+  // windowing settle — leaving the root jumping to its natural position).
+  //
+  // In lazy mode an expand resolves in two phases (node marked expanded, then
+  // children arrive asynchronously); the anchor is kept across both so the big
+  // reflow when children appear is compensated too.
   useLayoutEffect(() => {
     const { dx, dy } = anchorOffset
     prevPositionsRef.current = new Map(
-      layout.nodes.map((pn) => [pn.id, { x: pn.x + dx, y: pn.y + dy }])
+      layout.nodes.map((pn) => [pn.id, { x: pn.x, y: pn.y }])
     )
     const anchorId = anchorNodeRef.current
     if (anchorId) {
+      if (dx !== 0 || dy !== 0) onAnchorReflow?.(dx, dy)
       const anchorNode = nodeMap.get(anchorId)
-      // Keep the anchor while an expanded node is still waiting for its children
-      // to materialize — they may arrive in a later commit (F0Graph's own lazy
-      // mode, or a consumer like the DataCollection adapter that loads children
-      // asynchronously into the `nodes` prop). Without this the big reflow when
-      // the children appear would be uncompensated and the viewport would jump.
-      // Mode-agnostic: keyed on the tree shape, not on how the data is sourced.
       const stillExpanding =
         anchorNode !== undefined &&
         expandedNodes.has(anchorId) &&
@@ -364,7 +373,14 @@ export function useGraphRenderModel<T>({
         anchorNodeRef.current = null
       }
     }
-  }, [layout.nodes, anchorOffset, nodeMap, expandedNodes, anchorNodeRef])
+  }, [
+    layout.nodes,
+    anchorOffset,
+    nodeMap,
+    expandedNodes,
+    anchorNodeRef,
+    onAnchorReflow,
+  ])
 
   // ── Node-array windowing ──
   // Ids of the LAYOUT nodes (graph pills + expanders) whose box intersects the
@@ -381,13 +397,12 @@ export function useGraphRenderModel<T>({
   const windowedIds = useMemo((): Set<string> | null => {
     if (!enableNodeWindowing || !viewportRect) return null
     const fallbackWidth = nodeWidthProp ?? 256
-    const { dx, dy } = anchorOffset
     const ids = new Set<string>()
     for (const pn of layout.nodes) {
       if (
         nodeIntersectsRect(
-          pn.x + dx,
-          pn.y + dy,
+          pn.x,
+          pn.y,
           pn.width || fallbackWidth,
           pn.height || effectiveNodeHeight,
           viewportRect
@@ -401,7 +416,6 @@ export function useGraphRenderModel<T>({
     enableNodeWindowing,
     viewportRect,
     layout.nodes,
-    anchorOffset,
     nodeWidthProp,
     effectiveNodeHeight,
   ])
@@ -410,7 +424,6 @@ export function useGraphRenderModel<T>({
   // when windowing is off). Building here — rather than building everything and
   // filtering — is what makes the work O(on-screen) instead of O(visible tree).
   const rfNodes = useMemo((): RFNode[] => {
-    const { dx: anchorDx, dy: anchorDy } = anchorOffset
     const BASE_W = nodeWidthProp ?? 256
     const BASE_H = effectiveNodeHeight
     const yStretch = 1
@@ -467,8 +480,8 @@ export function useGraphRenderModel<T>({
         id: treeNode.id,
         type: "graphNode",
         position: {
-          x: (pos?.x ?? 0) + anchorDx,
-          y: (pos?.y ?? 0) * yStretch + anchorDy,
+          x: pos?.x ?? 0,
+          y: (pos?.y ?? 0) * yStretch,
         },
         width: BASE_W,
         sourcePosition: sourcePos,
@@ -510,7 +523,7 @@ export function useGraphRenderModel<T>({
       nodes.push({
         id: exp.id,
         type: "expanderNode",
-        position: { x: expX + anchorDx, y: expY + anchorDy },
+        position: { x: expX, y: expY },
         sourcePosition: sourcePos,
         targetPosition: targetPos,
         data: {
@@ -548,7 +561,7 @@ export function useGraphRenderModel<T>({
         id: `collapser-${parent.id}`,
         type: "collapserNode",
         zIndex: 10,
-        position: { x: colX + anchorDx, y: colY + anchorDy },
+        position: { x: colX, y: colY },
         sourcePosition: sourcePos,
         targetPosition: targetPos,
         data: {
@@ -567,7 +580,6 @@ export function useGraphRenderModel<T>({
     expanderNodes,
     expandedNodes,
     stableRenderNode,
-    anchorOffset,
     EXPANDER_Y_OFFSET,
     COLLAPSER_OFFSET_ADJUSTMENT,
     nodeWidthProp,

--- a/packages/react/src/patterns/F0Graph/utils.ts
+++ b/packages/react/src/patterns/F0Graph/utils.ts
@@ -1,5 +1,21 @@
 import type { GraphEdge, PositionedNode, TreeNode } from "./types"
 
+/**
+ * React Flow `fitViewOptions.nodes` for the initial frame: `[{ id }]` to open
+ * centered on `initialFocusNodeId`, or `undefined` to fit the whole graph.
+ * Returns `undefined` (fit-all fallback) when no target is given or the target
+ * isn't among the present nodes — so a missing node never leaves a blank frame.
+ */
+export function resolveInitialFitViewNodes(
+  initialFocusNodeId: string | undefined,
+  presentNodeIds: ReadonlySet<string>
+): [{ id: string }] | undefined {
+  if (!initialFocusNodeId || !presentNodeIds.has(initialFocusNodeId)) {
+    return undefined
+  }
+  return [{ id: initialFocusNodeId }]
+}
+
 /** Axis-aligned rectangle in flow-space coordinates. */
 export interface ViewportRect {
   minX: number

--- a/packages/react/src/patterns/F0Graph/utils.ts
+++ b/packages/react/src/patterns/F0Graph/utils.ts
@@ -8,12 +8,20 @@ import type { GraphEdge, PositionedNode, TreeNode } from "./types"
  */
 export function resolveInitialFitViewNodes(
   initialFocusNodeId: string | undefined,
+  childIds: readonly string[],
   presentNodeIds: ReadonlySet<string>
-): [{ id: string }] | undefined {
+): Array<{ id: string }> | undefined {
   if (!initialFocusNodeId || !presentNodeIds.has(initialFocusNodeId)) {
     return undefined
   }
-  return [{ id: initialFocusNodeId }]
+  // Frame the target together with its direct (present) children, so the
+  // initial view shows the top of the branch — the node and its first level —
+  // rather than zooming in on the single node.
+  const ids = [
+    initialFocusNodeId,
+    ...childIds.filter((id) => presentNodeIds.has(id)),
+  ]
+  return ids.map((id) => ({ id }))
 }
 
 /** Axis-aligned rectangle in flow-space coordinates. */

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
@@ -673,8 +673,10 @@ const DetailField = ({ label, value }: { label: string; value: string }) => (
  */
 const OrgChartExample = ({
   defaultExpandDepth,
+  focusOnEntry,
 }: {
   defaultExpandDepth: number
+  focusOnEntry?: string
 }) => {
   const [selected, setSelected] = useState<EmployeeNode | null>(null)
   const [revealId, setRevealId] = useState<string | undefined>(undefined)
@@ -692,6 +694,7 @@ const OrgChartExample = ({
               ...graphVisualization.options,
               defaultExpandDepth,
               revealNodeId: revealId,
+              focusOnEntry,
             },
           },
           tableVisualization,
@@ -754,4 +757,14 @@ export const OrgChart: Story = {
  */
 export const PreExpanded: Story = {
   render: () => <OrgChartExample defaultExpandDepth={2} />,
+}
+
+/**
+ * Opens framed on a specific root (`focusOnEntry: "ceo-a"`) instead of
+ * fit-to-all — via the OneDataCollection controlled path (expandedNodes is
+ * owned by the tree-data hook). Collapsing/expanding any node keeps the initial
+ * frame: the initial fit is one-shot and never re-fits on a later layout change.
+ */
+export const FocusOnRoot: Story = {
+  render: () => <OrgChartExample defaultExpandDepth={2} focusOnEntry="ceo-a" />,
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/reveal.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/reveal.test.ts
@@ -18,7 +18,8 @@ describe("resolveGraphReveal", () => {
     })
   })
 
-  it("does NOT auto-focus on entry by default (adopts the search value as handled)", () => {
+  it("never reveals on entry (adopts the search value as handled)", () => {
+    // Entry focus is handled by initialFocusNodeId, not by a reveal/pan here.
     const d = resolveGraphReveal({
       isInitialLoading: false,
       initialConsumed: false,
@@ -30,26 +31,10 @@ describe("resolveGraphReveal", () => {
     expect(d.lastRevealed).toBe("search-1") // tracks the search value, not revealed
   })
 
-  it("auto-focuses `focusOnEntry` once on entry, keeping search tracking intact", () => {
-    const d = resolveGraphReveal({
-      isInitialLoading: false,
-      initialConsumed: false,
-      focusOnEntry: "me",
-      revealNodeId: undefined,
-      lastRevealed: undefined,
-    })
-    expect(d.revealId).toBe("me")
-    expect(d.consumeInitial).toBe(true)
-    // lastRevealed stays on the (empty) search value so a later search pick fires.
-    expect(d.lastRevealed).toBeUndefined()
-  })
-
-  it("still reveals a later search selection after an entry auto-focus", () => {
-    // Entry consumed already; a fresh search selection differs from lastRevealed.
+  it("reveals a later search selection after entry", () => {
     const d = resolveGraphReveal({
       isInitialLoading: false,
       initialConsumed: true,
-      focusOnEntry: "me",
       revealNodeId: "search-2",
       lastRevealed: undefined,
     })
@@ -66,17 +51,5 @@ describe("resolveGraphReveal", () => {
     })
     expect(d.revealId).toBeNull()
     expect(d.lastRevealed).toBe("search-2")
-  })
-
-  it("ignores focusOnEntry after the initial render (entry-only)", () => {
-    // focusOnEntry changing later must not re-trigger a reveal.
-    const d = resolveGraphReveal({
-      isInitialLoading: false,
-      initialConsumed: true,
-      focusOnEntry: "me",
-      revealNodeId: undefined,
-      lastRevealed: "search-1",
-    })
-    expect(d.revealId).toBeNull()
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
@@ -116,19 +116,19 @@ export const GraphCollection = <
       loadNodePath,
       getParentId,
       loadNodeData,
+      focusOnEntry,
       zoomPreset,
       showControls,
     },
     { onLoadData, onLoadError }
   )
 
-  // Reveal driver. By default the graph does NOT auto-focus on entry (a
-  // consistent default view + clean search): the initial `revealNodeId` is
-  // adopted as "already handled", and only LATER changes (a fresh search
-  // selection) reveal. Opting into `focusOnEntry` reveals that node once on
-  // entry instead. "Find me" reveals via the controls, outside this path.
-  // The decision lives in the pure `resolveGraphReveal`; this effect only
-  // applies it and carries the refs across renders.
+  // Reveal driver. The graph never auto-focuses on entry via this path: the
+  // initial `revealNodeId` is adopted as "already handled", and only LATER
+  // changes (a fresh search selection) reveal — with the smooth pan. Entry
+  // focus is handled instead by `focusOnEntry`, which the tree-data hook
+  // pre-resolves before first paint so F0Graph opens framed on it (no pan).
+  // The decision lives in the pure `resolveGraphReveal`.
   const lastRevealedRef = useRef<string | undefined>(undefined)
   const initialRevealConsumedRef = useRef(false)
   useEffect(() => {
@@ -136,14 +136,13 @@ export const GraphCollection = <
     const decision = resolveGraphReveal({
       isInitialLoading,
       initialConsumed: initialRevealConsumedRef.current,
-      focusOnEntry,
       revealNodeId,
       lastRevealed: lastRevealedRef.current,
     })
     if (decision.consumeInitial) initialRevealConsumedRef.current = true
     lastRevealedRef.current = decision.lastRevealed
     if (decision.revealId) void revealNode(decision.revealId)
-  }, [revealNodeId, focusOnEntry, revealNode, isInitialLoading])
+  }, [revealNodeId, revealNode, isInitialLoading])
 
   // Clear the shared header search when ENTERING and LEAVING the graph view, so
   // it never points at a node here (the graph is a tree, not a filtered list).
@@ -199,6 +198,9 @@ export const GraphCollection = <
           expandedNodes={expandedNodes}
           onExpandedNodesChange={setExpandedNodes}
           focusedNode={focusedNode}
+          // Open framed on the entry target (pre-resolved above) with no
+          // fit-then-pan. Falls back to fit-to-all when it isn't resolvable.
+          initialFocusNodeId={focusOnEntry}
           highlightedNodes={highlightedNodes}
           selectionMode="single"
           showControls={showControls ?? true}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/reveal.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/reveal.ts
@@ -3,8 +3,6 @@ interface RevealState {
   isInitialLoading: boolean
   /** Whether the first ready render has already been handled. */
   initialConsumed: boolean
-  /** Opt-in node to auto-reveal once, on entry. */
-  focusOnEntry?: string
   /** Search-driven reveal target (ignored on entry). */
   revealNodeId?: string
   /** Last `revealNodeId` we adopted/acted on, to detect a *new* search pick. */
@@ -26,16 +24,16 @@ interface RevealDecision {
  *
  * Rules:
  * - While loading: nothing.
- * - First ready render: adopt the current `revealNodeId` as "already handled"
- *   (so an initial search value never yanks the view), and — only if
- *   `focusOnEntry` is set — reveal that node (the opt-in auto-focus).
+ * - First ready render: never reveal — adopt the current `revealNodeId` as
+ *   "already handled" so an initial search value doesn't yank the view. (Entry
+ *   focus is handled separately by `focusOnEntry` → `initialFocusNodeId`, which
+ *   frames the node on the first paint without a reveal/pan.)
  * - Later renders: reveal `revealNodeId` only when it *changes* (a fresh search
  *   selection). "Find me" reveals via the controls, outside this path.
  */
 export function resolveGraphReveal({
   isInitialLoading,
   initialConsumed,
-  focusOnEntry,
   revealNodeId,
   lastRevealed,
 }: RevealState): RevealDecision {
@@ -43,10 +41,9 @@ export function resolveGraphReveal({
     return { revealId: null, consumeInitial: false, lastRevealed }
   }
   if (!initialConsumed) {
-    // Keep `lastRevealed` tracking the search value (not focusOnEntry) so a
-    // later search selection of a different node still fires.
+    // Adopt the current search value as handled; never reveal on entry.
     return {
-      revealId: focusOnEntry ?? null,
+      revealId: null,
       consumeInitial: true,
       lastRevealed: revealNodeId,
     }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.test.tsx
@@ -372,3 +372,62 @@ describe("useDataCollectionTreeData — two-phase hydration", () => {
     expect(result.current.error).not.toBeNull()
   })
 })
+
+describe("useDataCollectionTreeData — focus on entry", () => {
+  it("pre-resolves and expands the focusOnEntry path on initial load, without focusing", async () => {
+    const fetchData = vi.fn(fetchByParent)
+    const source = buildSource(fetchData)
+    const loadNodePath = vi.fn(async () => [
+      employees.ceo,
+      employees.vp1,
+      employees.mgr1,
+    ])
+
+    const { result } = renderHook(() =>
+      useDataCollectionTreeData(
+        source,
+        buildOptions({
+          defaultExpandDepth: 0,
+          loadNodePath,
+          focusOnEntry: "mgr1",
+        }),
+        callbacks()
+      )
+    )
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false))
+
+    // Path resolved + ancestors expanded before the first paint...
+    expect(loadNodePath).toHaveBeenCalledWith("mgr1")
+    expect(result.current.expandedNodes.has("ceo")).toBe(true)
+    expect(result.current.expandedNodes.has("vp1")).toBe(true)
+    expect(result.current.nodes.map((node) => node.id)).toContain("mgr1")
+    // ...but NO focus/highlight — the initial viewport frames it (initialFocusNodeId).
+    expect(result.current.focusedNode).toBeUndefined()
+    expect(result.current.highlightedNodes.size).toBe(0)
+  })
+
+  it("falls back to the default view when focusOnEntry path resolution fails", async () => {
+    const fetchData = vi.fn(fetchByParent)
+    const source = buildSource(fetchData)
+    const loadNodePath = vi.fn(async () => {
+      throw new Error("no path")
+    })
+
+    const { result } = renderHook(() =>
+      useDataCollectionTreeData(
+        source,
+        buildOptions({
+          defaultExpandDepth: 1,
+          loadNodePath,
+          focusOnEntry: "mgr1",
+        }),
+        callbacks()
+      )
+    )
+
+    // Initial load still completes (no throw) → fit-to-all fallback.
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false))
+    expect(result.current.nodes.map((node) => node.id)).toContain("ceo")
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts
@@ -353,38 +353,49 @@ export function useDataCollectionTreeData<
     [ensureFrontierLoaded]
   )
 
+  // Resolve+merge a node's ancestor path and load the chain's children so the
+  // node exists in the tree, then return the ancestor ids to expand. Shared by
+  // `revealNode` (which also focuses/highlights) and the initial `focusOnEntry`
+  // pre-resolution (which only needs the node present + expanded).
+  const resolvePath = useCallback(
+    async (nodeId: string): Promise<string[]> => {
+      const opts = optionsRef.current
+      const pathRecords = opts.loadNodePath
+        ? await opts.loadNodePath(nodeId)
+        : []
+      if (pathRecords.length > 0) {
+        setNodes((prev) => {
+          const existing = new Set(prev.map((node) => node.id))
+          const additions = pathRecords
+            .filter((record) => !existing.has(getId(record)))
+            .map((record, index) => {
+              const parentId = opts.getParentId
+                ? opts.getParentId(record)
+                : index > 0
+                  ? getId(pathRecords[index - 1])
+                  : null
+              return toNode(record, parentId)
+            })
+          return additions.length > 0 ? [...prev, ...additions] : prev
+        })
+      }
+
+      const ancestorIds = pathRecords.map(getId).filter((id) => id !== nodeId)
+
+      // Connect the chain and load the node's own children (for its expander).
+      await Promise.all(
+        [...ancestorIds, nodeId].map((id) => loadChildrenOf(id))
+      )
+
+      return ancestorIds
+    },
+    [getId, toNode, loadChildrenOf]
+  )
+
   const revealNode = useCallback(
     async (nodeId: string): Promise<void> => {
-      const opts = optionsRef.current
       try {
-        // Resolve and merge the ancestor path so the node exists in the tree.
-        const pathRecords = opts.loadNodePath
-          ? await opts.loadNodePath(nodeId)
-          : []
-        if (pathRecords.length > 0) {
-          setNodes((prev) => {
-            const existing = new Set(prev.map((node) => node.id))
-            const additions = pathRecords
-              .filter((record) => !existing.has(getId(record)))
-              .map((record, index) => {
-                const parentId = opts.getParentId
-                  ? opts.getParentId(record)
-                  : index > 0
-                    ? getId(pathRecords[index - 1])
-                    : null
-                return toNode(record, parentId)
-              })
-            return additions.length > 0 ? [...prev, ...additions] : prev
-          })
-        }
-
-        const ancestorIds = pathRecords.map(getId).filter((id) => id !== nodeId)
-
-        // Connect the chain and load the node's own children (for its expander).
-        await Promise.all(
-          [...ancestorIds, nodeId].map((id) => loadChildrenOf(id))
-        )
-
+        const ancestorIds = await resolvePath(nodeId)
         setExpandedNodes(new Set([...expandedNodesRef.current, ...ancestorIds]))
         setFocusedNode(nodeId)
         setHighlightedNodes(new Set([nodeId]))
@@ -394,7 +405,7 @@ export function useDataCollectionTreeData<
         callbacksRef.current.onLoadError(dataError)
       }
     },
-    [getId, toNode, loadChildrenOf, setExpandedNodes]
+    [resolvePath, setExpandedNodes]
   )
 
   // Drop the centered/highlighted node (e.g. when the user clicks the empty
@@ -463,6 +474,21 @@ export function useDataCollectionTreeData<
         frontier = loadable.flatMap((_, index) => childArrays[index])
       }
 
+      // Focus-on-entry: pre-resolve the target's ancestor path and expand it now,
+      // BEFORE the first paint, so the node exists in the layout and F0Graph can
+      // open framed on it (via `initialFocusNodeId`) with no fit-then-pan. No
+      // focus/highlight is set here — the initial viewport does the centering.
+      // On failure we skip silently → F0Graph falls back to fit-to-all.
+      const focusOnEntry = optionsRef.current.focusOnEntry
+      if (focusOnEntry && optionsRef.current.loadNodePath) {
+        try {
+          const ancestorIds = await resolvePath(focusOnEntry)
+          for (const id of ancestorIds) expanded.add(id)
+        } catch {
+          // Ignore — fall back to the default fit-to-all initial view.
+        }
+      }
+
       setExpandedState(expanded)
 
       callbacksRef.current.onLoadData({
@@ -479,7 +505,7 @@ export function useDataCollectionTreeData<
     } finally {
       setIsInitialLoading(false)
     }
-  }, [fetchRecords, toNode, loadChildrenOf])
+  }, [fetchRecords, toNode, loadChildrenOf, resolvePath])
 
   const filtersKey = JSON.stringify(source.currentFilters)
   const navigationFiltersKey = JSON.stringify(source.currentNavigationFilters)


### PR DESCRIPTION
## Description

Adds an instant **"open already looking at this node"** for the graph — the org-chart case of landing on the current user (or their branch root) without a fit-to-all-then-pan — and the correctness fixes needed to make it hold as you interact (collapse/expand no longer move the view).

Rebased on `main` (includes #4612 windowing + #4625 `focusOnEntry`).

## Preview / Demo

- **`Graph/F0Graph` → InitialFocus** — passes `initialFocusNodeId` (a deep, off-center node); the graph opens already framed on it (no fit-to-all + pan). Compare with **LargeTree** (same data) which opens fit-to-all.
- **`Data Collection/Visualizations/Graph` → FocusOnRoot** — the OneDataCollection path with `focusOnEntry: "ceo-a"` (controlled expand + lazy loading): opens framed on the root, and collapsing/expanding keeps that frame.

### Before (performance issues already resolved in another PR) 
Dropped in the middle of the orgchart without any pattern 


https://github.com/user-attachments/assets/d6111c95-ead0-4ade-ae7a-6e280350058c



### After 
Now centered on your "root" the manager of the manager of the manager so you have a familiar starting point

https://github.com/user-attachments/assets/fdd9c23f-0f94-49ce-b085-1c7f8bc276e7



## Behavior

- With `focusOnEntry` (OneDataCollection) / `initialFocusNodeId` (F0Graph): the graph **opens already framed on the target + its direct children, no animation** — no fit-to-all first, no second pan.
- **Collapse / expand keeps the view put**: the toggled node stays visually fixed; the camera is only moved by explicit actions (pan, "Find me", search).
- Default (no target): unchanged — fit-to-all.
- Fallback: target not resolvable → fit-to-all (never a blank frame).
- Search / "Find me" reveals: unchanged.

## What's in this PR

**1. Feature — first-frame focus (two layers)**
- **`initialFocusNodeId`** (F0Graph, view layer): frame on a node **that is present** + its direct children on the mount-time fit.
- **`focusOnEntry`** (OneDataCollection, data layer): pre-resolves the node's ancestor path and expands it **before first paint** (the tree is lazy, so the node may not be loaded yet), then feeds it to `initialFocusNodeId`. This is the pre-paint, no-pan version of a reveal.

**2. Correctness fixes (so the frame survives interaction)**
- **fly-to no-refire**: the `focusedNode` fly-to only fires when the focus actually changes, not on every layout re-render.
- **one-shot initial fit**: the initial frame is applied once, imperatively — React Flow's queued `fitView` prop is no longer used, so a later layout change can't re-fire it as a fit-all.
- **anchor via viewport pan**: on collapse/expand the layout engine repositions the toggled node (dagre re-centers a parent over its children). Instead of offsetting node positions (which held for one commit then snapped back on the next node-windowing render — the "root jumps left on the first collapse" bug), we translate the **viewport** by the anchor's `(dx, dy)` delta before paint. Node positions stay raw, so `getNodePosition` / `contentBounds` (reveal, fit-view, windowing) stay consistent.

## Implementation

### F0Graph
- New **`initialFocusNodeId`** prop. Pure `resolveInitialFitViewNodes` picks the target + its present direct children (or `undefined` → fit-all fallback). Zoom capped by `INITIAL_FOCUS_MAX_ZOOM`. The fit is applied once, imperatively (`didInitialFitRef`), not via the `fitView` prop.
- `useGraphRenderModel` keeps node positions raw and reports the anchor's reflow delta via **`onAnchorReflow`**; `F0GraphView` applies it with `reactFlow.setViewport` (before paint, so no flicker).

### OneDataCollection graph viz
- `useDataCollectionTreeData` **pre-resolves the `focusOnEntry` ancestor path before first paint** (extracted `resolvePath`, shared with `revealNode`). No focus/highlight on entry — the initial viewport centers it. Resolution failure → silent fallback.
- `GraphCollection` passes `focusOnEntry` to the hook and `initialFocusNodeId` to F0Graph. `resolveGraphReveal` no longer reveals on entry; search / Find-me unchanged.

The monorepo needs nothing new — it already passes `focusOnEntry = root of the tree`; F0 frames the first paint and keeps it stable on collapse/expand.

## Acceptance criteria

- [x] First frame centered on the target + direct children, no jump
- [x] **Collapse / expand does not move the viewport** (only explicit actions do)
- [x] Default (no target) unchanged — fit-to-all
- [x] Fallback to fit-to-all when target can't be resolved
- [x] Search / "Find me" unchanged
- [x] Windowing + two-phase hydration: no regression

## Testing

- `utils.test.ts` — `resolveInitialFitViewNodes` (frame target / fallback).
- `F0Graph.focusNoRefire.test.tsx` — fly-to fires only on focus change; initial fit is one-shot (no re-fit on collapse).
- `useGraphRenderModel.test.ts` — anchor reports the `(dx, dy)` delta on reflow, and stays silent when the position is unchanged.
- `useDataCollectionTreeData.test.tsx` — `focusOnEntry` pre-resolution.
- Full F0Graph + OneDataCollection Graph suites green; `tsc` and `oxlint` clean.
