### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "4.22.2",
-  "packages/react-native": "0.56.0",
+  "packages/react-native": "0.57.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.57.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.56.0...f0-react-native-v0.57.0) (2026-07-06)
+
+
+### Features
+
+* **F0Wizard:** add ScrollComponent prop for keyboard-aware scrolling ([1a2ae78](https://github.com/factorialco/f0/commit/1a2ae789094c4d8c86b331d3f073457afabc8b3d))
+
+
+### Bug Fixes
+
+* **F0Wizard:** type test scroll mock; add footer testID ([d1ba2ae](https://github.com/factorialco/f0/commit/d1ba2ae140f2da9ccba03fa1f0b89cf0b335c4a3))
+
 ## [0.56.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.55.0...f0-react-native-v0.56.0) (2026-06-29)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.57.0</summary>

## [0.57.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.56.0...f0-react-native-v0.57.0) (2026-07-06)


### Features

* **F0Wizard:** add ScrollComponent prop for keyboard-aware scrolling ([1a2ae78](https://github.com/factorialco/f0/commit/1a2ae789094c4d8c86b331d3f073457afabc8b3d))


### Bug Fixes

* **F0Wizard:** type test scroll mock; add footer testID ([d1ba2ae](https://github.com/factorialco/f0/commit/d1ba2ae140f2da9ccba03fa1f0b89cf0b335c4a3))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).