### PR TITLE
fix(F0Graph): don't re-center focusedNode on layout changes

### DIFF
--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.focusNoRefire.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.focusNoRefire.test.tsx
@@ -1,0 +1,125 @@
+import React, { act } from "react"
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import type { GraphNode } from "../types"
+import { F0Graph } from "../F0Graph"
+
+// Spy React Flow instance so we can count fly-to (fitView) calls. Only the
+// public `useReactFlow` is mocked — the ReactFlow component renders normally.
+// (Name must start with `mock` for the hoisted vi.mock factory.)
+const mockReactFlow = {
+  fitView: vi.fn(),
+  setCenter: vi.fn(),
+  getZoom: () => 1,
+  getNode: vi.fn(),
+  fitBounds: vi.fn(),
+  zoomIn: vi.fn(),
+  zoomOut: vi.fn(),
+  setViewport: vi.fn(),
+  getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>()
+  return { ...actual, useReactFlow: () => mockReactFlow }
+})
+
+const NODES: GraphNode<string>[] = [
+  { id: "root", parentId: null, data: "Root", childrenCount: 2 },
+  { id: "a", parentId: "root", data: "A" },
+  { id: "b", parentId: "root", data: "B" },
+]
+
+const renderNodeFn = (node: GraphNode<string>) => (
+  <span data-testid={`node-${node.id}`}>{node.data}</span>
+)
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockReactFlow.fitView.mockClear()
+})
+afterEach(() => vi.useRealTimers())
+
+const settle = () => act(() => vi.advanceTimersByTime(200))
+
+describe("F0Graph — focusedNode fly-to does not re-fire on layout changes", () => {
+  it("does not re-center when focusedNode is unchanged across a collapse", () => {
+    const { rerender } = zeroRender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          focusedNode="root"
+          expandedNodes={new Set(["root"])}
+        />
+      </div>
+    )
+    settle()
+    const afterEntry = mockReactFlow.fitView.mock.calls.length
+    expect(afterEntry).toBeGreaterThanOrEqual(1) // flew once on entry
+
+    // Collapse `root` (layout change) — focusedNode is still "root".
+    rerender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          focusedNode="root"
+          expandedNodes={new Set()}
+        />
+      </div>
+    )
+    settle()
+
+    // No extra fly-to: the effect only reacts to a focusedNode change.
+    expect(mockReactFlow.fitView.mock.calls.length).toBe(afterEntry)
+  })
+
+  it("still flies when focusedNode changes to a new value", () => {
+    const { rerender } = zeroRender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          focusedNode="root"
+          expandedNodes={new Set(["root"])}
+        />
+      </div>
+    )
+    settle()
+    const afterEntry = mockReactFlow.fitView.mock.calls.length
+
+    rerender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          focusedNode="a"
+          expandedNodes={new Set(["root"])}
+        />
+      </div>
+    )
+    settle()
+
+    expect(mockReactFlow.fitView.mock.calls.length).toBe(afterEntry + 1)
+    expect(mockReactFlow.fitView).toHaveBeenLastCalledWith(
+      expect.objectContaining({ nodes: [{ id: "a" }] })
+    )
+  })
+})

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -427,23 +427,34 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
   })
 
   // ── Fly to the consumer-controlled focused node ──
+  // Latest fly-to logic, read via a ref so the effect below depends ONLY on
+  // `focusedNode`. Otherwise the effect would re-run on every layout-affecting
+  // change (collapse/expand recomputes `centerOnNode`'s identity) and re-center
+  // on the same node even though the focus never changed.
+  const flyToFocusedRef = useRef<(id: string) => void>(() => {})
+  flyToFocusedRef.current = (id: string) => {
+    // Windowing: the target may be off-screen and absent from React Flow's
+    // store, so center on its layout position instead of an id-based fitView
+    // (which silently no-ops for a missing node).
+    if (enableNodeWindowing && centerOnNode(id, 300)) return
+    reactFlow.fitView({
+      nodes: [{ id }],
+      duration: 300,
+      padding: FIT_VIEW_PADDING_LOOSE,
+    })
+  }
   useEffect(() => {
-    if (focusedNode) {
-      // Slight delay to allow layout to settle
-      const timer = setTimeout(() => {
-        // Windowing: the target may be off-screen and absent from React Flow's
-        // store, so center on its layout position instead of an id-based
-        // fitView (which silently no-ops for a missing node).
-        if (enableNodeWindowing && centerOnNode(focusedNode, 300)) return
-        reactFlow.fitView({
-          nodes: [{ id: focusedNode }],
-          duration: 300,
-          padding: FIT_VIEW_PADDING_LOOSE,
-        })
-      }, FOCUS_SETTLE_DELAY_MS)
-      return () => clearTimeout(timer)
-    }
-  }, [focusedNode, reactFlow, enableNodeWindowing, centerOnNode])
+    if (!focusedNode) return
+    // Fires only when `focusedNode` transitions to a new value (entry,
+    // search-select, "Find me") — never on layout re-renders while it's
+    // unchanged. Slight delay so the layout settles before flying.
+    const target = focusedNode
+    const timer = setTimeout(
+      () => flyToFocusedRef.current(target),
+      FOCUS_SETTLE_DELAY_MS
+    )
+    return () => clearTimeout(timer)
+  }, [focusedNode])
 
   // ── Split context values (wrappers subscribe to only what they need) ──
   const zoomContextValue = useMemo(


### PR DESCRIPTION
## Problem

The graph re-centers on the current `focusedNode` on the **first layout change** after focusing (e.g. collapsing the focused node's children) — the viewport jerks and re-centers even though `focusedNode` never changed.

## Root cause

The "fly to `focusedNode`" effect in `F0GraphView` depended on `centerOnNode`:

```ts
useEffect(() => { … fly to focusedNode … }, [focusedNode, reactFlow, enableNodeWindowing, centerOnNode])
```

`centerOnNode`'s identity changes on every layout-affecting render:
`collapse/expand → new layout.nodes → new positionMap → new getNodePosition → new centerOnNode`.
So the effect re-runs and re-applies the fly-to with the **same** `focusedNode` — the entry fly-to firing again. (It re-fires on *every* such layout change while a `focusedNode` is set, not only the first.)

Note it isn't triggered by `focusOnEntry` per se: entry uses `initialFocusNodeId` and leaves `focusedNode` undefined. It bites once something sets `focusedNode` — search-select, "Find me", or a consumer that pins it — and then the tree relayouts.

## Fix

The effect now depends **only on `focusedNode`**, reading the fly-to logic through a ref (`flyToFocusedRef`, refreshed each render). It fires only when `focusedNode` transitions to a new value (entry, search-select, "Find me"), never on layout re-renders while it's unchanged.

## Non-goals / unchanged
- Initial open centering, search-select centering, "Find me" centering — all still work (each sets a new `focusedNode`).
- Node windowing (#4612) and the fly-to's windowing/`fitView` paths — untouched.

## Testing
- New `F0Graph.focusNoRefire.test.tsx`: `focusedNode` unchanged across a collapse ⇒ no extra `fitView`; a genuine `focusedNode` change ⇒ flies to the new node. Full F0Graph suite green (229); typecheck / oxlint / oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)