### PR TITLE
chore: sync API surface check with main before diff

### DIFF
--- a/.github/workflows/api-surface.yaml
+++ b/.github/workflows/api-surface.yaml
@@ -10,9 +10,9 @@ jobs:
   detect-changes:
     uses: ./.github/workflows/_check-workspaces-changes.yaml
 
-  # Build the rolled-up type declarations on both the PR head and the base
-  # branch (main) in parallel. Each leg only needs the existing `build` script,
-  # so the base build works even though this workflow does not exist on main.
+  # Build the rolled-up type declarations for both sides of the comparison in
+  # parallel. Each leg only needs the existing `build` script, so the base
+  # build works even though this workflow does not exist on main.
   build-dts:
     needs: detect-changes
     # React source or core (whose types ripple into the React surface) changed.
@@ -33,9 +33,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # base: tip of the target branch (the "old version").
-          # head: the PR branch as-is, so we compare the PR's API against main.
-          ref: ${{ matrix.side == 'base' && github.event.pull_request.base.sha || github.event.pull_request.head.sha }}
+          # Both sides derive from the PR *merge commit* (github.sha for
+          # pull_request events: the PR head merged into the current tip of
+          # main), so the PR is synced with main before the API is snapshotted.
+          # Building the PR branch as-is would falsely flag everything that
+          # landed on main after the branch point as "removed" (breaking).
+          #   head: the merge commit itself (PR + latest main).
+          #   base: the merge commit's first parent — the exact main tip the
+          #         head side was merged with (checked out in the next step).
+          # Depth 2 makes both parents of the merge commit available.
+          fetch-depth: 2
+      - name: Check out base side (first parent of the merge commit)
+        if: matrix.side == 'base'
+        run: git checkout HEAD^1
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
       - uses: ./.github/actions/setup-node-pnpm


### PR DESCRIPTION
## Description

The "⚠️ Breaking public API changes" CI check could report false positives on PRs that were behind `main`: the `build-dts` job built the head side from the raw PR branch while the base side used the current tip of `main`, so any export that landed on `main` after the branch point existed in base but not in head and was flagged as "removed" (breaking) — even though the PR never touched it. This PR syncs the PR with `main` under the hood before the detection runs.

## Implementation details

- chore: build the head side of the API surface diff from the PR merge commit (`github.sha` on `pull_request` events — the PR head merged into the current tip of `main`) instead of the raw PR branch

- chore: derive the base side from that same merge commit's first parent (`git checkout HEAD^1` with `fetch-depth: 2`) instead of `pull_request.base.sha`, so both sides are pinned to the exact same `main` tip by construction

  <details>
  <summary>Why the first parent instead of pull_request.base.sha?</summary>

  The merge commit's first parent is the exact `main` tip the head side was merged with. Using the event payload's `base.sha` could still skew if `main` moved between the payload being created and the merge ref being computed. Deriving both sides from the one merge commit removes any timing skew between the two matrix legs.
  </details>

Notes: the comparison script (`check-api-surface.ts`) is unchanged — it just diffs the two `.d.ts` directories it's given. Conflicted PRs are not a concern: GitHub doesn't run `pull_request` workflows when the merge ref can't be created, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)