### PR TITLE
feat(F0Wizard): add ScrollComponent prop for keyboard-aware scrolling

### DIFF
--- a/packages/react-native/src/components/F0Wizard/F0Wizard.md
+++ b/packages/react-native/src/components/F0Wizard/F0Wizard.md
@@ -33,6 +33,28 @@ The **React Native** `F0Wizard` is a standalone `View`-based container with no b
 
 This design keeps `F0Wizard` composable and avoids coupling it to any specific navigation or overlay library.
 
+## Keyboard handling
+
+The Back/Next footer is pinned to the bottom of the container. By default, step content scrolls inside a plain React Native `ScrollView`, so a text input low on the screen can end up hidden behind the keyboard.
+
+To keep a focused input visible **while the footer stays pinned**, inject a keyboard-aware scroll component via `ScrollComponent`. `F0Wizard` measures the footer height (via `onLayout`) and forwards it as `bottomOffset`, so the focused field is scrolled clear of the Back/Next buttons — no magic numbers, and it adapts to button size and locale.
+
+`F0Wizard` intentionally adds **no keyboard dependency of its own**. Consumers opt in by passing a component such as `react-native-keyboard-controller`'s `KeyboardAwareScrollView` (which requires `KeyboardProvider` mounted at the app root). A plain `ScrollView` ignores the extra `bottomOffset` prop, so the default behavior is unchanged.
+
+<!-- prettier-ignore -->
+```tsx
+import { KeyboardAwareScrollView } from "react-native-keyboard-controller"
+
+<F0Wizard
+  ScrollComponent={KeyboardAwareScrollView}
+  steps={steps}
+  nextLabel="Next"
+  previousLabel="Back"
+  submitLabel="Submit"
+  onSubmit={handleSubmit}
+/>
+```
+
 ## Usage examples
 
 ### Basic

--- a/packages/react-native/src/components/F0Wizard/F0Wizard.tsx
+++ b/packages/react-native/src/components/F0Wizard/F0Wizard.tsx
@@ -173,7 +173,11 @@ const F0Wizard = React.memo(function F0Wizard({
           className="flex flex-1" internally (Uniwind + Tailwind), which collapses to 32px
           inside a flex-row container without an explicit height. The View wrapper
           provides the correct stretch behavior. */}
-      <View className={wizardFooterVariants()} onLayout={handleFooterLayout}>
+      <View
+        className={wizardFooterVariants()}
+        onLayout={handleFooterLayout}
+        testID={testID ? `${testID}-footer` : undefined}
+      >
         <View className={wizardFooterButtonVariants()}>
           <F0Button
             label={backButtonLabel}

--- a/packages/react-native/src/components/F0Wizard/F0Wizard.tsx
+++ b/packages/react-native/src/components/F0Wizard/F0Wizard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react"
-import { ScrollView, View } from "react-native"
+import { ScrollView, View, type LayoutChangeEvent } from "react-native"
 
 import { F0Button } from "../F0Button"
 import { F0Step } from "../F0Step"
@@ -30,6 +30,13 @@ import type { F0WizardProps } from "./F0Wizard.types"
  * sheet behavior. The consumer is responsible for embedding it inside a
  * `Modal`, bottom sheet, or full-screen layout as appropriate.
  *
+ * The Back/Next footer is pinned to the bottom of the container. Step content
+ * scrolls inside a `ScrollView` by default; to keep a focused input visible
+ * above the keyboard while the footer stays pinned, inject a keyboard-aware
+ * scroll component via `ScrollComponent` (F0Wizard forwards the measured footer
+ * height as `bottomOffset`, so the focused field clears the buttons — no magic
+ * numbers). F0Wizard adds no keyboard dependency of its own.
+ *
  * @example
  * <!-- prettier-ignore -->
  * <F0Wizard
@@ -59,6 +66,7 @@ const F0Wizard = React.memo(function F0Wizard({
   stepLabel,
   onStepChanged,
   onSubmit,
+  ScrollComponent = ScrollView,
   accessibilityLabel,
   testID,
 }: F0WizardProps) {
@@ -66,6 +74,12 @@ const F0Wizard = React.memo(function F0Wizard({
     Math.min(Math.max(0, defaultStepIndex), steps.length - 1)
   )
   const [isAdvancing, setIsAdvancing] = useState(false)
+
+  const [footerHeight, setFooterHeight] = useState(0)
+  const handleFooterLayout = useCallback((event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout
+    setFooterHeight((prev) => (prev === height ? prev : height))
+  }, [])
 
   const step = steps[currentStep]
   const isFirstStep = currentStep === 0
@@ -144,13 +158,14 @@ const F0Wizard = React.memo(function F0Wizard({
 
       {/* Scrollable content area */}
       <View className={wizardContentVariants()}>
-        <ScrollView
+        <ScrollComponent
           contentContainerStyle={wizardScrollContentStyle}
           keyboardShouldPersistTaps="handled"
+          bottomOffset={footerHeight}
           testID={testID ? `${testID}-content` : undefined}
         >
           {step?.renderContent({ stepIndex: currentStep })}
-        </ScrollView>
+        </ScrollComponent>
       </View>
 
       {/* Footer: Back + Next/Submit buttons.
@@ -158,7 +173,7 @@ const F0Wizard = React.memo(function F0Wizard({
           className="flex flex-1" internally (Uniwind + Tailwind), which collapses to 32px
           inside a flex-row container without an explicit height. The View wrapper
           provides the correct stretch behavior. */}
-      <View className={wizardFooterVariants()}>
+      <View className={wizardFooterVariants()} onLayout={handleFooterLayout}>
         <View className={wizardFooterButtonVariants()}>
           <F0Button
             label={backButtonLabel}

--- a/packages/react-native/src/components/F0Wizard/F0Wizard.types.ts
+++ b/packages/react-native/src/components/F0Wizard/F0Wizard.types.ts
@@ -1,4 +1,21 @@
 import React from "react"
+import type { ScrollViewProps } from "react-native"
+
+/**
+ * Props for the scroll container F0Wizard renders around each step's content.
+ *
+ * A keyboard-aware scroll component (e.g.
+ * `react-native-keyboard-controller`'s `KeyboardAwareScrollView`) can be
+ * injected via {@link F0WizardProps.ScrollComponent}. F0Wizard passes it a
+ * `bottomOffset` equal to the measured footer height so a focused input is
+ * scrolled clear of the pinned Back/Next footer. A plain `ScrollView` simply
+ * ignores the extra prop.
+ */
+export type F0WizardScrollComponentProps = ScrollViewProps & {
+  /** Height (px) of the pinned footer, so a keyboard-aware scroll component can
+   * offset the focused input above it. Ignored by a plain `ScrollView`. */
+  bottomOffset?: number
+}
 
 export interface F0WizardStep {
   /** Title displayed above the step content */
@@ -54,6 +71,22 @@ export interface F0WizardProps {
   onStepChanged?: (stepIndex: number) => void
   /** Called when the user confirms the last step. */
   onSubmit?: () => void | Promise<void>
+  /**
+   * Scroll container rendered around each step's content. Defaults to React
+   * Native's `ScrollView`.
+   *
+   * Inject a keyboard-aware scroll component (e.g.
+   * `react-native-keyboard-controller`'s `KeyboardAwareScrollView`) to scroll a
+   * focused input above the keyboard while the footer stays pinned. F0Wizard
+   * measures the footer height and passes it as `bottomOffset` so the focused
+   * field clears the Back/Next buttons — no magic numbers, adapts to button
+   * size and locale. F0Wizard adds no keyboard dependency of its own.
+   *
+   * @example
+   * import { KeyboardAwareScrollView } from "react-native-keyboard-controller"
+   * <F0Wizard ScrollComponent={KeyboardAwareScrollView} … />
+   */
+  ScrollComponent?: React.ComponentType<F0WizardScrollComponentProps>
   accessibilityLabel?: string
   testID?: string
 }

--- a/packages/react-native/src/components/F0Wizard/__tests__/F0Wizard.spec.tsx
+++ b/packages/react-native/src/components/F0Wizard/__tests__/F0Wizard.spec.tsx
@@ -405,6 +405,75 @@ describe("F0Wizard", () => {
     expect(screen.queryByText("Tell us about yourself")).toBeNull()
   })
 
+  it("renders step content through an injected ScrollComponent", () => {
+    const ScrollComponent = jest.fn(
+      ({ children }: { children?: React.ReactNode }) => <>{children}</>
+    )
+
+    render(
+      <F0Wizard
+        steps={makeSteps(1)}
+        testID="wizard"
+        {...LABELS}
+        ScrollComponent={ScrollComponent}
+      />
+    )
+
+    // The injected component is used and still renders the step content.
+    expect(ScrollComponent).toHaveBeenCalled()
+    expect(screen.getByTestId("content-0")).toBeTruthy()
+  })
+
+  it("forwards the measured footer height as bottomOffset to ScrollComponent", async () => {
+    const ScrollComponent = jest.fn(
+      ({ children }: { children?: React.ReactNode }) => <>{children}</>
+    )
+
+    render(
+      <F0Wizard
+        steps={makeSteps(1)}
+        testID="wizard"
+        {...LABELS}
+        ScrollComponent={ScrollComponent}
+      />
+    )
+
+    // The footer is the only node wiring an onLayout handler; fire it with a
+    // known height and assert F0Wizard forwards it as bottomOffset.
+    const footerHeight = 72
+    const footer = screen
+      .getByTestId("wizard")
+      .findAll((node) => typeof node.props?.onLayout === "function")[0]
+    fireEvent(footer, "layout", {
+      nativeEvent: { layout: { height: footerHeight, width: 300, x: 0, y: 0 } },
+    })
+
+    await waitFor(() => {
+      const lastCall =
+        ScrollComponent.mock.calls[ScrollComponent.mock.calls.length - 1]
+      expect(lastCall?.[0]?.bottomOffset).toBe(footerHeight)
+    })
+  })
+
+  it("passes keyboardShouldPersistTaps='handled' to ScrollComponent", () => {
+    const ScrollComponent = jest.fn(
+      ({ children }: { children?: React.ReactNode }) => <>{children}</>
+    )
+
+    render(
+      <F0Wizard
+        steps={makeSteps(1)}
+        testID="wizard"
+        {...LABELS}
+        ScrollComponent={ScrollComponent}
+      />
+    )
+
+    expect(ScrollComponent.mock.calls[0]?.[0]?.keyboardShouldPersistTaps).toBe(
+      "handled"
+    )
+  })
+
   it("canAdvance:false disables button and onNext is never called", async () => {
     const onNext = jest.fn().mockResolvedValue({ canAdvance: true })
     const steps: F0WizardStep[] = [

--- a/packages/react-native/src/components/F0Wizard/__tests__/F0Wizard.spec.tsx
+++ b/packages/react-native/src/components/F0Wizard/__tests__/F0Wizard.spec.tsx
@@ -8,7 +8,10 @@ import React from "react"
 import { Text } from "react-native"
 
 import { F0Wizard } from "../F0Wizard"
-import type { F0WizardStep } from "../F0Wizard.types"
+import type {
+  F0WizardScrollComponentProps,
+  F0WizardStep,
+} from "../F0Wizard.types"
 
 const makeSteps = (count: number): F0WizardStep[] =>
   Array.from({ length: count }, (_, i) => ({
@@ -407,7 +410,7 @@ describe("F0Wizard", () => {
 
   it("renders step content through an injected ScrollComponent", () => {
     const ScrollComponent = jest.fn(
-      ({ children }: { children?: React.ReactNode }) => <>{children}</>
+      ({ children }: F0WizardScrollComponentProps) => <>{children}</>
     )
 
     render(
@@ -426,7 +429,7 @@ describe("F0Wizard", () => {
 
   it("forwards the measured footer height as bottomOffset to ScrollComponent", async () => {
     const ScrollComponent = jest.fn(
-      ({ children }: { children?: React.ReactNode }) => <>{children}</>
+      ({ children }: F0WizardScrollComponentProps) => <>{children}</>
     )
 
     render(
@@ -438,13 +441,10 @@ describe("F0Wizard", () => {
       />
     )
 
-    // The footer is the only node wiring an onLayout handler; fire it with a
-    // known height and assert F0Wizard forwards it as bottomOffset.
+    // Fire the footer's onLayout with a known height and assert F0Wizard
+    // forwards it to the scroll component as bottomOffset.
     const footerHeight = 72
-    const footer = screen
-      .getByTestId("wizard")
-      .findAll((node) => typeof node.props?.onLayout === "function")[0]
-    fireEvent(footer, "layout", {
+    fireEvent(screen.getByTestId("wizard-footer"), "layout", {
       nativeEvent: { layout: { height: footerHeight, width: 300, x: 0, y: 0 } },
     })
 
@@ -457,7 +457,7 @@ describe("F0Wizard", () => {
 
   it("passes keyboardShouldPersistTaps='handled' to ScrollComponent", () => {
     const ScrollComponent = jest.fn(
-      ({ children }: { children?: React.ReactNode }) => <>{children}</>
+      ({ children }: F0WizardScrollComponentProps) => <>{children}</>
     )
 
     render(


### PR DESCRIPTION
## Description

`F0Wizard` (React Native) pins its Back/Next footer to the bottom of the container, but its default `ScrollView` is **not** keyboard-aware. When a step has a text input low on the screen, focusing it leaves the field hidden behind the keyboard with no way to scroll to it.

This adds an opt-in, dependency-free way to make the focused input scroll above the keyboard **while the footer stays pinned**.

## Screenshots (if applicable)
<img width="700" height="700" alt="ios_request_after (1)" src="https://github.com/user-attachments/assets/fe06f21f-cc87-4c47-90de-632d093c7170" />


## Implementation details

- **New optional prop `ScrollComponent`** on `F0Wizard`, defaulting to React Native's `ScrollView`. Consumers can inject a keyboard-aware scroll container — e.g. `react-native-keyboard-controller`'s `KeyboardAwareScrollView`.
- F0Wizard **measures the footer height** via `onLayout` and forwards it to the scroll component as `bottomOffset`, so the focused field is scrolled clear of the Back/Next buttons. No magic numbers — it adapts to button size, padding, and locale.
- **No new dependency:** F0Wizard does not import `react-native-keyboard-controller`. A plain `ScrollView` simply ignores the extra `bottomOffset` prop, so the default behavior is unchanged. Consumers that want keyboard-awareness opt in (and are responsible for mounting `KeyboardProvider`).
- Added the `F0WizardScrollComponentProps` type, JSDoc on the new prop, a "Keyboard handling" section in `F0Wizard.md`, and 3 unit tests (injected component is used, `bottomOffset` = measured footer height, `keyboardShouldPersistTaps` forwarded).

**Tests:** `pnpm test F0Wizard` → 31/31 pass. `pnpm lint`, `pnpm format:check`, `pnpm tsc` all clean.

**Downstream:** consumed by the Factorial mobile app to fix the Training Request wizard keyboard behavior (mobile PR to follow, gated on the next `@factorialco/f0-react-native` release + version bump).