### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.23.0",
+  "packages/react": "4.24.0",
   "packages/react-native": "0.57.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.24.0](https://github.com/factorialco/f0/compare/f0-react-v4.23.0...f0-react-v4.24.0) (2026-07-06)
+
+
+### Features
+
+* **F0Chat:** preview composer images as square thumbnails ([#4631](https://github.com/factorialco/f0/issues/4631)) ([9a640d4](https://github.com/factorialco/f0/commit/9a640d45d0e9c6f9847c68cedc8fb54d94bdf84c))
+
 ## [4.23.0](https://github.com/factorialco/f0/compare/f0-react-v4.22.2...f0-react-v4.23.0) (2026-07-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.23.0",
+  "version": "4.24.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.24.0</summary>

## [4.24.0](https://github.com/factorialco/f0/compare/f0-react-v4.23.0...f0-react-v4.24.0) (2026-07-06)


### Features

* **F0Chat:** preview composer images as square thumbnails ([#4631](https://github.com/factorialco/f0/issues/4631)) ([9a640d4](https://github.com/factorialco/f0/commit/9a640d45d0e9c6f9847c68cedc8fb54d94bdf84c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).