### PR TITLE
fix(OneFilterPicker): align chips row and neutral Clear button

### DIFF
--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersChipsList.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersChipsList.tsx
@@ -47,7 +47,7 @@ export function FiltersChipsList<Filters extends FiltersDefinition>({
   }
 
   return (
-    <div className="mt-2 flex items-start justify-between gap-2">
+    <div className="mt-2 flex items-start gap-2">
       <div className="flex flex-wrap items-center gap-2">
         {resultCount !== undefined && hasVisibleChips && (
           <span className="whitespace-nowrap font-medium text-f1-foreground-secondary">
@@ -103,7 +103,7 @@ export function FiltersChipsList<Filters extends FiltersDefinition>({
       </div>
 
       <F0Button
-        variant="ghost"
+        variant="neutral"
         label={i18n.actions.clear}
         size="sm"
         onClick={onClearAll}

--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersChipsList.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersChipsList.tsx
@@ -47,7 +47,7 @@ export function FiltersChipsList<Filters extends FiltersDefinition>({
   }
 
   return (
-    <div className="mt-2 flex items-start gap-2">
+    <div className="mt-2 flex items-center gap-2">
       <div className="flex flex-wrap items-center gap-2">
         {resultCount !== undefined && hasVisibleChips && (
           <span className="whitespace-nowrap font-medium text-f1-foreground-secondary">

--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersChipsList.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersChipsList.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from "motion/react"
 
 import { F0Button } from "@/components/F0Button"
+import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import { useI18n } from "@/lib/providers/i18n"
 
 import type { FiltersDefinition, FiltersState, FilterValue } from "../types"
@@ -50,14 +51,14 @@ export function FiltersChipsList<Filters extends FiltersDefinition>({
     <div className="mt-2 flex items-center gap-2">
       <div className="flex flex-wrap items-center gap-2">
         {resultCount !== undefined && hasVisibleChips && (
-          <span className="whitespace-nowrap font-medium text-f1-foreground-secondary">
-            {i18n.t(
+          <F0TagRaw
+            text={i18n.t(
               resultCount === 1
                 ? "filters.resultsFor.one"
                 : "filters.resultsFor.other",
               { count: resultCount }
             )}
-          </span>
+          />
         )}
         <AnimatePresence presenceAffectsLayout initial={false}>
           {hasVisibleChips &&


### PR DESCRIPTION
## Description

Fixes the active filter chips row in OneFilterPicker: removes `justify-between` so the Clear button sits next to the chips instead of being pushed to the far right, and switches the Clear button from `ghost` to `neutral` variant (size `sm`) to match design.

## Implementation details

- fix: change chips row from `mt-2 flex items-start justify-between gap-2` to `mt-2 flex items-start gap-2`
- fix: switch Clear button variant from `ghost` to `neutral`, keeping size `sm`
<img width="795" height="109" alt="Filters Fix" src="https://github.com/user-attachments/assets/daf1b36f-efa7-4d8e-bf6f-aa07bf7167ed" />

 