### PR TITLE
feat(OneDataCollection): type Kanban card metadata as CardMetadata

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -1,10 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 
-import type {
-  CardMetadata,
-  CardMetadataProperty,
-} from "@/components/F0Card/types"
-import type { IconType } from "@/components/F0Icon"
 import type { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
 import type { KanbanProps } from "@/ui/Kanban/types"
 
@@ -30,16 +25,6 @@ import type {
 
 import { ItemActionsDefinition } from "../../../item-actions"
 import { KanbanCollectionProps } from "./types"
-
-const toCardMetadata = (
-  items: ReadonlyArray<{
-    icon: IconType
-    property: CardMetadataProperty
-  }>
-): CardMetadata[] =>
-  items.map(({ icon, property }) =>
-    property.type === "file" ? { property } : { icon, property }
-  )
 
 const isInfiniteScrollPaginationInfo = (
   paginationInfo: PaginationInfo | undefined | null
@@ -273,9 +258,7 @@ export const KanbanCollection = <
           description={description ? description(item) : undefined}
           avatar={avatar ? avatar(item) : undefined}
           draggable={onMove !== undefined}
-          metadata={
-            optionsMetadata ? toCardMetadata(optionsMetadata(item)) : undefined
-          }
+          metadata={optionsMetadata ? [...optionsMetadata(item)] : undefined}
           compact
           forceVerticalMetadata
           selectable={source.selectable !== undefined}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/types.ts
@@ -1,6 +1,5 @@
 import { CardAvatarVariant } from "@/components/F0Card/components/CardAvatar"
-import { CardMetadataProperty } from "@/components/F0Card/types"
-import { IconType } from "@/components/F0Icon"
+import { CardMetadata } from "@/components/F0Card/types"
 import { NewColor } from "@/components/tags/F0TagDot"
 import { Variant } from "@/components/tags/F0TagStatus"
 import {
@@ -31,9 +30,7 @@ export type KanbanVisualizationOptions<
   title?: (record: Record) => string
   description?: (record: Record) => string
   avatar?: (record: Record) => CardAvatarVariant
-  metadata?: (
-    record: Record
-  ) => ReadonlyArray<{ icon: IconType; property: CardMetadataProperty }>
+  metadata?: (record: Record) => ReadonlyArray<CardMetadata>
   onMove?: KanbanOnMove<Record>
   onCreate?: KanbanOnCreate
 }


### PR DESCRIPTION
Companion to #4593.

## Changes
- Kanban `metadata` option now returns the shared `CardMetadata` type instead of a bespoke inline `{ icon: IconType; property: CardMetadataProperty }` shape.
- Removed the `toCardMetadata` shim in `Kanban.tsx` (its only job was to strip the icon for `file` cells, which the shared type models directly).

## Why
#4593 let `F0TagStatus` / the `status` value cell render an icon *inside* the chip. But the Kanban `metadata` contract required a leading `icon` per item, which `CardMetadata` renders as a separate external glyph — so a status cell with an inline icon showed a redundant second icon, and dropping the external one was a type error.

Rather than just softening the inline type to `icon?`, this types `metadata` as the design-system’s canonical `CardMetadata` (whose non-`file` branch already declares `icon?`). Benefits:
- **Single source of truth** — kanban can no longer drift from `CardMetadata`.
- **Optional icon for free** — a status cell can render its own inline icon without a redundant external one.
- **file/non-file discrimination for free** — `file` rows can no longer carry a stray icon.

Backward-compatible for real callers: non-`file` rows are still `{ icon?, property }`.

## Testing
- `pnpm tsc` on `packages/react` — no new errors (only pre-existing unrelated F0PdfViewer/react-pdf ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)