### PR TITLE
fix(OneDataCollection): disabled cell background fills full cell height

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
@@ -19,6 +19,7 @@ const cursorClass = {
 } as const
 
 export function BaseCell({
+  disabled = false,
   readonly = false,
   showRightBorder = true,
   cursor = "text",
@@ -29,6 +30,7 @@ export function BaseCell({
   hintPosition = "left",
   children,
 }: {
+  disabled?: boolean
   readonly?: boolean
   showRightBorder?: boolean
   cursor?: "text" | "pointer" | "default" | "not-allowed"
@@ -80,7 +82,8 @@ export function BaseCell({
             : borderOnHover
               ? "shadow-none [&:not(:focus-within)]:hover:shadow-[inset_0_0_0_1px_hsl(var(--neutral-30))] focus-within:relative focus-within:z-[1] focus-within:border-r-0 focus-within:bg-f1-background focus-within:shadow-[inset_0_0_0_1px_hsl(var(--selected-50))]"
               : "shadow-none",
-        readonly && "bg-f1-background-secondary"
+        readonly && "bg-f1-background-secondary",
+        disabled && "bg-f1-background-disabled"
       )}
     >
       <ErrorTooltip message={error}>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
@@ -15,6 +15,7 @@ export function DisabledCell<R extends RecordType>({
 
   return (
     <BaseCell
+      disabled
       borderOnHover={false}
       hint={hint}
       hintPosition="right"
@@ -24,7 +25,7 @@ export function DisabledCell<R extends RecordType>({
         className={cn(
           editableColumn.align === "right" ? "justify-end" : "",
           "flex p-4 min-h-12 items-center border-0 h-full",
-          "bg-f1-background-disabled h-full",
+          "h-full",
           "w-full",
           "[&_*]:text-f1-foreground-secondary"
         )}


### PR DESCRIPTION
## Description

Fixes the disabled editable-table cell rendering a grey background that did not span the full cell height, leaving thin white strips at the top and bottom on rows taller than the cell's content. The grey fill is now painted on the full-height `BaseCell` root instead of an inner content div that collapsed vertically.

## Screenshots

> Before: 
<img width="1440" height="900" alt="Screenshot 2026-07-09 at 08 49 44" src="https://github.com/user-attachments/assets/2f5822a5-0f62-45b4-a6bb-cfc59ed8848a" />

> After: 
<img width="1440" height="900" alt="Screenshot 2026-07-09 at 09 30 53" src="https://github.com/user-attachments/assets/c82f8b42-a2c5-4cdc-8166-1e6729a002b6" />

## Implementation details

- fix: paint `bg-f1-background-disabled` on the full-height `BaseCell` root via a new optional `disabled` prop, so the fill always covers the entire cell regardless of row height

  <details>
  <summary>Why?</summary>

  The background previously lived on `DisabledCell`'s inner content div. That div sits inside `ErrorTooltip`'s flex wrapper, which uses `items-center`, and it had no explicit height — so it collapsed to content height and was vertically centered, exposing the cell background as white gaps above and below. Moving the fill to the `BaseCell` root makes it independent of the height chain.
  </details>

