### PR TITLE
docs(cocreation): document welcome suggestion buttons

### DIFF
--- a/packages/react/src/patterns/Cocreation/__stories__/adoption.mdx
+++ b/packages/react/src/patterns/Cocreation/__stories__/adoption.mdx
@@ -146,5 +146,5 @@ When standing up a new co-creation flow:
 8. Verify the [Accessibility](?path=/docs/patterns-co-creation-accessibility--documentation)
    contract — keyboard, focus, announcements, reduced motion.
 
-For the first end-to-end instance to read alongside this checklist, see
-[Creation with AI](?path=/docs/patterns-co-creation-creation-with-ai--documentation).
+For the end-to-end walkthrough to read alongside this checklist, see the
+[Walkthrough](?path=/docs/patterns-co-creation-walkthrough--documentation).

--- a/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.mdx
+++ b/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.mdx
@@ -39,13 +39,13 @@ primary button (full width).
   <figure className="mx-auto mb-8 mt-0 max-w-2xl">
     <img
       src={chatFullscreen}
-      alt="The full-width chat welcome screen, with an action-driven header, a composer, and four starting-point cards below it."
+      alt="The full-width chat welcome screen: a quick-start suggestion button above the composer, the composer itself, and four starting-point cards below it."
       className="block w-full rounded-lg border border-solid border-f1-border dark:border-f1-border-secondary"
     />
     <figcaption className="mt-2 text-sm text-f1-foreground-secondary">
-      The chat opens full width, with an action-driven header. The user types
-      what they want (or dictates it with the mic), or picks a starting-point
-      card.
+      The chat opens full width. The user types what they want (or dictates it
+      with the mic), taps a quick-start suggestion above the composer, or picks
+      a starting-point card below.
     </figcaption>
   </figure>
 </Unstyled>
@@ -99,6 +99,19 @@ each flow — the survey example fills all four:
     </tbody>
   </table>
 </Unstyled>
+
+Above the composer sits a separate, optional row of quick-start buttons — the welcome
+suggestions (`welcomeScreenSuggestions`). They are **example prompts, not flows**: each button is
+a group (here, the "Create a Survey for..." pill) that opens a short list of starter prompts, and
+picking one sends its text straight to the AI as if the user had typed it. That is the line
+between the two entry points — **a suggestion sends a prompt, a card triggers a flow** (open a
+canvas, seed a template). Use suggestions to show the user _what to say_ and to lower the
+blank-composer cost. When a flow includes them, populate them with prompts tied to the domain or
+resource being created — the survey example offers "Employee satisfaction survey," "Onboarding
+feedback survey," and "Remote work pulse check." They render on both the side-panel and
+full-width welcome screens, and are independent of the cards: provide either, both, or neither.
+See [Building blocks](?path=/docs/patterns-co-creation-building-blocks--documentation) for the
+full cards-vs-suggestions contract.
 
 Clarifying questions narrow the intent before anything is drafted — here, the survey's type,
 audience, and length. The draft is then surfaced as an in-chat resource card; opening it moves

--- a/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.mdx
+++ b/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.mdx
@@ -3,22 +3,22 @@ import { Meta, Unstyled } from "@storybook/addon-docs/blocks"
 import chatFullscreen from "./assets/chat-fullscreen.png"
 import splitEmpty from "./assets/split-empty.png"
 
-<Meta title="Co-creation/Creation with AI" />
+<Meta title="Co-creation/Walkthrough" />
 
-# Creation with AI
+# Walkthrough
 
-**Creation with AI** is the first concrete instance of the
+This is an end-to-end walkthrough of the
 [Co-creation](?path=/docs/patterns-co-creation--documentation) pattern — the abstract flow
 grounded in one real resource. The resource here is a survey, but the structure is the
 pattern's, not the survey's: the user starts on a collection (Collection), describes what they
 want in a chat (Chat), then refines the resulting draft on a canvas while the conversation
-continues (Split). The walkthrough below maps each phase to what the survey example shows; the
+continues (Split). Each phase below maps to what the survey example shows; the
 mock itself runs full screen, so open it in its own canvas:
 
 <Unstyled>
   <a
     target="_parent"
-    href="/?path=/story/patterns-co-creation-creation-with-ai--surveys"
+    href="/?path=/story/patterns-co-creation-walkthrough--surveys"
     className="mb-8 inline-flex items-center gap-2 rounded-lg border border-solid border-f1-border bg-f1-background px-5 py-4 font-medium text-f1-foreground no-underline transition-all hover:shadow dark:border-f1-border-secondary dark:text-f1-foreground-inverse dark:hover:border-f1-border"
   >
     Open the interactive flow ↗

--- a/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.stories.tsx
+++ b/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.stories.tsx
@@ -95,7 +95,7 @@ import type { TabConfig } from "./tab-configs"
 import type { F0AiChatWelcomeCard } from "@/sds/ai/F0AiChat"
 
 /**
- * Co-creation patterns — "Creation with AI".
+ * Co-creation patterns — "Walkthrough".
  *
  * Interactive mockup of the AI-creation flow, built on a single chat-enabled
  * ApplicationFrame so the "One" switch (the F0AiChat trigger) is always in the
@@ -117,7 +117,7 @@ import type { F0AiChatWelcomeCard } from "@/sds/ai/F0AiChat"
  * template cards).
  */
 const meta = {
-  title: "Co-creation/Creation with AI",
+  title: "Co-creation/Walkthrough",
   // Manual MDX docs live in creation-with-ai.mdx; opt out of the globally
   // enabled autodocs so the section shows a single Documentation page.
   tags: ["!autodocs"],

--- a/packages/react/src/patterns/Cocreation/__stories__/index.mdx
+++ b/packages/react/src/patterns/Cocreation/__stories__/index.mdx
@@ -21,22 +21,22 @@ user approving every change. {/* TODO(creator): confirm the canonical one-line d
 
 ## Try the flow
 
-The pattern is demonstrated by an interactive mock — the **Creation with AI** example, which
-co-creates a survey from a typed intent to a ready-to-publish draft. It runs full screen, so it
+The pattern is demonstrated by an interactive **Walkthrough** — a mock that co-creates a survey
+from a typed intent to a ready-to-publish draft. It runs full screen, so it
 opens in its own canvas rather than cramped into this docs page:
 
 <Unstyled>
   <a
     target="_parent"
-    href="/?path=/story/patterns-co-creation-creation-with-ai--surveys"
+    href="/?path=/story/patterns-co-creation-walkthrough--surveys"
     className="mb-8 inline-flex items-center gap-2 rounded-lg border border-solid border-f1-border bg-f1-background px-5 py-4 font-medium text-f1-foreground no-underline transition-all hover:shadow dark:border-f1-border-secondary dark:text-f1-foreground-inverse dark:hover:border-f1-border"
   >
     Open the interactive flow ↗
   </a>
 </Unstyled>
 
-For a step-by-step walkthrough of what happens at each phase, see
-[Creation with AI](?path=/docs/patterns-co-creation-creation-with-ai--documentation).
+For a step-by-step tour of what happens at each phase, see the
+[Walkthrough](?path=/docs/patterns-co-creation-walkthrough--documentation).
 
 For open-ended assistance that does not produce a resource, use the chat surface directly
 ([`F0AiChat`](?path=/docs/sds-ai-f0aichat--documentation)). For creating and editing
@@ -120,10 +120,10 @@ creation warns** before the draft is lost.
       },
       {
         icon: Pencil,
-        title: "Creation with AI",
+        title: "Walkthrough",
         description:
-          "The first concrete instance of the pattern: creating a survey with AI, from intent to a ready-to-publish draft.",
-        href: "/?path=/docs/patterns-co-creation-creation-with-ai--documentation",
+          "The pattern run end to end on one real resource: creating a survey with AI, from intent to a ready-to-publish draft.",
+        href: "/?path=/docs/patterns-co-creation-walkthrough--documentation",
       },
     ]}
   />

--- a/packages/react/src/patterns/Cocreation/__stories__/index.mdx
+++ b/packages/react/src/patterns/Cocreation/__stories__/index.mdx
@@ -19,7 +19,24 @@ Instead of filling a form alone, the user describes what they want, the system p
 and drafts it, and the two refine it side by side until the resource is ready — with the
 user approving every change. {/* TODO(creator): confirm the canonical one-line definition. */}
 
-Want to see it first? **[Try the interactive demo ↗](?path=/story/patterns-co-creation-creation-with-ai--surveys)** — co-creating a survey from a typed intent to a ready-to-publish draft.
+## Try the flow
+
+The pattern is demonstrated by an interactive mock — the **Creation with AI** example, which
+co-creates a survey from a typed intent to a ready-to-publish draft. It runs full screen, so it
+opens in its own canvas rather than cramped into this docs page:
+
+<Unstyled>
+  <a
+    target="_parent"
+    href="/?path=/story/patterns-co-creation-creation-with-ai--surveys"
+    className="mb-8 inline-flex items-center gap-2 rounded-lg border border-solid border-f1-border bg-f1-background px-5 py-4 font-medium text-f1-foreground no-underline transition-all hover:shadow dark:border-f1-border-secondary dark:text-f1-foreground-inverse dark:hover:border-f1-border"
+  >
+    Open the interactive flow ↗
+  </a>
+</Unstyled>
+
+For a step-by-step walkthrough of what happens at each phase, see
+[Creation with AI](?path=/docs/patterns-co-creation-creation-with-ai--documentation).
 
 For open-ended assistance that does not produce a resource, use the chat surface directly
 ([`F0AiChat`](?path=/docs/sds-ai-f0aichat--documentation)). For creating and editing
@@ -121,22 +138,3 @@ through three phases — **Collection → Chat → Split** — described in
 [Phases](?path=/docs/patterns-co-creation-phases--documentation), and follows the contracts on
 the [Standard flow](?path=/docs/patterns-co-creation-standard-flow--documentation) page (the
 resource lives in a canvas inside the chat; the user approves every change; leaving warns).
-
-## Try the flow
-
-The pattern is demonstrated by an interactive mock — the **Creation with AI** example, which
-co-creates a survey from a typed intent to a ready-to-publish draft. It runs full screen, so it
-opens in its own canvas rather than cramped into this docs page:
-
-<Unstyled>
-  <a
-    target="_parent"
-    href="/?path=/story/patterns-co-creation-creation-with-ai--surveys"
-    className="mb-8 inline-flex items-center gap-2 rounded-lg border border-solid border-f1-border bg-f1-background px-5 py-4 font-medium text-f1-foreground no-underline transition-all hover:shadow dark:border-f1-border-secondary dark:text-f1-foreground-inverse dark:hover:border-f1-border"
-  >
-    Open the interactive flow ↗
-  </a>
-</Unstyled>
-
-For a step-by-step walkthrough of what happens at each phase, see
-[Creation with AI](?path=/docs/patterns-co-creation-creation-with-ai--documentation).

--- a/packages/react/src/patterns/Cocreation/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/Cocreation/__stories__/mockData.tsx
@@ -1,4 +1,4 @@
-// Mock data for the "Creation with AI" co-creation story — the collection
+// Mock data for the "Walkthrough" co-creation story — the collection
 // records, filters, sortings, data adapter, and visualization backing the
 // Surveys tab. Pure data; consumed by FlowContent's OneDataCollection source.
 

--- a/packages/react/src/patterns/Cocreation/__stories__/phases.mdx
+++ b/packages/react/src/patterns/Cocreation/__stories__/phases.mdx
@@ -78,7 +78,7 @@ Chat and Split. It runs full screen, so open it in its own canvas:
 <Unstyled>
   <a
     target="_parent"
-    href="/?path=/story/patterns-co-creation-creation-with-ai--surveys"
+    href="/?path=/story/patterns-co-creation-walkthrough--surveys"
     className="mb-8 inline-flex items-center gap-2 rounded-lg border border-solid border-f1-border bg-f1-background px-5 py-4 font-medium text-f1-foreground no-underline transition-all hover:shadow dark:border-f1-border-secondary dark:text-f1-foreground-inverse dark:hover:border-f1-border"
   >
     Open the interactive flow ↗

--- a/packages/react/src/patterns/Cocreation/__stories__/phases.mdx
+++ b/packages/react/src/patterns/Cocreation/__stories__/phases.mdx
@@ -42,8 +42,10 @@ as the user toggles the header trigger.
           <strong>Chat</strong>
         </td>
         <td>
-          The chat animates in so the user can describe what they want.
-          Clarifying questions narrow the intent before anything is drafted.
+          The chat animates in so the user can describe what they want — by
+          typing, tapping a quick-start suggestion, or picking a starting-point
+          card. Clarifying questions narrow the intent before anything is
+          drafted.
         </td>
         <td>
           Enters from Collection. Opens full width via the Create button, or as

--- a/packages/react/src/patterns/Cocreation/__stories__/standard-flow.mdx
+++ b/packages/react/src/patterns/Cocreation/__stories__/standard-flow.mdx
@@ -28,7 +28,7 @@ See it in the interactive mock (runs full screen, opens in its own canvas):
 <Unstyled>
   <a
     target="_parent"
-    href="/?path=/story/patterns-co-creation-creation-with-ai--surveys"
+    href="/?path=/story/patterns-co-creation-walkthrough--surveys"
     className="mb-8 inline-flex items-center gap-2 rounded-lg border border-solid border-f1-border bg-f1-background px-5 py-4 font-medium text-f1-foreground no-underline transition-all hover:shadow dark:border-f1-border-secondary dark:text-f1-foreground-inverse dark:hover:border-f1-border"
   >
     Open the interactive flow ↗

--- a/packages/react/src/patterns/Cocreation/__stories__/survey-mocks.ts
+++ b/packages/react/src/patterns/Cocreation/__stories__/survey-mocks.ts
@@ -1,4 +1,4 @@
-// Survey split-canvas mock for the "Creation with AI" co-creation story — a
+// Survey split-canvas mock for the "Walkthrough" co-creation story — a
 // representative Survey reproduced with the real SurveyAnsweringForm (inline,
 // read-only). Modeled on the SurveyAnsweringForm story's `sampleElements`,
 // themed to the "Employee engagement survey" card.
@@ -250,7 +250,7 @@ const SURVEY_DICTATION_TRANSCRIPTS = [
 ] as const
 
 /**
- * Survey-contextual voice dictation for the "Creation with AI" co-creation flow:
+ * Survey-contextual voice dictation for the "Walkthrough" co-creation flow:
  * streams a spoken-style survey-refinement request (follow-up questions and
  * triggers) into the composer so the user can review it and send. Wired to the
  * chat via the ApplicationFrame `ai.onTranscribe` prop.

--- a/packages/react/src/patterns/Cocreation/__stories__/tab-configs.ts
+++ b/packages/react/src/patterns/Cocreation/__stories__/tab-configs.ts
@@ -1,4 +1,4 @@
-// Per-tab configuration for the "Creation with AI" co-creation story — the
+// Per-tab configuration for the "Walkthrough" co-creation story — the
 // resource cards surfaced for the Surveys collection tab. Pure data; the story
 // wires it up via TabConfigProvider.
 


### PR DESCRIPTION
## Description

The Creation with AI walkthrough documented the welcome cards below the composer but never the quick-start suggestion buttons above the input, so readers had no guidance on what those buttons do or when to use them. This adds that coverage and corrects the screenshot alt/caption that mislabeled the suggestion pill as an "action-driven header."

## Implementation details

- docs: explain welcome suggestions on the full-screen chat start — they are example prompts (a click sends the prompt to the AI), versus welcome cards that trigger a host flow; note they are optional and, when present, should carry prompts tied to the resource being created
- docs: fix the chat welcome screenshot alt/caption, which called the "Create a Survey for..." suggestion pill an "action-driven header"
- docs: name all three entry points (type / quick-start suggestion / starting-point card) in the phases table Chat cell

  <details>
  <summary>Why here and not building-blocks?</summary>

  building-blocks.mdx already carries the full cards-vs-suggestions contract; creation-with-ai.mdx now links to it rather than repeating it. standard-flow.mdx covers resource-card lifecycle and is unrelated.
  </details>