### PR TITLE
fix(reactions): sync badge state with props so the picker can toggle existing reactions

### DIFF
--- a/packages/react/src/kits/Social/Reactions/reaction.tsx
+++ b/packages/react/src/kits/Social/Reactions/reaction.tsx
@@ -1,5 +1,5 @@
 import NumberFlow from "@number-flow/react"
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { EmojiImage, getEmojiLabel, useEmojiConfetti } from "@/lib/emojis"
@@ -31,6 +31,15 @@ export function Reaction({
   const [count, setCount] = useState(initialCount)
   const buttonRef = useRef<HTMLButtonElement>(null)
   const { fireEmojiConfetti } = useEmojiConfetti()
+
+  // Reconcile with the source of truth: clicking this emoji elsewhere (e.g. the
+  // picker) updates the parent's items, so honor prop changes after mount.
+  useEffect(() => {
+    setIsActive(hasReacted)
+  }, [hasReacted])
+  useEffect(() => {
+    setCount(initialCount)
+  }, [initialCount])
 
   const handleClick = (
     event: React.MouseEvent<HTMLButtonElement>,


### PR DESCRIPTION
## Problem

Selecting an emoji from the `Reactions` picker that is **already shown in the bar** doesn't mark/unmark the existing badge. The reaction is created/deleted correctly on the backend, but the badge's count and active state never update.

## Root cause

`Reaction` (`kits/Social/Reactions/reaction.tsx`) seeds its state from props **only at mount**:

```tsx
const [isActive, setIsActive] = useState(hasReacted)
const [count, setCount] = useState(initialCount)
// no effect re-syncs when the props change
```

Each badge is rendered with `key={emoji}`. The `Picker` reports the selection via `onSelect` → the consumer updates its `items`, but the existing badge (reused by its stable key) ignores the new `initialCount`/`hasReacted` props. Clicking a badge directly works only because it mutates its own internal state; the picker path can't reach that state.

## Fix

Reconcile the badge's internal state with its props via effects. The consumer is the source of truth through `items`, and optimistic clicks still apply instantly (the effect no-ops when the incoming value already matches).

## Context

Surfaced while migrating Factorial's post/comment reactions onto f0's v5 `Reactions` (FCT-55700). No API change; behavior is strictly more correct for any consumer that drives `items` from a parent.

## Testing

- oxfmt / oxlint / tsc green.
- No unit test added (no existing test file for this kit); verified by tracing all paths: mark/unmark from badge and from picker, and disappearance at count 0.