### PR TITLE
feat(OneDataCollection): opt-in auto-focus-on-entry for the graph viz

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/reveal.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/reveal.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveGraphReveal } from "../reveal"
+
+describe("resolveGraphReveal", () => {
+  it("does nothing while the tree is still loading", () => {
+    expect(
+      resolveGraphReveal({
+        isInitialLoading: true,
+        initialConsumed: false,
+        revealNodeId: "n1",
+        lastRevealed: undefined,
+      })
+    ).toEqual({
+      revealId: null,
+      consumeInitial: false,
+      lastRevealed: undefined,
+    })
+  })
+
+  it("does NOT auto-focus on entry by default (adopts the search value as handled)", () => {
+    const d = resolveGraphReveal({
+      isInitialLoading: false,
+      initialConsumed: false,
+      revealNodeId: "search-1",
+      lastRevealed: undefined,
+    })
+    expect(d.revealId).toBeNull()
+    expect(d.consumeInitial).toBe(true)
+    expect(d.lastRevealed).toBe("search-1") // tracks the search value, not revealed
+  })
+
+  it("auto-focuses `focusOnEntry` once on entry, keeping search tracking intact", () => {
+    const d = resolveGraphReveal({
+      isInitialLoading: false,
+      initialConsumed: false,
+      focusOnEntry: "me",
+      revealNodeId: undefined,
+      lastRevealed: undefined,
+    })
+    expect(d.revealId).toBe("me")
+    expect(d.consumeInitial).toBe(true)
+    // lastRevealed stays on the (empty) search value so a later search pick fires.
+    expect(d.lastRevealed).toBeUndefined()
+  })
+
+  it("still reveals a later search selection after an entry auto-focus", () => {
+    // Entry consumed already; a fresh search selection differs from lastRevealed.
+    const d = resolveGraphReveal({
+      isInitialLoading: false,
+      initialConsumed: true,
+      focusOnEntry: "me",
+      revealNodeId: "search-2",
+      lastRevealed: undefined,
+    })
+    expect(d.revealId).toBe("search-2")
+    expect(d.lastRevealed).toBe("search-2")
+  })
+
+  it("does not re-reveal the same search selection", () => {
+    const d = resolveGraphReveal({
+      isInitialLoading: false,
+      initialConsumed: true,
+      revealNodeId: "search-2",
+      lastRevealed: "search-2",
+    })
+    expect(d.revealId).toBeNull()
+    expect(d.lastRevealed).toBe("search-2")
+  })
+
+  it("ignores focusOnEntry after the initial render (entry-only)", () => {
+    // focusOnEntry changing later must not re-trigger a reveal.
+    const d = resolveGraphReveal({
+      isInitialLoading: false,
+      initialConsumed: true,
+      focusOnEntry: "me",
+      revealNodeId: undefined,
+      lastRevealed: "search-1",
+    })
+    expect(d.revealId).toBeNull()
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
@@ -13,6 +13,7 @@ import { ItemActionsDefinition } from "../../../item-actions"
 import { NavigationFiltersDefinition } from "../../../navigationFilters/types"
 import { SummariesDefinition } from "../../../summary"
 import { CollectionProps } from "../../../types"
+import { resolveGraphReveal } from "./reveal"
 import { GraphVisualizationOptions } from "./types"
 import { useDataCollectionTreeData } from "./useDataCollectionTreeData"
 
@@ -61,6 +62,7 @@ export const GraphCollection = <
   childrenFilters,
   defaultExpandDepth,
   revealNodeId,
+  focusOnEntry,
   loadNodePath,
   getParentId,
   loadNodeData,
@@ -120,26 +122,28 @@ export const GraphCollection = <
     { onLoadData, onLoadError }
   )
 
-  // Reveal a node selected from the shared Data Collection search — but NEVER on
-  // entry: opening the graph must not auto-focus anyone (a consistent default
-  // view + clean search). We adopt whatever `revealNodeId` exists when the tree
-  // first becomes ready as "already handled", then only react to LATER changes
-  // (a fresh search selection). "Find me" reveals directly via the controls and
-  // is unaffected.
+  // Reveal driver. By default the graph does NOT auto-focus on entry (a
+  // consistent default view + clean search): the initial `revealNodeId` is
+  // adopted as "already handled", and only LATER changes (a fresh search
+  // selection) reveal. Opting into `focusOnEntry` reveals that node once on
+  // entry instead. "Find me" reveals via the controls, outside this path.
+  // The decision lives in the pure `resolveGraphReveal`; this effect only
+  // applies it and carries the refs across renders.
   const lastRevealedRef = useRef<string | undefined>(undefined)
   const initialRevealConsumedRef = useRef(false)
   useEffect(() => {
     if (isInitialLoading) return
-    if (!initialRevealConsumedRef.current) {
-      initialRevealConsumedRef.current = true
-      lastRevealedRef.current = revealNodeId
-      return
-    }
-    if (revealNodeId && revealNodeId !== lastRevealedRef.current) {
-      lastRevealedRef.current = revealNodeId
-      void revealNode(revealNodeId)
-    }
-  }, [revealNodeId, revealNode, isInitialLoading])
+    const decision = resolveGraphReveal({
+      isInitialLoading,
+      initialConsumed: initialRevealConsumedRef.current,
+      focusOnEntry,
+      revealNodeId,
+      lastRevealed: lastRevealedRef.current,
+    })
+    if (decision.consumeInitial) initialRevealConsumedRef.current = true
+    lastRevealedRef.current = decision.lastRevealed
+    if (decision.revealId) void revealNode(decision.revealId)
+  }, [revealNodeId, focusOnEntry, revealNode, isInitialLoading])
 
   // Clear the shared header search when ENTERING and LEAVING the graph view, so
   // it never points at a node here (the graph is a tree, not a filtered list).

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/reveal.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/reveal.ts
@@ -1,0 +1,62 @@
+interface RevealState {
+  /** Tree still loading — do nothing yet. */
+  isInitialLoading: boolean
+  /** Whether the first ready render has already been handled. */
+  initialConsumed: boolean
+  /** Opt-in node to auto-reveal once, on entry. */
+  focusOnEntry?: string
+  /** Search-driven reveal target (ignored on entry). */
+  revealNodeId?: string
+  /** Last `revealNodeId` we adopted/acted on, to detect a *new* search pick. */
+  lastRevealed?: string
+}
+
+interface RevealDecision {
+  /** Node to reveal now, or `null` for none. */
+  revealId: string | null
+  /** Whether this run marks the initial ready render as handled. */
+  consumeInitial: boolean
+  /** The value `lastRevealed` should take after this run. */
+  lastRevealed: string | undefined
+}
+
+/**
+ * Decides what the graph should reveal on a given render — pure so the ref
+ * juggling in the effect stays trivial and this can be unit-tested.
+ *
+ * Rules:
+ * - While loading: nothing.
+ * - First ready render: adopt the current `revealNodeId` as "already handled"
+ *   (so an initial search value never yanks the view), and — only if
+ *   `focusOnEntry` is set — reveal that node (the opt-in auto-focus).
+ * - Later renders: reveal `revealNodeId` only when it *changes* (a fresh search
+ *   selection). "Find me" reveals via the controls, outside this path.
+ */
+export function resolveGraphReveal({
+  isInitialLoading,
+  initialConsumed,
+  focusOnEntry,
+  revealNodeId,
+  lastRevealed,
+}: RevealState): RevealDecision {
+  if (isInitialLoading) {
+    return { revealId: null, consumeInitial: false, lastRevealed }
+  }
+  if (!initialConsumed) {
+    // Keep `lastRevealed` tracking the search value (not focusOnEntry) so a
+    // later search selection of a different node still fires.
+    return {
+      revealId: focusOnEntry ?? null,
+      consumeInitial: true,
+      lastRevealed: revealNodeId,
+    }
+  }
+  if (revealNodeId && revealNodeId !== lastRevealed) {
+    return {
+      revealId: revealNodeId,
+      consumeInitial: false,
+      lastRevealed: revealNodeId,
+    }
+  }
+  return { revealId: null, consumeInitial: false, lastRevealed }
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
@@ -70,6 +70,16 @@ export type GraphVisualizationOptions<
    */
   revealNodeId?: string
   /**
+   * Id of a node to reveal **once, on entry** (e.g. the current user, or the
+   * root of their branch): when the tree first becomes ready, its ancestor
+   * path is loaded/expanded and the viewport centers on it. Unlike
+   * `revealNodeId` (which is ignored on entry so search stays clean), this is
+   * the opt-in "open the org chart already looking at me" behaviour. Requires
+   * `loadNodePath` to reveal nodes in not-yet-expanded branches. Omit to keep
+   * the default entry view (roots expanded to `defaultExpandDepth`).
+   */
+  focusOnEntry?: string
+  /**
    * Resolves the ancestor path (root → … → matched node) for a node so it can
    * be revealed, returning the records in root-first order. Required for
    * revealing nodes in branches that have not been expanded yet.


### PR DESCRIPTION
## Description

Adds an opt-in **`focusOnEntry`** option to the OneDataCollection graph visualization: when set (e.g. the current user, or the root of their branch), the org chart **opens already looking at that node** — its ancestor path is loaded/expanded and the viewport centers on it once, on entry.

Motivation: on large / "broken" org charts (thousands of top-level nodes), landing on a neutral default view is unhelpful; users want to open straight into their own neighbourhood. Pairs naturally with a lazy, user-anchored data strategy (climb `manager_id` to the root, load that branch) so the tree stays small.

## Behavior
- **Default (unchanged):** the graph does NOT auto-focus on entry — a consistent default view + clean search. The initial `revealNodeId` is adopted as "already handled"; only later search selections reveal.
- **With `focusOnEntry`:** that node is revealed once on entry (via the existing `loadNodePath` → expand ancestors → `focusedNode` flow), inheriting F0Graph's smooth constant-zoom centering. Search selection after entry still works.
- Opt-in; existing consumers are unaffected.

## Implementation
- New `focusOnEntry?: string` on `GraphVisualizationOptions`.
- The reveal decision is extracted to a **pure `resolveGraphReveal`** so the effect only applies it + carries refs; makes the (otherwise ref-heavy, hard-to-render-test) logic unit-testable.
- `GraphCollection` effect now drives off `resolveGraphReveal`.

## Testing
- `reveal.test.ts` — no auto-focus by default; focus-on-entry once; later search still fires; same-selection no-ops; `focusOnEntry` is entry-only. Full OneDataCollection Graph suite green (16); typecheck/oxlint/oxfmt clean.

## Notes
- Requires `loadNodePath` to reveal nodes in not-yet-expanded branches (same as `revealNodeId`).
- Depends on nothing new in F0Graph. The smooth (constant-zoom, proportional-duration) centering comes from #4621; until that lands, entry-focus uses the current `focusedNode` centering. Consumer wiring lives in the monorepo (which node to anchor on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)