### PR TITLE
feat(F0Chat): preview composer images as square thumbnails

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -353,6 +353,46 @@ describe("F0Chat", () => {
     expect(screen.getByText("report.pdf")).toBeInTheDocument()
   })
 
+  it("previews uploaded images as square thumbnails and other files as chips", async () => {
+    // The pdf uploads first — images must still render grouped at the front.
+    const uploadFiles = vi.fn().mockResolvedValue([
+      {
+        kind: "file",
+        url: "blob:doc",
+        name: "report.pdf",
+        mimeType: "application/pdf",
+      },
+      { kind: "image", url: "blob:img", name: "photo.png" },
+    ])
+    const { container } = renderChat(makeRuntime({ uploadFiles }))
+    const fileInput =
+      container.querySelector<HTMLInputElement>("input[type=file]")!
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(["doc"], "report.pdf", { type: "application/pdf" }),
+          new File(["img"], "photo.png", { type: "image/png" }),
+        ],
+      },
+    })
+    // The image resolves to an inline square preview, the pdf to a file chip.
+    const preview = await screen.findByRole("img", { name: /photo\.png/i })
+    expect(preview).toHaveAttribute("src", "blob:img")
+    const chip = screen.getByText("report.pdf")
+    // The image preview comes before the file chip despite uploading second.
+    expect(
+      preview.compareDocumentPosition(chip) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    // Each pending attachment carries its own remove action.
+    const removeButtons = screen.getAllByRole("button", { name: /^remove$/i })
+    expect(removeButtons).toHaveLength(2)
+    await userEvent.click(removeButtons[0])
+    expect(
+      screen.queryByRole("img", { name: /photo\.png/i })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText("report.pdf")).toBeInTheDocument()
+  })
+
   it("renders the empty state when there are no messages", () => {
     renderChat(makeRuntime({ messages: [] }))
     expect(screen.getByText(/no messages yet/i)).toBeInTheDocument()

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -44,11 +44,14 @@ import { ChatMentionPopover } from "./ChatMentionPopover"
 import { ChatReplyChip } from "./ChatReplyChip"
 import { ChatTextareaField } from "./ChatTextareaField"
 
-/** A pending composer attachment: a skeleton while it uploads, an F0FileItem
- * chip once the runtime resolves it (same pattern as the AI chat composer). */
+/** A pending composer attachment: a skeleton while it uploads, then a square
+ * image preview or an F0FileItem chip once the runtime resolves it. */
 type PendingAttachment =
-  | { id: string; status: "uploading"; name: string }
+  | { id: string; status: "uploading"; name: string; isImage: boolean }
   | { id: string; status: "ready"; attachment: F0ChatAttachment }
+
+const isImagePending = (att: PendingAttachment): boolean =>
+  att.status === "uploading" ? att.isImage : att.attachment.kind === "image"
 
 /** Composer: auto-growing textarea (no aura), attach, voice dictation, send.
  * Drag & drop is owned by the whole panel (F0Chat) and bridged here. */
@@ -117,6 +120,16 @@ export const ChatComposer = (): ReactNode => {
   const attachmentSeq = useRef(0)
 
   const isUploading = attachments.some((a) => a.status === "uploading")
+
+  // Images render grouped first: mixing thumbnails and file chips in arrival
+  // order makes the row jump in height at every boundary between the two.
+  const orderedAttachments = useMemo(
+    () => [
+      ...attachments.filter(isImagePending),
+      ...attachments.filter((att) => !isImagePending(att)),
+    ],
+    [attachments]
+  )
 
   // Transient error flashed in the textarea (too many files, upload/voice
   // failure), auto-cleared after a few seconds — same pattern as the AI chat.
@@ -199,6 +212,7 @@ export const ChatComposer = (): ReactNode => {
         id: `att-${attachmentSeq.current++}`,
         status: "uploading" as const,
         name: file.name,
+        isImage: file.type.startsWith("image/"),
       }))
       setAttachments((prev) => [...prev, ...pending])
       const pendingIds = new Set(pending.map((p) => p.id))
@@ -438,26 +452,54 @@ export const ChatComposer = (): ReactNode => {
             )}
           </AnimatePresence>
 
-          {/* Pending attachments — a skeleton while uploading, then an
-              F0FileItem chip with a remove action (same as the AI chat). */}
+          {/* Pending attachments — a skeleton while uploading, then a square
+              image preview (matching the message thumbnails) or an F0FileItem
+              chip, each with a remove action. */}
           {attachments.length > 0 && (
             <div
               aria-live="polite"
               aria-busy={isUploading}
-              className="flex flex-wrap gap-1 px-1 pt-1"
+              className="flex flex-wrap items-end gap-1 px-1 pt-1"
             >
-              {attachments.map((att) =>
+              {orderedAttachments.map((att) =>
                 att.status === "uploading" ? (
-                  <Skeleton key={att.id} className="h-9 w-36 rounded-[10px]" />
+                  <Skeleton
+                    key={att.id}
+                    className={cn(
+                      att.isImage ? "h-16 w-16 rounded-lg" : "h-9 w-36 rounded"
+                    )}
+                  />
+                ) : att.attachment.kind === "image" ? (
+                  <div key={att.id} className="group/attachment relative flex">
+                    <img
+                      src={att.attachment.thumbnailUrl ?? att.attachment.url}
+                      alt={att.attachment.name}
+                      className="h-16 w-16 rounded-lg border border-solid border-f1-border-secondary object-cover"
+                    />
+                    {/* Remove is hidden until hover; focus also reveals it so
+                        it stays reachable by keyboard. */}
+                    <div className="absolute right-1 top-1 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
+                      <ButtonInternal
+                        variant="outline"
+                        size="sm"
+                        hideLabel
+                        label={i18n.chat.removeFile}
+                        icon={Cross}
+                        onClick={() =>
+                          setAttachments((prev) =>
+                            prev.filter((a) => a.id !== att.id)
+                          )
+                        }
+                      />
+                    </div>
+                  </div>
                 ) : (
                   <F0FileItem
                     key={att.id}
                     size="md"
                     file={{
                       name: att.attachment.name,
-                      type:
-                        att.attachment.mimeType ??
-                        (att.attachment.kind === "image" ? "image/png" : ""),
+                      type: att.attachment.mimeType ?? "",
                     }}
                     actions={[
                       {

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
@@ -54,7 +54,7 @@ export const ChatMessageAttachments = ({
               key={`${image.url}-${i}`}
               type="button"
               onClick={() => openImagePreview(images, i)}
-              className="block overflow-hidden rounded-xl transition-opacity hover:opacity-90"
+              className="flex overflow-hidden rounded-xl transition-opacity hover:opacity-90"
               aria-label={i18n.chat.openImage}
             >
               <img


### PR DESCRIPTION
## Description

Images attached in the chat composer used to render as generic file chips, unlike the square thumbnails already shown on sent messages. The composer now previews image attachments as square thumbnails consistent with the transcript, keeping file chips for everything else.

## Implementation details

- feat: render ready image attachments in the composer as square thumbnails with a remove button that appears on hover (and on keyboard focus)
- feat: show a matching square skeleton while an image uploads, so the row keeps its height when the upload resolves
- feat: group image previews before file chips regardless of upload order, avoiding height jumps at every thumbnail/chip boundary
- fix: make message image thumbnails a flex button so the wrapper hugs the image
- test: cover composer image previews, images-first ordering and per-attachment removal