### PR TITLE
fix(emoji-picker): render picker in light-DOM (registered class + ref) so clicks work in popovers

### DIFF
--- a/packages/react/src/lib/EmojiPicker.test.tsx
+++ b/packages/react/src/lib/EmojiPicker.test.tsx
@@ -39,8 +39,8 @@ describe("EmojiPicker", () => {
   })
 
   it("degrades to nothing instead of crashing when construction throws", () => {
-    // The FCT-55700 failure mode: constructing the element throws "Illegal
-    // constructor". The render error boundary must contain it so the
+    // Constructing the element throws "Illegal constructor" (the duplicated-class
+    // failure mode). The render error boundary must contain it so the
     // surrounding UI keeps rendering.
     class ThrowingPicker {
       constructor() {

--- a/packages/react/src/lib/EmojiPicker.test.tsx
+++ b/packages/react/src/lib/EmojiPicker.test.tsx
@@ -3,21 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { EmojiPicker } from "./EmojiPicker"
 
-const realCreateElement = document.createElement.bind(document)
-
-type PickerElement = HTMLElement & {
-  props?: { onEmojiSelect?: unknown; set?: unknown }
-  update?: (props: object) => void
-}
-
-// Stand-in for the real <em-emoji-picker>. emoji-mart's real element kicks off
-// an async, network-bound init on append that can't complete in jsdom; these
-// tests only assert how the wrapper wires props onto the element, so a plain
-// element avoids that noise.
-function stubPickerElement(): PickerElement {
-  const el = realCreateElement("div") as PickerElement
-  el.update = vi.fn()
-  return el
+type PickerProps = {
+  ref?: { current: HTMLElement | null }
+  [key: string]: unknown
 }
 
 afterEach(() => {
@@ -25,67 +13,45 @@ afterEach(() => {
 })
 
 describe("EmojiPicker", () => {
-  it("mounts the element via createElement, never `new`", () => {
-    const stub = stubPickerElement()
-    const createElementSpy = vi
-      .spyOn(document, "createElement")
-      .mockImplementation((tag: string) =>
-        tag === "em-emoji-picker" ? stub : realCreateElement(tag)
-      )
-
-    const { container } = render(<EmojiPicker data={{}} />)
-
-    expect(createElementSpy).toHaveBeenCalledWith("em-emoji-picker")
-    expect(container.contains(stub)).toBe(true)
-  })
-
-  it("seeds props onto the element before appending so callbacks are wired", () => {
-    // emoji-mart reads `this.props` in connectedCallback (fired on append) to
-    // build the picker; a post-append update() is dropped while its internal
-    // component ref doesn't exist yet. So props — crucially onEmojiSelect — must
-    // be present on the element *before* it is appended, otherwise selecting an
-    // emoji does nothing.
+  it("constructs the registered em-emoji-picker class and renders into the ref", () => {
+    const constructed: PickerProps[] = []
+    class StubPicker {
+      constructor(props: PickerProps) {
+        constructed.push(props)
+        // Mirror emoji-mart: render into the provided ref (light DOM).
+        props.ref?.current?.append(document.createElement("span"))
+      }
+      update() {}
+    }
+    vi.spyOn(customElements, "get").mockReturnValue(
+      StubPicker as unknown as CustomElementConstructor
+    )
     const onEmojiSelect = vi.fn()
-    const stub = stubPickerElement()
-    let propsAtAppendTime: PickerElement["props"]
 
-    const originalAppend = HTMLElement.prototype.appendChild
-    vi.spyOn(HTMLElement.prototype, "appendChild").mockImplementation(function (
-      this: HTMLElement,
-      node: Node
-    ) {
-      if (node === stub) propsAtAppendTime = stub.props
-      return originalAppend.call(this, node) as Node
-    })
-    vi.spyOn(document, "createElement").mockImplementation((tag: string) =>
-      tag === "em-emoji-picker" ? stub : realCreateElement(tag)
+    const { container } = render(
+      <EmojiPicker data={{}} onEmojiSelect={onEmojiSelect} set="twitter" />
     )
 
-    render(
-      <EmojiPicker
-        data={{ a: 1 }}
-        onEmojiSelect={onEmojiSelect}
-        set="twitter"
-      />
-    )
-
-    expect(stub.props).toMatchObject({ set: "twitter", onEmojiSelect })
-    // The seed must happen before the append, not after.
-    expect(propsAtAppendTime).toMatchObject({ set: "twitter", onEmojiSelect })
+    expect(constructed).toHaveLength(1)
+    // The picker is built from the registry, with the caller's props + a ref.
+    expect(constructed[0]).toMatchObject({ set: "twitter", onEmojiSelect })
+    expect(constructed[0].ref?.current).toBe(container.querySelector("div"))
   })
 
-  it("degrades to nothing instead of crashing when the element fails to construct", () => {
-    // Constructing the element throws "Illegal constructor" (the duplicated-class
-    // failure mode). The render error boundary must contain it so the
+  it("degrades to nothing instead of crashing when construction throws", () => {
+    // The FCT-55700 failure mode: constructing the element throws "Illegal
+    // constructor". The render error boundary must contain it so the
     // surrounding UI keeps rendering.
-    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
-      if (tag === "em-emoji-picker") {
+    class ThrowingPicker {
+      constructor() {
         throw new TypeError(
           "Failed to construct 'HTMLElement': Illegal constructor"
         )
       }
-      return realCreateElement(tag)
-    })
+    }
+    vi.spyOn(customElements, "get").mockReturnValue(
+      ThrowingPicker as unknown as CustomElementConstructor
+    )
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
 
     expect(() => render(<EmojiPicker data={{}} />)).not.toThrow()

--- a/packages/react/src/lib/EmojiPicker.tsx
+++ b/packages/react/src/lib/EmojiPicker.tsx
@@ -1,7 +1,6 @@
 import { type RefObject, useEffect, useRef } from "react"
 
-// Side-effect import: registers the <em-emoji-picker> custom element so it is
-// available in the custom-element registry.
+// Registers the <em-emoji-picker> custom element (side-effect import).
 import "emoji-mart"
 
 import { RenderErrorBoundary } from "@/lib/RenderErrorBoundary"
@@ -36,12 +35,10 @@ function EmojiPickerElement(props: EmojiPickerProps) {
   useEffect(() => {
     if (!containerRef.current) return
 
-    // Construct the class from the custom-element registry, NOT the one
-    // @emoji-mart/react imports. Passing a `ref` makes emoji-mart render the
-    // picker into that element (light DOM), exactly like @emoji-mart/react — so
-    // clicks behave identically. `new` on the *registered* class is legal;
-    // @emoji-mart/react instead throws "Illegal constructor" when a duplicated,
-    // unregistered copy of the class lands in the bundle.
+    // Build from the *registered* class, not the copy @emoji-mart/react imports
+    // (a duplicated, unregistered copy is what throws "Illegal constructor").
+    // Passing `ref` renders the picker into the div in light-DOM mode — like
+    // @emoji-mart/react — so clicks keep working inside popovers.
     const Picker = customElements.get("em-emoji-picker") as
       | EmojiMartPickerCtor
       | undefined

--- a/packages/react/src/lib/EmojiPicker.tsx
+++ b/packages/react/src/lib/EmojiPicker.tsx
@@ -1,19 +1,13 @@
-import { useEffect, useRef } from "react"
+import { type RefObject, useEffect, useRef } from "react"
 
-// Side-effect import: registers the <em-emoji-picker> custom element so
-// document.createElement returns the registered class.
+// Side-effect import: registers the <em-emoji-picker> custom element so it is
+// available in the custom-element registry.
 import "emoji-mart"
 
 import { RenderErrorBoundary } from "@/lib/RenderErrorBoundary"
 
-type EmojiMartElement = HTMLElement & {
-  // emoji-mart reads `this.props` inside connectedCallback (fired on append) to
-  // build the picker, and only wires later `update()` calls once its internal
-  // component ref exists. Seeding `props` before append is what `new Picker(props)`
-  // did implicitly via the constructor.
-  props?: object
-  update?: (props: object) => void
-}
+type EmojiMartInstance = { update?: (props: object) => void }
+type EmojiMartPickerCtor = new (props: object) => EmojiMartInstance
 
 export type EmojiPickerProps = {
   data?: unknown
@@ -35,39 +29,37 @@ export type EmojiPickerProps = {
 
 function EmojiPickerElement(props: EmojiPickerProps) {
   const containerRef = useRef<HTMLDivElement>(null)
-  const elementRef = useRef<EmojiMartElement | null>(null)
+  const instanceRef = useRef<EmojiMartInstance | null>(null)
   const propsRef = useRef(props)
   propsRef.current = props
 
-  // createElement (not `new`, which @emoji-mart/react uses) instantiates the
-  // *registered* element class. With a duplicated emoji-mart class in the
-  // bundle, `new` on the unregistered copy throws "Illegal constructor" and
-  // crashes the page.
   useEffect(() => {
-    const container = containerRef.current
-    if (!container) return
+    if (!containerRef.current) return
 
-    const element = document.createElement(
-      "em-emoji-picker"
-    ) as EmojiMartElement
-    elementRef.current = element
-    // Seed props *before* appending: connectedCallback reads `this.props`
-    // synchronously on append to build the picker. A post-append `update()`
-    // is dropped because emoji-mart's attributeChangedCallback bails while its
-    // internal component ref doesn't exist yet, leaving callbacks (onEmojiSelect)
-    // and options unset — so selecting an emoji would do nothing.
-    element.props = propsRef.current
-    container.appendChild(element)
+    // Construct the class from the custom-element registry, NOT the one
+    // @emoji-mart/react imports. Passing a `ref` makes emoji-mart render the
+    // picker into that element (light DOM), exactly like @emoji-mart/react — so
+    // clicks behave identically. `new` on the *registered* class is legal;
+    // @emoji-mart/react instead throws "Illegal constructor" when a duplicated,
+    // unregistered copy of the class lands in the bundle.
+    const Picker = customElements.get("em-emoji-picker") as
+      | EmojiMartPickerCtor
+      | undefined
+    if (!Picker) return
+
+    instanceRef.current = new Picker({
+      ...propsRef.current,
+      ref: containerRef as RefObject<HTMLDivElement>,
+    })
 
     return () => {
-      element.remove()
-      elementRef.current = null
+      instanceRef.current = null
     }
   }, [])
 
-  // Push later prop changes to the live element (as @emoji-mart/react does).
+  // Push later prop changes to the live instance (as @emoji-mart/react does).
   useEffect(() => {
-    elementRef.current?.update?.(props)
+    instanceRef.current?.update?.(props)
   })
 
   return <div ref={containerRef} />


### PR DESCRIPTION
## Description

Follow-up to #4594 (FCT-55700). That PR stopped the "Illegal constructor" crash by mounting the emoji picker with `document.createElement("em-emoji-picker")` — but that renders the picker in **shadow-DOM** mode. Inside Radix popovers, shadow-DOM click retargeting let the dismissable layer treat emoji clicks as "outside" in some layouts, so **emojis couldn't be selected in some places**.

This restores the original light-DOM ("frame") rendering while keeping the crash immunity.

## Screenshots (if applicable)

N/A — behavioural. Covered by the `Kits/Social/Reactions` story (Chromatic) and the unit test.

## Implementation details

- Mount the picker with `new (customElements.get("em-emoji-picker"))({ ...props, ref })` instead of `document.createElement`:
  - Passing a `ref` makes emoji-mart render into the div (light-DOM "frame" mode) — **identical to `@emoji-mart/react`** and to the behavior before #4594, so clicks work exactly as before.
  - Constructing the class **from the registry** (not the copy `@emoji-mart/react` imports) is what keeps it immune to the duplicated/unregistered-copy "Illegal constructor" that #4594 was fixing — `new` on the *registered* class is always legal.
- Wrapped in `RenderErrorBoundary` (unchanged).
- Tests updated to assert the picker is built from the registry with props + ref, and that a throwing constructor is contained by the boundary.
