### PR TITLE
fix(dialog-alike): don't let the opening interaction immediately dismiss a dialog

### DIFF
--- a/packages/react/src/components/dialog-alike/common/Wrapper.tsx
+++ b/packages/react/src/components/dialog-alike/common/Wrapper.tsx
@@ -9,6 +9,8 @@ import { DialogWrapperProvider } from "./DialogWrapperProvider"
 import { DialogAlikeSize } from "./types"
 import { useIsSmallScreen } from "./utils"
 
+const OPEN_DISMISS_GRACE_MS = 300
+
 const dialogWrapperClassName = cva({
   variants: {
     position: {
@@ -124,8 +126,20 @@ export const DialogWrapper = ({
 
   const isSmallScreen = useIsSmallScreen()
 
+  const openedAtRef = useRef(0)
+  useEffect(() => {
+    if (isOpen) openedAtRef.current = Date.now()
+  }, [isOpen])
+
   const handleOpenChange = useCallback(
     (open: boolean) => {
+      // A non-modal dialog opened from a closing overlay (e.g. a menu item)
+      // sees that interaction's trailing events as an outside click and would
+      // dismiss itself in the same tick it opened. Ignore a close this soon
+      // after opening; real dismissals happen well after the grace window.
+      if (!open && Date.now() - openedAtRef.current < OPEN_DISMISS_GRACE_MS) {
+        return
+      }
       onOpenChange?.(open)
       // Do not call onClose here: the useEffect below runs when isOpen becomes
       // false and invokes onClose once. Calling onClose here would duplicate

--- a/packages/react/src/components/dialog-alike/common/__tests__/Wrapper.test.tsx
+++ b/packages/react/src/components/dialog-alike/common/__tests__/Wrapper.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest"
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest"
 
 import { forwardRef, type ReactNode } from "react"
 
@@ -9,11 +9,17 @@ import { DialogWrapper } from "../Wrapper"
 // Spy on the props DialogWrapper hands to DialogContent. Hoisted so the vi.mock
 // factory can reference it. This mirrors the sibling F0Drawer test's approach of
 // mocking the internal and asserting the wiring.
-const { dialogContentSpy } = vi.hoisted(() => ({ dialogContentSpy: vi.fn() }))
+const { dialogContentSpy, dialogRootSpy } = vi.hoisted(() => ({
+  dialogContentSpy: vi.fn(),
+  dialogRootSpy: vi.fn(),
+}))
 
 vi.mock("../dialog-primitive", () => ({
-  // Passthrough so its children always render.
-  Dialog: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  // Passthrough so its children always render; record props (incl. onOpenChange).
+  Dialog: ({ children, ...props }: { children?: ReactNode }) => {
+    dialogRootSpy(props)
+    return <>{children}</>
+  },
   // forwardRef so the ref DialogWrapper passes doesn't warn; the spy records props.
   DialogContent: forwardRef(function DialogContentMock(
     props: { children?: ReactNode },
@@ -78,5 +84,56 @@ describe("DialogWrapper portal target", () => {
     expect(dialogContentSpy).toHaveBeenCalledWith(
       expect.objectContaining({ container })
     )
+  })
+})
+
+describe("DialogWrapper open-dismiss grace window", () => {
+  const baseProps = {
+    isOpen: true,
+    onOpenChange: vi.fn(),
+    onClose: vi.fn(),
+    children: <div>Content</div>,
+    position: "center" as const,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers({ now: 1_000_000 })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const getRootOnOpenChange = () => {
+    const call = dialogRootSpy.mock.calls.at(-1)?.[0] as {
+      onOpenChange?: (open: boolean) => void
+    }
+    return call.onOpenChange!
+  }
+
+  it("ignores a close that fires within the grace window of opening", () => {
+    render(<DialogWrapper {...baseProps} />)
+
+    getRootOnOpenChange()(false)
+
+    expect(baseProps.onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it("propagates a close that fires after the grace window", () => {
+    render(<DialogWrapper {...baseProps} />)
+
+    vi.advanceTimersByTime(500)
+    getRootOnOpenChange()(false)
+
+    expect(baseProps.onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("always propagates open=true", () => {
+    render(<DialogWrapper {...baseProps} />)
+
+    getRootOnOpenChange()(true)
+
+    expect(baseProps.onOpenChange).toHaveBeenCalledWith(true)
   })
 })


### PR DESCRIPTION
## Description

Since #4552 the dialog-alike dialogs are **non-modal** (Radix `modal={false}`), so Radix's dismissable layer watches for outside interactions and closes the dialog on them. When a dialog is opened from a **closing overlay** — e.g. a dropdown / menu-item click, whose focus-restore and pointer sequence finish *after* the dialog has already mounted — that in-flight interaction is treated as an outside event and the dialog is dismissed in the same tick it opened.

Concretely: the payroll "change collaboration mode" status dialog (opened from the collaboration dropdown) mounts, immediately receives `onOpenChange(false)`, and closes before the user can act. At f0 3.10 / 4.8 the dialog was **modal**, so the opening interaction couldn't dismiss it — this is a regression introduced by the non-modal switch (same #4552 root as the pointer-events fix #4609, different symptom).

## Implementation details

`DialogWrapper.handleOpenChange` is the single sink every dismiss funnels through (Radix `onOpenChange`, Escape, outside-click). Record when the dialog last became open and ignore an outside-`close` that lands within a short grace window (300ms) of opening. Genuine user dismissals happen well after this window; `open=true` always propagates. No change to modal dialogs (they already `preventDefault` outside interactions).

## Testing

- New `DialogWrapper` unit tests: a close within the grace window is ignored; a close after it propagates; `open=true` always propagates. Existing Wrapper/stacking tests still pass (33/33 in the suite touched).
- End-to-end on the factorial monorepo: with **only this f0 change** built into the prod bundle (no app or test change), the previously-failing `payroll/payroll_policy/payroll_policy_workflow` E2E spec passes 2/2 (it was 100% failing at 4.20.1/4.21.1 because the status dialog auto-closed). Full investigation: [Debug doc](https://app.notion.com/p/factorialco/Debug-3915e6e051ee80418bcac01116f43d75).

**Before:**


https://github.com/user-attachments/assets/2d522117-aeaf-423c-b555-508e2931bbef

**After:**


https://github.com/user-attachments/assets/e04f1756-9786-4d52-99e4-706f352a3fdc

