### PR TITLE
fix: make OneDataCollection column-settings list scrollable

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
@@ -57,12 +57,14 @@ export const SortAndHideSettings = ({
   return (
     <div className="relative -mr-2 flex flex-col gap-2">
       {/*
-        `type="auto"` keeps the scrollbar visible whenever the list overflows
-        `max-h-56`. It defaulted to Radix's `type="hover"`, which hid the
-        scrollbar until the list was hovered, so entries past the ~8-row cap
-        looked absent rather than scrollable.
+        Cap the scrollable viewport (not the ScrollArea root) at ~8 rows.
+        Radix's viewport is `height: 100%`, which does not resolve against a
+        root that only has `max-height`, so a `max-h-*` on the root let the
+        list overflow and get clipped without ever scrolling. Constraining the
+        viewport itself makes it scroll, and `type="auto"` shows the scrollbar
+        while it overflows (default `type="hover"` hid it until hover).
       */}
-      <ScrollArea type="auto" className="max-h-56">
+      <ScrollArea type="auto" className="[&_[data-scroll-container]]:max-h-56">
         <SortAndHideList
           items={items}
           onChange={onChange}

--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
@@ -60,11 +60,11 @@ export const SortAndHideSettings = ({
         Cap the scrollable viewport (not the ScrollArea root) at ~8 rows.
         Radix's viewport is `height: 100%`, which does not resolve against a
         root that only has `max-height`, so a `max-h-*` on the root let the
-        list overflow and get clipped without ever scrolling. Constraining the
-        viewport itself makes it scroll, and `type="auto"` shows the scrollbar
-        while it overflows (default `type="hover"` hid it until hover).
+        list overflow and get clipped without ever scrolling — no scrollbar,
+        no wheel scroll. Constraining the viewport itself makes it scroll; the
+        scrollbar keeps the default hover behaviour.
       */}
-      <ScrollArea type="auto" className="[&_[data-scroll-container]]:max-h-56">
+      <ScrollArea className="[&_[data-scroll-container]]:max-h-56">
         <SortAndHideList
           items={items}
           onChange={onChange}

--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
@@ -56,7 +56,14 @@ export const SortAndHideSettings = ({
 
   return (
     <div className="relative -mr-2 flex flex-col gap-2">
-      <ScrollArea className="max-h-56">
+      {/*
+        `type="auto"` keeps the scrollbar visible whenever the list overflows
+        its max height. The ScrollArea defaults to Radix's `type="hover"`, which
+        hides the scrollbar until the user hovers the list — with more entries
+        than fit in `max-h-56` (~8 rows) the extra columns then look absent
+        rather than scrollable.
+      */}
+      <ScrollArea type="auto" className="max-h-56">
         <SortAndHideList
           items={items}
           onChange={onChange}

--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
@@ -57,14 +57,12 @@ export const SortAndHideSettings = ({
   return (
     <div className="relative -mr-2 flex flex-col gap-2">
       {/*
-        Let the list grow to fit the full set of entries (up to `max-h-[32rem]`)
-        and, when it still overflows, keep the scrollbar visible with
-        `type="auto"`. The previous `max-h-56` (~8 rows) plus Radix's default
-        `type="hover"` capped the list short behind an invisible, hover-only
-        scrollbar, so any entries past the cap looked absent rather than
-        scrollable.
+        `type="auto"` keeps the scrollbar visible whenever the list overflows
+        `max-h-56`. It defaulted to Radix's `type="hover"`, which hid the
+        scrollbar until the list was hovered, so entries past the ~8-row cap
+        looked absent rather than scrollable.
       */}
-      <ScrollArea type="auto" className="max-h-[32rem]">
+      <ScrollArea type="auto" className="max-h-56">
         <SortAndHideList
           items={items}
           onChange={onChange}

--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
@@ -57,13 +57,14 @@ export const SortAndHideSettings = ({
   return (
     <div className="relative -mr-2 flex flex-col gap-2">
       {/*
-        `type="auto"` keeps the scrollbar visible whenever the list overflows
-        its max height. The ScrollArea defaults to Radix's `type="hover"`, which
-        hides the scrollbar until the user hovers the list — with more entries
-        than fit in `max-h-56` (~8 rows) the extra columns then look absent
-        rather than scrollable.
+        Let the list grow to fit the full set of entries (up to `max-h-[32rem]`)
+        and, when it still overflows, keep the scrollbar visible with
+        `type="auto"`. The previous `max-h-56` (~8 rows) plus Radix's default
+        `type="hover"` capped the list short behind an invisible, hover-only
+        scrollbar, so any entries past the cap looked absent rather than
+        scrollable.
       */}
-      <ScrollArea type="auto" className="max-h-56">
+      <ScrollArea type="auto" className="max-h-[32rem]">
         <SortAndHideList
           items={items}
           onChange={onChange}


### PR DESCRIPTION
## Why?

In `OneDataCollection`'s **Table settings** popover, the column-visibility list caps at ~8 rows. When a collection has more columns than that, the extra toggles render but are **clipped and unreachable** — no scrollbar and no wheel scroll. Reported on the expenses spending table: Document type, Payment method, Reimbursable amount and Internal reference toggles are present in the DOM but can't be reached in the settings menu.

### Root cause
`SortAndHideSettings` put `max-h-56` on the ScrollArea **root**. Radix's scroll viewport is `height: 100%`, which doesn't resolve against a parent that only has `max-height`, so the viewport grew to the full content height and never overflowed. The root's `overflow-hidden` + `max-height` then clipped the list — no viewport overflow means no scrollbar and nothing to scroll.

## What?
Move the cap onto the scroll **viewport** instead of the root:

```tsx
- <ScrollArea className="max-h-56">
+ <ScrollArea className="[&_[data-scroll-container]]:max-h-56">
```

`[data-scroll-container]` is the attribute f0's `ScrollArea` sets on the Radix viewport. The viewport now overflows and scrolls, and the scrollbar keeps Radix's default **hover** behaviour (visible on hover).

## Before:

<img width="1191" height="831" alt="image" src="https://github.com/user-attachments/assets/d15860d5-60c0-4546-9828-645f0a830c75" />

## After:
<img width="1004" height="628" alt="image" src="https://github.com/user-attachments/assets/562f9241-1363-4611-b6c3-34f6d6a23e90" />


## Demo:

https://github.com/user-attachments/assets/02d9884f-4b38-40bc-9aec-3402e7b466bd



https://factorialmakers.atlassian.net/browse/FCT-58157