### PR TITLE
fix(OneDataCollection): use neutral variant for empty state actions

### DIFF
--- a/packages/react/src/components/OneEmptyState/types.ts
+++ b/packages/react/src/components/OneEmptyState/types.ts
@@ -23,7 +23,7 @@ export type ActionProps = {
    * @default "default"
    * @optional
    */
-  variant?: "default" | "outline" | "promote"
+  variant?: "default" | "outline" | "neutral" | "promote"
 
   /**
    * The icon of the action

--- a/packages/react/src/patterns/OneDataCollection/__stories__/empty-state.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/empty-state.mdx
@@ -56,6 +56,7 @@ const emptyStates = {
     actions: [
       {
         label: 'Clear filters',
+        variant: 'neutral',
         onClick: () => {
           console.log('clicked')
         }

--- a/packages/react/src/patterns/OneDataCollection/__stories__/empty-states.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/empty-states.stories.tsx
@@ -130,6 +130,7 @@ export const CustomMessagesAndActions: Story = {
           },
           {
             label: "Clear filters",
+            variant: "neutral" as const,
             onClick: () => {
               console.log("clicked")
             },

--- a/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useEmptyState.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useEmptyState.test.ts
@@ -1,0 +1,57 @@
+import { act } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRenderHook as renderHook } from "@/testing/test-utils"
+
+import { useEmptyState } from "../useEmptyState"
+
+describe("useEmptyState", () => {
+  it("uses the neutral variant for the default 'clear filters' action on no-results", () => {
+    const { result } = renderHook(() =>
+      useEmptyState(undefined, { retry: vi.fn(), clearFilters: vi.fn() })
+    )
+
+    act(() => {
+      result.current.setEmptyStateType("no-results")
+    })
+
+    expect(result.current.emptyState?.actions?.[0].variant).toBe("neutral")
+  })
+
+  it("uses the neutral variant for the default 'retry' action on error", () => {
+    const { result } = renderHook(() =>
+      useEmptyState(undefined, { retry: vi.fn(), clearFilters: vi.fn() })
+    )
+
+    act(() => {
+      result.current.setEmptyStateType("error")
+    })
+
+    expect(result.current.emptyState?.actions?.[0].variant).toBe("neutral")
+  })
+
+  it("does not force neutral onto a custom action's explicit variant", () => {
+    const { result } = renderHook(() =>
+      useEmptyState(
+        {
+          "no-results": {
+            actions: [
+              {
+                label: "Upgrade",
+                onClick: vi.fn(),
+                variant: "promote",
+              },
+            ],
+          },
+        },
+        { retry: vi.fn(), clearFilters: vi.fn() }
+      )
+    )
+
+    act(() => {
+      result.current.setEmptyStateType("no-results")
+    })
+
+    expect(result.current.emptyState?.actions?.[0].variant).toBe("promote")
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/hooks/useEmptyState.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useEmptyState.ts
@@ -45,6 +45,7 @@ export const useEmptyState = (
         {
           label: i18n.collections.emptyStates.noResults.clearFilters,
           onClick: actions.clearFilters,
+          variant: "neutral",
         },
       ],
     },
@@ -55,6 +56,7 @@ export const useEmptyState = (
         {
           label: i18n.collections.emptyStates.error.retry,
           onClick: actions.retry,
+          variant: "neutral",
         },
       ],
     },


### PR DESCRIPTION
## Description

The default "Clear filters" (no-results) and "Retry" (error) buttons in the Data Collection empty states rendered as primary/accent (red) buttons because no `variant` was set on the action, falling back to `F0Button`'s primary style. These are secondary actions and shouldn't compete visually with real primary CTAs, so they now default to `neutral`.

## Screenshots (if applicable)

Before: "Clear filters" rendered as a solid red primary button.
After: "Clear filters" and "Retry" render as neutral (grey) secondary buttons.

## Implementation details

- fix: default the `no-results` "Clear filters" and `error` "Retry" actions to `variant: "neutral"` instead of the unset primary/red default
- fix: widen `OneEmptyState`'s `ActionProps.variant` type to include `"neutral"`
- fix: update the `CustomMessagesAndActions` story and the empty-state docs code sample to use `variant: "neutral"` for their "Clear filters" example, so the docs don't teach the same red-button mistake
- test: add regression coverage for the default variants and confirm custom actions with an explicit variant (e.g. `promote`) aren't overridden


<img width="472" height="248" alt="Example1" src="https://github.com/user-attachments/assets/0c1c2993-aed5-4d93-8fae-664a7395b4b9" />