### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.22.2",
+  "packages/react": "4.23.0",
   "packages/react-native": "0.57.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.23.0](https://github.com/factorialco/f0/compare/f0-react-v4.22.2...f0-react-v4.23.0) (2026-07-06)
+
+
+### Features
+
+* **F0TagStatus:** add optional icon prop ([#4593](https://github.com/factorialco/f0/issues/4593)) ([4c1239e](https://github.com/factorialco/f0/commit/4c1239e478c753b130dcb424bb62bb0b1f96b8f7))
+
 ## [4.22.2](https://github.com/factorialco/f0/compare/f0-react-v4.22.1...f0-react-v4.22.2) (2026-07-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.22.2",
+  "version": "4.23.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.23.0</summary>

## [4.23.0](https://github.com/factorialco/f0/compare/f0-react-v4.22.2...f0-react-v4.23.0) (2026-07-06)


### Features

* **F0TagStatus:** add optional icon prop ([#4593](https://github.com/factorialco/f0/issues/4593)) ([4c1239e](https://github.com/factorialco/f0/commit/4c1239e478c753b130dcb424bb62bb0b1f96b8f7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).