### PR TITLE
feat(F0AudioPlayer): support lazy src resolution and known duration

### DIFF
--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayer.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayer.tsx
@@ -24,8 +24,8 @@ const containerVariants = cva({
 const F0AudioPlayerBase = forwardRef<HTMLDivElement, F0AudioPlayerProps>(
   (props, ref) => {
     const {
-      src,
-      preload = "metadata",
+      getSrc,
+      preload,
       autoPlay = false,
       disabled = false,
       ariaLabel,
@@ -47,8 +47,8 @@ const F0AudioPlayerBase = forwardRef<HTMLDivElement, F0AudioPlayerProps>(
       >
         <audio
           ref={controller.audioRef}
-          src={src}
-          preload={preload}
+          src={controller.currentSrc}
+          preload={preload ?? (getSrc ? "none" : "metadata")}
           autoPlay={autoPlay}
         />
 

--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayer.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayer.tsx
@@ -24,7 +24,7 @@ const containerVariants = cva({
 const F0AudioPlayerBase = forwardRef<HTMLDivElement, F0AudioPlayerProps>(
   (props, ref) => {
     const {
-      getSrc,
+      src,
       preload,
       autoPlay = false,
       disabled = false,
@@ -48,7 +48,7 @@ const F0AudioPlayerBase = forwardRef<HTMLDivElement, F0AudioPlayerProps>(
         <audio
           ref={controller.audioRef}
           src={controller.currentSrc}
-          preload={preload ?? (getSrc ? "none" : "metadata")}
+          preload={preload ?? (typeof src === "function" ? "none" : "metadata")}
           autoPlay={autoPlay}
         />
 

--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
@@ -26,7 +26,7 @@ const F0AudioPlayerCardBase = forwardRef<
     subtitle,
     actions,
     className,
-    getSrc,
+    src,
     preload,
     autoPlay = false,
     disabled = false,
@@ -73,7 +73,7 @@ const F0AudioPlayerCardBase = forwardRef<
       <audio
         ref={controller.audioRef}
         src={controller.currentSrc}
-        preload={preload ?? (getSrc ? "none" : "metadata")}
+        preload={preload ?? (typeof src === "function" ? "none" : "metadata")}
         autoPlay={autoPlay}
       />
 

--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
@@ -26,8 +26,8 @@ const F0AudioPlayerCardBase = forwardRef<
     subtitle,
     actions,
     className,
-    src,
-    preload = "metadata",
+    getSrc,
+    preload,
     autoPlay = false,
     disabled = false,
     ariaLabel,
@@ -72,8 +72,8 @@ const F0AudioPlayerCardBase = forwardRef<
     >
       <audio
         ref={controller.audioRef}
-        src={src}
-        preload={preload}
+        src={controller.currentSrc}
+        preload={preload ?? (getSrc ? "none" : "metadata")}
         autoPlay={autoPlay}
       />
 

--- a/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.stories.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.stories.tsx
@@ -83,9 +83,8 @@ export const LazySource: StoryObj<typeof F0AudioPlayerCard> = {
   render: (args) => (
     <F0AudioPlayerCard
       {...args}
-      src={undefined}
       duration={200}
-      getSrc={() =>
+      src={() =>
         new Promise((resolve) => setTimeout(() => resolve(SAMPLE_SRC), 400))
       }
     />

--- a/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.stories.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__stories__/F0AudioPlayer.stories.tsx
@@ -79,6 +79,23 @@ export const WithDataTestId: Story = {
   args: { dataTestId: "audio-player" },
 }
 
+export const LazySource: StoryObj<typeof F0AudioPlayerCard> = {
+  render: (args) => (
+    <F0AudioPlayerCard
+      {...args}
+      src={undefined}
+      duration={200}
+      getSrc={() =>
+        new Promise((resolve) => setTimeout(() => resolve(SAMPLE_SRC), 400))
+      }
+    />
+  ),
+  args: {
+    title: "AI Call with Alex Williams",
+    subtitle: "May 9, 2025 - 10:00am",
+  },
+}
+
 // Sample copy lifted from the design, long enough to demonstrate the
 // height-restricted scrollable transcript.
 const SAMPLE_SUMMARY =

--- a/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
@@ -262,10 +262,10 @@ describe("F0AudioPlayer lazy source", () => {
   })
 
   it("does not resolve or set a src until play is requested", () => {
-    const getSrc = vi.fn().mockResolvedValue("resolved.mp3")
-    render(<F0AudioPlayer src={getSrc} duration={100} />)
+    const resolveSrc = vi.fn().mockResolvedValue("resolved.mp3")
+    render(<F0AudioPlayer src={resolveSrc} duration={100} />)
 
-    expect(getSrc).not.toHaveBeenCalled()
+    expect(resolveSrc).not.toHaveBeenCalled()
     expect(getAudio()).not.toHaveAttribute("src")
   })
 
@@ -281,41 +281,41 @@ describe("F0AudioPlayer lazy source", () => {
     expect(screen.getByText("0:00 / 4:32")).toBeInTheDocument()
   })
 
-  it("resolves the src via getSrc and plays on first click", async () => {
-    const getSrc = vi.fn().mockResolvedValue("resolved.mp3")
-    render(<F0AudioPlayer src={getSrc} duration={100} />)
+  it("resolves the src function and plays on first click", async () => {
+    const resolveSrc = vi.fn().mockResolvedValue("resolved.mp3")
+    render(<F0AudioPlayer src={resolveSrc} duration={100} />)
 
     fireEvent.click(screen.getByRole("button", { name: "Play" }))
 
-    expect(getSrc).toHaveBeenCalledOnce()
+    expect(resolveSrc).toHaveBeenCalledOnce()
     await waitFor(() =>
       expect(getAudio()).toHaveAttribute("src", "resolved.mp3")
     )
     await waitFor(() => expect(playSpy).toHaveBeenCalled())
   })
 
-  it("re-resolves via getSrc once after a media error", async () => {
-    const getSrc = vi
+  it("re-resolves the src function once after a media error", async () => {
+    const resolveSrc = vi
       .fn()
       .mockResolvedValueOnce("first.mp3")
       .mockResolvedValueOnce("second.mp3")
-    render(<F0AudioPlayer src={getSrc} duration={100} />)
+    render(<F0AudioPlayer src={resolveSrc} duration={100} />)
 
     fireEvent.click(screen.getByRole("button", { name: "Play" }))
     await waitFor(() => expect(getAudio()).toHaveAttribute("src", "first.mp3"))
 
     fireEvent.error(getAudio())
     await waitFor(() => expect(getAudio()).toHaveAttribute("src", "second.mp3"))
-    expect(getSrc).toHaveBeenCalledTimes(2)
+    expect(resolveSrc).toHaveBeenCalledTimes(2)
   })
 
-  it("routes a getSrc rejection to onError and recovers on retry", async () => {
+  it("routes a src-resolver rejection to onError and recovers on retry", async () => {
     const onError = vi.fn()
-    const getSrc = vi
+    const resolveSrc = vi
       .fn()
       .mockRejectedValueOnce(new Error("expired"))
       .mockResolvedValueOnce("resolved.mp3")
-    render(<F0AudioPlayer src={getSrc} duration={100} onError={onError} />)
+    render(<F0AudioPlayer src={resolveSrc} duration={100} onError={onError} />)
 
     fireEvent.click(screen.getByRole("button", { name: "Play" }))
     await waitFor(() => expect(onError).toHaveBeenCalledWith(null))
@@ -326,6 +326,6 @@ describe("F0AudioPlayer lazy source", () => {
       expect(getAudio()).toHaveAttribute("src", "resolved.mp3")
     )
     await waitFor(() => expect(playSpy).toHaveBeenCalled())
-    expect(getSrc).toHaveBeenCalledTimes(2)
+    expect(resolveSrc).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
@@ -246,3 +246,69 @@ describe("F0AudioPlayerCard", () => {
     )
   })
 })
+
+describe("F0AudioPlayer lazy source", () => {
+  let playSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockImplementation(() => Promise.resolve())
+    vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("does not resolve or set a src until play is requested", () => {
+    const getSrc = vi.fn().mockResolvedValue("resolved.mp3")
+    render(<F0AudioPlayer getSrc={getSrc} duration={100} />)
+
+    expect(getSrc).not.toHaveBeenCalled()
+    expect(getAudio()).not.toHaveAttribute("src")
+  })
+
+  it("defaults preload to none in lazy mode", () => {
+    render(<F0AudioPlayer getSrc={vi.fn().mockResolvedValue("x.mp3")} />)
+    expect(getAudio()).toHaveAttribute("preload", "none")
+  })
+
+  it("shows the total time from the duration prop before loading", () => {
+    render(
+      <F0AudioPlayer
+        getSrc={vi.fn().mockResolvedValue("x.mp3")}
+        duration={272}
+      />
+    )
+    expect(screen.getByText("0:00 / 4:32")).toBeInTheDocument()
+  })
+
+  it("resolves the src via getSrc and plays on first click", async () => {
+    const getSrc = vi.fn().mockResolvedValue("resolved.mp3")
+    render(<F0AudioPlayer getSrc={getSrc} duration={100} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Play" }))
+
+    expect(getSrc).toHaveBeenCalledOnce()
+    await waitFor(() =>
+      expect(getAudio()).toHaveAttribute("src", "resolved.mp3")
+    )
+    await waitFor(() => expect(playSpy).toHaveBeenCalled())
+  })
+
+  it("re-resolves via getSrc once after a media error", async () => {
+    const getSrc = vi
+      .fn()
+      .mockResolvedValueOnce("first.mp3")
+      .mockResolvedValueOnce("second.mp3")
+    render(<F0AudioPlayer getSrc={getSrc} duration={100} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Play" }))
+    await waitFor(() => expect(getAudio()).toHaveAttribute("src", "first.mp3"))
+
+    fireEvent.error(getAudio())
+    await waitFor(() => expect(getAudio()).toHaveAttribute("src", "second.mp3"))
+    expect(getSrc).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
@@ -311,4 +311,24 @@ describe("F0AudioPlayer lazy source", () => {
     await waitFor(() => expect(getAudio()).toHaveAttribute("src", "second.mp3"))
     expect(getSrc).toHaveBeenCalledTimes(2)
   })
+
+  it("routes a getSrc rejection to onError and recovers on retry", async () => {
+    const onError = vi.fn()
+    const getSrc = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("expired"))
+      .mockResolvedValueOnce("resolved.mp3")
+    render(<F0AudioPlayer getSrc={getSrc} duration={100} onError={onError} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Play" }))
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(null))
+    expect(playSpy).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Play" }))
+    await waitFor(() =>
+      expect(getAudio()).toHaveAttribute("src", "resolved.mp3")
+    )
+    await waitFor(() => expect(playSpy).toHaveBeenCalled())
+    expect(getSrc).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
@@ -263,30 +263,27 @@ describe("F0AudioPlayer lazy source", () => {
 
   it("does not resolve or set a src until play is requested", () => {
     const getSrc = vi.fn().mockResolvedValue("resolved.mp3")
-    render(<F0AudioPlayer getSrc={getSrc} duration={100} />)
+    render(<F0AudioPlayer src={getSrc} duration={100} />)
 
     expect(getSrc).not.toHaveBeenCalled()
     expect(getAudio()).not.toHaveAttribute("src")
   })
 
   it("defaults preload to none in lazy mode", () => {
-    render(<F0AudioPlayer getSrc={vi.fn().mockResolvedValue("x.mp3")} />)
+    render(<F0AudioPlayer src={vi.fn().mockResolvedValue("x.mp3")} />)
     expect(getAudio()).toHaveAttribute("preload", "none")
   })
 
   it("shows the total time from the duration prop before loading", () => {
     render(
-      <F0AudioPlayer
-        getSrc={vi.fn().mockResolvedValue("x.mp3")}
-        duration={272}
-      />
+      <F0AudioPlayer src={vi.fn().mockResolvedValue("x.mp3")} duration={272} />
     )
     expect(screen.getByText("0:00 / 4:32")).toBeInTheDocument()
   })
 
   it("resolves the src via getSrc and plays on first click", async () => {
     const getSrc = vi.fn().mockResolvedValue("resolved.mp3")
-    render(<F0AudioPlayer getSrc={getSrc} duration={100} />)
+    render(<F0AudioPlayer src={getSrc} duration={100} />)
 
     fireEvent.click(screen.getByRole("button", { name: "Play" }))
 
@@ -302,7 +299,7 @@ describe("F0AudioPlayer lazy source", () => {
       .fn()
       .mockResolvedValueOnce("first.mp3")
       .mockResolvedValueOnce("second.mp3")
-    render(<F0AudioPlayer getSrc={getSrc} duration={100} />)
+    render(<F0AudioPlayer src={getSrc} duration={100} />)
 
     fireEvent.click(screen.getByRole("button", { name: "Play" }))
     await waitFor(() => expect(getAudio()).toHaveAttribute("src", "first.mp3"))
@@ -318,7 +315,7 @@ describe("F0AudioPlayer lazy source", () => {
       .fn()
       .mockRejectedValueOnce(new Error("expired"))
       .mockResolvedValueOnce("resolved.mp3")
-    render(<F0AudioPlayer getSrc={getSrc} duration={100} onError={onError} />)
+    render(<F0AudioPlayer src={getSrc} duration={100} onError={onError} />)
 
     fireEvent.click(screen.getByRole("button", { name: "Play" }))
     await waitFor(() => expect(onError).toHaveBeenCalledWith(null))

--- a/packages/react/src/components/F0AudioPlayer/__tests__/useAudioPlayer.test.ts
+++ b/packages/react/src/components/F0AudioPlayer/__tests__/useAudioPlayer.test.ts
@@ -91,4 +91,10 @@ describe("useAudioPlayer", () => {
     expect(result.current.isLoading).toBe(false)
     expect(onError).toHaveBeenCalledOnce()
   })
+
+  it("seeds the duration from initialDuration", () => {
+    const ref = makeRef()
+    const { result } = renderHook(() => useAudioPlayer(ref, {}, 272))
+    expect(result.current.duration).toBe(272)
+  })
 })

--- a/packages/react/src/components/F0AudioPlayer/types.ts
+++ b/packages/react/src/components/F0AudioPlayer/types.ts
@@ -26,13 +26,27 @@ export interface AudioPlayerDetailTab {
 export interface F0AudioPlayerProps
   extends WithDataTestIdProps, DataAttributes {
   /**
-   * The audio source URL.
+   * The audio source URL. Provide this or `getSrc`.
    */
-  src: string
+  src?: string
+
+  /**
+   * Lazily resolves the audio source URL the first time playback is requested.
+   * Use for on-demand credentials (e.g. presigned URLs) so the URL is only
+   * fetched on user intent. Ignored when `src` is set.
+   */
+  getSrc?: () => Promise<string>
+
+  /**
+   * Known total duration in seconds. Lets the player show the total time and an
+   * active seek bar before the audio loads (e.g. with `preload="none"`).
+   * Superseded by the real duration once metadata loads.
+   */
+  duration?: number
 
   /**
    * How much of the audio to preload.
-   * @default "metadata"
+   * @default "metadata" ("none" when `getSrc` is set)
    */
   preload?: "none" | "metadata" | "auto"
 

--- a/packages/react/src/components/F0AudioPlayer/types.ts
+++ b/packages/react/src/components/F0AudioPlayer/types.ts
@@ -26,16 +26,12 @@ export interface AudioPlayerDetailTab {
 export interface F0AudioPlayerProps
   extends WithDataTestIdProps, DataAttributes {
   /**
-   * The audio source URL. Provide this or `getSrc`.
+   * The audio source. Either a URL string, or a function that lazily resolves
+   * the URL the first time playback is requested. Use the function form for
+   * on-demand credentials (e.g. presigned URLs) so the URL is only fetched on
+   * user intent.
    */
-  src?: string
-
-  /**
-   * Lazily resolves the audio source URL the first time playback is requested.
-   * Use for on-demand credentials (e.g. presigned URLs) so the URL is only
-   * fetched on user intent. Ignored when `src` is set.
-   */
-  getSrc?: () => Promise<string>
+  src: string | (() => Promise<string>)
 
   /**
    * Known total duration in seconds. Lets the player show the total time and an
@@ -46,7 +42,7 @@ export interface F0AudioPlayerProps
 
   /**
    * How much of the audio to preload.
-   * @default "metadata" ("none" when `getSrc` is set)
+   * @default "metadata" ("none" when `src` is a function)
    */
   preload?: "none" | "metadata" | "auto"
 

--- a/packages/react/src/components/F0AudioPlayer/useAudioPlayer.ts
+++ b/packages/react/src/components/F0AudioPlayer/useAudioPlayer.ts
@@ -29,14 +29,15 @@ export interface AudioPlayerControls extends AudioPlayerState {
 
 export const useAudioPlayer = (
   audioRef: RefObject<HTMLAudioElement>,
-  callbacks: UseAudioPlayerCallbacks = {}
+  callbacks: UseAudioPlayerCallbacks = {},
+  initialDuration = 0
 ): AudioPlayerControls => {
   const callbacksRef = useRef(callbacks)
   callbacksRef.current = callbacks
 
   const [isPlaying, setIsPlaying] = useState(false)
   const [currentTime, setCurrentTime] = useState(0)
-  const [duration, setDuration] = useState(0)
+  const [duration, setDuration] = useState(initialDuration)
   const [buffered, setBuffered] = useState(0)
   const [playbackRate, setPlaybackRateState] = useState(1)
   const [isLoading, setIsLoading] = useState(true)
@@ -47,7 +48,9 @@ export const useAudioPlayer = (
     if (!audio) return
 
     const handleLoadedMetadata = () => {
-      setDuration(Number.isFinite(audio.duration) ? audio.duration : 0)
+      setDuration(
+        Number.isFinite(audio.duration) ? audio.duration : initialDuration
+      )
       setIsLoading(false)
     }
     const handleTimeUpdate = () => {
@@ -107,7 +110,7 @@ export const useAudioPlayer = (
       audio.removeEventListener("ratechange", handleRateChange)
       audio.removeEventListener("error", handleError)
     }
-  }, [audioRef])
+  }, [audioRef, initialDuration])
 
   const play = useCallback(() => {
     audioRef.current?.play().catch(() => {})

--- a/packages/react/src/components/F0AudioPlayer/useAudioPlayer.ts
+++ b/packages/react/src/components/F0AudioPlayer/useAudioPlayer.ts
@@ -35,6 +35,9 @@ export const useAudioPlayer = (
   const callbacksRef = useRef(callbacks)
   callbacksRef.current = callbacks
 
+  const initialDurationRef = useRef(initialDuration)
+  initialDurationRef.current = initialDuration
+
   const [isPlaying, setIsPlaying] = useState(false)
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(initialDuration)
@@ -49,7 +52,9 @@ export const useAudioPlayer = (
 
     const handleLoadedMetadata = () => {
       setDuration(
-        Number.isFinite(audio.duration) ? audio.duration : initialDuration
+        Number.isFinite(audio.duration)
+          ? audio.duration
+          : initialDurationRef.current
       )
       setIsLoading(false)
     }
@@ -110,7 +115,7 @@ export const useAudioPlayer = (
       audio.removeEventListener("ratechange", handleRateChange)
       audio.removeEventListener("error", handleError)
     }
-  }, [audioRef, initialDuration])
+  }, [audioRef])
 
   const play = useCallback(() => {
     audioRef.current?.play().catch(() => {})

--- a/packages/react/src/components/F0AudioPlayer/usePlayerController.ts
+++ b/packages/react/src/components/F0AudioPlayer/usePlayerController.ts
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useRef } from "react"
+import { RefObject, useCallback, useEffect, useRef, useState } from "react"
 
 import type { F0AudioPlayerProps } from "./types"
 import { AudioPlayerControls, useAudioPlayer } from "./useAudioPlayer"
@@ -8,6 +8,7 @@ export interface PlayerController extends Omit<
   "play" | "pause"
 > {
   audioRef: RefObject<HTMLAudioElement>
+  currentSrc: string | undefined
   playbackRates: number[]
 }
 
@@ -15,6 +16,9 @@ export const usePlayerController = (
   props: F0AudioPlayerProps
 ): PlayerController => {
   const {
+    src,
+    getSrc,
+    duration,
     playing,
     onPlayingChange,
     playbackRates = [1, 1.5, 2],
@@ -27,30 +31,84 @@ export const usePlayerController = (
   } = props
 
   const audioRef = useRef<HTMLAudioElement>(null)
+  const [resolvedSrc, setResolvedSrc] = useState(src)
+  const resolvingRef = useRef(false)
+  const playAfterResolveRef = useRef(false)
+  const refreshedRef = useRef(false)
 
-  const player = useAudioPlayer(audioRef, {
-    onPlay,
-    onPause,
-    onSeek,
-    onTimeUpdate,
-    onEnded,
-    onError,
-  })
+  const ensureSrc = useCallback(async () => {
+    if (!getSrc || resolvingRef.current) return
+    resolvingRef.current = true
+    try {
+      setResolvedSrc(await getSrc())
+    } finally {
+      resolvingRef.current = false
+    }
+  }, [getSrc])
 
-  // Drive the element from the controlled `playing` prop.
+  const handlePlay = useCallback(() => {
+    refreshedRef.current = false
+    onPlay?.()
+  }, [onPlay])
+
+  const handleError = useCallback(
+    (error: MediaError | null) => {
+      onError?.(error)
+      if (!getSrc || refreshedRef.current) return
+      refreshedRef.current = true
+      playAfterResolveRef.current = true
+      setResolvedSrc(undefined)
+      void ensureSrc()
+    },
+    [onError, getSrc, ensureSrc]
+  )
+
+  const player = useAudioPlayer(
+    audioRef,
+    {
+      onPlay: handlePlay,
+      onPause,
+      onSeek,
+      onTimeUpdate,
+      onEnded,
+      onError: handleError,
+    },
+    duration ?? 0
+  )
+
+  useEffect(() => {
+    if (src !== undefined) setResolvedSrc(src)
+  }, [src])
+
+  useEffect(() => {
+    if (!resolvedSrc || !playAfterResolveRef.current) return
+    playAfterResolveRef.current = false
+    player.play()
+  }, [resolvedSrc, player])
+
+  const toggle = useCallback(() => {
+    if (!player.isPlaying && !resolvedSrc && getSrc) {
+      playAfterResolveRef.current = true
+      void ensureSrc()
+      return
+    }
+    player.toggle()
+  }, [player, resolvedSrc, getSrc, ensureSrc])
+
   useEffect(() => {
     if (playing === undefined) return
     if (playing && !player.isPlaying) {
-      player.play()
+      if (!resolvedSrc && getSrc) {
+        playAfterResolveRef.current = true
+        void ensureSrc()
+      } else {
+        player.play()
+      }
     } else if (!playing && player.isPlaying) {
       player.pause()
     }
-  }, [playing, player])
+  }, [playing, player, resolvedSrc, getSrc, ensureSrc])
 
-  // `player.isPlaying` (from the audio element events) is the single source of
-  // truth. Notify the consumer only when it actually changes — including
-  // changes the consumer didn't initiate (e.g. autoplay blocked, playback
-  // ended) so a controlled parent never gets stuck out of sync.
   const reportedPlaying = useRef(player.isPlaying)
   useEffect(() => {
     if (reportedPlaying.current === player.isPlaying) return
@@ -60,6 +118,7 @@ export const usePlayerController = (
 
   return {
     audioRef,
+    currentSrc: resolvedSrc,
     isPlaying: player.isPlaying,
     currentTime: player.currentTime,
     duration: player.duration,
@@ -67,7 +126,7 @@ export const usePlayerController = (
     playbackRate: player.playbackRate,
     isLoading: player.isLoading,
     error: player.error,
-    toggle: player.toggle,
+    toggle,
     seek: player.seek,
     setPlaybackRate: player.setPlaybackRate,
     playbackRates,

--- a/packages/react/src/components/F0AudioPlayer/usePlayerController.ts
+++ b/packages/react/src/components/F0AudioPlayer/usePlayerController.ts
@@ -17,7 +17,6 @@ export const usePlayerController = (
 ): PlayerController => {
   const {
     src,
-    getSrc,
     duration,
     playing,
     onPlayingChange,
@@ -30,8 +29,11 @@ export const usePlayerController = (
     onError,
   } = props
 
+  const getSrc = typeof src === "function" ? src : undefined
+  const eagerSrc = typeof src === "function" ? undefined : src
+
   const audioRef = useRef<HTMLAudioElement>(null)
-  const [resolvedSrc, setResolvedSrc] = useState(src)
+  const [resolvedSrc, setResolvedSrc] = useState(eagerSrc)
   const resolvingRef = useRef(false)
   const playAfterResolveRef = useRef(false)
   const refreshedRef = useRef(false)
@@ -80,8 +82,8 @@ export const usePlayerController = (
   )
 
   useEffect(() => {
-    if (src !== undefined) setResolvedSrc(src)
-  }, [src])
+    if (eagerSrc !== undefined) setResolvedSrc(eagerSrc)
+  }, [eagerSrc])
 
   useEffect(() => {
     if (!resolvedSrc || !playAfterResolveRef.current) return

--- a/packages/react/src/components/F0AudioPlayer/usePlayerController.ts
+++ b/packages/react/src/components/F0AudioPlayer/usePlayerController.ts
@@ -41,10 +41,13 @@ export const usePlayerController = (
     resolvingRef.current = true
     try {
       setResolvedSrc(await getSrc())
+    } catch {
+      playAfterResolveRef.current = false
+      onError?.(null)
     } finally {
       resolvingRef.current = false
     }
-  }, [getSrc])
+  }, [getSrc, onError])
 
   const handlePlay = useCallback(() => {
     refreshedRef.current = false


### PR DESCRIPTION
Adds an on-demand source to `F0AudioPlayer` / `F0AudioPlayerCard`. Until now the
component required the URL up front and loaded it eagerly on mount. `src` now
also accepts a resolver function that produces the URL only when playback is
actually requested. Backward-compatible for the string case.

Why the lazy form is useful as a general capability:
- **No work until intent.** If the URL is expensive or side-effectful to produce
  (a network call, a signed/credentialed URL, a token mint), it isn't produced
  for a player the user never presses play on — which matters most in lists,
  where eager loading would resolve every item.
- **Resolution is tied to the moment of use.** For time-bounded URLs, the
  validity window starts at play rather than at render, so it isn't half-spent
  before the user interacts. Presigned recording URLs (e.g. ATS call recordings)
  are one example, but the pattern applies to any deferred source.
- **Metadata without a fetch.** `duration` lets the card show total time and an
  active seek bar with `preload="none"`, so nothing hits the network until play.

## Changes
- **`src: string | (() => Promise<string>)`** — a single required prop. Pass a
  URL string for the eager path, or a function that resolves the URL on the
  first play for the lazy path. Enforces exactly one source form at the type
  level (no separate optional props that could both be omitted or both set).
- **`duration?: number`** — seeds the total time and an active seek bar before
  any audio loads; superseded by real metadata once it arrives.
- **`preload` defaults to `"none"`** when `src` is a function (was always
  `"metadata"`), so lazy mode makes zero network requests before intent.
- **Expiry handling** — on a media error in lazy mode, the URL is re-resolved
  once and playback resumes, so an expired presigned URL self-heals.
- All lazy logic lives in the shared `usePlayerController` (which derives the
  eager string vs lazy resolver from `src`); both the player and the card pick
  it up. `usePlayerController` now exposes `currentSrc`.

Consumer shape:

```tsx
<F0AudioPlayerCard
  src={() => generatePlaybackUrl(callId)}  // presign, fires on play
  duration={recordingDurationSeconds}       // total time shown before load
  title="AI Call with Alex Williams"
  subtitle="May 9, 2025 – 10:00am"
/>
```

## Testing
- `pnpm vitest src/components/F0AudioPlayer` — 34 pass (resolve-on-play,
  no-fetch-until-play, `preload=none` default, duration display, expiry
  re-resolve, getSrc-rejection recovery).
- `pnpm lint` / `oxfmt` — clean.
- `tsc --noEmit` — no new errors.
- Added a `LazySource` Storybook story.

## Notes
- Experimental component; API is not yet stable.
- Seek-before-load: with `duration` known but audio not yet loaded, the scrubber
  is draggable before first play (sets `currentTime` on a src-less element —
  harmless). Left as-is to keep the change tight; can gate it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
